### PR TITLE
APC's added to powernets again

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -169,6 +169,9 @@
 					T = locate(src.x, src.y, controler.down_target)
 					if(T)
 						. += power_list(T, src, 12, 1)
+	else if(!d1)
+		if(T)
+			. += power_list(T, src, d1, 1)
 
 	if(d2 == 11 || d2 == 12)
 		var/turf/controlerlocation = locate(1, 1, z)


### PR DESCRIPTION
Fixes #4328

New z-level code wasn't handling d1 == 0 cables correctly.
