### PR TITLE
Properly fixes vines pulling through windoors

### DIFF
--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -20,7 +20,7 @@
 			if(!isnull(seed.chems["pacid"]))
 				spawn(rand(5,25)) floor.ex_act(3)
 			continue
-		else if(!floor.Enter(src))
+		if(!Adjacent(floor))
 			continue
 		neighbors |= floor
 	// Update all of our friends.

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -60,11 +60,13 @@
 	if(buckled_mob)
 		return
 
+	if(!Adjacent(victim))
+		return
+
 	victim.buckled = src
 	victim.update_canmove()
 	buckled_mob = victim
-	var/turf/T = get_turf(src)
-	if(victim.loc != T && T.Enter(victim, get_turf(victim)))
+	if(victim.loc != get_turf(src))
 		src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")
 		victim.loc = src.loc
 	victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"


### PR DESCRIPTION
Fixes #8253.

Previous fix was [this](https://github.com/Zuhayr/Baystation12/commit/b572763f7793c4546fefc1d929262ce2bf2a83d5), which definitely didn't work for certain arrangements of windoors.
