### PR TITLE
Ninja rebalancing

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -131,6 +131,21 @@
 
 	var/max_reagent_volume = 80 //Used when refilling.
 
+/obj/item/rig_module/chem_dispenser/ninja
+	interface_desc = "Dispenses loaded chemicals directly into the wearer's bloodstream. This variant is made to be extremely light and flexible."
+	
+	//just over a syringe worth of each. Want more? Go refill. Gives the ninja another reason to have to show their face.
+	charges = list(
+		list("tricordrazine", "tricordrazine", 0, 20),
+		list("tramadol",      "tramadol",      0, 20),
+		list("dexalin plus",  "dexalinp",      0, 20),
+		list("antibiotics",   "spaceacillin",  0, 20),
+		list("antitoxins",    "anti_toxin",    0, 20),
+		list("nutrients",     "nutriment",     0, 80),
+		list("hyronalin",     "hyronalin",     0, 20),
+		list("radium",        "radium",        0, 20)
+		)
+
 /obj/item/rig_module/chem_dispenser/accepts_item(var/obj/item/input_item, var/mob/living/user)
 
 	if(!input_item.is_open_container())

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -53,7 +53,7 @@
 	suit_type = "ominous"
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."
 	icon_state = "ninja_rig"
-	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
+	armor = list(melee = 50, bullet = 15, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 30)
 	slowdown = 0
 
 	req_access = list(access_syndicate)


### PR DESCRIPTION
As it is, Ninjas are pretty much tanks. This is not due to any one thing, but rather a combination of the modules they have access to - their ability to quickly escape combined with their ability to more or less completely recover from a hostile encounter once they have escaped. While I'm sure it was intended for ninjas to be hard to kill, when it is combined with the way they have complete control over their engagements through being able to pick their fights and disengage at will through teleporting, it's too much.

This PR reduces the Ninja's ability to soak up damage. I feel confident that with their 70 damage energy blade (which is a guaranteed decapitate if the victim fails their armour save, and is still a guaranteed two-hit decapitate even if the helmet softens both hits), their agility and the ability to escape from unfavourable engagements, not to mention their other tools, they will get along just fine.

If not, it seems like there's an entire dev cycle to adjust things.
