### PR TITLE
Bugfix:  Internals HUD click action.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -295,8 +295,13 @@
 							for(var/i=1, i<tankcheck.len+1, ++i)
 								if(istype(tankcheck[i], /obj/item/weapon/tank))
 									var/obj/item/weapon/tank/t = tankcheck[i]
-									switch(breathes)
-										if("nitrogen") 
+									if (!isnull(t.manipulated_by) && t.manipulated_by != C.real_name && findtext(t.desc,breathes))
+										contents.Add(t.air_contents.total_moles)	//Someone messed with the tank and put unknown gasses
+										continue					//in it, so we're going to believe the tank is what it says it is
+									switch(breathes)					
+																		//These tanks we're sure of their contents
+										if("nitrogen") 							//So we're a bit more picky about them.
+											
 											if(t.air_contents.nitrogen && !t.air_contents.oxygen)
 												contents.Add(t.air_contents.nitrogen)
 											else

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -255,6 +255,8 @@ Release Pressure: <A href='?src=\ref[src];pressure_adj=-1000'>-</A> <A href='?sr
 
 		if (href_list["remove_tank"])
 			if(holding)
+				if(istype(holding, /obj/item/weapon/tank))
+					holding.manipulated_by = usr.real_name
 				holding.loc = loc
 				holding = null
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1042,6 +1042,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if(5)
 			if((istype(A, /obj/item/weapon/tank)) || (istype(A, /obj/machinery/portable_atmospherics)))
+				if(istype(A, /obj/item/weapon/tank))
+					var/obj/item/weapon/tank/t = A
+					t.manipulated_by = user.real_name
 				var/obj/icon = A
 				for (var/mob/O in viewers(user, null))
 					O << "\red [user] has used [src] on \icon[icon] [A]"

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -15,7 +15,8 @@
 	var/distribute_pressure = ONE_ATMOSPHERE
 	var/integrity = 3
 	var/volume = 70
-
+	var/manipulated_by = null		//Used by _onclick/hud/screen_objects.dm internals to determine if someone has messed with our tank or not.
+						//If they have and we haven't scanned it with the PDA or gas analyzer then we might just breath whatever they put in it.
 /obj/item/weapon/tank/New()
 	..()
 
@@ -86,7 +87,7 @@
 			O << "\red [user] has used [W] on \icon[icon] [src]"
 
 		var/pressure = air_contents.return_pressure()
-
+		manipulated_by = user.real_name			//This person is aware of the contents of the tank.
 		var/total_moles = air_contents.total_moles()
 
 		user << "\blue Results of analysis of \icon[icon]"


### PR DESCRIPTION
Before:  If you had a tank on your back full of nice precious oxygen, and a tank of plasma in your hand and thought "I'll play it safe and turn on internals" and click the internals icon you would start sucking down plasma like you weren't really qualified to handle such things, how do you even get those two mixed up you big dummy!  Code was hardcoded junk.

After:  A check of what your species prefers to breath, you are an adult, I'm pretty sure you can remember if the tank on your back is oxygen or not, and you will turn on the fullest tank.
Code is now nolonger hardcoded junk, and is expandable by editing a couple of variables instead of hardcoding everything.  Double Rainbow, All The Way Across The Sky!

Also coded in a check for "Carbon Dioxide" in the event a downstream server uses a race that breathes that or we move dionaea to breathing it in the future.
