### PR TITLE
Minor formatting adjustment to Round Duration. Credit: SkyMarshal

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1566,7 +1566,7 @@
 					if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 						var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 						dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
-						dat += "Round Duration: <B>[round(world.time / 36000)]:[world.time / 600 % 60]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
+						dat += "Round Duration: <B>[round(world.time / 36000)]:[(((world.time / 600 % 60)/10) > 1 ? world.time / 600 % 60 : add_zero(world.time / 600 % 60, 2))]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
 						dat += "<B>Emergency shuttle</B><BR>"
 						if (!emergency_shuttle.online)
 							dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -167,7 +167,7 @@
 			if((ticker.current_state == GAME_STATE_PREGAME) && !going)
 				stat("Time To Start:", "DELAYED")
 			if((ticker.current_state == GAME_STATE_PLAYING) && going)
-				stat("Round Duration:", "[round(world.time / 36000)]:[world.time / 600 % 60]:[world.time / 100 % 6][world.time / 100 % 10]")
+				stat("Round Duration:", "[round(world.time / 36000)]:[(((world.time / 600 % 60)/10) > 1 ? world.time / 600 % 60 : add_zero(world.time / 600 % 60, 2))]:[world.time / 100 % 6][world.time / 100 % 10]")
 
 		statpanel("Lobby")
 		if(client.statpanel=="Lobby" && ticker)


### PR DESCRIPTION
Round Duration (Game tab and Admin tab > Secrets > Show traitor objectives) now shows as:

```
0:01:20
```

...instead of:

```
0:1:20
```
