### PR TITLE
Returns hoverpod step drain to 10

### DIFF
--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -5,7 +5,7 @@
 	initial_icon = "engineering_pod"
 	internal_damage_threshold = 80
 	step_in = 4
-	step_energy_drain = 15
+	step_energy_drain = 10
 	max_temperature = 20000
 	health = 150
 	infra_luminosity = 6


### PR DESCRIPTION
Was originally set to 15 in anticipation of allowing hoverpods to coast in space like jetpacks, thus greatly affecting power use in space. Unfortunately that never happened due to the global iterator code being ancient and hard to work with.
