### PR TITLE
Fixed infinite loop in powernet rebuild. (Issue #2385)

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -186,6 +186,9 @@
 			M.powernet = PN
 			P = M.get_connections()
 
+		else
+			return
+
 		if(P.len == 0)	return
 
 		O = P[1]


### PR DESCRIPTION
If a /obj/machinery/power wasn't anchored, it wouldn't get a new list of connections, so would endlessly loop on the old list, of which that object was the first entry, ensuring that the loop would never terminate.

This fix simply returns from the proc if there is no new list, and should also handle the case where, through a bug or half-added change, either get_connections() may return a list containing other object types, though for that case it would be preferable to check for unexpected object types and log the occurrence, to assist in debugging.
