### PR TITLE
Train fixes and rebalance

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -755,17 +755,21 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 /mob/proc/update_canmove()
-	if(buckled && (!buckled.movable))
+	if(istype(buckled, /obj/vehicle))
+		var/obj/vehicle/V = buckled
+		if(stat || weakened || paralysis || resting || sleeping || (status_flags & FAKEDEATH))
+			lying = 1
+			canmove = 0
+			pixel_y = V.mob_offset_y - 5
+		else
+			lying = 0
+			canmove = 1
+			pixel_y = V.mob_offset_y
+	else if(buckled && (!buckled.movable))
 		anchored = 1
 		canmove = 0
 		if( istype(buckled,/obj/structure/stool/bed/chair) )
 			lying = 0
-		else if(istype(buckled, /obj/vehicle))
-			var/obj/vehicle/V = buckled
-			if(V.standing_mob)
-				lying = 0
-			else
-				lying = 1
 		else
 			lying = 1
 	else if(buckled && (buckled.movable))

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -168,7 +168,7 @@
 		return 0
 
 	if(is_train_head())
-		if(direction == reverse_direction(dir))
+		if(direction == reverse_direction(dir) && tow)
 			return 0
 		if(Move(get_step(src, direction)))
 			return 1

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -7,10 +7,9 @@
 	powered = 1
 	locked = 0
 
-	standing_mob = 1
 	load_item_visible = 1
 	load_offset_x = 0
-	load_offset_y = 7
+	mob_offset_y = 7
 
 	var/car_limit = 3		//how many cars an engine can pull before performance degrades
 	active_engines = 1
@@ -31,10 +30,10 @@
 	passenger_allowed = 0
 	locked = 0
 
-	standing_mob = 1
 	load_item_visible = 1
 	load_offset_x = 0
 	load_offset_y = 4
+	mob_offset_y = 8
 
 //-------------------------------------------
 // Standard procs
@@ -267,10 +266,7 @@
 		return 0
 
 	..()
-	
-	if(istype(load, /mob/living/carbon/human))
-		load.pixel_y += 4
-	
+
 	if(load)
 		return 1
 
@@ -317,4 +313,4 @@
 		move_delay = max(0, (-car_limit * active_engines) + train_length - active_engines)	//limits base overweight so you cant overspeed trains
 		move_delay *= (1 / max(1, active_engines)) * 2 										//overweight penalty (scaled by the number of engines)
 		move_delay += config.run_speed 														//base reference speed
-		move_delay *= 1.05 																	//makes cargo trains 5% slower than running when not overweight
+		move_delay *= 1.1																	//makes cargo trains 10% slower than running when not overweight

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -43,10 +43,10 @@
 	..()
 	cell = new /obj/item/weapon/cell/high
 	verbs -= /atom/movable/verb/pull
-	verbs -= /obj/vehicle/train/cargo/engine/verb/stop_engine
 	key = new()
 	var/image/I = new(icon = 'icons/obj/vehicles.dmi', icon_state = "cargo_engine_overlay", layer = src.layer + 0.2) //over mobs
 	overlays += I
+	turn_off()	//so engine verbs are correctly set
 
 /obj/vehicle/train/cargo/engine/Move()
 	if(on && cell.charge < power_use)
@@ -116,6 +116,25 @@
 	else
 		..()
 		update_stats()
+
+		verbs -= /obj/vehicle/train/cargo/engine/verb/stop_engine
+		verbs -= /obj/vehicle/train/cargo/engine/verb/start_engine
+		
+		if(on)
+			verbs += /obj/vehicle/train/cargo/engine/verb/stop_engine
+		else
+			verbs += /obj/vehicle/train/cargo/engine/verb/start_engine
+
+/obj/vehicle/train/cargo/engine/turn_off()
+	..()
+
+	verbs -= /obj/vehicle/train/cargo/engine/verb/stop_engine
+	verbs -= /obj/vehicle/train/cargo/engine/verb/start_engine
+	
+	if(!on)
+		verbs += /obj/vehicle/train/cargo/engine/verb/start_engine
+	else
+		verbs += /obj/vehicle/train/cargo/engine/verb/stop_engine
 
 /obj/vehicle/train/cargo/RunOver(var/mob/living/carbon/human/H)
 	var/list/parts = list("head", "chest", "l_leg", "r_leg", "l_arm", "r_arm")
@@ -195,8 +214,6 @@
 	turn_on()
 	if (on)
 		usr << "You start [src]'s engine."
-		verbs += /obj/vehicle/train/cargo/engine/verb/stop_engine
-		verbs -= /obj/vehicle/train/cargo/engine/verb/start_engine
 	else
 		if(cell.charge < power_use)
 			usr << "[src] is out of power."
