### PR TITLE
Fixes/tweaks for NanoUI, updates to new PDA 

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -74,6 +74,8 @@ datum/mind
 			current.mind = null
 		if(new_character.mind)		//remove any mind currently in our new body's mind variable
 			new_character.mind.current = null
+			
+		nanomanager.user_transferred(current, new_character) // transfer active NanoUI instances to new user
 
 		current = new_character		//link ourself to our new body
 		new_character.mind = src	//and link our new body to ourself

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -485,6 +485,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		// When the UI is first opened this is the data it will use
 		ui.set_initial_data(data)
 		ui.open()
+		ui.set_auto_update(1)
 	else
 		// The UI is already open so push the new data to it
 		ui.push_data(data)
@@ -882,6 +883,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if(L)
 			L << "\icon[P] <b>Message from [src.owner] ([ownjob]), </b>\"[t]\" (<a href='byond://?src=\ref[P];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
+			nanomanager.update_user_uis(L, P) // Update the recieving user's PDA UI so that they can see the new message
+			
+		nanomanager.update_user_uis(U, P) // Update the sending user's PDA UI so that they can see the new message
 
 		log_pda("[usr] (PDA: [src.name]) sent \"[t]\" to [P.name]")
 		P.overlays.Cut()

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -13,7 +13,7 @@
 
 	var/datum/nanoui/ui = locate(uiref)
 
-	if (ui)
+	if (istype(ui))
 		ui.close()
 		
 		if(ui.ref)

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -112,5 +112,27 @@
 	for (var/datum/nanoui/ui in user.open_uis)
 		ui.close();
 
+ /**
+  * This is called when a player transfers from one mob to another
+  * Transfers all open UIs to the new mob
+  *
+  * @param oldMob /mob The user's old mob
+  * @param newMob /mob The user's new mob
+  *
+  * @return nothing
+  */
+/datum/nanomanager/proc/user_transferred(var/mob/oldMob, var/mob/newMob)
+	if (isnull(oldMob.open_uis) || !istype(oldMob.open_uis, /list) || open_uis.len == 0)
+		return 0 // has no open uis
 
+	if (isnull(newMob.open_uis) || !istype(newMob.open_uis, /list))
+		newMob.open_uis = list()
+
+	for (var/datum/nanoui/ui in oldMob.open_uis)
+		ui.user = newMob
+		newMob.open_uis.Add(ui)
+
+	oldMob.open_uis.Cut()
+	
+	return 1 // success
 

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -1,8 +1,9 @@
 // This is the window/UI manager for Nano UI
 // There should only ever be one (global) instance of nanomanger
 /datum/nanomanager
-	// the list of current open /nanoui UIs
+	// a list of current open /nanoui UIs, grouped by src_object and ui_key
 	var/open_uis[0]
+	// a list of current open /nanoui UIs, not grouped, for use in processing
 	var/list/processing_uis = list()
 
  /**
@@ -38,7 +39,7 @@
  /**
   * Update all /nanoui uis attached to src_object
   *
-  * @param src_object /obj|/mob The obj or mob which the uis belong to
+  * @param src_object /obj|/mob The obj or mob which the uis are attached to
   *
   * @return int The number of uis updated
   */
@@ -54,6 +55,48 @@
 				ui.process(1)
 				update_count++
 	return update_count
