### PR TITLE
Allows properly keyed radios to broadcast in robot talk and/or hivemind + some cleanup

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "cypherkey"
 	item_state = ""
+	w_class = 1
 	var/translate_binary = 0
 	var/translate_hive = 0
 	var/syndie = 0

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -19,6 +19,18 @@
 	keyslot1 = new /obj/item/device/encryptionkey/
 	recalculateChannels()
 
+/obj/item/device/radio/headset/handle_message_mode(mob/living/M as mob, message, channel)
+	if (channel == "special")
+		if (translate_binary)
+			var/datum/language/binary = all_languages["Robot Talk"]
+			binary.broadcast(M, message)
+		if (translate_hive)
+			var/datum/language/hivemind = all_languages["Hivemind"]
+			hivemind.broadcast(M, message)
+		return null
+	
+	return ..()
+
 /obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
 	if (aiOverride)
 		return ..(freq, level)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,6 +1,3 @@
-var/GLOBAL_RADIO_TYPE = 1 // radio type to use
-	// 0 = old radios
-	// 1 = new radios (subspace technology)
 
 
 /obj/item/device/radio
@@ -248,146 +245,85 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 
 	M.last_target_click = world.time
 
-	if(GLOBAL_RADIO_TYPE == 1) // NEW RADIO SYSTEMS: By Doohl
+	/* Quick introduction:
+		This new radio system uses a very robust FTL signaling technology unoriginally
+		dubbed "subspace" which is somewhat similar to 'blue-space' but can't
+		actually transmit large mass. Headsets are the only radio devices capable
+		of sending subspace transmissions to the Communications Satellite.
 
-		/* Quick introduction:
-			This new radio system uses a very robust FTL signaling technology unoriginally
-			dubbed "subspace" which is somewhat similar to 'blue-space' but can't
-			actually transmit large mass. Headsets are the only radio devices capable
-			of sending subspace transmissions to the Communications Satellite.
+		A headset sends a signal to a subspace listener/reciever elsewhere in space,
+		the signal gets processed and logged, and an audible transmission gets sent
+		to each individual headset.
+	*/
 
-			A headset sends a signal to a subspace listener/reciever elsewhere in space,
-			the signal gets processed and logged, and an audible transmission gets sent
-			to each individual headset.
-		*/
+	//#### Grab the connection datum ####//
+	var/datum/radio_frequency/connection = handle_message_mode(M, message, channel)
+	if (!istype(connection))
+		return
+	if (!connection)
+		return
 
-		//#### Grab the connection datum ####//
-		var/datum/radio_frequency/connection = handle_message_mode(M, message, channel)
-		if (!istype(connection))
-			return
-		if (!connection)
-			return
+	var/turf/position = get_turf(src)
 
-		var/turf/position = get_turf(src)
+	//#### Tagging the signal with all appropriate identity values ####//
 
-		//#### Tagging the signal with all appropriate identity values ####//
-
-		// ||-- The mob's name identity --||
-		var/displayname = M.name	// grab the display name (name you get when you hover over someone's icon)
-		var/real_name = M.real_name // mob's real name
-		var/mobkey = "none" // player key associated with mob
-		var/voicemask = 0 // the speaker is wearing a voice mask
-		if(M.client)
-			mobkey = M.key // assign the mob's key
+	// ||-- The mob's name identity --||
+	var/displayname = M.name	// grab the display name (name you get when you hover over someone's icon)
+	var/real_name = M.real_name // mob's real name
+	var/mobkey = "none" // player key associated with mob
+	var/voicemask = 0 // the speaker is wearing a voice mask
+	if(M.client)
+		mobkey = M.key // assign the mob's key
 
 
-		var/jobname // the mob's "job"
+	var/jobname // the mob's "job"
 
-		// --- Human: use their actual job ---
-		if (ishuman(M))
-			jobname = M:get_assignment()
+	// --- Human: use their actual job ---
+	if (ishuman(M))
+		jobname = M:get_assignment()
 
