### PR TITLE
Record Printout Changes and improved Console Interaction

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -359,7 +359,7 @@
 					t1 += data_core.get_manifest(0) // make it monochrome
 
 				P.info = t1
-				P.name = "paper- 'Crew Manifest'"
+				P.name = "Crew Manifest"
 				printing = null
 	if (modify)
 		modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -359,7 +359,7 @@
 					t1 += data_core.get_manifest(0) // make it monochrome
 
 				P.info = t1
-				P.name = "Crew Manifest"
+				P.name = text("Crew Manifest ([])", worldtime2text())
 				printing = null
 	if (modify)
 		modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -16,6 +16,14 @@
 	var/temp = null
 	var/printing = null
 
+/obj/machinery/computer/med_data/attackby(obj/item/O as obj, user as mob)
+	if(istype(O, /obj/item/weapon/card/id) && !scan)
+		usr.drop_item()
+		O.loc = src
+		scan = O
+		user << "You insert [O]."
+	..()
+
 /obj/machinery/computer/med_data/attack_ai(user as mob)
 	return src.attack_hand(user)
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -471,20 +471,26 @@
 			if (href_list["print_p"])
 				if (!( src.printing ))
 					src.printing = 1
+					var/datum/data/record/record1 = null
+					var/datum/data/record/record2 = null
+					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
+						record1 = active1
+					if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))
+						record2 = active2
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( src.loc )
 					P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
-					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
-						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", src.active1.fields["name"], src.active1.fields["id"], src.active1.fields["sex"], src.active1.fields["age"], src.active1.fields["fingerprint"], src.active1.fields["p_stat"], src.active1.fields["m_stat"])
-						P.name = text("Medical Record ([])", src.active1.fields["name"])
+					if (record1)
+						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", record1.fields["name"], record1.fields["id"], record1.fields["sex"], record1.fields["age"], record1.fields["fingerprint"], record1.fields["p_stat"], record1.fields["m_stat"])
+						P.name = text("Medical Record ([])", record1.fields["name"])
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
 						P.name = "Medical Record"
-					if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))
-						P.info += text("<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: []<BR>\nDNA: []<BR>\n<BR>\nMinor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nMajor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nAllergies: []<BR>\nDetails: []<BR>\n<BR>\nCurrent Diseases: [] (per disease info placed in log/comment section)<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", src.active2.fields["b_type"], src.active2.fields["b_dna"], src.active2.fields["mi_dis"], src.active2.fields["mi_dis_d"], src.active2.fields["ma_dis"], src.active2.fields["ma_dis_d"], src.active2.fields["alg"], src.active2.fields["alg_d"], src.active2.fields["cdi"], src.active2.fields["cdi_d"], src.active2.fields["notes"])
+					if (record2)
+						P.info += text("<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: []<BR>\nDNA: []<BR>\n<BR>\nMinor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nMajor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nAllergies: []<BR>\nDetails: []<BR>\n<BR>\nCurrent Diseases: [] (per disease info placed in log/comment section)<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", record2.fields["b_type"], record2.fields["b_dna"], record2.fields["mi_dis"], record2.fields["mi_dis_d"], record2.fields["ma_dis"], record2.fields["ma_dis_d"], record2.fields["alg"], record2.fields["alg_d"], record2.fields["cdi"], record2.fields["cdi_d"], record2.fields["notes"])
 						var/counter = 1
-						while(src.active2.fields[text("com_[]", counter)])
-							P.info += text("[]<BR>", src.active2.fields[text("com_[]", counter)])
+						while(record2.fields[text("com_[]", counter)])
+							P.info += text("[]<BR>", record2.fields[text("com_[]", counter)])
 							counter++
 					else
 						P.info += "<B>Medical Record Lost!</B><BR>"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -468,8 +468,10 @@
 					P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
 					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
 						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", src.active1.fields["name"], src.active1.fields["id"], src.active1.fields["sex"], src.active1.fields["age"], src.active1.fields["fingerprint"], src.active1.fields["p_stat"], src.active1.fields["m_stat"])
