### PR TITLE
Camera names are now sanitized

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -86,7 +86,8 @@
 					usr << "No network found please hang up and try your call again."
 					return
 
-				var/temptag = "[get_area(src)] ([rand(1, 999)])"
+				var/area/camera_area = get_area(src)
+				var/temptag = "[sanitize(camera_area.name)] ([rand(1, 999)])"
 				input = strip_html(input(usr, "How would you like to name the camera?", "Set Camera Name", temptag))
 
 				state = 4


### PR DESCRIPTION
When assembled cameras no longer default to names such as "The mproper Central Primary Hallway (632)" but instead "Central Primary Hallway (632)".
