### PR TITLE
Removes ninja mask, fixes ninja internals, fixes non-ninja voice changer

### DIFF
--- a/code/game/gamemodes/events/space_ninja.dm
+++ b/code/game/gamemodes/events/space_ninja.dm
@@ -531,7 +531,6 @@ As such, it's hard-coded for now. No reason for it not to be, really.
 	else
 		equip_to_slot_or_del(new /obj/item/clothing/under/color/black(src), slot_w_uniform)
 
-	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/voice/space_ninja(src), slot_wear_mask)
 	equip_to_slot_or_del(new /obj/item/device/flashlight(src), slot_belt)
 
 	var/obj/item/weapon/rig/light/ninja/ninjasuit = new(src)
@@ -546,16 +545,16 @@ As such, it's hard-coded for now. No reason for it not to be, really.
 
 	equip_to_slot_or_del(ninjasuit,slot_back)
 
-	if(istype(wear_suit,/obj/item/weapon/rig))
-		var/obj/item/weapon/rig/rig = wear_suit
-		if(rig.air_supply)
-			internal = rig.air_supply
-	if(!internal && s_store)
-		internal = s_store
-	if(internal)
-		internals.icon_state = "internal1"
-
 	spawn(10)
 		ninjasuit.toggle_seals(src,1)
+
+		if(istype(back,/obj/item/weapon/rig))
+			var/obj/item/weapon/rig/rig = back
+			if(rig.air_supply)
+				internal = rig.air_supply
+		if(!internal && s_store)
+			internal = s_store
+		if(internal)
+			internals.icon_state = "internal1"
 
 	return 1

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -10,13 +10,22 @@
 	var/obj/item/voice_changer/changer
 	origin_tech = "syndicate=4"
 
+/obj/item/clothing/mask/gas/voice/verb/Toggle_Voice_Changer()
+	set category = "Object"
+	set src in usr
+
+	changer.active = !changer.active
+	usr << "\blue You [changer.active ? "enable" : "disable"] the voice-changing module in \the [src]."
+
+/obj/item/clothing/mask/gas/voice/verb/Set_Voice(name as text)
+	set category = "Object"
+	set src in usr
+
+	var/voice = sanitize(copytext(name,1,MAX_MESSAGE_LEN))
+	if(!voice || !length(voice)) return
+	changer.voice = voice
+	usr << "\blue You are now mimicking <B>[changer.voice]</B>.</font>"
+
 /obj/item/clothing/mask/gas/voice/New()
 	..()
 	changer = new(src)
-
-/obj/item/clothing/mask/gas/voice/space_ninja
-	name = "ninja mask"
-	desc = "A close-fitting mask that acts both as an air filter and a post-modern fashion statement."
-	icon_state = "s-ninja"
-	item_state = "s-ninja_mask"
-	siemens_coefficient = 0.2

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -15,7 +15,7 @@
 	set src in usr
 
 	changer.active = !changer.active
-	usr << "\blue You [changer.active ? "enable" : "disable"] the voice-changing module in \the [src]."
+	usr << "<span class='notice'>You [changer.active ? "enable" : "disable"] the voice-changing module in \the [src].</span>"
 
 /obj/item/clothing/mask/gas/voice/verb/Set_Voice(name as text)
 	set category = "Object"
@@ -24,7 +24,7 @@
 	var/voice = sanitize(copytext(name,1,MAX_MESSAGE_LEN))
 	if(!voice || !length(voice)) return
 	changer.voice = voice
-	usr << "\blue You are now mimicking <B>[changer.voice]</B>.</font>"
+	usr << "<span class='notice'>You are now mimicking <B>[changer.voice]</B>.</span>"
 
 /obj/item/clothing/mask/gas/voice/New()
 	..()

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -269,7 +269,7 @@
 			if(!raw_choice)
 				return 0
 			voice_holder.voice = sanitize(copytext(raw_choice,1,MAX_MESSAGE_LEN))
-			usr << "You are now mimicking <B>[voice_holder.voice]</B>.</font>"
+			usr << "<font color='blue'>You are now mimicking <B>[voice_holder.voice]</B>.</font>"
 	return 1
 
 /obj/item/rig_module/maneuvering_jets


### PR DESCRIPTION
As in title.

Non-ninja voice changer now has verbs to toggle and set the voice.
Ninjas now do not start with disabled internals.
Ninja mask removed; its functionality is entirely duplicated by the ninja rig now.

Fixes #7465.
