### PR TITLE
More Z-level compatibility

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -45,8 +45,20 @@
 
 	return heard
 
+/proc/isStationLevel(var/level)
+	return level in config.station_levels
 
+/proc/isNotStationLevel(var/level)
+	return !isStationLevel()
 
+/proc/isPlayerLevel(var/level)
+	return level in config.player_levels
+
+/proc/isAdminLevel(var/level)
+	return level in config.admin_levels
+
+/proc/isNotAdminLevel(var/level)
+	return !isAdminLevel(level)
 
 //Magic constants obtained by using linear regression on right-angled triangles of sides 0<x<1, 0<y<1
 //They should approximate pythagoras theorem well enough for our needs.

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -152,6 +152,7 @@
 	var/use_overmap = 0
 
 	var/list/station_levels = list(1)				// Defines which Z-levels the station exists on.
+	var/list/admin_levels= list(2)					// Defines which Z-levels which are for admin functionality, for example including such areas as Central Command and the Syndicate Shuttle
 	var/list/contact_levels = list(1, 5)			// Defines which Z-levels which, for example, a Code Red announcement may affect
 	var/list/player_levels = list(1, 3, 4, 5, 6)	// Defines all Z-levels a character can typically reach
 
@@ -517,6 +518,9 @@
 
 				if("station_levels")
 					config.station_levels = text2numlist(value, ";")
+
+				if("admin_levels")
+					config.admin_levels = text2numlist(value, ";")
 
 				if("contact_levels")
 					config.contact_levels = text2numlist(value, ";")

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -82,7 +82,7 @@ var/list/blob_nodes = list()
 			sleep(-1)
 			if(!blobs.len)	break
 			var/obj/effect/blob/B = pick(blobs)
-			if(B.z != 1)
+			if(isNotStationLevel(B.z))
 				continue
 			B.Life()
 

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -7,12 +7,12 @@
 		return 1
 
 	for(var/obj/effect/blob/B in blob_cores)
-		if(B && B.z != 1)	continue
+		if(B && isNotStationLevel(B.z))	continue
 		return 0
 
 	var/nodes = 0
 	for(var/obj/effect/blob/B in blob_nodes)
-		if(B && B.z != 1)	continue
+		if(B && isNotStationLevel(B.z))	continue
 		nodes++
 		if(nodes > 4)//Perhapse make a new core with a low prob
 			return 0
@@ -62,7 +62,7 @@
 					if (istype(T, /turf/space))
 						numSpace += 1
 					else if(istype(T, /turf))
-						if (M.z!=1)
+						if (isNotStationLevel(M.z))
 							numOffStation += 1
 						else
 							numAlive += 1

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -62,7 +62,7 @@
 
 	proc/count()
 		for(var/turf/T in world)
-			if(T.z != 1)
+			if(isNotStationLevel(T.z)
 				continue
 
 			if(istype(T,/turf/simulated/floor))
@@ -84,7 +84,7 @@
 					src.r_wall += 1
 
 		for(var/obj/O in world)
-			if(O.z != 1)
+			if(isNotStationLevel(O.z))
 				continue
 
 			if(istype(O, /obj/structure/window))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -12,7 +12,7 @@ var/list/sacrificed = list()
 			for(var/obj/effect/rune/R in world)
 				if(R == src)
 					continue
-				if(R.word1 == cultwords["travel"] && R.word2 == cultwords["self"] && R.word3 == key && R.z != 2)
+				if(R.word1 == cultwords["travel"] && R.word2 == cultwords["self"] && R.word3 == key && isPlayerLevel(R.z))
 					index++
 					allrunesloc.len = index
 					allrunesloc[index] = R.loc

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -151,7 +151,7 @@
 		var/turf/T = get_turf(H)
 		if(!T)
 			continue
-		if(T.z != 1)
+		if(isNotStationLevel(T.z))
 			continue
 		for(var/datum/disease/D in H.viruses)
 			foundAlready = 1
@@ -211,7 +211,7 @@
 
 /* // Haha, this is way too laggy. I'll keep the prison break though.
 	for(var/obj/machinery/light/L in world)
-		if(L.z != 1) continue
+		if(isNotStationLevel(L.z)) continue
 		L.flicker(50)
 
 	sleep(100)
@@ -220,7 +220,7 @@
 		var/turf/T = get_turf(H)
 		if(!T)
 			continue
-		if(T.z != 1)
+		if(isNotStationLevel(T.z))
 			continue
 		if(istype(H,/mob/living/carbon/human))
 			H.apply_effect((rand(15,75)),IRRADIATE,0)
@@ -237,7 +237,7 @@
 		var/turf/T = get_turf(M)
 		if(!T)
 			continue
-		if(T.z != 1)
+		if(isNotStationLevel(T.z))
 			continue
 		M.apply_effect((rand(15,75)),IRRADIATE,0)
 	sleep(100)

--- a/code/game/gamemodes/events/clang.dm
+++ b/code/game/gamemodes/events/clang.dm
@@ -78,8 +78,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		walk_towards(immrod, end,1)
 	sleep(1)
 	while (immrod)
-		if (immrod.z != 1)
-			immrod.z = 1
+		if (isNotStationLevel(immrod.z))
+			immrod.z = pick(config.station_levels)
 		if(immrod.loc == end)
 			del(immrod)
 		sleep(10)

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -83,7 +83,7 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 		var/goal = locate(endx, endy, 1)
 		src.x = startx
 		src.y = starty
-		src.z = 1
+		src.z = pick(config.station_levels)
 		spawn(0)
 			walk_towards(src, goal, 1)
 		return

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -1,6 +1,6 @@
 /proc/Christmas_Game_Start()
 	for(var/obj/structure/flora/tree/pine/xmas in world)
-		if(xmas.z != 1)	continue
+		if(isNotStationLevel(xmas.z))	continue
 		for(var/turf/simulated/floor/T in orange(1,xmas))
 			for(var/i=1,i<=rand(1,5),i++)
 				new /obj/item/weapon/a_gift(T)

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -171,7 +171,7 @@ var/global/Holiday = null
 */
 /*			var/list/obj/containers = list()
 			for(var/obj/item/weapon/storage/S in world)
-				if(S.z != 1)	continue
+				if(isNotStationLevel(S.z))	continue
 				containers += S
 
 			message_admins("\blue DEBUG: Event: Egg spawned at [Egg.loc] ([Egg.x],[Egg.y],[Egg.z])")*/

--- a/code/game/gamemodes/events/miniblob.dm
+++ b/code/game/gamemodes/events/miniblob.dm
@@ -21,7 +21,7 @@
 				sleep(-1)
 				if(!blob_cores.len)	break
 				var/obj/effect/blob/B = pick(blob_cores)
-				if(B.z != 1)
+				if(isNotStationLevel(B.z))
 					continue
 				B.Life()
 		spawn(30)

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -33,7 +33,7 @@
 			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in world)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas || S.z != 1)
