### PR TITLE
Fixes most nullspace items, rewrites floor tiles not to del() so much

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -170,7 +170,7 @@
 
 	New()
 		..()
-		beaker = new /obj/item/weapon/reagent_containers/glass/beaker/large()
+		beaker = new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
 		spawn( 5 )
 			if(orient == "RIGHT")
 				icon_state = "sleeper_0-r"

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -228,7 +228,7 @@
 	if((!src.target || src.target == null) && emagged == 2)
 		if(!src.target || src.target == null)
 			for (var/turf/simulated/floor/D in view(7,src))
-				if(!(D in floorbottargets) && D != src.oldtarget && D.floor_tile)
+				if(!(D in floorbottargets) && D != src.oldtarget && D.floor_type)
 					src.oldtarget = D
 					src.target = D
 					break

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -296,10 +296,9 @@ var/global/list/holodeck_programs = list(
 /turf/simulated/floor/holofloor/grass
 	name = "Lush Grass"
 	icon_state = "grass1"
-	floor_tile = new/obj/item/stack/tile/grass
+	floor_type = /obj/item/stack/tile/grass
 
 	New()
-		floor_tile.New() //I guess New() isn't run on objects spawned without the definition of a turf to house them, ah well.
 		icon_state = "grass[pick("1","2","3","4")]"
 		..()
 		spawn(4)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -74,9 +74,9 @@
 	var/obj/item/weapon/gun/energy/E = installation	//All energy-based weapons are applicable
 	//var/obj/item/ammo_casing/shottype = E.projectile_type
 
-	projectile = intial(E.projectile_type)
+	projectile = initial(E.projectile_type)
 	eprojectile = projectile
-	shot_sound = intial(E.fire_sound)
+	shot_sound = initial(E.fire_sound)
 	eshot_sound = shot_sound
 
 	weapon_setup(installation)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -71,54 +71,55 @@
 	setup()
 
 /obj/machinery/porta_turret/proc/setup()
-	var/obj/item/weapon/gun/energy/E = new installation	//All energy-based weapons are applicable
+	var/obj/item/weapon/gun/energy/E = installation	//All energy-based weapons are applicable
 	//var/obj/item/ammo_casing/shottype = E.projectile_type
 
-	projectile = E.projectile_type
+	projectile = intial(E.projectile_type)
 	eprojectile = projectile
-	shot_sound = E.fire_sound
+	shot_sound = intial(E.fire_sound)
 	eshot_sound = shot_sound
 
-	weapon_setup(E)
+	weapon_setup(installation)
 
-/obj/machinery/porta_turret/proc/weapon_setup(var/obj/item/weapon/gun/energy/E)
-	if(/obj/item/weapon/gun/energy/laser/practice)
-		iconholder = 1
-		eprojectile = /obj/item/projectile/beam
+/obj/machinery/porta_turret/proc/weapon_setup(var/guntype)
+	switch(guntype)
+		if(/obj/item/weapon/gun/energy/laser/practice)
+			iconholder = 1
+			eprojectile = /obj/item/projectile/beam
 
 //			if(/obj/item/weapon/gun/energy/laser/practice/sc_laser)
 //				iconholder = 1
 //				eprojectile = /obj/item/projectile/beam
 
-	if(/obj/item/weapon/gun/energy/laser/retro)
-		iconholder = 1
+		if(/obj/item/weapon/gun/energy/laser/retro)
+			iconholder = 1
 
 //			if(/obj/item/weapon/gun/energy/laser/retro/sc_retro)
 //				iconholder = 1
 
-	if(/obj/item/weapon/gun/energy/laser/captain)
-		iconholder = 1
+		if(/obj/item/weapon/gun/energy/laser/captain)
+			iconholder = 1
 
-	if(/obj/item/weapon/gun/energy/lasercannon)
-		iconholder = 1
+		if(/obj/item/weapon/gun/energy/lasercannon)
+			iconholder = 1
 
-	if(/obj/item/weapon/gun/energy/taser)
-		eprojectile = /obj/item/projectile/beam
-		eshot_sound = 'sound/weapons/Laser.ogg'
+		if(/obj/item/weapon/gun/energy/taser)
+			eprojectile = /obj/item/projectile/beam
+			eshot_sound = 'sound/weapons/Laser.ogg'
 
-	if(/obj/item/weapon/gun/energy/stunrevolver)
-		eprojectile = /obj/item/projectile/beam
-		eshot_sound = 'sound/weapons/Laser.ogg'
+		if(/obj/item/weapon/gun/energy/stunrevolver)
+			eprojectile = /obj/item/projectile/beam
+			eshot_sound = 'sound/weapons/Laser.ogg'
 
-	if(/obj/item/weapon/gun/energy/gun)
-		eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
-		eshot_sound = 'sound/weapons/Laser.ogg'
-		egun = 1
+		if(/obj/item/weapon/gun/energy/gun)
+			eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
+			eshot_sound = 'sound/weapons/Laser.ogg'
+			egun = 1
 
-	if(/obj/item/weapon/gun/energy/gun/nuclear)
-		eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
-		eshot_sound = 'sound/weapons/Laser.ogg'
-		egun = 1
+		if(/obj/item/weapon/gun/energy/gun/nuclear)
+			eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
+			eshot_sound = 'sound/weapons/Laser.ogg'
+			egun = 1
 
 /obj/machinery/porta_turret/update_icon()
 	if(!anchored)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -130,7 +130,6 @@
 		var/price = prices[typepath]
 		if(isnull(amount)) amount = 1
 
-		var/atom/temp = new typepath(null)
 		var/datum/data/vending_product/R = new /datum/data/vending_product()
 
 		R.product_path = typepath
@@ -151,7 +150,8 @@
 		if(delay_product_spawn)
 			sleep(5) //sleep(1) did not seem to cut it, so here we are.
 
-		R.product_name = temp.name
+		var/atom/temp = typepath
+		R.product_name = initial(temp.name)
 
 //		world << "Added: [R.product_name]] - [R.amount] - [R.product_path]"
 	return

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -337,7 +337,7 @@
 			var/turf/simulated/floor/T = new_turf
 			if(!T.is_plating())
 				if(!T.broken && !T.burnt)
-					new T.floor_tile.type(T)
+					new T.floor_type(T)
 				T.make_plating()
 		return !new_turf.intact
 

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -48,7 +48,7 @@
 // temporary fix for broken icon until somebody gets around to make these player-buildable
 /turf/simulated/floor/mech_bay_recharge_floor/attackby(obj/item/C as obj, mob/user as mob)	
 	..()	
-	if(floor_tile)
+	if(floor_type)
 		icon_state = "recharge_floor"
 	else
 		icon_state = "support_lattice"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -15,9 +15,15 @@
 	var/obj/item/device/encryptionkey/keyslot2 = null
 	maxf = 1489
 
+	var/ks1type = /obj/item/device/encryptionkey
+	var/ks2type = null
+
 /obj/item/device/radio/headset/New()
 	..()
-	keyslot1 = new /obj/item/device/encryptionkey/
+	if(ks1type)
+		keyslot1 = new ks1type(src)
+	if(ks2type)
+		keyslot2 = new ks2type(src)
 	recalculateChannels(1)
 
 /obj/item/device/radio/headset/examine(mob/user)
@@ -50,76 +56,68 @@
 
 /obj/item/device/radio/headset/syndicate
 	origin_tech = "syndicate=3"
-/obj/item/device/radio/headset/syndicate/New()
-	..()
-	del(keyslot1)
-	keyslot1 = new /obj/item/device/encryptionkey/syndicate
 	syndie = 1
-	recalculateChannels(1)
+	ks1type = /obj/item/device/encryptionkey/syndicate
 
 /obj/item/device/radio/headset/binary
 	origin_tech = "syndicate=3"
-/obj/item/device/radio/headset/binary/New()
-	..()
-	del(keyslot1)
-	keyslot1 = new /obj/item/device/encryptionkey/binary
-	recalculateChannels(1)
+	ks1type = /obj/item/device/encryptionkey/binary
 
 /obj/item/device/radio/headset/headset_sec
 	name = "security radio headset"
 	desc = "This is used by your elite security force."
 	icon_state = "sec_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_sec
+	ks2type = /obj/item/device/encryptionkey/headset_sec
 
 /obj/item/device/radio/headset/headset_eng
 	name = "engineering radio headset"
 	desc = "When the engineers wish to chat like girls."
 	icon_state = "eng_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_eng
+	ks2type = /obj/item/device/encryptionkey/headset_eng
 
 /obj/item/device/radio/headset/headset_rob
 	name = "robotics radio headset"
 	desc = "Made specifically for the roboticists who cannot decide between departments."
 	icon_state = "rob_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_rob
+	ks2type = /obj/item/device/encryptionkey/headset_rob
 
 /obj/item/device/radio/headset/headset_med
 	name = "medical radio headset"
 	desc = "A headset for the trained staff of the medbay."
 	icon_state = "med_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_med
+	ks2type = /obj/item/device/encryptionkey/headset_med
 
 /obj/item/device/radio/headset/headset_sci
 	name = "science radio headset"
 	desc = "A sciency headset. Like usual."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_sci
+	ks2type = /obj/item/device/encryptionkey/headset_sci
 
 /obj/item/device/radio/headset/headset_medsci
 	name = "medical research radio headset"
 	desc = "A headset that is a result of the mating between medical and science."
 	icon_state = "med_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_medsci
+	ks2type = /obj/item/device/encryptionkey/headset_medsci
 
 /obj/item/device/radio/headset/headset_com
 	name = "command radio headset"
 	desc = "A headset with a commanding channel."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_com
+	ks2type = /obj/item/device/encryptionkey/headset_com
 
 /obj/item/device/radio/headset/heads/captain
 	name = "captain's headset"
 	desc = "The headset of the boss."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/captain
+	ks2type = /obj/item/device/encryptionkey/heads/captain
 
 /obj/item/device/radio/headset/heads/ai_integrated //No need to care about icons, it should be hidden inside the AI anyway.
 	name = "AI Subspace Transceiver"
@@ -127,7 +125,7 @@
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "radio"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/ai_integrated
+	ks2type = /obj/item/device/encryptionkey/heads/ai_integrated
 	var/myAi = null    // Atlantis: Reference back to the AI which has this radio.
 	var/disabledAi = 0 // Atlantis: Used to manually disable AI's integrated radio via intellicard menu.
 
@@ -141,35 +139,35 @@
 	desc = "Headset of the researching God."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/rd
+	ks2type = /obj/item/device/encryptionkey/heads/rd
 
 /obj/item/device/radio/headset/heads/hos
 	name = "head of security's headset"
 	desc = "The headset of the man who protects your worthless lifes."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/hos
+	ks2type = /obj/item/device/encryptionkey/heads/hos
 
 /obj/item/device/radio/headset/heads/ce
 	name = "chief engineer's headset"
 	desc = "The headset of the guy who is in charge of morons"
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/ce
+	ks2type = /obj/item/device/encryptionkey/heads/ce
 
 /obj/item/device/radio/headset/heads/cmo
 	name = "chief medical officer's headset"
 	desc = "The headset of the highly trained medical chief."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/cmo
+	ks2type = /obj/item/device/encryptionkey/heads/cmo
 
 /obj/item/device/radio/headset/heads/hop
 	name = "head of personnel's headset"
 	desc = "The headset of the guy who will one day be captain."
 	icon_state = "com_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/hop
+	ks2type = /obj/item/device/encryptionkey/heads/hop
 /*
 /obj/item/device/radio/headset/headset_mine
 	name = "mining radio headset"
@@ -190,14 +188,14 @@
 	desc = "A headset used by the QM and his slaves."
 	icon_state = "cargo_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_cargo
+	ks2type = /obj/item/device/encryptionkey/headset_cargo
 
 /obj/item/device/radio/headset/headset_service
 	name = "service radio headset"
 	desc = "Headset used by the service staff, tasked with keeping the station full, happy and clean."
 	icon_state = "srv_headset"
 	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_service
+	ks2type = /obj/item/device/encryptionkey/headset_service
 
 /obj/item/device/radio/headset/ert
 	name = "CentCom Response Team headset"
@@ -205,7 +203,7 @@
 	icon_state = "com_headset"
 	item_state = "headset"
 	freerange = 1
-	keyslot2 = new /obj/item/device/encryptionkey/ert
+	ks2type = /obj/item/device/encryptionkey/ert
 
 /obj/item/device/radio/headset/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -2,7 +2,7 @@
 /obj/structure/closet/fireaxecabinet
 	name = "Fire Axe Cabinet"
 	desc = "There is small label that reads \"For Emergency use only\" along with details for safe use of the axe. As if."
-	var/obj/item/weapon/twohanded/fireaxe/fireaxe = new/obj/item/weapon/twohanded/fireaxe
+	var/obj/item/weapon/twohanded/fireaxe/fireaxe
 	icon_state = "fireaxe1000"
 	icon_closed = "fireaxe1000"
 	icon_opened = "fireaxe1100"
@@ -13,6 +13,10 @@
 	var/hitstaken = 0
 	var/locked = 1
 	var/smashed = 0
+
+	New()
+		..()
+		fireaxe = new /obj/item/weapon/twohanded/fireaxe(src)
 
 	attackby(var/obj/item/O as obj, var/mob/user as mob)  //Marker -Agouri
 		//..() //That's very useful, Erro

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -25,7 +25,7 @@
 	new /obj/item/clothing/under/sl_suit(src)
 	new /obj/item/clothing/under/rank/bartender(src)
 	new /obj/item/clothing/under/rank/bartender(src)
-	new /obj/item/clothing/under/dress/dress_saloon
+	new /obj/item/clothing/under/dress/dress_saloon(src)
 	new /obj/item/clothing/suit/wcoat(src)
 	new /obj/item/clothing/suit/wcoat(src)
 	new /obj/item/clothing/shoes/black(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -21,7 +21,9 @@
 /obj/structure/closet/secure_closet/personal/patient/New()
 	..()
 	spawn(4)
-		contents = list()
+		// Not really the best way to do this, but it's better than "contents = list()"!
+		for(var/atom/movable/AM in contents)
+			del(AM)
 		new /obj/item/clothing/under/color/white( src )
 		new /obj/item/clothing/shoes/white( src )
 	return
@@ -51,7 +53,9 @@
 /obj/structure/closet/secure_closet/personal/cabinet/New()
 	..()
 	spawn(4)
-		contents = list()
+		// Not really the best way to do this, but it's better than "contents = list()"!
+		for(var/atom/movable/AM in contents)
+			del(AM)
 		new /obj/item/weapon/storage/backpack/satchel/withwallet( src )
 		new /obj/item/device/radio/headset( src )
 	return

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -246,9 +246,9 @@
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/slippers
-	new /obj/item/clothing/shoes/slippers
-	new /obj/item/clothing/shoes/slippers
+	new /obj/item/clothing/shoes/slippers(src)
+	new /obj/item/clothing/shoes/slippers(src)
+	new /obj/item/clothing/shoes/slippers(src)
 	return
 
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -5,9 +5,12 @@
 	icon_state = "extinguisher_closed"
 	anchored = 1
 	density = 0
-	var/obj/item/weapon/extinguisher/has_extinguisher = new/obj/item/weapon/extinguisher
+	var/obj/item/weapon/extinguisher/has_extinguisher
 	var/opened = 0
 
+/obj/structure/extinguisher_cabinet/New()
+	..()
+	has_extinguisher = new/obj/item/weapon/extinguisher(src)
 
 /obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user)
 	if(isrobot(user))

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -1,3 +1,11 @@
+#define LIGHTFLOOR_ON_BIT 4
+
+#define LIGHTFLOOR_STATE_OK 0
+#define LIGHTFLOOR_STATE_FLICKER 1
+#define LIGHTFLOOR_STATE_BREAKING 2
+#define LIGHTFLOOR_STATE_BROKEN 3
+#define LIGHTFLOOR_STATE_BITS 3
+
 //This is so damaged or burnt tiles or platings don't get remembered as the default tile
 var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","damaged4",
 				"damaged5","panelscorched","floorscorched1","floorscorched2","platingdmg1","platingdmg2",
@@ -35,13 +43,13 @@ var/list/wood_icons = list("wood","wood-broken")
 	var/burnt = 0
 	var/mineral = "metal"
 	var/floor_type = /obj/item/stack/tile/plasteel
-	var/lightfloor_state // for light floors, this is the state of the tile. 0-7, 0x4 is on-bit
+	var/lightfloor_state // for light floors, this is the state of the tile. 0-7, 0x4 is on-bit - use the helper procs below
 
 	proc/get_lightfloor_state()
-		return lightfloor_state & 3
+		return lightfloor_state & LIGHTFLOOR_STATE_BITS
 
 	proc/get_lightfloor_on()
-		return lightfloor_state & 4
+		return lightfloor_state & LIGHTFLOOR_ON_BIT
 
 	proc/set_lightfloor_state(n)
 		lightfloor_state = get_lightfloor_on() | n
@@ -50,7 +58,7 @@ var/list/wood_icons = list("wood","wood-broken")
 		lightfloor_state = get_lightfloor_state() | n
 
 	proc/toggle_lightfloor_on()
-		lightfloor_state ^= 4
+		lightfloor_state ^= LIGHTFLOOR_ON_BIT
 
 /turf/simulated/floor/New()
 	..()
@@ -120,17 +128,17 @@ turf/simulated/floor/proc/update_icon()
 	else if(is_light_floor())
 		if(get_lightfloor_on())
 			switch(get_lightfloor_state())
-				if(0)
+				if(LIGHTFLOOR_STATE_OK)
 					icon_state = "light_on"
 					SetLuminosity(5)
-				if(1)
+				if(LIGHTFLOOR_STATE_FLICKER)
 					var/num = pick("1","2","3","4")
 					icon_state = "light_on_flicker[num]"
 					SetLuminosity(5)
-				if(2)
+				if(LIGHTFLOOR_STATE_BREAKING)
 					icon_state = "light_on_broken"
 					SetLuminosity(5)
-				if(3)
+				if(LIGHTFLOOR_STATE_BROKEN)
 					icon_state = "light_off"
 					SetLuminosity(0)
 		else
@@ -321,7 +329,7 @@ turf/simulated/floor/proc/update_icon()
 		src.icon_state = "sand[pick("1","2","3")]"
 		burnt = 1
 
-//This proc will delete the floor_ tile and the update_iocn() proc will then change the icon_state of the turf
+//This proc will set floor_type to null and the update_icon() proc will then change the icon_state of the turf
 //This proc auto corrects the grass tiles' siding.
 /turf/simulated/floor/proc/make_plating()
 	if(istype(src,/turf/simulated/floor/engine)) return
@@ -569,3 +577,11 @@ turf/simulated/floor/proc/update_icon()
 					broken = 0
 				else
 					user << "\blue You need more welding fuel to complete this task."
+
+#undef LIGHTFLOOR_ON_BIT
+
+#undef LIGHTFLOOR_STATE_OK
+#undef LIGHTFLOOR_STATE_FLICKER
+#undef LIGHTFLOOR_STATE_BREAKING
+#undef LIGHTFLOOR_STATE_BROKEN
+#undef LIGHTFLOOR_STATE_BITS

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -52,10 +52,13 @@ var/list/wood_icons = list("wood","wood-broken")
 		return lightfloor_state & LIGHTFLOOR_ON_BIT
 
 	proc/set_lightfloor_state(n)
-		lightfloor_state = get_lightfloor_on() | n
+		lightfloor_state = get_lightfloor_on() | (n & LIGHTFLOOR_STATE_BITS)
 
 	proc/set_lightfloor_on(n)
-		lightfloor_state = get_lightfloor_state() | n
+		if(n)
+			lightfloor_state |= LIGHTFLOOR_ON_BIT
+		else
+			lightfloor_state &= ~LIGHTFLOOR_ON_BIT
 
 	proc/toggle_lightfloor_on()
 		lightfloor_state ^= LIGHTFLOOR_ON_BIT
@@ -482,6 +485,10 @@ turf/simulated/floor/proc/update_icon()
 				user << "\red You forcefully pry off the planks, destroying them in the process."
 			else
 				var/obj/item/I = new floor_type(src)
+				if(is_light_floor())
+					var/obj/item/stack/tile/light/L = I
+					L.on = get_lightfloor_on()
+					L.state = get_lightfloor_state()
 				user << "\red You remove the [I.name]."
 
 		make_plating()

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -16,17 +16,16 @@
 	name = "catwalk"
 	icon = 'icons/turf/catwalks.dmi'
 	icon_state = "catwalk0"
-	floor_tile = null
+	floor_type = null
 	intact = 0
 
 /turf/simulated/floor/light
 	name = "Light floor"
 	luminosity = 5
 	icon_state = "light_on"
-	floor_tile = new/obj/item/stack/tile/light
+	floor_type = /obj/item/stack/tile/light
 
 	New()
-		floor_tile.New() //I guess New() isn't run on objects spawned without the definition of a turf to house them, ah well.
 		var/n = name //just in case commands rename it in the ..() call
 		..()
 		spawn(4)
@@ -39,7 +38,7 @@
 /turf/simulated/floor/wood
 	name = "floor"
 	icon_state = "wood"
-	floor_tile = new/obj/item/stack/tile/wood
+	floor_type = /obj/item/stack/tile/wood
 
 /turf/simulated/floor/vault
 	icon_state = "rockvault"
@@ -100,7 +99,7 @@
 /turf/simulated/floor/plating
 	name = "plating"
 	icon_state = "plating"
-	floor_tile = null
+	floor_type = null
 	intact = 0
 
 /turf/simulated/floor/plating/airless
@@ -183,10 +182,9 @@
 /turf/simulated/floor/grass
 	name = "Grass patch"
 	icon_state = "grass1"
-	floor_tile = new/obj/item/stack/tile/grass
+	floor_type = /obj/item/stack/tile/grass
 
 	New()
-		floor_tile.New() //I guess New() isn't ran on objects spawned without the definition of a turf to house them, ah well.
 		icon_state = "grass[pick("1","2","3","4")]"
 		..()
 		spawn(4)
@@ -200,10 +198,9 @@
 /turf/simulated/floor/carpet
 	name = "Carpet"
 	icon_state = "carpet"
-	floor_tile = new/obj/item/stack/tile/carpet
+	floor_type = /obj/item/stack/tile/carpet
 
 	New()
-		floor_tile.New() //I guess New() isn't ran on objects spawned without the definition of a turf to house them, ah well.
 		if(!icon_state)
 			icon_state = "carpet"
 		..()

--- a/code/modules/projectiles/guns/projectile/pneumatic.dm
+++ b/code/modules/projectiles/guns/projectile/pneumatic.dm
@@ -14,7 +14,7 @@
 	var/max_w_class = 3                                 // Hopper intake size.
 	var/max_combined_w_class = 20                       // Total internal storage size.
 	var/obj/item/weapon/tank/tank = null                // Tank of gas for use in firing the cannon.
-	var/obj/item/weapon/storage/tank_container = new()  // Something to hold the tank item so we don't accidentally fire it.
+	var/obj/item/weapon/storage/tank_container  // Something to hold the tank item so we don't accidentally fire it.
 	var/pressure_setting = 10                           // Percentage of the gas in the tank used to fire the projectile.
 	var/possible_pressure_amounts = list(5,10,20,25,50) // Possible pressure settings.
 	var/minimum_tank_pressure = 10                      // Minimum pressure to fire the gun.
@@ -23,6 +23,7 @@
 	                                                    // analyzer with a force_divisor of 10 hit with a damage multiplier of 3000+.
 /obj/item/weapon/gun/launcher/pneumatic/New()
 	..()
+	tank_container = new(src)
 	tank_container.tag = "gas_tank_holder"
 
 /obj/item/weapon/gun/launcher/pneumatic/verb/set_pressure() //set amount of tank pressure.

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -40,8 +40,8 @@
 //-------------------------------------------
 /obj/vehicle/train/cargo/engine/New()
 	..()
-	cell = new /obj/item/weapon/cell/high
-	key = new()
+	cell = new /obj/item/weapon/cell/high(src)
+	key = new(src)
 	var/image/I = new(icon = 'icons/obj/vehicles.dmi', icon_state = "cargo_engine_overlay", layer = src.layer + 0.2) //over mobs
 	overlays += I
 	turn_off()	//so engine verbs are correctly set


### PR DESCRIPTION
Not sure of exact numbers on dev, but on master there were 11670 nullspace `/obj` (not counting `/obj/screen`) on a round-start map, of which approximately 11400 were nullspace floortiles that only ever got used as state containment boxes for light floors' on/off and repair state - not even reused when prying up the tiles again.

Current nullspace `/obj/item` at roundstart as of this PR:
- Nine radio headsets `/obj/item/device/radio/headset`
- One pair of meson goggles `/obj/item/clothing/glasses/meson`
- One station intercom `/obj/item/device/radio/intercom` (set to response team freqs?)
