### PR TITLE
AIs can now use the crew monitor console for tracking.

### DIFF
--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -17,6 +17,13 @@
 	if(href_list["update"])
 		src.updateDialog()
 		return 1
+	if(href_list["track"])
+		if(usr.isAI())
+			var/mob/living/silicon/ai/AI = usr
+			var/mob/living/carbon/human/H = locate(href_list["track"]) in mob_list
+			if(hassensorlevel(H, SUIT_SENSOR_TRACKING))
+				AI.ai_actual_track(H)
+		return 1
 
 /obj/nano_module/crew_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	user.set_machine(src)
@@ -36,7 +43,7 @@
 				if(H.w_uniform != C)
 					continue
 
-				var/list/crewmemberData = list("dead"=0, "oxy"=-1, "tox"=-1, "fire"=-1, "brute"=-1, "area"="", "x"=-1, "y"=-1)
+				var/list/crewmemberData = list("dead"=0, "oxy"=-1, "tox"=-1, "fire"=-1, "brute"=-1, "area"="", "x"=-1, "y"=-1, "ref" = "\ref[H]")
 
 				crewmemberData["sensor_type"] = C.sensor_mode
 				crewmemberData["name"] = H.get_authentification_name(if_no_id="Unknown")
@@ -62,6 +69,7 @@
 
 	crewmembers = sortByKey(crewmembers, "name")
 
+	data["isAI"] = user.isAI()
 	data["crewmembers"] = crewmembers
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -2,15 +2,29 @@
 Title: Crew Monitoring Console (Main content)
 Used In File(s): \code\game\machinery\computer\crew.dm
  -->
+ <style type="text/css">
+	table.wideTable   {
+        width:100%;
+    }
+	
+	td.living   {
+        width:180px;
+    }
+	
+	td.tracking   {
+        width:40px;
+    }
+</style>
+
 {{:helper.link('Show Tracker Map', 'pin-s', {'showMap' : 1})}}
-<table width="100%"><tbody>
+<table class='wideTable'><tbody>
 	{{for data.crewmembers}}
 		{{if value.sensor_type == 1}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td></tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}}</td><td><span class="neutral">Not Available</span></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 2}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td></tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 3}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td></tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td class='living'>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss">{{:value.oxy}}</span>/<span class="toxin">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>


### PR DESCRIPTION
Due to balance concerns, the headache of handling fake identities, meta, etc., this only works for crew members with tracking sensors enabled.
Only the AI will see the tracking buttons. Other mobs get the normal view.
![AIs view of a crew monitor console](https://www.dropbox.com/s/zdiemr13cfbsmte/Tracking.png?dl=1)
