### PR TITLE
Changed how ghosts using ghostears will see crewmember chatter.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -300,7 +300,8 @@ var/list/department_radio_keys = list(
 			message_range = 1
 
 	var/list/listening
-
+	var/list/onscreen
+	onscreen =  get_mobs_in_view(7, src)
 	listening = get_mobs_in_view(message_range, src)
 	for(var/mob/M in player_list)
 		if (!M.client)
@@ -377,9 +378,10 @@ var/list/department_radio_keys = list(
 
 		if (italics)
 			message_a = "<i>[message_a]</i>"
-
+		var/message_ghost = "<b>[message_a]</b>" // bold so ghosts know the person is in view.
 		rendered = "<span class='game say'><span class='name'>[GetVoice()]</span>[alt_name] <span class='message'>[message_a]</span></span>"
-		for (var/M in heard_a)
+		var/rendered_ghost = "<span class='game say'><span class='name'>[GetVoice()]</span>[alt_name] <span class='message'>[message_ghost]</span></span>"
+		for (var/mob/M in heard_a)
 			if(hascall(M,"show_message"))
 				var/deaf_message = ""
 				var/deaf_type = 1
@@ -388,7 +390,10 @@ var/list/department_radio_keys = list(
 				else
 					deaf_message = "<span class='notice'>You cannot hear yourself!</span>"
 					deaf_type = 2 // Since you should be able to hear yourself without looking
-				M:show_message(rendered, 2, deaf_message, deaf_type)
+				if (M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTEARS) &&  M in onscreen)
+					M:show_message(rendered_ghost, 2, deaf_message, deaf_type)
+				else
+					M:show_message(rendered, 2, deaf_message, deaf_type)
 				M << speech_bubble
 
 	if (length(heard_b))


### PR DESCRIPTION
If the crewmember is on the ghosts screen then their words will be bolded to help observers easily seperate offscreen chatter from on screen chatter.

Also:  Babies first pull request
