### PR TITLE
Expands on SkyMarshal's radiation changes

### DIFF
--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -211,7 +211,7 @@ datum/pipeline
 		
 		// Previously, the temperature would enter equilibrium at 26C or 294K.
 		// Only would happen if both sides (all 2 square meters of surface area) were exposed to sunlight.  We now assume it aligned edge on.
-		// It currently should stabilise at 85K or -183C.
+		// It currently should stabilise at 129.6K or -143.6C
 		heat_gain -= surface * STEFAN_BOLTZMANN_CONSTANT * thermal_conductivity * (air.temperature - COSMIC_RADIATION_TEMPERATURE) ** 4
 		
 		air.add_thermal_energy(heat_gain)

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -203,11 +203,11 @@ datum/pipeline
 	//surface must be the surface area in m^2
 	proc/radiate_heat_to_space(surface, thermal_conductivity)
 		var/gas_density = air.total_moles/air.volume
-		thermal_conductivity *= min(gas_density / ( RADIATOR_OPTIMUM_PRESSURE/(R_IDEAL_GAS_EQUATION*T20C) ), 1)
+		thermal_conductivity *= min(gas_density / ( RADIATOR_OPTIMUM_PRESSURE/(R_IDEAL_GAS_EQUATION*GAS_CRITICAL_TEMPERATURE) ), 1) //mult by density ratio
 		
 		// We only get heat from the star on the exposed surface area.
 		// If the HE pipes gain more energy from AVERAGE_SOLAR_RADIATION than they can radiate, then they have a net heat increase.
-		var/heat_gain = AVERAGE_SOLAR_RADIATION * RADIATOR_EXPOSED_SURFACE_AREA * thermal_conductivity 
+		var/heat_gain = AVERAGE_SOLAR_RADIATION * (RADIATOR_EXPOSED_SURFACE_AREA_RATIO * surface) * thermal_conductivity
 		
 		// Previously, the temperature would enter equilibrium at 26C or 294K.
 		// Only would happen if both sides (all 2 square meters of surface area) were exposed to sunlight.  We now assume it aligned edge on.

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -12,8 +12,16 @@
 #define STEFAN_BOLTZMANN_CONSTANT		5.6704e-8	//W/(m^2*K^4)
 #define COSMIC_RADIATION_TEMPERATURE	3.15		//K
 #define AVERAGE_SOLAR_RADIATION			200			//W/m^2. Kind of arbitrary. Really this should depend on the sun position much like solars.  From the numbers on Erebus, this'd be an orbit of 23.3 lightseconds.
-#define RADIATOR_OPTIMUM_PRESSURE		110			//kPa at 20 C
-#define RADIATOR_EXPOSED_SURFACE_AREA 0.03  //The pipe looks to be thin vertically and wide horizontally, so we'll assume that it's three centimeters thick and only explosed to the sun edge-on.
+#define RADIATOR_OPTIMUM_PRESSURE		3771		//kPa - this should be higher as gasses aren't great conductors until they are dense. Used the critical pressure for air.
+#define GAS_CRITICAL_TEMPERATURE		132.65		//K - the critical point temperature for air 
+
+/*
+	The pipe looks to be thin vertically and wide horizontally, so we'll assume that it's 
+	three centimeters thick, one meter wide, and only explosed to the sun 3 degrees off of edge-on. 
+	Since the radiatior is uniform along it's length, the ratio of surface area touched by sunlight 
+	to the total surface area is the same as the ratio of the perimeter of the cross-section.
+*/
+#define RADIATOR_EXPOSED_SURFACE_AREA_RATIO 0.04 // (3 cm + 100 cm * sin(3deg))/(2*(3+100 cm)) //unitless ratio
 
 #define CELL_VOLUME 2500	//liters in a cell
 #define MOLES_CELLSTANDARD (ONE_ATMOSPHERE*CELL_VOLUME/(T20C*R_IDEAL_GAS_EQUATION))	//moles in a 2.5 m^3 cell at 101.325 Pa and 20 degC


### PR DESCRIPTION
I noticed a few issues while looking through the radiation code. The value used for RADIATOR_EXPOSED_SURFACE_AREA seemed off as that quantity needs to be unitless for everything to work. Turns out the actual value is pretty similar though.

Also replaced the radiation pressure placeholder values with ones that have a bit more substance.
