### PR TITLE
Loyalty Implants

### DIFF
--- a/code/WorkInProgress/Sigyn/Department Sec/jobs.dm
+++ b/code/WorkInProgress/Sigyn/Department Sec/jobs.dm
@@ -83,9 +83,9 @@ proc/assign_sec_to_department(var/mob/living/carbon/human/H)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+
+		implant_loyalty(H)
+
 		return 1
 
 /obj/item/device/radio/headset/headset_sec/department/New()

--- a/code/WorkInProgress/Sigyn/Softcurity/jobs.dm
+++ b/code/WorkInProgress/Sigyn/Softcurity/jobs.dm
@@ -23,9 +23,9 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/taser(H), slot_s_store)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+
+		H.implant_loyalty(src) // Will not do so if config is set to disallow.
+
 		return 1
 
 
@@ -52,9 +52,9 @@
 		H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_l_store)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+
+		H.implant_loyalty(src) // // Will not do so if config is set to disallow.
+
 		return 1
 
 
@@ -89,9 +89,7 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/evidence(H), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/device/detective_scanner(H), slot_in_backpack)
 
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+		H.implant_loyalty(src) // Will not do so if config is set to disallow.
 		return 1
 
 
@@ -118,9 +116,9 @@
 		H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_l_store)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+
+		H.implant_loyalty(src) // Will not do so if config is set to disallow.
+
 		return 1
 
 /datum/job/hop

--- a/code/WorkInProgress/Sigyn/Softcurity/secure_closet.dm
+++ b/code/WorkInProgress/Sigyn/Softcurity/secure_closet.dm
@@ -70,7 +70,7 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 		new /obj/item/weapon/cartridge/hos(src)
 		new /obj/item/device/radio/headset/heads/hos(src)
-		new /obj/item/weapon/storage/lockbox/loyalty(src)
+		if (config.use_loyalty_implants) new /obj/item/weapon/storage/lockbox/loyalty(src)
 		new /obj/item/weapon/storage/flashbang_kit(src)
 		new /obj/item/weapon/storage/belt/security(src)
 		new /obj/item/device/flash(src)

--- a/code/WorkInProgress/kilakk/responseteam.dm
+++ b/code/WorkInProgress/kilakk/responseteam.dm
@@ -231,9 +231,7 @@ var/global/admin_emergency_team = 0 // Used for admin-spawned response teams
 	// equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(src), slot_in_backpack) // Regular medkit
 
 	// Loyalty implants
-	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)
-	L.imp_in = src
-	L.implanted = 1
+	implant_loyalty(src)
 
 	// ID cards
 	var/obj/item/weapon/card/id/E = new(src)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -112,6 +112,8 @@
 	var/revival_cloning = 1
 	var/revival_brain_life = -1
 
+	var/use_loyalty_implants = 0
+
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
 	var/run_speed = 0
@@ -521,10 +523,21 @@
 					config.revival_cloning = value
 				if("revival_brain_life")
 					config.revival_brain_life = value
+				if("organ_health_multiplier")
+					config.organ_health_multiplier = value / 100
+				if("organ_regeneration_multiplier")
+					config.organ_regeneration_multiplier = value / 100
+				if("bones_can_break")
+					config.bones_can_break = value
+				if("limbs_can_break")
+					config.limbs_can_break = value
+
+
 				if("run_speed")
 					config.run_speed = value
 				if("walk_speed")
 					config.walk_speed = value
+
 				if("human_delay")
 					config.human_delay = value
 				if("robot_delay")
@@ -537,14 +550,11 @@
 					config.slime_delay = value
 				if("animal_delay")
 					config.animal_delay = value
-				if("organ_health_multiplier")
-					config.organ_health_multiplier = value / 100
-				if("organ_regeneration_multiplier")
-					config.organ_regeneration_multiplier = value / 100
-				if("bones_can_break")
-					config.bones_can_break = value
-				if("limbs_can_break")
-					config.limbs_can_break = value
+
+
+				if("use_loyalty_implants")
+					config.use_loyalty_implants = 1
+
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -512,34 +512,31 @@ datum/mind
 					H << "\blue <Font size =3><B>Your loyalty implant has been deactivated.</B></FONT>"
 
 				if("add")
