### PR TITLE
Fixes #6180

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -45,7 +45,6 @@
 		return 0
 
 	var/obj/machinery/camera/C = track.cameras[camera]
-	track = null
 	src.eyeobj.setLoc(C)
 
 	return
@@ -175,6 +174,13 @@
 	src.track = null
 	ai_actual_track(target)
 
+/mob/living/silicon/ai/proc/ai_cancel_tracking(var/forced = 0)
+	if(!cameraFollow)
+		return
+
+	src << "Follow camera mode [forced ? "terminated" : "ended"]."
+	cameraFollow = null
+
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target as mob)
 	if(!istype(target))	return
 	var/mob/living/silicon/ai/U = usr
@@ -192,21 +198,17 @@
 			if (istype(target, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = target
 				if(H.wear_id && istype(H.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
-					U << "Follow camera mode terminated."
-					U.cameraFollow = null
+					U.ai_cancel_tracking(1)
 					return
 				if(istype(H.head, /obj/item/clothing/head/helmet/space/space_ninja))
-					U << "Follow camera mode terminated."
-					U.cameraFollow = null
+					U.ai_cancel_tracking(1)
 					return
 				if(H.digitalcamo)
-					U << "Follow camera mode terminated."
-					U.cameraFollow = null
+					U.ai_cancel_tracking(1)
 					return
 
 			if(istype(target.loc,/obj/effect/dummy))
-				U << "Follow camera mode ended."
-				U.cameraFollow = null
+				U.ai_cancel_tracking()
 				return
 
 			if (!near_camera(target))
@@ -215,7 +217,7 @@
 				continue
 
 			if(U.eyeobj)
-				U.eyeobj.setLoc(get_turf(target))
+				U.eyeobj.setLoc(get_turf(target), 0)
 			else
 				view_core()
 				return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -540,9 +540,6 @@ var/list/ai_verbs_default = list(
 
 
 /mob/living/silicon/ai/proc/switchCamera(var/obj/machinery/camera/C)
-
-	src.cameraFollow = null
-
 	if (!C || stat == DEAD) //C.can_use())
 		return 0
 
@@ -593,7 +590,6 @@ var/list/ai_verbs_default = list(
 	set category = "AI Commands"
 	set name = "Jump To Network"
 	unset_machine()
-	src.cameraFollow = null
 	var/cameralist[0]
 
 	if(check_unable())

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -35,12 +35,15 @@
 
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
-
-/mob/aiEye/proc/setLoc(var/T)
+/mob/aiEye/proc/setLoc(var/T, var/cancel_tracking = 1)
 
 	if(ai)
 		if(!isturf(ai.loc))
 			return
+
+		if(cancel_tracking)
+			ai.ai_cancel_tracking()
+
 		T = get_turf(T)
 		loc = T
 		cameranet.visibility(src)
@@ -85,7 +88,6 @@
 	if(istype(usr, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = usr
 		if(AI.eyeobj && AI.client.eye == AI.eyeobj)
-			AI.cameraFollow = null
 			AI.eyeobj.setLoc(src)
 
 // This will move the AIEye. It will also cause lights near the eye to light up, if toggled.
@@ -110,8 +112,6 @@
 	else
 		user.sprint = initial
 
-	user.cameraFollow = null
-
 	//user.unset_machine() //Uncomment this if it causes problems.
 	//user.lightNearbyCamera()
 
@@ -127,21 +127,19 @@
 
 /mob/living/silicon/ai/proc/view_core()
 	camera = null
-	cameraFollow = null
 	unset_machine()
 
-	if(src.eyeobj && src.loc)
-		src.eyeobj.loc = src.loc
-	else
+	if(!src.eyeobj)
 		src << "ERROR: Eyeobj not found. Creating new eye..."
 		src.eyeobj = new(src.loc)
 		src.eyeobj.ai = src
-		src.eyeobj.name = "[src.name] (AI Eye)" // Give it a name
+		src.SetName(src.name)
 
 	if(client && client.eye)
 		client.eye = src
 	for(var/datum/camerachunk/c in eyeobj.visibleCameraChunks)
 		c.remove(eyeobj)
+	src.eyeobj.setLoc(src)
 
 /mob/living/silicon/ai/proc/toggle_acceleration()
 	set category = "AI Commands"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -206,7 +206,9 @@
 ///mob/living/silicon/pai/attack_hand(mob/living/carbon/M as mob)
 
 /mob/living/silicon/pai/proc/switchCamera(var/obj/machinery/camera/C)
-	usr:cameraFollow = null
+	if(istype(usr, /mob/living))
+		var/mob/living/U = usr
+		U.cameraFollow = null
 	if (!C)
 		src.unset_machine()
 		src.reset_view(null)
@@ -216,7 +218,7 @@
 	// ok, we're alive, camera is good and in our network...
 
 	src.set_machine(src)
-	src:current = C
+	src.current = C
 	src.reset_view(C)
 	return 1
 
@@ -225,7 +227,7 @@
 	set name = "Cancel Camera View"
 	src.reset_view(null)
 	src.unset_machine()
-	src:cameraFollow = null
+	src.cameraFollow = null
 
 //Addition by Mord_Sith to define AI's network change ability
 /*
@@ -234,7 +236,7 @@
 	set name = "Change Camera Network"
 	src.reset_view(null)
 	src.unset_machine()
-	src:cameraFollow = null
+	src.cameraFollow = null
 	var/cameralist[0]
 
 	if(usr.stat == 2)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -493,8 +493,9 @@ var/list/slot_equipment_priority = list( \
 	reset_view(null)
 	unset_machine()
 	if(istype(src, /mob/living))
-		if(src:cameraFollow)
-			src:cameraFollow = null
+		var/mob/living/M = src
+		if(M.cameraFollow)
+			M.cameraFollow = null
 
 /mob/Topic(href, href_list)
 	if(href_list["mach_close"])


### PR DESCRIPTION
Changing AI eye location now always disables tracking by default, unless explicitly stated otherwise.
One can now double-click away from the AI core after using the relevant verb and unviewable turfs are filled with static as appropriate.
