### PR TITLE
Pod Launch Fix

### DIFF
--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -34,7 +34,7 @@
 	for(var/obj/machinery/door/poddoor/M in world)
 		if(M.id == id)
 			M.open()
-			return
+
 	sleep(20)
 
 	for(var/obj/machinery/mass_driver/M in world)
@@ -173,6 +173,12 @@
 				connected.power = t
 		if(href_list["alarm"])
 			alarm()
+		if(href_list["drive"])
+			for(var/obj/machinery/mass_driver/M in world)
+				if(M.id == id)
+					M.power = connected.power
+					M.drive()
+
 		if(href_list["time"])
 			timing = text2num(href_list["time"])
 		if(href_list["tp"])

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -174,7 +174,7 @@
 		if(href_list["alarm"])
 			alarm()
 		if(href_list["drive"])
-			for(var/obj/machinery/mass_driver/M in world)
+			for(var/obj/machinery/mass_driver/M in machines)
 				if(M.id == id)
 					M.power = connected.power
 					M.drive()


### PR DESCRIPTION
Fixed an error I found while making a map. Might add a pod launch area in Engineering now since it worked beautifully on my map.

I'm not sure this was intentional, was hard to see how it was missed if nobody purposely broke the pod launchers.

Not sure this has to go on the changelog either since only the abandoned ship uses it.
