### PR TITLE
Fixes atoms with no flags set being walkable

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -86,7 +86,7 @@
 
 	//Finally, check objects/mobs to block entry that are not on the border
 	for(var/atom/movable/obstacle in src)
-		if(obstacle.flags & ~ON_BORDER)
+		if(!(obstacle.flags & ON_BORDER))
 			if(!obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != obstacle))
 				mover.Bump(obstacle, 1)
 				return 0


### PR DESCRIPTION
Fixes atoms that have no flags set allowing movement into them regardless of their CanPass() proc, most notably hydrotrays.

Instead of checking only atoms that do not have the ON_BORDER flag set, the if statement was instead checking for all atoms that have any flag that isn't ON_BORDER set. 

As a result, if an obstacle does not have any flags set, then it's `CanPass()` will never be called and the proc will exit at the `return 1` below.

As a side note this also caused any atoms with ON_BORDER to have their `CanPass()` proc called twice in a row. It seems like this bug goes back to [2010](https://github.com/Baystation12/Baystation12/blame/54cdfe54bcc39f9552670b7c397752fff1b47e55/code/game/turfs/turf.dm#L89)
