### PR TITLE
Sanitizes player input.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -83,7 +83,7 @@
 /proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default)
 	return strip_html_properly(name, max_length)
-    
+
 // Used to get a trimmed, properly sanitized input, of max_length
 /proc/trim_strip_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	return trim(stripped_input(user, message, title, default, max_length))
@@ -342,7 +342,7 @@ proc/TextPreview(var/string,var/len=40)
 		input = copytext(input, 1, opentag) + copytext(input, (closetag + 1))
 	if(max_length)
 		input = copytext(input,1,max_length)
-	return input
+	return sanitize(input)
 
 /proc/trim_strip_html_properly(var/input, var/max_length = MAX_MESSAGE_LEN)
     return trim(strip_html_properly(input, max_length))


### PR DESCRIPTION
Purges \red, \blue, \green, \b, \i, etc. in player input due to abuse.

Of course Dream Maker had to make odd whitespace changes. Line 345 is the one change.
