### PR TITLE
Penetrating bullets are now more likely to go through glass doors

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -47,6 +47,7 @@
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
 		chance = round(damage/D.maxhealth*180)
+		if(D.glass) chance *= 2
 	else if(istype(A, /obj/structure/girder) || istype(A, /obj/structure/cultgirder))
 		chance = 100
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))


### PR DESCRIPTION
For glass airlocks, this makes the passthrough chance equal to that of non-reinforced walls.
