### PR TITLE
Removes explosive implants from nuke ops

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -247,9 +247,9 @@
 		synd_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/space/rig/syndi/human(synd_mob), slot_wear_suit)
 		synd_mob.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/rig/syndi/human(synd_mob), slot_head)
 
-	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)
-	E.imp_in = synd_mob
-	E.implanted = 1
+//	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)
+//	E.imp_in = synd_mob
+//	E.implanted = 1
 	synd_mob.update_icons()
 	return 1
 


### PR DESCRIPTION
The implants are not assigned to a specific limb, make nukes exteremely vulnerable to ion rifles (which will ruin any potential RP immediately and make the nuke op lament for the rest of the round in dchat) and are triggered by a phrase that stays the same each single round, which has the potential to ruin the entire round from the very start.

People do not want these, they have been a round ruiner several times already and are an artifact from when nuke-ops used dexplosive implants to explode upon death.

Please pull and remove.
