### PR TITLE
MedicHUD bugfix

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -58,6 +58,12 @@
 	dizziness = 0
 	jitteriness = 0
 
+	
+	hud_updateflag |= 1 << HEALTH_HUD
+	hud_updateflag |= 1 << STATUS_HUD
+
+	handle_hud_list()
+	
 	//Handle species-specific deaths.
 	if(species) species.handle_death(src)
 


### PR DESCRIPTION
Because the HUD stuff is now in Life() if someone dies their healthbar and status aren't updated.
We're fixing that here.
