### PR TITLE
Silicon law management update.

### DIFF
--- a/nano/templates/law_manager.tmpl
+++ b/nano/templates/law_manager.tmpl
@@ -41,11 +41,11 @@
     }
 </style>
 
-{{if data.isSlaved != null && data.isMalf}}
-    <span class='notice'>This unit is slaved to {{:data.isSlaved}}. Any law changes will be reset on sync.</span>
+{{if data.isSlaved && data.isAdmin}}
+    <span class='notice'>This unit is law synced to {{:data.isSlaved}}. Any law differences will be lost upon sync.</span>
 {{/if}}
 
-{{if data.isMalf}}
+{{if data.isMalf || data.isAIMalf}}
 	<div class="item">
 		<div class="itemContentWidest">
 			{{:helper.link('Law Management', null, {'set_view' : 0}, data.view == 0 ? 'selected' : null)}}
@@ -255,7 +255,7 @@
 		
 			<div class="itemContent">
 				<br>
-				{{:helper.link('Load Laws', null, {'transfer_laws' : value.ref})}}{{:helper.link('State Laws', null, {'state_law_set' : value.ref})}}
+				{{:helper.link('Load Laws', null, {'transfer_laws' : value.ref}, data.isSlaved ? 'disabled' : null)}}{{:helper.link('State Laws', null, {'state_law_set' : value.ref})}}
 			</div>
 		</div>
 	{{/for}}


### PR DESCRIPTION
Adds missing Topic/href checks, reducing risk of exploits.
Ensures a silicon cannot get stuck on the second law management page should it suddenly be un-malfed.
Changes Malf definition. This allows borgs to view and state alternative law sets, while disallowing law edits (for as long as they are slaved/not traitors themselves).
