### PR TITLE
Fixed a CATASTROPHIC GAME-CHANGING BUG with the Soda Dispenser that resulted in much immersuhan breaking: Grape Soda wasn't in the Soda Dispenser dispensable reagents list.

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -192,7 +192,7 @@
 		if(istype(B, /obj/item/device/multitool))
 			if(hackedcheck == 0)
 				user << "You change the mode from 'McNano' to 'Pizza King'."
-				dispensable_reagents += list("thirteenloko")
+				dispensable_reagents += list("thirteenloko","grapesoda")
 				hackedcheck = 1
 				return
 


### PR DESCRIPTION
THIS IS A VERY BAD AND HORRIBLE ISSUE THAT MUST BE FIXED AT ALL POSSIBLE MOMENTS.
