### PR TITLE
Fixes shotgun shell description

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -41,6 +41,10 @@
 		else
 			user << "\blue There is no bullet in the casing to inscribe anything into."
 
+/obj/item/ammo_casing/examine(mob/user)
+	..()
+	if (!BB)
+		user << "This one is spent."
 
 //Boxes of ammo
 /obj/item/ammo_magazine

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -67,7 +67,7 @@
 	name = "shotgun shell"
 	desc = "A blank shell."
 	icon_state = "blshell"
-	projectile_type = ""
+	projectile_type = "/obj/item/projectile/bullet/chameleon"
 	matter = list("metal" = 250)
 
 

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -38,7 +38,6 @@
 		return 0
 	AC.loc = get_turf(src) //Eject casing onto ground.
 	if(AC.BB)
-		AC.desc += " This one is spent."	//descriptions are magic - only when there's a projectile in the casing
 		in_chamber = AC.BB //Load projectile into chamber.
 		AC.BB.loc = src //Set projectile loc to gun.
 		return 1


### PR DESCRIPTION
Fixes shotgun shell description not indicating when a shell is spent, by checking the state of the `ammo_casing` instead of relying on the gun to modify the description, which doesn't always happen.

As a side effect shotgun blanks now fire chameleon bullets.

To avoid conflicts with the upcoming examine verb changes this PR is being opened to dev-freeze instead of master.
