### PR TITLE
Adjusts train supply costs to make the tug/cart ratio choice more interesting for players.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -235,7 +235,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_packs/cargotrain
 	name = "Cargo Train Tug"
 	contains = list(/obj/vehicle/train/cargo/engine)
-	cost = 30
+	cost = 45
 	containertype = /obj/structure/largecrate
 	containername = "Cargo Train Tug Crate"
 	group = "Operations"
@@ -243,7 +243,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_packs/cargotrailer
 	name = "Cargo Train Trolley"
 	contains = list(/obj/vehicle/train/cargo/trolley)
-	cost = 20
+	cost = 15
 	containertype = /obj/structure/largecrate
 	containername = "Cargo Train Trolley Crate"
 	group = "Operations"


### PR DESCRIPTION
Lowering the cost of carts gives players the option of making a tradeoff between less cost per cargo slots vs greater overall speed. This is because a train with less engines and more carts will be slower, but will cost less per cargo space.

Raised the cost of a tug so that the standard 1-tug 3-cart train costs 90 points as it did before.
