### PR TITLE
Ninjas can now phase jaunt.

### DIFF
--- a/code/game/gamemodes/events/space_ninja.dm
+++ b/code/game/gamemodes/events/space_ninja.dm
@@ -639,54 +639,66 @@ As such, it's hard-coded for now. No reason for it not to be, really.
 	playsound(loc, 'sound/effects/stealthoff.ogg', 75, 1)
 
 //=======//GENERIC VERB MODIFIERS//=======//
+var/list/ninja_verbs_default = list(
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjashift,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjasmoke,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjaboost,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjapulse,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjablade,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjastar,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjanet,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjajaunt
+)
+
+var/list/ninja_verbs_kamikaze = list(
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjasmoke,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjaboost,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjapulse,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjablade,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjastar,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjaslayer,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjawalk,
+	/obj/item/clothing/suit/space/space_ninja/proc/ninjamirage
+)
+
+var/list/ninja_verbs_equip = list(
+	/obj/item/clothing/suit/space/space_ninja/proc/deinit,
+	/obj/item/clothing/suit/space/space_ninja/proc/spideros,
+	/obj/item/clothing/suit/space/space_ninja/proc/stealth
+)
+
 
 /obj/item/clothing/suit/space/space_ninja/proc/grant_equip_verbs()
 	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/init
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/deinit
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/spideros
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/stealth
+	verbs |= ninja_verbs_equip
+
 	n_gloves.verbs += /obj/item/clothing/gloves/space_ninja/proc/toggled
 
 	s_initialized = 1
 
 /obj/item/clothing/suit/space/space_ninja/proc/remove_equip_verbs()
 	verbs += /obj/item/clothing/suit/space/space_ninja/proc/init
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/deinit
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/spideros
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/stealth
+	verbs -= ninja_verbs_equip
+
 	if(n_gloves)
 		n_gloves.verbs -= /obj/item/clothing/gloves/space_ninja/proc/toggled
 
 	s_initialized = 0
 
 /obj/item/clothing/suit/space/space_ninja/proc/grant_ninja_verbs()
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjashift
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjasmoke
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjaboost
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjapulse
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjablade
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjastar
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjanet
+	verbs |= ninja_verbs_default
 
 	s_initialized=1
 	slowdown=0
 
 /obj/item/clothing/suit/space/space_ninja/proc/remove_ninja_verbs()
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjashift
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjaboost
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjapulse
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjablade
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjastar
-	//verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjanet
+	verbs -= ninja_verbs_default
 
 //=======//KAMIKAZE VERBS//=======//
 
 /obj/item/clothing/suit/space/space_ninja/proc/grant_kamikaze(mob/living/carbon/U)
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjashift
-	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjanet
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjaslayer
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjawalk
-	verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjamirage
+	verbs -= ninja_verbs_default
+	verbs |= ninja_verbs_kamikaze
 
 	verbs -= /obj/item/clothing/suit/space/space_ninja/proc/stealth
 
@@ -707,12 +719,8 @@ As such, it's hard-coded for now. No reason for it not to be, really.
 
 /obj/item/clothing/suit/space/space_ninja/proc/remove_kamikaze(mob/living/carbon/U)
 	if(kamikaze)
-		verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjashift
-		verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjapulse
-		verbs += /obj/item/clothing/suit/space/space_ninja/proc/ninjastar
-		verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjaslayer
-		verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjawalk
-		verbs -= /obj/item/clothing/suit/space/space_ninja/proc/ninjamirage
+		verbs -= ninja_verbs_kamikaze
+		verbs += ninja_verbs_default
 
 		verbs += /obj/item/clothing/suit/space/space_ninja/proc/stealth
 		if(n_gloves)


### PR DESCRIPTION
Adds Phase Jaunt for a cost of 250 energy, compared to Phase Shift which costs 400E.
Randomly jumps the ninja 5-9 tiles straight ahead. Does not harm any creature in the way.
Adds cooldown to Phase Shift.

Cell power is now reduced directly in the ninjacost() proc.
Some cleanup of ninja verb-add/removal.

Based on #6311.
