### PR TITLE
Fixes phoron reactions

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -219,10 +219,10 @@ datum/gas_mixture/proc/zburn(obj/effect/decal/cleanable/liquid_fuel/liquid, forc
 		var/starting_energy = temperature * heat_capacity()
 
 		//determine the amount of oxygen used
-		var/used_oxidizers = min(total_oxidizers, 2 * total_fuel)
+		var/used_oxidizers = min(total_oxidizers, total_fuel / 2)
 
 		//determine the amount of fuel actually used
-		var/used_fuel_ratio = min(total_oxidizers / 2 , total_fuel) / total_fuel
+		var/used_fuel_ratio = min(2 * total_oxidizers , total_fuel) / total_fuel
 		total_fuel = total_fuel * used_fuel_ratio
 
 		var/total_reactants = total_fuel + used_oxidizers
@@ -232,9 +232,9 @@ datum/gas_mixture/proc/zburn(obj/effect/decal/cleanable/liquid_fuel/liquid, forc
 
 		//remove and add gasses as calculated
 		remove_by_flag(XGM_GAS_OXIDIZER, used_oxidizers * used_reactants_ratio)
-		remove_by_flag(XGM_GAS_FUEL, total_fuel * used_reactants_ratio * 3)
+		remove_by_flag(XGM_GAS_FUEL, total_fuel * used_reactants_ratio)
 
-		adjust_gas("carbon_dioxide", max(2 * total_fuel, 0))
+		adjust_gas("carbon_dioxide", max(total_fuel*used_reactants_ratio, 0))
 
 		if(liquid)
 			liquid.amount -= (liquid.amount * used_fuel_ratio * used_reactants_ratio) * 5 // liquid fuel burns 5 times as quick


### PR DESCRIPTION
**What happened before:**
Phoron and Oxygen burned up in a 3:2 ratio and was handled as a 1:2 reaction. In each tick it also generates as many carbon dioxide molecules as the entire reaction would create from now until it is finished.
3 Ph + 2 O2 -> lots and lots of CO2

**What happens now:**
Reaction gets consistently dealt as a 2:1 reaction and doesn't generate carbon dioxide out of literally nowhere.
2 Ph + 1 O2 -> 2 CO2

Will probably also have the effect that reactions are much faster now, not taking as much time to burn as it does now. Has been tested with bombs; don't worry, everything still works.
