### PR TITLE
Mops need a bucket to use.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -145,6 +145,7 @@
 		..()
 		src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 		src.modules += new /obj/item/weapon/trashbag(src)
+		src.modules += new /obj/item/weapon/reagent_containers/glass/bucket(src)
 		src.modules += new/obj/item/weapon/mop(src)
 		src.emag = new /obj/item/weapon/cleaner(src)
 


### PR DESCRIPTION
Apparently the buckets were removed months ago. Some messes are under an impassible object and the mop is useless without a water source, so having an internal 'bucket' inside the cyborg makes sense.
