### PR TITLE
fixes another heist mode breaking bug

### DIFF
--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -106,9 +106,19 @@ VOX HEIST ROUNDTYPE
 		vox.f_style = "Shaved"
 		for(var/datum/organ/external/limb in vox.organs)
 			limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT)
+		
+		//Now apply cortical stack.
+		var/datum/organ/external/E = vox.get_organ("head")	
+		var/obj/item/weapon/implant/cortical/I = new(vox)
+		I.imp_in = vox
+		I.implanted = 1
+		I.part = E
+		E.implants += I
+		cortical_stacks += I
+		
 		vox.equip_vox_raider()
 		vox.regenerate_icons()
-
+		
 		raider.objectives = raid_objectives
 		greet_vox(raider)
 


### PR DESCRIPTION
vox can never win their inviolate_crew objective due to not having cortical stacks put in them on setup.
i took this code from one_click_antag's create_vox_raider() and edited it slightly.
i was thinking about merging the two procs into one but i will leave that for you to decide.
