### PR TITLE
Fixes paper bundles not burning properly with a match

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -44,7 +44,7 @@
 		user << "<span class='notice'>You add [(W.name == "photo") ? "the photo" : W.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>"
 		user.drop_from_inventory(W)
 		W.loc = src
-	else if(istype(W, /obj/item/weapon/flame/lighter))
+	else if(istype(W, /obj/item/weapon/flame))
 		burnpaper(W, user)
 	else if(istype(W, /obj/item/weapon/paper_bundle))
 		user.drop_from_inventory(W)
@@ -69,7 +69,7 @@
 	return
 
 
-/obj/item/weapon/paper_bundle/proc/burnpaper(obj/item/weapon/flame/lighter/P, mob/user)
+/obj/item/weapon/paper_bundle/proc/burnpaper(obj/item/weapon/flame/P, mob/user)
 	var/class = "<span class='warning'>"
 
 	if(P.lit && !user.restrained())


### PR DESCRIPTION
Paper bundles would burn one paper at a time with a match, leaving a single paperclip that would suck papers into an un-interactable mess if you tried to clip anything to it. Lighters would burn the whole thing. Now, matches and lighters will both burn it all, and you need to detach papers to burn them individually, because that both makes sense and fixes https://github.com/Baystation12/Baystation12/issues/7041
