### PR TITLE
Fixes #6660

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -448,6 +448,7 @@
 	dir = direction
 	if(dir != NORTH)
 		layer = 5
+	climbable = 0 //flipping tables allows them to be used as makeshift barriers
 	flipped = 1
 	flags |= ON_BORDER
 	for(var/D in list(turn(direction, 90), turn(direction, -90)))
@@ -465,6 +466,7 @@
 
 	layer = initial(layer)
 	flipped = 0
+	climbable = initial(climbable)
 	flags &= ~ON_BORDER
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		var/obj/structure/table/T = locate() in get_step(src.loc,D)


### PR DESCRIPTION
It turns out the Enter() hack mentioned earlier didn't work so well, but adding an Adjacent() check did. Fixes #6660 
Also makes flipping tables block climbing, so that flipping tables actually has a purpose by making a barricade.
