### PR TITLE
Fixes #5844

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -141,11 +141,12 @@
 
 		if(damage > explosion_point)
 			for(var/mob/living/mob in living_mob_list)
-				if(istype(mob, /mob/living/carbon/human))
-					//Hilariously enough, running into a closet should make you get hit the hardest.
-					mob:hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1)) ) )
-				var/rads = DETONATION_RADS * sqrt( 1 / (get_dist(mob, src) + 1) )
-				mob.apply_effect(rads, IRRADIATE)
+				if(mob.loc.z == loc.z)
+					if(istype(mob, /mob/living/carbon/human))
+						//Hilariously enough, running into a closet should make you get hit the hardest.
+						mob:hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1)) ) )
+					var/rads = DETONATION_RADS * sqrt( 1 / (get_dist(mob, src) + 1) )
+					mob.apply_effect(rads, IRRADIATE)
 
 			explode()
 	else


### PR DESCRIPTION
Fixes #5844 by having a supermatter explosion only affect living entities on the same Z-level.
