### PR TITLE
Fix for appendictomy not being possible without admin intervention.

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -524,9 +524,9 @@ Called when surgeon interupted operation, or was interrupted (was not there with
 		if(S.implant)
 			implant_surgery(H,user)
 			return 1
-		else
+		/*else
 			user << "\red [H] is not bleeding in \his [S.display_name]!"
-			return 0
+			return 0*/
 
 	H.visible_message( \
 		"\red [user] is beginning to clamp bleeders in the wound in [H]'s [S.display_name] with [src].", \


### PR DESCRIPTION
For some reason organ, affected with scalpel (by organ.status |= BLEEDING) did not start to bleed.
That caused hemostat step to fail, and not advance appendix operation stage.
