### PR TITLE
Mutiny: Add Vox Heist Directive

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -252,6 +252,7 @@
 #include "code\game\gamemodes\mutiny\directives\research_to_ripleys_directive.dm"
 #include "code\game\gamemodes\mutiny\directives\tau_ceti_needs_women_directive.dm"
 #include "code\game\gamemodes\mutiny\directives\terminations_directive.dm"
+#include "code\game\gamemodes\mutiny\directives\vox_heist.dm"
 #include "code\game\gamemodes\ninja\ninja.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -7,14 +7,14 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 /datum/emergency_shuttle_controller
 	var/datum/shuttle/ferry/emergency/shuttle
 	var/list/escape_pods
-	
+
 	var/launch_time			//the time at which the shuttle will be launched
 	var/auto_recall = 0		//if set, the shuttle will be auto-recalled
 	var/auto_recall_time	//the time at which the shuttle will be auto-recalled
 	var/evac = 0			//1 = emergency evacuation, 0 = crew transfer
 	var/wait_for_launch = 0	//if the shuttle is waiting to launch
 	var/autopilot = 1		//set to 0 to disable the shuttle automatically launching
-	
+
 	var/deny_shuttle = 0	//allows admins to prevent the shuttle from being called
 	var/departed = 0		//if the shuttle has left the station at least once
 
@@ -25,13 +25,13 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 			recall()
 		if (world.time >= launch_time)	//time to launch the shuttle
 			stop_launch_countdown()
-			
+
 			if (!shuttle.location)	//leaving from the station
 				//launch the pods!
 				for (var/datum/shuttle/ferry/escape_pod/pod in escape_pods)
 					if (!pod.arming_controller || pod.arming_controller.armed)
 						pod.launch(src)
-			
+
 			if (autopilot)
 				shuttle.launch(src)
 
@@ -40,13 +40,13 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	if (!shuttle.location)	//at station
 		if (autopilot)
 			set_launch_countdown(SHUTTLE_LEAVETIME)	//get ready to return
-			
+
 			if (evac)
 				captain_announce("The Emergency Shuttle has docked with the station. You have approximately [round(estimate_launch_time()/60,1)] minutes to board the Emergency Shuttle.")
 				world << sound('sound/AI/shuttledock.ogg')
 			else
 				captain_announce("The scheduled Crew Transfer Shuttle has docked with the station. It will depart in approximately [round(emergency_shuttle.estimate_launch_time()/60,1)] minutes.")
-		
+
 		//arm the escape pods
 		if (evac)
 			for (var/datum/shuttle/ferry/escape_pod/pod in escape_pods)
@@ -63,22 +63,24 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 
 //calls the shuttle for an emergency evacuation
 /datum/emergency_shuttle_controller/proc/call_evac()
-	if(!can_call()) return
-	
+	if(!can_call()) return 0
+
 	//set the launch timer
 	autopilot = 1
 	set_launch_countdown(get_shuttle_prep_time())
 	auto_recall_time = rand(world.time + 300, launch_time - 300)
-	
+
 	//reset the shuttle transit time if we need to
 	shuttle.move_time = SHUTTLE_TRANSIT_DURATION
-	
+
 	evac = 1
 	captain_announce("An emergency evacuation shuttle has been called. It will arrive in approximately [round(estimate_arrival_time()/60)] minutes.")
 	world << sound('sound/AI/shuttlecalled.ogg')
 	for(var/area/A in world)
 		if(istype(A, /area/hallway))
 			A.readyalert()
+
+	return 1
 
 //calls the shuttle for a routine crew transfer
 /datum/emergency_shuttle_controller/proc/call_transfer()
@@ -88,10 +90,10 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	autopilot = 1
 	set_launch_countdown(get_shuttle_prep_time())
 	auto_recall_time = rand(world.time + 300, launch_time - 300)
-	
+
 	//reset the shuttle transit time if we need to
 	shuttle.move_time = SHUTTLE_TRANSIT_DURATION
-	
+
 	captain_announce("A crew transfer has been scheduled. The shuttle has been called. It will arrive in approximately [round(estimate_arrival_time()/60)] minutes.")
 
 //recalls the shuttle
@@ -104,7 +106,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	if (evac)
 		captain_announce("The emergency shuttle has been recalled.")
 		world << sound('sound/AI/shuttlerecalled.ogg')
-		
+
 		for(var/area/A in world)
 			if(istype(A, /area/hallway))
 				A.readyreset()
@@ -134,8 +136,10 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	return 1
 
 /datum/emergency_shuttle_controller/proc/get_shuttle_prep_time()
-	// During mutiny rounds, the shuttle takes twice as long.
-	if(ticker && istype(ticker.mode,/datum/game_mode/mutiny))
+	// During mutiny rounds, the shuttle takes longer. Unless of course the directive is finished.
+	if(!ticker) return SHUTTLE_PREPTIME
+	var/datum/game_mode/mutiny/m = ticker.mode
+	if(istype(m) && !m.ead.activated)
 		return SHUTTLE_PREPTIME * 3		//15 minutes
 
 	return SHUTTLE_PREPTIME
