### PR TITLE
Fixes #7366.

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -576,9 +576,9 @@ What a mess.*/
 		return photo.img
 	if(istype(user, /mob/living/silicon))
 		var/mob/living/silicon/tempAI = usr
-		var/datum/picture/selection = tempAI.GetPicture()
+		var/obj/item/weapon/photo/selection = tempAI.GetPicture()
 		if (selection)
-			return selection.fields["img"]
+			return selection.img
 
 /obj/machinery/computer/secure_data/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/mob/living/silicon/robot/photos.dm
+++ b/code/modules/mob/living/silicon/robot/photos.dm
@@ -3,11 +3,18 @@
 	if (!master_cam)
 		return
 
-	var/synced
-	synced = 0
-	for(var/datum/picture/z in aiCamera.aipictures)
-		if (!(master_cam.aipictures.Find(z)))
-			aiCamera.printpicture(null, z)
+	var/synced = 0
+	// Sync borg images to the master AI.
+	// We don't care about syncing the other way around
+	for(var/obj/item/weapon/photo/borg_photo in aiCamera.aipictures)
+		var/copied = 0
+		for(var/obj/item/weapon/photo/ai_photo in master_cam.aipictures)
+			if(borg_photo.id == ai_photo.id)
+				copied = 1
+				break
+		if(!copied)
+			master_cam.injectaialbum(borg_photo.copy(1), " (synced from [name])")
 			synced = 1
+
 	if(synced)
