### PR TITLE
Newscaster and photo cleanup

### DIFF
--- a/code/WorkInProgress/periodic_news.dm
+++ b/code/WorkInProgress/periodic_news.dm
@@ -143,10 +143,5 @@ proc/announce_newscaster_news(datum/news_announcement/news)
 		sendto.is_admin_channel = 1
 		news_network.network_channels += sendto
 
-	var/datum/feed_message/newMsg = new /datum/feed_message
-	newMsg.author = news.author ? news.author : sendto.author
-	newMsg.is_admin_message = !news.can_be_redacted
-	newMsg.body = news.message
-	newMsg.message_type = news.message_type
-
-	news_network.insert_message_in_channel(sendto, newMsg)
+	var/author = news.author ? news.author : sendto.author
+	news_network.SubmitArticle(news.message, author, news.channel_name, null, !news.can_be_redacted, news.message_type)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -7,7 +7,7 @@
 	var/log = 0
 	var/sound
 	var/newscast = 0
-	var/channel_name = "Public Station Announcements"
+	var/channel_name = "Station Announcements"
 	var/announcement_type = "Announcement"
 
 /datum/announcement/New(var/do_log = 0, var/new_sound = null, var/do_newscast = 0)

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -51,27 +51,27 @@
 			return TELECOMMS_RECEPTION_RECEIVER
 	return TELECOMMS_RECEPTION_NONE
 
-/proc/get_reception(var/atom/sender, var/receiver, var/message = "")
+/proc/get_reception(var/atom/sender, var/receiver, var/message = "", var/do_sleep = 1)
 	var/datum/reception/reception = new
 
 	// check if telecomms I/O route 1459 is stable
 	//var/telecomms_intact = telecomms_process(P.owner, owner, t)
 	reception.message_server = get_message_server()
 
-	var/datum/signal/signal = sender.telecomms_process()	// Be aware that this proc calls sleep, to simulate transmition delays
+	var/datum/signal/signal = sender.telecomms_process(do_sleep)	// Be aware that this proc calls sleep, to simulate transmition delays
 	reception.telecomms_reception |= get_sender_reception(sender, signal)
 	reception.telecomms_reception |= get_receiver_reception(receiver, signal)
 	reception.message = signal && signal.data["compression"] > 0 ? Gibberish(message, signal.data["compression"] + 50) : message
 
 	return reception
 
-/proc/get_receptions(var/atom/sender, var/list/atom/receivers)
+/proc/get_receptions(var/atom/sender, var/list/atom/receivers, var/do_sleep = 1)
 	var/datum/receptions/receptions = new
 	receptions.message_server = get_message_server()
 
 	var/datum/signal/signal
 	if(sender)
-		signal = sender.telecomms_process()
+		signal = sender.telecomms_process(do_sleep)
 		receptions.sender_reception = get_sender_reception(sender, signal)
 
 	for(var/atom/receiver in receivers)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -7,36 +7,35 @@
 	var/body =""
 	var/message_type ="Story"
 	var/datum/feed_channel/parent_channel
-	var/backup_body =""
-	var/backup_author =""
 	var/is_admin_message = 0
 	var/icon/img = null
-	var/icon/backup_img
+	var/icon/caption = ""
+	var/time_stamp = ""
+	var/backup_body = ""
+	var/backup_author = ""
+	var/icon/backup_img = null
+	var/icon/backup_caption = ""
 
 /datum/feed_channel
 	var/channel_name=""
 	var/list/datum/feed_message/messages = list()
-	//var/message_count = 0
 	var/locked=0
 	var/author=""
 	var/backup_author=""
 	var/censored=0
 	var/is_admin_channel=0
 	var/updated = 0
-	//var/page = null //For newspapers
-
-/datum/feed_channel/proc/announce_news()
-	return "Breaking news from [channel_name]!"
-
-/datum/feed_channel/station/announce_news()
-	return "New Station Announcement Available"
+	var/announcement = ""
 
 /datum/feed_message/proc/clear()
 	src.author = ""
 	src.body = ""
+	src.caption = ""
+	src.img = null
+	src.time_stamp = ""
 	src.backup_body = ""
 	src.backup_author = ""
-	src.img = null
+	src.backup_caption = ""
 	src.backup_img = null
 	parent_channel.update()
 
@@ -51,24 +50,49 @@
 	src.backup_author = ""
 	src.censored = 0
 	src.is_admin_channel = 0
+	src.announcement = ""
 	update()
 
 /datum/feed_network
 	var/list/datum/feed_channel/network_channels = list()
 	var/datum/feed_message/wanted_issue
 
-/datum/feed_network/proc/add_news(var/channel_name, var/datum/feed_message/newMsg)
-	for(var/datum/feed_channel/FC in news_network.network_channels)
+/datum/feed_network/New()
+	CreateFeedChannel("Station Announcements", "SS13", 1, 1, "New Station Announcement Available")
+
+/datum/feed_network/proc/CreateFeedChannel(var/channel_name, var/author, var/locked, var/adminChannel = 0, var/announcement_message)
+	var/datum/feed_channel/newChannel = new /datum/feed_channel
+	newChannel.channel_name = channel_name
+	newChannel.author = author
+	newChannel.locked = locked
+	newChannel.is_admin_channel = adminChannel
+	if(announcement_message)
+		newChannel.announcement = announcement_message
+	else
+		newChannel.announcement = "Breaking news from [channel_name]!"
+	network_channels += newChannel
+
+/datum/feed_network/proc/SubmitArticle(var/msg, var/author, var/channel_name, var/obj/item/weapon/photo/photo, var/adminMessage = 0, var/message_type = "")
+	var/datum/feed_message/newMsg = new /datum/feed_message
+	newMsg.author = author
+	newMsg.body = msg
+	newMsg.time_stamp = "[worldtime2text()]"
+	newMsg.is_admin_message = adminMessage
+	if(message_type)
+		newMsg.message_type = message_type
+	if(photo)
+		newMsg.img = photo.img
+		newMsg.caption = photo.scribble
+	for(var/datum/feed_channel/FC in network_channels)
 		if(FC.channel_name == channel_name)
-			insert_message_in_channel(FC, newMsg)
+			insert_message_in_channel(FC, newMsg) //Adding message to the network's appropriate feed_channel
 			break
 
 /datum/feed_network/proc/insert_message_in_channel(var/datum/feed_channel/FC, var/datum/feed_message/newMsg)
-	FC.messages += newMsg	//Adding message to the network's appropriate feed_channel
+	FC.messages += newMsg
 	newMsg.parent_channel = FC
 	FC.update()
-	var/announcement = FC.announce_news()
-	alert_readers(announcement)
+	alert_readers(FC.announcement)
 
 /datum/feed_network/proc/alert_readers(var/annoncement)
 	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
@@ -135,7 +159,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		// 1 = there has
 	var/scanned_user = "Unknown" //Will contain the name of the person who currently uses the newscaster
 	var/msg = "";                //Feed message
-	var/obj/item/weapon/photo/photo = null
+	var/datum/news_photo/photo_data = null
 	var/channel_name = ""; //the feed channel which will be receiving the feed, or being created
 	var/c_locked=0;        //Will our new channel be locked to public submissions?
 	var/hitstaken = 0      //Death at 3 hits from an item with force>=15
@@ -260,14 +284,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 							dat+="<B><FONT style='BACKGROUND-COLOR: LightGreen '><A href='?src=\ref[src];show_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A></FONT></B><BR>"
 						else
 							dat+="<B><A href='?src=\ref[src];show_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR></B>"
