### PR TITLE
Botany tool construction and clippers

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -76,6 +76,16 @@
 	name = "wrench"
 	path = /obj/item/weapon/wrench
 	category = "Tools"
+	
+/datum/autolathe/recipe/hatchet
+	name = "hatchet"
+	path = /obj/item/weapon/hatchet
+	category = "Tools"
+	
+/datum/autolathe/recipe/minihoe
+	name = "mini hoe"
+	path = /obj/item/weapon/minihoe
+	category = "Tools"
 
 /datum/autolathe/recipe/radio_headset
 	name = "radio headset"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -356,6 +356,12 @@
 	hidden = 1
 	category = "Arms and Ammunition"
 
+/datum/autolathe/recipe/tacknife
+	name = "tactical knife"
+	path = /obj/item/weapon/hatchet/tacknife
+	hidden = 1
+	category = "Arms and Ammunition"
+
 /datum/autolathe/recipe/stunshell
 	name = "ammunition (stun cartridge, shotgun)"
 	path = /obj/item/ammo_casing/shotgun/stunshell
@@ -385,3 +391,5 @@
 	path = /obj/item/weapon/handcuffs
 	hidden = 1
 	category = "General"
+
+

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -23,5 +23,6 @@
 		new /obj/item/clothing/head/greenbandana(src)
 		new /obj/item/weapon/minihoe(src)
 		new /obj/item/weapon/hatchet(src)
+		new /obj/item/weapon/wirecutters/clippers(src)
 //		new /obj/item/weapon/bee_net(src) //No more bees, March 2014
 		return


### PR DESCRIPTION
Adds hatchets and mini hoes to the autolathe recipe list. Material costs
are unchanged. Also adds plant clippers (reskinned wirecutters) to
secure hydroponics lockers.
