### PR TITLE
fixes #5876

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -229,7 +229,9 @@
 		adjustBruteLoss(damage)
 
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
-	if(!Proj)	return
+	if(!Proj || Proj.nodamage)
+		return
+	
 	adjustBruteLoss(Proj.damage)
 	return 0
 


### PR DESCRIPTION
stun beams killed simple animals cause nodamage was not checked
