### PR TITLE
Moderate level event weightings and balance

### DIFF
--- a/code/game/gamemodes/epidemic/epidemic.dm
+++ b/code/game/gamemodes/epidemic/epidemic.dm
@@ -113,7 +113,7 @@
 		world.Reboot()
 
 	var/datum/disease2/disease/lethal = new
-	lethal.makerandom(1)
+	lethal.makerandom(3)
 	lethal.infectionchance = 5
 
 	// the more doctors, the more will be infected

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -496,8 +496,14 @@
 			return
 
 	emergency_shuttle.call_transfer()
-	log_game("[key_name(user)] has called the shuttle.")
-	message_admins("[key_name_admin(user)] has called the shuttle.", 1)
+	
+	//delay events in case of an autotransfer
+	if (isnull(user))
+		event_manager.delay_events(EVENT_LEVEL_MODERATE, 9000) //15 minutes
+		event_manager.delay_events(EVENT_LEVEL_MAJOR, 9000) 
+	
+	log_game("[user? key_name(user) : "Autotransfer"] has called the shuttle.")
+	message_admins("[user? key_name_admin(user) : "Autotransfer"] has called the shuttle.", 1)
 
 	return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -608,12 +608,14 @@ var/list/admin_verbs_mentor = list(
 
 	var/datum/disease2/disease/D = new /datum/disease2/disease()
 
-	var/greater = ((input("Is this a lesser or greater disease?", "Give Disease") in list("Lesser", "Greater")) == "Greater")
+	var/severity = 1
+	var/greater = input("Is this a lesser, greater, or badmin disease?", "Give Disease") in list("Lesser", "Greater", "Badmin")
+	switch(greater)
+		if ("Lesser") severity = 1
+		if ("Greater") severity = 2
+		if ("Badmin") severity = 99
 
-	D.makerandom(greater)
-	if (!greater)
-		D.infectionchance = 1
-
+	D.makerandom(severity)
 	D.infectionchance = input("How virulent is this disease? (1-100)", "Give Disease", D.infectionchance) as num
 
 	if(istype(T,/mob/living/carbon/human))
@@ -626,8 +628,8 @@ var/list/admin_verbs_mentor = list(
 	infect_virus2(T,D,1)
 
 	feedback_add_details("admin_verb","GD2") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	log_admin("[key_name(usr)] gave [key_name(T)] a [(greater)? "greater":"lesser"] disease2 with infection chance [D.infectionchance].")
-	message_admins("\blue [key_name_admin(usr)] gave [key_name(T)] a [(greater)? "greater":"lesser"] disease2 with infection chance [D.infectionchance].", 1)
+	log_admin("[key_name(usr)] gave [key_name(T)] a [greater] disease2 with infection chance [D.infectionchance].")
+	message_admins("\blue [key_name_admin(usr)] gave [key_name(T)] a [greater] disease2 with infection chance [D.infectionchance].", 1)
 
 /client/proc/make_sound(var/obj/O in world) // -- TLE
 	set category = "Special Verbs"

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -18,19 +18,27 @@
 
 /datum/event/carp_migration/start()
 	if(severity == EVENT_LEVEL_MAJOR)
-		for(var/i = 1 to rand(3,5))
-			spawn_fish(landmarks_list.len)
+		spawn_fish(landmarks_list.len)
 	else if(severity == EVENT_LEVEL_MODERATE)
-		spawn_fish(rand(10,30))
+		spawn_fish(rand(4, 6)) 			//12 to 30 carp, in small groups
 	else
-		spawn_fish(rand(1, 5))
+		spawn_fish(rand(1, 3), 1, 2)	//1 to 6 carp, alone or in pairs
 
-/datum/event/carp_migration/proc/spawn_fish(var/limit)
+/datum/event/carp_migration/proc/spawn_fish(var/num_groups, var/group_size_min=3, var/group_size_max=5)
+	var/list/spawn_locations = list()
+
 	for(var/obj/effect/landmark/C in landmarks_list)
 		if(C.name == "carpspawn")
-			spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(C.loc))
-			if(spawned_carp.len >= limit)
-				return
+			spawn_locations.Add(C.loc)
+	spawn_locations = shuffle(spawn_locations)
+	num_groups = min(num_groups, spawn_locations.len)
+	
+	var/i = 1
+	while (i <= num_groups)
+		var/group_size = rand(group_size_min, group_size_max)
+		for (var/j = 1, j <= group_size, j++)
+			spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
+		i++
 
 /datum/event/carp_migration/end()
 	for(var/mob/living/simple_animal/hostile/carp/C in spawned_carp)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -21,7 +21,7 @@
 		for(var/i = 1 to rand(3,5))
 			spawn_fish(landmarks_list.len)
 	else if(severity == EVENT_LEVEL_MODERATE)
-		spawn_fish(landmarks_list.len)
+		spawn_fish(rand(10,30))
 	else
 		spawn_fish(rand(1, 5))
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -139,22 +139,22 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/moderate
 	severity = EVENT_LEVEL_MODERATE
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					10),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			20, list(ASSIGNMENT_SECURITY = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				5,	list(ASSIGNMENT_ENGINEER = 25, ASSIGNMENT_SECURITY = 25)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space vines",				/datum/event/spacevine, 				10,	list(ASSIGNMENT_ENGINEER = 5)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				0,	list(ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout, 	50,	list(ASSIGNMENT_AI = 25, ASSIGNMENT_SECURITY = 25)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,			 	0,	list(ASSIGNMENT_SECURITY = 50)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				25,	list(ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			15,	list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_JANITOR = 15)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			0,	list(ASSIGNMENT_MEDICAL = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,	list(ASSIGNMENT_MEDICAL = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,	list(ASSIGNMENT_MEDICAL = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		5,	list(ASSIGNMENT_SECURITY = 5), 1),
-		new /datum/event_meta/alien(EVENT_LEVEL_MODERATE, "Alien Infestation",	/datum/event/alien_infestation, 		2.5,list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
-		new /datum/event_meta/ninja(EVENT_LEVEL_MODERATE, "Space Ninja",		/datum/event/space_ninja, 				0,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,	list(ASSIGNMENT_AI = 25, ASSIGNMENT_CYBORG = 25, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SCIENTIST = 5)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1230),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			100, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				20,		list(ASSIGNMENT_SECURITY = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space vines",				/datum/event/spacevine, 				200,	list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				0,		list(ASSIGNMENT_ENGINEER = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(ASSIGNMENT_AI = 150, ASSIGNMENT_SECURITY = 120)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 100)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				200,	list(ASSIGNMENT_ENGINEER = 60)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			250,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 150)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			0,		list(ASSIGNMENT_MEDICAL = 50), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 150)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		100,	list(ASSIGNMENT_SECURITY = 30), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 50, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5)),
+		new /datum/event_meta/alien(EVENT_LEVEL_MODERATE, "Alien Infestation",	/datum/event/alien_infestation, 		2.5,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
+		new /datum/event_meta/ninja(EVENT_LEVEL_MODERATE, "Space Ninja",		/datum/event/space_ninja, 				0,		list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
 	)
 
 /datum/event_container/major

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -45,8 +45,8 @@
 
 	log_debug("Event '[EM.name]' has completed at [worldtime2text()].")
 
-/datum/event_manager/proc/delay_events(var/container, var/delay)
-	var/list/datum/event_container/EC = event_containers[container]
+/datum/event_manager/proc/delay_events(var/severity, var/delay)
+	var/list/datum/event_container/EC = event_containers[severity]
 	EC.next_event_time += delay
 
 /datum/event_manager/proc/Interact(var/mob/living/user)
@@ -96,7 +96,7 @@
 			html += "<td>[EM.max_weight]</td>"
 			html += "<td><A align='right' href='?src=\ref[src];toggle_oneshot=\ref[EM]'>[EM.one_shot]</A></td>"
 			html += "<td><A align='right' href='?src=\ref[src];toggle_enabled=\ref[EM]'>[EM.enabled]</A></td>"
-			html += "<td><span class='alert'>[EM.get_weight()]</span></td>"
+			html += "<td><span class='alert'>[EM.get_weight(number_active_with_role())]</span></td>"
 			html += "<td><A align='right' href='?src=\ref[src];remove=\ref[EM];EC=\ref[selected_event_container]'>Remove</A></td>"
 			html += "</tr>"
 		html += "</table>"

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -45,6 +45,10 @@
 
 	log_debug("Event '[EM.name]' has completed at [worldtime2text()].")
 
+/datum/event_manager/proc/delay_events(var/container, var/delay)
+	var/list/datum/event_container/EC = event_containers[container]
+	EC.next_event_time += delay
+
 /datum/event_manager/proc/Interact(var/mob/living/user)
 
 	var/html = GetInteractWindow()

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -8,7 +8,8 @@
 	power_failure(0)
 
 /datum/event/grid_check/announce()
-	command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check", new_sound = 'sound/AI/poweroff.ogg')
+	if (prob(30))
+		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check", new_sound = 'sound/AI/poweroff.ogg')
 
 /datum/event/grid_check/end()
 	power_restore()

--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -10,10 +10,10 @@ datum/event/viral_infection/setup()
 	for (var/i=0, i < num_diseases, i++)
 		var/datum/disease2/disease/D = new /datum/disease2/disease
 		
-		var/greater = 0 //whether the disease is of the greater or lesser variety
+		var/strength = 1 //whether the disease is of the greater or lesser variety
 		if (severity >= EVENT_LEVEL_MAJOR && prob(50))
-			greater = 1
-		D.makerandom(greater)
+			strength = 2
+		D.makerandom(strength)
 		viruses += D
 
 datum/event/viral_infection/announce()
@@ -32,6 +32,7 @@ datum/event/viral_infection/start()
 	severity = max(EVENT_LEVEL_MUNDANE, severity - 1)
 	var/actual_severity = severity * rand(1, 3)
 	while(actual_severity > 0 && candidates.len)
-		infect_mob(candidates[1], pick(viruses))
+		var/datum/disease2/disease/D = pick(viruses)
+		infect_mob(candidates[1], D.getcopy())
 		candidates.Remove(candidates[1])
 		actual_severity--

--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -1,11 +1,27 @@
+datum/event/viral_infection
+	var/list/viruses = list()
+
 datum/event/viral_infection/setup()
 	announceWhen = rand(0, 3000)
 	endWhen = announceWhen + 1
+	
+	//generate 1-3 viruses. This way there's an upper limit on how many individual diseases need to be cured if many people are initially infected
+	var/num_diseases = rand(1,3)
+	for (var/i=0, i < num_diseases, i++)
+		var/datum/disease2/disease/D = new /datum/disease2/disease
+		
+		var/greater = 0 //whether the disease is of the greater or lesser variety
+		if (severity >= EVENT_LEVEL_MAJOR && prob(50))
+			greater = 1
+		D.makerandom(greater)
+		viruses += D
 
 datum/event/viral_infection/announce()
 	command_announcement.Announce("Confirmed outbreak of level five biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak5.ogg')
 
 datum/event/viral_infection/start()
+	if(!viruses.len) return
+
 	var/list/candidates = list()	//list of candidate keys
 	for(var/mob/living/carbon/human/G in player_list)
 		if(G.client && G.stat != DEAD)
@@ -13,9 +29,9 @@ datum/event/viral_infection/start()
 	if(!candidates.len)	return
 	candidates = shuffle(candidates)//Incorporating Donkie's list shuffle
 
-	severity = severity == 1 ? 1 : severity - 1
+	severity = max(EVENT_LEVEL_MUNDANE, severity - 1)
 	var/actual_severity = severity * rand(1, 3)
 	while(actual_severity > 0 && candidates.len)
-		infect_mob_random_lesser(candidates[1])
+		infect_mob(candidates[1], pick(viruses))
 		candidates.Remove(candidates[1])
 		actual_severity--

--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -11,13 +11,22 @@ datum/event/viral_infection/setup()
 		var/datum/disease2/disease/D = new /datum/disease2/disease
 		
 		var/strength = 1 //whether the disease is of the greater or lesser variety
-		if (severity >= EVENT_LEVEL_MAJOR && prob(50))
+		if (severity >= EVENT_LEVEL_MAJOR && prob(75))
 			strength = 2
 		D.makerandom(strength)
 		viruses += D
 
 datum/event/viral_infection/announce()
-	command_announcement.Announce("Confirmed outbreak of level five biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak5.ogg')
+	var/level
+	if (severity == EVENT_LEVEL_MUNDANE)
+		return
+	else if (severity == EVENT_LEVEL_MODERATE)
+		level = pick("one", "two", "three", "four")
+	else
+		level = "five"
+	
+	if (severity == EVENT_LEVEL_MAJOR || prob(60))
+		command_announcement.Announce("Confirmed outbreak of level [level] biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak5.ogg')
 
 datum/event/viral_infection/start()
 	if(!viruses.len) return

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -80,7 +80,7 @@
 		clicks += 10
 
 	//Moving to the next stage
-	if(clicks > stage*100 && prob(10))
+	if(clicks > max(stage*100, 200) && prob(10))
 		if(stage == max_stage)
 			src.cure(mob)
 			mob.antibodies |= src.antigen

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -16,20 +16,21 @@
 	uniqueID = rand(0,10000)
 	..()
 
-/datum/disease2/disease/proc/makerandom(var/greater=0)
+/datum/disease2/disease/proc/makerandom(var/severity=1)
 	for(var/i=1 ; i <= max_stage ; i++ )
 		var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder
 		holder.stage = i
-		if(greater)
-			holder.getrandomeffect(2)
-		else
-			holder.getrandomeffect()
+		holder.getrandomeffect(severity)
 		effects += holder
 	uniqueID = rand(0,10000)
-	if (greater)
-		infectionchance = rand(60,90)
-	else
-		infectionchance = 1
+	switch(severity)
+		if(1)
+			infectionchance = 1
+		if(2)
+			infectionchance = rand(10,50)
+		else
+			infectionchance = rand(60,90)
+	
 	antigen |= text2num(pick(ANTIGENS))
 	antigen |= text2num(pick(ANTIGENS))
 	spreadtype = prob(70) ? "Airborne" : "Contact"

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -27,7 +27,7 @@
 		if(1)
 			infectionchance = 1
 		if(2)
-			infectionchance = rand(10,50)
+			infectionchance = rand(10,20)
 		else
 			infectionchance = rand(60,90)
 	

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -26,7 +26,10 @@
 			holder.getrandomeffect()
 		effects += holder
 	uniqueID = rand(0,10000)
-	infectionchance = rand(60,90)
+	if (greater)
+		infectionchance = rand(60,90)
+	else
+		infectionchance = 1
 	antigen |= text2num(pick(ANTIGENS))
 	antigen |= text2num(pick(ANTIGENS))
 	spreadtype = prob(70) ? "Airborne" : "Contact"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -40,7 +40,7 @@
 ////////////////////////////////////////////////////////////////
 
 /datum/disease2/effect
-	var/chance_maxm = 50
+	var/chance_maxm = 50 //note that disease effects only proc once every 3 ticks for humans
 	var/name = "Blanking effect"
 	var/stage = 4
 	var/maxm = 1
@@ -60,8 +60,7 @@
 	name = "Nil Syndrome"
 	stage = 4
 	badness = 1
-	activate()
-		return
+	chance_maxm = 0
 
 /datum/disease2/effect/gibbingtons
 	name = "Gibbingtons Syndrome"
@@ -256,6 +255,7 @@
 /datum/disease2/effect/groan
 	name = "Groaning Syndrome"
 	stage = 3
+	chance_maxm = 25
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.say("*groan")
 ////////////////////////STAGE 2/////////////////////////////////
@@ -263,6 +263,7 @@
 /datum/disease2/effect/scream
 	name = "Loudness Syndrome"
 	stage = 2
+	chance_maxm = 25
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.say("*scream")
 
@@ -275,6 +276,7 @@
 /datum/disease2/effect/sleepy
 	name = "Resting Syndrome"
 	stage = 2
+	chance_maxm = 15
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.say("*collapse")
 
@@ -301,6 +303,7 @@
 /datum/disease2/effect/fridge
 	name = "Refridgerator Syndrome"
 	stage = 2
+	chance_maxm = 25
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.say("*shiver")
 
@@ -346,17 +349,19 @@
 	name = "Flemmingtons"
 	stage = 1
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob << "\red Mucous runs down the back of your throat."
+		mob << "<span class='warning'>Mucous runs down the back of your throat.</span>"
 
 /datum/disease2/effect/drool
 	name = "Saliva Effect"
 	stage = 1
+	chance_maxm = 25
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.say("*drool")
 
 /datum/disease2/effect/twitch
 	name = "Twitcher"
 	stage = 1
+	chance_maxm = 25
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.say("*twitch")
 
@@ -364,4 +369,4 @@
 	name = "Headache"
 	stage = 1
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob << "<span class = 'notice'> Your head hurts a bit</span>"
+		mob << "<span class='warning'>Your head hurts a bit.</span>"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -56,6 +56,13 @@
 
 ////////////////////////STAGE 4/////////////////////////////////
 
+/datum/disease2/effect/nothing
+	name = "Nil Syndrome"
+	stage = 4
+	badness = 1
+	activate()
+		return
+
 /datum/disease2/effect/gibbingtons
 	name = "Gibbingtons Syndrome"
 	stage = 4
@@ -67,12 +74,14 @@
 	name = "Radian's Syndrome"
 	stage = 4
 	maxm = 3
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.radiation += (2*multiplier)
 
 /datum/disease2/effect/deaf
 	name = "Dead Ear Syndrome"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.ear_deaf += 20
 
@@ -101,12 +110,14 @@
 /datum/disease2/effect/killertoxins
 	name = "Toxification Syndrome"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.adjustToxLoss(15*multiplier)
 
 /datum/disease2/effect/dna
 	name = "Reverse Pattern Syndrome"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.bodytemperature = max(mob.bodytemperature, 350)
 		scramble(0,mob,10)
@@ -115,6 +126,7 @@
 /datum/disease2/effect/organs
 	name = "Shutdown Syndrome"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		if(istype(mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = mob
@@ -140,6 +152,7 @@
 /datum/disease2/effect/immortal
 	name = "Longevity Syndrome"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		if(istype(mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = mob
@@ -157,11 +170,10 @@
 		var/backlash_amt = 5*multiplier
 		mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
 
-////////////////////////STAGE 3/////////////////////////////////
-
 /datum/disease2/effect/bones
 	name = "Fragile Bones Syndrome"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		if(istype(mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = mob
@@ -173,6 +185,8 @@
 			var/mob/living/carbon/human/H = mob
 			for (var/datum/organ/external/E in H.organs)
 				E.min_broken_damage = initial(E.min_broken_damage)
+
+////////////////////////STAGE 3/////////////////////////////////
 
 /datum/disease2/effect/toxins
 	name = "Hyperacidity"
@@ -238,7 +252,6 @@
 	stage = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.apply_damage(2, CLONE)
-
 
 /datum/disease2/effect/groan
 	name = "Groaning Syndrome"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -33,7 +33,7 @@
 			multiplier = rand(1,effect.maxm)
 
 /datum/disease2/effectholder/proc/majormutate()
-	getrandomeffect(2)
+	getrandomeffect(3)
 
 ////////////////////////////////////////////////////////////////
 ////////////////////////EFFECTS/////////////////////////////////
@@ -66,7 +66,7 @@
 /datum/disease2/effect/gibbingtons
 	name = "Gibbingtons Syndrome"
 	stage = 4
-	badness = 2
+	badness = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.gib()
 
@@ -88,7 +88,7 @@
 /datum/disease2/effect/monkey
 	name = "Monkism Syndrome"
 	stage = 4
-	badness = 2
+	badness = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		if(istype(mob,/mob/living/carbon/human))
 			var/mob/living/carbon/human/h = mob
@@ -97,7 +97,7 @@
 /datum/disease2/effect/suicide
 	name = "Suicidal Syndrome"
 	stage = 4
-	badness = 2
+	badness = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.suiciding = 1
 		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -72,17 +72,13 @@ proc/airborne_can_reach(turf/source, turf/target)
 		return
 	if(M.reagents.has_reagent("spaceacillin"))
 		return
-
-	if(!istype(M,/mob/living/carbon))
-		return
-		
+	
 	if(!disease.affected_species.len)
 		return
-		
-	var/mob/living/carbon/C = M
-	if (!(C.species.name in disease.affected_species))
+	
+	if (!(M.species.name in disease.affected_species))
 		if (forced)
-			disease.affected_species[1] = C.species.name
+			disease.affected_species[1] = M.species.name
 		else
 			return //not compatible with this species
 

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -104,14 +104,13 @@ proc/airborne_can_reach(turf/source, turf/target)
 //Infects mob M with random lesser disease, if he doesn't have one
 /proc/infect_mob_random_lesser(var/mob/living/carbon/M)
 	var/datum/disease2/disease/D = new /datum/disease2/disease
-	D.makerandom()
-	D.infectionchance = 1
+	D.makerandom(1)
 	infect_mob(M, D)
 
 //Infects mob M with random greated disease, if he doesn't have one
 /proc/infect_mob_random_greater(var/mob/living/carbon/M)
 	var/datum/disease2/disease/D = new /datum/disease2/disease
-	D.makerandom(1)
+	D.makerandom(2)
 	infect_mob(M, D)
 
 //Fancy prob() function.

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -73,15 +73,18 @@ proc/airborne_can_reach(turf/source, turf/target)
 	if(M.reagents.has_reagent("spaceacillin"))
 		return
 
-	if(istype(M,/mob/living/carbon/monkey))
-		var/mob/living/carbon/monkey/chimp = M
-		if (!(chimp.greaterform in disease.affected_species))
-			return
+	if(!disease.affected_species.len)
+		return
 
-	if(istype(M,/mob/living/carbon/human))
-		var/mob/living/carbon/human/chump = M
-		if (!(chump.species.name in disease.affected_species))
-			return
+	if(!istype(M,/mob/living/carbon))
+		return
+		
+	var/mob/living/carbon/C = M
+	if (!(C.species.name in disease.affected_species))
+		if (forced)
+			disease.affected_species[1] = C.species.name
+		else
+			return //not compatible with this species
 
 //	log_debug("Infecting [M]")
 

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -96,20 +96,23 @@ proc/airborne_can_reach(turf/source, turf/target)
 		M.virus2["[D.uniqueID]"] = D
 		M.hud_updateflag |= 1 << STATUS_HUD
 
+//Infects mob M with disease D
+/proc/infect_mob(var/mob/living/carbon/M, var/datum/disease2/disease/D)
+	infect_virus2(M,D,1)
+	M.hud_updateflag |= 1 << STATUS_HUD
+
 //Infects mob M with random lesser disease, if he doesn't have one
 /proc/infect_mob_random_lesser(var/mob/living/carbon/M)
 	var/datum/disease2/disease/D = new /datum/disease2/disease
 	D.makerandom()
 	D.infectionchance = 1
-	infect_virus2(M,D,1)
-	M.hud_updateflag |= 1 << STATUS_HUD
+	infect_mob(M, D)
 
 //Infects mob M with random greated disease, if he doesn't have one
 /proc/infect_mob_random_greater(var/mob/living/carbon/M)
 	var/datum/disease2/disease/D = new /datum/disease2/disease
 	D.makerandom(1)
-	infect_virus2(M,D,1)
-	M.hud_updateflag |= 1 << STATUS_HUD
+	infect_mob(M, D)
 
 //Fancy prob() function.
 /proc/dprob(var/p)

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -73,10 +73,10 @@ proc/airborne_can_reach(turf/source, turf/target)
 	if(M.reagents.has_reagent("spaceacillin"))
 		return
 
-	if(!disease.affected_species.len)
-		return
-
 	if(!istype(M,/mob/living/carbon))
+		return
+		
+	if(!disease.affected_species.len)
 		return
 		
 	var/mob/living/carbon/C = M


### PR DESCRIPTION
- Moderate level carp event is now limited to between 10 to 30 carp.
- Differentiates moderate and major level virus events. Major virus events can produce greater viruses, while moderate level virus events are restricted to lesser viruses.
- Attempts to balance lesser and greater viruses better by making lesser viruses do nothing in stage 4. Before this there was not much of a difference between greater and lesser viruses as not very many syndromes were restricted (only Gibbington's, Monkism, and Suicide, while many deadly stage 4 effects like DNA reversal were still available for lesser viruses). After this change some lesser viruses can still be deadly if left unmanaged but will generally not be as much of a pressing danger, and may even cure themselves naturally.
- Adjusts the weightings for moderate level events. This was trickier than for the major level events as there were a lot more events to balance. The relative weightings were chosen with the help of input from IRC, and everything was scaled so that with 5 crew members in each department, 2 cyborgs, and an AI, there should be an average of 4 moderate events each round (note that the moderate event trigger fires 4-6 times in a three hour round).

For convenience, the weightings, probability per trigger, and expected events per round are given below assuming 5 people in each department, 2 cyborgs and an AI.

(Note: I pretty much ignored the alien infestation and ninja events when creating these weightings. They happen infrequently enough that they shouldn't influence the following values much)

| Event | Weight | Probability | Events Per Round | Expected Odds |
| --- | --- | --- | --- | --- |
| Carp School | 250 | 4% | 0.2 | 1 out of 5 rounds |
| Rogue Drones | 120 | 2% | 0.1 | 1 out of 10 rounds |
| Space Vines | 250 | 4% | 0.2 | 1 out of 5 rounds |
| Meteor Shower | 100 | 2% | 0.08 | 1 out of 12 rounds |
| Communication Blackout | 1250 | 20% | 1 | once a round |
| Prison Break | 500 | 8% | 0.4 | 1 out of 2-3 rounds |
| Grid Check | 500 | 8% | 0.4 | 1 out of 2-3 rounds |
| Electrical Storm | 500 | 8% | 0.4 | 1 out of 2-3 rounds |
| Radiation Storm | 250 | 4% | 0.2 | 1 out of 5 rounds |
| Appendicitis | 50 | 1% | 0.04 | 1 out of 25 rounds |
| Viral Infection | 750 | 12% | 0.6 | 1 out of 1-2 rounds |
| Spider Infestation | 250 | 4% | 0.2 | 1 out of 5 rounds |
| Ion Storm | 250 | 4% | 0.2 | 1 out of 5 rounds |
| _Nothing_ | 1230 | 20% | - | - |
| **Total** | 6250 | 100% | 4 | - |

The next table shows the same data but assuming 1 person per department, an AI and no cyborgs (i.e. lowpop).
