### PR TITLE
Adds Mentors.

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -315,6 +315,7 @@ proc/tg_list2text(list/list, glue=",")
 	if(rights & R_SOUNDS)		. += "[seperator]+SOUND"
 	if(rights & R_SPAWN)		. += "[seperator]+SPAWN"
 	if(rights & R_MOD)			. += "[seperator]+MODERATOR"
+	if(rights & R_MENTOR)		. += "[seperator]+MENTOR"
 	return .
 
 /proc/ui_style2icon(ui_style)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -60,6 +60,7 @@
 	var/respawn = 1
 	var/guest_jobban = 1
 	var/usewhitelist = 0
+	var/mods_are_mentors = 0
 	var/kick_inactive = 0				//force disconnect for inactive players
 	var/load_jobs_from_txt = 0
 	var/ToRban = 0
@@ -251,6 +252,9 @@
 
 				if ("log_runtime")
 					config.log_runtime = 1
+
+				if ("mentors")
+					config.mods_are_mentors = 1
 
 				if("allow_admin_ooccolor")
 					config.allow_admin_ooccolor = 1

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -52,7 +52,7 @@
 	var/num_admins_online = 0
 	if(holder)
 		for(var/client/C in admins)
-			if(R_ADMIN & C.holder.rights || !(R_MOD & C.holder.rights))
+			if(R_ADMIN & C.holder.rights || (!R_MOD & C.holder.rights && !R_MENTOR & C.holder.rights))
 				msg += "\t[C] is a [C.holder.rank]"
 
 				if(C.holder.fakekey)
@@ -70,7 +70,7 @@
 				msg += "\n"
 
 				num_admins_online++
-			else
+			else if(R_MOD & C.holder.rights || R_MENTOR & C.holder.rights)
 				modmsg += "\t[C] is a [C.holder.rank]"
 
 				if(isobserver(C.mob))
@@ -87,13 +87,13 @@
 
 	else
 		for(var/client/C in admins)
-			if(R_ADMIN & C.holder.rights || !(R_MOD & C.holder.rights))
+			if(R_ADMIN & C.holder.rights || (!R_MOD & C.holder.rights && !R_MENTOR & C.holder.rights))
 				if(!C.holder.fakekey)
 					msg += "\t[C] is a [C.holder.rank]\n"
 					num_admins_online++
-			else
+			else if (R_MOD & C.holder.rights || R_MENTOR & C.holder.rights)
 				modmsg += "\t[C] is a [C.holder.rank]\n"
 				num_mods_online++
 
-	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg + "\n<b> Current Moderators([num_mods_online]):</b>\n" + modmsg
+	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg + "\n<b> Current [config.mods_are_mentors ? "Mentors" : "Moderators"]([num_mods_online]):</b>\n" + modmsg
 	src << msg

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -41,6 +41,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 				if("sound","sounds")			rights |= R_SOUNDS
 				if("spawn","create")			rights |= R_SPAWN
 				if("mod")						rights |= R_MOD
+				if("mentor")				rights |= R_MENTOR
 
 		admin_ranks[rank] = rights
 		previous_rights = rights
@@ -51,7 +52,6 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		msg += "\t[rank] - [admin_ranks[rank]]\n"
 	testing(msg)
 	#endif
-
 
 /hook/startup/proc/loadAdmins()
 	load_admins()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,12 +1,13 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
-	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
+//	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
 	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
 	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
