### PR TITLE
Adjusts laser cannon damage

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -16,12 +16,13 @@
 	clumsy_check = 0
 
 obj/item/weapon/gun/energy/laser/retro
-	name ="retro laser"
+	name = "retro laser"
 	icon_state = "retro"
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's security or military forces. Nevertheless, it is still quite deadly and easy to maintain, making it a favorite amongst pirates and other outlaws."
 
 
 /obj/item/weapon/gun/energy/laser/captain
+	name = "antique laser gun"
 	icon_state = "caplaser"
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -93,7 +93,7 @@ var/list/beam_master = list()
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
-	damage = 40
+	damage = 60
 
 /obj/item/projectile/beam/xray
 	name = "xray beam"
@@ -105,11 +105,6 @@ var/list/beam_master = list()
 	icon_state = "u_laser"
 	damage = 50
 
-
-/obj/item/projectile/beam/deathlaser
-	name = "death laser"
-	icon_state = "heavylaser"
-	damage = 60
 
 /obj/item/projectile/beam/emitter
 	name = "emitter beam"


### PR DESCRIPTION
I was going to increase the damage to 60, but then I noticed that the laser cannon's fire delay was 20, just over 3x higher than the regular fire delay of 6. So 80 seems more fitting.

Also removed the unused "death laser" and gave a name to the captain's laser so that it doesn't inherit "laser carbine"

Fixes #6008
