### PR TITLE
Camera coverage fixes.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -31,12 +31,12 @@
 	var/alarm_on = 0
 	var/busy = 0
 
+	var/on_open_network = 0
+
 /obj/machinery/camera/New()
 	wires = new(src)
 	assembly = new(src)
 	assembly.state = 4
-
-	invalidateCameraCache()
 
 	/* // Use this to look for cameras that have the same c_tag.
 	for(var/obj/machinery/camera/C in cameranet.cameras)
@@ -56,18 +56,18 @@
 /obj/machinery/camera/emp_act(severity)
 	if(!isEmpProof())
 		if(prob(100/severity))
-			invalidateCameraCache()
 			stat |= EMPED
 			SetLuminosity(0)
 			kick_viewers()
-			triggerCameraAlarm(10 * severity)
+			triggerCameraAlarm(30 / severity)
 			update_icon()
+			update_coverage()
 
 			spawn(900)
 				stat &= ~EMPED
 				cancelCameraAlarm()
 				update_icon()
-				invalidateCameraCache()
+				update_coverage()
 			..()
 
 /obj/machinery/camera/bullet_act(var/obj/item/projectile/P)
@@ -114,7 +114,7 @@
 		destroy()
 
 /obj/machinery/camera/attackby(obj/W as obj, mob/living/user as mob)
-	invalidateCameraCache()
+	update_coverage()
 	// DECONSTRUCTION
 	if(isscrewdriver(W))
 		//user << "<span class='notice'>You start to [panel_open ? "close" : "open"] the camera's panel.</span>"
@@ -195,7 +195,7 @@
 		//legacy support, if choice is != 1 then just kick viewers without changing status
 		kick_viewers()
 	else
-		invalidateCameraCache()
+		update_coverage()
 		set_status( !src.status )
 		if (!(src.status))
 			visible_message("\red [user] has deactivated [src]!")
@@ -215,11 +215,11 @@
 
 //Used when someone breaks a camera
 /obj/machinery/camera/proc/destroy()
-	invalidateCameraCache()
 	stat |= BROKEN
 	kick_viewers()
 	triggerCameraAlarm()
 	update_icon()
+	update_coverage()
 
 	//sparks
 	var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
@@ -364,7 +364,7 @@
 			network_added = 1
 
 	if(network_added)
-		invalidateCameraCache()
+		update_coverage(1)
 
 /obj/machinery/camera/proc/remove_networks(var/list/networks)
 	var/network_removed
@@ -375,24 +375,24 @@
 			network_removed = 1
 
 	if(network_removed)
-		invalidateCameraCache()
+		update_coverage(1)
 
 /obj/machinery/camera/proc/replace_networks(var/list/networks)
 	if(networks.len != network.len)
 		network = networks
-		invalidateCameraCache()
+		update_coverage(1)
 		return
 
 	for(var/new_network in networks)
 		if(!(new_network in network))
 			network = networks
-			invalidateCameraCache()
+			update_coverage(1)
 			return
 
 /obj/machinery/camera/proc/clear_all_networks()
 	if(network.len)
 		network.Cut()
-		invalidateCameraCache()
+		update_coverage(1)
 
 /obj/machinery/camera/proc/nano_structure()
 	var/cam[0]
@@ -403,3 +403,17 @@
 	cam["y"] = y
 	cam["z"] = z
 	return cam
+
+/obj/machinery/camera/proc/update_coverage(var/network_change = 0)
+	if(network_change)
+		var/list/open_networks = difflist(network, restricted_camera_networks)
+		// Add or remove camera from the camera net as necessary
+		if(on_open_network && !open_networks.len)
+			cameranet.removeCamera(src)
+		else if(!on_open_network && open_networks.len)
+			on_open_network = 1
+			cameranet.addCamera(src)
+	else
+		cameranet.updateVisibility(src, 0)
+
+	invalidateCameraCache()

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -78,7 +78,7 @@
 			if(isscrewdriver(W))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 
-				var/input = strip_html(input(usr, "Which networks would you like to connect this camera to? Seperate networks with a comma. No Spaces!\nFor example: SS13,Security,Secret ", "Set Network", "SS13"))
+				var/input = strip_html(input(usr, "Which networks would you like to connect this camera to? Separate networks with a comma. No Spaces!\nFor example: SS13,Security,Secret ", "Set Network", "SS13"))
 				if(!input)
 					usr << "No input found please hang up and try your call again."
 					return
@@ -100,9 +100,6 @@
 				C.auto_turn()
 
 				C.replace_networks(uniquelist(tempnetwork))
-				tempnetwork = difflist(C.network,restricted_camera_networks)
-				if(!tempnetwork.len)//Camera isn't on any open network - remove its chunk from AI visibility.
-					cameranet.removeCamera(C)
 
 				C.c_tag = input
 

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -140,7 +140,6 @@
 	..()
 	name = "DV-136ZB #[rand(1000,9999)]"
 	c_tag = name
-	cameranet.removeCamera(src)		// Sorry, no AI spying.
 
 /obj/machinery/camera/spy/check_eye(var/mob/user as mob)
 	return 1

--- a/code/global.dm
+++ b/code/global.dm
@@ -10,7 +10,7 @@ var/global/list/med_hud_users            = list() // List of all entities using 
 var/global/list/sec_hud_users            = list() // List of all entities using a security HUD.
 
 // Those networks can only be accessed by pre-existing terminals. AIs and new terminals can't use them.
-var/list/restricted_camera_networks = list("thunder","ERT","NUKE")
+var/list/restricted_camera_networks = list("thunder","ERT","NUKE","Secret")
 
 var/global/list/global_mutations  = list() // List of hidden mutation things.
 var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called manually after an event.

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -33,7 +33,6 @@
 
 		camera = new /obj/machinery/camera(src)
 		camera.replace_networks(camera_networks)
-		cameranet.removeCamera(camera)
 		camera.c_tag = user.name
 		user << "\blue User scanned as [camera.c_tag]. Camera activated."
 		return 1

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -120,12 +120,14 @@ var/datum/cameranet/cameranet = new()
 			for(var/y = y1; y <= y2; y += 16)
 				if(chunkGenerated(x, y, T.z))
 					var/datum/camerachunk/chunk = getCameraChunk(x, y, T.z)
-					if(choice == 0)
-						// Remove the camera.
-						chunk.cameras -= c
-					else if(choice == 1)
-						// You can't have the same camera in the list twice.
-						chunk.cameras |= c
+					// Only add actual cameras to the list of cameras
+					if(istype(c, /obj/machinery/camera))
+						if(choice == 0)
+							// Remove the camera.
+							chunk.cameras -= c
+						else if(choice == 1)
+							// You can't have the same camera in the list twice.
+							chunk.cameras |= c
 					chunk.hasChanged()
 
 // Will check if a mob is on a viewable turf. Returns 1 if it is, otherwise returns 0.

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -64,7 +64,7 @@
 	else
 		changed = 1
 
-// The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
+// The actual updating. It gathers the visible turfs from cameras and puts them into the appropriate lists.
 
 /datum/camerachunk/proc/update()
 
@@ -76,14 +76,14 @@
 		var/obj/machinery/camera/c = camera
 
 		if(!c)
-			continue
+			cameras -= c
 
 		if(!c.can_use())
 			continue
 
 		var/turf/point = locate(src.x + 8, src.y + 8, src.z)
 		if(get_dist(point, c) > 24)
-			continue
+			cameras -= c
 
 		for(var/turf/t in c.can_see())
 			newVisibleTurfs[t] = t
@@ -143,14 +143,8 @@
 		if(t.x >= x && t.y >= y && t.x < x + 16 && t.y < y + 16)
 			turfs[t] = t
 
-	for(var/camera in cameras)
-		var/obj/machinery/camera/c = camera
-		if(!c)
-			continue
-
-		if(!c.can_use())
-			continue
-
+	// At this point we only have functional cameras
+	for(var/obj/machinery/camera/c in cameras)
 		for(var/turf/t in c.can_see())
 			visibleTurfs[t] = t
 

--- a/code/modules/mob/living/silicon/ai/freelook/update_triggers.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/update_triggers.dm
@@ -84,6 +84,7 @@
 
 /obj/machinery/camera/deactivate(user as mob, var/choice = 1)
 	..(user, choice)
+	invalidateCameraCache()
 	if(src.can_use())
 		cameranet.addCamera(src)
 	else
@@ -98,16 +99,11 @@
 		cameranet.cameras_unsorted = 1
 	else
 		dd_insertObjectList(cameranet.cameras, src)
-
-	var/list/open_networks = difflist(network,restricted_camera_networks) //...but if all of camera's networks are restricted, it only works for specific camera consoles.
-	if(open_networks.len) //If there is at least one open network, chunk is available for AI usage.
-		cameranet.addCamera(src)
+	update_coverage(1)
 
 /obj/machinery/camera/Del()
 	cameranet.cameras -= src
-	var/list/open_networks = difflist(network,restricted_camera_networks)
-	if(open_networks.len)
-		cameranet.removeCamera(src)
+	clear_all_networks()
 	..()
 
 #undef BORG_CAMERA_BUFFER

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1143,7 +1143,6 @@ var/list/robot_verbs_default = list(
 	//Disconnect it's camera so it's not so easily tracked.
 	if(src.camera)
 		src.camera.clear_all_networks()
-		cameranet.removeCamera(src.camera)
 
 
 /mob/living/silicon/robot/proc/ResetSecurityCodes()


### PR DESCRIPTION
Fixes issues with AI camera coverage not updating due to EMPs, destruction, etc., until something else nearby forced an update (a door opening/closing, an opaque object being created/destroyed, borg moving).

Was trying to fix #8269 but my refresh-camera-chunk-on-movement code only worked for cameras already on station, not those on the shuttle (even after being moved unto the station). Removed that bit for now.
