### PR TITLE
Adds feedback when handcuffs cannot be placed, fixes robot cuffs

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -41,6 +41,11 @@
 
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
+		
+		if (!H.has_organ_for_slot("handcuff"))
+			user << "\red [H] needs at least two wrists before you can cuff them together!"
+			return
+		
 		H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been handcuffed (attempt) by [user.name] ([user.ckey])</font>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to handcuff [H.name] ([H.ckey])</font>")
 		msg_admin_attack("[key_name(user)] attempted to handcuff [key_name(H)]")
@@ -150,6 +155,13 @@ var/last_chew = 0
 		var/turf/p_loc_m = C.loc
 		playsound(src.loc, cuff_sound, 30, 1, -2)
 		user.visible_message("\red <B>[user] is trying to put handcuffs on [C]!</B>")
+		
+		if (ishuman(C))
+			var/mob/living/carbon/human/H = C
+			if (!H.has_organ_for_slot("handcuff"))
+				user << "\red [H] needs at least two wrists before you can cuff them together!"
+				return
+		
 		spawn(30)
 			if(!C)	return
 			if(p_loc == user.loc && p_loc_m == C.loc)


### PR DESCRIPTION
Players now get a message when their cuff attempt fails due to lack of the necessary limbs, and robot cuffs now respect this requirement as well.
