### PR TITLE
Adds the Examine Tab.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -100,6 +100,7 @@
 #include "code\datums\computerfiles.dm"
 #include "code\datums\datacore.dm"
 #include "code\datums\datumvars.dm"
+#include "code\datums\descriptions.dm"
 #include "code\datums\disease.dm"
 #include "code\datums\mind.dm"
 #include "code\datums\mixed.dm"

--- a/code/datums/descriptions.dm
+++ b/code/datums/descriptions.dm
@@ -1,0 +1,22 @@
+/*
+This is what is supplied to the examine tab.  Everything has a 'descriptions' variable, which is null by default.  When it is not null,
+it contains this datum.  To add this datum to something, all you do is add this to the thing..
+
+	descriptions = new/datum/descriptions("I am some helpful blue text","I have backstory text about this obj.","You can use this to kill everyone.")
+
+First string is the 'info' var, second is the 'fluff' var, and third is the 'antag' var.  All are optional.  Just add it to the object you want to have it.
+
+If you are wondering, BYOND does not let you do desc = new/datum/descriptions .
+
+More strings can be added easily, but you will need to add a proc to retrieve it from the atom.  The procs are defined in atoms.dm.
+
+*/
+/datum/descriptions
+	var/info
+	var/fluff
+	var/antag
+
+/datum/descriptions/New(var/info, var/fluff, var/antag)
+	src.info = info
+	src.fluff = fluff
+	src.antag = antag

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -12,10 +12,8 @@
 	var/throwpass = 0
 	var/germ_level = GERM_LEVEL_AMBIENT // The higher the germ level, the more germ on the atom.
 
-	//Examine tab vars
-	var/desc_info = null //Blue 'tutorial' text, which details how this atom works, and perhaps some tips and tricks.
-	var/desc_fluff = null //Green text, with quotes, to tell a short blurb or a paragraph about this atom's place in the fluff, should one exist.
-
+	//Examine tab
+	var/datum/descriptions/descriptions = null //See code/datums/descriptions.dm for details.
 
 	///Chemistry.
 	var/datum/reagents/reagents = null
@@ -207,35 +205,52 @@ its easier to just keep the beam vertical.
 
 	user << "\icon[src] That's [f_name] [suffix]"
 
-	if(name) //This shouldn't be needed but I'm paranoid.
-		user.desc_name_holder = "[src.name]" //\icon[src]
+	var/datum/descriptions/D = descriptions
+	if(istype(D))
+		user.description_holders["info"] = get_descriptions_info()
+		user.description_holders["fluff"] = get_descriptions_fluff()
+		if(user.mind.special_role)
+			user.description_holders["antag"] = get_descriptions_antag()
+	else
+		user.description_holders["info"] = null
+		user.description_holders["fluff"] = null
+		user.description_holders["antag"] = null
 
-	user.desc_icon_holder = "\icon[src]"
+	if(name) //This shouldn't be needed but I'm paranoid.
+		user.description_holders["name"] = "[src.name]" //\icon[src]
+
+	user.description_holders["icon"] = "\icon[src]"
 
 	if(desc)
 		user << desc
-		user.desc_holder = src.desc
+		user.description_holders["desc"] = src.desc
 	else
-		user.desc_holder = null //This is needed, or else if you examine one thing with a desc, then another without, the panel will retain the first examined's desc.
-
-	user.desc_info_holder = get_desc_info()
-	user.desc_fluff_holder = get_desc_fluff()
+		user.description_holders["desc"] = null //This is needed, or else if you examine one thing with a desc, then another without, the panel will retain the first examined's desc.
 
 	return distance == -1 || (get_dist(src, user) <= distance)
 
 //Override these if you need special behaviour for a specific type.
 
-/atom/proc/get_desc_info()
-	if(desc_info)
-		return desc_info
+/atom/proc/get_descriptions_info()
+	var/datum/descriptions/D = descriptions
+	if(istype(D) && D.info)
+		return D.info
 	else
-		return
+		return null
 
-/atom/proc/get_desc_fluff()
-	if(desc_fluff)
-		return src.desc_fluff
+/atom/proc/get_descriptions_fluff()
+	var/datum/descriptions/D = descriptions
+	if(istype(D) && D.fluff)
+		return D.fluff
 	else
-		return
+		return null
+
+/atom/proc/get_descriptions_antag()
+	var/datum/descriptions/D = descriptions
+	if(istype(D) && D.antag)
+		return D.antag
+	else
+		return null
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.
 // see code/modules/mob/mob_movement.dm for more.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -12,6 +12,11 @@
 	var/throwpass = 0
 	var/germ_level = GERM_LEVEL_AMBIENT // The higher the germ level, the more germ on the atom.
 
