### PR TITLE
Diskette size change

### DIFF
--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -71,6 +71,7 @@
 	name = "Blank GNA disk"
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "datadisk0"
+	w_class = 1
 	var/datum/disease2/effectholder/effect = null
 	var/stage = 1
 


### PR DESCRIPTION
Changes viro diskette w_class from /3/ to 1, so you can actually store those in boxes.
