### PR TITLE
The AI system integrity restorer no longer needs head AND captain access

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "ai-fixer"
 	circuit = /obj/item/weapon/circuitboard/aifixer
-	req_access = list(access_captain, access_robotics, access_heads)
+	req_one_access = list(access_robotics, access_heads)
 	var/mob/living/silicon/ai/occupant = null
 	var/active = 0
 
@@ -17,7 +17,7 @@
 			user << "This terminal isn't functioning right now, get it working!"
 			return
 		I:transfer_ai("AIFIXER","AICARD",src,user)
-	
+
 	..()
 	return
 


### PR DESCRIPTION
The captain currently gets all accesses hence the removal. Might be more future proof to retain the check however.
