### PR TITLE
Changed bloodpack crate path in supplypacks.dm

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -380,7 +380,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containername = "Medical crate"
 	group = "Medical"
 
-/datum/supply_packs/medical
+/datum/supply_packs/bloodpack
 	name = "BloodPack crate"
 	contains = list(/obj/item/weapon/storage/box/bloodpacks,
                     /obj/item/weapon/storage/box/bloodpacks,


### PR DESCRIPTION
It's now `/datum/supply_packs/bloodpack`. Fixes #7409.
