### PR TITLE
Attempts to ensure that the captain is not a candidate for Mutiny directives

### DIFF
--- a/code/game/gamemodes/mutiny/directives/alien_fraud_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/alien_fraud_directive.dm
@@ -11,7 +11,7 @@ datum/directive/terminations/alien_fraud
 datum/directive/terminations/alien_fraud/get_crew_to_terminate()
 	var/list/aliens[0]
 	for(var/mob/M in player_list)
-		if (M.is_ready() && is_alien(M))
+		if (M.is_ready() && is_alien(M) && M != mode.head_loyalist.current)
 			aliens.Add(M)
 	return aliens
 

--- a/code/game/gamemodes/mutiny/directives/bluespace_contagion_directive.dm
+++ b/code/game/gamemodes/mutiny/directives/bluespace_contagion_directive.dm
@@ -6,7 +6,7 @@ datum/directive/bluespace_contagion
 	proc/get_infection_candidates()
 		var/list/candidates[0]
 		for(var/mob/M in player_list)
-			if (M.is_ready() && !M.is_mechanical())
+			if (M.is_ready() && !M.is_mechanical() && M != mode.head_loyalist.current)
 				candidates.Add(M)
 		return candidates
 


### PR DESCRIPTION
Or to be precise: Ensures the current head loyalist cannot be selected as a Directive candidate.
