### PR TITLE
Syndicate beacon power consumption and objective.

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -19,47 +19,50 @@
 	var/selfdestructing = 0
 	var/charges = 1
 
-	attack_hand(var/mob/user as mob)
-		usr.set_machine(src)
-		var/dat = "<font color=#005500><i>Scanning [pick("retina pattern", "voice print", "fingerprints", "dna sequence")]...<br>Identity confirmed,<br></i></font>"
-		if(istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon/ai))
-			if(is_special_character(user))
-				dat += "<font color=#07700><i>Operative record found. Greetings, Agent [user.name].</i></font><br>"
-			else if(charges < 1)
-				dat += "<TT>Connection severed.</TT><BR>"
-			else
-				var/honorific = "Mr."
-				if(user.gender == FEMALE)
-					honorific = "Ms."
-				dat += "<font color=red><i>Identity not found in operative database. What can the Syndicate do for you today, [honorific] [user.name]?</i></font><br>"
-				if(!selfdestructing)
-					dat += "<br><br><A href='?src=\ref[src];betraitor=1;traitormob=\ref[user]'>\"[pick("I want to switch teams.", "I want to work for you.", "Let me join you.", "I can be of use to you.", "You want me working for you, and here's why...", "Give me an objective.", "How's the 401k over at the Syndicate?")]\"</A><BR>"
-		dat += temptext
-		user << browse(dat, "window=syndbeacon")
-		onclose(user, "syndbeacon")
+/obj/machinery/syndicate_beacon/attack_hand(var/mob/user as mob)
+	usr.set_machine(src)
+	var/dat = "<font color=#005500><i>Scanning [pick("retina pattern", "voice print", "fingerprints", "dna sequence")]...<br>Identity confirmed,<br></i></font>"
+	if(istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon/ai))
+		if(is_special_character(user))
+			dat += "<font color=#07700><i>Operative record found. Greetings, Agent [user.name].</i></font><br>"
+		else if(charges < 1)
+			dat += "<TT>Connection severed.</TT><BR>"
+		else
+			var/honorific = "Mr."
+			if(user.gender == FEMALE)
+				honorific = "Ms."
+			dat += "<font color=red><i>Identity not found in operative database. What can the Syndicate do for you today, [honorific] [user.name]?</i></font><br>"
+			if(!selfdestructing)
+				dat += "<br><br><A href='?src=\ref[src];betraitor=1;traitormob=\ref[user]'>\"[pick("I want to switch teams.", "I want to work for you.", "Let me join you.", "I can be of use to you.", "You want me working for you, and here's why...", "Give me an objective.", "How's the 401k over at the Syndicate?")]\"</A><BR>"
+	dat += temptext
+	user << browse(dat, "window=syndbeacon")
+	onclose(user, "syndbeacon")
 
-	Topic(href, href_list)
-		if(href_list["betraitor"])
-			if(charges < 1)
+/obj/machinery/syndicate_beacon/Topic(href, href_list)
+	if(..())
+		return
+	if(href_list["betraitor"])
+		if(charges < 1)
+			src.updateUsrDialog()
+			return
+		var/mob/M = locate(href_list["traitormob"])
+		if(M.mind.special_role)
+			temptext = "<i>We have no need for you at this time. Have a pleasant day.</i><br>"
+			src.updateUsrDialog()
+			return
+		charges -= 1
+		switch(rand(1,2))
+			if(1)
+				temptext = "<font color=red><i><b>Double-crosser. You planned to betray us from the start. Allow us to repay the favor in kind.</b></i></font>"
 				src.updateUsrDialog()
+				spawn(rand(50,200)) selfdestruct()
 				return
