### PR TITLE
Stopped the mousepocalypse

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -910,7 +910,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/Topic(href, href_list, var/nowindow = 0)
 	if(!nowindow)
 		..()
-	if(usr.stat || usr.restrained())
+	if(usr.stat || usr.restrained()|| ismouse(usr))
 		return
 	add_fingerprint(usr)
 	if(href_list["close"])

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -910,7 +910,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/Topic(href, href_list, var/nowindow = 0)
 	if(!nowindow)
 		..()
-	if(usr.stat || usr.restrained()|| ismouse(usr))
+	if(usr.stat || usr.restrained()|| usr.small)
 		return
 	add_fingerprint(usr)
 	if(href_list["close"])

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -47,7 +47,7 @@
 		var/mob/M = AM
 		if(world.time - M.last_bumped <= 10) return	//Can bump-open one airlock per second. This is to prevent shock spam.
 		M.last_bumped = world.time
-		if(!M.restrained() && !ismouse(M))
+		if(!M.restrained() && !M.small)
 			bumpopen(M)
 		return
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -47,7 +47,7 @@
 		var/mob/M = AM
 		if(world.time - M.last_bumped <= 10) return	//Can bump-open one airlock per second. This is to prevent shock spam.
 		M.last_bumped = world.time
-		if(!M.restrained())
+		if(!M.restrained() && !ismouse(M))
 			bumpopen(M)
 		return
 

--- a/code/global.dm
+++ b/code/global.dm
@@ -103,6 +103,7 @@ var/list/shuttles = list(  )
 var/list/reg_dna = list(  )
 //	list/traitobj = list(  )
 
+var/mouse_respawn_time = 5 //Amount of time that must pass between a player dying as a mouse and repawning as a mouse. In minutes.
 
 var/CELLRATE = 0.002  // multiplier for watts per tick <> cell storage (eg: .002 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)
 var/CHARGELEVEL = 0.001 // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -16,6 +16,7 @@
 	var/moving			= null
 	var/adminobs		= null
 	var/area			= null
+	var/can_spawn_as_mouse = 1
 
 
 		///////////////

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -16,7 +16,7 @@
 	var/moving			= null
 	var/adminobs		= null
 	var/area			= null
-	var/can_spawn_as_mouse = 1
+	var/time_died_as_mouse = null //when the client last died as a mouse
 
 
 		///////////////

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -263,6 +263,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Become mouse"
 	set category = "Ghost"
 
+	if(client.can_spawn_as_mouse == 0)
+		src << "<span class='warning'>You may only spawn again as a mouse more than [mouse_respawn_time] minutes after your death.</span>"
+		return
+
 	//find a viable mouse candidate
 	var/mob/living/simple_animal/mouse/host
 	var/obj/machinery/atmospherics/unary/vent_pump/vent_found

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -263,8 +263,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Become mouse"
 	set category = "Ghost"
 
-	if(client.can_spawn_as_mouse == 0)
-		src << "<span class='warning'>You may only spawn again as a mouse more than [mouse_respawn_time] minutes after your death.</span>"
+	var/timedifference = world.time - client.time_died_as_mouse
+	if(client.time_died_as_mouse && timedifference <= mouse_respawn_time * 600)
+		var/timedifference_text
+		timedifference_text = time2text(mouse_respawn_time * 600 - timedifference,"mm:ss")
+		src << "<span class='warning'>You may only spawn again as a mouse more than [mouse_respawn_time] minutes after your death. You have [timedifference_text] left.</span>"
 		return
 
 	//find a viable mouse candidate

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -461,7 +461,7 @@ It can still be worn/put on as normal.
 */
 /obj/effect/equip_e/human/done()	//TODO: And rewrite this :< ~Carn
 	target.cpr_time = 1
-	if(ismouse(source)) return //mice cannot strip people
+	if(isanimal(source)) return //animals cannot strip people
 	if(!source || !target) return		//Target or source no longer exist
 	if(source.loc != s_loc) return		//source has moved
 	if(target.loc != t_loc) return		//target has moved

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -461,6 +461,7 @@ It can still be worn/put on as normal.
 */
 /obj/effect/equip_e/human/done()	//TODO: And rewrite this :< ~Carn
 	target.cpr_time = 1
+	if(ismouse(source)) return //mice cannot strip people
 	if(!source || !target) return		//Target or source no longer exist
 	if(source.loc != s_loc) return		//source has moved
 	if(target.loc != t_loc) return		//target has moved

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -5,6 +5,7 @@
 	icon_state = "crab"
 	icon_living = "crab"
 	icon_dead = "crab_dead"
+	small = 1
 	speak_emote = list("clicks")
 	emote_hear = list("clicks")
 	emote_see = list("clacks")

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -167,6 +167,7 @@
 	health = 1
 	var/amount_grown = 0
 	pass_flags = PASSTABLE | PASSGRILLE
+	small = 1
 
 /mob/living/simple_animal/chick/New()
 	..()
@@ -208,6 +209,7 @@ var/global/chicken_count = 0
 	var/eggsleft = 0
 	var/color
 	pass_flags = PASSTABLE
+	small = 1
 
 /mob/living/simple_animal/chicken/New()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -5,6 +5,7 @@
 	icon_state = "lizard"
 	icon_living = "lizard"
 	icon_dead = "lizard-dead"
