### PR TITLE
Amended speech synthesizer.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -41,7 +41,14 @@
 			modules += O
 
 /obj/item/weapon/robot_module/proc/add_languages(var/mob/living/silicon/robot/R)
-	R.add_language("Tradeband", 0)
+	R.add_language("Sol Common", 1)
+	R.add_language("Sinta'unathi", 1)
+	R.add_language("Siik'maas", 1)
+	R.add_language("Siik'tajr", 0)
+	R.add_language("Skrellian", 1)
+	R.add_language("Rootspeak", 1)
+	R.add_language("Tradeband", 1)
+	R.add_language("Gutter", 1)
 
 /obj/item/weapon/robot_module/standard
 	name = "standard robot module"
@@ -233,16 +240,6 @@
 		src.emag.name = "Mickey Finn's Special Brew"
 		return
 
-	add_languages(var/mob/living/silicon/robot/R)
-		//full set of languages
-		R.add_language("Sol Common", 1)
-		R.add_language("Sinta'unathi", 1)
-		R.add_language("Siik'maas", 1)
-		R.add_language("Siik'tajr", 0)
-		R.add_language("Skrellian", 1)
-		R.add_language("Rootspeak", 1)
-		R.add_language("Tradeband", 1)
-		R.add_language("Gutter", 1)
 
 /obj/item/weapon/robot_module/butler/respawn_consumable(var/mob/living/silicon/robot/R)
 	var/obj/item/weapon/reagent_containers/food/condiment/enzyme/E = locate() in src.modules


### PR DESCRIPTION
All robots can understand all languages, minus Vox, and cannot speak the Tajaran language that requires extra appendages such as tails ect, and cannot speak Vox as they can't understand it either.

Removed module specific languages and added them to the area where a robot has its languages added upon creation, making it so all modules will have them
