### PR TITLE
Adds fingerprints whenever an item is put in a human's hands

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -141,7 +141,6 @@
 		if(isliving(src.loc))
 			return
 		user.next_move = max(user.next_move+2,world.time + 2)
-	add_fingerprint(user)
 	user.put_in_active_hand(src)
 	if(src.loc == user)
 		src.pickup(user)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -1,3 +1,16 @@
+/*
+Add fingerprints to items when we put them in our hands.
+This saves us from having to call add_fingerprint() any time something is put in a human's hands programmatically.
+
+*/
+/mob/living/carbon/human/put_in_l_hand(var/obj/item/W)
+	. = ..()
+	if(.) W.add_fingerprint(src)
+
+/mob/living/carbon/human/put_in_r_hand(var/obj/item/W)
+	. = ..()
+	if(.) W.add_fingerprint(src)
+
 /mob/living/carbon/human/verb/quick_equip()
 	set name = "quick-equip"
 	set hidden = 1


### PR DESCRIPTION
This ensures that fingerprints are added in hundreds of cases where things are put in a player's hands programmatically, and saves the need to call `add_fingerprints()` whenever `put_in_hands()`, `put_in_active_hand()`, or `put_in_inactive_hand()` are called.
