### PR TITLE
Allows observers to face what they examine/point at.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -338,7 +338,7 @@
 				is_buckled = 1
 		else
 			is_buckled = 0
-	if( is_buckled || !A || !x || !y || !A.x || !A.y || (stat && !isobserver(src))) return
+	if(!A || !x || !y || !A.x || !A.y) return
 	var/dx = A.x - x
 	var/dy = A.y - y
 	if(!dx && !dy) return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -605,3 +605,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		src << "<span class='info'>Your key won't be shown when you speak in dead chat.</span>"
 	else
 		src << "<span class='info'>Your key will be publicly visible again.</span>"
+
+/mob/dead/observer/canface()
+	return 1


### PR DESCRIPTION
Also removes redundant checks no longer required after someone remade or added canface().

Was initially an attempt to fix lying mobs being unable to change facing to but https://github.com/Baystation12/Baystation12/blob/master/code/modules/mob/mob.dm#L764 complicates this.

Could perhaps change the canface() proc to something like below, but I'm not sure it's worth it simply to allow people lying down to turn about due to probably getting around all sorts of no-move cases in the !canmove check.

```
/mob/proc/canface()
    if(client.moving)                   return 0
    if(world.time < client.move_delay)  return 0
    if(stat==2)                         return 0
    if(anchored)                        return 0
    if(monkeyizing)                     return 0
    if(restrained())                    return 0
    if(resting)                         return 1
    if(!canmove)                        return 0
    return 1
```
