### PR TITLE
PDA newscast reception

### DIFF
--- a/code/WorkInProgress/computer3/computers/crew.dm
+++ b/code/WorkInProgress/computer3/computers/crew.dm
@@ -35,10 +35,7 @@
 					var/life_status = "[H.stat > 1 ? "<font color=red>Deceased</font>" : "Living"]"
 					var/damage_report = "(<font color='blue'>[dam1]</font>/<font color='green'>[dam2]</font>/<font color='orange'>[dam3]</font>/<font color='red'>[dam4]</font>)"
 
-					if(H.wear_id)
-						log += "<tr><td width='40%'>[H.wear_id.name]</td>"
-					else
-						log += "<tr><td width='40%'>Unknown</td>"
+					log += "<tr><td width='40%'>[H.get_id_name()]</td>"
 
 					switch(C.sensor_mode)
 						if(1)

--- a/code/WorkInProgress/periodic_news.dm
+++ b/code/WorkInProgress/periodic_news.dm
@@ -149,7 +149,4 @@ proc/announce_newscaster_news(datum/news_announcement/news)
 	newMsg.body = news.message
 	newMsg.message_type = news.message_type
 
-	sendto.messages += newMsg
-
-	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
-		NEWSCASTER.newsAlert(news.channel_name)
+	news_network.insert_message_in_channel(sendto, newMsg)

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -1,3 +1,8 @@
+#define TELECOMMS_RECEPTION_NONE 0
+#define TELECOMMS_RECEPTION_SENDER 1
+#define TELECOMMS_RECEPTION_RECEIVER 2
+#define TELECOMMS_RECEPTION_BOTH 3
+
 /proc/get_frequency_name(var/display_freq)
 	var/freq_text
 
@@ -16,3 +21,59 @@
 
 	return freq_text
 
+/datum/reception
+	var/obj/machinery/message_server/message_server = null
+	var/telecomms_reception = TELECOMMS_RECEPTION_NONE
+	var/message = ""
+
+/datum/receptions
+	var/obj/machinery/message_server/message_server = null
+	var/sender_reception = TELECOMMS_RECEPTION_NONE
+	var/list/receiver_reception = new
+
+/proc/get_message_server()
+	if(message_servers)
+		for (var/obj/machinery/message_server/MS in message_servers)
+			if(MS.active)
+				return MS
+	return null
+
+/proc/check_signal(var/datum/signal/signal)
+	return signal && signal.data["done"]
+
+/proc/get_sender_reception(var/atom/sender, var/datum/signal/signal)
+	return check_signal(signal) ? TELECOMMS_RECEPTION_SENDER : TELECOMMS_RECEPTION_NONE
+
+/proc/get_receiver_reception(var/receiver, var/datum/signal/signal)
+	if(receiver && check_signal(signal))
+		var/turf/pos = get_turf(receiver)
+		if(pos.z in signal.data["level"])
+			return TELECOMMS_RECEPTION_RECEIVER
+	return TELECOMMS_RECEPTION_NONE
+
+/proc/get_reception(var/atom/sender, var/receiver, var/message = "")
+	var/datum/reception/reception = new
+
+	// check if telecomms I/O route 1459 is stable
+	//var/telecomms_intact = telecomms_process(P.owner, owner, t)
+	reception.message_server = get_message_server()
+
+	var/datum/signal/signal = sender.telecomms_process()
+	reception.telecomms_reception |= get_sender_reception(sender, signal)
+	reception.telecomms_reception |= get_receiver_reception(receiver, signal)
+	reception.message = signal && signal.data["compression"] > 0 ? Gibberish(message, signal.data["compression"] + 50) : message
+
+	return reception
+
+/proc/get_receptions(var/atom/sender, var/list/receivers)
+	var/datum/receptions/receptions = new
+	receptions.message_server = get_message_server()
+
+	var/datum/signal/signal = sender.telecomms_process()
+	receptions.sender_reception = get_sender_reception(sender, signal)
+
+	if(receptions.sender_reception)
+		for(var/receiver in receivers)
+			receptions.receiver_reception[receiver] = get_receiver_reception(receiver, signal)
+
+	return receptions

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -58,22 +58,25 @@
 	//var/telecomms_intact = telecomms_process(P.owner, owner, t)
 	reception.message_server = get_message_server()
 
