### PR TITLE
Antags - Exploitable Information

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -264,7 +264,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	if(oldname)
 		//update the datacore records! This is goig to be a bit costly.
-		for(var/list/L in list(data_core.general,data_core.medical,data_core.security,data_core.locked))
+		for(var/list/L in list(data_core.general,data_core.medical,data_core.security,data_core.locked,data_core.exploit))
 			for(var/datum/data/record/R in L)
 				if(R.fields["name"] == oldname)
 					R.fields["name"] = newname

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -110,6 +110,16 @@
 			S.fields["notes"] = "No notes."
 		security += S
 
+        // Records with exploitative information
+		var/datum/data/record/E = new()
+		E.fields["id"]			= id
+		E.fields["name"]		= H.real_name
+		if(H.exploit_record && !jobban_isbanned(H, "Records"))
+			E.fields["notes"] = H.exploit_record
+		else
+			E.fields["notes"] = "No additional information acquired."
+		exploit += E
+
 		//Locked Record
 		var/datum/data/record/L = new()
 		L.fields["id"]			= md5("[H.real_name][H.mind.assigned_role]")

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -48,6 +48,7 @@
 	var/medical[] = list()
 	var/general[] = list()
 	var/security[] = list()
+	var/exploit[] = list()
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/locked[] = list()
 
@@ -303,7 +304,7 @@ var/global/list/PDA_Manifest = list()
 	throw_speed = 1
 	throw_range = 20
 	flags = FPRINT | TABLEPASS | CONDUCT
-	
+
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		user.drop_item()
 		src.throw_at(target, throw_range, throw_speed, user)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -62,6 +62,7 @@
 			new/datum/uplink_item(/obj/item/weapon/plastique, 2, "C-4 (Destroys walls)", "C4"),
 			new/datum/uplink_item(/obj/item/device/powersink, 5, "Powersink (DANGER!)", "PS",),
 			new/datum/uplink_item(/obj/item/device/radio/beacon/syndicate, 7, "Singularity Beacon (DANGER!)", "SB"),
+			new/datum/uplink_item(/obj/item/weapon/cartridge/information_uplink, 2, "Exploitable Information Uplink", "IU"),
 			new/datum/uplink_item(/obj/item/weapon/circuitboard/teleporter, 20, "Teleporter Circuit Board", "TP")
 			),
 		"Implants" = list(

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -44,9 +44,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/conversations = list()    // For keeping up with who we have PDA messsages from.
 	var/newmessage = 0			//To remove hackish overlay check
 
-	var/list/cartmodes = list(40, 42, 43, 433, 44, 441, 45, 451, 46, 48, 47, 49) // If you add more cartridge modes add them to this list as well.
-	var/list/no_auto_update = list(1, 40, 43, 44, 441, 45, 451)		     // These modes we turn off autoupdate
-	var/list/update_every_five = list(3, 41, 433, 46, 47, 48, 49)			     // These we update every 5 ticks
+	var/list/cartmodes = list(40, 42, 43, 433, 44, 441, 45, 451, 46, 48, 47, 49, 50, 501) // If you add more cartridge modes add them to this list as well.
+	var/list/no_auto_update = list(1, 40, 43, 44, 441, 45, 451, 50, 501)		     // These modes we turn off autoupdate
+	var/list/update_every_five = list(3, 41, 433, 46, 47, 48, 49)		 // These we update every 5 ticks
 
 	var/obj/item/weapon/card/id/id = null //Making it possible to slot an ID card into the PDA so it can function as both.
 	var/ownjob = null //related to above
@@ -385,7 +385,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					"access_hydroponics" = cartridge.access_hydroponics,\
 					"access_reagent_scanner" = cartridge.access_reagent_scanner,\
 					"access_remote_door" = cartridge.access_remote_door,\
-					"access_status_display" = cartridge.access_status_display\
+					"access_status_display" = cartridge.access_status_display,\
+					"access_exploit_information" = cartridge.access_exploit_information\
 			)
 			if(isnull(cartridge.radio))
 				cartdata["radio"] = 0
