### PR TITLE
Fixes airlock removing electronics check

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -905,7 +905,7 @@ About the new airlock wires panel:
 			beingcrowbarred = 1 //derp, Agouri
 		else
 			beingcrowbarred = 0
-		if( beingcrowbarred && src.p_open && (operating == -1 || (src.locked && welded && !src.arePowerSystemsOn() && BROKEN) || (density && welded && operating != 1 && !src.arePowerSystemsOn() && !src.locked)) )
+		if( beingcrowbarred && src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN)))) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -188,7 +188,7 @@
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/device/detective_scanner))
 		return
-	if(src.operating || isrobot(user))	return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
+	if(src.operating > 0 || isrobot(user))	return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
 	src.add_fingerprint(user)
 	if(!Adjacent(user))
 		user = null
@@ -250,13 +250,6 @@
 		repairing = null
 		return
 
-	if(src.density && (operable() && istype(I, /obj/item/weapon/card/emag)))
-		flick("door_spark", src)
-		sleep(6)
-		open()
-		operating = -1
-		return 1
-
 	//psa to whoever coded this, there are plenty of objects that need to call attack() on doors without bludgeoning them.
 	if(src.density && istype(I, /obj/item/weapon) && user.a_intent == "hurt" && !istype(I, /obj/item/weapon/card))
 		var/obj/item/weapon/W = I
@@ -268,6 +261,15 @@
 				playsound(src.loc, hitsound, 100, 1)
 				take_damage(W.force)
 		return
+
+	if(src.operating) return
+
+	if(src.density && (operable() && istype(I, /obj/item/weapon/card/emag)))
+		flick("door_spark", src)
+		sleep(6)
+		open()
+		operating = -1
+		return 1
 
 	if(src.allowed(user) && operable())
 		if(src.density)


### PR DESCRIPTION
Replaces `... && BROKEN ...` with `... && (stat & BROKEN) ...`
Also stops emagged status from preventing certain door actions.
