### PR TITLE
fixes alien castes not understanding each other

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -87,6 +87,8 @@
 			return 1
 		if (istype(other, src.type) || istype(src, other.type))
 			return 1
+		if(src.alien_talk_understand && other.alien_talk_understand)
+			return 1
 		return 0
 
 	//Language check.
@@ -159,4 +161,3 @@
 			return L
 
 	return null
-


### PR DESCRIPTION
only /mob/living/carbon/alien have this var set, so this will not touch anything else.
