### PR TITLE
Fix: Labcoat storage not closing properly...

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -36,6 +36,9 @@
 		if(istype(master, /obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = master
 			S.close(usr)
+		else if (istype(master, /obj/item/clothing/suit/storage))
+			var/obj/item/clothing/suit/storage/S = master
+			S.close(usr)
 	return 1
 
 


### PR DESCRIPTION
Fixed it by adding an if statement that causes the storage device to close when it is a storage device that is a suit.

Was bothering me ingame.

Closes #3887
