### PR TITLE
Virology fix

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -548,6 +548,7 @@
 			src.temphtml = "The replicator is not ready yet."
 		src.updateUsrDialog()
 		return
+	/*
 	else if (href_list["create_virus_culture"])
 		if(!wait)
 			var/obj/item/weapon/reagent_containers/glass/bottle/B = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
@@ -568,6 +569,7 @@
 			src.temphtml = "The replicator is not ready yet."
 		src.updateUsrDialog()
 		return
+	*/
 	else if (href_list["empty_beaker"])
 		beaker.reagents.clear_reagents()
 		src.updateUsrDialog()
@@ -629,7 +631,7 @@
 					for(var/datum/disease/D in Blood.data["viruses"])
 						if(!D.hidden[PANDEMIC])
 
-							dat += "<b>Disease Agent:</b> [D?"[D.agent] - <A href='?src=\ref[src];create_virus_culture=[D.type]'>Create virus culture bottle</A>":"none"]<BR>"
+							dat += "<b>Disease Agent:</b> [D?"[D.agent]":"none"]<BR>"
 							dat += "<b>Common name:</b> [(D.name||"none")]<BR>"
 							dat += "<b>Description: </b> [(D.desc||"none")]<BR>"
 							dat += "<b>Possible cure:</b> [(D.cure||"none")]<BR><BR>"


### PR DESCRIPTION
This ability should return when virus2 is ported fully and the machinery is added to the map.

This also fixes a possible exploit where you can supply a fake href and spawn a singularity instead of a virus(luckily it won't be added to the map though, but you can still trigger any New() proc you want)
