### PR TITLE
Decapitation Fixes, Head Reattachment Surgery

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -181,7 +181,7 @@
 
 	var/result = update_icon()
 	return result
-	
+
 /*
 This function completely restores a damaged organ to perfect condition.
 */
@@ -191,21 +191,21 @@ This function completely restores a damaged organ to perfect condition.
 	perma_injury = 0
 	brute_dam = 0
 	burn_dam = 0
-	
+
 	// handle internal organs
 	for(var/datum/organ/internal/current_organ in internal_organs)
 		current_organ.rejuvenate()
-	
+
 	// remove embedded objects and drop them on the floor
 	for(var/obj/implanted_object in implants)
 		if(!istype(implanted_object,/obj/item/weapon/implant))	// We don't want to remove REAL implants. Just shrapnel etc.
 			implanted_object.loc = owner.loc
 			implants -= implanted_object
-			
+
 	owner.updatehealth()
 	update_icon()
-	
-	
+
+
 /datum/organ/external/proc/createwound(var/type = CUT, var/damage)
 	if(damage == 0) return
 
@@ -886,17 +886,17 @@ obj/item/weapon/organ/head/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		switch(brain_op_stage)
 			if(0)
 				for(var/mob/O in (oviewers(brainmob) - user))
-					O.show_message("\red [brainmob] is beginning to have \his head cut open with [src] by [user].", 1)
-				brainmob << "\red [user] begins to cut open your head with [src]!"
-				user << "\red You cut [brainmob]'s head open with [src]!"
+					O.show_message("\red [brainmob] is beginning to have \his head cut open with [W] by [user].", 1)
+				brainmob << "\red [user] begins to cut open your head with [W]!"
+				user << "\red You cut [brainmob]'s head open with [W]!"
 
 				brain_op_stage = 1
 
 			if(2)
 				for(var/mob/O in (oviewers(brainmob) - user))
-					O.show_message("\red [brainmob] is having \his connections to the brain delicately severed with [src] by [user].", 1)
-				brainmob << "\red [user] begins to cut open your head with [src]!"
-				user << "\red You cut [brainmob]'s head open with [src]!"
+					O.show_message("\red [brainmob] is having \his connections to the brain delicately severed with [W] by [user].", 1)
+				brainmob << "\red [user] begins to cut open your head with [W]!"
+				user << "\red You cut [brainmob]'s head open with [W]!"
 
 				brain_op_stage = 3.0
 			else
@@ -905,20 +905,20 @@ obj/item/weapon/organ/head/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		switch(brain_op_stage)
 			if(1)
 				for(var/mob/O in (oviewers(brainmob) - user))
-					O.show_message("\red [brainmob] has \his skull sawed open with [src] by [user].", 1)
-				brainmob << "\red [user] begins to saw open your head with [src]!"
-				user << "\red You saw [brainmob]'s head open with [src]!"
+					O.show_message("\red [brainmob] has \his skull sawed open with [W] by [user].", 1)
+				brainmob << "\red [user] begins to saw open your head with [W]!"
+				user << "\red You saw [brainmob]'s head open with [W]!"
 
 				brain_op_stage = 2
 			if(3)
 				for(var/mob/O in (oviewers(brainmob) - user))
-					O.show_message("\red [brainmob] has \his spine's connection to the brain severed with [src] by [user].", 1)
-				brainmob << "\red [user] severs your brain's connection to the spine with [src]!"
-				user << "\red You sever [brainmob]'s brain's connection to the spine with [src]!"
+					O.show_message("\red [brainmob] has \his spine's connection to the brain severed with [W] by [user].", 1)
+				brainmob << "\red [user] severs your brain's connection to the spine with [W]!"
+				user << "\red You sever [brainmob]'s brain's connection to the spine with [W]!"
 
