### PR TITLE
Corrects the change log

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -54,64 +54,16 @@ should be listed in the changelog upon commit though. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
-<head>
-  <title>Baystation 12 Changelog</title>
-  <link rel="stylesheet" type="text/css" href="changelog.css">
-  <script type='text/javascript'>
-  
-	function changeText(tagID, newText, linkTagID){
-		var tag = document.getElementById(tagID);
-		tag.innerHTML = newText;
-		var linkTag = document.getElementById(linkTagID);
-		linkTag.removeAttribute("href");
-		linkTag.removeAttribute("onclick");
-	}
-
-  </script>  
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-</head>
-
-<body>
-<!-- 
-Header Section 
--->
-<table align='center' width='650'><tr><td>
-<table align='center' class="top">
-	<tr>
-		<td valign='top'>
-			<div align='center'><font size='3'><b>Space Station 13</b></font></div>
-			<p><div align='center'><font size='3'><a href="http://baystation12.net/wiki/">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
-			<font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/gpl.html">GPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
-			</td>
-	</tr>
-</table>
-<br><b>Baystation 12 Credit List</b>
-<table align='center' class="top">
-	<tr>
-		<td valign='top'>
-			<font size='2'><b>Code:</b> Abi79, Aryn, Cael_Aislinn, Ccomp5950, Chinsky, cib, CompactNinja, DopeGhoti, Erthilo, Hawk_v3, Head, Ispil, JoeyJo0, Lexusjjss, Melonstorm, Miniature, Mloc, NerdyBoy1104, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty<br></font>
-			<font size='2'><b>Sprites:</b> Apple_Master, Arcalane, Chinsky, CompactNinja, Deus Dactyl, Erthilo, Flashkirby, JoeyJo0, Miniature, Searif, Xenone, faux<br></font>
-			<font size='2'><b>Sounds:</b> Aryn<br></font>
-			<font size='2'><b>Thanks To:</b> /tg/ station, Goonstation, Animus Station, Daedalus, and original Spacestation 13 devs. Skibiliano for the IRC bot.</font>
-		</td>
-	</tr>
-</table>
-
-<!-- 
-Changelog Section 
--->
-
-<!-- NOTE TO UPDATERS!! Please only list things which are important to players. 
-Stuff which is in development and not yet visible to players or just code related 
-(ie. code improvements for expandability, etc.) should not be listed here. They 
-should be listed in the changelog upon commit though. Thanks. -->
-
-<!-- You can simply add changelogs using AddToChangelog.exe -->
-
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+    <h2 class='date'>31 August 2014</h2>
+	<h3 class='author'>Whitellama updated:</h3>
+    <ul class='changes bgimages16'>
+		<li class='bugfix'>Matches and candles can be used to burn papers, too.</li>
+		<li class='bugfix'>Observers have a bit more time (20 seconds, instead of 7.5) before the Diona join prompt disappears.</li>
+	</ul>
+</div>
 
 <div class='commit sansserif'>
 	<h2 class='date'>5 August 2014</h2>
@@ -127,18 +79,21 @@ should be listed in the changelog upon commit though. Thanks. -->
 </div>
 
 <div class='commit sansserif'>
+    <h2 class='date'>2 August 2014</h2>
+	<h3 class='author'>Whitellama updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Arcane tomes can now be stored on bookshelves.</li>
+		<li class='bugfix'>Dionaea players no longer crash on death, and now become nymphs properly.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>31 July 2014</h2>
 	<h3 class='author'>HarpyEagle updated:</h3>
 	<ul class='changes bgimages16'>
 		<li class='tweak'>Stun batons now work like tasers and deal agony instead of stun</li>
 		<li class='rscadd'>Being hit in the hands with a stun weapon will cause whatever is being held to be dropped</li>
 		<li class='tweak'>Handcuffs now require an aggressive grab to be used</li>
-	<h2 class='date'>31 August 2014</h2>
-	<h3 class='author'>Whitellama updated:</h3>
-	<ul class='changes bgimages16'>
-		<li class='bugfix'>Matches and candles can be used to burn papers, too.</li>
-		<li class='bugfix'>Observers have a bit more time (20 seconds, instead of 7.5) before the Diona join prompt disappears.</li>
-	</ul>
 </div>
 
 <div class='commit sansserif'>
@@ -147,12 +102,6 @@ should be listed in the changelog upon commit though. Thanks. -->
 	<ul class='changes bgimages16'>
 		<li class='rscadd'>Added dynamic flavour text.</li>
 		<li class='bugfix'>Fixed bug with suit fibers and fingerprints.</li>
-	<h2 class='date'>2 August 2014</h2>
-	<h3 class='author'>Whitellama updated:</h3>
-	<ul class='changes bgimages16'>
-		<li class='bugfix'>Arcane tomes can now be stored on bookshelves.</li>
-		<li class='bugfix'>Dionaea players no longer crash on death, and now become nymphs properly.</li>
-	</ul>
 </div>
 
 


### PR DESCRIPTION
Removes duplicate header section.
Whitelamma's entries are no longer sub-entries of other changelogs.
