### PR TITLE
Fix some problems with borg radios

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -626,7 +626,7 @@
 				<A href='byond://?src=\ref[src];freq=2'>+</A>
 				<A href='byond://?src=\ref[src];freq=10'>+</A><BR>
 				<A href='byond://?src=\ref[src];mode=1'>Toggle Broadcast Mode</A><BR>
-				<A href='byond://?src=\ref[src];shutup=1'>Toggle Loudspeaker</A><BR>
+				Loudspeaker: [shut_up ? "<A href='byond://?src=\ref[src];shutup=0'>Disengaged</A>" : "<A href='byond://?src=\ref[src];shutup=1'>Engaged</A>"]<BR>
 				"}
 
 	if(subspace_transmission)//Don't even bother if subspace isn't turned on

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -194,7 +194,7 @@
 		return radio_connection
 
 	// Otherwise, if a channel is specified, look for it.
-	if(channels)
+	if(channels && channels.len > 0)
 		if (message_mode == "department") // Department radio shortcut
 			message_mode = channels[1]
 
@@ -506,6 +506,7 @@
 	icon = 'icons/obj/robot_component.dmi' // Cyborgs radio icons should look like the component.
 	icon_state = "radio"
 	canhear_range = 3
+	subspace_transmission = 1
 
 /obj/item/device/radio/borg/talk_into()
 	. = ..()
@@ -594,11 +595,11 @@
 	if (href_list["mode"])
 		if(subspace_transmission != 1)
 			subspace_transmission = 1
-			usr << "Subspace Transmission is disabled"
+			usr << "Subspace Transmission is enabled"
 		else
 			subspace_transmission = 0
-			usr << "Subspace Transmission is enabled"
-		if(subspace_transmission == 1)//Simple as fuck, clears the channel list to prevent talking/listening over them if subspace transmission is disabled
+			usr << "Subspace Transmission is disabled"
+		if(subspace_transmission == 0)//Simple as fuck, clears the channel list to prevent talking/listening over them if subspace transmission is disabled
 			channels = list()
 		else
 			recalculateChannels()
@@ -628,7 +629,7 @@
 				<A href='byond://?src=\ref[src];shutup=1'>Toggle Loudspeaker</A><BR>
 				"}
 
-	if(!subspace_transmission)//Don't even bother if subspace isn't turned on
+	if(subspace_transmission)//Don't even bother if subspace isn't turned on
 		for (var/ch_name in channels)
 			dat+=text_sec_channel(ch_name, channels[ch_name])
 	dat+={"[text_wires()]</TT></body></html>"}


### PR DESCRIPTION
- Borg radio has a "Toggle broadcast mode" link, which is supposed to switch between subspace and bounced-ish comms. As it stands now, it's kinda backwards: with the telecomms off, the "subspace on" mode will broadcast just fine while "subspace off" mode will stop working. This fixes the labeling, switches subspace mode on by default, and disables secure channel talking without subspace. I am assuming here that this is actually the original intended behavior. 
- There was also a problem with the radio's channel list being set to an empty list, which caused an error when `handle_message_mode()` tried to subscript into it. This adds a check for that situation. I believe the cause for this was that the list was emptied when switching to subspace mode (mislabeled as not-subspace mode), but I'm not sure if the situation ever arises from elsewhere (ie, non-borgie radios). 
- Borg radio has a "toggle loudspeaker" option, but no feedback or way to check if the loudspeaker is on or off, other than finding someone to stand next to the borg and see if they can hear. This makes the loudspeaker toggle indicate if it is on or off.
