### PR TITLE
Moo fix

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -106,7 +106,7 @@
 // Can we speak this language, as opposed to just understanding it?
 /mob/proc/can_speak(datum/language/speaking)
 
-	return ((universal_speak && !(speaking.flags & UNTRANSLATABLE)) || speaking in src.languages)
+	return (universal_speak || speaking in src.languages)
 
 //TBD
 /mob/verb/check_languages()

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -74,7 +74,7 @@
 		return 1
 
 	//Universal speak makes everything understandable, for obvious reasons.
-	else if((src.universal_speak || src.universal_understand) && !(speaking.flags & UNTRANSLATABLE))
+	else if(src.universal_speak || src.universal_understand)
 		return 1
 
 	//Languages are handled after.

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -748,7 +748,7 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define RESTRICTED 2   		// Language can only be accquired by spawning or an admin.
 #define NONVERBAL 4    		// Language has a significant non-verbal component. Speech is garbled without line-of-sight
 #define SIGNLANG 8     		// Language is completely non-verbal. Speech is displayed through emotes for those who can understand.
-#define UNTRANSLATABLE 16 	// Language is not translated by universal_speak or universal_understand.
+#define UNTRANSLATABLE 16 	// Language is not translated by universal_speak or universal_understand. // reverted and unused at the moment
 
 //Flags for zone sleeping
 #define ZONE_ACTIVE 1


### PR DESCRIPTION
reverts the UNTRANSLATABLE language flag countering universal_speak and universal_understand.
should fix https://github.com/Baystation12/Baystation12/issues/5675
and https://github.com/Baystation12/Baystation12/issues/5610
and a few other runtime errors
