### PR TITLE
Allow server to initialize before players connect.

### DIFF
--- a/code/game/algorithm.dm
+++ b/code/game/algorithm.dm
@@ -27,7 +27,6 @@ Today, these people were mean:
 	LoadBans()
 	process_teleport_locs() //Sets up the wizard teleport locations
 	process_ghost_teleport_locs() //Sets up ghost teleport locations.
-	sleep_offline = 1
 
 	if (config.kick_inactive)
 		spawn(30)

--- a/code/game/cellautomata.dm
+++ b/code/game/cellautomata.dm
@@ -106,8 +106,6 @@
 
 	..()
 
-	sleep(50)
-
 	plmaster = new /obj/effect/overlay(  )
 	plmaster.icon = 'tile_effects.dmi'
 	plmaster.icon_state = "plasma"

--- a/code/game/master_controller.dm
+++ b/code/game/master_controller.dm
@@ -47,6 +47,12 @@ datum/controller/game_controller
 
 		world.tick_lag = config.Ticklag
 
+		//	Sleep for about 5 seconds to allow background initialization procs to finish
+		sleep(50)
+
+		//	Now that the game is world is fully initialized, pause server until a user connects.
+		world.sleep_offline = 1
+
 		setup_objects()
 
 		setupgenetics()


### PR DESCRIPTION
Without this patch, the first user had to wait for the server to
actually initialize the game. During this time the main window
of the client is not responsive to input. Now, when the first
player connects, they will see a fully initialized and responsive
lobby.
