### PR TITLE
Small batch fix, voting cleanup, admin-ERT verb uncomment

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -59,8 +59,8 @@ datum/controller/vote
 		if(auto_muted && !ooc_allowed)
 			auto_muted = 0
 			ooc_allowed = !( ooc_allowed )
-			world << "<b>The OOC channel has been automatically enabled due to vote cancellation.</b>"
-			log_admin("OOC was toggled automatically due to vote cancellation.")
+			world << "<b>The OOC channel has been automatically enabled due to vote end.</b>"
+			log_admin("OOC was toggled automatically due to vote end.")
 			message_admins("OOC has been toggled on automatically.")
 
 
@@ -154,12 +154,6 @@ datum/controller/vote
 				if("crew_transfer")
 					if(. == "Initiate Crew Transfer")
 						init_shift_change(null, 1)
-					if(auto_muted && !ooc_allowed)
-						auto_muted = 0
-						ooc_allowed = !( ooc_allowed )
-						world << "<b>The OOC channel has been automatically enabled due to vote end.</b>"
-						log_admin("OOC was toggled automatically due to vote end.")
-						message_admins("OOC has been toggled on automatically.")
 
 
 		if(restart)
@@ -235,7 +229,7 @@ datum/controller/vote
 			if(mode == "crew_transfer" && ooc_allowed)
 				auto_muted = 1
 				ooc_allowed = !( ooc_allowed )
-				world << "<b>The OOC channel has been automatically disabled due to the crew transfer vote.</b>"
+				world << "<b>The OOC channel has been automatically disabled due to a crew transfer vote.</b>"
 				log_admin("OOC was toggled automatically due to crew_transfer vote.")
 				message_admins("OOC has been toggled off automatically.")
 			if(mode == "gamemode" && ooc_allowed)
@@ -247,7 +241,7 @@ datum/controller/vote
 			if(mode == "custom" && ooc_allowed)
 				auto_muted = 1
 				ooc_allowed = !( ooc_allowed )
-				world << "<b>The OOC channel has been automatically disabled due to the custom vote.</b>"
+				world << "<b>The OOC channel has been automatically disabled due to a custom vote.</b>"
 				log_admin("OOC was toggled automatically due to custom vote.")
 				message_admins("OOC has been toggled off automatically.")
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -69,9 +69,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/check_customitem_activity,
 	/client/proc/man_up,
 	/client/proc/global_man_up
-	/* Currently unticked.
-	/client/proc/response_team
-	*/
+	/client/proc/response_team // Response Teams admin verb
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/maptools/new_clean.bat
+++ b/maptools/new_clean.bat
@@ -89,7 +89,7 @@ goto :qm_error
 echo ...
 echo That wasn't a valid response, or you didn't choose anything!
 echo Valid responses: y, n, yes, no
-goto :quitmayber
+goto :quitmaybe
 
 :exit
 pause

--- a/maptools/new_prepare.bat
+++ b/maptools/new_prepare.bat
@@ -65,7 +65,7 @@ goto :qm_error
 echo ...
 echo That wasn't a valid response, or you didn't choose anything!
 echo Valid responses: y, n, yes, no
-goto :quitmayber
+goto :quitmaybe
 
 :exit
 pause


### PR DESCRIPTION
- auto_mute was trying to unmute itself in some awkward places, removed that and added one overall check in reset()
- fixed a simple mistake that causes the entire program to crash if it gets called (because batch)
