### PR TITLE
Cyborg Resource Changes

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -111,13 +111,22 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 /obj/item/stack/sheet/plasteel
 	name = "plasteel"
 	singular_name = "plasteel sheet"
-	desc = "This sheet is an alloy of iron and phoron."
+	desc = "This sheet is an alloy of iron, coal and platinum."
 	icon_state = "sheet-plasteel"
 	item_state = "sheet-metal"
 	matter = list("metal" = 7500)
 	throwforce = 15.0
 	flags = FPRINT | TABLEPASS | CONDUCT
 	origin_tech = "materials=2"
+
+/obj/item/stack/sheet/plasteel/cyborg
+	name = "plasteel"
+	desc = "This sheet is an alloy of iron, coal and platinum."
+	icon_state = "sheet-plasteel"
+	item_state = "sheet-metal"
+	throwforce = 15.0
+	flags = FPRINT | TABLEPASS | CONDUCT
+
 
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 		recipes = plasteel_recipes

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,3 +1,13 @@
+
+
+
+
+
+// ##### READ IF ADDING NEW RESOURCES #####
+// Adding new consumable resources (such as metal, etc.) REQUIRES initialisation in New(), as well as entry in stacktypes !
+// Otherwise the cyborg player has to enter recharger for this resource to actually appear.
+// ##### END READ #####
+
 /obj/item/weapon/robot_module
 	name = "robot module"
 	icon = 'icons/obj/module.dmi'
@@ -166,7 +176,7 @@
 
 	stacktypes = list(
 		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel = 10,
+		/obj/item/stack/sheet/plasteel = 30,
 		/obj/item/stack/sheet/rglass = 50,
 		/obj/item/stack/rods = 50
 		)
@@ -182,6 +192,28 @@
 		src.modules += new /obj/item/weapon/crowbar(src)
 		src.modules += new /obj/item/weapon/pickaxe/plasmacutter(src)
 
+		// Metal
+		var/obj/item/stack/sheet/metal/cyborg/ME = new /obj/item/stack/sheet/metal/cyborg(src)
+		ME.amount = 50
+		src.modules += ME
+
+		// Reinforced Glass
+		var/obj/item/stack/sheet/rglass/cyborg/RG = new /obj/item/stack/sheet/rglass/cyborg(src)
+		RG.amount = 50
+		src.modules += RG
+
+		// Metal Rods
+		var/obj/item/stack/rods/RO = new /obj/item/stack/rods(src)
+		RO.amount = 50
+		src.modules += RO
+
+		// Plasteel
+		var/obj/item/stack/sheet/plasteel/cyborg/PS = new /obj/item/stack/sheet/plasteel(src)
+		PS.amount = 30
+		src.modules += PS
+
+
+
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
 
@@ -189,9 +221,10 @@
 		/obj/item/stack/sheet/metal = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
-		/obj/item/weapon/cable_coil = 50,
+		/obj/item/weapon/cable_coil = 30,
 		/obj/item/stack/rods = 15,
-		/obj/item/stack/tile/plasteel = 15
+		/obj/item/stack/tile/plasteel = 15,
+		/obj/item/stack/sheet/plasteel = 10
 		)
 
 	New()
@@ -213,21 +246,40 @@
 
 		src.emag = new /obj/item/borg/stun(src)
 
-		var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
-		M.amount = 50
-		src.modules += M
+		// Metal
+		var/obj/item/stack/sheet/metal/cyborg/ME = new /obj/item/stack/sheet/metal/cyborg(src)
+		ME.amount = 50
+		src.modules += ME
 
-		var/obj/item/stack/sheet/rglass/cyborg/R = new /obj/item/stack/sheet/rglass/cyborg(src)
-		R.amount = 50
-		src.modules += R
+		// Reinforced Glass
+		var/obj/item/stack/sheet/rglass/cyborg/RG = new /obj/item/stack/sheet/rglass/cyborg(src)
+		RG.amount = 50
+		src.modules += RG
 
-		var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src)
-		G.amount = 50
-		src.modules += G
+		// Glass
+		var/obj/item/stack/sheet/glass/GL = new /obj/item/stack/sheet/glass(src)
+		GL.amount = 50
+		src.modules += GL
 
-		var/obj/item/weapon/cable_coil/W = new /obj/item/weapon/cable_coil(src)
-		W.amount = 50
-		src.modules += W
+		// Cable Coil
+		var/obj/item/weapon/cable_coil/CC = new /obj/item/weapon/cable_coil(src)
+		CC.amount = 30
+		src.modules += CC
+
+		// Metal Rods
+		var/obj/item/stack/rods/RO = new /obj/item/stack/rods(src)
+		RO.amount = 15
+		src.modules += RO
+
+		// Floor Tiles
+		var/obj/item/stack/tile/plasteel/FT = new /obj/item/stack/tile/plasteel(src)
+		FT.amount = 15
+		src.modules += FT
+
+		// Plasteel
+		var/obj/item/stack/sheet/plasteel/cyborg/PS = new /obj/item/stack/sheet/plasteel(src)
+		PS.amount = 10
+		src.modules += PS
 
 		return
 


### PR DESCRIPTION
This changes few things with cyborg resources, mostly minor bugfixes/optimisations. Fixes #6676. List of stuff:
- Metal Rods and Floor tiles are now properly initialized in New(). Cyborgs no longer have to recharge to obtain these on round start.
- Minor cleanup related to above fix. Added few comments, and reminder to put initialization in New() if adding new resource on top of the file.
- Engineering module now gets tiny amount of plasteel (10 sheets). To compensate, construction module now gets 30 sheets instead of 10 (which won't change anything about fact that 99% players will pick engineering anyway as construction module is mostly useless). This allows engineering borgs do minor repairs involving reinforced walls.
- Engineering module cable coil amount changed from 50 to 30. Reason is that all cable coils have standardized max length of 30, and trying to pick up other cable coils laying around while having more than 30 results in you actually transferring cable TO that coil. You can always pull second coil with you when doing larger wire modifications.
- Cyborg plasteel is now subtype of regular sheet/plasteel - it is now consistent with other sheets (metal, rglass,..)
- Removed a lie. (plasteel is alloy of phoron and steel -> alloy of steel, coal, platinum) description change.
