### PR TITLE
Ion Law Visibility

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -527,6 +527,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			M.add_ion_law(input)
 			for(var/mob/living/silicon/ai/O in mob_list)
 				O << "\red " + input + "\red...LAWS UPDATED"
+				O.show_laws()
 
 	log_admin("Admin [key_name(usr)] has added a new AI law - [input]")
 	message_admins("Admin [key_name_admin(usr)] has added a new AI law - [input]", 1)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -75,6 +75,7 @@
 		target << "\red <b>You have detected a change in your laws information:</b>"
 		target << law
 		target.add_ion_law(law)
+		target.show_laws()
 
 	if(message_servers)
 		for (var/obj/machinery/message_server/MS in message_servers)

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -36,7 +36,7 @@
 	src.laws.add_ion_law(law)
 	for(var/mob/living/silicon/robot/R in mob_list)
 		if(R.lawupdate && (R.connected_ai == src))
-			R << "\red " + law + "\red...LAWS UPDATED"
+			R.show_laws()
 
 /mob/living/silicon/ai/proc/clear_ion_laws()
 	src.laws_sanity_check()


### PR DESCRIPTION
Ion laws (including the "random" ones by admins) are now more visible for the AI/robots when added.

Instead of simple "THIS IS A LAW ... LAWS UPDATED"-like text it shows full output of show-laws verb, which is much harder to miss. Single line of text is easy to miss in stressful situations when multiple radio channels are spammed.
