### PR TITLE
Unanchored stools and chairs

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -759,7 +759,6 @@
 	desc = "Apply butt."
 	icon = 'objects.dmi'
 	icon_state = "stool"
-	anchored = 1.0
 	flags = FPRINT
 	pressure_resistance = 3*ONE_ATMOSPHERE
 
@@ -768,6 +767,7 @@
 	desc = "This is used to lie in, sleep in or strap on."
 	icon_state = "bed"
 	var/mob/living/buckled_mob
+	anchored = 1.0
 
 /obj/structure/stool/bed/alien
 	name = "Resting contraption"
@@ -779,6 +779,7 @@
 	name = "chair"
 	desc = "You sit in this. Either by will or force."
 	icon_state = "chair"
+	anchored = 0
 
 /obj/structure/stool/bed/chair/comfy
 	name = "comfy chair"

--- a/code/game/objects/stool.dm
+++ b/code/game/objects/stool.dm
@@ -19,6 +19,13 @@
 		del(src)
 
 /obj/structure/stool/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/screwdriver))
+		if (src.anchored)
+			src.anchored = 0
+			user << "/blue You unfasten [src] from the floor."
+		else
+			src.anchored = 1
+			user << "/blue You fasten [src] to the floor."			
 	if(istype(W, /obj/item/weapon/wrench))
 		playsound(src.loc, 'Ratchet.ogg', 50, 1)
 		new /obj/item/stack/sheet/metal(src.loc)

--- a/code/game/objects/stool.dm
+++ b/code/game/objects/stool.dm
@@ -22,10 +22,10 @@
 	if(istype(W, /obj/item/weapon/screwdriver))
 		if (src.anchored)
 			src.anchored = 0
-			user << "/blue You unfasten [src] from the floor."
+			user << "\blue You unfasten [src] from the floor."
 		else
 			src.anchored = 1
-			user << "/blue You fasten [src] to the floor."			
+			user << "\blue You fasten [src] to the floor."
 	if(istype(W, /obj/item/weapon/wrench))
 		playsound(src.loc, 'Ratchet.ogg', 50, 1)
 		new /obj/item/stack/sheet/metal(src.loc)
@@ -118,7 +118,6 @@
 	return
 
 /obj/structure/stool/bed/chair/New()
-	src.verbs -= /atom/movable/verb/pull
 	if(src.dir == NORTH)
 		src.layer = FLY_LAYER
 	..()
@@ -152,11 +151,20 @@
 	icon_state = "down"
 	anchored = 0
 
-/obj/structure/stool/bed/roller/Move()
+//obj/structure/stool/bed/roller/Move()
+/obj/structure/stool/bed/Move()
 	..()
 	if(buckled_mob)
 		if(buckled_mob.buckled == src)
 			buckled_mob.loc = src.loc
+			buckled_mob.dir = src.dir
+
+/obj/structure/stool/bed/chair/Move()
+	..()
+	if(src.dir == NORTH)
+		src.layer = FLY_LAYER
+	else
+		src.layer = OBJ_LAYER
 
 /obj/structure/stool/bed/roller/buckle_mob(mob/M as mob, mob/user as mob)
 	if ((!( istype(M, /mob) ) || get_dist(src, user) > 1 || M.loc != src.loc || user.restrained() || usr.stat || M.buckled || istype(usr, /mob/living/silicon/pai)))


### PR DESCRIPTION
They can be anchored again with screwdriver.
Beds can be unfastened too (because they are subtype of stool, yeah).
Moving chairs with buckled people works fine too.
