### PR TITLE
Fixes #5827

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -14,6 +14,7 @@ var/list/department_radio_keys = list(
 	  ":t" = "Syndicate",	"#t" = "Syndicate",		".t" = "Syndicate",
 	  ":u" = "Supply",		"#u" = "Supply",		".u" = "Supply",
 	  ":g" = "changeling",	"#g" = "changeling",	".g" = "changeling",
+	  ":d" = "dronechat",	"#d" = "dronechat",		".d" = "dronechat",
 
 	  ":R" = "right ear",	"#R" = "right ear",		".R" = "right ear",
 	  ":L" = "left ear",	"#L" = "left ear",		".L" = "left ear",
@@ -30,6 +31,7 @@ var/list/department_radio_keys = list(
 	  ":T" = "Syndicate",	"#T" = "Syndicate",		".T" = "Syndicate",
 	  ":U" = "Supply",		"#U" = "Supply",		".U" = "Supply",
 	  ":G" = "changeling",	"#G" = "changeling",	".G" = "changeling",
+	  ":D" = "dronechat",	"#D" = "dronechat",		".D" = "dronechat",
 
 	  //kinda localization -- rastaf0
 	  //same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -103,7 +103,7 @@
 		return emote(copytext(message,2))
 	else if(length(message) >= 2)
 
-		if(copytext(message, 1 ,3) == ":d" || copytext(message, 1 ,3) == ":D")
+		if(parse_message_mode(message, "NONE") == "dronechat")
 
 			if(!is_component_functioning("radio"))
 				src << "\red Your radio transmitter isn't functional."


### PR DESCRIPTION
- Drones can now use .d to access Drone chat
- Cleaner and nicer check for dronechat, uses proper data from say.dm shortcut list.
- MISSING: .d alternative for "Russian localization" (Does anyone actually use that?)
