### PR TITLE
Fixes sanitizeSQL proc

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -16,7 +16,7 @@
 // Run all strings to be used in an SQL query through this proc first to properly escape out injection attempts.
 /proc/sanitizeSQL(var/t as text)
 	var/sqltext = dbcon.Quote(t);
-	return copytext(sqltext, 2, lentext(sqltext)-1);//Quote() adds quotes around input, we already do that
+	return copytext(sqltext, 2, lentext(sqltext));//Quote() adds quotes around input, we already do that
 
 /*
  * Text sanitization


### PR DESCRIPTION
Resolved an issue where an extra character was being removed. Resolves #6070 and potentially a few other database related issues.

Looks like the routine suffered from getting tripped up by copytext's weird end-1 behavior and was stripping two characters instead of just the quote at the end.
