### PR TITLE
Fixes ore scanner

### DIFF
--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -23,7 +23,7 @@
 		"exotic matter" = 0
 		)
 
-	for(var/turf/T in oview(3,get_turf(user)))
+	for(var/turf/T in range(3,get_turf(user)))
 
 		if(!T.has_resources)
 			continue


### PR DESCRIPTION
Before: it didn't scan dark tiles and the tile you were standing on.
Now: scans both.
