### PR TITLE
fixes #6023 and cleans up mech_bay.dm

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -6,43 +6,52 @@
 	var/obj/machinery/computer/mech_bay_power_console/recharge_console
 	var/obj/mecha/recharging_mecha = null
 
-	Entered(var/obj/mecha/mecha)
-		. = ..()
-		if(istype(mecha))
-			mecha.occupant_message("<b>Initializing power control devices.</b>")
-			init_devices()
-			if(recharge_console && recharge_port)
-				recharging_mecha = mecha
-				recharge_console.mecha_in(mecha)
-				return
-			else if(!recharge_console)
-				mecha.occupant_message("<font color='red'>Control console not found. Terminating.</font>")
-			else if(!recharge_port)
-				mecha.occupant_message("<font color='red'>Power port not found. Terminating.</font>")
-		return
+/turf/simulated/floor/mech_bay_recharge_floor/Entered(var/obj/mecha/mecha)
+	. = ..()
+	if(istype(mecha))
+		mecha.occupant_message("<b>Initializing power control devices.</b>")
+		init_devices()
+		if(recharge_console && recharge_port)
+			recharging_mecha = mecha
+			recharge_console.mecha_in(mecha)
+			return
+		else if(!recharge_console)
+			mecha.occupant_message("<font color='red'>Control console not found. Terminating.</font>")
+		else if(!recharge_port)
+			mecha.occupant_message("<font color='red'>Power port not found. Terminating.</font>")
+	return
 
-	Exited(atom)
-		. = ..()
-		if(atom == recharging_mecha)
-			recharging_mecha = null
-			if(recharge_console)
-				recharge_console.mecha_out()
-		return
-
-	proc/init_devices()
-		recharge_console = locate() in range(1,src)
-		recharge_port = locate(/obj/machinery/mech_bay_recharge_port, get_step(src, WEST))
+/turf/simulated/floor/mech_bay_recharge_floor/Exited(atom)
+	. = ..()
+	if(atom == recharging_mecha)
+		recharging_mecha = null
 		if(recharge_console)
-			recharge_console.recharge_floor = src
-			if(recharge_port)
-				recharge_console.recharge_port = recharge_port
+			recharge_console.mecha_out()
+	return
+
+/turf/simulated/floor/mech_bay_recharge_floor/proc/init_devices()
+	if(!recharge_console)
+		recharge_console = locate() in range(1,src)
+	if(!recharge_port)
+		recharge_port = locate() in get_step(src, WEST)
+
+	if(recharge_console)
+		recharge_console.recharge_floor = src
 		if(recharge_port)
-			recharge_port.recharge_floor = src
-			if(recharge_console)
-				recharge_port.recharge_console = recharge_console
-		return
+			recharge_console.recharge_port = recharge_port
+	if(recharge_port)
+		recharge_port.recharge_floor = src
+		if(recharge_console)
+			recharge_port.recharge_console = recharge_console
+	return
 
-
+// temporary fix for broken icon until somebody gets around to make these player-buildable
+/turf/simulated/floor/mech_bay_recharge_floor/attackby(obj/item/C as obj, mob/user as mob)	
+	..()	
+	if(floor_tile)
+		icon_state = "recharge_floor"
+	else
+		icon_state = "support_lattice"
 
 
 /obj/machinery/mech_bay_recharge_port
@@ -55,50 +64,50 @@
 	var/obj/machinery/computer/mech_bay_power_console/recharge_console
 	var/datum/global_iterator/mech_bay_recharger/pr_recharger
 
-	New()
-		..()
-		pr_recharger = new /datum/global_iterator/mech_bay_recharger(null,0)
-		return
+/obj/machinery/mech_bay_recharge_port/New()
+	..()
+	pr_recharger = new /datum/global_iterator/mech_bay_recharger(null,0)
+	return
 
