### PR TITLE
Bugfix:  Brand new players will have a client.player_age of 0

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -191,6 +191,7 @@
 	var/DBQuery/query = dbcon.NewQuery("SELECT id, datediff(Now(),firstseen) as age FROM erro_player WHERE ckey = '[sql_ckey]'")
 	query.Execute()
 	var/sql_id = 0
+	player_age = 0	// New players won't have an entry so knowing we have a connection we set this to zero to be updated if their is a record.
 	while(query.NextRow())
 		sql_id = query.item[1]
 		player_age = text2num(query.item[2])


### PR DESCRIPTION
Before:  When a client is created it's player_age variable is set to "Requires Database", then a select query is ran against the database to see if they have been seen before if they have logged in before this will have a row for them and it will set player age.  However if there is no row for them it doesn't change player_age from default.

After:   Before we check for an entry in the database we set their player_age to zero, we already checked we have a database connection so we know we will be able to pull this information and if we can't then it means they are a new player.  Set their player_age to zero and be done with it.

What this does:  Brand new players will no longer be able to bypass the jobs minimal age limit.
