### PR TITLE
Dev-Freeze fixes: Heaters, Freezers, Supermatter

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -119,7 +119,7 @@
 		cooling = 1
 		update_use_power(2)
 		
-		var/heat_transfer = min(abs(air_contents.get_thermal_energy_change(set_temperature)), active_power_usage)
+		var/heat_transfer = min(abs(air_contents.get_thermal_energy_change(set_temperature - 5)), active_power_usage)
 
 		//Assume the heat is being pumped into the hull which is fixed at heatsink_temperature
 		//not /really/ proper thermodynamics but whatever

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -62,7 +62,7 @@
 		update_use_power(0)
 		return
 	
-	if (network && air_contents.temperature < set_temperature)
+	if (network && air_contents.total_moles && air_contents.temperature < set_temperature)
 		update_use_power(2)
 		air_contents.add_thermal_energy(active_power_usage)
 	

--- a/code/ZAS/_gas_mixture_xgm.dm
+++ b/code/ZAS/_gas_mixture_xgm.dm
@@ -112,7 +112,7 @@
 
 //Returns the thermal energy change required to get to a new temperature
 /datum/gas_mixture/proc/get_thermal_energy_change(var/new_temperature)
-	return heat_capacity()*(new_temperature - temperature)
+	return heat_capacity()*(max(new_temperature, 0) - temperature)
 
 //Technically vacuum doesn't have a specific entropy. Just use a really big number (infinity would be ideal) here so that it's easy to add gas to vacuum and hard to take gas out.
 #define SPECIFIC_ENTROPY_VACUUM		150000

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -1,5 +1,5 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
-#define EMITTER_DAMAGE_POWER_TRANSFER 350 //used to transfer power to containment field generators
+#define EMITTER_DAMAGE_POWER_TRANSFER 400 //used to transfer power to containment field generators
 
 /obj/machinery/power/emitter
 	name = "Emitter"

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -1,4 +1,3 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
 #define EMITTER_DAMAGE_POWER_TRANSFER 400 //used to transfer power to containment field generators
 
 /obj/machinery/power/emitter

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -5,9 +5,19 @@
 #define OXYGEN_RELEASE_MODIFIER 1500        //Higher == less oxygen released at high temperature/power
 #define REACTION_POWER_MODIFIER 1.1                //Higher == more overall power
 
-//Controls how much power is produced by each collector in range - this is the main parameter for tweaking SM balance, as it basically controls how the power variable relates to the rest of the game.
-#define POWER_FACTOR 0.5              //Obtained from testing. Aiming to make the ideal running output (400 kW) run the SM to ~85% of the safety level.
+/*
+	How to tweak the SM
+	
+	POWER_FACTOR		directly controls how much power the SM puts out at a given level of excitation (power var). Making this lower means you have to work the SM harder to get the same amount of power.
+	CRITICAL_TEMPERATURE	The temperature at which the SM starts taking damage.
+	
+	CHARGING_FACTOR		Controls how much emitter shots excite the SM.
+	DAMAGE_RATE_LIMIT	Controls the maximum rate at which the SM will take damage due to high temperatures.
+*/
 
+//Controls how much power is produced by each collector in range - this is the main parameter for tweaking SM balance, as it basically controls how the power variable relates to the rest of the game.
+#define POWER_FACTOR 0.5              //Obtained from testing. Aiming to make the ideal running output (600 kW) run the SM to ~85% of the safety level.
+#define CRITICAL_TEMPERATURE 800       //K
 #define CHARGING_FACTOR 0.11
 #define DAMAGE_RATE_LIMIT 5                 //damage rate cap at power = 900, scales linearly with power
 
@@ -168,28 +178,31 @@
 		removed = env.remove(gasefficency * env.total_moles)	//Remove gas from surrounding area
 
 	if(!env || !removed || !removed.total_moles)
-		damage += max(((power-(1600*POWER_FACTOR)))/10, 0)	//exciting the supermatter in a vacuum means the internal energy is mostly locked inside.
+		damage += max((power-(2*CRITICAL_TEMPERATURE*POWER_FACTOR))/10, 0)	//exciting the supermatter in a vacuum means the internal energy is mostly locked inside.
 	else if (grav_pulling) //If supermatter is detonating, remove all air from the zone
 		env.remove(env.total_moles)
 	else
 		damage_archived = damage
 