-				user.attack_log += "\[[time_stamp()]\]<font color='red'> Debrained [brainmob.name] ([brainmob.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>"
-				brainmob.attack_log += "\[[time_stamp()]\]<font color='orange'> Debrained by [user.name] ([user.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>"
-				msg_admin_attack("[brainmob] ([brainmob.ckey]) debrained [user] ([user.ckey]) (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+				user.attack_log += "\[[time_stamp()]\]<font color='red'> Debrained [brainmob.name] ([brainmob.ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)])</font>"
+				brainmob.attack_log += "\[[time_stamp()]\]<font color='orange'> Debrained by [user.name] ([user.ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)])</font>"
+				msg_admin_attack("[user] ([user.ckey]) debrained [brainmob] ([brainmob.ckey]) (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 
 				var/obj/item/brain/B = new(loc)
 				B.transfer_identity(brainmob)

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -1,0 +1,188 @@
+//This is an uguu head restoration surgery TOTALLY not yoinked from chinsky's limb reattacher
+
+
+/datum/surgery_step/head/
+	can_infect = 0
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		if (!hasorgans(target))
+			return 0
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		if (!affected)
+			return 0
+		if (!(affected.status & ORGAN_DESTROYED))
+			return 0
+		if (affected.parent)
+			if (affected.parent.status & ORGAN_DESTROYED)
+				return 0
+		return target_zone == "head"
+
+
+/datum/surgery_step/head/peel
+	allowed_tools = list(
+	/obj/item/weapon/retractor = 100,		\
+	/obj/item/weapon/crowbar = 75,	\
+	/obj/item/weapon/kitchen/utensil/fork = 50, 		\
+	)
+
+	min_duration = 80
+	max_duration = 100
+
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("[user] starts peeling back tattered flesh where [target]'s head used to be with \the [tool].", \
+		"You start peeling back tattered flesh where [target]'s head used to be with \the [tool].")
+		..()
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("\blue [user] peels back tattered flesh where [target]'s head used to be with \the [tool].",	\
+		"\blue You peel back tattered flesh where [target]'s head used to be with \the [tool].")
+		affected.status |= ORGAN_CUT_AWAY
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		if (affected.parent)
+			affected = affected.parent
+			user.visible_message("\red [user]'s hand slips, ripping [target]'s [affected.display_name] open!", \
+			"\red Your hand slips,  ripping [target]'s [affected.display_name] open!")
+			affected.createwound(CUT, 10)
+
+
+/datum/surgery_step/head/shape
+	allowed_tools = list(
+	/obj/item/weapon/FixOVein = 100, 	\
+	/obj/item/weapon/cable_coil = 75,	\
+	/obj/item/device/assembly/mousetrap = 10) //ok chinsky
+
+	min_duration = 80
+	max_duration = 100
+
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		return ..() && affected.status & ORGAN_CUT_AWAY
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("[user] is beginning to reshape [target]'s esophagal and vocal region with \the [tool].", \
+		"You start to reshape [target]'s [affected.display_name] esophagal and vocal region with \the [tool].")
+		..()
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("\blue [user] has finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool].",	\
+		"\blue You have finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool].")
+		affected.open = 3
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		if (affected.parent)
+			affected = affected.parent
+			user.visible_message("\red [user]'s hand slips, further rending flesh on [target]'s neck!", \
+			"\red Your hand slips, further rending flesh on [target]'s neck!")
+			target.apply_damage(10, BRUTE, affected)
+
+/datum/surgery_step/head/suture
+	allowed_tools = list(
+	/obj/item/weapon/hemostat = 100, 	\
+	/obj/item/weapon/cable_coil = 60,	\
+	/obj/item/weapon/FixOVein = 80)
+
+	min_duration = 80
+	max_duration = 100
+
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		return ..() && affected.open == 3
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("[user] is stapling and suturing flesh into place in [target]'s esophagal and vocal region with \the [tool].", \
+		"You start to staple and suture flesh into place in [target]'s esophagal and vocal region with \the [tool].")
+		..()
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("\blue [user] has finished stapling [target]'s neck into place with \the [tool].",	\
+		"\blue You have finished stapling [target]'s neck into place with \the [tool].")
+		affected.open = 4
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		if (affected.parent)
+			affected = affected.parent
+			user.visible_message("\red [user]'s hand slips, ripping apart flesh on [target]'s neck!", \
+			"\red Your hand slips, ripping apart flesh on [target]'s neck!")
+			target.apply_damage(10, BRUTE, affected)
+
+/datum/surgery_step/head/prepare
+	allowed_tools = list(
+	/obj/item/weapon/cautery = 100,			\
+	/obj/item/clothing/mask/cigarette = 75,	\
+	/obj/item/weapon/lighter = 50,			\
+	/obj/item/weapon/weldingtool = 25
+	)
+
+	min_duration = 60
+	max_duration = 70
+
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		return ..() && affected.open == 4
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("[user] starts adjusting area around [target]'s neck with \the [tool].", \
+		"You start adjusting area around [target]'s neck with \the [tool].")
+		..()
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("\blue [user] has finished adjusting the area around [target]'s neck with \the [tool].",	\
+		"\blue You have finished adjusting the area around [target]'s neck with \the [tool].")
+		affected.status |= ORGAN_ATTACHABLE
+		affected.amputated = 1
+		affected.setAmputatedTree()
+		affected.open = 0
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		if (affected.parent)
+			affected = affected.parent
+			user.visible_message("\red [user]'s hand slips, searing [target]'s neck!", \
+			"\red Your hand slips, searing [target]'s [affected.display_name]!")
+			target.apply_damage(10, BURN, affected)
+
+
+/datum/surgery_step/head/attach
+	allowed_tools = list(/obj/item/weapon/organ/head = 100)
+	can_infect = 0
+
+	min_duration = 80
+	max_duration = 100
+
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/head = target.get_organ(target_zone)
+		return ..() && head.status & ORGAN_ATTACHABLE
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("[user] starts attaching [tool] to [target]'s reshaped neck.", \
+		"You start attaching [tool] to [target]'s reshaped neck.")
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("\blue [user] has attached [target]'s head to the body.",	\
+		"\blue You have attached [target]'s head to the body.")
+		affected.status = 0
+		affected.amputated = 0
+		affected.destspawn = 0
+		var/obj/item/weapon/organ/head/B = tool
+		B.brainmob.mind.transfer_to(target)
+		target.update_body()
+		target.updatehealth()
+		target.UpdateDamageIcon()
+		del(tool)
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/datum/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("\red [user]'s hand slips, damaging connectors on [target]'s neck!", \
+		"\red Your hand slips, damaging connectors on [target]'s neck!")
+		target.apply_damage(10, BRUTE, affected)


### PR DESCRIPTION
Added a new surgery- Head reattachment, for the decapitationally challenged. Performed via retractor, fix-o-vein, hemostat, cautery, head. Fixed logs and messages for decapitated brain removal - No longer shows as the head cutting the head open, and no longer shows the debrainee as the debrainer to admins.
![headrs1](https://f.cloud.github.com/assets/3288815/1419327/d351e9fe-3fc8-11e3-8ea3-8d3ae55660bc.png)
![headrs2](https://f.cloud.github.com/assets/3288815/1419329/db01834e-3fc8-11e3-96a4-8524d9c6feb2.png)