-			var/mob/M = locate(href_list["traitormob"])
-			if(M.mind.special_role)
-				temptext = "<i>We have no need for you at this time. Have a pleasant day.</i><br>"
-				src.updateUsrDialog()
-				return
-			charges -= 1
-			switch(rand(1,2))
-				if(1)
-					temptext = "<font color=red><i><b>Double-crosser. You planned to betray us from the start. Allow us to repay the favor in kind.</b></i></font>"
-					src.updateUsrDialog()
-					spawn(rand(50,200)) selfdestruct()
-					return
-			if(istype(M, /mob/living/carbon/human))
-				var/mob/living/carbon/human/N = M
-				ticker.mode.equip_traitor(N)
-				ticker.mode.traitors += N.mind
-				N.mind.special_role = "traitor"
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/N = M
+			ticker.mode.equip_traitor(N)
+			ticker.mode.traitors += N.mind
+			N.mind.special_role = "traitor"
+			if(!config.objectives_disabled)
 				var/objective = "Free Objective"
 				switch(rand(1,100))
 					if(1 to 50)
@@ -82,26 +85,23 @@
 				escape_objective.owner = N.mind
 				N.mind.objectives += escape_objective
 
-
-				M << "<B>You have joined the ranks of the Syndicate and become a traitor to the station!</B>"
-
-				message_admins("[N]/([N.ckey]) has accepted a traitor objective from a syndicate beacon.")
-				show_objectives(M.mind)
-
-		src.add_fingerprint(usr)
-		src.updateUsrDialog()
-		return
+			M << "<B>You have joined the ranks of the Syndicate and become a traitor to the station!</B>"
+			show_objectives(M.mind)
+			message_admins("[N]/([N.ckey]) has accepted a traitor objective from a syndicate beacon.")
 
 
-	proc/selfdestruct()
-		selfdestructing = 1
-		spawn() explosion(src.loc, rand(3,8), rand(1,3), 1, 10)
+	src.updateUsrDialog()
+	return
 
 
+/obj/machinery/syndicate_beacon/proc/selfdestruct()
+	selfdestructing = 1
+	spawn() explosion(src.loc, rand(3,8), rand(1,3), 1, 10)
 
-#define SCREWED 32
-
-/obj/machinery/singularity_beacon //not the best place for it but it's a hack job anyway -- Urist
+////////////////////////////////////////
+//Singularity beacon
+////////////////////////////////////////
+/obj/machinery/power/singularity_beacon
 	name = "ominous beacon"
 	desc = "This looks suspicious..."
 	icon = 'icons/obj/singularity.dmi'
@@ -112,105 +112,82 @@
 	layer = MOB_LAYER - 0.1 //so people can't hide it and it's REALLY OBVIOUS
 	stat = 0
 
-	var/active = 0 //It doesn't use up power, so use_power wouldn't really suit it
+	var/active = 0
 	var/icontype = "beacon"
-	var/obj/structure/cable/attached = null
 
 
-	proc/Activate(mob/user = null)
-		if(!checkWirePower())
-			if(user) user << "\blue The connected wire doesn't have enough current."
-			return
-		for(var/obj/machinery/singularity/singulo in world)
-			if(singulo.z == z)
-				singulo.target = src
-		icon_state = "[icontype]1"
-		active = 1
-		if(user) user << "\blue You activate the beacon."
+/obj/machinery/power/singularity_beacon/proc/Activate(mob/user = null)
+	if(surplus() < 1500)
+		if(user) user << "<span class='notice'>The connected wire doesn't have enough current.</span>"
+		return
+	for(var/obj/machinery/singularity/singulo in world)
+		if(singulo.z == z)
+			singulo.target = src
+	icon_state = "[icontype]1"
+	active = 1
+	machines |= src
+	if(user)
+		user << "<span class='notice'>You activate the beacon.</span>"
 
 
-	proc/Deactivate(mob/user = null)
-		for(var/obj/machinery/singularity/singulo in world)
-			if(singulo.target == src)
-				singulo.target = null
-		icon_state = "[icontype]0"
-		active = 0
-		if(user) user << "\blue You deactivate the beacon."
+/obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
+	for(var/obj/machinery/singularity/singulo in world)
+		if(singulo.target == src)
+			singulo.target = null
+	icon_state = "[icontype]0"
+	active = 0
+	if(user)
+		user << "<span class='notice'>You deactivate the beacon.</span>"
 
 
-	attack_ai(mob/user as mob)
+/obj/machinery/power/singularity_beacon/attack_ai(mob/user as mob)
+	return
+
+
+/obj/machinery/power/singularity_beacon/attack_hand(var/mob/user as mob)
+	if(anchored)
+		return active ? Deactivate(user) : Activate(user)
+	else
+		user << "<span class='danger'>You need to screw the beacon to the floor first!</span>"
 		return
 
 
