### PR TITLE
Crew Monitoring Computer improvements, wallets working with computers

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -563,6 +563,7 @@ var/global/datum/controller/occupations/job_master
 			var/obj/item/device/pda/pda = locate(/obj/item/device/pda,H)
 			pda.owner = H.real_name
 			pda.ownjob = C.assignment
+			pda.ownrank = C.rank
 			pda.name = "PDA-[H.real_name] ([pda.ownjob])"
 
 		return 1

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -84,26 +84,25 @@
 				crewmemberData["tox"] = round(H.getToxLoss(), 1)
 				crewmemberData["fire"] = round(H.getFireLoss(), 1)
 				crewmemberData["brute"] = round(H.getBruteLoss(), 1)
-				
+
 				crewmemberData["name"] = "Unknown"
-				crewmemberData["rank"] = "Unknown"				
-				if(H.wear_id && istype(H.wear_id, /obj/item/weapon/card/id) )
-					var/obj/item/weapon/card/id/I = H.wear_id
-					crewmemberData["name"] = I.name	
-					crewmemberData["rank"] = I.rank
-				else if(H.wear_id && istype(H.wear_id, /obj/item/device/pda) )
-					var/obj/item/device/pda/P = H.wear_id						
-					crewmemberData["name"] = (P.id ? P.id.name : "Unknown")				
-					crewmemberData["rank"] = (P.id ? P.id.rank : "Unknown")
-					
+				crewmemberData["rank"] = "Unknown"
+				if(H.wear_id)
+					if(istype(H.wear_id, /obj/item/weapon/card/id) )
+						var/obj/item/weapon/card/id/I = H.wear_id
+						crewmemberData["name"] = I.registered_name
+						crewmemberData["rank"] = I.rank
+					else if(istype(H.wear_id, /obj/item/device/pda) )
+						var/obj/item/device/pda/P = H.wear_id
+						crewmemberData["name"] = (P.id ? P.id.registered_name : P.owner)
+						crewmemberData["rank"] = (P.id ? P.id.rank : P.ownjob)
+
 				var/area/A = get_area(H)
 				crewmemberData["area"] = sanitize(A.name)
 				crewmemberData["x"] = pos.x
 				crewmemberData["y"] = pos.y
 
-				// Works around list += list2 merging lists; it's not pretty but it works
-				crewmembers += "temporary item"
-				crewmembers[crewmembers.len] = crewmemberData
+				crewmembers[++crewmembers.len] = crewmemberData
 
 	crewmembers = sortByKey(crewmembers, "name")
 
@@ -112,12 +111,12 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "crew_monitor.tmpl", "Crew Monitoring Computer", 900, 800)
-		
+
 		// adding a template with the key "mapContent" enables the map ui functionality
 		ui.add_template("mapContent", "crew_monitor_map_content.tmpl")
 		// adding a template with the key "mapHeader" replaces the map header content
 		ui.add_template("mapHeader", "crew_monitor_map_header.tmpl")
-				
+
 		ui.set_initial_data(data)
 		ui.open()
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -85,17 +85,9 @@
 				crewmemberData["fire"] = round(H.getFireLoss(), 1)
 				crewmemberData["brute"] = round(H.getBruteLoss(), 1)
 
-				crewmemberData["name"] = "Unknown"
-				crewmemberData["rank"] = "Unknown"
-				if(H.wear_id)
-					if(istype(H.wear_id, /obj/item/weapon/card/id) )
-						var/obj/item/weapon/card/id/I = H.wear_id
-						crewmemberData["name"] = I.registered_name
-						crewmemberData["rank"] = I.rank
-					else if(istype(H.wear_id, /obj/item/device/pda) )
-						var/obj/item/device/pda/P = H.wear_id
-						crewmemberData["name"] = (P.id ? P.id.registered_name : P.owner)
-						crewmemberData["rank"] = (P.id ? P.id.rank : P.ownjob)
+				crewmemberData["name"] = H.get_authentification_name(if_no_id="Unknown")
+				crewmemberData["rank"] = H.get_authentification_rank(if_no_id="Unknown", if_no_job="No Job")
+				crewmemberData["assignment"] = H.get_assignment(if_no_id="Unknown", if_no_job="No Job")
 
 				var/area/A = get_area(H)
 				crewmemberData["area"] = sanitize(A.name)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -58,7 +58,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/update_every_five = list(3, 41, 433, 46, 47, 48, 49)			     // These we update every 5 ticks
 
 	var/obj/item/weapon/card/id/id = null //Making it possible to slot an ID card into the PDA so it can function as both.
-	var/ownjob = null //related to above
+	var/ownjob = null //related to above - this is assignment (potentially alt title)
+	var/ownrank = null // this one is rank, never alt title
 
 	var/obj/item/device/paicard/pai = null	// A slot for a personal AI device
 
@@ -223,9 +224,13 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	detonate = 0
 
 
-/obj/item/device/pda/ai/proc/set_name_and_job(newname as text, newjob as text)
+/obj/item/device/pda/ai/proc/set_name_and_job(newname as text, newjob as text, newrank as null|text)
 	owner = newname
 	ownjob = newjob
+	if(newrank)
+		ownrank = newrank
+	else
+		ownrank = ownjob
 	name = newname + " (" + ownjob + ")"
 
 
@@ -602,6 +607,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			id_check(U, 1)
 		if("UpdateInfo")
 			ownjob = id.assignment
+			ownrank = id.rank
 			name = "PDA-[owner] ([ownjob])"
 		if("Eject")//Ejects the cart, only done from hub.
 			if (!isnull(cartridge))
@@ -1133,6 +1139,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if(!owner)
 			owner = idcard.registered_name
 			ownjob = idcard.assignment
