### PR TITLE
Fixes invisible slimes.

### DIFF
--- a/code/modules/mob/living/carbon/metroid/subtypes.dm
+++ b/code/modules/mob/living/carbon/metroid/subtypes.dm
@@ -31,24 +31,24 @@ proc/mutation_table(var/colour)
 		//Tier 3
 		if("dark blue")
 			slime_mutation[1] = "purple"
-			slime_mutation[2] = "blue"
-			slime_mutation[3] = "cerulean"
-			slime_mutation[4] = "cerulean"
+			slime_mutation[2] = "purple"
+			slime_mutation[3] = "blue"
+			slime_mutation[4] = "blue"
 		if("dark purple")
 			slime_mutation[1] = "purple"
-			slime_mutation[2] = "orange"
-			slime_mutation[3] = "sepia"
-			slime_mutation[4] = "sepia"
+			slime_mutation[2] = "purple"
+			slime_mutation[3] = "orange"
+			slime_mutation[4] = "orange"
 		if("yellow")
 			slime_mutation[1] = "metal"
-			slime_mutation[2] = "orange"
-			slime_mutation[3] = "bluespace"
-			slime_mutation[4] = "bluespace"
+			slime_mutation[2] = "metal"
+			slime_mutation[3] = "orange"
+			slime_mutation[4] = "orange"
 		if("silver")
 			slime_mutation[1] = "metal"
-			slime_mutation[2] = "blue"
-			slime_mutation[3] = "pyrite"
-			slime_mutation[4] = "pyrite"
+			slime_mutation[2] = "metal"
+			slime_mutation[3] = "blue"
+			slime_mutation[4] = "blue"
 		//Tier 4
 		if("pink")
 			slime_mutation[1] = "pink"


### PR DESCRIPTION
As in title. From commit logs, cerulean, sepia, bluespace and pyrite slimes look like a /tg/ feature [1](https://github.com/tgstation/-tg-station/commit/0a5b23c078c4c8253caee265da3af25d23b8f2d5) [2](https://github.com/tgstation/-tg-station/commit/c66a06d177a45de3790faa28613d52c9d42289d1) that never came to Bay.
