### PR TITLE
Partial fix for pAI emotes (one-third-reimplementation of audio emotes)

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -36,11 +36,15 @@
 				M.show_message(message)
 
 
+		// Type 1 (Visual) emotes are sent to anyone in view of the item
 		if (m_type & 1)
 			for (var/mob/O in viewers(src, null))
 				O.show_message(message, m_type)
+
+		// Type 2 (Audible) emotes are sent to anyone in hear range
+		// of the *LOCATION* -- this is important for pAIs to be heard
 		else if (m_type & 2)
-			for (var/mob/O in hearers(src.loc, null))
+			for (var/mob/O in hearers(get_turf(src), null))
 				O.show_message(message, m_type)
 
 /mob/proc/emote_dead(var/message)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -4,6 +4,7 @@
 	icon_state = "shadow"
 
 	robot_talk_understand = 0
+	emote_type = 2		// pAIs emotes are heard, not seen, so they can be seen through a container (eg. person)
 
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -89,6 +89,7 @@
 	var/list/languages = list()         // For speaking/listening.
 	var/list/abilities = list()         // For species-derived or admin-given powers.
 	var/list/speak_emote = list("says") // Verbs used when speaking. Defaults to 'say' if speak_emote is null.
+	var/emote_type = 1		// Define emote default type, 1 for seen emotes, 2 for heard emotes
 
 	var/name_archive //For admin things like possession
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -25,7 +25,7 @@
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 
 	if(use_me)
-		usr.emote("me",1,message)
+		usr.emote("me",usr.emote_type,message)
 	else
 		usr.emote(message)
 


### PR DESCRIPTION
This makes pAI actually able to use emotes
They however still can't hear emotes (not even their owns) because the game doesn't check recursively for emote listeners at all (aka. you can't see emotes from inside a locker, even though you should be able to 'hear' audio ones)

A partial fix could be to check to first level recursion (as the say code does), though this might not be desirable (creates overhead from SSD snorings and others)
Since full recursion is not desirable neither on say or emote code (unless you want your CPU to melt), the code will probably need to be hacked around to give pAIs a special treatement (keep a global list, check all pAIs for ones in hearing range)
