### PR TITLE
Fixes telekinetic tape placement on airlocks

### DIFF
--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -98,8 +98,8 @@
 	//is_blocked_turf(var/turf/T)
 		usr << "\blue You finish placing the [src]."	//Git Test
 
-/obj/item/taperoll/afterattack(var/atom/A, mob/user as mob)
-	if (istype(A, /obj/machinery/door/airlock))
+/obj/item/taperoll/afterattack(var/atom/A, mob/user as mob, proximity)
+	if (proximity && istype(A, /obj/machinery/door/airlock))
 		var/turf/T = get_turf(A)
 		var/obj/item/tape/P = new tape_type(T.x,T.y,T.z)
 		P.loc = locate(T.x,T.y,T.z)


### PR DESCRIPTION
- Fixes #7842 

Was originally fixed on dev here: #5836
But was broken here: https://github.com/Baystation12/Baystation12/commit/fcd1c7749a8d83d4eb754433550482d69f1f7b1c
