### PR TITLE
Adds 'me' hotkey, updates hotkeys-help

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -46,8 +46,9 @@ Hotkey-Mode: (hotkey-mode must be on)
 \te = equip
 \tr = throw
 \tt = say
+\ty = emote
 \tx = swap-hand
-\tz = activate held object (or y)
+\tz = activate held object
 \tf = cycle-intents-left
 \tg = cycle-intents-right
 \t1 = help-intent
@@ -73,6 +74,10 @@ Any-Mode: (hotkey doesn't need to be on)
 \tCtrl+2 = disarm-intent
 \tCtrl+3 = grab-intent
 \tCtrl+4 = harm-intent
+\tF1 = adminhelp
+\tF2 = ooc
+\tF3 = say
+\tF4 = emote
 \tDEL = pull
 \tINS = cycle-intents-right
 \tHOME = drop

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -367,7 +367,7 @@ macro "hotkeymode"
 		is-disabled = false
 	elem 
 		name = "Y"
-		command = "Activate-Held-Object"
+		command = "me"
 		is-disabled = false
 	elem 
 		name = "CTRL+Y"


### PR DESCRIPTION
Y is now me. Activate-held-item is now only Z instead of Z
and Y.

The hotkeys-help verb in the OOC tab is changed to include the changes
above, and the previously unmentioned function row hotkeys that are
pertinent to players. (Admin verbs are unmentioned)

This is my first pull so let me know if I've ruined everything.
