### PR TITLE
Update README with how to ignore baystation12.int

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ The more complicated and easier to update method is using git.  You'll need to d
 
 This will take a while to download, but it provides an easier method for updating.
 
+Once the repository is in place, run this command:
+```bash
+cd Baystation12
+git update-index --assume-unchanged baystation12.int
+```
+Now git will ignore changes to the file baystation12.int.
+
 ### INSTALLATION
 
 First-time installation should be fairly straightforward.  First, you'll need BYOND installed.  You can get it from [here](http://www.byond.com/).


### PR DESCRIPTION
No game change here. Based on the fiasco from my last PR, I added a note to README.md to let people know they can exec `git update-index --assume-unchanged baystation12.int` to avoid having to deal with it while staging commits so other people don't make the mistake I made.
