### PR TITLE
Various chem changes

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -223,7 +223,7 @@
 				else if(istype(R, /datum/reagent/toxin))
 					if(filter_effect < 3)
 						owner.adjustToxLoss(0.3 * PROCESS_ACCURACY)
-					owner.reagents.remove_reagent(R.id, ALCOHOL_METABOLISM*filter_effect)
+					owner.reagents.hl_remove_reagent(R.id, HL_REAGENTS_METABOLISM*filter_effect)
 
 /datum/organ/internal/kidney
 	name = "kidneys"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -532,6 +532,24 @@ datum
 
 				return 1
 
+			hl_remove_reagent(var/reagent, var/proportion, var/safety = 0)//For metabolism in the body. Reagent removed by proportion.
+				if(!isnum(proportion)) return 1
+
+				for(var/A in reagent_list)
+					var/datum/reagent/R = A
+					if (R.id == reagent)
+						if(R.volume < 0.1)
+							R.volume = 0
+						else
+							R.volume -= R.volume * proportion
+						update_total()
+						if(!safety)//So it does not handle reactions when it need not to
+							handle_reactions()
+						my_atom.on_reagent_change()
+						return 0
+
+				return 1
+
 			has_reagent(var/reagent, var/amount = -1)
 
 				for(var/A in reagent_list)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1975,12 +1975,16 @@ datum
 /////////////////////////Food Reagents////////////////////////////
 // Part of the food code. Nutriment is used instead of the old "heal_amt" code. Also is where all the food
 // 	condiments, additives, and such go.
+
+//Unlike most other chemicals, food and drink metabolize linearly
+
 		nutriment
 			name = "Nutriment"
 			id = "nutriment"
 			description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
 			reagent_state = SOLID
-			nutriment_factor = 15 * REAGENTS_METABOLISM
+			nutriment_factor = 15 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#664330" // rgb: 102, 67, 48
 
 			on_mob_life(var/mob/living/M as mob)
@@ -2000,7 +2004,7 @@ datum
 					M.adjustToxLoss(rand(-15, -5)))
 					M.updatehealth()
 */
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		lipozine
@@ -2008,13 +2012,13 @@ datum
 			id = "lipozine"
 			description = "A chemical compound that causes a powerful fat-burning reaction."
 			reagent_state = LIQUID
-			nutriment_factor = 10 * REAGENTS_METABOLISM
+			nutriment_factor = 10 * HL_REAGENTS_METABOLISM
 			color = "#BBEDA4" // rgb: 187, 237, 164
 			overdose = REAGENTS_OVERDOSE
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.nutrition = max(M.nutrition - nutriment_factor, 0)
+				M.nutrition = max(M.nutrition - nutriment_factor*volume, 0)
 				M.overeatduration = 0
 				if(M.nutrition < 0)//Prevent from going into negatives.
 					M.nutrition = 0
@@ -2026,7 +2030,7 @@ datum
 			id = "soysauce"
 			description = "A salty sauce made from the soy plant."
 			reagent_state = LIQUID
-			nutriment_factor = 2 * REAGENTS_METABOLISM
+			nutriment_factor = 2 * FOOD_METABOLISM
 			color = "#792300" // rgb: 121, 35, 0
 
 		ketchup
@@ -2034,7 +2038,7 @@ datum
 			id = "ketchup"
 			description = "Ketchup, catsup, whatever. It's tomato paste."
 			reagent_state = LIQUID
-			nutriment_factor = 5 * REAGENTS_METABOLISM
+			nutriment_factor = 5 * FOOD_METABOLISM
 			color = "#731008" // rgb: 115, 16, 8
 
 		capsaicin
@@ -2068,7 +2072,6 @@ datum
 				holder.remove_reagent("frostoil", 5)
 				holder.remove_reagent(src.id, FOOD_METABOLISM)
 				data++
-				..()
 				return
 
 		condensedcapsaicin