-		// --- Carbon Nonhuman ---
-		else if (iscarbon(M)) // Nonhuman carbon mob
-			jobname = "No id"
+	// --- Carbon Nonhuman ---
+	else if (iscarbon(M)) // Nonhuman carbon mob
+		jobname = "No id"
 
-		// --- AI ---
-		else if (isAI(M))
-			jobname = "AI"
+	// --- AI ---
+	else if (isAI(M))
+		jobname = "AI"
 
-		// --- Cyborg ---
-		else if (isrobot(M))
-			jobname = "Cyborg"
+	// --- Cyborg ---
+	else if (isrobot(M))
+		jobname = "Cyborg"
 
-		// --- Personal AI (pAI) ---
-		else if (istype(M, /mob/living/silicon/pai))
-			jobname = "Personal AI"
+	// --- Personal AI (pAI) ---
+	else if (istype(M, /mob/living/silicon/pai))
+		jobname = "Personal AI"
 
-		// --- Unidentifiable mob ---
-		else
-			jobname = "Unknown"
+	// --- Unidentifiable mob ---
+	else
+		jobname = "Unknown"
 
 
-		// --- Modifications to the mob's identity ---
+	// --- Modifications to the mob's identity ---
 
-		// The mob is disguising their identity:
-		if (ishuman(M) && M.GetVoice() != real_name)
-			displayname = M.GetVoice()
-			jobname = "Unknown"
-			voicemask = 1
+	// The mob is disguising their identity:
+	if (ishuman(M) && M.GetVoice() != real_name)
+		displayname = M.GetVoice()
+		jobname = "Unknown"
+		voicemask = 1
 
 
 
-	  /* ###### Radio headsets can only broadcast through subspace ###### */
+  /* ###### Radio headsets can only broadcast through subspace ###### */
 
-		if(subspace_transmission)
-			// First, we want to generate a new radio signal
-			var/datum/signal/signal = new
-			signal.transmission_method = 2 // 2 would be a subspace transmission.
-										   // transmission_method could probably be enumerated through #define. Would be neater.
-
-			// --- Finally, tag the actual signal with the appropriate values ---
-			signal.data = list(
-			  // Identity-associated tags:
-				"mob" = M, // store a reference to the mob
-				"mobtype" = M.type, 	// the mob's type
-				"realname" = real_name, // the mob's real name
-				"name" = displayname,	// the mob's display name
-				"job" = jobname,		// the mob's job
-				"key" = mobkey,			// the mob's key
-				"vmessage" = pick(M.speak_emote), // the message to display if the voice wasn't understood
-				"vname" = M.voice_name, // the name to display if the voice wasn't understood
-				"vmask" = voicemask,	// 1 if the mob is using a voice gas mask
-
-				// We store things that would otherwise be kept in the actual mob
-				// so that they can be logged even AFTER the mob is deleted or something
-
-			  // Other tags:
-				"compression" = rand(45,50), // compressed radio signal
-				"message" = message, // the actual sent message
-				"connection" = connection, // the radio connection to use
-				"radio" = src, // stores the radio used for transmission
-				"slow" = 0, // how much to sleep() before broadcasting - simulates net lag
-				"traffic" = 0, // dictates the total traffic sum that the signal went through
-				"type" = 0, // determines what type of radio input it is: normal broadcast
-				"server" = null, // the last server to log this signal
-				"reject" = 0,	// if nonzero, the signal will not be accepted by any broadcasting machinery
-				"level" = position.z, // The source's z level
-				"language" = speaking,
-				"verb" = verb
-			)
-			signal.frequency = connection.frequency // Quick frequency set
-
-		  //#### Sending the signal to all subspace receivers ####//
-
-			for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
-				R.receive_signal(signal)
-
-			// Allinone can act as receivers.
-			for(var/obj/machinery/telecomms/allinone/R in telecomms_list)
-				R.receive_signal(signal)
-
-			// Receiving code can be located in Telecommunications.dm
-			return
-
-
-	  /* ###### Intercoms and station-bounced radios ###### */
-
-		var/filter_type = 2
-
-		/* --- Intercoms can only broadcast to other intercoms, but bounced radios can broadcast to bounced radios and intercoms --- */
-		if(istype(src, /obj/item/device/radio/intercom))
-			filter_type = 1
-
-
+	if(subspace_transmission)
+		// First, we want to generate a new radio signal
 		var/datum/signal/signal = new
