### PR TITLE
Fix for xenoarch finds with missing sprites

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1287,6 +1287,7 @@
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_teleport.dm"
 #include "code\modules\research\xenoarchaeology\finds\finds.dm"
 #include "code\modules\research\xenoarchaeology\finds\finds_defines.dm"
+#include "code\modules\research\xenoarchaeology\finds\finds_eguns.dm"
 #include "code\modules\research\xenoarchaeology\finds\finds_fossils.dm"
 #include "code\modules\research\xenoarchaeology\finds\finds_misc.dm"
 #include "code\modules\research\xenoarchaeology\finds\finds_special.dm"

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -342,10 +342,10 @@
 		if(26)
 			//energy gun
 			var/spawn_type = pick(\
-			/obj/item/weapon/gun/energy/laser/practice,\
-			/obj/item/weapon/gun/energy/laser,\
-			/obj/item/weapon/gun/energy/xray,\
-			/obj/item/weapon/gun/energy/laser/captain)
+			/obj/item/weapon/gun/energy/laser/practice/xenoarch,\
+			/obj/item/weapon/gun/energy/laser/xenoarch,\
+			/obj/item/weapon/gun/energy/xray/xenoarch,\
+			/obj/item/weapon/gun/energy/laser/captain/xenoarch)
 			if(spawn_type)
 				var/obj/item/weapon/gun/energy/new_gun = new spawn_type(src.loc)
 				new_item = new_gun

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -146,6 +146,7 @@
 			"You wonder what the creator's mouth was shaped like")]."
 		if(4)
 			name = "statuette"
+			icon = 'icons/obj/xenoarchaeology.dmi'
 			item_type = "statuette"
 			icon_state = "statuette"
 			additional_desc = "It depicts a [pick("small","ferocious","wild","pleasing","hulking")] \
@@ -154,6 +155,8 @@
 			if(prob(25))
 				new_item = new /obj/item/weapon/vampiric(src.loc)
 		if(5)
+			name = "instrument"
+			icon = 'icons/obj/xenoarchaeology.dmi'
 			item_type = "instrument"
 			icon_state = "instrument"
 			if(prob(30))
@@ -256,17 +259,17 @@
 		if(16)
 			apply_prefix = 0
 			if(prob(25))
+				icon = 'icons/obj/xenoarchaeology.dmi'
 				item_type = "smooth green crystal"
 				icon_state = "Green lump"
 			else if(prob(33))
+				icon = 'icons/obj/xenoarchaeology.dmi'
 				item_type = "irregular purple crystal"
 				icon_state = "Phazon"
-			else if(prob(50))
+			else
+				icon = 'icons/obj/xenoarchaeology.dmi'
 				item_type = "rough red crystal"
 				icon_state = "changerock"
-			else
-				item_type = "smooth red crystal"
-				icon_state = "ore"
 			additional_desc = pick("It shines faintly as it catches the light.","It appears to have a faint inner glow.","It seems to draw you inward as you look it at.","Something twinkles faintly as you look at it.","It's mesmerizing to behold.")
 
 			apply_material_decorations = 0
@@ -285,8 +288,8 @@
 		if(18)
 			new_item = new /obj/item/device/radio/beacon(src.loc)
 			talkative = 0
-			new_item.icon_state = "unknown[rand(1,4)]"
 			new_item.icon = 'icons/obj/xenoarchaeology.dmi'
+			new_item.icon_state = "unknown[rand(1,4)]"
 			new_item.desc = ""
 		if(19)
 			apply_prefix = 0
@@ -451,7 +454,7 @@
 			//robot remains
 			apply_prefix = 0
 			item_type = "[pick("mechanical","robotic","cyborg")] [pick("remains","chassis","debris")]"
-			icon = 'icons/effects/blood.dmi'
+			icon = 'icons/mob/robots.dmi'
 			icon_state = "remainsrobot"
 			additional_desc = pick("Almost mistakeable for the remains of a modern cyborg.",\
 			"They are barely recognisable as anything other than a pile of waste metals.",\

--- a/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
@@ -1,0 +1,25 @@
+//snowflake guns for xenoarch because you can't override the update_icon() proc inside the giant mess that is find creation
+/obj/item/weapon/gun/energy/laser/xenoarch
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	update_icon()
+		return
+
+/obj/item/weapon/gun/energy/laser/practice/xenoarch
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	update_icon()
+		return
+
+/obj/item/weapon/gun/energy/laser/practice/xenoarch
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	update_icon()
+		return
+
+/obj/item/weapon/gun/energy/xray/xenoarch
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	update_icon()
+		return
+
+/obj/item/weapon/gun/energy/laser/captain/xenoarch
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	update_icon()
+		return


### PR DESCRIPTION
Fixes both the guns mentioned in https://github.com/Baystation12/Baystation12/issues/4637 as well as a few other items that were showing up icon-less.
