### PR TITLE
Made msay read-only for admins

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -60,7 +60,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/
 	/client/proc/cmd_admin_say,			/*admin-only ooc chat*/
 	/datum/admins/proc/PlayerNotes,
-	/client/proc/cmd_mod_say,
+//	/client/proc/cmd_mod_say,
 	/datum/admins/proc/show_player_info,
 	/client/proc/free_slot,			/*frees slot for chosen job*/
 	/client/proc/cmd_admin_change_custom_event,


### PR DESCRIPTION
To prevent accidental leaks of sensitive information into it.
![Alt Text](http://i.gyazo.com/a71ce86a2c413b4a310e9b0db63aecf4.png)
Admins can see the messages, but cannot directly write there. They can contact mentors via PM if needed.
