### PR TITLE
BugFix:  Cult Ghosts.  Not sending this to master because I'm still new.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -7,8 +7,15 @@
 /atom/proc/attackby(obj/item/W, mob/user)
 	return
 /atom/movable/attackby(obj/item/W, mob/user)
+
+	if(istype(W,/obj/item/weapon/tome))			// For some reason onclick intercepts this so we're sending it back where it belongs.
+		var/obj/item/weapon/tome/thistome = W
+		thistome.smackghost(src)
+		return
+
 	if(!(W.flags&NOBLUDGEON))
 		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
+
 
 /mob/living/attackby(obj/item/I, mob/user)
 	if(istype(I) && ismob(user))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -338,7 +338,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 //		usr << browse(null, "window=tank")
 
 	attack(mob/living/M as mob, mob/living/user as mob)
-
+		user.show_message("You attacked [M.name] they are a [M.type].  You asshole.")
 		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had the [name] used on him by [user.name] ([user.ckey])</font>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used [name] on [M.name] ([M.ckey])</font>")
 		msg_admin_attack("[user.name] ([user.ckey]) used [name] on [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
@@ -474,6 +474,20 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				words[w] = T.words[w]
 			user << "You copy the translation notes from your tome."
 
+	proc/smackghost(mob/dead/M as mob)
+		if(istype(M,/mob/dead))                              //Always time for sanity checks...though it should never happen.
+			if(M.invisibility != 0)
+				M.invisibility = 0
+				usr.visible_message( \
+					"\red [usr] drags the [M] to our plan of reality!", \
+					"\red You drag the [M] to our plan of reality!" \
+				)
+			else
+				usr.visible_message ( \
+					"\red [usr] just tried to smash his book into that ghost!  It's not very effective", \
+					"\red You get the feeling that the ghost can't become any more visible." \
+				)
+		return
 
 	examine()
 		set src in usr


### PR DESCRIPTION
When the new _onclick items were added it created a bug where when a player attacks a temporarily visible ghost with the tome it is supposed to pull the ghost back to the players world.

Instead it simply displayed a message that you attacked them.

Found the part in _onclick where the tome attack was being sent to and created a proc for the tome to instead smashghost()

Small feature added, now if the ghost is already visible it will display a different message then "you bring the ghost into this world"
