### PR TITLE
Fixes multiple runtimes in mutiny mode.

### DIFF
--- a/code/game/gamemodes/mutiny/directives/alien_fraud_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/alien_fraud_directive.dm
@@ -11,7 +11,7 @@ datum/directive/terminations/alien_fraud
 datum/directive/terminations/alien_fraud/get_crew_to_terminate()
 	var/list/aliens[0]
 	for(var/mob/M in player_list)
-		if (is_alien(M) && M.is_ready())
+		if (M.is_ready() && is_alien(M))
 			aliens.Add(M)
 	return aliens
 

--- a/code/game/gamemodes/mutiny/directives/bluespace_contagion_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/bluespace_contagion_directive.dm
@@ -6,7 +6,7 @@ datum/directive/bluespace_contagion
 	proc/get_infection_candidates()
 		var/list/candidates[0]
 		for(var/mob/M in player_list)
-			if (!M.is_mechanical() && M.is_ready())
+			if (M.is_ready() && !M.is_mechanical())
 				candidates.Add(M)
 		return candidates
 

--- a/code/game/gamemodes/mutiny/directives/financial_crisis_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/financial_crisis_directive.dm
@@ -8,7 +8,7 @@ datum/directive/terminations/financial_crisis/get_crew_to_terminate()
 	var/list/civilians[0]
 	var/list/candidates = civilian_positions - "Head of Personnel"
 	for(var/mob/M in player_list)
-		if (candidates.Find(M.mind.assigned_role) && M.is_ready())
+		if (M.is_ready() && candidates.Find(M.mind.assigned_role))
 			civilians.Add(M)
 	return civilians
 

--- a/code/game/gamemodes/mutiny/directives/ipc_virus_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/ipc_virus_directive.dm
@@ -16,14 +16,14 @@ datum/directive/ipc_virus
 	proc/get_ipcs()
 		var/list/machines[0]
 		for(var/mob/M in player_list)
-			if (M.get_species() == "Machine" && M.is_ready())
+			if (M.is_ready() && M.get_species() == "Machine")
 				machines.Add(M)
 		return machines
 
 	proc/get_roboticists()
 		var/list/roboticists[0]
 		for(var/mob/M in player_list)
-			if (roboticist_roles.Find(M.mind.assigned_role) && M.is_ready())
+			if (M.is_ready() && roboticist_roles.Find(M.mind.assigned_role))
 				roboticists.Add(M)
 		return roboticists
 

--- a/code/game/gamemodes/mutiny/directives/research_to_ripleys_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/research_to_ripleys_directive.dm
@@ -10,7 +10,7 @@ datum/directive/research_to_ripleys
 	proc/get_researchers()
 		var/list/researchers[0]
 		for(var/mob/M in player_list)
-			if (is_researcher(M) && M.is_ready())
+			if (M.is_ready() && is_researcher(M))
 				researchers.Add(M)
 		return researchers
 

--- a/code/game/gamemodes/mutiny/directives/tau_ceti_needs_women_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/tau_ceti_needs_women_directive.dm
@@ -13,7 +13,7 @@ datum/directive/tau_ceti_needs_women
 	proc/get_crew_of_target_gender()
 		var/list/targets[0]
 		for(var/mob/M in player_list)
-			if(is_target_gender(M) && !M.is_mechanical() && M.is_ready())
+			if(M.is_ready() && is_target_gender(M) && !M.is_mechanical())
 				targets.Add(M)
 		return targets
 
@@ -63,7 +63,7 @@ datum/directive/tau_ceti_needs_women/meets_prerequisites()
 	var/females = 0
 	var/males = 0
 	for(var/mob/M in player_list)
-		if(!M.is_mechanical() && M.get_species() != "Diona" && M.is_ready())
+		if(M.is_ready() && !M.is_mechanical() && M.get_species() != "Diona")
 			var/gender = M.get_gender()
 			if(gender == MALE)
 				males++


### PR DESCRIPTION
Example runtime:

runtime error: Cannot read null.assigned_role
proc name: get crew to terminate (/datum/directive/terminations/financial_crisis/get_crew_to_terminate)
  source file: financial_crisis_directive.dm,11
  usr: null
  src: /datum/directive/terminations/... (/datum/directive/terminations/financial_crisis)
  call stack:
/datum/directive/terminations/... (/datum/directive/terminations/financial_crisis): get crew to terminate()
/datum/directive/terminations/... (/datum/directive/terminations/financial_crisis): meets prerequisites()
mutiny (/datum/game_mode/mutiny): get directive candidates()
mutiny (/datum/game_mode/mutiny): pre setup()
/datum/controller/gameticker (/datum/controller/gameticker): setup()
/datum/controller/gameticker (/datum/controller/gameticker): pregame()
/datum/controller/game_control... (/datum/controller/game_controller): setup()
