### PR TITLE
powerchanges

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -85,7 +85,7 @@ Pod/Blast Doors computer
 /obj/machinery/computer/process()
 	if(stat & (NOPOWER|BROKEN))
 		return
-	use_power(250)
+	use_power(750)
 
 /obj/machinery/computer/proc/set_broken()
 	icon_state = initial(icon_state)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -114,7 +114,7 @@ Class Procs:
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)
-		use_power(7500/severity)
+		use_power(15000/severity)
 
 		var/obj/effect/overlay/pulse2 = new/obj/effect/overlay ( src.loc )
 		pulse2.icon = 'effects.dmi'
@@ -147,13 +147,15 @@ Class Procs:
 	if(prob(50))
 		del(src)
 
+#define POWER_USE_MULTIPLIER 3
+
 /obj/machinery/proc/auto_use_power()
 	if(!powered(power_channel))
 		return 0
 	if(src.use_power == 1)
-		use_power(idle_power_usage,power_channel)
+		use_power(idle_power_usage * POWER_USE_MULTIPLIER,power_channel)
 	else if(src.use_power >= 2)
-		use_power(active_power_usage,power_channel)
+		use_power(active_power_usage * POWER_USE_MULTIPLIER,power_channel)
 	return 1
 
 /obj/machinery/Topic(href, href_list)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -14,7 +14,7 @@
 	var/lastout = 0
 	var/loaddemand = 0
 	var/capacity = 10e6
-	var/charge = 9e6
+	var/charge = 5e6
 	var/charging = 0
 	var/chargemode = 0
 	var/chargecount = 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -14,7 +14,7 @@
 	var/lastout = 0
 	var/loaddemand = 0
 	var/capacity = 10e6
-	var/charge = 3e6
+	var/charge = 9e6
 	var/charging = 0
 	var/chargemode = 0
 	var/chargecount = 0


### PR DESCRIPTION
significantly increase overall stationwide power usage (increased starting SMES power to compensate) . exact increase is difficult/impossible to estimate without benchmarking typical round power usage, but is at max approximately triple usage. 

made a forum post about it, this one can stick around for a while to see if anyone has any objections. 
