### PR TITLE
Replaces dummy reagent colours

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents-Antidepressants.dm
+++ b/code/modules/reagents/Chemistry-Reagents-Antidepressants.dm
@@ -5,7 +5,7 @@
 	id = "methylphenidate"
 	description = "Improves the ability to concentrate."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#BF80BF"
 	custom_metabolism = 0.01
 	data = 0
 
@@ -33,7 +33,7 @@
 	id = "citalopram"
 	description = "Stabilizes the mind a little."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#FF80FF"
 	custom_metabolism = 0.01
 	data = 0
 
@@ -62,7 +62,7 @@
 	id = "paroxetine"
 	description = "Stabilizes the mind greatly, but has a chance of adverse effects."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#FF80BF"
 	custom_metabolism = 0.01
 	data = 0
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -712,7 +712,7 @@ datum
 			id = "ryetalyn"
 			description = "Ryetalyn can cure all genetic abnomalities via a catalytic process."
 			reagent_state = SOLID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#004000" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE
 
 			on_mob_life(var/mob/living/M as mob)
@@ -759,7 +759,7 @@ datum
 			id = "paracetamol"
 			description = "Most probably know this as Tylenol, but this chemical is a mild, simple painkiller."
 			reagent_state = LIQUID
-			color = "#C855DC"
+			color = "#C8A5DC"
 			overdose = 60
 			scannable = 1
 			custom_metabolism = 0.025 // Lasts 10 minutes for 15 units
@@ -775,7 +775,7 @@ datum
 			id = "tramadol"
 			description = "A simple, yet effective painkiller."
 			reagent_state = LIQUID
-			color = "#C8A5DC"
+			color = "#CB68FC"
 			overdose = 30
 			scannable = 1
 			custom_metabolism = 0.025 // Lasts 10 minutes for 15 units
@@ -791,7 +791,7 @@ datum
 			id = "oxycodone"
 			description = "An effective and very addictive painkiller."
 			reagent_state = LIQUID
-			color = "#C805DC"
+			color = "#800080"
 			overdose = 20
 			custom_metabolism = 0.25 // Lasts 10 minutes for 15 units
 
@@ -856,7 +856,7 @@ datum
 			id = "iron"
 			description = "Pure iron is a metal."
 			reagent_state = SOLID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#353535"
 			overdose = REAGENTS_OVERDOSE
 
 		gold
@@ -1015,7 +1015,7 @@ datum
 			id = "cryptobiolin"
 			description = "Cryptobiolin causes confusion and dizzyness."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#000055" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE
 
 			on_mob_life(var/mob/living/M as mob)
@@ -1033,7 +1033,7 @@ datum
 			id = "kelotane"
 			description = "Kelotane is a drug used to treat burns."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#FFA800" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
 
@@ -1051,7 +1051,7 @@ datum
 			id = "dermaline"
 			description = "Dermaline is the next step in burn medication. Works twice as good as kelotane and enables the body to restore even the direst heat-damaged tissue."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#FF8000" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE/2
 			scannable = 1
 
@@ -1069,7 +1069,7 @@ datum
 			id = "dexalin"
 			description = "Dexalin is used in the treatment of oxygen deprivation."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#0080FF" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
 
@@ -1092,7 +1092,7 @@ datum
 			id = "dexalinp"
 			description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#0040FF" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE/2
 			scannable = 1
 
@@ -1115,7 +1115,7 @@ datum
 			id = "tricordrazine"
 			description = "Tricordrazine is a highly potent stimulant, originally derived from cordrazine. Can be used to treat a wide range of injuries."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#8040FF" // rgb: 200, 165, 220
 			scannable = 1
 
 			on_mob_life(var/mob/living/M as mob, var/alien)
@@ -1135,7 +1135,7 @@ datum
 			id = "anti_toxin"
 			description = "Dylovene is a broad-spectrum antitoxin."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#00A000" // rgb: 200, 165, 220
 			scannable = 1
 
 			on_mob_life(var/mob/living/M as mob, var/alien)
@@ -1190,13 +1190,13 @@ datum
 						D.cure()
 				..()
 				return
