### PR TITLE
Changes in unarmed_attacks kick and stomp

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing
 	name = "clothing"
 	siemens_coefficient = 0.9
+	var/unarmed_damage = 0 //Damage modificator for unarmed_attacks (stomps, headbutts, boxing gloves ect)
 	var/list/species_restricted = null //Only these species can wear this kit.
 
 	/*
@@ -352,6 +353,7 @@ BLIND     // can't see anything
 
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
+	unarmed_damage = 2
 	species_restricted = list("exclude","Unathi","Tajara")
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/shoes.dmi')
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -3,6 +3,7 @@
 	name = "magboots"
 	icon_state = "magboots0"
 	species_restricted = null
+	unarmed_damage = 3
 	var/magpulse = 0
 	var/icon_base = "magboots"
 	icon_action_button = "action_blank"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -19,6 +19,7 @@
 	name = "\improper SWAT shoes"
 	desc = "When you want to turn up the heat."
 	icon_state = "swat"
+	unarmed_damage = 3
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	flags = NOSLIP
 	siemens_coefficient = 0.6
@@ -27,6 +28,7 @@
 	name = "combat boots"
 	desc = "When you REALLY want to turn up the heat"
 	icon_state = "swat"
+	unarmed_damage = 5
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	flags = NOSLIP
 	siemens_coefficient = 0.6
@@ -65,6 +67,7 @@
 	item_state = "clown_shoes"
 	slowdown = SHOES_SLOWDOWN+1
 	item_color = "clown"
+	unarmed_damage = 0
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
 
@@ -74,6 +77,7 @@
 	icon_state = "jackboots"
 	item_state = "jackboots"
 	item_color = "hosred"
+	unarmed_damage = 3
 	siemens_coefficient = 0.7
 
 /obj/item/clothing/shoes/cult
@@ -82,6 +86,7 @@
 	icon_state = "cult"
 	item_state = "cult"
 	item_color = "cult"
+	unarmed_damage = 2
 	siemens_coefficient = 0.7
 
 	cold_protection = FEET
@@ -100,6 +105,7 @@
 	desc = "Fluffy!"
 	icon_state = "slippers"
 	item_state = "slippers"
+	unarmed_damage = -1
 	species_restricted = null
 	w_class = 2
 
@@ -108,6 +114,7 @@
 	desc = "Fluffy..."
 	icon_state = "slippers_worn"
 	item_state = "slippers_worn"
+	unarmed_damage = -1
 	w_class = 2
 
 /obj/item/clothing/shoes/laceup

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -184,7 +184,7 @@
 				return 0
 
 			var/real_damage = rand_damage
-			real_damage += attack.damage // Adding species attack base damage
+			real_damage += attack.unarmed_damage(H)
 			real_damage *= damage_multiplier
 			rand_damage *= damage_multiplier
 			if(HULK in H.mutations)

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -183,6 +183,8 @@
 		return 0
 
 	if (!user.lying && (target.lying || zone in list("l_foot", "r_foot")))
+		if(target.grabbed_by == user && target.lying)
+			return 0
 		var/datum/organ/external/E = user.organs_by_name["l_foot"]
 		if(E && !(E.status & ORGAN_DESTROYED))
 			return 1

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -24,6 +24,9 @@
 
 	return 0
 
+/datum/unarmed_attack/proc/unarmed_damage()
+	return damage
+
 /datum/unarmed_attack/proc/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
 
 	var/stun_chance = rand(0, 100)
@@ -131,12 +134,12 @@
 
 /datum/unarmed_attack/kick
 	attack_verb = list("kicked", "kneed")
-	attack_noun = list("kick")
+	attack_noun = list("kick", "knee strike")
 	attack_sound = "swing_hit"
-	damage = 1
+	damage = 0
 
 /datum/unarmed_attack/kick/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
-	if (target.legcuffed)
+	if (user.legcuffed)
 		return 0
 
 	if(!(zone in list("l_leg", "r_leg", "l_foot", "r_foot", "groin")))
@@ -152,36 +155,34 @@
 
 	return 0
 
+/datum/unarmed_attack/kick/unarmed_damage(var/mob/living/carbon/human/user)
+	var/obj/item/clothing/shoes = user.shoes
+	if(!istype(shoes))
+		return damage
+	return damage + (shoes ? shoes.unarmed_damage : 0)
+
 /datum/unarmed_attack/kick/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/datum/organ/external/affecting = target.get_organ(zone)
 	var/organ = affecting.display_name
 
 	attack_damage = Clamp(attack_damage, 1, 5)
 
-	switch(zone)
-		if("groin", "l_leg", "r_leg")
-			// -- LOWER BODY -- //
-			switch(attack_damage)
-				if(1 to 2)	user.visible_message("<span class='danger'>[user] gave [target] a light [pick(attack_noun)] to the [organ]!</span>")
-				if(3 to 4)	user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target] in \his [organ]!</span>")
-				if(5)		user.visible_message("<span class='danger'>[user] landed a strong [pick(attack_noun)] against [target]'s [organ]!</span>")
-		if("l_foot", "r_foot")
-			// ----- FEET ----- //
-			switch(attack_damage)
-				if(1 to 4)	user.visible_message("<span class='danger'>[user] kicked [target] in \his [organ]!</span>")
-				if(5)		user.visible_message("<span class='danger'>[user] stomped down hard on [target]'s [organ]!</span>")
+	switch(attack_damage)
+		if(1 to 2)	user.visible_message("<span class='danger'>[user] gave [target] a light [pick(attack_noun)] to the [organ]!</span>")
+		if(3 to 4)	user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target] in \his [organ]!</span>")
+		if(5)		user.visible_message("<span class='danger'>[user] landed a strong [pick(attack_noun)] against [target]'s [organ]!</span>")
 
 /datum/unarmed_attack/stomp
 	attack_verb = null
 	attack_noun = list("kick")
 	attack_sound = "swing_hit"
-	damage = 3
+	damage = 0
 
 /datum/unarmed_attack/stomp/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
-	if (target.legcuffed)
+	if (user.legcuffed)
 		return 0
 
-	if (target.lying && !user.lying)
+	if (!user.lying && (target.lying || zone in list("l_foot", "r_foot")))
 		var/datum/organ/external/E = user.organs_by_name["l_foot"]
 		if(E && !(E.status & ORGAN_DESTROYED))
 			return 1
@@ -192,17 +193,21 @@
 
 		return 0
 
+/datum/unarmed_attack/stomp/unarmed_damage(var/mob/living/carbon/human/user)
+	var/obj/item/clothing/shoes = user.shoes
+	return damage + (shoes ? shoes.unarmed_damage : 0)
+
 /datum/unarmed_attack/stomp/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/datum/organ/external/affecting = target.get_organ(zone)
 	var/organ = affecting.display_name
+	var/obj/item/clothing/shoes = user.shoes
 
 	attack_damage = Clamp(attack_damage, 1, 5)
 
 	switch(attack_damage)
-		if(1 to 3)
-			user.visible_message("<span class='danger'>[user] [pick("gave a kick against", "kicked against", "stomped down on", "slammed their foot into")] [target]'s [organ]!</span>")
-		if(4 to 5)
-			user.visible_message("<span class='danger'>[user] [pick("landed a strong kick against", "kicked against", "stomped down hard on", "rammed their foot into")] [target]'s [organ]!</span>")
+		if(1 to 2)	user.visible_message("<span class='danger'>[user] [pick("clomped on", "treaded on")] [target]'s [organ]!</span>")
+		if(3 to 4)	user.visible_message("<span class='danger'>[user] [pick("stomped down on", "slammed their [shoes ? copytext(shoes.name, 1, -1) : "foot"] down onto")] [target]'s [organ]!</span>")
+		if(5)		user.visible_message("<span class='danger'>[user] [pick("landed a devastating stomp on", "stomped down hard on", "slammed their [shoes ? copytext(shoes.name, 1, -1) : "foot"] down hard onto")] [target]'s [organ]!</span>")
 
 /datum/unarmed_attack/diona
 	attack_verb = list("lashed", "bludgeoned")


### PR DESCRIPTION
Stomp attack messages will now differ more from kicks, exclusively being shown as stomp attacks and will take the type of shoewear in account for the calculation of the damage.

Additionally, people will no longer use the stomp attack on a person that they have in a grab.
