### PR TITLE
Hopefully allows things in inventories to see emotes.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -858,6 +858,7 @@
 #include "code\modules\mob\death.dm"
 #include "code\modules\mob\emote.dm"
 #include "code\modules\mob\hear_say.dm"
+#include "code\modules\mob\holder.dm"
 #include "code\modules\mob\inventory.dm"
 #include "code\modules\mob\language.dm"
 #include "code\modules\mob\login.dm"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -39,12 +39,30 @@
 		// Type 1 (Visual) emotes are sent to anyone in view of the item
 		if (m_type & 1)
 			for (var/mob/O in viewers(src, null))
+
+				if(O.status_flags & PASSEMOTES)
+
+					for(var/obj/item/weapon/holder/H in O.contents)
+						H.show_message(message, m_type)
+
+					for(var/mob/living/M in O.contents)
+						M.show_message(message, m_type)
+
 				O.show_message(message, m_type)
 
 		// Type 2 (Audible) emotes are sent to anyone in hear range
 		// of the *LOCATION* -- this is important for pAIs to be heard
 		else if (m_type & 2)
 			for (var/mob/O in hearers(get_turf(src), null))
+
+				if(O.status_flags & PASSEMOTES)
+
+					for(var/obj/item/weapon/holder/H in O.contents)
+						H.show_message(message, m_type)
+
+					for(var/mob/living/M in O.contents)
+						M.show_message(message, m_type)
+
 				O.show_message(message, m_type)
 
 /mob/proc/emote_dead(var/message)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -1,0 +1,51 @@
+//Helper object for picking dionaea (and other creatures) up.
+/obj/item/weapon/holder
+	name = "holder"
+	desc = "You shouldn't ever see this."
+	icon = 'icons/obj/objects.dmi'
+	slot_flags = SLOT_HEAD
+
+/obj/item/weapon/holder/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/item/weapon/holder/Del()
+	processing_objects.Remove(src)
+	..()
+
+/obj/item/weapon/holder/process()
+
+	if(istype(loc,/turf) || !(contents.len))
+
+		for(var/mob/M in contents)
+
+			var/atom/movable/mob_container
+			mob_container = M
+			mob_container.forceMove(get_turf(src))
+			M.reset_view()
+
+		del(src)
+
+/obj/item/weapon/holder/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	for(var/mob/M in src.contents)
+		M.attackby(W,user)
+
+/obj/item/weapon/holder/proc/show_message(var/message, var/m_type)
+	for(var/mob/living/M in contents)
+		M.show_message(message,m_type)
+
+//Mob specific holders.
+
+/obj/item/weapon/holder/diona
+
+	name = "diona nymph"
+	desc = "It's a tiny plant critter."
+	icon_state = "nymph"
+	origin_tech = "magnets=3;biotech=5"
+
+/obj/item/weapon/holder/drone
+
+	name = "maintenance drone"
+	desc = "It's a small maintenance robot."
+	icon_state = "drone"
+	origin_tech = "magnets=3;engineering=5"

--- a/code/modules/mob/living/carbon/monkey/diona.dm
+++ b/code/modules/mob/living/carbon/monkey/diona.dm
@@ -2,45 +2,6 @@
   Tiny babby plant critter plus procs.
 */
 
-//Helper object for picking dionaea (and other creatures) up.
-/obj/item/weapon/holder
-	name = "holder"
-	desc = "You shouldn't ever see this."
-
-/obj/item/weapon/holder/diona
-
-	name = "diona nymph"
-	desc = "It's a tiny plant critter."
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "nymph"
-	slot_flags = SLOT_HEAD
-	origin_tech = "magnets=3;biotech=5"
-
-/obj/item/weapon/holder/New()
-	..()
-	processing_objects.Add(src)
-
-/obj/item/weapon/holder/Del()
-	processing_objects.Remove(src)
-	..()
-
-/obj/item/weapon/holder/process()
-
-	if(istype(loc,/turf) || !(contents.len))
-
-		for(var/mob/M in contents)
-
-			var/atom/movable/mob_container
-			mob_container = M
-			mob_container.forceMove(get_turf(src))
-			M.reset_view()
-
-		del(src)
-
-/obj/item/weapon/holder/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	for(var/mob/M in src.contents)
-		M.attackby(W,user)
-
 //Mob defines.
 /mob/living/carbon/monkey/diona
 	name = "diona nymph"

--- a/code/modules/mob/living/carbon/monkey/diona.dm
+++ b/code/modules/mob/living/carbon/monkey/diona.dm
@@ -67,6 +67,7 @@
 			D.attack_hand(M)
 			M << "You scoop up [src]."
 			src << "[M] scoops you up."
+		M.status_flags |= PASSEMOTES
 		return
 
 	..()
