### PR TITLE
Fixes out of memory runtime errors and excessive HTML parsing.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -329,14 +329,25 @@ proc/TextPreview(var/string,var/len=40)
 //This means that it doesn't just remove < and > and call it a day.
 //Also limit the size of the input, if specified.
 /proc/strip_html_properly(var/input, var/max_length = MAX_MESSAGE_LEN)
+	if(!input)
+		return
 	var/opentag = 1 //These store the position of < and > respectively.
 	var/closetag = 1
 	while(1)
 		opentag = findtext(input, "<")
 		closetag = findtext(input, ">")
-		if(!closetag || !opentag)
+		if(closetag && opentag)
+			if(closetag < opentag)
+				input = copytext(input, (closetag + 1))
+			else
+				input = copytext(input, 1, opentag) + copytext(input, (closetag + 1))
+		else if(closetag || opentag)
+			if(opentag)
+				input = copytext(input, 1, opentag)
+			else
+				input = copytext(input, (closetag + 1))
+		else
 			break
-		input = copytext(input, 1, opentag) + copytext(input, (closetag + 1))
 	if(max_length)
 		input = copytext(input,1,max_length)
 	return sanitize(input)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -36,7 +36,7 @@
 	var/tmp/message_title = new_title ? new_title : title
 	var/tmp/message_sound = new_sound ? sound(new_sound) : sound
 
-	message = html_encode(message)
+	message = trim_strip_html_properly(message)
 	message_title = html_encode(message_title)
 
 	Message(message, message_title)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -110,7 +110,7 @@
 				if(message_cooldown)
 					usr << "Please allow at least one minute to pass between announcements"
 					return
-				var/input = stripped_input(usr, "Please write a message to announce to the station crew.", "Priority Announcement")
+				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement")
 				if(!input || !(usr in view(1,src)))
 					return
 				crew_announcement.Announce(input)

--- a/code/game/machinery/computer3/computers/communications.dm
+++ b/code/game/machinery/computer3/computers/communications.dm
@@ -115,7 +115,7 @@
 				if(message_cooldown)
 					usr << "Please allow at least one minute to pass between announcements"
 					return
-				var/input = stripped_input(usr, "Please write a message to announce to the station crew.", "Priority Announcement")
+				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement")
 				if(!input || !interactable())
 					return
 				crew_announcement.Announce(input)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -368,7 +368,7 @@ var/list/ai_verbs_default = list(
 	if(message_cooldown)
 		src << "Please allow one minute to pass between announcements."
 		return
-	var/input = stripped_input(usr, "Please write a message to announce to the station crew.", "A.I. Announcement")
+	var/input = input(usr, "Please write a message to announce to the station crew.", "A.I. Announcement")
 	if(!input)
 		return
 


### PR DESCRIPTION
Announcements are no longer parsed twice, avoiding messages such as `"T&#39;s nice".`
Alters the strip_html_properly proc to avoid out of memory runtimes.
