### PR TITLE
Cyborg Alt Titles

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -26,6 +26,7 @@
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
+	alt_titles = list("Android", "Robot")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -171,9 +171,14 @@
 
 	O.loc = loc
 	O.job = "Cyborg"
-
-	O.mmi = new /obj/item/device/mmi(O)
-	O.mmi.transfer_identity(src)//Does not transfer key/client.
+	if(O.mind.assigned_role == "Cyborg")
+		if(O.mind.role_alt_title == "Android")
+			O.mmi = new /obj/item/device/mmi/posibrain(O)
+		if(O.mind.role_alt_title == "Robot")
+			O.mmi = new /obj/item/device/mmi/posibrain(O) //Ravensdale wants a circuit based brain for another robot class, this is a placeholder.
+	else
+		O.mmi = new /obj/item/device/mmi(O)
+		O.mmi.transfer_identity(src)//Does not transfer key/client.
 
 	O.Namepick()
 


### PR DESCRIPTION
Added "Android" and "Robot" alt titles to cyborgs. They spawn with posibrains. Robot alt title waiting on an alt MMI/brain type from Ravensdale, but functions with posibrain right now.
