### PR TITLE
Fix detached disposal bins never changing to attached

### DIFF
--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -234,7 +234,7 @@
 							user << "There is already a [nicetype] at that location."
 							return
 
-					anchored = 1
+				anchored = 1
 				if(ispipe)
 					level = 1 // We don't want disposal bins to disappear under the floors
 					density = 0


### PR DESCRIPTION
This fixes an issue where wrenching a detached disposal bin (such as one you'd get from the pipe machine) never changes the state to attached, therefore preventing disposal bin installation.
