### PR TITLE
Makes forced launch handled by shuttle/process()

### DIFF
--- a/code/WorkInProgress/Chinsky/overmap/ships/computers/shuttle.dm
+++ b/code/WorkInProgress/Chinsky/overmap/ships/computers/shuttle.dm
@@ -83,7 +83,7 @@
 				shuttle_status = "Standing-by at station."
 			else
 				shuttle_status = "Standing-by at offsite location."
-		if(WAIT_LAUNCH)
+		if(WAIT_LAUNCH, FORCE_LAUNCH)
 			shuttle_status = "Shuttle has recieved command and will depart shortly."
 		if(WAIT_ARRIVE)
 			shuttle_status = "Proceeding to destination."

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -21,6 +21,7 @@
 		if (moving_status == SHUTTLE_IDLE) 
 			return	//someone cancelled the launch
 		
+		moving_status = SHUTTLE_INTRANSIT //shouldn't matter but just to be safe
 		move(origin, destination)
 		moving_status = SHUTTLE_IDLE
 

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -39,7 +39,7 @@
 				shuttle_status = "Standing-by at station."
 			else
 				shuttle_status = "Standing-by at offsite location."
-		if(WAIT_LAUNCH)
+		if(WAIT_LAUNCH, FORCE_LAUNCH)
 			shuttle_status = "Shuttle has recieved command and will depart shortly."
 		if(WAIT_ARRIVE)
 			shuttle_status = "Proceeding to destination."

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -46,7 +46,7 @@
 
 		//initiating or cancelling a launch ALWAYS requires authorization, but if we are already set to launch anyways than forcing does not.
 		//this is so that people can force launch if the docking controller cannot safely undock without needing X heads to swipe.
-		if (process_state != WAIT_LAUNCH && !C.has_authorization())
+		if (!(process_state == WAIT_LAUNCH || C.has_authorization()))
 			return 0
 	return ..()
 
@@ -175,7 +175,7 @@
 				shuttle_status = "Standing-by at [station_name]."
 			else
 				shuttle_status = "Standing-by at Central Command."
-		if(WAIT_LAUNCH)
+		if(WAIT_LAUNCH, FORCE_LAUNCH)
 			shuttle_status = "Shuttle has recieved command and will depart shortly."
 		if(WAIT_ARRIVE)
 			shuttle_status = "Proceeding to destination."

--- a/code/modules/shuttles/shuttle_ferry.dm
+++ b/code/modules/shuttles/shuttle_ferry.dm
@@ -1,7 +1,3 @@
-#define IDLE_STATE		0
-#define WAIT_LAUNCH		1
-#define WAIT_ARRIVE		2
-#define WAIT_FINISH		3
 
 #define DOCK_ATTEMPT_TIMEOUT 200	//how long in ticks we wait before assuming the docking controller is broken or blown up.
 
@@ -68,6 +64,10 @@
 		return area_station
 	return area_offsite
 
+/*
+	Please ensure that long_jump() and short_jump() are only called from here. This applies to subtypes as well.
+	Doing so will ensure that multiple jumps cannot be initiated in parallel.
+*/
 /datum/shuttle/ferry/proc/process()
 	switch(process_state)
 		if (WAIT_LAUNCH)
@@ -80,11 +80,21 @@
 					short_jump()
 
 				process_state = WAIT_ARRIVE
+
+		if (FORCE_LAUNCH)
+			if (move_time && area_transition)
+				long_jump(interim=area_transition, travel_time=move_time, direction=transit_direction)
+			else
+				short_jump()
+			
+			process_state = WAIT_ARRIVE
+		
 		if (WAIT_ARRIVE)
 			if (moving_status == SHUTTLE_IDLE)
 				dock()
 				in_use = null	//release lock
 				process_state = WAIT_FINISH
+		
 		if (WAIT_FINISH)
 			if (skip_docking_checks() || docking_controller.docked() || world.time > last_dock_attempt_time + DOCK_ATTEMPT_TIMEOUT)
 				process_state = IDLE_STATE
@@ -112,13 +122,7 @@
 
 	in_use = user	//obtain an exclusive lock on the shuttle
 
-	if (move_time && area_transition)
-		long_jump(interim=area_transition, travel_time=move_time, direction=transit_direction)
-	else
-		short_jump()
-
-
-	process_state = WAIT_ARRIVE
+	process_state = FORCE_LAUNCH
 
 /datum/shuttle/ferry/proc/cancel_launch(var/user)
 	if (!can_cancel()) return
@@ -150,13 +154,13 @@
 	return 0
 
 /datum/shuttle/ferry/proc/can_cancel()
-	if (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH)
+	if (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH || process_state == FORCE_LAUNCH)
 		return 1
 	return 0
 
 //returns 1 if the shuttle is getting ready to move, but is not in transit yet
 /datum/shuttle/ferry/proc/is_launching()
-	return (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH)	
+	return (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH || process_state == FORCE_LAUNCH)
 
 //This gets called when the shuttle finishes arriving at it's destination
 //This can be used by subtypes to do things when the shuttle arrives.

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -805,8 +805,9 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 //Ferry shuttle processing status
 #define IDLE_STATE		0
 #define WAIT_LAUNCH		1
-#define WAIT_ARRIVE		2
-#define WAIT_FINISH		3
+#define FORCE_LAUNCH	2
+#define WAIT_ARRIVE		3
+#define WAIT_FINISH		4
 
 //computer3 error codes, move lower in the file when it passes dev -Sayu
  #define PROG_CRASH      1  // Generic crash


### PR DESCRIPTION
Forced launches are now run by the shuttle controller through process() instead of in a separate 'thread' launched from the ui.

I'm hoping this will fix #7169 but I can't be sure. At the very least it's one less way for jump procs to be started in parallel, which I think is the cause of that issue.
