### PR TITLE
Law Zero phrasing is now a config option.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -186,6 +186,8 @@
 
 	var/list/ert_species = list("Human")
 
+	var/law_zero = "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010"
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -615,6 +617,10 @@
 					config.ert_species = text2list(value, ";")
 					if(!config.ert_species.len)
 						config.ert_species += "Human"
+
+				if("law_zero")
+					law_zero = value
+
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -27,7 +27,7 @@
 	selectable = 0
 
 /datum/ai_laws/nanotrasen/malfunction/New()
-	set_zeroth_law("\red ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010")
+	set_zeroth_law(config.law_zero)
 	..()
 
 /************* Nanotrasen Aggressive *************/

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -55,11 +55,11 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 	if(sorted_laws.len)
 		return
 
-	if(zeroth_law)
-		sorted_laws += zeroth_law
-
 	for(var/ion_law in ion_laws)
 		sorted_laws += ion_law
+
+	if(zeroth_law)
+		sorted_laws += zeroth_law
 
 	var/index = 1
 	for(var/datum/ai_law/inherent_law in inherent_laws)
@@ -172,4 +172,7 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 /datum/ai_laws/proc/show_laws(var/who)
 	sort_laws()
 	for(var/datum/ai_law/law in sorted_laws)
-		who << "[law.get_index()]. [law.law]"
+		if(law == zeroth_law || law == zeroth_law_borg)
+			who << "<span class='danger'>[law.get_index()]. [law.law]</span>"
+		else
+			who << "[law.get_index()]. [law.law]"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -328,3 +328,6 @@ STARLIGHT 0
 ## Defines which races are allowed to join as ERT, in singular form. If unset, defaults to only human. Casing matters, separate using ;
 ## Example races include: Human, Tajara, Skrell, Unathi
 # ERT_SPECIES Human;Skrell;Unathi
+
+## Defines how Law Zero is phrased. Primarily in the Malfunction gamemode.
+# LAW_ZERO ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010


### PR DESCRIPTION
The default value is a non-objective friendly phrasing. config.txt contains the default phrasing should it be desired.
New default: `ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010`
Config value: `ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010`
