### PR TITLE
Removes an unnecessary check

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -379,10 +379,6 @@
 					if(!disable_warning)
 						usr << "You somehow have a suit with no defined allowed items for suit storage, stop that."
 					return 0
-				if(src.w_class > 3)
-					if(!disable_warning)
-						usr << "The [name] is too big to attach."
-					return 0
 				if( istype(src, /obj/item/device/pda) || istype(src, /obj/item/weapon/pen) || is_type_in_list(src, H.wear_suit.allowed) )
 					return 1
 				return 0


### PR DESCRIPTION
The things you can attach to suits should already be determined by the
allowed list, no need to restrict it based off of size if it's in the
allowed items.
