### PR TITLE
Magboots action icon

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -237,6 +237,18 @@
 /obj/item/proc/equipped(var/mob/user, var/slot)
 	return
 
+//returns 1 if the item is equipped by a mob, 0 otherwise.
+//This might need some error trapping, not sure if get_equipped_items() is safe for non-human mobs.
+/obj/item/proc/is_equipped()
+	if(!ismob(loc)) 
+		return 0
+	
+	var/mob/M = loc
+	if(src in M.get_equipped_items())
+		return 1
+	else
+		return 0
+
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 //If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
 //Set disable_warning to 1 if you wish it to not give you outputs.

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -10,12 +10,7 @@
 
 
 /obj/item/weapon/storage/belt/proc/can_use()
-	if(!ismob(loc)) return 0
-	var/mob/M = loc
-	if(src in M.get_equipped_items())
-		return 1
-	else
-		return 0
+	return is_equipped()
 
 
 /obj/item/weapon/storage/belt/MouseDrop(obj/over_object as obj, src_location, over_location)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -4,6 +4,8 @@
 	icon_state = "magboots0"
 	species_restricted = null
 	var/magpulse = 0
+	icon_action_button = "action_blank"
+	action_button_name = "Toggle the magboots"
 //	flags = NOSLIP //disabled by default
 
 
@@ -13,21 +15,24 @@
 		set src in usr
 		if(usr.stat)
 			return
-		if(src.magpulse)
-			src.flags &= ~NOSLIP
-			src.slowdown = SHOES_SLOWDOWN
-			src.magpulse = 0
+		
+		src.attack_self(usr)
+
+	attack_self(mob/user)
+		if(magpulse)
+			flags &= ~NOSLIP
+			slowdown = SHOES_SLOWDOWN
+			magpulse = 0
 			icon_state = "magboots0"
-			usr << "You disable the mag-pulse traction system."
+			user << "You disable the mag-pulse traction system."
 		else
-			src.flags |= NOSLIP
-			src.slowdown = 2
-			src.magpulse = 1
+			flags |= NOSLIP
+			slowdown = 2
+			magpulse = 1
 			icon_state = "magboots1"
-			usr << "You enable the mag-pulse traction system."
-		usr.update_inv_shoes()	//so our mob-overlays update
-
-
+			user << "You enable the mag-pulse traction system."
+		user.update_inv_shoes()	//so our mob-overlays update
+	
 	examine()
 		set src in view()
 		..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -8,16 +8,6 @@
 	action_button_name = "Toggle the magboots"
 //	flags = NOSLIP //disabled by default
 
-
-	verb/toggle()
-		set name = "Toggle Magboots"
-		set category = "Object"
-		set src in usr
-		if(usr.stat)
-			return
-		
-		src.attack_self(usr)
-
 	attack_self(mob/user)
 		if(magpulse)
 			flags &= ~NOSLIP

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -198,17 +198,6 @@
 	species_restricted = list("Vox")
 	action_button_name = "Toggle the magclaws"
 
-//make sure these can only be used when equipped.
-/obj/item/clothing/shoes/magboots/vox/proc/can_use()
-	if(!ismob(loc)) 
-		return 0
-	
-	var/mob/M = loc
-	if(src in M.get_equipped_items())
-		return 1
-	else
-		return 0
-
 /obj/item/clothing/shoes/magboots/vox/attack_self(mob/user)
 	if(src.magpulse)
 		flags &= ~NOSLIP
@@ -216,7 +205,8 @@
 		canremove = 1
 		user << "You relax your deathgrip on the flooring."
 	else
-		if (!can_use())
+		//make sure these can only be used when equipped.
+		if (!is_equipped())
 			user << "You will have to put on the [src] before you can do that."
 			return
 		
@@ -228,6 +218,7 @@
 
 //In case they somehow come off while enabled.
 /obj/item/clothing/shoes/magboots/vox/dropped(mob/user as mob)
+	..()
 	if(src.magpulse)
 		user.visible_message("The [src] go limp as they are removed from [usr]'s feet.", "The [src] go limp as they are removed from your feet.")
 		flags &= ~NOSLIP

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -192,28 +192,53 @@
 /obj/item/clothing/shoes/magboots/vox
 
 	desc = "A pair of heavy, jagged armoured foot pieces, seemingly suitable for a velociraptor."
-	name = "vox boots"
+	name = "vox magclaws"
 	item_state = "boots-vox"
 	icon_state = "boots-vox"
 	species_restricted = list("Vox")
+	action_button_name = "Toggle the magclaws"
 
-	toggle()
-		//set name = "Toggle Floor Grip"
-		if(usr.stat)
+//make sure these can only be used when equipped.
+/obj/item/clothing/shoes/magboots/vox/proc/can_use()
+	if(!ismob(loc)) 
+		return 0
+	
+	var/mob/M = loc
+	if(src in M.get_equipped_items())
+		return 1
+	else
+		return 0
+
+/obj/item/clothing/shoes/magboots/vox/attack_self(mob/user)
+	if(src.magpulse)
+		flags &= ~NOSLIP
+		magpulse = 0
+		canremove = 1
+		user << "You relax your deathgrip on the flooring."
+	else
+		if (!can_use())
+			user << "You will have to put on the [src] before you can do that."
 			return
-		if(src.magpulse)
-			src.flags &= ~NOSLIP
-			src.magpulse = 0
-			usr << "You relax your deathgrip on the flooring."
-		else
-			src.flags |= NOSLIP
-			src.magpulse = 1
-			usr << "You dig your claws deeply into the flooring, bracing yourself."
+		
+		flags |= NOSLIP
+		magpulse = 1
+		canremove = 0	//kinda hard to take off magclaws when you are gripping them tightly.
+		user << "You dig your claws deeply into the flooring, bracing yourself."
+		user << "It would be hard to take off the [src] without relaxing your grip first."
 
+//In case they somehow come off while enabled.
+/obj/item/clothing/shoes/magboots/vox/dropped(mob/user as mob)
+	if(src.magpulse)
+		user.visible_message("The [src] go limp as they are removed from [usr]'s feet.", "The [src] go limp as they are removed from your feet.")
+		flags &= ~NOSLIP
+		magpulse = 0
+		canremove = 1
 
-	examine()
-		set src in view()
-		..()
+/obj/item/clothing/shoes/magboots/vox/examine()
+	set src in view()
+	..()
+	if (magpulse)
+		usr << "It would be hard to take these off without relaxing your grip first." //theoretically this message should only be seen by the wearer when the claws are equipped.
 
 //Species-specific Syndicate rigs.
 


### PR DESCRIPTION
See https://github.com/Baystation12/Baystation12/issues/4752.

Tested both regular magboots and magclaws on master, including the case where the magclaws are somehow removed when enabled.
