### PR TITLE
*NIX Log files part 2.

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -1,24 +1,33 @@
 //print an error message to world.log
+
+
+// On Linux/Unix systems the line endings are LF, on windows it's CRLF, admins that don't use notepad++
+// will get logs that are one big line if the system is Linux and they are using notepad.  This solves it by adding CR to every line ending
+// in the logs.  ascii character 13 = CR
+
+/var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
+								
+
 /proc/error(msg)
-	world.log << "## ERROR: [msg][world.system_type == UNIX ? ascii2text(13) :]"
+	world.log << "## ERROR: [msg][log_end]"
 
 //print a warning message to world.log
 /proc/warning(msg)
-	world.log << "## WARNING: [msg][world.system_type == UNIX ? ascii2text(13) :]"
+	world.log << "## WARNING: [msg][log_end]"
 
 //print a testing-mode debug message to world.log
 /proc/testing(msg)
-	world.log << "## TESTING: [msg][world.system_type == UNIX ? ascii2text(13) :]"
+	world.log << "## TESTING: [msg][log_end]"
 
 /proc/log_admin(text)
 	admin_log.Add(text)
 	if (config.log_admin)
-		diary << "\[[time_stamp()]]ADMIN: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]ADMIN: [text][log_end]"
 
 
 /proc/log_debug(text)
 	if (config.log_debug)
-		diary << "\[[time_stamp()]]DEBUG: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]DEBUG: [text][log_end]"
 
 	for(var/client/C in admins)
 		if(C.prefs.toggles & CHAT_DEBUGLOGS)
@@ -27,44 +36,47 @@
 
 /proc/log_game(text)
 	if (config.log_game)
-		diary << "\[[time_stamp()]]GAME: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]GAME: [text][log_end]"
 
 /proc/log_vote(text)
 	if (config.log_vote)
-		diary << "\[[time_stamp()]]VOTE: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]VOTE: [text][log_end]"
 
 /proc/log_access(text)
 	if (config.log_access)
-		diary << "\[[time_stamp()]]ACCESS: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]ACCESS: [text][log_end]"
 
 /proc/log_say(text)
 	if (config.log_say)
-		diary << "\[[time_stamp()]]SAY: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]SAY: [text][log_end]"
 
 /proc/log_ooc(text)
 	if (config.log_ooc)
-		diary << "\[[time_stamp()]]OOC: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]OOC: [text][log_end]"
 
 /proc/log_whisper(text)
 	if (config.log_whisper)
-		diary << "\[[time_stamp()]]WHISPER: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]WHISPER: [text][log_end]"
 
 /proc/log_emote(text)
 	if (config.log_emote)
-		diary << "\[[time_stamp()]]EMOTE: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]EMOTE: [text][log_end]"
 
 /proc/log_attack(text)
 	if (config.log_attack)
-		diary << "\[[time_stamp()]]ATTACK: [text][world.system_type == UNIX ? ascii2text(13) :]" //Seperate attack logs? Why?  FOR THE GLORY OF SATAN!
+		diary << "\[[time_stamp()]]ATTACK: [text][log_end]" //Seperate attack logs? Why?  FOR THE GLORY OF SATAN!
 
 /proc/log_adminsay(text)
 	if (config.log_adminchat)
-		diary << "\[[time_stamp()]]ADMINSAY: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]ADMINSAY: [text][log_end]"
 
 /proc/log_adminwarn(text)
 	if (config.log_adminwarn)
-		diary << "\[[time_stamp()]]ADMINWARN: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]ADMINWARN: [text][log_end]"
 
 /proc/log_pda(text)
 	if (config.log_pda)
-		diary << "\[[time_stamp()]]PDA: [text][world.system_type == UNIX ? ascii2text(13) :]"
+		diary << "\[[time_stamp()]]PDA: [text][log_end]"
+
+/proc/log_misc(text)
+	diary << "\[[time_stamp()]]MISC: [text][log_end]" 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -150,7 +150,7 @@
 
 		if (M.config_tag)
 			if(!(M.config_tag in modes))		// ensure each mode is added only once
