### PR TITLE
APC overlay bugfix.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -27,6 +27,7 @@
 #define APC_UPOVERLAY_ENVIRON1 1024
 #define APC_UPOVERLAY_ENVIRON2 2048
 #define APC_UPOVERLAY_LOCKED 4096
+#define APC_UPOVERLAY_OPERATING 8192
 
 #define APC_UPDATE_ICON_COOLDOWN 100 // 10 seconds
 
@@ -322,6 +323,9 @@
 		update_state |= UPSTATE_WIREEXP
 	if(update_state <= 1)
 		update_state |= UPSTATE_ALLGOOD
+
+	if(operating)
+		update_overlay |= APC_UPOVERLAY_OPERATING
 
 	if(update_state & UPSTATE_ALLGOOD)
 		if(locked)


### PR DESCRIPTION
Before:  If you turned off the breaker and fiddled with on/off states and turned on the breaker it wouldn't update the overlay because the check_updates wasn't doing an if(operating) check and would think it didn't need to update the overlays once you turned on the breaker.

After:  Check_update() is doing a check for the breaker being on or off and taking that into account with the update_overlay flags and will update the overlays properly.

Thanks Razharas from /tg/ #coderbus for bringing this to my attention.
