### PR TITLE
Built-in drone lighting

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -33,6 +33,16 @@
 		layer = MOB_LAYER
 		src << text("\blue You have stopped hiding.")
 
+/mob/living/silicon/robot/drone/verb/light()
+	set name = "Light On/Off"
+	set desc = "Activate a low power omnidirectional LED. Toggled on or off."
+	set category = "Drone"
+
+	if(luminosity)
+		SetLuminosity(0)
+		return
+	SetLuminosity(2)
+
 //Actual picking-up event.
 /mob/living/silicon/robot/drone/attack_hand(mob/living/carbon/human/M as mob)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -232,7 +232,7 @@
 		R.add_reagent("beer2", 50)
 		src.emag.name = "Mickey Finn's Special Brew"
 		return
-	
+
 	add_languages(var/mob/living/silicon/robot/R)
 		//full set of languages
 		R.add_language("Sol Common", 1)
@@ -307,7 +307,6 @@
 		)
 
 	New()
-		src.modules += new /obj/item/device/flashlight/drone(src)
 		src.modules += new /obj/item/weapon/weldingtool(src)
 		src.modules += new /obj/item/weapon/screwdriver(src)
 		src.modules += new /obj/item/weapon/wrench(src)
@@ -328,7 +327,7 @@
 			src.modules += W
 
 		return
-	
+
 	add_languages(var/mob/living/silicon/robot/R)
 		return	//not much ROM to spare in that tiny microprocessor!
 


### PR DESCRIPTION
Basically removes the penlight from the drone module and adds a verb under the drone tab to toggle the same luminosity 2 light on/off. Won't ghost lights, won't be the cause a luminosity stack if the drone somehow grabs another light.
