### PR TITLE
alien weeds performance and layer fixes

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -184,6 +184,7 @@
 
 	anchored = 1
 	density = 0
+	layer = 2
 	var/health = 15
 	var/obj/effect/alien/weeds/node/linked_node = null
 
@@ -191,6 +192,7 @@
 	icon_state = "weednode"
 	name = "purple sac"
 	desc = "Weird purple octopus-like thing."
+	layer = 3
 	luminosity = NODERANGE
 	var/node_range = NODERANGE
 
@@ -200,10 +202,10 @@
 
 /obj/effect/alien/weeds/New(pos, node)
 	..()
-	linked_node = node
 	if(istype(loc, /turf/space))
 		del(src)
 		return
+	linked_node = node
 	if(icon_state == "weeds")icon_state = pick("weeds", "weeds1", "weeds2")
 	spawn(rand(150, 200))
 		if(src)
@@ -230,15 +232,15 @@ Alien plants should do something if theres a lot of poison
 		del(src)
 		return
 
+	if(!linked_node || (get_dist(linked_node, src) > linked_node.node_range) )
+		return
+	
 	direction_loop:
 		for(var/dirn in cardinal)
 			var/turf/T = get_step(src, dirn)
 
 			if (!istype(T) || T.density || locate(/obj/effect/alien/weeds) in T || istype(T.loc, /area/arrival) || istype(T, /turf/space))
 				continue
-
-			if(!linked_node || get_dist(linked_node, src) > linked_node.node_range)
-				return
 
 	//		if (locate(/obj/movable, T)) // don't propogate into movables
 	//			continue


### PR DESCRIPTION
recently i fixed a couple of issues with /vg/'s alien weeds and nodes, 
and i see some applying to Bay12 too.

one of those issues was the order of checks in weeds/Life().
it should cancel the weed's search for tiles to expand to without starting
the direction loop first, saving quite a few proc calls.

another issue is alien weeds having the default OBJ_LAYER layer 3 which makes them grow
over all kinds of items and objects which makes sense i guess fluffwise but
is really annoying ingame for both crew and aliens.
( and this coming from the host of Alium Deathtrap 13 ;) )
nodes stay at layer 3 to appear properly over things like AI-holopads.

a really tiny improvement is setting linked_node after the space-turf check in weeds/New().

link to the /vg/ commit : https://github.com/d3athrow/vgstation13/commit/4dcb434f7258fe2acd266a1709ab2022389eb845
