### PR TITLE
pAI submission process change

### DIFF
--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -106,8 +106,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	if(!candidate)
 		candidate = new /datum/paiCandidate()
 		candidate.key = M.key
-		if(allowSubmit)
-			pai_candidates.Add(candidate)
+		pai_candidates.Add(candidate)
 
 	var/dat = ""
 	dat += {"
@@ -358,11 +357,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			else
 				asked.Remove(O.key)
 		if(O.client)
-			var/hasSubmitted = 0
-			for(var/datum/paiCandidate/c in paiController.pai_candidates)
-				if(c.key == O.key)
-					hasSubmitted = 1
-			if(!hasSubmitted && (O.client.prefs.be_special & BE_PAI))
+			if(O.client.prefs.be_special & BE_PAI)
 				question(O.client)
 
 /datum/paiController/proc/question(var/client/C)


### PR DESCRIPTION
Attempts  to fix  #6481.

Previously it appears observers would be asked once, and only once, if they wished to become a pAI.
If one closed the configuration window without pressing Submit you'd never get the chance to apply again.

Now asks observers every time someone requests a pAI, similar to posibrains and Dionaea pods.
There is already a built-in ask delay of one minute between such requests and ghosts can decide to opt out for the rest of the round.
