### PR TITLE
Limits body/cryo bags to a single mob.

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -37,7 +37,7 @@
 	icon_opened = "bodybag_open"
 	var/item_path = /obj/item/bodybag
 	density = 0
-
+	storage_capacity = (mob_size * 2) - 1
 
 	attackby(W as obj, mob/user as mob)
 		if (istype(W, /obj/item/weapon/pen))
@@ -108,20 +108,22 @@
 	item_path = /obj/item/bodybag/cryobag
 	open_sound = 'sound/items/zip.ogg'
 	close_sound = 'sound/items/zip.ogg'
+	store_misc = 0
+	store_items = 0
 	var/used = 0
 
-	open()
-		. = ..()
-		if(used)
-			var/obj/item/O = new/obj/item(src.loc)
-			O.name = "used stasis bag"
-			O.icon = src.icon
-			O.icon_state = "bodybag_used"
-			O.desc = "Pretty useless now.."
-			del(src)
+/obj/structure/closet/body_bag/cryobag/open()
+	. = ..()
+	if(used)
+		var/obj/item/O = new/obj/item(src.loc)
+		O.name = "used stasis bag"
+		O.icon = src.icon
+		O.icon_state = "bodybag_used"
+		O.desc = "Pretty useless now.."
+		del(src)
 
-	MouseDrop(over_object, src_location, over_location)
-		if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
-			if(!ishuman(usr))	return
-			usr << "\red You can't fold that up anymore.."
-		..()
+/obj/structure/closet/body_bag/cryobag/MouseDrop(over_object, src_location, over_location)
+	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
+		if(!ishuman(usr))	return
+		usr << "\red You can't fold that up anymore.."
+	..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -17,6 +17,12 @@
 	var/open_sound = 'sound/machines/click.ogg'
 	var/close_sound = 'sound/machines/click.ogg'
 
+	var/store_misc = 1
+	var/store_items = 1
+	var/store_mobs = 1
+
+	var/const/mob_size = 15
+
 /obj/structure/closet/New()
 	..()
 	spawn(1)
@@ -79,23 +85,41 @@
 		return 0
 
 	var/stored_units = 0
-	var/mob_size = 15
 
-	//Cham Projector Exception
+	if(store_misc)
+		stored_units = store_misc(stored_units)
+	if(store_items)
+		stored_units = store_items(stored_units)
+	if(store_mobs)
+		stored_units = store_mobs(stored_units)
+
+	src.icon_state = src.icon_closed
+	src.opened = 0
+
+	playsound(src.loc, close_sound, 15, 1, -3)
+	density = 1
+	return 1
+
+//Cham Projector Exception
+/obj/structure/closet/proc/store_misc(var/stored_units)
 	for(var/obj/effect/dummy/chameleon/AD in src.loc)
-		if(stored_units >= storage_capacity)
+		if(stored_units > storage_capacity)
 			break
 		AD.loc = src
 		stored_units++
+	return stored_units
 
+/obj/structure/closet/proc/store_items(var/stored_units)
 	for(var/obj/item/I in src.loc)
 		var/item_size = Ceiling(I.w_class / 2)
-		if(stored_units + item_size >= storage_capacity)
+		if(stored_units + item_size > storage_capacity)
 			continue
 		if(!I.anchored)
 			I.loc = src
 			stored_units += item_size
+	return stored_units
 
+/obj/structure/closet/proc/store_mobs(var/stored_units)
 	for(var/mob/M in src.loc)
 		if(stored_units + mob_size > storage_capacity)
 			break
@@ -110,13 +134,7 @@
 
 		M.loc = src
 		stored_units += mob_size
-
-	src.icon_state = src.icon_closed
-	src.opened = 0
-
-	playsound(src.loc, close_sound, 15, 1, -3)
-	density = 1
-	return 1
+	return stored_units
 
 /obj/structure/closet/proc/toggle(mob/user as mob)
 	if(!(src.opened ? src.close() : src.open()))


### PR DESCRIPTION
Also ensures that cryobags only attempt to store mobs and nothing else to reduce the risk of it being wasted.
Bodybags still accept everything simply because they are reusable.