+						P.name = text("Medical Record ([])", src.active1.fields["name"])
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
+						P.name = "Medical Record"
 					if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))
 						P.info += text("<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: []<BR>\nDNA: []<BR>\n<BR>\nMinor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nMajor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nAllergies: []<BR>\nDetails: []<BR>\n<BR>\nCurrent Diseases: [] (per disease info placed in log/comment section)<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", src.active2.fields["b_type"], src.active2.fields["b_dna"], src.active2.fields["mi_dis"], src.active2.fields["mi_dis_d"], src.active2.fields["ma_dis"], src.active2.fields["ma_dis_d"], src.active2.fields["alg"], src.active2.fields["alg_d"], src.active2.fields["cdi"], src.active2.fields["cdi_d"], src.active2.fields["notes"])
 						var/counter = 1
@@ -479,7 +481,6 @@
 					else
 						P.info += "<B>Medical Record Lost!</B><BR>"
 					P.info += "</TT>"
-					P.name = "paper- 'Medical Record'"
 					src.printing = null
 
 	src.add_fingerprint(usr)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -334,8 +334,10 @@ What a mess.*/
 					P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
 						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", active1.fields["name"], active1.fields["id"], active1.fields["sex"], active1.fields["age"], active1.fields["fingerprint"], active1.fields["p_stat"], active1.fields["m_stat"])
+						P.name = text("Security Record ([])", active1.fields["name"])
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
+						P.name = "Security Record"
 					if ((istype(active2, /datum/data/record) && data_core.security.Find(active2)))
 						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []<BR>\n<BR>\nMinor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nMajor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", active2.fields["criminal"], active2.fields["mi_crim"], active2.fields["mi_crim_d"], active2.fields["ma_crim"], active2.fields["ma_crim_d"], active2.fields["notes"])
 						var/counter = 1
@@ -345,7 +347,6 @@ What a mess.*/
 					else
 						P.info += "<B>Security Record Lost!</B><BR>"
 					P.info += "</TT>"
-					P.name = "paper - 'Security Record'"
 					printing = null
 					updateUsrDialog()
 //RECORD DELETE

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -329,20 +329,26 @@ What a mess.*/
 			if ("Print Record")
 				if (!( printing ))
 					printing = 1
+					var/datum/data/record/record1 = null
+					var/datum/data/record/record2 = null
+					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
+						record1 = active1
+					if ((istype(active2, /datum/data/record) && data_core.security.Find(active2)))
+						record2 = active2
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( loc )
 					P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
-					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
-						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", active1.fields["name"], active1.fields["id"], active1.fields["sex"], active1.fields["age"], active1.fields["fingerprint"], active1.fields["p_stat"], active1.fields["m_stat"])
-						P.name = text("Security Record ([])", active1.fields["name"])
+					if (record1)
+						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", record1.fields["name"], record1.fields["id"], record1.fields["sex"], record1.fields["age"], record1.fields["fingerprint"], record1.fields["p_stat"], record1.fields["m_stat"])
+						P.name = text("Security Record ([])", record1.fields["name"])
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
 						P.name = "Security Record"
-					if ((istype(active2, /datum/data/record) && data_core.security.Find(active2)))
-						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []<BR>\n<BR>\nMinor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nMajor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", active2.fields["criminal"], active2.fields["mi_crim"], active2.fields["mi_crim_d"], active2.fields["ma_crim"], active2.fields["ma_crim_d"], active2.fields["notes"])
+					if (record2)
+						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []<BR>\n<BR>\nMinor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nMajor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", record2.fields["criminal"], record2.fields["mi_crim"], record2.fields["mi_crim_d"], record2.fields["ma_crim"], record2.fields["ma_crim_d"], record2.fields["notes"])
 						var/counter = 1
-						while(active2.fields[text("com_[]", counter)])
-							P.info += text("[]<BR>", active2.fields[text("com_[]", counter)])
+						while(record2.fields[text("com_[]", counter)])
+							P.info += text("[]<BR>", record2.fields[text("com_[]", counter)])
 							counter++
 					else
 						P.info += "<B>Security Record Lost!</B><BR>"

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -126,331 +126,333 @@ obj/machinery/computer/forensic_scanning
 
 
 	Topic(href,href_list)
