### PR TITLE
Admin Request:  Logs now will end in CRLF on unix systems.

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -1,24 +1,24 @@
 //print an error message to world.log
 /proc/error(msg)
-	world.log << "## ERROR: [msg]"
+	world.log << "## ERROR: [msg][world.system_type == UNIX ? ascii2text(13) :]"
 
 //print a warning message to world.log
 /proc/warning(msg)
-	world.log << "## WARNING: [msg]"
+	world.log << "## WARNING: [msg][world.system_type == UNIX ? ascii2text(13) :]"
 
 //print a testing-mode debug message to world.log
 /proc/testing(msg)
-	world.log << "## TESTING: [msg]"
+	world.log << "## TESTING: [msg][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_admin(text)
 	admin_log.Add(text)
 	if (config.log_admin)
-		diary << "\[[time_stamp()]]ADMIN: [text]"
+		diary << "\[[time_stamp()]]ADMIN: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 
 /proc/log_debug(text)
 	if (config.log_debug)
-		diary << "\[[time_stamp()]]DEBUG: [text]"
+		diary << "\[[time_stamp()]]DEBUG: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 	for(var/client/C in admins)
 		if(C.prefs.toggles & CHAT_DEBUGLOGS)
@@ -27,44 +27,44 @@
 
 /proc/log_game(text)
 	if (config.log_game)
-		diary << "\[[time_stamp()]]GAME: [text]"
+		diary << "\[[time_stamp()]]GAME: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_vote(text)
 	if (config.log_vote)
-		diary << "\[[time_stamp()]]VOTE: [text]"
+		diary << "\[[time_stamp()]]VOTE: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_access(text)
 	if (config.log_access)
-		diary << "\[[time_stamp()]]ACCESS: [text]"
+		diary << "\[[time_stamp()]]ACCESS: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_say(text)
 	if (config.log_say)
-		diary << "\[[time_stamp()]]SAY: [text]"
+		diary << "\[[time_stamp()]]SAY: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_ooc(text)
 	if (config.log_ooc)
-		diary << "\[[time_stamp()]]OOC: [text]"
+		diary << "\[[time_stamp()]]OOC: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_whisper(text)
 	if (config.log_whisper)
-		diary << "\[[time_stamp()]]WHISPER: [text]"
+		diary << "\[[time_stamp()]]WHISPER: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_emote(text)
 	if (config.log_emote)
-		diary << "\[[time_stamp()]]EMOTE: [text]"
+		diary << "\[[time_stamp()]]EMOTE: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_attack(text)
 	if (config.log_attack)
-		diary << "\[[time_stamp()]]ATTACK: [text]" //Seperate attack logs? Why?
+		diary << "\[[time_stamp()]]ATTACK: [text][world.system_type == UNIX ? ascii2text(13) :]" //Seperate attack logs? Why?  FOR THE GLORY OF SATAN!
 
 /proc/log_adminsay(text)
 	if (config.log_adminchat)
-		diary << "\[[time_stamp()]]ADMINSAY: [text]"
+		diary << "\[[time_stamp()]]ADMINSAY: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_adminwarn(text)
 	if (config.log_adminwarn)
-		diary << "\[[time_stamp()]]ADMINWARN: [text]"
+		diary << "\[[time_stamp()]]ADMINWARN: [text][world.system_type == UNIX ? ascii2text(13) :]"
 
 /proc/log_pda(text)
 	if (config.log_pda)
-		diary << "\[[time_stamp()]]PDA: [text]"
+		diary << "\[[time_stamp()]]PDA: [text][world.system_type == UNIX ? ascii2text(13) :]"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -150,7 +150,7 @@
 
 		if (M.config_tag)
 			if(!(M.config_tag in modes))		// ensure each mode is added only once
-				diary << "Adding game mode [M.name] ([M.config_tag]) to configuration."
+				diary << "Adding game mode [M.name] ([M.config_tag]) to configuration.[world.system_type == UNIX ? ascii2text(13) :]"
 				src.modes += M.config_tag
 				src.mode_names[M.config_tag] = M.name
 				src.probabilities[M.config_tag] = M.probability
@@ -362,9 +362,9 @@
 						if (prob_name in config.modes)
 							config.probabilities[prob_name] = text2num(prob_value)
 						else
-							diary << "Unknown game mode probability configuration definition: [prob_name]."
+							diary << "Unknown game mode probability configuration definition: [prob_name].[world.system_type == UNIX ? ascii2text(13) :]"
 					else
-						diary << "Incorrect probability configuration definition: [prob_name]  [prob_value]."
+						diary << "Incorrect probability configuration definition: [prob_name]  [prob_value].[world.system_type == UNIX ? ascii2text(13) :]"
 
 				if("allow_random_events")
 					config.allow_random_events = 1
@@ -484,11 +484,11 @@
 					config.cult_ghostwriter_req_cultists = value
 
 				else
-					diary << "Unknown setting in configuration: '[name]'"
+					diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
 
 		else if(type == "game_options")
 			if(!value)
-				diary << "Unknown value for setting [name] in [filename]."
+				diary << "Unknown value for setting [name] in [filename].[world.system_type == UNIX ? ascii2text(13) :]"
 			value = text2num(value)
 
 			switch(name)
@@ -529,7 +529,7 @@
 				if("limbs_can_break")
 					config.limbs_can_break = value
 				else
-					diary << "Unknown setting in configuration: '[name]'"
+					diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
 
 /datum/configuration/proc/loadsql(filename)  // -- TLE
 	var/list/Lines = file2list(filename)
