### PR TITLE
Added a thing to give a message to admins when a tile is stepped on.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1187,6 +1187,7 @@
 #include "code\WorkInProgress\Cael_Aislinn\Tajara\tajaran.dm"
 #include "code\WorkInProgress\Cael_Aislinn\Tajara\whisper.dm"
 #include "code\WorkInProgress\Chinsky\ashtray.dm"
+#include "code\WorkInProgress\Mini\asay_trap.dm"
 #include "code\WorkInProgress\Mini\atmos_control.dm"
 #include "code\WorkInProgress\Mini\pipe_heater.dm"
 #include "code\WorkInProgress\Mloc\Shortcuts.dm"

--- a/code/WorkInProgress/Mini/asay_trap.dm
+++ b/code/WorkInProgress/Mini/asay_trap.dm
@@ -1,0 +1,12 @@
+/obj/effect/admin_log_trap
+	name = "Herprpr"
+	desc = "Stepping on this is good."
+	icon = 'screen1.dmi'
+	icon_state = "x2"
+	anchored = 1.0
+	unacidable = 1
+	invisibility = 101
+
+/obj/effect/admin_log_trap/HasEntered(AM as mob|obj)
+	if(istype(AM,/mob))
+		message_admins("[AM] ([AM:ckey]) stepped on an alerted tile in [get_area(src)]. <a href=\"byond://?src=%admin_ref%;teleto=\ref[src.loc]\">Jump</a>", admin_ref = 1)


### PR DESCRIPTION
To use, spawn a /obj/effect/admin_log_trap on whatever tile you want to have a message, then whenever anyone steps on that tile a message will sent to all admins, like explosions.

Feel free to move it out of my WIP folder if you want.

I probably could have put this directly on the turf entered() proc, but eh. Pretty easy to switch it over if it's needed, and this way you can see where they are if you want to (turn see_invisible up to >=101, if that still works)
