### PR TITLE
Admin Request:  Hide Debug Verbs

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -164,8 +164,55 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/ZoneTick
 	src.verbs += /client/proc/TestZASRebuild
 	//src.verbs += /client/proc/cmd_admin_rejuvenate
+	src.verbs += /client/proc/hide_debug_verbs
 
 	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/hide_debug_verbs()
+	set category = "Debug"
+	set name = "Hide Debug verbs"
+
+	if(!check_rights(R_DEBUG)) return
+
+	src.verbs -= /client/proc/do_not_use_these      //-errorage
+	src.verbs -= /client/proc/camera_view   //-errorage
+	src.verbs -= /client/proc/sec_camera_report     //-errorage
+	src.verbs -= /client/proc/intercom_view //-errorage
+	src.verbs -= /client/proc/air_status //Air things
+	src.verbs -= /client/proc/Cell //More air things
+	src.verbs -= /client/proc/atmosscan //check plumbing
+	src.verbs -= /client/proc/powerdebug //check power
+	src.verbs -= /client/proc/count_objects_on_z_level
+	src.verbs -= /client/proc/count_objects_all
+	src.verbs -= /client/proc/cmd_assume_direct_control     //-errorage
+	src.verbs -= /client/proc/jump_to_dead_group
+	src.verbs -= /client/proc/startSinglo
+	src.verbs -= /client/proc/ticklag       //allows you to set the ticklag.
+	src.verbs -= /client/proc/cmd_admin_grantfullaccess
+	src.verbs -= /client/proc/kaboom
+	src.verbs -= /client/proc/splash
+	src.verbs -= /client/proc/cmd_admin_areatest
+	src.verbs -= /client/proc/cmd_admin_rejuvenate
+	src.verbs -= /datum/admins/proc/show_traitor_panel
+	src.verbs -= /client/proc/print_jobban_old
+	src.verbs -= /client/proc/print_jobban_old_filter
+	src.verbs -= /client/proc/forceEvent
+	src.verbs -= /client/proc/break_all_air_groups
+	src.verbs -= /client/proc/regroup_all_air_groups
+	src.verbs -= /client/proc/kill_pipe_processing
+	src.verbs -= /client/proc/kill_air_processing
+	src.verbs -= /client/proc/disable_communication
+	src.verbs -= /client/proc/disable_movement
+	src.verbs -= /client/proc/Zone_Info
+	src.verbs -= /client/proc/Test_ZAS_Connection
+	src.verbs -= /client/proc/ZoneTick
+	src.verbs -= /client/proc/TestZASRebuild
+	//src.verbs -= /client/proc/cmd_admin_rejuvenate
+	src.verbs -= /client/proc/hide_debug_verbs
+
+	feedback_add_details("admin_verb","hDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+
 
 /client/proc/count_objects_on_z_level()
 	set category = "Mapping"

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -124,47 +124,51 @@ var/intercom_range_display_status = 0
 					del(F)
 	feedback_add_details("admin_verb","mIRD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+var/list/debug_verbs = list (
+	/client/proc/do_not_use_these       
+        ,/client/proc/camera_view    
+        ,/client/proc/sec_camera_report
+        ,/client/proc/intercom_view    
+        ,/client/proc/air_status 
+        ,/client/proc/Cell 
+        ,/client/proc/atmosscan 
+        ,/client/proc/powerdebug 
+        ,/client/proc/count_objects_on_z_level
+        ,/client/proc/count_objects_all
+        ,/client/proc/cmd_assume_direct_control
+        ,/client/proc/jump_to_dead_group
+        ,/client/proc/startSinglo
+        ,/client/proc/ticklag       
+        ,/client/proc/cmd_admin_grantfullaccess
+        ,/client/proc/kaboom
+        ,/client/proc/splash
+        ,/client/proc/cmd_admin_areatest
+        ,/client/proc/cmd_admin_rejuvenate
+        ,/datum/admins/proc/show_traitor_panel
+        ,/client/proc/print_jobban_old
+        ,/client/proc/print_jobban_old_filter
+        ,/client/proc/forceEvent
+        ,/client/proc/break_all_air_groups
+        ,/client/proc/regroup_all_air_groups
+        ,/client/proc/kill_pipe_processing
+        ,/client/proc/kill_air_processing
+        ,/client/proc/disable_communication
+        ,/client/proc/disable_movement
+        ,/client/proc/Zone_Info
+        ,/client/proc/Test_ZAS_Connection
+        ,/client/proc/ZoneTick
+        ,/client/proc/TestZASRebuild
+        ,/client/proc/hide_debug_verbs
+	)
+
+
 /client/proc/enable_debug_verbs()
 	set category = "Debug"
 	set name = "Debug verbs"
 
 	if(!check_rights(R_DEBUG)) return
 
-	src.verbs += /client/proc/do_not_use_these 			//-errorage
-	src.verbs += /client/proc/camera_view 				//-errorage
-	src.verbs += /client/proc/sec_camera_report 		//-errorage
-	src.verbs += /client/proc/intercom_view 			//-errorage
-	src.verbs += /client/proc/air_status //Air things
-	src.verbs += /client/proc/Cell //More air things
-	src.verbs += /client/proc/atmosscan //check plumbing
-	src.verbs += /client/proc/powerdebug //check power
-	src.verbs += /client/proc/count_objects_on_z_level
-	src.verbs += /client/proc/count_objects_all
-	src.verbs += /client/proc/cmd_assume_direct_control	//-errorage
-	src.verbs += /client/proc/jump_to_dead_group
-	src.verbs += /client/proc/startSinglo
-	src.verbs += /client/proc/ticklag	//allows you to set the ticklag.
-	src.verbs += /client/proc/cmd_admin_grantfullaccess
-	src.verbs += /client/proc/kaboom
-	src.verbs += /client/proc/splash
-	src.verbs += /client/proc/cmd_admin_areatest
-	src.verbs += /client/proc/cmd_admin_rejuvenate
-	src.verbs += /datum/admins/proc/show_traitor_panel
-	src.verbs += /client/proc/print_jobban_old
-	src.verbs += /client/proc/print_jobban_old_filter
-	src.verbs += /client/proc/forceEvent
-	src.verbs += /client/proc/break_all_air_groups
-	src.verbs += /client/proc/regroup_all_air_groups
-	src.verbs += /client/proc/kill_pipe_processing
-	src.verbs += /client/proc/kill_air_processing
-	src.verbs += /client/proc/disable_communication
-	src.verbs += /client/proc/disable_movement
-	src.verbs += /client/proc/Zone_Info
-	src.verbs += /client/proc/Test_ZAS_Connection
-	src.verbs += /client/proc/ZoneTick
-	src.verbs += /client/proc/TestZASRebuild
-	//src.verbs += /client/proc/cmd_admin_rejuvenate
-	src.verbs += /client/proc/hide_debug_verbs
+	verbs += debug_verbs
 
 	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -174,41 +178,7 @@ var/intercom_range_display_status = 0
 
 	if(!check_rights(R_DEBUG)) return
 
-	src.verbs -= /client/proc/do_not_use_these      //-errorage
-	src.verbs -= /client/proc/camera_view   //-errorage
-	src.verbs -= /client/proc/sec_camera_report     //-errorage
-	src.verbs -= /client/proc/intercom_view //-errorage
-	src.verbs -= /client/proc/air_status //Air things
-	src.verbs -= /client/proc/Cell //More air things
-	src.verbs -= /client/proc/atmosscan //check plumbing
-	src.verbs -= /client/proc/powerdebug //check power
-	src.verbs -= /client/proc/count_objects_on_z_level
-	src.verbs -= /client/proc/count_objects_all
-	src.verbs -= /client/proc/cmd_assume_direct_control     //-errorage
-	src.verbs -= /client/proc/jump_to_dead_group
-	src.verbs -= /client/proc/startSinglo
-	src.verbs -= /client/proc/ticklag       //allows you to set the ticklag.
-	src.verbs -= /client/proc/cmd_admin_grantfullaccess
-	src.verbs -= /client/proc/kaboom
-	src.verbs -= /client/proc/splash
-	src.verbs -= /client/proc/cmd_admin_areatest
-	src.verbs -= /client/proc/cmd_admin_rejuvenate
-	src.verbs -= /datum/admins/proc/show_traitor_panel
-	src.verbs -= /client/proc/print_jobban_old
-	src.verbs -= /client/proc/print_jobban_old_filter
-	src.verbs -= /client/proc/forceEvent
-	src.verbs -= /client/proc/break_all_air_groups
-	src.verbs -= /client/proc/regroup_all_air_groups
-	src.verbs -= /client/proc/kill_pipe_processing
-	src.verbs -= /client/proc/kill_air_processing
-	src.verbs -= /client/proc/disable_communication
-	src.verbs -= /client/proc/disable_movement
-	src.verbs -= /client/proc/Zone_Info
-	src.verbs -= /client/proc/Test_ZAS_Connection
-	src.verbs -= /client/proc/ZoneTick
-	src.verbs -= /client/proc/TestZASRebuild
-	//src.verbs -= /client/proc/cmd_admin_rejuvenate
-	src.verbs -= /client/proc/hide_debug_verbs
+	verbs -= debug_verbs
 
 	feedback_add_details("admin_verb","hDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
Gives admins (and devs) the ability to hide the debug verbs after enabling them.
