### PR TITLE
PDA NanoUI bugfix.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -330,10 +330,11 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	ui_tick++
+	var/datum/nanoui/old_ui = nanomanager.get_open_ui(user, src, "main")
 	var/auto_update = 1
 	if(mode in no_auto_update)
 		auto_update = 0
-	if(mode == lastmode && ui_tick % 5 && mode in update_every_five)
+	if(old_ui && (mode == lastmode && ui_tick % 5 && mode in update_every_five))
 		return
 
 	lastmode = mode


### PR DESCRIPTION
modes that update every 5 ticks won't require clicking the pda 5 times to get a UI window open.

We now check to see if a UI already exists if not we don't check

Fixes #4586