-		switch(href_list["operation"])
-			if("login")
-				var/mob/M = usr
-				if(istype(M,/mob/living/silicon))
-					authenticated = 1
-					updateDialog()
-					return
-				if (allowed(M))
-					authenticated = 1
-			if("logout")
-				authenticated = 0
-			if("clear")
-				if(canclear)
-					temp = null
-			if("eject")
-				if(scanning)
-					scanning.loc = loc
-					scanning = null
-				else
-					temp = "Eject Failed: No Object"
-			if("insert")
-				var/mob/M = usr
-				var/obj/item/I = M.get_active_hand()
-				if(I && istype(I))
-					if(istype(I, /obj/item/weapon/evidencebag))
-						scanning = I.contents[1]
-						scanning.loc = src
-						I.overlays -= scanning
-						I.icon_state = "evidenceobj"
+		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+			usr.set_machine(src)
+			switch(href_list["operation"])
+				if("login")
+					var/mob/M = usr
+					if(istype(M,/mob/living/silicon))
+						authenticated = 1
+						updateDialog()
+						return
+					if (allowed(M))
+						authenticated = 1
+				if("logout")
+					authenticated = 0
+				if("clear")
+					if(canclear)
+						temp = null
+				if("eject")
+					if(scanning)
+						scanning.loc = loc
+						scanning = null
 					else
-						scanning = I
+						temp = "Eject Failed: No Object"
+				if("insert")
+					var/mob/M = usr
+					var/obj/item/I = M.get_active_hand()
+					if(I && istype(I))
+						if(istype(I, /obj/item/weapon/evidencebag))
+							scanning = I.contents[1]
+							scanning.loc = src
+							I.overlays -= scanning
+							I.icon_state = "evidenceobj"
+						else
+							scanning = I
+							M.drop_item()
+							I.loc = src
+					else
+						usr << "Invalid Object Rejected."
+				if("card")  //Processing a fingerprint card.
+					var/mob/M = usr
+					var/obj/item/I = M.get_active_hand()
+					if(!(I && istype(I,/obj/item/weapon/f_card)))
+						I = card
+					if(I && istype(I,/obj/item/weapon/f_card))
+						card = I
+						if(!card.fingerprints)
+							card.fingerprints = list()
+						if(card.amount > 1 || !card.fingerprints.len)
+							usr << "\red ERROR: No prints/too many cards."
+							if(card.loc == src)
+								card.loc = src.loc
+							card = null
+							return
 						M.drop_item()
 						I.loc = src
-				else
-					usr << "Invalid Object Rejected."
-			if("card")  //Processing a fingerprint card.
-				var/mob/M = usr
-				var/obj/item/I = M.get_active_hand()
-				if(!(I && istype(I,/obj/item/weapon/f_card)))
-					I = card
-				if(I && istype(I,/obj/item/weapon/f_card))
-					card = I
-					if(!card.fingerprints)
-						card.fingerprints = list()
-					if(card.amount > 1 || !card.fingerprints.len)
-						usr << "\red ERROR: No prints/too many cards."
-						if(card.loc == src)
-							card.loc = src.loc
-						card = null
-						return
-					M.drop_item()
-					I.loc = src
-					process_card()
-				else
-					usr << "\red Invalid Object Rejected."
-			if("database") //Viewing all records in each database
-				canclear = 1
-				if(href_list["delete_record"])
-					delete_dossier(href_list["delete_record"])
-				if(href_list["delete_aux"])
-					delete_record(href_list["delete_aux"])
-				if((!misc || !misc.len) && (!files || !files.len))
-					temp = "Database is empty."
-				else
-					if(files && files.len)
-						temp = "<b>Criminal Evidence Database</b><br><br>"
-						temp += "Consolidated data points:<br>"
-						for(var/print in files)
-							var/list/file = files[print]
-							temp += "<a href='?src=\ref[src];operation=record;identifier=[print]'>{[file[2]]}</a><br>"
-						temp += "<br><a href='?src=\ref[src];operation=card'>{Insert Finger Print Card (To complete a Dossier)}</a><br><br><br>"
+						process_card()
 					else