@@ -203,14 +207,14 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 		if (shuttle.has_arrive_time())
 			var/timeleft = emergency_shuttle.estimate_arrival_time()
 			return "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
-		
+
 		if (waiting_to_leave())
 			if (shuttle.moving_status == SHUTTLE_WARMUP)
 				return "Departing..."
-			
+
 			var/timeleft = emergency_shuttle.estimate_launch_time()
 			return "ETD-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
-	
+
 	return ""
 /*
 	Some slapped-together star effects for maximum spess immershuns. Basically consists of a

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1182,18 +1182,7 @@ datum/mind
 			brigged_since = -1
 			return 0
 
-		var/is_currently_brigged = 0
-
-		if(istype(T.loc,/area/security/brig))
-			is_currently_brigged = 1
-			for(var/obj/item/weapon/card/id/card in current)
-				is_currently_brigged = 0
-				break // if they still have ID they're not brigged
-			for(var/obj/item/device/pda/P in current)
-				if(P.id)
-					is_currently_brigged = 0
-					break // if they still have ID they're not brigged
-
+		var/is_currently_brigged = current.is_in_brig()
 		if(!is_currently_brigged)
 			brigged_since = -1
 			return 0
@@ -1202,9 +1191,6 @@ datum/mind
 			brigged_since = world.time
 
 		return (duration <= world.time - brigged_since)
-
-
-
 
 //Initialisation procs
 /mob/living/proc/mind_initialize()

--- a/code/game/gamemodes/mutiny/directives/vox_heist.dm
+++ b/code/game/gamemodes/mutiny/directives/vox_heist.dm
@@ -1,0 +1,111 @@
+datum/directive/vox_heist
+  var/list/vox = list()
+  var/list/sympathizers = list()
+
+  proc/get_vox_candidates()
+    var/list/candidates[0]
+    for(var/mob/M in player_list)
+      if(M.is_ready() && is_vox(M))
+        candidates.Add(M)
+    return candidates
+
+  proc/get_sympathizer_candidates()
+    var/list/candidates[0]
+    for(var/mob/M in player_list)
+      if(M.is_ready() && !is_vox(M) && !M.is_mechanical() && M.mind.assigned_role != "Captain")
+        candidates[M] = get_weight(M)
+    return candidates
+
+  proc/is_vox(mob/M)
+    return M.get_species() == "Vox"
+
+  proc/get_weight(mob/M)
+    // You will have a high chance of being regarded as a vox sympathizer if your
+    // relationship with NanoTrasen is negative. Otherwise, command and security
+    // staff are pretty well trusted and maltreated alien races are easy suspects.
+    var/relation = M.client.prefs.nanotrasen_relation
+    if(relation == "Opposed")
+      return 8
+    if(relation == "Skeptical")
+      return 5
+    if(command_positions.Find(M.mind.assigned_role))
+      return 1
+    var/species = M.get_species()
+    if(species == "Tajaran" || species == "Unathi")
+      return 5
+    if(security_positions.Find(M.mind.assigned_role))
+      return 2
+    return 3
+
+datum/directive/vox_heist/get_description()
+  return {"
+    <p>
+      A vox warship has commandeered a NanoTrasen transport carrying 2,500 cubic meters of liquid phoron.
+      The raiders are willing to return the stolen cargo in exchange for the capture or execution of so-called "vox pariah" that are stationed aboard [station_name()].
+      If the transport is not recovered, the estimated loss of profits is a threat to the solvency of the company.
+      Predictive analysis has identified certain members of the crew as sympathetic to the vox pariah. Detain the sympathizers to guarantee a successful exchange.
+      Lethal force is authorized by the High Command Department of Security. Further information is classified.
+    </p>
+  "}
+
+datum/directive/vox_heist/initialize()
+  var/list/vox_candidates = get_vox_candidates()
+  for(var/mob/pariah in vox_candidates)
+    vox.Add(pariah.mind)
+
+  special_orders = list(
+    "Brig or kill all Vox Pariah.")
+
+  var/list/sympathizer_candidates = get_sympathizer_candidates()
+  var/list/sympathizer_names = list()
+  var/sympathizer_count = min(rand(2,4), sympathizer_candidates.len)
+  for(var/i=0, i < sympathizer_count, i++)
+    if(!sympathizer_candidates.len)
+      break
+
+    var/mob/candidate = pickweight(sympathizer_candidates)
+    sympathizer_candidates.Remove(candidate)
+    sympathizers.Add(candidate.mind)
+    sympathizer_names.Add("[candidate.mind.assigned_role] [candidate.mind.name]")
+
+  if(sympathizers.len)
+    special_orders.Add("Brig the following sympathizers: [list2text(sympathizer_names, ", ")]")
+
+datum/directive/vox_heist/meets_prerequisites()
+  var/list/candidates = get_vox_candidates()
+  return candidates.len >= 2
+
+datum/directive/vox_heist/directives_complete()
+  if(!vox.len && !sympathizers.len)
+    return 1
+
+  for(var/datum/mind/pariah in vox)
+    if(!pariah.current.is_in_brig())
+      return 0
+
+  for(var/datum/mind/sympathizer in sympathizers)
+    if(!sympathizer.current.is_in_brig())
+      return 0
+
+  return 1
+
+datum/directive/vox_heist/get_remaining_orders()
+  var/text = ""
+  for(var/datum/mind/pariah in vox)
+    if(!pariah.current.is_in_brig())
+      text += "<li>Brig or Kill [pariah]</li>"
+  for(var/datum/mind/sympathizer in sympathizers)
+    if(!sympathizer.current.is_in_brig())
+      text += "<li>Brig [sympathizer]</li>"
+  return text
+
+/hook/death/proc/vox_or_sympathizer_killed(mob/living/carbon/human/deceased, gibbed)
+  var/datum/directive/vox_heist/D = get_directive("vox_heist")
+  if(!D) return 1
+
+  var/datum/mind/M = deceased.mind
+  if(M in D.vox)
+    D.vox.Remove(M)
+  if(M in D.sympathizers)
+    D.sympathizers.Remove(M)
+  return 1

--- a/code/game/gamemodes/mutiny/emergency_authentication_device.dm
+++ b/code/game/gamemodes/mutiny/emergency_authentication_device.dm
@@ -37,6 +37,13 @@
 		else
 			return "Inactive"
 
+	proc/launch_shuttle()
+		spawn(rand(5 SECONDS, 45 SECONDS))
+			if(emergency_shuttle.call_evac())
+				spawn(20 SECONDS)
+					var/text = "[station_name()], we have confirmed your completion of Directive X. An evacuation shuttle is en route to receive your crew for debriefing."
+					command_alert(text, "Emergency Transmission")
+
 /obj/machinery/emergency_authentication_device/attack_hand(mob/user)
 	if(activated)
 		user << "\blue \The [src] is already active!"
@@ -51,6 +58,7 @@
 		activated = 1
 		user << "\blue You activate \the [src]!"
 		state("Command acknowledged. Initiating quantum entanglement relay to NanoTrasen High Command.")
+		launch_shuttle()
 		return
 
 	if(!captains_key && !secondary_key)

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -192,7 +192,7 @@ datum/game_mode/mutiny
 
 	proc/unbolt_vault_door()
 		var/obj/machinery/door/airlock/vault = locate(/obj/machinery/door/airlock/vault)
-		vault.lock()
+		vault.unlock(1)
 
 	proc/make_secret_transcript()
 		var/obj/machinery/computer/telecomms/server/S = locate(/obj/machinery/computer/telecomms/server)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -592,6 +592,25 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/is_ready()
 	return client && !!mind
 
+/mob/proc/is_in_brig()
+	if(!loc || !loc.loc)
+		return 0
+
+	// They should be in a cell or the Brig portion of the shuttle.
+	var/area/A = loc.loc
+	if(!istype(A, /area/security/brig))
+		if(!istype(A, /area/shuttle/escape) || loc.name != "Brig floor")
+			return 0
+
+	// If they still have their ID they're not brigged.
+	for(var/obj/item/weapon/card/id/card in src)
+		return 0
+	for(var/obj/item/device/pda/P in src)
+		if(P.id)
+			return 0
+
+	return 1
+
 /mob/proc/get_gender()
 	return gender
 


### PR DESCRIPTION
Adds a Vox Heist directive, wherein Vox raiders have captured a large quantity of liquid phoron from a NanoTrasen transport shuttle and will give it back in exchange for the station's Vox pariah personnel.

A predictive pattern analysis computer has identified several non-Vox crew who are to be regarded as Sympathizers for the pariah based on their behavior and background. To ensure the successful trade of the Vox for the phoron, suspected sympathizers should be detained until the exchange is complete. 

Due to the potential risk to NanoTrasen's solvency that the theft of so much phoron represents, Lethal Force is authorized against pariahs that resist detainment.

@Zuhayr is welcome tweak/refluff the story, but given the Vox's low standing with NanoTrasen and their own people, I figured they'd be a good focus for a directive that was slightly more aggressive than the current batch.

Other tweaks:
- Somehow the Vault door got re-bolted during Mutiny modes so it is once again unbolted.
- When the EAD is activated, the emergency shuttle is called at normal wait time. This seemed consistent with a lot of people's expectations that the completion of the Directive should wrap up the round. Especially pertinent for this directive where completion probably means there are going to be people in the brig.
- The brig section of the escape shuttle now counts as being brigged for the purpose of checking brig objectives.
