### PR TITLE
Fixes #6747

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -530,7 +530,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			for(var/datum/feed_channel/F in news_network.network_channels)
 				if( (!F.locked || F.author == scanned_user) && !F.censored)
 					available_channels += F.channel_name
-			src.channel_name = strip_html(input(usr, "Choose receiving Feed Channel", "Network Channel Handler") in available_channels )
+			src.channel_name = input(usr, "Choose receiving Feed Channel", "Network Channel Handler") in available_channels
 			src.updateUsrDialog()
 
 		else if(href_list["set_new_message"])

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -512,7 +512,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						index++
 						if(FM.img)
 							usr << browse_rsc(FM.img, "pda_news_tmp_photo_[feed["channel"]]_[index].png")
-						messages[++messages.len] = list("author" = FM.author, "body" = FM.body, "message_type" = FM.message_type, "has_image" = (FM.img != null), "index" = index)
+							// News stories are HTML-stripped but require newline replacement to be properly displayed in NanoUI
+						var/body = replacetext(FM.body, "\n", "<br>")
+						messages[++messages.len] = list("author" = FM.author, "body" = body, "message_type" = FM.message_type, "has_image" = (FM.img != null), "index" = index)
 				feed["messages"] = messages
 		data["feed"] = feed
 


### PR DESCRIPTION
Channel names are already HTML-stripped on creation. Removes second HTML-stripping when attempting to post a new story as this appears to break name comparison later.
PDAs should now properly display stories with newlines.
