### PR TITLE
View Variables Option:  Add/Remove Verb

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -258,6 +258,9 @@ client
 			body += "<option value='?_src_=vars;regenerateicons=\ref[D]'>Regenerate Icons</option>"
 			body += "<option value='?_src_=vars;addlanguage=\ref[D]'>Add Language</option>"
 			body += "<option value='?_src_=vars;remlanguage=\ref[D]'>Remove Language</option>"
+
+			body += "<option value='?_src_=vars;addverb=\ref[D]'>Add Verb</option>"
+			body += "<option value='?_src_=vars;remverb=\ref[D]'>Remove Verb</option>"
 			if(ishuman(D))
 				body += "<option value>---</option>"
 				body += "<option value='?_src_=vars;setmutantrace=\ref[D]'>Set Mutantrace</option>"
@@ -807,6 +810,53 @@ client
 			usr << "Removed [rem_language] from [H]."
 		else
 			usr << "Mob doesn't know that language."
+
+	else if(href_list["addverb"])
+		if(!check_rights(R_DEBUG))      return
+		
+		var/mob/living/H = locate(href_list["addverb"])
+		
+		if(!istype(H))
+			usr << "This can only be done to instances of type /mob/living"
+			return
+		var/list/possibleverbs = list()
+		possibleverbs += typesof(/mob/proc,/mob/verb,/mob/living/proc,/mob/living/verb)
+		switch(H.type)
+			if(/mob/living/carbon/human)
+				possibleverbs += typesof(/mob/living/carbon/proc,/mob/living/carbon/verb,/mob/living/carbon/human/verb,/mob/living/carbon/human/proc)
+			if(/mob/living/silicon/robot)
+				possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/robot/proc,/mob/living/silicon/robot/verb)
+			if(/mob/living/silicon/ai)
+				possibleverbs += typesof(/mob/living/silicon/proc,/mob/living/silicon/ai/proc,/mob/living/silicon/ai/verb)
+		possibleverbs -= H.verbs
+		
+		var/verb = input("Select a verb!", "Verbs",null) as anything in possibleverbs
+		if(!H)
+			usr << "Mob doesn't exist anymore"
+			return
+		if(!verb)
+			return
+		else
+			H.verbs += verb
+		
+	else if(href_list["remverb"])
+		if(!check_rights(R_DEBUG))      return
+
+		var/mob/H = locate(href_list["remverb"])
+
+		if(!istype(H))
+			usr << "This can only be done to instances of type /mob"
+			return
+		var/verb = input("Please choose a verb to remove.","Verbs",null) as null|anything in H.verbs
+		if(!H)
+			usr << "Mob doesn't exist anymore"
+			return
+		if(!verb)
+			return
+		else
+			H.verbs -= verb
+
+	
 
 	else if(href_list["regenerateicons"])
 		if(!check_rights(0))	return


### PR DESCRIPTION
Since we can't edit the verbs variable directly this allows us to do so safely.

It builds a list of procs and verbs for the mob type and allows the admin to add it.

Want to add self_destruct to a cyborg?  It will show up in Commands tab
Want to add RevConvert to a regular Rev?  Feel free!

Want to remove whisper from some loud mouth?  Go wild!

Adding procs that aren't usually available to players will create a commands tab, primarily this is for debugging since Advance ProcCall on mobs is awful.

I figured this would be useful when I noticed traitorpanel added RevHeads didn't get their RevConvert verbs and I could find no way of adding it otherwise.
