### PR TITLE
Self-naming APC's! Now even mapped in APC's will rename themselves

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -138,10 +138,10 @@
 	//if area isn't specified use current
 	if(isarea(A) && src.areastring == null)
 		src.area = A
-		name = "[area.name] APC"
+		name = "\improper [area.name] APC"
 	else
 		src.area = get_area_name(areastring)
-		name = "[area.name] APC"
+		name = "\improper [area.name] APC"
 	update_icon()
 
 	make_terminal()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -138,8 +138,10 @@
 	//if area isn't specified use current
 	if(isarea(A) && src.areastring == null)
 		src.area = A
+		name = "[area.name] APC"
 	else
 		src.area = get_area_name(areastring)
+		name = "[area.name] APC"
 	update_icon()
 
 	make_terminal()


### PR DESCRIPTION
depending on what zone they're in. Makes more mapping sanity.
