### PR TITLE
Fixes for grid_check random event.

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -4,8 +4,12 @@
 		command_alert("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure")
 		for(var/mob/M in player_list)
 			M << sound('sound/AI/poweroff.ogg')
+			
+	var/list/skipped_areas = list(/area/turret_protected/ai)
+	
 	for(var/obj/machinery/power/smes/S in world)
-		if(istype(get_area(S), /area/turret_protected) || S.z != 1)
+		var/area/current_area = get_area(S)
+		if(current_area.type in skipped_areas)
 			continue
 		S.last_charge = S.charge
 		S.last_output = S.output
@@ -16,43 +20,14 @@
 		S.updateicon()
 		S.power_change()
 
-	var/list/skipped_areas = list(/area/engine/engineering, /area/turret_protected/ai)
-
-	for(var/area/A in world)
-		if( !A.requires_power || A.always_unpowered )
-			continue
-
-		var/skip = 0
-		for(var/area_type in skipped_areas)
-			if(istype(A,area_type))
-				skip = 1
-				break
-		if(A.contents)
-			for(var/atom/AT in A.contents)
-				if(AT.z != 1) //Only check one, it's enough.
-					skip = 1
-				break
-		if(skip) continue
-		A.power_light = 0
-		A.power_equip = 0
-		A.power_environ = 0
-		A.power_change()
-
+	
 	for(var/obj/machinery/power/apc/C in world)
 		if(C.cell && C.z == 1)
-			var/area/A = get_area(C)
-
-			var/skip = 0
-			for(var/area_type in skipped_areas)
-				if(istype(A,area_type))
-					skip = 1
-					break
-			if(skip) continue
-
 			C.cell.charge = 0
 
 /proc/power_restore(var/announce = 1)
-
+	var/list/skipped_areas = list(/area/turret_protected/ai)
+	
 	if(announce)
 		command_alert("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal")
 		for(var/mob/M in player_list)
@@ -61,19 +36,14 @@
 		if(C.cell && C.z == 1)
 			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in world)
-		if(istype(get_area(S), /area/turret_protected) || S.z != 1)
+		var/area/current_area = get_area(S)
+		if(current_area.type in skipped_areas)
 			continue
 		S.charge = S.last_charge
 		S.output = S.last_output
 		S.online = S.last_online
 		S.updateicon()
 		S.power_change()
-	for(var/area/A in world)
-		if(A.name != "Space" && A.name != "Engine Walls" && A.name != "Chemical Lab Test Chamber" && A.name != "space" && A.name != "Escape Shuttle" && A.name != "Arrival Area" && A.name != "Arrival Shuttle" && A.name != "start area" && A.name != "Engine Combustion Chamber")
-			A.power_light = 1
-			A.power_equip = 1
-			A.power_environ = 1
-			A.power_change()
 
 /proc/power_restore_quick(var/announce = 1)
 

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -9,7 +9,7 @@
 	
 	for(var/obj/machinery/power/smes/S in world)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas)
+		if(current_area.type in skipped_areas || S.z != 1)
 			continue
 		S.last_charge = S.charge
 		S.last_output = S.output
@@ -37,7 +37,7 @@
 			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in world)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas)
+		if(current_area.type in skipped_areas || S.z != 1)
 			continue
 		S.charge = S.last_charge
 		S.output = S.last_output


### PR DESCRIPTION
There was an issue, when APC with removed cell in area was powered at power_restore() proc. That's was making area always powered despite APC being broken.
Removed part of code which unpowers area directly, bypassing the APC process code. This makes grid_check event less laggy and smooth. Downside is lights not being shut down immediatly.
AI SMES still not being affected after this fix.
