### PR TITLE
Adds "paranoid" option to remove more powerful debug options from R_DEBUG.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -81,6 +81,8 @@
 	var/limitalienplayers = 0
 	var/alien_to_human_ratio = 0.5
 
+	var/debugparanoid = 0
+
 	var/server
 	var/banappeals
 	var/wikiurl
@@ -223,6 +225,9 @@
 
 				if ("log_say")
 					config.log_say = 1
+
+				if ("debug_paranoid")
+					config.debugparanoid = 1
 
 				if ("log_admin")
 					config.log_admin = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -156,6 +156,12 @@ var/list/admin_verbs_debug = list(
 	/client/proc/SDQL_query,
 	/client/proc/SDQL2_query,
 	)
+
+var/list/admin_verbs_paranoid_debug = list(
+	/client/proc/callproc,
+	/client/proc/debug_controller
+	)
+
 var/list/admin_verbs_possess = list(
 	/proc/possess,
 	/proc/release
@@ -275,7 +281,10 @@ var/list/admin_verbs_mentor = list(
 		if(holder.rights & R_BAN)			verbs += admin_verbs_ban
 		if(holder.rights & R_FUN)			verbs += admin_verbs_fun
 		if(holder.rights & R_SERVER)		verbs += admin_verbs_server
-		if(holder.rights & R_DEBUG)			verbs += admin_verbs_debug
+		if(holder.rights & R_DEBUG)
+			verbs += admin_verbs_debug
+			if(config.debugparanoid && !check_rights(R_ADMIN)) 
+				verbs.Remove(admin_verbs_paranoid_debug)			//Right now it's just callproc but we can easily add others later on.
 		if(holder.rights & R_POSSESS)		verbs += admin_verbs_possess
 		if(holder.rights & R_PERMISSIONS)	verbs += admin_verbs_permissions
 		if(holder.rights & R_STEALTH)		verbs += /client/proc/stealth

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -30,6 +30,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	set name = "Advanced ProcCall"
 
 	if(!check_rights(R_DEBUG)) return
+	if(config.debugparanoid && !check_rights(R_ADMIN)) return
 
 	spawn(0)
 		var/target = null

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -260,3 +260,8 @@ REQ_CULT_GHOSTWRITER 6
 
 ## Uncomment to use overmap system for zlevel travel
 #USE_OVERMAP
+
+## Uncomment to make proccall require R_ADMIN instead of R_DEBUG
+## designed for environments where you have testers but don't want them
+## able to use the more powerful debug options.
+#DEBUG_PARANOID


### PR DESCRIPTION
The purpose of this is to allow for testers on our test server without them having advance proc call which can do some fun stuff with python, etc.

The default config is the status quo, you have to go out of your way and set this option in config to remove proccal from R_DEBUG
