### PR TITLE
Various mouse tweaks and improvements

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -56,7 +56,7 @@ var/list/mechtoys = list(
 
 	else if(istype(A, /mob/living)) // You Shall Not Pass!
 		var/mob/living/M = A
-		if(!M.lying && !istype(M, /mob/living/carbon/monkey) && !istype(M, /mob/living/carbon/slime))	//If your not laying down, or a small creature, no pass.
+		if(!M.lying && !istype(M, /mob/living/carbon/monkey) && !istype(M, /mob/living/carbon/slime) && !istype(M, /mob/living/simple_animal/mouse))	//If your not laying down, or a small creature, no pass.
 			return 0
 	return ..()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -265,23 +265,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	//find a viable mouse candidate
 	var/mob/living/simple_animal/mouse/host
-	var/list/mouse_candidates = list()
-	for(var/mob/living/simple_animal/mouse/M in world)
-		if(!M.ckey && !M.stat)
-			mouse_candidates.Add(M)
-	if(mouse_candidates.len)
-		host = pick(mouse_candidates)
+	var/obj/machinery/atmospherics/unary/vent_pump/vent_found
+	var/list/found_vents = list()
+	for(var/obj/machinery/atmospherics/unary/vent_pump/v in world)
+		if(!v.welded && v.z == src.z)
+			found_vents.Add(v)
+	if(found_vents.len)
+		vent_found = pick(found_vents)
+		host = new /mob/living/simple_animal/mouse(vent_found.loc)
 	else
-		var/obj/machinery/atmospherics/unary/vent_pump/vent_found
-		var/list/found_vents = list()
-		for(var/obj/machinery/atmospherics/unary/vent_pump/v in world)
-			if(!v.welded && v.z == src.z)
-				found_vents.Add(v)
-		if(found_vents.len)
-			vent_found = pick(found_vents)
-			host = new /mob/living/simple_animal/mouse(vent_found.loc)
-		else
-			src << "<span class='warning'>Unable to find any live mice, or unwelded vents to spawn one at.</span>"
+		src << "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>"
 
 	if(host)
 		host.ckey = src.ckey

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -18,10 +18,10 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat
 	response_help  = "pets the"
 	response_disarm = "gently pushes aside the"
-	response_harm   = "splats the"
+	response_harm   = "stamps on the"
 	density = 0
 	var/color //brown, gray and white, leave blank for random
-	layer = 2.5		//so they can hide under objects
+	layer = MOB_LAYER
 	min_oxy = 16 //Require atleast 16kPA oxygen
 	minbodytemp = 223		//Below -50 Degrees Celcius
 	maxbodytemp = 323	//Above 50 Degrees Celcius
@@ -136,8 +136,8 @@
 			open += O
 			*/
 
-mob/living/simple_animal/mouse/restrained() //Hotfix to stop mice from doing things with MouseDrop
-	return 1
+//mob/living/simple_animal/mouse/restrained() //Hotfix to stop mice from doing things with MouseDrop
+//	return 1
 
 /mob/living/simple_animal/mouse/HasEntered(AM as mob|obj)
 	if( ishuman(AM) )

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -196,6 +196,10 @@
 				if(sattisfaction_text)
 					M.emote("[sattisfaction_text]")
 				del(src)
+		if(ismouse(M))
+			var/mob/living/simple_animal/mouse/N = M
+			N.emote("nibbles away at the [src]")
+			N.health = min(N.health + 1, N.maxHealth)
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Player-controlled mice spawn next to a vent by default, spawn at MOB_LAYER, can nibble food to regain health, can pass through plastic flaps, and can climb into disposal units.

Mouse-attacking message changed from "splats the" to "stamps on the".

A side-effect of allowing mice to eat and climb into disposal units is that they can also pull objects and click+drag things (though clicking and dragging objects into a disposal unit did not work when tested).
