### PR TITLE
alternative to PR #5561, msay removal

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -22,8 +22,11 @@
 	set name = "Msay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))	return
-
+	if(config.mods_are_mentors && !check_rights(R_MENTOR))
+		return
+	else if(!check_rights(R_ADMIN|R_MOD))
+		return
+	
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	log_admin("MOD: [key_name(src)] : [msg]")
 


### PR DESCRIPTION
instead of removing msay from admins altogether like in
https://github.com/Baystation12/Baystation12/pull/5561
this will only block it when mentors are used instead of moderators.
