### PR TITLE
Runtime Error fix for Distance_ortho

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -122,7 +122,7 @@ proc
 		var/closed[] = new()
 		var/path[]
 		start = get_turf(start)
-		if(!start) return 0
+		if(!start || !end) return 0
 
 		open.Enqueue(new /PathNode(start,null,0,call(start,dist)(end)))
 

--- a/code/defines/turf.dm
+++ b/code/defines/turf.dm
@@ -146,7 +146,11 @@
 			return get_dist(src,t)
 
 	Distance_ortho(turf/t)
-		return abs(src.x - t.x) + abs(src.y - t.y)
+		if(t != null && src != null)
+			return abs(src.x - t.x) + abs(src.y - t.y)
+
+		else
+			return 99999
 
 	AdjacentTurfsSpace()
 		var/L[] = new()


### PR DESCRIPTION
Runtime Error thread mentioned on with Distance_ortho. It is caused by trying to path to null.

This pull request fixes it in two ways: Handling null properly in Distance_ortho, and returning early if AStar is given a null destination (since it wouldn't reach there anyway, why bother looking for a path? If some code actually tries to reach null, I guess that part should be left out, though I highly doubt SS13 has anything pathing to null...)
