### PR TITLE
Fixes Evidence Bags

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -7,14 +7,39 @@
 	icon_state = "evidenceobj"
 	item_state = ""
 	w_class = 2
+	var/obj/item/stored_item = null
 
-/obj/item/weapon/evidencebag/afterattack(obj/item/I, mob/user as mob, proximity)
-	if(!proximity) return
-	if(!in_range(I, user))
+/obj/item/weapon/evidencebag/MouseDrop(var/obj/item/I as obj)
+	if (!ishuman(usr))
 		return
 
-	if(!istype(I) || I.anchored == 1)
-		return ..()
+	var/mob/living/carbon/human/user = usr
+
+	if (!(user.l_hand == src || user.r_hand == src))
+		return //bag must be in your hands to use
+
+	if (isturf(I.loc))
+		if (!user.Adjacent(I))
+			return
+	else
+		//If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
+		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
+			var/sdepth = I.storage_depth(user)
+			if (sdepth == -1 || sdepth > 1)
+				return	//too deeply nested to access
+
+			var/obj/item/weapon/storage/U = I.loc
+			user.client.screen -= I
+			U.contents.Remove(I)
+		else if(user.l_hand == I)					//in a hand
+			user.drop_l_hand()
+		else if(user.r_hand == I)					//in a hand
+			user.drop_r_hand()
+		else
+			return
+
+	if(!istype(I) || I.anchored)
+		return
 
 	if(istype(I, /obj/item/weapon/evidencebag))
 		user << "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>"
@@ -26,19 +51,7 @@
 
 	if(contents.len)
 		user << "<span class='notice'>[src] already has something inside it.</span>"
-		return ..()
-
-	if(!isturf(I.loc)) //If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
-		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
-			var/obj/item/weapon/storage/U = I.loc
-			user.client.screen -= I
-			U.contents.Remove(I)
-		else if(user.l_hand == I)					//in a hand
-			user.drop_l_hand()
-		else if(user.r_hand == I)					//in a hand
-			user.drop_r_hand()
-		else
-			return
+		return
 
 	user.visible_message("[user] puts [I] into [src]", "You put [I] inside [src].",\
 	"You hear a rustle as someone puts something into a plastic bag.")
@@ -55,27 +68,34 @@
 	overlays += img
 	overlays += "evidence"	//should look nicer for transparent stuff. not really that important, but hey.
 
-	desc = "An evidence bag containing [I]. [I.desc]"
+	desc = "An evidence bag containing [I]."
 	I.loc = src
+	stored_item = I
 	w_class = I.w_class
 	return
 
 
 /obj/item/weapon/evidencebag/attack_self(mob/user as mob)
 	if(contents.len)
-		var/obj/item/I = contents[1]
+		var/obj/item/I = stored_item
 		user.visible_message("[user] takes [I] out of [src]", "You take [I] out of [src].",\
 		"You hear someone rustle around in a plastic bag, and remove something.")
 		overlays.Cut()	//remove the overlays
+
 		user.put_in_hands(I)
-		w_class = 1
+		stored_item = null
+
+		w_class = initial(w_class)
 		icon_state = "evidenceobj"
 		desc = "An empty evidence bag."
-
 	else
 		user << "[src] is empty."
 		icon_state = "evidenceobj"
 	return
+
+/obj/item/weapon/evidencebag/examine()
+	..()
+	if (stored_item) stored_item.examine()
 
 /obj/item/weapon/storage/box/evidence
 	name = "evidence bag box"

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,15 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>20 September 2014</h2>
+	<h3 class='author'>HarpyEagle updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Fixes evidence bags and boxes eating each other. Evidence bags now store items by dragging the bag onto the item to be stored.</li>
+	</ul>
+</div>
+
+
+<div class='commit sansserif'>
     <h2 class='date'>31 August 2014</h2>
 	<h3 class='author'>Whitellama updated:</h3>
     <ul class='changes bgimages16'>


### PR DESCRIPTION
Resolves the conflict between evidence bags and storage items by making evidence bags use drag and drop to store items. Fixes #6459. Fixes #6139.
