### PR TITLE
Context-base Combat Cleanup and Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/alien/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/alien/alien_species.dm
@@ -5,7 +5,7 @@
 
 	default_language = "Xenomorph"
 	language = "Hivemind"
-	unarmed_type = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
+	unarmed_types = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
 	hud_type = /datum/hud_data/alien
 	rarity_value = 3
 

--- a/code/modules/mob/living/carbon/human/alien/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/alien/alien_species.dm
@@ -5,8 +5,7 @@
 
 	default_language = "Xenomorph"
 	language = "Hivemind"
-	unarmed_type = /datum/unarmed_attack/claws/strong
-	secondary_unarmed_type = /datum/unarmed_attack/bite/strong
+	unarmed_type = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
 	hud_type = /datum/hud_data/alien
 	rarity_value = 3
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -95,10 +95,14 @@
 				return
 
 			// See if they can attack, and which attacks to use.
-			var/datum/unarmed_attack/attack = H.species.unarmed
-			if(!attack.is_usable(H))
-				attack = H.species.secondary_unarmed
-			if(!attack.is_usable(H))
+			var/datum/unarmed_attack/attack = null
+			for(var/datum/unarmed_attack/u_attack in H.species.unarmed)
+				if(!u_attack.is_usable(H, src))
+					continue
+				else
+					attack = u_attack
+					break
+			if(!attack)
 				return 0
 
 			var/damage = rand(1, 5)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -94,17 +94,6 @@
 				attack_generic(H,rand(1,3),"punched")
 				return
 
-			// See if they can attack, and which attacks to use.
-			var/datum/unarmed_attack/attack = null
-			for(var/datum/unarmed_attack/u_attack in H.species.unarmed)
-				if(!u_attack.is_usable(H, src))
-					continue
-				else
-					attack = u_attack
-					break
-			if(!attack)
-				return 0
-
 			var/damage = rand(1, 5)
 			var/block = 0
 			var/accurate = 0
@@ -159,7 +148,11 @@
 				if(prob(80))
 					hit_zone = ran_zone(hit_zone)
 				if(prob(15) && hit_zone != "chest") // Missed!
-					attack_message = "[H] attempted to strike [src], but missed!"
+					if(!src.lying)
+						attack_message = "[H] attempted to strike [src], but missed!"
+					else
+						attack_message = "[H] attempted to strike [src], but \he rolled out of the way!"
+						src.dir = pick(1, 2, 4, 8)
 					miss_type = 1
 			else
 				hit_zone = ran_zone(hit_zone)
@@ -167,6 +160,17 @@
 			if(!miss_type && block)
 				attack_message = "[H] went for [src]'s [affecting.display_name] but was blocked!"
 				miss_type = 2
+
+			// See what attack they use
+			var/datum/unarmed_attack/attack = null
+			for(var/datum/unarmed_attack/u_attack in H.species.unarmed)
+				if(!u_attack.is_usable(H, src, hit_zone))
+					continue
+				else
+					attack = u_attack
+					break
+			if(!attack)
+				return 0
 
 			if(!attack_message)
 				attack.show_attack(H, src, hit_zone, damage)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -207,7 +207,7 @@
 	name_plural = "Humans"
 	language = "Sol Common"
 	primitive = /mob/living/carbon/monkey
-	unarmed_type = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
+	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
 
 	flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
@@ -221,7 +221,7 @@
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	language = "Sinta'unathi"
 	tail = "sogtail"
