### PR TITLE
Fixes cheap lighters burning body parts other than the hands they're being held in

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -414,7 +414,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
 				else
 					user << "<span class='warning'>You burn yourself while lighting the lighter.</span>"
-					user.adjustFireLoss(5)
+					if (user.l_hand == src)
+						user.apply_damage(2,BURN,"l_hand")
+					else
+						user.apply_damage(2,BURN,"r_hand")
 					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src], they however burn their finger in the process.</span>")
 
 			user.SetLuminosity(user.luminosity + 2)


### PR DESCRIPTION
Fixes #5274

Retrieved the code lost in [this merge](https://github.com/Baystation12/Baystation12/commit/1c9b04ec74d1aefd1e3bdd10217f64e247d68aea#diff-fc8c9ab91734d0f9c6941329d5852c1fL361), tested working on current master.
