### PR TITLE
voting: failed gamemode votes will undelay too

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -163,13 +163,14 @@ datum/controller/vote
 							restart = 1
 						else
 							master_mode = .
-					if(!going)
-						going = 1
-						world << "<font color='red'><b>The round will start soon.</b></font>"
 				if("crew_transfer")
 					if(. == "Initiate Crew Transfer")
 						init_shift_change(null, 1)
 
+		if(mode == "gamemode") //fire this even if the vote fails.
+			if(!going)
+				going = 1
+				world << "<font color='red'><b>The round will start soon.</b></font>"
 
 		if(restart)
 			world << "World restarting due to vote..."


### PR DESCRIPTION
Moved the undelay code in voting.dm out of the success check, as
failures should get undelayed too.
