### PR TITLE
Fixes AIs seeing runes in the Alt+Click panel

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -45,6 +45,7 @@ var/list/ai_verbs_default = list(
 	anchored = 1 // -- TLE
 	density = 1
 	status_flags = CANSTUN|CANPARALYSE
+	shouldnt_see = list(/obj/effect/rune)
 	var/list/network = list("SS13")
 	var/obj/machinery/camera/camera = null
 	var/list/connected_robots = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -821,6 +821,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 			for(var/atom/A in listed_turf)
 				if(A.invisibility > see_invisible)
 					continue
+				if(is_type_in_list(A, shouldnt_see))
+					continue
 				statpanel(listed_turf.name, null, A)
 
 	if(spell_list && spell_list.len)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -217,6 +217,7 @@
 
 	var/immune_to_ssd = 0
 
-	var/turf/listed_turf = null  //the current turf being examined in the stat panel
+	var/turf/listed_turf = null  	//the current turf being examined in the stat panel
+	var/list/shouldnt_see = list()	//list of objects that this mob shouldn't see in the stat panel. this silliness is needed because of AI alt+click and cult blood runes
 
 	var/list/active_genes=list()


### PR DESCRIPTION
The AI can no longer alt-click turfs to see which runes, if any, are drawn there.
See https://github.com/tgstation/-tg-station/pull/6126.
