### PR TITLE
Jobs you can't select are struckthrough instead of just being red.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -418,7 +418,7 @@ datum/preferences
 
 		var/HTML = "<body>"
 		HTML += "<tt><center>"
-		HTML += "<b>Choose occupation chances</b><br>Unavailable occupations are in red.<br><br>"
+		HTML += "<b>Choose occupation chances</b><br>Unavailable occupations are crossed out.<br><br>"
 		HTML += "<center><a href='?_src_=prefs;preference=job;task=close'>\[Done\]</a></center><br>" // Easier to press up here.
 		HTML += "<table width='100%' cellpadding='1' cellspacing='0'><tr><td width='20%'>" // Table within a table for alignment, also allows you to easily add more colomns.
 		HTML += "<table width='100%' cellpadding='1' cellspacing='0'>"
@@ -443,11 +443,11 @@ datum/preferences
 			var/rank = job.title
 			lastJob = job
 			if(jobban_isbanned(user, rank))
-				HTML += "<font color=red>[rank]</font></td><td><font color=red><b> \[BANNED]</b></font></td></tr>"
+				HTML += "<del>[rank]</del></td><td><b> \[BANNED]</b></td></tr>"
 				continue
 			if(!job.player_old_enough(user.client))
 				var/available_in_days = job.available_in_days(user.client)
-				HTML += "<font color=red>[rank]</font></td><td><font color=red> \[IN [(available_in_days)] DAYS]</font></td></tr>"
+				HTML += "<del>[rank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"
 				continue
 			if((job_civilian_low & ASSISTANT) && (rank != "Assistant"))
 				HTML += "<font color=orange>[rank]</font></td><td></td></tr>"


### PR DESCRIPTION
Before:  It's going to be kinda confusing when a new player goes to setup their jobs and they see this: http://i.imgur.com/miK9Isk.png
Specifically "unavailable occupations are in red" and then a list of days till they can play that role but also RED [NEVER] which to a new player migth cause confusion thinking
they can never play that role.

After:  Remove the red and add a strikethrough ( http://i.imgur.com/BQ90xr6.png  ) to show "these jobs are unavailable" while making the other jobs look, well more available.