-					H.implant_loyalty(src)
-
-					if(config.use_loyalty_implants) // The following won't occur if there are not loyalty implants.
-						H << "\red <Font size =3><B>You somehow have become the recepient of a loyalty transplant, and it just activated!</B></FONT>"
-						if(src in ticker.mode.revolutionaries)
-							special_role = null
-							ticker.mode.revolutionaries -= src
-							src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
-						if(src in ticker.mode.head_revolutionaries)
-							special_role = null
-							ticker.mode.head_revolutionaries -=src
-							src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
-						if(src in ticker.mode.cult)
-							ticker.mode.cult -= src
-							ticker.mode.update_cult_icons_removed(src)
-							special_role = null
-							var/datum/game_mode/cult/cult = ticker.mode
-							if (istype(cult))
-								cult.memorize_cult_objectives(src)
-							current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being in a cult.  Have a productive day!</B></FONT>"
-							memory = ""
-						if(src in ticker.mode.traitors)
-							ticker.mode.traitors -= src
-							special_role = null
-							current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a traitor to Nanotrasen.  Have a nice day!</B></FONT>"
-							log_admin("[key_name_admin(usr)] has de-traitor'ed [current].")
-					else
-						usr << "Loyalty implants are currently disabled for your server in the configuration files."
+					H.implant_loyalty(H, override = TRUE)
+					H << "\red <Font size =3><B>You somehow have become the recepient of a loyalty transplant, and it just activated!</B></FONT>"
+					if(src in ticker.mode.revolutionaries)
+						special_role = null
+						ticker.mode.revolutionaries -= src
+						src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
+					if(src in ticker.mode.head_revolutionaries)
+						special_role = null
+						ticker.mode.head_revolutionaries -=src
+						src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
+					if(src in ticker.mode.cult)
+						ticker.mode.cult -= src
+						ticker.mode.update_cult_icons_removed(src)
+						special_role = null
+						var/datum/game_mode/cult/cult = ticker.mode
+						if (istype(cult))
+							cult.memorize_cult_objectives(src)
+						current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being in a cult.  Have a productive day!</B></FONT>"
+						memory = ""
+					if(src in ticker.mode.traitors)
+						ticker.mode.traitors -= src
+						special_role = null
+						current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a traitor to Nanotrasen.  Have a nice day!</B></FONT>"
+						log_admin("[key_name_admin(usr)] has de-traitor'ed [current].")
+				else
 
 
 		else if (href_list["revolution"])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -510,37 +510,37 @@ datum/mind
 								I.Del()
 								break
 					H << "\blue <Font size =3><B>Your loyalty implant has been deactivated.</B></FONT>"
-				if("add")
-					var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-					L.imp_in = H
-					L.implanted = 1
-					var/datum/organ/external/affected = H.organs_by_name["head"]
-					affected.implants += L
-					L.part = affected
 
-					H << "\red <Font size =3><B>You somehow have become the recepient of a loyalty transplant, and it just activated!</B></FONT>"
-					if(src in ticker.mode.revolutionaries)
-						special_role = null
-						ticker.mode.revolutionaries -= src
-						src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
-					if(src in ticker.mode.head_revolutionaries)
-						special_role = null
-						ticker.mode.head_revolutionaries -=src
-						src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
-					if(src in ticker.mode.cult)
-						ticker.mode.cult -= src
-						ticker.mode.update_cult_icons_removed(src)
-						special_role = null
-						var/datum/game_mode/cult/cult = ticker.mode
-						if (istype(cult))
-							cult.memorize_cult_objectives(src)
-						current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being in a cult.  Have a productive day!</B></FONT>"
-						memory = ""
-					if(src in ticker.mode.traitors)
-						ticker.mode.traitors -= src
-						special_role = null
-						current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a traitor to Nanotrasen.  Have a nice day!</B></FONT>"
-						log_admin("[key_name_admin(usr)] has de-traitor'ed [current].")
+				if("add")
+					H.implant_loyalty(src)
+
+					if(config.use_loyalty_implants) // The following won't occur if there are not loyalty implants.
+						H << "\red <Font size =3><B>You somehow have become the recepient of a loyalty transplant, and it just activated!</B></FONT>"
+						if(src in ticker.mode.revolutionaries)
+							special_role = null
+							ticker.mode.revolutionaries -= src
+							src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
+						if(src in ticker.mode.head_revolutionaries)
+							special_role = null
+							ticker.mode.head_revolutionaries -=src
+							src << "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>"
+						if(src in ticker.mode.cult)
+							ticker.mode.cult -= src
+							ticker.mode.update_cult_icons_removed(src)
+							special_role = null
+							var/datum/game_mode/cult/cult = ticker.mode
+							if (istype(cult))
+								cult.memorize_cult_objectives(src)
+							current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being in a cult.  Have a productive day!</B></FONT>"
+							memory = ""
+						if(src in ticker.mode.traitors)
+							ticker.mode.traitors -= src
+							special_role = null
+							current << "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a traitor to Nanotrasen.  Have a nice day!</B></FONT>"
+							log_admin("[key_name_admin(usr)] has de-traitor'ed [current].")
+					else
+						usr << "Loyalty implants are currently disabled for your server in the configuration files."
+
 
 		else if (href_list["revolution"])
 			current.hud_updateflag |= (1 << SPECIALROLE_HUD)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -681,14 +681,6 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	access = access_armory
 	group = "Security"
 
