### PR TITLE
Add headings to pencode

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -200,7 +200,14 @@
 	t = replacetext(t, "\[/large\]", "</font>")
 	t = replacetext(t, "\[sign\]", "<font face=\"[signfont]\"><i>[user.real_name]</i></font>")
 	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
-
+	
+	t = replacetext(t, "\[h1\]", "<H1>")
+	t = replacetext(t, "\[/h1\]", "</H1>")
+	t = replacetext(t, "\[h2\]", "<H2>")
+	t = replacetext(t, "\[/h2\]", "</H2>")
+	t = replacetext(t, "\[h3\]", "<H3>")
+	t = replacetext(t, "\[/h3\]", "</H3>")
+	
 	if(!iscrayon)
 		t = replacetext(t, "\[*\]", "<li>")
 		t = replacetext(t, "\[hr\]", "<HR>")
@@ -253,6 +260,9 @@
 		<br>
 		\[br\] : Creates a linebreak.<br>
 		\[center\] - \[/center\] : Centers the text.<br>
+		\[h1\] - \[/h1\] : Makes the text a first level heading<br>
+		\[h2\] - \[/h2\] : Makes the text a second level heading<br>
+		\[h3\] - \[/h3\] : Makes the text a third level heading<br>
 		\[b\] - \[/b\] : Makes the text <b>bold</b>.<br>
 		\[i\] - \[/i\] : Makes the text <i>italic</i>.<br>
 		\[u\] - \[/u\] : Makes the text <u>underlined</u>.<br>


### PR DESCRIPTION
This adds heading tags (`[h1]` through `[h3]`) to pencode, which output the corresponding `<H1>` through `<H3>` Byond-flavored HTML tags. 

This allows for simplification of document creation, by allowing people to mark up headings instead of marking up something like centered-large-bold font. It uses default formatting so far.