-						temp = ""
-					if(misc && misc.len)
-						temp += {"<b>Auxiliary Evidence Database</b><br><br>
-						This is where anything without fingerprints goes.<br><br>"}
-						for(var/atom in misc)
-							var/list/data_entry = misc[atom]
-							temp += "<a href='?src=\ref[src];operation=auxiliary;identifier=[atom]'>{[data_entry[3]]}</a><br>"
-			if("record") //Viewing a record from the "files" database.
-				canclear = 0
-				if(files)
-					var/list/dossier = files[href_list["identifier"]]
-					if(href_list["ren"])
-						var/new_title = copytext(sanitize(input("Rename to what?", "Dossier Editing", "Dossier [files.Find(href_list["identifier"])]") as null|text),1,MAX_MESSAGE_LEN)
-						if(new_title)
-							dossier[2] = new_title
+						usr << "\red Invalid Object Rejected."
+				if("database") //Viewing all records in each database
+					canclear = 1
+					if(href_list["delete_record"])
+						delete_dossier(href_list["delete_record"])
+					if(href_list["delete_aux"])
+						delete_record(href_list["delete_aux"])
+					if((!misc || !misc.len) && (!files || !files.len))
+						temp = "Database is empty."
+					else
+						if(files && files.len)
+							temp = "<b>Criminal Evidence Database</b><br><br>"
+							temp += "Consolidated data points:<br>"
+							for(var/print in files)
+								var/list/file = files[print]
+								temp += "<a href='?src=\ref[src];operation=record;identifier=[print]'>{[file[2]]}</a><br>"
+							temp += "<br><a href='?src=\ref[src];operation=card'>{Insert Finger Print Card (To complete a Dossier)}</a><br><br><br>"
 						else
-							usr << "Illegal or blank name."
-					temp = {"<b>Criminal Evidence Database</b><br><br>
-					Consolidated data points: [dossier[2]]<br>"}
-					var/print_string = "Fingerprints: Print not complete!<br>"
-					if(stringpercent(dossier[1]) <= FINGERPRINT_COMPLETE)
-						print_string = "Fingerprints: (80% or higher completion reached)<br>[dossier[1]]<br>"
-					temp += print_string
-					for(var/object in dossier)
-						if(object == dossier[1] || object == dossier[2])
-							continue
-						temp += "<hr>"
-						var/list/outputs = dossier[object]
-						var/list/prints = outputs[1]
-						temp += "<big><b>Object:</b> [outputs[4]]</big><br>"
-						temp += "&nbsp<b>Fingerprints:</b><br>"
-						temp += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
-						var/complete_prints = 0
-						for(var/print in prints)
-							if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
-								complete_prints++
-								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
-						if(complete_prints)
-							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
-						else
-							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
-						var/list/fibers = outputs[2]
+							temp = ""
+						if(misc && misc.len)
+							temp += {"<b>Auxiliary Evidence Database</b><br><br>
+							This is where anything without fingerprints goes.<br><br>"}
+							for(var/atom in misc)
+								var/list/data_entry = misc[atom]
+								temp += "<a href='?src=\ref[src];operation=auxiliary;identifier=[atom]'>{[data_entry[3]]}</a><br>"
+				if("record") //Viewing a record from the "files" database.
+					canclear = 0
+					if(files)
+						var/list/dossier = files[href_list["identifier"]]
+						if(href_list["ren"])
+							var/new_title = copytext(sanitize(input("Rename to what?", "Dossier Editing", "Dossier [files.Find(href_list["identifier"])]") as null|text),1,MAX_MESSAGE_LEN)
+							if(new_title)
+								dossier[2] = new_title
+							else
+								usr << "Illegal or blank name."
+						temp = {"<b>Criminal Evidence Database</b><br><br>
+						Consolidated data points: [dossier[2]]<br>"}
+						var/print_string = "Fingerprints: Print not complete!<br>"
+						if(stringpercent(dossier[1]) <= FINGERPRINT_COMPLETE)
+							print_string = "Fingerprints: (80% or higher completion reached)<br>[dossier[1]]<br>"
+						temp += print_string
+						for(var/object in dossier)
+							if(object == dossier[1] || object == dossier[2])
+								continue
+							temp += "<hr>"
+							var/list/outputs = dossier[object]
+							var/list/prints = outputs[1]
+							temp += "<big><b>Object:</b> [outputs[4]]</big><br>"
+							temp += "&nbsp<b>Fingerprints:</b><br>"
+							temp += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
+							var/complete_prints = 0
+							for(var/print in prints)
+								if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
+									complete_prints++
+									temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
+							if(complete_prints)
+								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
+							else
+								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
+							var/list/fibers = outputs[2]
+							if(fibers && fibers.len)
+								temp += "&nbsp<b>Fibers:</b><br>"
+								for(var/j = 1, j <= fibers.len, j++)
+									temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fibers[j]]<br>"
+							var/list/blood = outputs[3]
+							if(blood && blood.len)
+								temp += "&nbsp<b>Blood:</b><br>"
+								for(var/named in blood)
+									temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
+						temp += "<br><a href='?src=\ref[src];operation=record;identifier=[href_list["identifier"]];ren=true'>{Rename this Dossier}</a>"
+						temp += "<br><a href='?src=\ref[src];operation=database;delete_record=[href_list["identifier"]]'>{Delete this Dossier}</a>"
+						temp += "<br><a href='?src=\ref[src];operation=databaseprint;identifier=[href_list["identifier"]]'>{Print}</a>"
+					else
+						temp = "ERROR.  Database not found!<br>"
+					temp += "<br><a href='?src=\ref[src];operation=database'>{Return}</a>"
+				if("databaseprint") //Printing from the "files" database.
+					if(files)
+						var/obj/item/weapon/paper/P = new(loc)
+						var/list/dossier = files[href_list["identifier"]]
+						P.name = "\improper Database File ([dossier[2]])"
+						P.overlays += "paper_words"
+						P.info = "<b>Criminal Evidence Database</b><br><br>"
+						P.info += "Consolidated data points: [dossier[2]]<br>"
+						var/print_string = "Fingerprints: Print not complete!<br>"
+						if(stringpercent(dossier[1]) <= FINGERPRINT_COMPLETE)
+							print_string = "Fingerprints: (80% or higher completion reached)<br>[dossier[1]]<br>"
+						P.info += print_string
+						for(var/object in dossier)
+							if(object == dossier[1] || object == dossier[2])
+								continue
+							P.info += "<hr>"
+							var/list/outputs = dossier[object]
+							var/list/prints = outputs[1]
+							P.info += "<big><b>Object:</b> [outputs[4]]</big><br>"
+							P.info += "&nbsp<b>Fingerprints:</b><br>"
+							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
+							var/complete_prints = 0
+							for(var/print in prints)
+								if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
+									complete_prints++
+									P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
+							if(complete_prints)
+								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
+							else
+								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
+							var/list/fibers = outputs[2]
+							if(fibers && fibers.len)
+								P.info += "&nbsp<b>Fibers:</b><br>"
+								for(var/j = 1, j <= fibers.len, j++)
+									P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fibers[j]]<br>"
+							var/list/blood = outputs[3]
+							if(blood && blood.len)
+								P.info += "&nbsp<b>Blood:</b><br>"
+								for(var/named in blood)
+									P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
+					else
+						usr << "ERROR.  Database not found!<br>"
+				if("auxiliary") //Viewing a record from the "misc" database.
+					canclear = 0
+					if(misc)
+						temp = "<b>Auxiliary Evidence Database</b><br><br>"
+						var/list/outputs = misc[href_list["identifier"]]
+						temp += "<big><b>Consolidated data points:</b> [outputs[3]]</big><br>"
+						var/list/prints = outputs[4]
+						if(prints)
+							temp += "&nbsp<b>Fingerprints:</b><br>"
+							temp += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
+							var/complete_prints = 0
+							for(var/print in prints)
+								if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
+									complete_prints++
+									temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
+							if(complete_prints)
+								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
+							else
+								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
+						var/list/fibers = outputs[1]
 						if(fibers && fibers.len)
 							temp += "&nbsp<b>Fibers:</b><br>"
-							for(var/j = 1, j <= fibers.len, j++)
-								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fibers[j]]<br>"
-						var/list/blood = outputs[3]
+							for(var/fiber in fibers)
+								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fiber]<br>"
+						var/list/blood = outputs[2]
 						if(blood && blood.len)
 							temp += "&nbsp<b>Blood:</b><br>"
 							for(var/named in blood)
 								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
