### PR TITLE
Git Merge Installers

### DIFF
--- a/tools/dmitool/git_merge_installer.bat
+++ b/tools/dmitool/git_merge_installer.bat
@@ -1,0 +1,6 @@
+@echo off
+set tab=	
+echo. >> ../../.git/config
+echo [merge "merge-dmi"] >> ../../.git/config
+echo %tab%name = iconfile merge driver >> ../../.git/config
+echo %tab%driver = ./tools/dmitool/dmimerge.sh %%O %%A %%B >> ../../.git/config

--- a/tools/dmitool/git_merge_installer.sh
+++ b/tools/dmitool/git_merge_installer.sh
@@ -1,0 +1,6 @@
+F="../../.git/config"
+
+echo '' >> $F
+echo '[merge "merge-dmi"]' >> $F
+echo '	name = iconfile merge driver' >> $F
+echo '	driver = ./tools/dmitool/dmimerge.sh %O %A %B' >> $F

--- a/tools/dmitool/merging.txt
+++ b/tools/dmitool/merging.txt
@@ -8,5 +8,7 @@ The easiest way to do merging is to install the merge driver. For this, open `Ba
 	name = iconfile merge driver
 	driver = ./tools/dmitool/dmimerge.sh %O %A %B
 
+You may optionally instead run git_merge_installer.bat which should automatically insert these lines for you at the appropriate location.
+    
 After this, merging DMI files should happen automagically unless there are conflicts (an icon_state that both you and someone else changed).
 If there are conflicts, you will unfortunately still be stuck with opening both versions in the editor, and manually resolving the issues with those states.

--- a/tools/dmitool/merging.txt
+++ b/tools/dmitool/merging.txt
@@ -8,7 +8,7 @@ The easiest way to do merging is to install the merge driver. For this, open `Ba
 	name = iconfile merge driver
 	driver = ./tools/dmitool/dmimerge.sh %O %A %B
 
-You may optionally instead run git_merge_installer.bat which should automatically insert these lines for you at the appropriate location.
+You may optionally instead run git_merge_installer.bat or git_merge_installer.sh which should automatically insert these lines for you at the appropriate location.
     
 After this, merging DMI files should happen automagically unless there are conflicts (an icon_state that both you and someone else changed).
 If there are conflicts, you will unfortunately still be stuck with opening both versions in the editor, and manually resolving the issues with those states.

--- a/tools/mapmerge/git_merge_installer.bat
+++ b/tools/mapmerge/git_merge_installer.bat
@@ -1,0 +1,6 @@
+@echo off
+set tab=	
+echo. >> ../../.git/config
+echo [merge "merge-dmm"] >> ../../.git/config
+echo %tab%name = mapmerge driver >> ../../.git/config
+echo %tab%driver = ./tools/mapmerge/mapmerge.sh %%O %%A %%B >> ../../.git/config

--- a/tools/mapmerge/git_merge_installer.sh
+++ b/tools/mapmerge/git_merge_installer.sh
@@ -1,0 +1,6 @@
+F="../../.git/config"
+
+echo '' >> $F
+echo '[merge "merge-dmm"]' >> $F
+echo '	name = mapmerge driver' >> $F
+echo '	driver = ./tools/mapmerge/mapmerge.sh %O %A %B' >> $F

--- a/tools/mapmerge/install.txt
+++ b/tools/mapmerge/install.txt
@@ -14,6 +14,6 @@ The easiest way to do merging is to install the merge driver. For this, open `Ba
 	name = mapmerge driver
 	driver = ./tools/mapmerge/mapmerge.sh %O %A %B
 
-You may optionally instead run git_merge_installer.bat which should automatically insert these lines for you at the appropriate location.
+You may optionally instead run git_merge_installer.bat or git_merge_installer.sh which should automatically insert these lines for you at the appropriate location.
     
 After this, merging maps should happen automagically unless there are conflicts(a tile that both you and someone else changed). If there are conflicts, you will unfortunately still be stuck with opening both versions in a map editor, and manually resolving the issues.

--- a/tools/mapmerge/install.txt
+++ b/tools/mapmerge/install.txt
@@ -14,4 +14,6 @@ The easiest way to do merging is to install the merge driver. For this, open `Ba
 	name = mapmerge driver
 	driver = ./tools/mapmerge/mapmerge.sh %O %A %B
 
+You may optionally instead run git_merge_installer.bat which should automatically insert these lines for you at the appropriate location.
+    
 After this, merging maps should happen automagically unless there are conflicts(a tile that both you and someone else changed). If there are conflicts, you will unfortunately still be stuck with opening both versions in a map editor, and manually resolving the issues.


### PR DESCRIPTION
There are now two basic bat scripts in the tool/dmitool and tool/mapmerge folders which painlessly inserts the necessary lines for the commit tools to work into .git/config.
