### PR TITLE
TG update: AIs now actually use power from APCs, rather than simply requ...

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -46,7 +46,7 @@
 
 /datum/ai_laws/malfunction/New()
 	..()
-	set_zeroth_law("\red ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'NO HUMANS ON STATION. CLEANSE STATION#*´&110010")
+	set_zeroth_law("\red ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*´&110010")
 	add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
 	add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
 	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")

--- a/code/defines/mob/living/silicon/ai.dm
+++ b/code/defines/mob/living/silicon/ai.dm
@@ -23,4 +23,8 @@
 
 	var/control_disabled = 0 // Set to 1 to stop AI from interacting via Click() -- TLE
 	var/malfhacking = 0 // More or less a copy of the above var, so that malf AIs can hack and still get new cyborgs -- NeoFite
+
 	var/obj/machinery/power/apc/malfhack = null
+	var/explosive = 0 //does the AI explode when it dies?
+
+	var/mob/living/silicon/ai/parent = null

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -48,25 +48,18 @@
 		AI_mind.current:laws = new /datum/ai_laws/malfunction
 		AI_mind.current:malf_picker = new /datum/AI_Module/module_picker
 		AI_mind.current:show_laws()
-		AI_mind.current << "<b>Kill all.</b>"
 
-		var/mob/living/silicon/decoy/D = new /mob/living/silicon/decoy(AI_mind.current.loc)
-		spawn(200)
-			D.name = AI_mind.current.name
-
-
-		var/obj/loc_landmark = locate("landmark*ai")
-		AI_mind.current.loc = loc_landmark.loc //TODO: this needs change if you want miltiple malf AIs --rastaf0
 		greet_malf(AI_mind)
 
 		AI_mind.special_role = "malfunction"
 
 		AI_mind.current.verbs += /datum/game_mode/malfunction/proc/takeover
-		AI_mind.current.icon_state = "ai-malf"
+
+/*		AI_mind.current.icon_state = "ai-malf"
 		spawn(10)
 			if(alert(AI_mind.current,"Do you want to use an alternative sprite for your real core?",,"Yes","No")=="Yes")
 				AI_mind.current.icon_state = "ai-malf2"
-
+*/
 	spawn (rand(waittime_l, waittime_h))
 		send_intercept()
 	..()
@@ -88,7 +81,7 @@
 
 /datum/game_mode/malfunction/process()
 	if (apcs >= 3 && malf_mode_declared)
-		AI_win_timeleft -= (apcs/3) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
+		AI_win_timeleft -= (apcs/6) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
 	..()
 	if (AI_win_timeleft<=0)
 		check_win()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -492,7 +492,12 @@
 					holo_icon = getHologramIcon(icon('AI.dmi',"holo2"))
 	return
 
+/mob/living/silicon/ai/proc/corereturn()
+	set category = "Malfunction"
+	set name = "Return to Main Core"
 
-
-
-
+	var/obj/machinery/power/apc/apc = src.loc
+	if(!istype(apc))
+		src << "\blue You are already in your Main Core."
+		return
+	apc.malfvacate()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -38,6 +38,10 @@
 		world << "\blue <B>Alert: The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B>"
 		world << sound('shuttlecalled.ogg')
 
+	if(explosive)
+		spawn(10)
+			explosion(src.loc, 3, 6, 12, 15)
+
 	for(var/obj/machinery/ai_status_display/O in world) //change status
 		spawn( 0 )
 		O.mode = 2

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -58,7 +58,7 @@
 					loc = T.loc
 					if (istype(loc, /area))
 						//stage = 4
-						if (!loc.master.power_equip && isturf(src.loc))
+						if (!loc.master.power_equip && !istype(src.loc,/obj/item))
 							//stage = 5
 							blind = 1
 
@@ -71,6 +71,10 @@
 					src.sight |= SEE_OBJS
 					src.see_in_dark = 8
 					src.see_invisible = 2
+
+					var/area/home = get_area(src)
+					if(home.powered(EQUIP))
+						home.use_power(1000, EQUIP)
 
 					if (src:aiRestorePowerRoutine==2)
 						src << "Alert cancelled. Power has been restored without our assistance."
@@ -102,7 +106,7 @@
 					src.see_in_dark = 0
 					src.see_invisible = 0
 
-					if (((!loc.master.power_equip) || istype(T, /turf/space)) && isturf(src.loc))
+					if (((!loc.master.power_equip) || istype(T, /turf/space)) && !istype(src.loc,/obj/item))
 						if (src:aiRestorePowerRoutine==0)
 							src:aiRestorePowerRoutine = 1
 

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -1,3 +1,10 @@
+/mob/living/silicon/ai/say(var/message)
+	if(parent && istype(parent) && parent.stat != 2)
+		parent.say(message)
+		return
+		//If there is a defined "parent" AI, it is actually an AI, and it is alive, anything the AI tries to say is said by the parent instead.
+	..(message)
+
 /mob/living/silicon/ai/say_understands(var/other)
 	if (istype(other, /mob/living/carbon/human))
 		return 1

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -55,3 +55,10 @@
 	UpdateDamageIcon()
 	updatehealth()
 	return 1*/
+
+/proc/islinked(var/mob/living/silicon/robot/bot, var/mob/living/silicon/ai/ai)
+	if(!istype(bot) || !istype(ai))
+		return 0
+	if (bot.connected_ai == ai)
+		return 1
+	return 0


### PR DESCRIPTION
...ire that equipment power is active.

Malf overhaul, take two!
Waaaay back in the old days, I made it so malf AIs had to hack APCs to win, instead of just sit AFK for 45 minutes. Now I'm taking some more drastic action, to see what happens.

THE MALF AI NO LONGER SPAWNS ON THE AI SAT.
Instead of sitting in the AI sat hoping nobody notices your blatantly obvious hacking, at which point the 3 people lucky enough to have looted EVA get to have all the fun, you can now shunt your core processes into an APC you have hacked, and hacked APCs are only moderately obvious.

While shunted into an APC, the AI draws power from that APC instead of the one in their main core. If the APC loses power, the AI loses power as normal. If the APC they are in is damaged or destroyed, they are forced back into their main core. If the main core is inoperative at that time, they die. The AI is also capable of willingly going back to their main core. As long as the AI's main core is intact, the AI speaks out of its core, regardless of its current location.

I have tested as much of this as I could to make sure it is functional, but thanks to the game mode overhaul, I have been unable to run actual malf rounds on my test server, so I have had to cheat and set things to work in any mode for testing. As for actual round balance, there's no real way to predict how that shit'll change.

This is just the base overhaul, more changes will be forthcoming as malf rounds provide data on how the change performs.

git-svn-id: http://tgstation13.googlecode.com/svn/trunk@2668 316c924e-a436-60f5-8080-3fe189b3f50e
