### PR TITLE
Makes the cargo console force-launch command more obvious

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -515,7 +515,7 @@ var/list/mechtoys = list(
 				temp = "For safety reasons the automated supply shuttle cannot transport live organisms, classified nuclear weaponry or homing beacons.<BR><BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"
 			else
 				shuttle.launch(src)
-				temp = "Initiating launch sequence.<BR><BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"
+				temp = "Initiating launch sequence. \[<span class='warning'><A href='?src=\ref[src];force_send=1'>Force Launch</A></span>\]<BR><BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"
 		else
 			shuttle.launch(src)
 			temp = "The supply shuttle has been called and will arrive in approximately [round(supply_controller.movetime/600,1)] minutes.<BR><BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"


### PR DESCRIPTION
The docking controller system was designed with the prevention of unsafe shuttle launches as it's first priority. The last thing I wanted to happen was for shuttles to be taking off when they shouldn't and venting areas into space. At least, not without player input. 

Because the system errs so heavily on preventing launches, the force launch mechanism was built in as an important failsafe to allow shuttles to be moved regardless of docking state. It's something that I expect will need to be used occasionally.

That said, if a shuttle requires a force launch too often then something is probably wrong. However, the docking system should only ever stop shuttles from being moved _automatically_, and players should know that they have the option of manually moving shuttles via force launch.
