### PR TITLE
Fixes cyborg movement depending on actuators when not caused by cyborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -23,10 +23,10 @@
 	return tally+config.robot_delay
 
 // NEW: Use power while moving.
-/mob/living/silicon/robot/Move()
+/mob/living/silicon/robot/SelfMove(turf/n, direct)
 	if (!is_component_functioning("actuator"))
-		return
+		return 0
 
 	var/datum/robot_component/actuator/A = get_component("actuator")
 	if (cell_use_power(A.active_usage))
-		..()
+		return ..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -316,13 +316,16 @@
 		else if(mob.confused)
 			step(mob, pick(cardinal))
 		else
-			. = ..()
+			. = mob.SelfMove(n, direct)
 
 		moving = 0
 
 		return .
 
 	return
+
+/mob/proc/SelfMove(turf/n, direct)
+	return Move(n, direct)
 
 
 ///Process_Grab()


### PR DESCRIPTION
Partially fixes #6993. Not sure how much of a problem being able to (un)buckle or turn while locked down/actuator disabled is, I'm thinking turning isn't a mechanics issue, buckling possibly is, but not significant.
