### PR TITLE
Booze fix

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -229,7 +229,7 @@
 	energy = 100
 	accept_glass = 1
 	max_energy = 100
-	dispensable_reagents = list("water","ice","coffee","tea","icetea","space_cola","spacemountainwind","dr_gibb","space_up","tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","watermelonjuice")
+	dispensable_reagents = list("water","ice","coffee","tea","icetea","cola","spacemountainwind","dr_gibb","space_up","tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","watermelonjuice")
 
 	/obj/machinery/chem_dispenser/soda/attackby(var/obj/item/weapon/B as obj, var/mob/user as mob)
 		..()

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -183,7 +183,6 @@
 	return 1 // update UIs attached to this object
 
 /obj/machinery/chem_dispenser/attackby(var/obj/item/weapon/reagent_containers/B as obj, var/mob/user as mob)
-	world << "DEBUG:  got chem_dispenser attack by"
 	if(isrobot(user))
 		return
 
@@ -200,9 +199,7 @@
 	if(src.beaker)
 		user << "Something is already loaded into the machine."
 		return
-	world << "DEBUG:  Got to chem_dispenser/attackby istype check"
 	if(istype(B, /obj/item/weapon/reagent_containers/glass) || istype(B, /obj/item/weapon/reagent_containers/food))
-		world << "DEBUG: Passed istype check"
 		if(!accept_glass && istype(B,/obj/item/weapon/reagent_containers/food))
 			user << "<span class='notice'>This machine only accepts beakers</span>"
 		src.beaker =  B
@@ -259,7 +256,6 @@
 	dispensable_reagents = list("water","ice","coffee","tea","cream","lemon_lime","sugar","orangejuice","limejuice","cola","sodawater","tonic","beer","kahlua","whiskey","wine","vodka","gin","rum","tequilla","vermouth","cognac","ale","mead")
 
 	/obj/machinery/chem_dispenser/beer/attackby(var/obj/item/weapon/B as obj, var/mob/user as mob)
-		world << "DEBUG:  GOT BEER DISPENSER attackby"
 		..()
 
 		if(istype(B, /obj/item/device/multitool))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -10,9 +10,11 @@
 	icon_state = "dispenser"
 	use_power = 0
 	idle_power_usage = 40
+	var/ui_name = "Chem Dispenser 5000" 
 	var/energy = 100
 	var/max_energy = 100
-	var/amount = 30
+	var/amount = 30	
+	var/accept_glass = 0
 	var/beaker = null
 	var/recharged = 0
 	var/hackedcheck = 0
@@ -116,7 +118,7 @@
 	data["energy"] = energy
 	data["maxEnergy"] = max_energy
 	data["isBeakerLoaded"] = beaker ? 1 : 0
-
+	data["glass"] = accept_glass
 	var beakerContents[0]
 	var beakerCurrentVolume = 0
 	if(beaker && beaker:reagents && beaker:reagents.reagent_list.len)
@@ -142,7 +144,7 @@
 	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, ui_key)
 	if (!ui)
 		// the ui does not exist, so we'll create a new one
-		ui = new(user, src, ui_key, "chem_dispenser.tmpl", "Chem Dispenser 5000", 370, 605)
+		ui = new(user, src, ui_key, "chem_dispenser.tmpl", ui_name, 370, 605)
 		// When the UI is first opened this is the data it will use
 		ui.set_initial_data(data)
 		ui.open()
@@ -164,7 +166,7 @@
 
 	if(href_list["dispense"])
 		if (dispensable_reagents.Find(href_list["dispense"]) && beaker != null)
-			var/obj/item/weapon/reagent_containers/glass/B = src.beaker
+			var/obj/item/weapon/reagent_containers/B = src.beaker
 			var/datum/reagents/R = B.reagents
 			var/space = R.maximum_volume - R.total_volume
 
@@ -173,14 +175,15 @@
 
 	if(href_list["ejectBeaker"])
 		if(beaker)
-			var/obj/item/weapon/reagent_containers/glass/B = beaker
+			var/obj/item/weapon/reagent_containers/B = beaker
 			B.loc = loc
 			beaker = null
 
 	add_fingerprint(usr)
 	return 1 // update UIs attached to this object
 
-/obj/machinery/chem_dispenser/attackby(var/obj/item/weapon/reagent_containers/glass/B as obj, var/mob/user as mob)
+/obj/machinery/chem_dispenser/attackby(var/obj/item/weapon/reagent_containers/B as obj, var/mob/user as mob)
+	world << "DEBUG:  got chem_dispenser attack by"
 	if(isrobot(user))
 		return
 
