### PR TITLE
Changes last debug verb to proc and adds it to debug list

### DIFF
--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -14,12 +14,11 @@
 
 /obj/machinery/atmospherics/var/debug = 0
 
-/obj/machinery/atmospherics/verb/toggle_debug()
+/client/proc/atmos_toggle_debug(var/obj/machinery/atmospherics/M in view())
 	set name = "Toggle Debug Messages"
 	set category = "Debug"
-	set src in view()
-	debug = !debug
-	usr << "[src]: Debug messages toggled [debug? "on" : "off"]."
+	M.debug = !M.debug
+	usr << "[M]: Debug messages toggled [M.debug? "on" : "off"]."
 
 //Generalized gas pumping proc.
 //Moves gas from one gas_mixture to another and returns the amount of power needed (assuming 1 second), or -1 if no gas was pumped.

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -164,6 +164,7 @@ var/list/debug_verbs = list (
         ,/client/proc/view_power_update_stats_area
         ,/client/proc/view_power_update_stats_machines
         ,/client/proc/toggle_power_update_profiling
+		,/client/proc/atmos_toggle_debug
 	)
 
 


### PR DESCRIPTION
Changed the last debug verb to a proc and adds it to the debug list. It was probably missed due to not being a client verb.
