### PR TITLE
Virus nerf, fix broken effects

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -30,7 +30,7 @@
 			infectionchance = rand(10,20)
 		else
 			infectionchance = rand(60,90)
-	
+
 	antigen |= text2num(pick(ANTIGENS))
 	antigen |= text2num(pick(ANTIGENS))
 	spreadtype = prob(70) ? "Airborne" : "Contact"
@@ -88,7 +88,8 @@
 		clicks = 0
 	//Do nasty effects
 	for(var/datum/disease2/effectholder/e in effects)
-		e.runeffect(mob,stage)
+		if(prob(33))
+			e.runeffect(mob,stage)
 
 	//Short airborne spread
 	if(src.spreadtype == "Airborne")

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -9,7 +9,7 @@
 
 /datum/disease2/effectholder/proc/runeffect(var/mob/living/carbon/human/mob,var/stage)
 	if(happensonce > -1 && effect.stage <= stage && prob(chance))
-		effect.activate(mob)
+		effect.activate(mob, multiplier)
 		if(happensonce == 1)
 			happensonce = -1
 


### PR DESCRIPTION
As in title. Virus power reduced to 33% to avoid message-spam; this may make some high-level effects have virtually no effect, but it's probably better than *drool*drool*drool.

Broken effects were caused by multiplying effect strength by "multiplier" argument, which was not passed so was null; N*null = 0.

FIxes (partially) #7789.
Fixes #7926 
