### PR TITLE
Surgery Sterility

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -498,12 +498,12 @@
 		if(inhale_pp < safe_pressure_min)
 			if(prob(20))
 				spawn(0) emote("gasp")
-			
+
 			var/ratio = inhale_pp/safe_pressure_min
 			// Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!)
 			adjustOxyLoss(max(HUMAN_MAX_OXYLOSS*(1-ratio), 0))
 			failed_inhale = 1
-			
+
 			oxygen_alert = max(oxygen_alert, 1)
 		else
 			// We're in safe limits
@@ -629,8 +629,8 @@
 			if (temp_adj < BODYTEMP_COOLING_MAX) temp_adj = BODYTEMP_COOLING_MAX
 			//world << "Breath: [breath.temperature], [src]: [bodytemperature], Adjusting: [temp_adj]"
 			bodytemperature += temp_adj
-		
-		
+
+
 		breath.update_values()
 		return 1
 
@@ -724,6 +724,8 @@
 		else
 			if( !(COLD_RESISTANCE in mutations))
 				take_overall_damage(brute=LOW_PRESSURE_DAMAGE, used_weapon = "Low Pressure")
+				if(getOxyLoss() < 55) // 11 OxyLoss per 4 ticks when wearing internals;    unconsciousness in 16 ticks, roughly half a minute
+					adjustOxyLoss(4)  // 16 OxyLoss per 4 ticks when no internals present; unconsciousness in 13 ticks, roughly twenty seconds
 				pressure_alert = -2
 			else
 				pressure_alert = -1

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -75,6 +75,20 @@ proc/spread_germs_to_organ(datum/organ/external/E, mob/living/carbon/human/user)
 	if(user.gloves)
 		germ_level = user.gloves.germ_level
 
+	var/turf.T = get_turf(user)
+	var/area/A = T.loc
+	if(A)
+		for (var/mob/living/carbon/human/H in A.contents)
+			if (H.lying || germ_level >= 200)
+				continue
+			if (!(istype(H.head, /obj/item/clothing/head/helmet/space/rig/medical)||istype(H.head, /obj/item/clothing/head/helmet/space/rig/ert/medical)))
+				if (!istype(H.wear_mask, /obj/item/clothing/mask/surgical))
+					germ_level += 30 // Malus for masks
+				if (!istype(H.head, /obj/item/clothing/head/surgery))
+					germ_level += 30 // Malus for unproper head wear
+			if (!(istype(H.wear_suit, /obj/item/clothing/suit/space/rig/medical)||istype(H.wear_suit, /obj/item/clothing/suit/space/rig/ert/medical)))
+				if (!istype(H.w_uniform, /obj/item/clothing/under/rank/medical))
+					germ_level += 60 // Malus for unproper body wear
 	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
 proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)


### PR DESCRIPTION
Anyone that is in the same room as the patient will have an effect on germ spread during a surgery step with infection chance.

**Not wearing a mask:** 30 germ count penalty
**Not wearing a cap:** 30 germ count penalty
**Not wearing a suit of type rank/medical:** 60 germ count penalty

Having a medical hardsuit covering these areas will not cause a penalty.

Thus, the maximum penalty someone ignoring all sterile protection can give is 120.
Germ spread to body is capped at _GERM_LEVEL_MOVE_CAP_ (currently 200).
