### PR TITLE
Fixes #7295.

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -161,7 +161,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		var/text = "<FONT size = 2><B>The changelings were:</B></FONT>"
 		for(var/datum/mind/changeling in changelings)
 			var/changelingwin = changeling.current
-			text += printplayer(changeling)
+			text += print_player_full(changeling)
 
 			//Removed sanity if(changeling) because we -want- a runtime to inform us that the changelings list is incorrect and needs to be fixed.
 			text += "<br><b>Changeling ID:</b> [changeling.changeling.changelingID]."

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -334,7 +334,7 @@
 	if( cult.len || (ticker && istype(ticker.mode,/datum/game_mode/cult)) )
 		var/text = "<FONT size = 2><B>The cultists were:</B></FONT>"
 		for(var/datum/mind/cultist in cult)
-			text += printplayer(cultist)
+			text += print_player_full(cultist)
 		text += "<br>"
 
 		world << text

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -414,12 +414,12 @@ var/list/sacrificed = list()
 			else
 				ticker.mode.cult+=D.mind
 
-			D.mind.assigned_role = pick("Anguished", "Blasphemous", "Corrupt", "Cruel", "Depraved", "Despicable", "Disturbed", "Exacerbated", "Foul", "Hateful", "Inexorable", "Implacable", "Impure", "Malevolent", "Malignant", "Malicious", "Pained", "Profane", "Profligate", "Relentless", "Resentful", "Restless", "Spiteful", "Tormented", "Unclean", "Unforgiving", "Vengeful", "Vindictive", "Wicked", "Wronged")
-			D.mind.assigned_role += " "
-			D.mind.assigned_role += pick("Apparition", "Aptrgangr", "Dis", "Draugr", "Dybbuk", "Eidolon", "Fetch", "Fylgja", "Ghast", "Ghost", "Gjenganger", "Haint", "Phantom", "Phantasm", "Poltergeist", "Revenant", "Shade", "Shadow", "Soul", "Spectre", "Spirit", "Spook", "Visitant", "Wraith")
+			D.mind.assigned_role = "Manifest Ghost"
 			D.mind.special_role = "Cultist"
 			if(!chose_name)
-				D.real_name = D.mind.assigned_role
+				D.real_name = pick("Anguished", "Blasphemous", "Corrupt", "Cruel", "Depraved", "Despicable", "Disturbed", "Exacerbated", "Foul", "Hateful", "Inexorable", "Implacable", "Impure", "Malevolent", "Malignant", "Malicious", "Pained", "Profane", "Profligate", "Relentless", "Resentful", "Restless", "Spiteful", "Tormented", "Unclean", "Unforgiving", "Vengeful", "Vindictive", "Wicked", "Wronged")
+				D.real_name += " "
+				D.real_name += pick("Apparition", "Aptrgangr", "Dis", "Draugr", "Dybbuk", "Eidolon", "Fetch", "Fylgja", "Ghast", "Ghost", "Gjenganger", "Haint", "Phantom", "Phantasm", "Poltergeist", "Revenant", "Shade", "Shadow", "Soul", "Spectre", "Spirit", "Spook", "Visitant", "Wraith")
 
 			D << "<font color=\"purple\"><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</b></i></font>"
 			D << "<font color=\"purple\"><b><i>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</b></i></font>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -155,7 +155,7 @@
 
 	for(var/mob/M in player_list)
 		if(M.mind)
-			pltext += printplayer(M.mind)
+			pltext += print_player_lite(M.mind)
 		if(M.client)
 			clients++
 			if(ishuman(M))
@@ -183,7 +183,7 @@
 			if(isobserver(M))
 				ghosts++
 
-	var/text = "A round of <b>[src.name]</b> has ended."
+	var/text = ""
 	if(surviving_total > 0)
 		text += "<br>There [surviving_total>1 ? "were <b>[surviving_total] survivors</b>" : "was <b>one survivor</b>"]</b>"
 		text += " (<b>[escaped_total>0 ? escaped_total : "none"] [emergency_shuttle.evac ? "escaped" : "transferred"]</b>) and <b>[ghosts] ghosts</b>.</b><br>"
