### PR TITLE
fixes #5449

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1288,6 +1288,7 @@
 					chargecount++
 				else
 					chargecount = 0
+					charging = 0
 
 				if(chargecount == 10)
 


### PR DESCRIPTION
missing variable updating lead to APCs stuck in green status during powersinks.
see https://github.com/Baystation12/Baystation12/issues/5449
