### PR TITLE
Fixed nuke shuttle being a swirly vortex of death.

### DIFF
--- a/code/ZAS/Debug.dm
+++ b/code/ZAS/Debug.dm
@@ -7,6 +7,8 @@ var/image/zone_blocked = image('icons/Testing/Zone.dmi', icon_state = "zoneblock
 var/image/blocked = image('icons/Testing/Zone.dmi', icon_state = "fullblock")
 var/image/mark = image('icons/Testing/Zone.dmi', icon_state = "mark")
 
+/connection_edge/var/dbg_out = 0
+
 /turf/var/tmp/dbg_img
 /turf/proc/dbg(image/img, d = 0)
 	if(d > 0) img.dir = d

--- a/code/ZAS/Diagnostic.dm
+++ b/code/ZAS/Diagnostic.dm
@@ -17,6 +17,9 @@ client/proc/Zone_Info(turf/T as null|turf)
 			T:zone:dbg_data(src)
 		else
 			mob << "No zone here."
+			var/datum/gas_mixture/mix = T.return_air()
+			mob << "[mix.return_pressure()] kPa [mix.temperature]C"
+			mob << "O2: [mix.oxygen] N2: [mix.nitrogen] CO2: [mix.carbon_dioxide] TX: [mix.toxins]"
 	else
 		if(zone_debug_images)
 			for(var/zone in  zone_debug_images)

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -145,6 +145,7 @@ Class Procs:
 		else
 			space_edges++
 			space_coefficient += E.coefficient
+			M << "[E:air:return_pressure()]kPa"
 
 	M << "Zone Edges: [zone_edges]"
 	M << "Space Edges: [space_edges] ([space_coefficient] connections)"


### PR DESCRIPTION
This bug was actually in legacy ShareSpace code, I'm surprised it wasn't noticeable in the old ZAS.
