### PR TITLE
More proximity fixes

### DIFF
--- a/code/WorkInProgress/Wrongnumber/weldbackpack.dm
+++ b/code/WorkInProgress/Wrongnumber/weldbackpack.dm
@@ -34,13 +34,15 @@
 	user << "\blue The tank scoffs at your insolence.  It only provides services to welders."
 	return
 
-/obj/item/weapon/weldpack/afterattack(obj/O as obj, mob/user as mob)
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1 && src.reagents.total_volume < max_fuel)
+/obj/item/weapon/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
+	if(!proximity) // this replaces and improves the get_dist checks commented out below
+		return
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank) /*&& get_dist(src,O) <= 1*/ && src.reagents.total_volume < max_fuel)
 		O.reagents.trans_to(src, max_fuel)
 		user << "\blue You crack the cap off the top of the pack and fill it back up again from the tank."
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		return
-	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1 && src.reagents.total_volume == max_fuel)
+	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) /*&& get_dist(src,O) <= 1*/ && src.reagents.total_volume == max_fuel)
 		user << "\blue The pack is already full!"
 		return
 

--- a/code/WorkInProgress/Wrongnumber/weldbackpack.dm
+++ b/code/WorkInProgress/Wrongnumber/weldbackpack.dm
@@ -35,14 +35,14 @@
 	return
 
 /obj/item/weapon/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if(!proximity) // this replaces and improves the get_dist checks commented out below
+	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) /*&& get_dist(src,O) <= 1*/ && src.reagents.total_volume < max_fuel)
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume < max_fuel)
 		O.reagents.trans_to(src, max_fuel)
 		user << "\blue You crack the cap off the top of the pack and fill it back up again from the tank."
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		return
-	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) /*&& get_dist(src,O) <= 1*/ && src.reagents.total_volume == max_fuel)
+	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume == max_fuel)
 		user << "\blue The pack is already full!"
 		return
 

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -114,7 +114,9 @@
 		return
 	..()
 
-/obj/item/weapon/implanter/compressed/afterattack(atom/A, mob/user as mob)
+/obj/item/weapon/implanter/compressed/afterattack(atom/A, mob/user as mob, proximity)
+	if(!proximity)
+		return
 	if(istype(A,/obj/item) && imp)
 		var/obj/item/weapon/implant/compressed/c = imp
 		if (c.scanned)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -65,7 +65,9 @@
 				O.show_message(text("\red [] waves [] over []'s head.", user, src, M), 1)
 			return
 
-/obj/item/weapon/nullrod/afterattack(atom/A, mob/user as mob)
+/obj/item/weapon/nullrod/afterattack(atom/A, mob/user as mob, proximity)
+	if(!proximity)
+		return
 	if (istype(A, /turf/simulated/floor))
 		user << "\blue You hit the floor with the [src]."
 		call(/obj/effect/rune/proc/revealrunes)(src)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -6,7 +6,9 @@
 	name = "RoboTray"
 	desc = "An autoloading tray specialized for carrying refreshments."
 
-/obj/item/weapon/tray/robotray/afterattack(atom/target, mob/user as mob)
+/obj/item/weapon/tray/robotray/afterattack(atom/target, mob/user as mob, proximity)
+	if(!proximity)
+		return
 	if ( !target )
 		return
 	// pick up items, mostly copied from base tray pickup proc


### PR DESCRIPTION
Welder packs, compressed matter implants, null rods and robotrays.

Only three more places that the signature of `afterattack` looks like it needs a `proximity` var, I've left all three for various reasons:
- `code/game/objects/items/weapons/cards_ids.dm L108` (emag) because it seems to work as-is without `proximity`
- `code/game/objects/items/weapons/paint.dm L169` because it's commented out
- `code/WorkInProgress/SkyMarshal/portalathe.dm L8` because it's not marked for inclusion in the .dme
