### PR TITLE
Fixes #8258.

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -215,21 +215,21 @@ Max Output Pressure: [output_pressure] kPa<BR>"}
 
 /obj/machinery/computer/general_air_control/large_tank_control/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if(href_list["adj_pressure"])
 		var/change = text2num(href_list["adj_pressure"])
 		pressure_setting = between(0, pressure_setting + change, 50*ONE_ATMOSPHERE)
 		spawn(1)
 			src.updateUsrDialog()
-		return
+		return 1
 
 	if(href_list["adj_input_flow_rate"])
 		var/change = text2num(href_list["adj_input_flow_rate"])
 		input_flow_setting = between(0, input_flow_setting + change, ATMOS_DEFAULT_VOLUME_PUMP + 500) //default flow rate limit for air injectors
 		spawn(1)
 			src.updateUsrDialog()
-		return
+		return 1
 	
 	if(!radio_connection)
 		return 0
@@ -239,26 +239,32 @@ Max Output Pressure: [output_pressure] kPa<BR>"}
 	if(href_list["in_refresh_status"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "status" = 1)
+		return 1
 
 	if(href_list["in_toggle_injector"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "power_toggle" = 1)
+		return 1
 
 	if(href_list["in_set_flowrate"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "set_volume_rate" = "[input_flow_setting]")
+		return 1
 
 	if(href_list["out_refresh_status"])
 		output_info = null
 		signal.data = list ("tag" = output_tag, "status" = 1)
+		return 1
 
 	if(href_list["out_toggle_power"])
 		output_info = null
 		signal.data = list ("tag" = output_tag, "power_toggle" = 1)
+		return 1
 
 	if(href_list["out_set_pressure"])
 		output_info = null
 		signal.data = list ("tag" = output_tag, "set_internal_pressure" = "[pressure_setting]")
+		return 1
 
 	signal.data["sigtype"]="command"
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
@@ -329,21 +335,21 @@ Min Core Pressure: [pressure_limit] kPa<BR>"}
 
 /obj/machinery/computer/general_air_control/supermatter_core/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if(href_list["adj_pressure"])
 		var/change = text2num(href_list["adj_pressure"])
 		pressure_setting = between(0, pressure_setting + change, 10*ONE_ATMOSPHERE)
 		spawn(1)
 			src.updateUsrDialog()
-		return
+		return 1
 
 	if(href_list["adj_input_flow_rate"])
 		var/change = text2num(href_list["adj_input_flow_rate"])
 		input_flow_setting = between(0, input_flow_setting + change, ATMOS_DEFAULT_VOLUME_PUMP + 500) //default flow rate limit for air injectors
 		spawn(1)
 			src.updateUsrDialog()
-		return
+		return 1
 	
 	if(!radio_connection)
 		return 0
@@ -353,26 +359,32 @@ Min Core Pressure: [pressure_limit] kPa<BR>"}
 	if(href_list["in_refresh_status"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "status" = 1)
+		return 1
 
 	if(href_list["in_toggle_injector"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "power_toggle" = 1)
+		return 1
 
 	if(href_list["in_set_flowrate"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "set_volume_rate" = "[input_flow_setting]")
+		return 1
 
 	if(href_list["out_refresh_status"])
 		output_info = null
 		signal.data = list ("tag" = output_tag, "status" = 1)
+		return 1
 
 	if(href_list["out_toggle_power"])
 		output_info = null
 		signal.data = list ("tag" = output_tag, "power_toggle" = 1)
+		return 1
 
 	if(href_list["out_set_pressure"])
 		output_info = null
 		signal.data = list ("tag" = output_tag, "set_external_pressure" = "[pressure_setting]", "checks" = 1)
+		return 1
 
 	signal.data["sigtype"]="command"
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -71,7 +71,7 @@
 
 /obj/machinery/computer/operating/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 	return

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -113,7 +113,7 @@
 
 /obj/machinery/computer/aifixer/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if (href_list["fix"])
 		src.active = 1
 		src.overlays += image('icons/obj/computer.dmi', "ai-fixer-on")

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -84,7 +84,7 @@
 
 /obj/machinery/computer/arcade/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if (!src.blocked && !src.gameover)
 		if (href_list["attack"])

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -188,7 +188,7 @@
 
 /obj/machinery/computer/cloning/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if(loading)
 		return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -47,7 +47,7 @@
 
 /obj/machinery/computer/communications/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if (src.z > 1)
 		usr << "\red <b>Unable to establish a connection</b>: \black You're too far away from the station!"
 		return

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -109,12 +109,6 @@
 	if(istype(user, /mob/dead/observer)) return 0
 	return ..()
 
-/obj/machinery/computer/Topic(href, href_list)
-	/* Can't use topic as observer by default */
-	if(istype(usr, /mob/dead/observer)) return 0
-	return ..()
-
-
 /obj/machinery/computer/attackby(I as obj, user as mob)
 	if(istype(I, /obj/item/weapon/screwdriver) && circuit)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -106,7 +106,7 @@
 
 /obj/machinery/computer/guestpass/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	usr.set_machine(src)
 	if (href_list["mode"])
 		mode = text2num(href_list["mode"])

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -283,7 +283,7 @@
 
 /obj/machinery/computer/message_monitor/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if(!istype(usr, /mob/living))

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -98,7 +98,7 @@
 
 /obj/machinery/computer/robotics/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -208,7 +208,7 @@ I can't be bothered to look more of the actual code outside of switch but that p
 What a mess.*/
 /obj/machinery/computer/secure_data/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if (!( data_core.general.Find(active1) ))
 		active1 = null
 	if (!( data_core.security.Find(active2) ))

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -148,7 +148,7 @@ I can't be bothered to look more of the actual code outside of switch but that p
 What a mess.*/
 /obj/machinery/computer/skills/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if (!( data_core.general.Find(active1) ))
 		active1 = null
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -283,7 +283,7 @@ var/specops_shuttle_timeleft = 0
 
 /obj/machinery/computer/specops_shuttle/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.machine = src
@@ -541,7 +541,7 @@ var/specops_shuttle_timeleft = 0
 
 /obj/machinery/computer/specops_shuttle/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)

--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -49,7 +49,7 @@
 
 /obj/machinery/computer/ordercomp/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if( isturf(loc) && (in_range(src, usr) || istype(usr, /mob/living/silicon)) )
 		usr.set_machine(src)
@@ -224,7 +224,7 @@
 		world.log << "## ERROR: Eek. The supply/shuttle datum is missing somehow."
 		return
 	if(..())
-		return
+		return 1
 
 	if(isturf(loc) && ( in_range(src, usr) || istype(usr, /mob/living/silicon) ) )
 		usr.set_machine(src)

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -218,7 +218,7 @@ var/syndicate_elite_shuttle_timeleft = 0
 
 /obj/machinery/computer/syndicate_elite_shuttle/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)


### PR DESCRIPTION
Fixes #8258.
Main correction is the removal of Topic() in code/game/machinery/computer/computer.dm.
Issue introduced in #7617 where I stated multiple times this Topic()-return value was incorrect.
A return value of 1 is supposed to abort further Topic()-use, not 0.

Also ensures that computers return the correct value after the ..() check.
