### PR TITLE
Non-animated runes not cached.

### DIFF
--- a/code/game/magic/Uristrunes.dm
+++ b/code/game/magic/Uristrunes.dm
@@ -126,6 +126,6 @@ var/list/uristrune_cache = list()
 		result.Insert(I3, "", frame = 7, delay = 2)
 		result.Insert(I2, "", frame = 8, delay = 2)
 
-		uristrune_cache[lookup] = result
+	uristrune_cache[lookup] = result
 
 	return result


### PR DESCRIPTION
While looking through the code (for the first time in months), I noticed that only animated runes were being cached, the non-animated ones being recreated each time, since they weren't being inserted into the cache List.

Since the only difference is a level of indentation, it was probably just a line overlooked while removing a control flow statement, rather than a misguided attempt at premature optimization.
