### PR TITLE
Implements timed alerts...

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -28,6 +28,7 @@
 #include "code\__HELPERS\sanitize_values.dm"
 #include "code\__HELPERS\text.dm"
 #include "code\__HELPERS\time.dm"
+#include "code\__HELPERS\timed_alert.dm"
 #include "code\__HELPERS\type2type.dm"
 #include "code\__HELPERS\unsorted.dm"
 #include "code\_onclick\adjacent.dm"

--- a/code/__HELPERS/timed_alert.dm
+++ b/code/__HELPERS/timed_alert.dm
@@ -1,0 +1,43 @@
+/client
+
+        var/timed_alert/timed_alert
+
+        proc/timed_alert(question as text, title as text, default as text, time = 300, \
+        				 choice1 as text, choice2 as text, choice3 as text)
+
+                if(timed_alert) del(timed_alert) // Cleanup just in case.
+                var/timed_alert/ref_alert = new
+                timed_alert = ref_alert
+
+                var/ref_result
+                ref_result = ref_alert.timed_alert(src, question, title, time, choice1, choice2, choice3)
+
+                if (!ref_result) ref_result = default // This will result if the time out occurs.
+
+                if (ref_alert) del(ref_alert) // Clean up our mess afterwards..
+
+                return ref_result
+
+
+
+/mob
+	proc/timed_alert(question as text, title as text, default as text, time as num, \
+					 choice1 as text, choice2 as text, choice3 as text)
+
+		if (client) client.timed_alert(question, title, default, time, choice1, choice2, choice3)
+		return
+
+
+
+/timed_alert
+
+        proc/timed_alert(client/ref_client, question, title, time, choice1, choice2, choice3)
+                if (!ref_client) return
+                spawn (time) del src // When src is deleted, the proc ends immediately. The alert itself closes.
+
+                var/ref_answer
+                ref_answer = alert(ref_client, question, title, choice1, choice2, choice3)
+
+                if(!ref_client || !ref_answer) return
+                else return ref_answer
+

--- a/code/__HELPERS/timed_alert.dm
+++ b/code/__HELPERS/timed_alert.dm
@@ -1,43 +1,37 @@
-/client
+/client/var/timed_alert/timed_alert
 
