### PR TITLE
Removing reverselist() from all bot pathing.

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -225,7 +225,6 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 					next_dest_loc = closest_loc
 				if (next_dest_loc)
 					src.patrol_path = AStar(src.loc, next_dest_loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=null)
-					src.patrol_path = reverselist(src.patrol_path)
 		else
 			patrol_move()
 
@@ -235,7 +234,6 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		spawn(0)
 			if(!src || !target) return
 			src.path = AStar(src.loc, src.target.loc, /turf/proc/AdjacentTurfs, /turf/proc/Distance, 0, 30)
-			src.path = reverselist(src.path)
 			if(src.path.len == 0)
 				src.oldtarget = src.target
 				src.target = null

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -615,7 +615,6 @@ Auto Patrol: []"},
 // given an optional turf to avoid
 /obj/machinery/bot/ed209/proc/calc_path(var/turf/avoid = null)
 	src.path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
-	src.path = reverselist(src.path)
 
 
 // look for a criminal in view of the bot

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -357,7 +357,6 @@
 			var/turf/dest = get_step_towards(target,src)  //Can't pathfind to a tray, as it is dense, so pathfind to the spot next to the tray
 
 			src.path = AStar(src.loc, dest, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30,id=botcard)
-			src.path = reverselist(src.path)
 			if(src.path.len == 0)
 				for ( var/turf/spot in orange(1,target) ) //The closest one is unpathable, try  the other spots
 					if ( spot == dest ) //We already tried this spot

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -244,7 +244,6 @@
 				src.path = AStar(src.loc, src.target.loc, /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 30)
 			else
 				src.path = AStar(src.loc, src.target, /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 30)
-			src.path = reverselist(src.path)
 			if(src.path.len == 0)
 				src.oldtarget = src.target
 				src.target = null

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -299,7 +299,6 @@
 	if(src.patient && src.path.len == 0 && (get_dist(src,src.patient) > 1))
 		spawn(0)
 			src.path = AStar(src.loc, get_turf(src.patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30,id=botcard)
-			src.path = reverselist(src.path)
 			if(src.path.len == 0)
 				src.oldpatient = src.patient
 				src.patient = null

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -583,7 +583,6 @@ Auto Patrol: []"},
 // given an optional turf to avoid
 /obj/machinery/bot/secbot/proc/calc_path(var/turf/avoid = null)
 	src.path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
-	src.path = reverselist(src.path)
 
 
 // look for a criminal in view of the bot


### PR DESCRIPTION
As with my previous commit, reverselist() is causing problems in bot
pathing, it is unnecessary. Bot pathing only worked when reverselist()
was doing nothing.

Similar to https://github.com/Baystation12/Baystation12/commit/823021483353cdfcc83538522a01975ff773042a
and 
https://github.com/tgstation/-tg-station/commit/54d02d75a3da4ae3a73e00eea34d4bbfa3d6e73f

These problems are only noticeable with more complicated paths where reversing the order matters, i.e. not straight lines.
