### PR TITLE
Syndicate Upload Console - Uniform Appearance

### DIFF
--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -4,28 +4,25 @@ Title: Syndicate Uplink, uses some javascript to change nanoUI up a bit.
 Used In File(s): \code\game\objects\items\devices\uplinks.dm
  -->
 {{:helper.syndicateMode()}}
-{{if data.menu != 0}}
-    <div class="item">
-        <div class="itemContent">
-			{{:helper.link('Return', 'arrowreturn-1-w', {'return' : 1}, null, 'fixedLeftWide')}}
-		</div>
+<H2><span class="white">{{:data.welcome}}</span></H2>
+<br>
+<div class="item">
+	<div class="itemLabelNarrow">
+		<b>Functions</b>:
 	</div>
-    <br>
-{{/if}}
+	<div class="itemContent">
+		{{:helper.link('Request Items', 'gear', {'menu' : 0}, null, 'fixedLeftWider')}}
+		{{:helper.link('Exploitable Information', 'gear', {'menu' : 1}, null, 'fixedLeftWider')}}
+		{{:helper.link('Return', 'arrowreturn-1-w', {'return' : 1}, null, 'fixedLeft')}}
+		{{:helper.link('Close', 'gear', {'lock' : "1"}, null, 'fixedLeft')}}
+	</div>
+</div>
+<br>
+	
 {{if data.menu == 0}}
-    <H2><span class="white">{{:data.welcome}}</span></H2>
-    <br>
-    <div class="item">
-        <div class="itemLabelNarrow">
-            <b>Functions</b>:
-        </div>
-        <div class="itemContent">
-            {{:helper.link('Exploitable Information', 'gear', {'menu' : 1}, null, 'fixedLeftWider')}}
-            {{:helper.link('Close', 'gear', {'lock' : "1"}, null, 'fixedLeft')}}
-        </div>
-    </div>
-    <br>
-    <div class="item">
+    <H2><span class="white">Request items:</span></H2>
+    <span class="white"><i>Each item costs a number of tele-crystals as indicated by the number following their name.</i></span>
+	<div class="item">
         <div class="itemLabel">
             <b>Tele-Crystals</b>:
         </div>
@@ -33,10 +30,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
             {{:data.crystals}}
         </div>
     </div>
-    <H2><span class="white">Request items:</span></H2><br>
-    <span class="white"><i>Each item costs a number of tele-crystals as indicated by the number following their name.</i></span>
-
-    <br><br>
+    <br>
     {{for data.nano_items}}
         <div class="item">
             <H3><span class="white">{{:value.Category}}</span></H3>
@@ -53,7 +47,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
         {{:helper.link('Buy Random (??)' , 'gear', {'buy_item' : 'random'}, null, 'fixedLeftWidest')}}
     </div>
 {{else data.menu == 1}}
-    <H2><span class="white">Information Record List</span></H2>
+    <H2><span class="white">Information Record List:</span></H2>
     <br>
     <div class="item">
         Select a Record
@@ -65,7 +59,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
         </div>
     {{/for}}
 {{else data.menu == 11}}
-    <H2><span class="white">Information Record</span></H2>
+    <H2><span class="white">Information Record:</span></H2>
     <br>
     <div class="statusDisplayRecords">
         <div class="item">


### PR DESCRIPTION
Made all menus of the Syndicate upload console have a uniform header, giving a more professional appearance and quicker access to all functions.

For now the request item menu remains the default but this can be trivially changed into a proper submenu simply by changing the menu number 0 in row 14 and 22 to to an unused single-digit number, like 2.

![Main](https://www.dropbox.com/s/n7c47j4mtnqe0by/Syndi-Main.png?dl=1)![Records](https://www.dropbox.com/s/ruzhgcu0f1fde70/Syndi-Infos.png?dl=1)![Record](https://www.dropbox.com/s/0v5w0corzvaos9b/Syndi-Info.png?dl=1)
