### PR TITLE
Duplicates the speed of the gameticker!

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -71,13 +71,13 @@ var/list/beam_master = list()
 		..()
 
 	proc/cleanup(reference) //Waits .3 seconds then removes the overlay.
-		src = null
-		sleep(3)
-		var/list/turf_master = beam_master[reference]
-		for(var/laser_state in turf_master)
-			var/list/turfs = turf_master[laser_state]
-			for(var/turf/T in turfs)
-				T.overlays -= beam_master[laser_state]
+		src = null //we're getting deleted! this will keep the code running
+		spawn(3)
+			var/list/turf_master = beam_master[reference]
+			for(var/laser_state in turf_master)
+				var/list/turfs = turf_master[laser_state]
+				for(var/turf/T in turfs)
+					T.overlays -= beam_master[laser_state]
 		return
 
 /obj/item/projectile/beam/practice


### PR DESCRIPTION
The emtiter beams were holding back the gameticker, 0.3 seconds per beam, now the sleep() is replaced with a spawn() instead.

This will add lag due to everything being faster.

haha suck it mloc!
