### PR TITLE
TComms heat fix + repairing

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -21,6 +21,19 @@
 	if(istype(P, /obj/item/device/multitool))
 		attack_hand(user)
 
+
+	// REPAIRING: Use Nanopaste to repair 10-20 integrity points.
+	if(istype(P, /obj/item/stack/nanopaste))
+		var/obj/item/stack/nanopaste/T = P
+		if (integrity < 100)               								//Damaged, let's repair!
+			integrity = between(0, integrity + rand(10,20), 100)
+			T.use(1)
+			usr << "You apply the Nanopaste to [src], repairing some of the damage."
+		else
+			usr << "This machine is already in perfect condition."
+		return
+
+
 	switch(construct_op)
 		if(0)
 			if(istype(P, /obj/item/weapon/screwdriver))

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -224,7 +224,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			damage_chance = 50
 		if((T0C + 200) to INFINITY)					// More than 200C, INFERNO. Takes damage every tick.
 			damage_chance = 100
-	if (damage_chance > 100 || prob(damage_chance))
+	if (damage_chance && prob(damage_chance))
 		integrity = between(0, integrity - 1, 100)
 
 

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -215,10 +215,20 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	// Checks heat from the environment and applies any integrity damage
 	var/datum/gas_mixture/environment = loc.return_air()
 	switch(environment.temperature)
-		if(T0C to (T20C + 20))
+		if(0 to (T0C + 40))                         // Absolute zero to 40�C, safe
 			integrity = between(0, integrity, 100)
-		if((T20C + 20) to (T0C + 70))
+		if((T0C + 40) to (T0C + 70))                // 40�C-70�C, minor overheat, 10% chance of taking damage
+			if (prob(10))
+				integrity = max(0, integrity - 1)
+		if((T0C + 70) to (T0C + 130))				// 70�C-130�C, major overheat, 25% chance of taking damage
+			if (prob(25))
+				integrity = max(0, integrity - 1)
+		if((T0C + 130) to (T0C + 200))              // 130�C-200�C, dangerous overheat, 50% chance of taking damage
+			if (prob(50))
+				integrity = max(0, integrity - 1)
+		if((T0C + 200) to INFINITY)					// More than 200�C, INFERNO. Takes damage every tick.
 			integrity = max(0, integrity - 1)
+
 	if(delay)
 		delay--
 	else

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -215,18 +215,18 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	// Checks heat from the environment and applies any integrity damage
 	var/datum/gas_mixture/environment = loc.return_air()
 	switch(environment.temperature)
-		if(0 to (T0C + 40))                         // Absolute zero to 40�C, safe
+		if(0 to (T0C + 40))                         // Absolute zero to 40C, safe
 			integrity = between(0, integrity, 100)
-		if((T0C + 40) to (T0C + 70))                // 40�C-70�C, minor overheat, 10% chance of taking damage
+		if((T0C + 40) to (T0C + 70))                // 40C-70C, minor overheat, 10% chance of taking damage
 			if (prob(10))
 				integrity = max(0, integrity - 1)
-		if((T0C + 70) to (T0C + 130))				// 70�C-130�C, major overheat, 25% chance of taking damage
+		if((T0C + 70) to (T0C + 130))				// 70C-130C, major overheat, 25% chance of taking damage
 			if (prob(25))
 				integrity = max(0, integrity - 1)
-		if((T0C + 130) to (T0C + 200))              // 130�C-200�C, dangerous overheat, 50% chance of taking damage
+		if((T0C + 130) to (T0C + 200))              // 130C-200C, dangerous overheat, 50% chance of taking damage
 			if (prob(50))
 				integrity = max(0, integrity - 1)
-		if((T0C + 200) to INFINITY)					// More than 200�C, INFERNO. Takes damage every tick.
+		if((T0C + 200) to INFINITY)					// More than 200C, INFERNO. Takes damage every tick.
 			integrity = max(0, integrity - 1)
 
 	if(delay)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -214,20 +214,19 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 /obj/machinery/telecomms/proc/checkheat()
 	// Checks heat from the environment and applies any integrity damage
 	var/datum/gas_mixture/environment = loc.return_air()
+	var/damage_chance = 0                           // Percent based chance of applying 1 integrity damage this tick
 	switch(environment.temperature)
-		if(0 to (T0C + 40))                         // Absolute zero to 40C, safe
-			integrity = between(0, integrity, 100)
 		if((T0C + 40) to (T0C + 70))                // 40C-70C, minor overheat, 10% chance of taking damage
-			if (prob(10))
-				integrity = max(0, integrity - 1)
+			damage_chance = 10
 		if((T0C + 70) to (T0C + 130))				// 70C-130C, major overheat, 25% chance of taking damage
-			if (prob(25))
-				integrity = max(0, integrity - 1)
+			damage_chance = 25
 		if((T0C + 130) to (T0C + 200))              // 130C-200C, dangerous overheat, 50% chance of taking damage
-			if (prob(50))
-				integrity = max(0, integrity - 1)
+			damage_chance = 50
 		if((T0C + 200) to INFINITY)					// More than 200C, INFERNO. Takes damage every tick.
-			integrity = max(0, integrity - 1)
+			damage_chance = 100
+	if (damage_chance > 100 || prob(damage_chance))
+		integrity = between(0, integrity - 1, 100)
+
 
 	if(delay)
 		delay--


### PR DESCRIPTION
Fixes #5644
- TCommsat machinery now randomly takes overheat damage depending on heat level. Higher temperature = damage builds up faster.
- Adds ability to repair TCommsat machinery with Nanopaste. This heals 10-20 HP (integrity)
