### PR TITLE
Android Clocks and Instant Messengers

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -23,7 +23,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	//Secondary variables
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.
 	var/fon = 0 //Is the flashlight function on?
-	var/f_lum = 4 //Luminosity for the flashlight function
+	var/f_lum = 2 //Luminosity for the flashlight function
 	var/silent = 0 //To beep or not to beep, that is the question
 	var/toff = 0 //If 1, messenger disabled
 	var/tnote = null //Current Texts

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -23,7 +23,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	//Secondary variables
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.
 	var/fon = 0 //Is the flashlight function on?
-	var/f_lum = 2 //Luminosity for the flashlight function
+	var/f_lum = 4 //Luminosity for the flashlight function
 	var/silent = 0 //To beep or not to beep, that is the question
 	var/toff = 0 //If 1, messenger disabled
 	var/tnote = null //Current Texts
@@ -183,14 +183,73 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	default_cartridge = /obj/item/weapon/cartridge/medical
 	icon_state = "pda-gene"
 
+
 // Special AI/pAI PDAs that cannot explode.
 /obj/item/device/pda/ai
 	icon_state = "NONE"
 	ttone = "data"
 	detonate = 0
 
+
+/obj/item/device/pda/ai/proc/set_name_and_job(newname as text, newjob as text)
+	owner = newname
+	ownjob = newjob
+	name = newname + " (" + ownjob + ")"
+
+
+//AI verb and proc for sending PDA messages.
+/obj/item/device/pda/ai/verb/cmd_send_pdamesg()
+	set category = "AI IM"
+	set name = "Send Message"
+	set src in usr
+	if(usr.stat == 2)
+		usr << "You can't send PDA messages because you are dead!"
+		return
+	var/list/plist = available_pdas()
+	if (plist)
+		var/c = input(usr, "Please select a PDA") as null|anything in sortList(plist)
+		if (!c) // if the user hasn't selected a PDA file we can't send a message
+			return
+		var/selected = plist[c]
+		create_message(usr, selected)
+
+
+/obj/item/device/pda/ai/verb/cmd_toggle_pda_receiver()
+	set category = "AI IM"
+	set name = "Toggle Sender/Receiver"
+	set src in usr
+	if(usr.stat == 2)
+		usr << "You can't do that because you are dead!"
+		return
+	toff = !toff
+	usr << "<span class='notice'>PDA sender/receiver toggled [(toff ? "Off" : "On")]!</span>"
+
+
+/obj/item/device/pda/ai/verb/cmd_toggle_pda_silent()
+	set category = "AI IM"
+	set name = "Toggle Ringer"
+	set src in usr
+	if(usr.stat == 2)
+		usr << "You can't do that because you are dead!"
+		return
+	silent=!silent
+	usr << "<span class='notice'>PDA ringer toggled [(silent ? "Off" : "On")]!</span>"
+
+
+/obj/item/device/pda/ai/verb/cmd_show_message_log()
+	set category = "AI IM"
+	set name = "Show Message Log"
+	set src in usr
+	if(usr.stat == 2)
+		usr << "You can't do that because you are dead!"
+		return
+	var/HTML = "<html><head><title>AI PDA Message Log</title></head><body>[tnote]</body></html>"
+	usr << browse(HTML, "window=log;size=400x444;border=1;can_resize=1;can_close=1;can_minimize=0")
+
+
 /obj/item/device/pda/ai/can_use()
 	return 1
+
 
 /obj/item/device/pda/ai/attack_self(mob/user as mob)
 	if ((honkamt > 0) && (prob(60)))//For clown virus.
@@ -198,8 +257,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		playsound(loc, 'sound/items/bikehorn.ogg', 30, 1)
 	return
 
+
 /obj/item/device/pda/ai/pai
 	ttone = "assist"
