### PR TITLE
AI can now track people with max level sensors.

### DIFF
--- a/code/defines/procs/hud.dm
+++ b/code/defines/procs/hud.dm
@@ -12,13 +12,8 @@ proc/process_med_hud(var/mob/M, var/local_scanner, var/mob/Alt)
 		if(P.Mob.see_invisible < patient.invisibility)
 			continue
 
-		if(!local_scanner)
-			if(istype(patient.w_uniform, /obj/item/clothing/under))
-				var/obj/item/clothing/under/U = patient.w_uniform
-				if(U.sensor_mode < 2)
-					continue
-			else
-				continue
+		if(!(local_scanner || hassensorlevel(P, SUIT_SENSOR_VITAL)))
+			continue
 
 		P.Client.images += patient.hud_list[HEALTH_HUD]
 		if(local_scanner)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -211,7 +211,7 @@
 				U.ai_cancel_tracking()
 				return
 
-			if (!near_camera(target))
+			if (!trackable(target))
 				U << "Target is not near any active cameras."
 				sleep(100)
 				continue
@@ -233,6 +233,9 @@
 	else if(!cameranet.checkCameraVis(M))
 		return 0
 	return 1
+
+/proc/trackable(var/mob/living/M)
+	return near_camera(M) || (M.loc.z in config.station_levels && hassensorlevel(M, SUIT_SENSOR_TRACKING))
 
 /obj/machinery/camera/attack_ai(var/mob/living/silicon/ai/user as mob)
 	if (!istype(user))

--- a/code/global.dm
+++ b/code/global.dm
@@ -202,6 +202,12 @@ var/datum/event_manager/event_manager = new()
 #define EVENT_LEVEL_MODERATE 2
 #define EVENT_LEVEL_MAJOR 3
 
+// Suit sensor levels
+#define SUIT_SENSOR_OFF 0
+#define SUIT_SENSOR_BINARY 1
+#define SUIT_SENSOR_VITAL 2
+#define SUIT_SENSOR_TRACKING 3
+
 	//away missions
 var/list/awaydestinations = list()	//a list of landmarks that the warpgate can take you to
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -131,6 +131,13 @@ proc/iscuffed(A)
 			return 1
 	return 0
 
+proc/hassensorlevel(A, var/level)
+	var/mob/living/carbon/human/H = A
+	if(istype(H) && istype(H.w_uniform, /obj/item/clothing/under))
+		var/obj/item/clothing/under/U = H.w_uniform
+		return U.sensor_mode >= level
+	return 0
+
 /proc/hsl2rgb(h, s, l)
 	return //TODO: Implement
 


### PR DESCRIPTION
Crew members with tracking sensors enabled and in reception range (currently defined as being on the station Z-level) can now be tracked even without camera coverage.