-					/*for(var/datum/feed_channel/CHANNEL in src.channel_list)
-						dat+="<B>[CHANNEL.channel_name]: </B> <BR><FONT SIZE=1>\[created by: <FONT COLOR='maroon'>[CHANNEL.author]</FONT>\]</FONT><BR><BR>"
-						if( isemptylist(CHANNEL.messages) )
-							dat+="<I>No feed messages found in channel...</I><BR><BR>"
-						else
-							for(var/datum/feed_message/MESSAGE in CHANNEL.messages)
-								dat+="-[MESSAGE.body] <BR><FONT SIZE=1>\[[MESSAGE.message_type] by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>"*/
-
 				dat+="<BR><HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 				dat+="<BR><A href='?src=\ref[src];setScreen=[0]'>Back</A>"
 			if(2)
@@ -281,7 +297,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<HR><B><A href='?src=\ref[src];set_channel_receiving=1'>Receiving Channel</A>:</B> [src.channel_name]<BR>" //MARK
 				dat+="<B>Message Author:</B> <FONT COLOR='green'>[src.scanned_user]</FONT><BR>"
 				dat+="<B><A href='?src=\ref[src];set_new_message=1'>Message Body</A>:</B> [src.msg] <BR>"
-				dat+="<B><A href='?src=\ref[src];set_attachment=1'>Attach Photo</A>:</B>  [(src.photo ? "Photo Attached" : "No Photo")]</BR>"
+				dat+="<B><A href='?src=\ref[src];set_attachment=1'>Attach Photo</A>:</B>  [(src.photo_data ? "Photo Attached" : "No Photo")]</BR>"
 				dat+="<BR><A href='?src=\ref[src];submit_new_message=1'>Submit</A><BR><BR><A href='?src=\ref[src];setScreen=[0]'>Cancel</A><BR>"
 			if(4)
 				dat+="Feed story successfully submitted to [src.channel_name].<BR><BR>"
@@ -301,10 +317,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<BR><A href='?src=\ref[src];setScreen=[3]'>Return</A><BR>"
 			if(7)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed Channel to Network.</B></FONT><HR><BR>"
-				//var/list/existing_channels = list()            //Let's get dem existing channels - OBSOLETE
 				var/list/existing_authors = list()
 				for(var/datum/feed_channel/FC in news_network.network_channels)
-					//existing_channels += FC.channel_name       //OBSOLETE
 					if(FC.author == "\[REDACTED\]")
 						existing_authors += FC.backup_author
 					else
@@ -351,8 +365,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 							dat+="-[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
 								usr << browse_rsc(MESSAGE.img, "tmp_photo[i].png")
-								dat+="<img src='tmp_photo[i].png' width = '180'><BR><BR>"
-							dat+="<FONT SIZE=1>\[[MESSAGE.message_type] by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>"
+								dat+="<img src='tmp_photo[i].png' width = '180'><BR>"
+								if(MESSAGE.caption)
+									dat+="<FONT SIZE=1><B>[MESSAGE.caption]</B></FONT><BR>"
+								dat+="<BR>"
+							dat+="<FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author] - [MESSAGE.time_stamp]</FONT>\]</FONT><BR>"
 				dat+="<BR><HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 				dat+="<BR><A href='?src=\ref[src];setScreen=[1]'>Back</A>"
 			if(10)
@@ -417,7 +434,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<HR>"
 				dat+="<A href='?src=\ref[src];set_wanted_name=1'>Criminal Name</A>: [src.channel_name] <BR>"
 				dat+="<A href='?src=\ref[src];set_wanted_desc=1'>Description</A>: [src.msg] <BR>"
-				dat+="<A href='?src=\ref[src];set_attachment=1'>Attach Photo</A>: [(src.photo ? "Photo Attached" : "No Photo")]</BR>"
+				dat+="<A href='?src=\ref[src];set_attachment=1'>Attach Photo</A>: [(src.photo_data ? "Photo Attached" : "No Photo")]</BR>"
 				if(wanted_already)
 					dat+="<B>Wanted Issue created by:</B><FONT COLOR='green'> [news_network.wanted_issue.backup_author]</FONT><BR>"
 				else
@@ -468,14 +485,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		human_or_robot_user << browse(dat, "window=newscaster_main;size=400x600")
 		onclose(human_or_robot_user, "newscaster_main")
 
-	/*if(src.isbroken) //debugging shit
-		return
-	src.hitstaken++
-	if(src.hitstaken==3)
-		src.isbroken = 1
-	src.update_icon()*/
-
-
 /obj/machinery/newscaster/Topic(href, href_list)
 	if(..())
 		return
@@ -512,14 +521,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			else
 				var/choice = alert("Please confirm Feed channel creation","Network Channel Handler","Confirm","Cancel")
 				if(choice=="Confirm")
-					var/datum/feed_channel/newChannel = new /datum/feed_channel
-					newChannel.channel_name = src.channel_name
-					newChannel.author = src.scanned_user
-					newChannel.locked = c_locked
-					feedback_inc("newscaster_channels",1)
-					/*for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)    //Let's add the new channel in all casters.
-						NEWSCASTER.channel_list += newChannel*/                     //Now that it is sane, get it into the list. -OBSOLETE
-					news_network.network_channels += newChannel                        //Adding channel to the global network
+					news_network.CreateFeedChannel(src.channel_name, src.scanned_user, c_locked)
 					src.screen=5
 			src.updateUsrDialog()
 			//src.update_icon()
@@ -547,13 +549,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(src.msg =="" || src.msg=="\[REDACTED\]" || src.scanned_user == "Unknown" || src.channel_name == "" )
 				src.screen=6
 			else
-				var/datum/feed_message/newMsg = new /datum/feed_message
-				newMsg.author = src.scanned_user
-				newMsg.body = src.msg
-				if(photo)
-					newMsg.img = photo.img
+				var/image = photo_data ? photo_data.photo : null
 				feedback_inc("newscaster_stories",1)
-				news_network.add_news(src.channel_name, newMsg)
+				news_network.SubmitArticle(src.msg, src.scanned_user, src.channel_name, image, 0)
 				src.screen=4
 
 			src.updateUsrDialog()
@@ -620,8 +618,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 						WANTED.author = src.channel_name
 						WANTED.body = src.msg
 						WANTED.backup_author = src.scanned_user //I know, a bit wacky
-						if(photo)
-							WANTED.img = photo.img
+						if(photo_data)
+							WANTED.img = photo_data.photo.img
 						news_network.wanted_issue = WANTED
 						news_network.alert_readers()
 						src.screen = 15
@@ -632,8 +630,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 						news_network.wanted_issue.author = src.channel_name
 						news_network.wanted_issue.body = src.msg
 						news_network.wanted_issue.backup_author = src.scanned_user
-						if(photo)
-							news_network.wanted_issue.img = photo.img
+						if(photo_data)
+							news_network.wanted_issue.img = photo_data.photo.img
 						src.screen = 19
 
 			src.updateUsrDialog()
@@ -684,16 +682,18 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(MSG.is_admin_message)
 				alert("This channel was created by a Nanotrasen Officer. You cannot censor it.","Ok")
 				return
-			if(MSG.img != null)
-				MSG.backup_img = MSG.img
-				MSG.img = null
-			else
-				MSG.img = MSG.backup_img
 			if(MSG.body != "<B>\[REDACTED\]</B>")
 				MSG.backup_body = MSG.body
+				MSG.backup_caption = MSG.caption
+				MSG.backup_img = MSG.img
 				MSG.body = "<B>\[REDACTED\]</B>"
+				MSG.caption = "<B>\[REDACTED\]</B>"
+				MSG.img = null
 			else
 				MSG.body = MSG.backup_body
+				MSG.caption = MSG.caption
+				MSG.img = MSG.backup_img
+
 			MSG.parent_channel.update()
 			src.updateUsrDialog()
 
@@ -744,19 +744,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 
 /obj/machinery/newscaster/attackby(obj/item/I as obj, mob/user as mob)
