### PR TITLE
Re-move resource update

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -44,5 +44,3 @@
 	else
 		client.eye = src
 		client.perspective = MOB_PERSPECTIVE
-
-	nanomanager.send_resources(client)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -29,6 +29,5 @@
 	new_player_panel()
 	spawn(40)
 		if(client)
-			nanomanager.send_resources(client)
 			handle_privacy_poll()
 			client.playtitlemusic()


### PR DESCRIPTION
Re-applies #6666, re-fixes #6432. Seems to have been lost in merge resolution for #6670, and it was actually worse after losing it (it was updating both on `/client/New()` and `/mob/Login()`/`/mob/new_player/Login()`, leading to it being done _twice_ on client login to the server.

Also removes an update in `/mob/new_player/Login()` that I missed before (it doesn't call `..()`, so it has its own update call).
