### PR TITLE
Vending Machine PIN fix.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -52,6 +52,8 @@
 	var/const/WIRE_SHOCK = 3
 	var/const/WIRE_SHOOTINV = 4
 
+	var/check_accounts = 0		// 1 = requires PIN and checks accounts.  0 = You slide an ID, it vends, SPACE COMMUNISM!
+
 /obj/machinery/vending/New()
 	..()
 	spawn(4)
@@ -164,46 +166,51 @@
 	if (istype(I, /obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/C = I
 		visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
-		if(vendor_account)
-			var/attempt_pin = input("Enter pin code", "Vendor transaction") as num
-			var/datum/money_account/D = attempt_account_access(C.associated_account_number, attempt_pin, 2)
-			if(D)
-				var/transaction_amount = currently_vending.price
-				if(transaction_amount <= D.money)
+		if(check_accounts)
+			if(vendor_account)
+				var/attempt_pin = input("Enter pin code", "Vendor transaction") as num
+				var/datum/money_account/D = attempt_account_access(C.associated_account_number, attempt_pin, 2)
+				if(D)
+					var/transaction_amount = currently_vending.price
+					if(transaction_amount <= D.money)
+	
+						//transfer the money
+						D.money -= transaction_amount
+						vendor_account.money += transaction_amount
 
-					//transfer the money
-					D.money -= transaction_amount
-					vendor_account.money += transaction_amount
-
-					//create entries in the two account transaction logs
-					var/datum/transaction/T = new()
-					T.target_name = "[vendor_account.owner_name] (via [src.name])"
-					T.purpose = "Purchase of [currently_vending.product_name]"
-					if(transaction_amount > 0)
-						T.amount = "([transaction_amount])"
-					else
+						//create entries in the two account transaction logs
+						var/datum/transaction/T = new()
+						T.target_name = "[vendor_account.owner_name] (via [src.name])"
+						T.purpose = "Purchase of [currently_vending.product_name]"
+						if(transaction_amount > 0)
+							T.amount = "([transaction_amount])"
+						else
+							T.amount = "[transaction_amount]"
+						T.source_terminal = src.name
+						T.date = current_date_string
+						T.time = worldtime2text()
+						D.transaction_log.Add(T)
+						//
+						T = new()
+						T.target_name = D.owner_name
+						T.purpose = "Purchase of [currently_vending.product_name]"
 						T.amount = "[transaction_amount]"
-					T.source_terminal = src.name
-					T.date = current_date_string
-					T.time = worldtime2text()
-					D.transaction_log.Add(T)
-					//
-					T = new()
-					T.target_name = D.owner_name
-					T.purpose = "Purchase of [currently_vending.product_name]"
-					T.amount = "[transaction_amount]"
-					T.source_terminal = src.name
-					T.date = current_date_string
-					T.time = worldtime2text()
-					vendor_account.transaction_log.Add(T)
+						T.source_terminal = src.name
+						T.date = current_date_string
+						T.time = worldtime2text()
+						vendor_account.transaction_log.Add(T)
 
-					// Vend the item
-					src.vend(src.currently_vending, usr)
-					currently_vending = null
+						// Vend the item
+						src.vend(src.currently_vending, usr)
+						currently_vending = null
+				else
+					usr << "\icon[src]<span class='warning'>You don't have that much money!</span>"
 			else
-				usr << "\icon[src]<span class='warning'>You don't have that much money!</span>"
+				usr << "\icon[src]<span class='warning'>Unable to access account. Check security settings and try again.</span>"
 		else
-			usr << "\icon[src]<span class='warning'>Unable to access account. Check security settings and try again.</span>"
+			//Just Vend it.
+			src.vend(src.currently_vending, usr)
+			currently_vending = null
 	else
 		usr << "\icon[src]<span class='warning'>Unable to access vendor account. Please record the machine ID and call CentComm Support.</span>"
 


### PR DESCRIPTION
Removed requirement for PIN on vending machines with an easy way of adding it back in the future
or setting machines to not use it or use it depending on what we decide later on.

Someone attempted to make it where it would accept any PIN and this is just as annoying as typing in a PIN.

So...space communism, swipe your card and it spits out an item.  No PIN prompt at all.