-					temp += "<br><a href='?src=\ref[src];operation=record;identifier=[href_list["identifier"]];ren=true'>{Rename this Dossier}</a>"
-					temp += "<br><a href='?src=\ref[src];operation=database;delete_record=[href_list["identifier"]]'>{Delete this Dossier}</a>"
-					temp += "<br><a href='?src=\ref[src];operation=databaseprint;identifier=[href_list["identifier"]]'>{Print}</a>"
-				else
-					temp = "ERROR.  Database not found!<br>"
-				temp += "<br><a href='?src=\ref[src];operation=database'>{Return}</a>"
-			if("databaseprint") //Printing from the "files" database.
-				if(files)
-					var/obj/item/weapon/paper/P = new(loc)
-					var/list/dossier = files[href_list["identifier"]]
-					P.name = "\improper Database File ([dossier[2]])"
-					P.overlays += "paper_words"
-					P.info = "<b>Criminal Evidence Database</b><br><br>"
-					P.info += "Consolidated data points: [dossier[2]]<br>"
-					var/print_string = "Fingerprints: Print not complete!<br>"
-					if(stringpercent(dossier[1]) <= FINGERPRINT_COMPLETE)
-						print_string = "Fingerprints: (80% or higher completion reached)<br>[dossier[1]]<br>"
-					P.info += print_string
-					for(var/object in dossier)
-						if(object == dossier[1] || object == dossier[2])
-							continue
-						P.info += "<hr>"
-						var/list/outputs = dossier[object]
-						var/list/prints = outputs[1]
-						P.info += "<big><b>Object:</b> [outputs[4]]</big><br>"
-						P.info += "&nbsp<b>Fingerprints:</b><br>"
-						P.info += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
-						var/complete_prints = 0
-						for(var/print in prints)
-							if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
-								complete_prints++
-								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
-						if(complete_prints)
-							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
-						else
-							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
-						var/list/fibers = outputs[2]
+						temp += "<br><a href='?src=\ref[src];operation=database;delete_aux=[href_list["identifier"]]'>{Delete This Record}</a>"
+						temp += "<br><a href='?src=\ref[src];operation=auxiliaryprint;identifier=[href_list["identifier"]]'>{Print}</a>"
+					else
+						temp = "ERROR.  Database not found!<br>"
+					temp += "<br><a href='?src=\ref[src];operation=database'>{Return}</a>"
+				if("auxiliaryprint") //Printing from the "misc" database.
+					if(misc)
+						var/obj/item/weapon/paper/P = new(loc)
+						var/list/outputs = misc[href_list["identifier"]]
+						P.name = "\improper Auxiliary Database File ([outputs[3]])"
+						P.overlays += "paper_words"
+						P.info = "<b>Auxiliary Evidence Database</b><br><br>"
+						P.info += "<big><b>Consolidated data points:</b> [outputs[3]]</big><br>"
+						var/list/prints = outputs[4]
+						if(prints)
+							P.info += "&nbsp<b>Fingerprints:</b><br>"
+							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
+							var/complete_prints = 0
+							for(var/print in prints)
+								if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
+									complete_prints++
+									P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
+							if(complete_prints)
+								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
+							else
+								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
+						var/list/fibers = outputs[1]
 						if(fibers && fibers.len)
 							P.info += "&nbsp<b>Fibers:</b><br>"
