### PR TITLE
Fixes incorrect cable coil colours

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -228,6 +228,8 @@
 	src.amount = length
 	if (param_color)
 		color = param_color
+	else
+		color = item_color
 	pixel_x = rand(-2,2)
 	pixel_y = rand(-2,2)
 	updateicon()
@@ -236,6 +238,7 @@
 /obj/item/weapon/cable_coil/proc/updateicon()
 	if (!color)
 		color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_ORANGE, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
+		item_color = color
 	if(amount == 1)
 		icon_state = "coil1"
 		name = "cable piece"


### PR DESCRIPTION
cable_coil really needs to be properly cleaned out of item_color references, but cable.dm is ugly and I'm feeling lazy tonight, so here's a quick fix.
