### PR TITLE
[DEV] PDA Power Monitor Clarity Upgrade

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -263,6 +263,7 @@
 	/*		Power Monitor (Mode: 43 / 433)			*/
 	if(mode==43 || mode==433)
 		var/pMonData[0]
+		var/apcData[0]
 		for(var/obj/machinery/power/monitor/pMon in world)
 			if(!(pMon.stat & (NOPOWER|BROKEN)) )
 				pMonData[++pMonData.len] = list ("Name" = pMon.name, "ref" = "\ref[pMon]")
@@ -270,22 +271,25 @@
 						
 		values["powermonitors"] = pMonData
 
-		values["poweravail"] = powmonitor.powernet.avail
-		values["powerload"] = num2text(powmonitor.powernet.viewload,10)
+		if (!isnull(powmonitor.powernet))
+			values["powerconnected"] = 1
+			values["poweravail"] = powmonitor.powernet.avail
+			values["powerload"] = num2text(powmonitor.powernet.viewload,10)
+			var/list/L = list()
+			for(var/obj/machinery/power/terminal/term in powmonitor.powernet.nodes)
+				if(istype(term.master, /obj/machinery/power/apc))
+					var/obj/machinery/power/apc/A = term.master
+					L += A
 
-		var/list/L = list()
-		for(var/obj/machinery/power/terminal/term in powmonitor.powernet.nodes)
-			if(istype(term.master, /obj/machinery/power/apc))
-				var/obj/machinery/power/apc/A = term.master
-				L += A
-
-		var/list/Status = list(0,0,1,1) // Status:  off, auto-off, on, auto-on
-		var/list/chg = list(0,1,1)	// Charging: nope, charging, full
-		var/apcData[0]
-		for(var/obj/machinery/power/apc/A in L)
-			apcData[++apcData.len] = list("Name" = html_encode(A.area.name), "Equipment" = Status[A.equipment+1], "Lights" = Status[A.lighting+1], "Environment" = Status[A.environ+1], "CellPct" = A.cell ? round(A.cell.percent(),1) : -1, "CellStatus" = A.cell ? chg[A.charging+1] : 0)
+			var/list/Status = list(0,0,1,1) // Status:  off, auto-off, on, auto-on
+			var/list/chg = list(0,1,1)	// Charging: nope, charging, full
+			for(var/obj/machinery/power/apc/A in L)
+				apcData[++apcData.len] = list("Name" = html_encode(A.area.name), "Equipment" = Status[A.equipment+1], "Lights" = Status[A.lighting+1], "Environment" = Status[A.environ+1], "CellPct" = A.cell ? round(A.cell.percent(),1) : -1, "CellStatus" = A.cell ? chg[A.charging+1] : 0)
 	
-		values["apcs"] = apcData
+			values["apcs"] = apcData
+		else
+			values["powerconnected"] = 0
+
 
 				      
 	

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -245,12 +245,12 @@
 
 	/*		Signaler (Mode: 40)				*/
 
-	
+
 	if(istype(radio,/obj/item/radio/integrated/signal) && (mode==40))
 		var/obj/item/radio/integrated/signal/R = radio
 		values["signal_freq"] = format_frequency(R.frequency)
 		values["signal_code"] = R.code
-		
+
 
 	/*		Station Display (Mode: 42)			*/
 
@@ -266,9 +266,11 @@
 		var/apcData[0]
 		for(var/obj/machinery/power/monitor/pMon in world)
 			if(!(pMon.stat & (NOPOWER|BROKEN)) )
-				pMonData[++pMonData.len] = list ("Name" = pMon.name, "ref" = "\ref[pMon]")
-				if(isnull(powmonitor)) powmonitor = pMon 
-						
+				var/turf/monitorturf = locate(pMon.x,pMon.y,pMon.z)
+				var/area/monitorarea = monitorturf.loc
+				pMonData[++pMonData.len] = list ("Name" = html_encode(monitorarea ? pMon.name + " in " + monitorarea.name : pMon.name), "ref" = "\ref[pMon]")
+				if(isnull(powmonitor)) powmonitor = pMon
+
 		values["powermonitors"] = pMonData
 
 		if (!isnull(powmonitor.powernet))
@@ -285,25 +287,25 @@
 			var/list/chg = list(0,1,1)	// Charging: nope, charging, full
 			for(var/obj/machinery/power/apc/A in L)
 				apcData[++apcData.len] = list("Name" = html_encode(A.area.name), "Equipment" = Status[A.equipment+1], "Lights" = Status[A.lighting+1], "Environment" = Status[A.environ+1], "CellPct" = A.cell ? round(A.cell.percent(),1) : -1, "CellStatus" = A.cell ? chg[A.charging+1] : 0)
-	
+
 			values["apcs"] = apcData
 		else
 			values["powerconnected"] = 0
 
 
-				      
-	
-	
+
+
+
 
 	/*		General Records (Mode: 44 / 441 / 45 / 451)	*/
 	if(mode == 44 || mode == 441 || mode == 45 || mode ==451)
 		if(istype(active1, /datum/data/record) && (active1 in data_core.general))
 			values["general"] = active1.fields
 			values["general_exists"] = 1
