### PR TITLE
Fixes #5193

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -431,7 +431,8 @@
 	else
 		stop_pulling()
 		. = ..()
-	if ((s_active && !( s_active in contents ) ))
+
+	if (s_active && !( s_active in contents ) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
 		s_active.close(src)
 
 	if(update_slimes)


### PR DESCRIPTION
Fixes https://github.com/Baystation12/Baystation12/issues/5193

A better way to fix this might be to create a can_interact() proc for storage item types that would called whenever someone tries to add or remove an item from storage. This would by default check whether the mob is close enough to the storage item to use it, and we wouldn't need to auto-close storages altogether. 

But... this should work for now I guess.
