### PR TITLE
Updates to sun.dm and solar.dm

### DIFF
--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -2,14 +2,15 @@
 	var/angle
 	var/dx
 	var/dy
-	var/counter = 50		// to make the vars update during 1st call
+//	var/counter = 50		// to make the vars update during 1st call
 	var/rate
 	var/list/solars			// for debugging purposes, references solars_list at the constructor
+	var/nexttime = 3600		// Replacement for var/counter to force the sun to move every X IC minutes
 
 /datum/sun/New()
 
 	solars = solars_list
-	rate = rand(75,125)/100			// 75% - 125% of standard rotation
+	rate = rand(750,1250)/1000			// 75.0% - 125.0% of standard rotation
 	if(prob(50))
 		rate = -rate
 
@@ -17,13 +18,22 @@
 
 /datum/sun/proc/calc_position()
 
-	counter++
+/*	counter++
 	if(counter<50)		// count 50 pticks (50 seconds, roughly - about a 5deg change)
 		return
-	counter = 0
+	counter = 0 */
 
-	angle = ((rate*world.realtime/100)%360 + 360)%360		// gives about a 60 minute rotation time
-															// now 45 - 75 minutes, depending on rate
+	angle = ((rate*world.time/100)%360 + 360)%360
+	/*
+		Yields a 45 - 75 IC minute rotational period
+		Rotation rate can vary from 4.8 deg/min to 8 deg/min (288 to 480 deg/hr)
+	*/
+
+	//  To prevent excess server load the server only updates the sun's sight lines every 6 minutes
+	if(nexttime < world.time)
+		return
+	nexttime = nexttime + 3600	// 600 world.time ticks = 1 minute, 3600 = 6 minutes.
+
 	// now calculate and cache the (dx,dy) increments for line drawing
 
 	var/s = sin(angle)


### PR DESCRIPTION
Improved solar manual tracking by switching sun.dm and solar.dm to run off of the same clock (world.time) and added several options to the solar generator control computer.