-								
+
 		else
 			values["general_exists"] = 0
-	
+
 
 
 	/*		Medical Records (Mode: 44 / 441)	*/
@@ -320,7 +322,7 @@
 		else
 			values["medical_exists"] = 0
 
-	/*		Security Records (Mode:45 / 451)	*/	
+	/*		Security Records (Mode:45 / 451)	*/
 
 	if(mode == 45 || mode == 451)
 		var/secData[0]
@@ -352,15 +354,15 @@
 			if(SC.botlist && SC.botlist.len)
 				for(var/obj/machinery/bot/B in SC.botlist)
 					botsCount++
-					if(B.loc) 
+					if(B.loc)
 						botsData[++botsData.len] = list("Name" = sanitize(B.name), "Location" = sanitize(B.loc.loc.name), "ref" = "\ref[B]")
-		
+
 			if(!botsData.len)
 				botsData[++botsData.len] = list("Name" = "No bots found", "Location" = "Invalid", "ref"= null)
 
 			beepskyData["bots"] = botsData
 			beepskyData["count"] = botsCount
-		
+
 		else
 			beepskyData["active"] = 0
 			botsData[++botsData.len] = list("Name" = "No bots found", "Location" = "Invalid", "ref"= null)
@@ -383,10 +385,10 @@
 				var/area/loca = QC.botstatus["loca"]
 				var/loca_name = sanitize(loca.name)
 				muleData["botstatus"] =  list("loca" = loca_name, "mode" = QC.botstatus["mode"],"home"=QC.botstatus["home"],"powr" = QC.botstatus["powr"],"retn" =QC.botstatus["retn"], "pick"=QC.botstatus["pick"], "load" = QC.botstatus["load"], "dest" = sanitize(QC.botstatus["dest"]))
-	  
+
 			else
 				muleData["botstatus"] = list("loca" = null, "mode" = -1,"home"=null,"powr" = null,"retn" =null, "pick"=null, "load" = null, "dest" = null)
-		
+
 
 			var/mulebotsCount=0
 			for(var/obj/machinery/bot/B in QC.botlist)
@@ -401,7 +403,7 @@
 			muleData["count"] = mulebotsCount
 
 		else
-			muleData["botstatus"] =  list("loca" = null, "mode" = -1,"home"=null,"powr" = null,"retn" =null, "pick"=null, "load" = null, "dest" = null) 
+			muleData["botstatus"] =  list("loca" = null, "mode" = -1,"home"=null,"powr" = null,"retn" =null, "pick"=null, "load" = null, "dest" = null)
 			muleData["active"] = 0
 			mulebotsData[++mulebotsData.len] = list("Name" = "No bots found", "Location" = "Invalid", "ref"= null)
 			muleData["bots"] = mulebotsData
@@ -424,13 +426,13 @@
 		var/supplyOrderData[0]
 		for(var/S in supply_controller.shoppinglist)
 			var/datum/supply_order/SO = S
-		
+
 			supplyOrderData[++supplyOrderData.len] = list("Number" = SO.ordernum, "Name" = html_encode(SO.object.name), "ApprovedBy" = SO.orderedby, "Comment" = html_encode(SO.comment))
 		if(!supplyOrderData.len)
 			supplyOrderData[++supplyOrderData.len] = list("Number" = null, "Name" = null, "OrderedBy"=null)
-		
+
 		supplyData["approved"] = supplyOrderData
-		supplyData["approved_count"] = supplyOrderCount	
+		supplyData["approved_count"] = supplyOrderCount
 
 		var/requestCount = 0
 		var/requestData[0]
@@ -440,20 +442,20 @@
 			requestData[++requestData.len] = list("Number" = SO.ordernum, "Name" = html_encode(SO.object.name), "OrderedBy" = SO.orderedby, "Comment" = html_encode(SO.comment))
 		if(!requestData.len)
 			requestData[++requestData.len] = list("Number" = null, "Name" = null, "orderedBy" = null, "Comment" = null)
-	
+
 		supplyData["requests"] = requestData
 		supplyData["requests_count"] = requestCount
 
 
 		values["supply"] = supplyData
 
-	
+
 
 	/* 	Janitor Supplies Locator  (Mode: 49)      */
 	if(mode==49)
 		var/JaniData[0]
 		var/turf/cl = get_turf(src)
-	
+
 		if(cl)
 			JaniData["user_loc"] = list("x" = cl.x, "y" = cl.y)
 		else
@@ -466,14 +468,14 @@
 					continue
 				var/direction = get_dir(src, M)
 				MopData[++MopData.len] = list ("x" = ml.x, "y" = ml.y, "dir" = uppertext(dir2text(direction)), "status" = M.reagents.total_volume ? "Wet" : "Dry")
