### PR TITLE
Fixes runtime with yellow slime extracts.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -195,3 +195,25 @@
 		src.force = on_damage
 		src.damtype = "fire"
 		processing_objects += src
+		
+/obj/item/device/flashlight/slime
+	gender = PLURAL
+	name = "glowing slime extract"
+	desc = "A glowing ball of what appears to be amber."
+	icon = 'icons/obj/lighting.dmi'
+	icon_state = "floor1" //not a slime extract sprite but... something close enough!
+	item_state = "slime"
+	w_class = 1
+	m_amt = 0
+	g_amt = 0
+	brightness_on = 6
+	on = 1 //Bio-luminesence has one setting, on.
+	
+/obj/item/device/flashlight/slime/New()
+	SetLuminosity(brightness_on)
+	spawn(1) //Might be sloppy, but seems to be necessary to prevent further runtimes and make these work as intended... don't judge me!
+		update_brightness()
+		icon_state = initial(icon_state)
+	
+/obj/item/device/flashlight/slime/attack_self(mob/user)
+	return //Bio-luminescence does not toggle.

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1227,9 +1227,10 @@ datum
 			required_other = 1
 			on_reaction(var/datum/reagents/holder)
 				for(var/mob/O in viewers(get_turf_loc(holder.my_atom), null))
-					O.show_message(text("\red The slime begins to emit a soft light."), 1)
-				var/obj/item/slime_extract/yellow/Y = holder
-				Y.luminosity = 6
+					O.show_message(text("\red The contents of the slime core harden and begin to emit a warm, bright light."), 1)
+				var/obj/item/device/flashlight/slime/F = new /obj/item/device/flashlight/slime
+				F.loc = get_turf(holder.my_atom)
+			
 //Purple
 
 		slimepsteroid


### PR DESCRIPTION
Undefined variable /datum/reagents/var/luminosity
proc name: on reaction (/datum/chemical_reaction/slimeglow/on_reaction)
  source file: Chemistry-Recipes.dm,1232
  usr: Cassidy Harshman (/mob/living/carbon/human)
  src: Slime Glow (/datum/chemical_reaction/slimeglow)
  call stack:
Slime Glow (/datum/chemical_reaction/slimeglow): on reaction(/datum/reagents (/datum/reagents), 1)
/datum/reagents (/datum/reagents): handle reactions()
/datum/reagents (/datum/reagents): trans to(the used slime extract (/obj/item/slime_extract/yellow), 5, 1, 1)
the syringe (/obj/item/weapon/reagent_containers/syringe): afterattack(the used slime extract (/obj/item/slime_extract/yellow), Cassidy Harshman (/mob/living/carbon/human), 1, "icon-x=15;icon-y=15;left=1;scr...")

--Fixed.