+		if(current_area.type in skipped_areas || isNotStationLevel(S.z))
 			continue
 		S.charge = S.last_charge
 		S.output = S.last_output
@@ -46,7 +46,7 @@
 	if(announce)
 		command_announcement.Announce("All SMESs on [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
 	for(var/obj/machinery/power/smes/S in world)
-		if(S.z != 1)
+		if(isNotStationLevel(S.z))
 			continue
 		S.charge = S.capacity
 		S.output = 200000

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -382,11 +382,11 @@ var/global/datum/controller/gameticker/ticker
 			if(Player.stat != DEAD)
 				var/turf/playerTurf = get_turf(Player)
 				if(emergency_shuttle.departed && emergency_shuttle.evac)
-					if(playerTurf.z != 2)
+					if(isNotAdminLevel(playerTurf.z))
 						Player << "<font color='blue'><b>You managed to survive, but were marooned on [station_name()] as [Player.real_name]...</b></font>"
 					else
 						Player << "<font color='green'><b>You managed to survive the events on [station_name()] as [Player.real_name].</b></font>"
-				else if(playerTurf.z == 2)
+				else if(isAdminLevel(playerTurf.z))
 					Player << "<font color='green'><b>You successfully underwent crew transfer after events on [station_name()] as [Player.real_name].</b></font>"
 				else if(issilicon(Player))
 					Player << "<font color='green'><b>You remain operational after the events on [station_name()] as [Player.real_name].</b></font>"

--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -1404,7 +1404,7 @@ datum
 					var/turf/T = get_turf(target.current)
 					if(target.current.stat == 2)
 						return 1
-					else if((T) && (T.z != 1))//If they leave the station they count as dead for this
+					else if((T) && (isNotStationLevel(T.z)))//If they leave the station they count as dead for this
 						return 2
 					else
 						return 0

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -88,7 +88,7 @@ datum/objective/mutiny
 			if(target.current.stat == DEAD || !ishuman(target.current) || !target.current.ckey)
 				return 1
 			var/turf/T = get_turf(target.current)
-			if(T && (T.z != 1))			//If they leave the station they count as dead for this
+			if(T && isNotStationLevel(T.z))			//If they leave the station they count as dead for this
 				return 2
 			return 0
 		return 1
@@ -123,7 +123,7 @@ datum/objective/mutiny/rp
 				if(target in ticker.mode:head_revolutionaries)
 					return 1
 			var/turf/T = get_turf(target.current)
-			if(T && (T.z != 1))			//If they leave the station they count as dead for this
+			if(T && isNotStationLevel(T.z))			//If they leave the station they count as dead for this
 				rval = 2
 			return 0
 		return rval

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -367,7 +367,7 @@
 			if(headrev.current)
 				if(headrev.current.stat == DEAD)
 					text += "died"
-				else if(headrev.current.z != 1)
+				else if(isNotStationLevel(headrev.current.z))
 					text += "fled the station"
 				else
 					text += "survived the revolution"
@@ -390,7 +390,7 @@
 			if(rev.current)
 				if(rev.current.stat == DEAD)
 					text += "died"
-				else if(rev.current.z != 1)
+				else if(isNotStationLevel(rev.current.z))
 					text += "fled the station"
 				else
 					text += "survived the revolution"
@@ -415,7 +415,7 @@
 			if(head.current)
 				if(head.current.stat == DEAD)
 					text += "died"
-				else if(head.current.z != 1)
+				else if(isNotStationLevel(head.current.z))
 					text += "fled the station"
 				else
 					text += "survived the revolution"

--- a/code/game/mecha/medical/medical.dm
+++ b/code/game/mecha/medical/medical.dm
@@ -1,7 +1,7 @@
 /obj/mecha/medical/New()
 	..()
 	var/turf/T = get_turf(src)
-	if(T.z != 2)
+	if(isPlayerLevel(T.z))
 		new /obj/item/mecha_parts/mecha_tracking(src)
 	return
 

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -6,7 +6,7 @@
 /obj/mecha/working/New()
 	..()
 	var/turf/T = get_turf(src)
-	if(T.z != 2)
+	if(isPlayerLevel(T.z))
 		new /obj/item/mecha_parts/mecha_tracking(src)
 	return
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1283,11 +1283,11 @@
 						foo += text("<B>Is an AI</B> | ")
 					else
 						foo += text("<A HREF='?src=\ref[];makeai=\ref[]'>Make AI</A> | ", src, M)
-					if(M.z != 2)
+					if(isNotAdminLevel(M.z))
 						foo += text("<A HREF='?src=\ref[];sendtoprison=\ref[]'>Prison</A> | ", src, M)
 						foo += text("<A HREF='?src=\ref[];sendtomaze=\ref[]'>Maze</A> | ", src, M)
 					else
-						foo += text("<B>On Z = 2</B> | ")
+						foo += text("<B>On Z = [M.z]</B> | ")
 				else
 					foo += text("<B>Hasn't Entered Game</B> | ")
 				foo += text("<A HREF='?src=\ref[];revive=\ref[]'>Heal/Revive</A> | ", src, M)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -14,7 +14,7 @@
 
 /datum/event/brand_intelligence/start()
 	for(var/obj/machinery/vending/V in machines)
-		if(V.z != 1)	continue
+		if(isNotStationLevel(V.z))	continue
 		vendingMachines.Add(V)
 
 	if(!vendingMachines.len)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -17,7 +17,7 @@
 		var/turf/T = get_turf(H)
 		if(!T)
 			continue
-		if(T.z != 1)
+		if(isNotStationLevel(T.z))
 			continue
 		for(var/datum/disease/D in H.viruses)
 			foundAlready = 1

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -22,7 +22,7 @@
 				var/turf/T = get_turf(H)
 				if(!T)
 					continue
-				if(T.z != 1)
+				if(isNotStationLevel(T.z))
 					continue
 				if(istype(T.loc, /area/maintenance) || istype(T.loc, /area/crew_quarters))
 					continue
@@ -43,7 +43,7 @@
 				var/turf/T = get_turf(M)
 				if(!T)
 					continue
-				if(T.z != 1)
+				if(isNotStationLevel(T.z))
 					continue
 				M.apply_effect((rand(5,25)),IRRADIATE,0)
 			sleep(100)

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -41,7 +41,7 @@
 		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 		sparks.set_up(3, 0, D.loc)
 		sparks.start()
-		D.z = 2
+		D.z = config.admin_levels[1]
 		D.has_loot = 0
 
 		del(D)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -968,7 +968,7 @@
 	/*if(!malf.can_shunt)
 		malf << "<span class='warning'>You cannot shunt.</span>"
 		return*/
-	if(src.z != 1)
+	if(isNotStationLevel(src.z))
 		return
 	src.occupier = new /mob/living/silicon/ai(src,malf.laws,null,1)
 	src.occupier.adjustOxyLoss(malf.getOxyLoss())

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -267,6 +267,9 @@ CHARACTER_SLOTS 10
 ## Defines which Z-levels the station exists on. 
 STATION_LEVELS 1
 
+## Defines which Z-levels are used for admin functionality, such as Central Command and the Syndicate Shuttle
+ADMIN_LEVELS 2
+
 ## Defines which Z-levels which, for example, a Code Red announcement may affect
 CONTACT_LEVELS 1;5
 


### PR DESCRIPTION
Previously missed Z-level checks in the form "z  != X".  Utilized this regex which hopefully has caught most of them `[zZ](\s?)(!?)=(\s?)(\d+)` unless the right-hand side is non-numeric.
Adds more Z-level configuration, admin levels.
