### PR TITLE
Silicon camera runtime fix

### DIFF
--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -66,13 +66,13 @@
 	// TG uses a special garbage collector.. qdel(P)
 	del(P) //so 10 thousand pictures items are not left in memory should an AI take them and then view them all.
 
-/obj/item/device/camera/siliconcam/proc/deletepicture(obj/item/device/camera/siliconcam/cam)
-	var/datum/picture/selection = selectpicture(cam)
+/obj/item/device/camera/siliconcam/proc/deletepicture()
+	var/datum/picture/selection = selectpicture()
 
 	if(!selection)
 		return
 
-	cam.aipictures -= selection
+	aipictures -= selection
 	usr << "<span class='unconscious'>Image deleted</span>"
 
 /obj/item/device/camera/siliconcam/ai_camera/can_capture_turf(turf/T, mob/user)
@@ -147,7 +147,12 @@
 	set src in usr
 
 	// Explicitly only allow deletion from the local camera
-	deletepicture(src)
+	var/mob/living/silicon/robot/C = src.loc
+	if(C.connected_ai)
+		C << "Not allowed to delete from the remote database."
+		return
+
+	deletepicture()
 
 obj/item/device/camera/siliconcam/proc/getsource()
 	if(istype(src.loc, /mob/living/silicon/ai))


### PR DESCRIPTION
Silicons attempting to delete camera images no longer causes runtime errors.
Borgs now receive a message on attempting to delete remote errors rather than it failing quietly.

I am sorry original reporter of the issue I've been unable to find for not believing you ;_;

**Edit:** I remember now, it was a forum post. No Git issue to be found.