+	small = 1
 	speak_emote = list("hisses")
 	health = 5
 	maxHealth = 5

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -10,6 +10,7 @@
 	emote_hear = list("squeeks","squeaks","squiks")
 	emote_see = list("runs in a circle", "shakes", "scritches at something")
 	pass_flags = PASSTABLE
+	small = 1
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -48,6 +48,8 @@
 	src.stat = DEAD
 	src.icon_dead = "mouse_[color]_splat"
 	src.icon_state = "mouse_[color]_splat"
+	if(client)
+		client.time_died_as_mouse = world.time
 
 //copy paste from alien/larva, if that func is updated please update this one also
 /mob/living/simple_animal/mouse/verb/ventcrawl()
@@ -160,14 +162,8 @@
 
 /mob/living/simple_animal/mouse/Die()
 	if(client)
-		client.mouse_respawn_timer()
+		client.time_died_as_mouse = world.time
 	..()
-
-/client/proc/mouse_respawn_timer()
-	can_spawn_as_mouse = 0
-	spawn(mouse_respawn_time * 600)
-		can_spawn_as_mouse = 1
-	return
 
 /*
  * Mouse types

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -84,9 +84,11 @@
 			if(loc==startloc)
 				var/obj/target_vent = vents[selection_position]
 				if(target_vent)
+					/*
 					for(var/mob/O in oviewers(src, null))
 						if ((O.client && !( O.blinded )))
 							O.show_message(text("<B>[src] scrambles into the ventillation ducts!</B>"), 1)
+					*/
 					loc = target_vent.loc
 			else
 				src << "\blue You need to remain still while entering a vent."
@@ -107,15 +109,19 @@
 	if (layer != TURF_LAYER+0.2)
 		layer = TURF_LAYER+0.2
 		src << text("\blue You are now hiding.")
+		/*
 		for(var/mob/O in oviewers(src, null))
 			if ((O.client && !( O.blinded )))
 				O << text("<B>[] scurries to the ground!</B>", src)
+		*/
 	else
 		layer = MOB_LAYER
 		src << text("\blue You have stopped hiding.")
+		/*
 		for(var/mob/O in oviewers(src, null))
 			if ((O.client && !( O.blinded )))
 				O << text("[] slowly peaks up from the ground...", src)
+		*/
 
 //make mice fit under tables etc? this was hacky, and not working
 /*
@@ -151,6 +157,17 @@
 			M << "\blue \icon[src] Squeek!"
 			M << 'sound/effects/mousesqueek.ogg'
 	..()
+
+/mob/living/simple_animal/mouse/Die()
+	if(client)
+		client.mouse_respawn_timer()
+	..()
+
+/client/proc/mouse_respawn_timer()
+	can_spawn_as_mouse = 0
+	spawn(mouse_respawn_time * 600)
+		can_spawn_as_mouse = 1
+	return
 
 /*
  * Mouse types

--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -4,6 +4,7 @@
 	icon_state = "mushroom"
 	icon_living = "mushroom"
 	icon_dead = "mushroom_dead"
+	small = 1
 	speak_chance = 0
 	turns_per_move = 1
 	maxHealth = 5

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -33,6 +33,7 @@
 	icon_living = "parrot_fly"
 	icon_dead = "parrot_dead"
 	pass_flags = PASSTABLE
+	small = 1
 
 	speak = list("Hi","Hello!","Cracker?","BAWWWWK george mellons griffing me")
 	speak_emote = list("squawks","says","yells")

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -79,6 +79,7 @@
 	var/eye_stat = null//Living, potentially Carbon
 	var/lastpuke = 0
 	var/unacidable = 0
+	var/small = 0
 
 	var/name_archive //For admin things like possession
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -198,7 +198,10 @@
 				del(src)
 		if(ismouse(M))
 			var/mob/living/simple_animal/mouse/N = M
-			N.emote("nibbles away at the [src]")
+			N << text("\blue You nibble away at [src].")
+			if(prob(50))
+				N.visible_message("[N] nibbles away at [src].", "")
+			//N.emote("nibbles away at the [src]")
 			N.health = min(N.health + 1, N.maxHealth)
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -136,6 +136,7 @@
 	MouseDrop_T(mob/target, mob/user)
 		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai))
 			return
+		if(ismouse(user) && target != user) return //mice cannot put mobs other than themselves into disposal
 		src.add_fingerprint(user)
 		var/target_loc = target.loc
 		var/msg

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -136,7 +136,7 @@
 	MouseDrop_T(mob/target, mob/user)
 		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai))
 			return
-		if(ismouse(user) && target != user) return //mice cannot put mobs other than themselves into disposal
+		if(isanimal(user) && target != user) return //animals cannot put mobs other than themselves into disposal
 		src.add_fingerprint(user)
 		var/target_loc = target.loc
 		var/msg


### PR DESCRIPTION
Players have to wait 5 minutes between dying as a mouse and respawning as a mouse. Global variable mouse_respawn_time determines the respawn time in minutes.

Mice can no longer open airlocks.

Mice can no longer strip items from humans

Mice can no longer put other creatures into disposal units (though they can still climb into disposal units)

Messages for when mice hide and crawl into vents removed. Mouse nibbling message only displayed to observers half the time.
