### PR TITLE
atmos: fix everlasting fires

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -84,7 +84,7 @@ turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 			air_contents.trace_gases.Remove(fuel)
 
 	//check if there is something to combust
-	if(!air_contents.check_recombustability(liquid))
+	if(!air_contents.check_combustability(liquid))
 		//del src
 		RemoveFire()
 
@@ -116,7 +116,7 @@ turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 				var/datum/gas_mixture/acs = enemy_tile.return_air()
 				var/obj/effect/decal/cleanable/liquid_fuel/liq = locate() in enemy_tile
 				if(!acs) continue
-				if(!acs.check_recombustability(liq)) continue
+				if(!acs.check_combustability(liq)) continue
 				//If extinguisher mist passed over the turf it's trying to spread to, don't spread and
 				//reduce firelevel.
 				if(enemy_tile.fire_protection > world.time-30)
@@ -134,16 +134,8 @@ turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 ///////////////////////////////// FLOW HAS BEEN CREATED /// DONT DELETE THE FIRE UNTIL IT IS MERGED BACK OR YOU WILL DELETE AIR ///////////////////////////////////////////////
 
 	if(flow)
-
-		if(flow.check_recombustability(liquid))
-			//Ensure flow temperature is higher than minimum fire temperatures.
-				//this creates some energy ex nihilo but is necessary to get a fire started
-				//lets just pretend this energy comes from the ignition source and dont mention this again
-			//flow.temperature = max(PHORON_MINIMUM_BURN_TEMPERATURE+0.1,flow.temperature)
-
-			//burn baby burn!
-
-			flow.zburn(liquid,1)
+		//burn baby burn!
+		flow.zburn(liquid,1)
 		//merge the air back
 		S.assume_air(flow)
 
@@ -275,9 +267,9 @@ datum/gas_mixture/proc/check_combustability(obj/effect/decal/cleanable/liquid_fu
 	if(oxygen && (phoron || fuel || liquid))
 		if(liquid)
 			return 1
-		if (phoron >= 0.1)
+		if(QUANTIZE(phoron * vsc.fire_consuption_rate) >= 0.1)
 			return 1
-		if(fuel && fuel.moles >= 0.1)
+		if(fuel && QUANTIZE(fuel.moles * vsc.fire_consuption_rate) >= 0.1)
 			return 1
 
 	return 0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1581,14 +1581,14 @@ datum
 				var/turf/the_turf = get_turf(O)
 				var/datum/gas_mixture/napalm = new
 				var/datum/gas/volatile_fuel/fuel = new
-				fuel.moles = 5
+				fuel.moles = volume
 				napalm.trace_gases += fuel
 				the_turf.assume_air(napalm)
 			reaction_turf(var/turf/T, var/volume)
 				src = null
 				var/datum/gas_mixture/napalm = new
 				var/datum/gas/volatile_fuel/fuel = new
-				fuel.moles = 5
+				fuel.moles = volume
 				napalm.trace_gases += fuel
 				T.assume_air(napalm)
 				return


### PR DESCRIPTION
Fires were checking against a non-reduced air sample for existance, so the reduced sample wasn't working in zburn when it failed the check.
Also fixed volatilefuel not being scaled in the phoron reagent.
