### PR TITLE
Fixes the supply shuttle being stuck in warmup if forbidden atoms are aboard

### DIFF
--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -31,6 +31,7 @@
 		
 		if (at_station() && forbidden_atoms_check())
 			//cancel the launch because of forbidden atoms. announce over supply channel?
+			moving_status = SHUTTLE_IDLE
 			return
 		
 		//We pretend it's a long_jump by making the shuttle stay at centcom for the "in-transit" period.


### PR DESCRIPTION
Might be related to #5459, not sure though, especially since this bug would not cause the shuttle to remain in the undocking state.
