### PR TITLE
A few medical related fixes

### DIFF
--- a/code/WorkInProgress/virus2/base.dm
+++ b/code/WorkInProgress/virus2/base.dm
@@ -336,12 +336,6 @@ proc/airborne_can_reach(turf/source, turf/target)
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.toxloss += (2*multiplier)
 
-/datum/disease2/effect/greater/scream
-	name = "Random screaming syndrome"
-	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*scream")
-
 /datum/disease2/effect/greater/drowsness
 	name = "Automated sleeping syndrome"
 	stage = 3

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2045,7 +2045,7 @@ It can still be worn/put on as normal.
 				//SN src = null
 				del(src)
 				return
-			if ((target.health >= -99.0 && target.health < 0))
+			if ((target.health >= -99.0 && target.health < config.health_threshold_dead))
 				target.cpr_time = world.time
 				var/suff = min(target.getOxyLoss(), 7)
 				target.oxyloss -= suff

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1,4 +1,4 @@
-#define HUMAN_MAX_OXYLOSS 12 //Defines how much oxyloss humans can get per tick. No air applies this value.
+#define HUMAN_MAX_OXYLOSS 3 //Defines how much oxyloss humans can get per tick. No air applies this value.
 
 /mob/living/carbon/human
 	var
@@ -1106,9 +1106,14 @@
 	handle_shock()
 		..()
 
+		if(health < 0)
+			// health 0 makes you immediately collapse
+			shock_stage = max(shock_stage, 61)
+
 		if(traumatic_shock >= 80)
 			shock_stage += 1
 		else
+			if(shock_stage > 100) shock_stage = 100
 			shock_stage--
 			shock_stage = max(shock_stage, 0)
 			return

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -16,7 +16,7 @@
 		var/mob/living/carbon/human/M = src
 		for(var/name in M.organs)
 			var/datum/organ/external/organ = M.organs[name]
-			if(organ.destroyed)
+			if(organ.destroyed || organ.open)
 				src.traumatic_shock += 60
 			else if(organ.broken)
 				src.traumatic_shock += 40


### PR DESCRIPTION
- Fixed another problem related to the crit config
- Recovering from shock won't take forever anymore
- Reduced the max speed at which you suffocate, mainly to make crit slower. If this is found to affect normal suffocation too much, increase HUMAN_MAX_OXYLOSS again.
- Open organs now add a lot of shock, as well.
