### PR TITLE
No longer semi-telekenetic for on-wall objects.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -28,8 +28,12 @@
 	return 0
 
 /proc/in_range(source, user)
-	if(get_dist(source, user) <= 1)
-		return 1
+	if(source:pixel_x != 0 || source:pixel_y != 0 || source:pixel_z != 0) // Placed on the wall, assumably.
+		if(get_dist(source, user) < 1)
+			return 1
+	else
+		if(get_dist(source, user) <= 1)
+			return 1
 
 	return 0 //not in range and not telekinetic
 


### PR DESCRIPTION
During testing I noticed I was able to use most on-wall objects from 2 tiles away, (me > tile > wall) it's weird I never saw this before.

Any way, thinking of the most easy way to fix this, this seemed like a good way. Since every on-wall object, button and whatnot changes the pixel_ value, so you're most likely going to need to get closer.
Figured you guys may had some use for this as well. I guess it's not the best way to handle it, but that shouldn't really matter a lot.
