### PR TITLE
Because we HAVE to define Del() three times

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -19,14 +19,6 @@ var/list/GPS_list = list()
 /obj/item/device/gps/Del()
 	GPS_list.Remove(src)
 	..()
-/obj/item/device/gps/Del()
-	GPS_list.Remove(src)
-	..()
-
-/obj/item/device/gps/Del()
-	GPS_list.Remove(src)
-	..()
-
 /obj/item/device/gps/emp_act(severity)
 	emped = 1
 	overlays -= "working"


### PR DESCRIPTION
/obj/item/device/gps/Del()
    GPS_list.Remove(src)
    ..()
/obj/item/device/gps/Del()
    GPS_list.Remove(src)
    ..()
/obj/item/device/gps/Del()
    GPS_list.Remove(src)
    ..()
