### PR TITLE
trivial silicon show_system_integrity() fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -131,18 +131,6 @@
 				else if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)
 					if(M.client) M << "<b>[src]</b> transmits, \"[message]\""
 
-//Sick of trying to get this to display properly without redefining it.
-/mob/living/silicon/robot/drone/show_system_integrity()
-	if(!src.stat)
-		var/temphealth = health+35 //Brings it to 0.
-		if(temphealth<0)	temphealth = 0
-		//Convert to percentage.
-		temphealth = (temphealth / (maxHealth*2)) * 100
-
-		stat(null, text("System integrity: [temphealth]%"))
-	else
-		stat(null, text("Systems nonfunctional"))
-
 //Drones cannot be upgraded with borg modules so we need to catch some items before they get used in ..().
 /mob/living/silicon/robot/drone/attackby(obj/item/weapon/W as obj, mob/user as mob)
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -80,7 +80,7 @@
 // this function shows the health of the pAI in the Status panel
 /mob/living/silicon/proc/show_system_integrity()
 	if(!src.stat)
-		stat(null, text("System integrity: [(src.health+100)/2]%"))
+		stat(null, text("System integrity: [round((health/maxHealth)*100)]%"))
 	else
 		stat(null, text("Systems nonfunctional"))
 


### PR DESCRIPTION
broken percent calculation messed up health stat updates.
borg actual health and showed health % before this commit : 
200/200 = 150 %, 100/200 = 100 %, 0/200 = 50 %
drones before this commit : 
35/35 =>100 %, 17.5/35 = 75 %, 0/35 = 50 %