-	var/datum/signal/signal = sender.telecomms_process()
+	var/datum/signal/signal = sender.telecomms_process()	// Be aware that this proc calls sleep, to simulate transmition delays
 	reception.telecomms_reception |= get_sender_reception(sender, signal)
 	reception.telecomms_reception |= get_receiver_reception(receiver, signal)
 	reception.message = signal && signal.data["compression"] > 0 ? Gibberish(message, signal.data["compression"] + 50) : message
 
 	return reception
 
-/proc/get_receptions(var/atom/sender, var/list/receivers)
+/proc/get_receptions(var/atom/sender, var/list/atom/receivers)
 	var/datum/receptions/receptions = new
 	receptions.message_server = get_message_server()
 
-	var/datum/signal/signal = sender.telecomms_process()
-	receptions.sender_reception = get_sender_reception(sender, signal)
+	var/datum/signal/signal
+	if(sender)
+		signal = sender.telecomms_process()
+		receptions.sender_reception = get_sender_reception(sender, signal)
 
-	if(receptions.sender_reception)
-		for(var/receiver in receivers)
-			receptions.receiver_reception[receiver] = get_receiver_reception(receiver, signal)
+	for(var/atom/receiver in receivers)
+		if(!signal)
+			signal = receiver.telecomms_process()
+		receptions.receiver_reception[receiver] = get_receiver_reception(receiver, signal)
 
 	return receptions

--- a/code/game/gamemodes/events/ninja_equipment.dm
+++ b/code/game/gamemodes/events/ninja_equipment.dm
@@ -530,12 +530,12 @@ ________________________________________________________________________________
 				display_spideros()
 				return
 			P.tnote += "<i><b>&larr; From [!s_control?(A):"an unknown source"]:</b></i><br>[t]<br>"
-			if (!P.silent)
+			if (!P.message_silent)
 				playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
 				for (var/mob/O in hearers(3, P.loc))
 					O.show_message(text("\icon[P] *[P.ttone]*"))
-			P.overlays.Cut()
-			P.overlays += image('icons/obj/pda.dmi', "pda-r")
+			P.new_message = 1
+			P.update_icon()
 
 		if("Inject")
 			if( (href_list["tag"]=="radium"? (reagents.get_reagent_amount("radium"))<=(a_boost*a_transfer) : !reagents.get_reagent_amount(href_list["tag"])) )//Special case for radium. If there are only a_boost*a_transfer radium units left.

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -103,7 +103,7 @@ datum/game_mode/mutiny
 		if (!pda)
 			return 0
 
-		if (!pda.silent)
+		if (!pda.message_silent)
 			playsound(pda.loc, 'sound/machines/twobeep.ogg', 50, 1)
 			for (var/mob/O in hearers(3, pda.loc))
 				O.show_message(text("\icon[pda] *[pda.ttone]*"))

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -458,16 +458,7 @@
 						//Sender isn't faking as someone who exists
 						if(isnull(PDARec))
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[customsender]","[custommessage]")
-							if (!customrecepient.silent)
-								playsound(customrecepient.loc, 'sound/machines/twobeep.ogg', 50, 1)
-								for (var/mob/O in hearers(3, customrecepient.loc))
-									O.show_message(text("\icon[customrecepient] *[customrecepient.ttone]*"))
-								if( customrecepient.loc && ishuman(customrecepient.loc) )
-									var/mob/living/carbon/human/H = customrecepient.loc
-									H << "\icon[customrecepient] <b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
-								log_pda("[usr] (PDA: [customsender]) sent \"[custommessage]\" to [customrecepient.owner]")
-								customrecepient.overlays.Cut()
-								customrecepient.overlays += image('icons/obj/pda.dmi', "pda-r")
+							customrecepient.new_message(customsender, customsender, customjob, custommessage)
 						//Sender is faking as someone who exists
 						else
 
@@ -477,16 +468,7 @@
 							if(!customrecepient.conversations.Find("\ref[PDARec]"))
 								customrecepient.conversations.Add("\ref[PDARec]")
 
