### PR TITLE
Deletes AI eye along with the AI.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -194,6 +194,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/Del()
 	ai_list -= src
+	del(eyeobj)
 	..()
 
 /mob/living/silicon/ai/pointed(atom/A as mob|obj|turf in view())


### PR DESCRIPTION
Prevents AI eyes from stacking up as they get switched out during a round.
