### PR TITLE
Replaces connect type system

### DIFF
--- a/code/ATMOSPHERICS/_atmos_setup.dm
+++ b/code/ATMOSPHERICS/_atmos_setup.dm
@@ -14,6 +14,10 @@
 #define	PIPE_COLOR_YELLOW	"#ffcc00"
 #define	PIPE_COLOR_PURPLE	"#5c1ec0"
 
+#define CONNECT_TYPE_REGULAR	1
+#define CONNECT_TYPE_SUPPLY		2
+#define CONNECT_TYPE_SCRUBBER	4
+
 var/global/list/pipe_colors = list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_RED, "blue" = PIPE_COLOR_BLUE, "cyan" = PIPE_COLOR_CYAN, "green" = PIPE_COLOR_GREEN, "yellow" = PIPE_COLOR_YELLOW, "purple" = PIPE_COLOR_PURPLE)
 
 /proc/pipe_color_lookup(var/color)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -18,8 +18,7 @@ Pipelines + Other Objects -> Pipe network
 
 	layer = 2.4 //under wires with their 2.44
 
-	var/connect_types[] = list(1) //1=regular, 2=supply, 3=scrubber
-	var/connected_to = 1 //same as above, currently not used for anything
+	var/connect_types = CONNECT_TYPE_REGULAR
 	var/icon_connect_type = "" //"-supply" or "-scrubbers"
 
 	var/initialize_directions = 0
@@ -63,29 +62,10 @@ Pipelines + Other Objects -> Pipe network
 		return 0
 
 obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/atmos1, obj/machinery/atmospherics/atmos2)
-	var/i
-	var/list1[] = atmos1.connect_types
-	var/list2[] = atmos2.connect_types
-	for(i=1,i<=list1.len,i++)
-		var/j
-		for(j=1,j<=list2.len,j++)
-			if(list1[i] == list2[j])
-				var/n = list1[i]
-				return n
-	return 0
+	return (atmos1.connect_types & atmos2.connect_types)
 
-obj/machinery/atmospherics/proc/check_connect_types_construction(obj/machinery/atmospherics/atmos1, obj/item/pipe/pipe2)
-	var/i
-	var/list1[] = atmos1.connect_types
-	var/list2[] = pipe2.connect_types
-	for(i=1,i<=list1.len,i++)
-		var/j
-		for(j=1,j<=list2.len,j++)
-			if(list1[i] == list2[j])
-				var/n = list1[i]
-				return n
-	return 0
-
+/obj/machinery/atmospherics/proc/check_connect_types_construction(obj/machinery/atmospherics/atmos1, obj/item/pipe/pipe2)
+	return (atmos1.connect_types & pipe2.connect_types)
 
 /obj/machinery/atmospherics/proc/check_icon_cache(var/safety = 0)
 	if(!istype(icon_manager))

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -67,24 +67,33 @@ obj/machinery/atmospherics/binary
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					node1 = target
 					break
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					node2 = target
 					break
 
 		update_icon()
 		update_underlays()
+
+	/*
+	connect_nodes(var/node1_dir, var/node2_dir)
+		for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
+			if(target.initialize_directions & get_dir(target,src))
+				if (check_connect_types(target,src))
+					node1 = target
+					break
+
+		for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
+			if(target.initialize_directions & get_dir(target,src))
+				if (check_connect_types(target,src))
+					node2 = target
+					break
+	*/
 
 	build_network()
 		if(!network1 && node1)

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -27,7 +27,7 @@
 	active_power_usage = 7500	//This also doubles as a measure of how powerful the pump is, in Watts. 7500 W ~ 10 HP
 	var/last_power_draw = 0
 