+
 
 /*
  *	The Actual PDA
@@ -832,6 +893,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		usr << "<span class='notice'>You cannot do this while restrained.</span>"
 
+
 /obj/item/device/pda/proc/id_check(mob/user as mob, choice as num)//To check for IDs; 1 for in-pda use, 2 for out of pda use.
 	if(choice == 1)
 		if (id)
@@ -1071,21 +1133,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		M.Stun(8)
 		M.Weaken(5)
 
-
-//AI verb and proc for sending PDA messages.
-
-/mob/living/silicon/ai/verb/cmd_send_pdamesg()
-	set category = "AI Commands"
-	set name = "PDA - Send Message"
+/obj/item/device/pda/proc/available_pdas()
 	var/list/names = list()
 	var/list/plist = list()
 	var/list/namecounts = list()
 
-	if(usr.stat == 2)
-		usr << "You can't send PDA messages because you are dead!"
-		return
-
-	if(src.aiPDA.toff)
+	if (toff)
 		usr << "Turn on your receiver in order to send messages."
 		return
 
@@ -1098,8 +1151,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			continue
 		else if (P.toff)
 			continue
-		else if (P == src.aiPDA)
-			continue
 
 		var/name = P.owner
 		if (name in names)
@@ -1110,52 +1161,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			namecounts[name] = 1
 
 		plist[text("[name]")] = P
-
-	var/c = input(usr, "Please select a PDA") as null|anything in sortList(plist)
-
-	if (!c)
-		return
-
-	var/selected = plist[c]
-	src.aiPDA.create_message(src, selected)
-
-
-/mob/living/silicon/ai/verb/cmd_toggle_pda_receiver()
-	set category = "AI Commands"
-	set name = "PDA - Toggle Sender/Receiver"
-	if(usr.stat == 2)
-		usr << "You can't do that because you are dead!"
-		return
-	if(!isnull(aiPDA))
-		aiPDA.toff = !aiPDA.toff
-		usr << "<span class='notice'>PDA sender/receiver toggled [(aiPDA.toff ? "Off" : "On")]!</span>"
-	else
-		usr << "You do not have a PDA. You should make an issue report about this."
-
-/mob/living/silicon/ai/verb/cmd_toggle_pda_silent()
-	set category = "AI Commands"
-	set name = "PDA - Toggle Ringer"
-	if(usr.stat == 2)
-		usr << "You can't do that because you are dead!"
-		return
-	if(!isnull(aiPDA))
-		//0
-		aiPDA.silent = !aiPDA.silent
-		usr << "<span class='notice'>PDA ringer toggled [(aiPDA.silent ? "Off" : "On")]!</span>"
-	else
-		usr << "You do not have a PDA. You should make an issue report about this."
-
-/mob/living/silicon/ai/verb/cmd_show_message_log()
-	set category = "AI Commands"
-	set name = "PDA - Show Message Log"
-	if(usr.stat == 2)
-		usr << "You can't do that because you are dead!"
-		return
-	if(!isnull(aiPDA))
-		var/HTML = "<html><head><title>AI PDA Message Log</title></head><body>[aiPDA.tnote]</body></html>"
-		usr << browse(HTML, "window=log;size=400x444;border=1;can_resize=1;can_close=1;can_minimize=0")
-	else
-		usr << "You do not have a PDA. You should make an issue report about this."
+	return plist
+	
 
 //Some spare PDAs in a box
 /obj/item/weapon/storage/box/PDAs

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -174,28 +174,17 @@ var/list/ai_list = list()
 			//usr <<"You can only change your display once!"
 			//return
 
-/mob/living/silicon/ai/Stat()
-	..()
-	statpanel("Status")
-	if (client.statpanel == "Status")
-		stat(null, "Station Time: [worldtime2text()]")
-		if(emergency_shuttle.online && emergency_shuttle.location < 2)
-			var/timeleft = emergency_shuttle.timeleft()
-			if (timeleft)
-				stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
 
-		if(ticker.mode.name == "AI malfunction")
-			var/datum/game_mode/malfunction/malf = ticker.mode
-			for (var/datum/mind/malfai in malf.malf_ai)
-				if (mind == malfai)
-					if (malf.apcs >= 3)
-						stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/(malf.apcs/3), 0)] seconds")
+// displays the malf_ai information if the AI is the malf
+/mob/living/silicon/ai/show_malf_ai()
+	if(ticker.mode.name == "AI malfunction")
+		var/datum/game_mode/malfunction/malf = ticker.mode
+		for (var/datum/mind/malfai in malf.malf_ai)
+			if (mind == malfai) // are we the evil one?
+				if (malf.apcs >= 3)
+					stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/(malf.apcs/3), 0)] seconds")
 
-		if(!stat)
-			stat(null, text("System integrity: [(health+100)/2]%"))
-		else
-			stat(null, text("Systems nonfunctional"))
-
+					
 /mob/living/silicon/ai/proc/ai_alerts()
 	set category = "AI Commands"
 	set name = "Show Alerts"
@@ -232,17 +221,11 @@ var/list/ai_list = list()
 	viewalerts = 1
 	src << browse(dat, "window=aialerts&can_close=0")
 
+// this verb lets the ai see the stations manifest
 /mob/living/silicon/ai/proc/ai_roster()
 	set category = "AI Commands"
 	set name = "Show Crew Manifest"
-	var/dat
-
-	dat += "<h4>Crew Manifest</h4>"
-	if(data_core)
-		dat += data_core.get_manifest(0) // make it monochrome
-	dat += "<br>"
-	src << browse(dat, "window=airoster")
-	onclose(src, "airoster")
+	show_station_manifest()
 
 /mob/living/silicon/ai/proc/ai_call_shuttle()
 	set category = "AI Commands"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -75,23 +75,20 @@
 	..()
 	usr << browse_rsc('html/paigrid.png')			// Go ahead and cache the interface resources as early as possible
 
-
+	
+// this function shows the information about being silenced as a pAI in the Status panel
+/mob/living/silicon/pai/proc/show_silenced()
+	if(src.silence_time)
+		var/timeleft = round((silence_time - world.timeofday)/10 ,1)
+		stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+		
+		
 /mob/living/silicon/pai/Stat()
 	..()
 	statpanel("Status")
 	if (src.client.statpanel == "Status")
-		if(emergency_shuttle.online && emergency_shuttle.location < 2)
-			var/timeleft = emergency_shuttle.timeleft()
-			if (timeleft)
-				stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
-		if(src.silence_time)
-			var/timeleft = round((silence_time - world.timeofday)/10 ,1)
-			stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
-		if(!src.stat)
-			stat(null, text("System integrity: [(src.health+100)/2]%"))
-		else
-			stat(null, text("Systems nonfunctional"))
-
+		show_silenced()
+		
 	if (proc_holder_list.len)//Generic list for proc_holder objects.
 		for(var/obj/effect/proc_holder/P in proc_holder_list)
 			statpanel("[P.panel]","",P)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -29,6 +29,8 @@
 
 	var/obj/item/device/mmi/mmi = null
 
+	var/obj/item/device/pda/ai/rbPDA = null
+
 	var/opened = 0
 	var/emagged = 0
 	var/wiresexposed = 0
@@ -100,6 +102,12 @@
 	..()
 
 	playsound(loc, 'sound/voice/liveagain.ogg', 75, 1)
+
+// setup the PDA and its name
+/mob/living/silicon/robot/proc/setup_PDA()
+	if (!rbPDA)
+		rbPDA = new/obj/item/device/pda/ai(src)
+	rbPDA.set_name_and_job(custom_name,braintype)
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 //Improved /N
@@ -217,6 +225,8 @@
 	radio.config(channels)
 	updateicon()
 
+/
+
 /mob/living/silicon/robot/proc/updatename(var/prefix as text)
 
 	if(istype(mmi, /obj/item/device/mmi/posibrain))
@@ -231,6 +241,9 @@
 		changed_name = "[(prefix ? "[prefix] " : "")][braintype]-[num2text(ident)]"
 	real_name = changed_name
 	name = real_name
+	
+	// if we've changed our name, we also need to update the display name for our PDA
+	setup_PDA()
 
 /mob/living/silicon/robot/verb/Namepick()
 	if(custom_name)
@@ -249,6 +262,13 @@
 	set category = "Robot Commands"
 	set name = "Show Alerts"
 	robot_alerts()
+
+// this verb lets cyborgs see the stations manifest
+/mob/living/silicon/robot/verb/cmd_station_manifest()
+	set category = "Robot Commands"
+	set name = "Show Station Manifest"
+	show_station_manifest()
+
 
 /mob/living/silicon/robot/proc/robot_alerts()
 	var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"
@@ -280,35 +300,52 @@
 		return 1
 	return 0
 
+// this function shows information about the malf_ai gameplay type in the status screen
+/mob/living/silicon/robot/show_malf_ai()
+	..()
+	if(ticker.mode.name == "AI malfunction")
+		var/datum/game_mode/malfunction/malf = ticker.mode
+		for (var/datum/mind/malfai in malf.malf_ai)
+			if(connected_ai)
+				if(connected_ai.mind == malfai)
+					if(malf.apcs >= 3)
+						stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/(malf.apcs/3), 0)] seconds")
+			else if(ticker.mode:malf_mode_declared)
+				stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
+	return 0
+
+
+// this function displays jetpack pressure in the stat panel
+/mob/living/silicon/robot/proc/show_jetpack_pressure()
+	// if you have a jetpack, show the internal tank pressure
+	var/obj/item/weapon/tank/jetpack/current_jetpack = installed_jetpack()
+	if (current_jetpack)
+		stat("Internal Atmosphere Info", current_jetpack.name)
+		stat("Tank Pressure", current_jetpack.air_contents.return_pressure())
+
+
+// this function returns the robots jetpack, if one is installed
+/mob/living/silicon/robot/proc/installed_jetpack()
+	if(module)
+		return (locate(/obj/item/weapon/tank/jetpack) in module.modules)
+	return 0
+
+
+// this function displays the cyborgs current cell charge in the stat panel
+/mob/living/silicon/robot/proc/show_cell_power()
+	if(cell)
+		stat(null, text("Charge Left: [cell.charge]/[cell.maxcharge]"))
+	else
+		stat(null, text("No Cell Inserted!"))
+
+
+// update the status screen display
 /mob/living/silicon/robot/Stat()
 	..()
 	statpanel("Status")
 	if (client.statpanel == "Status")
-		if(emergency_shuttle.online && emergency_shuttle.location < 2)
-			var/timeleft = emergency_shuttle.timeleft()
-			if (timeleft)
-				stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
-
-		if(ticker.mode.name == "AI malfunction")
-			var/datum/game_mode/malfunction/malf = ticker.mode
-			for (var/datum/mind/malfai in malf.malf_ai)
-				if(connected_ai)
-					if(connected_ai.mind == malfai)
-						if(malf.apcs >= 3)
-							stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/(malf.apcs/3), 0)] seconds")
-				else if(ticker.mode:malf_mode_declared)
-					stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
-
-		if(cell)
-			stat(null, text("Charge Left: [cell.charge]/[cell.maxcharge]"))
-		else
-			stat(null, text("No Cell Inserted!"))
-
-		if(module)
-			internal = locate(/obj/item/weapon/tank/jetpack) in module.modules
-			if(internal)
-				stat("Internal Atmosphere Info", internal.name)
-				stat("Tank Pressure", internal.air_contents.return_pressure())
+		show_cell_power()
+		show_jetpack_pressure()
 
 /mob/living/silicon/robot/restrained()
 	return 0

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -145,3 +145,50 @@
 	if (bot.connected_ai == ai)
 		return 1
 	return 0
+	
+	
+// this function shows the health of the pAI in the Status panel
+/mob/living/silicon/proc/show_system_integrity()
+	if(!src.stat)
+		stat(null, text("System integrity: [(src.health+100)/2]%"))
+	else
+		stat(null, text("Systems nonfunctional"))
+
+	
+// This is a pure virtual function, it should be overwritten by all subclasses
+/mob/living/silicon/proc/show_malf_ai()
+	return 0
+
+	
+// this function displays the station time in the status panel
+/mob/living/silicon/proc/show_station_time()
+	stat(null, "Station Time: [worldtime2text()]")
+	
+	
+// this function displays the shuttles ETA in the status panel if the shuttle has been called
+/mob/living/silicon/proc/show_emergency_shuttle_eta()
+	if(emergency_shuttle.online && emergency_shuttle.location < 2)
+		var/timeleft = emergency_shuttle.timeleft()
+		if (timeleft)
+			stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+				
+				
+// This adds the basic clock, shuttle recall timer, and malf_ai info to all silicon lifeforms
+/mob/living/silicon/Stat()
+	..()
+	statpanel("Status")
+	if (src.client.statpanel == "Status")
+		show_station_time()
+		show_emergency_shuttle_eta()
+		show_system_integrity()
+		show_malf_ai()
+		
+// this function displays the stations manifest in a separate window
+/mob/living/silicon/proc/show_station_manifest()
+	var/dat
+	dat += "<h4>Crew Manifest</h4>"
+	if(data_core)
+		dat += data_core.get_manifest(0) // make it monochrome
+	dat += "<br>"
+	src << browse(dat, "window=airoster")
+	onclose(src, "airoster")


### PR DESCRIPTION
This refactors the Stat page for three of our four silicon lifeforms, the Cyborg/Android, the AI, and the pAI. I did not touch the posibrain.

It adds the clock, shuttle-recall timer, to the cyborg, as well as giving all three access to the Crew Manifest as a Verb. 

It revises the AI's instant messenger access, putting it in a AI IM tab, and gives the Cyborgs similar access. The pAI does not, as it has a full PDA interface.