-		damage = max( damage + min( ( (removed.temperature - 800) / 150 ), damage_inc_limit ) , 0 )
+		damage = max( damage + min( ( (removed.temperature - CRITICAL_TEMPERATURE) / 150 ), damage_inc_limit ) , 0 )
 		//Ok, 100% oxygen atmosphere = best reaction
 		//Maxes out at 100% oxygen pressure
 		oxygen = max(min((removed.gas["oxygen"] - (removed.gas["nitrogen"] * NITROGEN_RETARDATION_FACTOR)) / MOLES_CELLSTANDARD, 1), 0)
 
-		var/temp_factor = 100
-
-		if(oxygen > 0.8)
-			// with a perfect gas mix, make the power less based on heat
+		//calculate power gain for oxygen reaction
+		var/temp_factor
+		if (oxygen > 0.8)
+			//If chain reacting at oxygen == 1, we want the power at 800 K to stabilize at a level of 1200*POWER_FACTOR
+			var/equilibrium_power = 1200*POWER_FACTOR
+			temp_factor = ( (equilibrium_power/500)**3 )/800
 			icon_state = "[base_icon_state]_glow"
 		else
-			// in normal mode, base the produced energy around the heat
-			temp_factor = 60
+			//If chain reacting at oxygen == 0.8, we want the power at 700 K to stabilize at a power level of 300
+			var/equilibrium_power = 860*POWER_FACTOR
+			temp_factor = ( (equilibrium_power/500)**3 )/(700*0.8)
 			icon_state = base_icon_state
-
-		power = max( (removed.temperature * temp_factor / T0C) * oxygen + power, 0) //Total laser power plus an overload
+		
+		power = max( (removed.temperature * temp_factor) * oxygen + power, 0)
 
 		//We've generated power, now let's transfer it to the collectors for storing/usage
 		transfer_energy()
@@ -241,8 +254,8 @@
 				// Then bring it inside to explode instantly upon landing on a valid turf.
 
 
-	if(Proj.flag != "bullet")
-		power += Proj.damage * config_bullet_energy	* CHARGING_FACTOR
+	if(istype(Proj, /obj/item/projectile/beam))
+		power += Proj.damage * config_bullet_energy	* CHARGING_FACTOR 
 	else
 		damage += Proj.damage * config_bullet_energy
 	return 0
@@ -272,7 +285,7 @@
 /obj/machinery/power/supermatter/proc/transfer_energy()
 	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
 		if(get_dist(R, src) <= 15) // Better than using orange() every process
-			R.receive_pulse(power * POWER_FACTOR)
+			R.receive_pulse(power * POWER_FACTOR) //for collectors using standard phoron tanks at 1013 kPa, the actual power generated will be this power*POWER_FACTOR*20*29 = power*POWER_FACTOR*580
 	return
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -6,9 +6,9 @@
 #define REACTION_POWER_MODIFIER 1.1                //Higher == more overall power
 
 //Controls how much power is produced by each collector in range - this is the main parameter for tweaking SM balance, as it basically controls how the power variable relates to the rest of the game.
-#define POWER_FACTOR 0.35              //Obtained from testing. Aiming to make the ideal running output (600 kW) run the SM to ~85% of the safety level.
+#define POWER_FACTOR 0.5              //Obtained from testing. Aiming to make the ideal running output (400 kW) run the SM to ~85% of the safety level.
 
-#define CHARGING_FACTOR 0.55
+#define CHARGING_FACTOR 0.11
 #define DAMAGE_RATE_LIMIT 5                 //damage rate cap at power = 900, scales linearly with power
 
 


### PR DESCRIPTION
- Fixes #6123
- Reduces SM charging rate and increases output a bit. It should now be possible to start the engine without varedits. The engine output will likely need further tweaking, however this will probably have to come from playtesting. The engine layout still needs to be changed but I'm not sure what the best starting layout would be yet, and I'd rather not make any mapping changes until  #6133 is merged.
- I also plan to adjust the airlock air canister `filled` values to get airlocks to cycle faster, but again, not going to do any mapping changes yet.
  Update:
- Adjusted SM reaction parameters so that SM high-oxygen mode isn't so uncontrollable.