-	connect_types = list(1,2,3) //connects to regular, supply and scrubbers pipes
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER //connects to regular, supply and scrubbers pipes
 
 	var/on = 0
 	var/pump_direction = 1 //0 = siphoning, 1 = releasing

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -248,10 +248,7 @@
 			continue
 		for(var/obj/machinery/atmospherics/target in get_step(src, P.dir))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					P.node = target
 					break
 

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -81,10 +81,7 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node = target
 				break
 

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -82,27 +82,18 @@ obj/machinery/atmospherics/trinary
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					node1 = target
 					break
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					node2 = target
 					break
 		for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					node3 = target
 					break
 

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -199,26 +199,17 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node2 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node3_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node3 = target
 				break
 

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -46,10 +46,7 @@
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				var/c = check_connect_types(target,src)
-				if (c)
-					target.connected_to = c
-					src.connected_to = c
+				if (check_connect_types(target,src))
 					node = target
 					break
 

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -19,7 +19,7 @@
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
 	active_power_usage = 7500	//This also doubles as a measure of how powerful the pump is, in Watts. 7500 W ~ 10 HP
 
-	connect_types = list(1,2) //connects to regular and supply pipes
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY //connects to regular and supply pipes
 
 	var/area/initial_loc
 	level = 1

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -9,7 +9,7 @@
 	active_power_usage = 7500	//This also doubles as a measure of how powerful the pump is, in Watts. 7500 W ~ 10 HP
 	var/last_power_draw = 0
 
-	connect_types = list(1,3) //connects to regular and scrubber pipes
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER //connects to regular and scrubber pipes
 
 	level = 1
 

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -160,18 +160,12 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node2 = target
 				break
 

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -277,18 +277,12 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node2 = target
 				break
 
@@ -324,7 +318,7 @@
 	name = "Scrubbers pipe"
 	desc = "A one meter section of scrubbers pipe"
 	icon_state = "intact-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -333,7 +327,7 @@
 	name = "Air supply pipe"
 	desc = "A one meter section of supply pipe"
 	icon_state = "intact-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -359,7 +353,7 @@
 	name = "Scrubbers pipe"
 	desc = "A one meter section of scrubbers pipe"
 	icon_state = "intact-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -368,7 +362,7 @@
 	name = "Air supply pipe"
 	desc = "A one meter section of supply pipe"
 	icon_state = "intact-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -532,10 +526,7 @@
 		if(direction&connect_directions)
 			for(var/obj/machinery/atmospherics/target in get_step(src,direction))
 				if(target.initialize_directions & get_dir(target,src))
-					var/c = check_connect_types(target,src)
-					if (c)
-						target.connected_to = c
-						src.connected_to = c
+					if (check_connect_types(target,src))
 						node1 = target
 						connect_directions &= ~direction
 						break
@@ -547,10 +538,7 @@
 		if(direction&connect_directions)
 			for(var/obj/machinery/atmospherics/target in get_step(src,direction))
 				if(target.initialize_directions & get_dir(target,src))
-					var/c = check_connect_types(target,src)
-					if (c)
-						target.connected_to = c
-						src.connected_to = c
+					if (check_connect_types(target,src))
 						node2 = target
 						connect_directions &= ~direction
 						break
@@ -562,10 +550,7 @@
 		if(direction&connect_directions)
 			for(var/obj/machinery/atmospherics/target in get_step(src,direction))
 				if(target.initialize_directions & get_dir(target,src))
-					var/c = check_connect_types(target,src)
-					if (c)
-						target.connected_to = c
-						src.connected_to = c
+					if (check_connect_types(target,src))
 						node3 = target
 						connect_directions &= ~direction
 						break
@@ -589,7 +574,7 @@
 	name="Scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -598,7 +583,7 @@
 	name="Air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -624,7 +609,7 @@
 	name="Scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -633,7 +618,7 @@
 	name="Air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -796,37 +781,25 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,1))
 		if(target.initialize_directions & 2)
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,2))
 		if(target.initialize_directions & 1)
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node2 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,4))
 		if(target.initialize_directions & 8)
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node3 = target
 				break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,8))
 		if(target.initialize_directions & 4)
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node4 = target
 				break
 
