### PR TITLE
Adds NOBLOODY to holoswords

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -395,7 +395,7 @@ var/global/list/holodeck_programs = list(
 	throw_range = 5
 	throwforce = 0
 	w_class = 2.0
-	flags = FPRINT | TABLEPASS | NOSHIELD
+	flags = FPRINT | TABLEPASS | NOSHIELD | NOBLOODY
 	var/active = 0
 
 /obj/item/weapon/holo/esword/green


### PR DESCRIPTION
Although to be honest I think I would rather remove NOBLOODY from this and the energy swords and instead remove the blood overlay when the blade is derezzed. Energy swords deal brute damage, I feel like they are closer in nature to the dragon's tooth from Deus Ex than something like a lightsaber.
