### PR TITLE
AI camera/holopad fix

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -101,7 +101,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	hologram.SetLuminosity(2)	//hologram lighting
 	SetLuminosity(2)			//pad lighting
 	icon_state = "holopad1"
-	A.current = src
+	A.holo = src
 	master = A//AI is the master.
 	use_power = 2//Active power usage.
 	return 1
@@ -109,8 +109,8 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/proc/clear_holo()
 //	hologram.SetLuminosity(0)//Clear lighting.	//handled by the lighting controller when its ower is deleted
 	del(hologram)//Get rid of hologram.
-	if(master.current == src)
-		master.current = null
+	if(master.holo == src)
+		master.holo = null
 	master = null//Null the master, since no-one is using it now.
 	SetLuminosity(0)			//pad lighting (hologram lighting will be handled automatically since its owner was deleted)
 	icon_state = "holopad0"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -20,7 +20,7 @@ var/list/ai_list = list()
 	density = 1
 	status_flags = CANSTUN|CANPARALYSE
 	var/list/network = list("SS13")
-	var/obj/machinery/camera/current = null
+	var/obj/machinery/camera/camera = null
 	var/list/connected_robots = list()
 	var/aiRestorePowerRoutine = 0
 	//var/list/laws = list()
@@ -311,9 +311,9 @@ var/list/ai_list = list()
 	return
 
 /mob/living/silicon/ai/check_eye(var/mob/user as mob)
-	if (!current)
+	if (!camera)
 		return null
-	user.reset_view(current)
+	user.reset_view(camera)
 	return 1
 
 /mob/living/silicon/ai/blob_act()
@@ -490,10 +490,10 @@ var/list/ai_list = list()
 		updatehealth()
 
 /mob/living/silicon/ai/reset_view(atom/A)
-	if(current)
-		current.SetLuminosity(0)
+	if(camera)
+		camera.SetLuminosity(0)
 	if(istype(A,/obj/machinery/camera))
-		current = A
+		camera = A
 	..()
 	if(istype(A,/obj/machinery/camera))
 		if(camera_light_on)	A.SetLuminosity(AI_CAMERA_LUMINOSITY)
@@ -677,9 +677,9 @@ var/list/ai_list = list()
 	camera_light_on = !camera_light_on
 	src << "Camera lights [camera_light_on ? "activated" : "deactivated"]."
 	if(!camera_light_on)
-		if(current)
-			current.SetLuminosity(0)
-			current = null
+		if(camera)
+			camera.SetLuminosity(0)
+			camera = null
 	else
 		lightNearbyCamera()
 
@@ -690,23 +690,23 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/proc/lightNearbyCamera()
 	if(camera_light_on && camera_light_on < world.timeofday)
-		if(src.current)
+		if(src.camera)
 			var/obj/machinery/camera/camera = near_range_camera(src.eyeobj)
-			if(camera && src.current != camera)
-				src.current.SetLuminosity(0)
+			if(camera && src.camera != camera)
+				src.camera.SetLuminosity(0)
 				if(!camera.light_disabled)
-					src.current = camera
-					src.current.SetLuminosity(AI_CAMERA_LUMINOSITY)
+					src.camera = camera
+					src.camera.SetLuminosity(AI_CAMERA_LUMINOSITY)
 				else
-					src.current = null
+					src.camera = null
 			else if(isnull(camera))
-				src.current.SetLuminosity(0)
-				src.current = null
+				src.camera.SetLuminosity(0)
+				src.camera = null
 		else
 			var/obj/machinery/camera/camera = near_range_camera(src.eyeobj)
 			if(camera && !camera.light_disabled)
-				src.current = camera
-				src.current.SetLuminosity(AI_CAMERA_LUMINOSITY)
+				src.camera = camera
+				src.camera.SetLuminosity(AI_CAMERA_LUMINOSITY)
 		camera_light_on = world.timeofday + 1 * 20 // Update the light every 2 seconds.
 
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -47,9 +47,8 @@
 		if(ai.client)
 			ai.client.eye = src
 		//Holopad
-		if(istype(ai.current, /obj/machinery/hologram/holopad))
-			var/obj/machinery/hologram/holopad/H = ai.current
-			H.move_hologram()
+		if(ai.holo)
+			ai.holo.move_hologram()
 
 
 // AI MOVEMENT
@@ -61,7 +60,7 @@
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1
-
+	var/obj/machinery/hologram/holopad/holo = null
 
 // Intiliaze the eye by assigning it's "ai" variable to us. Then set it's loc to us.
 /mob/living/silicon/ai/New()
@@ -121,8 +120,7 @@
 
 
 /mob/living/silicon/ai/proc/view_core()
-
-	current = null
+	camera = null
 	cameraFollow = null
 	unset_machine()
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -144,8 +144,8 @@
 	if (!message)
 		return
 
-	var/obj/machinery/hologram/holopad/T = src.current
-	if(istype(T) && T.hologram && T.master == src)//If there is a hologram and its master is the user.
+	var/obj/machinery/hologram/holopad/T = src.holo
+	if(T && T.hologram && T.master == src)//If there is a hologram and its master is the user.
 		var/verb = say_quote(message)
 
 		//Human-like, sorta, heard by those who understand humans.

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -96,8 +96,8 @@
 
 /obj/item/weapon/paper/attack_ai(var/mob/living/silicon/ai/user as mob)
 	var/dist
-	if(istype(user) && user.current) //is AI
-		dist = get_dist(src, user.current)
+	if(istype(user) && user.camera) //is AI
+		dist = get_dist(src, user.camera)
 	else //cyborg or AI not seeing through a camera
 		dist = get_dist(src, user)
 	if(dist < 2)
@@ -113,7 +113,7 @@
 		user.visible_message("<span class='notice'>You show the paper to [M]. </span>", \
 			"<span class='notice'> [user] holds up a paper and shows it to [M]. </span>")
 		M << examine()
-	
+
 	else if(user.zone_sel.selecting == "mouth") // lipstick wiping
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M


### PR DESCRIPTION
Fixes an issue where toggling camera lights would disconnect AI eye movement from an active hologram, allowing free-roaming without the holopad deactivating as the hologram would never move out of range.

The opposite was also true, when activating a holopad the AI would "forget" which camera was last toggled, making it possible to light all cameras on the station with some juggling.
