### PR TITLE
Grabs prevent missing and increase point blank damage bonus

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -319,7 +319,7 @@ emp_act
 		if (O.throw_source)
 			var/distance = get_dist(O.throw_source, loc)
 			miss_chance = max(15*(distance-2), 0)
-		zone = get_zone_with_miss_chance(zone, src, miss_chance)
+		zone = get_zone_with_miss_chance(zone, src, miss_chance, ranged_attack=1)
 
 		if(!zone)
 			visible_message("\blue \The [O] misses [src] narrowly!")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -530,7 +530,7 @@
 						del(G)
 				if(GRAB_NECK)
 					//If the you move when grabbing someone then it's easier for them to break free. Same if the affected mob is immune to stun.
-					if (((world.time - G.assailant.l_move_time < 20 || !L.stunned) && prob(15)) || prob(3))
+					if (((world.time - G.assailant.l_move_time < 30 || !L.stunned) && prob(15)) || prob(3))
 						L.visible_message("<span class='warning'>[L] has broken free of [G.assailant]'s headlock!</span>")
 						del(G)
 		if(resisting)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -232,17 +232,22 @@ var/list/global/organ_rel_size = list(
 /proc/get_zone_with_miss_chance(zone, var/mob/target, var/miss_chance_mod = 0)
 	zone = check_zone(zone)
 
-	// you can only miss if your target is standing and not restrained
-	if(!target.buckled && !target.lying)
-		var/miss_chance = 10
-		if (zone in base_miss_chance)
-			miss_chance = base_miss_chance[zone]
-		miss_chance = max(miss_chance + miss_chance_mod, 0)
-		if(prob(miss_chance))
-			if(prob(70))
-				return null
-			return pick(base_miss_chance)
-
+	// you cannot miss if your target is prone or restrained
+	if(target.buckled || target.lying)
+		return zone
+	// if your target is being grabbed aggressively by someone you cannot miss either
+	for(var/obj/item/weapon/grab/G in target.grabbed_by)
+		if(G.state >= GRAB_AGGRESSIVE)
+			return zone
+	
+	var/miss_chance = 10
+	if (zone in base_miss_chance)
+		miss_chance = base_miss_chance[zone]
+	miss_chance = max(miss_chance + miss_chance_mod, 0)
+	if(prob(miss_chance))
+		if(prob(70))
+			return null
+		return pick(base_miss_chance)
 	return zone
 
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -229,16 +229,17 @@ var/list/global/organ_rel_size = list(
 // Emulates targetting a specific body part, and miss chances
 // May return null if missed
 // miss_chance_mod may be negative.
-/proc/get_zone_with_miss_chance(zone, var/mob/target, var/miss_chance_mod = 0)
+/proc/get_zone_with_miss_chance(zone, var/mob/target, var/miss_chance_mod = 0, var/ranged_attack=0)
 	zone = check_zone(zone)
 
 	// you cannot miss if your target is prone or restrained
 	if(target.buckled || target.lying)
 		return zone
 	// if your target is being grabbed aggressively by someone you cannot miss either
-	for(var/obj/item/weapon/grab/G in target.grabbed_by)
-		if(G.state >= GRAB_AGGRESSIVE)
-			return zone
+	if(!ranged_attack)
+		for(var/obj/item/weapon/grab/G in target.grabbed_by)
+			if(G.state >= GRAB_AGGRESSIVE)
+				return zone
 	
 	var/miss_chance = 10
 	if (zone in base_miss_chance)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -197,9 +197,22 @@
 			x_offset = rand(-1,1)
 
 	//Point blank bonus
-	if(pointblank) P.damage *= 1.3
-
-	//TODO: accuracy modifiers
+	if(pointblank) 
+		var/damage_mult = 1.3 //default point blank multiplier
+		
+		//determine multiplier due to the target being grabbed
+		if(ismob(target))
+			var/mob/M = target
+			if(M.grabbed_by.len)
+				var/grabstate = 0
+				for(var/obj/item/weapon/grab/G in M.grabbed_by)
+					grabstate = max(grabstate, G.state)
+				if(grabstate >= GRAB_NECK)
+					damage_mult = 1.5
+				else if (grabstate >= GRAB_AGGRESSIVE)
+					damage_mult = 3.0
+		
+		P.damage *= damage_mult
 
 	if(params)
 		P.set_clickpoint(params)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -208,9 +208,9 @@
 				for(var/obj/item/weapon/grab/G in M.grabbed_by)
 					grabstate = max(grabstate, G.state)
 				if(grabstate >= GRAB_NECK)
-					damage_mult = 1.5
-				else if (grabstate >= GRAB_AGGRESSIVE)
 					damage_mult = 3.0
+				else if (grabstate >= GRAB_AGGRESSIVE)
+					damage_mult = 1.5
 		
 		P.damage *= damage_mult
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -135,16 +135,21 @@
 	xo = new_x - starting_loc.x
 
 //Called when the projectile intercepts a mob. Returns 1 if the projectile hit the mob, 0 if it missed and should keep flying.
-/obj/item/projectile/proc/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier)
+/obj/item/projectile/proc/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier=0)
 	//accuracy bonus from aiming
