### PR TITLE
More great strides in species/language datum implementation.

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -17,9 +17,10 @@ var/global/list/landmarks_list = list()				//list of all landmarks created
 var/global/list/surgery_steps = list()				//list of all surgery steps  |BS12
 var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mobs target tracking.
 
-//Languages/species
+//Languages/species/whitelist.
 var/global/list/all_species[0]
 var/global/list/all_languages[0]
+var/global/list/whitelisted_species = list("Human")
 
 //Preferences stuff
 	//Hairstyles
@@ -84,6 +85,9 @@ var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Satchel Al
 	for(var/T in paths)
 		var/datum/species/S = new T
 		all_species[S.name] = S
+
+		if(S.flags & WHITELISTED)
+			whitelisted_species += S.name
 
 /* // Uncomment to debug chemical reaction list.
 /client/verb/debug_chemical_list()

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -123,20 +123,7 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 	if (H.gender == FEMALE)
 		g = "f"
 
-	var/icon/icobase
-	switch(H.get_species())
-		if("Tajaran")
-			icobase = 'icons/mob/human_races/r_tajaran.dmi'
-		if("Unathi")
-			icobase = 'icons/mob/human_races/r_lizard.dmi'
-		if("Skrell")
-			icobase = 'icons/mob/human_races/r_skrell.dmi'
-
-		if("Vox")
-			icobase = 'icons/mob/human_races/r_vox.dmi'
-
-		else
-			icobase = 'icons/mob/human_races/r_human.dmi'
+	var/icon/icobase = H.species.icobase
 
 	preview_icon = new /icon(icobase, "torso_[g]")
 	var/icon/temp
@@ -153,15 +140,13 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 		preview_icon.Blend(temp, ICON_OVERLAY)
 
 	// Skin tone
-	if(H.get_species() == "Human")
+	if(H.species.flags & HAS_SKIN_TONE)
 		if (H.s_tone >= 0)
 			preview_icon.Blend(rgb(H.s_tone, H.s_tone, H.s_tone), ICON_ADD)
 		else
 			preview_icon.Blend(rgb(-H.s_tone,  -H.s_tone,  -H.s_tone), ICON_SUBTRACT)
 
-	var/icon/eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = "eyes_s")
-	if(H.get_species()=="Vox")
-		eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = "vox_eyes_s")
+	var/icon/eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = H.species ? H.species.eyes : "eyes_s")
 
 	eyes_s.Blend(rgb(H.r_eyes, H.g_eyes, H.b_eyes), ICON_ADD)
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -444,16 +444,15 @@ client/proc/one_click_antag()
 	//Generates a list of candidates from active ghosts.
 	for(var/mob/dead/observer/G in player_list)
 		spawn(0)
-			if(is_alien_whitelisted(G, "Vox") || !config.usealienwhitelist)
-				switch(alert(G,"Do you wish to be considered for a vox raiding party arriving on the station?","Please answer in 30 seconds!","Yes","No"))
-					if("Yes")
-						if((world.time-time_passed)>300)//If more than 30 game seconds passed.
-							return
-						candidates += G
-					if("No")
+			switch(alert(G,"Do you wish to be considered for a vox raiding party arriving on the station?","Please answer in 30 seconds!","Yes","No"))
+				if("Yes")
+					if((world.time-time_passed)>300)//If more than 30 game seconds passed.
 						return
-					else
-						return
+					candidates += G
+				if("No")
+					return
+				else
+					return
 
 	sleep(300) //Debug.
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -799,31 +799,21 @@ datum/preferences
 						if(new_age)
 							age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 					if("species")
+
 						var/list/new_species = list("Human")
 						var/prev_species = species
 						var/whitelisted = 0
+
 						if(config.usealienwhitelist) //If we're using the whitelist, make sure to check it!
-							if(is_alien_whitelisted(user, "Soghun")) //Check for Unathi and admins
-								new_species += "Unathi"
-								whitelisted = 1
-							if(is_alien_whitelisted(user, "Tajaran")) //Check for Tajaran and admins
-								new_species += "Tajaran"
-								whitelisted = 1
-							if(is_alien_whitelisted(user, "Skrell")) //Check for Skrell and admins
-								new_species += "Skrell"
-								whitelisted = 1
-							if(is_alien_whitelisted(user, "Vox")) //Check for Skrell and admins
-								new_species += "Vox"
-								whitelisted = 1
-
-
+							for(var/S in whitelisted_species)
+								if(is_alien_whitelisted(user,S))
+									new_species += S
+									whitelisted = 1
 							if(!whitelisted)
 								alert(user, "You cannot change your species as you need to be whitelisted. If you wish to be whitelisted contact an admin in-game, on the forums, or on IRC.")
 						else //Not using the whitelist? Aliens for everyone!
-							new_species += "Tajaran"
-							new_species += "Unathi"
-							new_species += "Skrell"
-							new_species += "Vox"
+							new_species = whitelisted_species
+
 						species = input("Please select a species", "Character Generation", null) in new_species
 
 						if(prev_species != species)
@@ -872,31 +862,21 @@ datum/preferences
 							s_tone = 0
 
 					if("language")
-						var/list/new_language = list("None")
+						var/list/new_languages = list("None")
 						var/language_whitelisted = 0
 						if(config.usealienwhitelist)
-							if(is_alien_whitelisted(user, "Language_Soghun"))
-								new_language += "Unathi"
-								language_whitelisted = 1
-							if(is_alien_whitelisted(user, "Language_Tajaran"))
-								new_language += "Tajaran"
-								language_whitelisted = 1
-							if(is_alien_whitelisted(user, "Language_Skrell"))
-								new_language += "Skrell"
-								language_whitelisted = 1
-							if(is_alien_whitelisted(user, "Language_Kidan"))
-								new_language += "Kidan"
-								language_whitelisted = 1
-
-							if(!language_whitelisted)
-								alert(user, "You cannot select a secondary language as you need to be whitelisted.  If you wish to enable a language, post in the Alien Whitelist forums.")
-
+							for(var/L in all_languages)
+								if(is_alien_whitelisted(user, L))
+									new_languages += L
+									language_whitelisted = 1
 						else
-							new_language += "Unathi"
-							new_language += "Tajaran"
-							new_language += "Skrell"
-							new_language += "Kidan"
-						language = input("Please select a secondary language", "Character Generation", null) in new_language
+							for(var/L in all_languages)
+								new_languages += L
+
+						if(!language_whitelisted)
+							alert(user, "You cannot select a secondary language as you need to be whitelisted.  If you wish to enable a language, post in the Alien Whitelist forums.")
+
+						language = input("Please select a secondary language", "Character Generation", null) in new_languages
 
 					if("metadata")
 						var/new_metadata = input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , metadata)  as message|null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -18,7 +18,7 @@
 
 /mob/living/carbon/human/tajaran/New()
 	h_style = "Tajaran Ears"
-	set_species("Tajara")
+	set_species("Tajaran")
 	..()
 
 /mob/living/carbon/human/unathi/New()

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1,17 +1,3 @@
-#define NO_EAT 1
-#define NO_BREATHE 2
-#define NO_SLEEP 4
-#define NO_SHOCK 8
-#define NO_SCAN 16
-#define NON_GENDERED 32
-#define REQUIRE_LIGHT 64
-#define WHITELISTED 128
-#define HAS_SKIN_TONE 256
-#define HAS_LIPS 512
-#define HAS_UNDERWEAR 1024
-#define HAS_TAIL 2048
-#define IS_PLANT 4096
-
 /*
 	Datum-based species. Should make for much cleaner and easier to maintain mutantrace code.
 */