-/datum/supply_packs/loyalty
-	name = "Loyalty implant crate"
-	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
-	cost = 60
-	containertype = /obj/structure/closet/crate/secure
-	containername = "Loyalty implant crate"
-	access = access_armory
-	group = "Security"
 
 /datum/supply_packs/ballistic
 	name = "Ballistic gear crate"
@@ -724,6 +716,17 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containername = "Shotgun shells"
 	access = access_armory
 	group = "Security"
+
+/*
+/datum/supply_packs/loyalty
+	name = "Loyalty implant crate"
+	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Loyalty implant crate"
+	access = access_armory
+	group = "Security"
+*/
 
 /datum/supply_packs/expenergy
 	name = "Experimental energy gear crate"

--- a/code/game/gamemodes/epidemic/epidemic.dm
+++ b/code/game/gamemodes/epidemic/epidemic.dm
@@ -71,7 +71,7 @@
 	world << sound('sound/AI/commandreport.ogg')
 
 	// add an extra law to the AI to make sure it cooperates with the heads
-	var/extra_law = "Crew authorized to know of pathogen [virus_name]'s existence are: Heads of command, any crew member with loyalty implant. Do not allow unauthorized personnel to gain knowledge of [virus_name]. Aid authorized personnel in quarantining and neutrlizing the outbreak. This law overrides all other laws."
+	var/extra_law = "Crew authorized to know of pathogen [virus_name]'s existence are: Heads of command. Do not allow unauthorized personnel to gain knowledge of [virus_name]. Aid authorized personnel in quarantining and neutrlizing the outbreak. This law overrides all other laws."
 	for(var/mob/living/silicon/ai/M in world)
 		M.add_ion_law(extra_law)
 		M << "\red " + extra_law

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -32,13 +32,10 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H), slot_r_hand)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
 		world << "<b>[H.real_name] is the captain!</b>"
-		var/datum/organ/external/affected = H.organs_by_name["head"]
-		affected.implants += L
-		L.part = affected
+
+		H.implant_loyalty(src)
+
 		return 1
 
 	get_access()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -357,10 +357,8 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
-		var/datum/organ/external/affected = H.organs_by_name["head"]
-		affected.implants += L
-		L.part = affected
+
+		H.implant_loyalty(H)
+
+
 		return 1

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -39,12 +39,7 @@
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
-		var/datum/organ/external/affected = H.organs_by_name["head"]
-		affected.implants += L
-		L.part = affected
+		H.implant_loyalty(H)
 		return 1
 
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -2,10 +2,6 @@
 #define MALFUNCTION_PERMANENT 2
 
 
-/mob/living/carbon/human/
-
-
-
 /obj/item/weapon/implant
 	name = "implant"
 	icon = 'icons/obj/device.dmi'

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -1,5 +1,11 @@
 #define MALFUNCTION_TEMPORARY 1
 #define MALFUNCTION_PERMANENT 2
+
+
+/mob/living/carbon/human/
+
+
+
 /obj/item/weapon/implant
 	name = "implant"
 	icon = 'icons/obj/device.dmi'

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -113,8 +113,7 @@
 
 
 	New()
-		if (config.use_loyalty_implants)
-			src.imp = new /obj/item/weapon/implant/loyalty( src )
+		src.imp = new /obj/item/weapon/implant/loyalty( src )
 		..()
 		return
 

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -113,7 +113,8 @@
 
 
 	New()
-		src.imp = new /obj/item/weapon/implant/loyalty( src )
+		if (config.use_loyalty_implants)
+			src.imp = new /obj/item/weapon/implant/loyalty( src )
 		..()
 		return
 

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -60,8 +60,7 @@
 	name = "implanter-loyalty"
 
 /obj/item/weapon/implanter/loyalty/New()
-	if(config.use_loyalty_implants)
-		src.imp = new /obj/item/weapon/implant/loyalty( src )
+	src.imp = new /obj/item/weapon/implant/loyalty( src )
 	..()
 	update()
 	return

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -60,12 +60,11 @@
 	name = "implanter-loyalty"
 
 /obj/item/weapon/implanter/loyalty/New()
-	src.imp = new /obj/item/weapon/implant/loyalty( src )
+	if(config.use_loyalty_implants)
+		src.imp = new /obj/item/weapon/implant/loyalty( src )
 	..()
 	update()
 	return
-
-
 
 /obj/item/weapon/implanter/explosive
 	name = "implanter (E)"

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -158,9 +158,7 @@ var/global/sent_strike_team = 0
 	equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse_rifle(src), slot_r_hand)
 
 
-	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)//Here you go Deuryn
-	L.imp_in = src
-	L.implanted = 1
+	implant_loyalty(src)
 
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -317,8 +317,8 @@
 		if(armor >= 2)	return
 
 
