### PR TITLE
APC bugfix after someone messed with mah areas!

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -31,10 +31,12 @@ datum/controller/game_controller
 
 	var/last_thing_processed
 	var/mob/list/expensive_mobs = list()
+	var/rebuild_active_areas = 0
 
 datum/controller/game_controller/New()
 	//There can be only one master_controller. Out with the old and in with the new.
 	if(master_controller != src)
+		log_debug("Rebuilding Master Controller")
 		if(istype(master_controller))
 			Recover()
 			del(master_controller)
@@ -259,27 +261,37 @@ datum/controller/game_controller/proc/process_machines()
 			last_thing_processed = Machine.type
 			if(Machine.process() != PROCESS_KILL)
 				if(Machine)
-
-//					if(Machine.use_power)
-//						Machine.auto_use_power()
-
 					i++
 					continue
 		machines.Cut(i,i+1)
+
 	i=1
 	while(i<=active_areas.len)
 		var/area/A = active_areas[i]
-		if(A.powerupdate)
+		if(A.powerupdate && A.master == A)
 			A.powerupdate -= 1
-			for(var/obj/machinery/M in A)
-				if(M)
-					if(M.use_power)
-						M.auto_use_power()
+			for(var/area/SubArea in A.related)
+				for(var/obj/machinery/M in SubArea)
+					if(M)
+						if(M.use_power)
+							M.auto_use_power()
 			
-		if(A.apc.len)
+		if(A.apc.len && A.master == A)
 			i++
 			continue
+
+		A.powerupdate = 0
 		active_areas.Cut(i,i+1)
+
+
+	if(controller_iteration % 150 == 0 || rebuild_active_areas)	//Every 300 seconds we retest every area/machine
+		for(var/area/A in all_areas)
+			if(A == A.master)
+				A.powerupdate += 1
+				active_areas |= A
+		rebuild_active_areas = 0
+
+	
 		
 
 datum/controller/game_controller/proc/process_objects()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -244,7 +244,6 @@
 	return used
 
 /area/proc/clear_usage()
-
 	master.used_equip = 0
 	master.used_light = 0
 	master.used_environ = 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -193,7 +193,7 @@ Class Procs:
 	src.add_fingerprint(usr)
 
 	var/area/A = get_area(src)
-	A.powerupdate = 1
+	A.master.powerupdate = 1
 
 	return 0
 
@@ -236,7 +236,7 @@ Class Procs:
 	src.add_fingerprint(user)
 
 	var/area/A = get_area(src)
-	A.powerupdate = 1
+	A.master.powerupdate = 1
 
 	return 0
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1164,6 +1164,7 @@
 	lastused_equip = area.usage(EQUIP)
 	lastused_environ = area.usage(ENVIRON)
 	if(area.powerupdate)
+		if(debug) log_debug("power update in [area.name] / [name]")
 		area.clear_usage()
 
 	lastused_total = lastused_light + lastused_equip + lastused_environ
@@ -1187,16 +1188,16 @@
 	if(terminal && terminal.powernet)
 		perapc = terminal.powernet.perapc
 
-	//if(debug)
-		//world << "Status: [main_status] - Excess: [excess] - Last Equip: [lastused_equip] - Last Light: [lastused_light]"
+	if(debug)
+		log_debug( "Status: [main_status] - Excess: [excess] - Last Equip: [lastused_equip] - Last Light: [lastused_light]")
 
 	if(cell && !shorted)
-		var/cell_charge = cell.charge
+		//var/cell_charge = cell.charge
 		var/cell_maxcharge = cell.maxcharge
 
 		// draw power from cell as before
 
-		var/cellused = min(cell_charge, CELLRATE * lastused_total)	// clamp deduction to a max, amount left in cell
+		var/cellused = min(cell.charge, CELLRATE * lastused_total)	// clamp deduction to a max, amount left in cell
 		cell.use(cellused)
 
 		if(excess > 0 || perapc > lastused_total)		// if power excess, or enough anyway, recharge the cell
@@ -1207,10 +1208,9 @@
 
 		else		// no excess, and not enough per-apc
 
