### PR TITLE
Reverted "say error helper" before there is a better implementation or option to toggle it

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -13,6 +13,7 @@
 		usr << "\red Speech is currently admin-disabled."
 		return
 	//Let's try to make users fix their errors - we try to detect single, out-of-place letters and 'unintended' words
+	/*
 	var/first_letter = copytext(message,1,2)
 	if((copytext(message,2,3) == " " && first_letter != "I" && first_letter != "A" && first_letter != ";") || cmptext(copytext(message,1,5), "say ") || cmptext(copytext(message,1,4), "me ") || cmptext(copytext(message,1,6), "looc ") || cmptext(copytext(message,1,5), "ooc ") || cmptext(copytext(message,2,6), "say "))
 		var/response = alert(usr, "Do you really want to say this using the *say* verb?\n\n[message]\n", "Confirm your message", "Yes", "Edit message", "No")
@@ -22,6 +23,7 @@
 				return
 		else if(response == "No")
 			return
+	*/
 
 	set_typing_indicator(0)
 	usr.say(message)


### PR DESCRIPTION
Commented out the "say error helper" before we have a better implementation or before it can at least be toggleable. Current state doesn't fit way too many edge casess.
