### PR TITLE
Space Carp tweaks/changes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -34,7 +34,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	break_stuff_probability = 2
+	break_stuff_probability = 15
 
 	faction = "carp"
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -193,6 +193,10 @@
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()
 	if(prob(break_stuff_probability))
 		for(var/dir in cardinal) // North, South, East, West
+			for(var/obj/structure/window/obstacle in get_step(src, dir))
+				if(obstacle.dir == reverse_dir[dir]) // So that windows get smashed in the right order
+					obstacle.attack_animal(src)
+					return
 			var/obj/structure/obstacle = locate(/obj/structure, get_step(src, dir))
 			if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille))
 				obstacle.attack_animal(src)


### PR DESCRIPTION
Space carp were statistically inflicting damage to an obstacle every hundred seconds, not ever causing a single breach and becoming little to no threat for crew that are on the other side of these.
Readjusted back to 14 seconds, like it was once upon a time in the past.

Also fixed hostile mobs breaking windows in a random order. The window facing them will now be destroyed first.