-        var/timed_alert/timed_alert
-
-        proc/timed_alert(question as text, title as text, default as text, time = 300, \
+/client/proc/timed_alert(question as text, title as text, default as text, time = 300, \
         				 choice1 as text, choice2 as text, choice3 as text)
 
-                if(timed_alert) del(timed_alert) // Cleanup just in case.
-                var/timed_alert/ref_alert = new
-                timed_alert = ref_alert
+	if(timed_alert) del(timed_alert)
+	var/timed_alert/ref_alert = new
+	timed_alert = ref_alert
 
-                var/ref_result
-                ref_result = ref_alert.timed_alert(src, question, title, time, choice1, choice2, choice3)
+	var/ref_result
 
-                if (!ref_result) ref_result = default // This will result if the time out occurs.
+	ref_result = ref_alert.timed_alert(src, question, title, time, choice1, choice2, choice3)
+	if (!ref_result) ref_result = default
 
-                if (ref_alert) del(ref_alert) // Clean up our mess afterwards..
+	if (ref_alert) del(ref_alert)
 
-                return ref_result
+	return ref_result
 
 
-
-/mob
-	proc/timed_alert(question as text, title as text, default as text, time as num, \
+/mob/proc/timed_alert(question as text, title as text, default as text, time as num, \
 					 choice1 as text, choice2 as text, choice3 as text)
 
-		if (client) client.timed_alert(question, title, default, time, choice1, choice2, choice3)
-		return
+	if (client) client.timed_alert(question, title, default, time, choice1, choice2, choice3)
+	return
 
 
 
-/timed_alert
+/timed_alert/proc/timed_alert(client/ref_client, question, title, time, choice1, choice2, choice3)
+        if (!ref_client) return
+        spawn (time) del src // When src is deleted, the proc ends immediately. The alert itself closes.
 
-        proc/timed_alert(client/ref_client, question, title, time, choice1, choice2, choice3)
-                if (!ref_client) return
-                spawn (time) del src // When src is deleted, the proc ends immediately. The alert itself closes.
+        var/ref_answer
+        ref_answer = alert(ref_client, question, title, choice1, choice2, choice3)
 
-                var/ref_answer
-                ref_answer = alert(ref_client, question, title, choice1, choice2, choice3)
-
-                if(!ref_client || !ref_answer) return
-                else return ref_answer
+        if(!ref_client || !ref_answer) return
+        else return ref_answer
 

--- a/code/__HELPERS/timed_alert.dm
+++ b/code/__HELPERS/timed_alert.dm
@@ -1,37 +1,48 @@
 /client/var/timed_alert/timed_alert
 
-/client/proc/timed_alert(question as text, title as text, default as text, time = 300, \
-        				 choice1 as text, choice2 as text, choice3 as text)
 
-	if(timed_alert) del(timed_alert)
+/client/proc/timed_alert(question, title, default, time, choice, choice2, choice3)
+
+	if(timed_alert)
+		del(timed_alert)
+
 	var/timed_alert/ref_alert = new
 	timed_alert = ref_alert
 
 	var/ref_result
-
 	ref_result = ref_alert.timed_alert(src, question, title, time, choice1, choice2, choice3)
-	if (!ref_result) ref_result = default
 
-	if (ref_alert) del(ref_alert)
+	if (!ref_result)
+		ref_result = default
+
+	if (ref_alert)
+		del(ref_alert)
 
 	return ref_result
 
 
-/mob/proc/timed_alert(question as text, title as text, default as text, time as num, \
-					 choice1 as text, choice2 as text, choice3 as text)
 
-	if (client) client.timed_alert(question, title, default, time, choice1, choice2, choice3)
+/mob/proc/timed_alert(question, title, default, choice1, choice2, choice3)
+
+	if (client)
+		client.timed_alert(question, title, default, time, choice1, choice2, choice3)
+
 	return
 
 
 
 /timed_alert/proc/timed_alert(client/ref_client, question, title, time, choice1, choice2, choice3)
-        if (!ref_client) return
-        spawn (time) del src // When src is deleted, the proc ends immediately. The alert itself closes.
+	if (!ref_client)
+		return
 
-        var/ref_answer
-        ref_answer = alert(ref_client, question, title, choice1, choice2, choice3)
+    spawn (time)
+    	del src // When src is deleted, the proc ends immediately. The alert itself closes.
 
-        if(!ref_client || !ref_answer) return
-        else return ref_answer
+    var/ref_answer
+    ref_answer = alert(ref_client, question, title, choice1, choice2, choice3)
+
+    if(!ref_client || !ref_answer)
+    	return
+    else
+    	return ref_answer
 


### PR DESCRIPTION
Specifically, a new proc called "timed_alert" which may be called on either
a mob or a client. If it's called on a mob, the mob will call it on the
client. This is to allow this procedure to exhibit similar behavior to the
alert procedure.

When calling the procedure, one follows the following format:

timed_alert(question as text, title as text, default as text, time = 300, choice1 as text, choice2 as text, choice3 as text)

The two differences from alert are in the 'default' and 'time' variables.
For the time variable, one places how long before the popup will just time
out. For the default variable, one places the default result if the popup
times out.

This allows greater utility in a variety of situations-- One which immediately
comes to mind, and, truth be told, the reason why I looked into this at all
are cult runes. This would allow the conversion popup to have a natural
time-out, which, when elapsed, would cause the person to 'resist' naturally.
This is better because then people can't abuse just not answering the alert
to avoid the damage which comes from resisting.

Signed-off-by: Decius deciusreln97@gmail.com
