### PR TITLE
Ore box verbs

### DIFF
--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -7,6 +7,16 @@
 	name = "Ore Box"
 	desc = "A heavy box used for storing ore."
 	density = 1
+	var/amt_gold = 0
+	var/amt_silver = 0
+	var/amt_diamond = 0
+	var/amt_glass = 0
+	var/amt_iron = 0
+	var/amt_phoron = 0
+	var/amt_uranium = 0
+	var/amt_clown = 0
+	var/amt_strange = 0
+	var/last_update = 0
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/ore))
@@ -20,72 +30,117 @@
 		user << "\blue You empty the satchel into the box."
 	return
 
-/obj/structure/ore_box/attack_hand(obj, mob/user as mob)
-	var/amt_gold = 0
-	var/amt_silver = 0
-	var/amt_diamond = 0
-	var/amt_glass = 0
-	var/amt_iron = 0
-	var/amt_phoron = 0
-	var/amt_uranium = 0
-	var/amt_clown = 0
-	var/amt_strange = 0
+/obj/structure/ore_box/examine()
+	set name = "Examine"
+	set category = "IC"
+	set src in view(usr.client) //If it can be seen, it can be examined.
 
-
-	for (var/obj/item/weapon/ore/C in contents)
-		if (istype(C,/obj/item/weapon/ore/diamond))
-			amt_diamond++;
-		if (istype(C,/obj/item/weapon/ore/glass))
-			amt_glass++;
-		if (istype(C,/obj/item/weapon/ore/phoron))
-			amt_phoron++;
-		if (istype(C,/obj/item/weapon/ore/iron))
-			amt_iron++;
-		if (istype(C,/obj/item/weapon/ore/silver))
-			amt_silver++;
-		if (istype(C,/obj/item/weapon/ore/gold))
-			amt_gold++;
-		if (istype(C,/obj/item/weapon/ore/uranium))
-			amt_uranium++;
-		if (istype(C,/obj/item/weapon/ore/clown))
-			amt_clown++;
-		if (istype(C,/obj/item/weapon/ore/strangerock))
-			amt_strange++;
-
-	var/dat = text("<b>The contents of the ore box reveal...</b><br>")
-	if (amt_gold)
-		dat += text("Gold ore: [amt_gold]<br>")
-	if (amt_silver)
-		dat += text("Silver ore: [amt_silver]<br>")
-	if (amt_iron)
-		dat += text("Metal ore: [amt_iron]<br>")
-	if (amt_glass)
-		dat += text("Sand: [amt_glass]<br>")
-	if (amt_diamond)
-		dat += text("Diamond ore: [amt_diamond]<br>")
-	if (amt_phoron)
-		dat += text("Phoron ore: [amt_phoron]<br>")
-	if (amt_uranium)
-		dat += text("Uranium ore: [amt_uranium]<br>")
-	if (amt_clown)
-		dat += text("Bananium ore: [amt_clown]<br>")
-	if (amt_strange)
-		dat += text("Strange rocks: [amt_strange]<br>")
-
-	dat += text("<br><br><A href='?src=\ref[src];removeall=1'>Empty box</A>")
-	user << browse("[dat]", "window=orebox")
-	return
-
-/obj/structure/ore_box/Topic(href, href_list)
-	if(..())
+	if (!( usr ))
 		return
-	usr.set_machine(src)
-	src.add_fingerprint(usr)
-	if(href_list["removeall"])
-		for (var/obj/item/weapon/ore/O in contents)
-			contents -= O
-			O.loc = src.loc
-		usr << "\blue You empty the box"
-	src.updateUsrDialog()
+	usr << "That's an [src]."
+	usr << desc
+
+	if(!(src in view(1, usr))) //If you can't physically get to the ore box to open it, you can't see what's in it.
+		return
+
+	add_fingerprint(usr)
+
+	if(contents.len < 1)
+		usr << "It is empty"
+		return
+
+	if(world.time > last_update + 10)
+		update_orecount()
+		last_update = world.time
+
+	var/dat = text("<b>The contents of the ore box reveal...</b>")
+	if (amt_iron)
+		dat += text("<br>Metal ore: [amt_iron]")
+	if (amt_glass)
+		dat += text("<br>Sand: [amt_glass]")
+	if (amt_phoron)
+		dat += text("<br>Phoron ore: [amt_phoron]")
+	if (amt_uranium)
+		dat += text("<br>Uranium ore: [amt_uranium]")
+	if (amt_silver)
+		dat += text("<br>Silver ore: [amt_silver]")
+	if (amt_gold)
+		dat += text("<br>Gold ore: [amt_gold]")
+	if (amt_diamond)
+		dat += text("<br>Diamond ore: [amt_diamond]")
+	if (amt_strange)
+		dat += text("<br>Strange rocks: [amt_strange]")
+	if (amt_clown)
+		dat += text("<br>Bananium ore: [amt_clown]")
+
+	usr << dat
+
 	return
 
