### PR TITLE
More train fixes

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -54,7 +54,10 @@ var/list/mechtoys = list(
 	if (istype(A, /obj/structure/stool/bed) && B.buckled_mob)//if it's a bed/chair and someone is buckled, it will not pass
 		return 0
 
-	else if(istype(A, /mob/living)) // You Shall Not Pass!
+	if(istype(A, /obj/vehicle))	//no vehicles
+		return 0
+
+	if(istype(A, /mob/living)) // You Shall Not Pass!
 		var/mob/living/M = A
 		if(!M.lying && !istype(M, /mob/living/carbon/monkey) && !istype(M, /mob/living/carbon/slime) && !istype(M, /mob/living/simple_animal/mouse) && !istype(M, /mob/living/silicon/robot/drone))  //If your not laying down, or a small creature, no pass.
 			return 0
@@ -455,7 +458,7 @@ var/list/mechtoys = list(
 							if ("undocking") dat += "Undocking from station [shuttle.can_force()? "<span class='warning'><A href='?src=\ref[src];force_send=1'>Force Launch</A></span>" : ""]<BR>"
 					else
 						dat += "Station<BR>"
-					
+
 					if (shuttle.can_launch())
 						dat += "<A href='?src=\ref[src];send=1'>Send away</A>"
 					else if (shuttle.can_cancel())
@@ -472,14 +475,14 @@ var/list/mechtoys = list(
 					else
 						dat += "*Shuttle is busy*"
 					dat += "<BR>\n<BR>"
-		
-		
+
+
 		dat += {"<HR>\nSupply points: [supply_controller.points]<BR>\n<BR>
 		\n<A href='?src=\ref[src];order=categories'>Order items</A><BR>\n<BR>
 		\n<A href='?src=\ref[src];viewrequests=1'>View requests</A><BR>\n<BR>
 		\n<A href='?src=\ref[src];vieworders=1'>View orders</A><BR>\n<BR>
 		\n<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
-		
+
 
 	user << browse(dat, "window=computer;size=575x450")
 	onclose(user, "computer")
@@ -520,13 +523,13 @@ var/list/mechtoys = list(
 			shuttle.launch(src)
 			temp = "The supply shuttle has been called and will arrive in approximately [round(supply_controller.movetime/600,1)] minutes.<BR><BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"
 			post_signal("supply")
-	
+
 	if (href_list["force_send"])
 		shuttle.force_launch(src)
 
 	if (href_list["cancel_send"])
 		shuttle.cancel_launch(src)
-	
+
 	else if (href_list["order"])
 		//if(!shuttle.idle()) return	//this shouldn't be necessary it seems
 		if(href_list["order"] == "categories")

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -43,6 +43,7 @@
 	..()
 	cell = new /obj/item/weapon/cell/high
 	verbs -= /atom/movable/verb/pull
+	verbs -= /obj/vehicle/train/cargo/engine/verb/stop_engine
 	key = new()
 	var/image/I = new(icon = 'icons/obj/vehicles.dmi', icon_state = "cargo_engine_overlay", layer = src.layer + 0.2) //over mobs
 	overlays += I
@@ -70,8 +71,8 @@
 	if(istype(W, /obj/item/weapon/key/cargo_train))
 		if(!key)
 			user.drop_item()
+			W.forceMove(src)
 			key = W
-			W.loc = src
 			verbs += /obj/vehicle/train/cargo/engine/verb/remove_key
 		return
 	..()
@@ -97,7 +98,7 @@
 	var/obj/machinery/door/D = Obstacle
 	var/mob/living/carbon/human/H = load
 	if(istype(D) && istype(H))
-		D.Bumped(H)		//a little hacky, but hey, it works, and repects access rights
+		D.Bumped(H)		//a little hacky, but hey, it works, and respects access rights
 
 	..()
 
@@ -194,6 +195,8 @@
 	turn_on()
 	if (on)
 		usr << "You start [src]'s engine."
+		verbs += /obj/vehicle/train/cargo/engine/verb/stop_engine
+		verbs -= /obj/vehicle/train/cargo/engine/verb/start_engine
 	else
 		if(cell.charge < power_use)
 			usr << "[src] is out of power."
@@ -215,6 +218,8 @@
 	turn_off()
 	if (!on)
 		usr << "You stop [src]'s engine."
+		verbs -= /obj/vehicle/train/cargo/engine/verb/stop_engine
+		verbs += /obj/vehicle/train/cargo/engine/verb/start_engine
 
 /obj/vehicle/train/cargo/engine/verb/remove_key()
 	set name = "Remove key"
@@ -243,7 +248,7 @@
 /obj/vehicle/train/cargo/trolley/load(var/atom/movable/C)
 	if(ismob(C) && !passenger_allowed)
 		return 0
-	if(!istype(C,/obj/machinery) && !istype(C,/obj/structure/closet) && !istype(C,/obj/structure/largecrate) && !istype(C,/obj/structure/reagent_dispensers) && !istype(C,/obj/structure/ore_box) && !ismob(C))
+	if(!istype(C,/obj/machinery) && !istype(C,/obj/structure/closet) && !istype(C,/obj/structure/largecrate) && !istype(C,/obj/structure/reagent_dispensers) && !istype(C,/obj/structure/ore_box) && !istype(C, /mob/living/carbon/human))
 		return 0
 
 	..()
@@ -255,7 +260,7 @@
 		return 1
 
 /obj/vehicle/train/cargo/engine/load(var/atom/movable/C)
-	if(!ismob(C))
+	if(!istype(C, /mob/living/carbon/human))
 		return 0
 
 	return ..()

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -68,8 +68,7 @@
 
 	if(user != load)
 		if(user in src)		//for handling players stuck in src - this shouldn't happen - but just in case it does
-			user.loc = T
-			contents -= user
+			user.forceMove(T)
 			return 1
 		return 0
 
@@ -93,8 +92,7 @@
 		return 0
 
 	if(user != load && (user in src))
-		user.loc = loc			//for handling players stuck in src
-		contents -= user
+		user.forceMove(loc)			//for handling players stuck in src
 	else if(load)
 		unload(user)			//unload if loaded
 	else if(!load && !user.buckled)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -50,7 +50,7 @@
 		anchored = init_anc
 
 		if(load)
-			load.loc = loc
+			load.forceMove(loc)// = loc
 			load.dir = dir
 
 		return 1
@@ -196,7 +196,7 @@
 	new /obj/item/weapon/cable_coil/cut(Tsec)
 
 	if(cell)
-		cell.loc = Tsec
+		cell.forceMove(Tsec)
 		cell.update_icon()
 		cell = null
 
@@ -234,8 +234,8 @@
 		return
 
 	H.drop_from_inventory(C)
+	C.forceMove(src)
 	cell = C
-	C.loc = null	//this wont be GC'd since it's referrenced above
 	powercheck()
 	usr << "<span class='notice'>You install [C] in [src].</span>"
 
@@ -244,7 +244,8 @@
 		return
 
 	usr << "<span class='notice'>You remove [cell] from [src].</span>"
-	cell.loc = get_turf(H)
+	cell.forceMove(get_turf(H))
+	H.put_in_hands(cell)
 	cell = null
 	powercheck()
 
@@ -271,7 +272,7 @@
 	if(istype(crate))
 		crate.close()
 
-	C.loc = loc
+	C.forceMove(loc)
 	C.dir = dir
 	C.anchored = 1
 
@@ -310,7 +311,7 @@
 		var/list/options = new()
 		for(var/test_dir in alldirs)
 			var/new_dir = get_step_to(src, get_step(src, test_dir))
-			if(new_dir)
+			if(new_dir && load.Adjacent(new_dir))
 				options += new_dir
 		if(options.len)
 			dest = pick(options)
@@ -320,8 +321,7 @@
 	if(!isturf(dest))	//if there still is nowhere to unload, cancel out since the vehicle is probably in nullspace
 		return 0
 
-
-	load.loc = dest
+	load.forceMove(dest)
 	load.dir = get_dir(loc, dest)
 	load.anchored = initial(load.anchored)
 	load.pixel_x = initial(load.pixel_x)


### PR DESCRIPTION
- Fixes #5800
- Fixes #5808
- Cleaned up as many direct loc moves as possible
- Places removed cells in the removers hand
- Removes and adds engine start/stop verbs as they are needed
