### PR TITLE
Fixes renwick shield generators incorrectly using power

### DIFF
--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -20,7 +20,7 @@
 	var/strengthen_rate = 0.2
 	var/max_strengthen_rate = 0.5	//the maximum rate that the generator can increase the average field strength
 	var/dissipation_rate = 0.030	//the percentage of the shield strength that needs to be replaced each second
-	var/min_dissipation = 0.1		//will dissipate by at least this rate in renwicks per field tile (otherwise field would never dissipate completely as dissipation is a percentage)
+	var/min_dissipation = 0.01		//will dissipate by at least this rate in renwicks per field tile (otherwise field would never dissipate completely as dissipation is a percentage)
 	var/powered = 0
 	var/check_powered = 1
 	var/obj/machinery/shield_capacitor/owned_capacitor


### PR DESCRIPTION
- Shield generators now correctly use power according to actual field strength.
- Minimal shield dissipation rate now corresponds with 1 renwick field (changed from 10, which technically caused shields to always use max upkeep power ignoring field strength completely)

This issue made it impossible to create larger fields simply due to massive and illogical power usage.  So you can now actually create <b>weak</b> shield around the station. However don't expect these shields to stop everything you throw at them (for example, meteor hit breaches fields up to ~2 renwicks, and strong explosions can take as much as 6 renwicks.
