### PR TITLE
Bullet inscriptions

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -21,6 +21,26 @@
 		dir = pick(cardinal)
 
 
+/obj/item/ammo_casing/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/screwdriver))
+		if(BB)
+			if(initial(BB.name) == "bullet")
+				var/tmp_label = ""
+				var/label_text = sanitize(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label))
+				if(length(label_text) > 20)
+					user << "\red The inscription can be at most 20 characters long."
+				else
+					if(label_text == "")
+						user << "\blue You scratch the inscription off of [initial(BB)]."
+						BB.name = initial(BB.name)
+					else
+						user << "\blue You inscribe \"[label_text]\" into \the [initial(BB.name)]."
+						BB.name = "[initial(BB.name)] \"[label_text]\""
+			else
+				user << "\blue You can only inscribe a metal bullet."	//because inscribing beanbags is silly
+		else
+			user << "\blue There is no bullet in the casing to inscribe anything into."
+
 
 //Boxes of ammo
 /obj/item/ammo_magazine

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -46,7 +46,7 @@
 /obj/item/ammo_casing/c45r
 	desc = "A .45 rubber bullet casing."
 	caliber = ".45"
-	projectile_type = "/obj/item/projectile/bullet/weakbullet"
+	projectile_type = "/obj/item/projectile/bullet/weakbullet/rubber"
 
 /obj/item/ammo_casing/a12mm
 	desc = "A 12mm bullet casing."
@@ -75,7 +75,7 @@
 	name = "beanbag shell"
 	desc = "A weak beanbag shell."
 	icon_state = "bshell"
-	projectile_type = "/obj/item/projectile/bullet/weakbullet"
+	projectile_type = "/obj/item/projectile/bullet/weakbullet/beanbag"
 	m_amt = 500
 
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -18,6 +18,11 @@
 	weaken = 5
 	embed = 0
 
+/obj/item/projectile/bullet/weakbullet/beanbag		//because beanbags are not bullets
+	name = "beanbag"
+
+/obj/item/projectile/bullet/weakbullet/rubber
+	name = "rubber bullet"
 
 /obj/item/projectile/bullet/midbullet
 	damage = 20


### PR DESCRIPTION
- Can inscribe text into bullets by using a screwdriver on a bullet casing (I think it was @Ravensdale that suggested this on IRC)
- Does not work on non-metal type bullets (i.e. rubber bullets, beanbags, stunshots, etc)
- Added weakbullet subtypes "rubber bullet" and "beanbag" with appropriate names

I can shorten the allowed text length if 20 characters seems too much.

I also did some work on allowing you to unload magazines and refill them, but the further I dug into the code the messier it got. Instead I just opted to PR the inscription changes for now.
