### PR TITLE
Null message fix

### DIFF
--- a/code/WorkInProgress/Chinsky/ashtray.dm
+++ b/code/WorkInProgress/Chinsky/ashtray.dm
@@ -32,6 +32,7 @@
 				var/obj/item/butt = new cig.type_butt(src)
 				cig.transfer_fingerprints_to(butt)
 				del(cig)
+				W = butt
 			else if (cig.lit == 0)
 				user << "You place [cig] in [src] without even smoking it. Why would you do that?"
 


### PR DESCRIPTION
Fixes the "User places  in the glass ashtray" messages having a null object name if the cigarette is still lit.
