### PR TITLE
Inaprovaline no longer a substitute for breathing

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -308,9 +308,11 @@
 
 		var/datum/gas_mixture/environment = loc.return_air()
 		var/datum/gas_mixture/breath
+		
 		// HACK NEED CHANGING LATER
-		if(health < config.health_threshold_crit)
+		if(health < config.health_threshold_crit && !reagents.has_reagent("inaprovaline"))
 			losebreath++
+		
 		if(losebreath>0) //Suffocating so do not take a breath
 			losebreath--
 			if (prob(10)) //Gasp per 10 ticks? Sounds about right.
@@ -418,8 +420,6 @@
 			return
 
 		if(!breath || (breath.total_moles() == 0) || suiciding)
-			if(reagents.has_reagent("inaprovaline"))
-				return
 			if(suiciding)
 				adjustOxyLoss(2)//If you are suiciding, you should die a little bit faster
 				failed_last_breath = 1


### PR DESCRIPTION
Fixes inaprovaline being a substitute for breathing and internals. From what I understand, inaprovaline is supposed to be modeled after adrenaline: If the patient is in so much shock that they've stopped breathing (i.e. crit), a shot of inaprovaline will get them to start breathing again. It won't however act as a substitute for air -- you'll need dexaline for that.
