### PR TITLE
BugFix: Cult Ghosts...after a bit of professional advise from Chinsky.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -63,6 +63,23 @@
 	real_name = name
 	..()
 
+
+/mob/dead/attackby(obj/item/W, mob/user)
+	if(istype(W,/obj/item/weapon/tome))
+		var/mob/dead/M = src
+		if(src.invisibility != 0)
+			M.invisibility = 0
+			user.visible_message( \
+				"\red [user] drags ghost, [M], to our plan of reality!", \
+				"\red You drag [M] to our plan of reality!" \
+			)
+		else
+			user.visible_message ( \
+				"\red [user] just tried to smash his book into that ghost!  It's not very effective", \
+				"\red You get the feeling that the ghost can't become any more visible." \
+			)
+
+
 /mob/dead/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 1
 /*


### PR DESCRIPTION
Problem:  Cult members can't use the rune to see ghosts, then beat ghosts over the head.  it was being intercepted by _onclick and processed there and only displaying an angry red notice
that you hit that ghost.  Ghost didn't become visible, it disappeared soon after moving off the rune.

Solution:  Made an attackby for ghosts to check when they are being beat up by cultist with books, now they appear.

Minor feature change:  Now if a visible ghost gets hit it will give a different message than the standard "Ghost is pulled through from the other side".
