### PR TITLE
Runtime fixes: pick() from empty list

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,7 +46,11 @@
 			playsound(loc, hitsound, 50, 1, -1)
 		return hit
 	else
-		user.visible_message("<span class='danger'>[M] has been [pick(attack_verb)] with [src] by [user]!</span>")
+		if(attack_verb.len)
+			user.visible_message("<span class='danger'>[M] has been [pick(attack_verb)] with [src] by [user]!</span>")
+		else
+			user.visible_message("<span class='danger'>[M] has been attacked with [src] by [user]!</span>")
+		
 		if (hitsound)
 			playsound(loc, hitsound, 50, 1, -1)
 		switch(damtype)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -6,9 +6,13 @@
 	var/label = null
 	var/labels_left = 30
 	var/mode = 0	//off or on.
+	
+/obj/item/weapon/hand_labeler/attack()
+	return
 
 /obj/item/weapon/hand_labeler/afterattack(atom/A, mob/user as mob, proximity)
-	if(!proximity) return
+	if(!proximity) 
+		return
 	if(!mode)	//if it's off, give up.
 		return
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
@@ -24,10 +28,10 @@
 		user << "<span class='notice'>Label too big.</span>"
 		return
 	if(ishuman(A))
-		user << "<span class='notice'>You can't label humans.</span>"
+		user << "<span class='notice'>The label refuses to stick to [A.name].</span>"
 		return
 	if(issilicon(A))
-		user << "<span class='notice'>You can't label cyborgs.</span>"
+		user << "<span class='notice'>The label refuses to stick to [A.name].</span>"
 		return
 	if(istype(A, /obj/item/weapon/reagent_containers/glass))
 		user << "<span class='notice'>The label can't stick to the [A.name].  (Try using a pen)</span>"


### PR DESCRIPTION
Didn't realize how far-spread this runtime was until after I already put in a fix for hand labelers. All items without an attack_verb should now bonk people appropriately now and not produce a runtime.
