### PR TITLE
Fixes pAIs being spammed with "You are too small to pull that." when being pulled

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -432,7 +432,8 @@
 
 
 						step(pulling, get_dir(pulling.loc, T))
-						M.start_pulling(t)
+						if(t)
+							M.start_pulling(t)
 				else
 					if (pulling)
 						if (istype(pulling, /obj/structure/window))


### PR DESCRIPTION
Probably fixes a few other mobs too, didn't look at the pulling code for them.