-		signal.transmission_method = 2
+		signal.transmission_method = 2 // 2 would be a subspace transmission.
+									   // transmission_method could probably be enumerated through #define. Would be neater.
 
-
-		/* --- Try to send a normal subspace broadcast first */
-
+		// --- Finally, tag the actual signal with the appropriate values ---
 		signal.data = list(
-
+		  // Identity-associated tags:
 			"mob" = M, // store a reference to the mob
 			"mobtype" = M.type, 	// the mob's type
 			"realname" = real_name, // the mob's real name
@@ -396,192 +332,102 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 			"key" = mobkey,			// the mob's key
 			"vmessage" = pick(M.speak_emote), // the message to display if the voice wasn't understood
 			"vname" = M.voice_name, // the name to display if the voice wasn't understood
-			"vmask" = voicemask,	// 1 if the mob is using a voice gas mas
+			"vmask" = voicemask,	// 1 if the mob is using a voice gas mask
 
-			"compression" = 0, // uncompressed radio signal
+			// We store things that would otherwise be kept in the actual mob
+			// so that they can be logged even AFTER the mob is deleted or something
+
+		  // Other tags:
+			"compression" = rand(45,50), // compressed radio signal
 			"message" = message, // the actual sent message
 			"connection" = connection, // the radio connection to use
 			"radio" = src, // stores the radio used for transmission
-			"slow" = 0,
-			"traffic" = 0,
-			"type" = 0,
-			"server" = null,
-			"reject" = 0,
-			"level" = position.z,
+			"slow" = 0, // how much to sleep() before broadcasting - simulates net lag
+			"traffic" = 0, // dictates the total traffic sum that the signal went through
+			"type" = 0, // determines what type of radio input it is: normal broadcast
+			"server" = null, // the last server to log this signal
+			"reject" = 0,	// if nonzero, the signal will not be accepted by any broadcasting machinery
+			"level" = position.z, // The source's z level
 			"language" = speaking,
 			"verb" = verb
 		)
 		signal.frequency = connection.frequency // Quick frequency set
 
+	  //#### Sending the signal to all subspace receivers ####//
+
 		for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
 			R.receive_signal(signal)
 
+		// Allinone can act as receivers.
+		for(var/obj/machinery/telecomms/allinone/R in telecomms_list)
+			R.receive_signal(signal)
 
-		sleep(rand(10,25)) // wait a little...
-
-		if(signal.data["done"] && position.z in signal.data["level"])
-			// we're done here.
-			return
-
-	  	// Oh my god; the comms are down or something because the signal hasn't been broadcasted yet in our level.
-	  	// Send a mundane broadcast with limited targets:
-
-		//THIS IS TEMPORARY. YEAH RIGHT
-		if(!connection)	return	//~Carn
-
-		Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
-						  src, message, displayname, jobname, real_name, M.voice_name,
-		                  filter_type, signal.data["compression"], list(position.z), connection.frequency,verb,speaking)
+		// Receiving code can be located in Telecommunications.dm
+		return
 
 
+  /* ###### Intercoms and station-bounced radios ###### */
 
-	else // OLD RADIO SYSTEMS: By Goons?
+	var/filter_type = 2
 
