### PR TITLE
Fixes some printouts causing a runtime error when photocopied

### DIFF
--- a/code/WorkInProgress/autopsy.dm
+++ b/code/WorkInProgress/autopsy.dm
@@ -157,7 +157,7 @@
 	var/obj/item/weapon/paper/P = new(usr.loc)
 	P.name = "Autopsy Data ([target_name])"
 	P.info = "<tt>[scan_data]</tt>"
-	P.overlays += "paper_words"
+	P.icon_state = "paper_words"
 
 	if(istype(usr,/mob/living/carbon))
 		// place the item in the usr's hand if possible

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -505,5 +505,5 @@
 					if(!isnull(server.decryptkey))
 						info = "<center><h2>Daily Key Reset</h2></center><br>The new message monitor key is '[server.decryptkey]'.<br>Please keep this a secret and away from the clown.<br>If necessary, change the password to a more secure one."
 						info_links = info
-						overlays += "paper_words"
+						icon_state = "paper_words"
 						break

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -262,7 +262,7 @@ obj/machinery/computer/forensic_scanning
 						var/obj/item/weapon/paper/P = new(loc)
 						var/list/dossier = files[href_list["identifier"]]
 						P.name = "\improper Database File ([dossier[2]])"
-						P.overlays += "paper_words"
+						P.icon_state = "paper_words"
 						P.info = "<b>Criminal Evidence Database</b><br><br>"
 						P.info += "Consolidated data points: [dossier[2]]<br>"
 						var/print_string = "Fingerprints: Print not complete!<br>"
@@ -338,7 +338,7 @@ obj/machinery/computer/forensic_scanning
 						var/obj/item/weapon/paper/P = new(loc)
 						var/list/outputs = misc[href_list["identifier"]]
 						P.name = "\improper Auxiliary Database File ([outputs[3]])"
-						P.overlays += "paper_words"
+						P.icon_state = "paper_words"
 						P.info = "<b>Auxiliary Evidence Database</b><br><br>"
 						P.info += "<big><b>Consolidated data points:</b> [outputs[3]]</big><br>"
 						var/list/prints = outputs[4]
@@ -433,7 +433,7 @@ obj/machinery/computer/forensic_scanning
 						var/obj/item/weapon/paper/P = new(loc)
 						P.name = "\improper Scan Data ([scan_name])"
 						P.info = "<tt>[scan_data]</tt>"
-						P.overlays += "paper_words"
+						P.icon_state = "paper_words"
 					else
 						temp = "Print Failed: No Data"
 				if("erase")

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -80,6 +80,7 @@
 					p.loc = src.loc
 					p.update_icon()
 					p.icon_state = "paper_words"
+					p.name = bundle.name
 					p.pixel_y = rand(-8, 8)
 					p.pixel_x = rand(-9, 9)
 					sleep(15*j)


### PR DESCRIPTION
Simply replaces any "paper_words" overlays with icon_states, as the photocopier handles all overlays as stamps.
