### PR TITLE
Alt click fix

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -56,6 +56,21 @@
 	return 0
 
 /*
+Quick adjacency (to turf):
+* If you are in the same turf, always true
+* If you are not adjacent, then false
+*/
+/turf/proc/AdjacentQuick(var/atom/neighbor, var/atom/target = null)
+	var/turf/T0 = get_turf(neighbor)
+	if(T0 == src)
+		return 1
+
+	if(get_dist(src,T0) > 1)
+		return 0
+
+	return 1
+
+/*
 	Adjacency (to anything else):
 	* Must be on a turf
 	* In the case of a multiple-tile object, all valid locations are checked for adjacency.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -245,7 +245,7 @@
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
-	if(T && T.Adjacent(user))
+	if(T && T.AdjacentQuick(user))
 		if(user.listed_turf == T)
 			user.listed_turf = null
 		else


### PR DESCRIPTION
Fixes alt clicking on tiles blocked by windows.

Previously alt click used normal click code to determine if it could path to the object being clicked on. This meant you couldn't alt click on tiles that were blocked by windows. Since alt clicking just returns a list of objects I've added a simplified proc that just checks if the turf exists, and if it's in range.

Probably wont have any noticeable performance advantage, but in theory it's significantly shorter than the old way.