-		var/datum/radio_frequency/connection = null
-		if(channel && channels && channels.len > 0)
-			if (channel == "department")
-				//world << "DEBUG: channel=\"[channel]\" switching to \"[channels[1]]\""
-				channel = channels[1]
-			connection = secure_radio_connections[channel]
-		else
-			connection = radio_connection
-			channel = null
-		if (!istype(connection))
-			return
-		var/display_freq = connection.frequency
+	/* --- Intercoms can only broadcast to other intercoms, but bounced radios can broadcast to bounced radios and intercoms --- */
+	if(istype(src, /obj/item/device/radio/intercom))
+		filter_type = 1
 
-		//world << "DEBUG: used channel=\"[channel]\" frequency= \"[display_freq]\" connection.devices.len = [connection.devices.len]"
 
-		var/eqjobname
+	var/datum/signal/signal = new
+	signal.transmission_method = 2
 
-		if (ishuman(M))
-			eqjobname = M:get_assignment()
-		else if (iscarbon(M))
-			eqjobname = "No id" //only humans can wear ID
-		else if (isAI(M))
-			eqjobname = "AI"
-		else if (isrobot(M))
-			eqjobname = "Cyborg"//Androids don't really describe these too well, in my opinion.
-		else if (istype(M, /mob/living/silicon/pai))
-			eqjobname = "Personal AI"
-		else
-			eqjobname = "Unknown"
 
-		if (!(wires & WIRE_TRANSMIT))
-			return
+	/* --- Try to send a normal subspace broadcast first */
 
-		var/list/receive = list()
+	signal.data = list(
 
-		//for (var/obj/item/device/radio/R in radio_connection.devices)
-		for (var/obj/item/device/radio/R in connection.devices["[RADIO_CHAT]"]) // Modified for security headset code -- TLE
-			//if(R.accept_rad(src, message))
-			receive |= R.send_hear(display_freq, 0)
+		"mob" = M, // store a reference to the mob
+		"mobtype" = M.type, 	// the mob's type
+		"realname" = real_name, // the mob's real name
+		"name" = displayname,	// the mob's display name
+		"job" = jobname,		// the mob's job
+		"key" = mobkey,			// the mob's key
+		"vmessage" = pick(M.speak_emote), // the message to display if the voice wasn't understood
+		"vname" = M.voice_name, // the name to display if the voice wasn't understood
+		"vmask" = voicemask,	// 1 if the mob is using a voice gas mas
 
-		//world << "DEBUG: receive.len=[receive.len]"
-		var/list/heard_masked = list() // masked name or no real name
-		var/list/heard_normal = list() // normal message
-		var/list/heard_voice = list() // voice message
-		var/list/heard_garbled = list() // garbled message
+		"compression" = 0, // uncompressed radio signal
+		"message" = message, // the actual sent message
+		"connection" = connection, // the radio connection to use
+		"radio" = src, // stores the radio used for transmission
+		"slow" = 0,
+		"traffic" = 0,
+		"type" = 0,
+		"server" = null,
+		"reject" = 0,
+		"level" = position.z,
+		"language" = speaking,
+		"verb" = verb
+	)
+	signal.frequency = connection.frequency // Quick frequency set
 
