### PR TITLE
Removes Impedrezene from the Paralysis Pen

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -109,7 +109,6 @@
 	reagents = R
 	R.my_atom = src
 	R.add_reagent("zombiepowder", 10)
-	R.add_reagent("impedrezene", 25)
 	R.add_reagent("cryptobiolin", 15)
 	..()
 	return


### PR DESCRIPTION
Because random brain damage from a pen is terrible, especially if you're trying to extract information from the person.
