### PR TITLE
Maintenance movement nerf.

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1037,6 +1037,19 @@ var/list/ghostteleportlocs = list()
 	name = "Fore Starboard Solar Maintenance"
 	icon_state = "SolarcontrolA"
 
+/area/maintenance/Entered()
+	..()	
+	if(istype(usr,/mob/living/carbon/human))
+		usr.area_movement_delay = max(8-config.run_speed,0)
+
+	else if(istype(usr,/mob/living/silicon/robot))
+		usr.area_movement_delay = max(12-config.run_speed,0)
+		
+
+/area/maintenance/Exited()
+	if(istype(usr,/mob/living))
+		usr.area_movement_delay = 0
+
 
 /area/assembly/chargebay
 	name = "\improper Mech Bay"

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -44,6 +44,8 @@
 	if(mRun in mutations)
 		tally = 0
 
+	tally += area_movement_delay
+
 	return (tally+config.human_delay)
 
 /mob/living/carbon/human/Process_Spacemove(var/check_drift = 0)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -96,6 +96,8 @@
 	var/timeofdeath = 0.0//Living
 	var/cpr_time = 1.0//Carbon
 
+	var/area_movement_delay = 0
+
 
 	var/bodytemperature = 310.055	//98.7 F
 	var/drowsyness = 0.0//Carbon


### PR DESCRIPTION
If you are in maintenance, you are being slowed down to account for how careful you have to be walking through the dark area with cables and pipes running around.  Cyborgs get hit a bit harder.

Do not merge, pending discussion:  http://baystation12.net/forums/viewtopic.php?f=5&t=10111
