### PR TITLE
Space floating effect

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -299,6 +299,7 @@
 	var/area/oldarea = L.lastarea
 	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && (L.m_intent == "run")) // Being ready when you change areas gives you a chance to avoid falling all together.
 		thunk(L)
+		L.make_floating(0)
 
 	L.lastarea = newarea
 
@@ -326,6 +327,8 @@
 		if(gravitystate)
 			for(var/mob/living/carbon/human/M in SubA)
 				thunk(M)
+			for(var/mob/M1 in SubA)
+				M1.make_floating(0)
 
 /area/proc/thunk(mob)
 	if(istype(mob,/mob/living/carbon/human/))  // Only humans can wear magboots, so we give them a chance to.

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -329,6 +329,16 @@
 				thunk(M)
 			for(var/mob/M1 in SubA)
 				M1.make_floating(0)
+		else
+			for(var/mob/M in SubA)
+				if(M.Check_Dense_Object() && istype(src,/mob/living/carbon/human/))
+					var/mob/living/carbon/human/H = src
+					if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.flags & NOSLIP))  //magboots + dense_object = no floaty effect
+						H.make_floating(0)
+					else
+						H.make_floating(1)
+				else
+					M.make_floating(1)
 
 /area/proc/thunk(mob)
 	if(istype(mob,/mob/living/carbon/human/))  // Only humans can wear magboots, so we give them a chance to.

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -16,6 +16,7 @@
 					"<span class='notice'>[user.name] pulls you free from the gelatinous resin.</span>",\
 					"<span class='notice'>You hear squelching...</span>")
 				buckled_mob.pixel_y = 0
+				buckled_mob.old_y = 0
 				unbuckle()
 			else
 				buckled_mob.visible_message(\
@@ -25,6 +26,7 @@
 				spawn(1200)
 					if(user && buckled_mob && user.buckled == src)
 						buckled_mob.pixel_y = 0
+						buckled_mob.old_y = 0
 						unbuckle()
 			src.add_fingerprint(user)
 	return
@@ -52,6 +54,7 @@
 	M.dir = src.dir
 	M.update_canmove()
 	M.pixel_y = 6
+	M.old_y = 6
 	src.buckled_mob = M
 	src.add_fingerprint(user)
 	return

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -195,6 +195,7 @@
 	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.lying || user.stat || M.buckled || istype(usr, /mob/living/silicon/pai) )
 		return
 	M.pixel_y = 6
+	M.old_y = 6
 	density = 1
 	icon_state = "up"
 	..()
@@ -204,6 +205,7 @@
 	if(buckled_mob)
 		if(buckled_mob.buckled == src)	//this is probably unneccesary, but it doesn't hurt
 			buckled_mob.pixel_y = 0
+			buckled_mob.old_y = 0
 			buckled_mob.anchored = initial(buckled_mob.anchored)
 			buckled_mob.buckled = null
 			buckled_mob.update_canmove()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -130,6 +130,8 @@
 
 		else if(!istype(src, /turf/space))
 			M:inertia_dir = 0
+			var/mob/M1 = M
+			M1.make_floating(0)
 	..()
 	var/objects = 0
 	for(var/atom/A as mob|obj|turf|area in range(1))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -661,8 +661,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 // Typo from the oriignal coder here, below lies the jitteriness process. So make of his code what you will, the previous comment here was just a copypaste of the above.
 /mob/proc/jittery_process()
-	var/old_x = pixel_x
-	var/old_y = pixel_y
+	//var/old_x = pixel_x
+	//var/old_y = pixel_y
 	is_jittery = 1
 	while(jitteriness > 100)
 //		var/amplitude = jitteriness*(sin(jitteriness * 0.044 * world.time) + 1) / 70
@@ -670,8 +670,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 //		pixel_y = amplitude * cos(0.008 * jitteriness * world.time)
 
 		var/amplitude = min(4, jitteriness / 100)
