### PR TITLE
Beepsky will no longer attack monkeys while doing weapons authorization checks.

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -600,8 +600,6 @@ Auto Patrol: []"},
 
 			if(istype(C, /mob/living/carbon/human))
 				src.threatlevel = src.assess_perp(C)
-			else if((src.idcheck) && (istype(C, /mob/living/carbon/monkey)))
-				src.threatlevel = 4
 
 		else if(istype(M, /mob/living/simple_animal/hostile))
 			if(M.stat == DEAD)


### PR DESCRIPTION
I'd say it's a holdover from monkey epidemic but the truth is this is cael code that is being changed, it's been that way for over a year and I still can't wrap my head around why these lines were put in.
