### PR TITLE
Fixes a tiny typo and a comment

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1552,7 +1552,7 @@ datum
 				if(!M) M = holder.my_atom
 				if(toxpwr)
 					M.adjustToxLoss(toxpwr*REM)
-					if(alien) ..() //Kind of a catch-all for aliens without kidneys.
+				if(alien) ..() // Kind of a catch-all for aliens without the liver. Because this does not metabolize 'naturally', only removed by the liver.
 				return
 
 		toxin/amatoxin


### PR DESCRIPTION
So basically toxins are not processed like all other reagents - instead that is handled to the liver. Since dionae/dionas have no liver, toxins would never leave their system. There is a check for aliens to forcefully call ..(), but due to a typo it was only called if the drug had any toxpwr. Since mindbreaker (and several others) has toxpwr = 0, such drugs would never leave a poor diona's... khm, system.

The question to how diona even get affected by those in the first place stays open.

Fixes #6994.
