### PR TITLE
Fixes issue #2872, partially. Carp are now smashed by shuttles if they d...

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -279,6 +279,9 @@ datum/shuttle_controller
 						for(var/mob/living/carbon/bug in end_location) // If someone somehow is still in the shuttle's docking area...
 							bug.gib()
 
+						for(var/mob/living/simple_animal/pest in end_location) // And for the other kind of bug...
+							pest.gib()
+
 						start_location.move_contents_to(end_location)
 						settimeleft(SHUTTLELEAVETIME)
 						//send2irc("Server", "The Emergency Shuttle has docked with the station.")

--- a/code/game/machinery/computer/prisonshuttle.dm
+++ b/code/game/machinery/computer/prisonshuttle.dm
@@ -235,5 +235,12 @@ var/prison_shuttle_timeleft = 0
 						AM.Move(D)
 					if(istype(T, /turf/simulated))
 						del(T)
+
+				for(var/mob/living/carbon/bug in end_location) // If someone somehow is still in the shuttle's docking area...
+					bug.gib()
+
+				for(var/mob/living/simple_animal/pest in end_location) // And for the other kind of bug...
+					pest.gib()
+
 				start_location.move_contents_to(end_location)
 		return

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -77,6 +77,12 @@ var/specops_shuttle_timeleft = 0
 		if(istype(T, /turf/simulated))
 			del(T)
 
+	for(var/mob/living/carbon/bug in end_location) // If someone somehow is still in the shuttle's docking area...
+		bug.gib()
+
+	for(var/mob/living/simple_animal/pest in end_location) // And for the other kind of bug...
+		pest.gib()
+
 	start_location.move_contents_to(end_location)
 
 	for(var/turf/T in get_area_turfs(end_location) )

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -162,6 +162,12 @@ var/syndicate_elite_shuttle_timeleft = 0
 		if(istype(T, /turf/simulated))
 			del(T)
 
+	for(var/mob/living/carbon/bug in end_location) // If someone somehow is still in the shuttle's docking area...
+		bug.gib()
+
+	for(var/mob/living/simple_animal/pest in end_location) // And for the other kind of bug...
+		pest.gib()
+
 	start_location.move_contents_to(end_location)
 
 	for(var/turf/T in get_area_turfs(end_location) )

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -86,6 +86,9 @@ proc/move_mining_shuttle()
 		for(var/mob/living/carbon/bug in toArea) // If someone somehow is still in the shuttle's docking area...
 			bug.gib()
 
+		for(var/mob/living/simple_animal/pest in toArea) // And for the other kind of bug...
+			pest.gib()
+
 		fromArea.move_contents_to(toArea)
 		if (mining_shuttle_location)
 			mining_shuttle_location = 0

--- a/code/modules/research/research_shuttle.dm
+++ b/code/modules/research/research_shuttle.dm
@@ -49,6 +49,9 @@ proc/move_research_shuttle()
 		for(var/mob/living/carbon/bug in toArea) // If someone somehow is still in the shuttle's docking area...
 			bug.gib()
 
+		for(var/mob/living/simple_animal/pest in toArea) // And for the other kind of bug...
+			pest.gib()
+
 		fromArea.move_contents_to(toArea)
 		if (research_shuttle_location)
 			research_shuttle_location = 0


### PR DESCRIPTION
...on't get pushed out of the way. However, they can still end up in grille-windows, giving more motivation to replace them in shuttles with actual shuttle windows. Also gibs other simple_animal creatures that are in the way.
