### PR TITLE
Hazardly low pressure induces OxyLoss up to 55 points

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -498,12 +498,12 @@
 		if(inhale_pp < safe_pressure_min)
 			if(prob(20))
 				spawn(0) emote("gasp")
-			
+
 			var/ratio = inhale_pp/safe_pressure_min
 			// Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!)
 			adjustOxyLoss(max(HUMAN_MAX_OXYLOSS*(1-ratio), 0))
 			failed_inhale = 1
-			
+
 			oxygen_alert = max(oxygen_alert, 1)
 		else
 			// We're in safe limits
@@ -629,8 +629,8 @@
 			if (temp_adj < BODYTEMP_COOLING_MAX) temp_adj = BODYTEMP_COOLING_MAX
 			//world << "Breath: [breath.temperature], [src]: [bodytemperature], Adjusting: [temp_adj]"
 			bodytemperature += temp_adj
-		
-		
+
+
 		breath.update_values()
 		return 1
 
@@ -724,6 +724,8 @@
 		else
 			if( !(COLD_RESISTANCE in mutations))
 				take_overall_damage(brute=LOW_PRESSURE_DAMAGE, used_weapon = "Low Pressure")
+				if(getOxyLoss() < 55) // 11 OxyLoss per 4 ticks when wearing internals;    unconsciousness in 16 ticks, roughly half a minute
+					adjustOxyLoss(4)  // 16 OxyLoss per 4 ticks when no internals present; unconsciousness in 13 ticks, roughly twenty seconds
 				pressure_alert = -2
 			else
 				pressure_alert = -1


### PR DESCRIPTION
Induces OxyLoss when being in hazardly low pressures of 20 kPa and below.

**Internals on:** 11 OxyLoss per 4 ticks
**Internals off:** 16 OxyLoss per 4 ticks

Pressure-induced OxyLoss will stop when hitting 55 points, slightly above the threshold it causes unconsciousness. We do not want to cause deaths much sooner, we simply want to incapacitate them.

Breathing (the only part of the life proc where OxyLoss was handled so far) and Pressure Environments being entirely different procs makes the OxyLoss value getting changed _twice_ every _four_ ticks, in case internals are _on_.
The way this is currently handled, though, didn't actually allow for better solutions. Input is welcome.

Low pressures causing unconsciousness was [voted](http://baystation12.net/forums/viewtopic.php?f=5&t=10654&hilit=unconsciousness+vote) upon by the community.
