### PR TITLE
Adds robot synths

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -572,6 +572,7 @@
 #include "code\game\objects\items\robot\robot_items.dm"
 #include "code\game\objects\items\robot\robot_parts.dm"
 #include "code\game\objects\items\robot\robot_upgrades.dm"
+#include "code\game\objects\items\stacks\matter_synth.dm"
 #include "code\game\objects\items\stacks\medical.dm"
 #include "code\game\objects\items\stacks\nanopaste.dm"
 #include "code\game\objects\items\stacks\rods.dm"

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -162,7 +162,7 @@
 		if(istype(occupant, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = occupant
 			if(R.module)
-				R.module.respawn_consumable(R)
+				R.module.respawn_consumable(R, charge_rate)
 			if(!R.cell)
 				return
 			if(!R.cell.fully_charged())

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -162,7 +162,7 @@
 		if(istype(occupant, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = occupant
 			if(R.module)
-				R.module.respawn_consumable(R, charge_rate)
+				R.module.respawn_consumable(R, charge_rate / 250)
 			if(!R.cell)
 				return
 			if(!R.cell.fully_charged())

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -55,7 +55,7 @@
 	var/uses = 0
 	var/emagged = 0
 	var/failmsg = ""
-	var/charge = 1
+	var/charge = 0
 
 /obj/item/device/lightreplacer/New()
 	uses = max_uses / 2
@@ -122,11 +122,11 @@
 /obj/item/device/lightreplacer/proc/AddUses(var/amount = 1)
 	uses = min(max(uses + amount, 0), max_uses)
 
-/obj/item/device/lightreplacer/proc/Charge(var/mob/user)
-	charge += 1
-	if(charge > 7)
+/obj/item/device/lightreplacer/proc/Charge(var/mob/user, var/amount = 1)
+	charge += amount
+	if(charge > 6)
 		AddUses(1)
-		charge = 1
+		charge = 0
 
 /obj/item/device/lightreplacer/proc/ReplaceLight(var/obj/machinery/light/target, var/mob/living/U)
 

--- a/code/game/objects/items/stacks/matter_synth.dm
+++ b/code/game/objects/items/stacks/matter_synth.dm
@@ -1,6 +1,6 @@
 /datum/matter_synth
 	var/name = "Generic Synthesizer"
-	var/max_energy = 50000
+	var/max_energy = 60000
 	var/recharge_rate = 2000
 	var/energy
 

--- a/code/game/objects/items/stacks/matter_synth.dm
+++ b/code/game/objects/items/stacks/matter_synth.dm
@@ -1,0 +1,50 @@
+/datum/matter_synth
+	var/name = "Generic Synthesizer"
+	var/max_energy = 50000
+	var/recharge_rate = 2000
+	var/energy
+
+/datum/matter_synth/New(var/store = 0)
+	if(store)
+		max_energy = store
+	energy = max_energy
+	return
+
+/datum/matter_synth/proc/get_charge()
+	return energy
+
+/datum/matter_synth/proc/use_charge(var/amount)
+	if (energy >= amount)
+		energy -= amount
+		return 1
+	return 0
+
+/datum/matter_synth/proc/add_charge(var/amount)
+	energy = min(energy + amount, max_energy)
+
+/datum/matter_synth/proc/emp_act(var/severity)
+	use_charge(max_energy * 0.1 / severity)
+
+/datum/matter_synth/medicine
+	name = "Medicine Synthesizer"
+
+/datum/matter_synth/metal
+	name = "Metal Synthesizer"
+
+/datum/matter_synth/plasteel
+	name = "Plasteel Synthesizer"
+	max_energy = 10000
+
+/datum/matter_synth/glass
+	name = "Glass Synthesizer"
+
+/datum/matter_synth/wood
+	name = "Wood Synthesizer"
+
+/datum/matter_synth/plastic
+	name = "Plastic Synthesizer"
+
+/datum/matter_synth/wire
+	name = "Wire Synthesizer"
+	max_energy = 50
+	recharge_rate = 2

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -13,12 +13,21 @@
 	max_amount = 60
 	attack_verb = list("hit", "bludgeoned", "whacked")
 
+/obj/item/stack/rods/cyborg
+	name = "metal rod synthesizer"
+	desc = "A device that makes metal rods."
+	gender = MALE
+	matter = null
+	uses_charge = 1
+	charge_cost = 500
+	stacktype = /obj/item/stack/rods
+
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
 	..()
 	if (istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 
-		if(amount < 2)
+		if(get_amount() < 2)
 			user << "\red You need at least two rods to do this."
 			return
 
@@ -54,7 +63,7 @@
 				return 1
 
 	else if(!in_use)
-		if(amount < 2)
+		if(get_amount() < 2)
 			user << "\blue You need at least two rods to do this."
 			return
 		usr << "\blue Assembling grille..."

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -16,10 +16,10 @@
 /obj/item/stack/rods/cyborg
 	name = "metal rod synthesizer"
 	desc = "A device that makes metal rods."
-	gender = MALE
+	gender = NEUTER
 	matter = null
 	uses_charge = 1
-	charge_cost = 500
+	charge_costs = list(500)
 	stacktype = /obj/item/stack/rods
 
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -24,11 +24,11 @@
 /obj/item/stack/sheet/glass/cyborg
 	name = "glass synthesizer"
 	desc = "A device that makes glass."
-	gender = MALE
+	gender = NEUTER
 	singular_name = "glass"
 	matter = null
 	uses_charge = 1
-	charge_cost = 1000
+	charge_costs = list(1000)
 	stacktype = /obj/item/stack/sheet/glass
 
 /obj/item/stack/sheet/glass/attack_self(mob/user as mob)
@@ -154,31 +154,13 @@
 /obj/item/stack/sheet/glass/reinforced/cyborg
 	name = "reinforced glass synthesizer"
 	desc = "A device that makes reinforced glass."
-	gender = MALE
+	gender = NEUTER
 	matter = null
-	uses_charge = 1
-	charge_cost = 1000
+	uses_charge = 2
+	charge_costs = list(1000)
 	singular_name = "reinforced glass sheet"
 	icon_state = "sheet-rglass"
-	var/datum/matter_synth/metal_synth
-	var/datum/matter_synth/glass_synth
-	var/metal_charge = 500
-	var/glass_charge = 1000
-
-/obj/item/stack/sheet/glass/reinforced/cyborg/get_amount()
-	return min(round(metal_synth.energy / metal_charge), round(glass_synth.energy / glass_charge))
-
-/obj/item/stack/sheet/glass/reinforced/cyborg/use(var/amount) // Requires special checks, because it uses two storages
-	if(get_amount() < amount)
-		return 0
-	metal_synth.use_charge(amount * metal_charge)
-	glass_synth.use_charge(amount * glass_charge)
-	return 1
-
-/obj/item/stack/sheet/glass/reinforced/cyborg/add(var/amount)
-	metal_synth.add_charge(amount * metal_charge)
-	glass_synth.add_charge(amount * glass_charge)
-	return
+	charge_costs = list(500, 1000)
 
 /*
  * Phoron Glass sheets

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -22,12 +22,13 @@
 	var/list/construction_options = list("One Direction", "Full Window")
 
 /obj/item/stack/sheet/glass/cyborg
-	name = "glass"
-	desc = "HOLY SHEET! That is a lot of glass."
-	singular_name = "glass sheet"
-	icon_state = "sheet-glass"
+	name = "glass synthesizer"
+	desc = "A device that makes glass."
+	gender = MALE
+	singular_name = "glass"
 	matter = null
-	created_window = /obj/structure/window/basic
+	uses_charge = 1
+	charge_cost = 1000
 	stacktype = /obj/item/stack/sheet/glass
 
 /obj/item/stack/sheet/glass/attack_self(mob/user as mob)
@@ -69,7 +70,7 @@
 	if(!user.IsAdvancedToolUser())
 		return 0
 	var/title = "Sheet-[name]"
-	title += " ([src.amount] sheet\s left)"
+	title += " ([src.get_amount()] sheet\s left)"
 	switch(input(title, "What would you like to construct?") as null|anything in construction_options)
 		if("One Direction")
 			if(!src)	return 1
@@ -102,7 +103,7 @@
 		if("Full Window")
 			if(!src)	return 1
 			if(src.loc != user)	return 1
-			if(src.amount < 4)
+			if(src.get_amount() < 4)
 				user << "\red You need more glass to do that."
 				return 1
 			if(locate(/obj/structure/window) in user.loc)
@@ -124,7 +125,7 @@
 				user << "\red There is already a windoor in that location."
 				return 1
 
-			if(src.amount < 5)
+			if(src.get_amount() < 5)
 				user << "\red You need more glass to do that."
 				return 1
 
@@ -151,10 +152,33 @@
 	construction_options = list("One Direction", "Full Window", "Windoor")
 
 /obj/item/stack/sheet/glass/reinforced/cyborg
-	name = "reinforced glass"
-	desc = "Glass which has been reinforced with metal rods."
+	name = "reinforced glass synthesizer"
+	desc = "A device that makes reinforced glass."
+	gender = MALE
+	matter = null
+	uses_charge = 1
+	charge_cost = 1000
 	singular_name = "reinforced glass sheet"
 	icon_state = "sheet-rglass"
+	var/datum/matter_synth/metal_synth
+	var/datum/matter_synth/glass_synth
+	var/metal_charge = 500
+	var/glass_charge = 1000
+
+/obj/item/stack/sheet/glass/reinforced/cyborg/get_amount()
+	return min(round(metal_synth.energy / metal_charge), round(glass_synth.energy / glass_charge))
+
+/obj/item/stack/sheet/glass/reinforced/cyborg/use(var/amount) // Requires special checks, because it uses two storages
+	if(get_amount() < amount)
+		return 0
+	metal_synth.use_charge(amount * metal_charge)
+	glass_synth.use_charge(amount * glass_charge)
+	return 1
+
+/obj/item/stack/sheet/glass/reinforced/cyborg/add(var/amount)
+	metal_synth.add_charge(amount * metal_charge)
+	glass_synth.add_charge(amount * glass_charge)
+	return
 
 /*
  * Phoron Glass sheets

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -138,9 +138,9 @@ obj/item/stack/sheet/mineral/iron/New()
 
 /obj/item/stack/sheet/mineral/plastic/cyborg
 	name = "plastic sheets synthesizer"
-	gender = MALE
+	gender = NEUTER
 	uses_charge = 1
-	charge_cost = 1000
+	charge_costs = list(1000)
 	stacktype = /obj/item/stack/sheet/mineral/plastic
 
 /obj/item/stack/sheet/mineral/gold

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -137,9 +137,10 @@ obj/item/stack/sheet/mineral/iron/New()
 	recipes = plastic_recipes
 
 /obj/item/stack/sheet/mineral/plastic/cyborg
-	name = "plastic sheets"
-	icon_state = "sheet-plastic"
-	perunit = 2000
+	name = "plastic sheets synthesizer"
+	gender = MALE
+	uses_charge = 1
+	charge_cost = 1000
 	stacktype = /obj/item/stack/sheet/mineral/plastic
 
 /obj/item/stack/sheet/mineral/gold

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -88,10 +88,10 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 /obj/item/stack/sheet/metal/cyborg
 	name = "metal synthesizer"
 	desc = "A device that makes metal sheets."
-	gender = MALE
+	gender = NEUTER
 	matter = null
 	uses_charge = 1
-	charge_cost = 1000
+	charge_costs = list(1000)
 	stacktype = /obj/item/stack/sheet/metal
 
 /obj/item/stack/sheet/metal/New(var/loc, var/amount=null)
@@ -124,11 +124,11 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 /obj/item/stack/sheet/plasteel/cyborg
 	name = "plasteel synthesizer"
 	desc = "A device that makes plasteel sheets."
-	gender = MALE
+	gender = NEUTER
 	singular_name = "plasteel sheet"
 	matter = null
 	uses_charge = 1
-	charge_cost = 1000
+	charge_costs = list(1000)
 	stacktype = /obj/item/stack/sheet/plasteel
 
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
@@ -161,11 +161,11 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 /obj/item/stack/sheet/wood/cyborg
 	name = "wood synthesizer"
 	desc = "A device that makes wooden planks."
-	gender = MALE
+	gender = NEUTER
 	singular_name = "wood plank"
 	icon_state = "sheet-wood"
 	uses_charge = 1
-	charge_cost = 1000
+	charge_costs = list(1000)
 	stacktype = /obj/item/stack/sheet/wood
 
 /obj/item/stack/sheet/wood/New(var/loc, var/amount=null)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -86,12 +86,12 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	origin_tech = "materials=1"
 
 /obj/item/stack/sheet/metal/cyborg
-	name = "metal"
-	desc = "Sheets made out off metal. It has been dubbed Metal Sheets."
-	singular_name = "metal sheet"
-	icon_state = "sheet-metal"
-	throwforce = 14.0
-	flags = CONDUCT
+	name = "metal synthesizer"
+	desc = "A device that makes metal sheets."
+	gender = MALE
+	matter = null
+	uses_charge = 1
+	charge_cost = 1000
 	stacktype = /obj/item/stack/sheet/metal
 
 /obj/item/stack/sheet/metal/New(var/loc, var/amount=null)
@@ -121,9 +121,19 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	flags = CONDUCT
 	origin_tech = "materials=2"
 
+/obj/item/stack/sheet/plasteel/cyborg
+	name = "plasteel synthesizer"
+	desc = "A device that makes plasteel sheets."
+	gender = MALE
+	singular_name = "plasteel sheet"
+	matter = null
+	uses_charge = 1
+	charge_cost = 1000
+	stacktype = /obj/item/stack/sheet/plasteel
+
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
-		recipes = plasteel_recipes
-		return ..()
+	recipes = plasteel_recipes
+	return ..()
 
 /*
  * Wood
@@ -149,10 +159,13 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 	origin_tech = "materials=1;biotech=1"
 
 /obj/item/stack/sheet/wood/cyborg
-	name = "wooden plank"
-	desc = "One can only guess that this is a bunch of wood."
+	name = "wood synthesizer"
+	desc = "A device that makes wooden planks."
+	gender = MALE
 	singular_name = "wood plank"
 	icon_state = "sheet-wood"
+	uses_charge = 1
+	charge_cost = 1000
 	stacktype = /obj/item/stack/sheet/wood
 
 /obj/item/stack/sheet/wood/New(var/loc, var/amount=null)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -17,6 +17,9 @@
 	var/amount = 1
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/stacktype //determines whether different stack types can merge
+	var/uses_charge = 0
+	var/charge_cost = 1
+	var/datum/matter_synth/synth = null
 
 /obj/item/stack/New(var/loc, var/amount=null)
 	..()
@@ -27,13 +30,18 @@
 	return
 
 /obj/item/stack/Del()
+	if(uses_charge)
+		return
 	if (src && usr && usr.machine == src)
 		usr << browse(null, "window=stack")
 	..()
 
 /obj/item/stack/examine(mob/user)
 	if(..(user, 1))
-		user << "There are [src.amount] [src.singular_name]\s in the stack."
+		if(!uses_charge)
+			user << "There are [src.amount] [src.singular_name]\s in the stack."
+		else
+			user << "There is enough charge for [get_amount()]."
 
 /obj/item/stack/attack_self(mob/user as mob)
 	list_recipes(user)
@@ -41,14 +49,14 @@
 /obj/item/stack/proc/list_recipes(mob/user as mob, recipes_sublist)
 	if (!recipes)
 		return
-	if (!src || amount<=0)
+	if (!src || get_amount() <= 0)
 		user << browse(null, "window=stack")
 	user.set_machine(src) //for correct work of onclose
 	var/list/recipe_list = recipes
 	if (recipes_sublist && recipe_list[recipes_sublist] && istype(recipe_list[recipes_sublist], /datum/stack_recipe_list))
 		var/datum/stack_recipe_list/srl = recipe_list[recipes_sublist]
 		recipe_list = srl.recipes
-	var/t1 = text("<HTML><HEAD><title>Constructions from []</title></HEAD><body><TT>Amount Left: []<br>", src, src.amount)
+	var/t1 = text("<HTML><HEAD><title>Constructions from []</title></HEAD><body><TT>Amount Left: []<br>", src, src.get_amount())
 	for(var/i=1;i<=recipe_list.len,i++)
 		var/E = recipe_list[i]
 		if (isnull(E))
@@ -60,14 +68,14 @@
 
 		if (istype(E, /datum/stack_recipe_list))
 			var/datum/stack_recipe_list/srl = E
-			if (src.amount >= srl.req_amount)
+			if (src.get_amount() >= srl.req_amount)
 				t1 += "<a href='?src=\ref[src];sublist=[i]'>[srl.title] ([srl.req_amount] [src.singular_name]\s)</a>"
 			else
 				t1 += "[srl.title] ([srl.req_amount] [src.singular_name]\s)<br>"
 
 		if (istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E
-			var/max_multiplier = round(src.amount / R.req_amount)
+			var/max_multiplier = round(src.get_amount() / R.req_amount)
 			var/title as text
 			var/can_build = 1
 			can_build = can_build && (max_multiplier>0)
@@ -142,7 +150,7 @@
 		list_recipes(usr, text2num(href_list["sublist"]))
 
 	if (href_list["make"])
-		if (src.amount < 1) del(src) //Never should happen
+		if (src.get_amount() < 1) del(src) //Never should happen
 
 		var/list/recipes_list = recipes
 		if (href_list["sublist"])
@@ -165,28 +173,39 @@
 //Return 1 if an immediate subsequent call to use() would succeed.
 //Ensures that code dealing with stacks uses the same logic
 /obj/item/stack/proc/can_use(var/used)
-	if (amount < used)
+	if (get_amount() < used)
 		return 0
 	return 1
 
 /obj/item/stack/proc/use(var/used)
 	if (!can_use(used))
 		return 0
-	amount -= used
-	if (amount <= 0)
-		spawn(0) //delete the empty stack once the current context yields
-			if (amount <= 0) //check again in case someone transferred stuff to us
-				if(usr)
-					usr.before_take_item(src)
-				del(src)
-	return 1
+	if(!uses_charge)
+		amount -= used
+		if (amount <= 0)
+			spawn(0) //delete the empty stack once the current context yields
+				if (amount <= 0) //check again in case someone transferred stuff to us
+					if(usr)
+						usr.before_take_item(src)
+					del(src)
+		return 1
+	else
+		if(!synth)
+			return 0
+		return synth.use_charge(charge_cost * used) // Doesn't need to be deleted
+	return 0
 
 /obj/item/stack/proc/add(var/extra)
-	if(amount + extra > max_amount)
+	if(!uses_charge)
+		if(amount + extra > get_max_amount())
+			return 0
+		else
+			amount += extra
+		return 1
+	else if(!synth)
 		return 0
 	else
-		amount += extra
-	return 1
+		synth.add_charge(charge_cost * extra)
 
 /*
 	The transfer and split procs work differently than use() and add().
@@ -196,16 +215,16 @@
 
 //attempts to transfer amount to S, and returns the amount actually transferred
 /obj/item/stack/proc/transfer_to(obj/item/stack/S, var/tamount=null)
-	if (!amount)
+	if (!get_amount())
 		return 0
 	if (stacktype != S.stacktype)
 		return 0
 	if (isnull(tamount))
-		tamount = src.amount
+		tamount = src.get_amount()
 
-	var/transfer = max(min(tamount, src.amount, (S.max_amount - S.amount)), 0)
+	var/transfer = max(min(tamount, src.get_amount(), (S.get_max_amount() - S.get_amount())), 0)
 
-	var/orig_amount = src.amount
+	var/orig_amount = src.get_amount()
 	if (transfer && src.use(transfer))
 		S.add(transfer)
 		if (prob(transfer/orig_amount * 100))
@@ -219,6 +238,8 @@
 //creates a new stack with the specified amount
 /obj/item/stack/proc/split(var/tamount)
 	if (!amount)
+		return null
+	if(uses_charge)
 		return null
 
 	var/transfer = max(min(tamount, src.amount, initial(max_amount)), 0)
@@ -234,7 +255,18 @@
 	return null
 
 /obj/item/stack/proc/get_amount()
+	if(uses_charge)
+		if(!synth)
+			return 0
+		return round(synth.get_charge() / charge_cost)
 	return amount
+
+/obj/item/stack/proc/get_max_amount()
+	if(uses_charge)
+		if(!synth)
+			return 0
+		return round(synth.max_energy / charge_cost)
+	return max_amount
 
 /obj/item/stack/proc/add_to_stacks(mob/usr as mob)
 	for (var/obj/item/stack/item in usr.loc)

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -19,10 +19,10 @@
 /obj/item/stack/tile/plasteel/cyborg
 	name = "floor tile synthesizer"
 	desc = "A device that makes floor tiles."
-	gender = MALE
+	gender = NEUTER
 	matter = null
 	uses_charge = 1
-	charge_cost = 250
+	charge_costs = list(250)
 	stacktype = /obj/item/stack/tile/plasteel
 	build_type = /obj/item/stack/tile/plasteel
 

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -3,20 +3,28 @@
 	singular_name = "floor tile"
 	desc = "Those could work as a pretty decent throwing weapon"
 	icon_state = "tile"
-	w_class = 3.0
 	force = 6.0
 	matter = list("metal" = 937.5)
 	throwforce = 15.0
 	throw_speed = 5
 	throw_range = 20
 	flags = CONDUCT
-	max_amount = 60
 
 /obj/item/stack/tile/plasteel/New(var/loc, var/amount=null)
 	..()
 	src.pixel_x = rand(1, 14)
 	src.pixel_y = rand(1, 14)
 	return
+
+/obj/item/stack/tile/plasteel/cyborg
+	name = "floor tile synthesizer"
+	desc = "A device that makes floor tiles."
+	gender = MALE
+	matter = null
+	uses_charge = 1
+	charge_cost = 250
+	stacktype = /obj/item/stack/tile/plasteel
+	build_type = /obj/item/stack/tile/plasteel
 
 /*
 /obj/item/stack/tile/plasteel/attack_self(mob/user as mob)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -1,9 +1,18 @@
 /* Diffrent misc types of tiles
  * Contains:
+ *		Prototype
  *		Grass
  *		Wood
  *		Carpet
  */
+ 
+/obj/item/stack/tile
+	name = "tile"
+	singular_name = "tile"
+	desc = "A non-descript floor tile"
+	w_class = 3
+	max_amount = 60
+	var/build_type = null
 
 /*
  * Grass
@@ -13,13 +22,11 @@
 	singular_name = "grass floor tile"
 	desc = "A patch of grass like they often use on golf courses."
 	icon_state = "tile_grass"
-	w_class = 3.0
 	force = 1.0
 	throwforce = 1.0
 	throw_speed = 5
 	throw_range = 20
 	flags = CONDUCT
-	max_amount = 60
 	origin_tech = "biotech=1"
 
 /*
@@ -30,13 +37,19 @@
 	singular_name = "wood floor tile"
 	desc = "An easy to fit wooden floor tile."
 	icon_state = "tile-wood"
-	w_class = 3.0
 	force = 1.0
 	throwforce = 1.0
 	throw_speed = 5
 	throw_range = 20
 	flags = CONDUCT
-	max_amount = 60
+
+/obj/item/stack/tile/wood/cyborg
+	name = "wood floor tile synthesizer"
+	desc = "A device that makes wood floor tiles."
+	uses_charge = 1
+	charge_cost = 250
+	stacktype = /obj/item/stack/tile/wood
+	build_type = /obj/item/stack/tile/wood
 
 /*
  * Carpets
@@ -46,10 +59,8 @@
 	singular_name = "carpet"
 	desc = "A piece of carpet. It is the same size as a normal floor tile!"
 	icon_state = "tile-carpet"
-	w_class = 3.0
 	force = 1.0
 	throwforce = 1.0
 	throw_speed = 5
 	throw_range = 20
 	flags = CONDUCT
-	max_amount = 60

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -47,7 +47,7 @@
 	name = "wood floor tile synthesizer"
 	desc = "A device that makes wood floor tiles."
 	uses_charge = 1
-	charge_cost = 250
+	charge_costs = list(250)
 	stacktype = /obj/item/stack/tile/wood
 	build_type = /obj/item/stack/tile/wood
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -519,7 +519,10 @@ turf/simulated/floor/proc/update_icon()
 				var/obj/item/stack/tile/T = C
 				if (T.get_amount() < 1)
 					return
-				floor_type = T.type
+				if(!T.build_type)
+					floor_type = T.type
+				else
+					floor_type = T.build_type
 				intact = 1
 				if(istype(T,/obj/item/stack/tile/light))
 					var/obj/item/stack/tile/light/L = T

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -16,14 +16,6 @@
 	integrated_light_power = 2
 	local_transmit = 1
 
-	// We need to keep track of a few module items so we don't need to do list operations
-	// every time we need them. These get set in New() after the module is chosen.
-	var/obj/item/stack/sheet/metal/cyborg/stack_metal = null
-	var/obj/item/stack/sheet/wood/cyborg/stack_wood = null
-	var/obj/item/stack/sheet/glass/cyborg/stack_glass = null
-	var/obj/item/stack/sheet/mineral/plastic/cyborg/stack_plastic = null
-	var/obj/item/weapon/matter_decompiler/decompiler = null
-
 	//Used for self-mailing.
 	var/mail_destination = ""
 
@@ -55,15 +47,6 @@
 
 	verbs -= /mob/living/silicon/robot/verb/Namepick
 	module = new /obj/item/weapon/robot_module/drone(src)
-
-	//Grab stacks.
-	stack_metal = locate(/obj/item/stack/sheet/metal/cyborg) in src.module
-	stack_wood = locate(/obj/item/stack/sheet/wood/cyborg) in src.module
-	stack_glass = locate(/obj/item/stack/sheet/glass/cyborg) in src.module
-	stack_plastic = locate(/obj/item/stack/sheet/mineral/plastic/cyborg) in src.module
-
-	//Grab decompiler.
-	decompiler = locate(/obj/item/weapon/matter_decompiler) in src.module
 
 	//Some tidying-up.
 	flavor_text = "It's a tiny little repair drone. The casing is stamped with an NT logo and the subscript: 'NanoTrasen Recursive Repair Systems: Fixing Tomorrow's Problem, Today!'"

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -151,12 +151,10 @@
 	icon_state = "decompiler"
 
 	//Metal, glass, wood, plastic.
-	var/list/stored_comms = list(
-		"metal" = 0,
-		"glass" = 0,
-		"wood" = 0,
-		"plastic" = 0
-		)
+	var/datum/matter_synth/metal = null
+	var/datum/matter_synth/glass = null
+	var/datum/matter_synth/wood = null
+	var/datum/matter_synth/plastic = null
 
 /obj/item/weapon/matter_decompiler/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	return
@@ -178,10 +176,10 @@
 			src.loc.visible_message("\red [src.loc] sucks [M] into its decompiler. There's a horrible crunching noise.","\red It's a bit of a struggle, but you manage to suck [M] into your decompiler. It makes a series of visceral crunching noises.")
 			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
 			del(M)
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
+			if(wood)
+				wood.add_charge(2000)
+			if(plastic)
+				plastic.add_charge(2000)
 			return
 
 		else if(istype(M,/mob/living/silicon/robot/drone) && !M.client)
@@ -203,61 +201,66 @@
 			del(M)
 			new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
 
-			stored_comms["metal"] += 15
-			stored_comms["glass"] += 15
-			stored_comms["wood"] += 5
-			stored_comms["plastic"] += 5
+			if(metal)
+				metal.add_charge(15000)
+			if(glass)
+				glass.add_charge(15000)
+			if(wood)
+				wood.add_charge(2000)
+			if(plastic)
+				plastic.add_charge(1000)
 			return
 		else
 			continue
 
 	for(var/obj/W in T)
 		//Different classes of items give different commodities.
-		if (istype(W,/obj/item/weapon/cigbutt))
-			stored_comms["plastic"]++
+		if(istype(W,/obj/item/weapon/cigbutt))
+			if(plastic)
+				plastic.add_charge(500)
 		else if(istype(W,/obj/effect/spider/spiderling))
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
+			if(wood)
+				wood.add_charge(2000)
+			if(plastic)
+				plastic.add_charge(2000)
 		else if(istype(W,/obj/item/weapon/light))
 			var/obj/item/weapon/light/L = W
 			if(L.status >= 2) //In before someone changes the inexplicably local defines. ~ Z
-				stored_comms["metal"]++
-				stored_comms["glass"]++
+				if(metal)
+					metal.add_charge(250)
+				if(glass)
+					glass.add_charge(250)
 			else
 				continue
 		else if(istype(W,/obj/effect/decal/remains/robot))
-			stored_comms["metal"]++
-			stored_comms["metal"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
-			stored_comms["glass"]++
+			if(metal)
+				metal.add_charge(2000)
+			if(plastic)
+				plastic.add_charge(2000)
+			if(glass)
+				glass.add_charge(1000)
 		else if(istype(W,/obj/item/trash))
-			stored_comms["metal"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
+			if(metal)
+				metal.add_charge(1000)
+			if(plastic)
+				plastic.add_charge(3000)
 		else if(istype(W,/obj/effect/decal/cleanable/blood/gibs/robot))
-			stored_comms["metal"]++
-			stored_comms["metal"]++
-			stored_comms["glass"]++
-			stored_comms["glass"]++
+			if(metal)
+				metal.add_charge(2000)
+			if(glass)
+				glass.add_charge(2000)
 		else if(istype(W,/obj/item/ammo_casing))
-			stored_comms["metal"]++
+			if(metal)
+				metal.add_charge(1000)
 		else if(istype(W,/obj/item/weapon/shard/shrapnel))
-			stored_comms["metal"]++
-			stored_comms["metal"]++
-			stored_comms["metal"]++
+			if(metal)
+				metal.add_charge(1000)
 		else if(istype(W,/obj/item/weapon/shard))
-			stored_comms["glass"]++
-			stored_comms["glass"]++
-			stored_comms["glass"]++
+			if(glass)
+				glass.add_charge(1000)
 		else if(istype(W,/obj/item/weapon/reagent_containers/food/snacks/grown))
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["wood"]++
+			if(wood)
+				wood.add_charge(4000)
 		else if(istype(W,/obj/item/pipe))
 			// This allows drones and engiborgs to clear pipe assemblies from floors.
 		else
@@ -325,39 +328,3 @@
 	dat += resources
 
 	src << browse(dat, "window=robotmod")
-
-//Putting the decompiler here to avoid doing list checks every tick.
-/mob/living/silicon/robot/drone/use_power()
-
-	..()
-	if(!src.has_power || !decompiler)
-		return
-
-	//The decompiler replenishes drone stores from hoovered-up junk each tick.
-	for(var/type in decompiler.stored_comms)
-		if(decompiler.stored_comms[type] > 0)
-			var/obj/item/stack/sheet/stack
-			switch(type)
-				if("metal")
-					if(!stack_metal)
-						stack_metal = new /obj/item/stack/sheet/metal/cyborg(src.module)
-						stack_metal.amount = 1
-					stack = stack_metal
-				if("glass")
-					if(!stack_glass)
-						stack_glass = new /obj/item/stack/sheet/glass/cyborg(src.module)
-						stack_glass.amount = 1
-					stack = stack_glass
-				if("wood")
-					if(!stack_wood)
-						stack_wood = new /obj/item/stack/sheet/wood/cyborg(src.module)
-						stack_wood.amount = 1
-					stack = stack_wood
-				if("plastic")
-					if(!stack_plastic)
-						stack_plastic = new /obj/item/stack/sheet/mineral/plastic/cyborg(src.module)
-						stack_plastic.amount = 1
-					stack = stack_plastic
-
-			stack.amount++
-			decompiler.stored_comms[type]--;

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -579,6 +579,9 @@ var/list/robot_verbs_default = list(
 		show_cell_power()
 		show_jetpack_pressure()
 		stat(null, text("Lights: [lights_on ? "ON" : "OFF"]"))
+		if(module)
+			for(var/datum/matter_synth/ms in module.synths)
+				stat("[ms.name]: [ms.energy]/[ms.max_energy]")
 
 /mob/living/silicon/robot/restrained()
 	return 0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -7,9 +7,9 @@
 	flags = CONDUCT
 	var/channels = list()
 	var/list/modules = list()
+	var/list/datum/matter_synth/synths = list()
 	var/obj/item/emag = null
 	var/obj/item/borg/upgrade/jetpack = null
-	var/list/stacktypes
 
 /obj/item/weapon/robot_module/emp_act(severity)
 	if(modules)
@@ -17,40 +17,19 @@
 			O.emp_act(severity)
 	if(emag)
 		emag.emp_act(severity)
+	if(synths)
+		for(var/datum/synth/S in synths)
+			S.emp_act(severity)
 	..()
 	return
 
-/obj/item/weapon/robot_module/New()
-	..()
-	// Build initial inventory.
-	if(stacktypes && stacktypes.len)
-		for(var/stack_type in stacktypes)
-			var/obj/item/stack/new_stack = new stack_type (src)
-			new_stack.amount = stacktypes[stack_type]
-			modules |= new_stack
+/obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 
-/obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R)
+	if(!synths || !synths.len)
+		return
 
-	if(!stacktypes || !stacktypes.len) return
-
-	for(var/T in stacktypes)
-		var/obj/item/stack/S
-		for(var/obj/O in src.modules)
-			if(O.type == T)
-				S = O
-				break
-
-		if(!S)
-			src.modules -= null
-			S = new T(src)
-			src.modules |= S
-			S.amount = 1
-
-		if(!istype(S))
-			continue
-
-		if(S && S.amount < stacktypes[T])
-			S.amount++
+	for(var/datum/matter_synth/T in synths)
+		T.add_charge(amount * amount)
 
 /obj/item/weapon/robot_module/proc/rebuild()//Rebuilds the list so it's possible to add/remove items from the module
 	var/list/temp_list = modules
@@ -84,10 +63,6 @@
 
 /obj/item/weapon/robot_module/surgeon
 	name = "surgeon robot module"
-	stacktypes = list(
-		/obj/item/stack/medical/advanced/bruise_pack = 5,
-		/obj/item/stack/nanopaste = 5
-		)
 
 /obj/item/weapon/robot_module/surgeon/New()
 	..()
@@ -104,26 +79,34 @@
 	src.modules += new /obj/item/weapon/circular_saw(src)
 	src.modules += new /obj/item/weapon/surgicaldrill(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
-	src.modules += new /obj/item/stack/medical/advanced/bruise_pack(src)
-	src.modules += new /obj/item/stack/nanopaste(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
+
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
+	synths += medicine
+
+	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
+	N.uses_charge = 1
+	N.charge_cost = 1000
+	N.synth = medicine
+	B.uses_charge = 1
+	B.charge_cost = 1000
+	B.synth = medicine
+	src.modules += N
+	src.modules += B
+
 	return
 
-/obj/item/weapon/robot_module/surgeon/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/surgeon/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	if(src.emag)
 		var/obj/item/weapon/reagent_containers/spray/PS = src.emag
-		PS.reagents.add_reagent("pacid", 2)
+		PS.reagents.add_reagent("pacid", 2 * amount)
 	..()
 
 /obj/item/weapon/robot_module/crisis
 	name = "crisis robot module"
-	stacktypes = list(
-		/obj/item/stack/medical/ointment = 5,
-		/obj/item/stack/medical/bruise_pack = 5,
-		/obj/item/stack/medical/splint = 5
-		)
 
 /obj/item/weapon/robot_module/crisis/New()
 	..()
@@ -132,9 +115,6 @@
 	src.modules += new /obj/item/device/healthanalyzer(src)
 	src.modules += new /obj/item/device/reagent_scanner/adv(src)
 	src.modules += new /obj/item/roller_holder(src)
-	src.modules += new /obj/item/stack/medical/ointment(src)
-	src.modules += new /obj/item/stack/medical/bruise_pack(src)
-	src.modules += new /obj/item/stack/medical/splint(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
 	src.modules += new /obj/item/weapon/reagent_containers/robodropper(src)
@@ -143,9 +123,29 @@
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
+
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
+	synths += medicine
+
+	var/obj/item/stack/medical/ointment/O = new /obj/item/stack/medical/ointment(src)
+	var/obj/item/stack/medical/bruise_pack/B = new /obj/item/stack/medical/bruise_pack(src)
+	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
+	O.uses_charge = 1
+	O.charge_cost = 1000
+	O.synth = medicine
+	B.uses_charge = 1
+	B.charge_cost = 1000
+	B.synth = medicine
+	S.uses_charge = 1
+	S.charge_cost = 1000
+	S.synth = medicine
+	src.modules += O
+	src.modules += B
+	src.modules += S
+
 	return
 
-/obj/item/weapon/robot_module/crisis/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/crisis/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 
 	var/obj/item/weapon/reagent_containers/syringe/S = locate() in src.modules
 	if(S.mode == 2)
@@ -156,19 +156,12 @@
 
 	if(src.emag)
 		var/obj/item/weapon/reagent_containers/spray/PS = src.emag
-		PS.reagents.add_reagent("pacid", 2)
+		PS.reagents.add_reagent("pacid", 2 * amount)
 
 	..()
 
 /obj/item/weapon/robot_module/construction
 	name = "construction robot module"
-
-	stacktypes = list(
-		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel = 10,
-		/obj/item/stack/sheet/glass/reinforced = 50,
-		/obj/item/stack/rods = 50
-		)
 
 /obj/item/weapon/robot_module/construction/New()
 	..()
@@ -182,17 +175,32 @@
 	src.modules += new /obj/item/weapon/pickaxe/plasmacutter(src)
 	src.modules += new /obj/item/device/pipe_painter(src)
 
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal()
+	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel()
+	var/datum/matter_synth/glass = new /datum/matter_synth/glass()
+	synths += metal
+	synths += plasteel
+	synths += glass
+
+	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
+	M.synth = metal
+	src.modules += M
+
+	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
+	R.synth = metal
+	src.modules += R
+
+	var/obj/item/stack/sheet/plasteel/cyborg/S = new /obj/item/stack/sheet/plasteel/cyborg(src)
+	S.synth = metal
+	src.modules += S
+
+	var/obj/item/stack/sheet/glass/reinforced/cyborg/RG = new /obj/item/stack/sheet/glass/reinforced/cyborg(src)
+	RG.metal_synth = metal
+	RG.glass_synth = glass
+	src.modules += R
+
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
-
-	stacktypes = list(
-		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/glass = 50,
-		/obj/item/stack/sheet/glass/reinforced = 50,
-		/obj/item/stack/cable_coil/robot = 50,
-		/obj/item/stack/rods = 15,
-		/obj/item/stack/tile/plasteel = 15
-		)
 
 /obj/item/weapon/robot_module/engineering/New()
 	..()
@@ -212,6 +220,39 @@
 	src.modules += new /obj/item/weapon/matter_decompiler(src)
 	src.modules += new /obj/item/device/pipe_painter(src)
 	src.emag = new /obj/item/borg/stun(src)
+
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal(30000)
+	var/datum/matter_synth/glass = new /datum/matter_synth/glass(30000)
+	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
+	synths += metal
+	synths += glass
+	synths += wire
+
+	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
+	M.synth = metal
+	src.modules += M
+
+	var/obj/item/stack/sheet/glass/cyborg/G = new /obj/item/stack/sheet/glass/cyborg(src)
+	G.synth = glass
+	src.modules += G
+
+	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
+	R.synth = metal
+	src.modules += R
+
+	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
+	C.synth = wire
+	src.modules += C
+
+	var/obj/item/stack/tile/plasteel/cyborg/S = new /obj/item/stack/tile/plasteel/cyborg(src)
+	S.synth = metal
+	src.modules += S
+
+	var/obj/item/stack/sheet/glass/reinforced/cyborg/RG = new /obj/item/stack/sheet/glass/reinforced/cyborg(src)
+	RG.metal_synth = metal
+	RG.glass_synth = glass
+	src.modules += RG
+
 	return
 
 /obj/item/weapon/robot_module/security
@@ -228,7 +269,7 @@
 	src.emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
 	return
 
-/obj/item/weapon/robot_module/security/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/security/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/device/flash/F = locate() in src.modules
 	if(F.broken)
 		F.broken = 0
@@ -238,7 +279,7 @@
 		F.times_used--
 	var/obj/item/weapon/gun/energy/taser/cyborg/T = locate() in src.modules
 	if(T.power_supply.charge < T.power_supply.maxcharge)
-		T.power_supply.give(T.charge_cost)
+		T.power_supply.give(T.charge_cost * amount)
 		T.update_icon()
 	else
 		T.charge_tick = 0
@@ -258,12 +299,12 @@
 	src.emag.name = "Lube spray"
 	return
 
-/obj/item/weapon/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/device/lightreplacer/LR = locate() in src.modules
-	LR.Charge(R)
+	LR.Charge(R, amount)
 	if(src.emag)
 		var/obj/item/weapon/reagent_containers/spray/S = src.emag
-		S.reagents.add_reagent("lube", 2)
+		S.reagents.add_reagent("lube", 2 * amount)
 
 /obj/item/weapon/robot_module/butler
 	name = "service robot module"
@@ -327,12 +368,12 @@
 	R.add_language("Tradeband", 1)
 	R.add_language("Gutter", 1)
 
-/obj/item/weapon/robot_module/butler/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/butler/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/weapon/reagent_containers/food/condiment/enzyme/E = locate() in src.modules
-	E.reagents.add_reagent("enzyme", 2)
+	E.reagents.add_reagent("enzyme", 2 * amount)
 	if(src.emag)
 		var/obj/item/weapon/reagent_containers/food/drinks/cans/beer/B = src.emag
-		B.reagents.add_reagent("beer2", 2)
+		B.reagents.add_reagent("beer2", 2 * amount)
 
 /obj/item/weapon/robot_module/miner
 	name = "miner robot module"
@@ -392,17 +433,6 @@
 
 /obj/item/weapon/robot_module/drone
 	name = "drone module"
-	stacktypes = list(
-		/obj/item/stack/sheet/wood = 1,
-		/obj/item/stack/sheet/mineral/plastic = 1,
-		/obj/item/stack/sheet/glass/reinforced = 5,
-		/obj/item/stack/tile/wood = 5,
-		/obj/item/stack/rods = 15,
-		/obj/item/stack/tile/plasteel = 15,
-		/obj/item/stack/sheet/metal = 20,
-		/obj/item/stack/sheet/glass = 20,
-		/obj/item/stack/cable_coil/robot = 30
-		)
 
 /obj/item/weapon/robot_module/drone/New()
 	..()
@@ -419,15 +449,63 @@
 	src.emag = new /obj/item/weapon/pickaxe/plasmacutter(src)
 	src.emag.name = "Plasma Cutter"
 
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal(25000)
+	var/datum/matter_synth/glass = new /datum/matter_synth/glass(25000)
+	var/datum/matter_synth/wood = new /datum/matter_synth/wood(2000)
+	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(1000)
+	var/datum/matter_synth/wire = new /datum/matter_synth/wire(30)
+	synths += metal
+	synths += glass
+	synths += wood
+	synths += plastic
+	synths += wire
+
+	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
+	M.synth = metal
+	src.modules += M
+
+	var/obj/item/stack/sheet/glass/cyborg/G = new /obj/item/stack/sheet/glass/cyborg(src)
+	G.synth = glass
+	src.modules += G
+
+	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
+	R.synth = metal
+	src.modules += R
+
+	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
+	C.synth = wire
+	src.modules += C
+
+	var/obj/item/stack/tile/plasteel/cyborg/S = new /obj/item/stack/tile/plasteel/cyborg(src)
+	S.synth = metal
+	src.modules += S
+
+	var/obj/item/stack/sheet/glass/reinforced/cyborg/RG = new /obj/item/stack/sheet/glass/reinforced/cyborg(src)
+	RG.metal_synth = metal
+	RG.glass_synth = glass
+	src.modules += RG
+
+	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
+	WT.synth = wood
+	src.modules += WT
+
+	var/obj/item/stack/sheet/wood/cyborg/W = new /obj/item/stack/sheet/wood/cyborg(src)
+	W.synth = wood
+	src.modules += W
+
+	var/obj/item/stack/sheet/mineral/plastic/cyborg/P = new /obj/item/stack/sheet/mineral/plastic/cyborg(src)
+	P.synth = plastic
+	src.modules += P
+
 /obj/item/weapon/robot_module/drone/add_languages(var/mob/living/silicon/robot/R)
 	return	//not much ROM to spare in that tiny microprocessor!
 
-/obj/item/weapon/robot_module/drone/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/drone/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/weapon/reagent_containers/spray/cleaner/C = locate() in src.modules
-	C.reagents.add_reagent("cleaner", 3)
+	C.reagents.add_reagent("cleaner", 3 * amount)
 
 	var/obj/item/device/lightreplacer/LR = locate() in src.modules
-	LR.Charge(R)
+	LR.Charge(R, amount)
 
 	..()
 	return

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -18,18 +18,18 @@
 	if(emag)
 		emag.emp_act(severity)
 	if(synths)
-		for(var/datum/synth/S in synths)
+		for(var/datum/matter_synth/S in synths)
 			S.emp_act(severity)
 	..()
 	return
 
-/obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+/obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R, var/rate)
 
 	if(!synths || !synths.len)
 		return
 
 	for(var/datum/matter_synth/T in synths)
-		T.add_charge(amount * amount)
+		T.add_charge(T.recharge_rate * rate)
 
 /obj/item/weapon/robot_module/proc/rebuild()//Rebuilds the list so it's possible to add/remove items from the module
 	var/list/temp_list = modules
@@ -89,11 +89,11 @@
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	N.uses_charge = 1
-	N.charge_cost = 1000
-	N.synth = medicine
+	N.charge_costs = list(1000)
+	N.synths = list(medicine)
 	B.uses_charge = 1
-	B.charge_cost = 1000
-	B.synth = medicine
+	B.charge_costs = list(1000)
+	B.synths = list(medicine)
 	src.modules += N
 	src.modules += B
 
@@ -131,14 +131,14 @@
 	var/obj/item/stack/medical/bruise_pack/B = new /obj/item/stack/medical/bruise_pack(src)
 	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
 	O.uses_charge = 1
-	O.charge_cost = 1000
-	O.synth = medicine
+	O.charge_costs = list(1000)
+	O.synths = list(medicine)
 	B.uses_charge = 1
-	B.charge_cost = 1000
-	B.synth = medicine
+	B.charge_costs = list(1000)
+	B.synths = list(medicine)
 	S.uses_charge = 1
-	S.charge_cost = 1000
-	S.synth = medicine
+	S.charge_costs = list(1000)
+	S.synths = list(medicine)
 	src.modules += O
 	src.modules += B
 	src.modules += S
@@ -183,20 +183,19 @@
 	synths += glass
 
 	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
-	M.synth = metal
+	M.synths = list(metal)
 	src.modules += M
 
 	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
-	R.synth = metal
+	R.synths = list(metal)
 	src.modules += R
 
 	var/obj/item/stack/sheet/plasteel/cyborg/S = new /obj/item/stack/sheet/plasteel/cyborg(src)
-	S.synth = metal
+	S.synths = list(metal)
 	src.modules += S
 
 	var/obj/item/stack/sheet/glass/reinforced/cyborg/RG = new /obj/item/stack/sheet/glass/reinforced/cyborg(src)
-	RG.metal_synth = metal
-	RG.glass_synth = glass
+	RG.synths = list(metal, glass)
 	src.modules += R
 
 /obj/item/weapon/robot_module/engineering
@@ -217,40 +216,43 @@
 	src.modules += new /obj/item/device/analyzer(src)
 	src.modules += new /obj/item/taperoll/engineering(src)
 	src.modules += new /obj/item/weapon/gripper(src)
-	src.modules += new /obj/item/weapon/matter_decompiler(src)
 	src.modules += new /obj/item/device/pipe_painter(src)
 	src.emag = new /obj/item/borg/stun(src)
 
-	var/datum/matter_synth/metal = new /datum/matter_synth/metal(30000)
-	var/datum/matter_synth/glass = new /datum/matter_synth/glass(30000)
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal(40000)
+	var/datum/matter_synth/glass = new /datum/matter_synth/glass(40000)
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
 	synths += metal
 	synths += glass
 	synths += wire
 
+	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)
+	MD.metal = metal
+	MD.glass = glass
+	src.modules += MD
+
 	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
-	M.synth = metal
+	M.synths = list(metal)
 	src.modules += M
 
 	var/obj/item/stack/sheet/glass/cyborg/G = new /obj/item/stack/sheet/glass/cyborg(src)
-	G.synth = glass
+	G.synths = list(glass)
 	src.modules += G
 
 	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
-	R.synth = metal
+	R.synths = list(metal)
 	src.modules += R
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synth = wire
+	C.synths = list(wire)
 	src.modules += C
 
 	var/obj/item/stack/tile/plasteel/cyborg/S = new /obj/item/stack/tile/plasteel/cyborg(src)
-	S.synth = metal
+	S.synths = list(metal)
 	src.modules += S
 
 	var/obj/item/stack/sheet/glass/reinforced/cyborg/RG = new /obj/item/stack/sheet/glass/reinforced/cyborg(src)
-	RG.metal_synth = metal
-	RG.glass_synth = glass
+	RG.synths = list(metal, glass)
 	src.modules += RG
 
 	return
@@ -444,7 +446,6 @@
 	src.modules += new /obj/item/device/multitool(src)
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/weapon/gripper(src)
-	src.modules += new /obj/item/weapon/matter_decompiler(src)
 	src.modules += new /obj/item/weapon/reagent_containers/spray/cleaner/drone(src)
 	src.emag = new /obj/item/weapon/pickaxe/plasmacutter(src)
 	src.emag.name = "Plasma Cutter"
@@ -460,41 +461,47 @@
 	synths += plastic
 	synths += wire
 
+	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)
+	MD.metal = metal
+	MD.glass = glass
+	MD.wood = wood
+	MD.plastic = plastic
+	src.modules += MD
+
 	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
-	M.synth = metal
+	M.synths = list(metal)
 	src.modules += M
 
 	var/obj/item/stack/sheet/glass/cyborg/G = new /obj/item/stack/sheet/glass/cyborg(src)
-	G.synth = glass
+	G.synths = list(glass)
 	src.modules += G
 
 	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
-	R.synth = metal
+	R.synths = list(metal)
 	src.modules += R
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
-	C.synth = wire
+	C.synths = list(wire)
 	src.modules += C
 
 	var/obj/item/stack/tile/plasteel/cyborg/S = new /obj/item/stack/tile/plasteel/cyborg(src)
-	S.synth = metal
+	S.synths = list(metal)
 	src.modules += S
 
 	var/obj/item/stack/sheet/glass/reinforced/cyborg/RG = new /obj/item/stack/sheet/glass/reinforced/cyborg(src)
-	RG.metal_synth = metal
-	RG.glass_synth = glass
+	RG.synths = list(metal, glass)
 	src.modules += RG
 
 	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
-	WT.synth = wood
+	WT.synths = list(wood)
 	src.modules += WT
 
 	var/obj/item/stack/sheet/wood/cyborg/W = new /obj/item/stack/sheet/wood/cyborg(src)
-	W.synth = wood
+	W.synths = list(wood)
 	src.modules += W
 
 	var/obj/item/stack/sheet/mineral/plastic/cyborg/P = new /obj/item/stack/sheet/mineral/plastic/cyborg(src)
-	P.synth = plastic
+	P.synths = list(plastic)
 	src.modules += P
 
 /obj/item/weapon/robot_module/drone/add_languages(var/mob/living/silicon/robot/R)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -482,6 +482,15 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 
+/obj/item/stack/cable_coil/cyborg
+	name = "cable coil synthesizer"
+	desc = "A device that makes cable."
+	gender = MALE
+	matter = null
+	uses_charge = 1
+	charge_cost = 1
+	stacktype = /obj/item/stack/cable_coil
+
 /obj/item/stack/cable_coil/suicide_act(mob/user)
 	if(locate(/obj/structure/stool) in user.loc)
 		user.visible_message("<span class='suicide'>[user] is making a noose with the [src.name]! It looks like \he's trying to commit suicide.</span>")
@@ -576,7 +585,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		usr << "\blue You cannot do that."
 	..()
 
-/obj/item/stack/cable_coil/robot/verb/set_colour()
+/obj/item/stack/cable_coil/cyborg/verb/set_colour()
 	set name = "Change Colour"
 	set category = "Object"
 
@@ -606,26 +615,26 @@ obj/structure/cable/proc/cableColor(var/colorC)
 //   - Cable coil : merge cables
 /obj/item/stack/cable_coil/attackby(obj/item/weapon/W, mob/user)
 	..()
-	if( istype(W, /obj/item/weapon/wirecutters) && src.amount > 1)
-		src.amount--
+	if( istype(W, /obj/item/weapon/wirecutters) && src.get_amount() > 1)
+		src.use(1)
 		new/obj/item/stack/cable_coil(user.loc, 1,color)
 		user << "You cut a piece off the cable coil."
 		src.update_icon()
 		return
 	else if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
-		if(C.amount >= MAXCOIL)
+		if(C.get_amount() >= get_max_amount())
 			user << "The coil is too long, you cannot add any more cable to it."
 			return
 
-		if( (C.amount + src.amount <= MAXCOIL) )
+		if( (C.get_amount() + src.get_amount() <= get_max_amount()) )
 			user << "You join the cable coils together."
-			C.give(src.amount) // give it cable
-			src.use(src.amount) // make sure this one cleans up right
+			C.give(src.get_amount()) // give it cable
+			src.use(src.get_amount()) // make sure this one cleans up right
 			return
 
 		else
-			var/amt = MAXCOIL - C.amount
+			var/amt = get_max_amount() - C.get_amount()
 			user << "You transfer [amt] length\s of cable from one coil to the other."
 			C.give(amt)
 			src.use(amt)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -485,10 +485,10 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/cyborg
 	name = "cable coil synthesizer"
 	desc = "A device that makes cable."
-	gender = MALE
+	gender = NEUTER
 	matter = null
 	uses_charge = 1
-	charge_cost = 1
+	charge_costs = list(1)
 	stacktype = /obj/item/stack/cable_coil
 
 /obj/item/stack/cable_coil/suicide_act(mob/user)


### PR DESCRIPTION
Engineering, construction, crisis, and surgeon borgs, as well as drones, now have matter synthesizers. They serve as a source for metal and glass stacks as well as things made from them. Essentially: metal, metal rods, and floor tiles will run out at the same time, because using one of them will use others. They also won't disappear from inventory when exhausted. Also fixes cyborg cable pickup not picking beyond 30.

Also makes decompiler work.
