### PR TITLE
Attempts to prevent ninja infections, body temperature fix, icon fix

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -441,6 +441,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if (!(status & ORGAN_DEAD))
 			status |= ORGAN_DEAD
 			owner << "<span class='notice'>You can't feel your [display_name] anymore...</span>"
+			owner.update_body(1)
 
 		germ_level++
 		owner.adjustToxLoss(1)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -393,10 +393,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
 		//having an infection raises your body temperature
-		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 1)* min(germ_level/(INFECTION_LEVEL_ONE+300), 1) + owner.species.body_temperature
-		if (owner.bodytemperature < fever_temperature)
-			//world << "fever: [owner.bodytemperature] < [fever_temperature], raising temperature."
-			owner.bodytemperature++
+		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 1)* min(germ_level/(INFECTION_LEVEL_TWO), 1) + owner.species.body_temperature
+		if (fever_temperature > owner.bodytemperature)
+			//need to make sure we raise temperature fast enough to get around environmental cooling preventing us from reaching fever_temperature
+			owner.bodytemperature += (fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1
 
 		if(prob(round(germ_level/10)))
 			if (antibiotics < 5)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -393,7 +393,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
 		//having an infection raises your body temperature
-		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 1)* min(germ_level/(INFECTION_LEVEL_TWO), 1) + owner.species.body_temperature
+		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 1)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.species.body_temperature
 		if (fever_temperature > owner.bodytemperature)
 			//need to make sure we raise temperature fast enough to get around environmental cooling preventing us from reaching fever_temperature
 			owner.bodytemperature += (fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1
@@ -402,7 +402,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if (antibiotics < 5)
 				germ_level++
 
-			if (prob(5))	//adjust this to tweak how fast people take toxin damage from infections
+			if (prob(10))	//adjust this to tweak how fast people take toxin damage from infections
 				owner.adjustToxLoss(1)
 
 	if(germ_level >= INFECTION_LEVEL_TWO && antibiotics < 5)


### PR DESCRIPTION
Tweaks infections so that they are more readily apparent to the infected person during the early stages.
- Deals toxin damage more rapidly
- Fixes bodytemperature not rising to fever_temperature when infected.

Based on a (small) amount of testing on the dev server it seems that an infection of a single body part under the current settings was doing around 15 toxin damage over the hour or so it took to reach terminal stages. This is much lower than intended and has the potential to result in "ninja" infections where people have no idea that they are infected when suddenly they hit the terminal stage ("You can't feel your [X]!") and take massive toxloss.

Ideally the infection should be readily apparent with the patient having taken significant toxin damage, vomiting, etc, well before reaching such a late stage. I haven't done any testing with the new value though, yet.
