### PR TITLE
Fix for infinite loop in smokeFlow() proc.

### DIFF
--- a/code/game/objects/effects/chemsmoke.dm
+++ b/code/game/objects/effects/chemsmoke.dm
@@ -224,24 +224,25 @@
 	pending += location
 
 	while(pending.len)
-		for(var/turf/simulated/current in pending)
+		for(var/turf/current in pending)
 			for(var/D in cardinal)
-				var/turf/simulated/target = get_step(current, D)
-
+				var/turf/target = get_step(current, D)
 				if(wallList)
 					if(istype(target, /turf/simulated/wall))
 						if(!(target in wallList))
 							wallList += target
 						continue
-				if(!target.zone)
-					continue
+				
 				if(target in pending)
 					continue
 				if(target in complete)
 					continue
 				if(!(target in targetTurfs))
 					continue
-
+				if(current.c_airblock(target)) //this is needed to stop chemsmoke from passing through thin window walls
+					continue
+				if(target.c_airblock(current)) 
+					continue
 				pending += target
 
 			pending -= current


### PR DESCRIPTION
When chemical grenade being activated on any unsimulated turf (for example a space turf), smokeFlow() starts infinite while loop, overloading the server.
With the only one unsimulated turf in pending list while() loop can't finish itself and for() loop can't start.
This fix makes chemical grenades being able to explode in space without server going in infinite loop.

Also fixed issue with smoke being able to pass through glass walls with help of c_airblock() proc. That's the best solution I could come up with.
Zone check code was useless because every single turf besides walls (which allready checked) and unsimulated turfs have it, making algorithm believe that turfs behind the glass wall are being reachable by chemsmoke.
I don't know if it was intended not to spread smoke in airless or unsimulated areas, but a bunch of airless simulated floor tiles in space is good enough for this algorithm to start spreading smoke around.

P.S. this algorithm is good for large, open areas and horrible in narrow maint tunnels. It is creating only a single cloud of smoke for 50/50/50 recipie in 1 tile wide tunnel.
