### PR TITLE
Adds auto OOC mute for crew transfer votes

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -10,6 +10,7 @@ datum/controller/vote
 	var/list/voted = list()
 	var/list/voting = list()
 	var/list/current_votes = list()
+	var/auto_muted = 0
 
 	New()
 		if(vote != src)
@@ -52,6 +53,14 @@ datum/controller/vote
 		voted.Cut()
 		voting.Cut()
 		current_votes.Cut()
+
+		if(auto_muted && !ooc_allowed)
+			auto_muted = 0
+			ooc_allowed = !( ooc_allowed )
+			world << "<b>The OOC channel has been automatically enabled due to vote cancellation.</b>"
+			log_admin("OOC was toggled automatically due to vote cancellation.")
+			message_admins("OOC has been toggled on automatically.")
+
 
 	proc/get_result()
 		//get the highest number of votes
@@ -138,6 +147,12 @@ datum/controller/vote
 				if("crew_transfer")
 					if(. == "Initiate Crew Transfer")
 						init_shift_change(null, 1)
+					if(auto_muted && !ooc_allowed)
+						auto_muted = 0
+						ooc_allowed = !( ooc_allowed )
+						world << "<b>The OOC channel has been automatically enabled due to vote end.</b>"
+						log_admin("OOC was toggled automatically due to vote end.")
+						message_admins("OOC has been toggled on automatically.")
 
 
 		if(restart)
@@ -210,6 +225,13 @@ datum/controller/vote
 			if(mode == "gamemode" && going)
 				going = 0
 				world << "<font color='red'><b>Round start has been delayed.</b></font>"
+			if(mode == "crew_transfer" && ooc_allowed)
+				auto_muted = 1
+				ooc_allowed = !( ooc_allowed )
+				world << "<b>The OOC channel has been automatically disabled due to the crew transfer vote.</b>"
+				log_admin("OOC was toggled automatically due to crew_transfer vote.")
+				message_admins("OOC has been toggled off automatically.")
+
 
 			time_remaining = round(config.vote_period/10)
 			return 1


### PR DESCRIPTION
- Mutes OOC when a crew transfer vote starts
- Won't mute/unmute OOC if it was already muted
- Won't remute OOC if was unmuted during the transfer vote
- Unmutes OOC when the vote ends
