### PR TITLE
Halves radiation storm duration.

### DIFF
--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -262,13 +262,14 @@
 			return
 		if(alert("This will add a new event to the rotation. Continue?","Add Event!","Yes","No") != "Yes")
 			return
+		new_event.severity = selected_event_container.severity
 		selected_event_container.available_events += new_event
 		admin_log_and_message_admins("has added \a [severity_to_string[new_event.severity]] event '[new_event.name]' of type [new_event.event_type] with weight [new_event.weight].")
 		new_event = new
 	else if(href_list["clear"])
 		var/datum/event_container/EC = locate(href_list["clear"])
 		if(EC.next_event)
-			admin_log_and_message_admins("has unqueued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.")
+			admin_log_and_message_admins("has dequeued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.")
 			EC.next_event = null
 
 	Interact(usr)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -1,11 +1,11 @@
 /datum/event/radiation_storm
-	var/const/enterBelt 	= 60
-	var/const/leaveBelt 	= 170
-	var/const/revokeAccess	= 230
-
-	endWhen				= revokeAccess
-
-	var/postStartTicks
+	var/const/enterBelt		= 30
+	var/const/radIntervall 	= 5	// Enough time between enter/leave belt for 10 hits, as per original implementation
+	var/const/leaveBelt		= 80
+	var/const/revokeAccess	= 135
+	announceWhen			= 1
+	endWhen					= revokeAccess
+	var/postStartTicks 		= 0
 
 /datum/event/radiation_storm/announce()
 	command_announcement.Announce("High levels of radiation detected near the station. Please evacuate into one of the shielded maintenance tunnels.", "Anomaly Alert", new_sound = 'sound/AI/radiation.ogg')
@@ -18,10 +18,10 @@
 		command_announcement.Announce("The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt.", "Anomaly Alert")
 		radiate()
 
-	if(activeFor > enterBelt && activeFor < leaveBelt)
+	if(activeFor >= enterBelt && activeFor <= leaveBelt)
 		postStartTicks++
 
-	if(postStartTicks == 10)
+	if(postStartTicks == radIntervall)
 		postStartTicks = 0
 		radiate()
 

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -31,9 +31,6 @@
 		msg = "Unidentified hackers have targetted a combat drone wing deployed from the NMV Icarus. If any are sighted in the area, approach with caution."
 	command_announcement.Announce(msg, "Rogue drone alert")
 
-/datum/event/rogue_drone/tick()
-	return
-
 /datum/event/rogue_drone/end()
 	var/num_recovered = 0
 	for(var/mob/living/simple_animal/hostile/retaliate/malf_drone/D in drones_list)


### PR DESCRIPTION
Numbers were previously based on the assumption that the default number of master ticks were 10 rather than 20.
