### PR TITLE
Security Records Check

### DIFF
--- a/code/defines/procs/records.dm
+++ b/code/defines/procs/records.dm
@@ -39,6 +39,9 @@
 	data_core.security += R
 	return R
 
+/proc/find_security_record(field, value)
+	return find_record(field, value, data_core.security)
+
 /proc/find_record(field, value, list/L)
 	for(var/datum/data/record/R in L)
 		if(R.fields[field] == value)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -345,8 +345,8 @@ Class Procs:
 		if(id)
 			perpname = id.registered_name
 
-		var/datum/data/record/R = find_record("name", perpname, data_core.security)
-		if(!R || (R.fields["criminal"] == "*Arrest*"))
+		var/datum/data/record/R = find_security_record("name", perpname)
+		if(R && (R.fields["criminal"] == "*Arrest*"))
 			threatcount += 4
 
 	return threatcount


### PR DESCRIPTION
When machinery checks security records they now only check for explicitly set arrest status.
After the last refactoring they would check for either missing security records or arrest status.

Currently this means that Beepsky and turrets really do not like non-crew members, such as ERT personnel.

The alternatives are:
- Add an explicit check for Central Command/ERT ids.
- Make ERT members get either hidden security record or full crew records on creation. Add admin verbs to allow granting whichever mob they wish either of these two options.
