### PR TITLE
fixes computers eating cards

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -235,10 +235,6 @@ Class Procs:
 
 	src.add_fingerprint(user)
 
-	if(!allowed(user))
-		user << "\red Access Denied."
-		return 1
-
 	var/area/A = get_area(src)
 	A.master.powerupdate = 1
 

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -12,7 +12,10 @@
 	if(..(user))
 		return
 	//src.add_fingerprint(user)	//shouldn't need fingerprints just for looking at it.
-
+	if(!allowed(user))
+		user << "\red Access Denied."
+		return 1
+	
 	ui_interact(user)
 
 /obj/machinery/computer/shuttle_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)


### PR DESCRIPTION
this commit : 
https://github.com/Baystation12/Baystation12/commit/ea1060ac339c4b4ef1692f446865926cf262dd68

added in machinery's attack_hand() proc, line 238

```
if(!allowed(user))
        user << "\red Access Denied."
        return 1
```

to almost all machinery including computers, since they call this proc via their attack_hand() procs.

allowed(user), see access.dm line 94, in turn only checks the user's hand and wear_id,
NOT the card inside the machine,
as different machines have different vars and systems handling how they can be accessed.

instead of fixing the underlying problem, eject card verbs were added like this one : 
https://github.com/Baystation12/Baystation12/commit/30385c22371a4e47ac43eac2fc953f7f8854fad4

this PR reverts that nonsense machinery addition and adds the shuttle_control access check where it belongs.