-/mob/living/carbon/human/proc/implant_loyalty(mob/living/carbon/human/M)
-	if(!config.use_loyalty_implants) return
+/mob/living/carbon/human/proc/implant_loyalty(mob/living/carbon/human/M, override = FALSE) // Won't override by default.
+	if(!config.use_loyalty_implants && !override) return // Nuh-uh.
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(M)
 	L.imp_in = M

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -317,6 +317,16 @@
 		if(armor >= 2)	return
 
 
+/mob/living/carbon/human/proc/implant_loyalty(mob/living/carbon/human/M)
+	if(!config.use_loyalty_implants) return
+
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(M)
+	L.imp_in = M
+	L.implanted = 1
+	var/datum/organ/external/affected = M.organs_by_name["head"]
+	affected.implants += L
+	L.part = affected
+
 /mob/living/carbon/human/proc/is_loyalty_implanted(mob/living/carbon/human/M)
 	for(var/L in M.contents)
 		if(istype(L, /obj/item/weapon/implant/loyalty))

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1358,6 +1358,7 @@ datum/design/nanopaste
 	materials = list("$metal" = 7000, "$glass" = 7000)
 	build_path = "/obj/item/stack/nanopaste"
 
+/* // Removal of loyalty implants. Can't think of a way to add this to the config option.
 datum/design/implant_loyal
 	name = "loyalty implant"
 	desc = "Makes you loyal or such."
@@ -1366,6 +1367,7 @@ datum/design/implant_loyal
 	build_type = PROTOLATHE
 	materials = list("$metal" = 7000, "$glass" = 7000)
 	build_path = "/obj/item/weapon/implant/loyalty"
+*/
 
 datum/design/implant_chem
 	name = "chemical implant"

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -56,3 +56,11 @@ MONKEY_DELAY 0
 ALIEN_DELAY 0
 METROID_DELAY 0
 ANIMAL_DELAY 0
+
+
+### Miscellaneous ###
+
+## Config options which, of course, don't fit into previous categories.
+
+## Remove the # in front of this config option to have loyalty implants spawn by default on your server.
+#USE_LOYALTY_IMPLANTS

--- a/maps/tgstation2.dmm
+++ b/maps/tgstation2.dmm
@@ -134,7 +134,7 @@
 "acD" = (/obj/structure/stool/bed/chair{dir = 1},/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/machinery/atmospherics/unary/vent_pump{dir = 1; external_pressure_bound = 101.325; on = 1; pressure_checks = 1},/turf/simulated/floor{icon_state = "red"; dir = 6},/area/security/prison)
 "acE" = (/obj/structure/rack,/obj/item/weapon/gun/energy/laser,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/window/brigdoor{dir = 4; name = "Weapons locker"; req_access_txt = "3"},/turf/simulated/floor{icon_state = "vault"; dir = 8},/area/security/warden)
 "acF" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/camera{c_tag = "Brig East"; dir = 8},/turf/simulated/floor{icon_state = "redcorner"; dir = 4},/area/security/brig)
-"acG" = (/obj/structure/rack,/obj/item/weapon/storage/lockbox/loyalty,/turf/simulated/floor{icon_state = "vault"; dir = 8},/area/security/warden)
+"acG" = (/obj/structure/rack,/turf/simulated/floor{icon_state = "vault"; dir = 8},/area/security/warden)
 "acH" = (/obj/machinery/flasher/portable,/turf/simulated/floor{icon_state = "vault"; dir = 8},/area/security/warden)
 "acI" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/turf/simulated/floor,/area/security/brig)
 "acJ" = (/obj/structure/rack,/obj/item/clothing/suit/armor/riot,/obj/item/weapon/melee/baton,/obj/item/weapon/shield/riot,/obj/item/clothing/head/helmet/riot,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/window/brigdoor{dir = 8; name = "Weapons locker"; req_access_txt = "3"},/turf/simulated/floor{icon_state = "vault"; dir = 8},/area/security/warden)


### PR DESCRIPTION
Creates a configuration setting to allow the regular usage of loyalty implants on the server. If it's allowed, jobs set to spawn with loyalty implants will spawn with loyalty implants. If it's not, jobs set to spawn with loyalty implants will not spawn with loyalty implants.

Admins are still capable of spawning them in and using the player panel to give someone one, if they wish to for whatever reason. They still have the same mechanical features of loyalty implants, so it might be useful for certain events/special things that an admin wishes to use.

Removes all instances of loyalty implants from the map, and keeps them from spawning naturally if the configuration file is set to disallow them.

Comments out supply packs and designs for them, because I could not think of a suitable way to disable it only when it is configured to be disabled. Easy to enable back in through that, if a downstream server wishes to do so.

I'm pretty sure that's it. Feel free to yell at me for obvious blunders, and inform me of not so obvious blunders.
