### PR TITLE
Fixes #8255, #8231, #8265

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -72,7 +72,8 @@ var/list/medical_positions = list(
 	"Medical Doctor",
 	"Geneticist",
 	"Psychiatrist",
-	"Chemist"
+	"Chemist",
+	"Paramedic"
 )
 
 

--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -198,10 +198,10 @@
 	if(grown_seed.get_trait(TRAIT_TELEPORTING))
 		dat += "<br>The fruit is temporal/spatially unstable."
 
-	dat += "<br><br>\[<a href='?src=\ref[src];print=1'>print report</a>\]"
 	if(dat)
-		user << browse(dat,"window=plant_analyzer")
 		last_data = dat
+		dat += "<br><br>\[<a href='?src=\ref[src];print=1'>print report</a>\]"
+		user << browse(dat,"window=plant_analyzer")
 
 	return
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -199,6 +199,9 @@
 /mob/proc/on_hear_radio(part_a, speaker_name, track, part_b, formatted)
 	src << "[part_a][speaker_name][part_b][formatted]</span></span>"
 
+/mob/dead/observer/on_hear_radio(part_a, speaker_name, track, part_b, formatted)
+	src << "[part_a][track][part_b][formatted]</span></span>"
+
 /mob/living/silicon/on_hear_radio(part_a, speaker_name, track, part_b, formatted)
 	var/time = say_timestamp()
 	src << "[time][part_a][speaker_name][part_b][formatted]</span></span>"


### PR DESCRIPTION
Adds paramedic to the medical category, fixes #8255. Adds on_hear_radio override for observers to add the tracking link, fixes #8231. Moves the print report link on the plant scanner being added to the window to after the data is saved for printing, fixes #8265.