-	/client/proc/check_antagonists		/*shows all antags*/
+	/client/proc/check_antagonists,		/*shows all antags*/
+	/client/proc/cmd_mentor_check_new_players
 //	/client/proc/deadchat				/*toggles deadchat on/off*/
 	)
 var/list/admin_verbs_admin = list(
@@ -245,6 +246,18 @@ var/list/admin_verbs_mod = list(
 	/client/proc/jobbans,
 	/client/proc/cmd_admin_subtle_message 	/*send an message to somebody as a 'voice in their head'*/
 )
+
+var/list/admin_verbs_mentor = list(
+	/client/proc/cmd_admin_pm_context,
+	/client/proc/cmd_admin_pm_panel,
+	/datum/admins/proc/PlayerNotes,
+	/client/proc/admin_ghost,
+	/client/proc/cmd_mod_say,
+	/datum/admins/proc/show_player_info,
+//	/client/proc/dsay,
+	/client/proc/cmd_admin_subtle_message
+)
+
 /client/proc/add_admin_verbs()
 	if(holder)
 		verbs += admin_verbs_default
@@ -261,6 +274,7 @@ var/list/admin_verbs_mod = list(
 		if(holder.rights & R_SOUNDS)		verbs += admin_verbs_sounds
 		if(holder.rights & R_SPAWN)			verbs += admin_verbs_spawn
 		if(holder.rights & R_MOD)			verbs += admin_verbs_mod
+		if(holder.rights & R_MENTOR)		verbs += admin_verbs_mentor
 
 /client/proc/remove_admin_verbs()
 	verbs.Remove(

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -18,6 +18,8 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 
+	adminhelped = 1 //Determines if they get the message to reply by clicking the name.
+
 	/**src.verbs -= /client/verb/adminhelp
 
 	spawn(1200)
@@ -30,6 +32,8 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 	if(!msg)	return
 	var/original_msg = msg
+
+	
 
 	//explode the input msg into a list
 	var/list/msglist = text2list(msg, " ")

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -94,7 +94,10 @@
 	var/recieve_message = ""
 
 	if(holder && !C.holder)
-		recieve_message = "<font color='[recieve_color]' size='4'><b>-- Administrator private message --</b></font>\n"
+		recieve_message = "<font color='[recieve_color]' size='3'><b>-- Click the [recieve_pm_type]'s name to reply --</b></font>\n"
+		if(C.adminhelped)
+			C << recieve_message
+			C.adminhelped = 0
 
 		//AdminPM popup for ApocStation and anybody else who wants to use it. Set it with POPUP_ADMIN_PM in config.txt ~Carn
 		if(config.popup_admin_pm)
@@ -180,5 +183,5 @@
 		//check client/X is an admin and isn't the sender or recipient
 		if(X == C || X == src)
 			continue
-		if(X.key!=key && X.key!=C.key && (X.holder.rights & R_ADMIN) || (X.holder.rights & R_MOD) )
+		if(X.key!=key && X.key!=C.key && (X.holder.rights & R_ADMIN) || (X.holder.rights & (R_MOD|R_MENTOR)) )
 			X << "<B><font color='blue'>PM: [key_name(src, X, 0)]-&gt;[key_name(C, X, 0)]:</B> \blue [msg]</font>" //inform X

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -22,7 +22,7 @@
 	set name = "Msay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD))	return
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))	return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	log_admin("MOD: [key_name(src)] : [msg]")
@@ -32,6 +32,10 @@
 	var/color = "mod"
 	if (check_rights(R_ADMIN,0))
 		color = "adminmod"
+
+	var/channel = "MOD:"
+	if(config.mods_are_mentors)
+		channel = "MENTOR:"
 	for(var/client/C in admins)
-		if((R_ADMIN|R_MOD) & C.holder.rights)
-			C << "<span class='[color]'><span class='prefix'>MOD:</span> <EM>[key_name(src,1)]</EM> (<A HREF='?src=\ref[C.holder];adminplayerobservejump=\ref[mob]'>JMP</A>): <span class='message'>[msg]</span></span>"
+		if((R_ADMIN|R_MOD|R_MENTOR) & C.holder.rights)
+			C << "<span class='[color]'><span class='prefix'>[channel]</span> <EM>[key_name(src,1)]</EM> (<A HREF='?src=\ref[C.holder];adminplayerobservejump=\ref[mob]'>JMP</A>): <span class='message'>[msg]</span></span>"

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -23,6 +23,9 @@
 	if (src.holder.rights & R_MOD)
 		stafftype = "MOD"
 
+	if (src.holder.rights & R_MENTOR)
+		stafftype = "MENTOR"
+		
 	if (src.holder.rights & R_ADMIN)
 		stafftype = "ADMIN"
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -65,6 +65,37 @@
 	message_admins("\blue \bold SubtleMessage: [key_name_admin(usr)] -> [key_name_admin(M)] : [msg]", 1)
 	feedback_add_details("admin_verb","SMS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_mentor_check_new_players()	//Allows mentors / admins to determine who the newer players are.
+	set category = "Admin"
+	set name = "Check new Players"
+	if(!holder)
+		src << "Only staff members may use this command."
+
+	var/age = alert(src, "Age check", "Show accounts yonger then _____ days","7", "30" , "All")
+
+	if(age == "All") 
+		age = 9999999
+	else
+		age = text2num(age)
+
+	var/missing_ages = 0
+	var/msg = ""
+	for(var/client/C in clients)
+		if(C.player_age == "Requires database")
+			missing_ages = 1
+			continue
+		if(C.player_age < age)
+			msg += "[key_name_admin(C)]: account is [C.player_age] days old<br>"
+	
+	if(missing_ages)
+		src << "Some accounts did not have proper ages set in their clients.  This function requires database to be present"
+
+	if(msg != "")
+		src << browse(msg, "window=Player_age_check")
+	else
+		src << "No matches for that age range found."
+
+
 /client/proc/cmd_admin_world_narrate() // Allows administrators to fluff events a little easier -- TLE
 	set category = "Special Verbs"
 	set name = "Global Narrate"

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -18,6 +18,7 @@
 	var/area			= null
 	var/time_died_as_mouse = null //when the client last died as a mouse
 
+	var/adminhelped = 0
 
 		///////////////
 		//SOUND STUFF//

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -620,8 +620,9 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 #define R_SOUNDS		2048
 #define R_SPAWN			4096
 #define R_MOD			8192
+#define R_MENTOR		16384
 
-#define R_MAXPERMISSION 8192 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+#define R_MAXPERMISSION 16384 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
 #define R_HOST			65535
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -191,9 +191,12 @@
 				if (copytext(line, 1, 2) == ";")
 					continue
 
-				var/rights = admin_ranks["Moderator"]
+				var/title = "Moderator"
+				if(config.mods_are_mentors) title = "Mentor"
+				var/rights = admin_ranks[title]
+				
 				var/ckey = copytext(line, 1, length(line)+1)
-				var/datum/admins/D = new /datum/admins("Moderator", rights, ckey)
+				var/datum/admins/D = new /datum/admins(title, rights, ckey)
 				D.associate(directory[ckey])
 
 /world/proc/update_status()

--- a/config/example/admin_ranks.txt
+++ b/config/example/admin_ranks.txt
@@ -29,6 +29,8 @@
 
 Admin Observer
 Moderator		+MOD
+Mentor                  +MENTOR
+
 Admin Candidate	+ADMIN
 Trial Admin		+@ +SPAWN +REJUV +VAREDIT +BAN
 Badmin			+@ +POSSESS +BUILDMODE +SERVER +FUN

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -73,6 +73,12 @@ LOG_PDA
 ## disconnect players who did nothing during 10 minutes
 # KICK_INACTIVE
 
+## Use Mentors instead of Moderators.  Mentors are designed with the idea that
+###they help in pushing new people to be better at roleplay.  If you uncomment
+###this it will reduce the rights that your mods have.
+#MENTORS
+
+
 ## probablities for game modes chosen in "secret" and "random" modes
 ## 
 ## default probablity is 1, increase to make that mode more likely to be picked


### PR DESCRIPTION
Adds a config option MENTORS which sets the variable config.mods_are_mentors
Adds a rights level of R_MENTOR which gets msay, private message, aghost, notes, and a new proc for checking for new players (requires database support).

If the confic option for mentors is set then

```
the ckeys listed in moderators.txt file will instead be set as mentors, you can still make moderators by adding them in admins.txt

staffwho will show Mentors instead of Moderators as the heading above the listing of non-admins.
```

Also:  Players now get a message gently reminding them to click the name of the staff member to reply instead of ahelping over and over.