@@ -575,7 +575,7 @@
 			if ("enable_stat_tracking")
 				sqllogging = 1
 			else
-				diary << "Unknown setting in configuration: '[name]'"
+				diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
 
 /datum/configuration/proc/loadforumsql(filename)  // -- TLE
 	var/list/Lines = file2list(filename)
@@ -617,7 +617,7 @@
 			if ("authenticatedgroup")
 				forum_authenticated_group = value
 			else
-				diary << "Unknown setting in configuration: '[name]'"
+				diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
 
 /datum/configuration/proc/pick_mode(mode_name)
 	// I wish I didn't have to instance the game modes in order to look up

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -63,7 +63,7 @@ var/global/datum/getrev/revdata = new("config/svndir.txt")
 				s_archive = s
 			if(!revision)
 				abort()
-			diary << "Revision info loaded succesfully"
+			diary << "Revision info loaded succesfully[world.system_type == UNIX ? ascii2text(13) :]"
 			return
 		return abort()
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -57,7 +57,12 @@ var/global/datum/controller/gameticker/ticker
 			if(going)
 				pregame_timeleft--
 			if(pregame_timeleft == config.vote_autogamemode_timeleft)
-				vote.autogamemode()
+				if(!vote.time_remaining)
+					vote.autogamemode()	//Quit calling this over and over and over and over.
+					while(vote.time_remaining)
+						for(var/i=0, i<10, i++)
+							sleep(1)
+							vote.process()
 			if(pregame_timeleft <= 0)
 				current_state = GAME_STATE_SETTING_UP
 	while (!setup())

--- a/code/modules/admin/ToRban.dm
+++ b/code/modules/admin/ToRban.dm
@@ -22,7 +22,7 @@
 
 /proc/ToRban_update()
 	spawn(0)
-		diary << "Downloading updated ToR data..."
+		diary << "Downloading updated ToR data...[world.system_type == UNIX ? ascii2text(13) :]"
 		var/http[] = world.Export("http://exitlist.torproject.org/exit-addresses")
 
 		var/list/rawlist = file2list(http["CONTENT"])
@@ -36,10 +36,10 @@
 					if(!cleaned)	continue
 					F[cleaned] << 1
 			F["last_update"] << world.realtime
-			diary << "ToR data updated!"
+			diary << "ToR data updated![world.system_type == UNIX ? ascii2text(13) :]"
 			if(usr)	usr << "ToRban updated."
 			return 1
-		diary << "ToR data update aborted: no data."
+		diary << "ToR data update aborted: no data.[world.system_type == UNIX ? ascii2text(13) :]"
 		return 0
 
 /client/proc/ToRban(task in list("update","toggle","show","remove","remove all","find"))

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -66,8 +66,8 @@ DEBUG
 			log_admin("jobban_keylist was empty")
 	else
 		if(!establish_db_connection())
-			world.log << "Database connection failed. Reverting to the legacy ban system."
-			diary << "Database connection failed. Reverting to the legacy ban system."
+			world.log << "Database connection failed. Reverting to the legacy ban system.[world.system_type == UNIX ? ascii2text(13) :]"
+			diary << "Database connection failed. Reverting to the legacy ban system.[world.system_type == UNIX ? ascii2text(13) :]"
 			config.ban_legacy_system = 1
 			jobban_loadbanfile()
 			return

--- a/code/world.dm
+++ b/code/world.dm
@@ -14,8 +14,8 @@
 	href_logfile = file("data/logs/[date_string] hrefs.htm")
 	diary = file("data/logs/[date_string].log")
 	diaryofmeanpeople = file("data/logs/[date_string] Attack.log")
-	diary << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")]\n---------------------"
-	diaryofmeanpeople << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")]\n---------------------"
+	diary << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][world.system_type == UNIX ? ascii2text(13) :]\n---------------------[world.system_type == UNIX ? ascii2text(13) :]"
+	diaryofmeanpeople << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][world.system_type == UNIX ? ascii2text(13) :]\n---------------------"
 	changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
 
 	if(byond_version < RECOMMENDED_VERSION)
@@ -67,7 +67,7 @@
 //		..()
 
 /world/Topic(T, addr, master, key)
-	diary << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key]"
+	diary << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][world.system_type == UNIX ? ascii2text(13) :]"
 
 	if (T == "ping")
 		var/x = 1
@@ -147,7 +147,7 @@
 	if(Lines.len)
 		if(Lines[1])
 			master_mode = Lines[1]
-			diary << "Saved mode is '[master_mode]'"
+			diary << "Saved mode is '[master_mode]'[world.system_type == UNIX ? ascii2text(13) :]"
 
 /world/proc/save_mode(var/the_mode)
 	var/F = file("data/mode.txt")
@@ -181,7 +181,7 @@
 	if(config.admin_legacy_system)
 		var/text = file2text("config/moderators.txt")
 		if (!text)
-			diary << "Failed to load config/mods.txt\n"
+			diary << "Failed to load config/mods.txt[world.system_type == UNIX ? ascii2text(13) :]"
 		else
 			var/list/lines = text2list(text, "\n")
 			for(var/line in lines)


### PR DESCRIPTION
Also removed the "SERVER HAS CALLED FOR A VOTE" spam

asciitext(13) is Carriage Return character, since *nix systems use LF as their new line character this just adds CR to the already existing LF so on windows in text editors that don't detect the line end methods (notepad) they will show up properly instead on just one big long line.
