### PR TITLE
Gave ghosts their own emote proc, added colorful text to distinguish emotes made by ghosts.

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -18,6 +18,29 @@
 			return
 
 	. = src.say_dead(message)
+
+
+/mob/dead/observer/emote(var/act, var/type, var/message)
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+	if(!message)
+		return
+
+	if(act != "me")
+		return
+
+	log_emote("Ghost/[src.key] : [message]")
+
+	if(src.client)
+		if(src.client.prefs.muted & MUTE_DEADCHAT)
+			src << "\red You cannot emote in deadchat (muted)."
+			return
+
+		if(src.client.handle_spam_prevention(message, MUTE_DEADCHAT))
+			return
+
+	. = src.emote_dead(message)
+
 /*
 	for (var/mob/M in hearers(null, null))
 		if (!M.stat)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,5 +1,5 @@
 // All mobs should have custom emote, really..
-mob/proc/custom_emote(var/m_type=1,var/message = null)
+/mob/proc/custom_emote(var/m_type=1,var/message = null)
 
 	if(!use_me && usr == src)
 		usr << "You are unable to emote."
@@ -25,7 +25,7 @@ mob/proc/custom_emote(var/m_type=1,var/message = null)
  //Hearing gasp and such every five seconds is not good emotes were not global for a reason.
  // Maybe some people are okay with that.
 
-		for(var/mob/M in world)
+		for(var/mob/M in player_list)
 			if (!M.client)
 				continue //skip monkeys and leavers
 			if (istype(M, /mob/new_player))
@@ -42,3 +42,30 @@ mob/proc/custom_emote(var/m_type=1,var/message = null)
 		else if (m_type & 2)
 			for (var/mob/O in hearers(src.loc, null))
 				O.show_message(message, m_type)
+
+/mob/proc/emote_dead(var/message)
+
+	var/input
+	if(!message)
+		input = copytext(sanitize(input(src, "Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+	else
+		input = message
+
+	if(input)
+		message = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <b>[src]</b> [message]</span>"
+	else
+		return
+
+
+	if(message)
+		log_emote("Ghost/[src.key] : [message]")
+
+		for(var/mob/M in player_list)
+			if(istype(M, /mob/new_player))
+				continue
+
+			if(M.client && M.client.holder && (M.client.holder.rights & R_ADMIN|R_MOD) && (M.client.prefs.toggles & CHAT_DEAD))
+				M << message
+
+			else if(M.stat == DEAD)
+				M.show_message(message, 2)


### PR DESCRIPTION
- Added /mob/dead/observer/emote()
- Added a proc to be called whenever a ghost emotes something
- Added emote_dead, which displays the _fancy_ emote text to admins, mods, and those with M.stat DEAD

![emote_dead](https://f.cloud.github.com/assets/1355638/866339/eea1e950-f669-11e2-9beb-b040855246b1.png)
