### PR TITLE
Changed ERT headsets to show the Supply channel

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -121,7 +121,8 @@
 	desc = "An encyption key for a radio headset.  Contains cypherkeys."
 	icon_state = "cargo_cypherkey"
 	channels = list("Supply" = 1)
+
 /obj/item/device/encryptionkey/ert
 	name = "NanoTrasen ERT Radio Encryption Key"
 	desc = "An encyption key for a radio headset.  Contains cypherkeys."
-	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Mining" = 1, "Cargo" = 1,)
+	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1)


### PR DESCRIPTION
- ERT headsets now (correctly) show the Supply channel rather than the two non-existant Cargo/Mining channels.
