### PR TITLE
MedicalHUD takes hardcrit in account

### DIFF
--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -98,7 +98,7 @@
 				holder.icon_state = "hudhealth-100"
 				C.images += holder
 			else
-				holder.icon_state = "hud[RoundHealth(patient.health)]"
+				holder.icon_state = "hud[RoundHealth((patient.health-config.health_threshold_crit)/(patient.species.total_health-config.health_threshold_crit)*100)]"
 				C.images += holder
 
 			holder = patient.hud_list[STATUS_HUD]

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1688,7 +1688,7 @@
 		if(stat == 2)
 			holder.icon_state = "hudhealth-100" 	// X_X
 		else
-			var/percentage_health = RoundHealth(((0.0+health)/species.total_health)*100)
+			var/percentage_health = RoundHealth((health-config.health_threshold_crit)/(species.total_health-config.health_threshold_crit)*100)
 			holder.icon_state = "hud[percentage_health]"
 		hud_list[HEALTH_HUD] = holder
 


### PR DESCRIPTION
The HUD icon for hardcrit will now be shown when the patient actually entered it. At -50 health the system will now assume the patient to have reached 0 health and entered hardcrit.
