### PR TITLE
Fixes #8264

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -42,7 +42,6 @@
 	if(!node)
 		return
 	if(!on)
-		updateUsrDialog()
 		return
 
 	if(occupant)
@@ -57,7 +56,6 @@
 	if(abs(temperature_archived-air_contents.temperature) > 1)
 		network.update = 1
 
-	updateUsrDialog()
 	return 1
 
 
@@ -193,7 +191,6 @@
 		var/mob/M = G:affecting
 		if(put_mob(M))
 			del(G)
-	updateUsrDialog()
 	return
 
 /obj/machinery/atmospherics/unary/cryo_cell/update_icon()


### PR DESCRIPTION
Fixes #8264.
updateUsrDialog() doesn't play well with NanoUI, forcing it to re-open and reposition on each call.
