### PR TITLE
Configuration option:  Ability to set ERT to be admin call only.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -22,6 +22,7 @@
 	var/sql_enabled = 1					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
+	var/ert_admin_call_only = 0
 	var/allow_vote_mode = 0				// allow votes to change mode
 	var/allow_admin_jump = 1			// allows admin jumping
 	var/allow_admin_spawning = 1		// allows admin item spawning
@@ -289,6 +290,9 @@
 
 				if ("vote_autogamemode_timeleft")
 					config.vote_autogamemode_timeleft = text2num(value)
+
+				if("ert_admin_only")
+					config.ert_admin_call_only = 1
 
 				if ("allow_ai")
 					config.allow_ai = 1

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -69,7 +69,9 @@
 	if(screen == 1)
 		dat += "Select an event to trigger:<ul>"
 		dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>"
+		if(!config.ert_admin_call_only)
+			dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>"
+		
 		dat += "<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
 		dat += "<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>"
 		dat += "</ul>"
@@ -152,8 +154,9 @@
 			revoke_maint_all_access()
 			feedback_inc("alert_keycard_auth_maintRevoke",1)
 		if("Emergency Response Team")
-			trigger_armed_response_team(1)
-			feedback_inc("alert_keycard_auth_ert",1)
+			if(!config.ert_admin_call_only)
+				trigger_armed_response_team(1)
+				feedback_inc("alert_keycard_auth_ert",1)
 
 var/global/maint_all_access = 0
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -94,6 +94,9 @@ TRAITOR_SCALING
 ## if objectives are disabled
 #OBJECTIVES_DISABLED
 
+## make ERT's be only called by admins
+#ERT_ADMIN_ONLY
+
 ## If security is prohibited from being most antagonists
 #PROTECT_ROLES_FROM_ANTAGONIST
 


### PR DESCRIPTION
Admin request.

Default behavior is what we're used to, that two heads can call for the ERT
with the option turned on it removes the ability for players to call for an ERT and requires admin intervention.
