### PR TITLE
Fix emergency shields activating without being turned on

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -201,6 +201,7 @@
 
 /obj/machinery/shieldgen/power_change()
 	..()
+	if(!active) return
 	if (stat & NOPOWER)
 		collapse_shields()
 	else


### PR DESCRIPTION
As in title.

Fixes #6935.
