### PR TITLE
Bot attack fix

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -269,7 +269,7 @@ Auto Patrol: []"},
 				walk_to(src,0)
 
 			if (target)		// make sure target exists
-				if (get_dist(src, src.target) <= 1)		// if right next to perp
+				if (Adjacent(target))		// if right next to perp
 					playsound(src.loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 					src.icon_state = "[lasercolor]ed209-c"
 					spawn(2)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -284,7 +284,7 @@
 				continue
 
 
-	if(src.patient && (get_dist(src,src.patient) <= 1))
+	if(src.patient && Adjacent(patient))
 		if(!src.currently_healing)
 			src.currently_healing = 1
 			src.frustration = 0

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -219,7 +219,7 @@ Auto Patrol: []"},
 				walk_to(src,0)
 
 			if(target)		// make sure target exists
-				if(get_dist(src, src.target) <= 1 && isturf(src.target.loc))		// if right next to perp
+				if(Adjacent(target))		// if right next to perp
 					if(istype(src.target,/mob/living/carbon))
 						playsound(src.loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 						src.icon_state = "secbot-c"


### PR DESCRIPTION
Fixes #4967

Bots were only doing a simple distance check when trying to arrest/baton/inject mobs and were subsequently able to attack targets through windows.
Changed the distance check to an Adjacent check to check if they can actually reach their target.