-	proc/start_charge(var/obj/mecha/recharging_mecha)
-		if(stat&(NOPOWER|BROKEN))
-			recharging_mecha.occupant_message("<font color='red'>Power port not responding. Terminating.</font>")
-			return 0
-		else
-			if(recharging_mecha.cell)
-				recharging_mecha.occupant_message("Now charging...")
-				pr_recharger.start(list(src,recharging_mecha))
-				return 1
-			else
-				return 0
-
-	proc/stop_charge()
-		if(recharge_console && !recharge_console.stat)
-			recharge_console.icon_state = initial(recharge_console.icon_state)
-		pr_recharger.stop()
-		return
-
-	proc/active()
-		if(pr_recharger.active())
+/obj/machinery/mech_bay_recharge_port/proc/start_charge(var/obj/mecha/recharging_mecha)
+	if(stat&(NOPOWER|BROKEN))
+		recharging_mecha.occupant_message("<font color='red'>Power port not responding. Terminating.</font>")
+		return 0
+	else
+		if(recharging_mecha.cell)
+			recharging_mecha.occupant_message("Now charging...")
+			pr_recharger.start(list(src,recharging_mecha))
 			return 1
 		else
 			return 0
 
-	power_change()
-		if(powered())
-			stat &= ~NOPOWER
-		else
-			spawn(rand(0, 15))
-				stat |= NOPOWER
-				pr_recharger.stop()
-		return
+/obj/machinery/mech_bay_recharge_port/proc/stop_charge()
+	if(recharge_console && !recharge_console.stat)
+		recharge_console.icon_state = initial(recharge_console.icon_state)
+	pr_recharger.stop()
+	return
 
-	proc/set_voltage(new_voltage)
-		if(new_voltage && isnum(new_voltage))
-			pr_recharger.max_charge = new_voltage
-			return 1
-		else
-			return 0
+/obj/machinery/mech_bay_recharge_port/proc/active()
+	if(pr_recharger.active())
+		return 1
+	else
+		return 0
+
+/obj/machinery/mech_bay_recharge_port/power_change()
+	if(powered())
+		stat &= ~NOPOWER
+	else
+		spawn(rand(0, 15))
+			stat |= NOPOWER
+			pr_recharger.stop()
+	return
+
+/obj/machinery/mech_bay_recharge_port/proc/set_voltage(new_voltage)
+	if(new_voltage && isnum(new_voltage))
+		pr_recharger.max_charge = new_voltage
+		return 1
+	else
+		return 0
 
 
 /datum/global_iterator/mech_bay_recharger
@@ -106,23 +115,22 @@
 	var/max_charge = 45
 	check_for_null = 0 //since port.stop_charge() must be called. The checks are made in process()
 
-	process(var/obj/machinery/mech_bay_recharge_port/port, var/obj/mecha/mecha)
-		if(!port)
-			return 0
-		if(mecha && mecha in port.recharge_floor)
-			if(!mecha.cell)	return
-			var/delta = min(max_charge, mecha.cell.maxcharge - mecha.cell.charge)
-			if(delta>0)
-				mecha.give_power(delta)
-				port.use_power(delta*150)
-			else
-				mecha.occupant_message("<font color='blue'><b>Fully charged.</b></font>")
-				port.stop_charge()
+/datum/global_iterator/mech_bay_recharger/process(var/obj/machinery/mech_bay_recharge_port/port, var/obj/mecha/mecha)
+	if(!port)
+		return 0
+	if(mecha && mecha in port.recharge_floor)
+		if(!mecha.cell)
+			return
+		var/delta = min(max_charge, mecha.cell.maxcharge - mecha.cell.charge)
+		if(delta>0)
+			mecha.give_power(delta)
+			port.use_power(delta*150)
 		else
+			mecha.occupant_message("<font color='blue'><b>Fully charged.</b></font>")
 			port.stop_charge()
-		return
-
-
+	else
+		port.stop_charge()
+	return
 
 
 /obj/machinery/computer/mech_bay_power_console
