### PR TITLE
Firedoors and blast doors no longer block zones

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -24,6 +24,10 @@
 	dir = 1
 	explosion_resistance = 25
 	emitter_resistance = 50 // Lots of emitter blasts, it's *blast* door after all.
+	
+	//Most blast doors are infrequently toggled and sometimes used with regular doors anyways, 
+	//turning this off prevents awkward zone geometry in places like medbay lobby, for example.
+	block_air_zones = 0
 
 // Proc: Bumped()
 // Parameters: 1 (AM - Atom that tried to walk through this object)
@@ -157,6 +161,9 @@
 		stat &= ~BROKEN
 
 
+/obj/machinery/door/blast/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(air_group) return 1
+	return ..()
 
 
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -32,6 +32,7 @@
 	var/min_force = 10 //minimum amount of force needed to damage the door with a melee weapon
 	var/hitsound = 'sound/weapons/smash.ogg' //sound door makes when hit with a weapon
 	var/obj/item/stack/sheet/metal/repairing
+	var/block_air_zones = 1 //If set, air zones cannot merge across the door even when it is opened.
 
 	//Multi-tile doors
 	dir = EAST
@@ -115,7 +116,7 @@
 
 
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group) return 0
+	if(air_group) return !block_air_zones
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity
 	return !density

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,6 +22,10 @@
 	open_layer = DOOR_OPEN_LAYER - 0.01 // Just below doors when open
 	closed_layer = DOOR_CLOSED_LAYER + 0.01 // Just above doors when closed
 
+	//These are frequenly used with windows, so make sure zones can pass. 
+	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
+	block_air_zones = 0
+
 	var/blocked = 0
 	var/lockdown = 0 // When the door has detected a problem, it locks.
 	var/pdiff_alert = 0
@@ -381,9 +385,9 @@
 			overlays += "welded_open"
 	return
 
+//These are playing merry hell on ZAS.  Sorry fellas :(
 
 /obj/machinery/door/firedoor/border_only
-//These are playing merry hell on ZAS.  Sorry fellas :(
 /*
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'
 	glass = 1 //There is a glass window so you can see through the door


### PR DESCRIPTION
- Firedoors no longer block zones, allowing direct connections to form across windows to space. 
  This fixes #8169
- Blast doors no longer block zones as well. Blast doors are used far less frequently than regular doors, and allowing zones to pass over them fixes the awkward zone geometry seen in #4798.

Screenshot showing the improved zone geometry near medbay lobby and central primary.
![screenshot 2015-02-19 23 27 35](https://cloud.githubusercontent.com/assets/242428/6281437/6f57a074-b88f-11e4-9412-675b53c53304.png)
