### PR TITLE
Kun-Peng: Updating mapmerge scripts to point to BS12ship.dmm. Now with 50% less other stuff.

### DIFF
--- a/tools/mapmerge/1prepare_map.bat
+++ b/tools/mapmerge/1prepare_map.bat
@@ -1,4 +1,4 @@
-set MAPFILE=tgstation2.dmm
+set MAPFILE=BS12ship.dmm
 
 cd ../../maps
 copy %MAPFILE% %MAPFILE%.backup

--- a/tools/mapmerge/2clean_map.bat
+++ b/tools/mapmerge/2clean_map.bat
@@ -1,4 +1,4 @@
-set MAPFILE=tgstation2.dmm
+set MAPFILE=BS12ship.dmm
 
 java -jar MapPatcher.jar -clean ../../maps/%MAPFILE%.backup ../../maps/%MAPFILE% ../../maps/%MAPFILE%
 

--- a/tools/mapmerge/clean_map_git.sh
+++ b/tools/mapmerge/clean_map_git.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-MAPFILE='tgstation2.dmm'
+MAPFILE='BS12ship.dmm'
 
 git show HEAD:maps/$MAPFILE > tmp.dmm
 java -jar MapPatcher.jar -clean tmp.dmm '../../maps/'$MAPFILE '../../maps/'$MAPFILE


### PR DESCRIPTION
De-derped version. Targeting the Kun-Peng with the mapmerge bats to minimise file diffing.
