### PR TITLE
[DNM] Fixes cyborg latejoining, allows mid-round joining

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -21,7 +21,7 @@
 	flag = CYBORG
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
+	total_positions = 2
 	spawn_positions = 2
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -444,10 +444,7 @@ var/global/datum/controller/occupations/job_master
 			alt_title = H.mind.role_alt_title
 
 			switch(rank)
-				if("Cyborg")
-					H.Robotize()
-					return 1
-				if("AI","Clown")	//don't need bag preference stuff!
+				if("Cyborg","AI","Clown")	//don't need bag preference stuff!
 				else
 					switch(H.backbag) //BS12 EDIT
 						if(1)


### PR DESCRIPTION
Basically, this is #7002 without the runtimes and being left at the BS12 title screen.

The problem is that the job controller was `Robotize()`ing the new cyborg, then `AttemptLateSpawn()` tried to a) read from the now-deleted pre-robotization mob, and b) `Robotize()` again.
