### PR TITLE
More hardsuit fixes.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -255,16 +255,35 @@ BLIND     // can't see anything
 /obj/item/clothing/head/attack_self(mob/user)
 	if(brightness_on)
 		if(!isturf(user.loc))
-			user << "You cannot turn the light on while in this [user.loc]" //To prevent some lighting anomalities.
+			user << "You cannot turn the light on while in this [user.loc]"
 			return
 		on = !on
-		update_icon()
-		if(on)
-			user.SetLuminosity(user.luminosity + brightness_on)
-		else
-			user.SetLuminosity(user.luminosity - brightness_on)
+		update_light(user)
 	else
 		return ..(user)
+
+/obj/item/clothing/head/proc/update_light(var/mob/user = null)
+	if(on)
+		if(loc == user)
+			user.SetLuminosity(user.luminosity + brightness_on)
+		else if(isturf(loc))
+			SetLuminosity(brightness_on)
+	else
+		if(loc == user)
+			user.SetLuminosity(user.luminosity - brightness_on)
+		else if(isturf(loc))
+			SetLuminosity(0)
+	update_icon()
+
+/obj/item/clothing/head/pickup(mob/user)
+	if(on)
+		user.SetLuminosity(user.luminosity + brightness_on)
+		SetLuminosity(0)
+
+/obj/item/clothing/head/dropped(mob/user)
+	if(on)
+		user.SetLuminosity(user.luminosity - brightness_on)
+		SetLuminosity(brightness_on)
 
 /obj/item/clothing/head/update_icon(var/mob/user)
 
@@ -278,16 +297,6 @@ BLIND     // can't see anything
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		H.update_inv_head()
-
-/obj/item/clothing/head/proc/update_light(mob/user)
-
-	if(!brightness_on)
-		return
-
-	if(on)
-		if(light_overlay) overlays |= light_overlay
-		user.SetLuminosity(user.luminosity - brightness_on)
-		SetLuminosity(brightness_on)
 
 /obj/item/clothing/head/equipped(mob/user)
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -244,6 +244,7 @@ BLIND     // can't see anything
 	w_class = 2.0
 
 	var/light_overlay = "helmet_light"
+	var/light_applied
 	var/brightness_on
 	var/on = 0
 
@@ -258,32 +259,37 @@ BLIND     // can't see anything
 			user << "You cannot turn the light on while in this [user.loc]"
 			return
 		on = !on
+		user << "You [on ? "enable" : "disable"] the helmet light."
 		update_light(user)
 	else
 		return ..(user)
 
 /obj/item/clothing/head/proc/update_light(var/mob/user = null)
-	if(on)
+	if(on && !light_applied)
 		if(loc == user)
 			user.SetLuminosity(user.luminosity + brightness_on)
-		else if(isturf(loc))
-			SetLuminosity(brightness_on)
-	else
+		SetLuminosity(brightness_on)
+		light_applied = 1
+	else if(!on && light_applied)
 		if(loc == user)
 			user.SetLuminosity(user.luminosity - brightness_on)
-		else if(isturf(loc))
-			SetLuminosity(0)
-	update_icon()
-
-/obj/item/clothing/head/pickup(mob/user)
-	if(on)
-		user.SetLuminosity(user.luminosity + brightness_on)
 		SetLuminosity(0)
+		light_applied = 0
+	update_icon(user)
+
+/obj/item/clothing/head/equipped(mob/user)
+	..()
+	spawn(1)
+		if(on && loc == user && !light_applied)
+			user.SetLuminosity(user.luminosity + brightness_on)
+			light_applied = 1
 
 /obj/item/clothing/head/dropped(mob/user)
-	if(on)
-		user.SetLuminosity(user.luminosity - brightness_on)
-		SetLuminosity(brightness_on)
+	..()
+	spawn(1)
+		if(on && loc != user && light_applied)
+			user.SetLuminosity(user.luminosity - brightness_on)
+			light_applied = 0
 
 /obj/item/clothing/head/update_icon(var/mob/user)
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -4,28 +4,28 @@
 	icon_state = "magboots0"
 	species_restricted = null
 	var/magpulse = 0
+	var/icon_base = "magboots"
 	icon_action_button = "action_blank"
 	action_button_name = "Toggle the magboots"
-//	flags = NOSLIP //disabled by default
 
-	attack_self(mob/user)
-		if(magpulse)
-			flags &= ~NOSLIP
-			slowdown = SHOES_SLOWDOWN
-			magpulse = 0
-			icon_state = "magboots0"
-			user << "You disable the mag-pulse traction system."
-		else
-			flags |= NOSLIP
-			slowdown = 2
-			magpulse = 1
-			icon_state = "magboots1"
-			user << "You enable the mag-pulse traction system."
-		user.update_inv_shoes()	//so our mob-overlays update
+/obj/item/clothing/shoes/magboots/attack_self(mob/user)
+	if(magpulse)
+		flags &= ~NOSLIP
+		slowdown = SHOES_SLOWDOWN
+		magpulse = 0
+		if(icon_base) icon_state = "[icon_base]0"
+		user << "You disable the mag-pulse traction system."
+	else
+		flags |= NOSLIP
+		slowdown = 2
+		magpulse = 1
+		if(icon_base) icon_state = "[icon_base]1"
+		user << "You enable the mag-pulse traction system."
+	user.update_inv_shoes()	//so our mob-overlays update
 
