### PR TITLE
Add colour to AI private channel (144.7)

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -350,6 +350,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 				freq_text = "Special Ops"
 			if(1345)
 				freq_text = "Response Team"
+			if(1447)
+				freq_text = "AI Private"
 		//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO
 
 
@@ -377,6 +379,10 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		// command channel
 		else if (display_freq == COMM_FREQ)
 			part_a = "<span class='comradio'><span class='name'>"
+
+		// AI private channel
+		else if (display_freq == 1447)
+			part_a = "<span class='airadio'><span class='name'>"
 
 		// department radio formatting (poorly optimized, ugh)
 		else if (display_freq == SEC_FREQ)

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -30,6 +30,7 @@ em						{font-style: normal;	font-weight: bold;}
 .comradio				{color: #193A7A;}
 .syndradio				{color: #6D3F40;}
 .centradio				{color: #5C5C8A;}
+.airadio				{color: #FF00FF;}
 
 .secradio				{color: #A30000;}
 .engradio				{color: #A66300;}


### PR DESCRIPTION
Changes the AI private channel colour to magenta (#ff00ff), and changes
the marker from [144.7] to [AI Private].

Magenta is far enough from the Science channel (#993399) to be obvious,
but I'm open to alternative suggestions.
