### PR TITLE
Proposes a fix for #5224

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -410,6 +410,15 @@
 				AA.update_icon()
 
 	if(danger_level > 1)
+		if (!(mode == AALARM_MODE_PANIC || mode == AALARM_MODE_CYCLE))
+			var/turf/simulated/location = loc
+			if(istype(location))
+				var/datum/gas_mixture/environment = location.return_air()
+				var/environment_pressure = environment.return_pressure()
+				if (get_danger_level(environment_pressure, TLV["pressure"]) > 1)
+					mode = AALARM_MODE_OFF
+					apply_mode()
+		
 		air_doors_close(0)
 	else
 		air_doors_open(0)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -87,7 +87,6 @@
 	var/screen = AALARM_SCREEN_MAIN
 	var/area_uid
 	var/area/alarm_area
-	var/danger_level = 0
 	var/buildstage = 2 //2 is built, 1 is building, 0 is frame.
 
 	var/target_temperature = T0C+20
@@ -97,6 +96,13 @@
 
 	var/list/TLV = list()
 
+	var/danger_level = 0
+	var/pressure_dangerlevel = 0
+	var/oxygen_dangerlevel = 0
+	var/co2_dangerlevel = 0
+	var/phoron_dangerlevel = 0
+	var/temperature_dangerlevel = 0
+	var/other_dangerlevel = 0
 
 /obj/machinery/alarm/server/New()
 	..()
@@ -204,11 +210,17 @@
 				"You hear a click as a faint electronic humming stops.")
 
 	var/old_level = danger_level
+	var/old_pressurelevel = pressure_dangerlevel
 	danger_level = overall_danger_level()
 
 	if (old_level != danger_level)
 		refresh_danger_level()
 		update_icon()
+
+	if (old_pressurelevel != pressure_dangerlevel)
+		if (breach_detected())
+			mode = AALARM_MODE_OFF
+			apply_mode()
 
 	if (mode==AALARM_MODE_CYCLE && environment.return_pressure()<ONE_ATMOSPHERE*0.05)
 		mode=AALARM_MODE_FILL
@@ -242,12 +254,12 @@
 	for(var/datum/gas/G in environment.trace_gases)
 		other_moles+=G.moles
 
-	var/pressure_dangerlevel = get_danger_level(environment_pressure, TLV["pressure"])
-	var/oxygen_dangerlevel = get_danger_level(environment.oxygen*partial_pressure, TLV["oxygen"])
-	var/co2_dangerlevel = get_danger_level(environment.carbon_dioxide*partial_pressure, TLV["carbon dioxide"])
-	var/phoron_dangerlevel = get_danger_level(environment.phoron*partial_pressure, TLV["phoron"])
-	var/temperature_dangerlevel = get_danger_level(environment.temperature, TLV["temperature"])
-	var/other_dangerlevel = get_danger_level(other_moles*partial_pressure, TLV["other"])
+	pressure_dangerlevel = get_danger_level(environment_pressure, TLV["pressure"])
+	oxygen_dangerlevel = get_danger_level(environment.oxygen*partial_pressure, TLV["oxygen"])
+	co2_dangerlevel = get_danger_level(environment.carbon_dioxide*partial_pressure, TLV["carbon dioxide"])
+	phoron_dangerlevel = get_danger_level(environment.phoron*partial_pressure, TLV["phoron"])
+	temperature_dangerlevel = get_danger_level(environment.temperature, TLV["temperature"])
+	other_dangerlevel = get_danger_level(other_moles*partial_pressure, TLV["other"])
 
 	return max(
 		pressure_dangerlevel,
@@ -257,6 +269,24 @@
 		other_dangerlevel,
 		temperature_dangerlevel
 		)
+
+// Returns whether this air alarm thinks there is a breach, given the sensors that are available to it.
+/obj/machinery/alarm/proc/breach_detected()
+	var/turf/simulated/location = loc
+
+	if(!istype(location))
+		return 0
+	
+	var/datum/gas_mixture/environment = location.return_air()
+	var/environment_pressure = environment.return_pressure()
+	var/pressure_levels = TLV["pressure"]
+	
+	if (environment_pressure <= pressure_levels[1])		//low pressures
+		if (!(mode == AALARM_MODE_PANIC || mode == AALARM_MODE_CYCLE))
+			return 1
+	
+	return 0
+	
 
 /obj/machinery/alarm/proc/master_is_operating()
 	return alarm_area.master_air_alarm && !(alarm_area.master_air_alarm.stat & (NOPOWER|BROKEN))
@@ -410,15 +440,6 @@
 				AA.update_icon()
 
 	if(danger_level > 1)
-		if (!(mode == AALARM_MODE_PANIC || mode == AALARM_MODE_CYCLE))
-			var/turf/simulated/location = loc
-			if(istype(location))
-				var/datum/gas_mixture/environment = location.return_air()
-				var/environment_pressure = environment.return_pressure()
-				if (get_danger_level(environment_pressure, TLV["pressure"]) > 1)
-					mode = AALARM_MODE_OFF
-					apply_mode()
-		
 		air_doors_close(0)
 	else
 		air_doors_open(0)


### PR DESCRIPTION
Proposed fix for https://github.com/Baystation12/Baystation12/issues/5224. 
When an air alarm detects dangerous conditions, if the alert was triggered by dangerous pressure levels then the environmental mode will be set to off, so the room will not fill.

Once engineers or atmos techs come by and fix the breach, then they can reset the environmental mode manually or remotely. If no one comes by to fix the breach, then the vents being off shouldn't be a problem.
