### PR TITLE
Allow Security and Medical HUD to add comment to their respective records

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -413,7 +413,7 @@
 
 
 				msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
-				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>\n"
+				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"
 				//msg += "\[Set Hostile Identification\]\n"
 
 	if(istype(usr, /mob/living/carbon/human))
@@ -439,7 +439,6 @@
 
 
 			msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
-			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
 			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"
 
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -440,6 +440,7 @@
 
 			msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
 			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
+			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"
 
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -594,7 +594,7 @@
 						for (var/datum/data/record/R in data_core.general)
 							if (R.fields["id"] == E.fields["id"])
 
-								var/setmedical = input(usr, "Specify a new criminal status for this person.", "Medical HUD", R.fields["p_stat"]) in list("*Deceased*", "*Unconscious*", "Physically Unfit", "Active", "Cancel")
+								var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", R.fields["p_stat"]) in list("*Deceased*", "*Unconscious*", "Physically Unfit", "Active", "Cancel")
 
 								if(istype(H.glasses, /obj/item/clothing/glasses/hud/health))
 									if(setmedical != "Cancel")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -568,10 +568,69 @@
 									usr << "<b>Major Crimes:</b> [R.fields["ma_crim"]]"
 									usr << "<b>Details:</b> [R.fields["ma_crim_d"]]"
 									usr << "<b>Notes:</b> [R.fields["notes"]]"
+									usr << "<a href='?src=\ref[src];secrecordComment=`'>\[View Comment Log\]</a>"
 									read = 1
 
 				if(!read)
 					usr << "\red Unable to locate a data core entry for this person."
+
+	if (href_list["secrecordComment"])
+		if(istype(usr, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = usr
+			if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
+				var/perpname = "wot"
+				var/read = 0
+
+				if(wear_id)
+					if(istype(wear_id,/obj/item/weapon/card/id))
+						perpname = wear_id:registered_name
+					else if(istype(wear_id,/obj/item/device/pda))
+						var/obj/item/device/pda/tempPda = wear_id
+						perpname = tempPda.owner
+				else
+					perpname = src.name
+				for (var/datum/data/record/E in data_core.general)
+					if (E.fields["name"] == perpname)
+						for (var/datum/data/record/R in data_core.security)
+							if (R.fields["id"] == E.fields["id"])
+								if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
+									read = 1
+									var/counter = 1
+									while(R.fields[text("com_[]", counter)])
+										usr << text("[]", R.fields[text("com_[]", counter)])
+										counter++
+									if (counter == 1)
+										usr << "No comment found"
+									usr << "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>"
+
+				if(!read)
+					usr << "\red Unable to locate a data core entry for this person."
+
+	if (href_list["secrecordadd"])
+		if(istype(usr, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = usr
+			if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
+				var/perpname = "wot"
+				if(wear_id)
+					if(istype(wear_id,/obj/item/weapon/card/id))
+						perpname = wear_id:registered_name
+					else if(istype(wear_id,/obj/item/device/pda))
+						var/obj/item/device/pda/tempPda = wear_id
+						perpname = tempPda.owner
+				else
+					perpname = src.name
+				for (var/datum/data/record/E in data_core.general)
+					if (E.fields["name"] == perpname)
+						for (var/datum/data/record/R in data_core.security)
+							if (R.fields["id"] == E.fields["id"])
+								if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
+									var/t1 = copytext(sanitize(input("Add Comment:", "Sec. records", null, null)  as message),1,MAX_MESSAGE_LEN)
+									if ((!( t1 ) || src.stat || src.restrained() || !(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))))
+										return
+									var/counter = 1
+									while(R.fields[text("com_[]", counter)])
+										counter++
+									R.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], 2053<BR>[]",H.get_authentification_name(), H.get_assignment(), time2text(world.realtime, "DDD MMM DD hh:mm:ss"), t1)
 
 	if (href_list["medical"])
 		if(istype(usr, /mob/living/carbon/human))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -634,10 +634,69 @@
 									usr << "<b>Major Disabilities:</b> [R.fields["ma_dis"]]"
 									usr << "<b>Details:</b> [R.fields["ma_dis_d"]]"
 									usr << "<b>Notes:</b> [R.fields["notes"]]"
+									usr << "<a href='?src=\ref[src];medrecordComment=`'>\[View Comment Log\]</a>"
 									read = 1
 
 				if(!read)
 					usr << "\red Unable to locate a data core entry for this person."
+
+	if (href_list["medrecordComment"])
+		if(istype(usr, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = usr
+			if(istype(H.glasses, /obj/item/clothing/glasses/hud/health))
+				var/perpname = "wot"
+				var/read = 0
+
+				if(wear_id)
+					if(istype(wear_id,/obj/item/weapon/card/id))
+						perpname = wear_id:registered_name
+					else if(istype(wear_id,/obj/item/device/pda))
+						var/obj/item/device/pda/tempPda = wear_id
+						perpname = tempPda.owner
+				else
+					perpname = src.name
+				for (var/datum/data/record/E in data_core.general)
+					if (E.fields["name"] == perpname)
+						for (var/datum/data/record/R in data_core.medical)
+							if (R.fields["id"] == E.fields["id"])
+								if(istype(H.glasses, /obj/item/clothing/glasses/hud/health))
+									read = 1
+									var/counter = 1
+									while(R.fields[text("com_[]", counter)])
+										usr << text("[]", R.fields[text("com_[]", counter)])
+										counter++
+									if (counter == 1)
+										usr << "No comment found"
+									usr << "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>"
+
+				if(!read)
+					usr << "\red Unable to locate a data core entry for this person."
+
+	if (href_list["medrecordadd"])
+		if(istype(usr, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = usr
+			if(istype(H.glasses, /obj/item/clothing/glasses/hud/health))
+				var/perpname = "wot"
+				if(wear_id)
+					if(istype(wear_id,/obj/item/weapon/card/id))
+						perpname = wear_id:registered_name
+					else if(istype(wear_id,/obj/item/device/pda))
+						var/obj/item/device/pda/tempPda = wear_id
+						perpname = tempPda.owner
+				else
+					perpname = src.name
+				for (var/datum/data/record/E in data_core.general)
+					if (E.fields["name"] == perpname)
+						for (var/datum/data/record/R in data_core.medical)
+							if (R.fields["id"] == E.fields["id"])
+								if(istype(H.glasses, /obj/item/clothing/glasses/hud/health))
+									var/t1 = copytext(sanitize(input("Add Comment:", "Med. records", null, null)  as message),1,MAX_MESSAGE_LEN)
+									if ((!( t1 ) || src.stat || src.restrained() || !(istype(H.glasses, /obj/item/clothing/glasses/hud/health))))
+										return
+									var/counter = 1
+									while(R.fields[text("com_[]", counter)])
+										counter++
+									R.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], 2053<BR>[]",H.get_authentification_name(), H.get_assignment(), time2text(world.realtime, "DDD MMM DD hh:mm:ss"), t1)
 	..()
 	return
 


### PR DESCRIPTION
Idea from [this thread](http://baystation12.net/forums/viewtopic.php?f=5&t=7308)

Allow Medical and Security HUD to quickly add a comment to their respective records

It uses the currently existing record section, It just allow access through a hud.
The user have a quick access in the examine text, and can also read the comments after reading the record.
