### PR TITLE
Fixes NanoUI transfer runtime.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -72,10 +72,10 @@ datum/mind
 				current.remove_changeling_powers()
 				current.verbs -= /datum/changeling/proc/EvolutionMenu
 			current.mind = null
+			
+			nanomanager.user_transferred(current, new_character) // transfer active NanoUI instances to new user
 		if(new_character.mind)		//remove any mind currently in our new body's mind variable
 			new_character.mind.current = null
-
-		nanomanager.user_transferred(current, new_character) // transfer active NanoUI instances to new user
 
 		current = new_character		//link ourself to our new body
 		new_character.mind = src	//and link our new body to ourself

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -21,7 +21,7 @@
 		"nano/js/",\
 		"nano/templates/"\
 	)
-	
+
 	var/list/filenames = null
 	for (var/path in nano_asset_dirs)
 		filenames = flist(path)
@@ -48,15 +48,15 @@
 	if (isnull(ui)) // no ui has been passed, so we'll search for one
 	{
 		ui = get_open_ui(user, src_object, ui_key)
-	}	
-	if (!isnull(ui))		
+	}
+	if (!isnull(ui))
 		// The UI is already open
 		if (!force_open)
 			ui.push_data(data)
 			return ui
 		else
 			//testing("nanomanager/try_update_ui mob [user.name] [src_object:name] [ui_key] [force_open] - forcing opening of ui")
-			ui.close()		
+			ui.close()
 	return null
 
  /**
@@ -73,14 +73,14 @@
 	if (isnull(open_uis[src_object_key]) || !istype(open_uis[src_object_key], /list))
 		//testing("nanomanager/get_open_ui mob [user.name] [src_object:name] [ui_key] - there are no uis open")
 		return null
-	else if (isnull(open_uis[src_object_key][ui_key]) || !istype(open_uis[src_object_key][ui_key], /list))		
+	else if (isnull(open_uis[src_object_key][ui_key]) || !istype(open_uis[src_object_key][ui_key], /list))
 		//testing("nanomanager/get_open_ui mob [user.name] [src_object:name] [ui_key] - there are no uis open for this object")
 		return null
 
 	for (var/datum/nanoui/ui in open_uis[src_object_key][ui_key])
 		if (ui.user == user)
 			return ui
-				
+
 	//testing("nanomanager/get_open_ui mob [user.name] [src_object:name] [ui_key] - ui not found")
 	return null
 
@@ -91,21 +91,21 @@
   *
   * @return int The number of uis updated
   */
-/datum/nanomanager/proc/update_uis(src_object)	
+/datum/nanomanager/proc/update_uis(src_object)
 	var/src_object_key = "\ref[src_object]"
 	if (isnull(open_uis[src_object_key]) || !istype(open_uis[src_object_key], /list))
-		return 0	
+		return 0
 
 	var/update_count = 0
-	for (var/ui_key in open_uis[src_object_key])			
+	for (var/ui_key in open_uis[src_object_key])
 		for (var/datum/nanoui/ui in open_uis[src_object_key][ui_key])
 			if(ui && ui.src_object && ui.user)
 				ui.process(1)
 				update_count++
 	return update_count
-	
+
  /**
-  * Update /nanoui uis belonging to user 
+  * Update /nanoui uis belonging to user
   *
   * @param user /mob The mob who owns the uis
   * @param src_object /obj|/mob If src_object is provided, only update uis which are attached to src_object (optional)
@@ -118,15 +118,15 @@
 		return 0 // has no open uis
 
 	var/update_count = 0
-	for (var/datum/nanoui/ui in user.open_uis)		
+	for (var/datum/nanoui/ui in user.open_uis)
 		if ((isnull(src_object) || !isnull(src_object) && ui.src_object == src_object) && (isnull(ui_key) || !isnull(ui_key) && ui.ui_key == ui_key))
 			ui.process(1)
 			update_count++
-			
+
 	return update_count
-	
+
  /**
-  * Close /nanoui uis belonging to user 
+  * Close /nanoui uis belonging to user
   *
   * @param user /mob The mob who owns the uis
   * @param src_object /obj|/mob If src_object is provided, only close uis which are attached to src_object (optional)
@@ -137,16 +137,16 @@
 /datum/nanomanager/proc/close_user_uis(var/mob/user, src_object = null, ui_key = null)
 	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || open_uis.len == 0)
 		//testing("nanomanager/close_user_uis mob [user.name] has no open uis")
-		return 0 // has no open uis	
+		return 0 // has no open uis
 
 	var/close_count = 0
-	for (var/datum/nanoui/ui in user.open_uis)		
+	for (var/datum/nanoui/ui in user.open_uis)
 		if ((isnull(src_object) || !isnull(src_object) && ui.src_object == src_object) && (isnull(ui_key) || !isnull(ui_key) && ui.ui_key == ui_key))
 			ui.close()
 			close_count++
-			
-	//testing("nanomanager/close_user_uis mob [user.name] closed [open_uis.len] of [close_count] uis")	
-			
+
+	//testing("nanomanager/close_user_uis mob [user.name] closed [open_uis.len] of [close_count] uis")
+
 	return close_count
 
  /**
@@ -189,11 +189,11 @@
 	ui.user.open_uis.Remove(ui)
 	var/list/uis = open_uis[src_object_key][ui.ui_key]
 	uis.Remove(ui)
-	
+
 	//testing("nanomanager/ui_closed mob [ui.user.name] [ui.src_object:name] [ui.ui_key] - user.open_uis [ui.user.open_uis.len] | uis [uis.len] | processing_uis [processing_uis.len]")
-	
+
 	return 1
-	
+
  /**
   * This is called on user logout
   * Closes/clears all uis attached to the user's /mob
@@ -203,7 +203,7 @@
   * @return nothing
   */
 
-// 
+//
 /datum/nanomanager/proc/user_logout(var/mob/user)
 	//testing("nanomanager/user_logout user [user.name]")
 	return close_user_uis(user)
@@ -219,7 +219,7 @@
   */
 /datum/nanomanager/proc/user_transferred(var/mob/oldMob, var/mob/newMob)
 	//testing("nanomanager/user_transferred from mob [oldMob.name] to mob [newMob.name]")
-	if (isnull(oldMob.open_uis) || !istype(oldMob.open_uis, /list) || open_uis.len == 0)
+	if (!oldMob || isnull(oldMob.open_uis) || !istype(oldMob.open_uis, /list) || open_uis.len == 0)
 		//testing("nanomanager/user_transferred mob [oldMob.name] has no open uis")
 		return 0 // has no open uis
 
@@ -231,9 +231,9 @@
 		newMob.open_uis.Add(ui)
 
 	oldMob.open_uis.Cut()
-	
+
 	return 1 // success
-	
+
  /**
   * Sends all nano assets to the client
   * This is called on user login
@@ -244,6 +244,6 @@
   */
 
 /datum/nanomanager/proc/send_resources(client)
-	for(var/file in asset_files)			
+	for(var/file in asset_files)
 		client << browse_rsc(file)	// send the file to the client
 


### PR DESCRIPTION
No longer unconditionally attempts to transfer NanoUIs from one mob to another.
Previously caused runtimes if the source-mob was gibbed or otherwise destroyed.
