### PR TITLE
Allow for selection of one secondary language based on alienwhitelist.txt

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -64,6 +64,7 @@ datum/preferences
 	var/g_eyes = 0						//Eye color
 	var/b_eyes = 0						//Eye color
 	var/species = "Human"
+	var/language = "None"				//Secondary language
 
 		//Mob preview
 	var/icon/preview_icon_front = null
@@ -251,6 +252,7 @@ datum/preferences
 		dat += "(<a href='?_src_=prefs;preference=all;task=random'>&reg;</A>)"
 		dat += "<br>"
 		dat += "Species: <a href='byond://?src=\ref[user];preference=species;task=input'>[species]</a><br>"
+		dat += "Secondary Language:<br><a href='byond://?src=\ref[user];preference=language;task=input'>[language]</a><br>"
 		dat += "Blood Type: <a href='byond://?src=\ref[user];preference=b_type;task=input'>[b_type]</a><br>"
 		dat += "Skin Tone: <a href='?_src_=prefs;preference=s_tone;task=input'>[-s_tone + 35]/220<br></a>"
 		//dat += "Skin pattern: <a href='byond://?src=\ref[user];preference=skin_style;task=input'>Adjust</a><br>"
@@ -851,6 +853,32 @@ datum/preferences
 
 							s_tone = 0
 
+					if("language")
+						var/list/new_language = list("None")
+						var/language_whitelisted = 0
+						if(config.usealienwhitelist)
+							if(is_alien_whitelisted(user, "Language_Soghun"))
+								new_language += "Unathi"
+								language_whitelisted = 1
+							if(is_alien_whitelisted(user, "Language_Tajaran"))
+								new_language += "Tajaran"
+								language_whitelisted = 1
+							if(is_alien_whitelisted(user, "Language_Skrell"))
+								new_language += "Skrell"
+								language_whitelisted = 1
+							if(is_alien_whitelisted(user, "Language_Kidan"))
+								new_language += "Kidan"
+								language_whitelisted = 1
+
+							if(!language_whitelisted)
+								alert(user, "You cannot select a secondary language as you need to be whitelisted.  If you wish to enable a language, post in the Alien Whitelist forums.")
+
+						else
+							new_language += "Unathi"
+							new_language += "Tajaran"
+							new_language += "Skrell"
+							new_language += "Kidan"
+						language = input("Please select a secondary language", "Character Generation", null) in new_language
 
 					if("metadata")
 						var/new_metadata = input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , metadata)  as message|null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN	8
-#define SAVEFILE_VERSION_MAX	9
+#define SAVEFILE_VERSION_MAX	10
 
 //handles converting savefiles to new formats
 //MAKE SURE YOU KEEP THIS UP TO DATE!
@@ -103,6 +103,7 @@
 	S["gender"]				>> gender
 	S["age"]				>> age
 	S["species"]			>> species
+	S["language"]			>> language
 
 	//colors to be consolidated into hex strings (requires some work with dna code)
 	S["hair_red"]			>> r_hair
@@ -152,6 +153,7 @@
 	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= reject_bad_name(real_name)
 	if(isnull(species)) species = "Human"
+	if(isnull(language)) language = "None"
 	if(isnull(nanotrasen_relation)) nanotrasen_relation = initial(nanotrasen_relation)
 	if(!real_name) real_name = random_name()
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
@@ -206,6 +208,7 @@
 	S["gender"]				<< gender
 	S["age"]				<< age
 	S["species"]			<< species
+	S["language"]			<< language
 	S["hair_red"]			<< r_hair
 	S["hair_green"]			<< g_hair
 	S["hair_blue"]			<< b_hair

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -356,6 +356,20 @@
 				new_character.dna.mutantrace = "kidan"
 				new_character.kidan_talk_understand = 1
 
+		if(client.prefs.language == "Tajaran")
+			if(is_alien_whitelisted(src, "Language_Tajaran") || !config.usealienwhitelist)
+				new_character.tajaran_talk_understand = 1
+		if(client.prefs.language == "Unathi")
+			if(is_alien_whitelisted(src, "Language_Soghun") || !config.usealienwhitelist)
+				new_character.soghun_talk_understand = 1
+		if(client.prefs.language == "Skrell")
+			if(is_alien_whitelisted(src, "Language_Skrell") || !config.usealienwhitelist)
+				new_character.skrell_talk_understand = 1
+		if(client.prefs.language == "Kidan")
+			if(is_alien_whitelisted(src, "Language_Kidan") || !config.usealienwhitelist)
+				new_character.kidan_talk_understand = 1
+
+
 		if(ticker.random_players)
 			new_character.gender = pick(MALE, FEMALE)
 			client.prefs.real_name = random_name()


### PR DESCRIPTION
Based on what was described as essentially a bug: http://baystation12.net/forums/viewtopic.php?f=48&p=160931#p160931

This block of code more-or-less duplicates the current species selection, but instead allows for and sets a secondary language.  As with species selection, it is based on the key of the player.  Entries in alienwhitelist.txt for languages are of the form "key - Language_Species", with Soghun for Unathi for consistency's sake.  This preference is also saved.

Tested and working on my server at least is the admin all-species thing, selection and setting of languages, and the non-whitelisted error message.

Problems include not checking character name if such a thing is required and the ability to only select one language, but those can be fixed later if they become an issue.
