### PR TITLE
Tweaks shotgun beanbag rounds

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -21,6 +21,10 @@
 
 /obj/item/projectile/bullet/weakbullet/beanbag		//because beanbags are not bullets
 	name = "beanbag"
+	damage = 20
+	agony = 60
+	embed = 0
+	sharp = 0
 
 /obj/item/projectile/bullet/weakbullet/rubber
 	name = "rubber bullet"


### PR DESCRIPTION
It didn't seem appropriate that they were identical to the detective's .45 rubber rounds for a variety of reasons, this PR adjusts them to be based off the shotgun stunshot rounds, except they trade reduced agony for increased brute damage.
