### PR TITLE
Docking controllers updates

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -108,7 +108,9 @@
 
 //are we ready for undocking?
 /datum/computer/file/embedded_program/docking/airlock/ready_for_undocking()
-	return airlock_program.check_doors_secured()
+	var/ext_closed = airlock_program.check_exterior_door_secured()
+	var/int_closed = airlock_program.check_interior_door_secured()
+	return (ext_closed || int_closed)
 
 //An airlock controller to be used by the airlock-based docking port controller.
 //Same as a regular airlock controller but allows disabling of the regular airlock functions when docking

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -35,10 +35,10 @@
 	
 	if (istype(M, /obj/machinery/embedded_controller/radio/airlock))	//if our controller is an airlock controller than we can auto-init our tags
 		var/obj/machinery/embedded_controller/radio/airlock/controller = M
-		tag_exterior_door = controller.tag_exterior_door
-		tag_interior_door = controller.tag_interior_door
-		tag_airpump = controller.tag_airpump
-		tag_chamber_sensor = controller.tag_chamber_sensor
+		tag_exterior_door = controller.tag_exterior_door? controller.tag_exterior_door : "[id_tag]_outer"
+		tag_interior_door = controller.tag_interior_door? controller.tag_interior_door : "[id_tag]_inner"
+		tag_airpump = controller.tag_airpump? controller.tag_airpump : "[id_tag]_pump"
+		tag_chamber_sensor = controller.tag_chamber_sensor? controller.tag_chamber_sensor : "[id_tag]_sensor"
 		tag_exterior_sensor = controller.tag_exterior_sensor
 		tag_interior_sensor = controller.tag_interior_sensor
 		memory["secure"] = controller.tag_secure

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -248,9 +248,15 @@
 	return (state == STATE_WAIT && target_state == TARGET_NONE)
 
 //are the doors closed and locked?
+/datum/computer/file/embedded_program/airlock/proc/check_exterior_door_secured()
+	return (memory["exterior_status"]["state"] == "closed" &&  memory["exterior_status"]["lock"] == "locked")
+
+/datum/computer/file/embedded_program/airlock/proc/check_interior_door_secured()
+	return (memory["interior_status"]["state"] == "closed" &&  memory["interior_status"]["lock"] == "locked")
+
 /datum/computer/file/embedded_program/airlock/proc/check_doors_secured()
-	var/ext_closed = (memory["exterior_status"]["state"] == "closed" &&  memory["exterior_status"]["lock"] == "locked")
-	var/int_closed = (memory["interior_status"]["state"] == "closed" &&  memory["interior_status"]["lock"] == "locked")
+	var/ext_closed = check_exterior_door_secured()
+	var/int_closed = check_interior_door_secured()
 	return (ext_closed && int_closed)
 
 /datum/computer/file/embedded_program/airlock/proc/signalDoor(var/tag, var/command)

--- a/code/game/machinery/embedded_controller/escape_pod_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/escape_pod_docking_controller.dm
@@ -1,5 +1,6 @@
 //This controller goes on the escape pod itself
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod
+	name = "escape pod controller"
 	var/datum/shuttle/ferry/escape_pod/pod
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -58,7 +58,7 @@
 	if (istype(M, /obj/machinery/embedded_controller/radio/simple_docking_controller))
 		var/obj/machinery/embedded_controller/radio/simple_docking_controller/controller = M
 		
-		tag_door = controller.tag_door
+		tag_door = controller.tag_door? controller.tag_door : "[id_tag]_hatch"
 			
 		spawn(10)
 			signal_door("update")		//signals connected doors to update their status


### PR DESCRIPTION
- Attempts to simplify the mapping of docking controllers by cutting down on the number of tags that need to be entered. Optional tags have no default value.
- Gives the escape pod controller a name
- Loosens the docking requirements for airlocks. Now they will allow undocking if either the exterior or interior door is closed and locked, so even if one is broken undocking will still be allowed.
