### PR TITLE
The AI now have the ability to track senders of PDA messages.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1067,6 +1067,17 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	new_message = 1
 	update_icon()
 
+/obj/item/device/pda/ai/new_message(var/atom/movable/sending_unit, var/sender, var/sender_job, var/message)
+	var/track = ""
+	if(ismob(sending_unit.loc) && isAI(loc))
+		track = "(<a href='byond://?src=\ref[loc];track=\ref[sending_unit.loc];trackname=[html_encode(sender)]'>Follow</a>)"
+
+	var/reception_message = "\icon[src] <b>Message from [sender] ([sender_job]), </b>\"[message]\" (<a href='byond://?src=\ref[src];choice=Message;notap=1;skiprefresh=1;target=\ref[sending_unit]'>Reply</a>) [track]"
+	new_info(message_silent, newstone, reception_message)
+
+	log_pda("[usr] (PDA: [sending_unit]) sent \"[message]\" to [name]")
+	new_message = 1
+
 /obj/item/device/pda/verb/verb_remove_id()
 	set category = "Object"
 	set name = "Remove id"


### PR DESCRIPTION
Can only track the original owner of a PDA (or rather, anyone with the same name).
Cannot track the senders/receivers of intercepted messages.
All other tracking conditions apply (camera coverage, no agent ID, etc.).
