### PR TITLE
Chem grenade fix - again

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -151,6 +151,12 @@
 		for(var/obj/item/weapon/reagent_containers/glass/G in beakers)
 			G.reagents.trans_to(src, G.reagents.total_volume)
 
+		if(src.reagents.total_volume) //The possible reactions didnt use up all reagents.
+			var/datum/effect/effect/system/steam_spread/steam = new /datum/effect/effect/system/steam_spread()
+			steam.set_up(10, 0, get_turf(src))
+			steam.attach(src)
+			steam.start()
+
 			for(var/atom/A in view(affected_area, src.loc))
 				if( A == src ) continue
 				src.reagents.reaction(A, 1, 10)


### PR DESCRIPTION
- Restored "steam" code to chem grenades to handle grenades that don't have any reagents in them that react i.e. water grenades. (I removed it thinking it was only in there for handling foam reagents - which I fixed, but it seems it has more uses.)
  This splashes the surrounding area in whatever reagents were leftover in the grenade after all reactions have occurred.
