### PR TITLE
Possible fix fo inhale_pp ratio

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -491,10 +491,11 @@
 			if(prob(20))
 				spawn(0) emote("gasp")
 			if(inhale_pp > 0)
-				var/ratio = safe_pressure_min/inhale_pp
+				var/ratio = inhale_pp/safe_pressure_min
 
 				 // Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!)
-				adjustOxyLoss(min(5*ratio, HUMAN_MAX_OXYLOSS))
+				 // What's going on here? ratio will always be < 1, and HUMAN_MAX_OXYLOSS = 1...
+				adjustOxyLoss(min(5*(1/ratio), HUMAN_MAX_OXYLOSS))
 				failed_last_breath = 1
 				inhaled_gas_used = inhaling*ratio/6
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -494,8 +494,7 @@
 				var/ratio = inhale_pp/safe_pressure_min
 
 				 // Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!)
-				 // What's going on here? ratio will always be < 1, and HUMAN_MAX_OXYLOSS = 1...
-				adjustOxyLoss(min(5*(1/ratio), HUMAN_MAX_OXYLOSS))
+				adjustOxyLoss(min(5*(1 - ratio), HUMAN_MAX_OXYLOSS))
 				failed_last_breath = 1
 				inhaled_gas_used = inhaling*ratio/6
 


### PR DESCRIPTION
Some things about var/ratio used when inhale_pp < safe_pressure_min didn't make sense, and I'm thinking this is a possible error.

I think the amount of gas used should decrease with inhale_pp as, after all the oxyloss is being caused by the fact that fewer moles of a necessary gas are entering the bloodstream. In any case, it was very strange that the amount of inhaled gas used approached infinity as inhale_pp went to zero.

Also, if inhale_pp < safe_pressure_min then safe_pressure_min/inhale_pp is always > 1, but HUMAN_MAX_OXYLOSS = 1.
