### PR TITLE
Fixes hiding mobs being layered underneath vents

### DIFF
--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -16,8 +16,8 @@
 	if(stat == DEAD || paralysis || weakened || stunned || restrained())
 		return
 
-	if (layer != TURF_LAYER+0.2)
-		layer = TURF_LAYER+0.2
+	if (layer != 2.45)
+		layer = 2.45 //Just above cables with their 2.44
 		src << text("\blue You are now hiding.")
 	else
 		layer = MOB_LAYER


### PR DESCRIPTION
Fixes hiding mobs being layered underneath vents, which makes absolutely no sense as the vents are supposed to be embedded in the floor.

Instead they layer just above wires.
