### PR TITLE
Fixes grid_check events killing AI's SMES.

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -61,7 +61,7 @@
 		if(C.cell && C.z == 1)
 			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in world)
-		if(S.z != 1)
+		if(istype(get_area(S), /area/turret_protected) || S.z != 1)
 			continue
 		S.charge = S.last_charge
 		S.output = S.last_output


### PR DESCRIPTION
When power was turned off there is a check if the area is in a turret protected area.
If so, it's skipped (not setting the values for the SMES's previous power, leaving it at 0 as well as charging and output.

When power came back on there wasn't this same check.  Causing all turret protected area SMESes to be drained and off.

Added the same check to power_restore()

Resolves #4079
