### PR TITLE
Floorbots will no longer build floors over where shuttles

### DIFF
--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -204,7 +204,7 @@
 				src.target = T
 		if(!src.target || src.target == null)
 			for (var/turf/space/D in view(7,src))
-				if(!(D in floorbottargets) && D != src.oldtarget && (D.loc.name != "Space"))
+				if(!(D in floorbottargets) && D != src.oldtarget && (D.loc.name != "Space") && !istype(D.loc, /area/shuttle))
 					src.oldtarget = D
 					src.target = D
 					break


### PR DESCRIPTION
Probably a few other things it does this for (like if there are any shuttles that aren't /area/shuttle)