@@ -137,82 +145,90 @@
 	var/turf/simulated/floor/mech_bay_recharge_floor/recharge_floor
 	var/obj/machinery/mech_bay_recharge_port/recharge_port
 
-	proc/mecha_in(var/obj/mecha/mecha)
-		if(stat&(NOPOWER|BROKEN))
-			mecha.occupant_message("<font color='red'>Control console not responding. Terminating...</font>")
-			return
-		if(recharge_port && autostart)
-			var/answer = recharge_port.start_charge(mecha)
-			if(answer)
-				recharge_port.set_voltage(voltage)
-				src.icon_state = initial(src.icon_state)+"_on"
+/obj/machinery/computer/mech_bay_power_console/proc/mecha_in(var/obj/mecha/mecha)
+	if(stat&(NOPOWER|BROKEN))
+		mecha.occupant_message("<font color='red'>Control console not responding. Terminating...</font>")
 		return
+	if(recharge_port && autostart)
+		var/answer = recharge_port.start_charge(mecha)
+		if(answer)
+			recharge_port.set_voltage(voltage)
+			src.icon_state = initial(src.icon_state)+"_on"
+	return
 
-	proc/mecha_out()
+/obj/machinery/computer/mech_bay_power_console/proc/mecha_out()
+	if(recharge_port)
+		recharge_port.stop_charge()
+	return
+
+
+/obj/machinery/computer/mech_bay_power_console/power_change()
+	if(stat & BROKEN)
+		icon_state = initial(icon_state)+"_broken"
 		if(recharge_port)
 			recharge_port.stop_charge()
-		return
-
-
-	power_change()
-		if(stat & BROKEN)
-			icon_state = initial(icon_state)+"_broken"
+	else if(powered())
+		icon_state = initial(icon_state)
+		stat &= ~NOPOWER
+	else
+		spawn(rand(0, 15))
+			icon_state = initial(icon_state)+"_nopower"
+			stat |= NOPOWER
 			if(recharge_port)
 				recharge_port.stop_charge()
-		else if(powered())
-			icon_state = initial(icon_state)
-			stat &= ~NOPOWER
-		else
-			spawn(rand(0, 15))
-				icon_state = initial(icon_state)+"_nopower"
-				stat |= NOPOWER
-				if(recharge_port)
-					recharge_port.stop_charge()
 
