### PR TITLE
NanoUI fix

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -283,32 +283,20 @@ nanoui is used to open and update nano browser uis
 <html>
 	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 	<head>
-		[head_content]
-	</head>
-	<body scroll=auto data-url-parameters='[url_parameters_json]' data-template-data='[template_data_json]' data-initial-data='[initial_data_json]'>
 		<script type='text/javascript'>
 			function receiveUpdateData(jsonString)
 			{
-				// We need both jQuery and NanoUpdate to be able to recieve data
+				// We need both jQuery and NanoUpdate to be able to recieve data				
+				// At the moment any data received before those libraries are loaded will be lost
 				if (typeof NanoUpdate != 'undefined' && typeof jQuery != 'undefined')
 				{
 					NanoUpdate.receiveUpdateData(jsonString);
 				}
-				else
-				{
-					alert('receiveUpdateData ERROR: something is not defined!');
-					if (typeof NanoUpdate == 'undefined')
-					{
-						alert('NanoUpdate not defined!');
-					}
-					if (typeof jQuery == 'undefined')
-					{
-						alert('jQuery not defined!');
-					}
-				}
-				// At the moment any data received before those libraries are loaded will be lost
 			}
 		</script>
+		[head_content]
+	</head>
+	<body scroll=auto data-url-parameters='[url_parameters_json]' data-template-data='[template_data_json]' data-initial-data='[initial_data_json]'>		
 		<div id='uiWrapper'>
 			[title ? "<div id='uiTitleWrapper'><div id='uiStatusIcon' class='icon24 uiStatusGood'></div><div id='uiTitle'>[title]</div><div id='uiTitleFluff'></div></div>" : ""]
 			<div id='uiContent'>


### PR DESCRIPTION
- Moved the receiveUpdateData JavaScript into the head so that it's loaded first.

This is to prevent an error which occurs if an update is recieved from the server before the UI is fully loaded.