-	unarmed_type = list(/datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	primitive = /mob/living/carbon/monkey/unathi
 	darksight = 3
 	gluttonous = 1
@@ -248,7 +248,7 @@
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
 	language = "Siik'tajr"
 	tail = "tajtail"
-	unarmed_type = list(/datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
 
 	cold_level_1 = 200 //Default 260
@@ -290,7 +290,7 @@
 	deform = 'icons/mob/human_races/r_def_vox.dmi'
 	default_language = "Vox-pidgin"
 	language = "Galactic Common"
-	unarmed_type = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
+	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
 	rarity_value = 2
 
 	speech_sounds = list('sound/voice/shriek1.ogg')
@@ -377,7 +377,7 @@
 	icobase = 'icons/mob/human_races/r_diona.dmi'
 	deform = 'icons/mob/human_races/r_def_plant.dmi'
 	language = "Rootspeak"
-	unarmed_type = list(/datum/unarmed_attack/diona)
+	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/diona)
 	primitive = /mob/living/carbon/alien/diona
 	slowdown = 7
 	rarity_value = 3

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -12,17 +12,16 @@
 	var/prone_icon                                       // If set, draws this from icobase when mob is prone.
 	var/eyes = "eyes_s"                                  // Icon for eyes.
 
-	var/primitive                              // Lesser form, if any (ie. monkey for humans)
-	var/tail                                   // Name of tail image in species effects icon file.
-	var/datum/unarmed_attack/unarmed           // For empty hand harm-intent attack
-	var/datum/unarmed_attack/secondary_unarmed // For empty hand harm-intent attack if the first fails.
+	var/primitive                                 // Lesser form, if any (ie. monkey for humans)
+	var/tail                                      // Name of tail image in species effects icon file.
+	var/datum/unarmed_attack/list/unarmed = null  // For empty hand harm-intent attack
+	var/datum/unarmed_attack/secondary_unarmed    // For empty hand harm-intent attack if the first fails.
 	var/datum/hud_data/hud
 	var/hud_type
 	var/slowdown = 0
 	var/gluttonous        // Can eat some mobs. 1 for monkeys, 2 for people.
 	var/rarity_value = 1  // Relative rarity/collector value for this species. Only used by ninja and cultists atm.
-	var/unarmed_type =           /datum/unarmed_attack
-	var/secondary_unarmed_type = /datum/unarmed_attack/bite
+	var/unarmed_type = list(/datum/unarmed_attack, /datum/unarmed_attack/bite)
 
 	var/language                  // Default racial language, if any.
 	// Default language is used when 'say' is used without modifiers.
@@ -98,8 +97,9 @@
 	else
 		hud = new()
 
-	if(unarmed_type) unarmed = new unarmed_type()
-	if(secondary_unarmed_type) secondary_unarmed = new secondary_unarmed_type()
+	unarmed = list()
+	for(var/u_type in unarmed_type)
+		unarmed += new u_type()
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
@@ -207,7 +207,7 @@
 	name_plural = "Humans"
 	language = "Sol Common"
 	primitive = /mob/living/carbon/monkey
-	unarmed_type = /datum/unarmed_attack/punch
+	unarmed_type = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
 
 	flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
@@ -221,8 +221,7 @@
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	language = "Sinta'unathi"
 	tail = "sogtail"
-	unarmed_type = /datum/unarmed_attack/claws
-	secondary_unarmed_type = /datum/unarmed_attack/bite/sharp
+	unarmed_type = list(/datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	primitive = /mob/living/carbon/monkey/unathi
 	darksight = 3
 	gluttonous = 1
@@ -249,8 +248,7 @@
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
 	language = "Siik'tajr"
 	tail = "tajtail"
-	unarmed_type = /datum/unarmed_attack/claws
-	secondary_unarmed_type = /datum/unarmed_attack/bite/sharp
+	unarmed_type = list(/datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
 
 	cold_level_1 = 200 //Default 260
@@ -276,7 +274,7 @@
 	eyes = "skrell_eyes_s"
 	language = "Skrellian"
 	primitive = /mob/living/carbon/monkey/skrell
-	unarmed_type = /datum/unarmed_attack/punch
+	unarmed_type = list(/datum/unarmed_attack/punch)
 
 	flags = IS_WHITELISTED | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR
 
@@ -292,8 +290,7 @@
 	deform = 'icons/mob/human_races/r_def_vox.dmi'
 	default_language = "Vox-pidgin"
 	language = "Galactic Common"
-	unarmed_type = /datum/unarmed_attack/claws/strong
-	secondary_unarmed_type = /datum/unarmed_attack/bite/strong
+	unarmed_type = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
 	rarity_value = 2
 
 	speech_sounds = list('sound/voice/shriek1.ogg')
@@ -380,8 +377,7 @@
 	icobase = 'icons/mob/human_races/r_diona.dmi'
 	deform = 'icons/mob/human_races/r_def_plant.dmi'
 	language = "Rootspeak"
-	unarmed_type = /datum/unarmed_attack/diona
-	secondary_unarmed_type = null //Does a walking mass of dionaea even have jaws, as we understand them?
+	unarmed_type = list(/datum/unarmed_attack/diona)
 	primitive = /mob/living/carbon/alien/diona
 	slowdown = 7
 	rarity_value = 3
@@ -447,8 +443,7 @@
 	icobase = 'icons/mob/human_races/r_machine.dmi'
 	deform = 'icons/mob/human_races/r_machine.dmi'
 	language = "Tradeband"
-	unarmed_type = /datum/unarmed_attack/punch
-	secondary_unarmed_type = null
+	unarmed_type = list(/datum/unarmed_attack/punch)
 	rarity_value = 2
 
 	eyes = "blank_eyes"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -14,14 +14,13 @@
 
 	var/primitive                                 // Lesser form, if any (ie. monkey for humans)
 	var/tail                                      // Name of tail image in species effects icon file.
-	var/datum/unarmed_attack/list/unarmed = null  // For empty hand harm-intent attack
-	var/datum/unarmed_attack/secondary_unarmed    // For empty hand harm-intent attack if the first fails.
+	var/list/unarmed_attacks = null  // For empty hand harm-intent attack
 	var/datum/hud_data/hud
 	var/hud_type
 	var/slowdown = 0
 	var/gluttonous        // Can eat some mobs. 1 for monkeys, 2 for people.
 	var/rarity_value = 1  // Relative rarity/collector value for this species. Only used by ninja and cultists atm.
-	var/unarmed_type = list(/datum/unarmed_attack, /datum/unarmed_attack/bite)
+	var/list/unarmed_types = list(/datum/unarmed_attack, /datum/unarmed_attack/bite)
 
 	var/language                  // Default racial language, if any.
 	// Default language is used when 'say' is used without modifiers.
@@ -97,9 +96,9 @@
 	else
 		hud = new()
 
-	unarmed = list()
-	for(var/u_type in unarmed_type)
-		unarmed += new u_type()
+	unarmed_attacks = list()
+	for(var/u_type in unarmed_types)
+		unarmed_attacks += new u_type()
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
@@ -207,7 +206,7 @@
 	name_plural = "Humans"
 	language = "Sol Common"
 	primitive = /mob/living/carbon/monkey
-	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
 
 	flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
@@ -221,7 +220,7 @@
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	language = "Sinta'unathi"
 	tail = "sogtail"
-	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	primitive = /mob/living/carbon/monkey/unathi
 	darksight = 3
 	gluttonous = 1
@@ -248,7 +247,7 @@
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
 	language = "Siik'tajr"
 	tail = "tajtail"
-	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
 
 	cold_level_1 = 200 //Default 260
@@ -274,7 +273,7 @@
 	eyes = "skrell_eyes_s"
 	language = "Skrellian"
 	primitive = /mob/living/carbon/monkey/skrell
-	unarmed_type = list(/datum/unarmed_attack/punch)
+	unarmed_types = list(/datum/unarmed_attack/punch)
 
 	flags = IS_WHITELISTED | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR
 
@@ -290,7 +289,7 @@
 	deform = 'icons/mob/human_races/r_def_vox.dmi'
 	default_language = "Vox-pidgin"
 	language = "Galactic Common"
-	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
 	rarity_value = 2
 
 	speech_sounds = list('sound/voice/shriek1.ogg')
@@ -377,7 +376,7 @@
 	icobase = 'icons/mob/human_races/r_diona.dmi'
 	deform = 'icons/mob/human_races/r_def_plant.dmi'
 	language = "Rootspeak"
-	unarmed_type = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/diona)
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/diona)
 	primitive = /mob/living/carbon/alien/diona
 	slowdown = 7
 	rarity_value = 3
@@ -443,7 +442,7 @@
 	icobase = 'icons/mob/human_races/r_machine.dmi'
 	deform = 'icons/mob/human_races/r_machine.dmi'
 	language = "Tradeband"
-	unarmed_type = list(/datum/unarmed_attack/punch)
+	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2
 
 	eyes = "blank_eyes"
@@ -479,11 +478,10 @@
 	if(H.a_intent != "hurt")
 		return 0
 
-	if(unarmed.is_usable(H))
-		if(unarmed.shredding)
-			return 1
-	else if(secondary_unarmed.is_usable(H))
-		if(secondary_unarmed.shredding)
+	for(var/datum/unarmed_attack/attack in unarmed_attacks)
+		if(!attack.is_usable(H))
+			continue
+		if(attack.shredding)
 			return 1
 
 	return 0

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -9,7 +9,7 @@
 	var/sharp = 0
 	var/edge = 0
 
-/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user)
+/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/victim)
 	if(user.restrained())
 		return 0
 
