### PR TITLE
turns out things broke from abi's runtime fix because that proc shoult ever be called here

### DIFF
--- a/code/FEA/FEA_system.dm
+++ b/code/FEA/FEA_system.dm
@@ -329,8 +329,8 @@ datum
 					AG.process_group()
 
 			process_singletons()
-				for(var/turf/simulated/T in active_singletons)
-					T.process_cell()
+				//for(var/turf/simulated/T in active_singletons)	// this code shouldn't actually exist in the current version of FEA apparently,
+				//	T.process_cell()								// causes horrible gas variable glitching
 
 			process_super_conductivity()
 				for(var/turf/simulated/hot_potato in active_super_conductivity)


### PR DESCRIPTION
it causes the horrible -infinity temperature horrible bugs that I couldn't figure out where exactly the  bug originates (I'm guessing gas_mixture.mimic() ). This is why FEA needs to die.
