### PR TITLE
Department radio use on join

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -494,6 +494,7 @@ var/global/datum/controller/occupations/job_master
 
 		H << "<B>You are the [alt_title ? alt_title : rank].</B>"
 		H << "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
+		H << "<b>To speak on your department's radio channel use :h. For the use of other channels, examine your headset.</b>"
 		if(job.req_admin_notify)
 			H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
 


### PR DESCRIPTION
Adds a brief description on how to use the department and other channels on join.
Shamelessly stolen from https://github.com/tgstation/-tg-station/pull/4531
