### PR TITLE
Fixed Tape Recorders printing transcripts with a 'paper'-prefix

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -211,7 +211,7 @@
 	for(var/i=1,storedinfo.len >= i,i++)
 		t1 += "[storedinfo[i]]<BR>"
 	P.info = t1
-	P.name = "paper- 'Transcript'"
+	P.name = "Transcript"
 	canprint = 0
 	sleep(300)
 	canprint = 1


### PR DESCRIPTION
Small fix for the tape recorder printing Transcripts called "paper- 'Transcript'". We don't use the prefix anymore.
