### PR TITLE
Fixes #6783

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -787,6 +787,7 @@
 #include "code\modules\clothing\spacesuits\miscellaneous.dm"
 #include "code\modules\clothing\spacesuits\ninja.dm"
 #include "code\modules\clothing\spacesuits\rig.dm"
+#include "code\modules\clothing\spacesuits\spacesuits.dm"
 #include "code\modules\clothing\spacesuits\syndi.dm"
 #include "code\modules\clothing\spacesuits\void.dm"
 #include "code\modules\clothing\suits\alien.dm"

--- a/code/WorkInProgress/autopsy.dm
+++ b/code/WorkInProgress/autopsy.dm
@@ -170,9 +170,10 @@
 			usr.l_hand = P
 			P.layer = 20
 
-	if(istype(usr,/mob/living/carbon/human))
-		usr:update_inv_l_hand()
-		usr:update_inv_r_hand()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_l_hand()
+		M.update_inv_r_hand()
 
 /obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -10,6 +10,10 @@
 	*/
 	var/list/sprite_sheets_refit = null
 
+//Updates the icons of the mob wearing the clothing item, if any.
+/obj/item/clothing/proc/update_clothing_icon()
+	return
+
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(M as mob, slot)
 
@@ -80,7 +84,8 @@
 	else
 		icon = initial(icon)
 
-//Ears: headsets, earmuffs and tiny objects
+///////////////////////////////////////////////////////////////////////
+// Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears
 	name = "ears"
 	w_class = 1.0
@@ -121,6 +126,11 @@
 	if(istype(src,/obj/item/clothing/ears/offear))
 		del(src)
 
+/obj/item/clothing/ears/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_ears()
+
 /obj/item/clothing/ears/offear
 	name = "Other ear"
 	w_class = 5.0
@@ -142,7 +152,17 @@
 	item_state = "earmuffs"
 	slot_flags = SLOT_EARS | SLOT_TWOEARS
 
+///////////////////////////////////////////////////////////////////////
 //Glasses
+/*
+SEE_SELF  // can see self, no matter what
+SEE_MOBS  // can see all mobs, no matter what
+SEE_OBJS  // can see all objs, no matter what
+SEE_TURFS // can see all turfs (and areas), no matter what
+SEE_PIXELS// if an object is located on an unlit area, but some of its pixels are
+          // in a lit area (via pixel_x,y or smooth movement), can see those pixels
+BLIND     // can't see anything
+*/
 /obj/item/clothing/glasses
 	name = "glasses"
 	icon = 'icons/obj/clothing/glasses.dmi'
@@ -153,17 +173,13 @@
 	var/darkness_view = 0//Base human is 2
 	var/invisa_view = 0
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/eyes.dmi')
-/*
-SEE_SELF  // can see self, no matter what
-SEE_MOBS  // can see all mobs, no matter what
-SEE_OBJS  // can see all objs, no matter what
-SEE_TURFS // can see all turfs (and areas), no matter what
-SEE_PIXELS// if an object is located on an unlit area, but some of its pixels are
-          // in a lit area (via pixel_x,y or smooth movement), can see those pixels
-BLIND     // can't see anything
-*/
 
+/obj/item/clothing/glasses/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_glasses()
 
+///////////////////////////////////////////////////////////////////////
 //Gloves
 /obj/item/clothing/gloves
 	name = "gloves"
@@ -184,6 +200,11 @@ BLIND     // can't see anything
 	set src in usr
 	..()
 	return
+
+/obj/item/clothing/gloves/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_gloves()
 
 /obj/item/clothing/gloves/emp_act(severity)
 	if(cell)
@@ -217,6 +238,7 @@ BLIND     // can't see anything
 			species_restricted -= "Tajara"
 		return
 
+///////////////////////////////////////////////////////////////////////
 //Head
 /obj/item/clothing/head
 	name = "head"
@@ -225,6 +247,12 @@ BLIND     // can't see anything
 	slot_flags = SLOT_HEAD
 	w_class = 2.0
 
+/obj/item/clothing/head/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_head()
+
+///////////////////////////////////////////////////////////////////////
 //Mask
 /obj/item/clothing/mask
 	name = "mask"
@@ -234,8 +262,15 @@ BLIND     // can't see anything
 	body_parts_covered = FACE|EYES
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/masks.dmi')
 
