### PR TITLE
Additional support for non-Exodus maps.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -91,7 +91,7 @@
 		var/turf/T = get_turf(R)
 		if (!T)
 			continue
-		if(T.z == 2 || T.z > 7)
+		if(!(T.z in config.player_levels))
 			continue
 		var/tmpname = T.loc.name
 		if(areaindex[tmpname])


### PR DESCRIPTION
Teleport now also checks config for appropriate Z-levels instead of using hard-coded values.