+	//Examine tab vars
+	var/desc_info = null //Blue 'tutorial' text, which details how this atom works, and perhaps some tips and tricks.
+	var/desc_fluff = null //Yellow text, with quotes, to tell a short blurb or a paragraph about this atom's place in the fluff, should one exist.
+
+
 	///Chemistry.
 	var/datum/reagents/reagents = null
 
@@ -202,10 +207,35 @@ its easier to just keep the beam vertical.
 
 	user << "\icon[src] That's [f_name] [suffix]"
 
+	if(name) //This shouldn't be needed but I'm paranoid.
+		user.desc_name_holder = "[src.name]" //\icon[src]
+
+	user.desc_icon_holder = "\icon[src]"
+
 	if(desc)
 		user << desc
+		user.desc_holder = src.desc
+	else
+		user.desc_holder = null //This is needed, or else if you examine one thing with a desc, then another without, the panel will retain the first examined's desc.
+
+	user.desc_info_holder = get_desc_info()
+	user.desc_fluff_holder = get_desc_fluff()
 
 	return distance == -1 || (get_dist(src, user) <= distance)
+
+//Override these if you need special behaviour for a specific type.
+
+/atom/proc/get_desc_info()
+	if(desc_info)
+		return desc_info
+	else
+		return
+
+/atom/proc/get_desc_fluff()
+	if(desc_fluff)
+		return src.desc_fluff
+	else
+		return
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.
 // see code/modules/mob/mob_movement.dm for more.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -232,25 +232,19 @@ its easier to just keep the beam vertical.
 //Override these if you need special behaviour for a specific type.
 
 /atom/proc/get_descriptions_info()
-	var/datum/descriptions/D = descriptions
-	if(istype(D) && D.info)
-		return D.info
-	else
-		return null
+	if(descriptions && descriptions.info)
+		return descriptions.info
+	return
 
 /atom/proc/get_descriptions_fluff()
-	var/datum/descriptions/D = descriptions
-	if(istype(D) && D.fluff)
-		return D.fluff
-	else
-		return null
+	if(descriptions && descriptions.fluff)
+		return descriptions.fluff
+	return
 
 /atom/proc/get_descriptions_antag()
-	var/datum/descriptions/D = descriptions
-	if(istype(D) && D.antag)
-		return D.antag
-	else
-		return null
+	if(descriptions && descriptions.antag)
+		return descriptions.antag
+	return
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.
 // see code/modules/mob/mob_movement.dm for more.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -14,7 +14,7 @@
 
 	//Examine tab vars
 	var/desc_info = null //Blue 'tutorial' text, which details how this atom works, and perhaps some tips and tricks.
-	var/desc_fluff = null //Yellow text, with quotes, to tell a short blurb or a paragraph about this atom's place in the fluff, should one exist.
+	var/desc_fluff = null //Green text, with quotes, to tell a short blurb or a paragraph about this atom's place in the fluff, should one exist.
 
 
 	///Chemistry.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -451,6 +451,7 @@
 		msg += "\n[t_He] is [pose]"
 
 	user << msg
+	..()
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
 /proc/hasHUD(mob/M as mob, hudtype)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1277,7 +1277,7 @@
 	else
 		return ..()
 
-/mob/living/carbon/human/get_desc_fluff()
+/mob/living/carbon/human/get_descriptions_fluff()
 	return print_flavor_text(0)
 
 /mob/living/carbon/human/getDNA()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1236,7 +1236,7 @@
  		// Might need re-wording.
 		user << "<span class='alert'>There is no exposed flesh or thin material [target_zone == "head" ? "on their head" : "on their body"] to inject into.</span>"
 
-/mob/living/carbon/human/print_flavor_text()
+/mob/living/carbon/human/print_flavor_text(var/shrink = 1)
 	var/list/equipment = list(src.head,src.wear_mask,src.glasses,src.w_uniform,src.wear_suit,src.gloves,src.shoes)
 	var/head_exposed = 1
 	var/face_exposed = 1
@@ -1272,7 +1272,13 @@
 			if((T == "head" && head_exposed) || (T == "face" && face_exposed) || (T == "eyes" && eyes_exposed) || (T == "torso" && torso_exposed) || (T == "arms" && arms_exposed) || (T == "hands" && hands_exposed) || (T == "legs" && legs_exposed) || (T == "feet" && feet_exposed))
 				flavor_text += flavor_texts[T]
 				flavor_text += "\n\n"
-	return ..()
+	if(!shrink)
+		return flavor_text
+	else
+		return ..()
+
+/mob/living/carbon/human/get_desc_fluff()
+	return print_flavor_text(0)
 
 /mob/living/carbon/human/getDNA()
 	if(species.flags & NO_SCAN)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -172,6 +172,14 @@
 // ++++ROCKDTBEN++++ MOB PROCS //END
 
 
