### PR TITLE
Fixes door projectile damage

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -23,7 +23,7 @@
 	var/normalspeed = 1
 	var/heat_proof = 0 // For glass airlocks/opacity firedoors
 	var/air_properties_vary_with_direction = 0
-	var/maxhealth = 500
+	var/maxhealth = 300
 	var/health
 	var/min_force = 10 //minimum amount of force needed to damage the door with a melee weapon
 	var/hitsound = 'sound/weapons/smash.ogg' //sound door makes when hit with a weapon
@@ -127,13 +127,14 @@
 	return
 
 /obj/machinery/door/bullet_act(var/obj/item/projectile/Proj)
+	..()
+	
 	//Tasers and the like should not damage doors.
 	if(Proj.damage_type == HALLOSS)
 		return
 
 	if(Proj.damage)
-		take_damage(round(Proj.damage * 4))
-	..()
+		take_damage(Proj.damage)
 
 /obj/machinery/door/hitby(AM as mob|obj)
 


### PR DESCRIPTION
Not only does it not make much sense that projectiles do 4x as much damage to doors, it also makes it very easy to bust through multiple doors with a laser gun.

Removing the multiplier now makes it so that deciding to use your gun to break a door has a real cost, eating up a good portion of the clip.

| Weapon | Number of Shot to Break |
| --- | --- |
| C20r SMG | 15 |
| Laser Carbine | 8 |
| Shotgun | 5 |
| Laser Cannon | 4 |

Also fixes the return before parent call in bullet_act().
