### PR TITLE
Fixes vox leap special_role check

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -98,7 +98,7 @@
 	T.Weaken(5)
 
 	//Only official cool kids get the grab and no self-prone.
-	if(src.mind && src.mind.special_role)
+	if(!(src.mind && src.mind.special_role))
 		src.Weaken(5)
 		return
 


### PR DESCRIPTION
Who knows, some vox in a recent heist round might have lived had this bug not been present.
