### PR TITLE
Makes shotguns not break on point-blank fire (fixes part of #7358)

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -91,7 +91,6 @@
 
 		if(AC.BB)
 			in_chamber = AC.BB //Load projectile into chamber.
-			AC.BB.loc = src //Set projectile loc to gun.
 			return 1
 		return 0
 


### PR DESCRIPTION
The removed line didn't seem to do anything except spawn a bullet in the gun's contents when fired at point-blank range, which prevented loading two shells as noted in #7358.
