### PR TITLE
Fixes supply shuttle state when returning

### DIFF
--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -9,7 +9,7 @@
 	var/max_late_time = 300
 
 /datum/shuttle/ferry/supply/short_jump(var/area/origin,var/area/destination)
-	if(moving_status != SHUTTLE_IDLE) 
+	if(moving_status != SHUTTLE_IDLE)
 		return
 	
 	if(isnull(location))
@@ -20,9 +20,6 @@
 	if(!origin)
 		origin = get_location_area(location)
 
-	if (!at_station())	//at centcom
-		supply_controller.buy()
-	
 	//it would be cool to play a sound here
 	moving_status = SHUTTLE_WARMUP
 	spawn(warmup_time*10)
@@ -34,11 +31,15 @@
 			moving_status = SHUTTLE_IDLE
 			return
 		
+		if (!at_station())	//at centcom
+			supply_controller.buy()
+		
 		//We pretend it's a long_jump by making the shuttle stay at centcom for the "in-transit" period.
 		var/area/away_area = get_location_area(away_location)
-		if (origin == away_area)
-			moving_status = SHUTTLE_INTRANSIT	//pretend
-		else
+		moving_status = SHUTTLE_INTRANSIT
+		
+		//If we are at the away_area then we are just pretending to move, otherwise actually do the move
+		if (origin != away_area)
 			move(origin, away_area)
 
 		//wait ETA here.


### PR DESCRIPTION
When returning to centcom, the supply shuttle's state was not being set to INTRANSIT. This meant that you call the shuttle again while the old spawned process() was still running, causing who knows what to happen.

I have a feeling this fixes #6552, since I haven't been able to reproduce with these changes, however I wasn't able to reliably reproduce it before so I can't be sure.
