### PR TITLE
Teleport bug fix...maybe.

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -114,6 +114,11 @@ var/list/valid_secondary_effect_types = list(\
 #define TRIGGER_NITRO 12
 
 /obj/machinery/artifact/process()
+
+	var/turf/L = loc
+	if(isnull(L) || !istype(L)) 	// We're inside a container or on null turf, either way stop processing effects
+		return
+
 	if(my_effect)
 		my_effect.process()
 	if(secondary_effect)


### PR DESCRIPTION
Since we're unable to reproduce this bug in a testing environment and I've already concluded this isn't a telescience bug then I am leaning more towards Xenoarchiology, specifically the artifacts.

This sanity check basically makes it where if there is an artifact on null terf or inside a container it won't process the effect.  If it's the teleport effect of artifacts that is causing this
to happen and it's based on the item being in nullspace somehow then it should squash the bug.  Though the root of this is probably #4037 I cannot reproduce the runtime either.

So here goes, a stab in the dark.
