### PR TITLE
Changes emergency shutter layer

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -18,9 +18,9 @@
 	req_one_access = list(access_atmospherics, access_engine_equip)
 	opacity = 0
 	density = 0
-	layer = DOOR_OPEN_LAYER - 0.1
-	open_layer = DOOR_OPEN_LAYER - 0.1 // Just below doors when open
-	closed_layer = DOOR_CLOSED_LAYER + 0.1 // Just above doors when closed
+	layer = DOOR_OPEN_LAYER - 0.01
+	open_layer = DOOR_OPEN_LAYER - 0.01 // Just below doors when open
+	closed_layer = DOOR_CLOSED_LAYER + 0.01 // Just above doors when closed
 
 	var/blocked = 0
 	var/lockdown = 0 // When the door has detected a problem, it locks.


### PR DESCRIPTION
Decreases the difference from normal door layers to avoid tables being displayed over shutters as they close.