@@ -197,7 +200,11 @@
 	if(src.beaker)
 		user << "Something is already loaded into the machine."
 		return
-	if(istype(B, /obj/item/weapon/reagent_containers/glass||/obj/item/weapon/reagent_containers/food))
+	world << "DEBUG:  Got to chem_dispenser/attackby istype check"
+	if(istype(B, /obj/item/weapon/reagent_containers/glass) || istype(B, /obj/item/weapon/reagent_containers/food))
+		world << "DEBUG: Passed istype check"
+		if(!accept_glass && istype(B,/obj/item/weapon/reagent_containers/food))
+			user << "<span class='notice'>This machine only accepts beakers</span>"
 		src.beaker =  B
 		user.drop_item()
 		B.loc = src
@@ -221,9 +228,11 @@
 	icon_state = "soda_dispenser"
 	name = "soda fountain"
 	desc = "A drink fabricating machine, capable of producing many sugary drinks with just one touch."
+	ui_name = "Soda Dispens-o-matic"
 	energy = 100
+	accept_glass = 1
 	max_energy = 100
-	dispensable_reagents = list("water","ice","coffee","tea","icetea","space_cola","spacemountainwind","dr_gibb","space_up","tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice")
+	dispensable_reagents = list("water","ice","coffee","tea","icetea","space_cola","spacemountainwind","dr_gibb","space_up","tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","watermelonjuice")
 
 	/obj/machinery/chem_dispenser/soda/attackby(var/obj/item/weapon/B as obj, var/mob/user as mob)
 		..()
@@ -242,13 +251,17 @@
 /obj/machinery/chem_dispenser/beer
 	icon_state = "booze_dispenser"
 	name = "booze dispenser"
+	ui_name = "Booze Portal 9001"
 	energy = 100
+	accept_glass = 1
 	max_energy = 100
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
-	dispensable_reagents = list("water","ice","coffee","tea","cream","lemon_lime","sugar","orangejuice","limejuice","cola","sodawater","tonic","beer","kahlua","whiskey","wine","vodka","gin","rum","tequila","vermouth","cognac","ale","mead")
+	dispensable_reagents = list("water","ice","coffee","tea","cream","lemon_lime","sugar","orangejuice","limejuice","cola","sodawater","tonic","beer","kahlua","whiskey","wine","vodka","gin","rum","tequilla","vermouth","cognac","ale","mead")
 
 	/obj/machinery/chem_dispenser/beer/attackby(var/obj/item/weapon/B as obj, var/mob/user as mob)
+		world << "DEBUG:  GOT BEER DISPENSER attackby"
 		..()
+
 		if(istype(B, /obj/item/device/multitool))
 			if(hackedcheck == 0)
 				user << "You disable the 'nanotrasen-are-cheap-bastards' lock, enabling hidden and very expensive boozes."

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -229,7 +229,7 @@
 	energy = 100
 	accept_glass = 1
 	max_energy = 100
-	dispensable_reagents = list("water","ice","coffee","tea","icetea","cola","spacemountainwind","dr_gibb","space_up","tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","watermelonjuice")
+	dispensable_reagents = list("water","ice","coffee","cream","tea","icetea","cola","spacemountainwind","dr_gibb","space_up","tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","watermelonjuice")
 
 	/obj/machinery/chem_dispenser/soda/attackby(var/obj/item/weapon/B as obj, var/mob/user as mob)
 		..()
@@ -253,7 +253,7 @@
 	accept_glass = 1
 	max_energy = 100
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
-	dispensable_reagents = list("water","ice","coffee","tea","cream","lemon_lime","sugar","orangejuice","limejuice","cola","sodawater","tonic","beer","kahlua","whiskey","wine","vodka","gin","rum","tequilla","vermouth","cognac","ale","mead")
+	dispensable_reagents = list("lemon_lime","sugar","orangejuice","limejuice","sodawater","tonic","beer","kahlua","whiskey","wine","vodka","gin","rum","tequilla","vermouth","cognac","ale","mead")
 
 	/obj/machinery/chem_dispenser/beer/attackby(var/obj/item/weapon/B as obj, var/mob/user as mob)
 		..()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2563,7 +2563,7 @@ datum
 				return
 
 		drink/cold/spacemountainwind
