### PR TITLE
Virus Protection Fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -35,7 +35,7 @@
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)
 	var/slowdown = 0 // How much clothing is slowing you down. Negative values speeds you up
 	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
-	var/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	var/list/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/list/allowed = null //suit storage stuff.
 	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 	var/zoomdevicename = null //name used for message when binoculars/scope is used

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -12,6 +12,7 @@
 	siemens_coefficient = 0.9
 	var/gas_filter_strength = 1			//For gas mask filters
 	var/list/filtered_gases = list("phoron", "sleeping_agent")
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 75, rad = 0)
 
 /obj/item/clothing/mask/gas/filter_air(datum/gas_mixture/air)
 	var/datum/gas_mixture/filtered = new
@@ -32,7 +33,7 @@
 	desc = "A modernised version of the classic design, this mask will not only filter out phoron but it can also be connected to an air supply."
 	icon_state = "plaguedoctor"
 	item_state = "gas_mask"
-	armor = list(melee = 0, bullet = 0, laser = 2,energy = 2, bomb = 0, bio = 75, rad = 0)
+	armor = list(melee = 0, bullet = 0, laser = 2,energy = 2, bomb = 0, bio = 90, rad = 0)
 	body_parts_covered = HEAD|FACE
 
 /obj/item/clothing/mask/gas/swat

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -24,7 +24,7 @@
 	body_parts_covered = 0
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.01
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 25, rad = 0)
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 0)
 
 /obj/item/clothing/mask/fakemoustache
 	name = "fake moustache"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -138,7 +138,7 @@
 		piece.name = "[suit_type] [initial(piece.name)]"
 		piece.desc = "It seems to be part of a [src.name]."
 		piece.icon_state = "[initial(icon_state)]"
-		piece.armor = armor
+		piece.armor = armor.Copy()
 		piece.min_cold_protection_temperature = min_cold_protection_temperature
 		piece.max_heat_protection_temperature = max_heat_protection_temperature
 		piece.siemens_coefficient = siemens_coefficient
@@ -227,7 +227,7 @@
 				if(!failed_to_seal && M.back == src && piece == compare_piece)
 
 					if(!instant)
-						if(!do_after(M,SEAL_DELAY))
+						if(!do_after(M,SEAL_DELAY,needhand=0))
 							failed_to_seal = 1
 
 					piece.icon_state = "[initial(icon_state)][!seal_target ? "_sealed" : ""]"
@@ -251,6 +251,13 @@
 								else
 									helmet.flags &= ~AIRTIGHT
 								helmet.update_light(wearer)
+					
+					//sealed pieces become airtight, protecting against diseases
+					if (!seal_target)
+						piece.armor["bio"] = 100
+					else
+						piece.armor["bio"] = src.armor["bio"]
+					
 				else
 					failed_to_seal = 1
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -120,7 +120,7 @@ emp_act
 /mob/living/carbon/human/proc/getarmor_organ(var/datum/organ/external/def_zone, var/type)
 	if(!type)	return 0
 	var/protection = 0
-	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform)
+	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	for(var/gear in protective_gear)
 		if(gear && istype(gear ,/obj/item/clothing))
 			var/obj/item/clothing/C = gear

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -407,11 +407,10 @@
 			loc.assume_air(breath)
 
 			//spread some viruses while we are at it
-			if (virus2.len > 0)
-				if (prob(10) && get_infection_chance(src))
-//					log_debug("[src] : Exhaling some viruses")
-					for(var/mob/living/carbon/M in view(1,src))
-						src.spread_disease_to(M)
+			if (virus2.len > 0 && prob(10))
+//				log_debug("[src] : Exhaling some viruses")
+				for(var/mob/living/carbon/M in view(1,src))
+					src.spread_disease_to(M)
 
 
 	proc/get_breath_from_internal(volume_needed)

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -1,48 +1,57 @@
-//Returns 1 if mob can be infected, 0 otherwise. Checks his clothing.
-proc/get_infection_chance(var/mob/living/carbon/M, var/vector = "Airborne")
-	var/score = 0
+//Returns 1 if mob can be infected, 0 otherwise.
+proc/infection_check(var/mob/living/carbon/M, var/vector = "Airborne")
 	if (!istype(M))
 		return 0
 
-	if(istype(M, /mob/living/carbon/human))
+	var/protection = M.getarmor(null, "bio")	//gets the full body bio armour value, weighted by body part coverage.
+	var/score = round(0.06*protection) 			//scales 100% protection to 6.
 
