### PR TITLE
Chemsmoke tweaks and bug fixes

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -161,6 +161,10 @@
 				if( A == src ) continue
 				src.reagents.reaction(A, 1, 10)
 
+		if(istype(loc, /mob/living/carbon))		//drop dat grenade if it goes off in your hand
+			var/mob/living/carbon/C = loc
+			C.drop_from_inventory(src)
+			C.throw_mode_off()
 
 		invisibility = INVISIBILITY_MAXIMUM //Why am i doing this?
 		spawn(50)		   //To make sure all reagents can work


### PR DESCRIPTION
- Renamed the variable for the smoke density mechanic to density. Also clamped it to a minimum of 1 so it cant multiply reagents.
- Added some checks so the chemsmoke effect doesn't run if it's in nullspace.
- Removed an unnecessary distance calculation.
- Added a null turf check to prevent runtimes if a really big smoke grenade goes off at the edge of the map.
- Added a check so the reagent copy code doesn't run if there's no reagents to run it on.
- Added an If check to handle grenades going off in a mobs hand.