-			if( (cell_charge/CELLRATE+perapc) >= lastused_total)		// can we draw enough from cell+grid to cover last usage?
+			if( (cell.charge/CELLRATE+perapc) >= lastused_total)		// can we draw enough from cell+grid to cover last usage?
 
-				cell_charge = min(cell_maxcharge, cell_charge + CELLRATE * perapc)	//recharge with what we can
-				cell.charge = cell_charge
+				cell.charge = min(cell_maxcharge, cell.charge + CELLRATE * perapc)	//recharge with what we can
 				add_load(perapc)		// so draw what we can from the grid
 				charging = 0
 
@@ -1233,30 +1233,30 @@
 			longtermpower -= 2
 
 
-		if(cell_charge >= 1250 || longtermpower > 0)              // Put most likely at the top so we don't check it last, effeciency 101
+		if(cell.charge >= 1250 || longtermpower > 0)              // Put most likely at the top so we don't check it last, effeciency 101
 			if(autoflag != 3)
 				equipment = autoset(equipment, 1)
 				lighting = autoset(lighting, 1)
 				environ = autoset(environ, 1)
 				autoflag = 3
 				area.poweralert(1, src)
-				if(cell_charge >= 4000)
+				if(cell.charge >= 4000)
 					area.poweralert(1, src)                
-		else if(cell_charge < 1250 && cell_charge > 750 && longtermpower < 0)                       // <30%, turn off equipment
+		else if(cell.charge < 1250 && cell.charge > 750 && longtermpower < 0)                       // <30%, turn off equipment
 			if(autoflag != 2)
 				equipment = autoset(equipment, 2)
 				lighting = autoset(lighting, 1)
 				environ = autoset(environ, 1)
 				area.poweralert(0, src)
 				autoflag = 2
-		else if(cell_charge < 750 && cell_charge > 10 && longtermpower < 0)        // <15%, turn off lighting & equipment
+		else if(cell.charge < 750 && cell.charge > 10 && longtermpower < 0)        // <15%, turn off lighting & equipment
 			if(autoflag != 1)
 				equipment = autoset(equipment, 2)
 				lighting = autoset(lighting, 2)
 				environ = autoset(environ, 1)
 				area.poweralert(0, src)
 				autoflag = 1
-		else if(cell_charge <= 0)                                   // zero charge, turn all off
+		else if(cell.charge <= 0)                                   // zero charge, turn all off
 			if(autoflag != 0)
 				equipment = autoset(equipment, 0)
 				lighting = autoset(lighting, 0)
@@ -1269,7 +1269,7 @@
 		if(chargemode && charging == 1 && operating)
 			if(excess > 0)		// check to make sure we have enough to charge
 				// Max charge is perapc share, capped to cell capacity, or % per second constant (Whichever is smallest)
-				var/ch = min(perapc*CELLRATE, (cell_maxcharge - cell_charge), (cell_maxcharge*CHARGELEVEL))
+				var/ch = min(perapc*CELLRATE, (cell_maxcharge - cell.charge), (cell_maxcharge*CHARGELEVEL))
 				add_load(ch/CELLRATE) // Removes the power we're taking from the grid
 				cell.give(ch) // actually recharge the cell
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -218,6 +218,10 @@
 	if (!istype(src.loc, /turf) && !istype(usr, /mob/living/silicon/))
 		return 0 // Do not update ui
 
+	for(var/area/A in active_areas)
+		A.master.powerupdate = 3
+
+
 	if( href_list["cmode"] )
 		chargemode = !chargemode
 		if(!chargemode)


### PR DESCRIPTION
This was probably bound to happen either way the previous version was based upon a faulty understanding of how the areas worked this is much more robust and only messes with the master areas
and master areas needing power updates call power updates for the each of it's child areas.  Also added where messing with SMESes called for an update on all areas power consumption, probably
not required but doing so either way.

We also rebuild the active_areas list every 5 minutes, if you get a engineer that wants to build a new area off of the station with APC's set rebuild_all_areas in the master controller and it will
update instantly, otherwise wait 5 minutes.  The only downside to this 5 minutes is you might get free energy until that area becomes active.

Fixes #4662