+/mob/living/get_desc_fluff()
+	if(flavor_text) //Get flavor text for the yellow text.
+		return flavor_text
+	else if(desc_fluff) //No flavor text?  Try for hardcoded fluff instead.
+		return desc_fluff
+	else
+		return
+
 /mob/proc/get_contents()
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -172,13 +172,11 @@
 // ++++ROCKDTBEN++++ MOB PROCS //END
 
 
-/mob/living/get_desc_fluff()
+/mob/living/get_descriptions_fluff()
 	if(flavor_text) //Get flavor text for the green text.
 		return flavor_text
-	else if(desc_fluff) //No flavor text?  Try for hardcoded fluff instead.
-		return desc_fluff
-	else
-		return
+	else //No flavor text?  Try for hardcoded fluff instead.
+		return ..()
 
 /mob/proc/get_contents()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -173,7 +173,7 @@
 
 
 /mob/living/get_desc_fluff()
-	if(flavor_text) //Get flavor text for the yellow text.
+	if(flavor_text) //Get flavor text for the green text.
 		return flavor_text
 	else if(desc_fluff) //No flavor text?  Try for hardcoded fluff instead.
 		return desc_fluff

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -6,7 +6,7 @@
 	desc_info = "Drones are player-controlled synthetics which are lawed to maintain the station and not \
 				interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
 				They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
-				such as fire, radiation, vaccum, and more.  Ghosts can join the round as a maintenance drone by using the appropiate verb in the 'ghost' tab."
+				such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab."
 	//desc_fluff is already provided with flavor_text.
 	maxHealth = 35
 	health = 35

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -3,7 +3,13 @@
 	real_name = "drone"
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "repairbot"
-	desc_info = "Drones are player-controlled synthetics which are lawed to maintain the station and not \
+	descriptions = new/datum/descriptions("Drones are player-controlled synthetics which are lawed to maintain the station and not \
+				interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
+				They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
+				such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \
+				An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access.",\
+				,"An <u>Electromagnetic Sequencer</u> can be used to subvert the drone to your cause.")
+//	desc_info = "Drones are player-controlled synthetics which are lawed to maintain the station and not \
 				interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
 				They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
 				such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab."

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -9,10 +9,6 @@
 				such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \
 				An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access.",\
 				,"An <u>Electromagnetic Sequencer</u> can be used to subvert the drone to your cause.")
-//	desc_info = "Drones are player-controlled synthetics which are lawed to maintain the station and not \
-				interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
-				They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
-				such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab."
 	//desc_fluff is already provided with flavor_text.
 	maxHealth = 35
 	health = 35

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -3,6 +3,11 @@
 	real_name = "drone"
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "repairbot"
+	desc_info = "Drones are player-controlled synthetics which are lawed to maintain the station and not \
+				interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
+				They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
+				such as fire, radiation, vaccum, and more.  Ghosts can join the round as a maintenance drone by using the appropiate verb in the 'ghost' tab."
+	//desc_fluff is already provided with flavor_text.
 	maxHealth = 35
 	health = 35
 	universal_speak = 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -833,8 +833,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 					statpanel("Spells","[S.charge_counter]/[S.charge_max]",S)
 				if("holdervar")
 					statpanel("Spells","[S.holder_var_type] [S.holder_var_amount]",S)
-	if(client)
-		statpanel("Examine")
+	if(statpanel("Examine"))
 		stat(null,"[description_holders["icon"]]    <font size='5'>[description_holders["name"]]</font>") //The name, written in big letters.
 		stat(null,"[description_holders["desc"]]") //the default examine text.
 		if(description_holders["info"])

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -835,12 +835,15 @@ note dizziness decrements automatically in the mob's Life() proc.
 					statpanel("Spells","[S.holder_var_type] [S.holder_var_amount]",S)
 	if(client)
 		statpanel("Examine")
-		stat(null,"[desc_icon_holder]    <font size='5'>[desc_name_holder]</font>") //The name, written in big letters.
-		stat(null,"[desc_holder]") //the default examine text.
-		if(desc_info_holder)
-			stat(null,"<font color='#086A87'><b>[desc_info_holder]</b></font>") //Blue, informative text.
-		if(desc_fluff_holder)
-			stat(null,"<font color='#298A08'><b>[desc_fluff_holder]</b></font>") //Yellow, fluff-related text.
+		stat(null,"[description_holders["icon"]]    <font size='5'>[description_holders["name"]]</font>") //The name, written in big letters.
+		stat(null,"[description_holders["desc"]]") //the default examine text.
+		if(description_holders["info"])
+			stat(null,"<font color='#084B8A'><b>[description_holders["info"]]</b></font>") //Blue, informative text.
+		if(description_holders["fluff"])
+			stat(null,"<font color='#298A08'><b>[description_holders["fluff"]]</b></font>") //Yellow, fluff-related text.
+		if(mind.special_role)
+			if(description_holders["antag"])
+				stat(null,"<font color='#8A0808'><b>[description_holders["antag"]]</b></font>") //Red, malicious antag-related text
 
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -833,6 +833,15 @@ note dizziness decrements automatically in the mob's Life() proc.
 					statpanel("Spells","[S.charge_counter]/[S.charge_max]",S)
 				if("holdervar")
 					statpanel("Spells","[S.holder_var_type] [S.holder_var_amount]",S)
