### PR TITLE
Fixes #7354

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -57,7 +57,7 @@
 						a.triggerAlarm("Power", src, cameras, source)
 	return
 
-/area/proc/atmosalert(danger_level)
+/area/proc/atmosalert(danger_level, var/set_firelocks=1)
 //	if(type==/area) //No atmos alarms in space
 //		return 0 //redudant
 
@@ -68,7 +68,7 @@
 				danger_level = max(danger_level, AA.danger_level)
 
 	if(danger_level != atmosalm)
-		if (danger_level < 1 && atmosalm >= 1)
+		if (set_firelocks && danger_level < 1 && atmosalm >= 1)
 			//closing the doors on red and opening on green provides a bit of hysteresis that will hopefully prevent fire doors from opening and closing repeatedly due to noise
 			air_doors_open()
 
@@ -92,7 +92,8 @@
 				aiPlayer.triggerAlarm("Atmosphere", src, cameras, src)
 			for(var/obj/machinery/computer/station_alert/a in machines)
 				a.triggerAlarm("Atmosphere", src, cameras, src)
-			air_doors_close()
+			if (set_firelocks)
+				air_doors_close()
 
 		atmosalm = danger_level
 		for(var/area/RA in related)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -117,6 +117,18 @@
 
 	first_run()
 
+/obj/machinery/alarm/Del()
+	//If there's an active alarm, clear it after minute so that alarms don't keep going forver
+	delayed_reset()
+	..()
+
+//needed to cancel the alarm after it is deleted
+/obj/machinery/alarm/proc/delayed_reset()
+	var/area/A = alarm_area
+	src = null
+	spawn(600)
+		//It makes sense not to touch firelocks here. The alarm itself is gone, we have no idea what the atmos is like.
+		A.atmosalert(0, set_firelocks=0)
 
 /obj/machinery/alarm/proc/first_run()
 	alarm_area = get_area(src)
@@ -1281,6 +1293,20 @@ FIRE ALARM
 		wiresexposed = 1
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
+
+/obj/machinery/firealarm/Del()
+	//so fire alarms don't keep going forever
+	delayed_reset()
+	..()
+
+//needed to cancel the alarm after it is deleted
+/obj/machinery/firealarm/proc/delayed_reset()
+	var/area/A = get_area(src)
+	if (!A) return
+	
+	src = null
+	spawn(600)
+		A.firereset()
 
 /obj/machinery/firealarm/initialize()
 	if(z in config.contact_levels)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -55,9 +55,7 @@
 	if(!alarm_on)
 		triggerCameraAlarm()
 	
-	spawn(50)
-		src = null
-		cancelCameraAlarm() //so camera alarms don't just go on forever
+	cancelCameraAlarm()
 	..()
 
 /obj/machinery/camera/emp_act(severity)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -178,6 +178,10 @@
 		del(cell) // qdel
 	if(terminal)
 		disconnect_terminal()
+	
+	//If there's no more APC then there shouldn't be a cause for alarm I guess
+	area.poweralert(1, src) //so that alarms don't go on forever
+	
 	..()
 
 /obj/machinery/power/apc/proc/make_terminal()


### PR DESCRIPTION
Various machines cancel their alarms when deleted.

Some do so after 1 minute, others cannot do this unfortunately and must cancel their alarms right away.
