### PR TITLE
Fixes machines being usable after a power failure

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -288,6 +288,7 @@ datum/controller/game_controller/proc/process_machines_process()
 		last_thing_processed = Machine.type
 		if(Machine.process() != PROCESS_KILL)
 			if(Machine)
+				Machine.power_change()
 				if(Machine.use_power)
 					Machine.auto_use_power()
 				continue

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -63,8 +63,10 @@
 	if(!src.loc)
 		return 0
 
-	if(!use_power)
-		return 1
+	//Don't do this. It allows machines that set use_power to 0 when off (many machines) to
+	//be turned on again and used after a power failure because they never gain the NOPOWER flag.
+	//if(!use_power)
+	//	return 1
 
 	var/area/A = src.loc.loc		// make sure it's in an area
 	if(!A || !isarea(A) || !A.master)


### PR DESCRIPTION
- Fixes machines not gaining the NOPOWER flag after a power failure because they were turned off and had use_power set to 0.
- Fixes machines not gaining the NOPOWER flag after being moved into an area with no power.

Both bugs allowed power using machines to be used in areas with no power.
