### PR TITLE
Emergency shutters opened by silicons no longer autoclose.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,7 +22,7 @@
 	open_layer = DOOR_OPEN_LAYER - 0.01 // Just below doors when open
 	closed_layer = DOOR_CLOSED_LAYER + 0.01 // Just above doors when closed
 
-	//These are frequenly used with windows, so make sure zones can pass. 
+	//These are frequenly used with windows, so make sure zones can pass.
 	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
 	block_air_zones = 0
 
@@ -149,7 +149,7 @@
 	"\The [src]", "Yes, [density ? "open" : "close"]", "No")
 	if(answer == "No")
 		return
-	if(user.stat || user.stunned || user.weakened || user.paralysis || (!user.canmove && !isAI(user)) || (get_dist(src, user) > 1  && !isAI(user)))
+	if(user.stat || user.stunned || user.weakened || user.paralysis || (!user.canmove && !user.isSilicon()) || (get_dist(src, user) > 1  && !isAI(user)))
 		user << "Sorry, you must remain able bodied and close to \the [src] in order to use it."
 		return
 	if(density && (stat & (BROKEN|NOPOWER))) //can still close without power
@@ -169,7 +169,7 @@
 		if(alarmed)
 			// Accountability!
 			users_to_open |= user.name
-			needs_to_close = 1
+			needs_to_close = !user.isSilicon()
 		spawn()
 			open()
 	else
@@ -272,7 +272,7 @@
 				spawn(0)
 					close()
 			return
-		
+
 	return ..()
 
 // CHECK PRESSURE


### PR DESCRIPTION
The label of the tin tells all.
Also changed it so that all silicons, not only the AI, can open emergency shutters from a distance.
