### PR TITLE
AI alt-click fix

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -122,8 +122,8 @@
 	src.enabled = !src.enabled
 	src.updateTurrets()
 
-/atom/proc/AIAltClick()
-	return
+/atom/proc/AIAltClick(var/atom/A)
+	AltClick(A)
 
 /obj/machinery/door/airlock/AIAltClick() // Electrifies doors.
 	if(!secondsElectrified)
@@ -137,10 +137,10 @@
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	src.lethal = !src.lethal
 	src.updateTurrets()
-    
+
 /atom/proc/AIMiddleClick()
 	return
-    
+
 /obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
 	if(!src.lights)
 		Topic("aiEnable=10", list("aiEnable"="10"), 1) // 1 meaning no window (consistency!)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -250,7 +250,7 @@
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
 	if(T && user.TurfAdjacent(T))
-		if(user. == T)
+		if(user.listed_turf == T)
 			user.listed_turf = null
 		else
 			user.listed_turf = T


### PR DESCRIPTION
Adds a lost AltClick click-through for the AI. 
Includes a fix to make it possible to clear a turf alt-leftclick selection.
