### PR TITLE
VV drop down menu to resend NanoUI resource files.

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -259,6 +259,8 @@ client
 			body += "<option value='?_src_=vars;addlanguage=\ref[D]'>Add Language</option>"
 			body += "<option value='?_src_=vars;remlanguage=\ref[D]'>Remove Language</option>"
 
+			body += "<option value='?_src_=vars;fix_nano=\ref[D]'>Fix NanoUI</option>"
+
 			body += "<option value='?_src_=vars;addverb=\ref[D]'>Add Verb</option>"
 			body += "<option value='?_src_=vars;remverb=\ref[D]'>Remove Verb</option>"
 			if(ishuman(D))
@@ -859,6 +861,25 @@ client
 			H.verbs -= verb
 
 	
+	else if(href_list["fix_nano"])
+		if(!check_rights(R_DEBUG)) return
+
+		var/mob/H = locate(href_list["fix_nano"])
+
+		if(!istype(H) || !H.client)
+			usr << "This can only be done on mobs with clients"
+			return
+		
+				
+
+		nanomanager.send_resources(H.client)
+		
+		usr << "Resource files sent"
+		H << "Your NanoUI Resource files have been refreshed"
+
+		log_admin("[key_name(usr)] resent the NanoUI resource files to [key_name(H)] ")
+
+
 
 	else if(href_list["regenerateicons"])
 		if(!check_rights(0))	return


### PR DESCRIPTION
Some players are having issues with NanoUI not opening up or acting funny
before the only fix was to have them log out, and log back in, check if that worked.
If not log out, delete cache log back in, if that don't work not much can be done.

Now we just skip the whole logout login thing and force the server to send the files
to their client once again skipping the need for their character to take a dirtnap for a moment.
