### PR TITLE
Round-end feedback fix

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -374,12 +374,12 @@ var/global/datum/controller/gameticker/ticker
 /datum/controller/gameticker/proc/declare_completion()
 	world << "<br><br><br><font size=3><b>The round has ended.</b></font>"
 	for(var/mob/Player in player_list)
-		if(Player.mind)
+		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD)
 				var/turf/playerTurf = get_turf(Player)
 				if(emergency_shuttle.departed && emergency_shuttle.evac)
 					if(playerTurf.z != 2)
-						Player << "<font color='red'><b>You managed to survive, but were marooned on [station_name()]...</b></font>"
+						Player << "<font color='blue'><b>You managed to survive, but were marooned on [station_name()]...</b></font>"
 					else
 						Player << "<font color='green'><b>You managed to survive the events on [station_name()] as [Player.real_name].</b></font>"
 				else if(playerTurf.z == 2)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -121,6 +121,11 @@ proc/isdeaf(A)
 		return (M.sdisabilities & DEAF) || M.ear_deaf
 	return 0
 
+proc/isnewplayer(A)
+	if(istype(A, /mob/new_player))
+		return 1
+	return 0
+
 proc/hasorgans(A)
 	return ishuman(A)
 


### PR DESCRIPTION
People in the lobby who had not joined as observers were considered to be non-survivors at the end of round.
