### PR TITLE
Fix for LSD zombies.

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -48,9 +48,6 @@
 
 
 /mob/living/carbon/human/death(gibbed)
-	if(halloss > 0 && !gibbed)
-		halloss = 0
-		return
 	if(stat == DEAD)	return
 	if(healths)		healths.icon_state = "health5"
 	stat = DEAD


### PR DESCRIPTION
Winners do not use space drugs.
Fixes LSD giving you an ability to escape death once.
Whilst hilarious, this can be breaking things that depend on mob staying dead after calling death().
My guess is that at some point halloss was counted in UpdateHeath(), but it is not anymore, so people don't die from combination of halloss and other damages being over 200.
