### PR TITLE
Fixes mercenary mode showing up as nuclear in vote

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -9,6 +9,7 @@ datum/controller/vote
 	var/mode = null
 	var/question = null
 	var/list/choices = list()
+	var/list/gamemode_names = list()
 	var/list/voted = list()
 	var/list/voting = list()
 	var/list/current_votes = list()
@@ -217,6 +218,7 @@ datum/controller/vote
 						for (var/T in L)
 							var/datum/game_mode/M = new T()
 							if (M.config_tag == F)
+								gamemode_names[M.config_tag] = capitalize(M.name) //It's ugly to put this here but it works
 								additional_text.Add("<td align = 'center'>[M.required_players]</td>")
 								break
 				if("crew_transfer")
@@ -308,9 +310,9 @@ datum/controller/vote
 				if(!votes)	votes = 0
 				. += "<tr>"
 				if(current_votes[C.ckey] == i)
-					. += "<td><b><a href='?src=\ref[src];vote=[i]'>[choices[i]]</a></b></td><td align = 'center'>[votes]</td>"
+					. += "<td><b><a href='?src=\ref[src];vote=[i]'>[gamemode_names[choices[i]]]</a></b></td><td align = 'center'>[votes]</td>"
 				else
-					. += "<td><a href='?src=\ref[src];vote=[i]'>[choices[i]]</a></b></td><td align = 'center'>[votes]</td>"
+					. += "<td><a href='?src=\ref[src];vote=[i]'>[gamemode_names[choices[i]]]</a></b></td><td align = 'center'>[votes]</td>"
 
 				if (additional_text.len >= i)
 					. += additional_text[i]


### PR DESCRIPTION
All gamemodes in the vote just take the actual game mode name instead of the config name now. I hope this doesn't break things. Needs some testing. It also arguably uses some hacky code, but that shouldn't really be an issue since all the code in voting.dm is a mess anyway.
