### PR TITLE
Less wall and door destruction snowflake, allows obj to damage walls

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1059,10 +1059,6 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/New(var/newloc, var/obj/structure/door_assembly/assembly=null)
 	..()
 
-	//High-sec airlocks are much harder to completely break by emitters.
-	if(secured_wires)
-		emitter_resistance *= 3
-
 	//if assembly is given, create the new door from the assembly
 	if (assembly)
 		assembly_type = assembly.type

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -27,8 +27,7 @@
 	var/air_properties_vary_with_direction = 0
 	var/maxhealth = 300
 	var/health
-	var/emitter_hits = 0 // For use when tracking amount of emitter hits taken.
-	var/emitter_resistance = 10 // Amount of emitter hits doors whistand
+	var/destroy_hits = 10 //How many strong hits it takes to destroy the door
 	var/min_force = 10 //minimum amount of force needed to damage the door with a melee weapon
 	var/hitsound = 'sound/weapons/smash.ogg' //sound door makes when hit with a weapon
 	var/obj/item/stack/sheet/metal/repairing
@@ -139,18 +138,21 @@
 		return
 
 	// Emitter Blasts - these will eventually completely destroy the door, given enough time.
-	if (istype(Proj, /obj/item/projectile/beam/emitter))
-		if(health > 0)
-			Proj.damage /= 4
-		else
-			emitter_hits ++
-			if(emitter_hits >= emitter_resistance)
-				visible_message("\red <B>[src.name] breaks apart!</B>", 1)
-				new /obj/effect/decal/cleanable/ash(src.loc) // Turn it to ashes!
-				del(src)
+	if (Proj.damage > 90) 
+		destroy_hits--
+		if (destroy_hits <= 0)
+			visible_message("\red <B>\The [src.name] disintegrates!</B>")
+			switch (Proj.damage_type)
+				if(BRUTE)
+					new /obj/item/stack/sheet/metal(src.loc, 2)
+					new /obj/item/stack/rods(src.loc, 3)
+				if(BURN)
+					new /obj/effect/decal/cleanable/ash(src.loc) // Turn it to ashes!
+			del(src)
 
 	if(Proj.damage)
-		take_damage(Proj.damage)
+		//cap projectile damage so that there's still a minimum number of hits required to break the door
+		take_damage(min(Proj.damage, 100))
 
 
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -6,7 +6,7 @@
 	var/id = 1.0
 	dir = 1
 	explosion_resistance = 25
-	emitter_resistance = 50 // Lots of emitter blasts, it's blast door after all.
+	destroy_hits = 50 // Lots of emitter blasts, it's blast door after all.
 
 /obj/machinery/door/poddoor/New()
 	. = ..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -25,18 +25,26 @@
 
 /turf/simulated/wall/bullet_act(var/obj/item/projectile/Proj)
 
-	// Tasers and stuff? No thanks.
-	if(Proj.damage_type == HALLOSS)
+	// Tasers and stuff? No thanks. Also no clone or tox damage crap.
+	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		return
 
-	// Emitter blasts are somewhat weaker as emitters have large rate of fire and don't require limited power cell to run
-	if(istype(Proj, /obj/item/projectile/beam/emitter))
-		Proj.damage /= 4
+	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
+	var/damage = min(Proj.damage, 100) * armor
 
-	take_damage(Proj.damage * armor)
+	take_damage(damage)
 	return
 
-
+/turf/simulated/wall/hitby(AM as mob|obj, var/speed=5)
+	..()
+	if(ismob(AM))
+		return
+	
+	var/tforce = AM:throwforce * (speed/5)
+	if (tforce < 15)
+		return
+	
+	take_damage(tforce * armor)
 
 /turf/simulated/wall/Del()
 	for(var/obj/effect/E in src) if(E.name == "Wallrot") del E

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -35,12 +35,12 @@
 	take_damage(damage)
 	return
 
-/turf/simulated/wall/hitby(AM as mob|obj, var/speed=5)
+/turf/simulated/wall/hitby(AM as mob|obj, var/speed=THROWFORCE_SPEED_DIVISOR)
 	..()
 	if(ismob(AM))
 		return
 	
-	var/tforce = AM:throwforce * (speed/5)
+	var/tforce = AM:throwforce * (speed/THROWFORCE_SPEED_DIVISOR)
 	if (tforce < 15)
 		return
 	

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -297,11 +297,11 @@ emp_act
 	return 1
 
 //this proc handles being hit by a thrown atom