-							if (!customrecepient.silent)
-								playsound(customrecepient.loc, 'sound/machines/twobeep.ogg', 50, 1)
-								for (var/mob/O in hearers(3, customrecepient.loc))
-									O.show_message(text("\icon[customrecepient] *[customrecepient.ttone]*"))
-								if( customrecepient.loc && ishuman(customrecepient.loc) )
-									var/mob/living/carbon/human/H = customrecepient.loc
-									H << "\icon[customrecepient] <b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[customrecepient];choice=Message;skiprefresh=1;target=\ref[PDARec]'>Reply</a>)"
-								log_pda("[usr] (PDA: [PDARec.owner]) sent \"[custommessage]\" to [customrecepient.owner]")
-								customrecepient.overlays.Cut()
-								customrecepient.overlays += image('icons/obj/pda.dmi', "pda-r")
+							customrecepient.new_message(PDARec, custommessage)
 						//Finally..
 						ResetMessage()
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -21,17 +21,20 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	var/lastmode = 0
 	var/ui_tick = 0
+	var/nanoUI[0]
 
 	//Secondary variables
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.
 	var/fon = 0 //Is the flashlight function on?
 	var/f_lum = 2 //Luminosity for the flashlight function
-	var/silent = 0 //To beep or not to beep, that is the question
+	var/message_silent = 0 //To beep or not to beep, that is the question
+	var/news_silent = 0 //To beep or not to beep, that is the question
 	var/toff = 0 //If 1, messenger disabled
 	var/tnote[0]  //Current Texts
 	var/last_text //No text spamming
 	var/last_honk //Also no honk spamming that's bad too
-	var/ttone = "beep" //The ringtone!
+	var/ttone = "beep" //The PDA ringtone!
+	var/newstone = "beep, beep" //The news ringtone!
 	var/lock_code = "" // Lockcode to unlock uplink
 	var/honkamt = 0 //How many honks left when infected with honk.exe
 	var/mimeamt = 0 //How many silence left when infected with mime.exe
@@ -42,7 +45,13 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/active_conversation = null // New variable that allows us to only view a single conversation.
 	var/list/conversations = list()    // For keeping up with who we have PDA messsages from.
-	var/newmessage = 0			//To remove hackish overlay check
+	var/new_message = 0			//To remove hackish overlay check
+	var/new_news = 0
+
+	var/active_feed				// The selected feed
+	var/list/warrant			// The warrant as we last knew it
+	var/list/feeds = list()		// The list of feeds as we last knew them
+	var/list/feed_info = list()	// The data and contents of each feed as we last knew them
 
 	var/list/cartmodes = list(40, 42, 43, 433, 44, 441, 45, 451, 46, 48, 47, 49) // If you add more cartridge modes add them to this list as well.
 	var/list/no_auto_update = list(1, 40, 43, 44, 441, 45, 451)		     // These modes we turn off autoupdate
@@ -101,8 +110,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/mime
 	default_cartridge = /obj/item/weapon/cartridge/mime
 	icon_state = "pda-mime"
-	silent = 1
+	message_silent = 1
+	news_silent = 1
 	ttone = "silence"
+	newstone = "silence"
 
 /obj/item/device/pda/heads
 	default_cartridge = /obj/item/weapon/cartridge/head
@@ -172,7 +183,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	icon_state = "pda-libb"
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. This is model is a WGW-11 series e-reader."
 	note = "Congratulations, your station has chosen the Thinktronic 5290 WGW-11 Series E-reader and Personal Data Assistant!"
-	silent = 1 //Quiet in the library!
+	message_silent = 1 //Quiet in the library!
+	news_silent = 1
 
 /obj/item/device/pda/clear
 	icon_state = "pda-transp"
@@ -202,6 +214,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/ai
 	icon_state = "NONE"
 	ttone = "data"
+	newstone = "news"
 	detonate = 0
 
 
@@ -246,8 +259,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(usr.stat == 2)
 		usr << "You can't do that because you are dead!"
 		return
-	silent=!silent
-	usr << "<span class='notice'>PDA ringer toggled [(silent ? "Off" : "On")]!</span>"
+	message_silent=!message_silent
+	usr << "<span class='notice'>PDA ringer toggled [(message_silent ? "Off" : "On")]!</span>"
 
 
 /obj/item/device/pda/ai/verb/cmd_show_message_log()
@@ -355,7 +368,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	data["fon"] = fon					// Flashlight on?
 	data["pai"] = (isnull(pai) ? 0 : 1)			// pAI inserted?
 	data["note"] = note					// current pda notes
