### PR TITLE
The AI may now store and return to camera locations

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -1,3 +1,14 @@
+/mob/living/silicon/ai/var/stored_location = null // The last stored camera location
+
+/mob/living/silicon/ai/proc/InvalidTurf(turf/T as turf)
+	if(!T)
+		return 1
+	if(T.z == 2)
+		return 1
+	if(T.z > 6)
+		return 1
+	return 0
+
 /mob/living/silicon/ai/proc/get_camera_list()
 
 	if(src.stat == 2)
@@ -38,6 +49,30 @@
 
 	return
 
+/mob/living/silicon/ai/proc/ai_store_location()
+	set category = "AI Commands"
+	set name = "Store Camera Location"
+	set desc = "Stores your current camera location"
+
+	var/L = src.eyeobj.getLoc()
+	if (InvalidTurf(get_turf(L)))
+		src << "\red Unable to store this location"
+		return
+
+	stored_location = L
+	src << "Location stored"
+
+/mob/living/silicon/ai/proc/ai_goto_location()
+	set category = "AI Commands"
+	set name = "Goto Camera Location"
+	set desc = "Returns to your last stored camera location"
+
+	if (stored_location == null)
+		src << "\red No location stored"
+		return
+
+	src.eyeobj.setLoc(stored_location)
+
 // Used to allow the AI is write in mob names/camera name from the CMD line.
 /datum/trackable
 	var/list/names = list()
@@ -55,12 +90,7 @@
 	for(var/mob/living/M in mob_list)
 		// Easy checks first.
 		// Don't detect mobs on Centcom. Since the wizard den is on Centcomm, we only need this.
-		var/turf/T = get_turf(M)
-		if(!T)
-			continue
-		if(T.z == 2)
-			continue
-		if(T.z > 6)
+		if(InvalidTurf(get_turf(M)))
 			continue
 		if(M == usr)
 			continue

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -51,6 +51,12 @@
 			var/obj/machinery/hologram/holopad/H = ai.current
 			H.move_hologram()
 
+/mob/aiEye/proc/getLoc()
+
+	if(ai)
+		if(!isturf(ai.loc) || !ai.client)
+			return
+		return ai.eyeobj.loc
 
 // AI MOVEMENT
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -129,6 +129,7 @@
 	O.verbs += /mob/living/silicon/ai/proc/ai_roster
 	O.verbs += /mob/living/silicon/ai/proc/ai_store_location
 	O.verbs += /mob/living/silicon/ai/proc/ai_goto_location
+	O.verbs += /mob/living/silicon/ai/proc/ai_remove_location
 
 	O.job = "AI"
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -127,6 +127,8 @@
 	O.verbs += /mob/living/silicon/ai/proc/ai_camera_list
 	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
 	O.verbs += /mob/living/silicon/ai/proc/ai_roster
+	O.verbs += /mob/living/silicon/ai/proc/ai_store_location
+	O.verbs += /mob/living/silicon/ai/proc/ai_goto_location
 
 	O.job = "AI"
 


### PR DESCRIPTION
Grants the AI three new verbs: store-camera-location, goto-camera-location, remove-camera-location
These allows the AI to store and return to a number of camera locations, currently capped at 5.

Has similar limitations as the track-with-camera verb, disallowing saving locations where you cannot generally track entities either.
