### PR TITLE
Fixes runtime in Topics() when called from non-NanoUI sources.

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -21,6 +21,9 @@
 	if(!nowindow && ..())
 		return 1
 
+	if(!custom_state)
+		custom_state = default_state
+
 	// In the far future no checks are made in an overriding Topic() beyond if(..()) return
 	// Instead any such checks are made in CanUseTopic()
 	var/obj/host = nano_host()

--- a/code/modules/nano/nanointeraction.dm
+++ b/code/modules/nano/nanointeraction.dm
@@ -111,6 +111,8 @@
 		if(. == STATUS_UPDATE && (TK in mutations))	// If we have telekinesis and remain close enough, allow interaction.
 			return STATUS_INTERACTIVE
 
+/var/global/datum/topic_state/default_state = new()
+
 /datum/topic_state
 	var/flags = 0
 


### PR DESCRIPTION
Ops.
