### PR TITLE
Blast doors' sprite now doesn't disappear when damaged

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -21,6 +21,13 @@
 	else
 		return 0
 
+/obj/machinery/door/poddoor/update_icon()
+	if(density)
+		icon_state = "pdoor1"
+	else
+		icon_state = "pdoor0"
+	return
+
 /obj/machinery/door/poddoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	src.add_fingerprint(user)
 	if (!( istype(C, /obj/item/weapon/crowbar) || (istype(C, /obj/item/weapon/twohanded/fireaxe) && C:wielded == 1) ))


### PR DESCRIPTION
Fixes #7341.

Code taken from unmerged #7175.
