### PR TITLE
Alternative fix for manual runtimes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -504,11 +504,6 @@
 				if("python_path")
 					if(value)
 						config.python_path = value
-					else
-						if(world.system_type == UNIX)
-							config.python_path = "/usr/bin/env python2"
-						else //probably windows, if not this should work anyway
-							config.python_path = "python"
 
 				if("use_lib_nudge")
 					config.use_lib_nudge = 1
@@ -741,3 +736,11 @@
 			runnable_modes[M] = probabilities[M.config_tag]
 			//world << "DEBUG: runnable_mode\[[runnable_modes.len]\] = [M.config_tag]"
 	return runnable_modes
+
+/datum/configuration/proc/post_load()
+	//apply a default value to config.python_path, if needed
+	if (!config.python_path)
+		if(world.system_type == UNIX)
+			config.python_path = "/usr/bin/env python2"
+		else //probably windows, if not this should work anyway
+			config.python_path = "python"

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -111,6 +111,8 @@
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 		update_icon()
+		if(ticker && ticker.current_state == 3)//if the game is running
+			src.initialize()
 		return
 
 	first_run()

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1,6 +1,5 @@
 /*********************MANUALS (BOOKS)***********************/
 
-//Oh god what the fuck I am not good at computer
 /obj/item/weapon/book/manual
 	icon = 'icons/obj/library.dmi'
 	due_date = 0 // Game time in 1/10th seconds
@@ -13,7 +12,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Station Repairs and Construction"
 
-/obj/item/weapon/book/manual/engineering_construction/initialize()
+/obj/item/weapon/book/manual/engineering_construction/New()
 	..()
 	dat = {"
 
@@ -34,7 +33,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Particle Accelerator User's Guide"
 
-/obj/item/weapon/book/manual/engineering_particle_accelerator/initialize()
+/obj/item/weapon/book/manual/engineering_particle_accelerator/New()
 	..()
 	dat = {"<html>
 				<head>
@@ -81,7 +80,7 @@
 	author = "Waleed Asad"
 	title = "Supermatter Engine User's Guide"
 
-/obj/item/weapon/book/manual/supermatter_engine/initialize()
+/obj/item/weapon/book/manual/supermatter_engine/New()
 	..()
 	dat = {"<html>
 				<head>
@@ -193,7 +192,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Hacking"
 
-/obj/item/weapon/book/manual/engineering_hacking/initialize()
+/obj/item/weapon/book/manual/engineering_hacking/New()
 	..()
 	dat = {"
 
@@ -750,7 +749,7 @@
 	author = "NanoTrasen"
 	title = "Corporate Regulations"
 
-/obj/item/weapon/book/manual/security_space_law/initialize()
+/obj/item/weapon/book/manual/security_space_law/New()
 	..()
 	dat = {"
 
@@ -774,7 +773,7 @@
 	author = "NanoTrasen Medicine Department"
 	title = "NT Medical Diagnostics Manual"
 
-/obj/item/weapon/book/manual/medical_diagnostics_manual/initialize()
+/obj/item/weapon/book/manual/medical_diagnostics_manual/New()
 	..()
 	dat = {"<html>
 				<head>
@@ -821,7 +820,7 @@
 	author = "Engineering Encyclopedia"
 	title = "Engineering Textbook"
 
-/obj/item/weapon/book/manual/engineering_guide/initialize()
+/obj/item/weapon/book/manual/engineering_guide/New()
 	..()
 	dat = {"
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -16,12 +16,6 @@
 	var/damtype = "brute"
 	var/force = 0
 
-/obj/New()
-	..()
-	// If the game is already underway initialize will no longer be called for us
-	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
-		initialize()
-
 /obj/Topic(href, href_list, var/nowindow = 0)
 	// Calling Topic without a corresponding window open causes runtime errors
 	if(nowindow)

--- a/code/world.dm
+++ b/code/world.dm
@@ -6,6 +6,7 @@ var/global/datum/global_init/init = new ()
 /datum/global_init/New()
 
 	makeDatumRefLists()
+	load_configuration()
 
 	del(src)
 
@@ -33,8 +34,8 @@ var/global/datum/global_init/init = new ()
 	if(byond_version < RECOMMENDED_VERSION)
 		world.log << "Your server's byond version does not meet the recommended requirements for this server. Please update BYOND"
 
-	load_configuration()
-
+	config.post_load()
+	
 	if(config && config.server_name != null && config.server_suffix && world.port > 0)
 		// dumb and hardcoded but I don't care~
 		config.server_name += " #[(world.port % 1000) / 100]"
@@ -259,7 +260,7 @@ var/world_topic_spam_protect_time = world.timeofday
 	join_motd = file2text("config/motd.txt")
 
 
-/world/proc/load_configuration()
+/proc/load_configuration()
 	config = new /datum/configuration()
 	config.load("config/config.txt")
 	config.load("config/game_options.txt","game_options")


### PR DESCRIPTION
This PR proposes an alternative solution to the manual runtime, by loading the configuration before the map is created. This way we do not have to modify the creation of every object to get manuals to work.
