### PR TITLE
Fixes #6864.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -808,7 +808,7 @@ About the new airlock wires panel:
 	if (src.isElectrified())
 		if (istype(mover, /obj/item))
 			var/obj/item/i = mover
-			if (i.matter["metal"])
+			if (i.matter && ("metal" in i.matter) && i.matter["metal"] > 0)
 				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 				s.set_up(5, 1, src)
 				s.start()


### PR DESCRIPTION
See https://github.com/Baystation12/Baystation12/issues/6864#issuecomment-60617413

Fix confirmed to not runtime and still causing sparks if a metallic object past through.
Agree with mwerezak that this being necessary is a bit bothersome.
