### PR TITLE
Fixes a couple of bugs in apc/process()

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -406,6 +406,11 @@
 /datum/powernet/proc/surplus()
 	return max(avail - newload, 0)
 
+//Returns the amount of excess power (before refunding to SMESs) from last tick.
+//This is for machines that might adjust their power consumption using this data.
+/datum/powernet/proc/last_surplus()
+	return max(avail - load, 0)
+
 //Attempts to draw power from a powernet. Returns the actual amount of power drawn
 /datum/powernet/proc/draw_power(var/requested_amount)
 	var/surplus = max(avail - newload, 0)


### PR DESCRIPTION
APCs were skipping vital processing if not connected or no power was available. Also, APCs were not taking into account the fact that their charging rate is limited by CHARGELEVEL when deciding how much power to draw from the power net.

Any other issues that I haven't noticed notwithstanding, the only other problem I can see is that rooms with a power draw that exceeds perapc (rooms with high power consumption machinery such as atmospherics) will not be able to stay charged. This is however an issue that affected the old APC code anyways, as it has to do with the fact that there is virtually no load-balancing (calculating perapc from the past tick's `avail` is not load balancing, and toggling between charging and not charging does not occur in this case).

Each SMES adds it's output to the powernet and then on the next tick the powernet simply divides that amount by the number of APCs. So if one APC uses more than perapc and other apcs use less than perapc, that APC won't be able to stay charged even though there is enough power available. Some options would be implementing actual load balancing that allows large consumers to use more than perapc when other APCs use less, or putting rooms with lots of high power consumption machinery on their own power net.
