### PR TITLE
fixes building more than 1 grille per turf

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -52,15 +52,19 @@
 				use(1)
 			else
 				return 1
-	else
+
+	else if(!in_use)
 		if(amount < 2)
 			user << "\blue You need at least two rods to do this."
 			return
 		usr << "\blue Assembling grille..."
+		in_use = 1
 		if (!do_after(usr, 10))
+			in_use = 0
 			return
 		var/obj/structure/grille/F = new /obj/structure/grille/ ( usr.loc )
 		usr << "\blue You assemble a grille"
+		in_use = 0
 		F.add_fingerprint(usr)
 		use(2)
 	return


### PR DESCRIPTION
rapidly triggering attack_self() enabled building more than 1 per turf,
which is fairly abusive and not indended.
