### PR TITLE
Server crash fix.

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -348,7 +348,7 @@
 			//revolver
 			var/obj/item/weapon/gun/projectile/new_gun = new /obj/item/weapon/gun/projectile(src.loc)
 			new_item = new_gun
-			new_item.icon_state = "gun[rand(1,4)]"
+			//new_item.icon_state = "gun[rand(1,4)]" comenting this out because there aren't sprites named like that
 
 			//33% chance to be able to reload the gun with human ammunition
 			if(prob(66))
@@ -359,8 +359,10 @@
 			if(prob(33))
 				var/num_bullets = rand(1,new_gun.max_shells)
 				if(num_bullets < new_gun.loaded.len)
-					for(var/i = num_bullets, i <= new_gun.loaded.len, i++)
-						new_gun.loaded += new new_gun.ammo_type(src)
+					new_gun.loaded.Cut()
+					for(var/i = 1, i <= num_bullets, i++)
+						var/A = text2path(new_gun.ammo_type)
+						new_gun.loaded += new A(new_gun)
 				else
 					for(var/obj/item/I in new_gun)
 						if(new_gun.loaded.len > num_bullets)

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -348,7 +348,8 @@
 			//revolver
 			var/obj/item/weapon/gun/projectile/new_gun = new /obj/item/weapon/gun/projectile(src.loc)
 			new_item = new_gun
-			//new_item.icon_state = "gun[rand(1,4)]" comenting this out because there aren't sprites named like that
+			new_item.icon_state = "gun[rand(1,4)]"
+			new_item.icon = 'xenoarchaeology.dmi'
 
 			//33% chance to be able to reload the gun with human ammunition
 			if(prob(66))


### PR DESCRIPTION
Fixed the server crash, it was an infinite loop when a revolver spawned in the xenoarcheology. It added bullets (tried, because it didn't work either) over and over nonstop.

Commented out the sprite selection on the revolvers in the xenoarcheology spawn code, it selected wrong names and they ended up being invisible. Now they will have the default sprite, the black revolver.
EDIT: Removed the commented out code and changed the icon path to the correct one
