### PR TITLE
Reducing freezer power draw.

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -17,7 +17,7 @@
 	idle_power_usage = 5			//5 Watts for thermostat related circuitry
 	active_power_usage			//50 kW. The power rating of the freezer
 
-	var/max_power_usage = 50000	//power rating when the usage is turned up to 1
+	var/max_power_usage = 5000 //power rating when the usage is turned up to 1 //Reduced to 5kW for usability.
 	var/power_setting = 100
 
 	var/set_temperature = T20C	//thermostat
@@ -35,7 +35,7 @@
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(src)
-	
+
 	active_power_usage = max_power_usage * (power_setting/100)
 
 /obj/machinery/atmospherics/unary/freezer/initialize()
@@ -180,10 +180,10 @@
 
 /obj/machinery/atmospherics/unary/freezer/proc/set_power_level(var/new_power_setting)
 	power_setting = new_power_setting
-	
+
 	var/old_power_usage = active_power_usage
 	active_power_usage = max_power_usage * (power_setting/100)
-	
+
 	if (use_power >= 2 && old_power_usage != active_power_usage)
 		force_power_update()
 


### PR DESCRIPTION
Dropped a zero off the end.
- All of the solars runing at once cannot reliably power a single freezer.
- When the station is out of power, that's it, kaput, vamos, engine can't be started, cryo cannot run.
- The new engine is complex and new enough that there will be no room for error for the first weeks that this hits master.
- Massively increasing power draw for one set of machines without adjusting the rest of the station to compensate like this is not a great idea.