@@ -847,7 +820,7 @@
 	name="4-way scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map_4way-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -856,7 +829,7 @@
 	name="4-way air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map_4way-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -882,7 +855,7 @@
 	name="4-way scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map_4way-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -891,7 +864,7 @@
 	name="4-way air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map_4way-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -974,10 +947,7 @@
 /obj/machinery/atmospherics/pipe/cap/initialize()
 	for(var/obj/machinery/atmospherics/target in get_step(src, dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node = target
 				break
 
@@ -993,7 +963,7 @@
 	name = "scrubbers pipe endcap"
 	desc = "An endcap for scrubbers pipes"
 	icon_state = "cap-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -1002,7 +972,7 @@
 	name = "supply pipe endcap"
 	desc = "An endcap for supply pipes"
 	icon_state = "cap-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -1016,7 +986,7 @@
 	name = "scrubbers pipe endcap"
 	desc = "An endcap for scrubbers pipes"
 	icon_state = "cap-f-scrubbers"
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -1025,7 +995,7 @@
 	name = "supply pipe endcap"
 	desc = "An endcap for supply pipes"
 	icon_state = "cap-f-supply"
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -1084,10 +1054,7 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 
@@ -1269,10 +1236,7 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 
@@ -1299,7 +1263,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal
 	name="Universal pipe adapter"
 	desc = "An adapter for regular, supply and scrubbers pipes"
-	connect_types = list(1,2,3)
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	icon_state = "map_universal"
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/update_icon(var/safety = 0)
@@ -1334,7 +1298,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal
 	name="Universal pipe adapter"
 	desc = "An adapter for regular, supply and scrubbers pipes"
-	connect_types = list(1,2,3)
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	icon_state = "map_universal"
 
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/update_icon(var/safety = 0)

--- a/code/TriDimension/Pipes.dm
+++ b/code/TriDimension/Pipes.dm
@@ -134,10 +134,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/initialize()
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 
@@ -148,10 +145,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/initialize()
 			if(above)
 				for(var/obj/machinery/atmospherics/target in above)
 					if(target.initialize_directions && istype(target, /obj/machinery/atmospherics/pipe/zpipe/down))
-						var/c = check_connect_types(target,src)
-						if (c)
-							target.connected_to = c
-							src.connected_to = c
+						if (check_connect_types(target,src))
 							node2 = target
 							break
 
@@ -181,10 +175,7 @@ obj/machinery/atmospherics/pipe/zpipe/down/initialize()
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
 		if(target.initialize_directions & get_dir(target,src))
-			var/c = check_connect_types(target,src)
-			if (c)
-				target.connected_to = c
-				src.connected_to = c
+			if (check_connect_types(target,src))
 				node1 = target
 				break
 
@@ -195,10 +186,7 @@ obj/machinery/atmospherics/pipe/zpipe/down/initialize()
 			if(below)
 				for(var/obj/machinery/atmospherics/target in below)
 					if(target.initialize_directions && istype(target, /obj/machinery/atmospherics/pipe/zpipe/up))
-						var/c = check_connect_types(target,src)
-						if (c)
-							target.connected_to = c
-							src.connected_to = c
+						if (check_connect_types(target,src))
 							node2 = target
 							break
 
@@ -214,7 +202,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/scrubbers
 	icon_state = "up-scrubbers"
 	name = "upwards scrubbers pipe"
 	desc = "A scrubbers pipe segment to connect upwards."
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -223,7 +211,7 @@ obj/machinery/atmospherics/pipe/zpipe/up/supply
 	icon_state = "up-supply"
 	name = "upwards supply pipe"
 	desc = "A supply pipe segment to connect upwards."
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -232,7 +220,7 @@ obj/machinery/atmospherics/pipe/zpipe/down/scrubbers
 	icon_state = "down-scrubbers"
 	name = "downwards scrubbers pipe"
 	desc = "A scrubbers pipe segment to connect downwards."
-	connect_types = list(3)
+	connect_types = CONNECT_TYPE_SCRUBBER
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -241,7 +229,7 @@ obj/machinery/atmospherics/pipe/zpipe/down/supply
 	icon_state = "down-supply"
 	name = "downwards supply pipe"
 	desc = "A supply pipe segment to connect downwards."
-	connect_types = list(2)
+	connect_types = CONNECT_TYPE_SUPPLY
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -55,7 +55,7 @@ Buildable meters
 	var/pipe_type = 0
 	//var/pipe_dir = 0
 	var/pipename
-	var/connect_types[] = list(1) //1=regular, 2=supply, 3=scrubber
+	var/connect_types = CONNECT_TYPE_REGULAR
 	force = 7
 	icon = 'icons/obj/pipe-item.dmi'
 	icon_state = "simple"
@@ -83,26 +83,26 @@ Buildable meters
 			src.pipe_type = PIPE_INSULATED_STRAIGHT + is_bent
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/simple/hidden/supply))
 			src.pipe_type = PIPE_SUPPLY_STRAIGHT + is_bent
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers))
 			src.pipe_type = PIPE_SCRUBBERS_STRAIGHT + is_bent
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/visible/universal) || istype(make_from, /obj/machinery/atmospherics/pipe/simple/hidden/universal))
 			src.pipe_type = PIPE_UNIVERSAL
