### PR TITLE
Admin command:  Allow player to respawn

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -69,7 +69,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/check_customitem_activity,
 	/client/proc/man_up,
 	/client/proc/global_man_up,
-	/client/proc/response_team // Response Teams admin verb
+	/client/proc/response_team, // Response Teams admin verb
+	/client/proc/allow_character_respawn    /* Allows a ghost to respawn */	
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,


### PR DESCRIPTION
Created a proc that sets the ghosts timeofdeath to a time 30 minutes before round start, this does not effect the ghosts original body, just the ghost mobs.

Since ghosts may not respawn within 30 minutes of death this allows mods/admins to bypass it for ghosts and sends the player a message letting them know they can respawn now
as well as reminding them to roleplay correctly.

Before this admins were editing the variable directly.
