### PR TITLE
Removed the artifact stun effect

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact_analysis.dm
+++ b/code/modules/research/xenoarchaeology/artifact_analysis.dm
@@ -179,7 +179,7 @@
 		switch(cur_artifact.my_effect.effecttype)
 			if("healing")  src.aeffect1 = "Healing Device"
 			if("injure") src.aeffect1 = "Anti-biological Weapon"
-			if("stun") src.aeffect1 = "Non-lethal Stunning Trap"
+			// if("stun") src.aeffect1 = "Non-lethal Stunning Trap"
 			if("roboheal") src.aeffect1 = "Mechanoid Repair Module"
 			if("robohurt") src.aeffect1 = "Mechanoid Deconstruction Device"
 			if("cellcharge") src.aeffect1 = "Power Generator"

--- a/code/modules/research/xenoarchaeology/artifact_effect.dm
+++ b/code/modules/research/xenoarchaeology/artifact_effect.dm
@@ -97,7 +97,7 @@
 					user.weakened += 6
 					return 1
 				else user << "Nothing happens."
-			if("stun")
+			/*if("stun")
 				if (istype(user, /mob/living/carbon/))
 					user << "\red A powerful force overwhelms your consciousness."
 					user.paralysis += 30
@@ -105,7 +105,7 @@
 					user.weakened += 45
 					user.stuttering += 45
 					return 1
-				else user << "Nothing happens."
+				else user << "Nothing happens."*/
 			if("roboheal")
 				if (istype(user, /mob/living/silicon/robot))
 					user << "\blue Your systems report damaged components mending by themselves!"
@@ -224,7 +224,7 @@
 					M.adjustBrainLoss(1)
 					M.updatehealth()
 				return 1
-			if("stun")
+			/*if("stun")
 				for (var/mob/living/carbon/M in range(src.aurarange,originator))
 					if(istype(M:wear_suit,/obj/item/clothing/suit/bio_suit/anomaly) && istype(M:head,/obj/item/clothing/head/bio_hood/anomaly))
 						continue
@@ -234,7 +234,7 @@
 						M.stunned += 2
 						M.weakened += 2
 						M.stuttering += 2
-				return 1
+				return 1*/
 			if("roboheal")
 				for (var/mob/living/silicon/robot/M in range(src.aurarange,originator))
 					if(prob(10)) M << "\blue SYSTEM ALERT: Beneficial energy field detected!"
@@ -314,7 +314,7 @@
 					M.weakened += 3
 					M.updatehealth()
 				return 1
-			if("stun")
+			/*if("stun")
 				for (var/mob/living/carbon/M in range(src.aurarange,originator))
 					if(istype(M:wear_suit,/obj/item/clothing/suit/bio_suit/anomaly) && istype(M:head,/obj/item/clothing/head/bio_hood/anomaly))
 						continue
@@ -323,7 +323,7 @@
 					M.stunned += 4
 					M.weakened += 4
 					M.stuttering += 4
-				return 1
+				return 1*/
 			if("roboheal")
 				for (var/mob/living/silicon/robot/M in range(src.aurarange,originator))
 					M << "\blue SYSTEM ALERT: Structural damage has been repaired by energy pulse!"
@@ -413,7 +413,7 @@
 					M.adjustBrainLoss(3)
 					M.updatehealth()
 				return 1
-			if("stun")
+			/*if("stun")
 				for (var/mob/living/carbon/M in world)
 					if(istype(M:wear_suit,/obj/item/clothing/suit/bio_suit/anomaly) && istype(M:head,/obj/item/clothing/head/bio_hood/anomaly))
 						continue
@@ -422,7 +422,7 @@
 					M.stunned += 8
 					M.weakened += 8
 					M.stuttering += 8
-				return 1
+				return 1*/
 			if("roboheal")
 				for (var/mob/living/silicon/robot/M in world)
 					M << "\blue SYSTEM ALERT: Structural damage has been repaired by energy pulse!"

--- a/code/modules/research/xenoarchaeology/artifacts.dm
+++ b/code/modules/research/xenoarchaeology/artifacts.dm
@@ -48,17 +48,17 @@
 	// Precursor Artifacts do everything
 	switch(src.origin)
 		if("ancient") my_effect.effecttype = pick("roboheal","robohurt","cellcharge","celldrain")
-		if("martian") my_effect.effecttype = pick("healing","injure","stun","planthelper")
-		if("wizard") my_effect.effecttype = pick("stun","forcefield","teleport")
-		if("eldritch") my_effect.effecttype = pick("injure","stun","robohurt","celldrain")
-		if("precursor") my_effect.effecttype = pick("healing","injure","stun","roboheal","robohurt","cellcharge","celldrain","planthelper","forcefield","teleport")
+		if("martian") my_effect.effecttype = pick("healing","injure"/*,"stun"*/,"planthelper")
+		if("wizard") my_effect.effecttype = pick(/*"stun",*/"forcefield","teleport")
+		if("eldritch") my_effect.effecttype = pick("injure",/*"stun",*/"robohurt","celldrain")
+		if("precursor") my_effect.effecttype = pick("healing","injure",/*"stun",*/"roboheal","robohurt","cellcharge","celldrain","planthelper","forcefield","teleport")
 
 	// Select range based on the power
 	var/canworldpulse = 1
 	switch(my_effect.effecttype)
 		if("healing") my_effect.effectmode = pick("aura","pulse","contact")
 		if("injure") my_effect.effectmode = pick("aura","pulse","contact")
-		if("stun") my_effect.effectmode = pick("aura","pulse","contact")
+		// if("stun") my_effect.effectmode = pick("aura","pulse","contact")
 		if("roboheal") my_effect.effectmode = pick("aura","pulse","contact")
 		if("robohurt") my_effect.effectmode = pick("aura","pulse","contact")
 		if("cellcharge") my_effect.effectmode = pick("aura","pulse")
@@ -230,7 +230,7 @@
 	switch(A.effecttype)
 		if("healing") return 1
 		if("injure") return 0
-		if("stun") return 0
+		// if("stun") return 0
 		if("roboheal") return 1
 		if("robohurt") return 0
 		if("cellcharge") return 1


### PR DESCRIPTION
I think that the stun effect isn't good gameplay wise, given that it can stop you from doing anything, including moving away from the artifact or asking for help. That essentially causes those artifacts to be round enders for you, if you activate them, **unless** there is somebody nearby in an anomalist suit to drag you away, or you already were in an anomalist suit.

Normally, I do not mind something that can kill you, since you can respawn later, but this keeps you permanently immobilized with a chance of you never being able to rejoin the round. Overall, it's not enjoyable for a player who ends up in that situation.

Unless someone has another idea, I would propose removing the stun effect.
