### PR TITLE
PDA-Nano refresh / scroll fix (Messages/Notes/Records)

### DIFF
--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -169,7 +169,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 			<b>Notes</b>:
 		</div>
 	</div>
-	<div class="statusDisplayRecords" style="height: 225px">
+	<div class="statusDisplayRecords">
 	        <div class="item">
 	                <div class="itemContent" style="width: 100%;">
                                 <span class="average">{{:note}}</span>
@@ -250,7 +250,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 	</div>
 	<br><br>
 			<H3>Conversation with:&nbsp;<span class="average">{{:convo_name}}&nbsp;({{:convo_job}})</span></H3>
-        <div class="statusDisplay" style="height: 250px; overflow: auto;">
+        <div class="statusDisplay" style="overflow: auto;">
                 <div class="item">
                         <div class="itemContent" style="width: 100%;">
 				{{for messages}}
@@ -544,7 +544,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
 	{{else mode == 441}}
 	<H2>Medical Record</H2>
-	 <div class="statusDisplayRecords" style="height: 400px;">
+	 <div class="statusDisplayRecords">
 		<div class="item">
                         <div class="itemContent" style="width: 100%;">
 		{{if records.general_exists == 1}}
@@ -599,7 +599,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
         {{else mode == 451}}
         <H2>Security Record</H2>
-         <div class="statusDisplayRecords" style="height: 400px;">
+         <div class="statusDisplayRecords">
                 <div class="item">
                         <div class="itemContent" style="width: 100%;">
                 {{if records.general_exists == 1}}
@@ -712,7 +712,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				</span>
 			</div>
 		</div>
-		<div class="statusDisplayRecords" style="height: 325px">
+		<div class="statusDisplayRecords">
                 	<div class="item">
                         	<div class="itemContent" style="width: 100%;">
 				<span class="good"><B>Current Approved Orders</B></span><br>


### PR DESCRIPTION
Problem:  NanoUI auto updates, if you have a div with a scroll bar it will automatically scroll to the top.

Solution:  Remove the set size on these div's that have this issue and let the entire screen scroll instead since that isn't messed with on refresh.

Fixes #4376
