### PR TITLE
Crouching monkey, hidden mousetrap

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -43,7 +43,8 @@
 	var/Tickcomp = 0
 	var/socket_talk	= 0					// use socket_talk to communicate with other processes
 	var/list/resource_urls = null
-
+	var/antag_hud_allowed = 0			// Ghosts can turn on Antagovision to see a HUD of who is the bad guys this round.
+	var/antag_hud_restricted = 0                    // Ghosts that turn on Antagovision cannot rejoin the round.
 	var/list/mode_names = list()
 	var/list/modes = list()				// allowed modes
 	var/list/votable_modes = list()		// votable modes
@@ -60,6 +61,9 @@
 	var/ToRban = 0
 	var/automute_on = 0					//enables automuting/spam prevention
 	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access.
+
+	var/disable_player_mice = 0
+	var/uneducated_mice = 0 //Set to 1 to prevent newly-spawned mice from understanding human speech
 
 	var/usealienwhitelist = 0
 	var/limitalienplayers = 0
@@ -385,6 +389,11 @@
 				if("ticklag")
 					Ticklag = text2num(value)
 
+				if("allow_antag_hud")
+					config.antag_hud_allowed = 1
+				if("antag_hud_restricted")
+					config.antag_hud_restricted = 1
+
 				if("socket_talk")
 					socket_talk = text2num(value)
 
@@ -418,6 +427,12 @@
 
 				if("ghost_interaction")
 					config.ghost_interaction = 1
+
+				if("disable_player_mice")
+					config.disable_player_mice = 1
+
+				if("uneducated_mice")
+					config.uneducated_mice = 1
 
 				if("comms_password")
 					config.comms_password = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -43,8 +43,6 @@
 	var/Tickcomp = 0
 	var/socket_talk	= 0					// use socket_talk to communicate with other processes
 	var/list/resource_urls = null
-	var/antag_hud_allowed = 0			// Ghosts can turn on Antagovision to see a HUD of who is the bad guys this round.
-	var/antag_hud_restricted = 0                    // Ghosts that turn on Antagovision cannot rejoin the round.
 	var/list/mode_names = list()
 	var/list/modes = list()				// allowed modes
 	var/list/votable_modes = list()		// votable modes
@@ -388,11 +386,6 @@
 
 				if("ticklag")
 					Ticklag = text2num(value)
-
-				if("allow_antag_hud")
-					config.antag_hud_allowed = 1
-				if("antag_hud_restricted")
-					config.antag_hud_restricted = 1
 
 				if("socket_talk")
 					socket_talk = text2num(value)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -45,6 +45,7 @@
 			visible_message("\red <b>SPLAT!</b>")
 			M.splat()
 		playsound(target.loc, 'sound/effects/snap.ogg', 50, 1)
+		layer = MOB_LAYER - 0.2
 		armed = 0
 		update_icon()
 		pulse(0)
@@ -113,3 +114,15 @@
 /obj/item/device/assembly/mousetrap/armed
 	icon_state = "mousetraparmed"
 	armed = 1
+
+
+/obj/item/device/assembly/mousetrap/verb/hide_under()
+	set src in oview(1)
+	set name = "Hide"
+	set category = "Object"
+
+	if(usr.stat)
+		return
+
+	layer = TURF_LAYER+0.2
+	usr << "<span class='notice'>You hide [src].</span>"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -293,6 +293,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Become mouse"
 	set category = "Ghost"
 
+	if(config.disable_player_mice)
+		src << "<span class='warning'>Spawning as a mouse is currently disabled.</span>"
+		return
+
 	var/timedifference = world.time - client.time_died_as_mouse
 	if(client.time_died_as_mouse && timedifference <= mouse_respawn_time * 600)
 		var/timedifference_text
@@ -302,7 +306,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/response = alert(src, "Are you -sure- you want to become a mouse?","Are you sure you want to squeek?","Squeek!","Nope!")
 	if(response != "Squeek!") return  //Hit the wrong key...again.
