### PR TITLE
Removes density from filters and pumps

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -1,7 +1,7 @@
 obj/machinery/atmospherics/trinary/filter
 	icon = 'icons/obj/atmospherics/filter.dmi'
 	icon_state = "intact_off"
-	density = 1
+	density = 0
 
 	name = "Gas filter"
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -1,7 +1,7 @@
 obj/machinery/atmospherics/trinary/mixer
 	icon = 'icons/obj/atmospherics/mixer.dmi'
 	icon_state = "intact_off"
-	density = 1
+	density = 0
 
 	name = "Gas mixer"
 


### PR DESCRIPTION
It was all oh so simple. Seeing how you can hold these items in your hand and I believe fit them in your pack, doesn't make too much sense to have them block mob movement when wrenched down.
