### PR TITLE
Wheelchair Fixes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -295,14 +295,19 @@
 
 // Simple helper to face what you clicked on, in case it should be needed in more than one place
 /mob/proc/face_atom(var/atom/A)
-	if( stat || buckled || !A || !x || !y || !A.x || !A.y ) return
+	if( stat || (buckled && !buckled.movable) || !A || !x || !y || !A.x || !A.y ) return
 	var/dx = A.x - x
 	var/dy = A.y - y
 	if(!dx && !dy) return
 
+	var/direction
 	if(abs(dx) < abs(dy))
-		if(dy > 0)	usr.dir = NORTH
-		else		usr.dir = SOUTH
+		if(dy > 0)	direction = NORTH
+		else		direction = SOUTH
 	else
-		if(dx > 0)	usr.dir = EAST
-		else		usr.dir = WEST
+		if(dx > 0)	direction = EAST
+		else		direction = WEST
+	usr.dir = direction
+	if(buckled && buckled.movable)
+		buckled.dir = direction
+		buckled.handle_rotation()

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -108,12 +108,19 @@
 
 		playSpecials(curturf,effectin,soundin)
 
+		var/obj/structure/stool/bed/chair/C = null
+		if(isliving(teleatom))
+			var/mob/living/L = teleatom
+			if(L.buckled)
+				C = L.buckled
 		if(force_teleport)
 			teleatom.forceMove(destturf)
 			playSpecials(destturf,effectout,soundout)
 		else
 			if(teleatom.Move(destturf))
 				playSpecials(destturf,effectout,soundout)
+		if(C)
+			C.forceMove(destturf)
 
 		destarea.Entered(teleatom)
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -198,6 +198,8 @@
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()
+		accurate = 1
+		spawn(3000)	accurate = 0 //Accurate teleporting for 5 minutes
 		for(var/mob/B in hearers(src, null))
 			B.show_message("\blue Test fire completed.")
 	return
@@ -339,6 +341,7 @@
 
 	if (com)
 		com.icon_state = "tele0"
+		com.accurate = 0
 		for(var/mob/O in hearers(src, null))
 			O.show_message("\blue Teleporter disengaged!", 2)
 	src.add_fingerprint(usr)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -51,7 +51,12 @@ var/global/list/image/splatter_cache=list()
 	if(amount < 1)
 		return
 
-	if(perp.shoes)//Adding blood to shoes
+	var/datum/organ/external/l_foot = perp.get_organ("l_foot")
+	var/datum/organ/external/r_foot = perp.get_organ("r_foot")
+	var/hasfeet = 1
+	if((!l_foot || l_foot.status & ORGAN_DESTROYED) && (!r_foot || r_foot.status & ORGAN_DESTROYED))
+		hasfeet = 0
+	if(perp.shoes && !perp.buckled)//Adding blood to shoes
 		perp.shoes.blood_color = basecolor
 		perp.shoes:track_blood = max(amount,perp.shoes:track_blood)
 		if(!perp.shoes.blood_overlay)
@@ -62,12 +67,15 @@ var/global/list/image/splatter_cache=list()
 			perp.shoes.overlays += perp.shoes.blood_overlay
 		perp.shoes.blood_DNA |= blood_DNA.Copy()
 
-	else//Or feet
+	else if (hasfeet)//Or feet
 		perp.feet_blood_color = basecolor
 		perp.track_blood = max(amount,perp.track_blood)
 		if(!perp.feet_blood_DNA)
 			perp.feet_blood_DNA = list()
 		perp.feet_blood_DNA |= blood_DNA.Copy()
+	else if (perp.buckled && istype(perp.buckled, /obj/structure/stool/bed/chair/wheelchair))
+		var/obj/structure/stool/bed/chair/wheelchair/W = perp.buckled
+		W.bloodiness = 4
 
 	perp.update_inv_shoes(1)
 	amount--

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -555,7 +555,7 @@ steam.start() -- spawns the effect
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP))
+		if (istype(M, /mob/living/carbon/human) && (istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP) || M.buckled)
 			return
 
 		M.stop_pulling()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -11,7 +11,7 @@
 /obj/item/weapon/bananapeel/HasEntered(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
+		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP) || M.buckled)
 			return
 
 		M.stop_pulling()
@@ -26,7 +26,7 @@
 /obj/item/weapon/soap/HasEntered(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
+		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP) || M.buckled)
 			return
 
 		M.stop_pulling()

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -12,6 +12,7 @@
 	desc = "This is used to lie in, sleep in or strap on."
 	icon_state = "bed"
 	var/mob/living/buckled_mob
+	var/movable = 0 // For mobility checks
 
 /obj/structure/stool/bed/psych
 	name = "psychiatrists couch"
@@ -33,6 +34,9 @@
 
 /obj/structure/stool/bed/attack_hand(mob/user as mob)
 	manual_unbuckle(user)
+	return
+
+/obj/structure/stool/bed/proc/handle_rotation()
 	return
 
 /obj/structure/stool/bed/MouseDrop(atom/over_object)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -39,7 +39,7 @@
 		rotate()
 	return
 
-/obj/structure/stool/bed/chair/proc/handle_rotation()	//making this into a seperate proc so office chairs can call it on Move()
+/obj/structure/stool/bed/chair/handle_rotation()	//making this into a seperate proc so office chairs can call it on Move()
 	if(src.dir == NORTH)
 		src.layer = FLY_LAYER
 	else
@@ -107,6 +107,7 @@
 
 /obj/structure/stool/bed/chair/office
 	anchored = 0
+	movable = 1
 
 /obj/structure/stool/bed/chair/comfy/black
 	icon_state = "comfychair_black"