-		src << "<span class='notice'>Locally saved images synced with AI. Images were retained in local database in case of loss of connection with the AI.</span>"
+		src << "<span class='notice'>Images synced with AI. Local images will be retained in the case of loss of connection with the AI.</span>"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -159,9 +159,8 @@ var/list/robot_verbs_default = list(
 	connected_ai = select_active_ai_with_fewest_borgs()
 	if(connected_ai)
 		connected_ai.connected_robots += src
-		lawsync()
-		photosync()
 		lawupdate = 1
+		sync()
 	else
 		lawupdate = 0
 
@@ -178,6 +177,10 @@ var/list/robot_verbs_default = list(
 
 	playsound(loc, 'sound/mecha/nominalsyndi.ogg', 75, 0)
 
+/mob/living/silicon/robot/proc/sync()
+	if(lawupdate && connected_ai)
+		lawsync()
+		photosync()
 
 /mob/living/silicon/robot/drain_power(var/drain_check)
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -43,11 +43,11 @@
 	if(href_list["copy"])
 		if(stat & (BROKEN|NOPOWER))
 			return
-		
+
 		for(var/i = 0, i < copies, i++)
 			if(toner <= 0)
 				break
-			
+
 			if (istype(copyitem, /obj/item/weapon/paper))
 				copy(copyitem)
 				sleep(15)
@@ -60,7 +60,7 @@
 			else
 				usr << "<span class='warning'>\The [copyitem] can't be copied by \the [src].</span>"
 				break
-			
+
 			use_power(active_power_usage)
 		updateUsrDialog()
 	else if(href_list["remove"])
@@ -81,19 +81,18 @@
 	else if(href_list["aipic"])
 		if(!istype(usr,/mob/living/silicon)) return
 		if(stat & (BROKEN|NOPOWER)) return
-		
+
 		if(toner >= 5)
 			var/mob/living/silicon/tempAI = usr
 			var/obj/item/device/camera/siliconcam/camera = tempAI.aiCamera
 
 			if(!camera)
 				return
-			var/datum/picture/selection = camera.selectpicture()
+			var/obj/item/weapon/photo/selection = camera.selectpicture()
 			if (!selection)
 				return
 
-			var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (src.loc)
-			p.construct(selection)
+			var/obj/item/weapon/photo/p = photocopy(selection)
 			if (p.desc == "")
 				p.desc += "Copied by [tempAI.name]"
 			else
@@ -195,6 +194,7 @@
 
 /obj/machinery/photocopier/proc/photocopy(var/obj/item/weapon/photo/photocopy)
 	var/obj/item/weapon/photo/p = photocopy.copy()
+	p.loc = src.loc
 
 	var/icon/I = icon(photocopy.icon, photocopy.icon_state)
 	if(toner > 10)	//plenty of toner, go straight greyscale
@@ -210,6 +210,7 @@
 	if(toner < 0)
 		toner = 0
 		visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
+
 	return p
 
 //If need_toner is 0, the copies will still be lightened when low on toner, however it will not be prevented from printing. TODO: Implement print queues for fax machines and get rid of need_toner
@@ -220,7 +221,7 @@
 			toner = 0
 			visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
 			break
-		
+
 		if(istype(W, /obj/item/weapon/paper))
 			W = copy(W)
 		else if(istype(W, /obj/item/weapon/photo))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -21,16 +21,22 @@
 /********
 * photo *
 ********/
+var/global/photo_count = 0
+
 /obj/item/weapon/photo
 	name = "photo"
 	icon = 'icons/obj/items.dmi'
 	icon_state = "photo"
 	item_state = "paper"
 	w_class = 2.0
+	var/id
 	var/icon/img	//Big photo image
 	var/scribble	//Scribble on the back.
 	var/icon/tiny
 	var/photo_size = 3
+
+/obj/item/weapon/photo/New()
+	id = photo_count++
 
 /obj/item/weapon/photo/attack_self(mob/user as mob)
 	user.examinate(src)
@@ -270,8 +276,8 @@
 		y_c--
 		x_c = x_c - size
 
-	var/datum/picture/P = createpicture(target, user, turfs, mobs, flag)
-	printpicture(user, P)
+	var/obj/item/weapon/photo/p = createpicture(target, user, turfs, mobs, flag)
+	printpicture(user, p)
 
 /obj/item/device/camera/proc/createpicture(atom/target, mob/user, list/turfs, mobs, flag)
 	var/icon/photoimage = get_icon(turfs, target)
@@ -285,43 +291,37 @@
 	ic.Blend(small_img,ICON_OVERLAY, 10, 13)
 	pc.Blend(tiny_img,ICON_OVERLAY, 12, 19)
 
-	var/datum/picture/P = new()
-	P.fields["name"] = "photo"
-	P.fields["icon"] = ic
-	P.fields["tiny"] = pc
-	P.fields["img"] = photoimage
-	P.fields["desc"] = mobs
-	P.fields["pixel_x"] = rand(-10, 10)
-	P.fields["pixel_y"] = rand(-10, 10)
-	P.fields["size"] = size
+	var/obj/item/weapon/photo/p = new()
+	p.name = "photo"
+	p.icon = ic
+	p.tiny = pc
+	p.img = photoimage
+	p.desc = mobs
+	p.pixel_x = rand(-10, 10)
+	p.pixel_y = rand(-10, 10)
+	p.photo_size = size
 
-	return P
+	return p
 
-/obj/item/device/camera/proc/printpicture(mob/user, var/datum/picture/P)
-	var/obj/item/weapon/photo/Photo = new/obj/item/weapon/photo()
-	Photo.loc = user.loc
+/obj/item/device/camera/proc/printpicture(mob/user, obj/item/weapon/photo/p)
+	p.loc = user.loc
 	if(!user.get_inactive_hand())
-		user.put_in_inactive_hand(Photo)
-	Photo.construct(P)
+		user.put_in_inactive_hand(p)
 
-/obj/item/weapon/photo/proc/construct(var/datum/picture/P)
-	name = P.fields["name"]
-	icon = P.fields["icon"]
-	tiny = P.fields["tiny"]
-	img = P.fields["img"]
-	desc = P.fields["desc"]
-	pixel_x = P.fields["pixel_x"]
-	pixel_y = P.fields["pixel_y"]
-	photo_size = P.fields["size"]
-
-/obj/item/weapon/photo/proc/copy()
+/obj/item/weapon/photo/proc/copy(var/copy_id = 0)
 	var/obj/item/weapon/photo/p = new/obj/item/weapon/photo()
 
-	p.icon = icon(icon, icon_state)
-	p.img = icon(img)
-	p.tiny = icon(tiny)
 	p.name = name
+	p.icon = icon
+	p.tiny = tiny
+	p.img = img
 	p.desc = desc
+	p.pixel_x = pixel_x
+	p.pixel_y = pixel_y
+	p.photo_size = photo_size
 	p.scribble = scribble
+
+	if(copy_id)
+		p.id = id
 
 	return p


### PR DESCRIPTION
Kills unecessary photo datum which wasn't even used correctly anymore, causing runtimes and blank photos.
Photos have a global id for ease of synth syncing.
Changes how law/photo syncing is handled when pulsing the appropriate borg wire.
Also ensures re-synced borgs are added/removed from the appropriate AIs.

According to history most of the datum stuff was originally made by that @PsiOmegaDelta guy. What a scrub.
Some of it seem to have been incorrectly resolved merge conflicts by someone else but still.
