### PR TITLE
Removes E-bow Instant Stun. Slight tox buff.

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -40,7 +40,7 @@
 /obj/item/projectile/energy/bolt
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 10
+	damage = 15
 	damage_type = TOX
 	nodamage = 0
 	agony = 35

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -40,10 +40,10 @@
 /obj/item/projectile/energy/bolt
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 10
 	damage_type = TOX
 	nodamage = 0
-	agony = 35
+	agony = 40
 	stutter = 10
 
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -40,9 +40,10 @@
 /obj/item/projectile/energy/bolt
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 10
 	damage_type = TOX
 	nodamage = 0
+	agony = 30
 	stutter = 10
 
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -43,7 +43,7 @@
 	damage = 10
 	damage_type = TOX
 	nodamage = 0
-	agony = 30
+	agony = 35
 	stutter = 10
 
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -40,10 +40,9 @@
 /obj/item/projectile/energy/bolt
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 10
+	damage = 15
 	damage_type = TOX
 	nodamage = 0
-	weaken = 10
 	stutter = 10
 
 


### PR DESCRIPTION
The E-bow with the stun is currently the most powerful weapon in the game. Stuns on hit, causes immediate damage, unlimited ammo with recharge, and the stun is not affected by armor. You can viably stunlock someone to death just by occasionally shooting them without running out of ammo. Horrible design and it warrants an immediate removal until I finish my E-bow changes later.
