### PR TITLE
Crypods now displays the name of occupant.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -381,7 +381,7 @@
 			// Delete the mob.
 			del(occupant)
 			occupant = null
-
+			name = initial(name)
 
 	return
 
@@ -442,7 +442,6 @@
 			src.add_fingerprint(M)
 
 /obj/machinery/cryopod/verb/eject()
-
 	set name = "Eject Pod"
 	set category = "Object"
 	set src in oview(1)
@@ -464,6 +463,8 @@
 
 	src.go_out()
 	add_fingerprint(usr)
+
+	name = initial(name)
 	return
 
 /obj/machinery/cryopod/verb/move_inside()
@@ -511,6 +512,7 @@
 		time_entered = world.time
 
 		src.add_fingerprint(usr)
+		name = "[name] ([usr.name])"
 
 	return
 


### PR DESCRIPTION
When entering a cryopod the name of the occupant is appended to its name.
This allows the AI, and others, to at a glance see who is being processed.
