### PR TITLE
Station Alert Runtime Fix

### DIFF
--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -8,9 +8,9 @@
 	var/obj/nano_module/alarm_monitor/engineering/alarm_monitor
 
 /obj/machinery/computer/station_alert/New()
-	..()
 	alarm_monitor = new(src)
 	alarm_monitor.register(src, /obj/machinery/computer/station_alert/update_icon)
+	..()
 
 /obj/machinery/computer/station_alert/Del()
 	alarm_monitor.unregister(src)


### PR DESCRIPTION
Fixes an issue where station alert consoles could potentially runtime due to alarm_monitor not yet being initialized.

```
runtime error: Cannot execute null.active alarms().
proc name: update icon (/obj/machinery/computer/station_alert/update_icon)
  source file: station_alert.dm,41
  src: Station Alert Console (/obj/machinery/computer/station_alert)
  call stack:
Station Alert Console (/obj/machinery/computer/station_alert): update icon()
Station Alert Console (/obj/machinery/computer/station_alert): power change()
Station Alert Console (/obj/machinery/computer/station_alert): initialize()
Station Alert Console (/obj/machinery/computer/station_alert): New(the floor (125,138,2) (/turf/unsimulated/floor))
Station Alert Console (/obj/machinery/computer/station_alert): New(the floor (125,138,2) (/turf/unsimulated/floor))
```
