### PR TITLE
Cargo train fixes

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -462,6 +462,9 @@
 			secondarytargets += L
 
 /obj/machinery/porta_turret/proc/assess_living(var/mob/living/L)
+	if(!istype(L))
+		return TURRET_NOT_TARGET
+
 	if(L.invisibility >= INVISIBILITY_LEVEL_ONE) // Cannot see him. see_invisible is a mob-var
 		return TURRET_NOT_TARGET
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -262,12 +262,15 @@
 				move_delay += 7+config.walk_speed
 		move_delay += mob.movement_delay()
 
+		var/tickcomp = 0 //moved this out here so we can use it for vehicles
 		if(config.Tickcomp)
-			move_delay -= 1.3
-			var/tickcomp = ((1/(world.tick_lag))*1.3)
+			// move_delay -= 1.3 //~added to the tickcomp calculation below
+			tickcomp = ((1/(world.tick_lag))*1.3) - 1.3
 			move_delay = move_delay + tickcomp
 
 		if(istype(mob.buckled, /obj/vehicle))
+			//manually set move_delay for vehicles so we dont inherit any mob movement penalties
+			move_delay = world.time + mob.movement_delay() + 1 + config.run_speed + tickcomp
 			return mob.buckled.relaymove(mob,direct)
 
 		if(istype(mob.machine, /obj/machinery))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -269,8 +269,12 @@
 			move_delay = move_delay + tickcomp
 
 		if(istype(mob.buckled, /obj/vehicle))
-			//manually set move_delay for vehicles so we dont inherit any mob movement penalties
-			move_delay = world.time + mob.movement_delay() + 1 + config.run_speed + tickcomp
+			//manually set move_delay for vehicles so we don't inherit any mob movement penalties
+			//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
+			move_delay = world.time + tickcomp
+			//drunk driving
+			if(mob.confused)
+				direct = pick(cardinal)
 			return mob.buckled.relaymove(mob,direct)
 
 		if(istype(mob.machine, /obj/machinery))
@@ -289,6 +293,9 @@
 					var/datum/organ/external/r_hand = driver.get_organ("r_hand")
 					if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
 						return // No hands to drive your chair? Tough luck!
+				//drunk wheelchair driving
+				if(mob.confused)
+					direct = pick(cardinal)
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)
 

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -262,6 +262,25 @@
 
 	return ..()
 
+//-------------------------------------------
+// Latching/unlatching procs
+//-------------------------------------------
+
+/obj/vehicle/train/cargo/engine/latch(obj/vehicle/train/T, mob/user)
+	if(!istype(T) || !Adjacent(T))
+		return 0
+
+	//if we are attaching a trolley to an engine we don't care what direction
+	// it is in and it should probably be attached with the engine in the lead
+	if(istype(T, /obj/vehicle/train/cargo/trolley))
+		T.attach_to(src, user)
+	else
+		var/T_dir = get_dir(src, T)	//figure out where T is wrt src
+
+		if(dir == T_dir) 	//if car is ahead
+			src.attach_to(T, user)
+		else if(reverse_direction(dir) == T_dir)	//else if car is behind
+			T.attach_to(src, user)
 
 //-------------------------------------------------------
 // Stat update procs

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -46,7 +46,7 @@
 	overlays += I
 	turn_off()	//so engine verbs are correctly set
 
-/obj/vehicle/train/cargo/engine/Move()
+/obj/vehicle/train/cargo/engine/Move(var/turf/destination)
 	if(on && cell.charge < charge_use)
 		turn_off()
 		update_stats()
@@ -54,6 +54,10 @@
 			load << "The drive motor briefly whines, then drones to a stop."
 
 	if(is_train_head() && !on)
+		return 0
+	
+	//space check ~no flying space trains sorry
+	if(on && istype(destination, /turf/space))
 		return 0
 
 	return ..()
@@ -186,8 +190,8 @@
 
 /obj/vehicle/train/cargo/engine/verb/start_engine()
 	set name = "Start engine"
