### PR TITLE
Fixes unsolvable telescience equation.

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -12,7 +12,6 @@
 	var/z_co = 1
 	var/power_off
 	var/rotation_off
-	var/angle_off
 
 	var/rotation = 0
 	var/angle = 45
@@ -154,9 +153,8 @@
 
 		var/truePower = Clamp(power + power_off, 1, 1000)
 		var/trueRotation = rotation + rotation_off
-		var/trueAngle = Clamp(angle + angle_off, 1, 90)
 
-		var/datum/projectile_data/proj_data = projectile_trajectory(telepad.x, telepad.y, trueRotation, trueAngle, truePower)
+		var/datum/projectile_data/proj_data = projectile_trajectory(telepad.x, telepad.y, trueRotation, angle, truePower)
 		last_tele_data = proj_data
 
 		var/trueX = Clamp(round(proj_data.dest_x, 1), 1, world.maxx)
@@ -307,6 +305,5 @@
 
 /obj/machinery/computer/telescience/proc/recalibrate()
 	teles_left = rand(30, 40)
-	angle_off = rand(-25, 25)
 	power_off = rand(-4, 0)
 	rotation_off = rand(-10, 10)


### PR DESCRIPTION
Currently, telescience requires users to solve for two variables with only one equation (not possible). To best illustrate this problem, I'll present said problem alongside my solution:

`D = 2*(P-P_off)*sin(E-E_off)/10*(P-P_off)*cos(E-E_off) = (P-P_off)^2*sin(2*E-E_off)/10`
Where:
D is distance
P is power and Poff is power offset
E is elevation and Eoff is elevation offset.

As E and P can be set by the user and D can be measured, let's use a test case from the game where:
let D = 18, E = 45, and P = 20.

Thus:
`18 =  (20-P_off)^2*sin(2*45-E_off)/10 =  (20-P_off)^2*sin(90-E_off)/10`
Or after this patch:
`18 = (20-P_off)^2*sin(2*45)/10 =  (20-P_off)^2*1/10 = (20-P_off)^2/10`

And if we try to solve the variables in equations:

Before patch: (The notation here gets complex so excuse the external links)
P_off = http://www.wolframalpha.com/input/?i=solve+%2820-P%29^2*sin%2890-L%29%2F10+%3D+18+for+P
E_off = http://www.wolframalpha.com/input/?i=solve+%2820-P%29^2*sin%2890-L%29%2F10+%3D+18+for+L
Naturally, each variable can only be described in terms of the other; they cannot be solved for a real number.

After patch:
Let D = 29 (Distance will generally be greater if you VV and set angle_off (elevation offset) to 0)
`D = (P-P_off)^2/10 = (20-P_off)^2/10 = 29`
Therefore: `20 - P_off  = sqrt(D*10) = sqrt(290) ~= 17` 
Therefor `P_off ~= 3`
(In wolfram alpha format: http://www.wolframalpha.com/input/?i=solve++%2820-P_1%29^2%2F10+%3D+29 ) 

Thus, we are able to arrive at an answer and so make telescience actually a calculated science, instead of purely guesswork.

(As an alternative, an extra mechanic could be introduced which uses system of equations instead of a single equation and provides a measurable result separate from distance. If setup right, this would allow an equation with 2 unknown variables to be solved. Though, this would be a lot more effort).
