### PR TITLE
Talisman icon fix

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -42,6 +42,8 @@
 		return
 
 /obj/item/weapon/paper/update_icon()
+	if(icon_state == "paper_talisman")
+		return
 	if(info)
 		icon_state = "paper_words"
 		return


### PR DESCRIPTION
Makes talismans keep looking like talismans for more than a tick.
