### PR TITLE
Fixes voidsuit attachment deployment not checking mob_can_equip()

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -75,20 +75,15 @@
 	if(helmet)
 		if(H.head)
 			M << "You are unable to deploy your suit's helmet as \the [H.head] is in the way."
-		else
+		else if (H.equip_to_slot_if_possible(helmet, slot_head))
 			M << "Your suit's helmet deploys with a hiss."
-			//TODO: Species check, skull damage for forcing an unfitting helmet on?
-			helmet.loc = H
-			H.equip_to_slot(helmet, slot_head)
 			helmet.canremove = 0
 
 	if(boots)
 		if(H.shoes)
 			M << "You are unable to deploy your suit's magboots as \the [H.shoes] are in the way."
-		else
+		else if (H.equip_to_slot_if_possible(boots, slot_shoes))
 			M << "Your suit's boots deploy with a hiss."
-			boots.loc = H
-			H.equip_to_slot(boots, slot_shoes)
 			boots.canremove = 0
 
 /obj/item/clothing/suit/space/void/dropped()
@@ -139,12 +134,10 @@
 		if(H.head)
 			H << "<span class='danger'>You cannot deploy your helmet while wearing another helmet.</span>"
 			return
-		//TODO: Species check, skull damage for forcing an unfitting helmet on?
-		helmet.loc = H
-		helmet.pickup(H)
-		H.equip_to_slot(helmet, slot_head)
-		helmet.canremove = 0
-		H << "<font color='blue'><b>You deploy your suit helmet, sealing you off from the world.</b></font>"
+		if(H.equip_to_slot_if_possible(helmet, slot_head))
+			helmet.pickup(H)
+			helmet.canremove = 0
+			H << "<font color='blue'><b>You deploy your suit helmet, sealing you off from the world.</b></font>"
 	helmet.update_light(H)
 
 /obj/item/clothing/suit/space/void/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -130,14 +130,14 @@
 		return 1
 	return 0
 
-//This is a SAFE proc. Use this instead of equip_to_splot()!
+//This is a SAFE proc. Use this instead of equip_to_slot()!
 //set del_on_fail to have it delete W if it fails to equip
 //set disable_warning to disable the 'you are unable to equip that' warning.
 //unset redraw_mob to prevent the mob from being redrawn at the end.
 /mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
 	if(!istype(W)) return 0
 
-	if(!W.mob_can_equip(src, slot, disable_warning))
+	if(!W.mob_can_equip(src, slot))
 		if(del_on_fail)
 			del(W)
 		else


### PR DESCRIPTION
Prevents people from wearing helmets that they otherwise could not by attaching them to a voidsuit they can wear. Also it just seems a bit unnatural that voidsuit attachments would skip this check.
