### PR TITLE
do_after() checks both turf and loc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -728,13 +728,14 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 
 	var/delayfraction = round(delay/numticks)
 	var/original_loc = user.loc
+	var/original_turf = get_turf(user)
 	var/holding = user.get_active_hand()
 
 	for(var/i = 0, i<numticks, i++)
 		sleep(delayfraction)
 
 
-		if(!user || user.stat || user.weakened || user.stunned || (user.loc != original_loc))
+		if(!user || user.stat || user.weakened || user.stunned || user.loc != original_loc || get_turf(user) != original_turf)
 			return 0
 		if(needhand && !(user.get_active_hand() == holding))	//Sometimes you don't want the user to have to keep their active hand
 			return 0


### PR DESCRIPTION
Continuing from https://github.com/Baystation12/Baystation12/pull/4992, this PR has do_after() check both turf and loc.

This would keep the behaviour of the resist mechanic consistent in that if you get moved, the resist is interrupted.

It would also provide a way for players to oppose someone breaking out as currently there is no mechanic for holding the locker door shut on them.

Don't merge this without dev feedback, I guess.
