### PR TITLE
Partially corrects #5438

### DIFF
--- a/code/WorkInProgress/Mini/atmos_control.dm
+++ b/code/WorkInProgress/Mini/atmos_control.dm
@@ -11,7 +11,7 @@
 	circuit = "/obj/item/weapon/circuitboard/atmoscontrol"
 	var/obj/machinery/alarm/current
 	var/overridden = 0 //not set yet, can't think of a good way to do it
-	req_access = list(access_ce)
+	req_access = list(access_atmospherics)
 
 
 /obj/machinery/computer/atmoscontrol/attack_ai(var/mob/user as mob)


### PR DESCRIPTION
Central atmospherics computer now expects atmospherics access, rather than CE access, due to its location if nothing else.

Don't see why it's suddenly required however (did indeed deny my poor atmos tech access), it's been set to CE access since practically the dawn of time and atmos_control.dm appears to have no relevant changes.
Was unable to reproduce the issue with air alarms. Was able to swipe and then access them just fine, with access being denied if I had my id in an off-hand (non-selected).