@@ -2153,7 +2156,6 @@ datum
 				holder.remove_reagent("frostoil", 5)
 				holder.remove_reagent(src.id, FOOD_METABOLISM)
 				data++
-				..()
 				return
 
 		frostoil
@@ -2173,7 +2175,6 @@ datum
 					M.bodytemperature = max(M.bodytemperature - rand(10,20), 0)
 				holder.remove_reagent("capsaicin", 5)
 				holder.remove_reagent(src.id, FOOD_METABOLISM)
-				..()
 				return
 
 			reaction_turf(var/turf/simulated/T, var/volume)
@@ -2200,12 +2201,13 @@ datum
 			id = "coco"
 			description = "A fatty, bitter paste made from coco beans."
 			reagent_state = SOLID
-			nutriment_factor = 5 * REAGENTS_METABOLISM
+			nutriment_factor = 3 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#302000" // rgb: 48, 32, 0
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //By default it slowly disappears linearly.
 				return
 
 		hot_coco
@@ -2213,14 +2215,15 @@ datum
 			id = "hot_coco"
 			description = "Made with love! And cocoa beans."
 			reagent_state = LIQUID
-			nutriment_factor = 2 * REAGENTS_METABOLISM
+			nutriment_factor = 2 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#403010" // rgb: 64, 48, 16
 
 			on_mob_life(var/mob/living/M as mob)
 				if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.nutrition += nutriment_factor
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		psilocybin
@@ -2229,6 +2232,7 @@ datum
 			description = "A strong psycotropic derived from certain species of mushroom."
 			color = "#E700E7" // rgb: 231, 0, 231
 			overdose = REAGENTS_OVERDOSE
+			custom_metabolism = HL_REAGENTS_METABOLISM*2
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
@@ -2251,7 +2255,7 @@ datum
 						M.make_dizzy(20)
 						M.druggy = max(M.druggy, 40)
 						if(prob(30)) M.emote(pick("twitch","giggle"))
-				holder.remove_reagent(src.id, 0.2)
+				//holder.remove_reagent(src.id, 0.2)
 				data++
 				..()
 				return
@@ -2260,7 +2264,8 @@ datum
 			name = "Sprinkles"
 			id = "sprinkles"
 			description = "Multi-colored little bits of sugar, commonly found on donuts. Loved by cops."
-			nutriment_factor = 1 * REAGENTS_METABOLISM
+			nutriment_factor = 1 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#FF00FF" // rgb: 255, 0, 255
 
 			on_mob_life(var/mob/living/M as mob)
