### PR TITLE
Doors now remember their last command and retry if they fail

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -77,6 +77,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	icon_state = "door_closed"
 	power_channel = ENVIRON
 
+	explosion_resistance = 15
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI
 	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -6,7 +6,6 @@ obj/machinery/door/airlock
 	var/frequency
 	var/shockedby = list()
 	var/datum/radio_frequency/radio_connection
-	explosion_resistance = 15
 
 obj/machinery/door/airlock/proc/can_radio()
 	if( !arePowerSystemsOn() || (stat & NOPOWER) || isWireCut(AIRLOCK_WIRE_AI_CONTROL) )

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -6,12 +6,16 @@ obj/machinery/door/airlock
 	var/frequency
 	var/shockedby = list()
 	var/datum/radio_frequency/radio_connection
+	var/cur_command = null	//the command the door is currently attempting to complete
 
 obj/machinery/door/airlock/proc/can_radio()
 	if( !arePowerSystemsOn() || (stat & NOPOWER) || isWireCut(AIRLOCK_WIRE_AI_CONTROL) )
 		return 0
 	return 1
 
+obj/machinery/door/airlock/process()
+	..()
+	execute_current_command()
 
 obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 	if (!can_radio()) return
@@ -20,7 +24,19 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 
 	if(id_tag != signal.data["tag"] || !signal.data["command"]) return
 
-	switch(signal.data["command"])
+	cur_command = signal.data["command"]
+	execute_current_command()
+
+obj/machinery/door/airlock/proc/execute_current_command()
+	if (!cur_command)
+		return
+	
+	do_command(cur_command)
+	if (command_completed(cur_command))
+		cur_command = null
+
+obj/machinery/door/airlock/proc/do_command(var/command)
+	switch(command)
 		if("open")
 			open()
 
@@ -47,9 +63,30 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 
 			lock()
 			sleep(2)
-
+	
 	send_status()
 
+obj/machinery/door/airlock/proc/command_completed(var/command)
+	switch(command)
+		if("open")
+			return (!density)
+
+		if("close")
+			return density
+
+		if("unlock")
+			return !locked
+
+		if("lock")
+			return locked
+
+		if("secure_open")
+			return (locked && !density)
+
+		if("secure_close")
+			return (locked && density)
+	
+	return 1	//Unknown command. Just assume it's completed.
 
 obj/machinery/door/airlock/proc/send_status()
 	if(radio_connection)


### PR DESCRIPTION
This should prevent docking ports from requiring manual intervention if someone stands in the way of a door.
