### PR TITLE
Fixes #4758

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -95,7 +95,7 @@
 /datum/robot_component/binary_communication
 	name = "binary communication device"
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
-	energy_consumption = 1
+	energy_consumption = 0
 	max_damage = 30
 
 /datum/robot_component/camera

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -52,12 +52,11 @@
 /datum/robot_component/proc/is_powered()
 	return (installed == 1) && (brute_damage + electronics_damage < max_damage) && (!energy_consumption || powered)
 
-
-/datum/robot_component/proc/consume_power()
+/datum/robot_component/proc/update_power_state()
 	if(toggled == 0)
 		powered = 0
 		return
-	if(owner.cell.charge >= energy_consumption)
+	if(owner.cell && owner.cell.charge >= energy_consumption)
 		owner.cell.use(energy_consumption)
 		powered = 1
 	else
@@ -74,6 +73,10 @@
 	energy_consumption = 2
 	external_type = /obj/item/robot_parts/robot_component/actuator
 	max_damage = 50
+
+//A fixed and much cleaner implementation of /tg/'s special snowflake code.
+/datum/robot_component/actuator/is_powered()
+	return (installed == 1) && (brute_damage + electronics_damage < max_damage)
 
 /datum/robot_component/cell
 	name = "power cell"
@@ -92,7 +95,7 @@
 /datum/robot_component/binary_communication
 	name = "binary communication device"
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
-	energy_consumption = 0
+	energy_consumption = 1
 	max_damage = 30
 
 /datum/robot_component/camera

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -25,6 +25,9 @@
 	else
 		msg += "Its cover is closed.\n"
 
+	if(!has_power)
+		msg += "<span class='warning'>It appears to be running on backup power.</span>\n"
+	
 	switch(src.stat)
 		if(CONSCIOUS)
 			if(!src.client)	msg += "It appears to be in stand-by mode.\n" //afk

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -33,29 +33,23 @@
 
 /mob/living/silicon/robot/proc/use_power()
 
-	if (is_component_functioning("power cell") && cell)
-		if(src.cell.charge <= 0)
-			uneq_all()
-			src.stat = 1
-		else
-			if(src.module_state_1)
-				src.cell.use(3)
-			if(src.module_state_2)
-				src.cell.use(3)
-			if(src.module_state_3)
-				src.cell.use(3)
+	for(var/V in components)
+		var/datum/robot_component/C = components[V]
+		C.update_power_state()
 
-			for(var/V in components)
-				var/datum/robot_component/C = components[V]
-				C.consume_power()
+	if ( cell && is_component_functioning("power cell") && src.cell.charge > 0 )
+		if(src.module_state_1)
+			src.cell.use(3)
+		if(src.module_state_2)
+			src.cell.use(3)
+		if(src.module_state_3)
+			src.cell.use(3)
 
-			if(!is_component_functioning("actuator"))
-				Paralyse(3)
-
-			src.stat = 0
+		src.has_power = 1
 	else
-		uneq_all()
-		src.stat = 1
+		if (src.has_power)
+			src << "\red You are now running on emergency backup power."
+		src.has_power = 0
 
 
 /mob/living/silicon/robot/proc/handle_regular_status_updates()
@@ -79,7 +73,7 @@
 		death()
 
 	if (src.stat != 2) //Alive.
-		if (src.paralysis || src.stunned || src.weakened) //Stunned etc.
+		if (src.paralysis || src.stunned || src.weakened || !src.has_power) //Stunned etc.
 			src.stat = 1
 			if (src.stunned > 0)
 				AdjustStunned(-1)
@@ -124,6 +118,10 @@
 		src.druggy--
 		src.druggy = max(0, src.druggy)
 
+	//update the state of modules and components here
+	if (src.stat != 0)
+		uneq_all()
+	
 	if(!is_component_functioning("radio"))
 		radio.on = 0
 	else
@@ -133,6 +131,9 @@
 		src.blinded = 0
 	else
 		src.blinded = 1
+		
+	if(!is_component_functioning("actuator"))
+		src.Paralyse(3)
 
 
 	return 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -42,6 +42,7 @@
 	var/emagged = 0
 	var/wiresexposed = 0
 	var/locked = 1
+	var/has_power = 1
 	var/list/req_access = list(access_robotics)
 	var/ident = 0
 	//var/list/laws = list()


### PR DESCRIPTION
See https://github.com/Baystation12/Baystation12/issues/4758.

Fixed issue where removing the power cell would prevent certain checks on robot components. 
Also cleaned up /mob/living/silicon/robot/proc/use_power(), moved code related to status for better SRP. Added a line to the examine text to hint that the borg can still move without power. 
Sorry for all of this being in a single commit, things got screwed up with git.
