### PR TITLE
Removed Z-up function from Client/Center()

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -166,10 +166,12 @@
 
 
 /client/Center()
+	/* No 3D movement in 2D spessman game. dir 16 is Z Up
 	if (isobj(mob.loc))
 		var/obj/O = mob.loc
 		if (mob.canmove)
 			return O.relaymove(mob, 16)
+	*/
 	return
 
 


### PR DESCRIPTION
Turns out this was allowing mecha to travel semi-unrestricted upwards
through z-levels, including to Central Command and the Away Mission.
