### PR TITLE
Fixes Hotkey

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -46,8 +46,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \te = equip
 \tr = throw
 \tt = say
-\ty = emote
-\tx = swap-hand
+\tx = swap-hand (or y)
 \tz = activate held object
 \tf = cycle-intents-left
 \tg = cycle-intents-right

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -367,7 +367,7 @@ macro "hotkeymode"
 		is-disabled = false
 	elem 
 		name = "Y"
-		command = "me"
+		command = "Activate-Held-Object"
 		is-disabled = false
 	elem 
 		name = "CTRL+Y"


### PR DESCRIPTION
Reverts #7024 which changed the hotkey for Y to be used for emotes instead of Activating-Hand-Held.
No.
The reason both Y and Z are used for the same function is that otherwise every European using the Hotkey mode would have his controls fucked.
