### PR TITLE
Made portals clickable

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -22,6 +22,12 @@
 		return
 	return
 
+/obj/effect/portal/attack_hand(mob/user as mob)
+	spawn(0)
+		src.teleport(user)
+		return
+	return
+
 /obj/effect/portal/New()
 	spawn(300)
 		del(src)


### PR DESCRIPTION
Never again should a captain get stuck in the wall after using hand tele, and not being able to use it go get back, because that'd need you to walk out of a tile and walk back in.

Seriously, it's dumb.
