### PR TITLE
Airlock/door changes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -31,6 +31,7 @@
 	var/hitsound = 'sound/weapons/smash.ogg' //sound door makes when hit with a weapon
 	var/obj/item/stack/sheet/metal/repairing
 	var/block_air_zones = 1 //If set, air zones cannot merge across the door even when it is opened.
+	var/close_door_at = 0 //When to automatically close the door, if possible
 
 	//Multi-tile doors
 	dir = EAST
@@ -74,6 +75,24 @@
 	..()
 	return
 
+/obj/machinery/door/process()
+	if(close_door_at && world.time >= close_door_at)
+		if(autoclose)
+			close_door_at = next_close_time()
+			close()
+		else
+			close_door_at = 0
+
+/obj/machinery/door/proc/can_open()
+	if(!density || operating || !ticker)
+		return 0
+	return 1
+
+/obj/machinery/door/proc/can_close(var/forced = 0)
+	if(!density && !operating && !(!forced && (stat & (BROKEN|NOPOWER))))
+		return 1
+	return 0
+
 /obj/machinery/door/Bumped(atom/AM)
 	if(p_open || operating) return
 	if(ismob(AM))
@@ -97,7 +116,7 @@
 			if(mecha.occupant && (src.allowed(mecha.occupant) || src.check_access_list(mecha.operation_req_access)))
 				open()
 			else
-				flick("door_deny", src)
+				do_animate("deny")
 		return
 	if(istype(AM, /obj/structure/bed/chair/wheelchair))
 		var/obj/structure/bed/chair/wheelchair/wheel = AM
@@ -105,7 +124,7 @@
 			if(wheel.pulling && (src.allowed(wheel.pulling)))
 				open()
 			else
-				flick("door_deny", src)
+				do_animate("deny")
 		return
 	return
 
@@ -127,7 +146,7 @@
 
 	if(density)
 		if(allowed(user))	open()
-		else				flick("door_deny", src)
+		else				do_animate("deny")
 	return
 
 /obj/machinery/door/meteorhit(obj/M as obj)
@@ -264,7 +283,7 @@
 	if(src.operating) return
 
 	if(src.density && (operable() && istype(I, /obj/item/weapon/card/emag)))
-		flick("door_spark", src)
+		do_animate("spark")
 		sleep(6)
 		open()
 		operating = -1
@@ -277,8 +296,8 @@
 			close()
 		return
 
-	if(src.density && !(stat & (NOPOWER|BROKEN)))
-		flick("door_deny", src)
+	if(src.density)
+		do_animate("deny")
 	return
 
 /obj/machinery/door/proc/take_damage(var/damage)
@@ -355,23 +374,27 @@
 				flick("o_doorc1", src)
 			else
 				flick("doorc1", src)
+		if("spark")
+			if(density)
+				flick("door_spark", src)
 		if("deny")
-			flick("door_deny", src)
+			if(density && !(stat & (NOPOWER|BROKEN)))
+				flick("door_deny", src)
+				playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)
 	return
 
 
 /obj/machinery/door/proc/open()
-	if(!density)		return 1
-	if(operating > 0)	return
-	if(!ticker)			return 0
-	if(!operating)		operating = 1
+	if(!can_open()) return
+	if(!operating)	operating = 1
 
 	do_animate("opening")
 	icon_state = "door0"
 	src.SetOpacity(0)
-	sleep(10)
-	src.layer = open_layer
+	sleep(3)
 	src.density = 0
+	sleep(7)
+	src.layer = open_layer
 	explosion_resistance = 0
 	update_icon()
 	SetOpacity(0)
@@ -379,26 +402,26 @@
 
 	if(operating)	operating = 0
 
-	if(autoclose  && normalspeed)
-		spawn(150)
-			autoclose()
-	if(autoclose && !normalspeed)
-		spawn(5)
-			autoclose()
+	if(autoclose)
+		close_door_at = next_close_time()
 
 	return 1
 
+/obj/machinery/door/proc/next_close_time()
+	return world.time + (normalspeed ? 150 : 5)
 
 /obj/machinery/door/proc/close()
-	if(density)	return 1
-	if(operating > 0)	return
+	if(!can_close())
+		return
 	operating = 1
 
+	close_door_at = 0
+	do_animate("closing")
+	sleep(3)
 	src.density = 1
 	explosion_resistance = initial(explosion_resistance)
 	src.layer = closed_layer
-	do_animate("closing")
-	sleep(10)
+	sleep(7)
 	update_icon()
 	if(visible && !glass)
 		SetOpacity(1)	//caaaaarn!
@@ -430,12 +453,6 @@
 			source.thermal_conductivity = DOOR_HEAT_TRANSFER_COEFFICIENT
 		else
 			source.thermal_conductivity = initial(source.thermal_conductivity)
-
-/obj/machinery/door/proc/autoclose()
-	var/obj/machinery/door/airlock/A = src
-	if(!A.density && !A.operating && !A.locked && !A.welded && !(A.stat & (BROKEN|NOPOWER)) && A.autoclose)
-		close()
-	return
 
 /obj/machinery/door/Move(new_loc, new_dir)
 	//update_nearby_tiles()


### PR DESCRIPTION
It's now possible to pass through doors sooner after they start opening, and for longer as they're closing.
Doors no longer use sleeps to decide when to close. Avoids issues where quickly opening, closing, then opening a door again causes it to close pre-maturely.