-							for(var/j = 1, j <= fibers.len, j++)
-								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fibers[j]]<br>"
-						var/list/blood = outputs[3]
+							for(var/fiber in fibers)
+								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fiber]<br>"
+						var/list/blood = outputs[2]
 						if(blood && blood.len)
 							P.info += "&nbsp<b>Blood:</b><br>"
 							for(var/named in blood)
 								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
-				else
-					usr << "ERROR.  Database not found!<br>"
-			if("auxiliary") //Viewing a record from the "misc" database.
-				canclear = 0
-				if(misc)
-					temp = "<b>Auxiliary Evidence Database</b><br><br>"
-					var/list/outputs = misc[href_list["identifier"]]
-					temp += "<big><b>Consolidated data points:</b> [outputs[3]]</big><br>"
-					var/list/prints = outputs[4]
-					if(prints)
-						temp += "&nbsp<b>Fingerprints:</b><br>"
-						temp += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
-						var/complete_prints = 0
-						for(var/print in prints)
-							if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
-								complete_prints++
-								temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
-						if(complete_prints)
-							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
-						else
-							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
-					var/list/fibers = outputs[1]
-					if(fibers && fibers.len)
-						temp += "&nbsp<b>Fibers:</b><br>"
-						for(var/fiber in fibers)
-							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fiber]<br>"
-					var/list/blood = outputs[2]
-					if(blood && blood.len)
-						temp += "&nbsp<b>Blood:</b><br>"
-						for(var/named in blood)
-							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
-					temp += "<br><a href='?src=\ref[src];operation=database;delete_aux=[href_list["identifier"]]'>{Delete This Record}</a>"
-					temp += "<br><a href='?src=\ref[src];operation=auxiliaryprint;identifier=[href_list["identifier"]]'>{Print}</a>"
-				else
-					temp = "ERROR.  Database not found!<br>"
-				temp += "<br><a href='?src=\ref[src];operation=database'>{Return}</a>"
-			if("auxiliaryprint") //Printing from the "misc" database.
-				if(misc)
-					var/obj/item/weapon/paper/P = new(loc)
-					var/list/outputs = misc[href_list["identifier"]]
-					P.name = "\improper Auxiliary Database File ([outputs[3]])"
-					P.overlays += "paper_words"
-					P.info = "<b>Auxiliary Evidence Database</b><br><br>"
-					P.info += "<big><b>Consolidated data points:</b> [outputs[3]]</big><br>"
-					var/list/prints = outputs[4]
-					if(prints)
-						P.info += "&nbsp<b>Fingerprints:</b><br>"
-						P.info += "&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"
-						var/complete_prints = 0
-						for(var/print in prints)
-							if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
-								complete_prints++
-								P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[prints[print]]<br>"
-						if(complete_prints)
-							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;And [prints.len - complete_prints] unknown unique prints.<br>"
-						else
-							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No prints of sufficient completeness.<br>"
-					var/list/fibers = outputs[1]
-					if(fibers && fibers.len)
-						P.info += "&nbsp<b>Fibers:</b><br>"
-						for(var/fiber in fibers)
-							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[fiber]<br>"
-					var/list/blood = outputs[2]
-					if(blood && blood.len)
-						P.info += "&nbsp<b>Blood:</b><br>"
-						for(var/named in blood)
-							P.info += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
-				else
-					usr << "ERROR.  Database not found!<br>"
-			if("scan")
-				if(istype(scanning,/obj/item/weapon/f_card))
-					card = scanning
-					scanning = initial(scanning)
-					process_card()
-				else if(scanning)
-					scan_process = 3
-					scan_data = "Scanning [scanning]: 25% complete"
-					updateDialog()
-					sleep(50)
-					if(!scan_process)
-						scan_data = null
+					else
+						usr << "ERROR.  Database not found!<br>"
+				if("scan")
+					if(istype(scanning,/obj/item/weapon/f_card))
+						card = scanning
+						scanning = initial(scanning)
+						process_card()
+					else if(scanning)
+						scan_process = 3
+						scan_data = "Scanning [scanning]: 25% complete"
 						updateDialog()
