### PR TITLE
Fixes #7086

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -20,6 +20,7 @@
 	voice_name = "farwa"
 	speak_emote = list("mews")
 	icon_state = "tajkey1"
+	greaterform = "Tajara"
 	uni_append = list(0x0A0,0xE00) // 0A0E00
 
 /mob/living/carbon/monkey/skrell
@@ -27,6 +28,7 @@
 	voice_name = "neaera"
 	speak_emote = list("squicks")
 	icon_state = "skrellkey1"
+	greaterform = "Skrell"
 	uni_append = list(0x01C,0xC92) // 01CC92
 
 /mob/living/carbon/monkey/unathi
@@ -34,15 +36,24 @@
 	voice_name = "stok"
 	speak_emote = list("hisses")
 	icon_state = "stokkey1"
+	greaterform = "Unathi"
 	uni_append = list(0x044,0xC5D) // 044C5D
+
+/mob/living/carbon/monkey/initialize()
+	if (!species)
+		species = all_species[greaterform]
+		add_language(species.language)
 
 /mob/living/carbon/monkey/New()
 	var/datum/reagents/R = new/datum/reagents(1000)
 	reagents = R
 	R.my_atom = src
 
-	species = all_species[greaterform]
-	add_language(species.language)
+	//Ensure that the all_species list has been initialized.
+	//If not then this must be round-start and initialize() will
+	//be called directly by the master controller, later.
+	if (ticker && ticker.current_state >= GAME_STATE_SETTING_UP)
+		initialize()
 
 	if(name == initial(name)) //To stop Pun-Pun becoming generic.
 		name = "[name] ([rand(1, 1000)])"
@@ -80,23 +91,16 @@
 	return
 
 /mob/living/carbon/monkey/unathi/New()
-
-	dna.mutantrace = "lizard"
-	greaterform = "Unathi"
 	..()
+	dna.mutantrace = "lizard"
 
 /mob/living/carbon/monkey/skrell/New()
-
-	
-	dna.mutantrace = "skrell"
-	greaterform = "Skrell"
 	..()
+	dna.mutantrace = "skrell"
 
 /mob/living/carbon/monkey/tajara/New()
-
-	dna.mutantrace = "tajaran"
-	greaterform = "Tajara"
 	..()
+	dna.mutantrace = "tajaran"
 
 /mob/living/carbon/monkey/movement_delay()
 	var/tally = 0


### PR DESCRIPTION
Same fix from #7078.

Could be improved, perhaps by changing mapped-in monkies to be an object that spawns a monkey and getting rid of initialize(), but this PR does fix the runtime and does ensure that both round-start and later monkeys have their species set.

Fixes #7086
Fixes #7068