-		pixel_x = rand(-amplitude, amplitude)
-		pixel_y = rand(-amplitude/3, amplitude/3)
+		pixel_x = old_x + rand(-amplitude, amplitude)
+		pixel_y = old_y + rand(-amplitude/3, amplitude/3)
 
 		sleep(1)
 	//endwhile - reset the pixel offsets to zero
@@ -683,22 +683,35 @@ note dizziness decrements automatically in the mob's Life() proc.
 //handles up-down floaty effect in space
 /mob/proc/make_floating(var/n)
 
-	floatiness = n	// store what will be new value
+	floatiness = n
 
 	if(floatiness && !is_floating)
-		spawn(0)
-			floating_process()
+		start_floating()
+	else if(!floatiness && is_floating)
+		stop_floating()
 
-/mob/proc/floating_process()
+/mob/proc/start_floating()
+
 	is_floating = 1
-	while(floatiness)
-		var/amplitude = 2
-		var/frequency = 10
-		pixel_y = amplitude * sin(frequency * world.time)
-		sleep(1)
-	//endwhile - reset the pixel offsets to zero
+
+	var/amplitude = 2 //maximum displacement from original position
+	var/period = 36 //time taken for the mob to go up >> down >> original position, in deciseconds. Should be multiple of 4
+
+	var/top = old_y + amplitude
+	var/bottom = old_y - amplitude
+	var/half_period = period / 2
+	var/quarter_period = period / 4
+
+	animate(src, pixel_y = top, time = quarter_period, easing = SINE_EASING | EASE_OUT, loop = -1)		//up
+	animate(pixel_y = bottom, time = half_period, easing = SINE_EASING, loop = -1)						//down
+	animate(pixel_y = old_y, time = quarter_period, easing = SINE_EASING | EASE_IN, loop = -1)			//back
+
+/mob/proc/stop_floating()
+	animate(src, pixel_y = old_y, time = 5, easing = SINE_EASING | EASE_IN) //halt animation
+	//reset the pixel offsets to zero
 	is_floating = 0
-	pixel_y = 0
+
+
 
 /mob/Stat()
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -679,6 +679,27 @@ note dizziness decrements automatically in the mob's Life() proc.
 	pixel_x = old_x
 	pixel_y = old_y
 
+
+//handles up-down floaty effect in space
+/mob/proc/make_floating(var/n)
+
+	floatiness = n	// store what will be new value
+
+	if(floatiness && !is_floating)
+		spawn(0)
+			floating_process()
+
+/mob/proc/floating_process()
+	is_floating = 1
+	while(floatiness)
+		var/amplitude = 2
+		var/frequency = 10
+		pixel_y = amplitude * sin(frequency * world.time)
+		sleep(1)
+	//endwhile - reset the pixel offsets to zero
+	is_floating = 0
+	pixel_y = 0
+
 /mob/Stat()
 	..()
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -99,6 +99,8 @@
 
 
 	var/bodytemperature = 310.055	//98.7 F
+	var/old_x = 0
+	var/old_y = 0
 	var/drowsyness = 0.0//Carbon
 	var/dizziness = 0//Carbon
 	var/is_dizzy = 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -104,6 +104,8 @@
 	var/is_dizzy = 0
 	var/is_jittery = 0
 	var/jitteriness = 0//Carbon
+	var/is_floating = 0
+	var/floatiness = 0
 	var/charges = 0.0
 	var/nutrition = 400.0//Carbon
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -415,7 +415,8 @@
 			continue
 
 		if(istype(src,/mob/living/carbon/human/))  // Only humans can wear magboots, so we give them a chance to.
-			if((istype(turf,/turf/simulated/floor)) && (src.lastarea.has_gravity == 0) && !(istype(src:shoes, /obj/item/clothing/shoes/magboots) && (src:shoes:flags & NOSLIP)))
+			var/mob/living/carbon/human/H = src
+			if((istype(turf,/turf/simulated/floor)) && (src.lastarea.has_gravity == 0) && !(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.flags & NOSLIP)))
 				continue
 
 
