### PR TITLE
Limited locker capacity

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -106,6 +106,8 @@
 	desc = "A non-reusable plastic bag designed to prevent additional damage to an occupant at the cost of genetic damage."
 	icon = 'icons/obj/cryobag.dmi'
 	item_path = /obj/item/bodybag/cryobag
+	open_sound = 'sound/items/zip.ogg'
+	close_sound = 'sound/items/zip.ogg'
 	var/used = 0
 
 	open()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -14,6 +14,8 @@
 	var/lastbang
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate
 							  //then open it in a populated area to crash clients.
+	var/open_sound = 'sound/machines/click.ogg'
+	var/close_sound = 'sound/machines/click.ogg'
 
 /obj/structure/closet/New()
 	..()
@@ -66,10 +68,7 @@
 
 	src.icon_state = src.icon_opened
 	src.opened = 1
-	if(istype(src, /obj/structure/closet/body_bag))
-		playsound(src.loc, 'sound/items/zip.ogg', 15, 1, -3)
-	else
-		playsound(src.loc, 'sound/machines/click.ogg', 15, 1, -3)
+	playsound(src.loc, open_sound, 15, 1, -3)
 	density = 0
 	return 1
 
@@ -79,24 +78,26 @@
 	if(!src.can_close())
 		return 0
 
-	var/itemcount = 0
+	var/stored_units = 0
+	var/mob_size = 15
 
 	//Cham Projector Exception
 	for(var/obj/effect/dummy/chameleon/AD in src.loc)
-		if(itemcount >= storage_capacity)
+		if(stored_units >= storage_capacity)
 			break
 		AD.loc = src
-		itemcount++
+		stored_units++
 
 	for(var/obj/item/I in src.loc)
-		if(itemcount >= storage_capacity)
-			break
+		var/item_size = Ceiling(I.w_class / 2)
+		if(stored_units + item_size >= storage_capacity)
+			continue
 		if(!I.anchored)
 			I.loc = src
-			itemcount++
+			stored_units += item_size
 
 	for(var/mob/M in src.loc)
-		if(itemcount >= storage_capacity)
+		if(stored_units + mob_size > storage_capacity)
 			break
 		if(istype (M, /mob/dead/observer))
 			continue
@@ -108,14 +109,12 @@
 			M.client.eye = src
 
 		M.loc = src
-		itemcount++
+		stored_units += mob_size
 
 	src.icon_state = src.icon_closed
 	src.opened = 0
-	if(istype(src, /obj/structure/closet/body_bag))
-		playsound(src.loc, 'sound/items/zip.ogg', 15, 1, -3)
-	else
-		playsound(src.loc, 'sound/machines/click.ogg', 15, 1, -3)
+
+	playsound(src.loc, close_sound, 15, 1, -3)
 	density = 1
 	return 1
 


### PR DESCRIPTION
Mobs now requires 15 units of storage in a locker to fit. Allows two mobs in a single typical locker as they have a capacity of 30, assuming there are no other items inside.

Items take up (w_class / 2) rounded up capacity. Any higher, like a straight w_class, and many lockers cannot fit the items they originally contain. 

Also includes minor sound-play cleanup.
