### PR TITLE
Vote changes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -27,6 +27,8 @@
 	var/allow_admin_rev = 1				// allows admin revives
 	var/vote_delay = 6000				// minimum time between voting sessions (deciseconds, 10 minute default)
 	var/vote_period = 600				// length of voting period (deciseconds, default 1 minute)
+	var/vote_autotransfer_initial = 108000 // Length of time before the first autotransfer vote is called
+	var/vote_autotransfer_interval = 3600 // length of time before next sequential autotransfer vote
 	var/vote_no_default = 0				// vote does not default to nochange/norestart (tbi)
 	var/vote_no_dead = 0				// dead people can't vote (tbi)
 //	var/enable_authentication = 0		// goon authentication
@@ -264,6 +266,12 @@
 
 				if ("vote_period")
 					config.vote_period = text2num(value)
+
+				if ("vote_autotransfer_initial")
+					config.vote_autotransfer_initial = text2num(value)
+
+				if ("vote_autotransfer_interval")
+					config.vote_autotransfer_interval = text2num(value)
 
 				if ("allow_ai")
 					config.allow_ai = 1

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -46,6 +46,10 @@ datum/controller/vote
 
 				voting.Cut()
 
+	proc/autotransfer()
+		initiate_vote("crew_transfer","the server")
+
+
 	proc/reset()
 		initiator = null
 		time_remaining = 0
@@ -56,13 +60,13 @@ datum/controller/vote
 		voting.Cut()
 		current_votes.Cut()
 
-		if(auto_muted && !ooc_allowed)
+	/*	if(auto_muted && !ooc_allowed)
 			auto_muted = 0
 			ooc_allowed = !( ooc_allowed )
 			world << "<b>The OOC channel has been automatically enabled due to vote end.</b>"
 			log_admin("OOC was toggled automatically due to vote end.")
 			message_admins("OOC has been toggled on automatically.")
-
+	*/
 
 	proc/get_result()
 		//get the highest number of votes
@@ -202,6 +206,8 @@ datum/controller/vote
 						return 0
 					choices.Add(config.votable_modes)
 				if("crew_transfer")
+					if (get_security_level() == "red" || get_security_level() == "delta")
+						return 0
 					if(ticker.current_state <= 2)
 						return 0
 					question = "End the shift?"
@@ -230,7 +236,7 @@ datum/controller/vote
 					world << sound('sound/ambience/alarm4.ogg')
 				if("custom")
 					world << sound('sound/ambience/alarm4.ogg')
-			if(mode == "gamemode" && going)
+		/*	if(mode == "gamemode" && going)
 				going = 0
 				world << "<font color='red'><b>Round start has been delayed.</b></font>"
 			if(mode == "crew_transfer" && ooc_allowed)
@@ -251,7 +257,7 @@ datum/controller/vote
 				world << "<b>The OOC channel has been automatically disabled due to a custom vote.</b>"
 				log_admin("OOC was toggled automatically due to custom vote.")
 				message_admins("OOC has been toggled off automatically.")
-
+		*/
 
 
 
@@ -278,9 +284,9 @@ datum/controller/vote
 				var/votes = choices[choices[i]]
 				if(!votes)	votes = 0
 				if(current_votes[C.ckey] == i)
-					. += "<li><b><a href='?src=\ref[src];vote=[i]'>[choices[i]]</a></b></li>"
+					. += "<li><b><a href='?src=\ref[src];vote=[i]'>[choices[i]] ([votes] votes)</a></b></li>"
 				else
-					. += "<li><a href='?src=\ref[src];vote=[i]'>[choices[i]]</a></li>"
+					. += "<li><a href='?src=\ref[src];vote=[i]'>[choices[i]] ([votes] votes)</a></li>"
 
 			. += "</ul><hr>"
 			if(admin)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -10,7 +10,7 @@ var/global/datum/controller/gameticker/ticker
 	var/const/restart_timeout = 600
 	var/current_state = GAME_STATE_PREGAME
 
-	var/hide_mode = 1
+	var/hide_mode = 0
 	var/datum/game_mode/mode = null
 	var/event_time = null
 	var/event = 0

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -109,6 +109,12 @@ VOTE_DELAY 6000
 ## time period (deciseconds) which voting session will last (default 1 minute)
 VOTE_PERIOD 600
 
+## autovote initial delay (deciseconds) before first automatic transfer vote call (default 180 minutes)
+VOTE_AUTOTRANSFER_INITIAL 108000
+
+##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 60 minutes)
+Vote_AUTOTRANSFER_INTERVAL 36000
+
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -35,7 +35,7 @@ Header Section
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<font size='2'><b>Code:</b> Abi79, Aryn, Cael_Aislinn, Chinsky, cib, CompactNinja, DopeGhoti, Erthilo, Hawk_v3, Head, Ispil, Lexusjjss, Melonstorm, Miniature, Mloc, NerdyBoy1104, SkyMarshal, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty<br></font>
+			<font size='2'><b>Code:</b> Abi79, Aryn, Cael_Aislinn, Chinsky, cib, CompactNinja, DopeGhoti, Erthilo, Hawk_v3, Head, Ispil, Lexusjjss, Melonstorm, Miniature, Mloc, NerdyBoy1104, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty<br></font>
 			<font size='2'><b>Sprites:</b> Apple_Master, Arcalane, Chinsky, CompactNinja, Deus Dactyl, Erthilo, Flashkirby, Miniature, Searif, Xenone, faux<br></font>
 			<font size='2'><b>Sounds:</b> Aryn<br></font>
 			<font size='2'><b>Thanks To:</b> /tg/ station, Goonstation, Animus Station, Daedalus, and original Spacestation 13 devs. Skibiliano for the IRC bot.</font>
@@ -51,6 +51,19 @@ Changelog Section
 Stuff which is in development and not yet visible to players or just code related 
 (ie. code improvements for expandability, etc.) should not be listed here. They 
 should be listed in the changelog upon commit though. Thanks. -->
+
+<div class="commit sansserif">
+	<h2 class="date">September 24th, 2013</h2>
+	<h3 class="author">Snapshot updated:</h3>
+	<ul class="changes bgimages16">
+		<li class="rscdel">Removed hidden vote counts.</li>
+		<li class="rscdel">Removed hiding of vote results.</li>
+		<li class="rscdel">Removed OOC muting during votes.</li>
+		<li class="rscadd">Crew transfers are no longer callable during Red and Delta alert.</li>
+		<li class="wip">Started work on Auto transfer framework.</li>
+	</ul>
+</div>
+
 <div class="commit sansserif">
 	<h2 class="date">August 8th, 2013</h2>
 	<h3 class="author">Erthilo updated:</h3>


### PR DESCRIPTION
BE SURE TO ADD THESE LINES TO THE CONFIG.TXT FOR THE SERVER:

 ## autovote initial delay (deciseconds) before first automatic transfer vote call (default 180 minutes)
VOTE_AUTOTRANSFER_INITIAL 108000
## autovote delay (deciseconds) before sequential automatic transfer votes are called (default 60 minutes)

Vote_AUTOTRANSFER_INTERVAL 36000
