### PR TITLE
Fixes special shuttle consoles being deconstructible

### DIFF
--- a/code/modules/shuttles/departmental.dm
+++ b/code/modules/shuttles/departmental.dm
@@ -2,16 +2,16 @@
 	name = "mining shuttle console"
 	shuttle_tag = "Mining"
 	req_access = list(access_mining)
-	circuit = "/obj/item/weapon/circuitboard/mining_shuttle"
+	circuit = /obj/item/weapon/circuitboard/mining_shuttle
 
 /obj/machinery/computer/shuttle_control/engineering
 	name = "engineering shuttle console"
 	shuttle_tag = "Engineering"
 	req_one_access_txt = "11;24"
-	circuit = "/obj/item/weapon/circuitboard/engineering_shuttle"
+	circuit = /obj/item/weapon/circuitboard/engineering_shuttle
 
 /obj/machinery/computer/shuttle_control/research
 	name = "research shuttle console"
 	shuttle_tag = "Research"
 	req_access = list(access_research)
-	circuit = "/obj/item/weapon/circuitboard/research_shuttle"
+	circuit = /obj/item/weapon/circuitboard/research_shuttle

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -136,7 +136,7 @@
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "shuttle"
 	req_access = list(access_engine)
-	circuit = "/obj/item/weapon/circuitboard/engineering_shuttle"
+	circuit = null
 	
 	var/shuttle_tag  // Used to coordinate data in shuttle controller.
 	var/hacked = 0   // Has been emagged, no access restrictions.


### PR DESCRIPTION
Also in general, consoles that don't have their own circuit board should probably have their circuit var set to null.
