### PR TITLE
Reverting, please see details.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -965,7 +965,7 @@
 	set category = "Object"
 	set name = "Enter Exosuit"
 	set src in oview(1)
-	if ((ishuman(usr) && istajaran(usr)) == 0 || usr.stat) //Mechs can take Tajaran pilots now. (Because I have fixed the little bork that happened when fixing my little bork. Bork bork bork :P)
+	if (!ishuman(usr) || usr.stat) //Check if playable species and awake.
 		return
 	src.log_message("[usr] tries to move in.")
 	if (src.occupant)
@@ -1124,7 +1124,7 @@
 /obj/mecha/proc/go_out()
 	if(!src.occupant) return
 	var/atom/movable/mob_container
-	if(ishuman(occupant) || istajaran(occupant))
+	if(ishuman(occupant))
 		mob_container = src.occupant
 	else if(istype(occupant, /mob/living/carbon/brain))
 		var/mob/living/carbon/brain/brain = occupant
@@ -1133,7 +1133,7 @@
 		return
 	if(mob_container.forceMove(src.loc))//ejecting mob container
 	/*
-		if((ishuman(occupant) || istajaran(occupant)) && (return_pressure() > HAZARD_HIGH_PRESSURE))
+		if((ishuman(occupant)) && (return_pressure() > HAZARD_HIGH_PRESSURE))
 			use_internal_tank = 0
 			var/datum/gas_mixture/environment = get_turf_air()
 			if(environment)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1133,7 +1133,7 @@
 		return
 	if(mob_container.forceMove(src.loc))//ejecting mob container
 	/*
-		if((ishuman(occupant)) && (return_pressure() > HAZARD_HIGH_PRESSURE))
+		if(ishuman(occupant)) && (return_pressure() > HAZARD_HIGH_PRESSURE))
 			use_internal_tank = 0
 			var/datum/gas_mixture/environment = get_turf_air()
 			if(environment)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1133,7 +1133,7 @@
 		return
 	if(mob_container.forceMove(src.loc))//ejecting mob container
 	/*
-		if(ishuman(occupant)) && (return_pressure() > HAZARD_HIGH_PRESSURE))
+		if((ishuman(occupant)) && (return_pressure() > HAZARD_HIGH_PRESSURE))
 			use_internal_tank = 0
 			var/datum/gas_mixture/environment = get_turf_air()
 			if(environment)


### PR DESCRIPTION
Cib mentioned istype might check subtypes, and after finding and looking at the BYOND reference, I discovered it does. Seeing as how Tajarans are a subtype of humans, they are found by ishuman() and those istajarans() were unnecessary, and tajarans could enter mechs from the start.

As embarrassing as it is to admit this and put up a revert, it's better to keep the code clean in my opinion. Speaking of, I've got another pull request coming up for the istype procs for mobs :P
