### PR TITLE
Camera sorting improvements

### DIFF
--- a/code/WorkInProgress/computer3/computers/camera.dm
+++ b/code/WorkInProgress/computer3/computers/camera.dm
@@ -141,13 +141,13 @@
 		if (!computer || computer.z > 6)
 			return null
 
+		cameranet.process_sort()
+
 		var/list/L = list()
 		for(var/obj/machinery/camera/C in cameranet.cameras)
 			var/list/temp = C.network & key.networks
 			if(temp.len)
 				L.Add(C)
-
-		camera_sort(L)
 
 		return L
 	verify_machine(var/obj/machinery/camera/C,var/datum/file/camnet_key/key = null)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -581,3 +581,6 @@ datum/proc/dd_SortValue()
 
 /obj/machinery/dd_SortValue()
 	return "[sanitize(name)]"
+
+/obj/machinery/camera/dd_SortValue()
+	return "[c_tag]"

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -15,15 +15,11 @@
 	if(src.stat == 2)
 		return
 
-	var/list/L = list()
-	for (var/obj/machinery/camera/C in cameranet.cameras)
-		L.Add(C)
-
-	camera_sort(L)
+	cameranet.process_sort()
 
 	var/list/T = list()
 	T["Cancel"] = "Cancel"
-	for (var/obj/machinery/camera/C in L)
+	for (var/obj/machinery/camera/C in cameranet.cameras)
 		var/list/tempnetwork = C.network&src.network
 		if (tempnetwork.len)
 			T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
@@ -252,19 +248,3 @@
 
 /mob/living/silicon/ai/attack_ai(var/mob/user as mob)
 	ai_camera_list()
-
-/proc/camera_sort(list/L)
-	var/obj/machinery/camera/a
-	var/obj/machinery/camera/b
-
-	for (var/i = L.len, i > 0, i--)
-		for (var/j = 1 to i - 1)
-			a = L[j]
-			b = L[j + 1]
-			if (a.c_tag_order != b.c_tag_order)
-				if (a.c_tag_order > b.c_tag_order)
-					L.Swap(j, j + 1)
-			else
-				if (sorttext(a.c_tag, b.c_tag) < 0)
-					L.Swap(j, j + 1)
-	return L

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -37,14 +37,10 @@
 		data["current"] = null
 
 		if(isnull(camera_cache))
-			var/list/L = list()
-			for (var/obj/machinery/camera/C in cameranet.cameras)
-				if(can_access_camera(C))
-					L.Add(C)
-			camera_sort(L)
+			cameranet.process_sort()
 
 			var/cameras[0]
-			for(var/obj/machinery/camera/C in L)
+			for(var/obj/machinery/camera/C in cameranet.cameras)
 				var/cam[0]
 				cam["name"] = sanitize(C.c_tag)
 				cam["deact"] = !C.can_use()
@@ -72,7 +68,7 @@
 				cam["z"] = current.z
 
 				data["current"] = cam
-			
+
 
 		if(ui)
 			ui.load_cached_data(camera_cache)

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -7,9 +7,15 @@ var/datum/cameranet/cameranet = new()
 /datum/cameranet
 	// The cameras on the map, no matter if they work or not. Updated in obj/machinery/camera.dm by New() and Del().
 	var/list/cameras = list()
+	var/cameras_unsorted = 1
 	// The chunks of the map, mapping the areas that the cameras can see.
 	var/list/chunks = list()
 	var/ready = 0
+
+/datum/cameranet/proc/process_sort()
+	if(cameras_unsorted)
+		cameras = dd_sortedObjectList(cameras)
+		cameras_unsorted = 0
 
 // Checks if a chunk has been Generated in x, y, z.
 /datum/cameranet/proc/chunkGenerated(x, y, z)

--- a/code/modules/mob/living/silicon/ai/freelook/update_triggers.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/update_triggers.dm
@@ -92,7 +92,13 @@
 
 /obj/machinery/camera/New()
 	..()
-	cameranet.cameras += src //Camera must be added to global list of all cameras no matter what...
+	//Camera must be added to global list of all cameras no matter what...
+	if(cameranet.cameras_unsorted || !ticker)
+		cameranet.cameras += src
+		cameranet.cameras_unsorted = 1
+	else
+		dd_insertObjectList(cameranet.cameras, src)
+
 	var/list/open_networks = difflist(network,restricted_camera_networks) //...but if all of camera's networks are restricted, it only works for specific camera consoles.
 	if(open_networks.len) //If there is at least one open network, chunk is available for AI usage.
 		cameranet.addCamera(src)


### PR DESCRIPTION
As in title. Removes the old `camera_sort()` proc, replaces it with cameras sorting by `c_tag` in `dd_sortedObjectList` by default and all places which previously used `camera_sort` now call `cameranet.process_sort()`, which checks if the list needs sorting, and if it does, sorts it. Cameras created while the list is sorted after initial setup (i.e. when `ticker` is non-null) will use `dd_insertObjectList` instead, avoiding a full sort.
