### PR TITLE
Anti-suffocate

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -15,9 +15,8 @@
 /obj/proc/process()
 	processing_objects.Remove(src)
 	return 0
-//skytodo
-/*
-/obj/assume_air(datum/air_group/giver)
+
+/obj/assume_air(datum/gas_mixture/giver)
 	if(loc)
 		return loc.assume_air(giver)
 	else
@@ -34,7 +33,7 @@
 		return loc.return_air()
 	else
 		return null
-*/
+
 /obj/proc/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
 	//Return: (NONSTANDARD)
 	//		null if object handles breathing logic for lifeform


### PR DESCRIPTION
people suffocating in lockers and bodybags maybe cool, but suffocating in healing sleeper or dna modifier - bad, let's revert that back? And if any item must suffocate people - it may be made that way exclusively later.
