### PR TITLE
Vending machines: NanoUI, cash and other stuff

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -19,11 +19,6 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		return 1
 	return 0
 
-/datum/wires/vending/Interact(var/mob/living/user)
-	if(CanUse(user))
-		var/obj/machinery/vending/V = holder
-		V.attack_hand(user)
-
 /datum/wires/vending/GetInteractWindow()
 	var/obj/machinery/vending/V = holder
 	. += ..()

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -1,3 +1,5 @@
+#define CAT_HIDDEN 2   // Also in code/game/machinery/vending.dm
+
 /datum/wires/vending
 	holder_type = /obj/machinery/vending
 	wire_count = 4
@@ -27,7 +29,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	. += ..()
 	. += "<BR>The orange light is [V.seconds_electrified ? "off" : "on"].<BR>"
 	. += "The red light is [V.shoot_inventory ? "off" : "blinking"].<BR>"
-	. += "The green light is [V.extended_inventory ? "on" : "off"].<BR>"
+	. += "The green light is [(V.categories & CAT_HIDDEN) ? "on" : "off"].<BR>"
 	. += "The [V.scan_id ? "purple" : "yellow"] light is on.<BR>"
 
 /datum/wires/vending/UpdatePulsed(var/index)
@@ -36,7 +38,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		if(VENDING_WIRE_THROW)
 			V.shoot_inventory = !V.shoot_inventory
 		if(VENDING_WIRE_CONTRABAND)
-			V.extended_inventory = !V.extended_inventory
+			V.categories ^= CAT_HIDDEN
 		if(VENDING_WIRE_ELECTRIFY)
 			V.seconds_electrified = 30
 		if(VENDING_WIRE_IDSCAN)
@@ -48,7 +50,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		if(VENDING_WIRE_THROW)
 			V.shoot_inventory = !mended
 		if(VENDING_WIRE_CONTRABAND)
-			V.extended_inventory = 0
+			V.categories &= ~CAT_HIDDEN  
 		if(VENDING_WIRE_ELECTRIFY)
 			if(mended)
 				V.seconds_electrified = 0

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -179,7 +179,7 @@
 	return
 
 /obj/machinery/vending/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (currently_vending)
+	if (currently_vending && vendor_account && !vendor_account.suspended)
 		var/paid = 0
 		var/handled = 0
 		if(istype(W, /obj/item/weapon/card/id))
@@ -493,8 +493,12 @@
 				src.vend(R, usr)
 			else
 				src.currently_vending = R
-				src.status_message = "Please swipe a card or insert cash to pay for the item."
-				src.status_error = 0
+				if(!vendor_account || vendor_account.suspended)
+					src.status_message = "This machine is currently unable to process payments due to problems with the associated account."
+					src.status_error = 1
+				else
+					src.status_message = "Please swipe a card or insert cash to pay for the item."
+					src.status_error = 0
 
 		else if (href_list["cancelpurchase"])
 			src.currently_vending = null
@@ -611,7 +615,7 @@
 			new dump_path(src.loc)
 			R.amount--
 		break
-
+	
 	stat |= BROKEN
 	src.icon_state = "[initial(icon_state)]-broken"
 	return

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -488,7 +488,11 @@
 
 			var/key = text2num(href_list["vend"])
 			var/datum/data/vending_product/R = product_records[key]
-
+			
+			// This should not happen unless the request from NanoUI was bad
+			if(!(R.category & src.categories))
+				return
+			
 			if(R.price <= 0)
 				src.vend(R, usr)
 			else

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,14 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>12 February 2015</h2>
+	<h3 class='author'>Daranz updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Vending machines now use NanoUI and accept cash. The vendor account can now be suspended to disable all sales in all machines on station.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>4 February 2015</h2>
 	<h3 class='author'>RavingManiac updated:</h3>
 	<ul class='changes bgimages16'>

