### PR TITLE
Fixed halloss not slowing you down.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -12,7 +12,7 @@
 
 	if(reagents.has_reagent("nuka_cola")) return -1
 
-	var/health_deficiency = (100 - health - halloss)
+	var/health_deficiency = (100 - health + halloss)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
 	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80


### PR DESCRIPTION
Due to a sign error halloss did not slow you down. Indeed it made you faster if you were hurt.
