### PR TITLE
Fixes windows taking excessive damage from projectiles

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -59,7 +59,7 @@
 		return
 
 	..()
-	take_damage(Proj.damage * 4)
+	take_damage(Proj.damage)
 	return
 
 


### PR DESCRIPTION
For some reason https://github.com/Baystation12/Baystation12/commit/e0d48950b4a1690825c06d934554e3956c75f022 made windows take 4x damage from projectiles, making the detective's rubber bullets able to destroy a reinforced window in one hit, for example. This PR fixes that.
