### PR TITLE
AI Announcements & Verbs

### DIFF
--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,5 +1,6 @@
-/proc/captain_announce(var/text)
-	world << "<h1 class='alert'>Priority Announcement</h1>"
-	world << "<span class='alert'>[html_encode(text)]</span>"
+/proc/captain_announce(message as text, title = "Priority Announcement", announcer = "")
+	world << "<h1 class='alert'>[html_encode(title)]</h1>"
+	world << "<span class='alert'>[html_encode(message)]</span>"
+	if(announcer)
+		world << "<span class='alert'> -[html_encode(announcer)]</span>"
 	world << "<br>"
-

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -231,6 +231,7 @@ That prevents a few funky behaviors.
 								new /obj/structure/AIcore/deactivated(T.loc)
 								T.aiRestorePowerRoutine = 0
 								T.control_disabled = 1
+								T.aiRadio.disabledAi = 1
 								T.loc = C
 								C.AI = T
 								T.cancel_camera()
@@ -245,6 +246,7 @@ That prevents a few funky behaviors.
 						var/mob/living/silicon/ai/A = locate() in C//I love locate(). Best proc ever.
 						if(A)//If AI exists on the card. Else nothing since both are empty.
 							A.control_disabled = 0
+							A.aiRadio.disabledAi = 0
 							A.loc = T.loc//To replace the terminal.
 							C.icon_state = "aicard"
 							C.name = "inteliCard"

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -87,13 +87,14 @@
 			src.occupant.adjustToxLoss(-1)
 			src.occupant.adjustBruteLoss(-1)
 			src.occupant.updatehealth()
-			if (src.occupant.health >= 0 && src.occupant.stat == 2)
-				src.occupant.stat = 0
+			if (src.occupant.health >= 0 && src.occupant.stat == DEAD)
+				src.occupant.stat = CONSCIOUS
 				src.occupant.lying = 0
 				dead_mob_list -= src.occupant
 				living_mob_list += src.occupant
 				src.overlays -= image('icons/obj/computer.dmi', "ai-fixer-404")
 				src.overlays += image('icons/obj/computer.dmi', "ai-fixer-full")
+				src.occupant.add_ai_verbs()
 			src.updateUsrDialog()
 			sleep(10)
 		src.active = 0

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -11,6 +11,7 @@
 	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
+	remove_ai_verbs(src)
 
 	var/callshuttle = 0
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -119,7 +119,7 @@
 
 // Return to the Core.
 
-/mob/living/silicon/ai/verb/core()
+/mob/living/silicon/ai/proc/core()
 	set category = "AI Commands"
 	set name = "AI Core"
 
@@ -145,7 +145,7 @@
 	for(var/datum/camerachunk/c in eyeobj.visibleCameraChunks)
 		c.remove(eyeobj)
 
-/mob/living/silicon/ai/verb/toggle_acceleration()
+/mob/living/silicon/ai/proc/toggle_acceleration()
 	set category = "AI Commands"
 	set name = "Toggle Camera Acceleration"
 

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -1,4 +1,3 @@
-
 /mob/living/silicon/ai/proc/show_laws_verb()
 	set category = "AI Commands"
 	set name = "Show Laws"
@@ -107,7 +106,7 @@
 					sleep(10)
 				number++
 
-/mob/living/silicon/ai/verb/checklaws() //Gives you a link-driven interface for deciding what laws the statelaws() proc will share with the crew. --NeoFite
+/mob/living/silicon/ai/proc/checklaws() //Gives you a link-driven interface for deciding what laws the statelaws() proc will share with the crew. --NeoFite
 	set category = "AI Commands"
 	set name = "State Laws"
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -182,3 +182,7 @@
 			health = 100 - getOxyLoss() - getToxLoss() - getBruteLoss()
 		else
 			health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
+
+/mob/living/silicon/ai/rejuvenate()
+	..()
+	add_ai_verbs(src)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -120,7 +120,7 @@
 		O.show_laws()
 		O << "<b>These laws may be changed by other players, or by you being the traitor.</b>"
 
-	add_ai_verbs(O)
+	O.add_ai_verbs()
 	O.job = "AI"
 
 	O.rename_self("ai",1)


### PR DESCRIPTION
AI can now make station wide announcements. Checks both wireless and radio contact in case of being carded.
AI verbs are now stored in a practical list.
Removes AI verbs on death and adds them when restored.
Updates the captain_announcement proc to make it possible to include the announcer and alter the title.
