### PR TITLE
Space Lighting Fixes

### DIFF
--- a/code/WorkInProgress/Aryn/Lighting/Controller.dm
+++ b/code/WorkInProgress/Aryn/Lighting/Controller.dm
@@ -76,8 +76,10 @@ var/list/lit_z_levels = list(1,5)
 						world << "<font color=red>Progress: [round((turfs_updated/total_turfs)*100, 0.01)]% ([turfs_updated]/[total_turfs])"
 
 					var/turf/T = locate(x,y,z)
-					if(!T.light_overlay && !T.is_outside)
-						T.light_overlay = new(T)
+					if(!T.is_outside)
+						T.light_overlay = image(icon='icons/effects/ArynLights.dmi',icon_state="0000",layer=9)
+						T.light_overlay.invisibility = INVISIBILITY_LIGHTING
+						T.mouse_opacity = 0
 					//T.ResetValue()
 				if(!all_lightpoints_made) new/lightpoint(x+0.5,y+0.5,z)
 
@@ -89,7 +91,8 @@ var/list/lit_z_levels = list(1,5)
 	started = 1
 
 	for(var/turf/T)
-		if(T.light_overlay)
+		if(!T.is_outside && T.light_overlay)
+
 			T.ResetValue()
 			T.UpdateLight()
 

--- a/code/WorkInProgress/Aryn/Lighting/Controller.dm
+++ b/code/WorkInProgress/Aryn/Lighting/Controller.dm
@@ -77,9 +77,7 @@ var/list/lit_z_levels = list(1,5)
 
 					var/turf/T = locate(x,y,z)
 					if(!T.is_outside)
-						T.light_overlay = image(icon='icons/effects/ArynLights.dmi',icon_state="0000",layer=9)
-						T.light_overlay.invisibility = INVISIBILITY_LIGHTING
-						T.mouse_opacity = 0
+						T.light_overlay = new(T)
 					//T.ResetValue()
 				if(!all_lightpoints_made) new/lightpoint(x+0.5,y+0.5,z)
 

--- a/code/WorkInProgress/Aryn/Lighting/Engine.dm
+++ b/code/WorkInProgress/Aryn/Lighting/Engine.dm
@@ -53,18 +53,17 @@ Turf Procs:
 
 #define LIGHTCLAMP(x) ( max(0,min(3,round(x,1))) )
 
-//This is now an image because weird shit happens with /obj
-/*obj/effect/lighting_overlay
-	//anchored = 1
+atom/movable/lighting_overlay
+	anchored = 1
 	layer = 9
 	mouse_opacity = 0
 	icon = 'icons/effects/ArynLights.dmi'
 	icon_state = "0000"
-	invisibility = INVISIBILITY_LIGHTING*/
+	invisibility = INVISIBILITY_LIGHTING
 
 atom/var/light/light
 
-turf/var/image/light_overlay
+turf/var/atom/movable/lighting_overlay/light_overlay
 
 turf/var/lit_value = 0
 turf/var/max_brightness = 0
@@ -168,6 +167,13 @@ turf/proc/RemoveLight(light/light)
 turf/proc/ResetAllLights()
 	for(var/light/light in lit_by)
 		light.Reset()
+
+/turf/space/ResetAllLights()
+	var/atom/movable/lighting_overlay/overlay = locate() in src
+	overlay.loc = null
+	light_overlay = null
+	is_outside = 1
+	. = ..()
 
 turf/proc/ResetValue()
 	if(is_outside)

--- a/code/WorkInProgress/Aryn/Lighting/Engine.dm
+++ b/code/WorkInProgress/Aryn/Lighting/Engine.dm
@@ -54,6 +54,7 @@ Turf Procs:
 #define LIGHTCLAMP(x) ( max(0,min(3,round(x,1))) )
 
 atom/movable/lighting_overlay
+	name = ""
 	anchored = 1
 	layer = 9
 	mouse_opacity = 0

--- a/code/WorkInProgress/Aryn/Lighting/Engine.dm
+++ b/code/WorkInProgress/Aryn/Lighting/Engine.dm
@@ -53,17 +53,18 @@ Turf Procs:
 
 #define LIGHTCLAMP(x) ( max(0,min(3,round(x,1))) )
 
-obj/effect/lighting_overlay
+//This is now an image because weird shit happens with /obj
+/*obj/effect/lighting_overlay
 	//anchored = 1
 	layer = 9
 	mouse_opacity = 0
 	icon = 'icons/effects/ArynLights.dmi'
 	icon_state = "0000"
-	invisibility = INVISIBILITY_LIGHTING
+	invisibility = INVISIBILITY_LIGHTING*/
 
 atom/var/light/light
 
-turf/var/obj/effect/lighting_overlay/light_overlay
+turf/var/image/light_overlay
 
 turf/var/lit_value = 0
 turf/var/max_brightness = 0

--- a/code/WorkInProgress/Aryn/Lighting/Lightpoint.dm
+++ b/code/WorkInProgress/Aryn/Lighting/Lightpoint.dm
@@ -52,9 +52,14 @@ lightpoint
 	proc/max_value()
 		if(cached_value < 0)
 			var
-				valueA = (NW?(NW.lit_value):0)
-				valueB = (NE?(NE.lit_value):0)
-				valueC = (SW?(SW.lit_value):0)
-				valueD = (SE?(SE.lit_value):0)
+				valueA = value_of(NW)
+				valueB = value_of(NE)
+				valueC = value_of(SW)
+				valueD = value_of(SE)
 			cached_value = max(valueA,valueB,valueC,valueD)
 		return cached_value
+
+	proc/value_of(turf/T)
+		if(!T) return 0
+		if(T.is_outside) return min(lighting_controller.starlight,3)
+		return T.lit_value

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1,8 +1,8 @@
 //Config stuff
 #define SUPPLY_DOCKZ 2          //Z-level of the Dock.
 #define SUPPLY_STATIONZ 1       //Z-level of the Station.
-#define SUPPLY_STATION_AREATYPE "/area/supply/station" //Type of the supply shuttle area for station
-#define SUPPLY_DOCK_AREATYPE "/area/supply/dock"	//Type of the supply shuttle area for dock
+#define SUPPLY_STATION_AREATYPE /area/supply/station //Type of the supply shuttle area for station
+#define SUPPLY_DOCK_AREATYPE /area/supply/dock	//Type of the supply shuttle area for dock
 
 var/datum/controller/supply_shuttle/supply_shuttle = new()
 


### PR DESCRIPTION
- Light overlays are no longer objects and will not be eaten by the singulo, etc.
- Space edges are no longer pitch black.
- Creating space will now change the turf's light value to starlight.