@@ -531,9 +532,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				mode = round(mode/10)
 				if(mode==2)
 					active_conversation = null
-				if(mode==4)//Fix for cartridges. Redirects to hub.
+				if(mode >= 4 && mode <= 5)//Fix for cartridges. Redirects to hub.
 					mode = 0
-				else if(mode >= 40 && mode <= 49)//Fix for cartridges. Redirects to refresh the menu.
+				else if(mode >= 40 && mode <= 50)//Fix for cartridges. Redirects to refresh the menu.
 					cartridge.mode = mode
 		if ("Authenticate")//Checks for ID
 			id_check(U, 1)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -21,12 +21,14 @@
 	var/access_status_display = 0
 	var/access_quartermaster = 0
 	var/access_hydroponics = 0
+	var/access_exploit_information = 0
 	var/charges = 0
 	var/mode = null
 	var/menu
 	var/datum/data/record/active1 = null //General
 	var/datum/data/record/active2 = null //Medical
 	var/datum/data/record/active3 = null //Security
+	var/datum/data/record/active4 = null //Exploit
 	var/obj/machinery/power/monitor/powmonitor = null // Power Monitor
 	var/list/powermonitors = list()
 	var/message1	// used for status_displays
@@ -203,6 +205,12 @@
 	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
 	charges = 4
 
+/obj/item/weapon/cartridge/information_uplink
+	name = "Information Uplink"
+	desc = "A completely black cartridge save for an eye on the front"
+	icon_state = "cart-eye"
+	access_exploit_information = 1
+
 /obj/item/weapon/cartridge/proc/post_status(var/command, var/data1, var/data2)
 
 	var/datum/radio_frequency/frequency = radio_controller.return_frequency(1435)
@@ -245,12 +253,12 @@
 
 	/*		Signaler (Mode: 40)				*/
 
-	
+
 	if(istype(radio,/obj/item/radio/integrated/signal) && (mode==40))
 		var/obj/item/radio/integrated/signal/R = radio
 		values["signal_freq"] = format_frequency(R.frequency)
 		values["signal_code"] = R.code
-		
+
 
 	/*		Station Display (Mode: 42)			*/
 
@@ -266,8 +274,8 @@
 		for(var/obj/machinery/power/monitor/pMon in world)
 			if(!(pMon.stat & (NOPOWER|BROKEN)) )
 				pMonData[++pMonData.len] = list ("Name" = pMon.name, "ref" = "\ref[pMon]")
-				if(isnull(powmonitor)) powmonitor = pMon 
-						
+				if(isnull(powmonitor)) powmonitor = pMon
+
 		values["powermonitors"] = pMonData
 
 		values["poweravail"] = powmonitor.powernet.avail
@@ -284,23 +292,21 @@
 		var/apcData[0]
 		for(var/obj/machinery/power/apc/A in L)
 			apcData[++apcData.len] = list("Name" = html_encode(A.area.name), "Equipment" = Status[A.equipment+1], "Lights" = Status[A.lighting+1], "Environment" = Status[A.environ+1], "CellPct" = A.cell ? round(A.cell.percent(),1) : -1, "CellStatus" = A.cell ? chg[A.charging+1] : 0)
-	
+
 		values["apcs"] = apcData
 
-				      
-	
-	
+
+
+
 
 	/*		General Records (Mode: 44 / 441 / 45 / 451)	*/
-	if(mode == 44 || mode == 441 || mode == 45 || mode ==451)
+	if(mode == 44 || mode == 441 || mode == 45 || mode == 451 || mode == 50 || mode == 501)
 		if(istype(active1, /datum/data/record) && (active1 in data_core.general))
 			values["general"] = active1.fields
 			values["general_exists"] = 1
-								
+
 		else
 			values["general_exists"] = 0
-	
-
 
 	/*		Medical Records (Mode: 44 / 441)	*/
 
@@ -316,7 +322,7 @@
 		else
 			values["medical_exists"] = 0
 
