### PR TITLE
Replaces Vox telebaton with a stun baton

### DIFF
--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -14,7 +14,7 @@ var/global/vox_tick = 1
 		if(1) // Vox raider!
 			equip_to_slot_or_del(new /obj/item/clothing/suit/space/vox/carapace(src), slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/vox/carapace(src), slot_head)
-			equip_to_slot_or_del(new /obj/item/weapon/melee/telebaton(src), slot_belt)
+			equip_to_slot_or_del(new /obj/item/weapon/melee/baton/loaded(src), slot_belt)
 			equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/monocle(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
 			equip_to_slot_or_del(new /obj/item/device/chameleon(src), slot_l_store)
 


### PR DESCRIPTION
Since the telebaton nerf, the vox lost their ability for stuns so this should give them the ability to whack folks and take prisoners again. As well, the telebaton was pretty worthless as a weapon.
