### PR TITLE
Fixes gas entropy calculation + engine pump/injector flow imbalance issue

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -169,7 +169,7 @@
 			var/transfer_moles = pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 			
 			//limit flow rate from turfs
-			transfer_moles = min(transfer_moles, environment.total_moles*MAX_SIPHON_FLOWRATE/environment.volume)	//group_multiplier gets divided out here
+			transfer_moles = min(transfer_moles, environment.total_moles*air_contents.volume/environment.volume)	//group_multiplier gets divided out here
 			
 			power_draw = pump_gas(src, environment, air_contents, transfer_moles, active_power_usage)
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -13,6 +13,7 @@ var/global/list/rad_collectors = list()
 //	use_power = 0
 	var/obj/item/weapon/tank/phoron/P = null
 	var/last_power = 0
+	var/last_power_new = 0
 	var/active = 0
 	var/locked = 0
 	var/drainratio = 1
@@ -26,6 +27,11 @@ var/global/list/rad_collectors = list()
 	..()
 
 /obj/machinery/power/rad_collector/process()
+	//so that we don't zero out the meter if the SM is processed first.
+	last_power = last_power_new
+	last_power_new = 0
+	
+
 	if(P)
 		if(P.air_contents.gas["phoron"] == 0)
 			investigate_log("<font color='red'>out of fuel</font>.","singulo")
@@ -50,10 +56,7 @@ var/global/list/rad_collectors = list()
 
 
 /obj/machinery/power/rad_collector/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/device/analyzer) || istype(W, /obj/item/device/multitool))
-		user << "\blue \The [W] detects that [last_power]W were recently produced."
-		return 1
-	else if(istype(W, /obj/item/weapon/tank/phoron))
+	if(istype(W, /obj/item/weapon/tank/phoron))
 		if(!src.anchored)
 			user << "\red The [src] needs to be secured to the floor first."
 			return 1
@@ -96,6 +99,11 @@ var/global/list/rad_collectors = list()
 		..()
 		return 1
 
+/obj/machinery/power/rad_collector/examine()
+	..()
+	if (get_dist(usr, src) <= 3)
+		usr << "The meter indicates that \the [src] is collecting [last_power] W."
+		return 1
 
 /obj/machinery/power/rad_collector/ex_act(severity)
 	switch(severity)
@@ -122,7 +130,7 @@ var/global/list/rad_collectors = list()
 		var/power_produced = 0
 		power_produced = P.air_contents.gas["phoron"]*pulse_strength*20
 		add_avail(power_produced)
-		last_power = power_produced
+		last_power_new = power_produced
 		return
 	return
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -50,8 +50,8 @@ var/global/list/rad_collectors = list()
 
 
 /obj/machinery/power/rad_collector/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/device/analyzer))
-		user << "\blue The [W.name] detects that [last_power]W were recently produced."
+	if(istype(W, /obj/item/device/analyzer) || istype(W, /obj/item/device/multitool))
+		user << "\blue \The [W] detects that [last_power]W were recently produced."
 		return 1
 	else if(istype(W, /obj/item/weapon/tank/phoron))
 		if(!src.anchored)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -1,4 +1,4 @@
-#define EMITTER_DAMAGE_POWER_TRANSFER 400 //used to transfer power to containment field generators
+#define EMITTER_DAMAGE_POWER_TRANSFER 450 //used to transfer power to containment field generators
 
 /obj/machinery/power/emitter
 	name = "Emitter"

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -837,8 +837,8 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 
 //These balance how easy or hard it is to create huge pressure gradients with pumps and filters. Lower values means it takes longer to create large pressures differences.
 //Has no effect on pumping gasses from high pressure to low, only from low to high. Must be between 0 and 1.
-#define ATMOS_PUMP_EFFICIENCY	0.6
-#define ATMOS_FILTER_EFFICIENCY	0.45
+#define ATMOS_PUMP_EFFICIENCY	1.0
+#define ATMOS_FILTER_EFFICIENCY	1.0
 
 //will not bother pumping or filtering if the gas source as fewer than this amount of moles, to help with performance.
 #define MINUMUM_MOLES_TO_PUMP	0.01


### PR DESCRIPTION
Adjusted the gas entropy calculation so that the source gas mixture being at a higher temperature than the destination doesn't impede gas flow, but instead makes gas flow easier, like you might expect. Added a bunch of comments to the specific_entropy_gas() proc explaining it's significance for atmos machines in case anyone wants to tweak it. Fixes #6166

While testing this, I came across another issue with the SM engine, which was that the maximum flow rate out of the core through the vent pump was 2500 L/s, while the maximum flow rate into the core through the air injector was 200 L/s. Added a quick fix for this by limiting the flow rate of vent pumps to 200 L/s. A more thorough fix would probably involve implementing a way for players to control/limit the flow rate on both devices.

Also collected some data from testing the SM:
SM power - Stable Temperature - O2/TX %
60 kW - 179 K - 0/0
120 kW - 270 K - 0.3/0.3
180 kW - 390? K - 1/0.5

I wanted to collect some more data but just ran out of time. Plan on using this to adjust POWER_FACTOR later.

Also updated rad collector meters to be read by examining.
