### PR TITLE
Horrible alternate reality prevention

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/Tajara/tajara_transformation.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Tajara/tajara_transformation.dm
@@ -31,6 +31,7 @@
 	for(var/datum/disease/D in O.viruses)
 		D.affected_mob = O
 	O.flavor_text = flavor_text
+	O.universal_speak = 1 //hacky fix until someone can figure out how to make them only understand humans
 
 	if (client)
 		client.mob = O

--- a/code/WorkInProgress/Cael_Aislinn/Tajara/tajaran.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Tajara/tajaran.dm
@@ -5,6 +5,7 @@
 	icon = 'tajaran.dmi'
 	var/list/tajspeak_letters
 	//
+	universal_speak = 1 //hacky fix until someone can figure out how to make them only understand humans
 	taj_talk_understand = 1
 	voice_message = "mrowls"
 

--- a/code/WorkInProgress/SkyMarshal/wardrobes.dm
+++ b/code/WorkInProgress/SkyMarshal/wardrobes.dm
@@ -185,7 +185,7 @@
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
 		new /obj/item/weapon/storage/box(BPK)
 		new /obj/item/weapon/pen(src)
-		new /obj/item/weapon/storage/bible/booze(src)
+		new /obj/item/weapon/storage/bible(src)
 		new /obj/item/device/pda/chaplain(src)
 		new /obj/item/device/radio/headset(src)
 		new /obj/item/clothing/shoes/black(src)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -13,7 +13,7 @@
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 
-		var/obj/item/weapon/storage/bible/B = new /obj/item/weapon/storage/bible/booze(H)
+		var/obj/item/weapon/storage/bible/B = new /obj/item/weapon/storage/bible(H)
 		H.equip_if_possible(B, H.slot_l_hand)
 		H.equip_if_possible(new /obj/item/device/pda/chaplain(H), H.slot_belt)
 		H.equip_if_possible(new /obj/item/clothing/under/rank/chaplain(H), H.slot_w_uniform)
@@ -44,13 +44,6 @@
 						B.name = "The Book of Lorgar"
 					if("imperium")
 						B.name = "Uplifting Primer"
-					if("toolboxia")
-						B.name = "Toolbox Manifesto"
-					if("homosexuality")
-						B.name = "Guys Gone Wild"
-					if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks")
-						B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
-						H.brainloss = 100 // starts off retarded as fuck
 					if("science")
 						B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
 					else

--- a/code/game/objects/closets/secure/civilian.dm
+++ b/code/game/objects/closets/secure/civilian.dm
@@ -123,7 +123,7 @@
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
 		var/obj/item/weapon/storage/box/B = new(BPK)
 		new /obj/item/weapon/pen(B)
-		new /obj/item/weapon/storage/bible/booze(src)
+		new /obj/item/weapon/storage/bible(src)
 		new /obj/item/device/pda/chaplain(src)
 		new /obj/item/device/radio/headset(src)
 		new /obj/item/weapon/candlepack(src)

--- a/code/modules/critters/critter_defenses.dm
+++ b/code/modules/critters/critter_defenses.dm
@@ -32,6 +32,11 @@ Contains the procs that control attacking critters
 					O.show_message("\red <B>[user] has slashed at [src]!</B>", 1)
 				playsound(src.loc, 'slice.ogg', 25, 1, -1)
 
+			else if(user.type == /mob/living/carbon/human/tajaran)
+				for(var/mob/O in viewers(src, null))
+					O.show_message("\red <B>[user] has slashed at [src]!</B>", 1)
+				playsound(src.loc, 'slice.ogg', 25, 1, -1)
+
 			else
 				for(var/mob/O in viewers(src, null))
 					O.show_message("\red <B>[user] has bit [src]!</B>", 1)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -86,14 +86,14 @@
 				else
 					attack_verb = "punch"
 
-			if(src.type == /mob/living/carbon/human/tajaran)
+			if(M.type == /mob/living/carbon/human/tajaran)
 				attack_verb = "slash"
 
 			var/damage = rand(0, 9)
 			if(!damage)
-				if(src.type != /mob/living/carbon/human/tajaran)
+				if(M.type != /mob/living/carbon/human/tajaran)
 					playsound(loc, 'punchmiss.ogg', 25, 1, -1)
-				else if (src.type == /mob/living/carbon/human/tajaran)
+				else if (M.type == /mob/living/carbon/human/tajaran)
 					playsound(loc, 'slashmiss.ogg', 25, 1, -1)
 				visible_message("\red <B>[M] has attempted to [attack_verb] [src]!</B>")
 				return 0
@@ -101,9 +101,9 @@
 			var/armor_block = run_armor_check(affecting, "melee")
 
 			if(M.mutations & HULK)	damage += 5
-			if(src.type != /mob/living/carbon/human/tajaran)
+			if(M.type != /mob/living/carbon/human/tajaran)
 				playsound(loc, "punch", 25, 1, -1)
