### PR TITLE
Reverted changes regarding the Bible

### DIFF
--- a/code/game/objects/storage/bible.dm
+++ b/code/game/objects/storage/bible.dm
@@ -6,7 +6,7 @@
 	new /obj/item/weapon/spacecash(src)
 	new /obj/item/weapon/spacecash(src)
 
-/*/obj/item/weapon/storage/bible/proc/bless(mob/living/carbon/M as mob)
+/obj/item/weapon/storage/bible/proc/bless(mob/living/carbon/M as mob)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/heal_amt = 10
@@ -14,13 +14,13 @@
 			var/datum/organ/external/affecting = H.organs[name]
 			if(affecting.heal_damage(heal_amt, heal_amt))
 				H.UpdateDamageIcon()
-	return	*/
+	return
 
 /obj/item/weapon/storage/bible/attack(mob/M as mob, mob/living/user as mob)
 
-//	var/chaplain = 0
-//	if(user.mind && (user.mind.assigned_role == "Chaplain"))
-//		chaplain = 1
+	var/chaplain = 0
+	if(user.mind && (user.mind.assigned_role == "Chaplain"))
+		chaplain = 1
 
 
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
@@ -29,10 +29,10 @@
 	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
 		user << "\red You don't have the dexterity to do this!"
 		return
-//	if(!chaplain)
-//		user << "\red The book sizzles in your hands."
-//		user.take_organ_damage(0,10)
-//		return
+	if(!chaplain)
+		user << "\red The book sizzles in your hands."
+		user.take_organ_damage(0,10)
+		return
 
 	if ((user.mutations & CLUMSY) && prob(50))
 		user << "\red The [src] slips out of your hand and hits your head."
@@ -48,7 +48,7 @@
 			M << "\red The power of [src.deity_name] clears your mind of heresy!"
 			user << "\red You see how [M]'s eyes become clear, the cult no longer holds control over him!"
 			ticker.mode.remove_cultist(M.mind)
-/*		if ((istype(M, /mob/living/carbon/human) && prob(60)))
+		if ((istype(M, /mob/living/carbon/human) && prob(60)))
 			bless(M)
 			for(var/mob/O in viewers(M, null))
 				O.show_message(text("\red <B>[] heals [] with the power of [src.deity_name]!</B>", user, M), 1)
@@ -60,7 +60,7 @@
 				M << "\red You feel dumber."
 			for(var/mob/O in viewers(M, null))
 				O.show_message(text("\red <B>[] beats [] over the head with []!</B>", user, M, src), 1)
-			playsound(src.loc, "punch", 25, 1, -1)	*/
+			playsound(src.loc, "punch", 25, 1, -1)
 	else if(M.stat == 2)
 		for(var/mob/O in viewers(M, null))
 			O.show_message(text("\red <B>[] smacks []'s lifeless corpse with [].</B>", user, M, src), 1)


### PR DESCRIPTION
Reverted the change where the Bible wouldn't sizzle in the hands of non-chaplains (gameplay-wise, that is because the Bible is used in the cult game mode, and if we don't let that in, it would be possible for anyone to print bibles and use them against cult members).

Reverted the change where the Bible wouldn't be able to "bless" you, since the effects of blessings are pretty insignificant, and it's mainly there as a joke. On the subject of jokes, we've not yet decided whether we want to leave them in or not, so I'd suggest we don't touch those yet :)
