### PR TITLE
An Odysseus with patients now bypass mech movement-overrides.

### DIFF
--- a/code/game/mecha/mech_sensor.dm
+++ b/code/game/mecha/mech_sensor.dm
@@ -25,6 +25,14 @@
 	return 1
 
 /obj/machinery/mech_sensor/proc/is_blocked(O as obj)
+	if(istype(O, /obj/mecha/medical/odysseus))
+		var/obj/mecha/medical/odysseus/M = O
+		for(var/obj/item/mecha_parts/mecha_equipment/ME in M.equipment)
+			if(istype(ME, /obj/item/mecha_parts/mecha_equipment/tool/sleeper))
+				var/obj/item/mecha_parts/mecha_equipment/tool/sleeper/S = ME
+				if(S.occupant != null)
+					return 0
+
 	return istype(O, /obj/mecha) || istype(O, /obj/vehicle)
 
 /obj/machinery/mech_sensor/proc/give_feedback(O as obj)


### PR DESCRIPTION
What it says on the tin. An Odysseus with one or more patients is now allowed onboard shuttles.
Should be trivial to create an inheriting sensor with this special case but I went with YAGNI.
