### PR TITLE
Added a cap to chem dispenser charge

### DIFF
--- a/code/modules/chemical/Chemistry-Machinery.dm
+++ b/code/modules/chemical/Chemistry-Machinery.dm
@@ -154,7 +154,7 @@
 
 /obj/machinery/chem_dispenser/process()
 	if(stat & NOPOWER) return
-	if(!charging_reagents) return
+	if(!charging_reagents || src.energy > 30) return
 
 	use_power(10000)
 	src.energy += 0.05


### PR DESCRIPTION
It stops at 30 now, if you want to store higher you still can with chemistry charges.
Why? Because as of writing, my dispenser is at >100 charge. This doesn't really punish people who don't use the charge rapidly, because they most likely won't use the charges anyway. It has a slight effect on people who use all the charge, because if they go off to do something (get more charges from the QM or whatever) the dispenser won't go too high, but I've found it only increases by ~20 in the time I am away anyway, so not that big of a deal.
