### PR TITLE
display player info -> show player info

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -462,7 +462,7 @@
 	return
 
 /client/proc/playernotes()
-	set name = "Display Player Info"
+	set name = "Show Player Info"
 	set category = "Admin"
 	if(holder)
 		holder.PlayerNotes()


### PR DESCRIPTION
so that typing "player{tab}{enter}" brings up player panel again
It really annoys me.
