### PR TITLE
AI restoration console shows ion laws

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -38,18 +38,22 @@
 		var/laws
 		dat += "Stored AI: [src.occupant.name]<br>System integrity: [(src.occupant.health+100)/2]%<br>"
 
+		for (var/law in occupant.laws.ion)
+			if(law)
+				laws += "[ionnum()]: [law]<BR>"
+
 		if (src.occupant.laws.zeroth)
-			laws += "0: [src.occupant.laws.zeroth]<BR>"
+			laws += "0: [occupant.laws.zeroth]<BR>"
 
 		var/number = 1
-		for (var/index = 1, index <= src.occupant.laws.inherent.len, index++)
-			var/law = src.occupant.laws.inherent[index]
+		for (var/index = 1, index <= occupant.laws.inherent.len, index++)
+			var/law = occupant.laws.inherent[index]
 			if (length(law) > 0)
 				laws += "[number]: [law]<BR>"
 				number++
 
-		for (var/index = 1, index <= src.occupant.laws.supplied.len, index++)
-			var/law = src.occupant.laws.supplied[index]
+		for (var/index = 1, index <= occupant.laws.supplied.len, index++)
+			var/law = occupant.laws.supplied[index]
 			if (length(law) > 0)
 				laws += "[number]: [law]<BR>"
 				number++

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -37,11 +37,9 @@
 		for(var/mob/living/silicon/ai/A in src)
 			dat += "Stored AI: [A.name]<br>System integrity: [(A.health+100)/2]%<br>"
 
-			for (var/index = 1, index <= A.laws.ion.len, index++)
-				var/law = A.laws.ion[index]
-				if (length(law) > 0)
-					var/num = ionnum()
-					laws += "[num]. [law]"
+			for (var/law in A.laws.ion)
+				if(law)
+					laws += "[ionnum()]: [law]<BR>"
 
 			if (A.laws.zeroth)
 				laws += "0: [A.laws.zeroth]<BR>"


### PR DESCRIPTION
AI restoration console now displays ion laws just as the intelliCard does.
Fixes a minor problem with the intelliCard not adding newlines after ion laws.
