### PR TITLE
Add grape juicing to reagent grinder

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -852,6 +852,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/grown/orange = list("orangejuice" = 0),
 		/obj/item/weapon/reagent_containers/food/snacks/grown/lime = list("limejuice" = 0),
 		/obj/item/weapon/reagent_containers/food/snacks/watermelonslice = list("watermelonjuice" = 0),
+		/obj/item/weapon/reagent_containers/food/snacks/grown/grapes = list("grapejuice" = 0),
 		/obj/item/weapon/reagent_containers/food/snacks/grown/poisonberries = list("poisonberryjuice" = 0),
 	)
 


### PR DESCRIPTION
At some point in the past, grape juicing was added to the kitchen juicer (`/code/game/machinery/kitchen/juicer.dm`). It was, however, missing from the reagent grinder (`/code/modules/reagents/Chemistry-Machinery.dm`), which uses a separate list for juicing. Since the kitchen is currently equipped with the reagent grinder, and not the kitchen juicer, it was impossible to juice grapes with the kitchen equipment.

This change makes it possible to juice grapes using reagent grinders.