-	if (istype(shot_from, /obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
-		var/obj/item/weapon/gun/daddy = shot_from	//Kinda balanced by fact you need like 2 seconds to aim
+	if (istype(shot_from, /obj/item/weapon/gun))
+		var/obj/item/weapon/gun/daddy = shot_from
 		miss_modifier -= round(15*daddy.accuracy)
-		if (daddy.aim_targets && original in daddy.aim_targets) //As opposed to no-delay pew pew
+		
+		//If you aim at someone beforehead, it'll hit more often.
+		//Kinda balanced by fact you need like 2 seconds to aim
+		//As opposed to no-delay pew pew
+		if (daddy.aim_targets && original in daddy.aim_targets)
 			miss_modifier += -30
 
 	//roll to-hit
-	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, max(miss_modifier + 15*(distance-2), 0))
+	miss_modifier = max(miss_modifier + 15*(distance-2), 0)
+	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1))
 	if(!hit_zone)
 		visible_message("<span class='notice'>\The [src] misses [target_mob] narrowly!</span>")
 		return 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -181,7 +181,7 @@
 
 	return 1
 
-/obj/item/projectile/Bump(atom/A as mob|obj|turf|area)
+/obj/item/projectile/Bump(atom/A as mob|obj|turf|area, forced=0)
 	if(A == src)
 		return 0 //no
 	
@@ -189,7 +189,7 @@
 		loc = A.loc
 		return 0 //cannot shoot yourself
 
-	if(bumped || (A in permutated))
+	if((bumped && !forced) || (A in permutated))
 		return 0
 
 	var/passthrough = 0 //if the projectile should continue flying
@@ -200,11 +200,11 @@
 		var/mob/M = A
 		if(istype(A, /mob/living))
 			//if they have a neck grab on someone, that person gets hit instead
-			for(var/obj/item/weapon/grab/G in list(M.l_hand, M.r_hand))
-				if(G.state >= GRAB_NECK)
-					//If Bump() returns 0 (missed them or went through them) then we continue on to attack M.
-					if(Bump(G.affecting))
-						return
+			var/obj/item/weapon/grab/G = locate() in M
+			if(G && G.state >= GRAB_NECK)
+				visible_message("<span class='danger'>\The [M] uses [G.affecting] as a shield!</span>")
+				if(Bump(G.affecting, forced=1))
+					return //If Bump() returns 0 (keep going) then we continue on to attack M.
 			
 			passthrough = !attack_mob(M, distance)
 		else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -194,6 +194,13 @@
 	if(ismob(A))
 		var/mob/M = A
 		if(istype(A, /mob/living))
+			//if they have a neck grab on someone, that person gets hit instead
+			for(var/obj/item/weapon/grab/G in list(M.l_hand, M.r_hand))
+				if(G.state >= GRAB_NECK)
+					//If Bump() returns 0 (missed them or went through them) then we continue on to attack M.
+					if(Bump(G.affecting))
+						return
+			
 			passthrough = !attack_mob(M, distance)
 		else
 			passthrough = 1 //so ghosts don't stop bullets

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -401,10 +401,10 @@
 #define XENO_HOST   32768 // Tracks whether we're gonna be a baby alien's mummy.
 
 // Grab levels.
+#define GRAB_UPGRADING  -1
 #define GRAB_PASSIVE    1
 #define GRAB_AGGRESSIVE 2
 #define GRAB_NECK       3
-#define GRAB_UPGRADING  4
 #define GRAB_KILL       5
 
 // Security levels.

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -401,10 +401,10 @@
 #define XENO_HOST   32768 // Tracks whether we're gonna be a baby alien's mummy.
 
 // Grab levels.
-#define GRAB_UPGRADING  -1
 #define GRAB_PASSIVE    1
 #define GRAB_AGGRESSIVE 2
 #define GRAB_NECK       3
+#define GRAB_UPGRADING  4
 #define GRAB_KILL       5
 
 // Security levels.


### PR DESCRIPTION
- Having an aggressive grab on someone prevents melee and close ranged attacks from missing.
- Aggressive and neck grabs provide varying levels of damage multiplier
- Having a neck grab on someone makes them get hit by projectiles before you do. If they attack misses them or otherwise passes through them then it still may hit you, however.

I feel like this resolves #8224. Point blank damage is the same for the no-grab case, but you have options to prevent missing and increase damage.
