### PR TITLE
Supermatter Tweaks

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -9,7 +9,7 @@
 #define REACTION_POWER_MODIFIER 1.1                //Higher == more overall power
 
 //Controls how much power is produced by each collector in range.
-#define COLLECTION_FACTOR 1.0               //Aiming to make 400 kW output the equivalent of what 4 MW (power=1210) was from before by adjusting this
+#define COLLECTION_FACTOR 0.1               //Aiming to make 400 kW output the equivalent of what 4 MW (power=1210) was from before by adjusting this
 
 
 //These would be what you would get at point blank, decreases with distance

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -138,7 +138,12 @@
 		damage += max((power-1600)/10, 0)	//exciting the supermatter in a vacuum means the internal energy is mostly locked inside.
 	else
 		damage_archived = damage
-		damage = max( damage + ( (removed.temperature - 800) / 150 ) , 0 )
+		
+		//ensure that damage doesn't increase too quickly due to super high temperatures resulting from no coolant, for example. We dont want the SM exploding before anyone can react.
+		//want the cap to scale linearly with power. Let's aim for a cap of 5 at power = 900 (based on testing, equals roughly 5% per SM alert announcement).
+		var/damage_inc_limit = (explosion_point*0.005)*(power/900)
+		
+		damage = max( damage + min( ( (removed.temperature - 800) / 150 ), damage_inc_limit ) , 0 )
 		//Ok, 100% oxygen atmosphere = best reaction
 		//Maxes out at 100% oxygen pressure
 		oxygen = max(min((removed.oxygen - (removed.nitrogen * NITROGEN_RETARDATION_FACTOR)) / MOLES_CELLSTANDARD, 1), 0)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -166,9 +166,11 @@
 		//is on. An increase of 4*C @ 25% efficiency here results in an increase of 1*C / (#tilesincore) overall.
 		
 		var/thermal_power = THERMAL_RELEASE_MODIFIER
-		if(removed.total_moles < 35) thermal_power += 750   //If you don't add coolant, you are going to have a bad time.
 		
-		removed.temperature += ((device_energy * thermal_power) / max(1, removed.heat_capacity()))
+		//This shouldn't be necessary. If the number of moles is low, then heat_capacity should be tiny.
+		//if(removed.total_moles < 35) thermal_power += 750   //If you don't add coolant, you are going to have a bad time.
+		
+		removed.temperature += ((device_energy * thermal_power) / removed.heat_capacity())
 		
 		removed.temperature = max(0, min(removed.temperature, 10000))
 		

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -8,6 +8,9 @@
 #define OXYGEN_RELEASE_MODIFIER 1500        //Higher == less oxygen released at high temperature/power
 #define REACTION_POWER_MODIFIER 1.1                //Higher == more overall power
 
+//Controls how much power is produced by each collector in range.
+#define COLLECTION_FACTOR 1.0               //Aiming to make 400 kW output the equivalent of what 4 MW was from before by adjusting this
+
 
 //These would be what you would get at point blank, decreases with distance
 #define DETONATION_RADS 200
@@ -204,7 +207,7 @@
 
 
 	if(Proj.flag != "bullet")
-		power += Proj.damage * config_bullet_energy
+		power += Proj.damage * config_bullet_energy	* COLLECTION_FACTOR	//multiply by COLLECTION_FACTOR so the amount of shots you will need to give with an emitter is unaffected.
 	else
 		damage += Proj.damage * config_bullet_energy
 	return 0
@@ -234,7 +237,7 @@
 /obj/machinery/power/supermatter/proc/transfer_energy()
 	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
 		if(get_dist(R, src) <= 15) // Better than using orange() every process
-			R.receive_pulse(power)
+			R.receive_pulse(power * COLLECTION_FACTOR)
 	return
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -9,7 +9,7 @@
 #define REACTION_POWER_MODIFIER 1.1                //Higher == more overall power
 
 //Controls how much power is produced by each collector in range.
-#define COLLECTION_FACTOR 1.0               //Aiming to make 400 kW output the equivalent of what 4 MW was from before by adjusting this
+#define COLLECTION_FACTOR 1.0               //Aiming to make 400 kW output the equivalent of what 4 MW (power=1210) was from before by adjusting this
 
 
 //These would be what you would get at point blank, decreases with distance
@@ -190,11 +190,13 @@
 		if(!istype(l.glasses, /obj/item/clothing/glasses/meson))
 			l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
 
-	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
+	//adjusted range so that a power of 600 (pretty high) results in 8 tiles, roughly the distance from the core to the engine monitoring room.
+	//at power of 1210 this becomes 9 tiles --> increases very very slowly.
+	for(var/mob/living/l in range(src, round((power / 0.146484375) ** 0.25)))
 		var/rads = (power / 10) * sqrt( 1 / get_dist(l, src) )
 		l.apply_effect(rads, IRRADIATE)
 
-	power -= (power/500)**3		//losses due to radiation
+	power -= (power/500)**3		//energy losses due to radiation
 
 	return 1
 


### PR DESCRIPTION
SM now behaves the same in a space tile as it does in a vacuum. Being in space no longer removes the need for rad protection or mesons.

Fixes the way heat_capacity was being handled. The heat capacity was being clamped to a minimum of 1 so that when the SM was run with no coolant, the temperature was not being increased correctly.

Fixes the radiation range. For some reason the relation with power was set so low that the range would never go above 1 or 2 tiles, even if you ran the emitter continuously.

Tweaks the amount of power produced by the SM so that 400 kW is now the equivalent of what 4 MW was before.