-						return
-					scan_data = "Scanning [scanning]: 50% complete"
-					updateDialog()
-					scan_process = 2
-					sleep(50)
-					if(!scan_process)
-						scan_data = null
+						sleep(50)
+						if(!scan_process)
+							scan_data = null
+							updateDialog()
+							return
+						scan_data = "Scanning [scanning]: 50% complete"
 						updateDialog()
-						return
-					scan_data = "Scanning [scanning]: 75% complete"
-					updateDialog()
-					scan_process = 1
-					sleep(50)
-					if(!scan_process)
-						scan_data = null
+						scan_process = 2
+						sleep(50)
+						if(!scan_process)
+							scan_data = null
+							updateDialog()
+							return
+						scan_data = "Scanning [scanning]: 75% complete"
 						updateDialog()
-						return
+						scan_process = 1
+						sleep(50)
+						if(!scan_process)
+							scan_data = null
+							updateDialog()
+							return
+						if(scanning)
+							scan_process = 0
+							scan_name = scanning.name
+							scan_data = "<u>[scanning]</u><br><br>"
+							if (scanning.blood_DNA)
+								scan_data += "Blood Found:<br>"
+								for(var/blood in scanning.blood_DNA)
+									scan_data += "Blood type: [scanning.blood_DNA[blood]]\nDNA: [blood]<br><br>"
+							else
+								scan_data += "No Blood Found<br><br>"
+							if(!scanning.fingerprints)
+								scan_data += "No Fingerprints Found<br><br>"
+							else
+								scan_data += "Isolated [scanning.fingerprints.len] Fingerprints.  Loaded into database.<br>"
+								add_data(scanning)
+
+							if(!scanning.suit_fibers)
+								scan_data += "No Fibers/Materials Located<br>"
+							else
+								scan_data += "Fibers/Materials Found:<br>"
+								for(var/data in scanning.suit_fibers)
+									scan_data += "- [data]<br>"
+							if(istype(scanning,/obj/item/device/detective_scanner) || (istype(scanning, /obj/item/device/pda) && scanning:cartridge && scanning:cartridge.access_security))
+								scan_data += "<br><b>Data transfered from \the [scanning] to Database.</b><br>"
+								add_data_scanner(scanning)
+							else if(!scanning.fingerprints)
+								scan_data += "<br><b><a href='?src=\ref[src];operation=add'>Add to Database?</a></b><br>"
+					else
+						temp = "Scan Failed: No Object"
+
+
+				if("print") //Printing scan data
+					if(scan_data)
+						temp = "Scan Data Printed."
+						var/obj/item/weapon/paper/P = new(loc)
+						P.name = "\improper Scan Data ([scan_name])"
+						P.info = "<tt>[scan_data]</tt>"
+						P.overlays += "paper_words"
+					else
+						temp = "Print Failed: No Data"
+				if("erase")
+					scan_data = ""
+				if("cancel")
+					scan_process = 0
+				if("add") //Adding an object (Manually) to the database.
 					if(scanning)
