### PR TITLE
hear() proc cleanup

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -35,7 +35,7 @@
 
 // Like view but bypasses luminosity check
 
-/proc/hear(var/range, var/atom/source)
+/proc/view_no_luminosity(var/range, var/atom/source)
 
 	var/lum = source.luminosity
 	source.luminosity = 6
@@ -170,7 +170,7 @@
 	if(!T)
 		return hear
 
-	var/list/range = hear(R, T)
+	var/list/range = view_no_luminosity(R, T)
 
 	for(var/atom/A in range)
 		if(ismob(A))
@@ -199,7 +199,7 @@
 		if(R)
 			var/turf/speaker = get_turf(R)
 			if(speaker)
-				for(var/turf/T in hear(R.canhear_range,speaker))
+				for(var/turf/T in view_no_luminosity(R.canhear_range,speaker))
 					speaker_coverage[T] = T
 
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -230,7 +230,7 @@
 	if(isXRay())
 		see = range(view_range, pos)
 	else
-		see = hear(view_range, pos)
+		see = view_no_luminosity(view_range, pos)
 	return see
 
 /atom/proc/auto_turn()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -89,7 +89,7 @@ var/list/department_radio_keys = list(
 	if(T)
 
 		var/list/objects = list()
-		var/list/hear = hear(message_range, T)
+		var/list/hear = hearers(message_range, T)
 		var/list/hearturfs = list()
 
 		for(var/I in hear)


### PR DESCRIPTION
Gave /proc/hear() a more appropriate name, and switched say() to use the built-in hearers().
