### PR TITLE
Fixes two powernet related issues

### DIFF
--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -16,9 +16,11 @@
 
 /datum/powernet/New()
 	powernets += src
+	..()
 
 /datum/powernet/Del()
 	powernets -= src
+	..()
 
 //Returns the amount of excess power (before refunding to SMESs) from last tick.
 //This is for machines that might adjust their power consumption using this data.
@@ -110,8 +112,7 @@
 			S.restore()				// and restore some of the power that was used
 
 	//updates the viewed load (as seen on power computers)
-	viewload = 0.8*viewload + 0.2*load
-	viewload = round(viewload)
+	viewload = round(load)
 
 	//reset the powernet
 	load = 0


### PR DESCRIPTION
- First issue/oversight (not on issue tracker) is power monitoring consoles showing slightly inaccurate values. The code calculated some sort of level average which resulted in stupid values being reported (like load 500kW available 300kW for few ticks). This also fixes APC load partially showing as Other load on the console.
- Second fixed issue (Fixes #7869) resolved gamebreaking bug that caused total irreversible failure of all powernets if makepowernets() was called. This, for example, includes large enough explosions, via admin command, or few other cases.