@@ -148,7 +149,7 @@
 			victim.apply_effect(6, WEAKEN, 0)
 			victim.apply_effect(6, STUTTER, 0)
 			victim.take_organ_damage(10)
-		occupant.visible_message("<span class='danger'>[occupant] clashed into \the [A]!</span>")
+		occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")
 
 /obj/structure/stool/bed/chair/office/light
 	icon_state = "officechair_white"

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -73,6 +73,12 @@
 
 				bloodDNA = null
 
+		var/noslip = 0
+		for (var/obj/structure/stool/bed/chair/C in loc)
+			if (C.buckled_mob == M)
+				noslip = 1
+		if (noslip)
+			return // no slipping while sitting in a chair, plz
 		switch (src.wet)
 			if(1)
 				if(istype(M, /mob/living/carbon/human)) // Added check since monkeys don't have shoes
@@ -99,7 +105,7 @@
 						return
 
 			if(2) //lube                //can cause infinite loops - needs work
-				if(!istype(M, /mob/living/carbon/slime))
+				if(!istype(M, /mob/living/carbon/slime) && !M.buckled)
 					M.stop_pulling()
 					step(M, M.dir)
 					spawn(1) step(M, M.dir)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -112,7 +112,7 @@
 			return
 
 		//BubbleWrap: people in handcuffs are always switched around as if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
-		if((tmob.a_intent == "help" || tmob.restrained()) && (a_intent == "help" || src.restrained()) && tmob.canmove && canmove) // mutual brohugs all around!
+		if((tmob.a_intent == "help" || tmob.restrained()) && (a_intent == "help" || src.restrained()) && tmob.canmove && !tmob.buckled && canmove) // mutual brohugs all around!
 			var/turf/oldloc = loc
 			loc = tmob.loc
 			tmob.loc = oldloc

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -35,7 +35,7 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 
-	if(pulledby && istype(pulledby, /obj/structure/stool/bed/chair/wheelchair))
+	if(buckled && istype(buckled, /obj/structure/stool/bed/chair/wheelchair))
 		for(var/organ_name in list("l_hand","r_hand","l_arm","r_arm"))
 			var/datum/organ/external/E = get_organ(organ_name)
 			if(!E || (E.status & ORGAN_DESTROYED))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -755,7 +755,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 /mob/proc/update_canmove()
-	if(buckled)
+	if(buckled && (!buckled.movable))
 		anchored = 1
 		canmove = 0
 		if( istype(buckled,/obj/structure/stool/bed/chair) )
@@ -778,9 +778,9 @@ note dizziness decrements automatically in the mob's Life() proc.
 		anchored = 1
 		canmove = 0
 		lying = 0
-	else
+	else if (!buckled)
 		lying = !can_stand
-		canmove = has_limbs
+		//canmove = has_limbs
 
 	if(lying)
 		density = 0

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -199,8 +199,7 @@
 
 
 	if(!mob.canmove)
-		if (mob.buckled && (istype(mob.buckled, /obj/structure/stool/bed/chair/wheelchair) || istype(mob.buckled, /obj/vehicle))) // Exception for wheelchairs
-		else	return
+		return
 
 	//if(istype(mob.loc, /turf/space) || (mob.flags & NOGRAV))
 	//	if(!mob.Process_Spacemove(0))	return 0
@@ -246,7 +245,7 @@
 			move_delay -= 1.3
 			var/tickcomp = ((1/(world.tick_lag))*1.3)
 			move_delay = move_delay + tickcomp
-		
+
 		if(istype(mob.buckled, /obj/vehicle))
 			return mob.buckled.relaymove(mob,direct)
 
@@ -260,7 +259,7 @@
 					var/mob/living/carbon/human/driver = mob.buckled
 					var/datum/organ/external/l_hand = driver.get_organ("l_hand")
 					var/datum/organ/external/r_hand = driver.get_organ("r_hand")
-					if((!l_hand || l_hand.status & ORGAN_DESTROYED) && (!r_hand || r_hand.status & ORGAN_DESTROYED))
+					if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
 						return // No hands to drive your chair? Tough luck!
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -731,7 +731,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato/HasEntered(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
+		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP) || M.buckled)
 			return
 
 		M.stop_pulling()

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -19,6 +19,7 @@
 	var/emagged = 0
 	var/powered = 0		//set if vehicle is powered and should use fuel when moving
 	var/move_delay = 1	//set this to limit the speed of the vehicle
+	var/movable = 1
 
 	var/obj/item/weapon/cell/cell
 	var/power_use = 5	//set this to adjust the amount of power the vehicle uses per move
@@ -47,7 +48,7 @@
 			if(on && powered)
 				cell.use(power_use)
 		anchored = init_anc
-		
+
 		if(load)
 			load.loc = loc
 			load.dir = dir
@@ -288,7 +289,7 @@
 /obj/vehicle/proc/unload(var/mob/user, var/direction)
 	if(!load)
 		return
-	
+
 	var/turf/dest = null
 
 	//find a turf to unload to


### PR DESCRIPTION
**Changes the following:**
- Non-existant feet won't get blood-covered
- Wheelchairs will now leave blood tracks similar to those from mulebots
- Teleporting with wheelchairs now won't let you end up in space with the wheelchair teleporting to the targeted location
- Occupant now actually gets movement penalty when hands are damaged
- Stops wheelchair occupants from slipping (for now, might add a hilarious change later)
- Changes 'clash' into 'crash'
- Running over cat won't glitch out the everything
- Occupants will now be able to access the strip menu and use camera consoles properly
- Clicking somewhere while sitting in the wheel-/officechair will now face the player into the clicked direction

Now that I touched teleportation code, I saw that test-firing doesn't do anything at all - might change that in this PR as well so people stop ending up in space after test-firing, otherwise it has no use.
