### PR TITLE
Fixes newly-vended laptops opening windows and giving close messages

### DIFF
--- a/code/WorkInProgress/computer3/computer.dm
+++ b/code/WorkInProgress/computer3/computer.dm
@@ -131,8 +131,6 @@
 				for(var/typekey in spawn_files)
 					hdd.addfile(new typekey,1)
 
-		if(program)
-			program.execute(os)
 		update_icon()
 
 

--- a/code/WorkInProgress/computer3/laptop.dm
+++ b/code/WorkInProgress/computer3/laptop.dm
@@ -138,6 +138,9 @@
 			usr << "You can't reach it."
 			return
 
+		close_laptop(usr)
+
+	proc/close_laptop(mob/user = null)
 		if(istype(loc,/obj/item/device/laptop))
 			testing("Close closed computer")
 			return
@@ -146,7 +149,8 @@
 			return
 
 		if(stat&BROKEN)
-			usr << "\The [src] is broken!  You can't quite get it closed."
+			if(user)
+				user << "\The [src] is broken!  You can't quite get it closed."
 			return
 
 		if(!portable)
@@ -157,7 +161,8 @@
 			portable.loc = loc
 			loc = portable
 			stat |= MAINT
-			usr << "You close \the [src]."
+			if(user)
+				user << "You close \the [src]."
 
 	auto_use_power()
 		if(stat&MAINT)

--- a/code/WorkInProgress/computer3/lapvend.dm
+++ b/code/WorkInProgress/computer3/lapvend.dm
@@ -263,7 +263,7 @@
 		choose_progs(C)
 		vend()
 		popup.close()
-		newlap.close_computer()
+		newlap.close_laptop()
 		newlap = null
 		cardreader = 0
 		floppy = 0


### PR DESCRIPTION
As in title.

Before this commit (current behaviour):
- Vend laptop from vendor, swiping ID.
- Laptop is spawned, defaults to open.
- Laptop's `New()` causes program to execute, opening the "Welcome to NTOS" window.
- Vendor calls `verb/close_computer()` on laptop, giving a "You close the laptop" output.
- Window remains open, though the laptop is closed.

After this commit:
- Vend laptop from vendor, swiping ID.
- Laptop is spawned, defaults to open.
- Laptop's `New()` does not execute a program.
- Vendor calls `proc/close_laptop()` on laptop, giving no output.

`verb/close_computer()` has been modified slightly to perform the relevant checks on `usr` (adjacency, non-deadness etc.), then call `proc/close_laptop()`, which performs the relevant checks on the laptop.