-
-/*	if (istype(I, /obj/item/weapon/card/id) || istype(I, /obj/item/device/pda) ) //Name verification for channels or messages
-		if(src.screen == 4 || src.screen == 5)
-			if( istype(I, /obj/item/device/pda) )
-				var/obj/item/device/pda/P = I
-				if(P.id)
-					src.scanned_user = "[P.id.registered_name] ([P.id.assignment])"
-					src.screen=2
-			else
-				var/obj/item/weapon/card/id/T = I
-				src.scanned_user = text("[T.registered_name] ([T.assignment])")
-				src.screen=2*/  //Obsolete after autorecognition
-
 	if (src.isbroken)
 		playsound(src.loc, 'sound/effects/hit_on_shattered_glass.ogg', 100, 1)
 		for (var/mob/O in hearers(5, src.loc))
@@ -791,25 +778,34 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	user << "<font color='blue'>The newscaster controls are far too complicated for your tiny brain!</font>"
 	return
 
+/datum/news_photo
+	var/is_synth = 0
+	var/obj/item/weapon/photo/photo = null
+
+/datum/news_photo/New(var/obj/item/weapon/photo/p, var/synth)
+	is_synth = synth
+	photo = p
+
 /obj/machinery/newscaster/proc/AttachPhoto(mob/user as mob)
-	if(photo)
-		if(!issilicon(user))
-			photo.loc = src.loc
-			user.put_in_inactive_hand(photo)
-		photo = null
+	if(photo_data)
+		if(!photo_data.is_synth)
+			photo_data.photo.loc = src.loc
+			if(!issilicon(user))
+				user.put_in_inactive_hand(photo_data.photo)
+		del(photo_data)
+
 	if(istype(user.get_active_hand(), /obj/item/weapon/photo))
-		photo = user.get_active_hand()
+		var/obj/item/photo = user.get_active_hand()
 		user.drop_item()
 		photo.loc = src
+		photo_data = new(photo, 0)
 	else if(istype(user,/mob/living/silicon))
 		var/mob/living/silicon/tempAI = user
-		var/datum/picture/selection = tempAI.GetPicture()
+		var/obj/item/weapon/photo/selection = tempAI.GetPicture()
 		if (!selection)
 			return
 
-		var/obj/item/weapon/photo/P = new/obj/item/weapon/photo()
-		P.construct(selection)
-		photo = P
+		photo_data = new(selection, 1)
 
 
 //########################################################################################################################
@@ -830,10 +826,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	var/datum/feed_message/important_message = null
 	var/scribble=""
 	var/scribble_page = null
-
-/*obj/item/weapon/newspaper/attack_hand(mob/user as mob)
-	..()
-	world << "derp"*/
 
 obj/item/weapon/newspaper/attack_self(mob/user as mob)
 	if(ishuman(user))
@@ -974,12 +966,12 @@ obj/item/weapon/newspaper/attackby(obj/item/weapon/W as obj, mob/user as mob)
 			if(istype(human_user.wear_id, /obj/item/device/pda) )	//autorecognition, woo!
 				var/obj/item/device/pda/P = human_user.wear_id
 				if(P.id)
-					src.scanned_user = "[P.id.registered_name] ([P.id.assignment])"
+					src.scanned_user = GetNameAndAssignmentFromId(P.id)
 				else
 					src.scanned_user = "Unknown"
 			else if(istype(human_user.wear_id, /obj/item/weapon/card/id) )
 				var/obj/item/weapon/card/id/ID = human_user.wear_id
-				src.scanned_user ="[ID.registered_name] ([ID.assignment])"
+				src.scanned_user = GetNameAndAssignmentFromId(ID)
 			else
 				src.scanned_user ="Unknown"
 		else

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -641,7 +641,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	var/turf/position = get_turf(src)
 	return (position.z in signal.data["level"] && signal.data["done"])
 
-/atom/proc/telecomms_process()
+/atom/proc/telecomms_process(var/do_sleep = 1)
 
 	// First, we want to generate a new radio signal
 	var/datum/signal/signal = new
@@ -664,8 +664,9 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
   //#### Sending the signal to all subspace receivers ####//
 	for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
 		R.receive_signal(signal)
-
-	sleep(rand(10,25))
+		
+	if(do_sleep)
+		sleep(rand(10,25))
 
 	//world.log << "Level: [signal.data["level"]] - Done: [signal.data["done"]]"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -418,6 +418,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	data["new_Message"] = new_message
 	data["new_News"] = new_news
 
+	var/datum/reception/reception = get_reception(src, do_sleep = 0)
+	var/has_reception = reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER
+	data["reception"] = has_reception
+
 	if(mode==2)
 		var/convopdas[0]
 		var/pdas[0]
@@ -478,43 +482,43 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if(isnull(data["aircontents"]))
 			data["aircontents"] = list("reading" = 0)
 	if(mode==6)
-		if(news_network.network_channels.len != feeds.len)
-			var/datum/reception/reception = get_reception(src)
-			if(reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER)
-				feeds.Cut()
-				for(var/datum/feed_channel/channel in news_network.network_channels)
-					feeds[++feeds.len] = list("name" = channel.channel_name, "censored" = channel.censored)
-
+		if(has_reception)
+			feeds.Cut()
+			for(var/datum/feed_channel/channel in news_network.network_channels)
+				feeds[++feeds.len] = list("name" = channel.channel_name, "censored" = channel.censored)
 		data["feedChannels"] = feeds
 	if(mode==61)
-		var/list/feed = feed_info[active_feed]
-		if(!feed)
-			feed = list()
-			feed["updated"] = -1
-			feed_info[active_feed] = feed
 		var/datum/feed_channel/FC
 		for(FC in news_network.network_channels)
 			if(FC.channel_name == active_feed["name"])
 				break
-		if(FC.updated > feed["updated"])
-			var/datum/reception/reception = get_reception(src)
-			if(reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER)
-				feed["channel"] 	= FC.channel_name
-				feed["author"]		= FC.author
-				feed["updated"]		= FC.updated
-				feed["censored"]	= FC.censored
 
-				var/list/messages = list()
-				if(!FC.censored)
-					var/index = 0
-					for(var/datum/feed_message/FM in FC.messages)
-						index++
-						if(FM.img)
-							usr << browse_rsc(FM.img, "pda_news_tmp_photo_[feed["channel"]]_[index].png")
-							// News stories are HTML-stripped but require newline replacement to be properly displayed in NanoUI
-						var/body = replacetext(FM.body, "\n", "<br>")
-						messages[++messages.len] = list("author" = FM.author, "body" = body, "message_type" = FM.message_type, "has_image" = (FM.img != null), "index" = index)
-				feed["messages"] = messages
+		var/list/feed = feed_info[active_feed]
+		if(!feed)
+			feed = list()
+			feed["channel"] = FC.channel_name
+			feed["author"]	= "Unknown"
+			feed["censored"]= 0
+			feed["updated"] = -1
+			feed_info[active_feed] = feed
+
+		if(FC.updated > feed["updated"] && has_reception)
+			feed["author"]	= FC.author
+			feed["updated"]	= FC.updated
+			feed["censored"] = FC.censored
+
+			var/list/messages = list()
+			if(!FC.censored)
+				var/index = 0
+				for(var/datum/feed_message/FM in FC.messages)
+					index++
+					if(FM.img)
+						usr << browse_rsc(FM.img, "pda_news_tmp_photo_[feed["channel"]]_[index].png")
+					// News stories are HTML-stripped but require newline replacement to be properly displayed in NanoUI
+					var/body = replacetext(FM.body, "\n", "<br>")
+					messages[++messages.len] = list("author" = FM.author, "body" = body, "message_type" = FM.message_type, "time_stamp" = FM.time_stamp, "has_image" = (FM.img != null), "caption" = FM.caption, "index" = index)
+			feed["messages"] = messages
+
 		data["feed"] = feed
 
 	nanoUI = data
