### PR TITLE
Gas heaters heat faster

### DIFF
--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -1,4 +1,5 @@
 //TODO: Put this under a common parent type with freezers to cut down on the copypasta
+#define HEATER_PERF_MULT 2.5
 
 /obj/machinery/atmospherics/unary/heater
 	name = "gas heating system"
@@ -72,7 +73,7 @@
 
 	if (network && air_contents.total_moles && air_contents.temperature < set_temperature)
 		update_use_power(2)
-		air_contents.add_thermal_energy(active_power_usage)
+		air_contents.add_thermal_energy(active_power_usage * HEATER_PERF_MULT)
 
 		heating = 1
 		network.update = 1


### PR DESCRIPTION
Restores a symmetry between heaters and freezers. Also they were inadvertently nerfed quite a bit when their power use was lowered to 20kW, this PR undoes that nerf.
