### PR TITLE
Added Round Duration to Game tab. Also fixed extra "0" in Round Duration...

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1566,7 +1566,7 @@
 					if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 						var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 						dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
-						dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
+						dat += "Round Duration: <B>[round(world.time / 36000)]:[world.time / 600 % 60]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
 						dat += "<B>Emergency shuttle</B><BR>"
 						if (!emergency_shuttle.online)
 							dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -166,6 +166,8 @@
 				stat("Time To Start:", ticker.pregame_timeleft)
 			if((ticker.current_state == GAME_STATE_PREGAME) && !going)
 				stat("Time To Start:", "DELAYED")
+			if((ticker.current_state == GAME_STATE_PLAYING) && going)
+				stat("Round Duration:", "[round(world.time / 36000)]:[world.time / 600 % 60]:[world.time / 100 % 6][world.time / 100 % 10]")
 
 		statpanel("Lobby")
 		if(client.statpanel=="Lobby" && ticker)


### PR DESCRIPTION
... in Admin > Secrets panel when minutes are in the double-digits.

Tested for 30 minutes to make sure the format didn't warp.

Result was:

```
0:30:00
```

http://i.imgur.com/mjYu1.png
