### PR TITLE
Less screen wandering NanoUI windows.

### DIFF
--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -24,7 +24,6 @@
 		program.process()
 
 	update_icon()
-	src.updateDialog()
 
 /obj/machinery/embedded_controller/attack_ai(mob/user as mob)
 	src.ui_interact(user)


### PR DESCRIPTION
Calling updateDialog() forces a NanoUI window to re-open, which is a bit of a pain when done in process() as each re-opening would make the window relocate slightly below and to the right of its last location until it disappeared from the world.
This should prevent this behavior of anything base on embedded controls, such as docking and airlock cycle controllers.