-	examine(mob/user)
-		..(user)
-		var/state = "disabled"
-		if(src.flags&NOSLIP)
-			state = "enabled"
-		user << "Its mag-pulse traction system appears to be [state]."
+/obj/item/clothing/shoes/magboots/examine(mob/user)
+	..(user)
+	var/state = "disabled"
+	if(src.flags&NOSLIP)
+		state = "enabled"
+	user << "Its mag-pulse traction system appears to be [state]."

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -69,7 +69,6 @@
 	var/offline_slowdown = 10                                 // If the suit is deployed and unpowered, it sets slowdown to this.
 	var/vision_restriction
 	var/offline_vision_restriction = 1                        // 0 - none, 1 - welder vision, 2 - blind. Maybe move this to helmets.
-	var/list/suit_can_hold
 
 	// Wiring! How exciting.
 	var/datum/wires/rig/wires
@@ -123,10 +122,8 @@
 		verbs |= /obj/item/weapon/rig/proc/toggle_boots
 	if(chest_type)
 		chest = new chest_type(src)
-		if(suit_can_hold)
-			chest.allowed = suit_can_hold
-		else
-			chest.allowed = list()
+		if(allowed)
+			chest.allowed = allowed
 		verbs |= /obj/item/weapon/rig/proc/toggle_chest
 
 	for(var/obj/item/piece in list(gloves,helmet,boots,chest))
@@ -174,7 +171,7 @@
 
 	if(sealing) return
 
-	if(M && !(istype(M) && M.back == src ) && !istype(M,/mob/living/silicon) )
+	if(M && !(istype(M) && M.back == src ) && !istype(M,/mob/living/silicon))
 		return 0
 
 	if(!check_power_cost(M))

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -27,6 +27,7 @@
 	heat_protection = FEET
 	species_restricted = null
 	gender = PLURAL
+	icon_base = null
 
 /obj/item/clothing/suit/space/rig
 	name = "chestpiece"

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -12,6 +12,7 @@
 	offline_vision_restriction = 1
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/combat
+	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
 
 	initial_modules = list(
 		/obj/item/rig_module/mounted,
@@ -28,6 +29,7 @@
 	desc = "A blood-red hardsuit featuring some fairly illegal technology."
 	icon_state = "merc_rig"
 	suit_type = "crimson hardsuit"
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 
 	initial_modules = list(
 		/obj/item/rig_module/mounted,

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -53,7 +53,6 @@
 	suit_type = "ominous"
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."
 	icon_state = "ninja_rig"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/cell)
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	slowdown = 0
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -8,6 +8,8 @@
 	offline_slowdown = 10
 	offline_vision_restriction = 2
 
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
+
 	req_access = null
 	req_one_access = null
 
@@ -30,6 +32,8 @@
 	slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = 0
+
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
 
 	req_access = list(access_ce)
 
@@ -54,6 +58,9 @@
 	slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
+
+	//Todo: add xenoarch gear.
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical)
 
 	req_access = list(access_rd)
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -50,3 +50,133 @@
 	//Breach thresholds, should ideally be inherited by most (if not all) voidsuits.
 	breach_threshold = 18
 	can_breach = 1
