### PR TITLE
Fixes a suit breach issue and hardsuit emp handling

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -686,11 +686,12 @@
 /obj/item/weapon/rig/proc/malfunction()
 	return 0
 
-/obj/item/weapon/rig/emp_act(severity)
-	malfunctioning += severity*10
+/obj/item/weapon/rig/emp_act(severity_class)
+	//class 1 severity is the most severe, not least.
+	malfunctioning += round(30/severity_class)
 	if(malfunction_delay <= 0)
 		malfunction_delay = 20
-	take_hit(severity*10,"electrical pulse")
+	take_hit(round(30/severity_class),"electrical pulse")
 
 /obj/item/weapon/rig/proc/shock(mob/user)
 	if (electrocute_mob(user, cell, src))
@@ -699,12 +700,14 @@
 	return 0
 
 /obj/item/weapon/rig/proc/take_hit(damage,source)
-
 	if(!installed_modules.len)
 		return
 
-	if(!prob(max(0,(damage-(chest ? chest.breach_threshold : 0)))))
-		return
+	//given that module damage is spread out across all modules, even this is probably not enough for emp to affect rigs much.
+	if(source != "electrical pulse")
+		var/protection = chest? chest.breach_threshold : 0
+		if(!prob(max(0, damage - protection)))
+			return
 
 	var/list/valid_modules = list()
 	for(var/obj/item/rig_module/module in installed_modules)

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -38,7 +38,9 @@
 	flags_inv =          HIDEJUMPSUIT|HIDETAIL
 	flags =              STOPSPRESSUREDMAGE | THICKMATERIAL | AIRTIGHT
 	slowdown = 0
-	breach_threshold = 35
+	//With 0.2 resiliance, will reach 10 breach damage after 9 laser carbine blasts. Completely immune to smg hits.
+	breach_threshold = 28
+	resilience = 0.1
 	can_breach = 1
 	supporting_limbs = list()
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -48,6 +48,7 @@
 		)
 
 	//Breach thresholds, should ideally be inherited by most (if not all) voidsuits.
+	//With 0.2 resiliance, will reach 10 breach damage after 3 laser carbine blasts or 8 smg hits.
 	breach_threshold = 18
 	can_breach = 1
 


### PR DESCRIPTION
I have further plans to adjust how EMP affects hardsuits, however I wasn't comfortable including hardsuit tweaks on a PR to master without dev consent.

Prior to this EMP did not affect hardsuits at all. After this PR there is a meagre chance to disable modules. ~~However it still feels incomplete and I can see an argument for adjusting rig EMP handling here.~~ Probably best to just leave further changes to dev/freeze.

For example, consider a hardsuit with 5 modules. Suppose I manage to get 3 hits on it with an ion rifle before getting shot up enough that I have to retreat. The chance of a single module being disabled is 10%, with no other effects. Being hit by an EMP grenade does even less.

If not however, I will open further changes to dev, after these fixes are merged up to dev of course.
