### PR TITLE
color change for mentor OOC

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -43,7 +43,7 @@ var/global/normal_ooc_colour = "#002eb8"
 
 	var/display_colour = normal_ooc_colour
 	if(holder && !holder.fakekey)
-		display_colour = "#0099cc"	//light blue
+		display_colour = "#2e78d9"	//light blue
 		if(holder.rights & R_MOD && !(holder.rights & R_ADMIN))
 			display_colour = "#184880"	//dark blue
 		if(holder.rights & R_DEBUG && !(holder.rights & R_ADMIN))


### PR DESCRIPTION
The current color for mentors is way too bright! so, this...

![untitled](https://cloud.githubusercontent.com/assets/5078676/3156780/0240737e-eae7-11e3-860e-7248c5c09a2b.png)
