### PR TITLE
Updates synth airlock interface messages

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -885,14 +885,17 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/proc/check_synth_access(mob/user as mob)
-	if(emagged)
-		user << "<span class='warning'>Unable to interface: Airlock is unresponsive.</span>"
+	if(operating < 0) //emagged
+		user << "<span class='warning'>Unable to interface: Internal error.</span>"
 		return 0
 	if(!src.canAIControl())
 		if(src.canAIHack(user))
 			src.hack(user)
 		else
-			user << "<span class='warning'>Airlock AI control has been blocked with a firewall.</span>"
+			if (src.isAllPowerLoss()) //don't really like how this gets checked a second time, but not sure how else to do it.
+				user << "<span class='warning'>Unable to interface: Connection timed out.</span>"
+			else
+				user << "<span class='warning'>Unable to interface: Connection refused.</span>"
 		return 0
 	return 1
 


### PR DESCRIPTION
Fixed airlocks giving the player misleading messages about why they can't interface.
Related to #6456.