-			else if (src.type == /mob/living/carbon/human/tajaran)
+			else if (M.type == /mob/living/carbon/human/tajaran)
 				playsound(loc, 'slice.ogg', 25, 1, -1)
 
 			visible_message("\red <B>[M] has [attack_verb]ed [src]!</B>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -74,8 +74,8 @@
 		if("hurt")
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Punched [src.name] ([src.ckey])</font>")
 			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been punched by [M.name] ([M.ckey])</font>")
-			log_admin("ATTACK: [src] ([src.ckey]) punched [M] ([M.ckey]).")
-			message_admins("ATTACK: [src] ([src.ckey]) punched [M] ([M.ckey]).")
+			log_admin("ATTACK: [M] ([M.ckey]) punched [src] ([src.ckey]).")
+			message_admins("ATTACK: [M] ([M.ckey]) punched [src] ([src.ckey]).")
 
 			var/attack_verb
 			switch(M.mutantrace)
@@ -86,16 +86,25 @@
 				else
 					attack_verb = "punch"
 
+			if(src.type == /mob/living/carbon/human/tajaran)
+				attack_verb = "slash"
+
 			var/damage = rand(0, 9)
 			if(!damage)
-				playsound(loc, 'punchmiss.ogg', 25, 1, -1)
+				if(src.type != /mob/living/carbon/human/tajaran)
+					playsound(loc, 'punchmiss.ogg', 25, 1, -1)
+				else if (src.type == /mob/living/carbon/human/tajaran)
+					playsound(loc, 'slashmiss.ogg', 25, 1, -1)
 				visible_message("\red <B>[M] has attempted to [attack_verb] [src]!</B>")
 				return 0
 			var/datum/organ/external/affecting = get_organ(ran_zone(M.zone_sel.selecting))
 			var/armor_block = run_armor_check(affecting, "melee")
 
 			if(M.mutations & HULK)	damage += 5
-			playsound(loc, "punch", 25, 1, -1)
+			if(src.type != /mob/living/carbon/human/tajaran)
+				playsound(loc, "punch", 25, 1, -1)
+			else if (src.type == /mob/living/carbon/human/tajaran)
+				playsound(loc, 'slice.ogg', 25, 1, -1)
 
 			visible_message("\red <B>[M] has [attack_verb]ed [src]!</B>")
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -975,6 +975,11 @@
 				if(!druggy)
 					see_invisible = 2
 
+			else if (type == /mob/living/carbon/human/tajaran)
+//				sight |= SEE_MOBS
+//				sight |= SEE_OBJS
+				see_in_dark = 8
+
 			else if (seer)
 				var/obj/effect/rune/R = locate() in loc
 				if (istype(R) && R.word1 == wordsee && R.word2 == wordhell && R.word3 == wordjoin)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -222,7 +222,7 @@
 				else
 					attack_verb = "punch"
 
-			if(src.type == /mob/living/carbon/human/tajaran)
+			if(M.type == /mob/living/carbon/human/tajaran)
 				attack_verb = "slash"
 
 			if ((prob(75) && health > 0))
@@ -230,9 +230,9 @@
 					if ((O.client && !( O.blinded )))
 						O.show_message(text("\red <B>[] has [attack_verb]ed [name]!</B>", M), 1)
 
-				if(src.type != /mob/living/carbon/human/tajaran)
+				if(M.type != /mob/living/carbon/human/tajaran)
 					playsound(loc, "punch", 25, 1, -1)
-				else if(src.type == /mob/living/carbon/human/tajaran)
+				else if(M.type == /mob/living/carbon/human/tajaran)
 					playsound(loc, 'slice.ogg', 25, 1, -1)
 				var/damage = rand(5, 10)
 				if (prob(40))
@@ -248,9 +248,9 @@
 				updatehealth()
 				react_to_attack(M)
 			else
-				if(src.type != /mob/living/carbon/human/tajaran)
+				if(M.type != /mob/living/carbon/human/tajaran)
 					playsound(loc, 'punchmiss.ogg', 25, 1, -1)
-				else if(src.type == /mob/living/carbon/human/tajaran)
+				else if(M.type == /mob/living/carbon/human/tajaran)
 					playsound(loc, 'slashmiss.ogg', 25, 1, -1)
 				for(var/mob/O in viewers(src, null))
 					if ((O.client && !( O.blinded )))

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -222,12 +222,18 @@
 				else
 					attack_verb = "punch"
 
+			if(src.type == /mob/living/carbon/human/tajaran)
+				attack_verb = "slash"
+
 			if ((prob(75) && health > 0))
 				for(var/mob/O in viewers(src, null))
 					if ((O.client && !( O.blinded )))
 						O.show_message(text("\red <B>[] has [attack_verb]ed [name]!</B>", M), 1)
 
-				playsound(loc, "punch", 25, 1, -1)
+				if(src.type != /mob/living/carbon/human/tajaran)
+					playsound(loc, "punch", 25, 1, -1)
+				else if(src.type == /mob/living/carbon/human/tajaran)
+					playsound(loc, 'slice.ogg', 25, 1, -1)
 				var/damage = rand(5, 10)
 				if (prob(40))
 					damage = rand(10, 15)
@@ -242,7 +248,10 @@
 				updatehealth()
 				react_to_attack(M)
 			else
-				playsound(loc, 'punchmiss.ogg', 25, 1, -1)
+				if(src.type != /mob/living/carbon/human/tajaran)
+					playsound(loc, 'punchmiss.ogg', 25, 1, -1)
+				else if(src.type == /mob/living/carbon/human/tajaran)
+					playsound(loc, 'slashmiss.ogg', 25, 1, -1)
 				for(var/mob/O in viewers(src, null))
 					if ((O.client && !( O.blinded )))
 						O.show_message(text("\red <B>[] has attempted to [attack_verb] [name]!</B>", M), 1)


### PR DESCRIPTION
Tajaran/chaplain changes.
- Chaplains no longer start with booze/space cash in their bibles.
- Removed leftover TG chaplain code.
- Tajaran slash instead of punch now. (No bleeding yet due to examine crash bug)
- Tajaran see in the dark now.
- Tajaran have universal_speak 1 by default now (until a proper 'can understand humans' code is done).
- ADMIN LOG CHANGE: Punching now shows the correct targets. (Jim punching Joe will no longer report Joe punching Jim)
- Prevented a horrible alternate reality scenario where humans had claws instead of fingernails.