-
 		synaptizine
+
 			name = "Synaptizine"
 			id = "synaptizine"
 			description = "Synaptizine is used to treat various diseases."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#99CCFF" // rgb: 200, 165, 220
 			custom_metabolism = 0.01
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
@@ -1235,7 +1235,7 @@ datum
 			id = "hyronalin"
 			description = "Hyronalin is a medicinal drug used to counter the effect of radiation poisoning."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#408000" // rgb: 200, 165, 220
 			custom_metabolism = 0.05
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
@@ -1251,7 +1251,7 @@ datum
 			id = "arithrazine"
 			description = "Arithrazine is an unstable medication used for the most extreme cases of radiation poisoning."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#008000" // rgb: 200, 165, 220
 			custom_metabolism = 0.05
 			overdose = REAGENTS_OVERDOSE
 
@@ -1271,7 +1271,7 @@ datum
 			id = "alkysine"
 			description = "Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#FFFF66" // rgb: 200, 165, 220
 			custom_metabolism = 0.05
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
@@ -1309,7 +1309,7 @@ datum
 			id = "peridaxon"
 			description = "Used to encourage recovery of internal organs and nervous systems. Medicate cautiously."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#561EC3" // rgb: 200, 165, 220
 			overdose = 10
 			scannable = 1
 
@@ -1330,7 +1330,7 @@ datum
 			id = "bicaridine"
 			description = "Bicaridine is an analgesic medication and can be used to treat blunt trauma."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#BF0000" // rgb: 200, 165, 220
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
 
@@ -1348,7 +1348,7 @@ datum
 			id = "hyperzine"
 			description = "Hyperzine is a highly effective, long lasting, muscle stimulant."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#FF3300" // rgb: 200, 165, 220
 			custom_metabolism = 0.03
 			overdose = REAGENTS_OVERDOSE/2
 
@@ -1378,7 +1378,7 @@ datum
 			id = "cryoxadone"
 			description = "A chemical mixture with almost magical healing powers. Its main limitation is that the targets body temperature must be under 170K for it to metabolise correctly."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#8080FF" // rgb: 200, 165, 220
 			scannable = 1
 
 			on_mob_life(var/mob/living/M as mob)
@@ -1396,7 +1396,7 @@ datum
 			id = "clonexadone"
 			description = "A liquid compound similar to that used in the cloning process. Can be used to 'finish' the cloning process when used in conjunction with a cryo tube."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#80BFFF" // rgb: 200, 165, 220
 			scannable = 1
 
 			on_mob_life(var/mob/living/M as mob)
@@ -1443,7 +1443,7 @@ datum
 			id = "spaceacillin"
 			description = "An all-purpose antiviral agent."
 			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
+			color = "#C1C1C1" // rgb: 200, 165, 220
 			custom_metabolism = 0.01
 			overdose = REAGENTS_OVERDOSE
 			scannable = 1
@@ -1595,7 +1595,7 @@ datum
 			id = "phoron"
 			description = "Phoron in its liquid form."
 			reagent_state = LIQUID
-			color = "#E71B00" // rgb: 231, 27, 0
+			color = "#00BFFF" // rgb: 231, 27, 0
 			toxpwr = 3
 
 			on_mob_life(var/mob/living/M as mob)
@@ -1812,7 +1812,7 @@ datum
 			id = "stoxin"
 			description = "An effective hypnotic used to treat insomnia."
 			reagent_state = LIQUID
-			color = "#E895CC" // rgb: 232, 149, 204
+			color = "#009CA8" // rgb: 232, 149, 204
 			toxpwr = 0
 			custom_metabolism = 0.1
 			overdose = REAGENTS_OVERDOSE


### PR DESCRIPTION
Replaces the dummy reagent colours on dev-freeze. Similar to what Hubblenaut was trying to do earlier, except this only changes the colours and nothing else.

Uses the colours from the forum thread, with some minor adjustments. Kelotane/Dermaline were made a bit more yellow. Tramadol was made a bit more pale. I also threw in some colours for the missing reagents.
