### PR TITLE
Custom item fixes, Supermatter Crates.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -945,6 +945,25 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Engineering"
 	access = access_ce
 
+/datum/supply_packs/smbig
+	name = "Supermatter Core"
+	contains = list(/obj/machinery/power/supermatter)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/plasma
+	containername = "Supermatter crate (CAUTIION)"
+	access = access_ce
+	group = "Engineering"
+
+
+/datum/supply_packs/smsmall
+	name = "Supermatter Shard"
+	contains = list(/obj/machinery/power/supermatter/shard)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure/plasma
+	containername = "Supermatter crate (CAUTIION)"
+	access = access_ce
+	group = "Engineering"
+
 /datum/supply_packs/shield_cap
 	contains = list(/obj/item/weapon/circuitboard/shield_cap)
 	name = "Experimental shield capacitor circuitry"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -257,15 +257,6 @@
 	item_state = "neocoat"
 	flags = FPRINT | TABLEPASS
 
-//actual suits
-
-/obj/item/clothing/suit/creamsuit
-	name = "cream suit"
-	desc = "A cream coloured, genteel suit."
-	icon_state = "creamsuit"
-	item_state = "creamsuit"
-	flags = FPRINT | TABLEPASS
-
 //stripper
 
 /obj/item/clothing/under/stripper/stripper_pink

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -478,6 +478,7 @@
 	siemens_coefficient = 0.30
 	permeability_coefficient = 0.01
 	item_color="white"
+	species_restricted = list("exclude","Unathi")
 
 /obj/item/clothing/gloves/fluff/walter_brooks_1 //botanistpower: Walter Brooks
 	name = "mittens"
@@ -860,6 +861,7 @@
 	desc = "Made of a special fiber that gives special protection against biohazards. Has a cross on the chest denoting that the wearer is trained medical personnel and short sleeves."
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "medical_short"
+	item_state = "medical_short"
 	item_color = "medical_short"
 
 /obj/item/clothing/suit/storage/labcoat/fluff/red


### PR DESCRIPTION
Added a supermatter crate and supermatter shard crate, with appropriate CE-only open access for cargo. Fixed the custom item taj gloves to actually be wearable by taj, fixed a broken custom item sprite. Removed a /tg/ unlinked coat item.
