### PR TITLE
ED209 not showing on remote-control chip of security PDA

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -428,7 +428,7 @@ Code:
 						menu += "No bots found.<BR>"
 
 					else
-						for(var/obj/machinery/bot/secbot/B in SC.botlist)
+						for(var/obj/machinery/bot/B in SC.botlist)
 							if (B)
 								menu += "<A href='byond://?src=\ref[SC];op=control;bot=\ref[B]'>[B] at [B.loc.loc]</A><BR>"
 


### PR DESCRIPTION
ED-209 is a security bot, but not Beepski, do not expect for ED being Beepski and 'bang' - it appears on security pda as expected
