### PR TITLE
Airlock update

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -526,9 +526,13 @@ obj/machinery/atmospherics/pipe
 		var/build_killswitch = 1
 
 		var/obj/machinery/atmospherics/node1
-		New()
+		New()		
 			initialize_directions = dir
 			..()
+
+		high_volume
+			name = "Larger vent"
+			volume = 1000
 
 		process()
 			if(!parent)
@@ -539,7 +543,7 @@ obj/machinery/atmospherics/pipe
 				..()
 				return
 			else
-				parent.mingle_with_turf(loc, 250)
+				parent.mingle_with_turf(loc, volume)
 /*
 			if(!node1)
 				if(!nodealert)

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -73,6 +73,24 @@ obj/machinery/door/airlock/close(surpress_send)
 	if(!surpress_send) send_status()
 
 
+obj/machinery/door/airlock/Bumped(atom/AM)
+	..(AM)
+	if(istype(AM, /obj/mecha))
+		var/obj/mecha/mecha = AM
+		if(density && radio_connection && mecha.occupant && (src.allowed(mecha.occupant) || src.check_access_list(mecha.operation_req_access)))
+			var/datum/signal/signal = new
+			signal.transmission_method = 1 //radio signal
+			signal.data["tag"] = id_tag
+			signal.data["timestamp"] = world.time
+
+			signal.data["door_status"] = density?("closed"):("open")
+			signal.data["lock_status"] = locked?("locked"):("unlocked")
+
+			signal.data["bumped_with_access"] = 1
+
+			radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = RADIO_AIRLOCK)
+	return
+		
 obj/machinery/door/airlock/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	if(new_frequency)

--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -4,6 +4,7 @@
 #define AIRLOCK_STATE_CLOSED		0
 #define AIRLOCK_STATE_DEPRESSURIZE	1
 #define AIRLOCK_STATE_OUTOPEN		2
+#define AIRLOCK_STATE_BOTHOPEN		3
 
 datum/computer/file/embedded_program/airlock_controller
 	var/id_tag
@@ -11,11 +12,13 @@ datum/computer/file/embedded_program/airlock_controller
 	var/interior_door_tag
 	var/airpump_tag
 	var/sensor_tag
+	var/sensor_tag_int
 	var/sanitize_external
 
 	state = AIRLOCK_STATE_CLOSED
 	var/target_state = AIRLOCK_STATE_CLOSED
 	var/sensor_pressure = null
+	var/int_sensor_pressure = ONE_ATMOSPHERE
 
 	receive_signal(datum/signal/signal, receive_method, receive_param)
 		var/receive_tag = signal.data["tag"]
@@ -24,12 +27,19 @@ datum/computer/file/embedded_program/airlock_controller
 		if(receive_tag==sensor_tag)
 			if(signal.data["pressure"])
 				sensor_pressure = text2num(signal.data["pressure"])
+		else if(receive_tag==sensor_tag_int)
+			if(signal.data["pressure"])
+				int_sensor_pressure = text2num(signal.data["pressure"])
 
 		else if(receive_tag==exterior_door_tag)
 			memory["exterior_status"] = signal.data["door_status"]
+			if(signal.data["bumped_with_access"])
+				target_state = AIRLOCK_STATE_OUTOPEN
 
 		else if(receive_tag==interior_door_tag)
 			memory["interior_status"] = signal.data["door_status"]
+			if(signal.data["bumped_with_access"])
+				target_state = AIRLOCK_STATE_INOPEN
 
 		else if(receive_tag==airpump_tag)
 			if(signal.data["power"])
@@ -39,6 +49,10 @@ datum/computer/file/embedded_program/airlock_controller
 
 		else if(receive_tag==id_tag)
 			switch(signal.data["command"])
+				if("cycle_exterior")
+					target_state = AIRLOCK_STATE_OUTOPEN
+				if("cycle_interior")
+					target_state = AIRLOCK_STATE_INOPEN
 				if("cycle")
 					if(state < AIRLOCK_STATE_CLOSED)
 						target_state = AIRLOCK_STATE_OUTOPEN
@@ -59,6 +73,42 @@ datum/computer/file/embedded_program/airlock_controller
 				target_state = AIRLOCK_STATE_INOPEN
 			if("abort")
 				target_state = AIRLOCK_STATE_CLOSED
+			if("force_both")
+				target_state = AIRLOCK_STATE_BOTHOPEN
+				state = AIRLOCK_STATE_BOTHOPEN
+				var/datum/signal/signal = new
+				signal.data["tag"] = interior_door_tag
+				signal.data["command"] = "secure_open"
+				post_signal(signal)
+				signal = new
+				signal.data["tag"] = exterior_door_tag
+				signal.data["command"] = "secure_open"
+				post_signal(signal)
+			if("force_exterior")
+				target_state = AIRLOCK_STATE_OUTOPEN
+				state = AIRLOCK_STATE_OUTOPEN
+				var/datum/signal/signal = new
+				signal.data["tag"] = exterior_door_tag
+				signal.data["command"] = "secure_open"
+				post_signal(signal)
+			if("force_interior")
+				target_state = AIRLOCK_STATE_INOPEN
+				state = AIRLOCK_STATE_INOPEN
+				var/datum/signal/signal = new
+				signal.data["tag"] = interior_door_tag
+				signal.data["command"] = "secure_open"
+				post_signal(signal)
+			if("close")
+				target_state = AIRLOCK_STATE_CLOSED
+				state = AIRLOCK_STATE_CLOSED
+				var/datum/signal/signal = new
+				signal.data["tag"] = exterior_door_tag
+				signal.data["command"] = "secure_close"
+				post_signal(signal)
+				signal = new
+				signal.data["tag"] = interior_door_tag
+				signal.data["command"] = "secure_close"
+				post_signal(signal)
 
 	process()
 		var/process_again = 1
@@ -87,7 +137,7 @@ datum/computer/file/embedded_program/airlock_controller
 
 				if(AIRLOCK_STATE_PRESSURIZE)
 					if(target_state < state)
-						if(sensor_pressure >= ONE_ATMOSPHERE*0.95)
+						if(sensor_pressure >= int_sensor_pressure*0.95)
 							if(memory["interior_status"] == "open")
 								state = AIRLOCK_STATE_INOPEN
 								process_again = 1
@@ -142,7 +192,7 @@ datum/computer/file/embedded_program/airlock_controller
 							post_signal(signal)
 
 				if(AIRLOCK_STATE_DEPRESSURIZE)
-					var/target_pressure = ONE_ATMOSPHERE*0.05
+					var/target_pressure = ONE_ATMOSPHERE*0.04
 					if(sanitize_external)
 						target_pressure = ONE_ATMOSPHERE*0.01
 
@@ -199,6 +249,7 @@ datum/computer/file/embedded_program/airlock_controller
 							post_signal(signal)
 
 		memory["sensor_pressure"] = sensor_pressure
+		memory["int_sensor_pressure"] = int_sensor_pressure
 		memory["processing"] = state != target_state
 		//sensor_pressure = null //not sure if we can comment this out. Uncomment in case of problems -rastaf0
 
@@ -221,6 +272,7 @@ obj/machinery/embedded_controller/radio/airlock_controller
 	var/interior_door_tag
 	var/airpump_tag
 	var/sensor_tag
+	var/sensor_tag_int
 	var/sanitize_external
 
 	initialize()
@@ -233,6 +285,7 @@ obj/machinery/embedded_controller/radio/airlock_controller
 		new_prog.interior_door_tag = interior_door_tag
 		new_prog.airpump_tag = airpump_tag
 		new_prog.sensor_tag = sensor_tag
+		new_prog.sensor_tag_int = sensor_tag_int
 		new_prog.sanitize_external = sanitize_external
 
 		new_prog.master = src
@@ -253,12 +306,14 @@ obj/machinery/embedded_controller/radio/airlock_controller
 
 		var/state = 0
 		var/sensor_pressure = "----"
+		var/int_sensor_pressure = "----"
 		var/exterior_status = "----"
 		var/interior_status = "----"
 		var/pump_status = "----"
 		if(program)
 			state = program.state
 			sensor_pressure = program.memory["sensor_pressure"]
+			int_sensor_pressure = program.memory["int_sensor_pressure"]
 			exterior_status = program.memory["exterior_status"]
 			interior_status = program.memory["interior_status"]
 			pump_status = program.memory["pump_status"]
@@ -277,12 +332,20 @@ obj/machinery/embedded_controller/radio/airlock_controller
 			if(AIRLOCK_STATE_OUTOPEN)
 				state_options = {"<A href='?src=\ref[src];command=cycle_interior'>Cycle to Interior Airlock</A><BR>
 <A href='?src=\ref[src];command=cycle_closed'>Close Exterior Airlock</A><BR>"}
+			if(AIRLOCK_STATE_BOTHOPEN)
+				state_options = "<A href='?src=\ref[src];command=close'>Close Airlocks</A><BR>"
 
 		var/output = {"<B>Airlock Control Console</B><HR>
 [state_options]<HR>
 <B>Chamber Pressure:</B> [sensor_pressure] kPa<BR>
+<B>Internal Pressure:</B> [int_sensor_pressure] kPa<BR>
 <B>Exterior Door: </B> [exterior_status]<BR>
 <B>Interior Door: </B> [interior_status]<BR>
 <B>Control Pump: </B> [pump_status]<BR>"}
+
+		if(program && program.state == AIRLOCK_STATE_CLOSED)
+			output += {"<A href='?src=\ref[src];command=force_both'>Force Both Airlocks</A><br>
+	<A href='?src=\ref[src];command=force_interior'>Force Inner Airlock</A><br>
+	<A href='?src=\ref[src];command=force_exterior'>Force Outer Airlock</A>"}
 
 		return output


### PR DESCRIPTION
Makes airlock-control-panels able to use secondary pressure sensor. Pressure raises to the amount on secondary sensor or 1atm if it is not present.
Doors bumped by mechs send a message to airlock controller (if mech allowed at that door), which in turn simulates press on corresponding button.
Adds high-volume vents to use in place of airtanks on airlocks.
