### PR TITLE
Tasers will now cause movement slow downs on the first hit

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,8 +13,10 @@
 
 	if(reagents.has_reagent("nuka_cola")) return -1
 
-	var/health_deficiency = (100 - health + halloss)
+	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
+
+	if(halloss >= 10) tally += (halloss / 10)
 
 	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
 	if (hungry >= 70) tally += hungry/50


### PR DESCRIPTION
Before:  Tasers do 40 halloss damage and that drops to 39 on next life() tick so most people won't be slowed down by the first taser hit.

After:  If you have any halloss you will slow down some.  I've set it at 1 delay for every 10 halloss, this might need adjusting (15 instead of 10 possibly)
