### PR TITLE
Fixed bugs with power control module supply pack and collectible hat crate

### DIFF
--- a/code/defines/obj/storage.dm
+++ b/code/defines/obj/storage.dm
@@ -535,6 +535,13 @@
 	icon_state = "circuit"
 	item_state = "syringe_kit"
 
+/obj/item/weapon/storage/AirlockBox
+	name = "spare airlock electronics"
+	desc = "A box of spare airlock circuit boards."
+	icon = 'storage.dmi'
+	icon_state = "circuit"
+	item_state = "syringe_kit"
+
 /obj/item/weapon/storage/toolbox/syndicate
 	name = "red and black toolbox"
 	desc = "An oddly coloured toolbox."

--- a/code/defines/obj/supplypacks.dm
+++ b/code/defines/obj/supplypacks.dm
@@ -33,12 +33,13 @@
 	containername = "Empty Box crate"
 
 /datum/supply_packs/pcm
-	name = "Power Control Module supplies"
+	name = "APC and Airlock Electronics crate"
 	contains = list("/obj/item/weapon/storage/PCMBox",
-	"/obj/item/weapon/storage/PCMBox")
+	"/obj/item/weapon/storage/AirlockBox")
 	cost = 25
 	containertype = "/obj/structure/closet/crate"
 	containername = "Power Control Module crate"
+	group = "Engineering"
 
 /datum/supply_packs/body_bags
 	name = "Body Bag supplies"
@@ -764,6 +765,7 @@
 	containername = "Secruity Barriers crate"
 	group = "Security"
 
+/*
 /datum/supply_packs/randomised
 	var/num_contained = 3 //number of items picked to be contained in a randomised crate
 	contains = list("/obj/item/clothing/head/collectable/chef",
@@ -794,6 +796,7 @@
 	cost = 200
 	containertype = "/obj/structure/closet/crate"
 	containername = "Collectable hats crate! Brought to you by Bass.inc!"
+*/
 
 /datum/supply_packs/randomised/New()
 	var/list/tempContains = list()

--- a/code/game/objects/storage/storage.dm
+++ b/code/game/objects/storage/storage.dm
@@ -321,6 +321,32 @@
 	new /obj/item/weapon/reagent_containers/glass/bottle/ert/boost( src )
 	return
 
+/obj/item/weapon/storage/PCMBox/New()
+	..()
+	contents = list()
+	sleep(1)
+	new /obj/item/weapon/module/power_control( src )
+	new /obj/item/weapon/module/power_control( src )
+	new /obj/item/weapon/module/power_control( src )
+	new /obj/item/weapon/module/power_control( src )
+	new /obj/item/weapon/module/power_control( src )
+	new /obj/item/weapon/module/power_control( src )
+	new /obj/item/weapon/module/power_control( src )
+	return
+
+/obj/item/weapon/storage/AirlockBox/New()
+	..()
+	contents = list()
+	sleep(1)
+	new /obj/item/weapon/airlock_electronics( src )
+	new /obj/item/weapon/airlock_electronics( src )
+	new /obj/item/weapon/airlock_electronics( src )
+	new /obj/item/weapon/airlock_electronics( src )
+	new /obj/item/weapon/airlock_electronics( src )
+	new /obj/item/weapon/airlock_electronics( src )
+	new /obj/item/weapon/airlock_electronics( src )
+	return
+
 /obj/item/weapon/storage/box/syndicate/New()
 	..()
 	switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "screwed" = 1, "guns" = 1, "freedom" = 1, "hacker" = 1, "lordsingulo" = 1)))


### PR DESCRIPTION
This fixes the power control module supply pack so it actually delivers PCM's as promised. The crate also now contains a box full of airlock electronics, so the crate has been renamed "APC and Airlock Electronics crate".

I also finished commenting out the collectible hat crate. Someone had decided to get rid of it but forgot to remove it from the supply packs list, so they could still be ordered (although nothing would arrive).
