### PR TITLE
PDA Nano-UI Fix.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -619,8 +619,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if (in_range(src, U) && loc == U)
 					n = copytext(adminscrub(n), 1, MAX_MESSAGE_LEN)
 					if (mode == 1)
-						note = replacetext(n, "\n", "<BR>")
-						notehtml = n
+						note = html_decode(n)
+						notehtml = note
+						note = replacetext(note, "\n", "<br>")
 				else
 					ui.close()
 			if("Toggle Messenger")

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -165,7 +165,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 			<b>Notes</b>:
 		</div>
 	</div>
-	<div class="statusDisplay" style="height: 225px; overflow: auto;">
+	<div class="statusDisplayRecords" style="height: 225px">
 	        <div class="item">
 	                <div class="itemContent" style="width: 100%;">
                                 <span class="average">{^{:note}}</span>


### PR DESCRIPTION
Fixes the line breaks in notes so it doesn't piss of nanoUI when you have multiple lines.

Also fixed quotes, this will remove the ability to use less then and greater then in notes but not much I can do about that without
adding a bunch of replacetext procs encoding and decoding only those items.
