### PR TITLE
Bugfix:  AI Camera light toggle

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -666,10 +666,11 @@ var/list/ai_list = list()
 	camera_light_on = !camera_light_on
 	src << "Camera lights [camera_light_on ? "activated" : "deactivated"]."
 	if(!camera_light_on)
-		if(src.current)
-			src.current.SetLuminosity(0)
+		if(current)
+			current.SetLuminosity(0)
+			current = null
 	else
-		src.lightNearbyCamera()
+		lightNearbyCamera()
 
 
 


### PR DESCRIPTION
Fixes #3676

Before:  Toggling would get stuck where it wouldn't toggle the camera until you reset your view.

After:  Camera light toggles, you have to toggle off before turning on a new camera light though.
