### PR TITLE
Efficiency: Job lists

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -17,6 +17,7 @@ var/global/list/landmarks_list = list()				//list of all landmarks created
 var/global/list/surgery_steps = list()				//list of all surgery steps  |BS12
 var/global/list/side_effects = list()				//list of all medical sideeffects types by thier names |BS12
 var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mobs target tracking.
+var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 
 //Languages/species/whitelist.
 var/global/list/all_species[0]
@@ -85,6 +86,11 @@ var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Satchel Al
 		var/datum/medical_effect/M = new T
 		side_effects[M.name] = T
 
+	//List of job. I can't believe this was calculated multiple times per tick!
+	paths = typesof(/datum/job) -list(/datum/job,/datum/job/ai,/datum/job/cyborg)
+	for(var/T in paths)
+		var/datum/job/J = new T
+		joblist[J.title] = J
 
 	//Languages and species.
 	paths = typesof(/datum/language)-/datum/language

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -200,7 +200,7 @@ var/syndicate_code_response//Code response for traitors.
 							code_phrase += " "
 							code_phrase += pick(last_names)
 					if(2)
-						code_phrase += pick(get_all_jobs())//Returns a job.
+						code_phrase += pick(joblist)//Returns a job.
 				safety -= 1
 			if(2)
 				switch(rand(1,2))//Places or things.
@@ -270,7 +270,7 @@ var/syndicate_code_response//Code response for traitors.
 		if(5)
 			syndicate_code_phrase += pick("Do we have","Is there","Where is","Where's","Who's")
 			syndicate_code_phrase += " "
-			syndicate_code_phrase += "[pick(get_all_jobs())]"
+			syndicate_code_phrase += "[pick(joblist)]"
 			syndicate_code_phrase += "?"
 
 	switch(choice)
@@ -299,7 +299,7 @@ var/syndicate_code_response//Code response for traitors.
 					syndicate_code_response += pick(last_names)
 				else
 					syndicate_code_response += " the "
-					syndicate_code_response += "[pic(get_all_jobs())]"
+					syndicate_code_response += "[pic(joblist)]"
 				syndicate_code_response += "."
 			else
 				syndicate_code_response += pick("*shrug*","*smile*","*blink*","*sigh*","*laugh*","*nod*","*giggle*")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -357,7 +357,7 @@ datum/mind
 		if(!check_rights(R_ADMIN))	return
 
 		if (href_list["role_edit"])
-			var/new_role = input("Select new role", "Assigned role", assigned_role) as null|anything in get_all_jobs()
+			var/new_role = input("Select new role", "Assigned role", assigned_role) as null|anything in joblist
 			if (!new_role) return
 			assigned_role = new_role
 

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -213,11 +213,11 @@
 	if(prob(prob_right_job))
 		if(correct_person)
 			if(correct_person:assigned_role=="MODE")
-				changeling_job = pick(get_all_jobs())
+				changeling_job = pick(joblist)
 			else
 				changeling_job = correct_person:assigned_role
 	else
-		changeling_job = pick(get_all_jobs())
+		changeling_job = pick(joblist)
 	if(prob(prob_right_dude) && ticker.mode == "changeling")
 		if(correct_person:assigned_role=="MODE")
 			changeling_name = correct_person:current

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -440,10 +440,10 @@
 		rank = src:rank
 		assignment = src:assignment
 
-	if( rank in get_all_jobs() )
+	if( rank in joblist )
 		return rank
 
-	if( assignment in get_all_jobs() )
+	if( assignment in joblist )
 		return assignment
 
 	return "Unknown"
@@ -496,7 +496,7 @@ proc/FindNameFromID(var/mob/living/carbon/human/H)
 			return ID.registered_name
 
 proc/get_all_job_icons() //For all existing HUD icons
-	return get_all_jobs() + list("Prisoner")
+	return joblist + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation
 	if (!istype(src, /obj/item/device/pda) && !istype(src,/obj/item/weapon/card/id))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -108,7 +108,7 @@
 		header += "<hr>"
 
 		var/jobs_all = ""
-		var/list/alljobs = (istype(src,/obj/machinery/computer/card/centcom)? get_all_centcom_jobs() : get_all_jobs()) + "Custom"
+		var/list/alljobs = (istype(src,/obj/machinery/computer/card/centcom)? get_all_centcom_jobs() : joblist) + "Custom"
 		for(var/job in alljobs)
 			jobs_all += "<a href='?src=\ref[src];choice=assign;assign_target=[job]'>[replacetext(job, " ", "&nbsp")]</a> " //make sure there isn't a line break in the middle of a job
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -501,7 +501,7 @@ What a mess.*/
 						if ((istype(active1, /datum/data/record) && L.Find(rank)))
 							temp = "<h5>Rank:</h5>"
 							temp += "<ul>"
-							for(var/rank in get_all_jobs())
+							for(var/rank in joblist)
 								temp += "<li><a href='?src=\ref[src];choice=Change Rank;rank=[rank]'>[rank]</a></li>"
 							temp += "</ul>"
 						else
@@ -520,7 +520,7 @@ What a mess.*/
 					if ("Change Rank")
 						if (active1)
 							active1.fields["rank"] = href_list["rank"]
-							if(href_list["rank"] in get_all_jobs())
+							if(href_list["rank"] in joblist)
 								active1.fields["real_rank"] = href_list["real_rank"]
 
 					if ("Change Criminal Status")

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -354,7 +354,7 @@ What a mess.*/
 						if ((istype(active1, /datum/data/record) && L.Find(rank)))
 							temp = "<h5>Rank:</h5>"
 							temp += "<ul>"
-							for(var/rank in get_all_jobs())
+							for(var/rank in joblist)
 								temp += "<li><a href='?src=\ref[src];choice=Change Rank;rank=[rank]'>[rank]</a></li>"
 							temp += "</ul>"
 						else
@@ -373,7 +373,7 @@ What a mess.*/
 					if ("Change Rank")
 						if (active1)
 							active1.fields["rank"] = href_list["rank"]
-							if(href_list["rank"] in get_all_jobs())
+							if(href_list["rank"] in joblist)
 								active1.fields["real_rank"] = href_list["real_rank"]
 
 					if ("Delete Record (ALL) Execute")


### PR DESCRIPTION
Old method was creating a list of all /datum/job twice per tick PER sechuds in use, without counting all it's other applications. Switched it to a global list filled up once at boot.

I dunno github gud, I tried to make this PR clean 4 u <3
