### PR TITLE
Fixes laptop crew monitor program not showing assignment

### DIFF
--- a/code/WorkInProgress/computer3/computers/crew.dm
+++ b/code/WorkInProgress/computer3/computers/crew.dm
@@ -35,7 +35,7 @@
 					var/life_status = "[H.stat > 1 ? "<font color=red>Deceased</font>" : "Living"]"
 					var/damage_report = "(<font color='blue'>[dam1]</font>/<font color='green'>[dam2]</font>/<font color='orange'>[dam3]</font>/<font color='red'>[dam4]</font>)"
 
-					log += "<tr><td width='40%'>[H.get_id_name()]</td>"
+					log += "<tr><td width='40%'>[H.get_authentification_name()] ([H.get_assignment()])</td>"
 
 					switch(C.sensor_mode)
 						if(1)


### PR DESCRIPTION
As in title. Also changes name-find method to check ID inside PDA before PDA itself, as other computer-based systems (should) do.
