### PR TITLE
Runtime fix: Depth scanner now won't check the length of null lists.

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
@@ -28,7 +28,7 @@
 	user.visible_message("\blue [user] scans [A], the air around them humming gently.")
 	if(istype(A,/turf/simulated/mineral))
 		var/turf/simulated/mineral/M = A
-		if(M.finds.len || M.artifact_find)
+		if((M.finds && M.finds.len) || M.artifact_find)
 
 			//create a new scanlog entry
 			var/datum/depth_scan/D = new()


### PR DESCRIPTION
I would have had more on this PR but this runtime pretty much eats the entire log if there is a xenoarcheologists.

runtime error: Cannot read null.len
proc name: scan atom (/obj/item/device/depth_scanner/proc/scan_atom)
  source file: tools_depthscanner.dm,31
  usr: Some Guy (/mob/living/carbon/human)
  src: the depth analysis scanner (/obj/item/device/depth_scanner)
  call stack:
the depth analysis scanner (/obj/item/device/depth_scanner): scan atom(Some Guy (/mob/living/carbon/human), Rock (155,169,5) (/turf/simulated/mineral))
Rock (155,169,5) (/turf/simulated/mineral): attackby(the depth analysis scanner (/obj/item/device/depth_scanner), Some Guy (/mob/living/carbon/human))
Some Guy (/mob/living/carbon/human): ClickOn(Rock (155,169,5) (/turf/simulated/mineral), "icon-x=23;icon-y=13;left=1;scr...")
Rock (155,169,5) (/turf/simulated/mineral): Click(Rock (155,169,5) (/turf/simulated/mineral), "mapwindow.map", "icon-x=23;icon-y=13;left=1;scr...")