+			ownrank = idcard.rank
 			name = "PDA-[owner] ([ownjob])"
 			user << "<span class='notice'>Card scanned.</span>"
 		else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -263,40 +263,52 @@
 		var/obj/vehicle/V = AM
 		V.RunOver(src)
 
+// Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
+/mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")
+	var/obj/item/device/pda/pda = wear_id
+	if (istype(pda))
+		if (pda.id)
+			return pda.id.rank
+		else
+			return pda.ownrank
+	else
+		var/obj/item/weapon/card/id/id = get_idcard()
+		if(id)
+			return id.rank ? id.rank : if_no_job
+		else
+			return if_no_id
 
 //gets assignment from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_assignment(var/if_no_id = "No id", var/if_no_job = "No job")
 	var/obj/item/device/pda/pda = wear_id
-	var/obj/item/weapon/card/id/id = wear_id
 	if (istype(pda))
-		if (pda.id && istype(pda.id, /obj/item/weapon/card/id))
-			. = pda.id.assignment
+		if (pda.id)
+			return pda.id.assignment
 		else
-			. = pda.ownjob
-	else if (istype(id))
-		. = id.assignment
+			return pda.ownjob
 	else
-		return if_no_id
-	if (!.)
-		. = if_no_job
-	return
+		var/obj/item/weapon/card/id/id = get_idcard()
+		if(id)
+			return id.assignment ? id.assignment : if_no_job
+		else
+			return if_no_id
 
 //gets name from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_authentification_name(var/if_no_id = "Unknown")
 	var/obj/item/device/pda/pda = wear_id
-	var/obj/item/weapon/card/id/id = wear_id
 	if (istype(pda))
 		if (pda.id)
-			. = pda.id.registered_name
+			return pda.id.registered_name
 		else
-			. = pda.owner
-	else if (istype(id))
-		. = id.registered_name
+			return pda.owner
 	else
-		return if_no_id
-	return
+		var/obj/item/weapon/card/id/id = get_idcard()
+		if(id)
+			return id.registered_name
+		else
+			return if_no_id
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
 /mob/living/carbon/human/proc/get_visible_name()

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -6,11 +6,11 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 <table width="100%"><tbody>
 	{{for data.crewmembers}}
 		{{if value.sensor_type == 1}}
-			<tr><td>{{:value.name}} ({{:value.rank}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td></tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td></tr>
 		{{else value.sensor_type == 2}}
-			<tr><td>{{:value.name}} ({{:value.rank}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td></tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td></tr>
 		{{else value.sensor_type == 3}}
-			<tr><td>{{:value.name}} ({{:value.rank}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td></tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td></tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -6,11 +6,11 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 <table width="100%"><tbody>
 	{{for data.crewmembers}}
 		{{if value.sensor_type == 1}}
-			<tr><td>{{:value.name}}</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td></tr>
+			<tr><td>{{:value.name}} ({{:value.rank}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td></tr>
 		{{else value.sensor_type == 2}}
-			<tr><td>{{:value.name}}</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td></tr>
+			<tr><td>{{:value.name}} ({{:value.rank}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td></tr>
 		{{else value.sensor_type == 3}}
-			<tr><td>{{:value.name}}</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td></tr>
+			<tr><td>{{:value.name}} ({{:value.rank}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td></tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>

--- a/nano/templates/crew_monitor_map_content.tmpl
+++ b/nano/templates/crew_monitor_map_content.tmpl
@@ -6,7 +6,7 @@ Used In File(s): \code\game\machinery\computer\crew.dm
     {{if value.sensor_type == 3}}
         <div class="mapIcon mapIcon16 rank-{{:value.rank.ckey()}} {{:value.dead ? 'dead' : 'alive'}}" style="left: {{:(value.x)}}px; bottom: {{:(value.y - 1)}}px;" unselectable="on">
             <div class="tooltip hidden">
-                {{:value.name}} ({{:value.rank}}) ({{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}) (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>) ({{:value.area}}: {{:value.x}}, {{:value.y}})
+                {{:value.name}} ({{:value.assignment}}) ({{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}) (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>) ({{:value.area}}: {{:value.x}}, {{:value.y}})
             </div>
         </div>
     {{/if}}

--- a/nano/templates/crew_monitor_map_content.tmpl
+++ b/nano/templates/crew_monitor_map_content.tmpl
@@ -6,7 +6,7 @@ Used In File(s): \code\game\machinery\computer\crew.dm
     {{if value.sensor_type == 3}}
         <div class="mapIcon mapIcon16 rank-{{:value.rank.ckey()}} {{:value.dead ? 'dead' : 'alive'}}" style="left: {{:(value.x)}}px; bottom: {{:(value.y - 1)}}px;" unselectable="on">
             <div class="tooltip hidden">
-                {{:value.name}} ({{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}) (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>) ({{:value.area}}: {{:value.x}}, {{:value.y}})
+                {{:value.name}} ({{:value.rank}}) ({{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}) (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>) ({{:value.area}}: {{:value.x}}, {{:value.y}})
             </div>
         </div>
     {{/if}}


### PR DESCRIPTION
- Can now get crewmember names from PDAs, rather than reporting "Unknown" if the PDA does not contain an ID.
- No longer shows "Random Assistant's ID Card (Assistant)", now shows "Random Assistant (Assistant)".
- Wallets (and anything else implementing a `GetID` proc) work with `get_authentification_name`/`get_assignment`.
- New proc: `get_authentification_rank`, returns the rank from ID/PDA/wallet/whatever, like `get_authentification_name` etc.
- Alt-titles are shown on crew monitor.
