### PR TITLE
Fix to people without legs not being able to use consoles ect

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -30,7 +30,7 @@
 		if (src.z > 6)
 			user << "\red <b>Unable to establish a connection</b>: \black You're too far away from the station!"
 			return
-		if(stat & (NOPOWER|BROKEN))	return
+		if(NOPOWER|BROKEN)	return
 
 		if(!isAI(user))
 			user.set_machine(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -206,8 +206,8 @@ Class Procs:
 /obj/machinery/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN|MAINT))
 		return 1
-	if(user.lying || user.stat)
-		return 1
+	/*if(user.lying || user.stat)
+		return 1*/ //look at how fancy enabling legless people is!!!!
 	if ( ! (istype(usr, /mob/living/carbon/human) || \
 			istype(usr, /mob/living/silicon) || \
 			istype(usr, /mob/living/carbon/monkey) && ticker && ticker.mode.name == "monkey") )


### PR DESCRIPTION
commenting out a check that prevents people that are lying down from using consoles and machines
does not affect stunned, sleeping, or dead people attempting to use machines.
only affects living people who are lying down and somehow managing to get attack_hand to proc

the only instance this reliably occurs in is when a legless person is strapped to a chair and is attempting to use a console or machine.

seriously this doesn't affect anyone else

seriously.
its just a really old sanity check interfering with modern code.
