### PR TITLE
Borer tweaks

### DIFF
--- a/code/game/gamemodes/calamity/calamity.dm
+++ b/code/game/gamemodes/calamity/calamity.dm
@@ -411,11 +411,7 @@
 
 			var/mob/living/simple_animal/borer/roundstart/B = new(target_host)
 
-			player.current = B
-			B.mind = player
-			B.key = player.key
-			player.assigned_role = "Cortical Borer"
-			player.special_role = "Cortical Borer"
+			B.transfer_personality(player)
 
 			B.host = target_host
 			B.host_brain.name = target_host.name
@@ -423,10 +419,6 @@
 
 			var/datum/organ/external/head = target_host.get_organ("head")
 			head.implants += B
-
-			player.current << "\blue <b>You are a cortical borer!</b> You are a brain slug that worms its way \
-			into the head of its victim, lurking out of sight until it needs to take control."
-			player.current << "You can speak to your victim with <b>say</b>, to other borers with <b>say ;</b>, and use your Alien tab for abilities."
 
 			if(!config.objectives_disabled)
 				player.objectives += new /datum/objective/borer_survive()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -643,6 +643,12 @@
 		else
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Dionaea;jobban4=\ref[M]'>Dionaea</a></td>"
 
+		if(jobban_isbanned(M, "Borer"))
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Borer;jobban4=\ref[M]'><font color=red>Borer</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Borer;jobban4=\ref[M]'>Borer</a></td>"
+
+
 		jobs += "</tr></table>"
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -490,17 +490,17 @@
 		var/mob/living/simple_animal/borer/B = src.loc
 		var/mob/living/captive_brain/H = src
 
-		H << "\red <B>You begin doggedly resisting the parasite's control (this will take approximately sixty seconds).</B>"
-		B.host << "\red <B>You feel the captive mind of [src] begin to resist your control.</B>"
+		H << "<span class='danger'>You begin doggedly resisting the parasite's control (this will take approximately sixty seconds).</span>"
+		B.host << "<span class='danger'>You feel the captive mind of [src] begin to resist your control.</span>"
 
-		spawn(rand(400,500)+B.host.brainloss)
+		spawn(rand(200,250)+B.host.brainloss)
 
 			if(!B || !B.controlling)
 				return
 
 			B.host.adjustBrainLoss(rand(5,10))
-			H << "\red <B>With an immense exertion of will, you regain control of your body!</B>"
-			B.host << "\red <B>You feel control of the host brain ripped from your grasp, and retract your probosci before the wild neural impulses can damage you.</b>"
+			H << "<span class='danger'>With an immense exertion of will, you regain control of your body!</span>"
+			B.host << "<span class='danger'>You feel control of the host brain ripped from your grasp, and retract your probosci before the wild neural impulses can damage you.</span>"
 
 			B.detatch()
 

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -174,7 +174,7 @@
 //Procs for grabbing players.
 /mob/living/simple_animal/borer/proc/request_player()
 	for(var/mob/dead/observer/O in player_list)
-		if(jobban_isbanned(O, "Syndicate"))
+		if(jobban_isbanned(O, "Borer"))
 			continue
 		if(O.client)
 			if(O.client.prefs.be_special & BE_ALIEN)
@@ -193,15 +193,21 @@
 
 /mob/living/simple_animal/borer/proc/transfer_personality(var/client/candidate)
 
-	if(!candidate)
+	if(!candidate || !candidate.mob || !candidate.mob.mind)
 		return
 
 	src.mind = candidate.mob.mind
+	candidate.mob.mind.current = src
 	src.ckey = candidate.ckey
+
 	if(src.mind)
 		src.mind.assigned_role = "Cortical Borer"
 		src.mind.special_role = "Cortical Borer"
-		ticker.mode.borers |= src.mind
+
+	src << "<span class='notice'>You are a cortical borer!</span> You are a brain slug that worms its way \
+	into the head of its victim. Use stealth, persuasion and your powers of mind control to keep you, \
+	your host and your eventual spawn safe and warm."
+	src << "You can speak to your victim with <b>say</b>, to other borers with <b>say :x</b>, and use your Abilities tab to access powers."
 
 /mob/living/simple_animal/borer/can_use_vents()
 	return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -69,6 +69,10 @@
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 
+		var/datum/organ/external/E = H.organs_by_name["head"]
+		if(!E || (E.status & ORGAN_DESTROYED))
+			src << "\The [H] does not have a head!"
+
 		if(!H.species.has_organ["brain"])
 			src << "\The [H] does not seem to have an ear canal to breach."
 			return
@@ -124,6 +128,7 @@
 		src << "They are no longer in range!"
 		return
 
+/*
 /mob/living/simple_animal/borer/verb/devour_brain()
 	set category = "Abilities"
 	set name = "Devour Brain"
@@ -147,6 +152,7 @@
 
 	src << "<span class = 'danger'>It only takes a few moments to render the dead host brain down into a nutrient-rich slurry...</span>"
 	replace_brain()
+*/
 
 // BRAIN WORM ZOMBIES AAAAH.
 /mob/living/simple_animal/borer/proc/replace_brain()


### PR DESCRIPTION
- Adds Borer bantype.
- Halves borer resist time.
- Comments out Devour Brain verb (due to reports of players suiciding immediately to use this).
- Expands borer welcome text.
- Should stop borers infesting headless mobs.
