### PR TITLE
Fixes robot radio component not using power

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -689,6 +689,13 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	icon_state = "radio"
 	canhear_range = 3
 
+/obj/item/device/radio/borg/talk_into()
+	..()
+	if (isrobot(src.loc))
+		var/mob/living/silicon/robot/R = src.loc
+		var/datum/robot_component/C = R.components["radio"]
+		R.cell_use_power(C.active_usage)
+
 /obj/item/device/radio/borg/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()
 	user.set_machine(src)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -244,6 +244,12 @@
 			continue
 		M.show_message("<i><span class='game say'><span class='name'>synthesised voice</span> <span class='message'>beeps, \"beep beep beep\"</span></span></i>",2)
 
+	//robot binary xmitter component power usage
+	if (isrobot(speaker))
+		var/mob/living/silicon/robot/R = speaker
+		var/datum/robot_component/C = R.components["comms"]
+		R.cell_use_power(C.active_usage)
+
 /datum/language/binary/drone
 	name = "Drone Talk"
 	desc = "A heavily encoded damage control coordination stream."

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -112,7 +112,8 @@
 /datum/robot_component/radio
 	name = "radio"
 	external_type = /obj/item/robot_parts/robot_component/radio
-	active_usage = 10
+	idle_usage = 15		//it's not actually possible to tell when we receive a message over our radio, so just use 10W every tick for passive listening
+	active_usage = 75	//transmit power
 	max_damage = 40
 
 
@@ -122,7 +123,8 @@
 /datum/robot_component/binary_communication
 	name = "binary communication device"
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
-	active_usage = 10
+	idle_usage = 5
+	active_usage = 25
 	max_damage = 30
 
 


### PR DESCRIPTION
Discovered this while testing robot cameras.

Also shifts power usage so binary talk uses less power while radio uses more.
- [ ] Local testing.
