### PR TITLE
Fix for slime surgery runtime & o2 lockers bug

### DIFF
--- a/code/game/objects/closets/walllocker.dm
+++ b/code/game/objects/closets/walllocker.dm
@@ -20,6 +20,13 @@
 	var/amount = 3 // spawns each items X times.
 	icon_state = "emerg"
 
+/obj/structure/closet/walllocker/emerglocker/toggle(mob/user as mob)
+	src.attack_hand(user)
+	return 
+
+/obj/structure/closet/walllocker/emerglocker/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	return 
+
 /obj/structure/closet/walllocker/emerglocker/attack_hand(mob/user as mob)
 	if (istype(user, /mob/living/silicon/ai))	//Added by Strumpetplaya - AI shouldn't be able to
 		return									//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -6,6 +6,8 @@
 /datum/surgery_step/generic/
 	can_infect = 1
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		if (isslime(target))
+			return 0
 		if (target_zone == "eyes")	//there are specific steps for eye surgery
 			return 0
 		if (!hasorgans(target))
@@ -32,6 +34,8 @@
 	max_duration = 110
 
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		if(isslime(target))
+			return 0
 		var/datum/organ/external/affected = target.get_organ(target_zone)
 		return ..() && affected.open == 0 && target_zone != "mouth"
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -106,6 +106,8 @@
 	max_duration = 100
 
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		if(isslime(target))
+			return 0
 		var/datum/organ/external/affected = target.get_organ(target_zone)
 		var/can_fit = !affected.hidden && affected.cavity && tool.w_class <= get_max_wclass(affected)
 		return ..() && can_fit


### PR DESCRIPTION
fixes #4471

i don't know why slimes are getting though the target check but this works to get rid of the runtimes...

also did a fix for #4538
