### PR TITLE
Fixes #5984 by having ED-209s now pass through each other.

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -729,14 +729,21 @@ Auto Patrol: []"},
 	return threatcount
 
 /obj/machinery/bot/ed209/Bump(M as mob|obj) //Leave no door unopened!
-	if ((istype(M, /obj/machinery/door)) && (!isnull(src.botcard)))
+	if ((istype(M, /obj/machinery/door)) && !isnull(src.botcard))
 		var/obj/machinery/door/D = M
 		if (!istype(D, /obj/machinery/door/firedoor) && D.check_access(src.botcard) && !istype(D,/obj/machinery/door/poddoor))
 			D.open()
 			src.frustration = 0
-	else if ((istype(M, /mob/living/)) && (!src.anchored))
-		src.loc = M:loc
-		src.frustration = 0
+	else if(!src.anchored)
+		if ((istype(M, /mob/living/)))
+			var/mob/living/O = M
+			src.loc = O.loc
+			src.frustration = 0
+		else if (istype(M, /obj/machinery/bot))
+			var/obj/machinery/bot/B = M
+			if (B.dir != src.dir) // Avoids issues if two bots are currently patrolling in the same direction
+				src.loc = B.loc
+				src.frustration = 0
 	return
 
 /* terrible


### PR DESCRIPTION
ED-209s now pass through each other, unless walking in the same direction to avoid position shuffling behavior. 
Still haven't forgotten about the whole copy-paste issue.
