### PR TITLE
Bugfix: Infinite BoH in BoH, Soghun Stutter Removal

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -42,10 +42,15 @@
 		..()
 		return
 
-/*	attackby(obj/item/weapon/W as obj, mob/user as mob) //BoH+BoH=Singularity, commented out
+	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(crit_fail)
 			user << "\red The Bluespace generator isn't working."
 			return
+		if(istype(W, /obj/item/weapon/storage/backpack/holding) && !W.crit_fail)
+			user << "\red The Bluespace interfaces of the two devices conflict and malfunction."
+			del(W)
+			return
+			/* //BoH+BoH=Singularity, commented out.
 		if(istype(W, /obj/item/weapon/storage/backpack/holding) && !W.crit_fail)
 			investigate_log("has become a singularity. Caused by [user.key]","singulo")
 			user << "\red The Bluespace interfaces of the two devices catastrophically malfunction!"
@@ -56,8 +61,9 @@
 			log_game("[key_name(user)] detonated a bag of holding")
 			del(src)
 			return
+			*/
 		..()
-*/
+
 	proc/failcheck(mob/user as mob)
 		if (prob(src.reliability)) return 1 //No failure
 		if (prob(src.reliability))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -17,10 +17,10 @@
 				return
 
 	if(src.dna)
-		if(src.dna.mutantrace == "lizard")
+		/*if(src.dna.mutantrace == "lizard") //Soghun stutterss-s-ss-sss.
 			if(copytext(message, 1, 2) != "*")
 				message = dd_replacetext(message, "s", stutter("ss"))
-
+*/
 		if(src.dna.mutantrace == "metroid" && prob(5))
 			if(copytext(message, 1, 2) != "*")
 				if(copytext(message, 1, 2) == ";")


### PR DESCRIPTION
Forgot to add in a check for putting BoHs in a BoH after commenting out the singularity reaction. This just ends up deleting the secondary BoH. Also tracked down and removed the coded-in Soghun stutter, on request of a couple Soghun players. Just chugging along with 2 little things at a time.
