### PR TITLE
(Likely) fixes #7987.

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -41,6 +41,9 @@
 
 			var/cameras[0]
 			for(var/obj/machinery/camera/C in cameranet.cameras)
+				if(!can_access_camera(C))
+					continue
+
 				var/cam[0]
 				cam["name"] = sanitize(C.c_tag)
 				cam["deact"] = !C.can_use()


### PR DESCRIPTION
Fixes #7987.
Camera consoles again check that a given camera is accessible.

Camera caching appears to be per console, as opposed to globally shared, so this shouldn't cause any issues with cameras being unavailable in consoles that should be able to access them.
