### PR TITLE
Fixes #7857.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -122,6 +122,9 @@
 			L[tmpname] = I
 
 	var/desc = input("Please select a location to lock in.", "Locking Computer") in L
+	if(get_dist(src, usr) > 1)
+		return
+
 	src.locked = L[desc]
 	for(var/mob/O in hearers(src, null))
 		O.show_message("\blue Locked In", 2)


### PR DESCRIPTION
Fixes #7857.
Must now remain adjacent to the teleporter computer if you wish to change target location.
