### PR TITLE
Replaces 'SUPPLY' with 'CARGO' on cargo screens

### DIFF
--- a/code/game/machinery/supply_display.dm
+++ b/code/game/machinery/supply_display.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/status_display/supply_display/update()
 	if(!..() && mode == STATUS_DISPLAY_CUSTOM)
-		message1 = "SUPPLY"
+		message1 = "CARGO"
 		message2 = ""
 
 		var/datum/shuttle/ferry/supply/shuttle = supply_controller.shuttle


### PR DESCRIPTION
So now it shows the line with the arrival time properly.
