### PR TITLE
Missing nanomanager.update_uis() call in cryo.dm

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -131,9 +131,9 @@
 			if (beaker)
 				var/obj/item/weapon/reagent_containers/glass/B = beaker
 				B.loc = get_step(loc, SOUTH)
-				beaker = null
+				beaker = null		
 
-		updateUsrDialog()
+		nanomanager.update_uis(src) // update all UIs attached to this object
 		add_fingerprint(usr)
 		return
 


### PR DESCRIPTION
I added nanomanager.update_uis(src) to the cryo.dm Topic(). This method updates all UIs attached to the (src) object.
