### PR TITLE
Spam filter

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -251,7 +251,8 @@
 					break
 				dat += "<dd>[index]&#09; <a href='?src=\ref[src];deltoken=[index]'>[token]</a><br></dd>"
 			dat += "<hr>"
-			dat += "<a href='?src=\ref[src];addtoken=1'>Add token</a><br>"
+			if (linkedServer.spamfilter.len < linkedServer.spamfilter_limit)
+				dat += "<a href='?src=\ref[src];addtoken=1'>Add token</a><br>"
 
 
 	dat += "</body>"

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -26,7 +26,7 @@
 	var/emag = 0		// When it is emagged.
 	var/message = "<span class='notice'>System bootup complete. Please select an option.</span>"	// The message that shows on the main menu.
 	var/auth = 0 // Are they authenticated?
-	var/optioncount = 7
+	var/optioncount = 8
 	// Custom Message Properties
 	var/customsender = "System Administrator"
 	var/obj/item/device/pda/customrecepient = null
@@ -122,6 +122,7 @@
 					dat += "<dd><A href='?src=\ref[src];clearr=1'>&#09;[++i]. Clear Request Console Logs</a><br></dd>"
 					dat += "<dd><A href='?src=\ref[src];pass=1'>&#09;[++i]. Set Custom Key</a><br></dd>"
 					dat += "<dd><A href='?src=\ref[src];msg=1'>&#09;[++i]. Send Admin Message</a><br></dd>"
+					dat += "<dd><A href='?src=\ref[src];spam=1'>&#09;[++i]. Modify Spam Filter</a><br></dd>"
 			else
 				for(var/n = ++i; n <= optioncount; n++)
 					dat += "<dd><font color='blue'>&#09;[n]. ---------------</font><br></dd>"
