### PR TITLE
Added new BBCode tags, for tables and NT logo. 

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -192,6 +192,13 @@
 		t = replacetext(t, "\[/small\]", "</font>")
 		t = replacetext(t, "\[list\]", "<ul>")
 		t = replacetext(t, "\[/list\]", "</ul>")
+		t = replacetext(t, "\[table\]", "<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>")
+		t = replacetext(t, "\[/table\]", "</td></tr></table>")
+		t = replacetext(t, "\[grid\]", "<table>")
+		t = replacetext(t, "\[/grid\]", "</td></tr></table>")
+		t = replacetext(t, "\[row\]", "</td><tr>")
+		t = replacetext(t, "\[cell\]", "<td>")
+		t = replacetext(t, "\[logo\]", "<img src = http://baystation12.net/wiki/logo.png>")
 
 		t = "<font face=\"[deffont]\" color=[P.colour]>[t]</font>"
 	else // If it is a crayon, and he still tries to use these, make them empty!
@@ -201,6 +208,11 @@
 		t = replacetext(t, "\[/small\]", "")
 		t = replacetext(t, "\[list\]", "")
 		t = replacetext(t, "\[/list\]", "")
+		t = replacetext(t, "\[table\]", "")
+		t = replacetext(t, "\[/table\]", "")
+		t = replacetext(t, "\[row\]", "")
+		t = replacetext(t, "\[cell\]", "")
+		t = replacetext(t, "\[logo\]", "")
 
 		t = "<font face=\"[crayonfont]\" color=[P.colour]><b>[t]</b></font>"
 
@@ -284,7 +296,7 @@
 
 		if((!in_range(src, usr) && loc != usr && !( istype(loc, /obj/item/weapon/clipboard) ) && loc.loc != usr && usr.get_active_hand() != i)) // Some check to see if he's allowed to write
 			return
-
+/*
 		t = checkhtml(t)
 
 		// check for exploits
@@ -294,7 +306,8 @@
 				log_admin("PAPER: [usr] ([usr.ckey]) tried to use forbidden word in [src]: [bad].")
 				message_admins("PAPER: [usr] ([usr.ckey]) tried to use forbidden word in [src]: [bad].")
 				return
-
+*/
+		t = html_encode(t)
 		t = replacetext(t, "\n", "<BR>")
 		t = parsepencode(t, i, usr, iscrayon) // Encode everything from pencode to html
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -58,6 +58,15 @@ should be listed in the changelog upon commit though. Thanks. -->
 
 
 <div class='commit sansserif'>
+	<h2 class='date'>28 мая 2014</h2>
+	<h3 class='author'>Chinsky updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Adds few new paperBBcode tags, to make up for HTML removal.</li>
+		<li class='rscadd'>[logo] tag draws NT logo image (one from wiki).</li>
+		<li class='rscadd'>[table] [/table] tags mark borders of tables. [grid] [/grid] are borderless tables, useful of making layouts. Inside tables following tags are used: [row] marks beginning of new table row, [cell] - beginning of new table cell.</li>
+	</ul>
+</div>
+<div class='commit sansserif'>
 	<h2 class='date'>25 April 2014</h2>
 	<h3 class='author'>Various updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
Removes HTML support from paper.
Fixes #5056 and #4609
