### PR TITLE
Some fixes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -33,16 +33,21 @@
 	return 1
 
 /obj/item/clothing/proc/refit_for_species(var/target_species)
+	//Set species_restricted list
 	switch(target_species)
 		if("Human", "Skrell")	//humanoid bodytypes
 			species_restricted = list("exclude","Unathi","Tajaran","Diona","Vox")
 		else 
 			species_restricted = list(target_species)
 	
+	//Set icon
 	if (sprite_sheets_obj && (target_species in sprite_sheets_obj))
 		icon = sprite_sheets_obj[target_species]
+	else
+		icon = initial(icon)
 
 /obj/item/clothing/head/helmet/refit_for_species(var/target_species)
+	//Set species_restricted list
 	switch(target_species)
 		if("Skrell")
 			species_restricted = list("exclude","Unathi","Tajaran","Diona","Vox")
@@ -51,8 +56,11 @@
 		else 
 			species_restricted = list(target_species)
 	
+	//Set icon
 	if (sprite_sheets_obj && (target_species in sprite_sheets_obj))
 		icon = sprite_sheets_obj[target_species]
+	else
+		icon = initial(icon)
 
 
 //Ears: headsets, earmuffs and tiny objects

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -982,8 +982,7 @@ mob/proc/yank_out_object()
 	if(valid_objects.len == 1) //Yanking out last object - removing verb.
 		src.verbs -= /mob/proc/yank_out_object
 
-	if(istype(src,/mob/living/carbon/human))
-
+	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		var/datum/organ/external/affected
 
@@ -994,13 +993,16 @@ mob/proc/yank_out_object()
 
 		affected.implants -= selection
 		H.shock_stage+=20
-		H.bloody_hands(S)
 		affected.take_damage((selection.w_class * 3), 0, 0, 1, "Embedded object extraction")
 
 		if(prob(selection.w_class * 5)) //I'M SO ANEMIC I COULD JUST -DIE-.
 			var/datum/wound/internal_bleeding/I = new (15)
 			affected.wounds += I
 			H.custom_pain("Something tears wetly in your [affected] as [selection] is pulled free!", 1)
+		
+		if (ishuman(U))
+			var/mob/living/carbon/human/human_user = U
+			human_user.bloody_hands(H)
 
 	selection.loc = get_turf(src)
 

--- a/code/modules/projectiles/guns/projectile/crossbow.dm
+++ b/code/modules/projectiles/guns/projectile/crossbow.dm
@@ -84,6 +84,7 @@
 
 	if(!..()) return //Only do this on a successful shot.
 	icon_state = "crossbow"
+	tension = 0
 
 /obj/item/weapon/gun/launcher/crossbow/attack_self(mob/living/user as mob)
 	if(tension)


### PR DESCRIPTION
- Fixes inventory icon not reverting when refitting a suit for a species with no sprite sheet (mainly humans at the moment).
- Fixes "Yank Out Object" verb bloodying the wrong person's hands.
- Fixes crossbow tension not being reset when it is fired.
