### PR TITLE
Robot HUD fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -42,10 +42,7 @@
 			uneq_all()
 			src.stat = 1
 		else if (src.cell.charge <= 100)
-			src.module_active = null
-			src.module_state_1 = null
-			src.module_state_2 = null
-			src.module_state_3 = null
+			uneq_all()
 			src.sight_mode = 0
 			src.cell.use(1)
 		else

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -161,6 +161,10 @@
 		src.see_in_dark = 8
 		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
+	for(var/image/hud in client.images)  //COPIED FROM the human handle_regular_hud_updates() proc
+		if(copytext(hud.icon_state,1,4) == "hud") //ugly, but icon comparison is worse, I believe
+			del(hud)
+
 	var/obj/item/borg/sight/hud/hud = (locate(/obj/item/borg/sight/hud) in src)
 	if(hud && hud.hud)	hud.hud.process_hud(src)
 


### PR DESCRIPTION
Cyborg Medical+Security HUDs now properly remove images when disabled
Cyborg Items now properly remove themselves from the interface when power drops below 100

fixes #2108
