### PR TITLE
Surgery bugs

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -304,6 +304,8 @@ CIRCULAR SAW
 
 	var/mob/living/carbon/human/H = M
 	var/datum/organ/external/S = H.organs[user.zone_sel.selecting]
+	if(user.zone_sel.selecting == "mouth" || user.zone_sel.selecting == "eyes")
+		S = H.organs["head"]
 
 	if(((user.zone_sel.selecting == "l_arm") || (user.zone_sel.selecting == "r_arm") || (user.zone_sel.selecting == "l_leg") || (user.zone_sel.selecting == "r_leg")) & (istype(M, /mob/living/carbon/human)))
 		if(S.status & DESTROYED)
@@ -447,8 +449,6 @@ CIRCULAR SAW
 				return ..()
 			M:brain_op_stage = 0
 			S.open = 1
-			if(!try_bone_surgery(M, user))
-				return ..()
 		else
 			return ..()
 


### PR DESCRIPTION
Stopped attacking patient during head surgery with hemostat.
Was caused by try_bone_surgery called twice in code.
Removed one redunant call.

Fixed runtimes during face and eye surgery.
Null organ was caused by not being 'mouth' or 'eye' organ there.
Made it select 'head' as affected organ.

Related to Issue #1540
