### PR TITLE
Added a forced, immediate refresh of the icons after the character is made

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -430,6 +430,9 @@
 		// And uncomment this, too.
 		//new_character.dna.UpdateSE()
 
+		// Do the initial caching of the player's body icons.
+		new_character.regenerate_icons()
+
 		new_character.key = key		//Manually transfer the key to log them in
 
 		return new_character


### PR DESCRIPTION
Resolves #5869
This eliminates a race condition between spawning in and the icon cache being updated to include the body. This apparently wasn't an issue on initial spawn, but late spawn tended to have the manifest_inject (where the AI icon is made) happen before the first tick of life() when update_icon=1 would cause the icons to be generated.
