### PR TITLE
AI now handles the sunned status like other creatures do in their life.dm file

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -35,6 +35,10 @@
 			// Gain Power
 			adjustOxyLoss(-1)
 
+		// Handle EMP-stun
+		if(stunned)
+			AdjustStunned(-1)
+
 		//stage = 1
 		//if (istype(src, /mob/living/silicon/ai)) // Are we not sure what we are?
 		var/blind = 0


### PR DESCRIPTION
Previously AIs would be stunned indefinitely after being hit with an EMP-blast. This would prevent emergency shutters from being operated.
The stun status is now adjusted down in the Life()-proc like is done in the base living.dm (which is not called using ..() due to being very custom)
