### PR TITLE
Adjusts damaged stance system

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -55,8 +55,7 @@
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
-	if(can_stand <= 1)
-		tally += 5 //hopping around on one foot is slow
+	tally += 2*stance_damage //damaged/missing feet or legs is slow
 
 	if(mRun in mutations)
 		tally = 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -213,7 +213,7 @@
 	var/universal_speak = 0 // Set to 1 to enable the mob to speak to everyone -- TLE
 	var/universal_understand = 0 // Set to 1 to enable the mob to understand everyone, not necessarily speak
 
-	var/can_stand = 2 //Whether this mob have ability to stand
+	var/stance_damage = 0 //Whether this mob's ability to stand has been affected
 
 	var/immune_to_ssd = 0
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -104,16 +104,20 @@
 							W.germ_level += 1
 
 /mob/living/carbon/human/proc/handle_stance()
-	can_stand = 2
+	if (lying || resting)
+		return // don't need to process any of this if they aren't standing anyways
+	
+	stance_damage = 0
 	for (var/organ in list("l_leg","l_foot","r_leg","r_foot"))
 		var/datum/organ/external/E = organs_by_name[organ]
-		if ((E.status & ORGAN_DESTROYED) || E.is_malfunctioning() || (E.is_broken() && !(E.status & ORGAN_SPLINTED)) || !E.is_usable())
-			can_stand--			// let it fail even if just foot&leg
+		if (E.status & ORGAN_DESTROYED)
+			stance_damage += 2 // let it fail even if just foot&leg
+		else if (E.is_malfunctioning() || (E.is_broken() && !(E.status & ORGAN_SPLINTED)) || !E.is_usable())
+			stance_damage += 1
 
 	// standing is poor
-	if(can_stand <= 0)
-		Weaken(10)
-		if (!(lying || resting))
-			if(species && !(species.flags & NO_PAIN))
-				emote("scream")
-			emote("collapse")
+	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
+		Weaken(5)
+		if(species && !(species.flags & NO_PAIN))
+			emote("scream")
+		emote("collapse")


### PR DESCRIPTION
Makes the system for handling damaged stance behave a bit closer to what's on master, and more forgiving of broken legs and feet.

Having two broken legs/feet will now only make you fall over occasionally, like on master.
Having two missing feet or one missing leg (and hence missing foot) will stop you from standing. 

If both legs _and_ both feet are broken you will still be unable to stand, but that's fine since you would be pretty messed up anyways.

The movement penalty for damaged legs/feet also scales better.
