### PR TITLE
Fixes #6392

### DIFF
--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -14,7 +14,8 @@
 
 /obj/machinery/atmospherics/var/debug = 0
 
-/obj/machinery/atmospherics/verb/toggle_debug()
+//Can be called using the Advanced-Proc. Switch proc to verb to add it to atmospheric objects' verb-list.
+/obj/machinery/atmospherics/proc/toggle_debug()
 	set name = "Toggle Debug Messages"
 	set category = "Debug"
 	set src in view()


### PR DESCRIPTION
Turns a debug verb into a proc, allowing it to be called using advanced-proc or for easy revert in the future.
