### PR TITLE
Allows the AI to select which channel to state laws on

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -93,7 +93,7 @@ var/list/department_radio_keys = list(
 
 		if (speaking.flags & SIGNLANG)
 			say_signlang(message, pick(speaking.signlang_verb), speaking)
-			return
+			return 1
 
 	//speaking into radios
 	if(used_radios.len)
@@ -116,13 +116,13 @@ var/list/department_radio_keys = list(
 		if(pressure < SAY_MINIMUM_PRESSURE)
 			italics = 1
 			message_range = 1
-			
+
 			if (speech_sound)
 				sound_vol *= 0.5	//muffle the sound a bit, so it's like we're actually talking through contact
 
 	var/list/listening = list()
 	var/list/listening_obj = list()
-	
+
 	if(T)
 		var/list/hear = hear(message_range, T)
 		var/list/hearturfs = list()
@@ -144,7 +144,7 @@ var/list/department_radio_keys = list(
 				var/obj/O = I
 				hearturfs += O.locs[1]
 				listening_obj |= O
-			
+
 
 		for(var/mob/M in player_list)
 			if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS))
@@ -165,8 +165,9 @@ var/list/department_radio_keys = list(
 		spawn(0)
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking)
-	
+
 	log_say("[name]/[key] : [message]")
+	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)
 	for (var/mob/O in viewers(src, null))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -392,7 +392,7 @@ var/list/ai_list = list()
 		checklaws()
 
 	if (href_list["lawr"]) // Selects on which channel to state laws
-		var/setchannel = input(usr, "Specify channel.", "Channel selection") in list("State","Common","Science","Command","Medical","Engineering","Security","Supply","Cancel")
+		var/setchannel = input(usr, "Specify channel.", "Channel selection") in list("State","Common","Science","Command","Medical","Engineering","Security","Supply","Binary","Cancel")
 		if(setchannel == "Cancel")
 			return
 		lawchannel = setchannel

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -392,11 +392,10 @@ var/list/ai_list = list()
 		checklaws()
 
 	if (href_list["lawr"]) // Selects on which channel to state laws
-		var/setchannel = input(usr, "Specify channel.", "Channel selection") in list("State","Common","Science","Command","Medical","Engineering","Security","Supply","Binary","Cancel")
+		var/setchannel = input(usr, "Specify channel.", "Channel selection") in list("State","Common","Science","Command","Medical","Engineering","Security","Supply","Binary","Holopad", "Cancel")
 		if(setchannel == "Cancel")
 			return
 		lawchannel = setchannel
-
 		checklaws()
 
 	//Uncomment this line of code if you are enabling the AI Vocal (VOX) announcements.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -27,6 +27,7 @@ var/list/ai_list = list()
 	var/viewalerts = 0
 	var/lawcheck[1]
 	var/ioncheck[1]
+	var/lawchannel = "Common" // Default channel on which to state laws
 	var/icon/holo_icon//Default is assigned when AI is created.
 	var/obj/item/device/pda/ai/aiPDA = null
 	var/obj/item/device/multitool/aiMulti = null
@@ -388,6 +389,14 @@ var/list/ai_list = list()
 			if ("Yes") lawcheck[L+1] = "No"
 			if ("No") lawcheck[L+1] = "Yes"
 //		src << text ("Switching Law [L]'s report status to []", lawcheck[L+1])
+		checklaws()
+
+	if (href_list["lawr"]) // Selects on which channel to state laws
+		var/setchannel = input(usr, "Specify channel.", "Channel selection") in list("State","Common","Science","Command","Medical","Engineering","Security","Supply","Cancel")
+		if(setchannel == "Cancel")
+			return
+		lawchannel = setchannel
+
 		checklaws()
 
 	//Uncomment this line of code if you are enabling the AI Vocal (VOX) announcements.

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -64,8 +64,12 @@
 		if("Security") prefix = ":s "
 		if("Supply") prefix = ":u "
 		if("Binary") prefix = ":b "
