### PR TITLE
Fix for issue #4689

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -154,7 +154,7 @@
 	attack_generic(user, rand(10, 15))
 
 
-/obj/structure/window/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/window/attackby(obj/item/W as obj, mob/user as mob)
 	if(!istype(W)) return//I really wish I did not need this
 
 	if (istype(W, /obj/item/weapon/grab) && get_dist(src,user)<2)


### PR DESCRIPTION
Rods can't break reinforced windows. https://github.com/Baystation12/Baystation12/issues/4689

Fixed. Tested locally.
