### PR TITLE
Removes excessively spammy admin log messages

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -2,7 +2,7 @@
 /var/const/CLOSED = 2
 
 #define FIREDOOR_MAX_PRESSURE_DIFF 25 // kPa
-#define FIREDOOR_MAX_TEMP 50 // °C
+#define FIREDOOR_MAX_TEMP 50 // Â°C
 #define FIREDOOR_MIN_TEMP 0
 
 // Bitflags
@@ -164,6 +164,8 @@
 	var/needs_to_close = 0
 	if(density)
 		if(alarmed)
+			// Accountability!
+			users_to_open |= user.name
 			needs_to_close = 1
 		spawn()
 			open()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -164,10 +164,6 @@
 	var/needs_to_close = 0
 	if(density)
 		if(alarmed)
-			// Accountability!
-			users_to_open |= user.name
-			log_admin("[user]([user.ckey]) has opened an alarming emergency shutter.")
-			message_admins("[user]([user.ckey]) has opened an alarming emergency shutter.")
 			needs_to_close = 1
 		spawn()
 			open()


### PR DESCRIPTION
Spammy to the point of important things being easily missed, admins never really had a problem finding people griefing with emergency shutters before. Axing this thing.