@@ -452,7 +453,8 @@
 		return 0
 
 	if(istype(src,/mob/living/carbon/human/))
-		if(istype(src:shoes, /obj/item/clothing/shoes/magboots) && (src:shoes.flags & NOSLIP))  //magboots + dense_object = no floaty effect
+		var/mob/living/carbon/human/H = src
+		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.flags & NOSLIP))  //magboots + dense_object = no floaty effect
 			make_floating(0)
 		else
 			make_floating(1)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -403,11 +403,33 @@
 ///Return 1 for movement 0 for none
 /mob/proc/Process_Spacemove(var/check_drift = 0)
 
-	/*
-	if(istype(src,/mob/living/carbon))
-		if(src.l_hand && src.r_hand)
-			return 0
-	*/
+	if(!Check_Dense_Object()) //Nothing to push off of so end here
+		make_floating(1)
+		return 0
+
+	if(istype(src,/mob/living/carbon/human/))
+		var/mob/living/carbon/human/H = src
+		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.flags & NOSLIP))  //magboots + dense_object = no floaty effect
+			make_floating(0)
+		else
+			make_floating(1)
+	else
+		make_floating(1)
+
+	if(restrained()) //Check to see if we can do things
+		return 0
+
+	//Check to see if we slipped
+	if(prob(Process_Spaceslipping(5)))
+		src << "\blue <B>You slipped!</B>"
+		src.inertia_dir = src.last_move
+		step(src, src.inertia_dir)
+		return 0
+	//If not then we can reset inertia and move
+	inertia_dir = 0
+	return 1
+
+/mob/proc/Check_Dense_Object() //checks for anything to push off in the vicinity. also handles magboots on gravity-less floors tiles
 
 	var/dense_object = 0
 	for(var/turf/turf in oview(1,src))
@@ -447,32 +469,7 @@
 				dense_object++
 				break
 
-	//Nothing to push off of so end here
-	if(!dense_object)
-		make_floating(1)
-		return 0
-
-	if(istype(src,/mob/living/carbon/human/))
-		var/mob/living/carbon/human/H = src
-		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.flags & NOSLIP))  //magboots + dense_object = no floaty effect
-			make_floating(0)
-		else
-			make_floating(1)
-	else
-		make_floating(1)
-
-	if(restrained()) //Check to see if we can do things
-		return 0
-
-	//Check to see if we slipped
-	if(prob(Process_Spaceslipping(5)))
-		src << "\blue <B>You slipped!</B>"
-		src.inertia_dir = src.last_move
-		step(src, src.inertia_dir)
-		return 0
-	//If not then we can reset inertia and move
-	inertia_dir = 0
-	return 1
+	return dense_object
 
 
 /mob/proc/Process_Spaceslipping(var/prob_slip = 5)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -402,9 +402,6 @@
 ///For moving in space
 ///Return 1 for movement 0 for none
 /mob/proc/Process_Spacemove(var/check_drift = 0)
-	//First check to see if we can do things
-	if(restrained())
-		return 0
 
 	/*
 	if(istype(src,/mob/living/carbon))
@@ -451,9 +448,19 @@
 
 	//Nothing to push off of so end here
 	if(!dense_object)
+		make_floating(1)
 		return 0
 
+	if(istype(src,/mob/living/carbon/human/))
+		if(istype(src:shoes, /obj/item/clothing/shoes/magboots) && (src:shoes.flags & NOSLIP))  //magboots + dense_object = no floaty effect
+			make_floating(0)
+		else
+			make_floating(1)
+	else
+		make_floating(1)
 
+	if(restrained()) //Check to see if we can do things
+		return 0
 
 	//Check to see if we slipped
 	if(prob(Process_Spaceslipping(5)))


### PR DESCRIPTION
Mobs will bob up and down in space and zero-gravity unless they are both wearing magboots and within 1 tile of a dense object/turf.

Jittering and floating animations no longer interfere with mobs which are buckled to rollerbeds or alien beds.
