### PR TITLE
Fixes shutters texture when damaged

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -24,6 +24,13 @@
 			return
 	return
 
+/obj/machinery/door/poddoor/shutters/update_icon()
+	if(density)
+		icon_state = "shutter1"
+	else
+		icon_state = "shutter0"
+	return
+
 /obj/machinery/door/poddoor/shutters/open()
 	if(operating == 1) //doors can still open when emag-disabled
 		return


### PR DESCRIPTION
- Damaged shutters no longer transform into blast doors.
- Fixes #7443
