### PR TITLE
Cleans up slime saycode clutter

### DIFF
--- a/code/modules/mob/living/carbon/metroid/say.dm
+++ b/code/modules/mob/living/carbon/metroid/say.dm
@@ -21,3 +21,16 @@
 		return 1
 	return ..()
 
+/mob/living/carbon/slime/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+	if (speaker in Friends)
+		speech_buffer = list()
+		speech_buffer.Add(speaker)
+		speech_buffer.Add(lowertext(html_decode(message)))
+	..()
+
+/mob/living/carbon/slime/hear_radio(var/message, var/verb="says", var/datum/language/language=null, var/part_a, var/part_b, var/mob/speaker = null, var/hard_to_hear = 0, var/vname ="")
+	if (speaker in Friends)
+		speech_buffer = list()
+		speech_buffer.Add(speaker)
+		speech_buffer.Add(lowertext(html_decode(message)))
+	..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -117,12 +117,6 @@ proc/get_radio_key_from_channel(var/channel)
 				hearturfs += M.locs[1]
 				for(var/obj/O in M.contents)
 					listening_obj |= O
-				if (isslime(I))
-					var/mob/living/carbon/slime/S = I
-					if (src in S.Friends)
-						S.speech_buffer = list()
-						S.speech_buffer.Add(src)
-						S.speech_buffer.Add(lowertext(html_decode(message)))
 			else if(istype(I, /obj/))
 				var/obj/O = I
 				hearturfs += O.locs[1]


### PR DESCRIPTION
It was cluttering saycode used by every living mob in the game with something that only applies to slimes.
Also, code that really applies to hearing a message shouldn't have been mixed up with code for speaking a message. Really awful :/