-						scan_process = 0
-						scan_name = scanning.name
-						scan_data = "<u>[scanning]</u><br><br>"
-						if (scanning.blood_DNA)
-							scan_data += "Blood Found:<br>"
-							for(var/blood in scanning.blood_DNA)
-								scan_data += "Blood type: [scanning.blood_DNA[blood]]\nDNA: [blood]<br><br>"
-						else
-							scan_data += "No Blood Found<br><br>"
-						if(!scanning.fingerprints)
-							scan_data += "No Fingerprints Found<br><br>"
-						else
-							scan_data += "Isolated [scanning.fingerprints.len] Fingerprints.  Loaded into database.<br>"
-							add_data(scanning)
-
-						if(!scanning.suit_fibers)
-							scan_data += "No Fibers/Materials Located<br>"
-						else
-							scan_data += "Fibers/Materials Found:<br>"
-							for(var/data in scanning.suit_fibers)
-								scan_data += "- [data]<br>"
-						if(istype(scanning,/obj/item/device/detective_scanner) || (istype(scanning, /obj/item/device/pda) && scanning:cartridge && scanning:cartridge.access_security))
-							scan_data += "<br><b>Data transfered from \the [scanning] to Database.</b><br>"
-							add_data_scanner(scanning)
-						else if(!scanning.fingerprints)
-							scan_data += "<br><b><a href='?src=\ref[src];operation=add'>Add to Database?</a></b><br>"
-				else
-					temp = "Scan Failed: No Object"
-
-
-			if("print") //Printing scan data
-				if(scan_data)
-					temp = "Scan Data Printed."
-					var/obj/item/weapon/paper/P = new(loc)
-					P.name = "\improper Scan Data ([scan_name])"
-					P.info = "<tt>[scan_data]</tt>"
-					P.overlays += "paper_words"
-				else
-					temp = "Print Failed: No Data"
-			if("erase")
-				scan_data = ""
-			if("cancel")
-				scan_process = 0
-			if("add") //Adding an object (Manually) to the database.
-				if(scanning)
-					add_data(scanning)
-				else
-					temp = "Data Transfer Failed: No Object."
-			if("rename")
-				if(!files || !files[href_list["identifier"]])
-					temp = "ERROR: Record/Database not found!"
-				else
-					var/new_title = copytext(sanitize(input("Rename to what?", "Dossier Editing", "Dossier [files.Find(href_list["identifier"])]") as null|text),1,MAX_MESSAGE_LEN)
-					if(new_title)
-						var/list/file = files[href_list["identifier"]]
-						file[2] = new_title
+						add_data(scanning)
+					else
+						temp = "Data Transfer Failed: No Object."
+				if("rename")
+					if(!files || !files[href_list["identifier"]])
+						temp = "ERROR: Record/Database not found!"
+					else
+						var/new_title = copytext(sanitize(input("Rename to what?", "Dossier Editing", "Dossier [files.Find(href_list["identifier"])]") as null|text),1,MAX_MESSAGE_LEN)
+						if(new_title)
+							var/list/file = files[href_list["identifier"]]
+							file[2] = new_title
 		updateUsrDialog()
 
 	ex_act()


### PR DESCRIPTION
Changes the following:
- Changes the Medical and Security Record printout titles to the form [Medical/Security] Record (<crewname>), equivalent to Autopsy printouts.
  
  Example:
  Medical Record (Urist McUrist)
- Printouts of crew manifests from an ID Console will now have the station time on it:
  
  Example:
  Crew Manifest (12:32)
- Exiting a player record while printing at a Console will no longer cause a printout with lost records or another player's record
- Forensics Console now updates the Screen even when the user is simultaneously using a different console (equivalent to Medical and Security Consoles)
- Attacking a Medical Console with an ID card will insert the card and access the screen, equivalent to Security Consoles

(only lines 129-130 in forensic_scanning.dm were added, the next few hundred lines had to be indented, causing Git to recognize dozens and dozens of changes)
