### PR TITLE
Code effeciency project: /proc/get_mobs_in_view

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -180,20 +180,7 @@
 		
 	var/list/objects = list()
 
-	var/list/obj_to_check = list()					//IF SOMEONE DOESN'T HEAR SOMETHING AND ARE IN INSIDE A CONTAINER ADD IT TO THIS LIST.
-	obj_to_check += typesof(/obj/item/device/paicard)
-	obj_to_check += typesof(/obj/item/device/aicard)
-	obj_to_check += typesof(/obj/machinery/computer/aifixer)
-
 	for(var/obj/O in range)				//Get a list of objects in hearing range.  We'll check to see if any clients have their "eye" set to the object 
-		if(istype(O, /obj/item/device/radio))   //This avoids all that bullshit with recursion.  FUCK RECURSION  ~Ccomp
-			hear += O
-		if(O.type in obj_to_check)
-			for(var/mob/living/M in O.contents)
-				if(!(M in hear))
-					hear += M
-
-				
 		objects += O
 
 	for(var/client/C in clients)
@@ -207,9 +194,11 @@
 				hear += C.mob
 			
 		else if(!(C.mob in hear))
-			if(C.mob.loc in (hear|objects))
+			if(C.mob.loc && C.mob.loc in (hear|objects))
 				hear += C.mob
-			else if(C.mob.loc.loc in (hear|objects))  
+			else if(C.mob.loc.loc && C.mob.loc.loc in (hear|objects))  
+				hear += C.mob
+			else if(C.mob.loc.loc.loc && C.mob.loc.loc.loc in (hear|objects))   //Going a little deeper
 				hear += C.mob
 
 				

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -161,6 +161,8 @@
 // The old system would loop through lists for a total of 5000 per function call, in an empty server.
 // This new system will loop at around 1000 in an empty server.
 
+// SCREW THAT SHIT, we're not recursing.
+
 /proc/get_mobs_in_view(var/R, var/atom/source)
 	// Returns a list of mobs in range of R from source. Used in radio and say code.
 
@@ -172,18 +174,45 @@
 
 	var/list/range = hear(R, T)
 
-	for(var/atom/A in range)
-		if(ismob(A))
-			var/mob/M = A
-			if(M.client)
-				hear += M
-			//world.log << "Start = [M] - [get_turf(M)] - ([M.x], [M.y], [M.z])"
-		else if(istype(A, /obj/item/device/radio))
-			hear += A
+	for(var/mob/M in range)
+		if(M.client)
+			hear += M
+		
+	var/list/objects = list()
 
-		if(isobj(A) || ismob(A))
-			hear |= recursive_mob_check(A, hear, 3, 1, 0, 1)
+	var/list/obj_to_check = list()					//IF SOMEONE DOESN'T HEAR SOMETHING AND ARE IN INSIDE A CONTAINER ADD IT TO THIS LIST.
+	obj_to_check += typesof(/obj/item/device/paicard)
+	obj_to_check += typesof(/obj/item/device/aicard)
+	obj_to_check += typesof(/obj/machinery/computer/aifixer)
 
+	for(var/obj/O in range)				//Get a list of objects in hearing range.  We'll check to see if any clients have their "eye" set to the object 
+		if(istype(O, /obj/item/device/radio))   //This avoids all that bullshit with recursion.  FUCK RECURSION  ~Ccomp
+			hear += O
+		if(O.type in obj_to_check)
+			for(var/mob/living/M in O.contents)
+				if(!(M in hear))
+					hear += M
+
+				
+		objects += O
+
+	for(var/client/C in clients)
+		if(!istype(C) || !C.eye)
+			continue   			//I have no idea when this client check would be needed, but if this runtimes people won't hear anything
+							//So kinda paranoid about runtime avoidance.
+		if(C.mob in hear)
+			continue
+		if(C.eye in (hear|objects))
+			if(!(C.mob in hear))
+				hear += C.mob
+			
+		else if(!(C.mob in hear))
+			if(C.mob.loc in (hear|objects))
+				hear += C.mob
+			else if(C.mob.loc.loc in (hear|objects))  
+				hear += C.mob
+
+				
 	return hear
 
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -38,13 +38,15 @@
 
 		// Type 1 (Visual) emotes are sent to anyone in view of the item
 		if (m_type & 1)
-			for (var/mob/O in viewers(src, null))
+			var/list/can_see = get_mobs_in_view(1,src)  //Allows silicon & mmi mobs carried around to see the emotes of the person carrying them around.
+			can_see |= viewers(src,null)
+			for (var/mob/O in can_see)
 				O.show_message(message, m_type)
 
 		// Type 2 (Audible) emotes are sent to anyone in hear range
 		// of the *LOCATION* -- this is important for pAIs to be heard
 		else if (m_type & 2)
-			for (var/mob/O in hearers(get_turf(src), null))
+			for (var/mob/O in get_mobs_in_view(7,src))
 				O.show_message(message, m_type)
 
 /mob/proc/emote_dead(var/message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -302,7 +302,7 @@ var/list/department_radio_keys = list(
 	var/list/listening
 
 	listening = get_mobs_in_view(message_range, src)
-	var/list/onscreen = get_mobs_in_view(7, src)
+	var/list/onscreen = viewers()
 	for(var/mob/M in player_list)
 		if (!M.client)
 			continue //skip monkeys and leavers


### PR DESCRIPTION
Before:  Everytime you say something. This proc is ran.  Along with it, recurses through EVERY /obj/ & /mob/ in view's contents, and EVERY /obj/ & /mob/ in that contents...and once again.

After:  Fuck recursion, we're going to loop through clients and see if they are within any obj's or mobs within one iteration.  MUCH cheaper, and probably less buggy.

If someone can't hear everyone and they are within an object and it's not catching?  add it to the list commented for it of type checks.

Also, fixes #4191 if it wasn't already fixed.
