### PR TITLE
removes duplicate handle_hud_list()

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1188,15 +1188,13 @@
 		return 1
 
 	proc/handle_regular_hud_updates()
-		if(hud_updateflag)
+		if(hud_updateflag) // update our mob's hud overlays, AKA what others see flaoting above our head
 			handle_hud_list()
 
+		// now handle what we see on our screen
 
-		if(!client)	return 0
-
-		if(hud_updateflag)
-			handle_hud_list()
-
+		if(!client)
+			return 0
 
 		for(var/image/hud in client.images)
 			if(copytext(hud.icon_state,1,4) == "hud") //ugly, but icon comparison is worse, I believe


### PR DESCRIPTION
would have opened against master but the file gets changed rather often in dev at the moment,
so in order to prevent merge conflicts later this is against dev.
