### PR TITLE
Alternate fix to #6705

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -284,11 +284,3 @@
 		return 1
 	busy = 0
 	return 0
-
-/obj/machinery/camera/proc/is_functional()
-	if(istype(loc,/mob/living/silicon/robot))
-		var/mob/living/silicon/robot/R = loc
-		if(!R.stat && R.is_component_functioning("camera"))
-			return 1
-		return 0
-	return status

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -69,7 +69,7 @@
 
 	proc/can_access_camera(var/obj/machinery/camera/C)
 		var/list/shared_networks = src.network & C.network
-		if(shared_networks.len && C.is_functional())
+		if(shared_networks.len)
 			return 1
 		return 0
 

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -134,7 +134,33 @@
 	external_type = /obj/item/robot_parts/robot_component/camera
 	idle_usage = 10
 	max_damage = 40
+	var/obj/machinery/camera/camera
 
+/datum/robot_component/camera/New(mob/living/silicon/robot/R)
+	..()
+	camera = R.camera
+
+/datum/robot_component/camera/update_power_state()
+	..()
+	if (camera)
+		//check if camera component was deactivated
+		if (!powered && camera.status != powered)
+			camera.kick_viewers()
+		camera.status = powered
+
+/datum/robot_component/camera/install()
+	if (camera)
+		camera.status = 1
+
+/datum/robot_component/camera/uninstall()
+	if (camera)
+		camera.status = 0
+		camera.kick_viewers()
+
+/datum/robot_component/camera/destroy()
+	if (camera)
+		camera.status = 0
+		camera.kick_viewers()
 
 // SELF DIAGNOSIS MODULE
 // Analyses cyborg's modules, providing damage readouts and basic information


### PR DESCRIPTION
Implements an alternative fix for #6705

This one is less hacky (doesn't require every single camera to check whether they are inside a robot) and kicks viewers who are watching the camera when it is deactivated.
- [x] Local testing
