### PR TITLE
Roboscanner fix

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -24,7 +24,8 @@
 		"/obj/item/stack/cable_coil",
 		"/obj/item/device/t_scanner",
 		"/obj/item/device/analyzer",
-		"/obj/item/taperoll/engineering")
+		"/obj/item/taperoll/engineering",
+		"/obj/item/device/robotanalyzer")
 
 
 /obj/item/weapon/storage/belt/utility/full/New()

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -12,8 +12,8 @@
 	w_class = 2.0
 	throw_speed = 5
 	throw_range = 10
-	matter = list("metal" = 200)
-	origin_tech = "magnets=1;biotech=1"
+	matter = list("metal" = 500, "glass" = 200)
+	origin_tech = "magnets=2;biotech=1;engineering=2"
 	var/mode = 1;
 
 /obj/item/device/robotanalyzer/attack(mob/living/M as mob, mob/living/user as mob)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1321,6 +1321,15 @@ datum/design/batteryrack
 ////////////Medical Tools////////////////
 /////////////////////////////////////////
 
+datum/design/robot_scanner
+	name = "Cyborg Analyzer"
+	desc = "A hand-held scanner able to diagnose robotic injuries. "
+	id = "robot_scanner"
+	req_tech = list("magnets" = 3, "biotech" = 2, "engineering" = 3)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 500, "$glass" = 200)
+	build_path = "/obj/item/device/robotanalyzer"
+
 datum/design/mass_spectrometer
 	name = "Mass-Spectrometer"
 	desc = "A device for analyzing chemicals in the blood."


### PR DESCRIPTION
- Fixes #7011 
- Robot analyzers are now buildable in protolathe
- Robot analyzers can be carried in tool belts
