### PR TITLE
Added a lot of changes.

### DIFF
--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
 /obj/item/weapon/implant/freedom
-	name = "freedom"
+	name = "freedom implant"
 	desc = "Use this to escape from those evil Red Shirts."
 	item_color = "r"
 	var/activation_emote = "chuckle"

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -12,9 +12,7 @@
 	icon_action_button = "action_hardhat"
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECITON_TEMPERATURE
-	// species_restricted = list("exclude","Unathi","Tajaran","Skrell","Diona","Vox") Commented out to solve the issue of "OH FUCK I ROLLED NUKE OP ALIEN AND THERE AREN'T ANY ADMINS ABLE TO FIX IT ON", as it made nuke rounds a pain in the ass when one of your squaddies was unable to join in.
-	// TODO: Make nuke ops hardsuit sprites for Unathi, Tajaran, Skrell, Diona, and Vox so this can be uncommented and shit can work again.
-
+	species_restricted = list("exclude","Unathi","Tajaran","Skrell","Diona","Vox")
 	attack_self(mob/user)
 		if(!isturf(user.loc))
 			user << "You cannot turn the light on while in this [user.loc]" //To prevent some lighting anomalities.
@@ -48,8 +46,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECITON_TEMPERATURE
-	//species_restricted = list("exclude","Unathi","Tajaran","Diona","Vox") See comment on respective helmet.
-	// TODO: Make nuke ops hardsuit helmet sprites for Unathi, Tajaran, Skrell, Diona, and Vox so this can be uncommented.
+	species_restricted = list("exclude","Unathi","Tajaran","Diona","Vox")
 
 //Chief Engineer's rig
 /obj/item/clothing/head/helmet/space/rig/elite
@@ -92,7 +89,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 60)
 	siemens_coefficient = 0.6
 	var/obj/machinery/camera/camera
-
+	species_restricted = list("exclude","Vox")
 /obj/item/clothing/head/helmet/space/rig/syndi/attack_self(mob/user)
 	if(camera)
 		..(user)
@@ -118,6 +115,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 60)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 	siemens_coefficient = 0.6
+	species_restricted = list("exclude","Vox")
 
 
 //Wizard Rig

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -12,7 +12,8 @@
 	icon_action_button = "action_hardhat"
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECITON_TEMPERATURE
-	species_restricted = list("exclude","Unathi","Tajaran","Skrell","Diona","Vox")
+	// species_restricted = list("exclude","Unathi","Tajaran","Skrell","Diona","Vox") Commented out to solve the issue of "OH FUCK I ROLLED NUKE OP ALIEN AND THERE AREN'T ANY ADMINS ABLE TO FIX IT ON", as it made nuke rounds a pain in the ass when one of your squaddies was unable to join in.
+	// TODO: Make nuke ops hardsuit sprites for Unathi, Tajaran, Skrell, Diona, and Vox so this can be uncommented and shit can work again.
 
 	attack_self(mob/user)
 		if(!isturf(user.loc))
@@ -47,7 +48,8 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECITON_TEMPERATURE
-	species_restricted = list("exclude","Unathi","Tajaran","Diona","Vox")
+	//species_restricted = list("exclude","Unathi","Tajaran","Diona","Vox") See comment on respective helmet.
+	// TODO: Make nuke ops hardsuit helmet sprites for Unathi, Tajaran, Skrell, Diona, and Vox so this can be uncommented.
 
 //Chief Engineer's rig
 /obj/item/clothing/head/helmet/space/rig/elite

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1341,6 +1341,43 @@ datum/design/nanopaste
 	materials = list("$metal" = 7000, "$glass" = 7000)
 	build_path = "/obj/item/stack/nanopaste"
 