-				diary << "Adding game mode [M.name] ([M.config_tag]) to configuration.[world.system_type == UNIX ? ascii2text(13) :]"
+				log_misc("Adding game mode [M.name] ([M.config_tag]) to configuration.")
 				src.modes += M.config_tag
 				src.mode_names[M.config_tag] = M.name
 				src.probabilities[M.config_tag] = M.probability
@@ -362,9 +362,9 @@
 						if (prob_name in config.modes)
 							config.probabilities[prob_name] = text2num(prob_value)
 						else
-							diary << "Unknown game mode probability configuration definition: [prob_name].[world.system_type == UNIX ? ascii2text(13) :]"
+							log_misc("Unknown game mode probability configuration definition: [prob_name].")
 					else
-						diary << "Incorrect probability configuration definition: [prob_name]  [prob_value].[world.system_type == UNIX ? ascii2text(13) :]"
+						log_misc("Incorrect probability configuration definition: [prob_name]  [prob_value].")
 
 				if("allow_random_events")
 					config.allow_random_events = 1
@@ -484,11 +484,11 @@
 					config.cult_ghostwriter_req_cultists = value
 
 				else
-					diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
+					log_misc("Unknown setting in configuration: '[name]'")
 
 		else if(type == "game_options")
 			if(!value)
-				diary << "Unknown value for setting [name] in [filename].[world.system_type == UNIX ? ascii2text(13) :]"
+				log_misc("Unknown value for setting [name] in [filename].")
 			value = text2num(value)
 
 			switch(name)
@@ -529,7 +529,7 @@
 				if("limbs_can_break")
 					config.limbs_can_break = value
 				else
-					diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
+					log_misc("Unknown setting in configuration: '[name]'")
 
 /datum/configuration/proc/loadsql(filename)  // -- TLE
 	var/list/Lines = file2list(filename)
@@ -575,7 +575,7 @@
 			if ("enable_stat_tracking")
 				sqllogging = 1
 			else
-				diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
+				log_misc("Unknown setting in configuration: '[name]'")
 
 /datum/configuration/proc/loadforumsql(filename)  // -- TLE
 	var/list/Lines = file2list(filename)
@@ -617,7 +617,7 @@
 			if ("authenticatedgroup")
 				forum_authenticated_group = value
 			else
-				diary << "Unknown setting in configuration: '[name]'[world.system_type == UNIX ? ascii2text(13) :]"
+				log_misc("Unknown setting in configuration: '[name]'")
 
 /datum/configuration/proc/pick_mode(mode_name)
 	// I wish I didn't have to instance the game modes in order to look up

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -63,7 +63,7 @@ var/global/datum/getrev/revdata = new("config/svndir.txt")
 				s_archive = s
 			if(!revision)
 				abort()
-			diary << "Revision info loaded succesfully[world.system_type == UNIX ? ascii2text(13) :]"
+			log_misc("Revision info loaded succesfully")
 			return
 		return abort()
 

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -26,7 +26,7 @@ var/list/whitelist = list()
 /proc/load_alienwhitelist()
 	var/text = file2text("config/alienwhitelist.txt")
 	if (!text)
-		diary << "Failed to load config/alienwhitelist.txt\n"
+		log_misc("Failed to load config/alienwhitelist.txt")
 	else
 		alien_whitelist = text2list(text, "\n")
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -30,7 +30,7 @@
 						break
 
 			if(!input_plate)
-				diary << "a [src] didn't find an input plate."
+				log_misc("a [src] didn't find an input plate.")
 				return
 
 	Bumped(var/atom/A)

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -34,8 +34,8 @@ world/IsBanned(key,address,computer_id)
 		var/ckeytext = ckey(key)
 
 		if(!establish_db_connection())
-			world.log << "Ban database connection failure. Key [ckeytext] not checked"
-			diary << "Ban database connection failure. Key [ckeytext] not checked"
+			error("Ban database connection failure. Key [ckeytext] not checked")
+			log_misc("Ban database connection failure. Key [ckeytext] not checked")
 			return
 
 		var/failedcid = 1

--- a/code/modules/admin/ToRban.dm
+++ b/code/modules/admin/ToRban.dm
@@ -22,7 +22,7 @@
 
 /proc/ToRban_update()
 	spawn(0)
