### PR TITLE
Added a thing to select pill and bottle sprites to the chemmaster

### DIFF
--- a/code/modules/chemical/Chemistry-Machinery.dm
+++ b/code/modules/chemical/Chemistry-Machinery.dm
@@ -171,6 +171,8 @@
 	var/beaker = null
 	var/mode = 0
 	var/condi = 0
+	var/bottlesprite = "1" //yes, strings
+	var/pillsprite = "1"
 
 	New()
 		var/datum/reagents/R = new/datum/reagents(100)
@@ -293,6 +295,7 @@
 			P.name = "[name] pill"
 			P.pixel_x = rand(-7, 7) //random position
 			P.pixel_y = rand(-7, 7)
+			P.icon_state = "pill"+pillsprite
 			reagents.trans_to(P,50)
 		else if (href_list["createbottle"])
 			if(!condi)
@@ -302,10 +305,33 @@
 				P.name = "[name] bottle"
 				P.pixel_x = rand(-7, 7) //random position
 				P.pixel_y = rand(-7, 7)
+				P.icon_state = "bottle"+bottlesprite
 				reagents.trans_to(P,30)
 			else
 				var/obj/item/weapon/reagent_containers/food/condiment/P = new/obj/item/weapon/reagent_containers/food/condiment(src.loc)
 				reagents.trans_to(P,50)
+		else if(href_list["change_pill"])
+			#define MAX_PILL_SPRITE 20 //max icon state of the pill sprites
+			var/dat = "<table>"
+			for(var/i = 1 to MAX_PILL_SPRITE)
+				usr << browse_rsc(icon('chemical.dmi', "pill" + num2text(i)), "pill[i].png")
+				dat += "<tr><td><a href=\"?src=\ref[src]&pill_sprite=[i]\"><img src=\"pill[i].png\" /></a></td></tr>"
+			dat += "</table>"
+			usr << browse(dat, "window=chem_master")
+			return
+		else if(href_list["change_bottle"])
+			#define MAX_BOTTLE_SPRITE 20 //max icon state of the bottle sprites
+			var/dat = "<table>"
+			for(var/i = 1 to MAX_BOTTLE_SPRITE)
+				usr << browse_rsc(icon('chemical.dmi', "bottle" + num2text(i)), "bottle[i].png")
+				dat += "<tr><td><a href=\"?src=\ref[src]&bottle_sprite=[i]\"><img src=\"bottle[i].png\" /></a></td></tr>"
+			dat += "</table>"
+			usr << browse(dat, "window=chem_master")
+			return
+		else if(href_list["pill_sprite"])
+			pillsprite = min(max(href_list["pill_sprite"],0),MAX_PILL_SPRITE)
+		else if(href_list["bottle_sprite"])
+			bottlesprite = min(max(href_list["bottlesprite"],0),MAX_BOTTLE_SPRITE)
 		else
 			usr << browse(null, "window=chem_master")
 		src.updateUsrDialog()
@@ -355,8 +381,10 @@
 			else
 				dat += "Empty<BR>"
 			if(!condi)
-				dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (50 units max)</A><BR>"
-				dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (30 units max)</A>"
+				usr << browse_rsc(icon('chemical.dmi', "pill" + pillsprite), "pill.png")
+				dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (50 units max)</A><a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill.png\" /></a><BR>"
+				usr << browse_rsc(icon('chemical.dmi', "bottle" + bottlesprite), "bottle.png")
+				dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (30 units max)</A><a href=\"?src=\ref[src]&change_bottle=1\"><img src=\"bottle.png\" /></a>"
 			else
 				dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (50 units max)</A>"
 		if(!condi)


### PR DESCRIPTION
At some point I'd like to see bottles doing the same thing as beakers, where they show what chemicals are in them on the sprite. That however would involve messing with sprites and overlays and stuff, so I can't be bothered to actually do it at the moment. Just remember that this stuff will need to be changed for that.