+		if("Holopad") prefix = ":h "
+		else prefix = ""
 
-	src.say("[prefix]Current Active Laws:")
+	if(src.say("[prefix]Current Active Laws:") != 1)
+		return
+
 	//src.laws_sanity_check()
 	//src.laws.show_laws(world)
 	var/number = 1

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -51,24 +51,28 @@
 	src.laws_sanity_check()
 	src.laws.clear_supplied_laws()
 
-
-
-
-
 /mob/living/silicon/ai/proc/statelaws() // -- TLE
 //	set category = "AI Commands"
 //	set name = "State Laws"
-	src.say("Current Active Laws:")
+	/var/prefix = ""
+	switch(lawchannel)
+		if("Common") prefix = ";"
+		if("Science") prefix = ":n "
+		if("Command") prefix = ":c "
+		if("Medical") prefix = ":m "
+		if("Engineering") prefix = ":e "
+		if("Security") prefix = ":s "
+		if("Supply") prefix = ":u "
+
+	src.say("[prefix]Current Active Laws:")
 	//src.laws_sanity_check()
 	//src.laws.show_laws(world)
 	var/number = 1
 	sleep(10)
 
-
-
 	if (src.laws.zeroth)
 		if (src.lawcheck[1] == "Yes") //This line and the similar lines below make sure you don't state a law unless you want to. --NeoFite
-			src.say("0. [src.laws.zeroth]")
+			src.say("[prefix]0. [src.laws.zeroth]")
 			sleep(10)
 
 	for (var/index = 1, index <= src.laws.ion.len, index++)
@@ -76,7 +80,7 @@
 		var/num = ionnum()
 		if (length(law) > 0)
 			if (src.ioncheck[index] == "Yes")
-				src.say("[num]. [law]")
+				src.say("[prefix][num]. [law]")
 				sleep(10)
 
 	for (var/index = 1, index <= src.laws.inherent.len, index++)
@@ -84,10 +88,9 @@
 
 		if (length(law) > 0)
 			if (src.lawcheck[index+1] == "Yes")
-				src.say("[number]. [law]")
+				src.say("[prefix][number]. [law]")
 				sleep(10)
 			number++
-
 
 	for (var/index = 1, index <= src.laws.supplied.len, index++)
 		var/law = src.laws.supplied[index]
@@ -95,10 +98,9 @@
 		if (length(law) > 0)
 			if(src.lawcheck.len >= number+1)
 				if (src.lawcheck[number+1] == "Yes")
-					src.say("[number]. [law]")
+					src.say("[prefix][number]. [law]")
 					sleep(10)
 				number++
-
 
 /mob/living/silicon/ai/verb/checklaws() //Gives you a link-driven interface for deciding what laws the statelaws() proc will share with the crew. --NeoFite
 	set category = "AI Commands"
@@ -144,6 +146,8 @@
 				src.lawcheck[number+1] = "Yes"
 			list += {"<A href='byond://?src=\ref[src];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> [law]<BR>"}
 			number++
-	list += {"<br><br><A href='byond://?src=\ref[src];laws=1'>State Laws</A>"}
+
+	list += {"<br><A href='byond://?src=\ref[src];lawr=1'>Channel: [src.lawchannel]</A><br>"}
+	list += {"<A href='byond://?src=\ref[src];laws=1'>State Laws</A>"}
 
 	usr << browse(list, "window=laws")

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -63,6 +63,7 @@
 		if("Engineering") prefix = ":e "
 		if("Security") prefix = ":s "
 		if("Supply") prefix = ":u "
+		if("Binary") prefix = ":b "
 
 	src.say("[prefix]Current Active Laws:")
 	//src.laws_sanity_check()

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -1,9 +1,8 @@
 /mob/living/silicon/ai/say(var/message)
 	if(parent && istype(parent) && parent.stat != 2)
-		parent.say(message)
-		return
+		return parent.say(message)
 		//If there is a defined "parent" AI, it is actually an AI, and it is alive, anything the AI tries to say is said by the parent instead.
