### PR TITLE
Fix brain/posibrain languages

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -56,3 +56,6 @@
 		use_me = 1 //If it can move, let it emote
 	else							canmove = 0
 	return canmove
+
+/mob/living/carbon/brain/binarycheck()
+	return istype(loc, /obj/item/device/mmi)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -58,4 +58,4 @@
 	return canmove
 
 /mob/living/carbon/brain/binarycheck()
-	return istype(loc, /obj/item/device/mmi)
+	return istype(loc, /obj/item/device/mmi/digital)

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -24,8 +24,13 @@
 				return
 			else
 				message = Gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
+
+		if(speaking && speaking.flags & HIVEMIND)
+			speaking.broadcast(src,trim(message))
+			return
+
 		if(istype(container, /obj/item/device/mmi/radio_enabled))
 			var/obj/item/device/mmi/radio_enabled/R = container
 			if(R.radio)
 				spawn(0) R.radio.hear_talk(src, trim(sanitize(message)), verb, speaking)
-		..()
+		..(trim(message), speaking, verb)


### PR DESCRIPTION
As in title. Allows brains to talk over binary if they are in an MMI, and allows posibrains to talk over binary (since they're code-wise brains that are always in MMIs).

Also allows brains (both types) to speak in all languages in their list.

Fixes #7502.
