### PR TITLE
Examine fix

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -201,6 +201,7 @@ its easier to just keep the beam vertical.
 			f_name += "oil-stained [name][infix]."
 
 	user << "\icon[src] That's [f_name] [suffix]"
+	user << desc
 
 	return distance == -1 || (get_dist(src, user) <= distance)
 

--- a/code/modules/examine/descriptions/mobs.dm
+++ b/code/modules/examine/descriptions/mobs.dm
@@ -3,6 +3,6 @@
 	interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
 	They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
 	such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \
-	An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access."
+	An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access, and an active drone can be shut down in the same manner."
 
 	description_antag = "An Electromagnetic Sequencer can be used to subvert the drone to your cause."

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -11,26 +11,7 @@
 	var/description_fluff = null //Green text about the atom's fluff, if any exists.
 	var/description_antag = null //Malicious red text, for the antags.
 
-/atom/examine(mob/user, var/distance = -1, var/infix = "", var/suffix = "")
-	. = ..()
-	user.description_holders["info"] = get_description_info()
-	user.description_holders["fluff"] = get_description_fluff()
-	if(user.mind && user.mind.special_role || isobserver(user)) //Runtime prevention, as ghosts don't have minds.
-		user.description_holders["antag"] = get_description_antag()
-
-	if(name) //This shouldn't be needed but I'm paranoid.
-		user.description_holders["name"] = "[src.name]" //\icon[src]
-
-	user.description_holders["icon"] = "\icon[src]"
-
-	if(desc)
-		user << desc
-		user.description_holders["desc"] = src.desc
-	else
-		user.description_holders["desc"] = null //This is needed, or else if you examine one thing with a desc, then another without, the panel will retain the first examined's desc.
-
 //Override these if you need special behaviour for a specific type.
-
 /atom/proc/get_description_info()
 	if(description_info)
 		return description_info
@@ -46,10 +27,30 @@
 		return description_antag
 	return
 
-/mob/
-	var/description_holders[0]
+/mob/living/get_description_fluff()
+	if(flavor_text) //Get flavor text for the green text.
+		return flavor_text
+	else //No flavor text?  Try for hardcoded fluff instead.
+		return ..()
 
-/mob/Stat()
+/mob/living/carbon/human/get_description_fluff()
+	return print_flavor_text(0)
+
+/* The examine panel itself */
+
+/client/var/description_holders[0]
+
+/client/proc/update_description_holders(atom/A)
+	description_holders["info"] = A.get_description_info()
+	description_holders["fluff"] = A.get_description_fluff()
+	if(mob.mind && mob.mind.special_role || isobserver(src)) //ghosts don't have minds.
+		description_holders["antag"] = A.get_description_antag()
+
+	description_holders["name"] = "[A.name]"
+	description_holders["icon"] = "\icon[A]"
+	description_holders["desc"] = A.desc
+
+/client/Stat()
 	..()
 	if(statpanel("Examine"))
 		stat(null,"[description_holders["icon"]]    <font size='5'>[description_holders["name"]]</font>") //The name, written in big letters.
@@ -60,12 +61,3 @@
 			stat(null,"<font color='#298A08'><b>[description_holders["fluff"]]</b></font>") //Yellow, fluff-related text.
 		if(description_holders["antag"])
 			stat(null,"<font color='#8A0808'><b>[description_holders["antag"]]</b></font>") //Red, malicious antag-related text
-
-/mob/living/get_description_fluff()
-	if(flavor_text) //Get flavor text for the green text.
-		return flavor_text
-	else //No flavor text?  Try for hardcoded fluff instead.
-		return ..()
-
-/mob/living/carbon/human/get_description_fluff()
-	return print_flavor_text(0)

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -40,18 +40,17 @@
 
 /client/var/description_holders[0]
 
-/client/proc/update_description_holders(atom/A)
+/client/proc/update_description_holders(atom/A, update_antag_info=0)
 	description_holders["info"] = A.get_description_info()
 	description_holders["fluff"] = A.get_description_fluff()
-	if(mob.mind && mob.mind.special_role || isobserver(src)) //ghosts don't have minds.
-		description_holders["antag"] = A.get_description_antag()
+	description_holders["antag"] = (update_antag_info)? A.get_description_antag() : ""
 
 	description_holders["name"] = "[A.name]"
 	description_holders["icon"] = "\icon[A]"
 	description_holders["desc"] = A.desc
 
 /client/Stat()
-	..()
+	. = ..()
 	if(statpanel("Examine"))
 		stat(null,"[description_holders["icon"]]    <font size='5'>[description_holders["name"]]</font>") //The name, written in big letters.
 		stat(null,"[description_holders["desc"]]") //the default examine text.
@@ -61,3 +60,12 @@
 			stat(null,"<font color='#298A08'><b>[description_holders["fluff"]]</b></font>") //Yellow, fluff-related text.
 		if(description_holders["antag"])
 			stat(null,"<font color='#8A0808'><b>[description_holders["antag"]]</b></font>") //Red, malicious antag-related text
+
+//override examinate verb to update description holders when things are examined
+/mob/examinate(atom/A as mob|obj|turf in view())
+	if(..())
+		return 1
+
+	var/is_antag = ((mind && mind.special_role) || isobserver(src)) //ghosts don't have minds
+	if(client)
+		client.update_description_holders(A, is_antag)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -451,7 +451,6 @@
 		msg += "\n[t_He] is [pose]"
 
 	user << msg
-	..()
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
 /proc/hasHUD(mob/M as mob, hudtype)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -228,13 +228,10 @@ var/list/slot_equipment_priority = list( \
 
 	if((is_blind(src) || usr.stat) && !isobserver(src))
 		src << "<span class='notice'>Something is there but you can't see it.</span>"
-		return
+		return 1
 
 	face_atom(A)
 	A.examine(src)
-	
-	if(client)
-		client.update_description_holders(A)
 
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -232,6 +232,9 @@ var/list/slot_equipment_priority = list( \
 
 	face_atom(A)
 	A.examine(src)
+	
+	if(client)
+		client.update_description_holders(A)
 
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"


### PR DESCRIPTION
Fixes issues introduced with the examine tab system by decoupling the examine() proc from the code that updates a ~~mob's~~(now client's) description holders.

Puts a few things in more logical places.