@@ -783,7 +787,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if("Detonate")//Detonate PDA... maybe
 			if(cartridge && cartridge.access_detonate_pda)
 				var/obj/item/device/pda/P = locate(href_list["target"])
-				var/datum/reception/reception = get_reception(src, P, "")	// get_reception calls sleep further down the line
+				var/datum/reception/reception = get_reception(src, P, "", do_sleep = 0)
 				if(!(reception.message_server && reception.telecomms_reception & TELECOMMS_RECEPTION_SENDER))
 					U.show_message("\red An error flashes on your [src]: Connection unavailable", 1)
 					return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2561,12 +2561,8 @@
 		if(src.admincaster_feed_message.body =="" || src.admincaster_feed_message.body =="\[REDACTED\]" || src.admincaster_feed_channel.channel_name == "" )
 			src.admincaster_screen = 6
 		else
-			var/datum/feed_message/newMsg = new /datum/feed_message
-			newMsg.author = src.admincaster_signature
-			newMsg.body = src.admincaster_feed_message.body
-			newMsg.is_admin_message = 1
 			feedback_inc("newscaster_stories",1)
-			news_network.add_news(src.admincaster_feed_channel.channel_name, newMsg)
+			news_network.SubmitArticle(src.admincaster_feed_message.body, src.admincaster_signature, src.admincaster_feed_channel.channel_name, null, 1)
 			src.admincaster_screen=4
 
 		log_admin("[key_name_admin(usr)] submitted a feed story to channel: [src.admincaster_feed_channel.channel_name]!")

--- a/code/modules/economy/Events.dm
+++ b/code/modules/economy/Events.dm
@@ -52,46 +52,44 @@
 			affected_dest.temp_price_change[good_type] = rand(1,100) / 100
 
 /datum/event/economic_event/announce()
-	//copy-pasted from the admin verbs to submit new newscaster messages
-	var/datum/feed_message/newMsg = new /datum/feed_message
-	newMsg.author = "Nyx Daily"
-	newMsg.is_admin_message = 1
+	var/author = "Nyx Daily"
+	var/channel = author
 
 	//see if our location has custom event info for this event
-	newMsg.body = affected_dest.get_custom_eventstring()
-	if(!newMsg.body)
+	var/body = affected_dest.get_custom_eventstring()
+	if(!body)
 		switch(event_type)
 			if(RIOTS)
-				newMsg.body = "[pick("Riots have","Unrest has")] broken out on planet [affected_dest.name]. Authorities call for calm, as [pick("various parties","rebellious elements","peacekeeping forces","\'REDACTED\'")] begin stockpiling weaponry and armour. Meanwhile, food and mineral prices are dropping as local industries attempt empty their stocks in expectation of looting."
+				body = "[pick("Riots have","Unrest has")] broken out on planet [affected_dest.name]. Authorities call for calm, as [pick("various parties","rebellious elements","peacekeeping forces","\'REDACTED\'")] begin stockpiling weaponry and armour. Meanwhile, food and mineral prices are dropping as local industries attempt empty their stocks in expectation of looting."
 			if(WILD_ANIMAL_ATTACK)
-				newMsg.body = "Local [pick("wildlife","animal life","fauna")] on planet [affected_dest.name] has been increasing in agression and raiding outlying settlements for food. Big game hunters have been called in to help alleviate the problem, but numerous injuries have already occurred."
+				body = "Local [pick("wildlife","animal life","fauna")] on planet [affected_dest.name] has been increasing in agression and raiding outlying settlements for food. Big game hunters have been called in to help alleviate the problem, but numerous injuries have already occurred."
 			if(INDUSTRIAL_ACCIDENT)
-				newMsg.body = "[pick("An industrial accident","A smelting accident","A malfunction","A malfunctioning piece of machinery","Negligent maintenance","A cooleant leak","A ruptured conduit")] at a [pick("factory","installation","power plant","dockyards")] on [affected_dest.name] resulted in severe structural damage and numerous injuries. Repairs are ongoing."
+				body = "[pick("An industrial accident","A smelting accident","A malfunction","A malfunctioning piece of machinery","Negligent maintenance","A cooleant leak","A ruptured conduit")] at a [pick("factory","installation","power plant","dockyards")] on [affected_dest.name] resulted in severe structural damage and numerous injuries. Repairs are ongoing."
 			if(BIOHAZARD_OUTBREAK)
-				newMsg.body = "[pick("A \'REDACTED\'","A biohazard","An outbreak","A virus")] on [affected_dest.name] has resulted in quarantine, stopping much shipping in the area. Although the quarantine is now lifted, authorities are calling for deliveries of medical supplies to treat the infected, and gas to replace contaminated stocks."
+				body = "[pick("A \'REDACTED\'","A biohazard","An outbreak","A virus")] on [affected_dest.name] has resulted in quarantine, stopping much shipping in the area. Although the quarantine is now lifted, authorities are calling for deliveries of medical supplies to treat the infected, and gas to replace contaminated stocks."
 			if(PIRATES)
-				newMsg.body = "[pick("Pirates","Criminal elements","A [pick("mercenary","Donk Co.","Waffle Co.","\'REDACTED\'")] strike force")] have [pick("raided","blockaded","attempted to blackmail","attacked")] [affected_dest.name] today. Security has been tightened, but many valuable minerals were taken."
+				body = "[pick("Pirates","Criminal elements","A [pick("mercenary","Donk Co.","Waffle Co.","\'REDACTED\'")] strike force")] have [pick("raided","blockaded","attempted to blackmail","attacked")] [affected_dest.name] today. Security has been tightened, but many valuable minerals were taken."
 			if(CORPORATE_ATTACK)
-				newMsg.body = "A small [pick("pirate","Cybersun Industries","Gorlex Marauders","mercenary")] fleet has precise-jumped into proximity with [affected_dest.name], [pick("for a smash-and-grab operation","in a hit and run attack","in an overt display of hostilities")]. Much damage was done, and security has been tightened since the incident."
+				body = "A small [pick("pirate","Cybersun Industries","Gorlex Marauders","mercenary")] fleet has precise-jumped into proximity with [affected_dest.name], [pick("for a smash-and-grab operation","in a hit and run attack","in an overt display of hostilities")]. Much damage was done, and security has been tightened since the incident."
 			if(ALIEN_RAIDERS)
 				if(prob(20))
-					newMsg.body = "The Tiger Co-operative have raided [affected_dest.name] today, no doubt on orders from their enigmatic masters. Stealing wildlife, farm animals, medical research materials and kidnapping civilians. NanoTrasen authorities are standing by to counter attempts at bio-terrorism."
+					body = "The Tiger Co-operative have raided [affected_dest.name] today, no doubt on orders from their enigmatic masters. Stealing wildlife, farm animals, medical research materials and kidnapping civilians. NanoTrasen authorities are standing by to counter attempts at bio-terrorism."
 				else
-					newMsg.body = "[pick("The alien species designated \'United Exolitics\'","The alien species designated \'REDACTED\'","An unknown alien species")] have raided [affected_dest.name] today, stealing wildlife, farm animals, medical research materials and kidnapping civilians. It seems they desire to learn more about us, so the Navy will be standing by to accomodate them next time they try."
+					body = "[pick("The alien species designated \'United Exolitics\'","The alien species designated \'REDACTED\'","An unknown alien species")] have raided [affected_dest.name] today, stealing wildlife, farm animals, medical research materials and kidnapping civilians. It seems they desire to learn more about us, so the Navy will be standing by to accomodate them next time they try."
 			if(AI_LIBERATION)
