### PR TITLE
Fixes teleporting with an active chamelion projector

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -52,7 +52,7 @@
 
 	//must succeed in most cases
 	proc/setTeleatom(atom/movable/ateleatom)
-		if(istype(ateleatom, /obj/effect))
+		if(istype(ateleatom, /obj/effect) && !istype(ateleatom, /obj/effect/dummy/chameleon))
 			del(ateleatom)
 			return 0
 		if(istype(ateleatom))

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -130,10 +130,6 @@
 			O.show_message("\red Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.")
 		return
 	if (istype(M, /atom/movable))
-		if (istype(M, /obj/effect/dummy/chameleon))
-			for(var/mob/C in M)
-				C << "\red The projection field prevents you from entering!"
-			return
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy - 5), 3), 2)
 		else

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -316,6 +316,8 @@
 			icon_plating = "asteroid_dug"
 			icon_state = "asteroid_dug"
 			return
+		else
+			return
 	else
 		..(W,user)
 	if ((istype(W,/obj/item/weapon/pickaxe/drill)))
@@ -337,6 +339,9 @@
 			dug = 1
 			icon_plating = "asteroid_dug"
 			icon_state = "asteroid_dug"
+			return
+		else
+			return
 	else
 		..(W,user)
 
@@ -359,6 +364,9 @@
 			dug = 1
 			icon_plating = "asteroid_dug"
 			icon_state = "asteroid_dug"
+			return
+		else
+			return
 	else
 		..(W,user)
 


### PR DESCRIPTION
- Fixes issue #1029 and removes the hotfix for it. When you enter a teleporter disguised as an object you now come out still disguised, as opposed to just deleting yourself. 
- Better fix for #1180, more tools and doesn't shout at you if you move away.
- I don't know how to change two files with one commit/how to use github at all.
