### PR TITLE
Fix for security belts not holding all seven items sometimes

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -107,6 +107,7 @@
 	item_state = "security"//Could likely use a better one.
 	storage_slots = 7
 	max_w_class = 3
+	max_combined_w_class = 21
 	can_hold = list(
 		"/obj/item/weapon/grenade/flashbang",
 		"/obj/item/weapon/reagent_containers/spray/pepper",


### PR DESCRIPTION
Fix for security belts not holding all seven items if the total combined w_class of the items is over 14. They should now be able to hold seven of any items that fit in them.