+	
+ /**
+  * Update /nanoui uis belonging to user 
+  *
+  * @param user /mob The mob who owns the uis
+  * @param src_object /obj|/mob If src_object is provided, only update uis which are attached to src_object (optional)
+  * @param ui_key string If ui_key is provided, only update uis with a matching ui_key (optional)
+  *
+  * @return int The number of uis updated
+  */
+/datum/nanomanager/proc/update_user_uis(var/mob/user, src_object = null, ui_key = null)
+	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || open_uis.len == 0)
+		return 0 // has no open uis
+
+	var/update_count = 0
+	for (var/datum/nanoui/ui in user.open_uis)		
+		if ((isnull(src_object) || !isnull(src_object) && ui.src_object == src_object) && (isnull(ui_key) || !isnull(ui_key) && ui.ui_key == ui_key))
+			ui.process(1)
+			update_count++
+			
+	return update_count
+	
+ /**
+  * Close /nanoui uis belonging to user 
+  *
+  * @param user /mob The mob who owns the uis
+  * @param src_object /obj|/mob If src_object is provided, only close uis which are attached to src_object (optional)
+  * @param ui_key string If ui_key is provided, only close uis with a matching ui_key (optional)
+  *
+  * @return int The number of uis closed
+  */
+/datum/nanomanager/proc/close_user_uis(var/mob/user, src_object = null, ui_key = null)
+	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || open_uis.len == 0)
+		return 0 // has no open uis
+
+	var/close_count = 0
+	for (var/datum/nanoui/ui in user.open_uis)		
+		if ((isnull(src_object) || !isnull(src_object) && ui.src_object == src_object) && (isnull(ui_key) || !isnull(ui_key) && ui.ui_key == ui_key))
+			ui.close()
+			close_count++
+			
+	return close_count
 
  /**
   * Add a /nanoui ui to the list of open uis
@@ -106,11 +149,7 @@
 
 // 
 /datum/nanomanager/proc/user_logout(var/mob/user)
-	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || open_uis.len == 0)
-		return 0 // has no open uis
-
-	for (var/datum/nanoui/ui in user.open_uis)
-		ui.close();
+	return close_user_uis(user)
 
  /**
   * This is called when a player transfers from one mob to another

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -135,7 +135,6 @@ nanoui is used to open and update nano browser uis
 		if (dist > 4)
 			close()
 			return
-
 		
 		if ((allowed_user_stat > -1) && (user.stat > allowed_user_stat))
 			set_status(STATUS_DISABLED, push_update) // no updates, completely disabled (red visibility)
@@ -352,6 +351,7 @@ nanoui is used to open and update nano browser uis
 		window_size = "size=[width]x[height];"
 	update_status(0)
 	user << browse(get_html(), "window=[window_id];[window_size][window_options]")
+	winset(user, "mapwindow.map", "focus=true") // return keyboard focus to map
 	on_close_winset()
 	//onclose(user, window_id)
 	nanomanager.ui_opened(src)
@@ -405,7 +405,7 @@ nanoui is used to open and update nano browser uis
 	if (status != STATUS_INTERACTIVE || user != usr) // If UI is not interactive or usr calling Topic is not the UI user
 		return
 
-	if (src_object.Topic(href, href_list))
+	if (src_object && src_object.Topic(href, href_list))
 		nanomanager.update_uis(src_object) // update all UIs attached to src_object
 
  /**

--- a/nano/templates/TemplatesGuide.txt
+++ b/nano/templates/TemplatesGuide.txt
@@ -7,7 +7,4 @@ to easily add conditionals (if statements), loops (for loops) and custom formatt
 
 Templates are stored in the /nano/templates folder and the file extension is .tmpl.
 
-This guide is a work in progress. However the templating system is "JSRender", and documentation for it's
-markup syntax can be found here: http://www.jsviews.com/#jsrtags
-
-
+This guide is being replaced with a wiki entry, found here: http://baystation12.net/wiki/index.php?title=NanoUI

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -9,7 +9,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 			 <b>Functions</b>:
                 </div>
                 <div class="itemContent">
-			{^{:~link('Refresh', 'refresh', {'choice' : "Refresh"}, null, 'fixedLeft')}}
+			<!--{^{:~link('Refresh', 'refresh', {'choice' : "Refresh"}, null, 'fixedLeft')}}-->
 			{^{:~link('Close', 'gear', {'choice' : "Close"}, null, 'fixedLeft')}}
 			{^{if idInserted}} {^{:~link('Update PDA Info', 'eject', {'choice' : "UpdateInfo"}, null, 'fixedLeftWide')}} {{/if}}              
 			{^{if mode != 0}} {^{:~link('Return', 'arrowreturn-1-w', {'choice' : "Return"}, null, 'fixedLeft')}} {{/if}}


### PR DESCRIPTION
These changes were made by TG coders, I've added them to BS12:
- Transfer open ui instances when transferring a user to another mob
- Runtime fixes in the NanoUI Topic and nanoclose client verb
- Return focus to the map when a NanoUI is opened

New additions:
- Updated NanoUI's nanomanager with update_user_uis and close_user_uis procs. These procs allow you to update and close uis for a specific user and optionally a specific src_object and/or ui_key.
- Added a link to the new NanoUI wiki page in the TemplatesGuide.txt file.
- When a user sends or recieves a Message using a PDA, the UI (if open) will now update instantly to show the sent/received message (this uses the new nanomanager.update_user_uis proc).
