### PR TITLE
Fixes shuttle control NanoUI issue

### DIFF
--- a/nano/templates/escape_shuttle_control_console.tmpl
+++ b/nano/templates/escape_shuttle_control_console.tmpl
@@ -65,7 +65,7 @@
 <div class="item" style="padding-top: 10px">
 	{{for data.auth_list}}
 		{{if value.auth_hash}}
-			{{:helper.link(auth_name, 'eject', {'removeid' : value.auth_hash}, null, 'itemContentWide')}}
+			{{:helper.link(value.auth_name, 'eject', {'removeid' : value.auth_hash}, null, 'itemContentWide')}}
 		{{else}}
 			{{:helper.link("", 'eject', {'scanid' : 1}, null, 'itemContentWide')}}
 		{{/if}}


### PR DESCRIPTION
Should again be possible to initialize an early shuttle launch.
Even looking at the console gave some pretty evident error messages, curious that no one felt the need to report it.
