### PR TITLE
Crew manifests will now put alternate titles of jobs into their correct departments

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -7,8 +7,9 @@
 			manifest_inject(H)
 		return
 
-/obj/effect/datacore/proc/manifest_modify(var/name, var/assignment, var/alt_title = null)
+/obj/effect/datacore/proc/manifest_modify(var/name, var/assignment)
 	var/datum/data/record/foundrecord
+	var/real_title = assignment
 
 	for(var/datum/data/record/t in data_core.general)
 		if (t)
@@ -16,14 +17,18 @@
 				foundrecord = t
 				break
 
+	var/list/all_jobs = get_job_datums()
+
+	for(var/datum/job/J in all_jobs)
+		var/list/alttitles = get_alternate_titles(J.title)
+		if(!J)	continue
+		if(assignment in alttitles)
+			real_title = J.title
+			break
+
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment
-		if(alt_title)
-			foundrecord.fields["real_rank"] = alt_title
-		else
-			foundrecord.fields["real_rank"] = assignment
-
-
+		foundrecord.fields["real_rank"] = real_title
 
 /obj/effect/datacore/proc/manifest_inject(var/mob/living/carbon/human/H)
 	if(H.mind && (H.mind.assigned_role != "MODE"))

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -117,3 +117,26 @@ var/list/nonhuman_positions = list(
 
 /proc/guest_jobbans(var/job)
 	return ((job in command_positions) || (job in nonhuman_positions) || (job in security_positions))
+
+/proc/get_job_datums()
+	var/list/occupations = list()
+	var/list/all_jobs = typesof(/datum/job)
+
+	for(var/A in all_jobs)
+		var/datum/job/job = new A()
+		if(!job)	continue
+		occupations += job
+
+	return occupations
+
+/proc/get_alternate_titles(var/job)
+	var/list/jobs = get_job_datums()
+	var/list/titles = list()
+
+	for(var/datum/job/J in jobs)
+		if(!J)	continue
+		if(J.title == job)
+			titles = J.alt_titles
+
+	return titles
+


### PR DESCRIPTION
Fixes alt-title jobs being put into the "Miscellaneous" category whenever their ID is changed with the identification computer.