-		diary << "Downloading updated ToR data...[world.system_type == UNIX ? ascii2text(13) :]"
+		log_misc("Downloading updated ToR data...")
 		var/http[] = world.Export("http://exitlist.torproject.org/exit-addresses")
 
 		var/list/rawlist = file2list(http["CONTENT"])
@@ -36,10 +36,10 @@
 					if(!cleaned)	continue
 					F[cleaned] << 1
 			F["last_update"] << world.realtime
-			diary << "ToR data updated![world.system_type == UNIX ? ascii2text(13) :]"
+			log_misc("ToR data updated!")
 			if(usr)	usr << "ToRban updated."
 			return 1
-		diary << "ToR data update aborted: no data.[world.system_type == UNIX ? ascii2text(13) :]"
+		log_misc("ToR data update aborted: no data.")
 		return 0
 
 /client/proc/ToRban(task in list("update","toggle","show","remove","remove all","find"))

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -103,8 +103,8 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 
 		establish_db_connection()
 		if(!dbcon.IsConnected())
-			world.log << "Failed to connect to database in load_admins(). Reverting to legacy system."
-			diary << "Failed to connect to database in load_admins(). Reverting to legacy system."
+			error("Failed to connect to database in load_admins(). Reverting to legacy system.")
+			log_misc("Failed to connect to database in load_admins(). Reverting to legacy system.")
 			config.admin_legacy_system = 1
 			load_admins()
 			return
@@ -123,8 +123,8 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 			//find the client for a ckey if they are connected and associate them with the new admin datum
 			D.associate(directory[ckey])
 		if(!admin_datums)
-			world.log << "The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system."
-			diary << "The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system."
+			error("The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system.")
+			log_misc("The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system.")
 			config.admin_legacy_system = 1
 			load_admins()
 			return

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -66,8 +66,8 @@ DEBUG
 			log_admin("jobban_keylist was empty")
 	else
 		if(!establish_db_connection())
-			world.log << "Database connection failed. Reverting to the legacy ban system.[world.system_type == UNIX ? ascii2text(13) :]"
-			diary << "Database connection failed. Reverting to the legacy ban system.[world.system_type == UNIX ? ascii2text(13) :]"
+			error("Database connection failed. Reverting to the legacy ban system.")
+			log_misc("Database connection failed. Reverting to the legacy ban system.")
 			config.ban_legacy_system = 1
 			jobban_loadbanfile()
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1096,7 +1096,7 @@
 	var/tdamage = 0
 	var/ticks = 0
 	while (germs < 2501 && ticks < 100000 && round(damage/10)*20)
-		diary << "VIRUS TESTING: [ticks] : germs [germs] tdamage [tdamage] prob [round(damage/10)*20]"
+		log_misc("VIRUS TESTING: [ticks] : germs [germs] tdamage [tdamage] prob [round(damage/10)*20]")
 		ticks++
 		if (prob(round(damage/10)*20))
 			germs++

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -356,8 +356,8 @@
 				return
 			else
 				if(Debug)
-					diary <<"pulling disappeared? at [__LINE__] in mob.dm - pulling = [pulling]"
-					diary <<"REPORT THIS"
+					log_debug("pulling disappeared? at [__LINE__] in mob.dm - pulling = [pulling]")
+					log_debug("REPORT THIS")
 
 		/////
 		if(pulling && pulling.anchored)

--- a/code/modules/scripting/IDE.dm
+++ b/code/modules/scripting/IDE.dm
@@ -10,7 +10,7 @@ client/verb/tcssave()
 				var/obj/machinery/telecomms/server/Server = Machine.SelectedServer
 				var/tcscode=winget(src, "tcscode", "text")
 				var/msg="[mob.name] is adding script to server [Server]: [tcscode]"
-				diary << msg
+				log_misc(msg)
 				message_admins("[mob.name] has uploaded a NTLS script to [Machine.SelectedServer] ([mob.x],[mob.y],[mob.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[mob.x];Y=[mob.y];Z=[mob.z]'>JMP</a>)",0,1)
 				Server.setcode( tcscode ) // this actually saves the code from input to the server
 				src << output(null, "tcserror") // clear the errors

