### PR TITLE
Rewrites food slicing, energy weapons

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -114,8 +114,10 @@
 	name = "plastic knife"
 	desc = "The bluntest of blades."
 	icon_state = "pknife"
-	force = 10.0
-	throwforce = 10.0
+	force = 1
+	throwforce = 1
+	sharp = 0
+	edge = 1 //for cutting pizzas
 
 /obj/item/weapon/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob)
 	if ((CLUMSY in user.mutations) && prob(50))

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -1,53 +1,158 @@
 /obj/item/weapon/melee/energy
 	var/active = 0
+	var/active_force
+	var/active_throwforce
+	var/active_w_class
+	sharp = 0
+	edge = 0
 	flags = FPRINT | TABLEPASS | NOBLOODY
 
-	suicide_act(mob/user)
+/obj/item/weapon/melee/energy/proc/activate()
+	active = 1
+	force = active_force
+	throwforce = active_throwforce
+	sharp = 1
+	edge = 1
+	w_class = active_w_class
+	playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
+
+/obj/item/weapon/melee/energy/proc/deactivate()
+	active = 0
+	force = initial(force)
+	throwforce = initial(throwforce)
+	sharp = initial(sharp)
+	edge = initial(edge)
+	w_class = initial(w_class)
+	playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
+
+/obj/item/weapon/melee/energy/attack_self(mob/living/user as mob)
+	if (active)
+		if ((CLUMSY in user.mutations) && prob(50))
+			user.visible_message("\red [user] accidentally cuts \himself with \the [src].", "\red You accidentally cut yourself with \the [src].")
+			user.take_organ_damage(5,5)
+		deactivate()
+	else
+		activate()
+
+	if(istype(user,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		H.update_inv_l_hand()
+		H.update_inv_r_hand()
+
+	add_fingerprint(user)
+	return
+
+/obj/item/weapon/melee/energy/suicide_act(mob/user)
+	if (active)
 		viewers(user) << pick("\red <b>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</b>", \
 							"\red <b>[user] is falling on the [src.name]! It looks like \he's trying to commit suicide.</b>")
 		return (BRUTELOSS|FIRELOSS)
 
+/*
+ * Energy Axe
+ */
 /obj/item/weapon/melee/energy/axe
 	name = "energy axe"
 	desc = "An energised battle axe."
 	icon_state = "axe0"
-	force = 40.0
-	throwforce = 25.0
+	//active_force = 150 //holy...
+	active_force = 60
+	active_throwforce = 35
+	active_w_class = 5
+	//force = 40
+	//throwforce = 25
+	force = 20
+	throwforce = 10
 	throw_speed = 1
 	throw_range = 5
-	w_class = 3.0
+	w_class = 3
 	flags = FPRINT | CONDUCT | NOSHIELD | TABLEPASS | NOBLOODY
-	origin_tech = "combat=3"
+	origin_tech = "magnets=3;combat=4"
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	sharp = 1
 	edge = 1
 
-	suicide_act(mob/user)
-		viewers(user) << "\red <b>[user] swings the [src.name] towards /his head! It looks like \he's trying to commit suicide.</b>"
-		return (BRUTELOSS|FIRELOSS)
+/obj/item/weapon/melee/energy/axe/activate()
+	..()
+	icon_state = "axe1"
+	user << "\blue \The [src] is now energised."
 
+/obj/item/weapon/melee/energy/axe/deactivate()
+	..()
+	icon_state = initial(icon_state)
+	user << "\blue \The [src] is de-energised. It's just a regular axe now."
+
+/obj/item/weapon/melee/energy/axe/suicide_act(mob/user)
+	viewers(user) << "\red <b>[user] swings the [src.name] towards /his head! It looks like \he's trying to commit suicide.</b>"
+	return (BRUTELOSS|FIRELOSS)
+
+/*
+ * Energy Sword
+ */
 /obj/item/weapon/melee/energy/sword
 	color
 	name = "energy sword"
 	desc = "May the force be within you."
 	icon_state = "sword0"
-	force = 3.0
-	throwforce = 5.0
+	active_force = 30
+	active_throwforce = 20
+	active_w_class = 4
+	force = 3
+	throwforce = 5
 	throw_speed = 1
 	throw_range = 5
-	w_class = 2.0
+	w_class = 2
 	flags = FPRINT | TABLEPASS | NOSHIELD | NOBLOODY
 	origin_tech = "magnets=3;syndicate=4"
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	sharp = 1
-	edge = 1
+	var/attack_verb_active = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+
+/obj/item/weapon/melee/energy/sword/New()
+	item_color = pick("red","blue","green","purple")
+
+/obj/item/weapon/melee/energy/sword/green/New()
+	item_color = "green"
+
+/obj/item/weapon/melee/energy/sword/red/New()
+	item_color = "red"
+
+/obj/item/weapon/melee/energy/sword/blue/New()
+	item_color = "blue"
+
+/obj/item/weapon/melee/energy/sword/purple/New()
+	item_color = "purple"
+
+/obj/item/weapon/melee/energy/sword/activate()
+	..()
+	attack_verb = attack_verb_active
+	icon_state = "sword[item_color]"
+	user << "\blue \The [src] is now energised."
+
+/obj/item/weapon/melee/energy/sword/deactivate()
+	..()
+	attack_verb = initial(attack_verb)
+	icon_state = initial(icon_state)
+	user << "\blue It can now be concealed."
+
+/obj/item/weapon/melee/energy/sword/IsShield()
+	if(active)
+		return 1
+	return 0
 
 /obj/item/weapon/melee/energy/sword/pirate
 	name = "energy cutlass"
 	desc = "Arrrr matey."
 	icon_state = "cutlass0"
 
-/obj/item/weapon/melee/energy/blade
+/obj/item/weapon/melee/energy/sword/pirate/activate()
+	..()
+	icon_state = "cutlass1"
+
+/*
+ *Energy Blade
+ */
+
+//Can't be activated or deactivated, so not actually a subtype of energy
+/obj/item/weapon/melee/energy_blade
 	name = "energy blade"
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
@@ -61,3 +166,14 @@
 	flags = FPRINT | TABLEPASS | NOSHIELD | NOBLOODY
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/datum/effect/effect/system/spark_spread/spark_system
+
+/obj/item/weapon/melee/energy_blade/New()
+	spark_system = new /datum/effect/effect/system/spark_spread()
+	spark_system.set_up(5, 0, src)
+	spark_system.attach(src)
+
+/obj/item/weapon/melee/energy_blade/dropped()
+	del(src)
+
+/obj/item/weapon/melee/energy_blade/proc/throw()
+	del(src)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -7,7 +7,7 @@
 	edge = 0
 	flags = FPRINT | TABLEPASS | NOBLOODY
 
-/obj/item/weapon/melee/energy/proc/activate()
+/obj/item/weapon/melee/energy/proc/activate(mob/living/user)
 	active = 1
 	force = active_force
 	throwforce = active_throwforce
@@ -16,7 +16,7 @@
 	w_class = active_w_class
 	playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 
-/obj/item/weapon/melee/energy/proc/deactivate()
+/obj/item/weapon/melee/energy/proc/deactivate(mob/living/user)
 	active = 0
 	force = initial(force)
 	throwforce = initial(throwforce)
@@ -30,9 +30,9 @@
 		if ((CLUMSY in user.mutations) && prob(50))
 			user.visible_message("\red [user] accidentally cuts \himself with \the [src].", "\red You accidentally cut yourself with \the [src].")
 			user.take_organ_damage(5,5)
-		deactivate()
+		deactivate(user)
 	else
-		activate()
+		activate(user)
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
@@ -72,12 +72,12 @@
 	sharp = 1
 	edge = 1
 
-/obj/item/weapon/melee/energy/axe/activate()
+/obj/item/weapon/melee/energy/axe/activate(mob/living/user)
 	..()
 	icon_state = "axe1"
 	user << "\blue \The [src] is now energised."
 
-/obj/item/weapon/melee/energy/axe/deactivate()
+/obj/item/weapon/melee/energy/axe/deactivate(mob/living/user)
 	..()
 	icon_state = initial(icon_state)
 	user << "\blue \The [src] is de-energised. It's just a regular axe now."
@@ -104,7 +104,6 @@
 	w_class = 2
 	flags = FPRINT | TABLEPASS | NOSHIELD | NOBLOODY
 	origin_tech = "magnets=3;syndicate=4"
-	var/attack_verb_active = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
 /obj/item/weapon/melee/energy/sword/New()
 	item_color = pick("red","blue","green","purple")
@@ -121,15 +120,15 @@
 /obj/item/weapon/melee/energy/sword/purple/New()
 	item_color = "purple"
 
-/obj/item/weapon/melee/energy/sword/activate()
+/obj/item/weapon/melee/energy/sword/activate(mob/living/user)
 	..()
-	attack_verb = attack_verb_active
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	icon_state = "sword[item_color]"
 	user << "\blue \The [src] is now energised."
 
-/obj/item/weapon/melee/energy/sword/deactivate()
+/obj/item/weapon/melee/energy/sword/deactivate(mob/living/user)
 	..()
-	attack_verb = initial(attack_verb)
+	attack_verb = list()
 	icon_state = initial(icon_state)
 	user << "\blue It can now be concealed."
 
@@ -143,7 +142,7 @@
 	desc = "Arrrr matey."
 	icon_state = "cutlass0"
 
-/obj/item/weapon/melee/energy/sword/pirate/activate()
+/obj/item/weapon/melee/energy/sword/pirate/activate(mob/living/user)
 	..()
 	icon_state = "cutlass1"
 
@@ -151,8 +150,8 @@
  *Energy Blade
  */
 
-//Can't be activated or deactivated, so not actually a subtype of energy
-/obj/item/weapon/melee/energy_blade
+//Can't be activated or deactivated, so no reason to be a subtype of energy
+/obj/item/weapon/melee/energy/blade
 	name = "energy blade"
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
@@ -167,13 +166,13 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/datum/effect/effect/system/spark_spread/spark_system
 
-/obj/item/weapon/melee/energy_blade/New()
+/obj/item/weapon/melee/energy/blade/New()
 	spark_system = new /datum/effect/effect/system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-/obj/item/weapon/melee/energy_blade/dropped()
+/obj/item/weapon/melee/energy/blade/dropped()
 	del(src)
 
-/obj/item/weapon/melee/energy_blade/proc/throw()
+/obj/item/weapon/melee/energy/blade/proc/throw()
 	del(src)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -30,6 +30,10 @@
 		else
 			..()
 
+/*
+ * Energy Shield
+ */
+
 /obj/item/weapon/shield/energy
 	name = "energy combat shield"
 	desc = "A shield capable of stopping most projectile and melee attacks. It can be retracted, expanded, and stored anywhere."
@@ -44,6 +48,39 @@
 	origin_tech = "materials=4;magnets=3;syndicate=4"
 	attack_verb = list("shoved", "bashed")
 	var/active = 0
+
+/obj/item/weapon/shield/energy/IsShield()
+	if(active)
+		return 1
+	else
+		return 0
+
+/obj/item/weapon/shield/energy/attack_self(mob/living/user as mob)
+	if ((CLUMSY in user.mutations) && prob(50))
+		user << "\red You beat yourself in the head with [src]."
+		user.take_organ_damage(5)
+	active = !active
+	if (active)
+		force = 10
+		icon_state = "eshield[active]"
+		w_class = 4
+		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
+		user << "\blue [src] is now active."
+
+	else
+		force = 3
+		icon_state = "eshield[active]"
+		w_class = 1
+		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
+		user << "\blue [src] can now be concealed."
+
+	if(istype(user,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		H.update_inv_l_hand()
+		H.update_inv_r_hand()
+
+	add_fingerprint(user)
+	return
 
 /obj/item/weapon/cloaking_device
 	name = "cloaking device"

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -3,9 +3,6 @@
  *		Banhammer
  *		Sword
  *		Classic Baton
- *		Energy Blade
- *		Energy Axe
- *		Energy Shield
  */
 
 /*
@@ -14,50 +11,6 @@
 /obj/item/weapon/banhammer/attack(mob/M as mob, mob/user as mob)
 	M << "<font color='red'><b> You have been banned FOR NO REISIN by [user]<b></font>"
 	user << "<font color='red'> You have <b>BANNED</b> [M]</font>"
-
-/*
- * Sword
- */
-/obj/item/weapon/melee/energy/sword/IsShield()
-	if(active)
-		return 1
-	return 0
-
-/obj/item/weapon/melee/energy/sword/New()
-	item_color = pick("red","blue","green","purple")
-
-/obj/item/weapon/melee/energy/sword/attack_self(mob/living/user as mob)
-	if ((CLUMSY in user.mutations) && prob(50))
-		user << "\red You accidentally cut yourself with [src]."
-		user.take_organ_damage(5,5)
-	active = !active
-	if (active)
-		force = 30
-		if(istype(src,/obj/item/weapon/melee/energy/sword/pirate))
-			icon_state = "cutlass1"
-		else
-			icon_state = "sword[item_color]"
-		w_class = 4
-		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
-		user << "\blue [src] is now active."
-
-	else
-		force = 3
-		if(istype(src,/obj/item/weapon/melee/energy/sword/pirate))
-			icon_state = "cutlass0"
-		else
-			icon_state = "sword0"
-		w_class = 2
-		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
-		user << "\blue [src] can now be concealed."
-
-	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		H.update_inv_l_hand()
-		H.update_inv_r_hand()
-
-	add_fingerprint(user)
-	return
 
 /*
  * Classic Baton
@@ -182,86 +135,3 @@
 	else
 		return ..()
 
-
-/*
- *Energy Blade
- */
-//Most of the other special functions are handled in their own files.
-
-/obj/item/weapon/melee/energy/sword/green
-	New()
-		item_color = "green"
-
-/obj/item/weapon/melee/energy/sword/red
-	New()
-		item_color = "red"
-
-/obj/item/weapon/melee/energy/blade/New()
-	spark_system = new /datum/effect/effect/system/spark_spread()
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
-	return
-
-/obj/item/weapon/melee/energy/blade/dropped()
-	del(src)
-	return
-
-/obj/item/weapon/melee/energy/blade/proc/throw()
-	del(src)
-	return
-
-/*
- * Energy Axe
- */
-
-/obj/item/weapon/melee/energy/axe/attack_self(mob/user as mob)
-	src.active = !( src.active )
-	if (src.active)
-		user << "\blue The axe is now energised."
-		src.force = 150
-		src.icon_state = "axe1"
-		src.w_class = 5
-	else
-		user << "\blue The axe can now be concealed."
-		src.force = 40
-		src.icon_state = "axe0"
-		src.w_class = 5
-	src.add_fingerprint(user)
-	return
-
-
-/*
- * Energy Shield
- */
-/obj/item/weapon/shield/energy/IsShield()
-	if(active)
-		return 1
-	else
-		return 0
-
-/obj/item/weapon/shield/energy/attack_self(mob/living/user as mob)
-	if ((CLUMSY in user.mutations) && prob(50))
-		user << "\red You beat yourself in the head with [src]."
-		user.take_organ_damage(5)
-	active = !active
-	if (active)
-		force = 10
-		icon_state = "eshield[active]"
-		w_class = 4
-		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
-		user << "\blue [src] is now active."
-
-	else
-		force = 3
-		icon_state = "eshield[active]"
-		w_class = 1
-		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
-		user << "\blue [src] can now be concealed."
-
-	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		H.update_inv_l_hand()
-		H.update_inv_r_hand()
-
-	add_fingerprint(user)
-	return

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -18,14 +18,13 @@
  */
 /obj/item/weapon/twohanded
 	var/wielded = 0
-	var/force_unwielded = 0
 	var/force_wielded = 0
 	var/wieldsound = null
 	var/unwieldsound = null
 
 /obj/item/weapon/twohanded/proc/unwield()
 	wielded = 0
-	force = force_unwielded
+	force = initial(force)
 	name = "[initial(name)]"
 	update_icon()
 
@@ -108,12 +107,11 @@
 	icon_state = "fireaxe0"
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
-	force = 5
+	force = 10
 	sharp = 1
 	edge = 1
 	w_class = 4.0
 	slot_flags = SLOT_BACK
-	force_unwielded = 10
 	force_wielded = 40
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 
@@ -149,7 +147,6 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = 2.0
-	force_unwielded = 3
 	force_wielded = 30
 	wieldsound = 'sound/weapons/saberon.ogg'
 	unwieldsound = 'sound/weapons/saberoff.ogg'
@@ -189,11 +186,10 @@
 	force = 14
 	w_class = 4.0
 	slot_flags = SLOT_BACK
-	force_unwielded = 14
 	force_wielded = 22 // Was 13, Buffed - RR
 	throwforce = 20
 	throw_speed = 3
-	edge = 1
+	edge = 0
 	sharp = 1
 	flags = NOSHIELD
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -159,6 +159,8 @@
 	matter = list("metal" = 50)
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
+	sharp = 0
+	edge = 1
 
 /obj/item/weapon/shovel/spade
 	name = "spade"

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -71,7 +71,7 @@
 
 	name = lowertext("[fullname] sandwich")
 	if(length(name) > 80) name = "[pick(list("absurd","colossal","enormous","ridiculous"))] sandwich"
-	w_class = n_ceil(Clamp((ingredients.len/2),1,3))
+	w_class = n_ceil(Clamp((ingredients.len/2),2,4))
 
 /obj/item/weapon/reagent_containers/food/snacks/csandwich/Del()
 	for(var/obj/item/O in ingredients)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -10,6 +10,7 @@
 	var/slice_path
 	var/slices_num
 	center_of_mass = list("x"=15, "y"=15)
+	w_class = 2
 
 	//Placeholder for effect that trigger on eating that aren't tied to reagents.
 /obj/item/weapon/reagent_containers/food/snacks/proc/On_Consume(var/mob/M)
@@ -126,11 +127,10 @@
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/storage))
 		..() // -> item/attackby()
-	if(istype(W,/obj/item/weapon/storage))
-		..() // -> item/attackby()
-
+		return
+	
+	// Eating with forks
 	if(istype(W,/obj/item/weapon/kitchen/utensil))
-
 		var/obj/item/weapon/kitchen/utensil/U = W
 
 		if(!U.reagents)
@@ -158,64 +158,45 @@
 			del(src)
 		return
 
-	if((slices_num <= 0 || !slices_num) || !slice_path)
-		return 0
+	if (is_sliceable())
+		//these are used to allow hiding edge items in food that is not on a table/tray
+		var/can_slice_here = isturf(src.loc) && ((locate(/obj/structure/table) in src.loc) || (locate(/obj/machinery/optable) in src.loc) || (locate(/obj/item/weapon/tray) in src.loc))
+		var/hide_item = !has_edge(W) || !can_slice_here
+		
+		if (hide_item)
+			if (W.w_class >= src.w_class || W.is_robot_module())
+				return
+				
+			user << "\red You slip [W] inside [src]."
+			user.u_equip(W)
+			if ((user.client && user.s_active != src))
+				user.client.screen -= W
+			W.dropped(user)
+			add_fingerprint(user)
+			contents += W
+			return
+		
+		if (has_edge(W))
+			if (!can_slice_here)
+				user << "\red You cannot slice [src] here! You need a table or at least a tray to do it."
+				return
+			
+			var/slices_lost = 0
+			if (W.w_class > 3)
+				user.visible_message("\blue [user] crudely slices \the [src] with [W]!", "\blue You crudely slice \the [src] with your [W]!")
+				slices_lost = rand(1,min(1,round(slices_num/2)))
+			else
+				user.visible_message("\blue [user] slices \the [src]!", "\blue You slice \the [src]!")
+			
+			var/reagents_per_slice = reagents.total_volume/slices_num
+			for(var/i=1 to (slices_num-slices_lost))
+				var/obj/slice = new slice_path (src.loc)
+				reagents.trans_to(slice,reagents_per_slice)
+			del(src)
+			return
 
-	var/inaccurate = 0
-	if( \
-			istype(W, /obj/item/weapon/kitchenknife) || \
-			istype(W, /obj/item/weapon/butch) || \
-			istype(W, /obj/item/weapon/scalpel) || \
-			istype(W, /obj/item/weapon/kitchen/utensil/knife) \
-		)
-	else if( \
-			istype(W, /obj/item/weapon/circular_saw) || \
-			istype(W, /obj/item/weapon/melee/energy/sword) && W:active || \
-			istype(W, /obj/item/weapon/melee/energy/blade) || \
-			istype(W, /obj/item/weapon/shovel) || \
-			istype(W, /obj/item/weapon/hatchet) \
-		)
-		inaccurate = 1
-	else if(W.w_class <= 2 && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
-		if(!iscarbon(user))
-			return 1
-		user << "\red You slip [W] inside [src]."
-		user.u_equip(W)
-		if ((user.client && user.s_active != src))
-			user.client.screen -= W
-		W.dropped(user)
-		add_fingerprint(user)
-		contents += W
-		return
-	else
-		return 1
-	if ( \
-			!isturf(src.loc) || \
-			!(locate(/obj/structure/table) in src.loc) && \
-			!(locate(/obj/machinery/optable) in src.loc) && \
-			!(locate(/obj/item/weapon/tray) in src.loc) \
-		)
-		user << "\red You cannot slice [src] here! You need a table or at least a tray to do it."
-		return 1
-	var/slices_lost = 0
-	if (!inaccurate)
-		user.visible_message( \
-			"\blue [user] slices \the [src]!", \
-			"\blue You slice \the [src]!" \
-		)
-	else
-		user.visible_message( \
-			"\blue [user] crudely slices \the [src] with [W]!", \
-			"\blue You crudely slice \the [src] with your [W]!" \
-		)
-		slices_lost = rand(1,min(1,round(slices_num/2)))
-	var/reagents_per_slice = reagents.total_volume/slices_num
-	for(var/i=1 to (slices_num-slices_lost))
-		var/obj/slice = new slice_path (src.loc)
-		reagents.trans_to(slice,reagents_per_slice)
-	del(src)
-
-	return
+/obj/item/weapon/reagent_containers/food/snacks/proc/is_sliceable()
+	return (slices_num <= 0 || !slices_num || !slice_path)
 
 /obj/item/weapon/reagent_containers/food/snacks/Del()
 	if(contents)
@@ -241,7 +222,6 @@
 				N.visible_message("[N] nibbles away at [src].", "")
 			//N.emote("nibbles away at the [src]")
 			N.health = min(N.health + 1, N.maxHealth)
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// FOOD END

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2154,6 +2154,9 @@
 
 // sliceable is just an organization type path, it doesn't have any additional code or variables tied to it.
 
+/obj/item/weapon/reagent_containers/food/snacks/sliceable
+	w_class = 3 //Whole pizzas and cakes shouldn't fit in a pocket, you can slice them if you want to do that.
+
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/meatbread
 	name = "meatbread loaf"
 	desc = "The culinary base of every self-respecting eloquen/tg/entleman."


### PR DESCRIPTION
Rewrote food slicing so that any item with the edge var set can slice food. This meant making sure various items have the edge var set correctly, which led to fixing various issues with certain weapons... Mainly energy swords remaining sharp and edgy even when turned off and plastic knives having the same force as regular knives. While I was added I did a bunch of cleanup for energy swords (refactored de/activating to get rid of duplicate code), so this is targeting dev now.
