### PR TITLE
Hazard vests can hold gasmasks and eng tape

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -107,7 +107,8 @@
 	item_state = "hazard"
 	blood_overlay_type = "armor"
 	allowed = list (/obj/item/device/analyzer, /obj/item/device/flashlight, /obj/item/device/multitool, /obj/item/device/pipe_painter, /obj/item/device/radio, /obj/item/device/t_scanner, \
-	/obj/item/weapon/crowbar, /obj/item/weapon/screwdriver, /obj/item/weapon/weldingtool, /obj/item/weapon/wirecutters, /obj/item/weapon/wrench, /obj/item/weapon/tank/emergency_oxygen)
+	/obj/item/weapon/crowbar, /obj/item/weapon/screwdriver, /obj/item/weapon/weldingtool, /obj/item/weapon/wirecutters, /obj/item/weapon/wrench, /obj/item/weapon/tank/emergency_oxygen, \
+	/obj/item/clothing/mask/gas, /obj/item/taperoll/engineering)
 
 //Lawyer
 /obj/item/clothing/suit/storage/lawyer/bluejacket


### PR DESCRIPTION
Seems like the kind of gear they should be able to carry, especially gasmasks which are too big to fit in pockets or webbing, so the hazard vest is the only good way to have them handy.