-	/*		Security Records (Mode:45 / 451)	*/	
+	/*		Security Records (Mode:45 / 451)	*/
 
 	if(mode == 45 || mode == 451)
 		var/secData[0]
@@ -348,15 +354,15 @@
 			if(SC.botlist && SC.botlist.len)
 				for(var/obj/machinery/bot/B in SC.botlist)
 					botsCount++
-					if(B.loc) 
+					if(B.loc)
 						botsData[++botsData.len] = list("Name" = sanitize(B.name), "Location" = sanitize(B.loc.loc.name), "ref" = "\ref[B]")
-		
+
 			if(!botsData.len)
 				botsData[++botsData.len] = list("Name" = "No bots found", "Location" = "Invalid", "ref"= null)
 
 			beepskyData["bots"] = botsData
 			beepskyData["count"] = botsCount
-		
+
 		else
 			beepskyData["active"] = 0
 			botsData[++botsData.len] = list("Name" = "No bots found", "Location" = "Invalid", "ref"= null)
@@ -379,10 +385,10 @@
 				var/area/loca = QC.botstatus["loca"]
 				var/loca_name = sanitize(loca.name)
 				muleData["botstatus"] =  list("loca" = loca_name, "mode" = QC.botstatus["mode"],"home"=QC.botstatus["home"],"powr" = QC.botstatus["powr"],"retn" =QC.botstatus["retn"], "pick"=QC.botstatus["pick"], "load" = QC.botstatus["load"], "dest" = sanitize(QC.botstatus["dest"]))
-	  
+
 			else
 				muleData["botstatus"] = list("loca" = null, "mode" = -1,"home"=null,"powr" = null,"retn" =null, "pick"=null, "load" = null, "dest" = null)
-		
+
 
 			var/mulebotsCount=0
 			for(var/obj/machinery/bot/B in QC.botlist)
@@ -397,7 +403,7 @@
 			muleData["count"] = mulebotsCount
 
 		else
-			muleData["botstatus"] =  list("loca" = null, "mode" = -1,"home"=null,"powr" = null,"retn" =null, "pick"=null, "load" = null, "dest" = null) 
+			muleData["botstatus"] =  list("loca" = null, "mode" = -1,"home"=null,"powr" = null,"retn" =null, "pick"=null, "load" = null, "dest" = null)
 			muleData["active"] = 0
 			mulebotsData[++mulebotsData.len] = list("Name" = "No bots found", "Location" = "Invalid", "ref"= null)
 			muleData["bots"] = mulebotsData
@@ -420,13 +426,13 @@
 		var/supplyOrderData[0]
 		for(var/S in supply_controller.shoppinglist)
 			var/datum/supply_order/SO = S
-		
+
 			supplyOrderData[++supplyOrderData.len] = list("Number" = SO.ordernum, "Name" = html_encode(SO.object.name), "ApprovedBy" = SO.orderedby, "Comment" = html_encode(SO.comment))
 		if(!supplyOrderData.len)
 			supplyOrderData[++supplyOrderData.len] = list("Number" = null, "Name" = null, "OrderedBy"=null)
-		
+
 		supplyData["approved"] = supplyOrderData
-		supplyData["approved_count"] = supplyOrderCount	
+		supplyData["approved_count"] = supplyOrderCount
 
 		var/requestCount = 0
 		var/requestData[0]
@@ -436,20 +442,20 @@
 			requestData[++requestData.len] = list("Number" = SO.ordernum, "Name" = html_encode(SO.object.name), "OrderedBy" = SO.orderedby, "Comment" = html_encode(SO.comment))
 		if(!requestData.len)
 			requestData[++requestData.len] = list("Number" = null, "Name" = null, "orderedBy" = null, "Comment" = null)
-	
+
 		supplyData["requests"] = requestData
 		supplyData["requests_count"] = requestCount
 
 
 		values["supply"] = supplyData
 
-	
+
 
 	/* 	Janitor Supplies Locator  (Mode: 49)      */
 	if(mode==49)
 		var/JaniData[0]
 		var/turf/cl = get_turf(src)