@@ -63,7 +49,7 @@
 	flags = WHITELISTED | HAS_LIPS | HAS_UNDERWEAR | HAS_TAIL
 
 /datum/species/tajaran
-	name = "Tajara"
+	name = "Tajaran"
 	icobase = 'icons/mob/human_races/r_tajaran.dmi'
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
 	language = "Siik'mas"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -347,28 +347,21 @@
 		var/mob/living/carbon/human/new_character = new(loc)
 		new_character.lastarea = get_area(loc)
 
-		if(client.prefs.species == "Tajaran") //This is like the worst, but it works, so meh. - Erthilo
-			if(is_alien_whitelisted(src, "Tajaran") || !config.usealienwhitelist)
-				new_character.set_species("Tajara")
-				new_character.add_language("Siik'mas")
-		if(client.prefs.species == "Unathi")
-			if(is_alien_whitelisted(src, "Soghun") || !config.usealienwhitelist)
-				new_character.set_species("Unathi")
-				new_character.add_language("Sinta'unathi")
-		if(client.prefs.species == "Skrell")
-			if(is_alien_whitelisted(src, "Skrell") || !config.usealienwhitelist)
-				new_character.set_species("Skrell")
-				new_character.add_language("Skrellian")
+		var/datum/species/chosen_species
+		if(client.prefs.species)
+			chosen_species = all_species[client.prefs.species]
+		if(chosen_species)
+			if(is_alien_whitelisted(src, client.prefs.species) || !config.usealienwhitelist || !(chosen_species.flags & WHITELISTED))
+				new_character.set_species(client.prefs.species)
+				if(chosen_species.language)
+					new_character.add_language(chosen_species.language)
 
