### PR TITLE
No more sleeping in closets

### DIFF
--- a/code/WorkInProgress/Sigyn/Softcurity/secure_closet.dm
+++ b/code/WorkInProgress/Sigyn/Softcurity/secure_closet.dm
@@ -9,7 +9,6 @@
 	icon_off = "capsecureoff"
 
 	New()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/captain(src)
 		else
@@ -40,7 +39,6 @@
 	icon_off = "hopsecureoff"
 
 	New()
-		sleep(2)
 		new /obj/item/clothing/under/rank/head_of_personnel(src)
 		new /obj/item/clothing/suit/armor/vest(src)
 		new /obj/item/clothing/head/helmet(src)
@@ -66,7 +64,6 @@
 	icon_off = "hossecureoff"
 
 	New()
-		sleep(2)
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 		new /obj/item/weapon/cartridge/hos(src)
 		new /obj/item/device/radio/headset/heads/hos(src)
@@ -93,7 +90,6 @@
 
 
 	New()
-		sleep(2)
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 		new /obj/item/clothing/under/rank/advisor(src)
 		new /obj/item/device/radio/headset/headset_sec(src)
@@ -118,7 +114,6 @@
 	icon_off = "secoff"
 
 	New()
-		sleep(2)
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 		new /obj/item/device/radio/headset/headset_sec(src)
 		new /obj/item/weapon/storage/belt/security(src)
@@ -141,7 +136,6 @@
 	icon_off = "cabinetdetective_broken"
 
 	New()
-		sleep(2)
 		new /obj/item/clothing/under/det(src)
 		new /obj/item/clothing/suit/armor/det_suit(src)
 		new /obj/item/clothing/suit/det_suit(src)
@@ -173,7 +167,6 @@
 
 
 	New()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/ld50_syringe/choral(src)
 		new /obj/item/weapon/reagent_containers/ld50_syringe/choral(src)
 		return
@@ -197,7 +190,6 @@
 	req_access = list(access_court)
 
 	New()
-		sleep(2)
 		new /obj/item/clothing/shoes/brown(src)
 		new /obj/item/weapon/paper/Court (src)
 		new /obj/item/weapon/paper/Court (src)

--- a/code/game/objects/closets/ert.dm
+++ b/code/game/objects/closets/ert.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/head/helmet/space/ert/commander(src)
 		new /obj/item/clothing/suit/space/ert/commander(src)
 		new /obj/item/weapon/plastique(src)
@@ -34,7 +33,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/head/helmet/space/ert/security(src)
 		new /obj/item/clothing/suit/space/ert/security(src)
 		new /obj/item/weapon/plastique(src)
@@ -57,7 +55,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/head/helmet/space/ert/engineer(src)
 		new /obj/item/clothing/suit/space/ert/engineer(src)
 		new /obj/item/weapon/gun/energy/taser(src)
@@ -79,7 +76,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/head/helmet/space/ert/medical(src)
 		new /obj/item/clothing/suit/space/ert/medical(src)
 		new /obj/item/weapon/gun/energy/taser(src)

