### PR TITLE
Bugfix(3937) Blindfolds cause permenent blindness

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -128,7 +128,7 @@
 	desc = "Covers the eyes, preventing sight."
 	icon_state = "blindfold"
 	item_state = "blindfold"
-	vision_flags = BLIND
+	//vision_flags = BLIND  	// This flag is only supposed to be used if it causes permanent blindness, not temporary because of glasses
 
 /obj/item/clothing/glasses/sunglasses/prescription
 	name = "prescription sunglasses"


### PR DESCRIPTION
Removed BLIND vision flag from the object as that is already handled in mob/living/carbon/human/life.dm

Resolves #3937
