### PR TITLE
Fixes for docking controllers, emergency shuttle and airlock animations

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -648,9 +648,11 @@ About the new airlock wires panel:
 			else
 				flick("door_closing", src)
 		if("spark")
-			flick("door_spark", src)
+			if(density)
+				flick("door_spark", src)
 		if("deny")
-			flick("door_deny", src)
+			if(density)
+				flick("door_deny", src)
 	return
 
 /obj/machinery/door/airlock/attack_ai(mob/user as mob)

--- a/code/game/machinery/embedded_controller/docking_program_multi.dm
+++ b/code/game/machinery/embedded_controller/docking_program_multi.dm
@@ -197,7 +197,9 @@
 
 //checks if we are ready for undocking
 /datum/computer/file/embedded_program/airlock/multi_docking/proc/ready_for_undocking()
-	return check_doors_secured()
+	var/ext_closed = check_exterior_door_secured()
+	var/int_closed = check_interior_door_secured()
+	return (ext_closed || int_closed)
 
 /datum/computer/file/embedded_program/airlock/multi_docking/proc/open_doors()
 	toggleDoor(memory["interior_status"], tag_interior_door, memory["secure"], "open")

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -137,10 +137,3 @@
 
 /datum/computer/file/embedded_program/docking/simple/escape_pod/prepare_for_undocking()
 	eject_time = world.time + eject_delay*10
-
-/*
-/datum/computer/file/embedded_program/docking/simple/escape_pod/ready_for_undocking()
-	if (world.time < eject_time)
-		return 0
-	return ..()
-*/

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -34,15 +34,14 @@
 		if (moving_status == SHUTTLE_IDLE) 
 			return	//someone cancelled the launch
 		
-		move(departing, interim, direction)
-
 		moving_status = SHUTTLE_INTRANSIT
+		move(departing, interim, direction)
+		
 		arrive_time = world.time + travel_time*10
 		while (world.time < arrive_time)
 			sleep(5)
 
 		move(interim, destination, direction)
-
 		moving_status = SHUTTLE_IDLE
 
 /datum/shuttle/proc/dock()
@@ -69,6 +68,8 @@
 	return 0
 
 //just moves the shuttle from A to B, if it can be moved
+//A note to anyone overriding move in a subtype. move() must absolutely not, under any circumstances, fail to move the shuttle.
+//If you want to conditionally cancel shuttle launches, that logic must go in short_jump() or long_jump()
 /datum/shuttle/proc/move(var/area/origin, var/area/destination, var/direction=null)
 
 	//world << "move_shuttle() called for [shuttle_tag] leaving [origin] en route to [destination]."


### PR DESCRIPTION
The loosening of the undock restrictions for airlock-based docking ports was actually implemented a while back, but it seems I forgot to update the multi-airlock docking controllers as well, as they are a separate subtype of docking controller.
