### PR TITLE
Canister Logs

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -303,6 +303,7 @@ update_flag
 				release_log += "Valve was <b>opened</b> by [usr] ([usr.ckey]), starting the transfer into the [holding]<br>"
 			else
 				release_log += "Valve was <b>opened</b> by [usr] ([usr.ckey]), starting the transfer into the <font color='red'><b>air</b></font><br>"
+				log_open()
 		valve_open = !valve_open
 
 	if (href_list["remove_tank"])

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -175,3 +175,16 @@
 		return
 
 	..()
+
+/obj/machinery/portable_atmospherics/proc/log_open()
+	if(air_contents.gas.len == 0)
+		return
+
+	var/gases = ""
+	for(var/gas in air_contents.gas)
+		if(gases)
+			gases += ", [gas]"
+		else
+			gases = gas
+	log_admin("[usr] ([usr.ckey]) opened '[src.name]' containing [gases].")
+	message_admins("[usr] ([usr.ckey]) opened '[src.name]' containing [gases].")


### PR DESCRIPTION
Opening a non-empty canister without an inserted gas container now produces an admin message, not only a log note on the canister itself.