-		if(client.prefs.language == "Tajaran")
-			if(is_alien_whitelisted(src, "Language_Tajaran") || !config.usealienwhitelist)
-				new_character.add_language("Siik'mas")
-		if(client.prefs.language == "Unathi")
-			if(is_alien_whitelisted(src, "Language_Soghun") || !config.usealienwhitelist)
-				new_character.add_language("Sinta'unathi")
-		if(client.prefs.language == "Skrell")
-			if(is_alien_whitelisted(src, "Language_Skrell") || !config.usealienwhitelist)
-				new_character.add_language("Skrellian")
+		var/datum/language/chosen_language
+		if(client.prefs.language)
+			chosen_language = all_languages[client.prefs.language]
+		if(chosen_language)
+			if(is_alien_whitelisted(src, client.prefs.language) || !config.usealienwhitelist)
+				new_character.add_language(client.prefs.language)
 
 		if(ticker.random_players)
 			new_character.gender = pick(MALE, FEMALE)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -137,19 +137,13 @@ datum/preferences
 		if(gender == FEMALE)	g = "f"
 
 		var/icon/icobase
-		switch(species)
-			if("Tajaran")
-				icobase = 'icons/mob/human_races/r_tajaran.dmi'
-			if("Unathi")
-				icobase = 'icons/mob/human_races/r_lizard.dmi'
-			if("Skrell")
-				icobase = 'icons/mob/human_races/r_skrell.dmi'
+		var/datum/species/current_species = all_species[species]
 
-			if("Vox")
-				icobase = 'icons/mob/human_races/r_vox.dmi'
+		if(current_species)
+			icobase = current_species.icobase
+		else
+			icobase = 'icons/mob/human_races/r_human.dmi'
 
-			else
-				icobase = 'icons/mob/human_races/r_human.dmi'
 		preview_icon = new /icon(icobase, "torso_[g]")
 		preview_icon.Blend(new /icon(icobase, "groin_[g]"), ICON_OVERLAY)
 		preview_icon.Blend(new /icon(icobase, "head_[g]"), ICON_OVERLAY)
@@ -169,16 +163,13 @@ datum/preferences
 			preview_icon.Blend(temp, ICON_OVERLAY)
 
 		// Skin tone
-		if(species == "Human")
+		if(current_species && (current_species.flags & HAS_SKIN_TONE))
 			if (s_tone >= 0)
 				preview_icon.Blend(rgb(s_tone, s_tone, s_tone), ICON_ADD)
 			else
 				preview_icon.Blend(rgb(-s_tone,  -s_tone,  -s_tone), ICON_SUBTRACT)
 
-		var/icon/eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = "eyes_s")
-		if(species=="Vox")
-			eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = "vox_eyes_s")
-
+		var/icon/eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = current_species ? current_species.eyes : "eyes_s")
 		eyes_s.Blend(rgb(r_eyes, g_eyes, b_eyes), ICON_ADD)
 
 		var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -31,7 +31,7 @@
 /obj/machinery/computer/centrifuge/attack_hand(var/mob/user as mob)
 	if(..())
 		return
-	user.machine = src
+	user.set_machine(src)
 	var/dat= ""
 	if(curing)
 		dat = "Antibody isolation in progress"
@@ -86,12 +86,15 @@
 			if(sample)
 				isolate()
 			update_icon()
+
+	src.updateUsrDialog()
 	return
 
 /obj/machinery/computer/centrifuge/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+
+	if(usr) usr.set_machine(src)
 
 	switch(href_list["action"])
 		if("antibody")
@@ -99,33 +102,27 @@
 			var/datum/reagent/blood/B = locate(/datum/reagent/blood) in sample.reagents.reagent_list
 			if (!B)
 				state("\The [src.name] buzzes, \"No antibody carrier detected.\"", "blue")
-				return
 
-			if(sample.reagents.has_reagent("toxins"))
+			else if(sample.reagents.has_reagent("toxins"))
 				state("\The [src.name] beeps, \"Pathogen purging speed above nominal.\"", "blue")
 				delay = delay/2
-				return
 
-			curing = delay
-			playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
-			update_icon()
+			else
+				curing = delay
+				playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
+				update_icon()
 
 		if("isolate")
 			var/datum/reagent/blood/B = locate(/datum/reagent/blood) in sample.reagents.reagent_list
-			if (!B)
-				return
-
-			var/list/virus = virus_copylist(B.data["virus2"])
-			var/choice = href_list["isolate"];
-			if (choice in virus)
-				virus2 = virus[choice]
-			else
-				state("\The [src.name] buzzes, \"No such pathogen detected.\"", "blue")
-				return
-			isolating = 40
-			update_icon()
-			src.updateUsrDialog()
-			return
+			if (B)
+				var/list/virus = virus_copylist(B.data["virus2"])
+				var/choice = href_list["isolate"]
+				if (choice in virus)
+					virus2 = virus[choice]
+					isolating = 40
+					update_icon()
+				else
+					state("\The [src.name] buzzes, \"No such pathogen detected.\"", "blue")
 
 		if("sample")
 			if(sample)

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -39,7 +39,7 @@
 /obj/machinery/computer/diseasesplicer/attack_hand(var/mob/user as mob)
 	if(..())
 		return