-/obj/item/clothing/mask/proc/filter_air(datum/gas_mixture/air)
+/obj/item/clothing/mask/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_wear_mask()
 
+/obj/item/clothing/mask/proc/filter_air(datum/gas_mixture/air)
+	return
+
+///////////////////////////////////////////////////////////////////////
 //Shoes
 /obj/item/clothing/shoes
 	name = "shoes"
@@ -251,6 +286,12 @@ BLIND     // can't see anything
 	species_restricted = list("exclude","Unathi","Tajara")
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/shoes.dmi')
 
+/obj/item/clothing/shoes/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_shoes()
+
+///////////////////////////////////////////////////////////////////////
 //Suit
 /obj/item/clothing/suit
 	icon = 'icons/obj/clothing/suits.dmi'
@@ -265,74 +306,12 @@ BLIND     // can't see anything
 	siemens_coefficient = 0.9
 	w_class = 3
 
-//Spacesuit
-//Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.
-//      Meaning the the suit is defined directly after the corrisponding helmet. Just like below!
-/obj/item/clothing/head/helmet/space
-	name = "Space helmet"
-	icon_state = "space"
-	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
-	flags = FPRINT | TABLEPASS | HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
-	item_state = "space"
-	permeability_coefficient = 0.01
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
-	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
-	body_parts_covered = HEAD|FACE|EYES
-	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.9
-	species_restricted = list("exclude","Diona","Vox")
+/obj/item/clothing/suit/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_wear_suit()
 
-/obj/item/clothing/suit/space
-	name = "Space suit"
-	desc = "A suit that protects against low pressure environments. \"NSS EXODUS\" is written in large block letters on the back."
-	icon_state = "space"
-	item_state = "s_suit"
-	w_class = 4//bulky item
-	gas_transfer_coefficient = 0.01
-	permeability_coefficient = 0.02
-	flags = FPRINT | TABLEPASS | STOPSPRESSUREDMAGE | THICKMATERIAL
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/device/suit_cooling_unit)
-	slowdown = 3
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
-	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
-	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.9
-	species_restricted = list("exclude","Diona","Vox")
-
-	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
-
-/obj/item/clothing/suit/space/equipped(mob/M)
-	check_limb_support()
-	..()
-
-/obj/item/clothing/suit/space/dropped()
-	check_limb_support()
-	..()
-
-// Some space suits are equipped with reactive membranes that support
-// broken limbs - at the time of writing, only the ninja suit, but
-// I can see it being useful for other suits as we expand them. ~ Z
-// The actual splinting occurs in /datum/organ/external/proc/fracture()
-/obj/item/clothing/suit/space/proc/check_limb_support()
-
-	// If this isn't set, then we don't need to care.
-	if(!supporting_limbs || !supporting_limbs.len)
-		return
-
-	var/mob/living/carbon/human/H = src.loc
-
-	// If the holder isn't human, or the holder IS and is wearing the suit, it keeps supporting the limbs.
-	if(!istype(H) || H.wear_suit == src)
-		return
-
-	// Otherwise, remove the splints.
-	for(var/datum/organ/external/E in supporting_limbs)
-		E.status &= ~ ORGAN_SPLINTED
-	supporting_limbs = list()
-
+///////////////////////////////////////////////////////////////////////
 //Under clothing
 /obj/item/clothing/under
 	icon = 'icons/obj/clothing/uniforms.dmi'
@@ -355,6 +334,11 @@ BLIND     // can't see anything
 	var/rolled_down = 0
 	var/basecolor
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/uniform.dmi')
+
+/obj/item/clothing/under/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_w_uniform()
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user)
 	if(hastie)
@@ -480,7 +464,7 @@ BLIND     // can't see anything
 	if(basecolor + "_d_s" in icon_states('icons/mob/uniform.dmi'))
 		body_parts_covered = "[basecolor]" ? LEGS|LOWER_TORSO : UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 		item_color = item_color == "[basecolor]" ? "[basecolor]_d" : "[basecolor]"
-		usr.update_inv_w_uniform()
+		update_clothing_icon()
 	else
 		usr << "<span class='notice'>You cannot roll down the uniform!</span>"
 
