### PR TITLE
Changed the embed check to use its own var instead of checking damagetype

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -180,7 +180,7 @@ This function restores the subjects blood to max.
 /mob/living/carbon/human/proc/restore_blood()
 	var/blood_volume = vessel.get_reagent_amount("blood")
 	vessel.add_reagent("blood",560.0-blood_volume)
-	
+
 
 /*
 This function restores all organs.
@@ -252,8 +252,9 @@ This function restores all organs.
 			W.loc = src
 
 	else if(istype(used_weapon,/obj/item/projectile)) //We don't want to use the actual projectile item, so we spawn some shrapnel.
-		if(prob(75) && damagetype == BRUTE)
-			var/obj/item/projectile/P = used_weapon
+
+		var/obj/item/projectile/P = used_weapon
+		if(prob(75) && P.embed)
 			var/obj/item/weapon/shard/shrapnel/S = new()
 			S.name = "[P.name] shrapnel"
 			S.desc = "[S.desc] It looks like it was fired from [P.shot_from]."

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -50,6 +50,7 @@
 	var/drowsy = 0
 	var/agony = 0
 
+	var/embed = 0 // whether or not the projectile can embed itself in the mob
 
 	proc/on_hit(var/atom/target, var/blocked = 0)
 		if(blocked >= 2)		return 0//Full block

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -5,16 +5,18 @@
 	damage_type = BRUTE
 	nodamage = 0
 	flag = "bullet"
+	embed = 1
 
 	on_hit(var/atom/target, var/blocked = 0)
 		if (..(target, blocked))
 			var/mob/living/L = target
 			shake_camera(L, 3, 2)
 
-/obj/item/projectile/bullet/weakbullet
+/obj/item/projectile/bullet/weakbullet // "rubber" bullets
 	damage = 10
 	stun = 5
 	weaken = 5
+	embed = 0
 
 
 /obj/item/projectile/bullet/midbullet
@@ -48,6 +50,7 @@
 	stun = 10
 	weaken = 10
 	stutter = 10
+	embed = 0
 
 /obj/item/projectile/bullet/a762
 	damage = 25

--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -4,6 +4,7 @@
 	icon_state = "ice_1"
 	damage = 20
 	flag = "energy"
+	embed = 1
 
 /obj/item/projectile/forcebolt/strong
 	name = "force bolt"


### PR DESCRIPTION
- var/embed = 0
- The bullets the detective's revolver uses (weakbullet) will no longer embed into anything.
