### PR TITLE
atmos: remove a few force-deletes in merge code

### DIFF
--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -54,8 +54,6 @@ datum/pipe_network
 		for(var/datum/pipeline/line_member in giver.line_members)
 			line_member.network = src
 
-		del(giver)
-
 		update_network_gases()
 		return 1
 

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -173,7 +173,6 @@
 	if(connections) connections.update_all()
 
 /turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
-	del(giver)
 	return 0
 
 /turf/return_air()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -44,7 +44,6 @@
 
 
 /atom/proc/assume_air(datum/gas_mixture/giver)
-	del(giver)
 	return null
 
 /atom/proc/remove_air(amount)


### PR DESCRIPTION
Removes del(giver) from pipeline/merge(), turf/assume_air() and
atom/assume_air().
Thanks to valzargaming on reddit/github for pointing it out.
fixes #4717
