### PR TITLE
Fixes #7233.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -59,7 +59,7 @@
 
 	var/used_skillpoints = 0
 	var/skill_specialization = null
-	var/list/skills = null
+	var/list/skills = list()
 
 	var/icon/stand_icon = null
 	var/icon/lying_icon = null


### PR DESCRIPTION
Making sure the skills list for mobs is always initiated, even when not created for a player.
