### PR TITLE
More machinery list speedups

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -430,6 +430,29 @@ proc/listclearnulls(list/list)
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
+// Insert an object into a sorted list, preserving sortedness
+/proc/dd_insertObjectList(var/list/L, var/O)
+	var/min = 1
+	var/max = L.len
+	var/Oval = O:dd_SortValue()
+
+	while(1)
+		var/mid = min+round((max-min)/2)
+
+		if(mid == max)
+			L.Insert(mid, O)
+			return
+
+		var/Lmid = L[mid]
+		var/midval = Lmid:dd_SortValue()
+		if(Oval == midval)
+			L.Insert(mid, O)
+			return
+		else if(Oval < midval)
+			max = mid
+		else
+			min = mid+1
+
 /*
 proc/dd_sortedObjectList(list/incoming)
 	/*

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -121,6 +121,9 @@ datum/controller/game_controller/proc/setup_objects()
 	//Set up spawn points.
 	populate_spawn_points()
 
+	// Sort the machinery list so it doesn't cause a lagspike at roundstart
+	process_machines_sort()
+
 	world << "\red \b Initializations complete."
 	sleep(-1)
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -113,8 +113,11 @@ Class Procs:
 
 /obj/machinery/New()
 	..()
-	machines += src
-	machinery_sort_required = 1
+	if(!machinery_sort_required && ticker)
+		dd_insertObjectList(machines, src)
+	else
+		machines += src
+		machinery_sort_required = 1
 
 /obj/machinery/Del()
 	machines -= src


### PR DESCRIPTION
Adds `dd_insertObjectList()` proc; uses binary search to locate the position to insert at - this will call `dd_SortValue()` a maximum of about 15 times for each insertion rather than the full 5000+ call sort that insert-then-sort does

Adds call to `process_machines_sort()` in MC initialisation, avoiding having to do this at roundstart.

Changes `/obj/machinery/New()` to insert into the machinery list if the list is currently sorted and the machinery list has completed first initialisation (i.e. the MC has done the initial list sort)
