### PR TITLE
Custom items revamp DONUT MERGE UNTESTED

### DIFF
--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -1,19 +1,19 @@
 //switch this out to use a database at some point
 //list of ckey/ real_name and item paths
 //gives item to specific people when they join if it can
-//for multiple items just add mutliple entries, unless i change it to be a listlistlist
+//see config/custom_items.txt how to to add things to it (yes crazy idea i know)
 //yes, it has to be an item, you can't pick up nonitems
 
 /var/list/custom_items = list()
 
+//parses the config file into the above listlist
 /hook/startup/proc/loadCustomItems()
 	var/custom_items_file = file2text("config/custom_items.txt")
-	custom_items = text2list(custom_items_file, "\n")
-	return 1
+	var/list/file_list = text2list(custom_items_file, "\n")
+	for(var/line in file_list)
+		if(findtext(line, "#", 1, 2))
+			continue
 
-/proc/EquipCustomItems(mob/living/carbon/human/M)
-	for(var/line in custom_items)
-		// split & clean up
 		var/list/Entry = text2list(line, ":")
 		for(var/i = 1 to Entry.len)
 			Entry[i] = trim(Entry[i])
@@ -21,75 +21,87 @@
 		if(Entry.len < 3)
 			continue;
 
-		if(Entry[1] == M.ckey && Entry[2] == M.real_name)
+		if(!custom_items[Entry[1]])
+			custom_items[Entry[1]] = list()
+		custom_items[Entry[1]] += Entry
+
+	return 1
+
+//gets the relevant list for the key from the listlist if it exists, check to make sure they are meant to have it and then calls the giving function
+/proc/EquipCustomItems(mob/living/carbon/human/M)
+	var/list/key_list = custom_items[M.ckey]
+	if(!key_list || key_list.len < 1)
+		return
+
+	for(var/list/Entry in key_list)
+		if(Entry.len < 3)
+			continue;
+
+		if(Entry[1] != M.ckey || Entry[2] != "" || Entry[2] != M.real_name)
+			continue
+
+		//required access/job
+		var/obj/item/weapon/card/id/ID = M.wear_id	//should be an id even though pdas can also be there, due to this being run at spawn, before there is a chance to change it
+		if(Entry.len>=4 && length(Entry[4]) > 0)
+			var/required_access = 0;
+			required_access = text2num(Entry[4])
+
+			if(!required_access)
+				var/list/JobTitles = text2list(Entry[4])
+				var/ok = 0
+				var/CurrentTitle = M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role
+				for(var/title in JobTitles)
+					if(title == CurrentTitle)
+						ok = 1
+				if(ok == 0)
+					continue
+
+			else if(required_access != 0)
+				if(!(required_access in ID.access))
+					continue
+
+		//the else looks redundant and that it should probably be not an else and just not have the if, but then if there was a name/desc/icon_state set then all the items would get the same one, and i dont want the config file to be wider than it already has to be
+		if(findtext(Entry[3], ","))
 			var/list/Paths = text2list(Entry[3], ",")
 			for(var/P in Paths)
-				var/ok = 0  // 1 if the item was placed successfully
-				P = trim(P)
-				var/path = text2path(P)
-				if(!path) continue
+				//ids make the standard id be different, instead of spawning a new one (because clunky as fuck)
+				if(P == "/obj/item/weapon/card/id")
+					continue
+				PlaceCustomItem(M, P)
+		else
+			var/obj/item/Item
+			if(Entry[3] == "/obj/item/weapon/card/id")
+				Item = ID
+			else
+				Item = PlaceCustomItem(M,Entry[3])
+			if(!istype(Item))
+				continue
+			if(Entry.len < 5)
+				continue
+			if(Entry[5] != "")
+				Item.name = Entry[5]
+				if(istype(Item, /obj/item/weapon/card/id))
+					Item.name += "[M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role]"
+			if(Entry.len < 6)
+				continue
+			if(Entry[6] != "")
+				Item.desc = Entry[6]
 
-				var/obj/item/Item = new path()
-				if(istype(Item,/obj/item/weapon/card/id))
-					//id card needs to replace the original ID
-					if(M.ckey == "nerezza" && M.real_name == "Asher Spock" && M.mind.role_alt_title && M.mind.role_alt_title != "Emergency Physician")
-						//only spawn ID if asher is joining as an emergency physician
-						ok = 1
-						del(Item)
-						goto skip
-					var/obj/item/weapon/card/id/I = Item
-					for(var/obj/item/weapon/card/id/C in M)
-						//default settings
-						I.name = "[M.real_name]'s ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
-						I.registered_name = M.real_name
-						I.access = C.access
-						I.assignment = C.assignment
-						I.blood_type = C.blood_type
-						I.dna_hash = C.dna_hash
-						I.fingerprint_hash = C.fingerprint_hash
-						//I.pin = C.pin
+//actually sticks the item on the person
+/proc/PlaceCustomItem(mob/living/carbon/human/M, var/path)
+	if(!path) return
 