+
+	//Inbuilt devices.
+	var/obj/item/clothing/shoes/magboots/boots = null // Deployable boots, if any.
+	var/obj/item/clothing/head/helmet/helmet = null   // Deployable helmet, if any.
+
+/obj/item/clothing/suit/space/void/equipped(mob/M)
+	..()
+
+	var/mob/living/carbon/human/H = M
+
+	if(!istype(H)) return
+
+	if(H.wear_suit != src)
+		return
+
+	if(helmet)
+		if(H.head)
+			M << "You are unable to deploy your suit's helmet as \the [H.head] is in the way."
+		else
+			M << "Your suit's helmet deploys with a hiss."
+			//TODO: Species check, skull damage for forcing an unfitting helmet on?
+			helmet.loc = H
+			H.equip_to_slot(helmet, slot_head)
+			helmet.canremove = 0
+
+	if(boots)
+		if(H.shoes)
+			M << "You are unable to deploy your suit's magboots as \the [H.shoes] are in the way."
+		else
+			M << "Your suit's boots deploy with a hiss."
+			boots.loc = H
+			H.equip_to_slot(boots, slot_shoes)
+			boots.canremove = 0
+
+/obj/item/clothing/suit/space/void/dropped()
+	..()
+
+	var/mob/living/carbon/human/H
+
+	if(helmet)
+		H = helmet.loc
+		if(istype(H))
+			if(helmet && H.head == helmet)
+				helmet.canremove = 1
+				H.drop_from_inventory(helmet)
+				helmet.loc = src
+
+	if(boots)
+		H = boots.loc
+		if(istype(H))
+			if(boots && H.shoes == boots)
+				boots.canremove = 1
+				H.drop_from_inventory(boots)
+				boots.loc = src
+
+/obj/item/clothing/suit/space/void/verb/toggle_helmet()
+
+	set name = "Toggle Helmet"
+	set category = "Object"
+	set src in usr
+
+	if(!istype(src.loc,/mob/living)) return
+
+	if(!helmet)
+		usr << "There is no helmet installed."
+		return
+
+	var/mob/living/carbon/human/H = usr
+
+	if(!istype(H)) return
+	if(H.stat) return
+	if(H.wear_suit != src) return
+
+	if(H.head == helmet)
+		H << "\blue You retract your suit helmet."
+		helmet.canremove = 1
+		H.drop_from_inventory(helmet)
+		helmet.loc = src
+	else
+		if(H.head)
+			H << "\red You cannot deploy your helmet while wearing another helmet."
+			return
+		//TODO: Species check, skull damage for forcing an unfitting helmet on?
+		helmet.loc = H
+		helmet.pickup(H)
+		H.equip_to_slot(helmet, slot_head)
+		helmet.canremove = 0
+		H << "\blue You deploy your suit helmet, sealing you off from the world."
+	helmet.update_light(H)
+
+/obj/item/clothing/suit/space/void/attackby(obj/item/W as obj, mob/user as mob)
+
+	if(!istype(user,/mob/living)) return
+
+	if(istype(src.loc,/mob/living))
+		user << "How do you propose to modify a hardsuit while it is being worn?"
+		return
+
+	if(istype(W,/obj/item/weapon/screwdriver))
+		if(helmet)
+			user << "You detatch \the [helmet] from \the [src]'s helmet mount."
+			helmet.loc = get_turf(src)
+			src.helmet = null
+		else if (boots)
+			user << "You detatch \the [helmet] from \the [src]'s helmet mount."
+			helmet.loc = get_turf(src)
+			src.helmet = null
+		else
+			user << "\The [src] does not have anything installed."
+		return
+	else if(istype(W,/obj/item/clothing/head/helmet/space))
+		if(helmet)
+			user << "\The [src] already has a helmet installed."
+		else
+			user << "You attach \the [W] to \the [src]'s helmet mount."
+			user.drop_item()
+			W.loc = src
+			src.helmet = W
+		return
+	else if(istype(W,/obj/item/clothing/shoes/magboots))
+		if(boots)
+			user << "\The [src] already has magboots installed."
+		else
+			user << "You attach \the [W] to \the [src]'s boot mounts."
+			user.drop_item()
+			W.loc = src
+			boots = W
+		return
+
+	..()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -130,14 +130,14 @@
 		helmet.loc = src
 	else
 		if(H.head)
-			H << "\red You cannot deploy your helmet while wearing another helmet."
+			H << "<span class='danger'>You cannot deploy your helmet while wearing another helmet.</span>"
 			return
 		//TODO: Species check, skull damage for forcing an unfitting helmet on?
 		helmet.loc = H
 		helmet.pickup(H)
 		H.equip_to_slot(helmet, slot_head)
 		helmet.canremove = 0
-		H << "\blue You deploy your suit helmet, sealing you off from the world."
+		H << "<font color='blue'><b>You deploy your suit helmet, sealing you off from the world.</b></font>"
 	helmet.update_light(H)
 
 /obj/item/clothing/suit/space/void/attackby(obj/item/W as obj, mob/user as mob)
@@ -145,7 +145,7 @@
 	if(!istype(user,/mob/living)) return
 
 	if(istype(src.loc,/mob/living))
-		user << "How do you propose to modify a hardsuit while it is being worn?"
+		user << "<span class='danger'>How do you propose to modify a hardsuit while it is being worn?</span>"
 		return
 
 	if(istype(W,/obj/item/weapon/screwdriver))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1245,8 +1245,7 @@
 			if(copytext(hud.icon_state,1,4) == "hud") //ugly, but icon comparison is worse, I believe
 				client.images.Remove(hud)
 
-		for(var/hud in global_huds)
-			client.screen.Remove(hud)
+		client.screen.Remove(global_hud.blurry, global_hud.druggy, global_hud.vimpaired, global_hud.darkMask, global_hud.nvg, global_hud.thermal, global_hud.meson)
 
 		update_action_buttons()
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1245,7 +1245,8 @@
 			if(copytext(hud.icon_state,1,4) == "hud") //ugly, but icon comparison is worse, I believe
 				client.images.Remove(hud)
 
-		client.screen -= global_huds
+		for(var/hud in global_huds)
+			client.screen.Remove(hud)
 
 		update_action_buttons()
 


### PR DESCRIPTION
Does not quite solve #7206. Picking up an already-lit hat will not apply the luminosity to the holder properly until the light is toggled. This bug does not seem to occur when the helmet is mounted on a voidsuit and does not occur at all with hardsuits.
