### PR TITLE
Rudimentary uplink descriptions.

### DIFF
--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -11,12 +11,21 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/cost = 0
 	var/path = null
 	var/reference = ""
+	var/description = ""
 
-datum/uplink_item/New(var/itemPath, var/itemCost as num, var/itemName as text, var/itemReference as text)
+datum/uplink_item/New(var/itemPath, var/itemCost as num, var/itemName as text, var/itemReference as text, var/itemDescription)
 	cost = itemCost
 	path = itemPath
 	name = itemName
-	reference = itemReference
+	description = itemDescription
+
+
+datum/uplink_item/proc/description()
+	if(!description)
+		// Fallback description
+		var/obj/temp = src.path
+		description = replacetext(initial(temp.desc), "\n", "<br>")
+	return description
 
 datum/nano_item_lists
 	var/list/items_nano
@@ -41,15 +50,16 @@ datum/nano_item_lists
 	uses = ticker.mode.uplink_uses
 	ItemsCategory = ticker.mode.uplink_items
 
-	var/datum/nano_item_lists/IL = generate_item_lists()
-	nanoui_items = IL.items_nano
-	ItemsReference = IL.items_reference
-
 	world_uplinks += src
 
 /obj/item/device/uplink/Del()
 	world_uplinks -= src
 	..()
+
+/obj/item/device/uplink/proc/generate_items()
+	var/datum/nano_item_lists/IL = generate_item_lists()
+	nanoui_items = IL.items_nano
+	ItemsReference = IL.items_reference
 
 // BS12 no longer use this menu but there are forks that do, hency why we keep it
 /obj/item/device/uplink/proc/generate_menu()
@@ -87,7 +97,7 @@ datum/nano_item_lists
 	for(var/category in ItemsCategory)
 		nano[++nano.len] = list("Category" = category, "items" = list())
 		for(var/datum/uplink_item/I in ItemsCategory[category])
-			nano[nano.len]["items"] += list(list("Name" = I.name, "Cost" = I.cost, "obj_path" = I.reference))
+			nano[nano.len]["items"] += list(list("Name" = I.name, "Description" = I.description(),"Cost" = I.cost, "obj_path" = I.reference))
 			reference[I.reference] = I
 
 	var/datum/nano_item_lists/result = new
@@ -189,6 +199,8 @@ datum/nano_item_lists
 	data["welcome"] = welcome
 	data["crystals"] = uses
 	data["menu"] = nanoui_menu
+	if(!nanoui_items)
+		generate_items()
 	data["nano_items"] = nanoui_items
 	data += nanoui_data
 

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -39,6 +39,12 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
             <div class="item">
                 {{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span>
             </div>
+            
+            {{if itemValue.Cost <= data.crystals}}
+                <div class="item">
+                    {{:itemValue.Description}}
+                </div>
+            {{/if}}
         {{/for}}
         <br>
     {{/for}}


### PR DESCRIPTION
Allows for a custom description for uplink items. If no description is given it falls back to whatever description is on the uplink item itself.
![Syndicate Description](https://www.dropbox.com/s/qb4osq6qorsh8hj/SyndicateDescription.png?dl=1)
