### PR TITLE
Adds intent-based firing control to guns, fixes targeting bug

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -53,10 +53,24 @@
 /obj/item/weapon/gun/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params)
 	if(flag)	return //It's adjacent, is the user, or is on the user's person
 	if(istype(target, /obj/machinery/recharger) && istype(src, /obj/item/weapon/gun/energy))	return//Shouldnt flag take care of this?
-	if(user && user.client && user.client.gun_mode && !(A in target))
-		PreFire(A,user,params) //They're using the new gun system, locate what they're aiming at.
-	else
-		Fire(A,user,params) //Otherwise, fire normally.
+	
+	
+	//decide whether to aim or shoot normally
+	var/aiming = 0
+	if(user && user.client && !(A in target))
+		var/client/C = user.client
+		//If help intent is on and we have clicked on an eligible target, switch to aim mode automatically
+		if(user.a_intent == "help" && isliving(A) && !C.gun_mode)
+			C.ToggleGunMode()
+		
+		if(C.gun_mode)
+			aiming = PreFire(A,user,params) //They're using the new gun system, locate what they're aiming at.
+	
+	if (!aiming)
+		if(user && user.a_intent == "help") //regardless of what happens, refuse to shoot if help intent is on
+			user << "\red You refrain from firing your [src] as your intent is set to help."
+		else
+			Fire(A,user,params) //Otherwise, fire normally.
 
 /obj/item/weapon/gun/proc/isHandgun()
 	return 1

--- a/code/modules/projectiles/targeting.dm
+++ b/code/modules/projectiles/targeting.dm
@@ -43,19 +43,23 @@
 		del(target)
 
 //Compute how to fire.....
+//Return 1 if a target was found, 0 otherwise.
 /obj/item/weapon/gun/proc/PreFire(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, params)
 	//Lets not spam it.
 	if(lock_time > world.time - 2) return
-	.
-	if(ismob(A) && isliving(A) && !(A in target))
+	
+	user.dir = get_cardinal_dir(src, A)
+	if(isliving(A) && !(A in target))
 		Aim(A) 	//Clicked a mob, aim at them
-	else  		//Didn't click someone, check if there is anyone along that guntrace
-		var/mob/living/M = GunTrace(usr.x,usr.y,A.x,A.y,usr.z,usr)  //Find dat mob.
-		if(M && isliving(M) && M in view(user) && !(M in target))
-			Aim(M) //Aha!  Aim at them!
-		else if(!ismob(M) || (ismob(M) && !(M in view(user)))) //Nope!  They weren't there!
-			Fire(A,user,params)  //Fire like normal, then.
-	usr.dir = get_cardinal_dir(src, A)
+		return 1
+
+	//Didn't click someone, check if there is anyone along that guntrace
+	var/mob/living/M = GunTrace(usr.x,usr.y,A.x,A.y,usr.z,usr)  //Find dat mob.
+	if(isliving(M) && (M in view(user)) && !(M in target))
+		Aim(M) //Aha!  Aim at them!
+		return 1
+	
+	return 0
 
 //Aiming at the target mob.
 /obj/item/weapon/gun/proc/Aim(var/mob/living/M)
@@ -79,6 +83,12 @@
 	if(src != M.equipped())
 		stop_aim()
 		return
+	
+	//reflex firing is disabled when help intent is set
+	if (M.a_intent == "help")
+		M << "\red You refrain from firing your [src] as your intent is set to help."
+		return
+	
 	M.last_move_intent = world.time
 	if(can_fire())
 		var/firing_check = can_hit(T,usr) //0 if it cannot hit them, 1 if it is capable of hitting, and 2 if a special check is preventing it from firing.


### PR DESCRIPTION
Adds some of the gun firing control ideas described in [this thread](http://baystation12.net/forums/viewtopic.php?f=5&t=11441).

Also fixes missing brackets in PreFire() preventing targeting people using GunTrace(), due to the low precedence of the `in` operator.

When help intent is set, the player will not fire their gun when clicking on atoms, or by reflex due to targeting. If targeting is off, clicking on a targetable mob will switch targeting mode on and target that mob.

When any other intent is set, firing guns works as normal. Because of the fixed bug, if targeting is turned on you can now target mobs by clicking on a turf between you and the desired mob using GunTrace(). If they are already targeted then clicking on that turf will fire the weapon.