-			connect_types = list(1,2,3)
+			connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple))
 			src.pipe_type = PIPE_SIMPLE_STRAIGHT + is_bent
 		else if(istype(make_from, /obj/machinery/atmospherics/portables_connector))
 			src.pipe_type = PIPE_CONNECTOR
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold/hidden/supply))
 			src.pipe_type = PIPE_SUPPLY_MANIFOLD
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers))
 			src.pipe_type = PIPE_SCRUBBERS_MANIFOLD
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold))
 			src.pipe_type = PIPE_MANIFOLD
@@ -134,21 +134,21 @@ Buildable meters
 			src.pipe_type = PIPE_MTVALVE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply))
 			src.pipe_type = PIPE_SUPPLY_MANIFOLD4W
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers))
 			src.pipe_type = PIPE_SCRUBBERS_MANIFOLD4W
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w))
 			src.pipe_type = PIPE_MANIFOLD4W
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/cap/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/cap/hidden/supply))
 			src.pipe_type = PIPE_SUPPLY_CAP
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/cap/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/cap/hidden/scrubbers))
 			src.pipe_type = PIPE_SCRUBBERS_CAP
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/cap))
 			src.pipe_type = PIPE_CAP
@@ -159,21 +159,21 @@ Buildable meters
 ///// Z-Level stuff
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/zpipe/up/supply))
 			src.pipe_type = PIPE_SUPPLY_UP
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers))
 			src.pipe_type = PIPE_SCRUBBERS_UP
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/zpipe/up))
 			src.pipe_type = PIPE_UP
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/zpipe/down/supply))
 			src.pipe_type = PIPE_SUPPLY_DOWN
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers))
 			src.pipe_type = PIPE_SCRUBBERS_DOWN
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/zpipe/down))
 			src.pipe_type = PIPE_DOWN
@@ -182,13 +182,13 @@ Buildable meters
 		src.pipe_type = pipe_type
 		src.set_dir(dir)
 		if (pipe_type == 29 || pipe_type == 30 || pipe_type == 33 || pipe_type == 35 || pipe_type == 37 || pipe_type == 39 || pipe_type == 41)
-			connect_types = list(2)
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.color = PIPE_COLOR_BLUE
 		else if (pipe_type == 31 || pipe_type == 32 || pipe_type == 34 || pipe_type == 36 || pipe_type == 38 || pipe_type == 40 || pipe_type == 42)
-			connect_types = list(3)
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.color = PIPE_COLOR_RED
 		else if (pipe_type == 28)
-			connect_types = list(1,2,3)
+			connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	//src.pipe_dir = get_pipe_dir()
 	update()
 	src.pixel_x = rand(-5, 5)


### PR DESCRIPTION
Replaces the connect type system used by the supply/scrubber pipe system. The lists of integers seemed really unnecessary.

I haven't been able to test this PR much.

Incidentally there's a ton of duplicated code that could be replaced if atmos machinery and piping stored their nodes as a pair of lists, but I'm not about to rewrite everything.