-	
+
 		if(!MopData.len)
 			MopData[++MopData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
-	
+
 
 		var/BucketData[0]
 		for(var/obj/structure/mopbucket/B in world)
-			var/turf/bl = get_turf(B)	
+			var/turf/bl = get_turf(B)
 			if(bl)
 				if(bl.z != cl.z)
 					continue
@@ -491,8 +493,8 @@
 					continue
 				var/direction = get_dir(src,B)
 				CbotData[++CbotData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.on ? "Online" : "Offline")
-	
-	
+
+
 		if(!CbotData.len)
 			CbotData[++CbotData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
 		var/CartData[0]
@@ -505,7 +507,7 @@
 				CartData[++CartData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.reagents.total_volume/100)
 		if(!CartData.len)
 			CartData[++CartData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
-	
+
 
 
 
@@ -516,7 +518,7 @@
 		values["janitor"] = JaniData
 
 	return values
-			
+
 
 
 
@@ -529,8 +531,8 @@
 		usr << browse(null, "window=pda")
 		return
 
-		
-		
+
+
 
 	switch(href_list["choice"])
 		if("Medical Records")

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -509,9 +509,9 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
 
 	{{else data.mode == 43}}
-        <H2>Station Powermonitors</H2>
+        <H2>Station Power Monitors</H2>
         <div class="item">
-            Select A power monitor:
+            Select a power monitor:
         </div>
         {{for data.records.powermonitors}}
             <div class="item">
@@ -522,39 +522,42 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
     {{else data.mode == 433}}
         <H2>Powernet Status</H2>
-        <div class="item">
-            <div class="itemLabelNarrow">
-                <b>Current Load</b>:
-            </div>
-            <div class="itemContent">
-                <span class="average">{{:data.records.powerload}} W</span>
-            </div>
-        </div>
-        <div class="item">
-            <div class="itemLabelNarrow">
-                <b>Total Power</b>:
-            </div>
-            <div class="itemContent">
-                <span class="average">{{:data.records.poweravail}} W</span>
-            </div>
-        </div>
-        <br>
-        <div class="item">
-            <table class="curvedEdges"><tbody>
-                {{for data.records.apcs}}
-                    {{if index % 20 === 0}}
-                        <tr class=><th>&nbsp;Area&nbsp;</th><th>&nbsp;Eqp.&nbsp;</th><th>&nbsp;Lgt.&nbsp;</th><th>&nbsp;Env&nbsp;</th><th>&nbsp;Cell&nbsp;</th></tr>
-                    {{/if}}
-                    <tr class=><td><span class="average">{{:value.Name}}</span></td>
-                        {{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Equipment==1 ? '#4f7529' : '#8f1414')}}
-                        {{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Lights==1 ? '#4f7529' : '#8f1414')}}
-                        {{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Environment==1 ? '#4f7529' : '#8f1414')}}
-                        {{:helper.string('<td bgcolor="{0}">{1}</td>', value.CellStatus==1 ? '#4f7529' : '#8f1414', value.CellStatus==-1 ? 'No Cell' : CellPct + '%')}}
-                    </tr>
-                {{/for}}
-            </tbody></table>
-        </div>
-
+		{{if data.records.powerconnected == 1}}
+			<div class="item">
+				<div class="itemLabelNarrow">
+					<b>Current Load</b>:
+				</div>
+				<div class="itemContent">
+					<span class="average">{{:data.records.powerload}} W</span>
+				</div>
+			</div>
+			<div class="item">
+				<div class="itemLabelNarrow">
+					<b>Total Power</b>:
+				</div>
+				<div class="itemContent">
+					<span class="average">{{:data.records.poweravail}} W</span>
+				</div>
+			</div>
+			<br>
+			<div class="item">
+				<table class="curvedEdges"><tbody>
+					{{for data.records.apcs}}
+						{{if index % 20 === 0}}
+							<tr class=><th>&nbsp;Area&nbsp;</th><th>&nbsp;Eqp.&nbsp;</th><th>&nbsp;Lgt.&nbsp;</th><th>&nbsp;Env&nbsp;</th><th>&nbsp;Cell&nbsp;</th></tr>
+						{{/if}}
+						<tr class=><td><span class="average">{{:value.Name}}</span></td>
+							{{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Equipment==1 ? '#4f7529' : '#8f1414')}}
+							{{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Lights==1 ? '#4f7529' : '#8f1414')}}
+							{{:helper.string('<td bgcolor="{0}">&nbsp;</td>', value.Environment==1 ? '#4f7529' : '#8f1414')}}
+							{{:helper.string('<td bgcolor="{0}">{1}</td>', value.CellStatus==1 ? '#4f7529' : '#8f1414', value.CellStatus==-1 ? 'No Cell' : value.CellPct + '%')}}
+						</tr>
+					{{/for}}
+				</tbody></table>
+			</div>
+		{{else}}
+			<b>Power monitor not connected to net</b>
+		{{/if}}
 
 	{{else data.mode == 44}}
 	    <H2>Medical Record List</H2>


### PR DESCRIPTION
Depends on #6248, so if you're going to merge this, you'll want to merge that first.

In any case, this simply makes the PDA show where the power monitor is that you're looking at. This reduces ambiguity when you have multiple power monitors by the same name, such as if the players have made multiple consoles in game or prior to #6246, the two monitor computers in engineering as shown in the screenshot below)
![monitor](https://cloud.githubusercontent.com/assets/6076355/4105624/bfb89bae-31ad-11e4-9878-52887c1855e9.jpg)
