### PR TITLE
Xenomorphs no longer a whitelisted race.

### DIFF
--- a/code/modules/mob/living/carbon/human/alien/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/alien/alien_species.dm
@@ -26,7 +26,7 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	flags = IS_WHITELISTED | NO_BREATHE | NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON
+	flags = NO_BREATHE | NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON
 
 	reagent_tag = IS_XENOS
 


### PR DESCRIPTION
Fixes #6894.
@Zuhayr, might it be xenomorphs were intended for whitelisting?
If so I'll instead look at filtering out the base Xenomorph as it's currently very human-looking.