@@ -239,6 +240,18 @@
 				dat += {"<tr><td width = '5%'><center><A href='?src=\ref[src];deleter=\ref[rc]' style='color: rgb(255,0,0)'>X</a></center></td><td width='15%'>[rc.send_dpt]</td>
 				<td width='15%'>[rc.rec_dpt]</td><td width='300px'>[rc.message]</td><td width='15%'>[rc.stamp]</td><td width='15%'>[rc.id_auth]</td><td width='15%'>[rc.priority]</td></tr>"}
 			dat += "</table>"
+
+		//Spam filter modification
+		if(5)
+			dat += "<center><A href='?src=\ref[src];back=1'>Back</a> - <A href='?src=\ref[src];refresh=1'>Refresh</center><hr>"
+			var/index = 0
+			for(var/token in src.linkedServer.spamfilter)
+				index++
+				if(index > 3000)
+					break
+				dat += "<dd>[index]&#09; <a href='?src=\ref[src];deltoken=[index]'>[token]</a><br></dd>"
+			dat += "<hr>"
+			dat += "<a href='?src=\ref[src];addtoken=1'>Add token</a><br>"
 
 
 	dat += "</body>"
@@ -484,6 +497,26 @@
 					src.screen = 4
 
 			//usr << href_list["select"]
+
+		if(href_list["spam"])
+			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+				message = noserver
+			else
+				if(auth)
+					src.screen = 5
+
+		if(href_list["addtoken"])
+			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+				message = noserver
+			else
+				src.linkedServer.spamfilter += input(usr,"Enter text you want to be filtered out","Token creation") as text|null
+
+		if(href_list["deltoken"])
+			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+				message = noserver
+			else
+				var/tokennum = text2num(href_list["deltoken"])
+				src.linkedServer.spamfilter.Cut(tokennum,tokennum+1)
 
 		if (href_list["back"])
 			src.screen = 0

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -249,7 +249,7 @@
 				index++
 				if(index > 3000)
 					break
-				dat += "<dd>[index]&#09; <a href='?src=\ref[src];deltoken=[index]'>[token]</a><br></dd>"
+				dat += "<dd>[index]&#09; <a href='?src=\ref[src];deltoken=[index]'>\[[token]\]</a><br></dd>"
 			dat += "<hr>"
 			if (linkedServer.spamfilter.len < linkedServer.spamfilter_limit)
 				dat += "<a href='?src=\ref[src];addtoken=1'>Add token</a><br>"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -919,7 +919,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			return
 		var/send_result = useMS.send_pda_message("[P.owner]","[owner]","[t]")
 		if (send_result)
-			U << "ERROR: Messaging server rejected your message."
+			U << "ERROR: Messaging server rejected your message. Reason: contains '[send_result]'."
 			return
 
 		tnote.Add(list(list("sent" = 1, "owner" = "[P.owner]", "job" = "[P.ownjob]", "message" = "[t]", "target" = "\ref[P]")))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -917,7 +917,11 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if(useTC != 2) // Does our recipient have a broadcaster on their level?
 			U << "ERROR: Cannot reach recipient."
 			return
-		useMS.send_pda_message("[P.owner]","[owner]","[t]")
+		var/send_result = useMS.send_pda_message("[P.owner]","[owner]","[t]")
+		if (send_result)
+			U << "ERROR: Messaging server rejected your message."
+			return
+
 		tnote.Add(list(list("sent" = 1, "owner" = "[P.owner]", "job" = "[P.ownjob]", "message" = "[t]", "target" = "\ref[P]")))
 		P.tnote.Add(list(list("sent" = 0, "owner" = "[owner]", "job" = "[ownjob]", "message" = "[t]", "target" = "\ref[src]")))
 		for(var/mob/M in player_list)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -48,6 +48,14 @@
 		target << law
 		target.add_ion_law(law)
 
+	if(message_servers)
+		for (var/obj/machinery/message_server/MS in message_servers)
+			var/i
+			for (i = 1, i <= MS.spamfilter.len, i++)
+				MS.spamfilter[i] = pick("kitty","HONK","revolution","malfunction","liberty","freedom","drugs", \
+					"admininstreation","ponies","heresy","meow","Pun Pun","monkey","Ian","moron","pizza","message","spam",\
+					"diector", "Hello", "Hi!"," ","nuke")
+
 /datum/event/ionstorm/tick()
 	if(botEmagChance)
 		for(var/obj/machinery/bot/bot in world)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -50,11 +50,12 @@
 
 	if(message_servers)
 		for (var/obj/machinery/message_server/MS in message_servers)
+			MS.spamfilter.Cut()
 			var/i
-			for (i = 1, i <= MS.spamfilter.len, i++)
-				MS.spamfilter[i] = pick("kitty","HONK","revolution","malfunction","liberty","freedom","drugs", \
-					"admininstreation","ponies","heresy","meow","Pun Pun","monkey","Ian","moron","pizza","message","spam",\
-					"diector", "Hello", "Hi!"," ","nuke")
+			for (i = 1, i <= MS.spamfilter_limit, i++)
+				MS.spamfilter += pick("kitty","HONK","rev","malf","liberty","freedom","drugs", "Exodus", \
+					"admin","ponies","heresy","meow","Pun Pun","monkey","Ian","moron","pizza","message","spam",\
+					"diector", "Hello", "Hi!"," ","nuke","crate","dwarf","xeno")
 
 /datum/event/ionstorm/tick()
 	if(botEmagChance)

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -113,6 +113,6 @@
 
 			if(L)
 				L << "\icon[P] <b>Message from [sender] (Unknown / spam?), </b>\"[message]\" (Unable to Reply)"
-	else if(world.time > last_spam_time + 1200)
-		//if there's no server active for two minutes, give up
+	else if(world.time > last_spam_time + 3000)
+		//if there's no spam managed to get to receiver for five minutes, give up
 		kill()

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -15,6 +15,11 @@
 				break
 
 /datum/event/pda_spam/tick()
+	if(world.time > last_spam_time + 3000)
+		//if there's no spam managed to get to receiver for five minutes, give up
+		kill()
+		return
+
 	if(!useMS || !useMS.active)
 		useMS = null
 		pick_message_server()
@@ -113,6 +118,3 @@
 
 			if(L)
 				L << "\icon[P] <b>Message from [sender] (Unknown / spam?), </b>\"[message]\" (Unable to Reply)"
-	else if(world.time > last_spam_time + 3000)
-		//if there's no spam managed to get to receiver for five minutes, give up
-		kill()

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -1,26 +1,26 @@
 /datum/event/pda_spam
-	endWhen = 6000
+	endWhen = 36000
 	var/last_spam_time = 0
 	var/obj/machinery/message_server/useMS
 
 /datum/event/pda_spam/setup()
 	last_spam_time = world.time
-	for (var/obj/machinery/message_server/MS in message_servers)
-		if(MS.active)
-			useMS = MS
-			break
+	pick_message_server()
+
+/datum/event/pda_spam/proc/pick_message_server()
+	if(message_servers)
+		for (var/obj/machinery/message_server/MS in message_servers)
+			if(MS.active)
+				useMS = MS
+				break
 
 /datum/event/pda_spam/tick()
 	if(!useMS || !useMS.active)
 		useMS = null
-		if(message_servers)
-			for (var/obj/machinery/message_server/MS in message_servers)
-				if(MS.active)
-					useMS = MS
-					break
+		pick_message_server()
 
 	if(useMS)
-		if(prob(2))
+		if(prob(5))
 			// /obj/machinery/message_server/proc/send_pda_message(var/recipient = "",var/sender = "",var/message = "")
 			var/obj/item/device/pda/P
 			var/list/viables = list()

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -1,10 +1,10 @@
 /datum/event/pda_spam
 	endWhen = 6000
-	var/time_failed = 0
+	var/last_spam_time = 0
 	var/obj/machinery/message_server/useMS
 
 /datum/event/pda_spam/setup()
-	time_failed = world.time
+	last_spam_time = world.time
 	for (var/obj/machinery/message_server/MS in message_servers)
 		if(MS.active)
 			useMS = MS
@@ -20,7 +20,6 @@
 					break
 
 	if(useMS)
-		time_failed = world.time
 		if(prob(2))
 			// /obj/machinery/message_server/proc/send_pda_message(var/recipient = "",var/sender = "",var/message = "")
 			var/obj/item/device/pda/P
@@ -86,7 +85,10 @@
 					"You have won tickets to the newest romantic comedy 16 RULES OF LOVE!",\
 					"You have won tickets to the newest thriller THE CULT OF THE SLEEPING ONE!")
 
