### PR TITLE
Removing automatic IPC whitelist

### DIFF
--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -36,8 +36,6 @@ var/list/whitelist = list()
 		return 1
 	if(species == "human" || species == "Human")
 		return 1
-	if(species == "machine" || species == "Machine")
-		return 1
 	if(check_rights(R_ADMIN, 0))
 		return 1
 	if(!alien_whitelist)


### PR DESCRIPTION
IPCs are going to be getting some mechanical overhauls in the main future, and thus we are locking them down from play for now.