-	..(message)
+	return ..(message)
 
 // These Verbs are commented out since we've disabled the AI vocal (VOX) announcements.
 // If you re-enable them there is 3 lines in ai.dm Topic() that you need to uncomment as well.

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -60,7 +60,7 @@
 		return
 
 	var/verb = say_quote(message)
-	
+
 	//parse radio key and consume it
 	var/message_mode = parse_message_mode(message, "general")
 	if (message_mode)
@@ -68,31 +68,31 @@
 			message = trim(copytext(message,2))
 		else
 			message = trim(copytext(message,3))
-	
+
 	if(message_mode && bot_type == IS_ROBOT && message_mode != "binary" && !R.is_component_functioning("radio"))
 		src << "\red Your radio isn't functional at this time."
 		return
-	
-	
+
+
 	//parse language key and consume it
 	var/datum/language/speaking = parse_language(message)
 	if (speaking)
 		verb = speaking.speech_verb
 		message = copytext(message,3)
-	
-	
+
+
 	switch(message_mode)
 		if("department")
 			switch(bot_type)
 				if(IS_AI)
-					AI.holopad_talk(message)
+					return AI.holopad_talk(message)
 				if(IS_ROBOT)
 					log_say("[key_name(src)] : [message]")
 					R.radio.talk_into(src,message,message_mode,verb,speaking)
 				if(IS_PAI)
 					log_say("[key_name(src)] : [message]")
 					P.radio.talk_into(src,message,message_mode,verb,speaking)
-			return
+			return 1
 
 		if("binary")
 			switch(bot_type)
@@ -105,12 +105,13 @@
 					return
 
 			robot_talk(message)
-			return
+			return 1
 		if("general")
 			switch(bot_type)
 				if(IS_AI)
 					if (AI.aiRadio.disabledAi)
 						src << "\red System Error - Transceiver Disabled"
+						return
 					else
 						log_say("[key_name(src)] : [message]")
 						AI.aiRadio.talk_into(src,message,null,verb,speaking)
@@ -120,7 +121,7 @@
 				if(IS_PAI)
 					log_say("[key_name(src)] : [message]")
 					P.radio.talk_into(src,message,null,verb,speaking)
-			return
+			return 1
 
 		else
 			if(message_mode && message_mode in radiochannels)
@@ -128,6 +129,7 @@
 					if(IS_AI)
 						if (AI.aiRadio.disabledAi)
 							src << "\red System Error - Transceiver Disabled"
+							return
 						else
 							log_say("[key_name(src)] : [message]")
 							AI.aiRadio.talk_into(src,message,message_mode,verb,speaking)
@@ -137,7 +139,7 @@
 					if(IS_PAI)
 						log_say("[key_name(src)] : [message]")
 						P.radio.talk_into(src,message,message_mode,verb,speaking)
-				return
+				return 1
 
 	return ..(message,speaking,verb)
 
@@ -172,7 +174,8 @@
 		This is another way of saying that we won't bother dealing with them.*/
 	else
 		src << "No holopad connected."
-	return
+		return
+	return 1
 
 /mob/living/proc/robot_talk(var/message)
 


### PR DESCRIPTION
The AI can now select which channel which to state laws on.
![Selection menu](https://www.dropbox.com/s/phqow0hsmy7rg81/StateLaws4.png?dl=1)

Can state laws as follow:
State plainly - Allows for using the intercom or stating to anyone who might be in the core itself
Over all standard radio channels. This excludes the special ERT, syndicate, etc. channels.
Over binary and holopad.

Example flow:
https://www.dropbox.com/s/hfy6k597vdnwnpm/StateLaws1.png
https://www.dropbox.com/s/lrfod9lk0woqud3/StateLaws2.png
https://www.dropbox.com/s/9mly7b09f40kw1s/StateLaws3.png
https://www.dropbox.com/s/phqow0hsmy7rg81/StateLaws4.png
https://www.dropbox.com/s/d5fu1bzb79k3lyj/StateLaws5.png