@@ -2272,7 +2277,8 @@ datum
 					..()
 					return
 				*/
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
+				return
 
 /*	//removed because of meta bullshit. this is why we can't have nice things.
 		syndicream
@@ -2298,12 +2304,13 @@ datum
 			id = "cornoil"
 			description = "An oil derived from various types of corn."
 			reagent_state = LIQUID
-			nutriment_factor = 20 * REAGENTS_METABOLISM
+			nutriment_factor = 20 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#302000" // rgb: 48, 32, 0
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 			reaction_turf(var/turf/simulated/T, var/volume)
 				if (!istype(T)) return
@@ -2345,12 +2352,13 @@ datum
 			id = "dry_ramen"
 			description = "Space age food, since August 25, 1958. Contains dried noodles, vegetables, and chemicals that boil in contact with water."
 			reagent_state = SOLID
-			nutriment_factor = 1 * REAGENTS_METABOLISM
+			nutriment_factor = 1 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#302000" // rgb: 48, 32, 0
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		hot_ramen
@@ -2358,14 +2366,15 @@ datum
 			id = "hot_ramen"
 			description = "The noodles are boiled, the flavors are artificial, just like being back in school."
 			reagent_state = LIQUID
-			nutriment_factor = 5 * REAGENTS_METABOLISM
+			nutriment_factor = 5 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#302000" // rgb: 48, 32, 0
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
 				if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = min(310, M.bodytemperature + (10 * TEMPERATURE_DAMAGE_COEFFICIENT))
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		hell_ramen
@@ -2373,13 +2382,14 @@ datum
 			id = "hell_ramen"
 			description = "The noodles are boiled, the flavors are artificial, just like being back in school."
 			reagent_state = LIQUID
-			nutriment_factor = 5 * REAGENTS_METABOLISM
+			nutriment_factor = 5 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#302000" // rgb: 48, 32, 0
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
 				M.bodytemperature += 10 * TEMPERATURE_DAMAGE_COEFFICIENT
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 /* We're back to flour bags
@@ -2407,12 +2417,13 @@ datum
 			id = "rice"
 			description = "Enjoy the great taste of nothing."
 			reagent_state = SOLID
-			nutriment_factor = 1 * REAGENTS_METABOLISM
+			nutriment_factor = 1 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#FFFFFF" // rgb: 0, 0, 0
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		cherryjelly
@@ -2420,24 +2431,27 @@ datum
 			id = "cherryjelly"
 			description = "Totally the best. Only to be spread on foods with excellent lateral symmetry."
 			reagent_state = LIQUID
-			nutriment_factor = 1 * REAGENTS_METABOLISM
+			nutriment_factor = 1 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 			color = "#801E28" // rgb: 128, 30, 40
 
 			on_mob_life(var/mob/living/M as mob)
 				M.nutrition += nutriment_factor
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////// DRINKS BELOW, Beer is up there though, along with cola. Cap'n Pete's Cuban Spiced Rum////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+//Unlike most other chemicals, food and drink metabolize linearly
+
 		drink
 			name = "Drink"
 			id = "drink"
 			description = "Uh, some kind of drink."
 			reagent_state = LIQUID
-			nutriment_factor = 1 * REAGENTS_METABOLISM
+			nutriment_factor = 1 * FOOD_METABOLISM
 			color = "#E78108" // rgb: 231, 129, 8
 			var/adj_dizzy = 0
 			var/adj_drowsy = 0
@@ -2457,7 +2471,9 @@ datum
 					if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 						M.bodytemperature = min(310, M.bodytemperature + (25 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-				..()
+				if( (overdose > 0) && (volume >= overdose))//Overdosing, wooo
+					M.adjustToxLoss(overdose_dam * (volume - overdose))
+				holder.remove_reagent(src.id, custom_metabolism) //By default it slowly disappears linearly.
 				return
 
 		drink/orangejuice
@@ -2580,7 +2596,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(M.getBruteLoss() && prob(20)) M.heal_organ_damage(1,0)
-				holder.remove_reagent("capsaicin", 10*REAGENTS_METABOLISM)
+				holder.remove_reagent("capsaicin", 10*FOOD_METABOLISM)
 				..()
 				return
 
@@ -2624,7 +2640,7 @@ datum
 				..()
 				M.make_jittery(5)
 				if(adj_temp > 0)
-					holder.remove_reagent("frostoil", 10*REAGENTS_METABOLISM)
+					holder.remove_reagent("frostoil", 10*FOOD_METABOLISM)
 
 				holder.remove_reagent(src.id, 0.1)
 
@@ -2802,7 +2818,6 @@ datum
 					M.bodytemperature = max(M.bodytemperature - rand(10,20), 0)
 				holder.remove_reagent("capsaicin", 5)
 				holder.remove_reagent(src.id, FOOD_METABOLISM)
-				..()
 				return
 
 		drink/cold/rewriter
@@ -2824,6 +2839,7 @@ datum
 			reagent_state = LIQUID
 			color = "#FF8CFF" // rgb: 255, 140, 255
 			nutriment_factor = 1 * FOOD_METABOLISM
+			custom_metabolism = FOOD_METABOLISM
 
 			on_mob_life(var/mob/living/M as mob)
 				M:nutrition += nutriment_factor
@@ -2835,7 +2851,7 @@ datum
 				if(M:getToxLoss() && prob(50)) M:adjustToxLoss(-2)
 				if(M.dizziness !=0) M.dizziness = max(0,M.dizziness-15)
 				if(M.confused !=0) M.confused = max(0,M.confused - 5)
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 //////////////////////////////////////////////The ten friggen million reagents that get you drunk//////////////////////////////////////////////
@@ -2845,6 +2861,7 @@ datum
 			id = "atomicbomb"
 			description = "Nuclear proliferation never tasted so good."
 			reagent_state = LIQUID
+			custom_metabolism = ALCOHOL_METABOLISM
 			color = "#666300" // rgb: 102, 99, 0
 
 			on_mob_life(var/mob/living/M as mob)
@@ -2861,7 +2878,7 @@ datum
 					if(201 to INFINITY)
 						M.sleeping += 1
 						M.adjustToxLoss(2)
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		gargle_blaster
@@ -2869,6 +2886,7 @@ datum
 			id = "gargleblaster"
 			description = "Whoah, this stuff looks volatile!"
 			reagent_state = LIQUID
+			custom_metabolism = ALCOHOL_METABOLISM
 			color = "#664300" // rgb: 102, 67, 0
 
 			on_mob_life(var/mob/living/M as mob)
@@ -2884,7 +2902,7 @@ datum
 					M.druggy = max(M.druggy, 55)
 				else if(data >=200)
 					M.adjustToxLoss(2)
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		neurotoxin
@@ -2892,6 +2910,7 @@ datum
 			id = "neurotoxin"
 			description = "A strong neurotoxin that puts the subject into a death-like state."
 			reagent_state = LIQUID
+			custom_metabolism = ALCOHOL_METABOLISM
 			color = "#2E2E61" // rgb: 46, 46, 97
 
 			on_mob_life(var/mob/living/carbon/M as mob)
@@ -2909,7 +2928,7 @@ datum
 					M.druggy = max(M.druggy, 55)
 				else if(data >=200)
 					M.adjustToxLoss(2)
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly.
 				return
 
 		hippies_delight
@@ -2917,6 +2936,7 @@ datum
 			id = "hippiesdelight"
 			description = "You just don't get it maaaan."
 			reagent_state = LIQUID
+			custom_metabolism = ALCOHOL_METABOLISM
 			color = "#664300" // rgb: 102, 67, 0
 
 			on_mob_life(var/mob/living/M as mob)
@@ -2948,8 +2968,7 @@ datum
 						M.druggy = max(M.druggy, 75)
 						if(prob(40)) M.emote(pick("twitch","giggle"))
 						if(prob(30)) M.adjustToxLoss(2)
-				holder.remove_reagent(src.id, 0.2)
-				..()
+				holder.remove_reagent(src.id, custom_metabolism) //It slowly disappears linearly
 				return
 
 /*boozepwr chart
@@ -3018,7 +3037,6 @@ datum
 						else if(istype(L))
 							L.take_damage(0.1, 1)
 						H.adjustToxLoss(0.1)
-				..()
 				return
 
 			reaction_obj(var/obj/O, var/volume)
@@ -3044,7 +3062,7 @@ datum
 			description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
 			color = "#664300" // rgb: 102, 67, 0
 			boozepwr = 1
-			nutriment_factor = 1 * FOOD_METABOLISM
+			nutriment_factor = 1 * ALCOHOL_METABOLISM
 
 			on_mob_life(var/mob/living/M as mob)
 				M:jitteriness = max(M:jitteriness-3,0)
@@ -3089,7 +3107,7 @@ datum
 			description = "A potent mixture of caffeine and alcohol."
 			color = "#102000" // rgb: 16, 32, 0
 			boozepwr = 2
-			nutriment_factor = 1 * FOOD_METABOLISM
+			nutriment_factor = 1 * ALCOHOL_METABOLISM
 
 			on_mob_life(var/mob/living/M as mob)
 				M:drowsyness = max(0,M:drowsyness-7)
@@ -3102,7 +3120,7 @@ datum
 		ethanol/vodka
 			name = "Vodka"
 			id = "vodka"
-			description = "Number one drink AND fueling choice for Russians worldwide."
+			description = "Number one drink AND fueling choice for Russians galaxywide."
 			color = "#0064C8" // rgb: 0, 100, 200
 			boozepwr = 2
 
@@ -3117,7 +3135,7 @@ datum
 			description = "This appears to be beer mixed with milk. Disgusting."
 			color = "#895C4C" // rgb: 137, 92, 76
 			boozepwr = 1
-			nutriment_factor = 2 * FOOD_METABOLISM
+			nutriment_factor = 2 * ALCOHOL_METABOLISM
 
 		ethanol/threemileisland
 			name = "Three Mile Island Iced Tea"
@@ -3263,7 +3281,7 @@ datum
 							var/datum/organ/internal/heart/L = H.internal_organs_by_name["heart"]
 							if (L && istype(L))
 								L.take_damage(100, 0)
-				holder.remove_reagent(src.id, FOOD_METABOLISM)
+				holder.remove_reagent(src.id, ALCOHOL_METABOLISM)
 
 		ethanol/deadrum
 			name = "Deadrum"
@@ -3610,7 +3628,7 @@ datum
 			reagent_state = LIQUID
 			color = "#664300" // rgb: 102, 67, 0
 			boozepwr = 1.5
-			nutriment_factor = 1 * FOOD_METABOLISM
+			nutriment_factor = 1 * ALCOHOL_METABOLISM
 
 		ethanol/iced_beer
 			name = "Iced Beer"
@@ -3703,7 +3721,7 @@ datum
 			name = "Driest Martini"
 			id = "driestmartini"
 			description = "Only for the experienced. You think you see sand floating in the glass."
-			nutriment_factor = 1 * FOOD_METABOLISM
+			nutriment_factor = 1 * ALCOHOL_METABOLISM
 			color = "#2E6671" // rgb: 46, 102, 113
 			boozepwr = 4
 
@@ -3711,7 +3729,7 @@ datum
 			name = "Banana Mama"
 			id = "bananahonk"
 			description = "A drink from Clown Heaven."
-			nutriment_factor = 1 * REAGENTS_METABOLISM
+			nutriment_factor = 1 * ALCOHOL_METABOLISM
 			color = "#FFFF91" // rgb: 255, 255, 140
 			boozepwr = 4
 
@@ -3719,7 +3737,7 @@ datum
 			name = "Silencer"
 			id = "silencer"
 			description = "A drink from Mime Heaven."
-			nutriment_factor = 1 * FOOD_METABOLISM
+			nutriment_factor = 1 * ALCOHOL_METABOLISM
 			color = "#664300" // rgb: 102, 67, 0
 			boozepwr = 4
 

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -1,6 +1,11 @@
 
 //Not to be confused with /obj/item/weapon/reagent_containers/food/drinks/bottle
 
+#define BOTTLE_CHEMICAL "bottle-4"
+#define BOTTLE_POISON "bottle-1"
+#define BOTTLE_MEDICINE "bottle-2"
+#define BOTTLE_VIRUS "bottle-3"
+
 /obj/item/weapon/reagent_containers/glass/bottle
 	name = "bottle"
 	desc = "A small bottle."
@@ -59,7 +64,7 @@
 	name = "inaprovaline bottle"
 	desc = "A small bottle. Contains inaprovaline - used to stabilize patients."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
+	icon_state = BOTTLE_MEDICINE
 
 	New()
 		..()
@@ -69,7 +74,7 @@
 	name = "toxin bottle"
 	desc = "A small bottle of toxins. Do not drink, it is poisonous."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle12"
+	icon_state = BOTTLE_POISON
 
 	New()
 		..()
@@ -79,7 +84,7 @@
 	name = "cyanide bottle"
 	desc = "A small bottle of cyanide. Bitter almonds?"
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle12"
+	icon_state = BOTTLE_POISON
 
 	New()
 		..()
@@ -89,7 +94,7 @@
 	name = "soporific bottle"
 	desc = "A small bottle of soporific. Just the fumes make you sleepy."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle20"
+	icon_state = BOTTLE_POISON
 
 	New()
 		..()
@@ -99,7 +104,7 @@
 	name = "Chloral Hydrate Bottle"
 	desc = "A small bottle of Choral Hydrate. Mickey's Favorite!"
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle20"
+	icon_state = BOTTLE_POISON
 
 	New()
 		..()
@@ -109,7 +114,7 @@
 	name = "dylovene bottle"
 	desc = "A small bottle of dylovene. Counters poisons, and repairs damage. A wonder drug."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle17"
+	icon_state = BOTTLE_MEDICINE
 
 	New()
 		..()
@@ -119,7 +124,7 @@
 	name = "unstable mutagen bottle"
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle20"
+	icon_state = BOTTLE_CHEMICAL
 
 	New()
 		..()
@@ -129,7 +134,7 @@
 	name = "ammonia bottle"
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle20"
+	icon_state = BOTTLE_CHEMICAL
 
 	New()
 		..()
@@ -139,7 +144,7 @@
 	name = "diethylamine bottle"
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle17"
+	icon_state = BOTTLE_CHEMICAL
 
 	New()
 		..()
@@ -149,7 +154,7 @@
 	name = "Flu virion culture bottle"
 	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/advance/flu(0)
@@ -160,7 +165,7 @@
 	name = "Epiglottis virion culture bottle"
 	desc = "A small bottle. Contains Epiglottis virion culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/advance/voice_change(0)
@@ -171,7 +176,7 @@
 	name = "Liver enhancement virion culture bottle"
 	desc = "A small bottle. Contains liver enhancement virion culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/advance/heal(0)
@@ -182,7 +187,7 @@
 	name = "Hullucigen virion culture bottle"
 	desc = "A small bottle. Contains hullucigen virion culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/advance/hullucigen(0)
@@ -193,7 +198,7 @@
 	name = "Pierrot's Throat culture bottle"
 	desc = "A small bottle. Contains H0NI<42 virion culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/pierrot_throat(0)
@@ -204,7 +209,7 @@
 	name = "Rhinovirus culture bottle"
 	desc = "A small bottle. Contains XY-rhinovirus culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/advance/F = new /datum/disease/advance/cold(0)
@@ -215,7 +220,7 @@
 	name = "Random culture bottle"
 	desc = "A small bottle. Contains a random disease."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/advance/F = new(0)
@@ -226,7 +231,7 @@
 	name = "Retrovirus culture bottle"
 	desc = "A small bottle. Contains a retrovirus culture in a synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/dna_retrovirus(0)
@@ -238,7 +243,7 @@
 	name = "GBS culture bottle"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS+ culture in synthblood medium."//Or simply - General BullShit
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	amount_per_transfer_from_this = 5
 
 	New()
@@ -253,7 +258,7 @@
 	name = "GBS culture bottle"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS- culture in synthblood medium."//Or simply - General BullShit
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/fake_gbs(0)
@@ -280,7 +285,7 @@
 	name = "Brainrot culture bottle"
 	desc = "A small bottle. Contains Cryptococcus Cosmosis culture in synthblood medium."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/brainrot(0)
@@ -291,7 +296,7 @@
 	name = "Magnitis culture bottle"
 	desc = "A small bottle. Contains a small dosage of Fukkos Miracos."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/magnitis(0)
@@ -303,7 +308,7 @@
 	name = "Wizarditis culture bottle"
 	desc = "A small bottle. Contains a sample of Rincewindus Vulgaris."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_VIRUS
 	New()
 		..()
 		var/datum/disease/F = new /datum/disease/wizarditis(0)
@@ -314,7 +319,7 @@
 	name = "Polytrinic Acid Bottle"
 	desc = "A small bottle. Contains a small amount of Polytrinic Acid"
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle17"
+	icon_state = BOTTLE_CHEMICAL
 	New()
 		..()
 		reagents.add_reagent("pacid", 60)
@@ -332,7 +337,7 @@
 	name = "Capsaicin Bottle"
 	desc = "A small bottle. Contains hot sauce."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle3"
+	icon_state = BOTTLE_CHEMICAL
 	New()
 		..()
 		reagents.add_reagent("capsaicin", 60)
@@ -341,7 +346,7 @@
 	name = "Frost Oil Bottle"
 	desc = "A small bottle. Contains cold sauce."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle17"
+	icon_state = BOTTLE_CHEMICAL
 	New()
 		..()
 		reagents.add_reagent("frostoil", 60)

--- a/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
@@ -11,7 +11,7 @@
 	name = "internal inaprovaline bottle"
 	desc = "A small bottle. Contains inaprovaline - used to stabilize patients."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
+	icon_state = BOTTLE_MEDICINE
 	reagent = "inaprovaline"
 
 	New()
@@ -24,7 +24,7 @@
 	name = "internal anti-toxin bottle"
 	desc = "A small bottle of Anti-toxins. Counters poisons, and repairs damage, a wonder drug."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle17"
+	icon_state = BOTTLE_MEDICINE
 	reagent = "anti_toxin"
 
 	New()

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -79,8 +79,10 @@
 // Factor of how fast mob nutrition decreases
 #define HUNGER_FACTOR 0.05
 
-// How many units of reagent are consumed per tick, by default.
+// How many units of reagent are consumed per tick, by default. Used for IV drip and cigarette injection rates.
 #define REAGENTS_METABOLISM 0.2
+// Proportion of reagent consumed per tick, by default. Used for metabolism in body.
+#define HL_REAGENTS_METABOLISM 0.02
 
 // By defining the effect multiplier this way, it'll exactly adjust
 // all effects according to how they originally were with the 0.4 metabolism

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -60,7 +60,7 @@ should be listed in the changelog upon commit though. Thanks. -->
 	<h2 class='date'>14 October 2014</h2>
 	<h3 class='author'>RavingManiac updated:</h3>
 	<ul class='changes bgimages16'>
-		<li class='tweak'>Chemicals now heal and damage proportionate to the volume present in the mob. Chemicals are also naturally removed at a proportional rate (think half-lives).</li>
+		<li class='tweak'>Chemicals now heal and damage proportionate to the volume present in the mob. Chemicals are also naturally removed at a proportional rate (think half-lives). Food and drink are exempt from this.</li>
 		<li class='rscadd'>Chem bottles now use chemical overlays like beakers do.</li>
 		<li class='rscadd'>Sniper scope now shifts your view in the direction you are facing.</li>
 		<li class='rscadd'>New item: Binoculars. Used similarly to sniper scope. Adminspawn-only for now.</li>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,18 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>14 October 2014</h2>
+	<h3 class='author'>RavingManiac updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='tweak'>Chemicals now heal and damage proportionate to the volume present in the mob. Chemicals are also naturally removed at a proportional rate (think half-lives).</li>
+		<li class='rscadd'>Chem bottles now use chemical overlays like beakers do.</li>
+		<li class='rscadd'>Sniper scope now shifts your view in the direction you are facing.</li>
+		<li class='rscadd'>New item: Binoculars. Used similarly to sniper scope. Adminspawn-only for now.</li>
+	</ul>
+</div>
+
+
+<div class='commit sansserif'>
 	<h2 class='date'>1 October 2014</h2>
 	<h3 class='author'>Zuhayr updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
Most reagent effects now scale with volume. Reagents are also consumed as a proportion of reagent volume removed per tick. Effects balanced around ~15 units of reagent (accounting for decreasing effect as reagent diminishes). Effect does not apply to food and drink.

All reagent bottles, including those on the map at roundstart, now use overlay sprites. Colors for some reagents (antitoxin, inaprovaline, iron, kelotane, dermaline, bicaridine, dexalin, dexalin plus) added.
