### PR TITLE
Can no longer e-mag unpowered doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -146,7 +146,7 @@
 		user = null
 	if(!src.requiresID())
 		user = null
-	if(src.density && (istype(I, /obj/item/weapon/card/emag)||istype(I, /obj/item/weapon/melee/energy/blade)))
+	if(src.density && ((operable() && istype(I, /obj/item/weapon/card/emag)) || istype(I, /obj/item/weapon/melee/energy/blade)))
 		flick("door_spark", src)
 		sleep(6)
 		open()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -161,9 +161,9 @@ Class Procs:
 /obj/machinery/proc/update_use_power(var/new_use_power)
 	if (new_use_power == use_power)
 		return	//don't need to do anything
-	
+
 	use_power = new_use_power
-	
+
 	//force area power update
 	var/area/A = get_area(src)
 	if(A && A.master)
@@ -178,9 +178,15 @@ Class Procs:
 		use_power(active_power_usage,power_channel, 1)
 	return 1
 
+/obj/machinery/proc/operable(var/additional_flags = 0)
+	return !inoperable(additional_flags)
+
+/obj/machinery/proc/inoperable(var/additional_flags = 0)
+	return (stat & (NOPOWER|BROKEN|additional_flags))
+
 /obj/machinery/Topic(href, href_list)
 	..()
-	if(stat & (NOPOWER|BROKEN))
+	if(inoperable())
 		return 1
 	if(usr.restrained() || usr.lying || usr.stat)
 		return 1
@@ -222,7 +228,7 @@ Class Procs:
 	return src.attack_hand(user)
 
 /obj/machinery/attack_hand(mob/user as mob)
-	if(stat & (NOPOWER|BROKEN|MAINT))
+	if(inoperable(MAINT))
 		return 1
 	if(user.lying || user.stat)
 		return 1
@@ -272,7 +278,7 @@ Class Procs:
   playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 
 /obj/machinery/proc/shock(mob/user, prb)
-	if(stat & (BROKEN|NOPOWER))
+	if(inoperable())
 		return 0
 	if(!prob(prb))
 		return 0


### PR DESCRIPTION
One can no longer use e-mags to force open doors which are broken or without power.
Adds in support procs for checking if machinery if operable or not.
