### PR TITLE
Updated the linkage between the NanoTrasen IRC bot and the server.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -816,6 +816,8 @@
 #include "code\modules\events\viral_infection.dm"
 #include "code\modules\events\viral_outbreak.dm"
 #include "code\modules\events\wallrot.dm"
+#include "code\modules\ext_scripts\irc.dm"
+#include "code\modules\ext_scripts\python.dm"
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\Hallucination.dm"
 #include "code\modules\flufftext\TextFilters.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -76,7 +76,6 @@
 	var/alert_desc_delta = "The station's self-destruct mechanism has been engaged. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
 
 	var/forbid_singulo_possession = 0
-	var/useircbot = 0
 
 	//game_options.txt configs
 
@@ -117,6 +116,11 @@
 	var/assistant_maint = 0 //Do assistants get maint access?
 	var/gateway_delay = 18000 //How long the gateway takes before it activates. Default is half an hour.
 	var/ghost_interaction = 0
+
+	var/use_irc_bot = 0
+	var/main_irc = ""
+	var/admin_irc = ""
+	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 
 
 /datum/configuration/New()
@@ -359,8 +363,8 @@
 				if("allow_holidays")
 					Holiday = 1
 
-				if("useircbot")
-					useircbot = 1
+				if("use_irc_bot")
+					use_irc_bot = 1
 
 				if("ticklag")
 					Ticklag = text2num(value)
@@ -398,6 +402,21 @@
 
 				if("ghost_interaction")
 					config.ghost_interaction = 1
+
+				if("main_irc")
+					config.main_irc = value
+
+				if("admin_irc")
+					config.admin_irc = value
+
+				if("python_path")
+					if(value)
+						config.python_path = value
+					else
+						if(world.system_type == UNIX)
+							config.python_path = "/usr/bin/env python2"
+						else //probably windows, if not this should work anyway
+							config.python_path = "python"
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -281,7 +281,7 @@ datum/shuttle_controller
 
 						start_location.move_contents_to(end_location)
 						settimeleft(SHUTTLELEAVETIME)
-						send2irc("Server", "The Emergency Shuttle has docked with the station.")
+						//send2irc("Server", "The Emergency Shuttle has docked with the station.")
 						captain_announce("The Emergency Shuttle has docked with the station. You have [round(timeleft()/60,1)] minutes to board the Emergency Shuttle.")
 						world << sound('sound/AI/shuttledock.ogg')
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -195,7 +195,7 @@ Implants;
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	send2irc("Server", "Round just ended.")
+	send2mainirc("A round of [src.name] has ended - [surviving_total] survivors, [ghosts] ghosts.")
 
 	return 0
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -142,7 +142,7 @@ var/global/datum/controller/gameticker/ticker
 		if(C.holder)
 			admins_number++
 	if(admins_number == 0)
-		send2irc("Server", "Round just started with no admins online!")
+		send2adminirc("Round has started with no admins online.")
 
 	supply_shuttle.process() 		//Start the supply shuttle regenerating points -- TLE
 	master_controller.process()		//Start master_controller.process()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -106,15 +106,10 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins.")
 	if(admin_number_present <= 0)
 		if(!admin_number_afk)
-			send2irc(ckey, "[original_msg] - No admins online")
+			send2adminirc("ADMINHELP from [key_name(src)]: [original_msg] - !!No admins online!!")
 		else
-			send2irc(ckey, "[original_msg] - All admins AFK ([admin_number_afk])")
+			send2adminirc("ADMINHELP from [key_name(src)]: [original_msg] - !!All admins AFK ([admin_number_afk])!!")
 	else
-		send2irc(ckey, original_msg)
+		send2adminirc("ADMINHELP from [key_name(src)]: [original_msg]")
 	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	return
