### PR TITLE
Several quickfixes for atmos cooling issues.

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -9,7 +9,7 @@
 
 	anchored = 1.0
 
-	var/heatsink_temperature = T20C		//the constant temperature resevoir into which the freezer pumps heat. Probably the hull of the station or something.
+	var/heatsink_temperature = 70 //T20C	//the constant temperature resevoir into which the freezer pumps heat. Probably the hull of the station or something.
 	var/internal_volume = 600	//L
 
 	var/on = 0
@@ -137,6 +137,7 @@
 		//not /really/ proper thermodynamics but whatever
 		var/cop = air_contents.temperature/heatsink_temperature	//heatpump coefficient of performance from thermodynamics -> power used = heat_transfer/cop
 		heat_transfer = min(heat_transfer, cop * active_power_usage)	//limit heat transfer by available power
+		heat_transfer *= 10 //Temp fix for cryo being unusable.
 
 		var/removed = -air_contents.add_thermal_energy(-heat_transfer)		//remove the heat
 		if (debug)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -12,7 +12,7 @@
 	use_power = 1
 	idle_power_usage = 20
 	active_power_usage = 200
-	
+
 	var/temperature_archived
 	var/mob/living/carbon/occupant = null
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
@@ -45,7 +45,7 @@
 
 	if(air_contents)
 		temperature_archived = air_contents.temperature
-		heat_gas_contents()
+		//heat_gas_contents()
 		expel_gas()
 
 	if(abs(temperature_archived-air_contents.temperature) > 1)


### PR DESCRIPTION
- Reduced heatsink temp to 70K.
- Multiplied the temp reduction value by 10 (to compensate for reduced power draw)
- Commented out cryo gas heating for the sake of making it usable.
