### PR TITLE
Research Safety

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -48,7 +48,7 @@ datum/design						//Datum for object designs, used in construction
 	var/reliability = 100				//Reliability of the device.
 	var/build_type = null				//Flag as to what kind machine the design is built in. See defines.
 	var/list/materials = list()			//List of materials. Format: "id" = amount.
-	var/build_path = ""					//The file path of the object that gets created
+	var/build_path = null				//The path of the object that gets created
 	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access
 	var/category = null //Primarily used for Mech Fabricators, but can be used for anything
 
@@ -74,7 +74,7 @@ datum/design/seccamera
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/security"
+	build_path = /obj/item/weapon/circuitboard/security
 
 datum/design/aicore
 	name = "Circuit Design (AI Core)"
@@ -83,7 +83,7 @@ datum/design/aicore
 	req_tech = list("programming" = 4, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/aicore"
+	build_path = /obj/item/weapon/circuitboard/aicore
 
 datum/design/aiupload
 	name = "Circuit Design (AI Upload)"
@@ -92,7 +92,7 @@ datum/design/aiupload
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/aiupload"
+	build_path = /obj/item/weapon/circuitboard/aiupload
 
 datum/design/borgupload
 	name = "Circuit Design (Cyborg Upload)"
@@ -101,7 +101,7 @@ datum/design/borgupload
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/borgupload"
+	build_path = /obj/item/weapon/circuitboard/borgupload
 
 datum/design/med_data
 	name = "Circuit Design (Medical Records)"
@@ -110,7 +110,7 @@ datum/design/med_data
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/med_data"
+	build_path = /obj/item/weapon/circuitboard/med_data
 
 datum/design/operating
 	name = "Circuit Design (Operating Computer)"
@@ -119,7 +119,7 @@ datum/design/operating
 	req_tech = list("programming" = 2, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/operating"
+	build_path = /obj/item/weapon/circuitboard/operating
 
 datum/design/pandemic
 	name = "Circuit Design (PanD.E.M.I.C. 2200)"
@@ -128,7 +128,7 @@ datum/design/pandemic
 	req_tech = list("programming" = 2, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/pandemic"
+	build_path = /obj/item/weapon/circuitboard/pandemic
 
 datum/design/scan_console
 	name = "Circuit Design (DNA Machine)"
@@ -137,7 +137,7 @@ datum/design/scan_console
 	req_tech = list("programming" = 2, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/scan_consolenew"
+	build_path = /obj/item/weapon/circuitboard/scan_consolenew
 
 datum/design/comconsole
 	name = "Circuit Design (Communications)"
@@ -146,7 +146,7 @@ datum/design/comconsole
 	req_tech = list("programming" = 2, "magnets" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/communications"
+	build_path = /obj/item/weapon/circuitboard/communications
 
 datum/design/idcardconsole
 	name = "Circuit Design (ID Computer)"
@@ -155,7 +155,7 @@ datum/design/idcardconsole
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/card"
+	build_path = /obj/item/weapon/circuitboard/card
 
 datum/design/crewconsole
 	name = "Circuit Design (Crew monitoring computer)"
@@ -164,7 +164,7 @@ datum/design/crewconsole
 	req_tech = list("programming" = 3, "magnets" = 2, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/crew"
+	build_path = /obj/item/weapon/circuitboard/crew
 
 datum/design/teleconsole
 	name = "Circuit Design (Teleporter Console)"
@@ -173,7 +173,7 @@ datum/design/teleconsole
 	req_tech = list("programming" = 3, "bluespace" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/teleporter"
+	build_path = /obj/item/weapon/circuitboard/teleporter
 
 datum/design/secdata
 	name = "Circuit Design (Security Records Console)"
@@ -182,7 +182,7 @@ datum/design/secdata
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/secure_data"
+	build_path = /obj/item/weapon/circuitboard/secure_data
 
 datum/design/atmosalerts
 	name = "Circuit Design (Atmosphere Alert)"
@@ -191,7 +191,7 @@ datum/design/atmosalerts
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/atmos_alert"
+	build_path = /obj/item/weapon/circuitboard/atmos_alert
 
 datum/design/air_management
 	name = "Circuit Design (Atmospheric Monitor)"
@@ -200,7 +200,7 @@ datum/design/air_management
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/air_management"
+	build_path = /obj/item/weapon/circuitboard/air_management
 
 /* Uncomment if someone makes these buildable
 datum/design/general_alert
@@ -210,7 +210,7 @@ datum/design/general_alert
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/general_alert"
+	build_path = /obj/item/weapon/circuitboard/general_alert"
 */
 
 datum/design/robocontrol
@@ -220,7 +220,7 @@ datum/design/robocontrol
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/robotics"
+	build_path = /obj/item/weapon/circuitboard/robotics
 
 datum/design/dronecontrol
 	name = "Circuit Design (Drone Control Console)"
@@ -229,7 +229,7 @@ datum/design/dronecontrol
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/drone_control"
+	build_path = /obj/item/weapon/circuitboard/drone_control
 
 datum/design/clonecontrol
 	name = "Circuit Design (Cloning Machine Console)"
@@ -238,7 +238,7 @@ datum/design/clonecontrol
 	req_tech = list("programming" = 3, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/cloning"
+	build_path = /obj/item/weapon/circuitboard/cloning
 
 datum/design/clonepod
 	name = "Circuit Design (Clone Pod)"
@@ -247,7 +247,7 @@ datum/design/clonepod
 	req_tech = list("programming" = 3, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/clonepod"
+	build_path = /obj/item/weapon/circuitboard/clonepod
 
 datum/design/clonescanner
 	name = "Circuit Design (Cloning Scanner)"
@@ -256,7 +256,7 @@ datum/design/clonescanner
 	req_tech = list("programming" = 3, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/clonescanner"
+	build_path = /obj/item/weapon/circuitboard/clonescanner
 
 datum/design/arcademachine
 	name = "Circuit Design (Arcade Machine)"
@@ -265,7 +265,7 @@ datum/design/arcademachine
 	req_tech = list("programming" = 1)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/arcade"
+	build_path = /obj/item/weapon/circuitboard/arcade
 
 datum/design/powermonitor
 	name = "Circuit Design (Power Monitor)"
@@ -274,7 +274,7 @@ datum/design/powermonitor
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/powermonitor"
+	build_path = /obj/item/weapon/circuitboard/powermonitor
 
 datum/design/solarcontrol
 	name = "Circuit Design (Solar Control)"
@@ -283,7 +283,7 @@ datum/design/solarcontrol
 	req_tech = list("programming" = 2, "powerstorage" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/solar_control"
+	build_path = /obj/item/weapon/circuitboard/solar_control
 
 datum/design/prisonmanage
 	name = "Circuit Design (Prisoner Management Console)"
@@ -292,7 +292,7 @@ datum/design/prisonmanage
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/prisoner"
+	build_path = /obj/item/weapon/circuitboard/prisoner
 
 datum/design/mechacontrol
 	name = "Circuit Design (Exosuit Control Console)"
@@ -301,7 +301,7 @@ datum/design/mechacontrol
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha_control"
+	build_path = /obj/item/weapon/circuitboard/mecha_control
 
 datum/design/mechapower
 	name = "Circuit Design (Mech Bay Power Control Console)"
@@ -310,7 +310,7 @@ datum/design/mechapower
 	req_tech = list("programming" = 2, "powerstorage" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mech_bay_power_console"
+	build_path = /obj/item/weapon/circuitboard/mech_bay_power_console
 
 datum/design/rdconsole
 	name = "Circuit Design (R&D Console)"
@@ -319,7 +319,7 @@ datum/design/rdconsole
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/rdconsole"
+	build_path = /obj/item/weapon/circuitboard/rdconsole
 
 datum/design/ordercomp
 	name = "Circuit Design (Supply ordering console)"
@@ -328,7 +328,7 @@ datum/design/ordercomp
 	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/ordercomp"
+	build_path = /obj/item/weapon/circuitboard/ordercomp
 
 datum/design/supplycomp
 	name = "Circuit Design (Supply shuttle console)"
@@ -337,7 +337,7 @@ datum/design/supplycomp
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/supplycomp"
+	build_path = /obj/item/weapon/circuitboard/supplycomp
 
 datum/design/comm_monitor
 	name = "Circuit Design (Telecommunications Monitoring Console)"
@@ -346,7 +346,7 @@ datum/design/comm_monitor
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/comm_monitor"
+	build_path = /obj/item/weapon/circuitboard/comm_monitor
 
 datum/design/comm_server
 	name = "Circuit Design (Telecommunications Server Monitoring Console)"
@@ -355,7 +355,7 @@ datum/design/comm_server
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/comm_server"
+	build_path = /obj/item/weapon/circuitboard/comm_server
 
 datum/design/message_monitor
 	name = "Circuit Design (Messaging Monitor Console)"
@@ -364,7 +364,7 @@ datum/design/message_monitor
 	req_tech = list("programming" = 5)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/message_monitor"
+	build_path = /obj/item/weapon/circuitboard/message_monitor
 
 datum/design/aifixer
 	name = "Circuit Design (AI Integrity Restorer)"
@@ -373,7 +373,7 @@ datum/design/aifixer
 	req_tech = list("programming" = 3, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/aifixer"
+	build_path = /obj/item/weapon/circuitboard/aifixer
 
 // VERY VERY EXPENSIVE (needs diamonds and stuff)
 datum/design/smes_cell
@@ -383,7 +383,7 @@ datum/design/smes_cell
 	req_tech = list("powerstorage" = 7, "engineering" = 5) // Higher than obtained by deconstructing existing boards. Needs more RnD effor to make
 	build_type = IMPRINTER
 	materials = list("$glass" = 4000, "sacid" = 40, "$gold" = 1000, "$silver" = 1000, "$diamond" = 500)
-	build_path = "/obj/item/weapon/circuitboard/smes"
+	build_path = /obj/item/weapon/circuitboard/smes
 
 ///////////////////////////////////
 //////////AI Module Disks//////////
@@ -395,7 +395,7 @@ datum/design/safeguard_module
 	req_tech = list("programming" = 3, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/safeguard"
+	build_path = /obj/item/weapon/aiModule/safeguard
 
 datum/design/onehuman_module
 	name = "Module Design (OneHuman)"
@@ -404,7 +404,7 @@ datum/design/onehuman_module
 	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$diamond" = 100)
-	build_path = "/obj/item/weapon/aiModule/oneHuman"
+	build_path = /obj/item/weapon/aiModule/oneHuman
 
 datum/design/protectstation_module
 	name = "Module Design (ProtectStation)"
@@ -413,7 +413,7 @@ datum/design/protectstation_module
 	req_tech = list("programming" = 3, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/protectStation"
+	build_path = /obj/item/weapon/aiModule/protectStation
 
 datum/design/notele_module
 	name = "Module Design (TeleporterOffline Module)"
@@ -422,7 +422,7 @@ datum/design/notele_module
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/teleporterOffline"
+	build_path = /obj/item/weapon/aiModule/teleporterOffline
 
 datum/design/quarantine_module
 	name = "Module Design (Quarantine)"
@@ -431,7 +431,7 @@ datum/design/quarantine_module
 	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/quarantine"
+	build_path = /obj/item/weapon/aiModule/quarantine
 
 datum/design/oxygen_module
 	name = "Module Design (OxygenIsToxicToHumans)"
@@ -440,7 +440,7 @@ datum/design/oxygen_module
 	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/oxygen"
+	build_path = /obj/item/weapon/aiModule/oxygen
 
 datum/design/freeform_module
 	name = "Module Design (Freeform)"
@@ -449,7 +449,7 @@ datum/design/freeform_module
 	req_tech = list("programming" = 4, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/freeform"
+	build_path = /obj/item/weapon/aiModule/freeform
 
 datum/design/reset_module
 	name = "Module Design (Reset)"
@@ -458,7 +458,7 @@ datum/design/reset_module
 	req_tech = list("programming" = 3, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$gold" = 100)
-	build_path = "/obj/item/weapon/aiModule/reset"
+	build_path = /obj/item/weapon/aiModule/reset
 
 datum/design/purge_module
 	name = "Module Design (Purge)"
@@ -467,7 +467,7 @@ datum/design/purge_module
 	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$diamond" = 100)
-	build_path = "/obj/item/weapon/aiModule/purge"
+	build_path = /obj/item/weapon/aiModule/purge
 
 datum/design/freeformcore_module
 	name = "Core Module Design (Freeform)"
@@ -476,7 +476,7 @@ datum/design/freeformcore_module
 	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$diamond" = 100)
-	build_path = "/obj/item/weapon/aiModule/freeformcore"
+	build_path = /obj/item/weapon/aiModule/freeformcore
 
 datum/design/asimov
 	name = "Core Module Design (Asimov)"
@@ -485,7 +485,7 @@ datum/design/asimov
 	req_tech = list("programming" = 3, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$diamond" = 100)
-	build_path = "/obj/item/weapon/aiModule/asimov"
+	build_path = /obj/item/weapon/aiModule/asimov
 
 datum/design/paladin_module
 	name = "Core Module Design (P.A.L.A.D.I.N.)"
@@ -494,7 +494,7 @@ datum/design/paladin_module
 	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$diamond" = 100)
-	build_path = "/obj/item/weapon/aiModule/paladin"
+	build_path = /obj/item/weapon/aiModule/paladin
 
 datum/design/tyrant_module
 	name = "Core Module Design (T.Y.R.A.N.T.)"
@@ -503,7 +503,7 @@ datum/design/tyrant_module
 	req_tech = list("programming" = 4, "syndicate" = 2, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20, "$diamond" = 100)
-	build_path = "/obj/item/weapon/aiModule/tyrant"
+	build_path = /obj/item/weapon/aiModule/tyrant
 
 
 
@@ -517,7 +517,7 @@ datum/design/subspace_receiver
 	req_tech = list("programming" = 4, "engineering" = 3, "bluespace" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/receiver"
+	build_path = /obj/item/weapon/circuitboard/telecomms/receiver
 
 datum/design/telecomms_bus
 	name = "Circuit Design (Bus Mainframe)"
@@ -526,7 +526,7 @@ datum/design/telecomms_bus
 	req_tech = list("programming" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/bus"
+	build_path = /obj/item/weapon/circuitboard/telecomms/bus
 
 datum/design/telecomms_hub
 	name = "Circuit Design (Hub Mainframe)"
@@ -535,7 +535,7 @@ datum/design/telecomms_hub
 	req_tech = list("programming" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/hub"
+	build_path = /obj/item/weapon/circuitboard/telecomms/hub
 
 datum/design/telecomms_relay
 	name = "Circuit Design (Relay Mainframe)"
@@ -544,7 +544,7 @@ datum/design/telecomms_relay
 	req_tech = list("programming" = 3, "engineering" = 4, "bluespace" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/relay"
+	build_path = /obj/item/weapon/circuitboard/telecomms/relay
 
 datum/design/telecomms_processor
 	name = "Circuit Design (Processor Unit)"
@@ -553,7 +553,7 @@ datum/design/telecomms_processor
 	req_tech = list("programming" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/processor"
+	build_path = /obj/item/weapon/circuitboard/telecomms/processor
 
 datum/design/telecomms_server
 	name = "Circuit Design (Server Mainframe)"
@@ -562,7 +562,7 @@ datum/design/telecomms_server
 	req_tech = list("programming" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/server"
+	build_path = /obj/item/weapon/circuitboard/telecomms/server
 
 datum/design/subspace_broadcaster
 	name = "Circuit Design (Subspace Broadcaster)"
@@ -571,7 +571,7 @@ datum/design/subspace_broadcaster
 	req_tech = list("programming" = 4, "engineering" = 4, "bluespace" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/telecomms/broadcaster"
+	build_path = /obj/item/weapon/circuitboard/telecomms/broadcaster
 
 
 ///////////////////////////////////
@@ -585,7 +585,7 @@ datum/design/intellicard
 	req_tech = list("programming" = 4, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list("$glass" = 1000, "$gold" = 200)
-	build_path = "/obj/item/device/aicard"
+	build_path = /obj/item/device/aicard
 
 datum/design/paicard
 	name = "Personal Artificial Intelligence Card"
@@ -594,7 +594,7 @@ datum/design/paicard
 	req_tech = list("programming" = 2)
 	build_type = PROTOLATHE
 	materials = list("$glass" = 500, "$metal" = 500)
-	build_path = "/obj/item/device/paicard"
+	build_path = /obj/item/device/paicard
 
 datum/design/posibrain
 	name = "Positronic Brain"
@@ -604,7 +604,7 @@ datum/design/posibrain
 
 	build_type = PROTOLATHE
 	materials = list("$metal" = 2000, "$glass" = 1000, "$silver" = 1000, "$gold" = 500, "$phoron" = 500, "$diamond" = 100)
-	build_path = "/obj/item/device/mmi/posibrain"
+	build_path = /obj/item/device/mmi/posibrain
 
 ///////////////////////////////////
 //////////Mecha Module Disks///////
@@ -617,7 +617,7 @@ datum/design/ripley_main
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/ripley/main"
+	build_path = /obj/item/weapon/circuitboard/mecha/ripley/main
 
 datum/design/ripley_peri
 	name = "Circuit Design (APLU \"Ripley\" Peripherals Control module)"
@@ -626,7 +626,7 @@ datum/design/ripley_peri
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/ripley/peripherals"
+	build_path = /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 
 datum/design/odysseus_main
 	name = "Circuit Design (\"Odysseus\" Central Control module)"
@@ -635,7 +635,7 @@ datum/design/odysseus_main
 	req_tech = list("programming" = 3,"biotech" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/odysseus/main"
+	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/main
 
 datum/design/odysseus_peri
 	name = "Circuit Design (\"Odysseus\" Peripherals Control module)"
@@ -644,7 +644,7 @@ datum/design/odysseus_peri
 	req_tech = list("programming" = 3,"biotech" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/odysseus/peripherals"
+	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
 
 datum/design/gygax_main
 	name = "Circuit Design (\"Gygax\" Central Control module)"
@@ -653,7 +653,7 @@ datum/design/gygax_main
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/gygax/main"
+	build_path = /obj/item/weapon/circuitboard/mecha/gygax/main
 
 datum/design/gygax_peri
 	name = "Circuit Design (\"Gygax\" Peripherals Control module)"
@@ -662,7 +662,7 @@ datum/design/gygax_peri
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/gygax/peripherals"
+	build_path = /obj/item/weapon/circuitboard/mecha/gygax/peripherals
 
 datum/design/gygax_targ
 	name = "Circuit Design (\"Gygax\" Weapons & Targeting Control module)"
@@ -671,7 +671,7 @@ datum/design/gygax_targ
 	req_tech = list("programming" = 4, "combat" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/gygax/targeting"
+	build_path = /obj/item/weapon/circuitboard/mecha/gygax/targeting
 
 datum/design/durand_main
 	name = "Circuit Design (\"Durand\" Central Control module)"
@@ -680,7 +680,7 @@ datum/design/durand_main
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/durand/main"
+	build_path = /obj/item/weapon/circuitboard/mecha/durand/main
 
 datum/design/durand_peri
 	name = "Circuit Design (\"Durand\" Peripherals Control module)"
@@ -689,7 +689,7 @@ datum/design/durand_peri
 	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/durand/peripherals"
+	build_path = /obj/item/weapon/circuitboard/mecha/durand/peripherals
 
 datum/design/durand_targ
 	name = "Circuit Design (\"Durand\" Weapons & Targeting Control module)"
@@ -698,7 +698,7 @@ datum/design/durand_targ
 	req_tech = list("programming" = 4, "combat" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/durand/targeting"
+	build_path = /obj/item/weapon/circuitboard/mecha/durand/targeting
 
 datum/design/honker_main
 	name = "Circuit Design (\"H.O.N.K\" Central Control module)"
@@ -707,7 +707,7 @@ datum/design/honker_main
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/honker/main"
+	build_path = /obj/item/weapon/circuitboard/mecha/honker/main
 
 datum/design/honker_peri
 	name = "Circuit Design (\"H.O.N.K\" Peripherals Control module)"
@@ -716,7 +716,7 @@ datum/design/honker_peri
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/honker/peripherals"
+	build_path = /obj/item/weapon/circuitboard/mecha/honker/peripherals
 
 datum/design/honker_targ
 	name = "Circuit Design (\"H.O.N.K\" Weapons & Targeting Control module)"
@@ -725,7 +725,7 @@ datum/design/honker_targ
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mecha/honker/targeting"
+	build_path = /obj/item/weapon/circuitboard/mecha/honker/targeting
 
 ////////////////////////////////////////
 /////////// Mecha Equpment /////////////
@@ -737,7 +737,7 @@ datum/design/mech_scattershot
 	id = "mech_scattershot"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
 	category = "Exosuit Equipment"
 
 datum/design/mech_laser
@@ -746,7 +746,7 @@ datum/design/mech_laser
 	id = "mech_laser"
 	build_type = MECHFAB
 	req_tech = list("combat" = 3, "magnets" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	category = "Exosuit Equipment"
 
 datum/design/mech_laser_rigged
@@ -755,7 +755,7 @@ datum/design/mech_laser_rigged
 	id = "mech_laser_rigged"
 	build_type = MECHFAB
 	req_tech = list("combat" = 2, "magnets" = 2)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/energy/riggedlaser"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/riggedlaser
 	category = "Exosuit Equipment"
 
 datum/design/mech_laser_heavy
@@ -764,7 +764,7 @@ datum/design/mech_laser_heavy
 	id = "mech_laser_heavy"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "magnets" = 4)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	category = "Exosuit Equipment"
 
 datum/design/mech_ion
@@ -773,7 +773,7 @@ datum/design/mech_ion
 	id = "mech_ion"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "magnets" = 4)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
 	category = "Exosuit Equipment"
 
 datum/design/mech_grenade_launcher
@@ -782,7 +782,7 @@ datum/design/mech_grenade_launcher
 	id = "mech_grenade_launcher"
 	build_type = MECHFAB
 	req_tech = list("combat" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang
 	category = "Exosuit Equipment"
 
 datum/design/clusterbang_launcher
@@ -791,7 +791,7 @@ datum/design/clusterbang_launcher
 	id = "clusterbang_launcher"
 	build_type = MECHFAB
 	req_tech = list("combat"= 5, "materials" = 5, "syndicate" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang/limited"
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang/limited
 	category = "Exosuit Equipment"
 
 datum/design/mech_wormhole_gen
@@ -800,7 +800,7 @@ datum/design/mech_wormhole_gen
 	id = "mech_wormhole_gen"
 	build_type = MECHFAB
 	req_tech = list("bluespace" = 3, "magnets" = 2)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/wormhole_generator"
+	build_path = /obj/item/mecha_parts/mecha_equipment/wormhole_generator
 	category = "Exosuit Equipment"
 
 datum/design/mech_teleporter
@@ -809,7 +809,7 @@ datum/design/mech_teleporter
 	id = "mech_teleporter"
 	build_type = MECHFAB
 	req_tech = list("bluespace" = 10, "magnets" = 5)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/teleporter"
+	build_path = /obj/item/mecha_parts/mecha_equipment/teleporter
 	category = "Exosuit Equipment"
 
 datum/design/mech_rcd
@@ -818,7 +818,7 @@ datum/design/mech_rcd
 	id = "mech_rcd"
 	build_type = MECHFAB
 	req_tech = list("materials" = 4, "bluespace" = 3, "magnets" = 4, "powerstorage"=4, "engineering" = 4)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/tool/rcd"
+	build_path = /obj/item/mecha_parts/mecha_equipment/tool/rcd
 	category = "Exosuit Equipment"
 
 datum/design/mech_gravcatapult
@@ -827,7 +827,7 @@ datum/design/mech_gravcatapult
 	id = "mech_gravcatapult"
 	build_type = MECHFAB
 	req_tech = list("bluespace" = 2, "magnets" = 3, "engineering" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/gravcatapult"
+	build_path = /obj/item/mecha_parts/mecha_equipment/gravcatapult
 	category = "Exosuit Equipment"
 
 datum/design/mech_repair_droid
@@ -836,7 +836,7 @@ datum/design/mech_repair_droid
 	id = "mech_repair_droid"
 	build_type = MECHFAB
 	req_tech = list("magnets" = 3, "programming" = 3, "engineering" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/repair_droid"
+	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
 	category = "Exosuit Equipment"
 
 datum/design/mech_phoron_generator
@@ -845,7 +845,7 @@ datum/design/mech_phoron_generator
 	id = "mech_phoron_generator"
 	build_type = MECHFAB
 	req_tech = list("phorontech" = 2, "powerstorage"= 2, "engineering" = 2)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/phoron_generator"
+	build_path = /obj/item/mecha_parts/mecha_equipment/generator
 	category = "Exosuit Equipment"
 
 datum/design/mech_energy_relay
@@ -854,7 +854,7 @@ datum/design/mech_energy_relay
 	id = "mech_energy_relay"
 	build_type = MECHFAB
 	req_tech = list("magnets" = 4, "powerstorage" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay"
+	build_path = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	category = "Exosuit Equipment"
 
 datum/design/mech_ccw_armor
@@ -863,7 +863,7 @@ datum/design/mech_ccw_armor
 	id = "mech_ccw_armor"
 	build_type = MECHFAB
 	req_tech = list("materials" = 5, "combat" = 4)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster"
+	build_path = /obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster
 	category = "Exosuit Equipment"
 
 datum/design/mech_proj_armor
@@ -872,7 +872,7 @@ datum/design/mech_proj_armor
 	id = "mech_proj_armor"
 	build_type = MECHFAB
 	req_tech = list("materials" = 5, "combat" = 5, "engineering"=3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster"
+	build_path = /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
 	category = "Exosuit Equipment"
 
 datum/design/mech_syringe_gun
@@ -881,7 +881,7 @@ datum/design/mech_syringe_gun
 	id = "mech_syringe_gun"
 	build_type = MECHFAB
 	req_tech = list("materials" = 3, "biotech"=4, "magnets"=4, "programming"=3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/tool/syringe_gun"
+	build_path = /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
 	category = "Exosuit Equipment"
 
 datum/design/mech_diamond_drill
@@ -890,7 +890,7 @@ datum/design/mech_diamond_drill
 	id = "mech_diamond_drill"
 	build_type = MECHFAB
 	req_tech = list("materials" = 4, "engineering" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill"
+	build_path = /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill
 	category = "Exosuit Equipment"
 
 datum/design/mech_generator_nuclear
@@ -899,7 +899,7 @@ datum/design/mech_generator_nuclear
 	id = "mech_generator_nuclear"
 	build_type = MECHFAB
 	req_tech = list("powerstorage"= 3, "engineering" = 3, "materials" = 3)
-	build_path = "/obj/item/mecha_parts/mecha_equipment/generator/nuclear"
+	build_path = /obj/item/mecha_parts/mecha_equipment/generator/nuclear
 	category = "Exosuit Equipment"
 
 
@@ -913,7 +913,7 @@ datum/design/design_disk
 	req_tech = list("programming" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 30, "$glass" = 10)
-	build_path = "/obj/item/weapon/disk/design_disk"
+	build_path = /obj/item/weapon/disk/design_disk
 
 datum/design/tech_disk
 	name = "Technology Data Storage Disk"
@@ -922,7 +922,7 @@ datum/design/tech_disk
 	req_tech = list("programming" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 30, "$glass" = 10)
-	build_path = "/obj/item/weapon/disk/tech_disk"
+	build_path = /obj/item/weapon/disk/tech_disk
 
 ////////////////////////////////////////
 /////////////Stock Parts////////////////
@@ -935,7 +935,7 @@ datum/design/basic_capacitor
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/stock_parts/capacitor"
+	build_path = /obj/item/weapon/stock_parts/capacitor
 
 datum/design/basic_sensor
 	name = "Basic Sensor Module"
@@ -944,7 +944,7 @@ datum/design/basic_sensor
 	req_tech = list("magnets" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 50, "$glass" = 20)
-	build_path = "/obj/item/weapon/stock_parts/scanning_module"
+	build_path = /obj/item/weapon/stock_parts/scanning_module
 
 datum/design/micro_mani
 	name = "Micro Manipulator"
@@ -953,7 +953,7 @@ datum/design/micro_mani
 	req_tech = list("materials" = 1, "programming" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 30)
-	build_path = "/obj/item/weapon/stock_parts/manipulator"
+	build_path = /obj/item/weapon/stock_parts/manipulator
 
 datum/design/basic_micro_laser
 	name = "Basic Micro-Laser"
@@ -962,7 +962,7 @@ datum/design/basic_micro_laser
 	req_tech = list("magnets" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 10, "$glass" = 20)
-	build_path = "/obj/item/weapon/stock_parts/micro_laser"
+	build_path = /obj/item/weapon/stock_parts/micro_laser
 
 datum/design/basic_matter_bin
 	name = "Basic Matter Bin"
@@ -971,7 +971,7 @@ datum/design/basic_matter_bin
 	req_tech = list("materials" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list("$metal" = 80)
-	build_path = "/obj/item/weapon/stock_parts/matter_bin"
+	build_path = /obj/item/weapon/stock_parts/matter_bin
 
 datum/design/adv_capacitor
 	name = "Advanced Capacitor"
@@ -980,7 +980,7 @@ datum/design/adv_capacitor
 	req_tech = list("powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/stock_parts/capacitor/adv"
+	build_path = /obj/item/weapon/stock_parts/capacitor/adv
 
 datum/design/adv_sensor
 	name = "Advanced Sensor Module"
@@ -989,7 +989,7 @@ datum/design/adv_sensor
 	req_tech = list("magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 20)
-	build_path = "/obj/item/weapon/stock_parts/scanning_module/adv"
+	build_path = /obj/item/weapon/stock_parts/scanning_module/adv
 
 datum/design/nano_mani
 	name = "Nano Manipulator"
@@ -998,7 +998,7 @@ datum/design/nano_mani
 	req_tech = list("materials" = 3, "programming" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 30)
-	build_path = "/obj/item/weapon/stock_parts/manipulator/nano"
+	build_path = /obj/item/weapon/stock_parts/manipulator/nano
 
 datum/design/high_micro_laser
 	name = "High-Power Micro-Laser"
@@ -1007,7 +1007,7 @@ datum/design/high_micro_laser
 	req_tech = list("magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 10, "$glass" = 20)
-	build_path = "/obj/item/weapon/stock_parts/micro_laser/high"
+	build_path = /obj/item/weapon/stock_parts/micro_laser/high
 
 datum/design/adv_matter_bin
 	name = "Advanced Matter Bin"
@@ -1016,7 +1016,7 @@ datum/design/adv_matter_bin
 	req_tech = list("materials" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 80)
-	build_path = "/obj/item/weapon/stock_parts/matter_bin/adv"
+	build_path = /obj/item/weapon/stock_parts/matter_bin/adv
 
 datum/design/super_capacitor
 	name = "Super Capacitor"
@@ -1026,7 +1026,7 @@ datum/design/super_capacitor
 	build_type = PROTOLATHE
 	reliability_base = 71
 	materials = list("$metal" = 50, "$glass" = 50, "$gold" = 20)
-	build_path = "/obj/item/weapon/stock_parts/capacitor/super"
+	build_path = /obj/item/weapon/stock_parts/capacitor/super
 
 datum/design/phasic_sensor
 	name = "Phasic Sensor Module"
@@ -1036,7 +1036,7 @@ datum/design/phasic_sensor
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 20, "$silver" = 10)
 	reliability_base = 72
-	build_path = "/obj/item/weapon/stock_parts/scanning_module/phasic"
+	build_path = /obj/item/weapon/stock_parts/scanning_module/phasic
 
 datum/design/pico_mani
 	name = "Pico Manipulator"
@@ -1046,7 +1046,7 @@ datum/design/pico_mani
 	build_type = PROTOLATHE
 	materials = list("$metal" = 30)
 	reliability_base = 73
-	build_path = "/obj/item/weapon/stock_parts/manipulator/pico"
+	build_path = /obj/item/weapon/stock_parts/manipulator/pico
 
 datum/design/ultra_micro_laser
 	name = "Ultra-High-Power Micro-Laser"
@@ -1056,7 +1056,7 @@ datum/design/ultra_micro_laser
 	build_type = PROTOLATHE
 	materials = list("$metal" = 10, "$glass" = 20, "$uranium" = 10)
 	reliability_base = 70
-	build_path = "/obj/item/weapon/stock_parts/micro_laser/ultra"
+	build_path = /obj/item/weapon/stock_parts/micro_laser/ultra
 
 datum/design/super_matter_bin
 	name = "Super Matter Bin"
@@ -1066,7 +1066,7 @@ datum/design/super_matter_bin
 	build_type = PROTOLATHE
 	materials = list("$metal" = 80)
 	reliability_base = 75
-	build_path = "/obj/item/weapon/stock_parts/matter_bin/super"
+	build_path = /obj/item/weapon/stock_parts/matter_bin/super
 
 
 
@@ -1077,7 +1077,7 @@ datum/design/subspace_ansible
 	req_tech = list("programming" = 3, "magnets" = 4, "materials" = 4, "bluespace" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 80, "$silver" = 20)
-	build_path = "/obj/item/weapon/stock_parts/subspace/ansible"
+	build_path = /obj/item/weapon/stock_parts/subspace/ansible
 
 datum/design/hyperwave_filter
 	name = "Hyperwave Filter"
@@ -1086,7 +1086,7 @@ datum/design/hyperwave_filter
 	req_tech = list("programming" = 3, "magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 40, "$silver" = 10)
-	build_path = "/obj/item/weapon/stock_parts/subspace/filter"
+	build_path = /obj/item/weapon/stock_parts/subspace/filter
 
 datum/design/subspace_amplifier
 	name = "Subspace Amplifier"
@@ -1095,7 +1095,7 @@ datum/design/subspace_amplifier
 	req_tech = list("programming" = 3, "magnets" = 4, "materials" = 4, "bluespace" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 10, "$gold" = 30, "$uranium" = 15)
-	build_path = "/obj/item/weapon/stock_parts/subspace/amplifier"
+	build_path = /obj/item/weapon/stock_parts/subspace/amplifier
 
 datum/design/subspace_treatment
 	name = "Subspace Treatment Disk"
@@ -1104,7 +1104,7 @@ datum/design/subspace_treatment
 	req_tech = list("programming" = 3, "magnets" = 2, "materials" = 4, "bluespace" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 10, "$silver" = 20)
-	build_path = "/obj/item/weapon/stock_parts/subspace/treatment"
+	build_path = /obj/item/weapon/stock_parts/subspace/treatment
 
 datum/design/subspace_analyzer
 	name = "Subspace Analyzer"
@@ -1113,7 +1113,7 @@ datum/design/subspace_analyzer
 	req_tech = list("programming" = 3, "magnets" = 4, "materials" = 4, "bluespace" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 10, "$gold" = 15)
-	build_path = "/obj/item/weapon/stock_parts/subspace/analyzer"
+	build_path = /obj/item/weapon/stock_parts/subspace/analyzer
 
 datum/design/subspace_crystal
 	name = "Ansible Crystal"
@@ -1122,7 +1122,7 @@ datum/design/subspace_crystal
 	req_tech = list("magnets" = 4, "materials" = 4, "bluespace" = 2)
 	build_type = PROTOLATHE
 	materials = list("$glass" = 1000, "$silver" = 20, "$gold" = 20)
-	build_path = "/obj/item/weapon/stock_parts/subspace/crystal"
+	build_path = /obj/item/weapon/stock_parts/subspace/crystal
 
 datum/design/subspace_transmitter
 	name = "Subspace Transmitter"
@@ -1131,7 +1131,7 @@ datum/design/subspace_transmitter
 	req_tech = list("magnets" = 5, "materials" = 5, "bluespace" = 3)
 	build_type = PROTOLATHE
 	materials = list("$glass" = 100, "$silver" = 10, "$uranium" = 15)
-	build_path = "/obj/item/weapon/stock_parts/subspace/transmitter"
+	build_path = /obj/item/weapon/stock_parts/subspace/transmitter
 
 ////////////////////////////////////////
 //////////////////Power/////////////////
@@ -1144,7 +1144,7 @@ datum/design/basic_cell
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE |MECHFAB
 	materials = list("$metal" = 700, "$glass" = 50)
-	build_path = "/obj/item/weapon/cell"
+	build_path = /obj/item/weapon/cell
 	category = "Misc"
 
 datum/design/high_cell
@@ -1154,7 +1154,7 @@ datum/design/high_cell
 	req_tech = list("powerstorage" = 2)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
 	materials = list("$metal" = 700, "$glass" = 60)
-	build_path = "/obj/item/weapon/cell/high"
+	build_path = /obj/item/weapon/cell/high
 	category = "Misc"
 
 datum/design/super_cell
@@ -1165,7 +1165,7 @@ datum/design/super_cell
 	reliability_base = 75
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 700, "$glass" = 70)
-	build_path = "/obj/item/weapon/cell/super"
+	build_path = /obj/item/weapon/cell/super
 	category = "Misc"
 
 datum/design/hyper_cell
@@ -1176,7 +1176,7 @@ datum/design/hyper_cell
 	reliability_base = 70
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 400, "$gold" = 150, "$silver" = 150, "$glass" = 70)
-	build_path = "/obj/item/weapon/cell/hyper"
+	build_path = /obj/item/weapon/cell/hyper
 	category = "Misc"
 
 datum/design/light_replacer
@@ -1186,7 +1186,7 @@ datum/design/light_replacer
 	req_tech = list("magnets" = 3, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 1500, "$silver" = 150, "$glass" = 3000)
-	build_path = "/obj/item/device/lightreplacer"
+	build_path = /obj/item/device/lightreplacer
 
 ////////////////////////////////////////
 //////////////MISC Boards///////////////
@@ -1199,7 +1199,7 @@ datum/design/destructive_analyzer
 	req_tech = list("programming" = 2, "magnets" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/destructive_analyzer"
+	build_path = /obj/item/weapon/circuitboard/destructive_analyzer
 
 datum/design/protolathe
 	name = "Protolathe Board"
@@ -1208,7 +1208,7 @@ datum/design/protolathe
 	req_tech = list("programming" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/protolathe"
+	build_path = /obj/item/weapon/circuitboard/protolathe
 
 datum/design/circuit_imprinter
 	name = "Circuit Imprinter Board"
@@ -1217,7 +1217,7 @@ datum/design/circuit_imprinter
 	req_tech = list("programming" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/circuit_imprinter"
+	build_path = /obj/item/weapon/circuitboard/circuit_imprinter
 
 datum/design/autolathe
 	name = "Autolathe Board"
@@ -1226,7 +1226,7 @@ datum/design/autolathe
 	req_tech = list("programming" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/autolathe"
+	build_path = /obj/item/weapon/circuitboard/autolathe
 
 datum/design/rdservercontrol
 	name = "R&D Server Control Console Board"
@@ -1235,7 +1235,7 @@ datum/design/rdservercontrol
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/rdservercontrol"
+	build_path = /obj/item/weapon/circuitboard/rdservercontrol
 
 datum/design/rdserver
 	name = "R&D Server Board"
@@ -1244,7 +1244,7 @@ datum/design/rdserver
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/rdserver"
+	build_path = /obj/item/weapon/circuitboard/rdserver
 
 datum/design/mechfab
 	name = "Exosuit Fabricator Board"
@@ -1253,7 +1253,7 @@ datum/design/mechfab
 	req_tech = list("programming" = 3, "engineering" = 3)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/mechfab"
+	build_path = /obj/item/weapon/circuitboard/mechfab
 
 datum/design/gas_heater
 	name = "Gas Heating System Board"
@@ -1262,7 +1262,7 @@ datum/design/gas_heater
 	req_tech = list("powerstorage" = 2, "engineering" = 1)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/unary_atmos/heater"
+	build_path = /obj/item/weapon/circuitboard/unary_atmos/heater
 
 datum/design/gas_cooler
 	name = "Gas Cooling System Board"
@@ -1271,7 +1271,7 @@ datum/design/gas_cooler
 	req_tech = list("magnets" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/unary_atmos/cooler"
+	build_path = /obj/item/weapon/circuitboard/unary_atmos/cooler
 
 /////////////////////////////////////////
 ////////////Power Stuff//////////////////
@@ -1285,7 +1285,7 @@ datum/design/pacman
 	build_type = IMPRINTER
 	reliability_base = 79
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/pacman"
+	build_path = /obj/item/weapon/circuitboard/pacman
 
 datum/design/superpacman
 	name = "SUPERPACMAN-type Generator Board"
@@ -1295,7 +1295,7 @@ datum/design/superpacman
 	build_type = IMPRINTER
 	reliability_base = 76
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/pacman/super"
+	build_path = /obj/item/weapon/circuitboard/pacman/super
 
 datum/design/mrspacman
 	name = "MRSPACMAN-type Generator Board"
@@ -1305,7 +1305,7 @@ datum/design/mrspacman
 	build_type = IMPRINTER
 	reliability_base = 74
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/pacman/mrs"
+	build_path = /obj/item/weapon/circuitboard/pacman/mrs
 
 datum/design/batteryrack
 	name = "Cell rack PSU Board"
@@ -1314,7 +1314,7 @@ datum/design/batteryrack
 	req_tech = list("powerstorage" = 3, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list("$glass" = 2000, "sacid" = 20)
-	build_path = "/obj/item/weapon/circuitboard/batteryrack"
+	build_path = /obj/item/weapon/circuitboard/batteryrack
 
 
 /////////////////////////////////////////
@@ -1329,7 +1329,7 @@ datum/design/mass_spectrometer
 	build_type = PROTOLATHE
 	materials = list("$metal" = 30, "$glass" = 20)
 	reliability_base = 76
-	build_path = "/obj/item/device/mass_spectrometer"
+	build_path = /obj/item/device/mass_spectrometer
 
 datum/design/adv_mass_spectrometer
 	name = "Advanced Mass-Spectrometer"
@@ -1339,7 +1339,7 @@ datum/design/adv_mass_spectrometer
 	build_type = PROTOLATHE
 	materials = list("$metal" = 30, "$glass" = 20)
 	reliability_base = 74
-	build_path = "/obj/item/device/mass_spectrometer/adv"
+	build_path = /obj/item/device/mass_spectrometer/adv
 
 datum/design/reagent_scanner
 	name = "Reagent Scanner"
@@ -1349,7 +1349,7 @@ datum/design/reagent_scanner
 	build_type = PROTOLATHE
 	materials = list("$metal" = 30, "$glass" = 20)
 	reliability_base = 76
-	build_path = "/obj/item/device/reagent_scanner"
+	build_path = /obj/item/device/reagent_scanner
 
 datum/design/adv_reagent_scanner
 	name = "Advanced Reagent Scanner"
@@ -1359,7 +1359,7 @@ datum/design/adv_reagent_scanner
 	build_type = PROTOLATHE
 	materials = list("$metal" = 30, "$glass" = 20)
 	reliability_base = 74
-	build_path = "/obj/item/device/reagent_scanner/adv"
+	build_path = /obj/item/device/reagent_scanner/adv
 
 datum/design/mmi
 	name = "Man-Machine Interface"
@@ -1369,7 +1369,7 @@ datum/design/mmi
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 1000, "$glass" = 500)
 	reliability_base = 76
-	build_path = "/obj/item/device/mmi"
+	build_path = /obj/item/device/mmi
 	category = "Misc"
 
 datum/design/mmi_radio
@@ -1380,7 +1380,7 @@ datum/design/mmi_radio
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 1200, "$glass" = 500)
 	reliability_base = 74
-	build_path = "/obj/item/device/mmi/radio_enabled"
+	build_path = /obj/item/device/mmi/radio_enabled
 	category = "Misc"
 
 datum/design/synthetic_flash
@@ -1391,7 +1391,7 @@ datum/design/synthetic_flash
 	build_type = MECHFAB
 	materials = list("$metal" = 750, "$glass" = 750)
 	reliability_base = 76
-	build_path = "/obj/item/device/flash/synthetic"
+	build_path = /obj/item/device/flash/synthetic
 	category = "Misc"
 
 datum/design/nanopaste
@@ -1401,7 +1401,7 @@ datum/design/nanopaste
 	req_tech = list("materials" = 4, "engineering" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 7000, "$glass" = 7000)
-	build_path = "/obj/item/stack/nanopaste"
+	build_path = /obj/item/stack/nanopaste
 
 /* // Removal of loyalty implants. Can't think of a way to add this to the config option.
 datum/design/implant_loyal
@@ -1411,7 +1411,7 @@ datum/design/implant_loyal
 	req_tech = list("materials" = 2, "biotech" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 7000, "$glass" = 7000)
-	build_path = "/obj/item/weapon/implant/loyalty"
+	build_path = /obj/item/weapon/implant/loyalty"
 */
 
 datum/design/implant_chem
@@ -1421,7 +1421,7 @@ datum/design/implant_chem
 	req_tech = list("materials" = 2, "biotech" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/implant/chem"
+	build_path = /obj/item/weapon/implant/chem
 
 datum/design/implant_free
 	name = "freedom implant"
@@ -1430,7 +1430,7 @@ datum/design/implant_free
 	req_tech = list("syndicate" = 2, "biotech" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/implant/freedom"
+	build_path = /obj/item/weapon/implant/freedom
 
 datum/design/chameleon
 	name = "Chameleon Kit"
@@ -1439,7 +1439,7 @@ datum/design/chameleon
 	req_tech = list("syndicate" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 500)
-	build_path = "/obj/item/weapon/storage/box/syndie_kit/chameleon"
+	build_path = /obj/item/weapon/storage/box/syndie_kit/chameleon
 
 
 datum/design/bluespacebeaker
@@ -1450,7 +1450,7 @@ datum/design/bluespacebeaker
 	build_type = PROTOLATHE
 	materials = list("$metal" = 3000, "$phoron" = 3000, "$diamond" = 500)
 	reliability_base = 76
-	build_path = "/obj/item/weapon/reagent_containers/glass/beaker/bluespace"
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 
 datum/design/noreactbeaker
 	name = "cryostasis beaker"
@@ -1460,7 +1460,7 @@ datum/design/noreactbeaker
 	build_type = PROTOLATHE
 	materials = list("$metal" = 3000)
 	reliability_base = 76
-	build_path = "/obj/item/weapon/reagent_containers/glass/beaker/noreact"
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	category = "Misc"
 
 datum/design/scalpel_laser1
@@ -1470,7 +1470,7 @@ datum/design/scalpel_laser1
 	req_tech = list("biotech" = 2, "materials" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 12500, "$glass" = 7500)
-	build_path = "/obj/item/weapon/scalpel/laser1"
+	build_path = /obj/item/weapon/scalpel/laser1
 
 datum/design/scalpel_laser2
 	name = "Improved Laser Scalpel"
@@ -1479,7 +1479,7 @@ datum/design/scalpel_laser2
 	req_tech = list("biotech" = 3, "materials" = 4, "magnets" = 4)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 12500, "$glass" = 7500, "$silver" = 2500)
-	build_path = "/obj/item/weapon/scalpel/laser2"
+	build_path = /obj/item/weapon/scalpel/laser2
 
 datum/design/scalpel_laser3
 	name = "Advanced Laser Scalpel"
@@ -1488,7 +1488,7 @@ datum/design/scalpel_laser3
 	req_tech = list("biotech" = 4, "materials" = 6, "magnets" = 5)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 12500, "$glass" = 7500, "$silver" = 2000, "$gold" = 1500)
-	build_path = "/obj/item/weapon/scalpel/laser3"
+	build_path = /obj/item/weapon/scalpel/laser3
 
 datum/design/scalpel_manager
 	name = "Incision Management System"
@@ -1497,7 +1497,7 @@ datum/design/scalpel_manager
 	req_tech = list("biotech" = 4, "materials" = 7, "magnets" = 5, "programming" = 4)
 	build_type = PROTOLATHE
 	materials = list ("$metal" = 12500, "$glass" = 7500, "$silver" = 1500, "$gold" = 1500, "$diamond" = 750)
-	build_path = "/obj/item/weapon/scalpel/manager"
+	build_path = /obj/item/weapon/scalpel/manager
 
 /////////////////////////////////////////
 /////////////////Weapons/////////////////
@@ -1511,7 +1511,7 @@ datum/design/nuclear_gun
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 1000, "$uranium" = 500)
 	reliability_base = 76
-	build_path = "/obj/item/weapon/gun/energy/gun/nuclear"
+	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	locked = 1
 
 datum/design/stunrevolver
@@ -1521,7 +1521,7 @@ datum/design/stunrevolver
 	req_tech = list("combat" = 3, "materials" = 3, "powerstorage" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 4000)
-	build_path = "/obj/item/weapon/gun/energy/stunrevolver"
+	build_path = /obj/item/weapon/gun/energy/stunrevolver
 	locked = 1
 
 datum/design/lasercannon
@@ -1531,7 +1531,7 @@ datum/design/lasercannon
 	req_tech = list("combat" = 4, "materials" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 10000, "$glass" = 1000, "$diamond" = 2000)
-	build_path = "/obj/item/weapon/gun/energy/lasercannon"
+	build_path = /obj/item/weapon/gun/energy/lasercannon
 	locked = 1
 
 datum/design/decloner
@@ -1541,7 +1541,7 @@ datum/design/decloner
 	req_tech = list("combat" = 8, "materials" = 7, "biotech" = 5, "powerstorage" = 6)
 	build_type = PROTOLATHE
 	materials = list("$gold" = 5000,"$uranium" = 10000, "mutagen" = 40)
-	build_path = "/obj/item/weapon/gun/energy/decloner"
+	build_path = /obj/item/weapon/gun/energy/decloner
 	locked = 1
 
 datum/design/chemsprayer
@@ -1552,7 +1552,7 @@ datum/design/chemsprayer
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 1000)
 	reliability_base = 100
-	build_path = "/obj/item/weapon/reagent_containers/spray/chemsprayer"
+	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer
 
 datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
@@ -1561,7 +1561,7 @@ datum/design/rapidsyringe
 	req_tech = list("combat" = 3, "materials" = 3, "engineering" = 3, "biotech" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 1000)
-	build_path = "/obj/item/weapon/gun/syringe/rapidsyringe"
+	build_path = /obj/item/weapon/gun/syringe/rapidsyringe
 /*
 datum/design/largecrossbow
 	name = "Energy Crossbow"
@@ -1570,7 +1570,7 @@ datum/design/largecrossbow
 	req_tech = list("combat" = 4, "materials" = 5, "engineering" = 3, "biotech" = 4, "syndicate" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 1000, "$uranium" = 1000, "$silver" = 1000)
-	build_path = "/obj/item/weapon/gun/energy/crossbow/largecrossbow"
+	build_path = /obj/item/weapon/gun/energy/crossbow/largecrossbow"
 */
 datum/design/temp_gun
 	name = "Temperature Gun"
@@ -1579,7 +1579,7 @@ datum/design/temp_gun
 	req_tech = list("combat" = 3, "materials" = 4, "powerstorage" = 3, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 500, "$silver" = 3000)
-	build_path = "/obj/item/weapon/gun/energy/temperature"
+	build_path = /obj/item/weapon/gun/energy/temperature
 	locked = 1
 
 datum/design/flora_gun
@@ -1589,7 +1589,7 @@ datum/design/flora_gun
 	req_tech = list("materials" = 2, "biotech" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 2000, "$glass" = 500, "$uranium" = 500)
-	build_path = "/obj/item/weapon/gun/energy/floragun"
+	build_path = /obj/item/weapon/gun/energy/floragun
 
 datum/design/large_grenade
 	name = "Large Grenade"
@@ -1599,7 +1599,7 @@ datum/design/large_grenade
 	build_type = PROTOLATHE
 	materials = list("$metal" = 3000)
 	reliability_base = 79
-	build_path = "/obj/item/weapon/grenade/chem_grenade/large"
+	build_path = /obj/item/weapon/grenade/chem_grenade/large
 
 datum/design/smg
 	name = "Submachine Gun"
@@ -1608,7 +1608,7 @@ datum/design/smg
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 8000, "$silver" = 2000, "$diamond" = 1000)
-	build_path = "/obj/item/weapon/gun/projectile/automatic"
+	build_path = /obj/item/weapon/gun/projectile/automatic
 	locked = 1
 
 datum/design/ammo_9mm
@@ -1618,7 +1618,7 @@ datum/design/ammo_9mm
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 3750, "$silver" = 100)
-	build_path = "/obj/item/ammo_magazine/c9mm"
+	build_path = /obj/item/ammo_magazine/c9mm
 
 datum/design/stunshell
 	name = "Stun Shell"
@@ -1627,7 +1627,7 @@ datum/design/stunshell
 	req_tech = list("combat" = 3, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 4000)
-	build_path = "/obj/item/ammo_casing/shotgun/stunshell"
+	build_path = /obj/item/ammo_casing/shotgun/stunshell
 
 datum/design/phoronpistol
 	name = "phoron pistol"
@@ -1636,7 +1636,7 @@ datum/design/phoronpistol
 	req_tech = list("combat" = 5, "phorontech" = 4)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 5000, "$glass" = 1000, "$phoron" = 3000)
-	build_path = "/obj/item/weapon/gun/energy/toxgun"
+	build_path = /obj/item/weapon/gun/energy/toxgun
 /////////////////////////////////////////
 /////////////////Mining//////////////////
 /////////////////////////////////////////
@@ -1648,7 +1648,7 @@ datum/design/jackhammer
 	req_tech = list("materials" = 3, "powerstorage" = 2, "engineering" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 2000, "$glass" = 500, "$silver" = 500)
-	build_path = "/obj/item/weapon/pickaxe/jackhammer"
+	build_path = /obj/item/weapon/pickaxe/jackhammer
 
 datum/design/drill
 	name = "Mining Drill"
@@ -1657,7 +1657,7 @@ datum/design/drill
 	req_tech = list("materials" = 2, "powerstorage" = 3, "engineering" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 6000, "$glass" = 1000) //expensive, but no need for miners.
-	build_path = "/obj/item/weapon/pickaxe/drill"
+	build_path = /obj/item/weapon/pickaxe/drill
 
 datum/design/plasmacutter
 	name = "Plasma Cutter"
@@ -1667,7 +1667,7 @@ datum/design/plasmacutter
 	build_type = PROTOLATHE
 	materials = list("$metal" = 1500, "$glass" = 500, "$gold" = 500, "$phoron" = 500)
 	reliability_base = 79
-	build_path = "/obj/item/weapon/pickaxe/plasmacutter"
+	build_path = /obj/item/weapon/pickaxe/plasmacutter
 
 datum/design/pick_diamond
 	name = "Diamond Pickaxe"
@@ -1676,7 +1676,7 @@ datum/design/pick_diamond
 	req_tech = list("materials" = 6)
 	build_type = PROTOLATHE
 	materials = list("$diamond" = 3000)
-	build_path = "/obj/item/weapon/pickaxe/diamond"
+	build_path = /obj/item/weapon/pickaxe/diamond
 
 datum/design/drill_diamond
 	name = "Diamond Mining Drill"
@@ -1686,7 +1686,7 @@ datum/design/drill_diamond
 	build_type = PROTOLATHE
 	materials = list("$metal" = 3000, "$glass" = 1000, "$diamond" = 3750) //Yes, a whole diamond is needed.
 	reliability_base = 79
-	build_path = "/obj/item/weapon/pickaxe/diamonddrill"
+	build_path = /obj/item/weapon/pickaxe/diamonddrill
 
 datum/design/mesons
 	name = "Optical Meson Scanners"
@@ -1695,7 +1695,7 @@ datum/design/mesons
 	req_tech = list("magnets" = 2, "engineering" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/clothing/glasses/meson"
+	build_path = /obj/item/clothing/glasses/meson
 
 /////////////////////////////////////////
 //////////////Blue Space/////////////////
@@ -1708,7 +1708,7 @@ datum/design/beacon
 	req_tech = list("bluespace" = 1)
 	build_type = PROTOLATHE
 	materials = list ("$metal" = 20, "$glass" = 10)
-	build_path = "/obj/item/device/radio/beacon"
+	build_path = /obj/item/device/radio/beacon
 
 datum/design/bag_holding
 	name = "Bag of Holding"
@@ -1718,7 +1718,7 @@ datum/design/bag_holding
 	build_type = PROTOLATHE
 	materials = list("$gold" = 3000, "$diamond" = 1500, "$uranium" = 250)
 	reliability_base = 80
-	build_path = "/obj/item/weapon/storage/backpack/holding"
+	build_path = /obj/item/weapon/storage/backpack/holding
 
 /*
 datum/design/bluespace_crystal
@@ -1729,7 +1729,7 @@ datum/design/bluespace_crystal
 	build_type = PROTOLATHE
 	materials = list("$gold" = 1500, "$diamond" = 3000, "$phoron" = 1500)
 	reliability_base = 100
-	build_path = "/obj/item/bluespace_crystal/artificial"
+	build_path = /obj/item/bluespace_crystal/artificial"
 */
 
 /////////////////////////////////////////
@@ -1743,7 +1743,7 @@ datum/design/health_hud
 	req_tech = list("biotech" = 2, "magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/clothing/glasses/hud/health"
+	build_path = /obj/item/clothing/glasses/hud/health
 
 datum/design/security_hud
 	name = "Security HUD"
@@ -1752,7 +1752,7 @@ datum/design/security_hud
 	req_tech = list("magnets" = 3, "combat" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/clothing/glasses/hud/security"
+	build_path = /obj/item/clothing/glasses/hud/security
 	locked = 1
 
 /////////////////////////////////////////
@@ -1766,7 +1766,7 @@ datum/design/security_hud
 			build_type = PROTOLATHE
 			req_tech = list("materials" = 1)
 			materials = list("$gold" = 3000, "iron" = 15, "copper" = 10, "$silver" = 2500)
-			build_path = "/obj/item/weapon/banhammer" */
+			build_path = /obj/item/weapon/banhammer" */
 
 ////////////////////////////////////////
 //Disks for transporting design datums//
@@ -1796,7 +1796,7 @@ datum/design/borg_syndicate_module
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "syndicate" = 3)
-	build_path = "/obj/item/borg/upgrade/syndicate"
+	build_path = /obj/item/borg/upgrade/syndicate
 	category = "Cyborg Upgrade Modules"
 
 /////////////////////////////////////////
@@ -1809,7 +1809,7 @@ datum/design/binaryencrypt
 	req_tech = list("syndicate" = 2)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 300, "$glass" = 300)
-	build_path = "/obj/item/device/encryptionkey/binary"
+	build_path = /obj/item/device/encryptionkey/binary
 datum/design/pda
 	name = "PDA"
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. Functionality determined by a preprogrammed ROM cartridge."
@@ -1817,7 +1817,7 @@ datum/design/pda
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/device/pda"
+	build_path = /obj/item/device/pda
 datum/design/cart_basic
 	name = "Generic Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1825,7 +1825,7 @@ datum/design/cart_basic
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge"
+	build_path = /obj/item/weapon/cartridge
 datum/design/cart_engineering
 	name = "Power-ON Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1833,7 +1833,7 @@ datum/design/cart_engineering
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/engineering"
+	build_path = /obj/item/weapon/cartridge/engineering
 datum/design/cart_atmos
 	name = "BreatheDeep Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1841,7 +1841,7 @@ datum/design/cart_atmos
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/atmos"
+	build_path = /obj/item/weapon/cartridge/atmos
 datum/design/cart_medical
 	name = "Med-U Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1849,7 +1849,7 @@ datum/design/cart_medical
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/medical"
+	build_path = /obj/item/weapon/cartridge/medical
 datum/design/cart_chemistry
 	name = "ChemWhiz Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1857,7 +1857,7 @@ datum/design/cart_chemistry
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/chemistry"
+	build_path = /obj/item/weapon/cartridge/chemistry
 datum/design/cart_security
 	name = "R.O.B.U.S.T. Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1865,7 +1865,7 @@ datum/design/cart_security
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/security"
+	build_path = /obj/item/weapon/cartridge/security
 	locked = 1
 datum/design/cart_janitor
 	name = "CustodiPRO Cartridge"
@@ -1874,7 +1874,7 @@ datum/design/cart_janitor
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/janitor"
+	build_path = /obj/item/weapon/cartridge/janitor
 
 /*
 datum/design/cart_clown
@@ -1884,7 +1884,7 @@ datum/design/cart_clown
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/clown"
+	build_path = /obj/item/weapon/cartridge/clown"
 datum/design/cart_mime
 	name = "Gestur-O 1000 Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1892,7 +1892,7 @@ datum/design/cart_mime
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/mime"
+	build_path = /obj/item/weapon/cartridge/mime"
 */
 
 datum/design/cart_science
@@ -1902,7 +1902,7 @@ datum/design/cart_science
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/science"
+	build_path = /obj/item/weapon/cartridge/signal/science
 datum/design/cart_quartermaster
 	name = "Space Parts & Space Vendors Cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -1910,7 +1910,7 @@ datum/design/cart_quartermaster
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/quartermaster"
+	build_path = /obj/item/weapon/cartridge/quartermaster
 	locked = 1
 datum/design/cart_hop
 	name = "Human Resources 9001 Cartridge"
@@ -1919,7 +1919,7 @@ datum/design/cart_hop
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/hop"
+	build_path = /obj/item/weapon/cartridge/hop
 	locked = 1
 datum/design/cart_hos
 	name = "R.O.B.U.S.T. DELUXE Cartridge"
@@ -1928,7 +1928,7 @@ datum/design/cart_hos
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/hos"
+	build_path = /obj/item/weapon/cartridge/hos
 	locked = 1
 datum/design/cart_ce
 	name = "Power-On DELUXE Cartridge"
@@ -1937,7 +1937,7 @@ datum/design/cart_ce
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/ce"
+	build_path = /obj/item/weapon/cartridge/ce
 	locked = 1
 datum/design/cart_cmo
 	name = "Med-U DELUXE Cartridge"
@@ -1946,7 +1946,7 @@ datum/design/cart_cmo
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/cmo"
+	build_path = /obj/item/weapon/cartridge/cmo
 	locked = 1
 datum/design/cart_rd
 	name = "Signal Ace DELUXE Cartridge"
@@ -1955,7 +1955,7 @@ datum/design/cart_rd
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/rd"
+	build_path = /obj/item/weapon/cartridge/rd
 	locked = 1
 datum/design/cart_captain
 	name = "Value-PAK Cartridge"
@@ -1964,5 +1964,5 @@ datum/design/cart_captain
 	req_tech = list("engineering" = 2, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
-	build_path = "/obj/item/weapon/cartridge/captain"
+	build_path = /obj/item/weapon/cartridge/captain
 	locked = 1


### PR DESCRIPTION
Research build paths are now type safe, ensuring the object type that is to be constructed always exists.
Corrects two non-existing types, changes from `/obj/item/mecha_parts/mecha_equipment/phoron_generator` and `/obj/item/weapon/cartridge/science` to `/obj/item/mecha_parts/mecha_equipment/generator` and `/obj/item/weapon/cartridge/signal/science` respectively.