@@ -91,7 +91,7 @@
 	sharp = 1
 	edge = 1
 
-/datum/unarmed_attack/bite/is_usable(var/mob/living/carbon/human/user)
+/datum/unarmed_attack/bite/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/victim)
 	if (user.wear_mask && istype(user.wear_mask, /obj/item/clothing/mask/muzzle))
 		return 0
 	return 1

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -147,7 +147,7 @@
 	else
 		if (M.a_intent == "hurt")
 			var/datum/unarmed_attack/attack = null
-			for(var/datum/unarmed_attack/u_attack in M.species.unarmed)
+			for(var/datum/unarmed_attack/u_attack in M.species.unarmed_attacks)
 				if(!u_attack.is_usable(M, src))
 					continue
 				else
@@ -156,7 +156,7 @@
 			if(!attack)
 				return 0
 			if ((prob(75) && health > 0))
-				visible_message("\red <B>[M] [pick(attack.attack_verb)]ed [src]!</B>")
+				visible_message("\red <B>[M] [pick(attack.attack_verb)] [src]!</B>")
 
 				playsound(loc, "punch", 25, 1, -1)
 				var/damage = rand(5, 10)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -146,7 +146,15 @@
 		help_shake_act(M)
 	else
 		if (M.a_intent == "hurt")
-			var/datum/unarmed_attack/attack = M.species.unarmed
+			var/datum/unarmed_attack/attack = null
+			for(var/datum/unarmed_attack/u_attack in M.species.unarmed)
+				if(!u_attack.is_usable(M, src))
+					continue
+				else
+					attack = u_attack
+					break
+			if(!attack)
+				return 0
 			if ((prob(75) && health > 0))
 				visible_message("\red <B>[M] [pick(attack.attack_verb)]ed [src]!</B>")
 


### PR DESCRIPTION
Species will now use a list of unarmed_attacks that will be checked for usability in the order the list contains them.
The kicking and stomping attack logs from the unarmed_attack punch were moved to their own unarmed_attacks called kick and stomp and made available to player races.

Furthermore, quite a few fixes for stuff that was broken still, including a runtime error and several calculation misakes.
