### PR TITLE
Fixes Cannot execute null.on removed()

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -640,9 +640,10 @@ It can still be worn/put on as normal.
 						W.hold.close(usr)
 				usr.put_in_hands(tie)
 				suit.hastie = null*/
-			suit.hastie.on_removed(usr)
-			suit.hastie = null
-			target.update_inv_w_uniform()
+			if(suit && suit.hastie)
+				suit.hastie.on_removed(usr)
+				suit.hastie = null
+				target.update_inv_w_uniform()
 		if("id")
 			slot_to_process = slot_wear_id
 			if (target.wear_id)


### PR DESCRIPTION
runtime error: Cannot execute null.on removed().
proc name: done (/obj/effect/equip_e/human/done)
  source file: inventory.dm,643
  usr: Ikya Railey (/mob/living/carbon/human)
  src: the human (/obj/effect/equip_e/human)
  call stack:
the human (/obj/effect/equip_e/human): done()
the human (/obj/effect/equip_e/human): process()

Corrected by putting in a check to see if the tie(or other suit accessory) is actually there or not, just like the way the rest of the garments in this proc functions.
