### PR TITLE
fixes robo- and amputated limbs not working on spawn

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1576,25 +1576,23 @@ datum/preferences
 	// Destroy/cyborgize organs
 
 	for(var/name in organ_data)
-		var/datum/organ/external/O = character.organs_by_name[name]
-		var/datum/organ/internal/I = character.internal_organs_by_name[name]
-		var/status = organ_data[name]
 
-		if(!I || !O)
-			continue
-
-		if(status == "amputated")
-			O.amputated = 1
-			O.status |= ORGAN_DESTROYED
-			O.destspawn = 1
-		if(status == "cyborg")
-			O.status |= ORGAN_ROBOT
-		if(status == "assisted")
-			I.mechassist()
-		else if(status == "mechanical")
-			I.mechanize()
-
-		else continue
+		var/status = organ_data[name]		
+		var/datum/organ/external/O = character.organs_by_name[name]		
+		if(O)
+			if(status == "amputated")
+				O.amputated = 1
+				O.status |= ORGAN_DESTROYED
+				O.destspawn = 1
+			else if(status == "cyborg")
+				O.status |= ORGAN_ROBOT
+		else			
+			var/datum/organ/internal/I = character.internal_organs_by_name[name]
+			if(I)
+				if(status == "assisted")
+					I.mechassist()
+				else if(status == "mechanical")
+					I.mechanize()
 
 	if(underwear > underwear_m.len || underwear < 1)
 		underwear = 0 //I'm sure this is 100% unnecessary, but I'm paranoid... sue me. //HAH NOW NO MORE MAGIC CLONING UNDIES


### PR DESCRIPTION
i pulled in some patches from upstream today, then my players reported
robotic and amputated limbs are not appearing on spawn.
not exactly sure what happened here, but it looks like
somebody tried to fix one issue and created a bigger one.
organs are never in both organs_by_name and internal_organs_by_name,
so the flag setters became unreachable due to `if(!I || !O) continue`
