### PR TITLE
Solves a runtime when someone tries to mop up blood.

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -40,7 +40,7 @@
 		user.visible_message("<span class='warning'>[user] begins to clean \the [get_turf(A)].</span>")
 
 		if(do_after(user, 40))
-			var/turf/T = A
+			var/turf/T = get_turf(A)
 			if(T)
 				T.clean(src)
 			user << "<span class='notice'>You have finished mopping!</span>"


### PR DESCRIPTION
proc name: afterattack (/obj/item/weapon/mop/afterattack)
  source file: mop.dm,45
runtime error: undefined proc or verb /obj/effect/decal/cleanable/blood/tracks/footprints/clean().
