### PR TITLE
Barsign change mechanism

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -10,3 +10,15 @@
 		//on = 0
 		//brightness_on = 4 //uncomment these when the lighting fixes get in
 		return
+
+/obj/structure/sign/double/barsign/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/card = I
+		if(access_bar in card.GetAccess())
+			var/sign_type = input(user,"What would you like to change the barsign to?") in list("Cancel", "Pink Flamingo", "Magma Sea", "Limbo", "Rusty Axe", "Armok Bar", "Broken Drum", "Mead Bay", "The Damn Wall", "The Cavern", "Cindi Kate", "The Orchard", "The Saucy Clown", "The Clowns Head")
+			if(sign_type == "Cancel")
+				return
+			else
+				sign_type = replacetext(lowertext(sign_type), " ", "") // lowercase, strip spaces - along with choices for user options, avoids huge if-else-else
+				src.ChangeSign(sign_type)
+				user << "You change the barsign."

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -15,8 +15,8 @@
 	if(istype(I, /obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/card = I
 		if(access_bar in card.GetAccess())
-			var/sign_type = input(user,"What would you like to change the barsign to?") in list("Cancel", "Pink Flamingo", "Magma Sea", "Limbo", "Rusty Axe", "Armok Bar", "Broken Drum", "Mead Bay", "The Damn Wall", "The Cavern", "Cindi Kate", "The Orchard", "The Saucy Clown", "The Clowns Head")
-			if(sign_type == "Cancel")
+			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in list("Pink Flamingo", "Magma Sea", "Limbo", "Rusty Axe", "Armok Bar", "Broken Drum", "Mead Bay", "The Damn Wall", "The Cavern", "Cindi Kate", "The Orchard", "The Saucy Clown", "The Clowns Head")
+			if(sign_type == null)
 				return
 			else
 				sign_type = replacetext(lowertext(sign_type), " ", "") // lowercase, strip spaces - along with choices for user options, avoids huge if-else-else


### PR DESCRIPTION
Added a mechanism for bartenders to change the appearance of their barsign, by using their ID (or any ID with bar access) on the barsign.

![](http://puu.sh/9bwdj/2306960d8b.png)
