### PR TITLE
Ghost following double-click fix

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -25,6 +25,7 @@
 
 	// Otherwise jump
 	else
+		following = null
 		loc = get_turf(A)
 
 /mob/dead/observer/ClickOn(var/atom/A, var/params)


### PR DESCRIPTION
Allows ghosts to double-click tiles to move and stop following people, rather than just being pulled back to the followed mob, as is the case since #6640.