@@ -490,10 +474,7 @@ BLIND     // can't see anything
 
 	hastie.on_removed(user)
 	hastie = null
-
-	if(istype(loc, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = loc
-		H.update_inv_w_uniform()
+	update_clothing_icon()
 
 /obj/item/clothing/under/verb/removetie()
 	set name = "Remove Accessory"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -156,7 +156,7 @@
 			icon_state = "[initial(icon_state)]up"
 			usr << "You push \the [src] up out of your face."
 
-		usr.update_inv_glasses()
+		update_clothing_icon()
 
 /obj/item/clothing/glasses/welding/superior
 	name = "superior welding goggles"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -48,7 +48,7 @@
 			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 			icon_state = "[initial(icon_state)]up"
 			usr << "You push the [src] up out of your face."
-		usr.update_inv_head()	//so our mob-overlays update
+		update_clothing_icon()	//so our mob-overlays update
 
 
 /*

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -26,7 +26,7 @@
 			else
 				icon_state = "[item_color]soft"
 				usr << "You flip the hat back in normal position."
-			usr.update_inv_head()	//so our mob-overlays update
+			update_clothing_icon()	//so our mob-overlays update
 
 /obj/item/clothing/head/soft/red
 	name = "red cap"

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -34,7 +34,7 @@
 				flags |= MASKCOVERSMOUTH | MASKINTERNALS
 				icon_state = "breath"
 				usr << "You pull the mask up to cover your face."
-			usr.update_inv_wear_mask()
+			update_clothing_icon()
 
 /obj/item/clothing/mask/breath/medical
 	desc = "A close-fitting sterile mask that can be connected to an air supply."

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -1,0 +1,67 @@
+//Spacesuit
+//Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.
+//      Meaning the the suit is defined directly after the corrisponding helmet. Just like below!
+/obj/item/clothing/head/helmet/space
+	name = "Space helmet"
+	icon_state = "space"
+	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
+	flags = FPRINT | TABLEPASS | HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
+	item_state = "space"
+	permeability_coefficient = 0.01
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
+	body_parts_covered = HEAD|FACE|EYES
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.9
+	species_restricted = list("exclude","Diona","Vox")
+
+/obj/item/clothing/suit/space
+	name = "Space suit"
+	desc = "A suit that protects against low pressure environments. \"NSS EXODUS\" is written in large block letters on the back."
+	icon_state = "space"
+	item_state = "s_suit"
+	w_class = 4//bulky item
+	gas_transfer_coefficient = 0.01
+	permeability_coefficient = 0.02
+	flags = FPRINT | TABLEPASS | STOPSPRESSUREDMAGE | THICKMATERIAL
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/device/suit_cooling_unit)
+	slowdown = 3
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
+	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.9
+	species_restricted = list("exclude","Diona","Vox")
+
+	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
+
+/obj/item/clothing/suit/space/equipped(mob/M)
+	check_limb_support()
+	..()
+
+/obj/item/clothing/suit/space/dropped()
+	check_limb_support()
+	..()
+
+// Some space suits are equipped with reactive membranes that support
+// broken limbs - at the time of writing, only the ninja suit, but
+// I can see it being useful for other suits as we expand them. ~ Z
+// The actual splinting occurs in /datum/organ/external/proc/fracture()
+/obj/item/clothing/suit/space/proc/check_limb_support()
+
+	// If this isn't set, then we don't need to care.
+	if(!supporting_limbs || !supporting_limbs.len)
+		return
+
+	var/mob/living/carbon/human/H = src.loc
+
+	// If the holder isn't human, or the holder IS and is wearing the suit, it keeps supporting the limbs.
+	if(!istype(H) || H.wear_suit == src)
+		return
+
+	// Otherwise, remove the splints.
+	for(var/datum/organ/external/E in supporting_limbs)
+		E.status &= ~ ORGAN_SPLINTED
+	supporting_limbs = list()

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -184,7 +184,7 @@
 			else
 				usr << "You attempt to button-up the velcro on your [src], before promptly realising how retarded you are."
 				return
-		usr.update_inv_wear_suit()	//so our overlays update
+		update_clothing_icon()	//so our overlays update
 
 //Medical
 /obj/item/clothing/suit/storage/fr_jacket
@@ -212,7 +212,7 @@
 			if("fr_jacket")
 				src.icon_state = "fr_jacket_open"
 				usr << "You unbutton the jacket."
-		usr.update_inv_wear_suit()	//so our overlays update
+		update_clothing_icon()	//so our overlays update
 
 //Mime
 /obj/item/clothing/suit/suspenders

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -2,7 +2,7 @@
 	name = "labcoat"
 	desc = "A suit that protects against minor chemical spills."
 	icon_state = "labcoat_open"
-	item_state = "labcoat"
+	item_state = "labcoat" //Is this even used for anything?
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper)
@@ -17,6 +17,7 @@
 		if(!usr.canmove || usr.stat || usr.restrained())
 			return 0
 
+		//Why???
 		switch(icon_state)
 			if("labcoat_open")
 				src.icon_state = "labcoat"
@@ -93,7 +94,7 @@
 			else
 				usr << "You attempt to button-up the velcro on your [src], before promptly realising how silly you are."
 				return
-		usr.update_inv_wear_suit()	//so our overlays update
+		update_clothing_icon()	//so our overlays update
 
 /obj/item/clothing/suit/storage/labcoat/red
 	name = "red labcoat"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -219,7 +219,7 @@
 	else
 		usr << "You button-up some imaginary buttons on your [src]."
 		return
-	usr.update_inv_wear_suit()
+	update_clothing_icon()
 
 //pyjamas
 //originally intended to be pinstripes >.>

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -27,7 +27,7 @@
 		icon_state = "psyche"
 		item_color = "psyche"
 		update_icon()
-		usr.update_inv_w_uniform()
+		update_clothing_icon()
 
 	verb/change()
 		set name = "Change Jumpsuit Appearance"
@@ -49,8 +49,7 @@
 		item_state = A.item_state
 		item_color = A.item_color
 		body_parts_covered = A.body_parts_covered
-		if(usr)
-			usr.update_inv_w_uniform()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //*****************
 //**Chameleon Hat**
@@ -81,7 +80,7 @@
 		icon_state = "greysoft"
 		item_color = "grey"
 		update_icon()
-		usr.update_inv_head()
+		update_clothing_icon()
 
 	verb/change()
 		set name = "Change Hat/Helmet Appearance"
@@ -104,8 +103,7 @@
 		item_color = A.item_color
 		flags_inv = A.flags_inv
 		body_parts_covered = A.body_parts_covered
-		if(usr)
-			usr.update_inv_head()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //******************
 //**Chameleon Suit**
@@ -135,7 +133,7 @@
 		icon_state = "armor"
 		item_color = "armor"
 		update_icon()
-		usr.update_inv_wear_suit()
+		update_clothing_icon()
 
 	verb/change()
 		set name = "Change Exosuit Appearance"
@@ -158,8 +156,7 @@
 		item_color = A.item_color
 		flags_inv = A.flags_inv
 		body_parts_covered = A.body_parts_covered
-		if(usr)
-			usr.update_inv_wear_suit()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //*******************
 //**Chameleon Shoes**
@@ -189,7 +186,7 @@
 		item_state = "black"
 		item_color = "black"
 		update_icon()
-		usr.update_inv_shoes()
+		update_clothing_icon()
 
 	verb/change()
 		set name = "Change Footwear Appearance"
@@ -210,8 +207,7 @@
 		icon_state = A.icon_state
 		item_state = A.item_state
 		item_color = A.item_color
-		if(usr)
-			usr.update_inv_shoes()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //**********************
 //**Chameleon Backpack**
@@ -238,7 +234,9 @@
 		icon_state = "backpack"
 		item_state = "backpack"
 		update_icon()
-		usr.update_inv_back()
+		if (ismob(src.loc))
+			var/mob/M = src.loc
+			M.update_inv_back()
 
 	verb/change()
 		set name = "Change Backpack Appearance"
@@ -259,8 +257,11 @@
 		icon_state = A.icon_state
 		item_state = A.item_state
 		item_color = A.item_color
-		if(usr)
-			usr.update_inv_back()	//so our overlays update.
+		
+		//so our overlays update.
+		if (ismob(src.loc))
+			var/mob/M = src.loc
+			M.update_inv_back()
 
 //********************
 //**Chameleon Gloves**
@@ -289,7 +290,7 @@
 		icon_state = "black"
 		item_color = "brown"
 		update_icon()
-		usr.update_inv_gloves()
+		update_clothing_icon()
 
 	verb/change()
 		set name = "Change Gloves Appearance"
@@ -311,8 +312,7 @@
 		item_state = A.item_state
 		item_color = A.item_color
 		flags_inv = A.flags_inv
-		if(usr)
-			usr.update_inv_gloves()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //******************
 //**Chameleon Mask**
@@ -340,7 +340,8 @@
 		desc = "It's a gas mask."
 		icon_state = "gas_alt"
 		update_icon()
-		usr.update_inv_wear_mask()
+		update_clothing_icon()
+
 	verb/change()
 		set name = "Change Mask Appearance"
 		set category = "Object"
@@ -361,8 +362,7 @@
 		item_state = A.item_state
 		flags_inv = A.flags_inv
 		body_parts_covered = A.body_parts_covered
-		if(usr)
-			usr.update_inv_wear_mask()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //*********************
 //**Chameleon Glasses**
@@ -389,7 +389,7 @@
 		desc = "It's a set of mesons."
 		icon_state = "meson"
 		update_icon()
-		usr.update_inv_glasses()
+		update_clothing_icon()
 
 	verb/change()
 		set name = "Change Glasses Appearance"
@@ -410,8 +410,7 @@
 		icon_state = A.icon_state
 		item_state = A.item_state
 		flags_inv = A.flags_inv
-		if(usr)
-			usr.update_inv_glasses()	//so our overlays update.
+		update_clothing_icon()	//so our overlays update.
 
 //*****************
 //**Chameleon Gun**
@@ -441,8 +440,10 @@
 		desc = "It's a desert eagle."
 		icon_state = "deagle"
 		update_icon()
-		usr.update_inv_r_hand()
-		usr.update_inv_l_hand()
+		if (ismob(src.loc))
+			var/mob/M = src.loc
+			M.update_inv_r_hand()
+			M.update_inv_l_hand()
 
 	verb/change()
 		set name = "Change Gun Appearance"
@@ -463,6 +464,9 @@
 		icon_state = A.icon_state
 		item_state = A.item_state
 		flags_inv = A.flags_inv
-		if(usr)
-			usr.update_inv_r_hand()
-			usr.update_inv_l_hand()	//so our overlays update.
+		
+		//so our overlays update.
+		if (ismob(src.loc))
+			var/mob/M = src.loc
+			M.update_inv_r_hand()
+			M.update_inv_l_hand()

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -936,7 +936,7 @@
 			if("lombardi_jacket_open")
 				src.icon_state = "lombardi_jacket"
 				usr << "You button up the jacket."
-		usr.update_inv_wear_suit()
+		update_clothing_icon()
 
 //////////// Uniforms ////////////
 
@@ -1098,7 +1098,7 @@
 
 	src.icon_state = "[item_color]"
 	src.item_state = "[item_color]"
-	usr.update_inv_w_uniform()
+	update_clothing_icon()
 
 ////// Wyatt's Ex-Commander Jumpsuit - RawrTaicho
 /obj/item/clothing/under/fluff/wyatt_1

--- a/code/modules/projectiles/guns/projectile/pneumatic.dm
+++ b/code/modules/projectiles/guns/projectile/pneumatic.dm
@@ -47,7 +47,9 @@
 		tank = null
 		icon_state = "pneumatic"
 		item_state = "pneumatic"
-		usr.update_icons()
+		if (ismob(src.loc))
+			var/mob/M = src.loc
+			M.update_icons()
 	else
 		usr << "There's no tank in [src]."
 


### PR DESCRIPTION
Adds an update_clothing_icon() proc to clothing items that will call the relevant icon update proc on the mob which is equipping the clothing, if any. Changes various clothing procs to not call update icon procs on usr
which may not even be the mob wearing the clothing.

I can't think of many good reasons why icon update procs should be called on `usr` when updating the appearance of worn items. Sure, for some clothing procs `usr` will happen to be the mob actually wearing the clothing, but should the verb ever become callable by anyone not wearing the clothing (like if buttoning someone else's labcoat ever becomes possible) the code will no longer work as intended, from what I understand. Also it seems like it can confuse people who don't seem to understand `usr`, like whoever wrote emp_act() for the chameleon suit.

Fixes #6783
