### PR TITLE
Fixes #7802.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -195,7 +195,10 @@ its easier to just keep the beam vertical.
 			f_name = "some "
 		else
 			f_name = "a "
-		f_name += "<span class='danger'>blood-stained</span> [name][infix]!"
+		if(blood_color != "#030303")
+			f_name += "<span class='danger'>blood-stained</span> [name][infix]!"
+		else
+			f_name += "oil-stained [name][infix]."
 
 	user << "\icon[src] That's [f_name] [suffix]"
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -115,12 +115,7 @@
 			size = "bulky"
 		if(5.0)
 			size = "huge"
-		else
-	//if ((CLUMSY in usr.mutations) && prob(50)) t = "funny-looking"
-	usr << "This is a [blood_DNA ? blood_color != "#030303" ? "bloody " : "oil-stained " : ""]\icon[src][src.name]. It is a [size] item."
-	if(src.desc)
-		usr << src.desc
-	return
+	return ..(user, distance, "", "It is a [size] item.")
 
 /obj/item/attack_hand(mob/user as mob)
 	if (!user) return


### PR DESCRIPTION
item/examine() now properly calls and returns the result of ..().
Corrects both distance-based examine text and missing stack count reporting.
