### PR TITLE
RevConvert prompt button order swap.

### DIFF
--- a/code/game/gamemodes/revolution/rp-revolution.dm
+++ b/code/game/gamemodes/revolution/rp-revolution.dm
@@ -296,7 +296,7 @@ mob/living/carbon/human/proc
 				src << "\red Attempting to convert [M]..."
 				log_admin("[src]([src.ckey]) attempted to convert [M].")
 				message_admins("\red [src]([src.ckey]) attempted to convert [M].")
-				var/choice = alert(M,"Asked by [src]: Do you want to join the revolution?","Align Thyself with the Revolution!","No!","Yes!")
+				var/choice = alert(M,"Asked by [src]: Do you want to join the revolution?","Align Thyself with the Revolution!","Yes!","No!")
 				if(choice == "Yes!")
 					ticker.mode:add_revolutionary(M.mind)
 					M << "\blue You join the revolution!"


### PR DESCRIPTION
Before:  No / Yes

After:  Yes / No

Leave up for 24 hours, if there was a reason for it to be "reversed" I want people to be able to look at this and explain it if so.