-/mob/living/carbon/human/hitby(atom/movable/AM as mob|obj,var/speed = 5)
+/mob/living/carbon/human/hitby(atom/movable/AM as mob|obj,var/speed = THROWFORCE_SPEED_DIVISOR)
 	if(istype(AM,/obj/))
 		var/obj/O = AM
 
-		if(in_throw_mode && !get_active_hand() && speed <= 5)	//empty active hand and we're in throw mode
+		if(in_throw_mode && !get_active_hand() && speed <= THROWFORCE_SPEED_DIVISOR)	//empty active hand and we're in throw mode
 			if(canmove && !restrained())
 				if(isturf(O.loc))
 					put_in_active_hand(O)
@@ -313,7 +313,7 @@ emp_act
 		if(istype(O,/obj/item/weapon))
 			var/obj/item/weapon/W = O
 			dtype = W.damtype
-		var/throw_damage = O.throwforce*(speed/5)
+		var/throw_damage = O.throwforce*(speed/THROWFORCE_SPEED_DIVISOR)
 
 		var/zone
 		if (istype(O.thrower, /mob/living))
@@ -375,9 +375,9 @@ emp_act
 					affecting.embed(I)
 
 		// Begin BS12 momentum-transfer code.
-		if(O.throw_source && speed >= 15)
+		if(O.throw_source && speed >= THROWNOBJ_KNOCKBACK_SPEED)
 			var/obj/item/weapon/W = O
-			var/momentum = speed/2
+			var/momentum = speed/THROWNOBJ_KNOCKBACK_DIVISOR
 			var/dir = get_dir(O.throw_source, src)
 
 			visible_message("\red [src] staggers under the impact!","\red You stagger under the impact!")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -100,14 +100,14 @@
 	..()
 
 //this proc handles being hit by a thrown atom
-/mob/living/hitby(atom/movable/AM as mob|obj,var/speed = 5)//Standardization and logging -Sieve
+/mob/living/hitby(atom/movable/AM as mob|obj,var/speed = THROWFORCE_SPEED_DIVISOR)//Standardization and logging -Sieve
 	if(istype(AM,/obj/))
 		var/obj/O = AM
 		var/dtype = BRUTE
 		if(istype(O,/obj/item/weapon))
 			var/obj/item/weapon/W = O
 			dtype = W.damtype
-		var/throw_damage = O.throwforce*(speed/5)
+		var/throw_damage = O.throwforce*(speed/THROWFORCE_SPEED_DIVISOR)
 
 		var/miss_chance = 15
 		if (O.throw_source)
@@ -136,9 +136,9 @@
 					msg_admin_attack("[src.name] ([src.ckey]) was hit by a [O], thrown by [M.name] ([assailant.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 
 		// Begin BS12 momentum-transfer code.
-		if(O.throw_source && speed >= 15)
+		if(O.throw_source && speed >= THROWNOBJ_KNOCKBACK_SPEED)
 			var/obj/item/weapon/W = O
-			var/momentum = speed/2
+			var/momentum = speed/THROWNOBJ_KNOCKBACK_DIVISOR
 			var/dir = get_dir(O.throw_source, src)
 
 			visible_message("\red [src] staggers under the impact!","\red You stagger under the impact!")

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -68,6 +68,9 @@
 #define SHOE_MIN_COLD_PROTECTION_TEMPERATURE 2.0	//For gloves
 #define SHOE_MAX_HEAT_PROTECTION_TEMPERATURE 1500		//For gloves
 
+#define THROWFORCE_SPEED_DIVISOR 5		//The throwing speed value at which the throwforce multiplier is exactly 1.
+#define THROWNOBJ_KNOCKBACK_SPEED 15	//The minumum speed of a thrown object that will cause living mobs it hits to be knocked back.
+#define THROWNOBJ_KNOCKBACK_DIVISOR 2	//Affects how much speed the mob is knocked back with
 
 #define PRESSURE_DAMAGE_COEFFICIENT 4 //The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT, with the maximum of MAX_PRESSURE_DAMAGE
 #define MAX_HIGH_PRESSURE_DAMAGE 4	//This used to be 20... I got this much random rage for some retarded decision by polymorph?! Polymorph now lies in a pool of blood with a katana jammed in his spleen. ~Errorage --PS: The katana did less than 20 damage to him :(


### PR DESCRIPTION
Fixes the dev portion of #7538 

Removes the snowflake door and wall damage logic for being hit by emitter projectiles. Replaces randomly dividing projectile damage with a damage cap, and whether a projectile can damage a door is determined by how powerful the projectile is.
