### PR TITLE
Adds colored department radio channels

### DIFF
--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -74,7 +74,6 @@ Radio:
 1359 - Security
 1441 - death squad
 1443 - Confession Intercom
-1349 - Miners
 1347 - Cargo techs
 
 Devices:
@@ -110,9 +109,20 @@ var/list/radiochannels = list(
 	"Supply" = 1347,
 )
 //depenging helpers
-var/list/DEPT_FREQS = list(1351,1355,1357,1359,1213, 1443, 1441,1347)
+var/list/DEPT_FREQS = list(1351, 1355, 1357, 1359, 1213, 1443, 1441, 1347)
+
+// central command channels, i.e deathsquid & response teams
+var/list/CENT_FREQS = list(1441, 1443)
+
 var/const/COMM_FREQ = 1353 //command, colored gold in chat window
 var/const/SYND_FREQ = 1213
+
+// department channels
+var/const/SEC_FREQ = 1359
+var/const/ENG_FREQ = 1357
+var/const/SCI_FREQ = 1351
+var/const/MED_FREQ = 1355
+var/const/SUP_FREQ = 1347
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -341,12 +341,10 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 				freq_text = "Engineering"
 			if(1359)
 				freq_text = "Security"
-//			if(1349)
-//				freq_text = "Mining"
 			if(1347)
 				freq_text = "Supply"
 			if(1441)
-				freq_text = "Death Squad"
+				freq_text = "Special Ops"
 			if(1443)
 				freq_text = "Response Team"
 		//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO
@@ -365,10 +363,35 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		var/part_b = "</span><b> \icon[radio]\[[freq_text]\][part_b_extra]</b> <span class='message'>" // Tweaked for security headsets -- TLE
 		var/part_c = "</span></span>"
 
-		if (display_freq==SYND_FREQ)
+		// syndies!
+		if (display_freq == SYND_FREQ)
 			part_a = "<span class='syndradio'><span class='name'>"
-		else if (display_freq==COMM_FREQ)
+
+		// centcomm channels (deathsquid and ert)
+		else if (display_freq in CENT_FREQS)
+			part_a = "<span class='centradio'><span class='name'>"
+
+		// command channel
+		else if (display_freq == COMM_FREQ)
 			part_a = "<span class='comradio'><span class='name'>"
+
+		// department radio formatting (poorly optimized, ugh)
+		else if (display_freq == SEC_FREQ)
+			part_a = "<span class='secradio'><span class='name'>"
+
+		else if (display_freq == ENG_FREQ)
+			part_a = "<span class='engradio'><span class='name'>"
+
+		else if (display_freq == SCI_FREQ)
+			part_a = "<span class='sciradio'><span class='name'>"
+
+		else if (display_freq == MED_FREQ)
+			part_a = "<span class='medradio'><span class='name'>"
+
+		else if (display_freq == SUP_FREQ) // cargo
+			part_a = "<span class='supradio'><span class='name'>"
+
+		// If all else fails and it's a dept_freq, color me purple!
 		else if (display_freq in DEPT_FREQS)
 			part_a = "<span class='deptradio'><span class='name'>"
 
@@ -406,8 +429,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.msg_deathsquad += blackbox_msg
 				if(1213)
 					blackbox.msg_syndicate += blackbox_msg
-//				if(1349)
-//					blackbox.msg_mining += blackbox_msg
 				if(1347)
 					blackbox.msg_cargo += blackbox_msg
 				else
@@ -629,8 +650,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 				freq_text = "Engineering"
 			if(1359)
 				freq_text = "Security"
-//			if(1349)
-//				freq_text = "Mining"
 			if(1347)
 				freq_text = "Supply"
 		//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO
@@ -685,8 +704,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.msg_deathsquad += blackbox_msg
 				if(1213)
 					blackbox.msg_syndicate += blackbox_msg
-//				if(1349)
-//					blackbox.msg_mining += blackbox_msg
 				if(1347)
 					blackbox.msg_cargo += blackbox_msg
 				else

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -142,12 +142,7 @@
 	id = "Supply Server"
 	freq_listening = list(1347)
 	autolinkers = list("supply")
-/*
-/obj/machinery/telecomms/server/presets/mining
-	id = "Mining Server"
-	freq_listening = list(1349)
-	autolinkers = list("mining")
-*/
+
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
 	freq_listening = list()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -499,8 +499,6 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 					freq_text = "Engineering"
 				if(1359)
 					freq_text = "Security"
-//				if(1349)
-//					freq_text = "Mining"
 				if(1347)
 					freq_text = "Supply"
 			//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -26,8 +26,15 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .deptradio				{color: #993399;}
-.comradio				{color: #885500;}
+.comradio				{color: #193A7A;}
 .syndradio				{color: #6D3F40;}
+.centradio				{color: #5C5C8A;}
+
+.secradio				{color: #A30000;}
+.engradio				{color: #A66300;}
+.medradio				{color: #008160;}
+.sciradio				{color: #993399;}
+.supradio				{color: #5F4519;}
 
 .alert					{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,17 @@ Stuff which is in development and not yet visible to players or just code relate
 (ie. code improvements for expandability, etc.) should not be listed here. They 
 should be listed in the changelog upon commit though. Thanks. -->
 <div class="commit sansserif">
+	<h2 class="date">July 30th, 2013</h2>
+	<h3 class="author">Erthilo updated:</h3>
+	<ul class="changes bgimages16">
+		<li class="bugfix">EFTPOS and ATM machines should now connect to databases.</li>
+		<li class="bugfix">Gravitational Catapults can now be removed from mechs.</li>
+		<li class="bugfix">Ghost manifest rune paper naming now works correctly.</li>
+		<li class="bugfix">Fix for newscaster special characters. Still not recommended.</li>
+	</ul>
+</div>
+
+<div class="commit sansserif">
 	<h2 class="date">30.07.2013</h2>
 	<h3 class="author">Kilakk updated:</h3>
 	<ul class="changes bgimages16">

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,14 @@ Stuff which is in development and not yet visible to players or just code relate
 (ie. code improvements for expandability, etc.) should not be listed here. They 
 should be listed in the changelog upon commit though. Thanks. -->
 <div class="commit sansserif">
+	<h2 class="date">30.07.2013</h2>
+	<h3 class="author">Kilakk updated:</h3>
+	<ul class="changes bgimages16">
+		<li class="rscadd">Added colored department radio channels.</li>
+	</ul>
+</div>
+
+<div class="commit sansserif">
 	<h2 class="date">28.07.2013</h2>
 	<h3 class="author">Segrain updated:</h3>
 	<ul class="changes bgimages16">


### PR DESCRIPTION
- Added colored department radio channels, see below for colors.
- Removed the tcomms server for the non-existant mining channel.

![radiocolors](https://f.cloud.github.com/assets/1355638/882342/feb82134-f960-11e2-99f6-bcdfff487573.png)
![ertradio](https://f.cloud.github.com/assets/1355638/882343/0394f39e-f961-11e2-832d-e6f888fddde6.png)
