### PR TITLE
Changeling Fix

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -149,7 +149,7 @@
 		src << "<span class='warning'>We do not know how to parse this creature's DNA!</span>"
 		return
 
-	if(NOCLONE in T.mutations)
+	if(HUSK in T.mutations)
 		src << "<span class='warning'>This creature's DNA is ruined beyond useability!</span>"
 		return
 

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -176,7 +176,6 @@
 				var/datum/organ/external/affecting = T.get_organ(src.zone_sel.selecting)
 				if(affecting.take_damage(39,0,1,0,"large organic needle"))
 					T:UpdateDamageIcon()
-					continue
 
 		feedback_add_details("changeling_powers","A[stage]")
 		if(!do_mob(src, T, 150))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -96,5 +96,5 @@
 
 /mob/living/carbon/human/proc/Drain()
 	ChangeToHusk()
-	//mutations |= NOCLONE
+	mutations |= NOCLONE
 	return

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -96,5 +96,5 @@
 
 /mob/living/carbon/human/proc/Drain()
 	ChangeToHusk()
-	mutations |= NOCLONE
+	mutations |= HUSK
 	return


### PR DESCRIPTION
- Fixes #7550 and one other bug which is not on issue tracker
- Uncomments one line of code which caused #7550, considering reasons for this being commented out no longer apply. (parasting is no longer cheap OP ability you have from start) Changeling rewrite is probably going to occur soon anyway (but that's something for Dev after feature freeze is lifted, see http://baystation12.net/forums/viewtopic.php?f=5&t=11789 for discussion).
- Removes one line which caused bug with "Absorb" ability - victim was immediately absorbed after the "You stab the X with proboscis" part, instead of waiting few seconds as it should.
