### PR TITLE
Fixes mech sensors preventing shuttle undocking

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -303,11 +303,17 @@
 			signalDoor(tag_exterior_door, command)
 			signalDoor(tag_interior_door, command)
 
+datum/computer/file/embedded_program/airlock/proc/signal_mech_sensor(var/command)
+	var/datum/signal/signal = new
+	signal.data["tag"] = tag_mech_sensor
+	signal.data["command"] = command
+	post_signal(signal)
+
 /datum/computer/file/embedded_program/airlock/proc/enable_mech_regulation()
-	signalDoor(tag_mech_sensor, "enable")
+	signal_mech_sensor("enable")
 
 /datum/computer/file/embedded_program/airlock/proc/disable_mech_regulation()
-	signalDoor(tag_mech_sensor, "disable")
+	signal_mech_sensor("disable")
 
 /*----------------------------------------------------------
 toggleDoor()

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -96,12 +96,13 @@
 	signal.data["command"] = command
 	post_signal(signal)
 
-/datum/computer/file/embedded_program/docking/simple/proc/signal_mech_sensor(var/command)
-	signal_door(command)
+///datum/computer/file/embedded_program/docking/simple/proc/signal_mech_sensor(var/command)
+//	signal_door(command)
+//	return
 
 /datum/computer/file/embedded_program/docking/simple/proc/open_door()
 	if(memory["door_status"]["state"] == "closed")
-		signal_mech_sensor("enable")
+		//signal_mech_sensor("enable")
 		signal_door("secure_open")
 	else if(memory["door_status"]["lock"] == "unlocked")
 		signal_door("lock")
@@ -109,7 +110,7 @@
 /datum/computer/file/embedded_program/docking/simple/proc/close_door()
 	if(memory["door_status"]["state"] == "open")
 		signal_door("secure_close")
-		signal_mech_sensor("disable")
+		//signal_mech_sensor("disable")
 	else if(memory["door_status"]["lock"] == "unlocked")
 		signal_door("lock")
 

--- a/nano/templates/escape_shuttle_control_console.tmpl
+++ b/nano/templates/escape_shuttle_control_console.tmpl
@@ -65,9 +65,9 @@
 <div class="item" style="padding-top: 10px">
 	{{for data.auth_list}}
 		{{if value.auth_hash}}
-			{{:~link(auth_name, 'eject', {'removeid' : value.auth_hash}, null, 'itemContentWide')}}
+			{{:helper.link(auth_name, 'eject', {'removeid' : value.auth_hash}, null, 'itemContentWide')}}
 		{{else}}
-			{{:~link("", 'eject', {'scanid' : 1}, null, 'itemContentWide')}}
+			{{:helper.link("", 'eject', {'scanid' : 1}, null, 'itemContentWide')}}
 		{{/if}}
 	{{/for}}
 </div>


### PR DESCRIPTION
Fixes mech sensor code causing the docking controllers to send "enable" and "disable" commands to airlocks. This causes the previous "secure_close" command to be overwritten, so the door never closes automatically.

Airlock controllers now use a signal_mech_sensor() proc to send commands to mech sensors. Docking controllers don't appear to store the mech sensor tag anywhere so the mech sensor code was left commented out.

Also fixes an error in the transfer/emergency shuttle console NanoUI template.
