### PR TITLE
Abstract var repurposed

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -630,7 +630,7 @@
 	set category = "Object"
 
 	var/obj/item/I = get_active_hand()
-	if(I && !I.abstract)
+	if(I && !istype(I, /obj/item/weapon/grab))
 		I.showoff(src)
 
 /*

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -79,6 +79,9 @@ REAGENT SCANNER
 	origin_tech = "magnets=1;biotech=1"
 	var/mode = 1;
 
+/obj/item/device/healthanalyzer/mounted
+	abstract = 1
+
 
 /obj/item/device/healthanalyzer/attack(mob/living/M as mob, mob/living/user as mob)
 	if (( (CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50))

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -175,6 +175,9 @@
 	return (user.Adjacent(T) && !user.stat)
 
 
+/obj/item/weapon/rcd/mounted
+	abstract = 1
+
 /obj/item/weapon/rcd/mounted/useResource(var/amount, var/mob/user)
 	var/cost = amount*30
 	if(istype(loc,/obj/item/rig_module))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -191,7 +191,8 @@
 /obj/structure/closet/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(src.opened)
 		if(istype(W, /obj/item/weapon/grab))
-			src.MouseDrop_T(W:affecting, user)      //act like they were dragged onto the closet
+			var/obj/item/weapon/grab/G = W
+			src.MouseDrop_T(G.affecting, user)      //act like they were dragged onto the closet
 		if(istype(W,/obj/item/tk_grab))
 			return 0
 		if(istype(W, /obj/item/weapon/weldingtool))
@@ -203,6 +204,8 @@
 			for(var/mob/M in viewers(src))
 				M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 3, "You hear welding.", 2)
 			del(src)
+			return
+		if(istype(W, /obj/item) && W.abstract)
 			return
 		if(isrobot(user))
 			return

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -66,10 +66,13 @@
 /obj/structure/closet/secure_closet/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(src.opened)
 		if(istype(W, /obj/item/weapon/grab))
+			var/obj/item/weapon/grab/G = W
 			if(src.large)
-				src.MouseDrop_T(W:affecting, user)	//act like they were dragged onto the closet
+				src.MouseDrop_T(G.affecting, user)	//act like they were dragged onto the closet
 			else
-				user << "<span class='notice'>The locker is too small to stuff [W:affecting] into!</span>"
+				user << "<span class='notice'>The locker is too small to stuff [G.affecting] into!</span>"
+		if(istype(W, /obj/item) && W.abstract)
+			return
 		if(isrobot(user))
 			return
 		user.drop_item()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -68,6 +68,8 @@
 
 /obj/structure/closet/crate/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(opened)
+		if(istype(W, /obj/item) && W.abstract)
+			return
 		if(isrobot(user))
 			return
 		user.drop_item()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -416,6 +416,9 @@
 
 
 	// Handle dismantling or placing things on the table from here on.
+	if(istype(W, /obj/item) && W.abstract)
+		return
+
 	if(isrobot(user))
 		return
 

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -144,7 +144,7 @@
 	active_power_cost = 5
 	passive_power_cost = 0
 
-	gun_type = /obj/item/weapon/gun/energy/crossbow/ninja
+	gun_type = /obj/item/weapon/gun/energy/crossbow/ninja/mounted
 
 /obj/item/rig_module/mounted/energy_blade/process()
 

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -14,6 +14,7 @@
 	icon = 'icons/obj/rig_modules.dmi'
 	icon_state = "module"
 	matter = list("metal" = 20000, "plastic" = 30000, "glass" = 5000)
+	abstract = 1
 
 	var/damage = 0
 	var/obj/item/weapon/rig/holder

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -33,7 +33,7 @@
 	suit_overlay_active = "plasmacutter"
 	suit_overlay_inactive = "plasmacutter"
 
-	device_type = /obj/item/weapon/pickaxe/plasmacutter
+	device_type = /obj/item/weapon/pickaxe/plasmacutter/mounted
 
 /obj/item/rig_module/device/healthscanner
 	name = "health scanner module"
@@ -41,7 +41,7 @@
 	interface_name = "health scanner"
 	interface_desc = "Shows an informative health readout when used on a subject."
 
-	device_type = /obj/item/device/healthanalyzer
+	device_type = /obj/item/device/healthanalyzer/mounted
 
 /obj/item/rig_module/device/drill
 	name = "hardsuit drill mount"
@@ -51,7 +51,7 @@
 	suit_overlay_active = "mounted-drill"
 	suit_overlay_inactive = "mounted-drill"
 
-	device_type = /obj/item/weapon/pickaxe/diamonddrill
+	device_type = /obj/item/weapon/pickaxe/diamonddrill/mounted
 
 /obj/item/rig_module/device/anomaly_scanner
 	name = "hardsuit anomaly scanner"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -118,6 +118,9 @@
 	desc = "A rock cutter that uses bursts of hot plasma. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	drill_verb = "cutting"
 
+/obj/item/weapon/pickaxe/plasmacutter/mounted
+	abstract = 1
+
 /obj/item/weapon/pickaxe/diamond
 	name = "diamond pickaxe"
 	icon_state = "dpickaxe"
@@ -134,6 +137,9 @@
 	origin_tech = "materials=6;powerstorage=4;engineering=5"
 	desc = "Yours is the drill that will pierce the heavens!"
 	drill_verb = "drilling"
+
+/obj/item/weapon/pickaxe/diamonddrill/mounted
+	abstract = 1
 
 /obj/item/weapon/pickaxe/borgdrill
 	name = "cyborg mining drill"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -714,10 +714,10 @@
 	return 0
 
 /mob/living/carbon/human/abiotic(var/full_body = 0)
-	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask || src.head || src.shoes || src.w_uniform || src.wear_suit || src.glasses || src.l_ear || src.r_ear || src.gloves)))
+	if(full_body && ((src.l_hand && !istype(src.l_hand, /obj/item/weapon/grab)) || (src.r_hand && !istype(src.r_hand, /obj/item/weapon/grab)) || (src.back || src.wear_mask || src.head || src.shoes || src.w_uniform || src.wear_suit || src.glasses || src.l_ear || src.r_ear || src.gloves)))
 		return 1
 
-	if( (src.l_hand && !src.l_hand.abstract) || (src.r_hand && !src.r_hand.abstract) )
+	if( (src.l_hand && !istype(src.l_hand, /obj/item/weapon/grab)) || (src.r_hand && !istype(src.r_hand, /obj/item/weapon/grab)) )
 		return 1
 
 	return 0

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -13,7 +13,6 @@
 	var/last_upgrade = 0
 
 	layer = 21
-	abstract = 1
 	item_state = "nothing"
 	w_class = 5.0
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -387,10 +387,10 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 
 /mob/proc/abiotic(var/full_body = 0)
-	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask)))
+	if(full_body && ((src.l_hand && !istype(src.l_hand, /obj/item/weapon/grab)) || (src.r_hand && !istype(src.r_hand, /obj/item/weapon/grab)) || (src.back || src.wear_mask)))
 		return 1
 
-	if((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )))
+	if((src.l_hand && !istype(src.l_hand, /obj/item/weapon/grab)) || (src.r_hand && !istype(src.r_hand, /obj/item/weapon/grab)))
 		return 1
 
 	return 0

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -77,6 +77,9 @@ obj/item/weapon/gun/energy/laser/retro
 	isHandgun()
 		return 0
 
+/obj/item/weapon/gun/energy/lasercannon/mounted
+	abstract = 1
+
 /obj/item/weapon/gun/energy/lasercannon/mounted/load_into_chamber()
 	if(in_chamber)
 		return 1

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -35,6 +35,9 @@
 		else
 			user.update_inv_r_hand()
 
+/obj/item/weapon/gun/energy/gun/mounted
+	abstract = 1
+
 /obj/item/weapon/gun/energy/gun/mounted/load_into_chamber()
 	if(in_chamber)
 		return 1

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -93,6 +93,9 @@
 	name = "energy dart thrower"
 	projectile_type = "/obj/item/projectile/energy/dart"
 
+/obj/item/weapon/gun/energy/crossbow/ninja/mounted
+	abstract = 1
+
 /obj/item/weapon/gun/energy/crossbow/largecrossbow
 	name = "Energy Crossbow"
 	desc = "A weapon favored by mercenary infiltration teams."


### PR DESCRIPTION
- Fixes #7807 
- Replaced the few uses of the abstract var with type checks for grab (this was the only thing abstract was being used for)
- Repurposed the /obj/item abstract var for checking if an item can be
  placed in crates, closets and tables
- Created several "mounted" variants of items for use with rigs
- Removed a couple of colons
