### PR TITLE
Makes starlight strength configurable.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -606,7 +606,8 @@
 					config.event_delay_upper[EVENT_LEVEL_MAJOR] = MinutesToTicks(values[3])
 
 				if("starlight")
-					config.starlight = 1
+					value = text2num(value)
+					config.starlight = value >= 0 ? value : 0
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -20,7 +20,7 @@ var/list/accessible_z_levels = list("1" = 5, "3" = 10, "4" = 15, "5" = 10, "6" =
 	if(!config.starlight)
 		return
 	if(locate(/turf/simulated) in orange(src,1))
-		SetLuminosity(3)
+		SetLuminosity(config.starlight)
 	else
 		SetLuminosity(0)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -322,5 +322,5 @@ EVENT_CUSTOM_START_MAJOR 80;100
 ## Uncomment to disable respawning by default.
 #DISABLE_RESPAWN
 
-## Uncomment to make space turfs have a short-range ambient light.
-# STARLIGHT
+## Strength of ambient star light. Set to 0 or less to turn off.
+STARLIGHT 0


### PR DESCRIPTION
Now possible configure the ambient light from the stars, rather than have it be a hardcoded value.
Some results of tested values:
1 - Lights up own turf (likely as strongly as if it had no luminance).
2 - Light illumination of adjacent turfs.
3-  Bright illumination of adjacent turfs.
