### PR TITLE
Made LOOC show character names of living players, fixing #5633

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -130,6 +130,10 @@ var/global/normal_ooc_colour = "#002eb8"
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
 
 	var/list/heard = get_mobs_in_view(7, src.mob)
+	var/mob/S = src.mob
+	var/display_name = S.key
+	if(S.stat != DEAD)
+		display_name = S.name
 	for(var/mob/M in heard)
 		if(!M.client)
 			continue
@@ -138,7 +142,6 @@ var/global/normal_ooc_colour = "#002eb8"
 			continue //they are handled after that
 
 		if(C.prefs.toggles & CHAT_LOOC)
-			var/display_name = src.key
 			if(holder)
 				if(holder.fakekey)
 					if(C.holder)
@@ -148,7 +151,8 @@ var/global/normal_ooc_colour = "#002eb8"
 			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
 	for(var/client/C in admins)
 		if(C.prefs.toggles & CHAT_LOOC)
-			var/prefix = "(R)LOOC"
-			if (C.mob in heard)
-				prefix = "LOOC"
-			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[src.key]:</EM> <span class='message'>[msg]</span></span></font>"
+			var/prefix = "LOOC"
+			if (!(C.mob in heard))
+				prefix = "(R)LOOC"
+				display_name = S.key
+			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -151,8 +151,7 @@ var/global/normal_ooc_colour = "#002eb8"
 			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
 	for(var/client/C in admins)
 		if(C.prefs.toggles & CHAT_LOOC)
-			var/prefix = "LOOC"
-			if (!(C.mob in heard))
-				prefix = "(R)LOOC"
-				display_name = S.key
+			var/prefix = "(R)LOOC"
+			if (C.mob in heard)
+				prefix = "LOOC"
 			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"


### PR DESCRIPTION
This fixes #5633. Basically, any living player who uses LOOC will send their message with their character's name to anyone listening in the area. Observers/Dead folks who LOOC will show their BYOND keys.

Admins who hear global LOOC will see character names of people in their area, and keys of people across the map. This made the most sense to me, so it's easy for an admin to tell who's LOOCing in their area vs globally, in addition to the (R)LOOC prefix. It'd be easy to have admins see both name and key, or whatever else, should I be crazy in putting it this way.
