### PR TITLE
Cyborg portalathe

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -146,7 +146,8 @@
 		src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 		src.modules += new /obj/item/weapon/trashbag(src)
 		src.modules += new /obj/item/weapon/reagent_containers/glass/bucket(src)
-		src.modules += new/obj/item/weapon/mop(src)
+		src.modules += new /obj/item/weapon/mop(src)
+		src.modules += new /obj/item/device/portalathe(src)
 		src.emag = new /obj/item/weapon/cleaner(src)
 
 		var/datum/reagents/R = new/datum/reagents(1000)


### PR DESCRIPTION
Janiborgs can now replace lights on-the-go, and they also have buckets fixed (whoops! :D)

Edit: it now says lights instead of windows. D'oh

Oh yeah, and this was born for me trying to decide what could make janitor borgs more useful, without giving them unlimited space cleaner. Engineers don't replace lights, Janitors do but they're not always there, so that means a janiborg could probably fill in without being a major balance issue :D
