### PR TITLE
Dirt

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -21,6 +21,7 @@
 obj/item/weapon/mop/proc/clean(turf/simulated/A)
 	if(reagents.has_reagent("water", 1))
 		A.clean_blood()
+		A.dirt = 0
 		for(var/obj/effect/O in A)
 			if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
 				del(O)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -8,7 +8,7 @@
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed
 	var/max_fire_temperature_sustained = 0 //The max temperature of the fire which it was subjected to
-
+	var/dirt = 0
 /turf/simulated/New()
 	..()
 	levelupdate()
@@ -21,6 +21,11 @@
 	if (istype(A,/mob/living/carbon))
 		var/mob/living/carbon/M = A
 		if(M.lying)	return
+		dirt++
+		if (dirt > 40)
+			dirt = 0
+			if (!locate(/obj/effect/decal/cleanable/dirt, src))
+				new/obj/effect/decal/cleanable/dirt(src)
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -23,16 +23,6 @@
 		if(M.lying)	return
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			if(istype(H.shoes, /obj/item/clothing/shoes/clown_shoes))
-				var/obj/item/clothing/shoes/clown_shoes/O = H.shoes
-				if(H.m_intent == "run")
-					if(O.footstep >= 2)
-						O.footstep = 0
-						playsound(src, "clownstep", 50, 1) // this will get annoying very fast.
-					else
-						O.footstep++
-				else
-					playsound(src, "clownstep", 20, 1)
 
 			var/list/bloodDNA = null
 			if(H.shoes)


### PR DESCRIPTION
Makes dirt overlay appear over tile if people walk over it often.
Gives janitors something to do (and legit excuse for tater janitors to go everywhere)

Also removes clown shoes sound. Sue me.