-	data["silent"] = silent					// does the pda make noise when it receives a message?
+	data["message_silent"] = message_silent					// does the pda make noise when it receives a message?
+	data["news_silent"] = news_silent					// does the pda make noise when it receives news?
 	data["toff"] = toff					// is the messenger function turned off?
 	data["active_conversation"] = active_conversation	// Which conversation are we following right now?
 
@@ -402,7 +416,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		data["cartridge"] = cartdata
 
 	data["stationTime"] = worldtime2text()
-	data["newMessage"] = newmessage
+	data["new_Message"] = new_message
+	data["new_News"] = new_news
 
 	if(mode==2)
 		var/convopdas[0]
@@ -463,7 +478,45 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					)
 		if(isnull(data["aircontents"]))
 			data["aircontents"] = list("reading" = 0)
+	if(mode==6)
+		if(news_network.network_channels.len != feeds.len)
+			var/datum/reception/reception = get_reception(src)
+			if(reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER)
+				feeds.Cut()
+				for(var/datum/feed_channel/channel in news_network.network_channels)
+					feeds[++feeds.len] = list("name" = channel.channel_name, "censored" = channel.censored)
 
+		data["feedChannels"] = feeds
+	if(mode==61)
+		var/list/feed = feed_info[active_feed]
+		if(!feed)
+			feed = list()
+			feed["updated"] = -1
+			feed_info[active_feed] = feed
+		var/datum/feed_channel/FC
+		for(FC in news_network.network_channels)
+			if(FC.channel_name == active_feed["name"])
+				break
+		if(FC.updated > feed["updated"])
+			var/datum/reception/reception = get_reception(src)
+			if(reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER)
+				feed["channel"] 	= FC.channel_name
+				feed["author"]		= FC.author
+				feed["updated"]		= FC.updated
+				feed["censored"]	= FC.censored
+
+				var/list/messages = list()
+				if(!FC.censored)
+					var/index = 0
+					for(var/datum/feed_message/FM in FC.messages)
+						index++
+						if(FM.img)
+							usr << browse_rsc(FM.img, "pda_news_tmp_photo_[feed["channel"]]_[index].png")
+						messages[++messages.len] = list("author" = FM.author, "body" = FM.body, "message_type" = FM.message_type, "has_image" = (FM.img != null), "index" = index)
+				feed["messages"] = messages
+		data["feed"] = feed
+
+	nanoUI = data
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -622,7 +675,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if("Toggle Messenger")
 			toff = !toff
 		if("Toggle Ringer")//If viewing texts then erase them, if not then toggle silent status
-			silent = !silent
+			message_silent = !message_silent
+		if("Toggle News")
+			news_silent = !news_silent
 		if("Clear")//Clears messages
 			if(href_list["option"] == "All")
 				tnote.Cut()
@@ -652,6 +707,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			else
 				ui.close()
 				return 0
+		if("Newstone")
+			var/t = input(U, "Please enter new news tone", name, newstone) as text
+			if (in_range(src, U) && loc == U)
+				if (t)
+					t = copytext(sanitize(t), 1, 20)
+					newstone = t
+			else
+				ui.close()
+				return 0
 		if("Message")
 
 			var/obj/item/device/pda/P = locate(href_list["target"])
@@ -667,6 +731,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if(P == n)
 					active_conversation=P
 					mode=21
+		if("Select Feed")
+			var/n = href_list["name"]
+			for(var/f in feeds)
+				if(f["name"] == n)
+					active_feed = f
+					mode=61
 		if("Send Honk")//Honk virus
 			if(cartridge && cartridge.access_clown)//Cartridge checks are kind of unnecessary since everything is done through switch.
 				var/obj/item/device/pda/P = locate(href_list["target"])//Leaving it alone in case it may do something useful, I guess.
@@ -687,8 +757,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					if (!P.toff && cartridge.charges > 0)
 						cartridge.charges--
 						U.show_message("\blue Virus sent!", 1)
-						P.silent = 1
+						P.message_silent = 1
+						P.news_silent = 1
 						P.ttone = "silence"
+						P.newstone = "silence"
 				else
 					U << "PDA not found."
 			else
@@ -710,7 +782,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if("Detonate")//Detonate PDA... maybe
 			if(cartridge && cartridge.access_detonate_pda)
 				var/obj/item/device/pda/P = locate(href_list["target"])