--- a/code/game/objects/closets/secure/civilian.dm
+++ b/code/game/objects/closets/secure/civilian.dm
@@ -5,7 +5,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/chef(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -20,7 +19,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
@@ -39,7 +37,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/bartender(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -57,7 +54,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/hydro
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -72,7 +68,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/janitor(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -86,7 +81,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/lawyer(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -102,7 +96,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/librarian(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -116,7 +109,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/chaplain(src)
 		//
 		new /obj/item/weapon/storage/backpack/cultpack (src)

--- a/code/game/objects/closets/secure/research.dm
+++ b/code/game/objects/closets/secure/research.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/scientist(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)
@@ -35,7 +34,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/wardrobe/rd(src)
 		//
 		var/obj/item/weapon/storage/backpack/BPK = new /obj/item/weapon/storage/backpack(src)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -23,13 +23,11 @@
 
 	var/const/mob_size = 15
 
-/obj/structure/closet/New()
-	..()
-	spawn(1)
-		if(!opened)		// if closed, any item at the crate's loc is put in the contents
-			for(var/obj/item/I in src.loc)
-				if(I.density || I.anchored || I == src) continue
-				I.loc = src
+/obj/structure/closet/initialize()
+	if(!opened)		// if closed, any item at the crate's loc is put in the contents
+		for(var/obj/item/I in src.loc)
+			if(I.density || I.anchored || I == src) continue
+			I.loc = src
 
 /obj/structure/closet/alter_health()
 	return get_turf(src)

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -6,7 +6,6 @@
 
 /obj/structure/closet/athletic_mixed/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/shorts/grey(src)
 	new /obj/item/clothing/under/shorts/black(src)
 	new /obj/item/clothing/under/shorts/red(src)
@@ -30,7 +29,6 @@
 
 /obj/structure/closet/boxinggloves/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/gloves/boxing/blue(src)
 	new /obj/item/clothing/gloves/boxing/green(src)
 	new /obj/item/clothing/gloves/boxing/yellow(src)
@@ -43,7 +41,6 @@
 
 /obj/structure/closet/masks/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/mask/luchador(src)
 	new /obj/item/clothing/mask/luchador/rudos(src)
 	new /obj/item/clothing/mask/luchador/tecnicos(src)
@@ -57,7 +54,6 @@
 
 /obj/structure/closet/lasertag/red/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/gun/energy/laser/redtag(src)
 	new /obj/item/weapon/gun/energy/laser/redtag(src)
 	new /obj/item/clothing/suit/redtag(src)
@@ -72,7 +68,6 @@
 
 /obj/structure/closet/lasertag/blue/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/gun/energy/laser/bluetag(src)
 	new /obj/item/weapon/gun/energy/laser/bluetag(src)
 	new /obj/item/clothing/suit/bluetag(src)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -36,7 +36,6 @@
 
 /obj/structure/closet/gimmick/russian/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
@@ -58,7 +57,6 @@
 
 /obj/structure/closet/gimmick/tacticool/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/glasses/eyepatch(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/clothing/gloves/swat(src)
@@ -85,14 +83,12 @@
 
 /obj/structure/closet/thunderdome/New()
 	..()
-	sleep(2)
 
 /obj/structure/closet/thunderdome/tdred
 	name = "red-team Thunderdome closet"
 
 /obj/structure/closet/thunderdome/tdred/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
@@ -120,7 +116,6 @@
 
 /obj/structure/closet/thunderdome/tdgreen/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/armor/tdome/green(src)
 	new /obj/item/clothing/suit/armor/tdome/green(src)
 	new /obj/item/clothing/suit/armor/tdome/green(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -16,7 +16,6 @@
 
 /obj/structure/closet/gmcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/device/radio/headset/headset_service(src)
@@ -43,7 +42,6 @@
 
 /obj/structure/closet/chefcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/sundress(src)
 	new /obj/item/clothing/under/waiter(src)
 	new /obj/item/clothing/under/waiter(src)
@@ -65,7 +63,6 @@
 
 /obj/structure/closet/jcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/janitor(src)
 	new /obj/item/device/radio/headset/headset_service(src)
 	new /obj/item/weapon/cartridge/janitor(src)

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -7,7 +7,6 @@
 
 /obj/structure/closet/l3closet/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/bio_suit/general( src )
 	new /obj/item/clothing/head/bio_hood/general( src )
 
@@ -19,7 +18,6 @@
 
 /obj/structure/closet/l3closet/general/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/general( src )
 	new /obj/item/clothing/head/bio_hood/general( src )
@@ -32,7 +30,6 @@
 
 /obj/structure/closet/l3closet/virology/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/virology( src )
 	new /obj/item/clothing/head/bio_hood/virology( src )
@@ -47,7 +44,6 @@
 
 /obj/structure/closet/l3closet/security/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/security( src )
 	new /obj/item/clothing/head/bio_hood/security( src )
@@ -60,7 +56,6 @@
 
 /obj/structure/closet/l3closet/janitor/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/janitor( src )
 	new /obj/item/clothing/head/bio_hood/janitor( src )
@@ -73,7 +68,6 @@
 
 /obj/structure/closet/l3closet/scientist/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/scientist( src )
 	new /obj/item/clothing/head/bio_hood/scientist( src )

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -7,7 +7,6 @@
 
 /obj/structure/closet/malf/suits/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/tank/jetpack/void(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/clothing/head/helmet/space/nasavoid(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -11,7 +11,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/cargotech(src)
 		new /obj/item/clothing/shoes/black(src)
 		new /obj/item/device/radio/headset/headset_cargo(src)
@@ -31,7 +30,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/cargo(src)
 		new /obj/item/clothing/shoes/brown(src)
 		new /obj/item/device/radio/headset/headset_cargo(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -11,7 +11,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/industrial(src)
 		else
@@ -51,7 +50,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/gloves/yellow(src)
 		new /obj/item/clothing/gloves/yellow(src)
 		new /obj/item/weapon/storage/toolbox/electrical(src)
@@ -80,7 +78,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/head/welding(src)
 		new /obj/item/clothing/head/welding(src)
 		new /obj/item/clothing/head/welding(src)
@@ -107,7 +104,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/industrial(src)
 		else
@@ -137,7 +133,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/industrial(src)
 		else

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -18,7 +18,6 @@
 
 	New()
 		..()
-		sleep(2)
 		for(var/i = 0, i < 6, i++)
 			new /obj/item/weapon/reagent_containers/food/snacks/flour(src)
 		new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
@@ -44,7 +43,6 @@
 
 	New()
 		..()
-		sleep(2)
 		for(var/i = 0, i < 4, i++)
 			new /obj/item/weapon/reagent_containers/food/snacks/meat/monkey(src)
 		return
@@ -63,7 +61,6 @@
 
 	New()
 		..()
-		sleep(2)
 		for(var/i = 0, i < 5, i++)
 			new /obj/item/weapon/reagent_containers/food/drinks/milk(src)
 		for(var/i = 0, i < 3, i++)
@@ -87,7 +84,6 @@
 
 	New()
 		..()
-		sleep(2)
 		for(var/i = 0, i < 3, i++)
 			new /obj/item/weapon/spacecash/c1000(src)
 		for(var/i = 0, i < 5, i++)

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -11,7 +11,6 @@
 
 	New()
 		..()
-		sleep(2)
 		switch(rand(1,2))
 			if(1)
 				new /obj/item/clothing/suit/apron(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -12,7 +12,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/box/autoinjectors(src)
 		new /obj/item/weapon/storage/box/syringes(src)
 		new /obj/item/weapon/reagent_containers/dropper(src)
@@ -41,7 +40,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/tank/anesthetic(src)
 		new /obj/item/weapon/tank/anesthetic(src)
 		new /obj/item/weapon/tank/anesthetic(src)
@@ -64,7 +62,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/medic(src)
 		else
@@ -115,7 +112,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/medic(src)
 		else
@@ -153,7 +149,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/device/assembly/signaler(src)
 		new /obj/item/device/radio/electropack(src)
 		new /obj/item/device/radio/electropack(src)
@@ -176,7 +171,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/box/pillbottles(src)
 		new /obj/item/weapon/storage/box/pillbottles(src)
 		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/scientist(src)
 		//new /obj/item/clothing/suit/labcoat/science(src)
 		new /obj/item/clothing/suit/storage/labcoat(src)
@@ -35,7 +34,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/suit/bio_suit/scientist(src)
 		new /obj/item/clothing/head/bio_hood/scientist(src)
 		new /obj/item/clothing/under/rank/research_director(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/captain(src)
 		else
@@ -47,7 +46,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/glasses/sunglasses(src)
 		new /obj/item/clothing/suit/armor/vest(src)
 		new /obj/item/clothing/head/helmet(src)
@@ -71,7 +69,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/head_of_personnel(src)
 		new /obj/item/clothing/under/dress/dress_hop(src)
 		new /obj/item/clothing/under/dress/dress_hr(src)
@@ -101,7 +98,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
@@ -143,7 +139,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
@@ -180,7 +175,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
@@ -249,7 +243,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/det(src)
 		new /obj/item/clothing/under/det/black(src)
 		new /obj/item/clothing/under/det/slob(src)
@@ -291,7 +284,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/ld50_syringe/choral(src)
 		new /obj/item/weapon/reagent_containers/ld50_syringe/choral(src)
 		return
@@ -318,7 +310,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/shoes/brown(src)
 		new /obj/item/weapon/paper/Court (src)
 		new /obj/item/weapon/paper/Court (src)

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -11,7 +11,6 @@
 
 /obj/structure/closet/syndicate/personal/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/tank/jetpack/oxygen(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/clothing/under/syndicate(src)
@@ -30,7 +29,6 @@
 
 /obj/structure/closet/syndicate/suit/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/tank/jetpack/oxygen(src)
 	new /obj/item/clothing/shoes/magboots(src)
 	new /obj/item/clothing/suit/space/rig/syndi(src)
@@ -43,7 +41,7 @@
 
 /obj/structure/closet/syndicate/nuclear/New()
 	..()
-	sleep(2)
+	
 	new /obj/item/ammo_magazine/a12mm(src)
 	new /obj/item/ammo_magazine/a12mm(src)
 	new /obj/item/ammo_magazine/a12mm(src)
@@ -77,7 +75,6 @@
 		var/rare_max = 20 //Maximum HONK HONK HONK in the HONK for HONK rare HONK
 
 
-		sleep(2)
 
 		var/pickednum = rand(1, 50)
 
@@ -141,7 +138,6 @@
 		/obj/item/stack/rods
 		)
 
-		sleep(2)
 
 		for(var/i = 0, i<2, i++)
 			for(var/res in resources)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -171,7 +171,6 @@
 
 /obj/structure/closet/bombcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/bomb_suit( src )
 	new /obj/item/clothing/under/color/black( src )
 	new /obj/item/clothing/shoes/black( src )
@@ -187,7 +186,6 @@
 
 /obj/structure/closet/bombclosetsecurity/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/bomb_suit/security( src )
 	new /obj/item/clothing/under/rank/security( src )
 	new /obj/item/clothing/shoes/brown( src )
@@ -208,7 +206,6 @@
 
 /obj/structure/closet/hydrant/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/device/flashlight(src)


### PR DESCRIPTION
Removes the 2-tick sleep caused by every closet in New().
Moves the code that sucks up items into closets to initialize() to avoid processing still null objects.
