### PR TITLE
Attempts to fix #6344

### DIFF
--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -106,8 +106,8 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	if(!candidate)
 		candidate = new /datum/paiCandidate()
 		candidate.key = M.key
-		pai_candidates.Add(candidate)
-
+		if(allowSubmit)
+			pai_candidates.Add(candidate)
 
 	var/dat = ""
 	dat += {"


### PR DESCRIPTION
pAI setup made in the lobby screen no longer adds clients to the list of available candidates.
Should hopefully allow them to again see the pAI recruitment screen when one is requested.