-	set category = "Object"
-	set src in view(1)
+	set category = "Vehicle"
+	set src in view(0)
 
 	if(!istype(usr, /mob/living/carbon/human))
 		return
@@ -207,8 +211,8 @@
 
 /obj/vehicle/train/cargo/engine/verb/stop_engine()
 	set name = "Stop engine"
-	set category = "Object"
-	set src in view(1)
+	set category = "Vehicle"
+	set src in view(0)
 
 	if(!istype(usr, /mob/living/carbon/human))
 		return
@@ -223,8 +227,8 @@
 
 /obj/vehicle/train/cargo/engine/verb/remove_key()
 	set name = "Remove key"
-	set category = "Object"
-	set src in view(1)
+	set category = "Vehicle"
+	set src in view(0)
 
 	if(!istype(usr, /mob/living/carbon/human))
 		return
@@ -251,7 +255,12 @@
 	if(!istype(C,/obj/machinery) && !istype(C,/obj/structure/closet) && !istype(C,/obj/structure/largecrate) && !istype(C,/obj/structure/reagent_dispensers) && !istype(C,/obj/structure/ore_box) && !istype(C, /mob/living/carbon/human))
 		return 0
 
-	..()
+	//if there are any items you don't want to be able to interact with, add them to this check
+	// ~no more shielded, emitter armed death trains
+	if(istype(C, /obj/machinery))
+		load_object(C)
+	else
+		..()
 
 	if(load)
 		return 1
@@ -261,6 +270,45 @@
 		return 0
 
 	return ..()
+
+//Load the object "inside" the trolley and add an overlay of it.
+//This prevents the object from being interacted with until it has
+// been unloaded. A dummy object is loaded instead so the loading
+// code knows to handle it correctly.
+/obj/vehicle/train/cargo/trolley/proc/load_object(var/atom/movable/C)
+	if(!isturf(C.loc)) //To prevent loading things from someone's inventory, which wouldn't get handled properly.
+		return 0
+	if(load || C.anchored)
+		return 0
+
+	var/datum/vehicle_dummy_load/dummy_load = new()
+	load = dummy_load
+
+	if(!load)
+		return
+	dummy_load.actual_load = C
+	C.forceMove(src)
+
+	if(load_item_visible)
+		C.pixel_x += load_offset_x
+		C.pixel_y += load_offset_y
+		C.layer = layer
+
+		overlays += C
+
+		//we can set these back now since we have already cloned the icon into the overlay
+		C.pixel_x = initial(C.pixel_x)
+		C.pixel_y = initial(C.pixel_y)
+		C.layer = initial(C.layer)
+
+/obj/vehicle/train/cargo/trolley/unload(var/mob/user, var/direction)
+	if(istype(load, /datum/vehicle_dummy_load))
+		var/datum/vehicle_dummy_load/dummy_load = load
+		load = dummy_load.actual_load
+		dummy_load.actual_load = null
+		del(dummy_load)
+		overlays.Cut()
+	..()
 
 //-------------------------------------------
 // Latching/unlatching procs

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -114,7 +114,7 @@
 /obj/vehicle/train/verb/unlatch_v()
 	set name = "Unlatch"
 	set desc = "Unhitches this train from the one in front of it."
-	set category = "Object"
+	set category = "Vehicle"
 	set src in view(1)
 
 	if(!istype(usr, /mob/living/carbon/human))
@@ -221,7 +221,7 @@
 	var/train_length = 0
 	while(T)
 		train_length++
-		if (powered && on)
+		if (T.powered && T.on)
 			active_engines++
 		T.update_car(train_length, active_engines)
 		T = T.lead

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -116,7 +116,7 @@
 	set desc = "Unhitches this train from the one in front of it."
 	set category = "Object"
 	set src in view(1)
-	
+
 	if(!istype(usr, /mob/living/carbon/human))
 		return
 
@@ -131,6 +131,7 @@
 //-------------------------------------------
 
 //attempts to attach src as a follower of the train T
