### PR TITLE
Reserve PascalCase inits

### DIFF
--- a/code/controllers/lighting_controller.dm
+++ b/code/controllers/lighting_controller.dm
@@ -65,7 +65,7 @@ datum/controller/lighting/proc/process()
 //Does not loop. Should be run prior to process() being called for the first time.
 //Note: if we get additional z-levels at runtime (e.g. if the gateway thin ever gets finished) we can initialize specific
 //z-levels with the z_level argument
-datum/controller/lighting/proc/Initialize(var/z_level)
+datum/controller/lighting/proc/initializeLighting(var/z_level)
 	processing = 0
 	spawn(-1)
 		set background = 1

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -84,7 +84,7 @@ datum/controller/game_controller/proc/setup()
 		if(ticker)
 			ticker.pregame()
 
-	lighting_controller.Initialize()
+	lighting_controller.initializeLighting()
 
 
 datum/controller/game_controller/proc/setup_objects()

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -16,11 +16,11 @@
 
 	New(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
 		..()
-		if(!Init(arglist(args)))
+		if(!initTeleport(arglist(args)))
 			return 0
 		return 1
 
-	proc/Init(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
+	proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
 		if(!setTeleatom(ateleatom))
 			return 0
 		if(!setDestination(adestination))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -33,7 +33,7 @@
 	var/datum/dna2/record/buf=null
 	var/read_only = 0 //Well,it's still a floppy disk
 
-/obj/item/weapon/disk/data/proc/Initialize()
+/obj/item/weapon/disk/data/proc/initializeDisk()
 	buf = new
 	buf.dna=new
 
@@ -42,7 +42,7 @@
 	read_only = 1
 
 	New()
-		Initialize()
+		initializeDisk()
 		buf.types=DNA2_BUF_UE|DNA2_BUF_UI
 		//data = "066000033000000000AF00330660FF4DB002690"
 		//data = "0C80C80C80C80C80C8000000000000161FBDDEF" - Farmer Jeff
@@ -57,7 +57,7 @@
 	read_only = 1
 
 	New()
-		Initialize()
+		initializeDisk()
 		buf.types=DNA2_BUF_SE
 		var/list/new_SE=list(0x098,0x3E8,0x403,0x44C,0x39F,0x4B0,0x59D,0x514,0x5FC,0x578,0x5DC,0x640,0x6A4)
 		for(var/i=new_SE.len;i<=DNA_SE_LENGTH;i++)


### PR DESCRIPTION
Makes the existing (handful of) uses of `Init()` and `Initialize()` into more descriptive camelCase. 
Would like to use the PascalCase version for stdlib (soon(tm)).

also github allowing forking parent repos when, this took far too long