-		for (var/mob/R in receive)
-			if (R.client && !(R.client.prefs.toggles & CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
-				continue
-			if (R.say_understands(M))
-				if (ishuman(M) && M.GetVoice() != M.real_name)
-					heard_masked += R
-				else
-					heard_normal += R
-			else
-				heard_voice += R
+	for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
+		R.receive_signal(signal)
 
-		if (length(heard_masked) || length(heard_normal) || length(heard_voice) || length(heard_garbled))
-			var/part_a = "<span class='radio'><span class='name'>"
-			//var/part_b = "</span><b> \icon[src]\[[format_frequency(frequency)]\]</b> <span class='message'>"
-			var/freq_text= get_frequency_name(display_freq)
 
-			var/part_b = "</span><b> \icon[src]\[[freq_text]\]</b> <span class='message'>" // Tweaked for security headsets -- TLE
-			var/part_c = "</span></span>"
+	sleep(rand(10,25)) // wait a little...
 
-			if (display_freq in ANTAG_FREQS)
-				part_a = "<span class='syndradio'><span class='name'>"
-			else if (display_freq==COMM_FREQ)
-				part_a = "<span class='comradio'><span class='name'>"
-			else if (display_freq in DEPT_FREQS)
-				part_a = "<span class='deptradio'><span class='name'>"
+	if(signal.data["done"] && position.z in signal.data["level"])
+		// we're done here.
+		return
 
-			var/quotedmsg = M.say_quote(message)
+	// Oh my god; the comms are down or something because the signal hasn't been broadcasted yet in our level.
+	// Send a mundane broadcast with limited targets:
 
-			//This following recording is intended for research and feedback in the use of department radio channels.
+	//THIS IS TEMPORARY. YEAH RIGHT
+	if(!connection)	return	//~Carn
 
-			var/part_blackbox_b = "</span><b> \[[freq_text]\]</b> <span class='message'>" // Tweaked for security headsets -- TLE
-			var/blackbox_msg = "[part_a][M.name][part_blackbox_b][quotedmsg][part_c]"
-			//var/blackbox_admin_msg = "[part_a][M.name] (Real name: [M.real_name])[part_blackbox_b][quotedmsg][part_c]"
-			if(istype(blackbox))
-				//BR.messages_admin += blackbox_admin_msg
-				switch(display_freq)
-					if(PUB_FREQ)
-						blackbox.msg_common += blackbox_msg
-					if(SCI_FREQ)
-						blackbox.msg_science += blackbox_msg
-					if(COMM_FREQ)
-						blackbox.msg_command += blackbox_msg
-					if(MED_FREQ)
-						blackbox.msg_medical += blackbox_msg
-					if(ENG_FREQ)
-						blackbox.msg_engineering += blackbox_msg
-					if(SEC_FREQ)
-						blackbox.msg_security += blackbox_msg
-					if(DTH_FREQ)
-						blackbox.msg_deathsquad += blackbox_msg
-					if(SYND_FREQ)
-						blackbox.msg_syndicate += blackbox_msg
-					if(SUP_FREQ)
-						blackbox.msg_cargo += blackbox_msg
-					else
-						blackbox.messages += blackbox_msg
+	Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
+					  src, message, displayname, jobname, real_name, M.voice_name,
+					  filter_type, signal.data["compression"], list(position.z), connection.frequency,verb,speaking)
 
-			//End of research and feedback code.
-
-			if (length(heard_masked))
-				var/N = M.name
-				var/J = eqjobname
-				if(ishuman(M) && M.GetVoice() != M.real_name)
-					N = M.GetVoice()
-					J = "Unknown"
-				var/rendered = "[part_a][N][part_b][quotedmsg][part_c]"
-				for (var/mob/R in heard_masked)
-					if(istype(R, /mob/living/silicon/ai))
-						R.show_message("[part_a]<a href='byond://?src=\ref[src];track2=\ref[R];track=\ref[M]'>[N] ([J]) </a>[part_b][quotedmsg][part_c]", 2)
-					else
-						R.show_message(rendered, 2)
-
-			if (length(heard_normal))
-				var/rendered = "[part_a][M.real_name][part_b][quotedmsg][part_c]"
-
-				for (var/mob/R in heard_normal)
-					if(istype(R, /mob/living/silicon/ai))
-						R.show_message("[part_a]<a href='byond://?src=\ref[src];track2=\ref[R];track=\ref[M]'>[M.real_name] ([eqjobname]) </a>[part_b][quotedmsg][part_c]", 2)
-					else
-						R.show_message(rendered, 2)
-
-			if (length(heard_voice))
-				var/rendered = "[part_a][M.voice_name][part_b][pick(M.speak_emote)][part_c]"
-
-				for (var/mob/R in heard_voice)
-					if(istype(R, /mob/living/silicon/ai))
-						R.show_message("[part_a]<a href='byond://?src=\ref[src];track2=\ref[R];track=\ref[M]'>[M.voice_name] ([eqjobname]) </a>[part_b][pick(M.speak_emote)][part_c]", 2)
-					else
-						R.show_message(rendered, 2)
-
-			if (length(heard_garbled))
-				quotedmsg = M.say_quote(stars(message))
-				var/rendered = "[part_a][M.voice_name][part_b][quotedmsg][part_c]"
-
-				for (var/mob/R in heard_voice)
-					if(istype(R, /mob/living/silicon/ai))
-						R.show_message("[part_a]<a href='byond://?src=\ref[src];track2=\ref[R];track=\ref[M]'>[M.voice_name]</a>[part_b][quotedmsg][part_c]", 2)
-					else
-						R.show_message(rendered, 2)
 
 /obj/item/device/radio/hear_talk(mob/M as mob, msg, var/verb = "says", var/datum/language/speaking = null)
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -426,15 +426,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 
 
-/client/proc/cmd_switch_radio()
-	set category = "Debug"
-	set name = "Switch Radio Mode"
-	set desc = "Toggle between normal radios and experimental radios. Have a coder present if you do this."
-
-	GLOBAL_RADIO_TYPE = !GLOBAL_RADIO_TYPE // toggle
-	log_admin("[key_name(src)] has turned the experimental radio system [GLOBAL_RADIO_TYPE ? "on" : "off"].")
-	message_admins("[key_name_admin(src)] has turned the experimental radio system [GLOBAL_RADIO_TYPE ? "on" : "off"].", 0)
-	feedback_add_details("admin_verb","SRM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_areatest()
 	set category = "Mapping"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -114,13 +114,18 @@
 			return
 		else
 			if(message_mode)
-				if(message_mode in (radiochannels | "department"))
-					if(l_ear && istype(l_ear,/obj/item/device/radio))
-						l_ear.talk_into(src,message, message_mode, verb, speaking)
-						used_radios += l_ear
-					else if(r_ear && istype(r_ear,/obj/item/device/radio))
-						r_ear.talk_into(src,message, message_mode, verb, speaking)
-						used_radios += r_ear
+				if(l_ear && istype(l_ear,/obj/item/device/radio))
+					l_ear.talk_into(src,message, message_mode, verb, speaking)
+					used_radios += l_ear
+				else if(r_ear && istype(r_ear,/obj/item/device/radio))
+					r_ear.talk_into(src,message, message_mode, verb, speaking)
+					used_radios += r_ear
+
+	var/sound/speech_sound
+	var/sound_vol
+	if(species.speech_sounds && prob(20))
+		speech_sound = sound(pick(species.speech_sounds))
+		sound_vol = 50
 
 	//speaking into radios
 	if(used_radios.len)
@@ -131,15 +136,7 @@
 			if(M != src)
 				M.show_message("<span class='notice'>[src] talks into [used_radios.len ? used_radios[1] : "the radio."]</span>")
 			if (speech_sound)
-				src.playsound_local(get_turf(src), speech_sound, sound_vol * 0.5, 1)
-
-		speech_sound = null	//so we don't play it twice.
-
-	var/sound/speech_sound
-	var/sound_vol
-	if(species.speech_sounds && prob(20))
-		speech_sound = sound(pick(species.speech_sounds))
-		sound_vol = 50
+				sound_vol *= 0.5
 
 	..(message, speaking, verb, alt_name, italics, message_range, speech_sound, sound_vol)	//ohgod we should really be passing a datum here.
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -162,9 +162,7 @@
 
 				if(findtext(temp, "*", 1, 2))	//emotes
 					return
-				world << "Text after stuff is [temp]"
 				temp = copytext(trim_left(temp), 1, rand(5,8))
-				world << "Text after trimming is [temp]"
 
 				var/trimmed = trim_left(temp)
 				if(length(trimmed))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -122,13 +122,26 @@
 						r_ear.talk_into(src,message, message_mode, verb, speaking)
 						used_radios += r_ear
 
+	//speaking into radios
+	if(used_radios.len)
+		italics = 1
+		message_range = 1
+
+		for(var/mob/living/M in hearers(5, src))
+			if(M != src)
+				M.show_message("<span class='notice'>[src] talks into [used_radios.len ? used_radios[1] : "the radio."]</span>")
+			if (speech_sound)
+				src.playsound_local(get_turf(src), speech_sound, sound_vol * 0.5, 1)
+
+		speech_sound = null	//so we don't play it twice.
+
 	var/sound/speech_sound
 	var/sound_vol
 	if(species.speech_sounds && prob(20))
 		speech_sound = sound(pick(species.speech_sounds))
 		sound_vol = 50
 
-	..(message, speaking, verb, alt_name, italics, message_range, used_radios, speech_sound, sound_vol)	//ohgod we should really be passing a datum here.
+	..(message, speaking, verb, alt_name, italics, message_range, speech_sound, sound_vol)	//ohgod we should really be passing a datum here.
 
 /mob/living/carbon/human/proc/forcesay(list/append)
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -59,7 +59,7 @@ var/list/department_radio_keys = list(
 		if(!istype(dongle)) return
 		if(dongle.translate_binary) return 1
 
-/mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", var/italics=0, var/message_range = world.view, var/list/used_radios = list(), var/sound/speech_sound, var/sound_vol)
+/mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", var/italics=0, var/message_range = world.view, var/sound/speech_sound, var/sound_vol)
 
 	var/turf/T = get_turf(src)
 
@@ -72,20 +72,6 @@ var/list/department_radio_keys = list(
 		if (speaking.flags & SIGNLANG)
 			say_signlang(message, pick(speaking.signlang_verb), speaking)
 			return 1
-
-	//speaking into radios
-	if(used_radios.len)
-		italics = 1
-		message_range = 1
-
-		if (!istype(src, /mob/living/silicon/ai)) // Atlantis: Prevents nearby people from hearing the AI when it talks using it's integrated radio.
-			for(var/mob/living/M in hearers(5, src))
-				if(M != src)
-					M.show_message("<span class='notice'>[src] talks into [used_radios.len ? used_radios[1] : "the radio."]</span>")
-				if (speech_sound)
-					src.playsound_local(get_turf(src), speech_sound, sound_vol * 0.5, 1)
-
-		speech_sound = null	//so we don't play it twice.
 
 	//make sure the air can transmit speech
 	var/datum/gas_mixture/environment = T.return_air()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -3,6 +3,7 @@ var/list/department_radio_keys = list(
 	  ":l" = "left ear",	"#l" = "left ear",		".l" = "left ear",
 	  ":i" = "intercom",	"#i" = "intercom",		".i" = "intercom",
 	  ":h" = "department",	"#h" = "department",	".h" = "department",
+	  ":0" = "special",		"#0" = "special",		".0" = "special", //activate radio-specific special functions
 	  ":c" = "Command",		"#c" = "Command",		".c" = "Command",
 	  ":n" = "Science",		"#n" = "Science",		".n" = "Science",
 	  ":m" = "Medical",		"#m" = "Medical",		".m" = "Medical",

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -130,7 +130,7 @@
 			return 1
 
 		else
-			if(message_mode && message_mode in radiochannels)
+			if(message_mode)
 				switch(bot_type)
 					if(IS_AI)
 						if (AI.aiRadio.disabledAi)


### PR DESCRIPTION
This was originally meant to be included in Zuhayr's xenorewrite and _was_ merged into the PR, but while looking through radio code I noticed it wasn't present on master (I guess it got lost when he closed and reopened his PRs?).

This is targeted to master since it was going to be included in the last merge, however it can be switched to dev if that is preferred.

Original PR description:

> - Allows properly keyed radios to broadcast in robot talk and/or hivemind
> - Fixes encryption key w_class
> - Cleans up used_radio handling in saycode
> - Removes unused devices/radio code
