### PR TITLE
[DEV] PDAs now behave properly with unconnected power monitors

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -263,6 +263,7 @@
 	/*		Power Monitor (Mode: 43 / 433)			*/
 	if(mode==43 || mode==433)
 		var/pMonData[0]
+		var/apcData[0]
 		for(var/obj/machinery/power/monitor/pMon in world)
 			if(!(pMon.stat & (NOPOWER|BROKEN)) )
 				pMonData[++pMonData.len] = list ("Name" = pMon.name, "ref" = "\ref[pMon]")
@@ -270,22 +271,25 @@
 						
 		values["powermonitors"] = pMonData
 
-		values["poweravail"] = powmonitor.powernet.avail
-		values["powerload"] = num2text(powmonitor.powernet.viewload,10)
+		if (!isnull(powmonitor.powernet))
+			values["powerconnected"] = 1
+			values["poweravail"] = powmonitor.powernet.avail
+			values["powerload"] = num2text(powmonitor.powernet.viewload,10)
+			var/list/L = list()
+			for(var/obj/machinery/power/terminal/term in powmonitor.powernet.nodes)
+				if(istype(term.master, /obj/machinery/power/apc))
+					var/obj/machinery/power/apc/A = term.master
+					L += A
 
-		var/list/L = list()
-		for(var/obj/machinery/power/terminal/term in powmonitor.powernet.nodes)
-			if(istype(term.master, /obj/machinery/power/apc))
-				var/obj/machinery/power/apc/A = term.master
-				L += A
-
-		var/list/Status = list(0,0,1,1) // Status:  off, auto-off, on, auto-on
-		var/list/chg = list(0,1,1)	// Charging: nope, charging, full
-		var/apcData[0]
-		for(var/obj/machinery/power/apc/A in L)
-			apcData[++apcData.len] = list("Name" = html_encode(A.area.name), "Equipment" = Status[A.equipment+1], "Lights" = Status[A.lighting+1], "Environment" = Status[A.environ+1], "CellPct" = A.cell ? round(A.cell.percent(),1) : -1, "CellStatus" = A.cell ? chg[A.charging+1] : 0)
+			var/list/Status = list(0,0,1,1) // Status:  off, auto-off, on, auto-on
+			var/list/chg = list(0,1,1)	// Charging: nope, charging, full
+			for(var/obj/machinery/power/apc/A in L)
+				apcData[++apcData.len] = list("Name" = html_encode(A.area.name), "Equipment" = Status[A.equipment+1], "Lights" = Status[A.lighting+1], "Environment" = Status[A.environ+1], "CellPct" = A.cell ? round(A.cell.percent(),1) : -1, "CellStatus" = A.cell ? chg[A.charging+1] : 0)
 	
-		values["apcs"] = apcData
+			values["apcs"] = apcData
+		else
+			values["powerconnected"] = 0
+
 
 				      
 	

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -509,9 +509,9 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
 
 	{{else data.mode == 43}}
-        <H2>Station Powermonitors</H2>
+        <H2>Station Power Monitors</H2>
         <div class="item">
-            Select A power monitor:
+            Select a power monitor:
         </div>
         {{for data.records.powermonitors}}
             <div class="item">
@@ -522,39 +522,42 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
     {{else data.mode == 433}}
         <H2>Powernet Status</H2>
-        <div class="item">
-            <div class="itemLabelNarrow">
-                <b>Current Load</b>:
-            </div>
-            <div class="itemContent">
-                <span class="average">{{:data.records.powerload}} W</span>
-            </div>
-        </div>
-        <div class="item">
-            <div class="itemLabelNarrow">
-                <b>Total Power</b>:
-            </div>
-            <div class="itemContent">
-                <span class="average">{{:data.records.poweravail}} W</span>
-            </div>
-        </div>
-        <br>
-        <div class="item">
-            <table class="curvedEdges"><tbody>
-                {{for data.records.apcs}}
-                    {{if index % 20 === 0}}
-                        <tr class=><th>&nbsp;Area&nbsp;</th><th>&nbsp;Eqp.&nbsp;</th><th>&nbsp;Lgt.&nbsp;</th><th>&nbsp;Env&nbsp;</th><th>&nbsp;Cell&nbsp;</th></tr>
-                    {{/if}}
-                    <tr class=><td><span class="average">{{:value.Name}}</span></td>
-                        {{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Equipment==1 ? '#4f7529' : '#8f1414')}}
-                        {{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Lights==1 ? '#4f7529' : '#8f1414')}}
-                        {{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Environment==1 ? '#4f7529' : '#8f1414')}}
-                        {{:helper.string('<td bgcolor="{0}">{1}</td>', value.CellStatus==1 ? '#4f7529' : '#8f1414', value.CellStatus==-1 ? 'No Cell' : CellPct + '%')}}
-                    </tr>
-                {{/for}}
-            </tbody></table>
-        </div>
-
+		{{if data.records.powerconnected == 1}}
+			<div class="item">
+				<div class="itemLabelNarrow">
+					<b>Current Load</b>:
+				</div>
+				<div class="itemContent">
+					<span class="average">{{:data.records.powerload}} W</span>
+				</div>
+			</div>
+			<div class="item">
+				<div class="itemLabelNarrow">
+					<b>Total Power</b>:
+				</div>
+				<div class="itemContent">
+					<span class="average">{{:data.records.poweravail}} W</span>
+				</div>
+			</div>
+			<br>
+			<div class="item">
+				<table class="curvedEdges"><tbody>
+					{{for data.records.apcs}}
+						{{if index % 20 === 0}}
+							<tr class=><th>&nbsp;Area&nbsp;</th><th>&nbsp;Eqp.&nbsp;</th><th>&nbsp;Lgt.&nbsp;</th><th>&nbsp;Env&nbsp;</th><th>&nbsp;Cell&nbsp;</th></tr>
+						{{/if}}
+						<tr class=><td><span class="average">{{:value.Name}}</span></td>
+							{{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Equipment==1 ? '#4f7529' : '#8f1414')}}
+							{{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Lights==1 ? '#4f7529' : '#8f1414')}}
+							{{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Environment==1 ? '#4f7529' : '#8f1414')}}
+							{{:helper.string('<td bgcolor="{0}">{1}</td>', value.CellStatus==1 ? '#4f7529' : '#8f1414', value.CellStatus==-1 ? 'No Cell' : value.CellPct + '%')}}
+						</tr>
+					{{/for}}
+				</tbody></table>
+			</div>
+		{{else}}
+			<b>Power monitor not connected to net</b>
+		{{/if}}
 
 	{{else data.mode == 44}}
 	    <H2>Medical Record List</H2>


### PR DESCRIPTION
FIxes an issue where PDAs would throw a runtime and also a client error when a power monitor was not connected to the network when using the PowerON cart by identifying disconnected terminals and reporting them as such. Also cleans up a few typos in the template related to the power monitor and fixes a bug with the template missing a "value." in front of CellPct.