+
+/obj/structure/ore_box/verb/empty_box()
+	set name = "Empty Ore Box"
+	set category = "Object"
+	set src in view(1) //You can only empty the box if you can physically reach it
+
+	if( usr.stat || usr.restrained() )
+		return
+
+	add_fingerprint(usr)
+
+	if(contents.len < 1)
+		usr << "\red The ore box is empty"
+		return
+
+	for (var/obj/item/weapon/ore/O in contents)
+		contents -= O
+		O.loc = src.loc
+	usr << "\blue You empty the ore box"
+
+	return
+
+// Updates ore tally
+/obj/structure/ore_box/proc/update_orecount()
+	amt_iron = 0
+	amt_glass = 0
+	amt_phoron = 0
+	amt_uranium = 0
+	amt_silver = 0
+	amt_gold = 0
+	amt_diamond = 0
+	amt_strange = 0
+	amt_clown = 0
+
+	for(var/obj/item/weapon/ore/O in contents)
+		if(!istype(O))
+			continue
+
+		if (istype(O, /obj/item/weapon/ore/iron))
+			amt_iron++
+			continue
+		if (istype(O, /obj/item/weapon/ore/glass))
+			amt_glass++
+			continue
+		if (istype(O, /obj/item/weapon/ore/phoron))
+			amt_phoron++
+			continue
+		if (istype(O, /obj/item/weapon/ore/uranium))
+			amt_uranium++
+			continue
+		if (istype(O, /obj/item/weapon/ore/silver))
+			amt_silver++
+			continue
+		if (istype(O, /obj/item/weapon/ore/gold))
+			amt_gold++
+			continue
+		if (istype(O, /obj/item/weapon/ore/diamond))
+			amt_diamond++
+			continue
+		if (istype(O, /obj/item/weapon/ore/strangerock))
+			amt_strange++
+			continue
+		if (istype(O, /obj/item/weapon/ore/clown))
+			amt_clown++
+			continue
+
+	return

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -40,13 +40,16 @@
 	usr << "That's an [src]."
 	usr << desc
 
-	if(!(src in view(1, usr))) //If you can't physically get to the ore box to open it, you can't see what's in it.
+	if(!istype(usr, /mob/living/carbon/human)) //Only living, intelligent creatures with hands can check the contents of ore boxes.
+		return
+
+	if(!Adjacent(usr)) //Can only check the contents of ore boxes if you can physically reach them.
 		return
 
 	add_fingerprint(usr)
 
 	if(contents.len < 1)
-		usr << "It is empty"
+		usr << "It is empty."
 		return
 
 	if(world.time > last_update + 10)
@@ -81,9 +84,17 @@
 /obj/structure/ore_box/verb/empty_box()
 	set name = "Empty Ore Box"
 	set category = "Object"
-	set src in view(1) //You can only empty the box if you can physically reach it
+	set src in view(1)
+
+	if(!istype(usr, /mob/living/carbon/human)) //Only living, intelligent creatures with hands can empty ore boxes.
+		usr << "\red You are physically incapable of emptying the ore box."
+		return
 
 	if( usr.stat || usr.restrained() )
+		return
+
+	if(!Adjacent(usr)) //You can only empty the box if you can physically reach it
+		usr << "You cannot reach the ore box."
 		return
 
 	add_fingerprint(usr)
@@ -98,6 +109,7 @@
 	usr << "\blue You empty the ore box"
 
 	return
+
 
 // Updates ore tally
 /obj/structure/ore_box/proc/update_orecount()


### PR DESCRIPTION
Removed attack_hand proc that would open a browser window to view the contents of an ore box.
Integrated it into the examine verb, and added an empty ore box verb for emptying it.
Restricted usage of checking contents and emptying it to only if you are standing next to the box as you would have to physically open the box to check the contents.
The for loop that tallies the box contents is restricted to only run once per second to prevent server spam.

Rewritten based on feedback from the last PR, and targeted dev because _phoron_