+	if(client)
+		statpanel("Examine")
+		stat(null,"[desc_icon_holder]    <font size='5'>[desc_name_holder]</font>") //The name, written in big letters.
+		stat(null,"[desc_holder]") //the default examine text.
+		if(desc_info_holder)
+			stat(null,"<font color='#086A87'><b>[desc_info_holder]</b></font>") //Blue, informative text.
+		if(desc_fluff_holder)
+			stat(null,"<font color='#298A08'><b>[desc_fluff_holder]</b></font>") //Yellow, fluff-related text.
+
 
 
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -223,3 +223,11 @@
 	var/list/shouldnt_see = list()	//list of objects that this mob shouldn't see in the stat panel. this silliness is needed because of AI alt+click and cult blood runes
 
 	var/list/active_genes=list()
+
+	//Examine tab vars
+	//These hold the descriptions and other info, to relay to the actual tab.
+	var/desc_name_holder = null
+	var/desc_holder = null
+	var/desc_info_holder = null
+	var/desc_fluff_holder = null
+	var/desc_icon_holder = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -226,8 +226,13 @@
 
 	//Examine tab vars
 	//These hold the descriptions and other info, to relay to the actual tab.
-	var/desc_name_holder = null
-	var/desc_holder = null
-	var/desc_info_holder = null
-	var/desc_fluff_holder = null
-	var/desc_icon_holder = null
+	var/description_holders[0]
+	/*
+	description_holders["name"] = null
+	description_holders["icon"] = null
+	description_holders["desc"] = null
+	description_holders["info"] = null
+	description_holders["fluff"] = null
+	description_holders["antag"] = null
+	*/
+

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -227,12 +227,4 @@
 	//Examine tab vars
 	//These hold the descriptions and other info, to relay to the actual tab.
 	var/description_holders[0]
-	/*
-	description_holders["name"] = null
-	description_holders["icon"] = null
-	description_holders["desc"] = null
-	description_holders["info"] = null
-	description_holders["fluff"] = null
-	description_holders["antag"] = null
-	*/
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1820,7 +1820,7 @@ window "infowindow"
 	elem "info"
 		type = INFO
 		pos = 0,0
-		size = 638x475
+		size = 636x451
 		anchor1 = 0,0
 		anchor2 = 100,100
 		font-family = ""
@@ -1843,7 +1843,7 @@ window "infowindow"
 		tab-font-family = ""
 		tab-font-size = 0
 		tab-font-style = ""
-		allow-html = false
+		allow-html = true
 		multi-line = true
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""


### PR DESCRIPTION
Adds a new tab dedicated to giving additional information on anything you examine.  This is a great tool to help new players learn game mechanics without needing to use the wiki, as important information about how things work can be determined by examining something that catches their interest.  This is also a great tool for expanding the fluff and lore, as now you can write paragraphs and embellish to your hearts content, without clogging the chat log.  There is also a third category, for antag-related assistance, visible only when an antag, as requested by PsiGamma.

~~At the basic level, two new variables defined at the /atom/ level, desc_info, and desc_fluff, are what is shown to the tab when someone examines the atom.  desc_info is for helpful information, tips, some tricks, and anything else helpful to new players or returning veterns.  desc_fluff is for any backstory for the atom, if one exists.  Both vars are optional, as in, if they are null, they will not appear in the examine tab.~~
The system now uses a datum named descriptions, containing at this time, three variables for the descriptions.

When someone examines anything, the name, icon, and datum contents are copied to an assoc list in the mob, which are what the tab displays.

If needed, you can override the procs get_descriptions_info() and get_descriptions_fluff() if you need to do special behaviour for your text (for example, at mob/living level, if the mob has flavor text, it it used instead of the datum  If no flavor text exists, it will use the datum, if it exists.  At the mob/living/human level, it retrieves the full flavor text from each slot of the human.)

The unfortunate part is that writing all of the datums will be a large undertaking, but I think it will be worth the effort.

Picture of a finalized example, the maintenance drone, now with 200% more antag: http://puu.sh/fZhZi/901f2c202c.png
