### PR TITLE
Nerf to shield blobs

### DIFF
--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -6,7 +6,7 @@
 	density = 1
 	opacity = 0
 	anchored = 1
-	health = 100
+	health = 60
 	brute_resist = 1
 	fire_resist = 2
 


### PR DESCRIPTION
Now they take 2 hits instead of 3, that way they are a little easier to deal with and hopefully not as much meta will have to occur.
