### PR TITLE
Tape fixes

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -13,7 +13,7 @@
 	user.put_in_hands(tape)
 */
 
-/obj/item/weapon/tape_roll/proc/stick(var/obj/item/weapon/W, mob/user as mob)
+/obj/item/weapon/tape_roll/proc/stick(var/obj/item/weapon/W, mob/user)
 	if(!istype(W, /obj/item/weapon/paper))
 		return
 	
@@ -30,14 +30,14 @@
 	w_class = 1
 	layer = 4
 	anchored = 1 //it's sticky, no you cant move it
-	
+
 	var/obj/item/weapon/stuck = null
 
 /obj/item/weapon/ducttape/New()
 	..()
 	flags |= NOBLUDGEON
 
-/obj/item/weapon/ducttape/examine(mob/user as mob)
+/obj/item/weapon/ducttape/examine(mob/user)
 	return stuck.examine(user)
 
 /obj/item/weapon/ducttape/proc/attach(var/obj/item/weapon/W)
@@ -47,7 +47,7 @@
 	name = W.name + " (taped)"
 	overlays = W.overlays
 
-/obj/item/weapon/ducttape/attack_self(mob/user as mob)
+/obj/item/weapon/ducttape/attack_self(mob/user)
 	if(!stuck)
 		return
 
@@ -60,7 +60,7 @@
 	overlays = null
 	del(src)
 
-/obj/item/weapon/ducttape/afterattack(var/A, mob/user as mob, flag, params)
+/obj/item/weapon/ducttape/afterattack(var/A, mob/user, flag, params)
 	if(!in_range(user, A) || istype(A, /obj/machinery/door) || !stuck)
 		return
 
@@ -70,6 +70,9 @@
 	var/dir_offset = 0
 	if(target_turf != source_turf)
 		dir_offset = get_dir(source_turf, target_turf)
+		if(!(dir_offset in cardinal))
+			user << "You cannot reach that from here."		// can only place stuck papers in cardinal directions, to
+			return											// reduce papers around corners issue.
 
 	user.drop_from_inventory(src)
 	forceMove(source_turf)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -35,8 +35,9 @@
 		user.drop_from_inventory(P)
 		P.loc = src
 		if(istype(user,/mob/living/carbon/human))
-			user:update_inv_l_hand()
-			user:update_inv_r_hand()
+			var/mob/living/carbon/human/H = user
+			H.update_inv_l_hand()
+			H.update_inv_r_hand()
 	else if(istype(W, /obj/item/weapon/photo))
 		amount++
 		if(screen == 2)
@@ -57,6 +58,8 @@
 		user << "<span class='notice'>You add \the [W.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>"
 		del(W)
 	else
+		if(istype(W, /obj/item/weapon/tape_roll))
+			return 0
 		if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/toy/crayon))
 			usr << browse("", "window=[name]") //Closes the dialog
 		P = src[page]


### PR DESCRIPTION
- Fixes #7921 
- Fixes #7865 

To get around the paper taped around corners issue I restricted sticking them in only cardinal directions. It's not perfect, but it will resolve the issue of standing right in front of a taped paper and not being able to pick it up because it's actually two tiles away.
