### PR TITLE
Wireless Wires Bugfix

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -70,8 +70,12 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 
 		var/lighting_controller_was_processing = lighting_controller.processing	//Pause the lighting updates for a bit
 		lighting_controller.processing = 0
+
+
+		var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range
 		var/powernet_rebuild_was_deferred_already = defer_powernet_rebuild
-		if(defer_powernet_rebuild != 2)
+		// Large enough explosion. For performance reasons, powernets will be rebuilt manually
+		if(!defer_powernet_rebuild && (approximate_intensity > 25))
 			defer_powernet_rebuild = 1
 
 		if(heavy_impact_range > 1)
@@ -110,9 +114,9 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		sleep(8)
 
 		if(!lighting_controller.processing)	lighting_controller.processing = lighting_controller_was_processing
-		if(!powernet_rebuild_was_deferred_already)
-			if(defer_powernet_rebuild != 2)
-				defer_powernet_rebuild = 0
+		if(!powernet_rebuild_was_deferred_already && defer_powernet_rebuild)
+			makepowernets()
+			defer_powernet_rebuild = 0
 
 	return 1
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -206,8 +206,6 @@ var/global/list/uneatable = list(
 
 /obj/machinery/singularity/proc/eat()
 	set background = 1
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
 	// Let's just make this one loop.
 	for(var/atom/X in orange(grav_pull,src))
 		var/dist = get_dist(X, src)
@@ -226,9 +224,6 @@ var/global/list/uneatable = list(
 		// Turf and movable atoms
 		else if(dist <= consume_range && (isturf(X) || istype(X, /atom/movable)))
 			consume(X)
-
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
 	return
 
 
@@ -567,11 +562,7 @@ var/global/list/uneatable = list(
 
 /obj/machinery/singularity/narsie/wizard/eat()
 	set background = 1
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
 	for(var/atom/X in orange(consume_range,src))
 		if(isturf(X) || istype(X, /atom/movable))
 			consume(X)
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
 	return


### PR DESCRIPTION
- This removes the dreaded wireless wires bug, which caused wires disconnected by explosions to actually still conduct power until powernet was manually updated.
- This is done by actually calling makepowernets() after explosion is processed. Since makepowernets is quite laggy on it's own, and defer_powernet_rebuild is suposed to limit lag, i have added check for explosion strength. Weak explosions will no longer use defer powernet rebuild, because amount of affected wires will likely be very low, and makepowernets() would actually lag more than just del() on few cables.
- This also adresses issue with (on bay currenly unused) singularity, which exhibits similar behavior when eating wires (wireless wires bug)
