### PR TITLE
Removed R&D lockboxes.

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -394,10 +394,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 								new_item.investigate_log("built by [key]","singulo")
 							new_item.reliability = being_built.reliability
 							if(linked_lathe.hacked) being_built.reliability = max((reliability / 2), 0)
-							if(being_built.locked)
+							/*if(being_built.locked)
 								var/obj/item/weapon/storage/lockbox/L = new/obj/item/weapon/storage/lockbox(linked_lathe.loc)
 								new_item.loc = L
-								L.name += " ([new_item.name])"
+								L.name += " ([new_item.name])"*/
 							else
 								new_item.loc = linked_lathe.loc
 							linked_lathe.busy = 0


### PR DESCRIPTION
As per the (yet incomplete) poll and Duntada Man's post in [this](http://baystation12.net/forums/viewtopic.php?f=5&t=9376&sid=f5565960a8071de1bcfc9c890e14ea3b&start=15) thread, the R&D console now causes all protolathe items to appear directly from the protolathe, regardless of the status of the "locked" variable.
