### PR TITLE
New System for CO2 Asphixyation

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -460,7 +460,7 @@
 				inhaling = breath.nitrogen
 			if("phoron")
 				inhaling = breath.phoron
-			if("C02")
+			if("carbon_dioxide")
 				inhaling = breath.carbon_dioxide
 			else
 				inhaling = breath.oxygen
@@ -470,13 +470,13 @@
 				poison = breath.oxygen
 			if("nitrogen")
 				poison = breath.nitrogen
-			if("C02")
+			if("carbon_dioxide")
 				poison = breath.carbon_dioxide
 			else
 				poison = breath.phoron
 
 		switch(species.exhale_type)
-			if("C02")
+			if("carbon_dioxide")
 				exhaling = breath.carbon_dioxide
 			if("oxygen")
 				exhaling = breath.oxygen
@@ -521,7 +521,7 @@
 				breath.nitrogen -= inhaled_gas_used
 			if("phoron")
 				breath.phoron -= inhaled_gas_used
-			if("C02")
+			if("carbon_dioxide")
 				breath.carbon_dioxide-= inhaled_gas_used
 			else
 				breath.oxygen -= inhaled_gas_used
@@ -534,7 +534,7 @@
 					breath.nitrogen += inhaled_gas_used
 				if("phoron")
 					breath.phoron += inhaled_gas_used
-				if("C02")
+				if("CO2")
 					breath.carbon_dioxide += inhaled_gas_used
 
 		// Too much exhaled gas in the air

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -561,7 +561,7 @@
 			co2_alert = 1
 			failed_exhale = 1
 			
-		if(exhaled_pp > safe_exhaled_max * 0.6)
+		else if(exhaled_pp > safe_exhaled_max * 0.6)
 			if (prob(0.3))
 				var/word = pick("a little dizzy","short of breath")
 				src << "\red You feel [word]."

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -548,7 +548,7 @@
 			failed_exhale = 1
 			
 		else if(exhaled_pp > safe_exhaled_max * 0.7)
-			if (!co2_alert || prob(15))
+			if (!co2_alert || prob(1))
 				var/word = pick("dizzy","short of breath","faint","momentarily confused")
 				src << "\red You feel [word]."
 			
@@ -562,7 +562,7 @@
 			failed_exhale = 1
 			
 		if(exhaled_pp > safe_exhaled_max * 0.6)
-			if (prob(1))
+			if (prob(0.3))
 				var/word = pick("a little dizzy","short of breath")
 				src << "\red You feel [word]."
 			

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -519,6 +519,10 @@
 		switch(species.breath_type)
 			if("nitrogen")
 				breath.nitrogen -= inhaled_gas_used
+			if("phoron")
+				breath.phoron -= inhaled_gas_used
+			if("C02")
+				breath.carbon_dioxide-= inhaled_gas_used
 			else
 				breath.oxygen -= inhaled_gas_used
 
@@ -551,7 +555,7 @@
 			//scale linearly from 0 to 1 between safe_exhaled_max and safe_exhaled_max*0.7
 			var/ratio = 1.0 - (safe_exhaled_max - exhaled_pp)/(safe_exhaled_max*0.3)
 			
-			//give them some oxyloss, up to the limit - we don't want people falling unconcious until they're pretty close to safe_exhaled_max
+			//give them some oxyloss, up to the limit - we don't want people falling unconcious due to CO2 alone until they're pretty close to safe_exhaled_max.
 			if (getOxyLoss() < 50*ratio)
 				adjustOxyLoss(HUMAN_MAX_OXYLOSS)
 			co2_alert = 1

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -19,7 +19,7 @@
 
 	var/breath_type = "oxygen"   // Non-oxygen gas breathed, if any.
 	var/poison_type = "phoron"   // Poisonous air.
-	var/exhale_type = "C02"      // Exhaled gas type.
+	var/exhale_type = "carbon_dioxide"      // Exhaled gas type.
 
 	var/cold_level_1 = 260  // Cold damage level 1 below this point.
 	var/cold_level_2 = 200  // Cold damage level 2 below this point.


### PR DESCRIPTION
Too much CO2 now affects /living/carbon/humans gradually instead of longer knocking them out after 12 seconds and killing them after 30.

This was going to be the first part of a change to mob CO2 production intended to make the presence of working scrubbers more relevant, except the only way I could think of doing it was to increase breathing rates, requiring corresponding adjustments to the size of all internals tanks. If I do that I will probably propose it in a separate PR.
