### PR TITLE
Fixes "Do not allow use of items" option doing nothing.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -80,6 +80,9 @@
 		throw_item(A)
 		return
 
+	if(!istype(A,/obj/item/weapon/gun) && !isturf(A) && !istype(A,/obj/screen))
+		last_target_click = world.time
+
 	var/obj/item/W = get_active_hand()
 
 	if(W == A)


### PR DESCRIPTION
The var that should trigger autofire was not set anywhere in code.
Probably was lost during move to new clicking system.