-				newMsg.body = "A [pick("\'REDACTED\' was detected on","S.E.L.F operative infiltrated","malignant computer virus was detected on","rogue [pick("slicer","hacker")] was apprehended on")] [affected_dest.name] today, and managed to infect [pick("\'REDACTED\'","a sentient sub-system","a class one AI","a sentient defence installation")] before it could be stopped. Many lives were lost as it systematically begin murdering civilians, and considerable work must be done to repair the affected areas."
+				body = "A [pick("\'REDACTED\' was detected on","S.E.L.F operative infiltrated","malignant computer virus was detected on","rogue [pick("slicer","hacker")] was apprehended on")] [affected_dest.name] today, and managed to infect [pick("\'REDACTED\'","a sentient sub-system","a class one AI","a sentient defence installation")] before it could be stopped. Many lives were lost as it systematically begin murdering civilians, and considerable work must be done to repair the affected areas."
 			if(MOURNING)
-				newMsg.body = "[pick("The popular","The well-liked","The eminent","The well-known")] [pick("professor","entertainer","singer","researcher","public servant","administrator","ship captain","\'REDACTED\'")], [pick( random_name(pick(MALE,FEMALE)), 40; "\'REDACTED\'" )] has [pick("passed away","committed suicide","been murdered","died in a freakish accident")] on [affected_dest.name] today. The entire planet is in mourning, and prices have dropped for industrial goods as worker morale drops."
+				body = "[pick("The popular","The well-liked","The eminent","The well-known")] [pick("professor","entertainer","singer","researcher","public servant","administrator","ship captain","\'REDACTED\'")], [pick( random_name(pick(MALE,FEMALE)), 40; "\'REDACTED\'" )] has [pick("passed away","committed suicide","been murdered","died in a freakish accident")] on [affected_dest.name] today. The entire planet is in mourning, and prices have dropped for industrial goods as worker morale drops."
 			if(CULT_CELL_REVEALED)
-				newMsg.body = "A [pick("dastardly","blood-thirsty","villanous","crazed")] cult of [pick("The Elder Gods","Nar'sie","an apocalyptic sect","\'REDACTED\'")] has [pick("been discovered","been revealed","revealed themselves","gone public")] on [affected_dest.name] earlier today. Public morale has been shaken due to [pick("certain","several","one or two")] [pick("high-profile","well known","popular")] individuals [pick("performing \'REDACTED\' acts","claiming allegiance to the cult","swearing loyalty to the cult leader","promising to aid to the cult")] before those involved could be brought to justice. The editor reminds all personnel that supernatural myths will not be tolerated on NanoTrasen facilities."
+				body = "A [pick("dastardly","blood-thirsty","villanous","crazed")] cult of [pick("The Elder Gods","Nar'sie","an apocalyptic sect","\'REDACTED\'")] has [pick("been discovered","been revealed","revealed themselves","gone public")] on [affected_dest.name] earlier today. Public morale has been shaken due to [pick("certain","several","one or two")] [pick("high-profile","well known","popular")] individuals [pick("performing \'REDACTED\' acts","claiming allegiance to the cult","swearing loyalty to the cult leader","promising to aid to the cult")] before those involved could be brought to justice. The editor reminds all personnel that supernatural myths will not be tolerated on NanoTrasen facilities."
 			if(SECURITY_BREACH)
-				newMsg.body = "There was [pick("a security breach in","an unauthorised access in","an attempted theft in","an anarchist attack in","violent sabotage of")] a [pick("high-security","restricted access","classified","\'REDACTED\'")] [pick("\'REDACTED\'","section","zone","area")] this morning. Security was tightened on [affected_dest.name] after the incident, and the editor reassures all NanoTrasen personnel that such lapses are rare."
+				body = "There was [pick("a security breach in","an unauthorised access in","an attempted theft in","an anarchist attack in","violent sabotage of")] a [pick("high-security","restricted access","classified","\'REDACTED\'")] [pick("\'REDACTED\'","section","zone","area")] this morning. Security was tightened on [affected_dest.name] after the incident, and the editor reassures all NanoTrasen personnel that such lapses are rare."
 			if(ANIMAL_RIGHTS_RAID)
-				newMsg.body = "[pick("Militant animal rights activists","Members of the terrorist group Animal Rights Consortium","Members of the terrorist group \'REDACTED\'")] have [pick("launched a campaign of terror","unleashed a swathe of destruction","raided farms and pastures","forced entry to \'REDACTED\'")] on [affected_dest.name] earlier today, freeing numerous [pick("farm animals","animals","\'REDACTED\'")]. Prices for tame and breeding animals have spiked as a result."
+				body = "[pick("Militant animal rights activists","Members of the terrorist group Animal Rights Consortium","Members of the terrorist group \'REDACTED\'")] have [pick("launched a campaign of terror","unleashed a swathe of destruction","raided farms and pastures","forced entry to \'REDACTED\'")] on [affected_dest.name] earlier today, freeing numerous [pick("farm animals","animals","\'REDACTED\'")]. Prices for tame and breeding animals have spiked as a result."
 			if(FESTIVAL)
-				newMsg.body = "A [pick("festival","week long celebration","day of revelry","planet-wide holiday")] has been declared on [affected_dest.name] by [pick("Governor","Commissioner","General","Commandant","Administrator")] [random_name(pick(MALE,FEMALE))] to celebrate [pick("the birth of their [pick("son","daughter")]","coming of age of their [pick("son","daughter")]","the pacification of rogue military cell","the apprehension of a violent criminal who had been terrorising the planet")]. Massive stocks of food and meat have been bought driving up prices across the planet."
+				body = "A [pick("festival","week long celebration","day of revelry","planet-wide holiday")] has been declared on [affected_dest.name] by [pick("Governor","Commissioner","General","Commandant","Administrator")] [random_name(pick(MALE,FEMALE))] to celebrate [pick("the birth of their [pick("son","daughter")]","coming of age of their [pick("son","daughter")]","the pacification of rogue military cell","the apprehension of a violent criminal who had been terrorising the planet")]. Massive stocks of food and meat have been bought driving up prices across the planet."
 
-	news_network.add_news("Nyx Daily", newMsg)
+	news_network.SubmitArticle(body, author, channel, null, 1)
 
 /datum/event/economic_event/end()
 	for(var/good_type in dearer_goods)

--- a/code/modules/economy/Events_Mundane.dm
+++ b/code/modules/economy/Events_Mundane.dm
@@ -11,78 +11,76 @@
 	if(!event_type)
 		return
 
-	//copy-pasted from the admin verbs to submit new newscaster messages
-	var/datum/feed_message/newMsg = new /datum/feed_message
-	newMsg.author = "Nyx Daily"
-	newMsg.is_admin_message = 1
+	var/author = "Nyx Daily"
+	var/channel = author
 
 	//see if our location has custom event info for this event
-	newMsg.body = affected_dest.get_custom_eventstring()
-	if(!newMsg.body)
-		newMsg.body = ""
+	var/body = affected_dest.get_custom_eventstring()
+	if(!body)
+		body = ""
 		switch(event_type)
 			if(RESEARCH_BREAKTHROUGH)
-				newMsg.body = "A major breakthough in the field of [pick("phoron research","super-compressed materials","nano-augmentation","bluespace research","volatile power manipulation")] \
+				body = "A major breakthough in the field of [pick("phoron research","super-compressed materials","nano-augmentation","bluespace research","volatile power manipulation")] \
 				was announced [pick("yesterday","a few days ago","last week","earlier this month")] by a private firm on [affected_dest.name]. \
 				NanoTrasen declined to comment as to whether this could impinge on profits."
 
 			if(ELECTION)
