### PR TITLE
Rename "latex gloves" to "medical gloves"

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -4,7 +4,7 @@
  *
  *	Contains:
  *		Empty box, starter boxes (survival/engineer),
- *		Latex glove and sterile mask boxes,
+ *		Medical glove and sterile mask boxes,
  *		Syringe, beaker, dna injector boxes,
  *		Blanks, flashbangs, and EMP grenade boxes,
  *		Tracking and chemical implant boxes,
@@ -46,8 +46,8 @@
 
 
 /obj/item/weapon/storage/box/gloves
-	name = "box of latex gloves"
-	desc = "Contains white gloves."
+	name = "box of medical gloves"
+	desc = "Contains sterile purple medical gloves."
 	New()
 		..()
 		new /obj/item/clothing/gloves/latex(src)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -53,13 +53,13 @@
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECITON_TEMPERATURE
 
 /obj/item/clothing/gloves/latex
-	name = "latex gloves"
-	desc = "Sterile latex gloves."
+	name = "medical gloves"
+	desc = "Sterile medical gloves, designed to protect against blood-borne pathogens."
 	icon_state = "latex"
 	item_state = "lgloves"
 	siemens_coefficient = 0.30
 	permeability_coefficient = 0.01
-	color="white"
+	color="purple"
 
 	cmo
 		color = "medical"		//Exists for washing machines. Is not different from latex gloves in any way.


### PR DESCRIPTION
Figured I ought to do this after I whined about it in IRC ...

Commit Message:
Minor nitpicky change - IRL, nitrile gloves are used over latex
due to latex allergens and latex's permeability to pathogens.

To avoid having to track the name change through every merge,
only the description and color are changed - "medical" gloves
so we don't have to worry about material and purple because
that's the color of the nitrile gloves I have around.
