### PR TITLE
Fractures and severed limbs cause cuffs to fall off

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -775,13 +775,9 @@ var/list/sacrificed = list()
 					return
 				cultist.buckled = null
 				if (cultist.handcuffed)
-					cultist.handcuffed.loc = cultist.loc
-					cultist.handcuffed = null
-					cultist.update_inv_handcuffed()
+					cultist.drop_from_inventory(cultist.handcuffed)
 				if (cultist.legcuffed)
-					cultist.legcuffed.loc = cultist.loc
-					cultist.legcuffed = null
-					cultist.update_inv_legcuffed()
+					cultist.drop_from_inventory(cultist.legcuffed)
 				if (istype(cultist.wear_mask, /obj/item/clothing/mask/muzzle))
 					cultist.u_equip(cultist.wear_mask)
 				if(istype(cultist.loc, /obj/structure/closet)&&cultist.loc:welded)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -92,6 +92,28 @@
 			return
 	return
 
+var/last_chew = 0
+/mob/living/carbon/human/RestrainedClickOn(var/atom/A)
+	if (A != src) return ..()
+	if (last_chew + 26 > world.time) return
+
+	var/mob/living/carbon/human/H = A
+	if (H.a_intent != "hurt") return
+	if (H.zone_sel.selecting != "mouth") return
+
+	var/datum/organ/external/O = H.organs_by_name[H.hand?"l_hand":"r_hand"]
+	if (!O) return
+
+	var/s = "\red [H.name] chews on \his [O.display_name]!"
+	H.visible_message(s, "\red You chew on your [O.display_name]!")
+	H.attack_log += text("\[[time_stamp()]\] <font color='red'>[s] ([H.ckey])</font>")
+	log_attack("[s] ([H.ckey])")
+
+	if(O.take_damage(3,0,1,"teeth marks"))
+		H:UpdateDamageIcon()
+
+	last_chew = world.time
+
 /obj/item/weapon/handcuffs/cable
 	name = "cable restraints"
 	desc = "Looks like some cables tied together. Could be used to tie something up."

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -98,8 +98,11 @@ var/last_chew = 0
 	if (last_chew + 26 > world.time) return
 
 	var/mob/living/carbon/human/H = A
+	if (!H.handcuffed) return
 	if (H.a_intent != "hurt") return
 	if (H.zone_sel.selecting != "mouth") return
+	if (H.wear_mask) return
+	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket)) return
 
 	var/datum/organ/external/O = H.organs_by_name[H.hand?"l_hand":"r_hand"]
 	if (!O) return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -256,7 +256,14 @@
 	buckled = initial(src.buckled)
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
+
+		if (C.handcuffed && !initial(C.handcuffed))
+			C.drop_from_inventory(C.handcuffed)
 		C.handcuffed = initial(C.handcuffed)
+
+		if (C.legcuffed && !initial(C.legcuffed))
+			C.drop_from_inventory(C.legcuffed)
+		C.legcuffed = initial(C.legcuffed)
 
 /mob/living/proc/rejuvenate()
 
@@ -627,8 +634,6 @@
 							O.show_message("\red <B>[CM] manages to remove the handcuffs!</B>", 1)
 						CM << "\blue You successfully remove \the [CM.handcuffed]."
 						CM.drop_from_inventory(CM.handcuffed)
-						CM.handcuffed = null
-						CM.update_inv_handcuffed()
 
 		else if(CM.legcuffed && CM.canmove && (CM.last_special <= world.time))
 			CM.next_move = world.time + 100

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -583,18 +583,14 @@ This function completely restores a damaged organ to perfect condition.
 			"\The [owner.handcuffed.name] falls off of [owner.name].",\
 			"\The [owner.handcuffed.name] falls off you.")
 
-		owner.handcuffed.loc = owner.loc
-		owner.handcuffed = null
-		owner.update_inv_handcuffed()
+		owner.drop_from_inventory(owner.handcuffed)
 
 	if (owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT, LEG_LEFT, LEG_RIGHT))
 		owner.visible_message(\
 			"\The [owner.legcuffed.name] falls off of [owner.name].",\
 			"\The [owner.legcuffed.name] falls off you.")
 
-		owner.legcuffed.loc = owner.loc
-		owner.legcuffed = null
-		owner.update_inv_legcuffed()
+		owner.drop_from_inventory(owner.legcuffed)
 
 /datum/organ/external/proc/bandage()
 	var/rval = 0

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -570,10 +570,31 @@ This function completely restores a damaged organ to perfect condition.
 
 			owner.update_body(1)
 
+			// OK so maybe your limb just flew off, but if it was attached to a pair of cuffs then hooray! Freedom!
+			release_restraints()
 
 /****************************************************
 			   HELPERS
 ****************************************************/
+
+/datum/organ/external/proc/release_restraints()
+	if (owner.handcuffed && body_part in list(ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT))
+		owner.visible_message(\
+			"\The [owner.handcuffed.name] falls off of [owner.name].",\
+			"\The [owner.handcuffed.name] falls off you.")
+
+		owner.handcuffed.loc = owner.loc
+		owner.handcuffed = null
+		owner.update_inv_handcuffed()
+
+	if (owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT, LEG_LEFT, LEG_RIGHT))
+		owner.visible_message(\
+			"\The [owner.legcuffed.name] falls off of [owner.name].",\
+			"\The [owner.legcuffed.name] falls off you.")
+
+		owner.legcuffed.loc = owner.loc
+		owner.legcuffed = null
+		owner.update_inv_legcuffed()
 
 /datum/organ/external/proc/bandage()
 	var/rval = 0
@@ -603,7 +624,10 @@ This function completely restores a damaged organ to perfect condition.
 /datum/organ/external/proc/fracture()
 	if(status & ORGAN_BROKEN)
 		return
-	owner.visible_message("\red You hear a loud cracking sound coming from \the [owner].","\red <b>Something feels like it shattered in your [display_name]!</b>","You hear a sickening crack.")
+	owner.visible_message(\
+		"\red You hear a loud cracking sound coming from \the [owner].",\
+		"\red <b>Something feels like it shattered in your [display_name]!</b>",\
+		"You hear a sickening crack.")
 
 	if(owner.species && !(owner.species.flags & NO_PAIN))
 		owner.emote("scream")
@@ -611,6 +635,10 @@ This function completely restores a damaged organ to perfect condition.
 	status |= ORGAN_BROKEN
 	broken_description = pick("broken","fracture","hairline fracture")
 	perma_injury = brute_dam
+
+	// Fractures have a chance of getting you out of restraints
+	if (prob(25))
+		release_restraints()
 
 /datum/organ/external/proc/robotize()
 	src.status &= ~ORGAN_BROKEN


### PR DESCRIPTION
Handcuffs fall off if your hands or arms get severed. Likewise, leg cuffs drop if your feet or legs do.
Fractures in these limbs have a 25% chance to cause cuffs to fall off.

While restrained, if you switch to "harm" intent with "mouth" selected, you can click on yourself to chew through your own wrists. You can use this to fracture your active hand, but it's not guaranteed to free you and even if it does you'll probably pass out from shock/blood loss in a minute.

There's a graphical glitch where the cuffs still appear in your inventory after they've dropped (you can pick them up to fix the glitch) but this happens even if the cuffs fall off for other reasons and I couldn't figure out how to fix it. Something to do with the effect/equip_e object? I didn't really understand that code otherwise I would have fixed that as well.