-		if (vector == "Airborne")
-			if(M.internal)	//not breathing infected air helps greatly
-				score = 30
-			if(M.wear_mask)
-				score += 5
-				if(istype(M:wear_mask, /obj/item/clothing/mask/surgical) && !M.internal)
-					score += 10
-			if(istype(M:wear_suit, /obj/item/clothing/suit/space) && istype(M:head, /obj/item/clothing/head/helmet/space))
-				score += 20
-			if(istype(M:wear_suit, /obj/item/clothing/suit/bio_suit) && istype(M:head, /obj/item/clothing/head/bio_hood))
-				score += 30
+	switch(vector)
+		if("Airborne")
+			if(M.internal)
+				score = 6	//not breathing infected air helps greatly
+				var/obj/item/I = M.wear_mask
+				
+				//masks provide a small bonus and can replace overall bio protection
+				score = max(score, round(0.06*I.armor["bio"]))
+				if (istype(I, /obj/item/clothing/mask))
+					score += 1 //this should be added after
+		
+		if("Contact")
+			if(istype(M, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = M
+				
+				//gloves provide a larger bonus
+				if (istype(H.gloves, /obj/item/clothing/gloves))
+					score += 2
 
-
-		if (vector == "Contact")
-			if(M:gloves) score += 15
-			if(istype(M:wear_suit, /obj/item/clothing/suit/space) && istype(M:head, /obj/item/clothing/head/helmet/space))
-				score += 15
-			if(istype(M:wear_suit, /obj/item/clothing/suit/bio_suit) && istype(M:head, /obj/item/clothing/head/bio_hood))
-				score += 15
-
-
-//	log_debug("[M]'s resistance to [vector] viruses: [score]")
-
-	if(score >= 30)
+	if(score >= 6)
 		return 0
-	else if(score == 25 && prob(99))
+	else if(score >= 5 && prob(99))
 		return 0
-	else if(score == 20 && prob(95))
+	else if(score >= 4 && prob(95))
 		return 0
-	else if(score == 15 && prob(75))
+	else if(score >= 3 && prob(75))
 		return 0
-	else if(score == 10 && prob(55))
+	else if(score >= 2 && prob(55))
 		return 0
-	else if(score == 5 && prob(35))
+	else if(score >= 1 && prob(35))
 		return 0
-//	log_debug("Infection got through")
 	return 1
+
+//Similar to infection check, but used for when M is spreading the virus.
+/proc/infection_spreading_check(var/mob/living/carbon/M, var/vector = "Airborne")
+	if (!istype(M))
+		return 0
+
+	var/protection = M.getarmor(null, "bio")	//gets the full body bio armour value, weighted by body part coverage.
+	
+	if (vector == "Airborne")
+		var/obj/item/I = M.wear_mask
+		if (istype(I))
+			protection = max(protection, round(0.06*I.armor["bio"]))
+	
+	return prob(protection)
 
 //Checks if table-passing table can reach target (5 tile radius)
 proc/airborne_can_reach(turf/source, turf/target)
@@ -84,16 +93,13 @@ proc/airborne_can_reach(turf/source, turf/target)
 
 //	log_debug("Infecting [M]")
 
-	if(prob(disease.infectionchance) || forced)
-		// certain clothes can prevent an infection
-		if(!forced && !get_infection_chance(M, disease.spreadtype))
-			return
-
+	if(forced || (infection_check(M, disease.spreadtype) && prob(disease.infectionchance)))
 		var/datum/disease2/disease/D = disease.getcopy()
 		D.minormutate()
 //		log_debug("Adding virus")
 		M.virus2["[D.uniqueID]"] = D
 		M.hud_updateflag |= 1 << STATUS_HUD
+
 
 //Infects mob M with disease D
 /proc/infect_mob(var/mob/living/carbon/M, var/datum/disease2/disease/D)
@@ -126,12 +132,15 @@ proc/airborne_can_reach(turf/source, turf/target)
 //			log_debug("Attempting virus [ID]")
 			var/datum/disease2/disease/V = virus2[ID]
 			if(V.spreadtype != vector) continue
+			
+			//It's hard to get other people sick if you're in an airtight suit.
+			if(!infection_spreading_check(src, V.spreadtype)) continue
 
 			if (vector == "Airborne")
 				if(airborne_can_reach(get_turf(src), get_turf(victim)))
 //					log_debug("In range, infecting")
 					infect_virus2(victim,V)
-				else
+//				else
 //					log_debug("Could not reach target")
 
 			if (vector == "Contact")
@@ -148,7 +157,7 @@ proc/airborne_can_reach(turf/source, turf/target)
 			var/mob/living/carbon/human/H = victim
 			var/datum/organ/external/select_area = H.get_organ(src.zone_sel.selecting)
 			var/list/clothes = list(H.head, H.wear_mask, H.wear_suit, H.w_uniform, H.gloves, H.shoes)
-			for(var/obj/item/clothing/C in clothes )
+			for(var/obj/item/clothing/C in clothes)
 				if(C && istype(C))
 					if(C.body_parts_covered & select_area.body_part)
 						nudity = 0
@@ -156,4 +165,5 @@ proc/airborne_can_reach(turf/source, turf/target)
 			for (var/ID in victim.virus2)
 				var/datum/disease2/disease/V = victim.virus2[ID]
 				if(V && V.spreadtype != vector) continue
+				if(!infection_spreading_check(victim, V.spreadtype)) continue
 				infect_virus2(src,V)


### PR DESCRIPTION
- Improves the infection_chance logic. Instead of basing an item's protective value on magic type bits, the bio armor value is used instead, which is much more flexible. I focused on roughly following the existing behaviour for determining the infection chance, so if anyone has ideas for more radical improvements to the logic, suggestions are appreciated.
- ~~Made airborne_can_reach() delete it's dummy obj after using it instead of just setting it's loc to null.~~
- Hardsuits gain voidsuit-level bio protection when sealed, and return to the default value when unsealed. Together with the infection_chance change, this fixes #7867.
- Adjusted surgical mask and gasmask bio protection.
- Wearing items that provide bio protection also help prevent a player from spreading diseases.
- Fixes #7909 
