### PR TITLE
exploit fix, electric boogaloo : canister edition

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -275,10 +275,15 @@ update_flag
 
 /obj/machinery/portable_atmospherics/canister/Topic(href, href_list)
 
-	//Do not use "if(..()) return" here, canisters will stop working in unpowered areas like space or on the derelict.	
+	//Do not use "if(..()) return" here, canisters will stop working in unpowered areas like space or on the derelict. // yeah but without SOME sort of Topic check any dick can mess with them via exploits as he pleases -walter0o
 	if (!istype(src.loc, /turf))
 		return 0
-		
+
+	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr)) // exploit protection -walter0o
+		usr << browse(null, "window=canister")
+		onclose(usr, "canister")
+		return
+
 	if(href_list["toggle"])
 		if (valve_open)
 			if (holding)


### PR DESCRIPTION
https://github.com/Baystation12/Baystation12/commit/024a0baa49df0cb1ec8af4967fefe9d5575453eb removed the exploit protection of canisters without replacement, this commit fixes that.

without this, anybody can open/close valves and all other forms of messing with any canister from anywhere.

ALWAYS keep in mind, NanoUI will update the fancy buttons CLIENTSIDE, that does NOT protect against exploits !

the actual buttonpush can still be spoofed to the server even if NanoUI disabled/hid/greyed-out/removed the button !
