### PR TITLE
Fixes being able to hear people through a vacuum

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -8,7 +8,19 @@
 			//Does the speaker have a client?  It's either random stuff that observers won't care about (Experiment 97B says, 'EHEHEHEHEHEHEHE')
 			//Or someone snoring.  So we make it where they won't hear it.
 		return
-
+	
+	//make sure the air can transmit speech - hearer's side
+	var/turf/T = get_turf(src)
+	if (T)
+		var/datum/gas_mixture/environment = T.return_air()
+		var/pressure = (environment)? environment.return_pressure() : 0
+		if(pressure < SOUND_MINIMUM_PRESSURE && get_dist(speaker, src) > 1)
+			return
+			
+		if (pressure < ONE_ATMOSPHERE*0.4) //sound distortion pressure, to help clue people in that the air is thin, even if it isn't a vacuum yet
+			italics = 1
+			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
+	
 	if(sleeping || stat == 1)
 		hear_sleep(message)
 		return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -73,22 +73,21 @@ var/list/department_radio_keys = list(
 		if (speaking.flags & SIGNLANG)
 			say_signlang(message, pick(speaking.signlang_verb), speaking)
 			return 1
-
-	//make sure the air can transmit speech
-	var/datum/gas_mixture/environment = T.return_air()
-	if(environment)
-		var/pressure = environment.return_pressure()
-		if(pressure < SOUND_MINIMUM_PRESSURE)
-			italics = 1
-			message_range = 1
-
-			if (speech_sound)
-				sound_vol *= 0.5	//muffle the sound a bit, so it's like we're actually talking through contact
-
+	
 	var/list/listening = list()
 	var/list/listening_obj = list()
 
 	if(T)
+		//make sure the air can transmit speech - speaker's side
+		var/datum/gas_mixture/environment = T.return_air()
+		var/pressure = (environment)? environment.return_pressure() : 0
+		if(pressure < SOUND_MINIMUM_PRESSURE)
+			message_range = 1
+		
+		if (pressure < ONE_ATMOSPHERE*0.4) //sound distortion pressure, to help clue people in that the air is thin, even if it isn't a vacuum yet
+			italics = 1
+			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
+	
 		var/list/hear = hear(message_range, T)
 		var/list/hearturfs = list()
 


### PR DESCRIPTION
Fixes being able to hear someone while in space just because the speaker is in a room with air.

Adds the pressure check to the hearer's side to handle the case when the speaker is in air but the hearer is not. Having checks on both sides means a bit more code but it is faster than checking the speaker's air repeatedly on the hearer's side.
