### PR TITLE
Optimization of machinery sort?

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -278,9 +278,17 @@ datum/controller/game_controller/proc/process_diseases()
 		active_diseases.Cut(i,i+1)
 
 datum/controller/game_controller/proc/process_machines()
+	process_machines_sort()
 	process_machines_process()
 	process_machines_power()
 	process_machines_rebuild()
+
+/var/global/machinery_sort_required = 0
+datum/controller/game_controller/proc/process_machines_sort()
+	if(machinery_sort_required)
+		machinery_sort_required = 0
+		machines = dd_sortedObjectList(machines)
+
 datum/controller/game_controller/proc/process_machines_process()
 	var/i = 1
 	while(i<=machines.len)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -114,6 +114,7 @@ Class Procs:
 /obj/machinery/New()
 	..()
 	machines += src
+	machinery_sort_required = 1
 
 /obj/machinery/Del()
 	machines -= src
@@ -161,15 +162,15 @@ Class Procs:
 /obj/machinery/proc/update_use_power(var/new_use_power)
 	if (new_use_power == use_power)
 		return	//don't need to do anything
-	
+
 	use_power = new_use_power
-	
+
 	//force area power update
 	//use_power() forces an area power update on the next tick so have to pass the correct power amount for this tick
 	if (use_power >= 2)
 		use_power(active_power_usage)
 	else if (use_power == 1)
-		use_power(idle_power_usage) 
+		use_power(idle_power_usage)
 	else
 		use_power(0)
 


### PR DESCRIPTION
Machinery sort optimization based on comments in #6140.

When an object is added to the machinery list the flag machinery_sort_required, defined in master_controller, is set to true.
The list is assumed to remain sorted on object removal, unless BYOND has some magic logical thinking.

When the master controller eventually process machinery the flag is checked, sorting conducted if required, and then continues as always.

Sorting is done in process_machines() rather than machinery/../New(), which is how PDAs do it, to attempt to minimize the number of times sorting will be required, due to being a much larger list which is also likely to be modified more often. It also appears to be the most reasonable *process() proc to use.

The list may not always be sorted if iterated over right after a new machine has been created but this should be of no consequence.
If a machine changes name after its creation then the list may end up unsorted as well, should also be of minor consequence.

@Ccomp5950, others, does this seem reasonable?
