### PR TITLE
Adds visible emote shortcut to complement the audible emote shortcut

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -25,6 +25,8 @@
 
 	if(copytext(message,1,2) == "*")
 		return emote(copytext(message,2))
+	else if(copytext(message,1,2) == "^")
+		return custom_emote(1, copytext(message,2))
 
 	if(name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -23,10 +23,9 @@
 
 	var/message_mode = parse_message_mode(message, "headset")
 
-	if(copytext(message,1,2) == "*")
-		return emote(copytext(message,2))
-	else if(copytext(message,1,2) == "^")
-		return custom_emote(1, copytext(message,2))
+	switch(copytext(message,1,2))
+		if("*") return emote(copytext(message,2))
+		if("^") return custom_emote(1, copytext(message,2))
 
 	if(name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"


### PR DESCRIPTION
While it is a bit out of the ordinary, I decided to open this PR to dev-freeze instead of dev because 
- In terms of user interface, it mirrors the existing say shortcut for audible emotes. From a user perspective it completes that system, so that there are shortcuts for both types of emotes.
- Minimal change to code.
- dev is really far away and this would be very convenient for "t" say keyboard users.