--- a/nano/templates/vending_machine.tmpl
+++ b/nano/templates/vending_machine.tmpl
@@ -1,0 +1,56 @@
+<!-- 
+	Interface for vending machines 
+	See: code/game/machinery/vending.dm
+-->
+
+{{if data.mode == 0}} <!-- Listing -->
+<h2>Items available</h2>
+<div class='item'>
+	{{for data.products}}
+	<div class='item'>
+			<div style='float'>
+				{{if value.price > 0}}
+					{{:helper.link('Buy (' + value.price + ')', 'cart', { "vend" : value.key }, value.amount > 0 ? null : 'disabled')}}
+				{{else}}
+					{{:helper.link('Vend', 'circle-arrow-s', { "vend" : value.key }, value.amount > 0 ? null : 'disabled')}}
+				{{/if}}
+			</div>
+		<div class='itemContent'>
+		{{if value.color}}<span style='color:{{:value.color}}'>{{:value.name}}</span>
+		{{else}}{{:value.name}}
+		{{/if}}
+			 ({{:value.amount ? value.amount : "NONE LEFT"}})
+		</div>
+	</div>
+	{{empty}}
+	No items available!
+	{{/for}}
+</div>
+{{if data.coin}}
+<h2>Coin</h2>
+<div class='item'>
+	<div class='itemLabel'>Coin deposited:</div> 
+	<div class='itemContent'>{{:helper.link(data.coin, 'eject', {'remove_coin' : 1})}}</div>
+</div>
+{{/if}}
+{{else data.mode == 1}} <!-- Payment screen -->
+<h2>Item selected</h2>
+<div class='item'>
+	<div class='item'>
+		<div class='itemLabel'>Item selected:</div> <div class='itemContent'>{{:data.product}}</div>
+		<div class='itemLabel'>Charge:</div> <div class='itemContent'>{{:data.price}}</div>
+	</div>
+	<div class='statusDisplay' style='overflow: auto;'>
+		{{if data.message_err}} <span class='uiIcon16 icon-alert' ></span>{{/if}} {{:data.message}}
+	</div>
+	<div class='item'>
+		{{:helper.link('Cancel', 'arrowreturn-1-w', {'cancelpurchase' : 1})}}
+	</div>
+</div>
+{{/if}}
+{{if data.panel}}
+<h2>Maintenance panel</h2>
+<div class='item'>
+	<div class='itemLabel'>Speaker</div><div class='item'>{{:helper.link(data.speaker ? 'Enabled' : 'Disabled',  'gear', {'togglevoice' : 1})}}</div>
+</div>
+{{/if}}


### PR DESCRIPTION
This adds NanoUI to vending machines, and makes them able to take payments in cash. It also includes some refactoring of the vending machine code, both to make the aforementioned tasks easier, as well as to eliminate some problems that arise from use of, ahem, creative code.

The vending machines now accept cash. This includes both bills (banknotes), as well as bundles. Machines will take cash as payment for purchases and deliver change as needed. Chargecards (ewallets) can also be used in place of ID cards, with the same mechanics (previously, they had to be inserted prior to making a purchase).

Machines record all transactions to the vendor account. This includes chargecard and cash transactions. Names on card are used instead of mob name, with cash purchases being recorded as '(cash)' and no name whatsoever. 

Machines now feature NanoUI. All error and status messages are now displayed inside NanoUI instead of going to the chatlog. This means that the user will be informed of fund shortages or suspended accounts via NanoUI. 

Suspending the vendor account now kills vending of items that require payment in all machines on station. This might be useful in rev rounds, for the historically proven method of subjugating people through imposed hunger.

This is what it looks like: [One](https://cloud.githubusercontent.com/assets/156239/6160117/a1396294-b25e-11e4-89de-e3c6f1604d32.png), [Two](https://cloud.githubusercontent.com/assets/156239/6160116/a1391604-b25e-11e4-9297-baa15fe1454a.png)