-	attack_hand(var/mob/user as mob)
-		if(stat & SCREWED)
-			return active ? Deactivate(user) : Activate(user)
-		else
-			user << "\red You need to screw the beacon to the floor first!"
+/obj/machinery/power/singularity_beacon/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W,/obj/item/weapon/screwdriver))
+		if(active)
+			user << "<span class='danger'>You need to deactivate the beacon first!</span>"
 			return
 
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(istype(W,/obj/item/weapon/screwdriver))
-			if(active)
-				user << "\red You need to deactivate the beacon first!"
-				return
-
-			if(stat & SCREWED)
-				stat &= ~SCREWED
-				anchored = 0
-				user << "\blue You unscrew the beacon from the floor."
-				attached = null
-				return
-			else
-				var/turf/T = loc
-				if(isturf(T) && !T.intact)
-					attached = locate() in T
-				if(!attached)
-					user << "This device must be placed over an exposed cable."
-					return
-				stat |= SCREWED
-				anchored = 1
-				user << "\blue You screw the beacon to the floor and attach the cable."
-				return
-		..()
-		return
-
-
-	Del()
-		if(active) Deactivate()
-		..()
-
-	/*
-	* Added for a simple way to check power. Verifies that the beacon
-	* is connected to a wire, the wire is part of a powernet (that part's
-	* sort of redundant, since all wires either join or create one when placed)
-	* and that the powernet has at least 1500 power units available for use.
-	* Doesn't use them, though, just makes sure they're there.
-	* - QualityVan, Aug 11 2012
-	*/
-	proc/checkWirePower()
-		if(!attached)
-			return 0
-		var/datum/powernet/PN = attached.get_powernet()
-		if(!PN)
-			return 0
-		if(PN.avail < 1500)
-			return 0
-		return 1
-
-	process()
-		if(!active)
+		if(anchored)
+			anchored = 0
+			user << "<span class='notice'>You unscrew the beacon from the floor.</span>"
+			disconnect_from_network()
 			return
 		else
-			if(!checkWirePower())
-				Deactivate()
-		return
+			if(!connect_to_network())
+				user << "This device must be placed over an exposed cable."
+				return
+			anchored = 1
+			user << "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>"
+			return
+	..()
+	return
 
 
-/obj/machinery/singularity_beacon/syndicate
+/obj/machinery/power/singularity_beacon/Del()
+	if(active)
+		Deactivate()
+	..()
+
+//stealth direct power usage
+/obj/machinery/power/singularity_beacon/process()
+	if(!active)
+		return PROCESS_KILL
+	else
+		if(draw_power(1500) < 1500)
+			Deactivate()
+
+
+/obj/machinery/power/singularity_beacon/syndicate
 	icontype = "beaconsynd"
 	icon_state = "beaconsynd0"
-
-#undef SCREWED
-

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -43,7 +43,7 @@
 /obj/item/device/radio/beacon/syndicate/attack_self(mob/user as mob)
 	if(user)
 		user << "\blue Locked In"
-		new /obj/machinery/singularity_beacon/syndicate( user.loc )
+		new /obj/machinery/power/singularity_beacon/syndicate( user.loc )
 		playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)
 		del(src)
 	return

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -42,7 +42,7 @@ var/global/list/uneatable = list(
 		spawn(temp)
 			del(src)
 	..()
-	for(var/obj/machinery/singularity_beacon/singubeacon in machines)
+	for(var/obj/machinery/power/singularity_beacon/singubeacon in machines)
 		if(singubeacon.active)
 			target = singubeacon
 			break


### PR DESCRIPTION
Cleans up syndicate beacon power consumption.
Objectives are now only given if not disabled.
Relative-proc cleanup.

Much again borrowed from /tg/, I r horrible thief.
