### PR TITLE
Fixes a few issues with noise-language.

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -20,26 +20,14 @@
 	throw_speed = 4
 	throw_range = 20
 
-/obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, var/verb="says")
+/obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, var/verb="says", datum/language/speaking=null)
 	if(recording)
-		//var/ending = copytext(msg, length(msg))
-		timestamp+= timerecorded
-	/*
-		if(M.stuttering)
-			storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] stammers, \"[msg]\""
-			return
-		if(M.getBrainLoss() >= 60)
-			storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] gibbers, \"[msg]\""
-			return
-		if(ending == "?")
-			storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] asks, \"[msg]\""
-			return
-		else if(ending == "!")
-			storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] exclaims, \"[msg]\""
-			return
-	*/
-		storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] [verb], \"[msg]\""
-		return
+		timestamp += timerecorded
+
+		if(speaking)
+			storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] [speaking.format_message_plain(msg, verb)]"
+		else
+			storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] [verb], \"[msg]\""
 
 /obj/item/device/taperecorder/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -186,12 +186,13 @@ var/global/floorIsLava = 0
 	var/f = 1
 	for(var/k in all_languages)
 		var/datum/language/L = all_languages[k]
-		if(!f) body += " | "
-		else f = 0
-		if(L in M.languages)
-			body += "<a href='?src=\ref[src];toglang=\ref[M];lang=[html_encode(k)]' style='color:#006600'>[k]</a>"
-		else
-			body += "<a href='?src=\ref[src];toglang=\ref[M];lang=[html_encode(k)]' style='color:#ff0000'>[k]</a>"
+		if(!(L.flags & INNATE))
+			if(!f) body += " | "
+			else f = 0
+			if(L in M.languages)
+				body += "<a href='?src=\ref[src];toglang=\ref[M];lang=[html_encode(k)]' style='color:#006600'>[k]</a>"
+			else
+				body += "<a href='?src=\ref[src];toglang=\ref[M];lang=[html_encode(k)]' style='color:#ff0000'>[k]</a>"
 
 	body += {"<br>
 		</body></html>

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -88,6 +88,9 @@
 /datum/language/proc/format_message(message, verb)
 	return "[verb], <span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
 
+/datum/language/proc/format_message_plain(message, verb)
+	return "[verb], \"[capitalize(message)]\""
+
 /datum/language/proc/format_message_radio(message, verb)
 	return "[verb], <span class='[colour]'>\"[capitalize(message)]\"</span>"
 
@@ -121,10 +124,13 @@
 	name = "Noise"
 	desc = "Noises"
 	key = ""
-	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG
+	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
 
 /datum/language/noise/format_message(message, verb)
 	return "<span class='message'><span class='[colour]'>[message]</span></span>"
+
+/datum/language/noise/format_message_plain(message, verb)
+	return message
 
 /datum/language/noise/format_message_radio(message, verb)
 	return "<span class='[colour]'>[message]</span>"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -36,6 +36,8 @@
 		else
 			message = copytext(message,3)
 
+	message = trim_left(message)
+
 	//parse the language code and consume it
 	var/datum/language/speaking = parse_language(message)
 	if(speaking)
@@ -61,10 +63,11 @@
 	message = trim(message)
 
 	if(speech_problem_flag)
-		var/list/handle_r = handle_speech_problems(message)
-		message = handle_r[1]
-		verb = handle_r[2]
-		speech_problem_flag = handle_r[3]
+		if(!speaking || !(speaking.flags & NO_STUTTER))
+			var/list/handle_r = handle_speech_problems(message)
+			message = handle_r[1]
+			verb = handle_r[2]
+			speech_problem_flag = handle_r[3]
 
 	if(!message || message == "")
 		return

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -681,6 +681,7 @@ var/list/be_special_flags = list(
 #define NONGLOBAL 32		// Do not add to general languages list
 #define INNATE 64			// All mobs can be assumed to speak and understand this language (audible emotes)
 #define NO_TALK_MSG 128		// Do not show the "\The [speaker] talks into \the [radio]" message
+#define NO_STUTTER 256		// No stuttering, slurring, or other speech problems
 
 //Flags for zone sleeping
 #define ZONE_ACTIVE 1


### PR DESCRIPTION
Fixes #8138.
Fixes #8213.
Allows a space between radio and language codes.
Stops noise language showing up in the player panel, since it's irrelevant whether a mob has it or not (due to the `INNATE` flag).