@@ -218,8 +235,6 @@
 	turn_off()
 	if (!on)
 		usr << "You stop [src]'s engine."
-		verbs -= /obj/vehicle/train/cargo/engine/verb/stop_engine
-		verbs += /obj/vehicle/train/cargo/engine/verb/start_engine
 
 /obj/vehicle/train/cargo/engine/verb/remove_key()
 	set name = "Remove key"

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -32,6 +32,8 @@
 			tow.Move(old_loc)
 		return 1
 	else
+		if(lead)
+			unattach()
 		return 0
 
 /obj/vehicle/train/Bump(atom/Obstacle)
@@ -48,13 +50,21 @@
 		if(istype(A, /mob/living))
 			var/mob/living/M = A
 			visible_message("\red [src] knocks over [M]!")
-			M.apply_effects(5, 5)							//knock people down if you hit them
-			M.apply_damages(5 * train_length / move_delay)	// and do damage according to how fast the train is going and how heavy it is			
+			M.apply_effects(5, 5)				//knock people down if you hit them
+			M.apply_damages(22 / move_delay)	// and do damage according to how fast the train is going
 			if(istype(load, /mob/living/carbon/human))
 				var/mob/living/D = load
 				D << "\red You hit [M]!"
 				msg_admin_attack("[D.name] ([D.ckey]) hit [M.name] ([M.ckey]) with [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 
+
+//-------------------------------------------
+// Vehicle procs
+//-------------------------------------------
+/obj/vehicle/train/explode()
+	tow.unattach()
+	unattach()
+	..()
 
 
 //-------------------------------------------
@@ -79,7 +89,7 @@
 	return 1
 
 /obj/vehicle/train/MouseDrop_T(var/atom/movable/C, mob/user as mob)
-	if(user.buckled || user.stat || user.restrained() || !Adjacent(user) || !user.Adjacent(C) || !istype(C))
+	if(user.buckled || user.stat || user.restrained() || !Adjacent(user) || !user.Adjacent(C) || !istype(C) || (user == C && !user.canmove))
 		return
 	if(istype(C,/obj/vehicle/train))
 		latch(C, user)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -24,11 +24,11 @@
 	var/obj/item/weapon/cell/cell
 	var/power_use = 5	//set this to adjust the amount of power the vehicle uses per move
 
-	var/standing_mob = 0		//if a mob loaded on the vehicle should be standing
 	var/atom/movable/load		//all vehicles can take a load, since they should all be a least drivable
 	var/load_item_visible = 1	//set if the loaded item should be overlayed on the vehicle sprite
 	var/load_offset_x = 0		//pixel_x offset for item overlay
 	var/load_offset_y = 0		//pixel_y offset for item overlay
+	var/mob_offset_y = 0		//pixel_y offset for mob overlay
 
 //-------------------------------------------
 // Standard procs
@@ -44,10 +44,14 @@
 
 		var/init_anc = anchored
 		anchored = 0
-		if(..())
-			if(on && powered)
-				cell.use(power_use)
+		if(!..())
+			anchored = init_anc
+			return 0
+
 		anchored = init_anc
+
+		if(on && powered)
+			cell.use(power_use)			
 
 		if(load)
 			load.forceMove(loc)// = loc
@@ -200,6 +204,11 @@
 		cell.update_icon()
 		cell = null
 
+	//stuns people who are thrown off a train that has been blown up
+	if(istype(load, /mob/living))
+		var/mob/living/M = load
+		M.apply_effects(5, 5)
+
 	unload()
 
 	new /obj/effect/gibspawner/robot(Tsec)
@@ -280,7 +289,10 @@
 
 	if(load_item_visible)
 		C.pixel_x += load_offset_x
-		C.pixel_y += load_offset_y
+		if(ismob(C))
+			C.pixel_y += mob_offset_y
+		else
+			C.pixel_y += load_offset_y
 		C.layer = layer + 0.1		//so it sits above the vehicle
 
 	if(ismob(C))


### PR DESCRIPTION
- Fixes #5850
- Fixes #5840
- Fixes #5821

Also fixed a few other bugs and did a little rebalancing:
- Slowed trains to 90% of walking speed (5% nerf)
- Capped emagged train impact damage at 10 (run over damage remains unchanged)
- Mobs are now stunned when they are thrown off a destroyed train
- More fix details in the commit logs

DOWNSTREAM:
I removed the "standing_mob" variable as standing is now handled by whether the mob can stand or not (note: the changes to mob.dm).
I also added a mob_offset_y var so mobs have a different pixel_y offset to other items.
