### PR TITLE
Removes Rootspeak from AI and robot languages

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -100,7 +100,6 @@ var/list/ai_list = list()
 	add_language("Siik'maas", 0)
 	add_language("Siik'tajr", 0)
 	add_language("Skrellian", 0)
-	add_language("Rootspeak", 0)
 	add_language("Tradeband", 1)
 	add_language("Gutter", 0)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -47,7 +47,6 @@
 	R.add_language("Siik'maas", 0)
 	R.add_language("Siik'tajr", 0)
 	R.add_language("Skrellian", 0)
-	R.add_language("Rootspeak", 0)
 	R.add_language("Tradeband", 0)
 	R.add_language("Gutter", 0)
 


### PR DESCRIPTION
Given that PR https://github.com/Baystation12/Baystation12/pull/5628 has merged, this seems appropriate.
