### PR TITLE
Attemps to fix #8390 + solid bonus

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -38,6 +38,11 @@
 	return cameras
 
 /area/proc/atmosalert(danger_level, var/alarm_source)
+	if (danger_level == 0)
+		atmosphere_alarm.clearAlarm(master, alarm_source)
+	else
+		atmosphere_alarm.triggerAlarm(master, alarm_source, severity = danger_level)
+
 	//Check all the alarms before lowering atmosalm. Raising is perfectly fine.
 	for (var/area/RA in related)
 		for (var/obj/machinery/alarm/AA in RA)
@@ -50,11 +55,6 @@
 			air_doors_open()
 		else if (danger_level >= 2 && atmosalm < 2)
 			air_doors_close()
-
-		if (danger_level == 0)
-			atmosphere_alarm.clearAlarm(master, alarm_source)
-		else
-			atmosphere_alarm.triggerAlarm(master, alarm_source, severity = danger_level)
 
 		atmosalm = danger_level
 		for(var/area/RA in related)

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -3,7 +3,7 @@
 	desc = "Holds item of clothing you shouldn't be showing off in the hallways."
 	icon = 'icons/obj/closet.dmi'
 	icon_state = "cabinet_closed"
-
+	density = 1
 
 /obj/structure/undies_wardrobe/attack_hand(mob/user as mob)
 	src.add_fingerprint(user)


### PR DESCRIPTION
Attempts to fix #8390 by setting/resetting alarm status before it's affected by the total area alarm state.
Makes wardrobes solid.
