### PR TITLE
Radio fixes

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -32,8 +32,6 @@
 /obj/item/device/radio/intercom/receive_range(freq, level)
 	if (!on)
 		return -1
-	if (!(src.wires & WIRE_RECEIVE))
-		return -1
 	if(!(0 in level))
 		var/turf/position = get_turf(src)
 		if(isnull(position) || !(position.z in level))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -135,11 +135,11 @@
 				return
 
 	else if (href_list["talk"])
-		broadcasting = text2num(href_list["talk"])
+		broadcasting = !(wires.IsIndexCut(WIRE_TRANSMIT) || wires.IsIndexCut(WIRE_SIGNAL)) && text2num(href_list["talk"])
 	else if (href_list["listen"])
 		var/chan_name = href_list["ch_name"]
 		if (!chan_name)
-			listening = text2num(href_list["listen"])
+			listening = !(wires.IsIndexCut(WIRE_RECEIVE) || wires.IsIndexCut(WIRE_SIGNAL)) && text2num(href_list["listen"])
 		else
 			if (channels[chan_name] & FREQ_LISTENING)
 				channels[chan_name] &= ~FREQ_LISTENING


### PR DESCRIPTION
Intercoms no longer have to check wiring, they can simply use the listening/broadcast flags like they already did.
Can no longer enable reception/broadcasting if the relevant cables have been cut.
