### PR TITLE
Add round start check to Declare Ready

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -95,7 +95,10 @@
 			return 1
 
 		if(href_list["ready"])
-			ready = !ready
+			if(!ticker || ticker.current_state <= GAME_STATE_PREGAME) // Make sure we don't ready up after the round has started
+				ready = !ready
+			else
+				ready = 0
 
 		if(href_list["refresh"])
 			src << browse(null, "window=playersetup") //closes the player setup window


### PR DESCRIPTION
Added a check to 'declare ready' to prevent readying up after the round
started. Allowing this to happen caused a bug where the player would be
unable to change their character setup if they declared ready after the
round started, such as to look at the manifest to see which character
would be best to play, until after reconnecting.

Fixes #5201

Please do comment to let me know if the internals thing needed to be included? I don't think it did, but this is my first time touching BYOND code in awhile.
