### PR TITLE
Less Lethal AI

### DIFF
--- a/maps/tgstation2.dmm
+++ b/maps/tgstation2.dmm
@@ -3049,7 +3049,7 @@
 "bgG" = (/obj/machinery/atm{pixel_y = 28},/turf/simulated/floor,/area/hallway/primary/starboard)
 "bgH" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor{icon_state = "neutral"; dir = 4},/area/crew_quarters/sleep)
 "bgI" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/plating,/area/maintenance/arrivals)
-"bgJ" = (/obj/machinery/door/window{dir = 2; name = "AI Core Door"; req_access_txt = "109"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/flasher{id = "AI"; pixel_x = 22; pixel_y = 24},/obj/machinery/turretid/lethal{name = "AI Chamber turret control"; pixel_x = 36; pixel_y = 24},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
+"bgJ" = (/obj/machinery/door/window{dir = 2; name = "AI Core Door"; req_access_txt = "109"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/flasher{id = "AI"; pixel_x = 22; pixel_y = 24},/obj/machinery/turretid/stun{name = "AI Chamber turret control"; pixel_x = 36; pixel_y = 24},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "bgK" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "bgL" = (/obj/item/weapon/extinguisher,/obj/effect/decal/cleanable/generic,/turf/simulated/floor/plating,/area/maintenance/evahallway)
 "bgM" = (/turf/simulated/wall,/area/crew_quarters/sleep/engi_wash)


### PR DESCRIPTION
Fixes a minor mistake in the AI core after the portable turret port.
The turrets again begin in stun instead of lethal mode.

While minor it gives people (and admins) a chance to see if the AI made a deliberate decision to alter the setting.