-				var/datum/reception/reception = get_reception(src, P, "")
+				var/datum/reception/reception = get_reception(src, P, "")	// get_reception calls sleep further down the line
 				if(!(reception.message_server && reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER))
 					U.show_message("\red An error flashes on your [src]: Connection unavailable", 1)
 					return
@@ -776,14 +848,25 @@ var/global/list/obj/item/device/pda/PDAs = list()
 //EXTRA FUNCTIONS===================================
 
 	if (mode == 2||mode == 21)//To clear message overlays.
-		overlays.Cut()
-		newmessage = 0
+		new_message = 0
+		update_icon()
+
+	if (mode == 6||mode == 61)//To clear news overlays.
+		new_news = 0
+		update_icon()
 
 	if ((honkamt > 0) && (prob(60)))//For clown virus.
 		honkamt--
 		playsound(loc, 'sound/items/bikehorn.ogg', 30, 1)
 
 	return 1 // return 1 tells it to refresh the UI in NanoUI
+
+/obj/item/device/pda/update_icon()
+	..()
+
+	overlays.Cut()
+	if(new_message || new_news)
+		overlays += image('icons/obj/pda.dmi', "pda-r")
 
 /obj/item/device/pda/proc/detonate_act(var/obj/item/device/pda/P)
 	//TODO: sometimes these attacks show up on the message server
@@ -883,7 +966,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/datum/reception/reception = get_reception(src, P, t)
 	t = reception.message
 
-	if(reception.message_server && reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER) // only send the message if it's stable
+	if(reception.message_server && (reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER)) // only send the message if it's stable
 		if(reception.telecomms_reception & TELECOMMS_RECEPTION_RECEIVER == 0) // Does our recipient have a broadcaster on their level?
 			U << "ERROR: Cannot reach recipient."
 			return
@@ -915,33 +998,48 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if(ai.aiPDA != P && ai.aiPDA != src)
 					ai.show_message("<i>Intercepted message from <b>[who]</b>: [t]</i>")
 
-
-		if (!P.silent)
-			playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
-		for (var/mob/O in hearers(3, P.loc))
-			if(!P.silent) O.show_message(text("\icon[P] *[P.ttone]*"))
-		//Search for holder of the PDA.
-		var/mob/living/L = null
-		if(P.loc && isliving(P.loc))
-			L = P.loc
-		//Maybe they are a pAI!
-		else
-			L = get(P, /mob/living/silicon)
-
-
-		if(L)
-			L << "\icon[P] <b>Message from [src.owner] ([ownjob]), </b>\"[t]\" (<a href='byond://?src=\ref[P];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
-			nanomanager.update_user_uis(L, P) // Update the receiving user's PDA UI so that they can see the new message
-
-		nanomanager.update_user_uis(U, P) // Update the sending user's PDA UI so that they can see the new message
-
-		log_pda("[usr] (PDA: [src.name]) sent \"[t]\" to [P.name]")
-		P.overlays.Cut()
-		P.overlays += image('icons/obj/pda.dmi', "pda-r")
-		P.newmessage = 1
+		P.new_message_from_pda(src, t)
+		nanomanager.update_user_uis(U, src) // Update the sending user's PDA UI so that they can see the new message
 	else
 		U << "<span class='notice'>ERROR: Messaging server is not responding.</span>"
 
