### PR TITLE
Fixes #5640 Make sparks effect target mob, not organ

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -355,7 +355,7 @@ INFECTION_LEVEL_THREE	above this germ level the player will take additional toxi
 Note that amputating the affected organ does in fact remove the infection from the player's body.
 */
 /datum/organ/external/proc/update_germs()
-	
+
 	if(status & (ORGAN_ROBOT|ORGAN_DESTROYED) || (owner.species && owner.species.flags & IS_PLANT)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
 		germ_level = 0
 		return
@@ -363,7 +363,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(owner.bodytemperature >= 170)	//cryo stops germs from moving and doing their bad stuffs
 		//** Syncing germ levels with external wounds
 		handle_germ_sync()
-		
+
 		//** Handle antibiotics and curing infections
 		handle_antibiotics()
 
@@ -386,10 +386,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /datum/organ/external/proc/handle_germ_effects()
 	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
-	
+
 	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE && prob(60))	//this could be an else clause, but it looks cleaner this way
 		germ_level--	//since germ_level increases at a rate of 1 per second with dirty wounds, prob(60) should give us about 5 minutes before level one.
-	
+
 	if(germ_level >= INFECTION_LEVEL_ONE)
 		//having an infection raises your body temperature
 		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 1)* min(germ_level/INFECTION_LEVEL_THREE, 1) + owner.species.body_temperature
@@ -400,7 +400,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(prob(round(germ_level/10)))
 			if (antibiotics < 5)
 				germ_level++
-			
+
 			if (prob(5))	//adjust this to tweak how fast people take toxin damage from infections
 				owner.adjustToxLoss(1)
 
@@ -411,7 +411,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if (I.germ_level > 0 && I.germ_level < min(germ_level, INFECTION_LEVEL_TWO))	//once the organ reaches whatever we can give it, or level two, switch to a different one
 				if (!target_organ || I.germ_level > target_organ.germ_level)	//choose the organ with the highest germ_level
 					target_organ = I
-		
+
 		if (!target_organ)
 			//figure out which organs we can spread germs to and pick one at random
 			var/list/candidate_organs = list()
@@ -420,7 +420,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 					candidate_organs += I
 			if (candidate_organs.len)
 				target_organ = pick(candidate_organs)
-		
+
 		if (target_organ)
 			target_organ.germ_level++
 
@@ -800,8 +800,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		owner.u_equip(c_hand)
 		owner.emote("me", 1, "drops what they were holding, their [hand_name] malfunctioning!")
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, src)
-		spark_system.attach(src)
+		spark_system.set_up(5, 0, owner)
+		spark_system.attach(owner)
 		spark_system.start()
 		spawn(10)
 			del(spark_system)


### PR DESCRIPTION
The malfunction sparks were referencing a var src, which in most other places is the main object itself, here that's the organ and it doesn't have a loc. Changed it to reference the organ's owner, which is the mob itself and DOES have a loc.) Looks like a copy/paste error as other calls to the sparks DO call src, which makes sense as the object itself sparks, not a sub element of the object (like an organ.)

As a side note, it seems my Dream Maker didn't like some of the empty whitespace that was in the file as well.