-	
+
 
 	//find a viable mouse candidate
 	var/mob/living/simple_animal/mouse/host
@@ -318,6 +322,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		src << "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>"
 
 	if(host)
+		if(config.uneducated_mice)
+			host.universal_understand = 0
 		host.ckey = src.ckey
 		host << "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>"
 

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -67,8 +67,18 @@
 		G.process()
 
 	if(!client && stat == CONSCIOUS)
+
 		if(prob(33) && canmove && isturf(loc))
-			step(src, pick(cardinal))
+
+			var/isBeingPulled = 0
+
+			for(var/mob/M in range(src, 1)) //won't move if being pulled
+				if(M.pulling == src)
+					isBeingPulled = 1
+
+			if(isBeingPulled == 0)
+				step(src, pick(cardinal))
+
 		if(prob(1))
 			emote(pick("scratch","jump","roll","tail"))
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -63,6 +63,7 @@
 	src.stat = DEAD
 	src.icon_dead = "mouse_[body_color]_splat"
 	src.icon_state = "mouse_[body_color]_splat"
+	layer = MOB_LAYER
 	if(client)
 		client.time_died_as_mouse = world.time
 
@@ -179,6 +180,7 @@
 	..()
 
 /mob/living/simple_animal/mouse/Die()
+	layer = MOB_LAYER
 	if(client)
 		client.time_died_as_mouse = world.time
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -27,6 +27,7 @@
 	minbodytemp = 223		//Below -50 Degrees Celcius
 	maxbodytemp = 323	//Above 50 Degrees Celcius
 	universal_speak = 0
+	universal_understand = 1
 
 /mob/living/simple_animal/mouse/Life()
 	..()
@@ -50,6 +51,7 @@
 
 /mob/living/simple_animal/mouse/New()
 	..()
+	name = "[name] ([rand(1, 1000)])"
 	if(!body_color)
 		body_color = pick( list("brown","gray","white") )
 	icon_state = "mouse_[body_color]"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -207,6 +207,7 @@
 
 	//Whether or not mobs can understand other mobtypes. These stay in /mob so that ghosts can hear everything.
 	var/universal_speak = 0 // Set to 1 to enable the mob to speak to everyone -- TLE
+	var/universal_understand = 0 // Set to 1 to enable the mob to understand everyone, not necessarily speak
 	var/robot_talk_understand = 0
 	var/alien_talk_understand = 0
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -66,7 +66,7 @@
 	if(!other)
 		return 1
 	//Universal speak makes everything understandable, for obvious reasons.
-	else if(other.universal_speak || src.universal_speak)
+	else if(other.universal_speak || src.universal_speak || src.universal_understand)
 		return 1
 	else if (src.stat == 2)
 		return 1
@@ -83,7 +83,7 @@
 		else
 			return 0
 
-	else if(other.universal_speak || src.universal_speak)
+	else if(other.universal_speak || src.universal_speak || src.universal_understand)
 		return 1
 	else if(isAI(src) && ispAI(other))
 		return 1

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,15 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>18 December 2013</h2>
+	<h3 class='author'>RavingManiac updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Mousetraps can now be "hidden" through the right-click menu. This makes them go under tables, clutter and the like. The filthy rodents will never see it coming!</li>
+		<li class='tweak'>Monkeys will no longer move randomly while being pulled.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>24 November 2013</h2>
 	<h3 class='author'>Yinadele updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
Monkeys will no longer move randomly while being pulled.

Added "hide" verb to mousetraps, placing them on the same layer as hidden mice.

Triggered mousetraps and dead mice will be moved back to the top layer.

Changelog updated accordingly.

Two config variables added - disable_player_mice and uneducated_mice. The first, if enabled, prevents players from spawning as mice, and the second, if enabled, prevents mice from understanding human speech (which they now do my default)

universal_understand = 1 now allows player-controlled mobs to understand what everybody is saying without necessarily allowing them to talk back intelligibly. Mice have universal_understand = 1 by default.
