### PR TITLE
Fixes #7356 - Calamity round start runtime.

### DIFF
--- a/code/game/gamemodes/calamity/calamity.dm
+++ b/code/game/gamemodes/calamity/calamity.dm
@@ -91,7 +91,7 @@
 
 	// Add the cortical borer event
 	var/list/moderate_event_list = EModerate.available_events
-	var/event = new /datum/event_meta(EVENT_LEVEL_MODERATE, "Borer Infestation", /datum/event/borer_infestation, 400, one_shot = 1)
+	var/event = new /datum/event_meta(EVENT_LEVEL_MODERATE, "Borer Infestation", /datum/event/borer_infestation, 400, is_one_shot = 1)
 	moderate_event_list.Add(event)
 
 	if(chosen_atypes)

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -106,7 +106,7 @@
 		html += "<td><A align='right' href='?src=\ref[src];set_name=\ref[new_event]'>[new_event.name ? new_event.name : "Enter Event"]</A></td>"
 		html += "<td><A align='right' href='?src=\ref[src];set_type=\ref[new_event]'>[new_event.event_type ? new_event.event_type : "Select Type"]</A></td>"
 		html += "<td><A align='right' href='?src=\ref[src];set_weight=\ref[new_event]'>[new_event.weight ? new_event.weight : 0]</A></td>"
-		html += "<td><A align='right' href='?src=\ref[src];set_oneshot=\ref[new_event]'>[new_event.one_shot]</A></td>"
+		html += "<td><A align='right' href='?src=\ref[src];toggle_oneshot=\ref[new_event]'>[new_event.one_shot]</A></td>"
 		html += "</tr>"
 		html += "</table>"
 		html += "<A align='right' href='?src=\ref[src];add=\ref[selected_event_container]'>Add</A><br>"


### PR DESCRIPTION
Clam now uses the proper arg name when trying to create the borer event.
Fixes a minor issue in the event manager, where the wrong Topic arg was used.
