### PR TITLE
AI shortcut updates

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -81,6 +81,7 @@
 	than anything else in the game, atoms have separate procs
 	for AI shift, ctrl, and alt clicking.
 */
+
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
 	A.AIShiftClick(src)
 /mob/living/silicon/ai/CtrlClickOn(var/atom/A)
@@ -113,14 +114,19 @@
 	else
 		Topic("aiDisable=4", list("aiDisable"="4"), 1)
 
-/obj/machinery/power/apc/AICtrlClick() // turns off APCs.
+/obj/machinery/power/apc/AICtrlClick() // turns off/on APCs.
 	Topic("breaker=1", list("breaker"="1"), 0) // 0 meaning no window (consistency! wait...)
 
+/obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
+	src.enabled = !src.enabled
+	src.updateTurrets()
 
 /atom/proc/AIAltClick()
 	return
 
-/obj/machinery/door/airlock/AIAltClick() // Eletrifies doors.
+/obj/machinery/door/airlock/AIAltClick() // Electrifies doors.
+	if(emagged)
+		return
 	if(!secondsElectrified)
 		// permenant shock
 		Topic("aiEnable=6", list("aiEnable"="6"), 1) // 1 meaning no window (consistency!)
@@ -128,3 +134,14 @@
 		// disable/6 is not in Topic; disable/5 disables both temporary and permenant shock
 		Topic("aiDisable=5", list("aiDisable"="5"), 1)
 	return
+
+/obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
+	src.lethal = !src.lethal
+	src.updateTurrets()
+
+//
+// Override AdjacentQuick for AltClicking
+//
+
+/mob/living/silicon/ai/TurfAdjacent(var/turf/T)
+	return (cameranet && cameranet.checkTurfVis(T))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -88,6 +88,8 @@
 	A.AICtrlClick(src)
 /mob/living/silicon/ai/AltClickOn(var/atom/A)
 	A.AIAltClick(src)
