### PR TITLE
Sniper Rifle fixes

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -188,14 +188,15 @@ datum/hud/New(mob/owner)
 
 
 //Triggered when F12 is pressed (Unless someone changed something in the DMF)
-/mob/verb/button_pressed_F12()
+/mob/verb/button_pressed_F12(var/full = 0 as null)
 	set name = "F12"
 	set hidden = 1
 
 	if(hud_used)
 		if(ishuman(src))
-			if(!src.client) return
-
+			if(!client) return
+			if(client.view != world.view)
+				return
 			if(hud_used.hud_shown)
 				hud_used.hud_shown = 0
 				if(src.hud_used.adding)
@@ -209,10 +210,15 @@ datum/hud/New(mob/owner)
 
 				//Due to some poor coding some things need special treatment:
 				//These ones are a part of 'adding', 'other' or 'hotkeybuttons' but we want them to stay
-				src.client.screen += src.hud_used.l_hand_hud_object	//we want the hands to be visible
-				src.client.screen += src.hud_used.r_hand_hud_object	//we want the hands to be visible
-				src.client.screen += src.hud_used.action_intent		//we want the intent swticher visible
-				src.hud_used.action_intent.screen_loc = ui_acti_alt	//move this to the alternative position, where zone_select usually is.
+				if(!full)
+					src.client.screen += src.hud_used.l_hand_hud_object	//we want the hands to be visible
+					src.client.screen += src.hud_used.r_hand_hud_object	//we want the hands to be visible
+					src.client.screen += src.hud_used.action_intent		//we want the intent swticher visible
+					src.hud_used.action_intent.screen_loc = ui_acti_alt	//move this to the alternative position, where zone_select usually is.
+				else
+					src.client.screen -= src.healths
+					src.client.screen -= src.internals
+					src.client.screen -= src.gun_setting_icon
 
 				//These ones are not a part of 'adding', 'other' or 'hotkeybuttons' but we want them gone.
 				src.client.screen -= src.zone_sel	//zone_sel is a mob variable for some reason.
@@ -225,7 +231,12 @@ datum/hud/New(mob/owner)
 					src.client.screen += src.hud_used.other
 				if(src.hud_used.hotkeybuttons && !src.hud_used.hotkey_ui_hidden)
 					src.client.screen += src.hud_used.hotkeybuttons
-
+				if(src.healths)
+					src.client.screen |= src.healths
+				if(src.internals)
+					src.client.screen |= src.internals
+				if(src.gun_setting_icon)
+					src.client.screen |= src.gun_setting_icon
 
 				src.hud_used.action_intent.screen_loc = ui_acti //Restore intent selection to the original position
 				src.client.screen += src.zone_sel				//This one is a special snowflake

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1192,6 +1192,13 @@
 			see_in_dark = 8
 			if(!druggy)		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 			if(healths)		healths.icon_state = "health7"	//DEAD healthmeter
+			if(client)
+				if(client.view != world.view)
+					if(locate(/obj/item/weapon/gun/energy/sniperrifle, contents))
+						var/obj/item/weapon/gun/energy/sniperrifle/s = locate() in src
+						if(s.zoom)
+							s.zoom()
+
 		else
 			sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = species.darksight

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -186,6 +186,12 @@
 		if(L.incorporeal_move)//Move though walls
 			Process_Incorpmove(direct)
 			return
+		if(mob.client)
+			if(mob.client.view != world.view)
+				if(locate(/obj/item/weapon/gun/energy/sniperrifle, mob.contents))		// If mob moves while zoomed in with sniper rifle, unzoom them.
+					var/obj/item/weapon/gun/energy/sniperrifle/s = locate() in mob
+					if(s.zoom)
+						s.zoom()
 
 	if(Process_Grab())	return
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -228,6 +228,9 @@ obj/item/weapon/gun/energy/staff/focus
 	if(usr.stat || !(istype(usr,/mob/living/carbon/human)))
 		usr << "You are unable to focus down the scope of the rifle."
 		return
+	if(!zoom && global_hud.darkMask[1] in usr.client.screen)
+		usr << "Your welding equipment gets in the way of you looking down the scope"
+		return
 	if(!zoom && usr.get_active_hand() != src)
 		usr << "You are too distracted to look down the scope, perhaps if it was in your active hand this might work better"
 		return

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -205,37 +205,37 @@ obj/item/weapon/gun/energy/staff/focus
 	projectile_type = "/obj/item/projectile/energy/plasma"
 
 /obj/item/weapon/gun/energy/sniperrifle
