### PR TITLE
Xeno balancing

### DIFF
--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_facehugger.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_facehugger.dm
@@ -96,8 +96,8 @@ var/const/MAX_ACTIVE_TIME = 400
 	..()
 	if(stat == CONSCIOUS)
 		icon_state = "[initial(icon_state)]"
-		Attach(hit_atom)
 		throwing = 0
+	GoIdle(30,50) //stunned for a few seconds - allows throwing them to be useful for positioning but not as an offensive action (unless you're setting up a trap)
 
 /obj/item/clothing/mask/facehugger/proc/Attach(M as mob)
 
@@ -124,12 +124,14 @@ var/const/MAX_ACTIVE_TIME = 400
 
 	L.visible_message("\red \b [src] leaps at [L]'s face!")
 
+	/* Tentatively removed since huggers can't be thrown anymore
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		if(H.head && H.head.flags & HEADCOVERSMOUTH)
 			H.visible_message("\red \b [src] smashes against [H]'s [H.head]!")
 			Die()
 			return
+	*/
 
 	if(iscarbon(M))
 		var/mob/living/carbon/target = L
@@ -191,7 +193,7 @@ var/const/MAX_ACTIVE_TIME = 400
 
 	return
 
-/obj/item/clothing/mask/facehugger/proc/GoIdle()
+/obj/item/clothing/mask/facehugger/proc/GoIdle(var/min_time=MIN_ACTIVE_TIME, var/max_time=MAX_ACTIVE_TIME)
 	if(stat == DEAD || stat == UNCONSCIOUS)
 		return
 
@@ -200,7 +202,7 @@ var/const/MAX_ACTIVE_TIME = 400
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
 
-	spawn(rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
+	spawn(rand(min_time,max_time))
 		GoActive()
 	return
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -93,8 +93,7 @@
 		return
 
 	if(check_alien_ability(75,1,"egg sac"))
-		for(var/mob/O in viewers(src, null))
-			O.show_message(text("\green <B>[src] has laid an egg!</B>"), 1)
+		visible_message("\green <B>[src] has laid an egg!</B>")
 		new /obj/effect/alien/egg(loc)
 
 	return
@@ -110,9 +109,7 @@
 		return
 
 	if(check_alien_ability(500))
-		src << "\green You begin to evolve!"
-		for(var/mob/O in viewers(src, null))
-			O.show_message(text("\green <B>[src] begins to twist and contort!</B>"), 1)
+		visible_message("\green <B>[src] begins to twist and contort!</B>", "\green You begin to evolve!")
 		src.set_species("Xenomorph Queen")
 
 	return
@@ -123,8 +120,7 @@
 	set category = "Abilities"
 
 	if(check_alien_ability(50,1,"resin spinner"))
-		for(var/mob/O in viewers(src, null))
-			O.show_message(text("\green <B>[src] has planted some alien weeds!</B>"), 1)
+		visible_message("\green <B>[src] has planted some alien weeds!</B>")
 		new /obj/effect/alien/weeds/node(loc)
 	return
 
@@ -176,11 +172,7 @@
 		src << "You cannot spit neurotoxin in your current state."
 		return
 
-	src << "\green You spit neurotoxin at [target]."
-
-	for(var/mob/O in oviewers())
-		if ((O.client && !(O.blinded )))
-			O << "\red [src] spits neurotoxin at [target]!"
+	visible_message("<span class='warning'>[src] spits neurotoxin at [target]!</span>", "\green You spit neurotoxin at [target].")
 
 	//I'm not motivated enough to revise this. Prjectile code in general needs update.
 	// Maybe change this to use throw_at? ~ Z
@@ -218,9 +210,7 @@
 	if(!check_alien_ability(75,1,"resin spinner"))
 		return
 
-	src << "\green You shape a [choice]."
-	for(var/mob/O in viewers(src, null))
-		O.show_message(text("\red <B>[src] vomits up a thick purple substance and begins to shape it!</B>"), 1)
+	visible_message("<span class='warning'><B>[src] vomits up a thick purple substance and begins to shape it!</B></span>", "\green You shape a [choice].")
 	switch(choice)
 		if("resin door")
 			new /obj/structure/mineral_door/resin(loc)

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -110,7 +110,7 @@
 	name = "Xenomorph Drone"
 	caste_name = "drone"
 	weeds_plasma_rate = 15
-	slowdown = 2
+	slowdown = 1
 	tail = "xenos_drone_tail"
 	rarity_value = 5
 
@@ -149,7 +149,7 @@
 	name = "Xenomorph Hunter"
 	weeds_plasma_rate = 5
 	caste_name = "hunter"
-	slowdown = -1
+	slowdown = -2
 	total_health = 150
 	tail = "xenos_hunter_tail"
 
@@ -177,7 +177,7 @@
 	name = "Xenomorph Sentinel"
 	weeds_plasma_rate = 10
 	caste_name = "sentinel"
-	slowdown = 1
+	slowdown = 0
 	total_health = 125
 	tail = "xenos_sentinel_tail"
 
@@ -209,7 +209,7 @@
 	weeds_heal_rate = 5
 	weeds_plasma_rate = 20
 	caste_name = "queen"
-	slowdown = 5
+	slowdown = 4
 	tail = "xenos_queen_tail"
 	rarity_value = 10
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -767,6 +767,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 			suit.supporting_limbs |= src
 	return
 
+/datum/organ/external/proc/mend_fracture()
+	if(status & ORGAN_ROBOT)
+		return 0	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
+	if(brute_dam > min_broken_damage * config.organ_health_multiplier)
+		return 0	//will just immediately fracture again
+	
+	status &= ~ORGAN_BROKEN
+	return 1
+
 /datum/organ/external/proc/robotize()
 	src.status &= ~ORGAN_BROKEN
 	src.status &= ~ORGAN_BLEEDING


### PR DESCRIPTION
- Facehuggers become stunned for a short period when thrown. This allows throwing huggers to remain useful for positioning them and setting up traps but not as an offensive ranged weapon.
- Because of the above, helmet facehugger protection is no longer necessary and can be tentatively removed.
- Xenos receive a slight speedup across the board, so that sentinals are now on par with human move speed, drones are a bit slower than humans and hunters are a bit faster. That plus the fixes to the way NO_PAIN affects movement slowdown with damage, should mean xenos are faster overall.
- Weed regeneration occurs at full speed when resting, and is slower when not resting.
- Weed regeneration mends broken bones after all other damage is healed.
