### PR TITLE
Bugfix:  Hyposprays now fit in medical belts.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -97,7 +97,7 @@
 		"/obj/item/device/flashlight/pen",
 		"/obj/item/clothing/mask/surgical",
 		"/obj/item/clothing/gloves/latex",
-        "/obj/item/weapon/reagent_containers/hypospray/autoinjector"
+	        "/obj/item/weapon/reagent_containers/hypospray"
 	)
 
 


### PR DESCRIPTION
Problem:  Person fixing bug #2006 was a bit too specific about type of autoinjectors able to fit in belt.

Solution:  Be less specific.  Now hyposprays fit in belts.