-				newMsg.body = "The pre-selection of an additional candidates was announced for the upcoming [pick("supervisors council","advisory board","governership","board of inquisitors")] \
+				body = "The pre-selection of an additional candidates was announced for the upcoming [pick("supervisors council","advisory board","governership","board of inquisitors")] \
 				election on [affected_dest.name] was announced earlier today, \
 				[pick("media mogul","web celebrity", "industry titan", "superstar", "famed chef", "popular gardener", "ex-army officer", "multi-billionaire")] \
 				[random_name(pick(MALE,FEMALE))]. In a statement to the media they said '[pick("My only goal is to help the [pick("sick","poor","children")]",\
 				"I will maintain NanoTrasen's record profits","I believe in our future","We must return to our moral core","Just like... chill out dudes")]'."
 
 			if(RESIGNATION)
-				newMsg.body = "NanoTrasen regretfully announces the resignation of [pick("Sector Admiral","Division Admiral","Ship Admiral","Vice Admiral")] [random_name(pick(MALE,FEMALE))]."
+				body = "NanoTrasen regretfully announces the resignation of [pick("Sector Admiral","Division Admiral","Ship Admiral","Vice Admiral")] [random_name(pick(MALE,FEMALE))]."
 				if(prob(25))
 					var/locstring = pick("Segunda","Salusa","Cepheus","Andromeda","Gruis","Corona","Aquila","Asellus") + " " + pick("I","II","III","IV","V","VI","VII","VIII")
-					newMsg.body += " In a ceremony on [affected_dest.name] this afternoon, they will be awarded the \
+					body += " In a ceremony on [affected_dest.name] this afternoon, they will be awarded the \
 					[pick("Red Star of Sacrifice","Purple Heart of Heroism","Blue Eagle of Loyalty","Green Lion of Ingenuity")] for "
 					if(prob(33))
-						newMsg.body += "their actions at the Battle of [pick(locstring,"REDACTED")]."
+						body += "their actions at the Battle of [pick(locstring,"REDACTED")]."
 					else if(prob(50))
-						newMsg.body += "their contribution to the colony of [locstring]."
+						body += "their contribution to the colony of [locstring]."
 					else
-						newMsg.body += "their loyal service over the years."
+						body += "their loyal service over the years."
 				else if(prob(33))
-					newMsg.body += " They are expected to settle down in [affected_dest.name], where they have been granted a handsome pension."
+					body += " They are expected to settle down in [affected_dest.name], where they have been granted a handsome pension."
 				else if(prob(50))
-					newMsg.body += " The news was broken on [affected_dest.name] earlier today, where they cited reasons of '[pick("health","family","REDACTED")]'"
+					body += " The news was broken on [affected_dest.name] earlier today, where they cited reasons of '[pick("health","family","REDACTED")]'"
 				else
-					newMsg.body += " Administration Aerospace wishes them the best of luck in their retirement ceremony on [affected_dest.name]."
+					body += " Administration Aerospace wishes them the best of luck in their retirement ceremony on [affected_dest.name]."
 
 			if(CELEBRITY_DEATH)
-				newMsg.body = "It is with regret today that we announce the sudden passing of the "
+				body = "It is with regret today that we announce the sudden passing of the "
 				if(prob(33))
-					newMsg.body += "[pick("distinguished","decorated","veteran","highly respected")] \
+					body += "[pick("distinguished","decorated","veteran","highly respected")] \
 					[pick("Ship's Captain","Vice Admiral","Colonel","Lieutenant Colonel")] "
 				else if(prob(50))
-					newMsg.body += "[pick("award-winning","popular","highly respected","trend-setting")] \
+					body += "[pick("award-winning","popular","highly respected","trend-setting")] \
 					[pick("comedian","singer/songwright","artist","playwright","TV personality","model")] "
 				else
-					newMsg.body += "[pick("successful","highly respected","ingenious","esteemed")] \
+					body += "[pick("successful","highly respected","ingenious","esteemed")] \
 					[pick("academic","Professor","Doctor","Scientist")] "
 
-				newMsg.body += "[random_name(pick(MALE,FEMALE))] on [affected_dest.name] [pick("last week","yesterday","this morning","two days ago","three days ago")]\
+				body += "[random_name(pick(MALE,FEMALE))] on [affected_dest.name] [pick("last week","yesterday","this morning","two days ago","three days ago")]\
 				[pick(". Assassination is suspected, but the perpetrators have not yet been brought to justice",\
 				" due to mercenary infiltrators (since captured)",\
 				" during an industrial accident",\
 				" due to [pick("heart failure","kidney failure","liver failure","brain hemorrhage")]")]"
 
 			if(BARGAINS)
-				newMsg.body += "BARGAINS! BARGAINS! BARGAINS! Commerce Control on [affected_dest.name] wants you to know that everything must go! Across all retail centres, \
+				body += "BARGAINS! BARGAINS! BARGAINS! Commerce Control on [affected_dest.name] wants you to know that everything must go! Across all retail centres, \
 				all goods are being slashed, and all retailors are onboard - so come on over for the \[shopping\] time of your life."
 
 			if(SONG_DEBUT)
-				newMsg.body += "[pick("Singer","Singer/songwriter","Saxophonist","Pianist","Guitarist","TV personality","Star")] [random_name(pick(MALE,FEMALE))] \
+				body += "[pick("Singer","Singer/songwriter","Saxophonist","Pianist","Guitarist","TV personality","Star")] [random_name(pick(MALE,FEMALE))] \
 				announced the debut of their new [pick("single","album","EP","label")] '[pick("Everyone's","Look at the","Baby don't eye those","All of those","Dirty nasty")] \
 				[pick("roses","three stars","starships","nanobots","cyborgs","Skrell","Sren'darr")] \
 				[pick("on Venus","on Reade","on Moghes","in my hand","slip through my fingers","die for you","sing your heart out","fly away")]' \
 				with [pick("pre-puchases available","a release tour","cover signings","a launch concert")] on [affected_dest.name]."
 
 			if(MOVIE_RELEASE)
-				newMsg.body += "From the [pick("desk","home town","homeworld","mind")] of [pick("acclaimed","award-winning","popular","stellar")] \
+				body += "From the [pick("desk","home town","homeworld","mind")] of [pick("acclaimed","award-winning","popular","stellar")] \
 				[pick("playwright","author","director","actor","TV star")] [random_name(pick(MALE,FEMALE))] comes the latest sensation: '\
 				[pick("Deadly","The last","Lost","Dead")] [pick("Starships","Warriors","outcasts","Tajarans","Unathi","Skrell")] \
 				[pick("of","from","raid","go hunting on","visit","ravage","pillage","destroy")] \
@@ -90,52 +88,51 @@
 				. Own it on webcast today, or visit the galactic premier on [affected_dest.name]!"
 
 			if(BIG_GAME_HUNTERS)
-				newMsg.body += "Game hunters on [affected_dest.name] "
+				body += "Game hunters on [affected_dest.name] "
 				if(prob(33))
-					newMsg.body += "were surprised when an unusual species experts have since identified as \
+					body += "were surprised when an unusual species experts have since identified as \
 					[pick("a subclass of mammal","a divergent abhuman species","an intelligent species of lemur","organic/cyborg hybrids")] turned up. Believed to have been brought in by \
 					[pick("alien smugglers","early colonists","mercenary raiders","unwitting tourists")], this is the first such specimen discovered in the wild."
 				else if(prob(50))
-					newMsg.body += "were attacked by a vicious [pick("nas'r","diyaab","samak","predator which has not yet been identified")]\
+					body += "were attacked by a vicious [pick("nas'r","diyaab","samak","predator which has not yet been identified")]\
 					. Officials urge caution, and locals are advised to stock up on armaments."
 				else
-					newMsg.body += "brought in an unusually [pick("valuable","rare","large","vicious","intelligent")] [pick("mammal","predator","farwa","samak")] for inspection \
+					body += "brought in an unusually [pick("valuable","rare","large","vicious","intelligent")] [pick("mammal","predator","farwa","samak")] for inspection \
 					[pick("today","yesterday","last week")]. Speculators suggest they may be tipped to break several records."
 
 			if(GOSSIP)