+datum/design/implant_loyal
+	name = "loyalty implant"
+	desc = "Makes you loyal or such."
+	id = "implant_loyal"
+	req_tech = list("materials" = 2, "biotech" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 7000, "$glass" = 7000)
+	build_path = "/obj/item/weapon/implant/loyalty"
+
+datum/design/implant_chem
+	name = "chemical implant"
+	desc = "Injects things."
+	id = "implant_chem"
+	req_tech = list("materials" = 2, "biotech" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/implant/chem"
+
+datum/design/implant_free
+	name = "freedom implant"
+	desc = "Use this to escape from those evil Red Shirts."
+	id = "implant_free"
+	req_tech = list("syndicate" = 2, "biotech" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/implant/freedom"
+
+datum/design/chameleon
+	name = "Chameleon Jumpsuit"
+	desc = "It's a plain jumpsuit. It seems to have a small dial on the wrist."
+	id = "chameleon"
+	req_tech = list("syndicate" = 2)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 500)
+	build_path = "/obj/item/clothing/under/chameleon"
+
+
 datum/design/bluespacebeaker
 	name = "bluespace beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology and Element Cuban combined with the Compound Pete. Can hold up to 300 units."
@@ -1350,7 +1387,6 @@ datum/design/bluespacebeaker
 	materials = list("$metal" = 3000, "$plasma" = 3000, "$diamond" = 500)
 	reliability_base = 76
 	build_path = "/obj/item/weapon/reagent_containers/glass/beaker/bluespace"
-	category = "Misc"
 
 datum/design/noreactbeaker
 	name = "cryostasis beaker"
@@ -1406,17 +1442,17 @@ datum/design/decloner
 	materials = list("$gold" = 5000,"$uranium" = 10000, "mutagen" = 40)
 	build_path = "/obj/item/weapon/gun/energy/decloner"
 	locked = 1
-/*
+
 datum/design/chemsprayer
 	name = "Chem Sprayer"
 	desc = "An advanced chem spraying device."
 	id = "chemsprayer"
-	req_tech = list("combat" = 3, "materials" = 3, "engineering" = 3, "biotech" = 2)
+	req_tech = list("materials" = 3, "engineering" = 3, "biotech" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 1000)
 	reliability_base = 100
 	build_path = "/obj/item/weapon/chemsprayer"
-*/
+
 datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
 	desc = "A gun that fires many syringes."
@@ -1642,3 +1678,167 @@ datum/design/borg_syndicate_module
 	req_tech = list("combat" = 4, "syndicate" = 3)
 	build_path = "/obj/item/borg/upgrade/syndicate"
 	category = "Cyborg Upgrade Modules"
+
+/////////////////////////////////////////
+/////////////PDA and Radio stuff/////////
+/////////////////////////////////////////
+datum/design/binaryencrypt
+	name = "Binary Encrpytion Key"
+	desc = "An encyption key for a radio headset.  Contains cypherkeys."
+	id = "binaryencrypt"
+	req_tech = list("syndicate" = 2)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 300, "$glass" = 300)
+	build_path = "/obj/item/device/encryptionkey/binary"
+datum/design/pda
+	name = "PDA"
+	desc = "A portable microcomputer by Thinktronic Systems, LTD. Functionality determined by a preprogrammed ROM cartridge."
+	id = "pda"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/device/pda"
+datum/design/cart_basic
+	name = "Generic Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_basic"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge"
+datum/design/cart_engineering
+	name = "Power-ON Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_engineering"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/engineering"
+datum/design/cart_atmos
+	name = "BreatheDeep Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_atmos"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/atmos"
+datum/design/cart_medical
+	name = "Med-U Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_medical"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/medical"
+datum/design/cart_chemistry
+	name = "ChemWhiz Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_chemistry"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/chemistry"
+datum/design/cart_security
+	name = "R.O.B.U.S.T. Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_security"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/security"
+datum/design/cart_janitor
+	name = "CustodiPRO Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_janitor"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/janitor"
+datum/design/cart_clown
+	name = "Honkworks 5.0 Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_clown"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/clown"
+datum/design/cart_mime
+	name = "Gestur-O 1000 Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_mime"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/mime"
+datum/design/cart_toxins
+	name = "Signal Ace 2 Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_toxins"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/toxins"
+datum/design/cart_quartermaster
+	name = "Space Parts & Space Vendors Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_quartermaster"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/quartermaster"
+datum/design/cart_hop
+	name = "Human Resources 9001 Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_hop"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/hop"
+datum/design/cart_hos
+	name = "R.O.B.U.S.T. DELUXE Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_hos"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/hos"
+datum/design/cart_ce
+	name = "Power-On DELUXE Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_ce"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/ce"
+datum/design/cart_cmo
+	name = "Med-U DELUXE Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_cmo"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/cmo"
+datum/design/cart_rd
+	name = "Signal Ace DELUXE Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_rd"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/rd"
+datum/design/cart_captain
+	name = "Value-PAK Cartridge"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_captain"
+	req_tech = list("engineering" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/captain"
+datum/design/cart_traitor
+	name = "Detomatix Cart"
+	desc = "A data cartridge for portable microcomputers."
+	id = "cart_traitor"
+	req_tech = list("syndicate" = 2, "powerstorage" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 50, "$glass" = 50)
+	build_path = "/obj/item/weapon/cartridge/syndicate"


### PR DESCRIPTION
You can now produce PDAs, and most the PDA carts from R&D.
You can produce some syndicate stuff if you have illegal research to 2 or 3, like binary keys and chameleon jumpsuits, to make up for the poor traitors who waste their hard-earned gear on getting syndicate research.
After a discussion in the bs12 IRC, the species lock on Syndicate Nuke Ops RIGsuits has been removed to make sure that people who roll alien Nuke Ops can still help out, instead of being useless and stuck on the shuttle, since there aren't any alien nuke ops rig suit sprites, and they can't wear the default suits.
You can produce Chemical Implants, Loyalty Implants, and(if you have syndicate illegal tech research) Freedom Implants.
Uncommented the Chemsprayer from production and removed it's combat requirement. It's fairly harmless, and people who abuse it can be banned. Janitors will love using it with space cleaner.
