### PR TITLE
Fixes #5487

### DIFF
--- a/code/modules/research/xenoarchaeology/misc.dm
+++ b/code/modules/research/xenoarchaeology/misc.dm
@@ -110,4 +110,4 @@
 
 /obj/machinery/alarm/isolation
 	name = "Isolation room air control"
-	req_access = list(access_research)
+	req_one_access = list(access_research, access_atmospherics, access_engine_equip)


### PR DESCRIPTION
Isolation air alarms now expect atmos, engineering, OR research access.
Permissions look fine in the map var editor.
