### PR TITLE
Staff now have a "re-admin self" button after de-admining themselves.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -662,6 +662,17 @@ var/list/admin_verbs_mentor = list(
 	log_admin("[key_name(usr)] used 'kill air'.")
 	message_admins("\blue [key_name_admin(usr)] used 'kill air'.", 1)
 
+/client/proc/readmin_self()
+	set name = "Re-Admin self"
+	set category = "Admin"
+
+	if(deadmin_holder)
+		deadmin_holder.reassociate()
+		log_admin("[src] re-admined themself.")
+		message_admins("[src] re-admined themself.", 1)
+		src << "<span class='interface'>You now have the keys to control the planet, or atleast a small space station</span>"
+		verbs -= /client/proc/readmin_self
+
 /client/proc/deadmin_self()
 	set name = "De-admin self"
 	set category = "Admin"
@@ -672,6 +683,7 @@ var/list/admin_verbs_mentor = list(
 			message_admins("[src] deadmined themself.", 1)
 			deadmin()
 			src << "<span class='interface'>You are now a normal player.</span>"
+			verbs |= /client/proc/readmin_self
 	feedback_add_details("admin_verb","DAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/toggle_log_hrefs()

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -34,8 +34,16 @@ var/list/admin_datums = list()
 	if(owner)
 		admins -= owner
 		owner.remove_admin_verbs()
+		owner.deadmin_holder = owner.holder
 		owner.holder = null
-		owner = null
+
+/datum/admins/proc/reassociate()
+	if(owner)
+		admins += owner
+		owner.holder = src
+		owner.deadmin_holder = null
+		owner.add_admin_verbs()
+		
 
 /*
 checks if usr is an admin with at least ONE of the flags in rights_required. (Note, they don't need all the flags)
@@ -50,6 +58,7 @@ proc/admin_proc()
 NOTE: it checks usr! not src! So if you're checking somebody's rank in a proc which they did not call
 you will have to do something like if(client.holder.rights & R_ADMIN) yourself.
 */
+
 /proc/check_rights(rights_required, show_msg=1)
 	if(usr && usr.client)
 		if(rights_required)
@@ -82,8 +91,7 @@ you will have to do something like if(client.holder.rights & R_ADMIN) yourself.
 
 
 /client/proc/deadmin()
-	admin_datums -= ckey
 	if(holder)
 		holder.disassociate()
-		del(holder)
+		//del(holder)
 	return 1

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -3,6 +3,7 @@
 		//ADMIN THINGS//
 		////////////////
 	var/datum/admins/holder = null
+	var/datum/admins/deadmin_holder = null
 	var/buildmode		= 0
 
 	var/last_message	= "" //Contains the last message sent by this client - used to protect against copy-paste spamming.


### PR DESCRIPTION
Stores their admin datum in a deadmin_holder variable in the client, and just moves it back upon re-admining.

Also self deadmin's will be admins once again upon rejoining.
