### PR TITLE
SMES fix, AI's can now use them.

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -215,7 +215,7 @@
 
 //world << "[href] ; [href_list[href]]"
 
-	if (!istype(src.loc, /turf) || istype(usr, /mob/living/silicon/ai))
+	if (!istype(src.loc, /turf) && !istype(usr, /mob/living/silicon/))
 		return 0 // Do not update ui
 
 	if( href_list["cmode"] )


### PR DESCRIPTION
Thinking this was a typo, though quite honestly I'm not sure why this test
is even here as distance checks are built into nanoUI but since feradan put it in
I'm kinda not wanting to remove it.