-
-proc/send2irc(msg,msg2)
-	if(config.useircbot)
-		shell("python [config.nudge_script_path] [msg] [msg2]")
 	return

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -1,0 +1,14 @@
+/proc/send2irc(var/channel, var/msg)
+	if(config.use_irc_bot)
+		ext_python("ircbot_message.py", "[channel] [msg]")
+	return
+
+/proc/send2mainirc(var/msg)
+	if(config.use_irc_bot && config.main_irc)
+		ext_python("ircbot_message.py", "[config.main_irc] [msg]")
+	return
+
+/proc/send2adminirc(var/msg)
+	if(config.use_irc_bot && config.admin_irc)
+		ext_python("ircbot_message.py", "[config.admin_irc] [msg]")
+	return

--- a/code/modules/ext_scripts/python.dm
+++ b/code/modules/ext_scripts/python.dm
@@ -1,0 +1,9 @@
+/proc/ext_python(var/script, var/args, var/scriptsprefix = 1)
+	if(scriptsprefix) script = "scripts/" + script
+
+	if(world.system_type == MS_WINDOWS)
+		script = replacetext(script, "/", "\\")
+
+	var/command = config.python_path + " " + script + " " + args
+
+	return shell(command)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -7,26 +7,7 @@
 
 			message_admins("Admin logout: [key_name(src)]")
 			if(admins_number == 0) //Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
-				var/cheesy_message = pick( list(  \
-					"I have no admins online!",\
-					"I'm all alone :(",\
-					"I'm feeling lonely :(",\
-					"I'm so lonely :(",\
-					"Why does nobody love me? :(",\
-					"I want a man :(",\
-					"Where has everyone gone?",\
-					"I need a hug :(",\
-					"Someone come hold me :(",\
-					"I need someone on me :(",\
-					"What happened? Where has everyone gone?",\
-					"Forever alone :("\
-				) )
-
-				if(cheesy_message)
-					cheesy_message += " (No admins online)"
-
-
-				send2irc("Server", "[cheesy_message]")
+				send2adminirc("[key_name(src)] logged out - no more admins online.")
 	..()
 
 	return 1

--- a/config/config.txt
+++ b/config/config.txt
@@ -213,3 +213,20 @@ ALIEN_PLAYER_RATIO 0.2
 
 ##Remove the # to let ghosts spin chairs
 #GHOST_INTERACTION
+
+## Uncomment this to enable external .rsc downloads. URLs must be separated by no more than one space.
+## The linked .zip file should contain the required .rsc
+#resource_urls http://firstserver.org/myresource.zip http://secondserver.org/myresource.zip  http://10.22.11.1/myresource.zip
+
+## Uncomment to enable sending data to the IRC bot.
+#USE_IRC_BOT
+
+## IRC channel to send information to.  Leave blank to disable.
+#MAIN_IRC #main
+
+## IRC channel to send adminhelps to.  Leave blank to disable adminhelps-to-irc.
+#ADMIN_IRC #admin
+
+## Path to the python executable on the system.  Leave blank for default.
+## Default is "python" on Windows, "/usr/bin/env python2" on UNIX.
+PYTHON_PATH

--- a/scripts/ircbot_message.py
+++ b/scripts/ircbot_message.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python2
+
+# Two arguments, channel and message.
+# EG: "nudge.py #adminchannel ADMINHELP, people are killing me!"
+
+import sys,pickle,socket
+
+def pack():
+    ip = sys.argv[1]
+    try:
+        data = sys.argv[2:] #The rest of the arguments is data
+    except:
+        data = "NO DATA SPECIFIED"
+    dictionary = {"ip":ip,"data":data}
+    pickled = pickle.dumps(dictionary)
+    nudge(pickled)
+def nudge(data):
+       HOST = "5.39.81.199"
+       PORT = 45678
+       size = 1024
+       s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+       s.connect((HOST,PORT))
+       s.send(data)
+       s.close()
+    
+if __name__ == "__main__" and len(sys.argv) > 1: # If not imported and more than one argument
+    pack()
+    


### PR DESCRIPTION
- Server will now send adminhelps to the admin channel, with information if there is no admins online.
- Server will inform the admin channel if the last admin online logs out.
- When a round ends, the server will alert the main channel, supplying some statistics.

Additionally, laid the groundwork for an external scripts system.

This is fully configurable/togglable in the config.txt file.

Cleared by headmins for bypassing BEF - this is essential for admins.
