### PR TITLE
Update door_control.dm

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -80,12 +80,16 @@
 	if(normaldoorcontrol)
 		for(var/obj/machinery/door/airlock/D in range(range))
 			if(D.id_tag == src.id)
+				if(specialfunctions & OPEN)
+					if (D.density)
+						spawn(0)
+							D.open()
+							return
+					else
+						spawn(0)
+							D.close()
+							return
 				if(desiredstate == 1)
-					if(specialfunctions & OPEN)
-						if (D.density)
-							spawn( 0 )
-								D.open()
-								return
 					if(specialfunctions & IDSCAN)
 						D.aiDisabledIdScanner = 1
 					if(specialfunctions & BOLTS)
@@ -95,13 +99,7 @@
 						D.secondsElectrified = -1
 					if(specialfunctions & SAFE)
 						D.safe = 0
-
 				else
-					if(specialfunctions & OPEN)
-						if (!D.density)
-							spawn( 0 )
-								D.close()
-								return
 					if(specialfunctions & IDSCAN)
 						D.aiDisabledIdScanner = 0
 					if(specialfunctions & BOLTS)


### PR DESCRIPTION
The var desiredstate doesn't update when the airlock closes automatically and so most of the time players have to hit the button twice when exiting the medbay, etc.. This keeps all functionality but with one button press.
