### PR TITLE
Grass seed runtime fix

### DIFF
--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -37,7 +37,7 @@ obj/machinery/seed_extractor/attackby(var/obj/item/O as obj, var/mob/user as mob
 	else if(istype(O, /obj/item/stack/tile/grass))
 		var/obj/item/stack/tile/grass/S = O
 		if (S.use(1))
-			user << "<span class='notice'>You extract some seeds from the [S.name].</span>"
+			user << "<span class='notice'>You extract some seeds from the grass tile.</span>"
 			new /obj/item/seeds/grassseed(loc)
 
 	return


### PR DESCRIPTION
Fixes grass seeds causing a runtime when putting a stack through the seed extractor with only 1 tile left in the stack.

If the `use()` case above this line uses up the last of the tiles it will delete the grass tile before continuing this code. It would then runtime on `null.name` since the tile had been deleted.

I'm sure there's a more robust way of fixing it, but eh, this bit of code is only for one specific tile type.
