### PR TITLE
Fixes radio code conflict with galactic common

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -3,7 +3,7 @@ var/list/department_radio_keys = list(
 	  ":l" = "left ear",	"#l" = "left ear",		".l" = "left ear",
 	  ":i" = "intercom",	"#i" = "intercom",		".i" = "intercom",
 	  ":h" = "department",	"#h" = "department",	".h" = "department",
-	  ":0" = "special",		"#0" = "special",		".0" = "special", //activate radio-specific special functions
+	  ":b" = "special",		"#b" = "special",		".b" = "special", //activate radio-specific special functions
 	  ":c" = "Command",		"#c" = "Command",		".c" = "Command",
 	  ":n" = "Science",		"#n" = "Science",		".n" = "Science",
 	  ":m" = "Medical",		"#m" = "Medical",		".m" = "Medical",


### PR DESCRIPTION
Forgot to update that since galactic common was added.

Originally used :0 since the message mode was made more general than just binary talk, but really that's all it is used for. I don't think anyone ever makes hivetalk encryption keys anyways.
