### PR TITLE
Update Travis to check split map files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
   - cd ..
 
 script:
-  - (! grep -q 'step_[xy]' maps/tgstation2.dmm)
+  - $(for i in 1 2 3 4 5 6; do (grep -q 'step_[xy]' maps/exodus-$i.dmm; if [ $? -eq 1 ]; then exit 0; else exit 1; fi) done)
   - DreamMaker baystation12.dme


### PR DESCRIPTION
Changes the maps that Travis checks to exodus-1.dmm through exodus-6.dmm, and ensures it errors if it can't find any of those.

`grep` returns 0 if it found the pattern, 1 if it did not, 2 if the file did not exist.
