### PR TITLE
Fixes manual runtimes, ensures initialize is called even after round start

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -111,8 +111,6 @@
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 		update_icon()
-		if(ticker && ticker.current_state == 3)//if the game is running
-			src.initialize()
 		return
 
 	first_run()

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -13,7 +13,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Station Repairs and Construction"
 
-/obj/item/weapon/book/manual/engineering_construction/New()
+/obj/item/weapon/book/manual/engineering_construction/initialize()
 	..()
 	dat = {"
 
@@ -34,7 +34,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Particle Accelerator User's Guide"
 
-/obj/item/weapon/book/manual/engineering_particle_accelerator/New()
+/obj/item/weapon/book/manual/engineering_particle_accelerator/initialize()
 	..()
 	dat = {"<html>
 				<head>
@@ -81,7 +81,7 @@
 	author = "Waleed Asad"
 	title = "Supermatter Engine User's Guide"
 
-/obj/item/weapon/book/manual/supermatter_engine/New()
+/obj/item/weapon/book/manual/supermatter_engine/initialize()
 	..()
 	dat = {"<html>
 				<head>
@@ -193,7 +193,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Hacking"
 
-/obj/item/weapon/book/manual/engineering_hacking/New()
+/obj/item/weapon/book/manual/engineering_hacking/initialize()
 	..()
 	dat = {"
 
@@ -750,7 +750,7 @@
 	author = "NanoTrasen"
 	title = "Corporate Regulations"
 
-/obj/item/weapon/book/manual/security_space_law/New()
+/obj/item/weapon/book/manual/security_space_law/initialize()
 	..()
 	dat = {"
 
@@ -774,7 +774,7 @@
 	author = "NanoTrasen Medicine Department"
 	title = "NT Medical Diagnostics Manual"
 
-/obj/item/weapon/book/manual/medical_diagnostics_manual/New()
+/obj/item/weapon/book/manual/medical_diagnostics_manual/initialize()
 	..()
 	dat = {"<html>
 				<head>
@@ -821,7 +821,7 @@
 	author = "Engineering Encyclopedia"
 	title = "Engineering Textbook"
 
-/obj/item/weapon/book/manual/engineering_guide/New()
+/obj/item/weapon/book/manual/engineering_guide/initialize()
 	..()
 	dat = {"
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -16,6 +16,12 @@
 	var/damtype = "brute"
 	var/force = 0
 
+/obj/New()
+	..()
+	// If the game is already underway initialize will no longer be called for us
+	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
+		initialize()
+
 /obj/Topic(href, href_list, var/nowindow = 0)
 	// Calling Topic without a corresponding window open causes runtime errors
 	if(nowindow)


### PR DESCRIPTION
Manuals would cause a runtime on server start due to configuration not yet being initialized.
A small but potentially far reaching change in objs.dm.
