### PR TITLE
Fix num2hex()'s handling of zero

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -50,8 +50,10 @@
 		placeholder = 2
 	if (!( isnum(num) ))
 		return
-	if (!( num ))
-		return "0"
+	if (num == 0)
+		var/final = ""
+		for(var/i=1 to placeholder) final = "[final]0"
+		return final
 	var/hex = ""
 	var/i = 0
 	while(16 ** i < num)


### PR DESCRIPTION
As in title. Fixes purely blue colors appearing green in the character setup window (due to (0,0,0xYZ) being converted to "#00YZ"), probably fixes some other weirdness too.
