### PR TITLE
Fixes possible href exploit with APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -888,6 +888,11 @@
 	if(!can_use(usr, 1))
 		return 1
 
+	if(!istype(usr, /mob/living/silicon) && locked)
+		// Shouldn't happen, this is here to prevent href exploits
+		usr << "You must unlock the panel to use this!"
+		return 1
+
 	if (href_list["lock"])
 		coverlocked = !coverlocked
 


### PR DESCRIPTION
As in title. The only protection for the links was the fact that the NanoUI template didn't show them if the panel was locked, which is trivial to bypass by editing the template in your cache.
