### PR TITLE
Compressed matter implanter fix

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -51,7 +51,7 @@
 
 				src.imp = null
 				update()
-				
+
 	return
 
 
@@ -120,6 +120,12 @@
 		if (c.scanned)
 			user << "\red Something is already scanned inside the implant!"
 			return
-		imp:scanned = A
+		c.scanned = A
+		if(istype(A.loc,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = A.loc
+			H.u_equip(A)
+		else if(istype(A.loc,/obj/item/weapon/storage))
+			var/obj/item/weapon/storage/S = A.loc
+			S.remove_from_storage(A)
 		A.loc.contents.Remove(A)
 		update()


### PR DESCRIPTION
Items were not correctly removed from the game world if you compressed them while they were in your hand or in a storage container. This would result in the item existing inside the implant and the game world simultaneously. Subsequently activating the implant would teleport the item to you.

This fixes said space time anomalies by correctly removing the item from either your character, or the storage container.

Also removed a colon.