-	user.machine = src
+	user.set_machine(src)
 	var/dat
 	if(splicing)
 		dat = "Splicing in progress."
@@ -111,11 +111,14 @@
 			d.effect = memorybank
 			state("The [src.name] zings", "blue")
 
+	src.updateUsrDialog()
 	return
 
 /obj/machinery/computer/diseasesplicer/Topic(href, href_list)
 	if(..())
 		return
+
+	if(usr) usr.set_machine(src)
 
 	if (href_list["grab"])
 		memorybank = locate(href_list["grab"])

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -51,13 +51,14 @@
 /obj/machinery/disease2/incubator/Topic(href, href_list)
 	if(..()) return
 
+	if(usr) usr.set_machine(src)
+
 	if (href_list["ejectchem"])
 		if(beaker)
 			beaker.loc = src.loc
 			beaker = null
 	if(!dish)
 		return
-	usr.machine = src
 	if (href_list["power"])
 		on = !on
 		if(on)
@@ -78,19 +79,17 @@
 	if(href_list["virus"])
 		if (!dish)
 			state("\The [src.name] buzzes, \"No viral culture sample detected.\"", "blue")
-			return
+		else
+			var/datum/reagent/blood/B = locate(/datum/reagent/blood) in beaker.reagents.reagent_list
+			if (!B)
+				state("\The [src.name] buzzes, \"No suitable breeding enviroment detected.\"", "blue")
+			else
+				if (!B.data["virus2"])
+					B.data["virus2"] = list()
+				var/list/virus = list("[dish.virus2.uniqueID]" = dish.virus2.getcopy())
+				B.data["virus2"] = virus
 
-		var/datum/reagent/blood/B = locate(/datum/reagent/blood) in beaker.reagents.reagent_list
-		if (!B)
-			state("\The [src.name] buzzes, \"No suitable breeding enviroment detected.\"", "blue")
-			return
-
-		if (!B.data["virus2"])
-			B.data["virus2"] = list()
-		var/list/virus = list("[dish.virus2.uniqueID]" = dish.virus2.getcopy())
-		B.data["virus2"] = virus
-
-		state("\The [src.name] pings, \"Injection complete.\"", "blue")
+				state("\The [src.name] pings, \"Injection complete.\"", "blue")
 
 
 	src.add_fingerprint(usr)
@@ -99,7 +98,7 @@
 /obj/machinery/disease2/incubator/attack_hand(mob/user as mob)
 	if(stat & BROKEN)
 		return
-	user.machine = src
+	user.set_machine(src)
 	var/dat = ""
 	if(!dish)
 		dat = "Please insert dish into the incubator.<BR>"
@@ -151,7 +150,7 @@
 
 			else if(prob(5))
 				dish.virus2.minormutate()
-			 radiation -= 1
+			radiation -= 1
 		if(toxins && prob(5))
 			dish.virus2.infectionchance -= 1
 		if(toxins > 50)
@@ -165,3 +164,5 @@
 			foodsupply += 10
 		if(!beaker.reagents.remove_reagent("toxin",1))
 			toxins += 1
+
+	src.updateUsrDialog()

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -144,7 +144,7 @@
 		if(istype(mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = mob
 			for (var/datum/organ/external/E in H.organs)
-				E.status ^= ORGAN_DEAD
+				E.status &= ~ORGAN_DEAD
 
 /datum/disease2/effect/immortal
 	name = "Longevity Syndrome"

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -702,3 +702,18 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 	"ERT",
 	"NUKE"
 	)
+
+//Species flags.
+#define NO_EAT 1
+#define NO_BREATHE 2
+#define NO_SLEEP 4
+#define NO_SHOCK 8
+#define NO_SCAN 16
+#define NON_GENDERED 32
+#define REQUIRE_LIGHT 64
+#define WHITELISTED 128
+#define HAS_SKIN_TONE 256
+#define HAS_LIPS 512
+#define HAS_UNDERWEAR 1024
+#define HAS_TAIL 2048
+#define IS_PLANT 4096


### PR DESCRIPTION
Generalizes the preference, new_player and spawn checks for available/whitelisted species. Removes vox whitelist from raid spawn. Totally breaks the already broken language whitelisting and breaks the unathi/soghun replacement since the whitelist is still outdated. Do not merge dev to master while the master whitelist has Soghun instead of Unathi.

Also contains fixes from master.

To be done: 
- set primitive forms on species datums, add primitive form check to monkeyize() proc.
- generalize breathing code in case of abnormal gasses.
