### PR TITLE
Fixed cell chargers being infinite energy sources.

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -187,8 +187,8 @@
 			var/heat_capacity = gas.heat_capacity()
 			var/energy_used = min( abs( heat_capacity*(gas.temperature - target_temperature) ), MAX_ENERGY_CHANGE)
 
-			//Use power.  Assuming that each power unit represents 1000 watts....
-			use_power(energy_used/1000, ENVIRON)
+			//Use power.  Assuming that each power unit represents 1 watts....
+			use_power(energy_used, ENVIRON)
 
 			//We need to cool ourselves.
 			if(environment.temperature > target_temperature)

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -10,6 +10,7 @@
 	power_channel = EQUIP
 	var/obj/item/weapon/cell/charging = null
 	var/chargelevel = -1
+	var/efficiency = 0.875	//<1.0 means some power is lost in the charging process, >1.0 means free energy.
 	proc
 		updateicon()
 			icon_state = "ccharger[charging ? 1 : 0]"
@@ -91,8 +92,10 @@
 		//world << "ccpt [charging] [stat]"
 		if(!charging || (stat & (BROKEN|NOPOWER)) || !anchored)
 			return
-
-		use_power(200)		//this used to use CELLRATE, but CELLRATE is fucking awful. feel free to fix this properly!
-		charging.give(175)	//inefficiency.
-
+		
+		var/power_used = 100000	//for 200 units of charge. Yes, thats right, 100 kW. Is something wrong with CELLRATE?
+		
+		power_used = charging.give(power_used*CELLRATE*efficiency)
+		use_power(power_used)
+		
 		updateicon()

--- a/code/global.dm
+++ b/code/global.dm
@@ -115,7 +115,8 @@ var/list/reg_dna = list(  )
 
 var/mouse_respawn_time = 5 //Amount of time that must pass between a player dying as a mouse and repawning as a mouse. In minutes.
 
-var/CELLRATE = 0.002  // multiplier for watts per tick <> cell storage (eg: 0.02 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)
+var/CELLRATE = 0.002	// multiplier for watts per tick <> cell storage (eg: 0.02 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)
+						//It's a conversion constant. power_used*CELLRATE = charge_provided, or charge_used/CELLRATE = power_provided
 var/CHARGELEVEL = 0.0005 // Cap for how fast cells charge, as a percentage-per-tick (0.01 means cellcharge is capped to 1% per second)
 
 var/shuttle_z = 2	//default

--- a/code/modules/power/pacman2.dm
+++ b/code/modules/power/pacman2.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 29/05/2012 15:03:05
 
 
-//Baseline portable generator. Has all the default handling. Not intended to be used on it's own (since it generates unlimited power).
+//PACMAN variant that can run on the small plasma tanks.
 /obj/machinery/power/port_gen/pacman2
 	name = "Pacman II"
 	desc = "P.A.C.M.A.N. type II portable generator. Uses liquid plasma as a fuel source."

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -93,6 +93,7 @@ display round(lastgen) and plasmatank amount
 	else
 		usr << "\blue The generator is off."
 
+//A power generator that runs on solid plasma sheets.
 /obj/machinery/power/port_gen/pacman
 	name = "P.A.C.M.A.N.-type Portable Generator"
 	var/sheets = 0


### PR DESCRIPTION
Looks like someone modified the cell chargers without understanding that the units of power are not the same as the units of charge. The result is that cell chargers would give their power cell much much more energy then they used, so theoretically you could run power-consuming machinery forever by swapping the APC between two power cells.

I changed the power used to preserve the old charging rate, so power cells will still charge in the same amount of time. Incidentally, the value for CELLRATE might be far too low.
