### PR TITLE
Minor photo cache improvement.

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -57,10 +57,10 @@ var/global/photo_count = 0
 		user << "<span class='notice'>It is too far away.</span>"
 
 /obj/item/weapon/photo/proc/show(mob/user as mob)
-	user << browse_rsc(img, "tmp_photo.png")
+	user << browse_rsc(img, "tmp_photo_[id].png")
 	user << browse("<html><head><title>[name]</title></head>" \
 		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
-		+ "<img src='tmp_photo.png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" \
+		+ "<img src='tmp_photo_[id].png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" \
 		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]"\
 		+ "</body></html>", "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
 	onclose(user, "[name]")


### PR DESCRIPTION
According to http://www.byond.com/docs/ref/info.html#/proc/browse_rsc browse_rsc() does not resend already cached data, however there is likely also a check to ensure that this data is up to date (using a checksum or otherwise) or clients would only ever see the first photo they viewed in a given round.

This small change attempts to ensure that a given photo only has to be downloaded once by appending the photo id to the file name, reducing (but most likely not completely preventing) situations similar to #7966 from happening.

tl;dr: The BYOND client does not like being made to read icons which no longer exist/are still being loaded. This attempts to reduce the occasions this can happen.
