### PR TITLE
Fix/adjustment: AI less borgs will spawn corporate instead of asimov/emergency locker item spawns

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -22,29 +22,29 @@
 /obj/structure/closet/emcloset/New()
 	..()
 
-	if (prob(40))
-		new /obj/item/weapon/storage/toolbox/emergency(src)
-
-	switch (pickweight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10, "nothing" = 4, "delete" = 1)))
+	switch (pickweight(list("small" = 55, "aid" = 25, "tank" = 10, "both" = 10, "nothing" = 0, "delete" = 0)))
 		if ("small")
 			new /obj/item/weapon/tank/emergency_oxygen(src)
 			new /obj/item/weapon/tank/emergency_oxygen(src)
-
+			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/clothing/mask/breath(src)
 		if ("aid")
 			new /obj/item/weapon/tank/emergency_oxygen(src)
-			new /obj/item/weapon/storage/firstaid/o2(src)
-
-		if ("tank")
-			new /obj/item/weapon/tank/air(src)
-
-		if ("both")
-			new /obj/item/weapon/tank/emergency_oxygen(src)
+			new /obj/item/weapon/storage/toolbox/emergency(src)
 			new /obj/item/clothing/mask/breath(src)
-
+		if ("tank")
+			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
+			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
+			new /obj/item/clothing/mask/breath(src)
+		if ("both")
+			new /obj/item/weapon/storage/toolbox/emergency(src)
+			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
+			new /obj/item/clothing/mask/breath(src)
 		if ("nothing")
 			// doot
 
-		// teehee
+		// teehee - Ah, tg coders...
 		if ("delete")
 			del(src)
 
@@ -56,7 +56,7 @@
 /obj/structure/closet/emcloset/legacy/New()
 	new /obj/item/weapon/tank/oxygen(src)
 	new /obj/item/clothing/mask/gas(src)
-
+	
 /*
  * Fire Closet
  */

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -32,6 +32,7 @@
 			new /obj/item/weapon/tank/emergency_oxygen(src)
 			new /obj/item/weapon/storage/toolbox/emergency(src)
 			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/weapon/storage/firstaid/o2(src)
 		if ("tank")
 			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 			new /obj/item/clothing/mask/breath(src)
@@ -41,6 +42,7 @@
 			new /obj/item/weapon/storage/toolbox/emergency(src)
 			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 			new /obj/item/clothing/mask/breath(src)
+			new /obj/item/weapon/storage/firstaid/o2(src)
 		if ("nothing")
 			// doot
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -81,7 +81,7 @@
 		icon_state = "secborg"
 		modtype = "Synd"
 	else
-		laws = new /datum/ai_laws/asimov()
+		laws = new /datum/ai_laws/nanotrasen()
 		connected_ai = select_active_ai_with_fewest_borgs()
 		if(connected_ai)
 			connected_ai.connected_robots += src


### PR DESCRIPTION
Makes it so borgs that spawn unbound to an AI will spawn with the corporate lawset we use instead of Asimov.

Emergency O2 lockers should spawn with masks, an assortment of tanks and the odd toolbox. Instead of random tanks, nothing, and MAYBE a mask in one locker on the entire map.
