### PR TITLE
Round no longer ends suddenly

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -40,7 +40,7 @@
 	var/traitor_scaling = 0 			//if amount of traitors scales based on amount of players
 	var/objectives_disabled = 0 			//if objectives are disabled or not
 	var/protect_roles_from_antagonist = 0// If security and such can be traitor/cult/other
-	var/continous_rounds = 1			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
+	var/continous_rounds = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/allow_Metadata = 0				// Metadata is supported.
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/Ticklag = 0.9

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -129,7 +129,7 @@ Implants;
 		return 1
 	return 0
 
-/datum/game_mode/proc/cleanup()	//the end conditions specified by check_finished() have been met, let's clean up.
+/datum/game_mode/proc/cleanup()	//This is called when the round has ended but not the game, if any cleanup would be necessary in that case.
 	return
 
 /datum/game_mode/proc/declare_completion()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -129,6 +129,8 @@ Implants;
 		return 1
 	return 0
 
+/datum/game_mode/proc/cleanup()	//the end conditions specified by check_finished() have been met, let's clean up.
+	return
 
 /datum/game_mode/proc/declare_completion()
 	var/clients = 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -12,6 +12,7 @@ var/global/datum/controller/gameticker/ticker
 
 	var/hide_mode = 0
 	var/datum/game_mode/mode = null
+	var/post_game = 0
 	var/event_time = null
 	var/event = 0
 
@@ -309,8 +310,10 @@ var/global/datum/controller/gameticker/ticker
 
 		emergency_shuttle.process()
 
-		var/mode_finished = mode.check_finished() || (emergency_shuttle.location == 2 && emergency_shuttle.alert == 1)
-		if(!mode.explosion_in_progress && mode_finished)
+		var/mode_finished = (!post_game && mode.check_finished())
+		var/game_finished = (emergency_shuttle.location == 2 || mode.station_was_nuked)
+		
+		if(!mode.explosion_in_progress && game_finished && (mode_finished || post_game))
 			current_state = GAME_STATE_FINISHED
 
 			spawn
@@ -340,7 +343,17 @@ var/global/datum/controller/gameticker/ticker
 						world << "\blue <B>An admin has delayed the round end</B>"
 				else
 					world << "\blue <B>An admin has delayed the round end</B>"
-
+		
+		else if (mode_finished)
+			post_game = 1
+			
+			mode.cleanup()
+			
+			//call a transfer shuttle vote
+			spawn(50)
+				world << "\red The round has ended!"
+				vote.autotransfer()
+			
 		return 1
 
 	proc/getfactionbyname(var/name)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -310,8 +310,14 @@ var/global/datum/controller/gameticker/ticker
 
 		emergency_shuttle.process()
 
-		var/mode_finished = (!post_game && mode.check_finished())
-		var/game_finished = (emergency_shuttle.location == 2 || mode.station_was_nuked)
+		var/game_finished = 0
+		var/mode_finished = 0
+		if (config.continous_rounds)
+			game_finished = (emergency_shuttle.location == 2 || mode.station_was_nuked)
+			mode_finished = (!post_game && mode.check_finished())
+		else
+			game_finished = (mode.check_finished() || (emergency_shuttle.location == 2 && emergency_shuttle.alert == 1))
+			mode_finished = game_finished
 		
 		if(!mode.explosion_in_progress && game_finished && (mode_finished || post_game))
 			current_state = GAME_STATE_FINISHED

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -275,3 +275,12 @@ datum/game_mode/proc/auto_declare_completion_heist()
 	if (!(is_raider_crew_alive()) || (vox_shuttle_location && (vox_shuttle_location == "start")))
 		return 1
 	return ..()
+
+/datum/game_mode/heist/cleanup()
+	//the skipjack and everything in it have left and aren't coming back, so get rid of them.
+	var/area/skipjack = locate(/area/shuttle/vox/station)
+	for (var/mob/living/M in skipjack.contents)
+		//maybe send the player a message that they've gone home/been kidnapped? Someone responsible for vox lore should write that.
+		Del(M)
+	for (var/obj/O in skipjack.contents)
+		Del(O)	//no hiding in lockers or anything


### PR DESCRIPTION
This PR proposes changing how the end of the round is handled once the current game mode's end conditions have been satisfied, for example, when the vox return back to darkspace. Instead of forcing the game to immediately end, a crew transfer vote is called instead.

Because this PR touches gameticker, I thought it would be important that devs and admins have a chance to provide input and feedback before it is merged.

Also it would be nice to get feedback on how to cleanup the game modes after the mode has ended.
For heist, I'm thinking that everyone on the skipjack should be turned into an observer. The skipjack has returned to the arkship and isn't coming back any time soon. I don't think any of the other game modes need to do cleanup.
