### PR TITLE
Key card and rad storm additions

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -93,6 +93,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	normalspeed = 1
 	var/obj/item/weapon/airlock_electronics/electronics = null
 	var/hasShocked = 0 //Prevents multiple shocks from happening
+	var/maintAccessReqRevoked = 0 // Used in the procs to revoke maint access/give maint access to all maint doors. Boolean.
 
 /obj/machinery/door/airlock/command
 	name = "Airlock"

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -10,10 +10,14 @@
 	spawn()
 		world << sound('sound/AI/radiation.ogg')
 		command_alert("High levels of radiation detected near the station. Please evacuate into one of the shielded maintenance tunnels.", "Anomaly Alert")
+		make_maint_all_access()
+
 
 		sleep(600)
 
+
 		command_alert("The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt.", "Anomaly Alert")
+
 		for(var/i = 0, i < 10, i++)
 			for(var/mob/living/carbon/human/H in living_mob_list)
 				var/turf/T = get_turf(H)
@@ -23,16 +27,19 @@
 					continue
 				if(istype(T.loc, /area/maintenance) || istype(T.loc, /area/crew_quarters))
 					continue
+
 				if(istype(H,/mob/living/carbon/human))
-					H.apply_effect((rand(2,15)),IRRADIATE,0)
+					H.apply_effect((rand(15,35)),IRRADIATE,0)
 					if(prob(5))
-						H.apply_effect((rand(10,30)),IRRADIATE,0)
+						H.apply_effect((rand(40,70)),IRRADIATE,0)
 						if (prob(75))
-							randmutb(H)
+							randmutb(H) // Applies bad mutation
 							domutcheck(H,null,1)
 						else
-							randmutg(H)
+							randmutg(H) // Applies good mutation
 							domutcheck(H,null,1)
+
+
 			for(var/mob/living/carbon/monkey/M in living_mob_list)
 				var/turf/T = get_turf(M)
 				if(!T)
@@ -43,4 +50,10 @@
 			sleep(100)
 
 
-		command_alert("The station has passed the radiation belt. Please report to medbay if you experience any unusual symptoms.", "Anomaly Alert")
+		command_alert("The station has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all access again shortly.", "Anomaly Alert")
+
+
+		sleep(600) // Want to give them time to get out of maintenance.
+
+
+		revoke_maint_all_access()

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -144,17 +144,32 @@
 		if("Red alert")
 			set_security_level(SEC_LEVEL_RED)
 			feedback_inc("alert_keycard_auth_red",1)
-		if("Emergency Maintenance Access")
+		if("Grant Emergency Maintenance Access")
 			make_maint_all_access()
-			feedback_inc("alert_keycard_auth_maint",1)
+			feedback_inc("alert_keycard_auth_maintGrant",1)
+		if("Revoke Emergency Maintenance Access")
+			revoke_maint_all_access()
+			feedback_inc("alert_keycard_auth_maintRevoke",1)
 		if("Emergency Rescue Team")
 			trigger_armed_response_team(1)
 			feedback_inc("alert_keycard_auth_ert",1)
 
 /proc/make_maint_all_access()
 	for(var/obj/machinery/door/airlock/A in machines)
-		if(A.z == 1)
+		if(A.z == 1 && access_maint_tunnels in A.req_access)
+			A.maintAccessReqRevoked = 1
 			A.req_access.Remove(access_maint_tunnels)
 
 	world << "<font size=4 color='red'>Attention!</font>"
-	world << "<font color='red'>The maintenance access requirement has been revoked on all airlocks. All crew members are now permitted access to emergency maintenance areas.</font>"
+	world << "<font color='red'>The maintenance access requirement has been revoked on all airlocks.</font>"
+
+/proc/revoke_maint_all_access()
+	for(var/obj/machinery/door/airlock/A in machines)
+		if(A.z == 1 && A.maintAccessReqRevoked == 1)
+			A.maintAccessReqRevoked = 0
+			A.req_access.Add(access_maint_tunnels)
+
+	world << "<font size=4 color='red'>Attention!</font>"
+	world << "<font color='red'>The maintenance access requirement has been readded on all maintenance airlocks.</font>"
+
+

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -70,7 +70,8 @@
 		dat += "Select an event to trigger:<ul>"
 		dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"
 		dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Rescue Team'>Emergency Rescue Team</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
+		dat += "<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
+		dat += "<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>"
 		dat += "</ul>"
 		user << browse(dat, "window=keycard_auth;size=500x250")
 	if(screen == 2)


### PR DESCRIPTION
Added revoke maintenance all access ability via keycard console

Radiation Storms now will unlock maintenance until they are over. When they are over, a message in the regular ending message announces that maintenance will be locked to regular status again soon, and then after a minute it locks alongside a message that it is now locked. The rad-storm is also put closer to its original strength, due to the fact that maintenance will actually be capable of being easily accessed during it, now.