@@ -526,7 +526,7 @@ proc/get_nt_opposed()
 		player.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
 		obj_count++
 
-/datum/game_mode/proc/printplayer(var/datum/mind/ply)
+/datum/game_mode/proc/print_player_lite(var/datum/mind/ply)
 	var/role = ply.assigned_role == "MODE" ? "\improper[ply.special_role]" : "\improper[ply.assigned_role]"
 	var/text = "<br><b>[ply.name]</b> (<b>[ply.key]</b>) as \a <b>[role]</b> ("
 	if(ply.current)
@@ -540,6 +540,11 @@ proc/get_nt_opposed()
 		text += "body destroyed"
 	text += ")"
 
+	return text
+
+/datum/game_mode/proc/print_player_full(var/datum/mind/ply)
+	var/text = print_player_lite(ply)
+
 	var/TC_uses = 0
 	var/uplink_true = 0
 	var/purchases = ""
@@ -547,9 +552,15 @@ proc/get_nt_opposed()
 		if(H && H.uplink_owner && H.uplink_owner == ply)
 			TC_uses += H.used_TC
 			uplink_true = 1
-			for(var/log in H.purchase_log)
-				purchases += "<BIG>[log]</BIG>"
+			var/list/refined_log = new()
+			for(var/datum/uplink_item/UI in H.purchase_log)
+				var/obj/I = new UI.path
+				refined_log.Add("[H.purchase_log[UI]]x\icon[I][I.name]")
+				del(I)
+			purchases = english_list(refined_log, nothing_text = "")
 	if(uplink_true)
-		text += " (used [TC_uses] TC) [purchases]"
+		text += " (used [TC_uses] TC)"
+		if(purchases)
+			text += "<br>[purchases]"
 
 	return text

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -376,7 +376,7 @@ var/global/datum/controller/gameticker/ticker
 
 
 /datum/controller/gameticker/proc/declare_completion()
-	world << "<br><br><br><font size=3><b>The round has ended.</b></font>"
+	world << "<br><br><br><H1>A round of [mode.name] has ended!</H1>"
 	for(var/mob/Player in player_list)
 		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -313,7 +313,7 @@ var/global/list/turf/synd_spawn = list()
 		var/text = "<FONT size = 2><B>The mercenaries were:</B></FONT>"
 
 		for(var/datum/mind/syndicate in syndicates)
-			text += printplayer(syndicate)
+			text += print_player_full(syndicate)
 
 		world << text
 	return 1

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -180,7 +180,7 @@
 		var/text = "<FONT size = 2><B>The traitors were:</B></FONT>"
 		for(var/datum/mind/traitor in traitors)
 			var/traitorwin = 1
-			text += printplayer(traitor)
+			text += print_player_full(traitor)
 
 			if(traitor.objectives.len)//If the traitor had no objectives, don't need to process this.
 				var/count = 1

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -128,11 +128,7 @@ datum/nano_item_lists
 			var/mob/living/carbon/human/A = usr
 			A.put_in_any_hand_if_possible(I)
 
-		if(istype(I ,/obj/item/weapon/storage/box/) && I.contents.len>0)
-			for(var/atom/o in I)
-				purchase_log += "\icon[o]"
-		else
-			purchase_log += "\icon[I]"
+		purchase_log[UI] = purchase_log[UI] + 1
 
 		return 1
 	return 0
@@ -192,7 +188,7 @@ datum/nano_item_lists
 	data["menu"] = nanoui_menu
 	data["nano_items"] = nanoui_items
 	data += nanoui_data
-	
+
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)


### PR DESCRIPTION
Cleans up round end summary.
Attempts to improve how the traitor purchase log is presented.
Ghosts made manifest now have different names and assignments, otherwise one would get messages like "Anguished Phantom played as an Anguished Phantom".
Instead the message is now "Anguished Phantom played as a Manifest Ghost".

Current summary view. Shall we keep or remove the item a names?
![Round end summary](https://www.dropbox.com/s/1qnbahxrwxznzm8/RoundEnd.png?dl=1)
