### PR TITLE
Fixes shuttle ETA being given before arrive_time is set

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -34,10 +34,11 @@
 		if (moving_status == SHUTTLE_IDLE) 
 			return	//someone cancelled the launch
 		
+		arrive_time = world.time + travel_time*10
 		moving_status = SHUTTLE_INTRANSIT
 		move(departing, interim, direction)
 		
-		arrive_time = world.time + travel_time*10
+		
 		while (world.time < arrive_time)
 			sleep(5)
 

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -16,12 +16,15 @@
 	else
 		travel_time = SHUTTLE_TRANSIT_DURATION
 
-	//update move_time so we get correct ETAs
+	//update move_time and launch_time so we get correct ETAs
 	move_time = travel_time
+	emergency_shuttle.launch_time = world.time
 
 	..()
 
 /datum/shuttle/ferry/emergency/move(var/area/origin,var/area/destination)
+	..(origin, destination)
+
 	if (origin == area_station)	//leaving the station
 		emergency_shuttle.departed = 1
 
@@ -29,8 +32,6 @@
 			captain_announce("The Emergency Shuttle has left the station. Estimate [round(emergency_shuttle.estimate_arrival_time()/60,1)] minutes until the shuttle docks at Central Command.")
 		else
 			captain_announce("The Crew Transfer Shuttle has left the station. Estimate [round(emergency_shuttle.estimate_arrival_time()/60,1)] minutes until the shuttle docks at Central Command.")
-
-	..(origin, destination)
 
 /datum/shuttle/ferry/emergency/can_launch(var/user)
 	if (istype(user, /obj/machinery/computer/shuttle_control/emergency))


### PR DESCRIPTION
Because the escape shuttle makes it's announcement inside an override of move(), arrive_time needs to be set before move() is called so that the correct ETA can be announced.

Having the announcement made inside /shuttle/ferry/emergency/move() seems kind of a bad way to do things, but the alternative is duplicating a lot of code inside the emergency shuttle's long_jump() proc. Still, that might be preferable to the way it is done now though.
