### PR TITLE
Invulnerable windows fix

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -108,7 +108,12 @@
 
 		if( O.flags&ON_BORDER) // windows have throwpass but are on border, check them first
 			if( O.dir & target_dir || O.dir&(O.dir-1) ) // full tile windows are just diagonals mechanically
-				return 0
+				var/obj/structure/window/W = target_atom
+				if(istype(W))
+					if(!W.is_fulltile())	//exception for breaking full tile windows on top of single pane windows
+						return 0
+				else
+					return 0
 
 		else if( !border_only ) // dense, not on border, cannot pass over
 			return 0


### PR DESCRIPTION
Due to checks in Adjacent() full tile windows behind/on top of single pane windows were invulnerable.
This adds an exception so if the target object is a full tile window it will still be able to be hit if it is behind single glass panes.

**NOTE:** You will have to break the full tile window before you can break the single pane window. I couldn't find an easy way around this without completely invalidating the adjacent checks for other windows when breaking windows.
