### PR TITLE
Fix clean_map_git.sh

### DIFF
--- a/tools/mapmerge/clean_map_git.sh
+++ b/tools/mapmerge/clean_map_git.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 for i in {1..6}
 do


### PR DESCRIPTION
As in title.

`for x in {low..high}` does not work in sh.

Also makes the file executable.
