### PR TITLE
fixes vox armalis being a choosable race

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -251,7 +251,7 @@
 	breath_type = "nitrogen"
 	poison_type = "oxygen"
 
-	flags = NO_SCAN | NO_BLOOD | HAS_TAIL | NO_PAIN | IS_WHITELISTED
+	flags = NO_SCAN | NO_BLOOD | HAS_TAIL | NO_PAIN
 
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"


### PR DESCRIPTION
the IS_WHITELISTED flag will add the species to the whitelisted_species list,
which in turn gets used as the base list of choosable species in the char setup when
the server config has species whitelisting off.

unless you want giant combat spessbirds as crew ( as a security force maybe ? ;) ),
this is a bug.
