### PR TITLE
Fixes #4547

### DIFF
--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -12,7 +12,7 @@
 	var/obj/machinery/atmospherics/pipe/P = A
 
 	var/turf/T = P.loc
-	if (T.level==1 && isturf(T) && T.intact)
+	if (P.level < 2 && T.level==1 && isturf(T) && T.intact)
 		user << "\red You must remove the plating first."
 		return
 

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -7,9 +7,15 @@
 	var/mode = "grey"
 
 /obj/item/device/pipe_painter/afterattack(atom/A, mob/user as mob)
-	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/pipe/tank) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated))
+	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/pipe/tank) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated) || !in_range(user, A))
 		return
 	var/obj/machinery/atmospherics/pipe/P = A
+
+	var/turf/T = P.loc
+	if (T.level==1 && isturf(T) && T.intact)
+		user << "\red You must remove the plating first."
+		return
+
 	P.pipe_color = mode
 	user.visible_message("<span class='notice'>[user] paints \the [P] [mode].</span>","<span class='notice'>You paint \the [P] [mode].</span>")
 	P.update_icon()


### PR DESCRIPTION
Fixes #4547.
Ensures that one can only paint pipes within range and when there is no blocking floor tile.