+/mob/living/silicon/ai/MiddleClickOn(var/atom/A)
+    A.AIMiddleClick(src)
 
 /*
 	The following criminally helpful code is just the previous code cleaned up;
@@ -103,7 +105,6 @@
 	else
 		Topic("aiDisable=7", list("aiDisable"="7"), 1)
 	return
-
 
 /atom/proc/AICtrlClick()
 	return
@@ -126,16 +127,26 @@
 
 /obj/machinery/door/airlock/AIAltClick() // Electrifies doors.
 	if(!secondsElectrified)
-		// permenant shock
+		// permanent shock
 		Topic("aiEnable=6", list("aiEnable"="6"), 1) // 1 meaning no window (consistency!)
 	else
-		// disable/6 is not in Topic; disable/5 disables both temporary and permenant shock
+		// disable/6 is not in Topic; disable/5 disables both temporary and permanent shock
 		Topic("aiDisable=5", list("aiDisable"="5"), 1)
 	return
 
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	src.lethal = !src.lethal
 	src.updateTurrets()
+    
+/atom/proc/AIMiddleClick()
+	return
+    
+/obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
+	if(!src.lights)
+		Topic("aiEnable=10", list("aiEnable"="10"), 1) // 1 meaning no window (consistency!)
+	else
+		Topic("aiDisable=10", list("aiDisable"="10"), 1)
+	return
 
 //
 // Override AdjacentQuick for AltClicking

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -125,8 +125,6 @@
 	return
 
 /obj/machinery/door/airlock/AIAltClick() // Electrifies doors.
-	if(emagged)
-		return
 	if(!secondsElectrified)
 		// permenant shock
 		Topic("aiEnable=6", list("aiEnable"="6"), 1) // 1 meaning no window (consistency!)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -249,13 +249,16 @@
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
-	if(T && T.AdjacentQuick(user))
-		if(user.listed_turf == T)
+	if(T && user.TurfAdjacent(T))
+		if(user. == T)
 			user.listed_turf = null
 		else
 			user.listed_turf = T
 			user.client.statpanel = T.name
 	return
+
+/mob/proc/TurfAdjacent(var/turf/T)
+	return T.AdjacentQuick(src)
 
 /*
 	Misc helpers

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -55,13 +55,13 @@
 	set name = "Store Camera Location"
 	set desc = "Stores your current camera location by the given name"
 
-	if(stored_locations.len >= max_locations)
-		src << "\red Cannot store additional locations. Remove one first"
-		return
-
-	loc = trim(loc)
+	loc = copytext(sanitize(loc), 1, MAX_MESSAGE_LEN)
 	if(!loc)
 		src << "\red Must supply a location name"
+		return
+
+	if(stored_locations.len >= max_locations)
+		src << "\red Cannot store additional locations. Remove one first"
 		return
 
 	if(loc in stored_locations)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -971,10 +971,11 @@ About the new airlock wires panel:
 				if(1)
 					//disable idscan
 					if(src.isWireCut(AIRLOCK_WIRE_IDSCAN))
-						usr << "The IdScan wire has been cut - So, you can't disable it, but it is already disabled anyway."
+						usr << "The IdScan wire has been cut - The IdScan feature is already disabled."
 					else if(src.aiDisabledIdScanner)
-						usr << "You've already disabled the IdScan feature."
+						usr << "The IdScan feature is already disabled."
 					else
+						usr << "The IdScan feature has been disabled."
 						src.aiDisabledIdScanner = 1
 				if(2)
 					//disrupt main power
@@ -991,35 +992,19 @@ About the new airlock wires panel:
 				if(4)
 					//drop door bolts
 					if(src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						usr << "You can't drop the door bolts - The door bolt control wire has been cut."
+						usr << "The door bolt control wire has been cut - The door bolts are already dropped."
+					else if(src.locked)
+						usr << "The door bolts are already dropped."
 					else
 						src.lock()
+						usr << "The door bolts have been dropped."
 				if(5)
 					//un-electrify door
 					if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY))
-						usr << text("Can't un-electrify the airlock - The electrification wire is cut.")
-					else if(src.secondsElectrified==-1 || src.secondsElectrified>0)
+						usr << text("The electrification wire is cut - Cannot un-electrify the door.")
+					else if(secondsElectrified != 0)
 						usr << "The door is now un-electrified."
 						src.secondsElectrified = 0
-
-				if(8)
-					// Safeties!  We don't need no stinking safeties!
-					if (src.isWireCut(AIRLOCK_WIRE_SAFETY))
-						usr << text("Control to door sensors is disabled.")
-					else if (src.safe)
-						safe = 0
-					else
-						usr << text("Firmware reports safeties already overriden.")
-
-				if(9)
-					// Door speed control
-					if(src.isWireCut(AIRLOCK_WIRE_SPEED))
-						usr << text("Control to door timing circuitry has been severed.")
-					else if (src.normalspeed)
-						normalspeed = 0
-					else
-						usr << text("Door timing circurity already accellerated.")
-
 				if(7)
 					//close door
 					if(src.welded)
@@ -1030,15 +1015,31 @@ About the new airlock wires panel:
 						close()
 					else
 						open()
-
+				if(8)
+					// Safeties!  We don't need no stinking safeties!
+					if (src.isWireCut(AIRLOCK_WIRE_SAFETY))
+						usr << text("Control to door sensors is disabled.")
+					else if (src.safe)
+						safe = 0
+					else
+						usr << text("Firmware reports safeties already overridden.")
+				if(9)
+					// Door speed control
+					if(src.isWireCut(AIRLOCK_WIRE_SPEED))
+						usr << text("Control to door timing circuitry has been severed.")
+					else if (src.normalspeed)
+						normalspeed = 0
+					else
+						usr << text("Door timing circuity already accelerated.")
 				if(10)
 					// Bolt lights
 					if(src.isWireCut(AIRLOCK_WIRE_LIGHT))
-						usr << text("Control to door bolt lights has been severed.</a>")
+						usr << "The bolt lights wire has been cut - The door bolt lights are already disabled."
 					else if (src.lights)
 						lights = 0
+						usr << "The door bolt lights have been disabled."
 					else
-						usr << text("Door bolt lights are already disabled!")
+						usr << "The door bolt lights are already disabled!"
 
 		else if(href_list["aiEnable"])
 			var/code = text2num(href_list["aiEnable"])
@@ -1046,20 +1047,23 @@ About the new airlock wires panel:
 				if(1)
 					//enable idscan
 					if(src.isWireCut(AIRLOCK_WIRE_IDSCAN))
-						usr << "You can't enable IdScan - The IdScan wire has been cut."
+						usr << "The IdScan wire has been cut - The IdScan feature cannot be enabled."
 					else if(src.aiDisabledIdScanner)
+						usr << "The IdScan feature has been enabled."
 						src.aiDisabledIdScanner = 0
 					else
-						usr << "The IdScan feature is not disabled."
+						usr << "The IdScan feature is already enabled."
 				if(4)
 					//raise door bolts
 					if(src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						usr << text("The door bolt control wire is cut - you can't raise the door bolts.<br>\n")
+						usr << "The door bolt control wire has been cut - The door bolts cannot be raised."
 					else if(!src.locked)
-						usr << text("The door bolts are already up.<br>\n")
+						usr << "The door bolts are already raised."
 					else
-						src.unlock()
-
+						if(src.unlock())
+							usr << "The door bolts have been raised."
+						else
+							usr << "Unable to raise door bolts."
 				if(5)
 					//electrify door for 30 seconds
 					if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY))
@@ -1067,7 +1071,7 @@ About the new airlock wires panel:
 					else if(src.secondsElectrified==-1)
 						usr << text("The door is already indefinitely electrified. You'd have to un-electrify it before you can re-electrify it with a non-forever duration.<br>\n")
 					else if(src.secondsElectrified!=0)
-						usr << text("The door is already electrified. You can't re-electrify it while it's already electrified.<br>\n")
+						usr << text("The door is already electrified. Cannot re-electrify it while it's already electrified.<br>\n")
 					else
 						shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 						usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
@@ -1078,7 +1082,6 @@ About the new airlock wires panel:
 								src.secondsElectrified-=1
 								if(src.secondsElectrified<0)
 									src.secondsElectrified = 0
-								src.updateUsrDialog()
 								sleep(10)
 				if(6)
 					//electrify door indefinitely
@@ -1093,27 +1096,6 @@ About the new airlock wires panel:
 						usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
 						usr << "The door is now electrified."
 						src.secondsElectrified = -1
-
-				if (8) // Not in order >.>
-					// Safeties!  Maybe we do need some stinking safeties!
-					if (src.isWireCut(AIRLOCK_WIRE_SAFETY))
-						usr << text("Control to door sensors is disabled.")
-					else if (!src.safe)
-						safe = 1
-						src.updateUsrDialog()
-					else
-						usr << text("Firmware reports safeties already in place.")
-
-				if(9)
-					// Door speed control
-					if(src.isWireCut(AIRLOCK_WIRE_SPEED))
-						usr << text("Control to door timing circuitry has been severed.")
-					else if (!src.normalspeed)
-						normalspeed = 1
-						src.updateUsrDialog()
-					else
-						usr << text("Door timing circurity currently operating normally.")
-
 				if(7)
 					//open door
 					if(src.welded)
@@ -1124,16 +1106,31 @@ About the new airlock wires panel:
 						open()
 					else
 						close()
-
+				if (8)
+					// Safeties!  Maybe we do need some stinking safeties!
+					if (src.isWireCut(AIRLOCK_WIRE_SAFETY))
+						usr << text("Control to door sensors is disabled.")
+					else if (!src.safe)
+						safe = 1
+					else
+						usr << text("Firmware reports safeties already in place.")
+				if(9)
+					// Door speed control
+					if(src.isWireCut(AIRLOCK_WIRE_SPEED))
+						usr << text("Control to door timing circuitry has been severed.")
+					else if (!src.normalspeed)
+						normalspeed = 1
+					else
+						usr << text("Door timing circuity currently operating normally.")
 				if(10)
 					// Bolt lights
 					if(src.isWireCut(AIRLOCK_WIRE_LIGHT))
-						usr << text("Control to door bolt lights has been severed.</a>")
+						usr << "The bolt lights wire has been cut - The door bolt lights cannot be enabled."
 					else if (!src.lights)
 						lights = 1
-						src.updateUsrDialog()
+						usr << "The door bolt lights have been enabled"
 					else
-						usr << text("Door bolt lights are already enabled!")
+						usr << "The door bolt lights are already enabled!"
 
 	add_fingerprint(usr)
 	update_icon()
@@ -1322,13 +1319,15 @@ About the new airlock wires panel:
 	update_icon()
 
 /obj/machinery/door/airlock/proc/unlock(var/forced=0)
-	if (!src.locked) return
+	if (!src.locked) return 0
 
 	if(forced || src.arePowerSystemsOn()) //only can raise bolts if power's on
 		src.locked = 0
 		for(var/mob/M in range(1,src))
 			M.show_message("You hear a click from the bottom of the door.", 2)
 		update_icon()
+		return 1
+	return 0
 
 /obj/machinery/door/airlock/New()
 	..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -540,8 +540,8 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/canAIControl()
 	return ((src.aiControlDisabled!=1) && (!src.isAllPowerCut()));
 
-/obj/machinery/door/airlock/proc/canAIHack()
-	return ((src.aiControlDisabled==1) && (!hackProof) && (!src.isAllPowerCut()));
+/obj/machinery/door/airlock/proc/canAIHack(var/user as mob)
+	return (isAI(user) && src.aiControlDisabled==1 && !hackProof && !src.isAllPowerCut());
 
 /obj/machinery/door/airlock/proc/arePowerSystemsOn()
 	return (src.secondsMainPowerLost==0 || src.secondsBackupPowerLost==0)
@@ -651,12 +651,8 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/attack_ai(mob/user as mob)
-	if(!src.canAIControl())
-		if(src.canAIHack())
-			src.hack(user)
-			return
-		else
-			user << "Airlock AI control has been blocked with a firewall. Unable to hack."
+	if (!check_synth_access(user))
+		return
 
 	//Separate interface for the AI.
 	user.set_machine(src)
@@ -772,7 +768,7 @@ About the new airlock wires panel:
 				user << "Alert cancelled. Airlock control has been restored without our assistance."
 				src.aiHacking=0
 				return
-			else if(!src.canAIHack())
+			else if(!src.canAIHack(user))
 				user << "We've lost our connection! Unable to hack airlock."
 				src.aiHacking=0
 				return
@@ -784,7 +780,7 @@ About the new airlock wires panel:
 				user << "Alert cancelled. Airlock control has been restored without our assistance."
 				src.aiHacking=0
 				return
-			else if(!src.canAIHack())
+			else if(!src.canAIHack(user))
 				user << "We've lost our connection! Unable to hack airlock."
 				src.aiHacking=0
 				return
@@ -794,7 +790,7 @@ About the new airlock wires panel:
 				user << "Alert cancelled. Airlock control has been restored without our assistance."
 				src.aiHacking=0
 				return
-			else if(!src.canAIHack())
+			else if(!src.canAIHack(user))
 				user << "We've lost our connection! Unable to hack airlock."
 				src.aiHacking=0
 				return
@@ -889,6 +885,17 @@ About the new airlock wires panel:
 		..(user)
 	return
 
+/obj/machinery/door/airlock/proc/check_synth_access(mob/user as mob)
+	if(emagged)
+		user << "<span class='warning'>Unable to interface: Airlock is unresponsive.</span>"
+		return 0
+	if(!src.canAIControl())
+		if(src.canAIHack(user))
+			src.hack(user)
+		else
+			user << "<span class='warning'>Airlock AI control has been blocked with a firewall.</span>"
+		return 0
+	return 1
 
 /obj/machinery/door/airlock/Topic(href, href_list, var/nowindow = 0)
 	if(!nowindow)
@@ -951,7 +958,10 @@ About the new airlock wires panel:
 			src.signalers[wirenum] = null
 
 
-	if(istype(usr, /mob/living/silicon) && src.canAIControl())
+	if(istype(usr, /mob/living/silicon))
+		if (!check_synth_access(usr))
+			return
+
 		//AI
 		//aiDisable - 1 idscan, 2 disrupt main power, 3 disrupt backup power, 4 drop door bolts, 5 un-electrify door, 7 close door, 8 door safties, 9 door speed
 		//aiEnable - 1 idscan, 4 raise door bolts, 5 electrify door for 30 seconds, 6 electrify door indefinitely, 7 open door,  8 door safties, 9 door speed
@@ -961,7 +971,7 @@ About the new airlock wires panel:
 				if(1)
 					//disable idscan
 					if(src.isWireCut(AIRLOCK_WIRE_IDSCAN))
-						usr << "The IdScan wire has been cut - So, you can't disable it, but it is already disabled anyways."
+						usr << "The IdScan wire has been cut - So, you can't disable it, but it is already disabled anyway."
 					else if(src.aiDisabledIdScanner)
 						usr << "You've already disabled the IdScan feature."
 					else
@@ -988,9 +998,8 @@ About the new airlock wires panel:
 					//un-electrify door
 					if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY))
 						usr << text("Can't un-electrify the airlock - The electrification wire is cut.")
-					else if(src.secondsElectrified==-1)
-						src.secondsElectrified = 0
-					else if(src.secondsElectrified>0)
+					else if(src.secondsElectrified==-1 || src.secondsElectrified>0)
+						usr << "The door is now un-electrified."
 						src.secondsElectrified = 0
 
 				if(8)
@@ -1001,8 +1010,6 @@ About the new airlock wires panel:
 						safe = 0
 					else
 						usr << text("Firmware reports safeties already overriden.")
-
-
 
 				if(9)
 					// Door speed control
@@ -1032,8 +1039,6 @@ About the new airlock wires panel:
 						lights = 0
 					else
 						usr << text("Door bolt lights are already disabled!")
-
-
 
 		else if(href_list["aiEnable"])
 			var/code = text2num(href_list["aiEnable"])
@@ -1066,6 +1071,7 @@ About the new airlock wires panel:
 					else
 						shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 						usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
+						usr << "The door is now electrified for thirty seconds."
 						src.secondsElectrified = 30
 						spawn(10)
 							while (src.secondsElectrified>0)
@@ -1085,6 +1091,7 @@ About the new airlock wires panel:
 					else
 						shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 						usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
+						usr << "The door is now electrified."
 						src.secondsElectrified = -1
 
 				if (8) // Not in order >.>

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -128,6 +128,9 @@ var/datum/cameranet/cameranet = new()
 
 	// 0xf = 15
 	var/turf/position = get_turf(target)
+	return checkTurfVis(position)
+
+/datum/cameranet/proc/checkTurfVis(var/turf/position)
 	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z)
 	if(chunk)
 		if(chunk.changed)
@@ -135,7 +138,6 @@ var/datum/cameranet/cameranet = new()
 		if(chunk.visibleTurfs[position])
 			return 1
 	return 0
-
 
 // Debug verb for VVing the chunk that the turf is in.
 /*

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -721,7 +721,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 				stat(null,"MasterController-ERROR")
 
 	if(listed_turf && client)
-		if(get_dist(listed_turf,src) > 1)
+		if(!TurfAdjacent(listed_turf))
 			listed_turf = null
 		else
 			statpanel(listed_turf.name, null, listed_turf)

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -114,6 +114,18 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>20 July 2014</h2>
+	<h3 class='author'>PsiOmegaDelta updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>AI can now store up to five camera locations and return to them when desired.</li>
+		<li class='rscadd'>AI can now alt+left click turfs in camera view to list and interact with the objects.</li>
+		<li class='rscadd'>AI can now ctrl+click turret controls to enable/disable turrets.</li>
+		<li class='rscadd'>AI can now alt+click turret controls to toggle stun/lethal mode.</li>
+		<li class='rscadd'>AI can now select which channel to state laws on.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>1 July 2014</h2>
 	<h3 class='author'>Mloc updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
- AI can now alt+left click turfs in camera view (turfs without static) to list and interact with objects in the status tab. For example allows for interacting with emergency shutters beneath grills.
- ctrl-clicking a turret control enables/disables turrets
- alt-clicking a turret control toggles stun/lethal settings.
- alt-clicking doors now gives feedback when electrified/un-electrified as, unlike most other shortcuts, this doesn't have a visual cue. Felt rather important when alt+clicking can also be used to list turf objects.
- When using shortcuts on doors and the AI-control is disabled, hacking is now automatically initiated as if the AI had attempted to open the door control menu.
- When borgs/AIs try to interact with an emagged door they now receive a feedback message that it's unresponsive.

Parts of implementation done by porting code from tg-station.
