### PR TITLE
IPC Fixes:  "OH NO ROBOTIC LIMBS...on a robot...no shit" and Rejuvination fix.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -258,8 +258,9 @@
 				continue
 			if(temp.status & ORGAN_ROBOT)
 				if(!(temp.brute_dam + temp.burn_dam))
-					wound_flavor_text["[temp.display_name]"] = "<span class='warning'>[t_He] has a robot [temp.display_name]!</span>\n"
-					continue
+					if(!species.flags & IS_SYNTHETIC)
+						wound_flavor_text["[temp.display_name]"] = "<span class='warning'>[t_He] has a robot [temp.display_name]!</span>\n"
+						continue
 				else
 					wound_flavor_text["[temp.display_name]"] = "<span class='warning'>[t_He] has a robot [temp.display_name], it has"
 				if(temp.brute_dam) switch(temp.brute_dam)
@@ -274,7 +275,8 @@
 						wound_flavor_text["[temp.display_name]"] += " some burns"
 					if(21 to INFINITY)
 						wound_flavor_text["[temp.display_name]"] += pick(" a lot of burns"," severe melting")
-				wound_flavor_text["[temp.display_name]"] += "!</span>\n"
+				if(wound_flavor_text["[temp.display_name]"])
+					wound_flavor_text["[temp.display_name]"] += "!</span>\n"
 			else if(temp.wounds.len > 0)
 				var/list/wound_descriptors = list()
 				for(var/datum/wound/W in temp.wounds)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -192,8 +192,9 @@
 This function restores the subjects blood to max.
 */
 /mob/living/carbon/human/proc/restore_blood()
-	var/blood_volume = vessel.get_reagent_amount("blood")
-	vessel.add_reagent("blood",560.0-blood_volume)
+	if(!species.flags & NO_BLOOD)
+		var/blood_volume = vessel.get_reagent_amount("blood")
+		vessel.add_reagent("blood",560.0-blood_volume)
 
 
 /*

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -198,7 +198,10 @@ This function completely restores a damaged organ to perfect condition.
 */
 /datum/organ/external/proc/rejuvenate()
 	damage_state = "00"
-	status = 0
+	if(status & 128)	//Robotic organs stay robotic.  Fix because right click rejuvinate makes IPC's organs organic.
+		status = 128
+	else
+		status = 0
 	perma_injury = 0
 	brute_dam = 0
 	burn_dam = 0


### PR DESCRIPTION
Before:  When examining an IPC it would toss up red messages about them having robotic limbs as if it's not normal.  Using the admin verb "Rejuvenate" on a IPC would set all of their organs to be organic.

After:  IPC's when examined will only talk about their robotic limbs if they are damaged.  Also their limbs won't magically become organic upon rejuvenation.
