### PR TITLE
Fixes #7665, #7653, #7677. Fixes wire colors.

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -7,7 +7,7 @@
 
 var/list/same_wires = list()
 // 14 colours, if you're adding more than 14 wires then add more colours here
-var/list/wireColours = list("red", "blue", "green", "white", "orange", "brown", "gold", "gray", "cyan", "navy", "purple", "pink", "black", "yellow")
+var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown", "gold", "gray", "cyan", "navy", "purple", "pink", "black", "yellow")
 
 /datum/wires
 
@@ -97,7 +97,7 @@ var/list/wireColours = list("red", "blue", "green", "white", "orange", "brown", 
 		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A></td></tr>"
 	html += "</table>"
 	html += "</div>"
-	
+
 	if (random)
 		html += "<i>\The [holder] appears to have tamper-resistant electronics installed.</i><br><br>" //maybe this could be more generic?
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -23,7 +23,8 @@
 
 /obj/machinery/autolathe/interact(mob/user as mob)
 
-	if(..() || disabled)
+	if(..() || (disabled && !panel_open))
+		user << "\red \The [src] is disabled!"
 		return
 
 	if (shocked)
@@ -31,7 +32,7 @@
 
 	var/dat = "<center><h1>Autolathe Control Panel</h1><hr/>"
 
-	if(panel_open == 0)
+	if(!disabled)
 		dat += "<table width = '100%'>"
 		var/material_top = "<tr>"
 		var/material_bottom = "<tr>"
@@ -81,7 +82,7 @@
 
 		dat += "</table><hr>"
 	//Hacking.
-	else
+	if(panel_open)
 		dat += "<h2>Maintenance Panel</h2>"
 		dat += wires.GetInteractWindow()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1135,7 +1135,7 @@ About the new airlock wires panel:
 	update_icon()
 
 /obj/machinery/door/airlock/proc/hasPower()
-	return ((src.secondsMainPowerLost==0 || src.secondsBackupPowerLost==0) && !(stat & NOPOWER|BROKEN))
+	return ((src.secondsMainPowerLost==0 || src.secondsBackupPowerLost==0) && !(stat & (NOPOWER|BROKEN)))
 
 /obj/machinery/door/airlock/proc/prison_open()
 	src.unlock()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -826,7 +826,7 @@
 			src.overlays += "fab-load-[material]"//loading animation is now an overlay based on material type. No more spontaneous conversion of all ores to metal. -vey
 			sleep(10)
 
-			while(src.resources[material] < res_max_amount && stack)
+			while(src.resources[material] < res_max_amount && stack.amount >= 1)
 				src.resources[material] += amnt
 				stack.use(1)
 				count++


### PR DESCRIPTION
The exosuit fabricator will check that the amount of materials in a stack is greater than 0, rather than that it just exists, fixes #7665. Adds missing parenthesis in logic in `/obj/machinery/door/airlock/proc/hasPower()`, fixes #7653. Allows the autolathe maintenance panel to be accessed even if it is disabled, fixes #7677. Adds feedback when someone interacts with a disabled autolathe while the panel is closed. Change the white wire to dark red for readability.