-						//custom stuff
-						if(M.ckey == "fastler" && M.real_name == "Fastler Greay") //This is a Lifetime ID
-							I.name = "[M.real_name]'s Lifetime ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
-						else if(M.ckey == "nerezza" && M.real_name == "Asher Spock") //This is an Odysseus Specialist ID
-							I.name = "[M.real_name]'s Odysseus Specialist ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
-							I.access += list(access_robotics) //Station-based mecha pilots need this to access the recharge bay.
-						else if(M.ckey == "roaper" && M.real_name == "Ian Colm") //This is a Technician ID
-							I.name = "[M.real_name]'s Technician ID ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
+	var/obj/item/Item = new path()
 
-						//replace old ID
-						del(C)
-						ok = M.equip_if_possible(I, slot_wear_id, 0)	//if 1, last argument deletes on fail
-						break
-				else if(istype(Item,/obj/item/weapon/storage/belt))
-					if(M.ckey == "jakksergal" && M.real_name == "Nashi Ra'hal" && M.mind.role_alt_title && M.mind.role_alt_title != "Nurse" && M.mind.role_alt_title != "Chemist")
-						ok = 1
-						del(Item)
-						goto skip
-					var/obj/item/weapon/storage/belt/medical/fluff/nashi_belt/I = Item
-					if(istype(M.belt,/obj/item/weapon/storage/belt))
-						for(var/obj/item/weapon/storage/belt/B in M)
-							del(B)
-							M.belt=null
-						ok = M.equip_if_possible(I, slot_belt, 0)
-						break
-					if(istype(M.belt,/obj/item/device/pda))
-						for(var/obj/item/device/pda/Pda in M)
-							M.belt=null
-							M.equip_if_possible(Pda, slot_l_store, 0)
-						ok = M.equip_if_possible(I, slot_belt, 0)
-				else if(istype(M.back,/obj/item/weapon/storage) && M.back:contents.len < M.back:storage_slots) // Try to place it in something on the mob's back
-					Item.loc = M.back
-					ok = 1
-
-				else
-					for(var/obj/item/weapon/storage/S in M.contents) // Try to place it in any item that can store stuff, on the mob.
-						if (S.contents.len < S.storage_slots)
-							Item.loc = S
-							ok = 1
-							break
-
-				skip:
-				if (ok == 0) // Finally, since everything else failed, place it on the ground
-					Item.loc = get_turf(M.loc)
+	if(M.equip_to_appropriate_slot(Item))
+		return Item
+	if(istype(M.back,/obj/item/weapon/storage) && M.back:contents.len < M.back:storage_slots) // Try to place it in something on the mob's back
+		Item.loc = M.back
+		return Item
+	else
+		for(var/obj/item/weapon/storage/S in M.contents) // Try to place it in any item that can store stuff, on the mob.
+			if (S.contents.len < S.storage_slots)
+				Item.loc = S
+				return Item
+		Item.loc = get_turf(M.loc)
+		return Item

--- a/config/example/custom_items.txt
+++ b/config/example/custom_items.txt
@@ -1,1 +1,14 @@
-ckey: name: /path/to/obj
+# custom items for people and shit in here
+# basic:
+#	ckey: name: /path/to/obj
+# additional options
+#	ckey: name: /path/to/obj: required access OR job title: item name: description: icon state
+# required access is one of the numbers from 
+# if required access is 0 or blank then always gets it
+# job title means if the item wants chemist but they are pharmacist then it wont do it (can be comma separated to have multiple, eg Chemist, Pharmacist if it's for both jobs
+# yes they have to be in that order, and if you want a custom description you need to have a custom name too
+# you can leave any othe than the ckey and path blank if you want and it will use the default for whatever the item is
+# paths can be comma separated, but you wont be able to set custom name/desc/icon in this file, it will have to be done via an item definition (in code/modules/customitems/item_defines.dm) or by having multiple entries in this config
+# unless its an id, because fuck code duplication
+# if icon state is set then the icon had better be in icons/obj/custom_items.dmi otherwise it'll be invisible
+# also # at the start means the line is a comment


### PR DESCRIPTION
no more bloody ckey checks in my beautiful subsystem
only parses once, instead of every time someone spawns
equips custom items to the appropriate slot if it can (probably unlikely, given that it's done after everything for the job is equipped) before falling back to backpack/box/ground

people who will NEED config changes (can be done on live now without breaking anything):
jakksergal: Nashi Ra'hal: /obj/item/weapon/storage/belt/medical/fluff/nashi_belt: Nurse, Chemist

other ones can be simplified by this (ie removing a bunch of the definitions) but will continue working fine (even if they are updated before this hits master)