--- a/code/modules/scripting/Implementations/_Logic.dm
+++ b/code/modules/scripting/Implementations/_Logic.dm
@@ -257,7 +257,7 @@ proc/n_inrange(var/num, var/min=-1, var/max=1)
 		var/list/dat = list()
 		while (i < lenh)
 			var/found = findtext(haystack, a, i, 0)
-			//diary << "findtext([haystack], [a], [i], 0)=[found]"
+			//log_misc("findtext([haystack], [a], [i], 0)=[found]")
 			if (found == 0) // Not found
 				break
 			else
@@ -265,9 +265,9 @@ proc/n_inrange(var/num, var/min=-1, var/max=1)
 					dat+=found
 					count+=1
 				else
-					//diary << "Script found [a] [count] times, aborted"
+					//log_misc("Script found [a] [count] times, aborted")
 					break
-			//diary << "Found [a] at [found]! Moving up..."
+			//log_misc("Found [a] at [found]! Moving up...")
 			i = found + lena
 		if (count == 0)
 			return haystack
@@ -281,11 +281,11 @@ proc/n_inrange(var/num, var/min=-1, var/max=1)
 			//CharCopy (dest + targetIndex, src + sourceIndex, count);
 			//CharCopy (dest + curPos, source + lastReadPos, precopy);
 			buf+=copytext(haystack,lastReadPos,precopy)
-			diary << "buf+=copytext([haystack],[lastReadPos],[precopy])"
-			diary<<"[buf]"
+			log_misc("buf+=copytext([haystack],[lastReadPos],[precopy])")
+			log_misc("[buf]")
 			lastReadPos = dat[i] + lena
 			//CharCopy (dest + curPos, replace, newValue.length);
 			buf+=b
-			diary<<"[buf]"
+			log_misc("[buf]")
 		buf+=copytext(haystack,lastReadPos, 0)
 		return buf

--- a/code/world.dm
+++ b/code/world.dm
@@ -14,8 +14,8 @@
 	href_logfile = file("data/logs/[date_string] hrefs.htm")
 	diary = file("data/logs/[date_string].log")
 	diaryofmeanpeople = file("data/logs/[date_string] Attack.log")
-	diary << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][world.system_type == UNIX ? ascii2text(13) :]\n---------------------[world.system_type == UNIX ? ascii2text(13) :]"
-	diaryofmeanpeople << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][world.system_type == UNIX ? ascii2text(13) :]\n---------------------"
+	diary << "[log_end]\n[log_end]\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]"
+	diaryofmeanpeople << "[log_end]\n[log_end]\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]"
 	changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
 
 	if(byond_version < RECOMMENDED_VERSION)
@@ -67,7 +67,7 @@
 //		..()
 
 /world/Topic(T, addr, master, key)
-	diary << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][world.system_type == UNIX ? ascii2text(13) :]"
+	diary << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][log_end]"
 
 	if (T == "ping")
 		var/x = 1
@@ -147,7 +147,7 @@
 	if(Lines.len)
 		if(Lines[1])
 			master_mode = Lines[1]
-			diary << "Saved mode is '[master_mode]'[world.system_type == UNIX ? ascii2text(13) :]"
+			log_misc("Saved mode is '[master_mode]'")
 
 /world/proc/save_mode(var/the_mode)
 	var/F = file("data/mode.txt")
@@ -181,7 +181,7 @@
 	if(config.admin_legacy_system)
 		var/text = file2text("config/moderators.txt")
 		if (!text)
-			diary << "Failed to load config/mods.txt[world.system_type == UNIX ? ascii2text(13) :]"
+			error("Failed to load config/mods.txt")
 		else
 			var/list/lines = text2list(text, "\n")
 			for(var/line in lines)


### PR DESCRIPTION
CR+LF added to new lines, created a global variable log_end that can be used
on newlines instead of checking if we're a *NIX system each time.

log_misc("blahblah...[log_end]\nMoreblahblah[log_end]")

put [log_end] prior to any \n and it will show up correctly in windows.

Also created log_misc() proc to log to diary, and removed a bunch of

diary << stuff all over the place.
