### PR TITLE
Minor fixes

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -224,8 +224,9 @@ mob/living/carbon/human/airflow_hit(atom/A)
 //	for(var/mob/M in hearers(src))
 //		M.show_message("\red <B>[src] slams into [A]!</B>",1,"\red You hear a loud slam!",2)
 	playsound(src.loc, "punch", 25, 1, -1)
-	loc:add_blood(src)
-	bloody_body(src)
+	if (prob(33))
+		loc:add_blood(src)
+		bloody_body(src)
 	var/b_loss = airflow_speed * vsc.airflow_damage
 
 	var/blocked = run_armor_check("head","melee")

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -225,10 +225,7 @@ mob/living/carbon/human/airflow_hit(atom/A)
 //		M.show_message("\red <B>[src] slams into [A]!</B>",1,"\red You hear a loud slam!",2)
 	playsound(src.loc, "punch", 25, 1, -1)
 	loc:add_blood(src)
-	if (src.wear_suit)
-		src.wear_suit.add_blood(src)
-	if (src.w_uniform)
-		src.w_uniform.add_blood(src)
+	bloody_body(src)
 	var/b_loss = airflow_speed * vsc.airflow_damage
 
 	var/blocked = run_armor_check("head","melee")

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -51,6 +51,9 @@
 		stampoverlay.icon_state = "paper_stamp-cent"
 		if(!R.stamped)
 			R.stamped = new
+		R.offset_x += 0
+		R.offset_y += 0
+		R.ico += "paper_stamp-cent"
 		R.stamped += /obj/item/weapon/stamp
 		R.overlays += stampoverlay
 		R.stamps += "<HR><i>This paper has been stamped by the EFTPOS device.</i>"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -376,8 +376,13 @@
 		stamps += (stamps=="" ? "<HR>" : "<BR>") + "<i>This paper has been stamped with the [P.name].</i>"
 
 		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-		var/x = rand(-2, 2)
-		var/y = rand(-3, 2)
+		var/{x; y;}
+		if(istype(P, /obj/item/weapon/stamp/captain) || istype(P, /obj/item/weapon/stamp/centcomm))
+			x = rand(-2, 0)
+			y = rand(-1, 2)
+		else
+			x = rand(-2, 2)
+			y = rand(-3, 2)
 		offset_x += x
 		offset_y += y
 		stampoverlay.pixel_x = x


### PR DESCRIPTION
Fixes ZAS airflow not updating suit icons when ramming people into the floor, the runtime error that occurs when attempting to copy an EFTPOS paper and the Captain's and CentComm's stamp having the chance to show up partly off the paper's edge.

All seem to have been bugs that were not reported yet.
