### PR TITLE
Fix runtime while electrocuting slimes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -239,7 +239,7 @@
 	src.updatehealth()
 
 // damage MANY external organs, in random order
-/mob/living/proc/take_overall_damage(var/brute, var/burn)
+/mob/living/proc/take_overall_damage(var/brute, var/burn, var/used_weapon = null)
 	adjustBruteLoss(brute)
 	adjustFireLoss(burn)
 	src.updatehealth()


### PR DESCRIPTION
Proc called "take_overall_damage" with unexpected "used_weapon" parameter is /mob/living/carbon/electrocute_act

Error itself:
runtime error: bad arg name 'used_weapon'
proc name: take overall damage (/mob/living/proc/take_overall_damage)
  usr: the grey adult slime (800) (/mob/living/carbon/slime/adult)
  src: the grey adult slime (800) (/mob/living/carbon/slime/adult)
  call stack:
the grey adult slime (800) (/mob/living/carbon/slime/adult): take overall damage(0, 43)
the grey adult slime (800) (/mob/living/carbon/slime/adult): electrocute act(43, the grille (/obj/structure/grille), 1)
electrocute mob(the grey adult slime (800) (/mob/living/carbon/slime/adult), /datum/powernet (/datum/powernet), the grille (/obj/structure/grille), 1)
the grille (/obj/structure/grille): shock(the grey adult slime (800) (/mob/living/carbon/slime/adult), 70)
the grille (/obj/structure/grille): Bumped(the grey adult slime (800) (/mob/living/carbon/slime/adult))
the grey adult slime (800) (/mob/living/carbon/slime/adult): Bump(the grille (/obj/structure/grille), 1)
