### PR TITLE
Lobby menu refreshment

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -341,6 +341,7 @@ var/global/datum/controller/occupations/job_master
 		for(var/mob/new_player/player in unassigned)
 			if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
 				player.ready = 0
+				player.new_player_panel_proc()
 				unassigned -= player
 		return 1
 


### PR DESCRIPTION
If one is returned to the lobby after failing to acquire a job the lobby menu should now be refreshed, properly displaying View Crew Manifest/Join Round instead of Declare Ready.
