### PR TITLE
Removes the special name coloring of those with special roles from inappropriate times.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -538,7 +538,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		else if(M.name)
 			name = M.name
 
-		if(is_special_character(M))
+		if(include_link && is_special_character(M))
 			. += "/(<font color='#FFA500'>[name]</font>)" //Orange
 		else
 			. += "/([name])"


### PR DESCRIPTION
Basically if we don't want a privmsg link we're not going to include the font change as well.  This should fix it from displaying the coloring code in logs and other places not meant to be html (irc bot).