-				newMsg.body += "[pick("TV host","Webcast personality","Superstar","Model","Actor","Singer")] [random_name(pick(MALE,FEMALE))] "
+				body += "[pick("TV host","Webcast personality","Superstar","Model","Actor","Singer")] [random_name(pick(MALE,FEMALE))] "
 				if(prob(33))
-					newMsg.body += "and their partner announced the birth of their [pick("first","second","third")] child on [affected_dest.name] early this morning. \
+					body += "and their partner announced the birth of their [pick("first","second","third")] child on [affected_dest.name] early this morning. \
 					Doctors say the child is well, and the parents are considering "
 					if(prob(50))
-						newMsg.body += capitalize(pick(first_names_female))
+						body += capitalize(pick(first_names_female))
 					else
-						newMsg.body += capitalize(pick(first_names_male))
-					newMsg.body += " for the name."
+						body += capitalize(pick(first_names_male))
+					body += " for the name."
 				else if(prob(50))
-					newMsg.body += "announced their [pick("split","break up","marriage","engagement")] with [pick("TV host","webcast personality","superstar","model","actor","singer")] \
+					body += "announced their [pick("split","break up","marriage","engagement")] with [pick("TV host","webcast personality","superstar","model","actor","singer")] \
 					[random_name(pick(MALE,FEMALE))] at [pick("a society ball","a new opening","a launch","a club")] on [affected_dest.name] yesterday, pundits are shocked."
 				else
-					newMsg.body += "is recovering from plastic surgery in a clinic on [affected_dest.name] for the [pick("second","third","fourth")] time, reportedly having made the decision in response to "
-					newMsg.body += "[pick("unkind comments by an ex","rumours started by jealous friends",\
+					body += "is recovering from plastic surgery in a clinic on [affected_dest.name] for the [pick("second","third","fourth")] time, reportedly having made the decision in response to "
+					body += "[pick("unkind comments by an ex","rumours started by jealous friends",\
 					"the decision to be dropped by a major sponsor","a disasterous interview on Nyx Tonight")]."
 			if(TOURISM)
-				newMsg.body += "Tourists are flocking to [affected_dest.name] after the surprise announcement of [pick("major shopping bargains by a wily retailer",\
+				body += "Tourists are flocking to [affected_dest.name] after the surprise announcement of [pick("major shopping bargains by a wily retailer",\
 				"a huge new ARG by a popular entertainment company","a secret tour by popular artiste [random_name(pick(MALE,FEMALE))]")]. \
 				Nyx Daily is offering discount tickets for two to see [random_name(pick(MALE,FEMALE))] live in return for eyewitness reports and up to the minute coverage."
 
-	news_network.add_news("Nyx Daily", newMsg)
+	news_network.SubmitArticle(body, author, channel, null, 1)
 
 /datum/event/trivial_news
 	endWhen = 10
 
 /datum/event/trivial_news/announce()
-	//copy-pasted from the admin verbs to submit new newscaster messages
-	var/datum/feed_message/newMsg = new /datum/feed_message
-	newMsg.author = "Editor Mike Hammers"
-	//newMsg.is_admin_message = 1
+	var/author = "Editor Mike Hammers"
+	var/channel = "The Gibson Gazette"
+
 	var/datum/trade_destination/affected_dest = pick(weighted_mundaneevent_locations)
-	newMsg.body = pick(
+	var/body = pick(
 	"Tree stuck in tajaran; firefighters baffled.",\
 	"Armadillos want aardvarks removed from dictionary claims 'here first'.",\
 	"Angel found dancing on pinhead ordered to stop; cited for public nuisance.",\
@@ -220,4 +217,4 @@
 	"Broccoli discovered to be colonies of tiny aliens with murder on their minds"\
 	)
 
-	news_network.add_news("The Gibson Gazette", newMsg)
+	news_network.SubmitArticle(body, author, channel, null, 1)

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -77,26 +77,8 @@ var/global/economy_init = 0
 	if(economy_init)
 		return 2
 
-	var/datum/feed_channel/newChannel = new /datum/feed_channel/station
-	newChannel.channel_name = "Public Station Announcements"
-	newChannel.author = "Automated Announcement Listing"
-	newChannel.locked = 1
-	newChannel.is_admin_channel = 1
-	news_network.network_channels += newChannel
-
-	newChannel = new /datum/feed_channel
-	newChannel.channel_name = "Nyx Daily"
-	newChannel.author = "CentComm Minister of Information"
-	newChannel.locked = 1
-	newChannel.is_admin_channel = 1
-	news_network.network_channels += newChannel
-
-	newChannel = new /datum/feed_channel
-	newChannel.channel_name = "The Gibson Gazette"
-	newChannel.author = "Editor Mike Hammers"
-	newChannel.locked = 1
-	newChannel.is_admin_channel = 1
-	news_network.network_channels += newChannel
+	news_network.CreateFeedChannel("Nyx Daily", "CentComm Minister of Information", 1, 1)
+	news_network.CreateFeedChannel("The Gibson Gazette", "Editor Mike Hammers", 1, 1)
 
 	for(var/loc_type in typesof(/datum/trade_destination) - /datum/trade_destination)
 		var/datum/trade_destination/D = new loc_type

--- a/code/modules/events/money_lotto.dm
+++ b/code/modules/events/money_lotto.dm
@@ -23,12 +23,11 @@
 			deposit_success = 1
 
 /datum/event/money_lotto/announce()
-	var/datum/feed_message/newMsg = new /datum/feed_message
-	newMsg.author = "NanoTrasen Editor"
-	newMsg.is_admin_message = 1
+	var/author = "NanoTrasen Editor"
+	var/channel = "Nyx Daily"
 
-	newMsg.body = "Nyx Daily wishes to congratulate <b>[winner_name]</b> for recieving the Nyx Stellar Slam Lottery, and receiving the out of this world sum of [winner_sum] credits!"
+	var/body = "Nyx Daily wishes to congratulate <b>[winner_name]</b> for recieving the Nyx Stellar Slam Lottery, and receiving the out of this world sum of [winner_sum] credits!"
 	if(!deposit_success)
-		newMsg.body += "<br>Unfortunately, we were unable to verify the account details provided, so we were unable to transfer the money. Send a cheque containing the sum of $500 to ND 'Stellar Slam' office on the Nyx gateway containing updated details, and your winnings'll be re-sent within the month."
+		body += "<br>Unfortunately, we were unable to verify the account details provided, so we were unable to transfer the money. Send a cheque containing the sum of 5000 Thalers to ND 'Stellar Slam' office on the Nyx gateway containing updated details, and your winnings'll be re-sent within the month."
 
-	news_network.add_news("Nyx Daily", newMsg)
+	news_network.SubmitArticle(body, author, channel, null, 1)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -34,8 +34,8 @@
 				dat += "<a href='byond://?src=\ref[src];add=1'>+</a><BR><BR>"
 		else if(toner)
 			dat += "Please insert paper to copy.<BR><BR>"
-		if(istype(user,/mob/living/silicon))
-			dat += "<a href='byond://?src=\ref[src];aipic=1'>Print photo from database</a><BR><BR>"
+			if(istype(user,/mob/living/silicon))
+				dat += "<a href='byond://?src=\ref[src];aipic=1'>Print photo from database</a><BR><BR>"
 		dat += "Current toner level: [toner]"
 		if(!toner)
 			dat +="<BR>Please insert a new toner cartridge!"
@@ -122,18 +122,20 @@
 
 				if(!camera)
 					return
-				var/datum/picture/selection = camera.selectpicture()
+				var/obj/item/weapon/photo/selection = camera.selectpicture()
 				if (!selection)
 					return
 
-				var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (src.loc)
-				p.construct(selection)
+				var/obj/item/weapon/photo/p = photocopy(selection)
+				p.loc = src.loc
 				if (p.desc == "")
-					p.desc += "Copied by [tempAI.name]"
+					p.desc += "Copy by [tempAI.name]"
 				else
-					p.desc += " - Copied by [tempAI.name]"
-				toner -= 5
+					p.desc += " - Copy by [tempAI.name]"
+
 				sleep(15)
+			else
+				usr << "<span class='notice'>The photocopier couldn't finish the printjob.</span>"
 			updateUsrDialog()
 
 	attackby(obj/item/O as obj, mob/user as mob)
@@ -244,24 +246,18 @@
 
 
 /obj/machinery/photocopier/proc/photocopy(var/obj/item/weapon/photo/photocopy)
-	var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (src.loc)
+	var/obj/item/weapon/photo/p = photocopy.copy()
+
 	var/icon/I = icon(photocopy.icon, photocopy.icon_state)
-	var/icon/img = icon(photocopy.img)
-	var/icon/tiny = icon(photocopy.tiny)
 	if(toner > 10)	//plenty of toner, go straight greyscale
 		I.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))		//I'm not sure how expensive this is, but given the many limitations of photocopying, it shouldn't be an issue.
