### PR TITLE
Misc saycode fixes.

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -106,7 +106,7 @@
 		track = "<a href='byond://?src=\ref[src];track=\ref[speaker]'>[speaker_name] ([jobname])</a>"
 
 	if(istype(src, /mob/dead/observer))
-		if(speaker_name != speaker.real_name)
+		if(speaker_name != speaker.real_name && !isAI(speaker)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
 			speaker_name = "[speaker.real_name] ([speaker_name])"
 		track = "[speaker_name] (<a href='byond://?src=\ref[src];track=\ref[speaker]'>follow</a>)"
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1120,6 +1120,7 @@
 				speech_problem_flag = 1
 				stuttering = max(stuttering-1, 0)
 			if (slurring)
+				speech_problem_flag = 1
 				slurring = max(slurring-1, 0)
 			if(silent)
 				speech_problem_flag = 1

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -106,7 +106,7 @@
 			return
 		else
 			if(message_mode)
-				if(message_mode in radiochannels)
+				if(message_mode in (radiochannels | "department"))
 					if(l_ear && istype(l_ear,/obj/item/device/radio))
 						l_ear.talk_into(src,message, message_mode, verb, speaking)
 						used_radios += l_ear

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -117,7 +117,7 @@
 
 	if(used_radios.len)
 		italics = 1
-		message_range = 3
+		message_range = 1
 
 	var/datum/gas_mixture/environment = loc.return_air()
 	if(environment)


### PR DESCRIPTION
Humans can use :h again for their departments.
Drunks will slur
and eavesdrop distance on people talking into headsets dropped back to 1