@@ -108,6 +109,8 @@
 
 	if(istype(M,/mob/living/carbon/human))
 		M << "You feel your being twine with that of [src] as it merges with your biomass."
+		M.status_flags |= PASSEMOTES
+
 		src << "You feel your being twine with that of [M] as you merge with its biomass."
 		src.loc = M
 		src.verbs += /mob/living/carbon/monkey/diona/proc/split
@@ -127,9 +130,18 @@
 
 	src.loc << "You feel a pang of loss as [src] splits away from your biomass."
 	src << "You wiggle out of the depths of [src.loc]'s biomass and plop to the ground."
+
+	var/mob/living/M = src.loc
+
 	src.loc = get_turf(src)
 	src.verbs -= /mob/living/carbon/monkey/diona/proc/split
 	src.verbs += /mob/living/carbon/monkey/diona/proc/merge
+
+	if(istype(M))
+		for(var/atom/A in M.contents)
+			if(istype(A,/mob/living/simple_animal/borer) || istype(A,/obj/item/weapon/holder))
+				return
+	M.status_flags &= ~PASSEMOTES
 
 /mob/living/carbon/monkey/diona/verb/fertilize_plant()
 
@@ -269,16 +281,16 @@
 		if(client.prefs.muted & MUTE_IC)
 			src << "\red You cannot speak in IC (Muted)."
 			return
-	
+
 	message =  trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
-	
+
 
 	if(stat == 2)
 		return say_dead(message)
 
 	var/datum/language/speaking = null
 
-	
+
 
 	if(length(message) >= 2)
 		var/channel_prefix = copytext(message, 1 ,3)
@@ -292,7 +304,7 @@
 	if(speaking)
 		message = trim(copytext(message,3))
 
-	message = capitalize(trim_left(message))	
+	message = capitalize(trim_left(message))
 
 	if(!message || stat)
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -460,6 +460,13 @@
 		else if(istype(H.loc,/obj/item))
 			src << "You struggle free of [H.loc]."
 			H.loc = get_turf(H)
+
+		if(istype(M))
+			for(var/atom/A in M.contents)
+				if(istype(A,/mob/living/simple_animal/borer) || istype(A,/obj/item/weapon/holder))
+					return
+
+		M.status_flags &= ~PASSEMOTES
 		return
 
 	//Resisting control by an alien mind.

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -33,18 +33,6 @@
 		layer = MOB_LAYER
 		src << text("\blue You have stopped hiding.")
 
-//DRONE PICKUP.
-//Item holder.
-/obj/item/weapon/holder/drone
-
-	name = "maintenance drone"
-	desc = "It's a small maintenance robot."
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "drone"
-	slot_flags = SLOT_HEAD
-	origin_tech = "magnets=3;engineering=5"
-
-
 //Actual picking-up event.
 /mob/living/silicon/robot/drone/attack_hand(mob/living/carbon/human/M as mob)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -54,6 +54,7 @@
 		D.attack_hand(M)
 		M << "You scoop up [src]."
 		src << "[M] scoops you up."
+		M.status_flags |= PASSEMOTES
 		return
 
 	..()

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -58,7 +58,6 @@
 
 	..()
 
-
 	if(host)
 
 		if(!stat && !host.stat)
@@ -338,7 +337,13 @@ mob/living/simple_animal/borer/proc/detatch()
 		host_brain.name = "host brain"
 		host_brain.real_name = "host brain"
 
+	var/mob/living/H = host
 	host = null
+
+	for(var/atom/A in H.contents)
+		if(istype(A,/mob/living/simple_animal/borer) || istype(A,/obj/item/weapon/holder))
+			return
+	H.status_flags &= ~PASSEMOTES
 
 /mob/living/simple_animal/borer/verb/infest()
 	set category = "Alien"
@@ -406,6 +411,7 @@ mob/living/simple_animal/borer/proc/detatch()
 
 		host_brain.name = M.name
 		host_brain.real_name = M.real_name
+		host.status_flags |= PASSEMOTES
 
 		return
 	else

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -453,6 +453,7 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define CANPARALYSE	4
 #define CANPUSH		8
 #define LEAPING		16
+#define PASSEMOTES	32      //Mob has a cortical borer or holders inside of it that need to see emotes.
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define DISFIGURED	16384	//I'll probably move this elsewhere if I ever get wround to writing a bitflag mob-damage system


### PR DESCRIPTION
Opening this to dev-freeze in the perhaps vain hope that it will get merged. It's a fix-bug-feature-thing, really.

Haven't had much of a chance to test this yet since it requires a minimum of 3 keys.
- Adds a PASSEMOTES flag.
- Changes borers and dionaea to set this flag.
- Uses this flag in custom_emote() to pass emotes to holders and borers in a mob's inventory.