+/obj/item/device/pda/proc/new_info(var/beep_silent, var/message_tone, var/reception_message)
+	if (!beep_silent)
+		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
+		for (var/mob/O in hearers(3, loc))
+			O.show_message(text("\icon[src] *[message_tone]*"))
+	//Search for holder of the PDA.
+	var/mob/living/L = null
+	if(loc && isliving(loc))
+		L = loc
+	//Maybe they are a pAI!
+	else
+		L = get(src, /mob/living/silicon)
+
+	if(L)
+		if(reception_message)
+			L << reception_message
+		nanomanager.update_user_uis(L, src) // Update the receiving user's PDA UI so that they can see the new message
+
+/obj/item/device/pda/proc/new_news(var/message)
+	new_info(news_silent, newstone, news_silent ? "" : "\icon[src] <b>[message]</b>")
+
+	new_news = 1
+	update_icon()
+
+/obj/item/device/pda/ai/new_news(var/message)
+	// Do nothing
+
+/obj/item/device/pda/proc/new_message_from_pda(var/obj/item/device/pda/sending_device, var/message)
+	new_message(sending_device.name, sending_device.owner, sending_device.ownjob, message)
+
+/obj/item/device/pda/proc/new_message(var/sending_unit, var/sender, var/sender_job, var/message)
+	var/reception_message = "\icon[src] <b>Message from [sender] ([sender_job]), </b>\"[message]\" (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
+	new_info(news_silent, newstone, reception_message)
+
+	log_pda("[usr] (PDA: [sending_unit]) sent \"[message]\" to [name]")
+	new_message = 1
+	update_icon()
 
 /obj/item/device/pda/verb/verb_remove_id()
 	set category = "Object"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2566,14 +2566,8 @@
 			newMsg.body = src.admincaster_feed_message.body
 			newMsg.is_admin_message = 1
 			feedback_inc("newscaster_stories",1)
-			for(var/datum/feed_channel/FC in news_network.network_channels)
-				if(FC.channel_name == src.admincaster_feed_channel.channel_name)
-					FC.messages += newMsg                  //Adding message to the network's appropriate feed_channel
-					break
+			news_network.add_news(src.admincaster_feed_channel.channel_name, newMsg)
 			src.admincaster_screen=4
-
-		for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
-			NEWSCASTER.newsAlert(src.admincaster_feed_channel.channel_name)
 
 		log_admin("[key_name_admin(usr)] submitted a feed story to channel: [src.admincaster_feed_channel.channel_name]!")
 		src.access_news_network()

--- a/code/modules/economy/Events.dm
+++ b/code/modules/economy/Events.dm
@@ -91,12 +91,7 @@
 			if(FESTIVAL)
 				newMsg.body = "A [pick("festival","week long celebration","day of revelry","planet-wide holiday")] has been declared on [affected_dest.name] by [pick("Governor","Commissioner","General","Commandant","Administrator")] [random_name(pick(MALE,FEMALE))] to celebrate [pick("the birth of their [pick("son","daughter")]","coming of age of their [pick("son","daughter")]","the pacification of rogue military cell","the apprehension of a violent criminal who had been terrorising the planet")]. Massive stocks of food and meat have been bought driving up prices across the planet."
 
-	for(var/datum/feed_channel/FC in news_network.network_channels)
-		if(FC.channel_name == "Nyx Daily")
-			FC.messages += newMsg
-			break
-	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
-		NEWSCASTER.newsAlert("Nyx Daily")
+	news_network.add_news("Nyx Daily", newMsg)
 
 /datum/event/economic_event/end()
 	for(var/good_type in dearer_goods)

--- a/code/modules/economy/Events_Mundane.dm
+++ b/code/modules/economy/Events_Mundane.dm
@@ -124,12 +124,7 @@
 				"a huge new ARG by a popular entertainment company","a secret tour by popular artiste [random_name(pick(MALE,FEMALE))]")]. \
 				Nyx Daily is offering discount tickets for two to see [random_name(pick(MALE,FEMALE))] live in return for eyewitness reports and up to the minute coverage."
 
-	for(var/datum/feed_channel/FC in news_network.network_channels)
-		if(FC.channel_name == "Nyx Daily")
-			FC.messages += newMsg
-			break
-	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
-		NEWSCASTER.newsAlert("Nyx Daily")
+	news_network.add_news("Nyx Daily", newMsg)
 
 /datum/event/trivial_news
 	endWhen = 10
@@ -225,9 +220,4 @@
 	"Broccoli discovered to be colonies of tiny aliens with murder on their minds"\
 	)
 
-	for(var/datum/feed_channel/FC in news_network.network_channels)
-		if(FC.channel_name == "The Gibson Gazette")
-			FC.messages += newMsg
-			break
-	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
-		NEWSCASTER.newsAlert("The Gibson Gazette")
+	news_network.add_news("The Gibson Gazette", newMsg)

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -77,7 +77,7 @@ var/global/economy_init = 0
 	if(economy_init)
 		return 2
 
-	var/datum/feed_channel/newChannel = new /datum/feed_channel
+	var/datum/feed_channel/newChannel = new /datum/feed_channel/station
 	newChannel.channel_name = "Public Station Announcements"
 	newChannel.author = "Automated Announcement Listing"
 	newChannel.locked = 1