-			name = "Space Mountain Wind"
+			name = "MountainWind"
 			id = "spacemountainwind"
 			description = "Blows right through you like a space wind."
 			color = "#102000" // rgb: 16, 32, 0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2540,7 +2540,7 @@ datum
 			color = "#619494" // rgb: 97, 148, 148
 
 		drink/cold/space_cola
-			name = "Cola"
+			name = "Space Cola"
 			id = "cola"
 			description = "A refreshing beverage."
 			reagent_state = LIQUID

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2563,7 +2563,7 @@ datum
 				return
 
 		drink/cold/spacemountainwind
-			name = "MountainWind"
+			name = "Mountain Wind"
 			id = "spacemountainwind"
 			description = "Blows right through you like a space wind."
 			color = "#102000" // rgb: 16, 32, 0

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -303,11 +303,11 @@ div.notice {
     border-color: #666666;
 }
 .fixedLeft {
-    width: 130px;
+    width: 110px;
     float: left;
 }
 .fixedLeftWide {
-    width: 260px;
+    width: 150px;
     float: left;
 }
 

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -176,6 +176,8 @@ h4 {
     width: 16px;
     height: 16px;
 }
+
+
 div.notice {
     clear: both;
 }
@@ -301,9 +303,14 @@ div.notice {
     border-color: #666666;
 }
 .fixedLeft {
-    width: 110px;
+    width: 130px;
     float: left;
 }
+.fixedLeftWide {
+    width: 260px;
+    float: left;
+}
+
 .floatRight {
     float: right;
 }

--- a/nano/templates/chem_dispenser.tmpl
+++ b/nano/templates/chem_dispenser.tmpl
@@ -26,23 +26,32 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 <div class="item">&nbsp;</div>
 <div class="item">
 	<div class="itemLabel" style="width: 100%;">
-		Chemical Dispenser
+		{^{if glass}}
+			Drink Dispenser
+		{{else}}
+			Chemical Dispenser
+		{{/if}}
 	</div>
 </div>
 <div class="item">
-	<div class="itemContent" style="width: 100%;">
+	<div class="itemContentWide" style="width: 100%;">
 		{^{for chemicals}}
-			{^{:~link(title, 'circle-arrow-s', commands, null, 'fixedLeft')}}
+			{^{:~link(title, 'circle-arrow-s', commands, null, ~root.glass ? 'fixedLeftWide' : 'fixedLeft' )}}
 		{{/for}}
+		
 	</div>
 </div>
 <div class="item">&nbsp;</div>
 <div class="item">
 	<div class="itemLabel">
-		Beaker Contents
+		{^{if glass}}
+			Glass
+		{{else}}
+			Beaker
+		{{/if}} Contents
 	</div>
 	<div class="itemContent">
-		{^{:~link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, isBeakerLoaded ? null : 'disabled', 'floatRight')}}
+		{^{:~link(glass ? 'Eject Glass' : 'Eject Beaker', 'eject', {'ejectBeaker' : 1}, isBeakerLoaded ? null : 'disabled', 'floatRight')}}
 	</div>
 </div>
 <div class="statusDisplay" style="height: 225px; overflow: auto;">
@@ -53,10 +62,21 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 				{^{for beakerContents}}
 					<span class="highlight">{^{:volume}} units of {^{:name}}</span><br>
 				{{else}}
-					<span class="bad">Beaker is empty</span>
+					<span class="bad">
+							{^{if glass}}
+								Glass
+							{{else}}
+								Beaker
+							{{/if}}
+								 is empty</span>
 				{{/for}}
 			{{else}}
-				<span class="average"><i>No beaker loaded</i></span>
+				<span class="average"><i>No 
+							{^{if glass}}
+								Glass
+							{{else}}
+								Beaker
+							{{/if}} loaded</i></span>
 			{{/if}}
 		</div>
 	</div>


### PR DESCRIPTION
Fixed booze dispensers / soda dispensers.

They both will now accept regular drinking glasses instead of just beakers.

They both will now have buttons able to see things as large as "Watermelon Juice"

They both don't look exactly like a chem dispenser in their UI's and have different contexts "Drink Dispenser" instead of "Chemical Dispenser", Glass instead of Beaker, and new UI titles for each.

Space cola will now show up in the Soda dispenser

Taquila will now show up in the booze dispenser.

http://imgur.com/itZLI4G
