### PR TITLE
Robot fixes, removal of toddler item.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -570,6 +570,7 @@
 	w_class = 3
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 
+/* NYET.
 /obj/item/weapon/toddler
 	icon_state = "toddler"
 	name = "toddler"
@@ -577,3 +578,4 @@
 	force = 5
 	w_class = 4.0
 	slot_flags = SLOT_BACK
+*/

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -63,16 +63,21 @@
 	else
 		powered = 0
 
+/datum/robot_component/armour
+	name = "armour plating"
+	energy_consumption = 0
+	external_type = /obj/item/robot_parts/robot_component/armour
+	max_damage = 60
 
 /datum/robot_component/actuator
 	name = "actuator"
 	energy_consumption = 2
 	external_type = /obj/item/robot_parts/robot_component/actuator
-	max_damage = 60
+	max_damage = 50
 
 /datum/robot_component/cell
 	name = "power cell"
-	max_damage = 60
+	max_damage = 50
 
 /datum/robot_component/cell/destroy()
 	..()
@@ -81,8 +86,8 @@
 /datum/robot_component/radio
 	name = "radio"
 	external_type = /obj/item/robot_parts/robot_component/radio
-	energy_consumption = 3
-	max_damage = 10
+	energy_consumption = 1
+	max_damage = 40
 
 /datum/robot_component/binary_communication
 	name = "binary communication device"
@@ -93,8 +98,8 @@
 /datum/robot_component/camera
 	name = "camera"
 	external_type = /obj/item/robot_parts/robot_component/camera
-	energy_consumption = 2
-	max_damage = 20
+	energy_consumption = 1
+	max_damage = 40
 
 /datum/robot_component/diagnosis_unit
 	name = "self-diagnosis unit"
@@ -111,6 +116,7 @@
 	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
 	components["camera"] = new/datum/robot_component/camera(src)
 	components["comms"] = new/datum/robot_component/binary_communication(src)
+	components["armour"] = new/datum/robot_component/armour(src)
 
 /mob/living/silicon/robot/proc/is_component_functioning(module_name)
 	var/datum/robot_component/C = components[module_name]
@@ -134,6 +140,9 @@
 
 /obj/item/robot_parts/robot_component/actuator
 	name = "actuator"
+
+/obj/item/robot_parts/robot_component/armour
+	name = "armour plating"
 
 /obj/item/robot_parts/robot_component/camera
 	name = "camera"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -3,8 +3,8 @@
 	real_name = "Cyborg"
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "robot"
-	maxHealth = 300
-	health = 300
+	maxHealth = 200
+	health = 200
 	universal_speak = 1
 
 	var/sight_mode = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -107,17 +107,17 @@
 			camera.status = 0
 
 	initialize_components()
-	if(!unfinished)
-		// Create all the robot parts.
-		for(var/V in components) if(V != "power cell")
-			var/datum/robot_component/C = components[V]
-			C.installed = 1
-			C.wrapped = new C.external_type
+	//if(!unfinished)
+	// Create all the robot parts.
+	for(var/V in components) if(V != "power cell")
+		var/datum/robot_component/C = components[V]
+		C.installed = 1
+		C.wrapped = new C.external_type
 
-		if(!cell)
-			cell = new /obj/item/weapon/cell(src)
-			cell.maxcharge = 7500
-			cell.charge = 7500
+	if(!cell)
+		cell = new /obj/item/weapon/cell(src)
+		cell.maxcharge = 7500
+		cell.charge = 7500
 
 	..()
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -1,9 +1,9 @@
 /mob/living/silicon/robot/updatehealth()
 	if(status_flags & GODMODE)
-		health = 100
+		health = 200
 		stat = CONSCIOUS
 		return
-	health = 100 - (getBruteLoss() + getFireLoss())
+	health = 200 - (getBruteLoss() + getFireLoss())
 	return
 
 /mob/living/silicon/robot/getBruteLoss()
@@ -47,6 +47,14 @@
 		if(C.installed == 1) rval += C
 	return rval
 
+/mob/living/silicon/robot/proc/get_armour()
+
+	if(!components.len) return 0
+	var/datum/robot_component/C = components["armour"]
+	if(C && C.installed == 1)
+		return C
+	return 0
+
 /mob/living/silicon/robot/heal_organ_damage(var/brute, var/burn)
 	var/list/datum/robot_component/parts = get_damaged_components(brute,burn)
 	if(!parts.len)	return
@@ -74,6 +82,11 @@
 			brute -= absorb_brute
 			burn -= absorb_burn
 			src << "\red Your shield absorbs some of the impact!"
+
+	var/datum/robot_component/armour/A = get_armour()
+	if(A)
+		A.take_damage(brute,burn,sharp)
+		return
 
 	var/datum/robot_component/C = pick(components)
 	C.take_damage(brute,burn,sharp)
@@ -114,6 +127,11 @@
 			brute -= absorb_brute
 			burn -= absorb_burn
 			src << "\red Your shield absorbs some of the impact!"
+
+	var/datum/robot_component/armour/A = get_armour()
+	if(A)
+		A.take_damage(brute,burn,sharp)
+		return
 
 	while(parts.len && (brute>0 || burn>0) )
 		var/datum/robot_component/picked = pick(parts)


### PR DESCRIPTION
- Reduced power draw of components.
- Doubled total HP of components, overall.
- Add armour plating component that must be destroyed or uninstalled before other components are damaged.
- Removed 'unfinished' check so that robots built in Robotics will spawn fully equipped.
- Commented out toddler toy item.
