### PR TITLE
Runtime fixes

### DIFF
--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -47,9 +47,8 @@ proc/sql_report_death(var/mob/living/carbon/human/H)
 	if(!H.key || !H.mind)
 		return
 
-	var/turf/T = H.loc
-	var/area/placeofdeath = get_area(T.loc)
-	var/podname = placeofdeath.name
+	var/area/placeofdeath = get_area(H)
+	var/podname = placeofdeath ? placeofdeath.name : "Unknown area"
 
 	var/sqlname = sanitizeSQL(H.real_name)
 	var/sqlkey = sanitizeSQL(H.key)
@@ -82,9 +81,8 @@ proc/sql_report_cyborg_death(var/mob/living/silicon/robot/H)
 	if(!H.key || !H.mind)
 		return
 
-	var/turf/T = H.loc
-	var/area/placeofdeath = get_area(T.loc)
-	var/podname = placeofdeath.name
+	var/area/placeofdeath = get_area(H)
+	var/podname = placeofdeath ? placeofdeath.name : "Unknown area"
 
 	var/sqlname = sanitizeSQL(H.real_name)
 	var/sqlkey = sanitizeSQL(H.key)

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -32,7 +32,7 @@
 		EC.process()
 
 /datum/event_manager/proc/event_complete(var/datum/event/E)
-	if(!E.event_meta)	// datum/event is used here and there for random reasons, maintaining "backwards compatibility"
+	if(!E.event_meta || !E.severity)	// datum/event is used here and there for random reasons, maintaining "backwards compatibility"
 		log_debug("Event of '[E.type]' with missing meta-data has completed.")
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -859,7 +859,9 @@ note dizziness decrements automatically in the mob's Life() proc.
 			canmove = 1
 			pixel_y = V.mob_offset_y
 	else if(buckled)
-		if (!buckled.movable)
+		// var/movable is defined at /obj/structure/stool/bed level
+		// If we're buckled to something else, such as vines, assume it's stationary.
+		if (!istype(buckled) || !buckled.movable)
 			anchored = 1
 			canmove = 0
 			if(istype(buckled,/obj/structure/stool/bed/chair) )

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -410,6 +410,8 @@ nanoui is used to open and update nano browser uis
   * @return nothing
   */
 /datum/nanoui/proc/open()
+	if(!user.client)
+		return
 
 	var/window_size = ""
 	if (width && height)

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -11,16 +11,17 @@ proc/infection_check(var/mob/living/carbon/M, var/vector = "Airborne")
 			if(M.internal)
 				score = 6	//not breathing infected air helps greatly
 				var/obj/item/I = M.wear_mask
-				
+
 				//masks provide a small bonus and can replace overall bio protection
-				score = max(score, round(0.06*I.armor["bio"]))
-				if (istype(I, /obj/item/clothing/mask))
-					score += 1 //this should be added after
-		
+				if(I)
+					score = max(score, round(0.06*I.armor["bio"]))
+					if (istype(I, /obj/item/clothing/mask))
+						score += 1 //this should be added after
+
 		if("Contact")
 			if(istype(M, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
-				
+
 				//gloves provide a larger bonus
 				if (istype(H.gloves, /obj/item/clothing/gloves))
 					score += 2
@@ -45,12 +46,12 @@ proc/infection_check(var/mob/living/carbon/M, var/vector = "Airborne")
 		return 0
 
 	var/protection = M.getarmor(null, "bio")	//gets the full body bio armour value, weighted by body part coverage.
-	
+
 	if (vector == "Airborne")
 		var/obj/item/I = M.wear_mask
 		if (istype(I))
 			protection = max(protection, round(0.06*I.armor["bio"]))
-	
+
 	return prob(protection)
 
 //Checks if table-passing table can reach target (5 tile radius)
@@ -80,10 +81,10 @@ proc/airborne_can_reach(turf/source, turf/target)
 		return
 	if(M.reagents.has_reagent("spaceacillin"))
 		return
-	
+
 	if(!disease.affected_species.len)
 		return
-	
+
 	if (!(M.species.name in disease.affected_species))
 		if (forced)
 			disease.affected_species[1] = M.species.name
@@ -131,7 +132,7 @@ proc/airborne_can_reach(turf/source, turf/target)
 //			log_debug("Attempting virus [ID]")
 			var/datum/disease2/disease/V = virus2[ID]
 			if(V.spreadtype != vector) continue
-			
+
 			//It's hard to get other people sick if you're in an airtight suit.
 			if(!infection_spreading_check(src, V.spreadtype)) continue
 


### PR DESCRIPTION
Fixes the following runtimes:

```
runtime error: Cannot read null.name
proc name: sql report cyborg death (/proc/sql_report_cyborg_death)
  source file: statistics.dm,87
  usr: the maintenance drone (106) (/mob/living/silicon/robot/drone)
  src: null
```

```
runtime error: Cannot read null.name
proc name: sql report death (/proc/sql_report_death)
  source file: statistics.dm,52
  usr: null
  src: null
```

The null.armor runtime occur every time a virus checks if nearby mobs can be infected, easily filled the runtime log.

```
runtime error: Cannot read null.armor
proc name: infection check (/proc/infection_check)
  source file: helpers.dm,16
  usr: null
  src: null
```

```
runtime error: bad client
proc name: open (/datum/nanoui/proc/open)
  source file: nanoui.dm,419
  usr: null
  src: /datum/nanoui (/datum/nanoui)
/datum/nanoui (/datum/nanoui): open()
```

This one appears to happen whenever a mob checks if it can move and is buckled down by non-beds, such as vines. Also filled the runtime log.

```
runtime error: undefined variable /obj/effect/plantsegment/var/movable
proc name: update canmove (/mob/proc/update_canmove)
  source file: mob.dm,862
  usr: null
  src: the monkey (643) (/mob/living/carbon/monkey)
```
