### PR TITLE
Ports /tg/'s starlight luminance.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -182,6 +182,8 @@
 	var/dooc_allowed = 1
 	var/dsay_allowed = 1
 
+	var/starlight = 0	// Whether space turfs have ambient light or not
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -602,6 +604,9 @@
 					config.event_delay_upper[EVENT_LEVEL_MUNDANE] = MinutesToTicks(values[1])
 					config.event_delay_upper[EVENT_LEVEL_MODERATE] = MinutesToTicks(values[2])
 					config.event_delay_upper[EVENT_LEVEL_MAJOR] = MinutesToTicks(values[3])
+
+				if("starlight")
+					config.starlight = 1
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -14,6 +14,15 @@ var/list/accessible_z_levels = list("1" = 5, "3" = 10, "4" = 15, "5" = 10, "6" =
 /turf/space/New()
 	if(!istype(src, /turf/space/transit))
 		icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
+	update_starlight()
+
+/turf/space/proc/update_starlight()
+	if(!config.starlight)
+		return
+	if(locate(/turf/simulated) in orange(src,1))
+		SetLuminosity(3)
+	else
+		SetLuminosity(0)
 
 /turf/space/attackby(obj/item/C as obj, mob/user as mob)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -251,6 +251,9 @@
 		if(air_master)
 			air_master.mark_for_update(src)
 
+		for(var/turf/space/S in range(W,1))
+			S.update_starlight()
+
 		W.levelupdate()
 		return W
 
@@ -271,6 +274,9 @@
 
 		if(air_master)
 			air_master.mark_for_update(src)
+
+		for(var/turf/space/S in range(W,1))
+			S.update_starlight()
 
 		W.levelupdate()
 		return W

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -321,3 +321,6 @@ EVENT_CUSTOM_START_MAJOR 80;100
 
 ## Uncomment to disable respawning by default.
 #DISABLE_RESPAWN
+
+## Uncomment to make space turfs have a short-range ambient light.
+# STARLIGHT


### PR DESCRIPTION
Because configuration is initialized before the map we also don't have the same runtime issues that were corrected by https://github.com/tgstation/-tg-station/pull/7920.
