### PR TITLE
Bugfix (3778) Power cells in exosuits have the same amount of power as a highcap cell

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -115,6 +115,7 @@
 		cell = C
 		return
 	cell = new(src)
+	cell.name = "high-capacity power cell"
 	cell.charge = 15000
 	cell.maxcharge = 15000
 


### PR DESCRIPTION
Issue:  Mechs are created/spawned with a high-capaciter cell that is named "Power cell" and confuses some of the less bright roboticists and their beards.

Solution:  Shave the roboticist, and also renamed the cell that spawns to properly reflect it's higher capacity.

Resolves #3778
