### PR TITLE
Fixed a runtime error related to the group_multiplier of an air mixture being 0

### DIFF
--- a/code/FEA/FEA_gas_mixture.dm
+++ b/code/FEA/FEA_gas_mixture.dm
@@ -41,13 +41,13 @@ datum
 
 			temperature = 0 //in Kelvin, use calculate_temperature() to modify
 
-			var/group_multiplier = 1
+			group_multiplier = 1
 				//Size of the group this gas_mixture is representing.
 				//=1 for singletons
 
 			graphic
 
-			var/list/datum/gas/trace_gases = list()
+			list/datum/gas/trace_gases = list()
 
 			tmp
 				oxygen_archived

--- a/code/ZAS/Processing.dm
+++ b/code/ZAS/Processing.dm
@@ -56,22 +56,26 @@ zone
 			if(T.zone && T.zone != src)
 				RemoveTurf(T)
 				if(dbg_output) world << "Removed invalid turf."
-			else if(!T.zone)
-				T.zone = src
+				if(air.group_multiplier <= 0) // No more turfs belong to this zone, so we can get rid of it
+					del(src)
+			else							  // Turf was valid, so we can handle it
+				if(!T.zone)
+					T.zone = src
 
-			if(istype(T,/turf/simulated))
-				var/turf/simulated/S = T
-				if(S.fire_protection) S.fire_protection--
-				if(check)
-					if(S.HasDoor(1))
-						S.update_visuals()
-					else
-						S.update_visuals(air)
+				if(istype(T,/turf/simulated))
+					var/turf/simulated/S = T
+					if(S.fire_protection) S.fire_protection--
+					if(check)
+						if(S.HasDoor(1))
+							S.update_visuals()
+						else
+							S.update_visuals(air)
 
-				if(air.temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
-					for(var/atom/movable/item in S)
-						item.temperature_expose(air, air.temperature, CELL_VOLUME)
-					S.temperature_expose(air, air.temperature, CELL_VOLUME)
+					if(air.temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+						for(var/atom/movable/item in S)
+							item.temperature_expose(air, air.temperature, CELL_VOLUME)
+						S.temperature_expose(air, air.temperature, CELL_VOLUME)
+
 		air.graphic_archived = air.graphic
 
 		air.temperature = max(TCMB,air.temperature)

--- a/code/game/json.dm
+++ b/code/game/json.dm
@@ -99,4 +99,3 @@ proc/send2irc(msg,msg2)
 proc/send2adminirc(channel,msg)
 	world << channel << " "<< msg
 	shell("python nudge.py '[channel]' [msg]")
-p	//test

--- a/code/game/objects/items/weapons/mops_cleaners.dm
+++ b/code/game/objects/items/weapons/mops_cleaners.dm
@@ -353,6 +353,10 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A as turf)
 	..()
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user as mob)
+	if (isnull(A))
+		user << "\red You've encountered a nasty bug. You should tell a developer what you were trying to clean with the mop."
+		return
+
 	if (src.reagents.total_volume < 1 || mopcount >= 5)
 		user << "\blue Your mop is dry!"
 		return


### PR DESCRIPTION
In certain cases, zones would be emptied completely of turfs, thereby causing division by zero errors in FEA due to operations involving group_multiplier.
