### PR TITLE
Fixes laptop power draw, improves cell chargers

### DIFF
--- a/code/WorkInProgress/computer3/laptop.dm
+++ b/code/WorkInProgress/computer3/laptop.dm
@@ -157,15 +157,15 @@
 			return
 		if(use_power && istype(battery) && battery.charge > 0)
 			if(use_power == 1)
-				battery.use(idle_power_usage)
+				battery.use(idle_power_usage*CELLRATE) //idle and active_power_usage are in WATTS. battery.use() expects CHARGE.
 			else
-				battery.use(active_power_usage)
+				battery.use(active_power_usage*CELLRATE)
 			return 1
 		return 0
 
 	use_power(var/amount, var/chan = -1)
 		if(battery && battery.charge > 0)
-			battery.use(amount)
+			battery.use(amount*CELLRATE)
 
 	power_change()
 		if( !battery || battery.charge <= 0 )

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -7,12 +7,12 @@ obj/machinery/recharger
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 4
-	var/power_rating = 15000	//15 kW
+	active_power_usage = 15000	//15 kW
 	var/obj/item/charging = null
 	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton, /obj/item/device/laptop, /obj/item/weapon/cell)
 	var/icon_state_charged = "recharger2"
 	var/icon_state_charging = "recharger1"
-	var/icon_state_idle = "recharger0"
+	var/icon_state_idle = "recharger0" //also when unpowered
 
 obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
 	if(istype(user,/mob/living/silicon))
@@ -24,6 +24,7 @@ obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
 	
 	if(allowed)
 		if(charging)
+			user << "\red \A [charging] is already charging here."
 			return
 		// Checks to make sure he's not in space doing it, and that the area got proper power.
 		var/area/a = get_area(src)
@@ -66,45 +67,60 @@ obj/machinery/recharger/attack_paw(mob/user as mob)
 
 obj/machinery/recharger/process()
 	if(stat & (NOPOWER|BROKEN) || !anchored)
+		update_use_power(0)
+		icon_state = icon_state_idle
 		return
 
-	if(charging)
+	if(!charging)
+		update_use_power(1)
+		icon_state = icon_state_idle
+	else
 		if(istype(charging, /obj/item/weapon/gun/energy))
 			var/obj/item/weapon/gun/energy/E = charging
 			if(!E.power_supply.fully_charged())
 				icon_state = icon_state_charging
-				var/charge_used = E.power_supply.give(power_rating*CELLRATE)
-				use_power(charge_used/CELLRATE)
+				E.power_supply.give(active_power_usage*CELLRATE)
+				update_use_power(2)
 			else
 				icon_state = icon_state_charged
+				update_use_power(1)
 			return
+		
 		if(istype(charging, /obj/item/weapon/melee/baton))
 			var/obj/item/weapon/melee/baton/B = charging
 			if(B.bcell)
 				if(!B.bcell.fully_charged())
 					icon_state = icon_state_charging
-					var/charge_used = B.bcell.give(power_rating*CELLRATE)
-					use_power(charge_used/CELLRATE)
+					B.bcell.give(active_power_usage*CELLRATE)
+					update_use_power(2)
 				else
 					icon_state = icon_state_charged
+					update_use_power(1)
+			else
+				icon_state = icon_state_idle
+				update_use_power(1)
 			return
+		
 		if(istype(charging, /obj/item/device/laptop))
 			var/obj/item/device/laptop/L = charging
 			if(!L.stored_computer.battery.fully_charged())
 				icon_state = icon_state_charging
-				var/charge_used = L.stored_computer.battery.give(power_rating*CELLRATE)
-				use_power(charge_used/CELLRATE)
+				L.stored_computer.battery.give(active_power_usage*CELLRATE)
+				update_use_power(2)
 			else
 				icon_state = icon_state_charged
+				update_use_power(1)
 			return
+		
 		if(istype(charging, /obj/item/weapon/cell))
 			var/obj/item/weapon/cell/C = charging
 			if(!C.fully_charged())
 				icon_state = icon_state_charging
-				var/charge_used = C.give(power_rating*CELLRATE)
-				use_power(charge_used/CELLRATE)
+				C.give(active_power_usage*CELLRATE)
+				update_use_power(2)
 			else
 				icon_state = icon_state_charged
+				update_use_power(1)
 			return
 
 obj/machinery/recharger/emp_act(severity)
@@ -129,12 +145,12 @@ obj/machinery/recharger/update_icon()	//we have an update_icon() in addition to 
 	else
 		icon_state = icon_state_idle
 
-// Atlantis: No need for that copy-pasta code, just use var to store icon_states instead.
+
 obj/machinery/recharger/wallcharger
 	name = "wall recharger"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "wrecharger0"
-	power_rating = 25000	//25 kW , It's more specialized than the standalone recharger (guns and batons only) so make it more powerful
+	active_power_usage = 25000	//25 kW , It's more specialized than the standalone recharger (guns and batons only) so make it more powerful
 	allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton)
 	icon_state_charged = "wrecharger2"
 	icon_state_charging = "wrecharger1"


### PR DESCRIPTION
I thought the fix for laptop power draw was included in PR #5619, but somehow it got lost.
- Laptops no longer draw 200 times as much power as they should, due to missing unit conversion
- Cell chargers no longer call use_power() in their process()
- Converted cell_charger.dm to absolute pathnames

Laptop battery capacity should probably be reduced by 200 to account for the reduced power draw. I have not done this in this PR though as they are currently using the default line of power cells. Really we should probably add a distinction between the industrial-sized power cells used by APCs and Cyborgs (they are w_class 3... it doesn't make sense that they are able to fit inside a laptop, much less a stun baton), and the ones used by devices.
