### PR TITLE
Fixes wizard's mutate lazers not working

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -23,7 +23,7 @@
 /mob/living/carbon/human/RangedAttack(var/atom/A)
 	if(!gloves && !mutations.len) return
 	var/obj/item/clothing/gloves/G = gloves
-	if((LASER in mutations) && a_intent == "harm")
+	if((LASER in mutations) && a_intent == "hurt")
 		LaserEyes(A) // moved into a proc below
 
 	else if(istype(G) && G.Touch(A,0)) // for magic gloves


### PR DESCRIPTION
Why you ever had to change the name of intent is beyond my understanding. Anyway, this one wasn't changed, so lazer eyes didn't work, and wizards couldn't pewpewpew with mutate.