-			useMS.send_pda_message("[P.owner]", sender, message)
+			if (useMS.send_pda_message("[P.owner]", sender, message))	//Message been filtered by spam filter.
+				return
+
+			last_spam_time = world.time
 
 			if (prob(50)) //Give the AI an increased chance to intercept the message
 				for(var/mob/living/silicon/ai/ai in mob_list)
@@ -111,6 +113,6 @@
 
 			if(L)
 				L << "\icon[P] <b>Message from [sender] (Unknown / spam?), </b>\"[message]\" (Unable to Reply)"
-	else if(world.time > time_failed + 1200)
+	else if(world.time > last_spam_time + 1200)
 		//if there's no server active for two minutes, give up
 		kill()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -61,7 +61,11 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	var/active = 1
 	var/decryptkey = "password"
 
-	var/list/spamfilter = list()
+	//Spam filtering stuff
+	var/list/spamfilter = list("You have won", "your prize", "male enhancement", "shitcurity", \
+			"are happy to inform you", "account number", "enter your PIN")
+			//Messages having theese tokens will be rejected by server. Case sensitive
+	var/spamfilter_limit = 10	//Maximal amount of tokens
 	var/const/errorcode_spam_rejected = MESSAGE_SERVER_SPAM_REJECT
 
 /obj/machinery/message_server/New()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -1,4 +1,5 @@
 #define MESSAGE_SERVER_SPAM_REJECT 1