--- a/code/modules/events/money_lotto.dm
+++ b/code/modules/events/money_lotto.dm
@@ -31,10 +31,4 @@
 	if(!deposit_success)
 		newMsg.body += "<br>Unfortunately, we were unable to verify the account details provided, so we were unable to transfer the money. Send a cheque containing the sum of $500 to ND 'Stellar Slam' office on the Nyx gateway containing updated details, and your winnings'll be re-sent within the month."
 
-	for(var/datum/feed_channel/FC in news_network.network_channels)
-		if(FC.channel_name == "Nyx Daily")
-			FC.messages += newMsg
-			break
-
-	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
-		NEWSCASTER.newsAlert("Nyx Daily")
+	news_network.add_news("Nyx Daily", newMsg)

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -104,10 +104,10 @@
 			//Commented out because we don't send messages like this anymore.  Instead it will just popup in their chat window.
 			//P.tnote += "<i><b>&larr; From [sender] (Unknown / spam?):</b></i><br>[message]<br>"
 
-			if (!P.silent)
+			if (!P.message_silent)
 				playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
 			for (var/mob/O in hearers(3, P.loc))
-				if(!P.silent) O.show_message(text("\icon[P] *[P.ttone]*"))
+				if(!P.message_silent) O.show_message(text("\icon[P] *[P.ttone]*"))
 			//Search for holder of the PDA.
 			var/mob/living/L = null
 			if(P.loc && isliving(P.loc))

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -223,7 +223,7 @@
 				if(href_list["toggler"])
 					pda.toff = !pda.toff
 				else if(href_list["ringer"])
-					pda.silent = !pda.silent
+					pda.message_silent = !pda.message_silent
 				else if(href_list["target"])
 					if(silence_time)
 						return alert("Communications circuits remain uninitialized.")
