### PR TITLE
Multiz fixes and mapping features

### DIFF
--- a/code/TriDimension/Structures_presets.dm
+++ b/code/TriDimension/Structures_presets.dm
@@ -1,0 +1,11 @@
+/obj/multiz/stairs/north_up
+	suggest_dir = SOUTH
+
+/obj/multiz/stairs/south_up
+	suggest_dir = NORTH
+
+/obj/multiz/stairs/east_up
+	suggest_dir = WEST
+
+/obj/multiz/stairs/west_up
+	suggest_dir = EAST

--- a/code/TriDimension/Turfs.dm
+++ b/code/TriDimension/Turfs.dm
@@ -26,6 +26,11 @@
 					var/soft = 0
 					for(var/atom/A in floorbelow.contents)
 						if(A.density)
+							if(istype(A, /obj/structure/window))
+								var/obj/structure/window/W = A
+								blocked = W.is_fulltile()
+								if(blocked)
+									break
 							blocked = 1
 							break
 						if(istype(A, /obj/machinery/atmospherics/pipe/zpipe/up) && istype(AM,/obj/item/pipe))

--- a/code/TriDimension/controller_presets.dm
+++ b/code/TriDimension/controller_presets.dm
@@ -1,0 +1,37 @@
+/obj/effect/landmark/zcontroller/level_1_bottom
+	up = 1
+	up_target = 2
+
+/obj/effect/landmark/zcontroller/level_2_mid
+	up = 1
+	up_target = 3
+	down = 1
+	down_target = 1
+
+/obj/effect/landmark/zcontroller/level_3_mid
+	up = 1
+	up_target = 4
+	down = 1
+	down_target = 2
+
+/obj/effect/landmark/zcontroller/level_4_mid
+	up = 1
+	up_target = 5
+	down = 1
+	down_target = 3
+
+/obj/effect/landmark/zcontroller/level_2_top
+	down = 1
+	down_target = 1
+
+/obj/effect/landmark/zcontroller/level_3_top
+	down = 1
+	down_target = 2
+
+/obj/effect/landmark/zcontroller/level_4_top
+	down = 1
+	down_target = 3
+
+/obj/effect/landmark/zcontroller/level_5_top
+	down = 1
+	down_target = 4


### PR DESCRIPTION
Allows stairs to be in any of the four cardinal directions through a suggest_dir var, and adds preset objects for each of the four directions.

Allows falling into the same turf as a non-full-tile window.

Adds preset z-level controllers.
