### PR TITLE
Allows clicking floors to drop pipes

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -189,7 +189,12 @@ Buildable meters
 	icon_state = islist[pipe_type + 1]
 
 //called when a turf is attacked with a pipe item
-// place the pipe on the turf, setting pipe level to 1 (underfloor) if the turf is not intact
+/obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity)
+	if(!proximity) return
+	if(istype(target))
+		user.drop_from_inventory(src, target)
+	else
+		return ..()
 
 // rotate the pipe item clockwise
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -85,15 +85,18 @@
 	return 0
 
 
-/mob/proc/drop_from_inventory(var/obj/item/W)
+/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W)
+		if(!Target)
+			Target = loc
+
 		if(client)	client.screen -= W
 		u_equip(W)
 		if(!W) return 1 // self destroying objects (tk, grabs)
 		W.layer = initial(W.layer)
-		W.loc = loc
+		W.loc = Target
 
-		var/turf/T = get_turf(loc)
+		var/turf/T = get_turf(Target)
 		if(isturf(T))
 			T.Entered(W)
 
@@ -316,4 +319,3 @@
 		if (del_on_fail)
 			del(W)
 	return equipped
-


### PR DESCRIPTION
This makes it possible to install pipes under immovable objects, similar to power cables.
Expands drop_from_inventory to get proper layering when the drop location isn't necessarily the same turf as the mob stands on.

Other variants, like drop_item that tables/racks use (used in floor.dm instead), made the pipes disappear into limbo but maybe I did something wrong.