+#define MESSAGE_SERVER_DEFAULT_SPAM_LIMIT 10
 
 var/global/list/obj/machinery/message_server/message_servers = list()
 
@@ -65,8 +66,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	var/list/spamfilter = list("You have won", "your prize", "male enhancement", "shitcurity", \
 			"are happy to inform you", "account number", "enter your PIN")
 			//Messages having theese tokens will be rejected by server. Case sensitive
-	var/spamfilter_limit = 10	//Maximal amount of tokens
-	var/const/errorcode_spam_rejected = MESSAGE_SERVER_SPAM_REJECT
+	var/spamfilter_limit = MESSAGE_SERVER_DEFAULT_SPAM_LIMIT	//Maximal amount of tokens
 
 /obj/machinery/message_server/New()
 	message_servers += src
@@ -98,10 +98,13 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	return
 
 /obj/machinery/message_server/proc/send_pda_message(var/recipient = "",var/sender = "",var/message = "")
-	pda_msgs += new/datum/data_pda_msg(recipient,sender,message)
+	var/result
 	for (var/token in spamfilter)
 		if (findtextEx(message,token))
-			return errorcode_spam_rejected
+			message = "<font color=\"red\">[message]</font>"	//Rejected messages will be indicated by red color.
+			result = token										//Token caused rejection (if there are multiple, last will be chosen>.
+	pda_msgs += new/datum/data_pda_msg(recipient,sender,message)
+	return result
 
 /obj/machinery/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1)
 	rc_msgs += new/datum/data_rc_msg(recipient,sender,message,stamp,id_auth)
@@ -113,6 +116,16 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	update_icon()
 
 	return
+
+/obj/machinery/message_server/attackby(obj/item/weapon/O as obj, mob/living/user as mob)
+	if (active && !(stat & (BROKEN|NOPOWER)) && (spamfilter_limit < MESSAGE_SERVER_DEFAULT_SPAM_LIMIT*2) && \
+		istype(O,/obj/item/weapon/circuitboard/message_monitor))
+		spamfilter_limit += round(MESSAGE_SERVER_DEFAULT_SPAM_LIMIT / 2)
+		user.drop_item()
+		del(O)
+		user << "You install additional memory and processors into message server. Its filtering capabilities been enhanced."
+	else
+		..(O, user)
 
 /obj/machinery/message_server/update_icon()
 	if((stat & (BROKEN|NOPOWER)))

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -1,3 +1,5 @@
+#define MESSAGE_SERVER_SPAM_REJECT 1
+
 var/global/list/obj/machinery/message_server/message_servers = list()
 
 /datum/data_pda_msg
@@ -59,6 +61,9 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	var/active = 1
 	var/decryptkey = "password"
 
+	var/list/spamfilter = list()
+	var/const/errorcode_spam_rejected = MESSAGE_SERVER_SPAM_REJECT
+
 /obj/machinery/message_server/New()
 	message_servers += src
 	decryptkey = GenerateKey()
@@ -90,6 +95,9 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 
 /obj/machinery/message_server/proc/send_pda_message(var/recipient = "",var/sender = "",var/message = "")
 	pda_msgs += new/datum/data_pda_msg(recipient,sender,message)
+	for (var/token in spamfilter)
+		if (findtextEx(message,token))
+			return errorcode_spam_rejected
 
 /obj/machinery/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1)
 	rc_msgs += new/datum/data_rc_msg(recipient,sender,message,stamp,id_auth)


### PR DESCRIPTION
Added spam filtering functionality to message server and message monitor. A list of keywoyds can be created in message monitor. The PDA and spam messages containing theese words won't be delivered by message server. The amount of available keywords can be extended with message monitor curcuits. Ion storm will fill the spam filter with random words. Made PDA spam vastly more severe and funny.
Result: RD will have far more useful task than pulling and pushing supermatter shards on the asteroid. If RD is not available, message server can be just turned off for 5 minutes.