+//Note: there is a modified version of this in code\modules\vehicles\cargo_train.dm specifically for cargo train engines
 /obj/vehicle/train/proc/attach_to(obj/vehicle/train/T, mob/user)
 	if (get_dist(src, T) > 1)
 		user << "\red [src] is too far away from [T] to hitch them together."
@@ -139,11 +140,11 @@
 	if (lead)
 		user << "\red [src] is already hitched to something."
 		return
-	
+
 	if (T.tow)
 		user << "\red [T] is already towing something."
 		return
-	
+
 	//check for cycles.
 	var/obj/vehicle/train/next_car = T
 	while (next_car)
@@ -151,15 +152,15 @@
 			user << "\red That seems very silly."
 			return
 		next_car = next_car.lead
-	
+
 	//latch with src as the follower
 	lead = T
 	T.tow = src
 	set_dir(lead.dir)
-	
+
 	if(user)
 		user << "\blue You hitch [src] to [T]."
-	
+
 	update_stats()
 
 
@@ -168,10 +169,10 @@
 	if (!lead)
 		user << "\red [src] is not hitched to anything."
 		return
-	
+
 	lead.tow = null
 	lead.update_stats()
-	
+
 	user << "\blue You unhitch [src] from [lead]."
 	lead = null
 
@@ -190,7 +191,7 @@
 
 //returns 1 if this is the lead car of the train
 /obj/vehicle/train/proc/is_train_head()
-	if (lead) 
+	if (lead)
 		return 0
 	return 1
 
@@ -209,7 +210,7 @@
 		if (T.tow == src)
 			lead.tow = null
 			lead.update_stats()
-			
+
 			lead = null
 			update_stats()
 			return

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -39,6 +39,7 @@
 
 /obj/vehicle/Move()
 	if(world.time > l_move_time + move_delay)
+		var/old_loc = get_turf(src)
 		if(on && powered && cell.charge < charge_use)
 			turn_off()
 
@@ -48,6 +49,7 @@
 			anchored = init_anc
 			return 0
 
+		set_dir(get_dir(old_loc, loc))
 		anchored = init_anc
 
 		if(on && powered)
@@ -152,6 +154,10 @@
 			turn_on()
 
 /obj/vehicle/attack_ai(mob/user as mob)
+	return
+
+// For downstream compatibility (in particular Paradise)
+/obj/vehicle/proc/handle_rotation()
 	return
 
 //-------------------------------------------

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -1,3 +1,9 @@
+//Dummy object for holding items in vehicles.
+//Prevents items from being interacted with.
+/datum/vehicle_dummy_load
+	var/name = "dummy load"
+	var/actual_load
+
 /obj/vehicle
 	name = "vehicle"
 	icon = 'icons/obj/vehicles.dmi'
@@ -55,8 +61,10 @@
 		if(on && powered)
 			cell.use(charge_use)
 
-		if(load)
-			load.forceMove(loc)// = loc
+		//Dummy loads do not have to be moved as they are just an overlay
+		//See load_object() proc in cargo_trains.dm for an example
+		if(load && !istype(load, /datum/vehicle_dummy_load))
+			load.forceMove(loc)
 			load.set_dir(dir)
 
 		return 1
@@ -263,8 +271,8 @@
 // calling this parent proc.
 //-------------------------------------------
 /obj/vehicle/proc/load(var/atom/movable/C)
-	//define allowed items for loading in specific vehicle definitions
-
+	//This loads objects onto the vehicle so they can still be interacted with.
+	//Define allowed items for loading in specific vehicle definitions.
 	if(!isturf(C.loc)) //To prevent loading things from someone's inventory, which wouldn't get handled properly.
 		return 0
 	if(load || C.anchored)


### PR DESCRIPTION
- Fixes #5906
- Fixes #5939
- Fixes #6282
- Fixes #6634
- Fixes #7414
- Fixes #7609
- Fixed a bug with updating train stats (causing trains to be super slow if hitched while running)
- Updated train verbs (start/stop/remove key) to only show up if you are in the same turf
- Moved all train specific verbs to their own verb category: "Vehicle"
