### PR TITLE
PDA NanoUI Optimizations.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -11,6 +11,8 @@
 		return
 
 /obj/effect/datacore/proc/manifest_modify(var/name, var/assignment)
+	if(PDA_Manifest.len)
+		PDA_Manifest.Cut()
 	var/datum/data/record/foundrecord
 	var/real_title = assignment
 
@@ -34,6 +36,9 @@
 		foundrecord.fields["real_rank"] = real_title
 
 /obj/effect/datacore/proc/manifest_inject(var/mob/living/carbon/human/H)
+	if(PDA_Manifest.len)
+		PDA_Manifest.Cut()
+
 	if(H.mind && (H.mind.assigned_role != "MODE"))
 		var/assignment
 		if(H.mind.role_alt_title)

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -51,6 +51,8 @@
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/locked[] = list()
 
+
+
 /obj/effect/datacore/proc/get_manifest(monochrome, OOC)
 	var/list/heads = new()
 	var/list/sec = new()
@@ -165,9 +167,16 @@
 
 /*
 We can't just insert in HTML into the nanoUI so we need the raw data to play with.
+Instead of creating this list over and over when someone leaves their PDA open to the page
+we'll only update it when it changes.  The PDA_Manifest global list is zeroed out upon any change
+using /obj/effect/datacore/proc/manifest_inject( ), or manifest_insert( )
 */
 
+var/global/list/PDA_Manifest = list()
+
 /obj/effect/datacore/proc/get_manifest_json()
+	if(PDA_Manifest.len)
+		return PDA_Manifest
 	var/heads[0]
 	var/sec[0]
 	var/eng[0]
@@ -227,7 +236,8 @@ We can't just insert in HTML into the nanoUI so we need the raw data to play wit
 		if(!department && !(name in heads))
 			misc[++misc.len] = list("name" = name, "rank" = rank, "active" = isactive)
 
-	return list(\
+
+	PDA_Manifest = list(\
 		"heads" = heads,\
 		"sec" = sec,\
 		"eng" = eng,\
@@ -237,6 +247,7 @@ We can't just insert in HTML into the nanoUI so we need the raw data to play wit
 		"bot" = bot,\
 		"misc" = misc\
 		)
+	return PDA_Manifest
 
 
 

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -289,6 +289,8 @@ What a mess.*/
 				temp += "<a href='?src=\ref[src];choice=Clear Screen'>No</a>"
 
 			if ("Purge All Records")
+				if(PDA_Manifest.len)
+					PDA_Manifest.Cut()
 				for(var/datum/data/record/R in data_core.security)
 					del(R)
 				temp = "All Employment records deleted."
@@ -300,6 +302,9 @@ What a mess.*/
 					temp += "<a href='?src=\ref[src];choice=Clear Screen'>No</a>"
 //RECORD CREATE
 			if ("New Record (General)")
+				
+				if(PDA_Manifest.len)
+					PDA_Manifest.Cut()
 				var/datum/data/record/G = new /datum/data/record()
 				G.fields["name"] = "New Record"
 				G.fields["id"] = text("[]", add_zero(num2hex(rand(1, 1.6777215E7)), 6))
@@ -372,12 +377,16 @@ What a mess.*/
 				switch(href_list["choice"])
 					if ("Change Rank")
 						if (active1)
+							if(PDA_Manifest.len)
+								PDA_Manifest.Cut()
 							active1.fields["rank"] = href_list["rank"]
 							if(href_list["rank"] in get_all_jobs())
 								active1.fields["real_rank"] = href_list["real_rank"]
 
 					if ("Delete Record (ALL) Execute")
 						if (active1)
+							if(PDA_Manifest.len)
+								PDA_Manifest.Cut()
 							for(var/datum/data/record/R in data_core.medical)
 								if ((R.fields["name"] == active1.fields["name"] || R.fields["id"] == active1.fields["id"]))
 									del(R)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -240,6 +240,9 @@ obj/machinery/computer/cryopod/Topic(href, href_list)
 					current_mode.possible_traitors.Remove(occupant)
 
 			// Delete them from datacore.
+			
+			if(PDA_Manifest.len)
+				PDA_Manifest.Cut()
 			for(var/datum/data/record/R in data_core.medical)
 				if ((R.fields["name"] == occupant.real_name))
 					del(R)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -676,6 +676,8 @@
 								if(setmedical != "Cancel")
 									R.fields["p_stat"] = setmedical
 									modified = 1
+									if(PDA_Manifest.len)
+										PDA_Manifest.Cut()
 
 									spawn()
 										if(istype(usr,/mob/living/carbon/human))


### PR DESCRIPTION
We won't regenerate the list for Manifests every tick while viewing the manifest, instead we have a global variable for it PDA_Manifest that we Cut() if there is a change to the manifest then when the next player goes to view the manifest on their PDA it will recreate the list that one time.

Some sections of the PDA will no longer auto-refresh every tick because...well that's dumb.

Modes that will no longer autoupdate at all:  Viewing medical/sec records, viewing notes (will update when you change them of course), and the station alert menu.
Modes that will only autoupdate every 5 ticks:  APC list (Because it's a huge fuck off list), the manifest, mulebots and secbots screens, supply requests/orders, and janitor supply locator)

Some other things that I just can't remember right now.
