### PR TITLE
Fixes #8334.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1002,7 +1002,7 @@ About the new airlock wires panel:
 	if(operating || welded || locked)
 		return
 	if(!forced)
-		//despite the name, this wire is for general door control. 
+		//despite the name, this wire is for general door control.
 		//Bolts are already covered by the check for locked, above
 		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
 			return
@@ -1076,7 +1076,7 @@ About the new airlock wires panel:
 		emitter_resistance *= 3
 
 	//if assembly is given, create the new door from the assembly
-	if (assembly)
+	if (assembly && istype(assembly))
 		assembly_type = assembly.type
 
 		electronics = assembly.electronics

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -40,7 +40,8 @@ proc/createRandomZlevel()
 		var/map = pick(potentialRandomZlevels)
 		var/file = file(map)
 		if(isfile(file))
-			maploader.load_map(file, load_speed = 100)
+			maploader.load_map(file)
+			world.log << "away mission loaded: [map]"
 
 		for(var/obj/effect/landmark/L in landmarks_list)
 			if (L.name != "awaystart")

--- a/code/modules/maps/dmm_suite.dm
+++ b/code/modules/maps/dmm_suite.dm
@@ -53,10 +53,9 @@ dmm_suite{
 
 		*/
 
-	verb/load_map(var/dmm_file as file, var/z_offset as num, var/load_speed as num)
+	verb/load_map(var/dmm_file as file, var/z_offset as num)
 		// dmm_file: A .dmm file to load (Required).
 		// z_offset: A number representing the z-level on which to start loading the map (Optional).
-		// load_speed: How many tiles should be loaded per second, defaults to no pause (Optional)
 
 	verb/write_map(var/turf/t1 as turf, var/turf/t2 as turf, var/flags as num){
 		// t1: A turf representing one corner of a three dimensional grid (Required).


### PR DESCRIPTION
Fixes #8334.
Removes references to the load_speed argument in load_map as it doesn't actually exist.
For some reason the dmm_suit injects itself as an argument in airlocks. Putting a band-aid on the symptom.
