### PR TITLE
Giving atmos techs magboots for ZAS immunity.

### DIFF
--- a/code/game/objects/closets/firecloset.dm
+++ b/code/game/objects/closets/firecloset.dm
@@ -18,6 +18,7 @@
 	new /obj/item/weapon/tank/oxygen/red(src)
 	new /obj/item/weapon/extinguisher(src)
 	new /obj/item/clothing/head/helmet/space/fire_helmet(src)
+	new /obj/item/clothing/shoes/magboots(src) //[Redacted] ZAS! >:C
 
 	/*switch (pickweight(list("nothing" = 5, "bare-bones" = 35, "basic" = 40, "pickpocketed" = 10, "untouched" = 10)))
 		if ("nothing")


### PR DESCRIPTION
Trying to fight a fire about 10 minutes before I wrote this, I was thrown around the room by ZAS as the fire let off wave after wave of heated air. I could not fight the fire, and probably couldn't escape, until the CE finally arrived and saved my bloody (literally) ass.

With ZAS, atmos techs can not handle fires like they should, due to the highly violent air currents they encounter. To make the job possible, I have simply given each locker a pair of magboots.
