### PR TITLE
Plasma glass processing fix

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -298,6 +298,7 @@
 						new /obj/item/stack/sheet/mineral/clown(output.loc)
 					else
 						on = 0
+					continue
 				if (selected_glass == 1 && selected_gold == 0 && selected_silver == 0 && selected_diamond == 0 && selected_plasma == 1 && selected_uranium == 0 && selected_iron == 0 && selected_clown == 0)
 					if (ore_glass > 0 && ore_plasma > 0)
 						ore_glass--;
@@ -305,6 +306,7 @@
 						new /obj/item/stack/sheet/glass/plasmaglass(output.loc)
 					else
 						on = 0
+					continue
 				if (selected_glass == 1 && selected_gold == 0 && selected_silver == 0 && selected_diamond == 0 && selected_plasma == 1 && selected_uranium == 0 && selected_iron == 1 && selected_clown == 0)
 					if (ore_glass > 0 && ore_plasma > 0 && ore_iron > 0)
 						ore_glass--;


### PR DESCRIPTION
Fixes #4560

Code was missing continue statements.
Not that we ever use it on bay, but clown metal would have had the same problem.
