### PR TITLE
Syndicate borg code refactoring.

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -1,7 +1,7 @@
 
 /obj/item/device/encryptionkey/
 	name = "Standard Encrpytion Key"
-	desc = "An encyption key for a radio headset. Contains cypherkeys."
+	desc = "An encryption key for a radio headset. Contains cypherkeys."
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "cypherkey"
 	item_state = ""

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -131,7 +131,7 @@ var/list/ai_verbs_default = list(
 
 	//Languages
 	add_language("Robot Talk", 1)
-	add_language("Galactic Common", 0)
+	add_language("Galactic Common", 1)
 	add_language("Sol Common", 0)
 	add_language("Sinta'unathi", 0)
 	add_language("Siik'tajr", 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -78,25 +78,22 @@ var/list/robot_verbs_default = list(
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/braintype = "Cyborg"
 
-/mob/living/silicon/robot/drain_power(var/drain_check)
+/mob/living/silicon/robot/syndicate
+	lawupdate = 0
+	scrambledcodes = 1
+	icon_state = "securityrobot"
+	modtype = "Security"
+	lawchannel = "State"
 
-	if(drain_check)
-		return 1
+/mob/living/silicon/robot/syndicate/New()
+	if(!cell)
+		cell = new /obj/item/weapon/cell(src)
+		cell.maxcharge = 25000
+		cell.charge = 25000
 
-	if(!cell || !cell.charge)
-		return 0
+	..()
 
-	if(cell.charge)
-		src << "<span class='danger'>Warning: Unauthorized access through power channel 12 detected.</span>"
-		var/drained_power = rand(200,400)
-		if(cell.charge < drained_power)
-			drained_power = cell.charge
-			cell.use(drained_power)
-			return drained_power
-
-	return 0
-
-/mob/living/silicon/robot/New(loc,var/syndie = 0,var/unfinished = 0)
+/mob/living/silicon/robot/New(loc,var/unfinished = 0)
 	spark_system = new /datum/effect/effect/system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
@@ -112,23 +109,11 @@ var/list/robot_verbs_default = list(
 	updatename("Default")
 	updateicon()
 
-	if(syndie)
-		if(!cell)
-			cell = new /obj/item/weapon/cell(src)
-
-		laws = new /datum/ai_laws/antimov()
-		lawupdate = 0
-		scrambledcodes = 1
-		cell.maxcharge = 25000
-		cell.charge = 25000
-		module = new /obj/item/weapon/robot_module/syndicate(src)
-		hands.icon_state = "standard"
-		icon_state = "secborg"
-		modtype = "Security"
-	init()
-
 	radio = new /obj/item/device/radio/borg(src)
 	common_radio = radio
+
+	init()
+
 	if(!scrambledcodes && !camera)
 		camera = new /obj/machinery/camera(src)
 		camera.c_tag = real_name
@@ -181,6 +166,36 @@ var/list/robot_verbs_default = list(
 		lawupdate = 0
 
 	playsound(loc, 'sound/voice/liveagain.ogg', 75, 1)
+
+/mob/living/silicon/robot/syndicate/init()
+	aiCamera = new/obj/item/device/camera/siliconcam/robot_camera(src)
+
+	laws = new /datum/ai_laws/syndicate_override
+	module = new /obj/item/weapon/robot_module/syndicate(src)
+
+	radio.keyslot = new /obj/item/device/encryptionkey/syndicate(radio)
+	radio.recalculateChannels()
+
+	playsound(loc, 'sound/mecha/nominalsyndi.ogg', 75, 0)
+
+
+/mob/living/silicon/robot/drain_power(var/drain_check)
+
+	if(drain_check)
+		return 1
+
+	if(!cell || !cell.charge)
+		return 0
+
+	if(cell.charge)
+		src << "<span class='danger'>Warning: Unauthorized access through power channel 12 detected.</span>"
+		var/drained_power = rand(200,400)
+		if(cell.charge < drained_power)
+			drained_power = cell.charge
+			cell.use(drained_power)
+			return drained_power
+
+	return 0
 
 // setup the PDA and its name
 /mob/living/silicon/robot/proc/setup_PDA()
@@ -1292,6 +1307,16 @@ var/list/robot_verbs_default = list(
 		use_power(RC.active_usage)
 		return 1
 	return 0
+
+/mob/living/silicon/robot/syndicate/canUseTopic(atom/movable/M)
+	if(stat || lockcharge || stunned || weakened)
+		return
+	if(z in config.admin_levels)
+		return 1
+	if(istype(M, /obj/machinery))
+		var/obj/machinery/Machine = M
+		return Machine.emagged
+	return 1
 
 /mob/living/silicon/robot/proc/notify_ai(var/notifytype, var/oldname, var/newname)
 	if(!connected_ai)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -376,13 +376,29 @@
 /obj/item/weapon/robot_module/syndicate
 	name = "illegal robot module"
 
-	New()
+	New(var/mob/living/silicon/robot/R)
+		loc = R
+
 		src.modules += new /obj/item/device/flashlight(src)
 		src.modules += new /obj/item/device/flash(src)
 		src.modules += new /obj/item/weapon/melee/energy/sword(src)
 		src.modules += new /obj/item/weapon/gun/energy/pulse_rifle/destroyer(src)
 		src.modules += new /obj/item/weapon/card/emag(src)
+
+		var/jetpack = new/obj/item/weapon/tank/jetpack/carbondioxide(src)
+		src.modules += jetpack
+		R.internals = jetpack
+
 		return
+
+/obj/item/weapon/robot_module/syndicate/add_languages(var/mob/living/silicon/robot/R)
+	//full set of languages
+	R.add_language("Sol Common", 1)
+	R.add_language("Tradeband", 1)
+	R.add_language("Sinta'unathi", 0)
+	R.add_language("Siik'tajr", 0)
+	R.add_language("Skrellian", 0)
+	R.add_language("Gutter", 1)
 
 /obj/item/weapon/robot_module/combat
 	name = "combat robot module"


### PR DESCRIPTION
Refactors the borg syndicate code to be more accessible to adminbus.
Syndicate borgs now have a jetpack module.
Overrides canUseTopic() to limit what the Syndi-borg can interact with.
Still has all access, may be more limited in the future if Bump() is refactored /tg/ style.

Admins: Still spawn with care.
