### PR TITLE
Adjusts major event weightings, fixes meteor event

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -160,11 +160,11 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/major
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			50),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	0,	list(ASSIGNMENT_SECURITY = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	0,	list(ASSIGNMENT_MEDICAL = 10), 	1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				0,	list(ASSIGNMENT_ENGINEER = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,	list(ASSIGNMENT_ENGINEER = 10),	1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			1320),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	0,	list(ASSIGNMENT_SECURITY =  3), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	0,	list(ASSIGNMENT_MEDICAL =  30), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				0,	list(ASSIGNMENT_ENGINEER = 60), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,	list(ASSIGNMENT_ENGINEER =  3),	1),
 	)
 
 

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -13,7 +13,7 @@
 
 /datum/event/meteor_wave/tick()
 	if(IsMultiple(activeFor, 3))
-		spawn_meteors(rand(2,5))
+		meteor_wave(rand(2,5))
 
 /datum/event/meteor_wave/end()
 	command_announcement.Announce("The station has cleared the meteor storm.", "Meteor Alert")
@@ -34,7 +34,7 @@
 //meteor showers are lighter and more common,
 /datum/event/meteor_shower/tick()
 	if(activeFor >= next_meteor)
-		spawn_meteors(rand(1,4))
+		meteor_wave(rand(1,4))
 		next_meteor += rand(20,100)
 		waves--
 		if(waves <= 0)


### PR DESCRIPTION
Adjusts the weightings for major events in an attempt to make the high-impact events proportionately rare.

The weightings were calculated assuming 7 crew members in each of the relevant departments. Different amounts of crew members will shift the frequencies of the the events accordingly.

The weightings were chosen to give certain odds for each event occuring each time a major event fires. These are shown in the following table:

| Event | Targeted Odds | Targeted Weighting |
| --- | --- | --- |
| Space Carp Migration | 1 out of 100 | 1% |
| Virus Infection | 1 out of 10 | 10% |
| Blob Attack | 1 out of 5 | 22% |
| Meteor Storm | 1 out of 100 | 1% |
| Nothing |  | 66% |

I did not change how often major events fire. Since nothing has roughly a 66% chance of occurring and the major event fires between 2 and 3 times per round, we can expect roughly 0.8 events per round.

Disclaimer: All of this is really, really, approximate. 