-	
+
 		if(cl)
 			JaniData["user_loc"] = list("x" = cl.x, "y" = cl.y)
 		else
@@ -462,14 +468,14 @@
 					continue
 				var/direction = get_dir(src, M)
 				MopData[++MopData.len] = list ("x" = ml.x, "y" = ml.y, "dir" = uppertext(dir2text(direction)), "status" = M.reagents.total_volume ? "Wet" : "Dry")
-	
+
 		if(!MopData.len)
 			MopData[++MopData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
-	
+
 
 		var/BucketData[0]
 		for(var/obj/structure/mopbucket/B in world)
-			var/turf/bl = get_turf(B)	
+			var/turf/bl = get_turf(B)
 			if(bl)
 				if(bl.z != cl.z)
 					continue
@@ -487,8 +493,8 @@
 					continue
 				var/direction = get_dir(src,B)
 				CbotData[++CbotData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.on ? "Online" : "Offline")
-	
-	
+
+
 		if(!CbotData.len)
 			CbotData[++CbotData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
 		var/CartData[0]
@@ -501,7 +507,7 @@
 				CartData[++CartData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.reagents.total_volume/100)
 		if(!CartData.len)
 			CartData[++CartData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
-	
+
 
 
 
@@ -511,10 +517,20 @@
 		JaniData["carts"] = CartData
 		values["janitor"] = JaniData
 
+    /*		Exploitative Information (Mode:50 / 501)	*/
+	if(mode == 50 || mode == 501)
+		var/exploitData[0]
+		for(var/datum/data/record/R in sortRecord(data_core.general))
+			exploitData[++exploitData.len] = list(Name = R.fields["name"],"ref" = "\ref[R]")
+		values["exploit_records"] = exploitData
+
+		if(istype(active4, /datum/data/record) && (active4 in data_core.exploit))
+			values["exploit"] = active4.fields
+			values["exploit_exists"] = 1
+		else
+			values["exploit_exists"] = 0
+
 	return values
-			
-
-
 
 
 /obj/item/weapon/cartridge/Topic(href, href_list)
@@ -525,8 +541,8 @@
 		usr << browse(null, "window=pda")
 		return
 
-		
-		
+
+
 
 	switch(href_list["choice"])
 		if("Medical Records")
@@ -554,6 +570,19 @@
 						break
 				active1 = R
 				active3 = S
+
+		if("Exploitative Information")
+			var/datum/data/record/R = locate(href_list["target"])
+			var/datum/data/record/I = locate(href_list["target"])
+			loc:mode = 501
+			mode = 501
+			if (R in data_core.general)
+				for (var/datum/data/record/E in data_core.exploit)
+					if ((E.fields["name"] == R.fields["name"] || E.fields["id"] == R.fields["id"]))
+						I = E
+						break
+				active1 = R
+				active4 = I
 
 		if("Send Signal")
 			spawn( 0 )

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -118,6 +118,7 @@ datum/preferences
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""
+	var/exploit_record = ""
 	var/disabilities = 0
 
 	var/nanotrasen_relation = "Neutral"
@@ -397,7 +398,7 @@ datum/preferences
 
 	dat += "<a href='byond://?src=\ref[user];preference=flavor_text;task=open'><b>Set Flavor Text</b></a><br>"
 
-	dat += "<a href='byond://?src=\ref[user];preference=pAI><b>pAI Configuration</b></a><br>"
+	dat += "<a href='byond://?src=\ref[user];preference=pAI'><b>pAI Configuration</b></a><br>"
 	dat += "<br>"
 
 	dat += "<br><b>Hair</b><br>"
@@ -595,6 +596,13 @@ datum/preferences
 	HTML += "<b>Antagonist Options</b> <hr />"
 	HTML += "<br>"
 	HTML +="Uplink Type : <b><a href='?src=\ref[user];preference=antagoptions;antagtask=uplinktype;active=1'>[uplinklocation]</a></b>"
+	HTML +="<br>"
+	HTML +="Exploitable information about you : "
+	HTML += "<br>"
+	if(jobban_isbanned(user, "Records"))
+		HTML += "<b>You are banned from using character records.</b><br>"
+	else
+		HTML +="<b><a href=\"byond://?src=\ref[user];preference=records;task=exploitable_record\">[TextPreview(exploit_record,40)]</a></b>"
 	HTML +="<br>"
 	HTML +="<hr />"
 	HTML +="<a href='?src=\ref[user];preference=antagoptions;antagtask=done;active=1'>\[Done\]</a>"
@@ -949,6 +957,16 @@ datum/preferences
 				gen_record = genmsg
 				SetRecords(user)
 
+		if(href_list["task"] == "exploitable_record")
+			var/exploitmsg = input(usr,"Set exploitable information about you here.","Exploitable Information",html_decode(exploit_record)) as message
+
+			if(exploitmsg != null)
+				exploitmsg = copytext(exploitmsg, 1, MAX_PAPER_MESSAGE_LEN)
+				exploitmsg = html_encode(exploitmsg)
+
+				exploit_record = exploitmsg
+				SetAntagoptions(user)
+
 	else if (href_list["preference"] == "antagoptions")
 		if(text2num(href_list["active"]) == 0)
 			SetAntagoptions(user)
@@ -1001,16 +1019,16 @@ datum/preferences
 					user << "\red That item will exceed the maximum loadout cost of [MAX_GEAR_COST] points."
 
 		else if(href_list["task"] == "remove")
-		
+
 			if(isnull(gear) || !islist(gear))
 				gear = list()
 			if(!gear.len)
 				return
-			
+
 			var/choice = input(user, "Select gear to remove: ") as null|anything in gear
 			if(!choice)
 				return
-			
+
 			for(var/gear_name in gear)
 				if(gear_name == choice)
 					gear -= gear_name
@@ -1519,6 +1537,7 @@ datum/preferences
 	character.med_record = med_record
 	character.sec_record = sec_record
 	character.gen_record = gen_record
+	character.exploit_record = exploit_record
 
 	character.gender = gender
 	character.age = age

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -160,7 +160,7 @@
 	S["gen_record"]			>> gen_record
 	S["be_special"]			>> be_special
 	S["disabilities"]		>> disabilities
-	S["player_alt_titles"]		>> player_alt_titles
+	S["player_alt_titles"]	>> player_alt_titles
 	S["used_skillpoints"]	>> used_skillpoints
 	S["skills"]				>> skills
 	S["skill_specialization"] >> skill_specialization
@@ -175,6 +175,7 @@
 	//S["skin_style"]			>> skin_style
 
 	S["uplinklocation"] >> uplinklocation
+	S["exploit_record"]	>> exploit_record
 
 	S["UI_style_color"]		<< UI_style_color
 	S["UI_style_alpha"]		<< UI_style_alpha
@@ -315,6 +316,7 @@
 	//S["skin_style"]			<< skin_style
 
 	S["uplinklocation"] << uplinklocation
+	S["exploit_record"]	<< exploit_record
 
 	S["UI_style_color"]		<< UI_style_color
 	S["UI_style_alpha"]		<< UI_style_alpha

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -69,6 +69,7 @@
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""
+	var/exploit_record = ""
 	var/blinded = null
 	var/bhunger = 0			//Carbon
 	var/ajourn = 0

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -68,7 +68,11 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             <div class="itemContent">
                 {{:helper.link('Notekeeper', 'note', {'choice' : "1"}, null, 'fixedLeftWide')}}
                 {{:helper.link('Messenger', data.newMessage ? 'mail-closed' : 'mail-open', {'choice' : "2"}, null, 'fixedLeftWide')}}
-                {{:helper.link('Crew Manifest', 'contact', {'choice' : "41"}, null, 'fixedLeftWide')}}
+                {{:helper.link('Crew Manifest', 'contact', {'choice' : "41"}, null, 'fixedLeftWide')}}           
+
+                {{if data.cartridge && data.cartridge.access.access_exploit_information == 1}}
+                    {{:helper.link('Information Uplink', 'alert', {'choice' : "50"}, null, 'fixedLeftWider')}}  
+                {{/if}}
             </div>
         </div>
         <br>
@@ -559,7 +563,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 	{{else data.mode == 44}}
 	    <H2>Medical Record List</H2>
         <div class="item">
-	        Select A record
+	        Select a Record
 	    </div>
 	    <br>
 		{{for data.records.medical_records}}
@@ -615,7 +619,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
  	{{else data.mode == 45}}
         <H2>Security Record List</H2>
         <div class="item">
-            Select A record
+            Select a Record
         </div>
         <br>
         {{for data.records.security_records}}
@@ -944,10 +948,56 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                     {{/if}}
                 {{/for}}
             </div>
+            
+            
+    {{else data.mode == 50}}
+	    <H2>Information Record List</H2>
+        <div class="item">
+	        Select a Record
+	    </div>
+	    <br>
+		{{for data.records.exploit_records}}
+            <div class="item">
+                 {{:helper.link(value.Name, 'gear', {'cartmenu' : "1", 'choice' : "Exploitative Information",'target' : value.ref}, null, null)}}
+            </div>
+		{{/for}}
+
+	{{else data.mode == 501}}
+        <H2>Information Record</H2>
+        <div class="statusDisplayRecords">
+            <div class="item">
+                <div class="itemContent" style="width: 100%;">
+                    {{if data.records.general_exists == 1}}
+                        <span class="good">Name:		</span> <span class="average">{{:data.records.general.name}}	</span><br>
+                        <span class="good">Sex:			</span> <span class="average">{{:data.records.general.sex}}		</span><br>
+                        <span class="good">Species:		</span> <span class="average">{{:data.records.general.species}}	</span><br>
+                        <span class="good">Age:			</span> <span class="average">{{:data.records.general.age}}		</span><br>
+                        <span class="good">Rank:		</span> <span class="average">{{:data.records.general.rank}}	</span><br>
+                        <span class="good">Fingerprint:		</span> <span class="average">{{:data.records.general.fingerprint}}	</span><br>
+                        <span class="good">Physical Status:	</span> <span class="average">{{:data.records.general.p_stat}}	</span><br>
+                        <span class="good">Mental Status:	</span> <span class="average">{{:data.records.general.m_stat}}	</span><br><br>
+                    {{else}}
+                        <span class="bad">
+                            General Record Lost!<br><br>
+                        </span>
+                    {{/if}}
+                    {{if data.records.exploit_exists == 1}}
+                        Acquired Information:<br>
+                        <span class="good">Notes:		</span> <span class="average">{{:data.records.exploit.notes}}	</span><br><br>
+                    {{else}}
+                        <span class="bad">
+                            No exploitative information acquired!
+                            <br>
+                            <br>
+                        </span>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+        
     {{/if}}
 {{else}}
     <div class="wholeScreen">
         <br><br><br><br><br><br><br>No Owner information found, please swipe ID
     </div>
 {{/if}}
-


### PR DESCRIPTION
Players are now able to add exploitable information about their characters under the Setup > Antag option menu.

Syndicate agents can buy a cartridge for 2 telecrystals named "Exploitable Information Uplink" in the menu.
When inserted into a PDA it allows access to general information + exploitable information.

Based on http://baystation12.net/forums/viewtopic.php?f=5&t=11149

![Information Setup](https://www.dropbox.com/s/v0ya7a5674mg1a2/Antag-Setup.png?dl=1)
![Syndicate Menu](https://www.dropbox.com/s/7n5f3ei7uigtkim/Antag-Exploitable.png?dl=1)
![PDA Menu](https://www.dropbox.com/s/o756jqxovfd65my/Antag-PDA.png?dl=1)
![Information Viewing](https://www.dropbox.com/s/mwy7deqx9x8euvw/Antag-Information.png?dl=1)
