### PR TITLE
Adjusts secondary unarmed attacks

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -250,6 +250,7 @@
 	language = "Siik'tajr"
 	tail = "tajtail"
 	unarmed_type = /datum/unarmed_attack/claws
+	secondary_unarmed_type = /datum/unarmed_attack/bite/eye_tooth
 	darksight = 8
 
 	cold_level_1 = 200 //Default 260
@@ -378,6 +379,7 @@
 	deform = 'icons/mob/human_races/r_def_plant.dmi'
 	language = "Rootspeak"
 	unarmed_type = /datum/unarmed_attack/diona
+	secondary_unarmed_type = null //Does a walking mass of dionaea even have jaws, as we understand them?
 	primitive = /mob/living/carbon/alien/diona
 	slowdown = 7
 	rarity_value = 3
@@ -444,6 +446,7 @@
 	deform = 'icons/mob/human_races/r_machine.dmi'
 	language = "Tradeband"
 	unarmed_type = /datum/unarmed_attack/punch
+	secondary_unarmed_type = null
 	rarity_value = 2
 
 	eyes = "blank_eyes"
@@ -514,6 +517,14 @@
 	return 0
 
 /datum/unarmed_attack/bite
+	attack_verb = list("bite") // 'x has biteed y', needs work.
+	attack_sound = 'sound/weapons/bite.ogg'
+	shredding = 0
+	damage = 3
+	sharp = 0
+	edge = 0
+
+/datum/unarmed_attack/bite/eye_tooth
 	attack_verb = list("bite") // 'x has biteed y', needs work.
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0


### PR DESCRIPTION
I'm not entirely sure about the extent that biting is used at the moment, but it was still bothering me that humans had a bite attack that was stronger than their punch.

I'm also considering changing the unathi secondary to something other than `bite/strong`. 15 damage seems extreme, although it might make sense for unathi, I dunno.

Edit: Actually, unathi/taj claws deal a mere 2 points more damage than regular fists. Unless claw damage is buffed, I'm definitely going to remove `bite/strong` from unathi, as otherwise the 15 damage is really inconsistent.
