### PR TITLE
Say code tweaks (GhostRADIO, Unconscious folks and holopad talk ohmy!)

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -4,7 +4,7 @@
 	if(!client)
 		return
 
-	if(sleeping)
+	if(sleeping || stat == 1)
 		hear_sleep(message)
 		return
 
@@ -30,6 +30,8 @@
 
 	var/track = null
 	if(istype(src, /mob/dead/observer))
+		if(italics && client.prefs.toggles & CHAT_GHOSTRADIO)
+			return
 		if(speaker_name != speaker.real_name)
 			speaker_name = "[speaker.real_name] ([speaker_name])"
 		track = "(<a href='byond://?src=\ref[src];track=\ref[speaker]'>follow</a>) "
@@ -50,7 +52,7 @@
 	if(!client)
 		return
 
-	if(sleeping)
+	if(sleeping || stat==1) //If unconscious or sleeping
 		hear_sleep(message)
 		return
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -27,6 +27,9 @@
 		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 		return say_dead(message)
 
+	if(copytext(message,1,2) == "*")
+		return emote(copytext(message,2))
+
 	var/bot_type = 0			//Let's not do a fuck ton of type checks, thanks.
 	if(istype(src, /mob/living/silicon/ai))
 		bot_type = IS_AI

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -132,17 +132,16 @@
 
 	var/obj/machinery/hologram/holopad/T = src.current
 	if(istype(T) && T.hologram && T.master == src)//If there is a hologram and its master is the user.
-		var/message_a = say_quote(message)
+		var/verb = say_quote(message)
 
 		//Human-like, sorta, heard by those who understand humans.
-		var/rendered_a = "<span class='game say'><span class='name'>[name]</span> <span class='message'>[message_a]</span></span>"
+		var/rendered_a = "<span class='game say'><span class='name'>[name]</span> [verb], <span class='message'>\"[message]\"</span></span>"
 
 		//Speach distorted, heard by those who do not understand AIs.
-		message = stars(message)
-		var/message_b = say_quote(message)
-		var/rendered_b = "<span class='game say'><span class='name'>[voice_name]</span> <span class='message'>[message_b]</span></span>"
+		var/message_stars = stars(message)
+		var/rendered_b = "<span class='game say'><span class='name'>[voice_name]</span> [verb], <span class='message'>\"[message_stars]\"</span></span>"
 
-		src << "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> <span class='message'>[message_a]</span></span></i>"//The AI can "hear" its own message.
+		src << "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> [verb], <span class='message'>[message]</span></span></i>"//The AI can "hear" its own message.
 		for(var/mob/M in hearers(T.loc))//The location is the object, default distance.
 			if(M.say_understands(src))//If they understand AI speak. Humans and the like will be able to.
 				M.show_message(rendered_a, 2)


### PR DESCRIPTION
Cutting out on how much speech ghosts hear, if they are already hearing the person speaking over the radio through GHOSTRADIO then they won't hear them speak into the radio.  So one line instead of 2.

Unconscious people will not hear speech, treated just like they are sleeping as far as hear_say and hear_radio are concerned.

And holopads work again, instead of truncating the message.  This is a derp fix on my part as I changed how say_quote works, say_quote should not be used to change the message but used to change the verb.

Also silicon emotes.  *law   

fixes #4841
