### PR TITLE
Fix response to '?status' requests

### DIFF
--- a/code/game/topic.dm
+++ b/code/game/topic.dm
@@ -9,7 +9,7 @@
 		s["enter"] = enter_allowed
 		s["vote"] = config.allow_vote_mode
 		s["ai"] = config.allow_ai
-		s["host"] = host ? host : null
+		s["host"] = config.hosteddy
 		s["players"] = list()
 		s["admins"] = 0
 		var/n = 0


### PR DESCRIPTION
Small bugfix; the code until now always gave a null 'host' name, which is why that ugly hack was needed in the PHP/other code that parses server data.
