### PR TITLE
Fixes #8107.

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -198,7 +198,7 @@
 	var/obj/item/device/radio/R	= new (src)
 	var/AN = "Self-Destruct System"
 
-	R.autosay("Caution. Self-Destruct sequence has been actived. Self-destructing in Ten..", AN)
+	R.autosay("Caution. Self-Destruct sequence has been activated. Self-destructing in Ten..", AN)
 	for (var/i=9 to 1 step -1)
 		sleep(10)
 		var/msg = ""

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -167,10 +167,11 @@
 		return
 
 	var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(src, null, null, 1)
+	A.SetName(from)
 	Broadcast_Message(connection, A,
 						0, "*garbled automated announcement*", src,
 						message, from, "Automated Announcement", from, "synthesized voice",
-						4, 0, list(1), PUB_FREQ)
+						4, 0, list(0), connection.frequency, "states")
 	del(A)
 	return
 


### PR DESCRIPTION
Fixes #8107.
The announcer again uses its given name, rather than a randomly selected one.
The announcer now states its business, rather than talks about it.
The announcer now uses the given frequency instead of defaulting to public.
