### PR TITLE
Icon file definition for purple comb + changelog typo fix

### DIFF
--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -71,6 +71,7 @@
 	name = "purple comb"
 	desc = "A pristine purple comb made from flexible plastic."
 	w_class = 1.0
+	icon = 'icons/obj/items.dmi'
 	icon_state = "purplecomb"
 	item_state = "purplecomb"
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -66,8 +66,8 @@ should be listed in the changelog upon commit though. Thanks. -->
 
 
 <div class='commit sansserif'>
-	<h2 class='date'>1 September 2015</h2>
-	<h3 class='author'> updated:</h3>
+	<h2 class='date'>9 January 2015</h2>
+	<h3 class='author'>Zuhayr updated:</h3>
 	<ul class='changes bgimages16'>
 		<li class='tweak'>Voice changers no longer use ID cards. They have Toggle and Set Voice verbs on the actual mask object now.</li>
 	</ul>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,15 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>18 February 2015</h2>
+	<h3 class='author'>TwistedAkai updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Purple Combs should now be visible and have their proper icon</li>
+	</ul>
+</div>
+
+
+<div class='commit sansserif'>
 	<h2 class='date'>1 September 2015</h2>
 	<h3 class='author'> updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
- Purple Comb was using weapons.dmi instead of items.dmi.
  Added changelog entry so players know it's not broken anymore.
  Fixed Zuhayr's probable typo with most likely intention as a separate commit since it's not related.
