### PR TITLE
Fixes #7880.

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -236,7 +236,11 @@
 	return 1
 
 /proc/trackable(var/mob/living/M)
-	return near_camera(M) || (M.loc.z in config.station_levels && hassensorlevel(M, SUIT_SENSOR_TRACKING))
+	var/turf/T = get_turf(M)
+	if(T && (T.z in config.station_levels) && hassensorlevel(M, SUIT_SENSOR_TRACKING))
+		return 1
+
+	return near_camera(M)
 
 /obj/machinery/camera/attack_ai(var/mob/living/silicon/ai/user as mob)
 	if (!istype(user))


### PR DESCRIPTION
Fixes #7880.
Adds () around the `M.z in list` check, otherwise BYOND attempts to check `M.z in (list && hassensorlevel)` instead.
Also attempts to properly acquire the current Z position.
