### PR TITLE
Fixes air alarms not updating icons, fixes siphoning or cycling being stopped even though environmental mode is set

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -87,8 +87,6 @@
 			for(var/area/RA in related)
 				for(var/obj/machinery/camera/C in RA)
 					C.network.Remove("Atmosphere Alarms")
-				for (var/obj/machinery/alarm/AA in RA)
-					AA.update_icon()
 			for(var/mob/living/silicon/aiPlayer in player_list)
 				aiPlayer.cancelAlarm("Atmosphere", src, src)
 			for(var/obj/machinery/computer/station_alert/a in machines)
@@ -101,8 +99,6 @@
 				for(var/obj/machinery/camera/C in RA)
 					cameras += C
 					C.network.Add("Atmosphere Alarms")
-				for (var/obj/machinery/alarm/AA in RA)
-					AA.update_icon()
 			for(var/mob/living/silicon/aiPlayer in player_list)
 				aiPlayer.triggerAlarm("Atmosphere", src, cameras, src)
 			for(var/obj/machinery/computer/station_alert/a in machines)
@@ -110,6 +106,10 @@
 			air_doors_close()
 		
 		atmosalm = danger_level
+		for(var/area/RA in related)
+			for (var/obj/machinery/alarm/AA in RA)
+				AA.update_icon()
+		
 		return 1
 	return 0
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -405,6 +405,12 @@
 	return 1
 
 /obj/machinery/alarm/proc/apply_mode()
+	//propagate mode to other air alarms in the area
+	//TODO: make it so that players can choose between applying the new mode to the room they are in (related area) vs the entire alarm area
+	for (var/area/RA in alarm_area.related)
+		for (var/obj/machinery/alarm/AA in RA)
+			AA.mode = mode
+	
 	switch(mode)
 		if(AALARM_MODE_SCRUBBING)
 			for(var/device_id in alarm_area.air_scrub_names)


### PR DESCRIPTION
Fixes air alarms not panic siphoning or cycling through the environmental mode setting when the alarm area contains multiple air alarms.

Also _finally_ fixes the air alarm icon update, for real (I really, really hope). I'm not sure how I missed the fact that the icon was being updated in the wrong place the first time.
