### PR TITLE
Fixes doors being usable remotely when broken

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -34,14 +34,17 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 
 /datum/wires/airlock/GetInteractWindow()
 	var/obj/machinery/door/airlock/A = holder
+	var/haspower = A.arePowerSystemsOn() //If there's no power, then no lights will be on.
+	
 	. += ..()
-	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]", (A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
-	(A.lights ? "The door bolt lights are on." : "The door bolt lights are off!"),
-	((A.hasPower()) ? "The test light is on." : "The test light is off!"),
-	((A.aiControlDisabled==0 && !A.emagged) ? "The 'AI control allowed' light is on." : "The 'AI control allowed' light is off."),
-	(A.safe==0 ? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."),
-	(A.normalspeed==0 ? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),
-	(A.aiDisabledIdScanner==0 ? "The IDScan light is on." : "The IDScan light is off."))
+	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]", 
+	(A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
+	((A.lights && haspower) ? "The door bolt lights are on." : "The door bolt lights are off!"),
+	((haspower) ? "The test light is on." : "The test light is off!"),
+	((A.aiControlDisabled==0 && !A.emagged && haspower)? "The 'AI control allowed' light is on." : "The 'AI control allowed' light is off."),
+	((A.safe==0 && haspower)? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."),
+	((A.normalspeed==0 && haspower)? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),
+	((A.aiDisabledIdScanner==0 && haspower)? "The IDScan light is on." : "The IDScan light is off."))
 
 /datum/wires/airlock/UpdateCut(var/index, var/mended)
 
@@ -127,7 +130,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 	switch(index)
 		if(AIRLOCK_WIRE_IDSCAN)
 			//Sending a pulse through flashes the red light on the door (if the door has power).
-			if(A.hasPower() && A.density)
+			if(A.arePowerSystemsOn() && A.density)
 				A.do_animate("deny")
 		if(AIRLOCK_WIRE_MAIN_POWER1 || AIRLOCK_WIRE_MAIN_POWER2)
 			//Sending a pulse through either one causes a breaker to trip, disabling the door for 10 seconds if backup power is connected, or 1 minute if not (or until backup power comes back on, whichever is shorter).
@@ -139,7 +142,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 				A.locked = 1
 				A.audible_message("You hear a click from the bottom of the door.", null,  1)
 			else
-				if(A.hasPower()) //only can raise bolts if power's on
+				if(A.arePowerSystemsOn()) //only can raise bolts if power's on
 					A.locked = 0
 					A.audible_message("You hear a click from the bottom of the door.", null, 1)
 			A.update_icon()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -330,7 +330,7 @@ About the new airlock wires panel:
 	return ((src.aiControlDisabled==1) && (!hackProof) && (!src.isAllPowerLoss()));
 
 /obj/machinery/door/airlock/proc/arePowerSystemsOn()
-	if (stat & NOPOWER)
+	if (stat & (NOPOWER|BROKEN))
 		return 0
 	return (src.secondsMainPowerLost==0 || src.secondsBackupPowerLost==0)
 
@@ -451,7 +451,7 @@ About the new airlock wires panel:
 			if(density)
 				flick("door_spark", src)
 		if("deny")
-			if(density && !(stat & (BROKEN|NOPOWER)))
+			if(density && src.arePowerSystemsOn())
 				flick("door_deny", src)
 	return
 
@@ -900,12 +900,7 @@ About the new airlock wires panel:
 		var/obj/item/weapon/pai_cable/cable = C
 		cable.plugin(src, user)
 	else if(!repairing && istype(C, /obj/item/weapon/crowbar))
-		var/beingcrowbarred = null
-		if(istype(C, /obj/item/weapon/crowbar) )
-			beingcrowbarred = 1 //derp, Agouri
-		else
-			beingcrowbarred = 0
-		if( beingcrowbarred && src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN)))) )
+		if(src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN)))) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40))
@@ -936,7 +931,7 @@ About the new airlock wires panel:
 
 				del(src)
 				return
-		else if(arePowerSystemsOn() && !(stat & BROKEN))
+		else if(arePowerSystemsOn())
 			user << "\blue The airlock's motors resist your efforts to force it."
 		else if(locked)
 			user << "\blue The airlock's bolts prevent it from being forced."
@@ -946,22 +941,22 @@ About the new airlock wires panel:
 			else
 				spawn(0)	close(1)
 
-	else if(istype(C, /obj/item/weapon/twohanded/fireaxe) && (!arePowerSystemsOn() || (stat & BROKEN)))
+	else if(istype(C, /obj/item/weapon/twohanded/fireaxe) && !arePowerSystemsOn())
 		if(locked)
 			user << "\blue The airlock's bolts prevent it from being forced."
 		else if( !welded && !operating )
 			if(density)
 				var/obj/item/weapon/twohanded/fireaxe/F = C
-				if(F:wielded)
+				if(F.wielded)
 					spawn(0)	open(1)
 				else
-					user << "\red You need to be wielding the Fire axe to do that."
+					user << "\red You need to be wielding \the [C] to do that."
 			else
 				var/obj/item/weapon/twohanded/fireaxe/F = C
-				if(F:wielded)
+				if(F.wielded)
 					spawn(0)	close(1)
 				else
-					user << "\red You need to be wielding the Fire axe to do that."
+					user << "\red You need to be wielding \the [C] to do that."
 
 	else
 		..()
@@ -1007,7 +1002,9 @@ About the new airlock wires panel:
 	if(operating || welded || locked)
 		return
 	if(!forced)
-		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_DOOR_BOLTS) )
+		//despite the name, this wire is for general door control. 
+		//Bolts are already covered by the check for locked, above
+		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
 			return
 	if(safe)
 		for(var/turf/turf in locs)
@@ -1134,9 +1131,6 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/power_change() //putting this is obj/machinery/door itself makes non-airlock doors turn invisible for some reason
 	..()
 	update_icon()
-
-/obj/machinery/door/airlock/proc/hasPower()
-	return ((src.secondsMainPowerLost==0 || src.secondsBackupPowerLost==0) && !(stat & (NOPOWER|BROKEN)))
 
 /obj/machinery/door/airlock/proc/prison_open()
 	src.unlock()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -8,11 +8,6 @@ obj/machinery/door/airlock
 	var/datum/radio_frequency/radio_connection
 	var/cur_command = null	//the command the door is currently attempting to complete
 
-obj/machinery/door/airlock/proc/can_radio()
-	if(!arePowerSystemsOn())
-		return 0
-	return 1
-
 obj/machinery/door/airlock/process()
 	..()
 	if (arePowerSystemsOn())
@@ -20,8 +15,6 @@ obj/machinery/door/airlock/process()
 
 obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 	if (!arePowerSystemsOn()) return //no power
-
-	if (!can_radio()) return //no radio
 
 	if(!signal || signal.encryption) return
 


### PR DESCRIPTION
Fixes airlock doors being able to be opened and closed remotely (by buttons, airlocks, or docking) when broken.

Also removes a redundant proc, and refactors a few checks.
