### PR TITLE
Actually rectifies issue #3182, by making the activity list be based on ...

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -80,17 +80,7 @@
 			var/name = t.fields["name"]
 			var/rank = t.fields["rank"]
 			var/real_rank = t.fields["real_rank"]
-
-			var/active = 0
-			for(var/mob/M in player_list) if(M.name == name)
-				// For dead ones, have a chance to get their status wrong
-				if(M.stat == 2)
-					active = M.x % 2 // Should be good enough, avoids their status flipping constantly
-					break
-				else if(M.client && M.client.inactivity <= 10 * 60 * 10)
-					active = 1
-					break
-			isactive[name] = active ? "Active" : "SSD"
+			isactive[name] = t.fields["p_stat"]
 
 			//world << "[name]: [rank]"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -349,13 +349,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				dat += "<ul>"
 				dat += "<li><a href='byond://?src=\ref[src];choice=1'><img src=pda_notes.png> Notekeeper</a></li>"
 				dat += "<li><a href='byond://?src=\ref[src];choice=2'><img src=pda_mail.png> Messenger</a></li>"
+				dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png> View Crew Manifest</a></li>"
 				//dat += "<li><a href='byond://?src=\red[src];choice=chatroom'><img src=pda_chatroom.png> Nanotrasen Relay Chat</a></li>"
 
 				if (cartridge)
 					if (cartridge.access_clown)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Honk'><img src=pda_honk.png> Honk Synthesizer</a></li>"
-					if (cartridge.access_manifest)
-						dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png> View Crew Manifest</a></li>"
 					if(cartridge.access_status_display)
 						dat += "<li><a href='byond://?src=\ref[src];choice=42'><img src=pda_status.png> Set Status Display</a></li>"
 					dat += "</ul>"
@@ -500,7 +499,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						dat += " <img src=pda_locked.png>"
 					dat += "</li>"
 
-
+			if (41) //crew manifest
+				dat += "<h4><img src=pda_notes.png> Crew Manifest</h4>"
+				dat += "Entries cannot be modified from this terminal.<br><br>"
+				if(data_core)
+					dat += data_core.get_manifest(1) // make it monochrome
+				dat += "<br>"
 
 			else//Else it links to the cart menu proc. Although, it really uses menu hub 4--menu 4 doesn't really exist as it simply redirects to hub.
 				dat += cart
@@ -572,6 +576,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					mode = 0
 				if("chatroom") // chatroom hub
 					mode = 5
+				if("41") //Manifest
+					mode = 41
 
 
 //MAIN FUNCTIONS===================================
@@ -700,7 +706,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 									difficulty += P.cartridge.access_engine
 									difficulty += P.cartridge.access_clown
 									difficulty += P.cartridge.access_janitor
-									difficulty += P.cartridge.access_manifest * 2
 								else
 									difficulty += 2
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -11,7 +11,6 @@
 	var/access_engine = 0
 	var/access_atmos = 0
 	var/access_medical = 0
-	var/access_manifest = 1 // Make all jobs able to access the manifest
 	var/access_clown = 0
 	var/access_mime = 0
 	var/access_janitor = 0
@@ -68,7 +67,6 @@
 		icon_state = "cart-s"
 		access_security = 1
 		access_medical = 1
-		access_manifest = 1
 
 
 	janitor
@@ -132,13 +130,11 @@
 	head
 		name = "Easy-Record DELUXE"
 		icon_state = "cart-h"
-		access_manifest = 1
 		access_status_display = 1
 
 	hop
 		name = "HumanResources9001"
 		icon_state = "cart-h"
-		access_manifest = 1
 		access_status_display = 1
 		access_quartermaster = 1
 		access_janitor = 1
@@ -152,7 +148,6 @@
 	hos
 		name = "R.O.B.U.S.T. DELUXE"
 		icon_state = "cart-hos"
-		access_manifest = 1
 		access_status_display = 1
 		access_security = 1
 
@@ -164,7 +159,6 @@
 	ce
 		name = "Power-On DELUXE"
 		icon_state = "cart-ce"
-		access_manifest = 1
 		access_status_display = 1
 		access_engine = 1
 		access_atmos = 1
@@ -172,7 +166,6 @@
 	cmo
 		name = "Med-U DELUXE"
 		icon_state = "cart-cmo"
-		access_manifest = 1
 		access_status_display = 1
 		access_reagent_scanner = 1
 		access_medical = 1
@@ -180,7 +173,6 @@
 	rd
 		name = "Signal Ace DELUXE"
 		icon_state = "cart-rd"
-		access_manifest = 1
 		access_status_display = 1
 		access_reagent_scanner = 1
 		access_atmos = 1
@@ -194,7 +186,6 @@
 		name = "Value-PAK Cartridge"
 		desc = "Now with 200% more value!"
 		icon_state = "cart-c"
-		access_manifest = 1
 		access_engine = 1
 		access_security = 1
 		access_medical = 1
@@ -276,14 +267,6 @@ Code:
 [radio:code]
 <a href='byond://?src=\ref[src];choice=Signal Code;scode=1'>+</a>
 <a href='byond://?src=\ref[src];choice=Signal Code;scode=5'>+</a><br>"}
-			if (41) //crew manifest
-
-				menu = "<h4><img src=pda_notes.png> Crew Manifest</h4>"
-				menu += "Entries cannot be modified from this terminal.<br><br>"
-				if(data_core)
-					menu += data_core.get_manifest(1) // make it monochrome
-				menu += "<br>"
-
 
 			if (42) //status displays
 				menu = "<h4><img src=pda_status.png> Station Status Display Interlink</h4>"


### PR DESCRIPTION
...the physical status (p_stat) in the records instead of an automated activity checker. Also makes it so that PDA manifest code is default on all PDAs, with or without a cartridge.