@@ -668,7 +668,7 @@
 	dat += {"<b>Signal/Receiver Status:</b> <A href='byond://?src=\ref[src];software=pdamessage;toggler=1'>
 	[(pda.toff) ? "<font color='red'> \[Off\]</font>" : "<font color='green'> \[On\]</font>"]</a><br>
 	<b>Ringer Status:</b> <A href='byond://?src=\ref[src];software=pdamessage;ringer=1'>
-	[(pda.silent) ? "<font color='red'> \[Off\]</font>" : "<font color='green'> \[On\]</font>"]</a><br><br>"}
+	[(pda.message_silent) ? "<font color='red'> \[Off\]</font>" : "<font color='green'> \[On\]</font>"]</a><br><br>"}
 	dat += "<ul>"
 	if(!pda.toff)
 		for (var/obj/item/device/pda/P in sortAtom(PDAs))

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -412,6 +412,12 @@ div.notice {
     float: left;
 }
 
+.fixedLeftWiderRed {
+    width: 220px;
+    float: left;
+	background: #ee0000;
+}
+
 .floatRight {
     float: right;
 }

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -67,8 +67,9 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             </div>
             <div class="itemContent">
                 {{:helper.link('Notekeeper', 'note', {'choice' : "1"}, null, 'fixedLeftWide')}}
-                {{:helper.link('Messenger', data.newMessage ? 'mail-closed' : 'mail-open', {'choice' : "2"}, null, 'fixedLeftWide')}}
+                {{:helper.link('Messenger', data.new_Message ? 'mail-closed' : 'mail-open', {'choice' : "2"}, null, 'fixedLeftWide')}}
                 {{:helper.link('Crew Manifest', 'contact', {'choice' : "41"}, null, 'fixedLeftWide')}}
+				{{:helper.link('News', data.new_News ? 'mail-closed' : 'mail-open', {'choice' : "6"}, null, 'fixedLeftWide')}}
             </div>
         </div>
         <br>
@@ -207,7 +208,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <b>Messenger Functions</b>:
             </div>
             <div class ="itemContent">
-                {{:helper.link(data.silent==1 ? 'Ringer: Off' : 'Ringer: On', data.silent==1 ? 'volume-off' : 'volume-on', {'choice' : "Toggle Ringer"}, null, 'fixedLeftWide')}}
+                {{:helper.link(data.message_silent==1 ? 'Ringer: Off' : 'Ringer: On', data.message_silent==1 ? 'volume-off' : 'volume-on', {'choice' : "Toggle Ringer"}, null, 'fixedLeftWide')}}
                 {{:helper.link(data.toff==1 ? 'Messenger: Off' : 'Messenger: On',data.toff==1 ? 'close':'check', {'choice' : "Toggle Messenger"}, null, 'fixedLeftWide')}}
                 {{:helper.link('Set Ringtone', 'comment', {'choice' : "Ringtone"}, null, 'fixedLeftWide')}}
                 {{:helper.link('Delete all Conversations', 'trash', {'choice' : "Clear", 'option' : "All"}, null, 'fixedLeftWider')}}
@@ -946,7 +947,61 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span><br>
                     {{/if}}
                 {{/for}}
+                
+    {{else data.mode == 6}}
+        <H2><span class="white">InstaNews ED 2.0.9</span></H2>
+        
+        <div class="item">
+            <div class="itemLabelNarrow">
+                <b>Functions</b>:
             </div>
+            <div class ="itemContent">
+					{{:helper.link(data.news_silent==1 ? 'Ringer: Off' : 'Ringer: On', data.news_silent==1 ? 'volume-off' : 'volume-on', {'choice' : "Toggle News"}, null, 'fixedLeftWide')}}
+                {{:helper.link('Set news tone', 'comment', {'choice' : "Newstone"}, null, 'fixedLeftWide')}}
+            </div>
+        </div>
+        
+		<div class="item">
+            <div class="itemContent">
+                {{for data.feedChannels}}
+                    {{if value.censored}}
+						{{:helper.link(value.name, 'circle-arrow-s', {'choice' : "Select Feed", 'feed' : value.feed, 'name' : value.name } , null, 'fixedLeftWiderRed')}}
+                    {{else}}
+                        {{:helper.link(value.name, 'circle-arrow-s', {'choice' : "Select Feed", 'feed' : value.feed, 'name' : value.name } , null, 'fixedLeftWider')}}
+                    {{/if}}
+                {{empty}}
+                    <I>No active channels found...</I>
+                {{/for}}
+            </div>
+		</div>
+
+    {{else data.mode == 61}}      
+        <H2><span class="white">{{:data.feed.channel}}</span></H2>
+        <span class="white">Created by: </span><span class="average">{{:data.feed.author}}</span>
+        <div class="statusDisplay" style="overflow: auto;">
+            <div class="item">
+                <div class="itemContent" style="width: 100%;">
+					{{if data.feed.censored}}
+						<H3><span class="bad">Attention</span></H3>
+						This channel has been deemed as threatening to the welfare of the station, and marked with a Nanotrasen D-Notice.<br>
+						No further feed story additions are allowed while the D-Notice is in effect.<br>
+					{{else}}
+						{{for data.feed.messages}}
+							-{{:value.body}}<br>
+							{{if value.has_image}}
+								pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png<br>
+								<img src='pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png' width = '180'><br>
+							{{/if}}
+							<FONT SIZE=1>[{{:value.message_type}} by <span class="average">{{:value.author}}</span>]<br></FONT>
+							<br>
+						{{empty}}
+							<I>No feed messages found in channel...</I>
+						{{/for}}
+					{{/if}}
+				</div>
+            </div>
+        </div>
+        
     {{/if}}
 {{else}}
     <div class="wholeScreen">


### PR DESCRIPTION
One can one access and view newsfeeds from the comfort of one's PDA.
- Possible to change and disable the newsmessage beep.
- PDAs are only notified about news if they have reception.
- PDAs can only fetch new feeds and their messages if they have reception.

![Main view](https://www.dropbox.com/s/io16g6j7wavijub/PDA-News-Main.png?dl=1)
![Feed view](https://www.dropbox.com/s/tz6ep076a0gnjeq/PDA-News-Feed.png?dl=1)
![Custom Channel](https://www.dropbox.com/s/ck67fqep9yii7wt/PDA-Progress.png?dl=1)

Known issues:
- Unlike browse() NanoUI does not appear to wait for browse_rsc(), the method which to transfers image to the client's cache, to finish.
  This may result in newsfeeds not always displaying their images the first time they are viewed.

Features I remember working on but didn't wrap up:
- [x] Censored channels are not marked properly. Messages are purged, which is correct, but visual ques and censorship notice is missing.
