### PR TITLE
More tweaks

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -710,6 +710,17 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	access = access_security
 	group = "Security"
 
+/datum/supply_packs/flareguns
+	name = "Flare guns crate"
+	contains = list(/obj/item/weapon/gun/projectile/sec/flash,
+					/obj/item/ammo_magazine/c45m/flash,
+					/obj/item/weapon/gun/projectile/shotgun/doublebarrel/flare,
+					/obj/item/weapon/storage/box/flashshells)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Flare gun crate"
+	access = access_security
+	group = "Security"
 
 /datum/supply_packs/eweapons
 	name = "Experimental weapons crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -696,15 +696,15 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "Weapons crate"
 	contains = list(/obj/item/weapon/melee/baton,
 					/obj/item/weapon/melee/baton,
-					/obj/item/weapon/gun/energy/laser,
-					/obj/item/weapon/gun/energy/laser,
+					/obj/item/weapon/gun/energy/gun,
+					/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/gun/projectile/sec,
 					/obj/item/weapon/gun/projectile/sec,
 					/obj/item/weapon/storage/box/flashbangs,
 					/obj/item/weapon/storage/box/flashbangs)
-	cost = 30
+	cost = 40
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Weapons crate"
 	access = access_security
@@ -777,7 +777,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "Energy weapons crate"
 	contains = list(/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser,
-					/obj/item/weapon/gun/energy/gun)
+					/obj/item/weapon/gun/energy/laser)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "energy weapons crate"
@@ -789,9 +789,10 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	contains = list(/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/weapon/storage/box/shotgunammo,
-					/obj/item/weapon/gun/projectile/shotgun/pump,
+					/obj/item/weapon/storage/box/shotgunshells,
+					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
-	cost = 50
+	cost = 65
 	containertype = /obj/structure/closet/crate/secure
 	containername = "Shotgun crate"
 	access = access_armory

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -177,8 +177,8 @@
 	icon_state = "energykill100"
 	item_to_spawn()
 		return pick(prob(2);/obj/item/weapon/gun/energy/laser,\
-					prob(1);/obj/item/weapon/gun/energy/gun,\
-					prob(2);/obj/item/weapon/gun/energy/stunrevolver)
+					prob(2);/obj/item/weapon/gun/energy/gun,\
+					prob(1);/obj/item/weapon/gun/energy/stunrevolver)
 
 /obj/random/projectile
 	name = "Random Projectile Weapon"
@@ -206,15 +206,15 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "45-10"
 	item_to_spawn()
-		return pick(prob(3);/obj/item/weapon/storage/box/beanbags,\
-					prob(1);/obj/item/weapon/storage/box/shotgunammo,\
-					prob(2);/obj/item/weapon/storage/box/shotgunshells,\
-					prob(2);/obj/item/weapon/storage/box/stunshells,\
-					prob(1);/obj/item/ammo_magazine/c45m,\
-					prob(2);/obj/item/ammo_magazine/c45m/rubber,\
-					prob(2);/obj/item/ammo_magazine/c45m/flash,\
-					prob(1);/obj/item/ammo_magazine/mc9mmt,\
-					prob(3);/obj/item/ammo_magazine/mc9mmt/rubber)
+		return pick(prob(6);/obj/item/weapon/storage/box/beanbags,\
+					prob(2);/obj/item/weapon/storage/box/shotgunammo,\
+					prob(4);/obj/item/weapon/storage/box/shotgunshells,\
+					prob(1);/obj/item/weapon/storage/box/stunshells,\
+					prob(2);/obj/item/ammo_magazine/c45m,\
+					prob(4);/obj/item/ammo_magazine/c45m/rubber,\
+					prob(4);/obj/item/ammo_magazine/c45m/flash,\
+					prob(2);/obj/item/ammo_magazine/mc9mmt,\
+					prob(6);/obj/item/ammo_magazine/mc9mmt/rubber)
 
 
 /obj/random/action_figure

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -51,7 +51,7 @@
 	name = "\improper STS-35 automatic rifle"
 	desc = "A durable, rugged looking automatic weapon of a make popular on the frontier worlds. Uses 7.62mm rounds. It is unmarked."
 	icon_state = "arifle"
-	item_state = "shotgun"
+	item_state = "l6closednomag" //placeholder
 	w_class = 4
 	force = 10
 	caliber = "a762"
@@ -68,7 +68,8 @@
 	name = "\improper W-T 550 Saber"
 	desc = "A cheap, mass produced Ward-Takahashi PDW. Uses 9mm rounds."
 	icon_state = "wt550"
-	w_class = 3.0
+	item_state = "c20r" //placeholder
+	w_class = 3
 	caliber = "9mm"
 	origin_tech = "combat=5;materials=2"
 	slot_flags = SLOT_BELT
@@ -89,7 +90,7 @@
 	name = "\improper Z8 Bulldog"
 	desc = "An older model bullpup carbine, made by the now defunct Zendai Foundries. Uses armor piercing 5.56mm rounds. Makes you feel like a space marine when you hold it."
 	icon_state = "carbine"
-	item_state = "shotgun"
+	item_state = "l6closednomag" //placeholder
 	w_class = 4
 	force = 10
 	caliber = "a556"

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -65,6 +65,11 @@
 	origin_tech = "combat=3;materials=1"
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 
+/obj/item/weapon/gun/projectile/shotgun/doublebarrel/flare
+	name = "signal shotgun"
+	desc = "A double-barreled shotgun meant to fire signal flash shells."
+	ammo_type = /obj/item/ammo_casing/shotgun/flash
+
 //this is largely hacky and bad :(	-Pete
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -2,7 +2,7 @@
 	name = "\improper PTRS-7 rifle"
 	desc = "A portable anti-armour rifle fitted with a scope. Originally designed to used against armoured exosuits, it is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 14.5mm shells."
 	icon_state = "heavysniper"
-	item_state = "shotgun"
+	item_state = "l6closednomag" //placeholder
 	w_class = 4
 	force = 10
 	slot_flags = SLOT_BACK


### PR DESCRIPTION
- Attempts to find better placeholder item_states for several guns: The STS-35, Z8, and PTRS previously used the shotgun state. While the l6closednomag state is a bit poorer quality, it's more distinctly a rifle and less confusing to see. The WT550 now uses the c20r state as a placeholder, so that it will no longer be mistaken for a pistol.
- Adjusted the armoury spawner lists and weapons crate loadouts: Stunshells are now rare like they were intended to be - they are only obtainable from a hacked autolathe for the same reason. Shotgun crates come with two combat shotguns, instead of one combat and one pump, as they are less likely to spawn in the armoury. The weapons crate comes with two energy guns instead of two laser carbines, for thematic consistency - all the other guns in the crate are pistols. The energy weapons crate now comes with three carbines instead.
- Bonus: Added a flaregun crate and signal shotgun, so that double-barrelled shotguns are orderable.