-	set_broken()
-		icon_state = initial(icon_state)+"_broken"
-		stat |= BROKEN
+/obj/machinery/computer/mech_bay_power_console/set_broken()
+	icon_state = initial(icon_state)+"_broken"
+	stat |= BROKEN
+	if(recharge_port)
+		recharge_port.stop_charge()
+
+/obj/machinery/computer/mech_bay_power_console/attack_hand(mob/user as mob)
+	if(..())
+		return
+	if(!recharge_floor || !recharge_port)
+		var/turf/simulated/floor/mech_bay_recharge_floor/F = locate() in range(1,src)
+		if(F)
+			F.init_devices()
+	
+	var/output = "<html><head><title>[src.name]</title></head><body>"
+	if(!recharge_floor)
+		output += "<font color='red'>Mech Bay Recharge Station not initialized.</font><br>"
+	else
+		output += {"<b>Mech Bay Recharge Station Data:</b><div style='margin-left: 15px;'>
+						<b>Mecha: </b>[recharge_floor.recharging_mecha||"None"]<br>"}
+		if(recharge_floor.recharging_mecha)
+			var/cell_charge = recharge_floor.recharging_mecha.get_charge()
+			output += "<b>Cell charge: </b>[isnull(cell_charge)?"No powercell found":"[recharge_floor.recharging_mecha.cell.charge]/[recharge_floor.recharging_mecha.cell.maxcharge]"]<br>"
+		output += "</div>"
+	if(!recharge_port)
+		output += "<font color='red'>Mech Bay Power Port not initialized.</font><br>"
+	else
+		output += "<b>Mech Bay Power Port Status: </b>[recharge_port.active()?"Now charging":"On hold"]<br>"
+
+	/*
+	output += {"<hr>
+					<b>Settings:</b>
+					<div style='margin-left: 15px;'>
+					<b>Start sequence on succesful init: </b><a href='?src=\ref[src];autostart=1'>[autostart?"On":"Off"]</a><br>
+					<b>Recharge Port Voltage: </b><a href='?src=\ref[src];voltage=30'>Low</a> - <a href='?src=\ref[src];voltage=45'>Medium</a> - <a href='?src=\ref[src];voltage=60'>High</a><br>
+					</div>"}
+	*/
+
+	output += "</ body></html>"
+	user << browse(output, "window=mech_bay_console")
+	onclose(user, "mech_bay_console")
+	return
+
+// unused at the moment, also lacks any kind of exploit prevention
+/* 
+/obj/machinery/computer/mech_bay_power_console/Topic(href, href_list)
+	if(href_list["autostart"])
+		autostart = !autostart
+	if(href_list["voltage"])
+		voltage = text2num(href_list["voltage"])
 		if(recharge_port)
-			recharge_port.stop_charge()
-
-	attack_hand(mob/user as mob)
-		if(..()) return
-		var/output = "<html><head><title>[src.name]</title></head><body>"
-		if(!recharge_floor)
-			output += "<font color='red'>Mech Bay Recharge Station not initialized.</font><br>"
-		else
-			output += {"<b>Mech Bay Recharge Station Data:</b><div style='margin-left: 15px;'>
-							<b>Mecha: </b>[recharge_floor.recharging_mecha||"None"]<br>"}
-			if(recharge_floor.recharging_mecha)
-				var/cell_charge = recharge_floor.recharging_mecha.get_charge()
-				output += "<b>Cell charge: </b>[isnull(cell_charge)?"No powercell found":"[recharge_floor.recharging_mecha.cell.charge]/[recharge_floor.recharging_mecha.cell.maxcharge]"]<br>"
-			output += "</div>"
-		if(!recharge_port)
-			output += "<font color='red'>Mech Bay Power Port not initialized.</font><br>"
-		else
-			output += "<b>Mech Bay Power Port Status: </b>[recharge_port.active()?"Now charging":"On hold"]<br>"
-
-		/*
-		output += {"<hr>
-						<b>Settings:</b>
-						<div style='margin-left: 15px;'>
-						<b>Start sequence on succesful init: </b><a href='?src=\ref[src];autostart=1'>[autostart?"On":"Off"]</a><br>
-						<b>Recharge Port Voltage: </b><a href='?src=\ref[src];voltage=30'>Low</a> - <a href='?src=\ref[src];voltage=45'>Medium</a> - <a href='?src=\ref[src];voltage=60'>High</a><br>
-						</div>"}
-		*/
-
-		output += "</ body></html>"
-		user << browse(output, "window=mech_bay_console")
-		onclose(user, "mech_bay_console")
-		return
-
-
-	Topic(href, href_list)
-		if(href_list["autostart"])
-			autostart = !autostart
-		if(href_list["voltage"])
-			voltage = text2num(href_list["voltage"])
-			if(recharge_port)
-				recharge_port.set_voltage(voltage)
-		updateUsrDialog()
-		return
+			recharge_port.set_voltage(voltage)
+	updateUsrDialog()
+	return
+*/


### PR DESCRIPTION
- adds tile update on attackby() to fix #6023 using a so far dormant icon state ( line 49 )
- adds missing console initalization on attack_hand() ( line 189 )
- comments unreachable ( via normal means ) mech_bay_power_console/Topic ( line 225 )
- gets rid of relative paths, leaving procs unchanged

note : recharge-floors currently don't care about what direction the console is, unlike the charger-port which always has to be west of the floor.
this should be probably changed to console having to be east of the floor, as most mappers do that anyway and to reduce the chance of future bugs. awaiting feedback on that one.
 like the charger and floor.