-   name = "L.W.A.P. Sniper Rifle"
-   desc = "A rifle constructed of lightweight materials, fitted with a SMART aiming-system scope."
-   icon = 'icons/obj/gun.dmi'
-   icon_state = "sniper"
-   fire_sound = 'sound/weapons/marauder.ogg'
-   origin_tech = "combat=6;materials=5;powerstorage=4"
-   projectile_type = "/obj/item/projectile/beam/sniper"
-   slot_flags = SLOT_BACK
-   charge_cost = 250
-   fire_delay = 35
-   w_class = 4.0
+	name = "L.W.A.P. Sniper Rifle"
+	desc = "A rifle constructed of lightweight materials, fitted with a SMART aiming-system scope."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "sniper"
+	fire_sound = 'sound/weapons/marauder.ogg'
+	origin_tech = "combat=6;materials=5;powerstorage=4"
+	projectile_type = "/obj/item/projectile/beam/sniper"
+	slot_flags = SLOT_BACK
+	charge_cost = 250
+	fire_delay = 35
+	w_class = 4.0
 
-   var/zoom = 0
+	var/zoom = 0
 
 /obj/item/weapon/gun/energy/sniperrifle/dropped(mob/user)
 	user.client.view = world.view
 	zoom = 0
 
 /obj/item/weapon/gun/energy/sniperrifle/verb/zoom()
-   set category = "Special Verbs"
-   set name = "Zoom"
-   set popup_menu = 0
-   if(usr.stat || !(istype(usr,/mob/living/carbon/human)))
-      usr << "No."
-      return
+	set category = "Special Verbs"
+	set name = "Zoom"
+	set popup_menu = 0
+	if(usr.stat || !(istype(usr,/mob/living/carbon/human)))
+		usr << "No."
+		return
 
-   src.zoom = !src.zoom
-   usr << ("<font color='[src.zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>")
-   if(zoom)
-      usr.client.view = 12
-      usr << sound('sound/mecha/imag_enh.ogg',volume=50)
-   else
-      usr.client.view = world.view//world.view - default mob view size
-   return
+	src.zoom = !src.zoom
+	usr << ("<font color='[src.zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>")
+	if(zoom)
+		usr.client.view = 12
+		usr << sound('sound/mecha/imag_enh.ogg',volume=50)
+	else
+		usr.client.view = world.view  //world.view - default mob view size
+	return

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -221,6 +221,14 @@ obj/item/weapon/gun/energy/staff/focus
 /obj/item/weapon/gun/energy/sniperrifle/dropped(mob/user)
 	user.client.view = world.view
 
+
+
+/*
+This is called from 
+modules/mob/mob_movement.dm if you move you will be zoomed out
+modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
+*/
+
 /obj/item/weapon/gun/energy/sniperrifle/verb/zoom()
 	set category = "Object"
 	set name = "Use Sniper Scope"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -216,26 +216,32 @@ obj/item/weapon/gun/energy/staff/focus
 	charge_cost = 250
 	fire_delay = 35
 	w_class = 4.0
-
 	var/zoom = 0
 
 /obj/item/weapon/gun/energy/sniperrifle/dropped(mob/user)
 	user.client.view = world.view
-	zoom = 0
 
 /obj/item/weapon/gun/energy/sniperrifle/verb/zoom()
-	set category = "Special Verbs"
-	set name = "Zoom"
+	set category = "Object"
+	set name = "Use Sniper Scope"
 	set popup_menu = 0
 	if(usr.stat || !(istype(usr,/mob/living/carbon/human)))
-		usr << "No."
+		usr << "You are unable to focus down the scope of the rifle."
+		return
+	if(!zoom && usr.get_active_hand() != src)
+		usr << "You are too distracted to look down the scope, perhaps if it was in your active hand this might work better"
 		return
 
-	src.zoom = !src.zoom
-	usr << ("<font color='[src.zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>")
-	if(zoom)
+	if(usr.client.view == world.view)
+		if(!usr.hud_used.hud_shown)
+			usr.button_pressed_F12(1)	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
+		usr.button_pressed_F12(1)
 		usr.client.view = 12
-		usr << sound('sound/mecha/imag_enh.ogg',volume=50)
+		zoom = 1
 	else
-		usr.client.view = world.view  //world.view - default mob view size
+		usr.client.view = world.view
+		if(!usr.hud_used.hud_shown)
+			usr.button_pressed_F12(1)
+		zoom = 0
+	usr << "<font color='[zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>"
 	return


### PR DESCRIPTION
You have no HUD when zoomed.  None, I'm unable to move every HUD element while zoomed in so you lose it.  Consider it part of your concentration while zoomed in.

If you move while zoomed in you automatically zoom out, you lose concentration.

If the rifle isn't in your active hand you can't zoom in.

If you die while zoomed in, you are zoomed out.

If you have welding equipment on, you ain't zooming in.

Also some poor soul used spaces instead of tabs for indention.  I fixed that in a separate commit so you can view just the changes by looking at fbcf162 and b260d51