-		img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
-		tiny.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
+		p.img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
+		p.tiny.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
 	else			//not much toner left, lighten the photo
 		I.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
-		img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
-		tiny.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
+		p.img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
+		p.tiny.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
 	p.icon = I
-	p.img = img
-	p.tiny = tiny
-	p.name = photocopy.name
-	p.desc = photocopy.desc
-	p.scribble = photocopy.scribble
 	toner -= 5	//photos use a lot of ink!
 	if(toner < 0)
 		toner = 0

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -286,7 +286,7 @@
 	pc.Blend(tiny_img,ICON_OVERLAY, 12, 19)
 
 	var/datum/picture/P = new()
-	P.fields["author"] = user
+	P.fields["name"] = "photo"
 	P.fields["icon"] = ic
 	P.fields["tiny"] = pc
 	P.fields["img"] = photoimage
@@ -305,6 +305,7 @@
 	Photo.construct(P)
 
 /obj/item/weapon/photo/proc/construct(var/datum/picture/P)
+	name = P.fields["name"]
 	icon = P.fields["icon"]
 	tiny = P.fields["tiny"]
 	img = P.fields["img"]
@@ -312,3 +313,15 @@
 	pixel_x = P.fields["pixel_x"]
 	pixel_y = P.fields["pixel_y"]
 	photo_size = P.fields["size"]
+
+/obj/item/weapon/photo/proc/copy()
+	var/obj/item/weapon/photo/p = new/obj/item/weapon/photo()
+
+	p.icon = icon(icon, icon_state)
+	p.img = icon(img)
+	p.tiny = icon(tiny)
+	p.name = name
+	p.desc = desc
+	p.scribble = scribble
+
+	return p

--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -8,7 +8,7 @@
 /obj/item/device/camera/siliconcam
 	var/in_camera_mode = 0
 	var/photos_taken = 0
-	var/list/aipictures = list()
+	var/list/obj/item/weapon/photo/aipictures = list()
 
 /obj/item/device/camera/siliconcam/ai_camera //camera AI can take pictures with
 	name = "AI photo camera"
@@ -22,7 +22,9 @@
 /obj/item/device/camera/siliconcam/proc/injectaialbum(var/datum/picture/P, var/sufix = "") //stores image information to a list similar to that of the datacore
 	photos_taken++
 	P.fields["name"] = "Image [photos_taken][sufix]"
-	aipictures += P
+	var/obj/item/weapon/photo/photo = new
+	photo.construct(P)
+	aipictures += photo
 
 /obj/item/device/camera/siliconcam/proc/injectmasteralbum(var/datum/picture/P) //stores image information to a list similar to that of the datacore
 	var/mob/living/silicon/robot/C = src.loc
@@ -44,30 +46,27 @@
 	if(cam.aipictures.len == 0)
 		usr << "<span class='userdanger'>No images saved</span>"
 		return
-	for(var/datum/picture/t in cam.aipictures)
-		nametemp += t.fields["name"]
-	find = input("Select image (numbered in order taken)") in nametemp
+	for(var/obj/item/weapon/photo/t in cam.aipictures)
+		nametemp += t.name
+	find = input("Select image (numbered in order taken)") as null|anything in nametemp
+	if(!find)
+		return
 
-	for(var/datum/picture/q in cam.aipictures)
-		if(q.fields["name"] == find)
+	for(var/obj/item/weapon/photo/q in cam.aipictures)
+		if(q.name == find)
 			return q
 
 /obj/item/device/camera/siliconcam/proc/viewpictures()
-	var/datum/picture/selection = selectpicture()
+	var/obj/item/weapon/photo/selection = selectpicture()
 
 	if(!selection)
 		return
 
-	var/obj/item/weapon/photo/P = new/obj/item/weapon/photo()
-	P.construct(selection)
-	P.show(usr)
-	usr << P.desc
-
-	// TG uses a special garbage collector.. qdel(P)
-	del(P) //so 10 thousand pictures items are not left in memory should an AI take them and then view them all.
+	selection.show(usr)
+	usr << selection.desc
 
 /obj/item/device/camera/siliconcam/proc/deletepicture()
-	var/datum/picture/selection = selectpicture()
+	var/selection = selectpicture()
 
 	if(!selection)
 		return

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -189,6 +189,16 @@ h4 {
     color: #272727;
 }
 
+.caption {
+    font-size: 10px;
+    font-weight: bold;
+	padding: 5px;
+}
+
+.footer {
+	font-size: 10px;
+}
+
 .noticePlaceholder {
     position: relative;
     font-size: 12px;

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -961,6 +961,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             </div>
         </div>
         
+		{{if data.reception != 1}}
+			<span class="bad">No reception with newscaster network.</span>
+		{{/if}}
+		
 		<div class="item">
             <div class="itemContent">
                 {{for data.feedChannels}}
@@ -977,7 +981,12 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 
     {{else data.mode == 61}}      
         <H2><span class="white">{{:data.feed.channel}}</span></H2>
-        <span class="white">Created by: </span><span class="average">{{:data.feed.author}}</span>
+        <span class="white">Created by: </span><span class="average">{{:data.feed.author}}<br></span>
+		
+		{{if data.reception != 1}}
+			<span class="bad">No reception with newscaster network.</span>
+		{{/if}}
+		
         <div class="statusDisplay" style="overflow: auto;">
             <div class="item">
                 <div class="itemContent" style="width: 100%;">
@@ -989,10 +998,12 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 						{{for data.feed.messages}}
 							-{{:value.body}}<br>
 							{{if value.has_image}}
-								pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png<br>
 								<img src='pda_news_tmp_photo_{{:data.feed.channel}}_{{:value.index}}.png' width = '180'><br>
+								{{if value.caption}}
+									<span class="caption">{{:value.caption}}</span><br>
+								{{/if}}
 							{{/if}}
-							<FONT SIZE=1>[{{:value.message_type}} by <span class="average">{{:value.author}}</span>]<br></FONT>
+							<span class="footer">[{{:value.message_type}} by <span class="average">{{:value.author}}</span> - {{:value.time_stamp}}]</span><br>
 							<br>
 						{{empty}}
 							<I>No feed messages found in channel...</I>


### PR DESCRIPTION
Synthetics can no longer magically print color images using a black-and-white photocopier.
No longer possible for organics to acquire a synth-image by un-attaching it from a newscaster submission.
News articles now come with a timestamp and photo captions, if anything was penned on an attached photo.
Reception-checks no longer unconditionally sleeps the thread. Was causing havoc with NanoUI.

Misc. code refactoring.

I was just planning to add a timestamp, instead I accidentally the whole thing :frowning:
