### PR TITLE
(mostly) silicon adjustments/features

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -79,7 +79,16 @@
 		updateicon()
 
 /obj/machinery/cell_charger/attack_ai(mob/user)
-	return
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Borgs can remove the cell if they are near enough
+		if(!src.charging)
+			return
+
+		charging.loc = src.loc
+		charging.updateicon()
+		charging = null
+		update_icon()
+		user.visible_message("[user] removes the cell from the charger.", "You remove the cell from the charger.")
+
 
 /obj/machinery/cell_charger/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -40,7 +40,8 @@
 	user << "That's an [src]."
 	user << desc
 
-	if(!istype(user, /mob/living/carbon/human)) //Only living, intelligent creatures with hands can check the contents of ore boxes.
+	// Borgs can now check contents too.
+	if((!istype(user, /mob/living/carbon/human)) && (!istype(user, /mob/living/silicon/robot)))
 		return
 
 	if(!Adjacent(user)) //Can only check the contents of ore boxes if you can physically reach them.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -229,7 +229,7 @@ var/list/ai_verbs_default = list(
 */
 /obj/machinery/ai_powersupply
 	name="Power Supply"
-	active_power_usage=1000
+	active_power_usage=50000 // Station AIs use significant amounts of power. This, when combined with charged SMES should mean AI lasts for 1hr without external power.
 	use_power = 2
 	power_channel = EQUIP
 	var/mob/living/silicon/ai/powered_ai = null

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -255,6 +255,8 @@
 			stored_comms["wood"]++
 			stored_comms["wood"]++
 			stored_comms["wood"]++
+		else if(istype(W,/obj/item/pipe))
+			// This allows drones and engiborgs to clear pipe assemblies from floors.
 		else
 			continue
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -29,6 +29,13 @@
 	//Item currently being held.
 	var/obj/item/wrapped = null
 
+// VEEEEERY limited version for mining borgs. Basically only for swapping cells and upgrading the drills.
+/obj/item/weapon/gripper/miner
+	can_hold = list(
+	/obj/item/weapon/cell,
+	/obj/item/weapon/stock_parts
+	)
+
 /obj/item/weapon/gripper/paperwork
 	name = "paperwork gripper"
 	desc = "A simple grasping tool for clerical work."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -367,6 +367,9 @@
 		src.modules += new /obj/item/weapon/storage/bag/ore(src)
 		src.modules += new /obj/item/weapon/pickaxe/borgdrill(src)
 		src.modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
+		src.modules += new /obj/item/weapon/gripper/miner(src)
+		src.modules += new /obj/item/weapon/mining_scanner(src)
+		src.modules += new /obj/item/weapon/crowbar(src)
 		src.emag = new /obj/item/weapon/pickaxe/plasmacutter(src)
 		return
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -189,7 +189,7 @@
 		/obj/item/stack/sheet/metal = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/glass/reinforced = 50,
-		/obj/item/stack/cable_coil = 50,
+		/obj/item/stack/cable_coil/robot = 50,
 		/obj/item/stack/rods = 15,
 		/obj/item/stack/tile/plasteel = 15
 		)
@@ -225,7 +225,7 @@
 		G.amount = 50
 		src.modules += G
 
-		var/obj/item/stack/cable_coil/W = new /obj/item/stack/cable_coil(src)
+		var/obj/item/stack/cable_coil/robot/W = new /obj/item/stack/cable_coil/robot(src)
 		W.amount = 50
 		src.modules += W
 
@@ -406,7 +406,7 @@
 		/obj/item/stack/tile/plasteel = 15,
 		/obj/item/stack/sheet/metal = 20,
 		/obj/item/stack/sheet/glass = 20,
-		/obj/item/stack/cable_coil = 30
+		/obj/item/stack/cable_coil/robot = 30
 		)
 
 	New()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -181,6 +181,7 @@
 		src.modules += new /obj/item/weapon/wrench(src)
 		src.modules += new /obj/item/weapon/crowbar(src)
 		src.modules += new /obj/item/weapon/pickaxe/plasmacutter(src)
+		src.modules += new /obj/item/device/pipe_painter(src)
 
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
@@ -210,6 +211,7 @@
 		src.modules += new /obj/item/taperoll/engineering(src)
 		src.modules += new /obj/item/weapon/gripper(src)
 		src.modules += new /obj/item/weapon/matter_decompiler(src)
+		src.modules += new /obj/item/device/pipe_painter(src)
 
 		src.emag = new /obj/item/borg/stun(src)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1139,7 +1139,7 @@
 		else if(longtermpower > -10)
 			longtermpower -= 2
 
-		if(cell.charge >= 1250 || longtermpower > 0)              // Put most likely at the top so we don't check it last, effeciency 101
+		if((cell.percent() > 30) || longtermpower > 0)              // Put most likely at the top so we don't check it last, effeciency 101
 			if(autoflag != 3)
 				equipment = autoset(equipment, 1)
 				lighting = autoset(lighting, 1)
@@ -1148,21 +1148,21 @@
 				area.poweralert(1, src)
 				if(cell.charge >= 4000)
 					area.poweralert(1, src)
-		else if(cell.charge < 1250 && cell.charge > 750 && longtermpower < 0)                       // <30%, turn off equipment
+		else if((cell.percent() <= 30) && (cell.percent() > 15) && longtermpower < 0)                       // <30%, turn off equipment
 			if(autoflag != 2)
 				equipment = autoset(equipment, 2)
 				lighting = autoset(lighting, 1)
 				environ = autoset(environ, 1)
 				area.poweralert(0, src)
 				autoflag = 2
-		else if(cell.charge < 750 && cell.charge > 10)        // <15%, turn off lighting & equipment
+		else if(cell.percent() <= 15)        // <15%, turn off lighting & equipment
 			if((autoflag > 1 && longtermpower < 0) || (autoflag > 1 && longtermpower >= 0))
 				equipment = autoset(equipment, 2)
 				lighting = autoset(lighting, 2)
 				environ = autoset(environ, 1)
 				area.poweralert(0, src)
 				autoflag = 1
-		else if(cell.charge <= 0)                                   // zero charge, turn all off
+		else                                   // zero charge, turn all off
 			if(autoflag != 0)
 				equipment = autoset(equipment, 0)
 				lighting = autoset(lighting, 0)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -590,6 +590,31 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		usr << "\blue You cannot do that."
 	..()
 
+/obj/item/stack/cable_coil/robot/verb/set_colour()
+	set name = "Change Colour"
+	set category = "Object"
+
+	var/list/possible_colours = list ("Yellow", "Green", "Pink", "Blue", "Orange", "Cyan", "Red")
+	var/selected_type = input("Pick new colour.", "Cable Colour", null, null) as null|anything in possible_colours
+
+	if(selected_type)
+		switch(selected_type)
+			if("Yellow")
+				color = COLOR_YELLOW
+			if("Green")
+				color = COLOR_GREEN
+			if("Pink")
+				color = COLOR_PINK
+			if("Blue")
+				color = COLOR_BLUE
+			if("Orange")
+				color = COLOR_ORANGE
+			if("Cyan")
+				color = COLOR_CYAN
+			else
+				color = COLOR_RED
+		usr << "You change your cable coil's colour to [selected_type]"
+
 // Items usable on a cable coil :
 //   - Wirecutters : cut them duh !
 //   - Cable coil : merge cables

--- a/maps/exodus-1.dmm
+++ b/maps/exodus-1.dmm
@@ -3301,7 +3301,7 @@
 "bly" = (/obj/machinery/vending/coffee,/turf/simulated/floor/wood,/area/bridge/meeting_room)
 "blz" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "blA" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
-"blB" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/machinery/light/small{dir = 1},/obj/machinery/power/apc{dir = 1; name = "north bump"; pixel_x = 0; pixel_y = 24},/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
+"blB" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/machinery/light/small{dir = 1},/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/obj/machinery/power/apc/super{dir = 1; name = "north bump"; pixel_y = 24},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "blC" = (/obj/machinery/door/window{dir = 2; name = "AI Core Door"; req_access_txt = "109"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/flasher{id = "AI"; pixel_x = 22; pixel_y = 24},/obj/machinery/turretid/stun{name = "AI Chamber turret control"; pixel_x = 36; pixel_y = 24},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "blD" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "blE" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/bluegrid,/area/turret_protected/ai)


### PR DESCRIPTION
Read specific commits for full info. In short:
- Borg cable coil can now be recolored using rightclick menu option
- AIs now use <b>significantly</b> more power. By default, full 1coil SMES can keep the AI alive for 60 minutes now. APC gives additional ~8 minutes of power.
- APCs no longer use hardcoded values for Auto-OFF settings, instead reverted to good old percent (30% equip, 15% light) system.
- Cyborgs now have tools to properly work with atmospherics. Both construction and engineering modules have pipe painter, which is a must. Also, matter decompiler may be used to clear unused pipe assemblies from the ground (as cyborgs cannot put them into the dispenser).
