### PR TITLE
Updates drill and scanner

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -642,6 +642,7 @@
 #include "code\game\objects\items\weapons\circuitboards\computer\telecomms.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\biogenerator.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\cloning.dm"
+#include "code\game\objects\items\weapons\circuitboards\machinery\mining_drill.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\pacman.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\power.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\recharge_station.dm"

--- a/code/game/objects/items/weapons/circuitboards/machinery/mining_drill.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/mining_drill.dm
@@ -1,0 +1,15 @@
+#ifndef T_BOARD
+#error T_BOARD macro is not defined but we need it! 
+#endif
+
+/obj/item/weapon/circuitboard/miningdrill
+	name = T_BOARD("mining drill head")
+	build_path = "/obj/machinery/mining/drill"
+	board_type = "machine"
+	origin_tech = "programming=1;engineering=1"
+	frame_desc = "Requires 1 capacitor, 1 cell, 1 matter bin, and 1 micro laser."
+	req_components = list(
+							"/obj/item/weapon/stock_parts/capacitor" = 1,
+							"/obj/item/weapon/cell" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 1,
+							"/obj/item/weapon/stock_parts/micro_laser" = 1)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -14,7 +14,6 @@
 	var/supported = 0
 	var/active = 0
 	var/list/resource_field = list()
-	var/open = 0
 
 	var/ore_types = list(
 		"iron" = /obj/item/weapon/ore/iron,
@@ -30,10 +29,10 @@
 		)
 
 	//Upgrades
-	var/obj/item/weapon/stock_parts/matter_bin/storage
-	var/obj/item/weapon/stock_parts/micro_laser/cutter
-	var/obj/item/weapon/stock_parts/capacitor/cellmount
-	var/obj/item/weapon/cell/cell
+	var/harvest_speed
+	var/capacity
+	var/charge_use
+	var/obj/item/weapon/cell/cell = null
 
 	//Flags
 	var/need_update_field = 0
@@ -43,13 +42,14 @@
 
 	..()
 
-	storage = new(src)
-	cutter = new(src)
-	cellmount = new(src)
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/miningdrill(src)
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)
+	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
+	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
+	component_parts += new /obj/item/weapon/cell/high(src)
 
-	cell = new(src)
-	cell.maxcharge = 10000
-	cell.charge = cell.maxcharge
+	RefreshParts()
 
 /obj/machinery/mining/drill/process()
 
@@ -74,11 +74,11 @@
 		return
 
 	//Drill through the flooring, if any.
-	if(istype(get_turf(src),/turf/simulated/floor/plating/airless/asteroid))
+	if(istype(get_turf(src), /turf/simulated/floor/plating/airless/asteroid))
 		var/turf/simulated/floor/plating/airless/asteroid/T = get_turf(src)
 		if(!T.dug)
 			T.gets_dug()
-	else if(istype(get_turf(src),/turf/simulated/floor))
+	else if(istype(get_turf(src), /turf/simulated/floor))
 		var/turf/simulated/floor/T = get_turf(src)
 		T.ex_act(2.0)
 
@@ -94,20 +94,20 @@
 
 		if(!harvesting) return
 
-		var/total_harvest = get_harvest_capacity() //Ore harvest-per-tick.
+		var/total_harvest = harvest_speed //Ore harvest-per-tick.
 		var/found_resource = 0 //If this doesn't get set, the area is depleted and the drill errors out.
 
 		for(var/metal in ore_types)
 
-			if(contents.len >= get_storage_capacity())
+			if(contents.len >= capacity)
 				system_error("insufficient storage space")
 				active = 0
 				need_player_check = 1
 				update_icon()
 				return
 
-			if(contents.len + total_harvest >= get_storage_capacity())
-				total_harvest = get_storage_capacity() - contents.len
+			if(contents.len + total_harvest >= capacity)
+				total_harvest = capacity - contents.len
 
 			if(total_harvest <= 0) break
 			if(harvesting.resources[metal])
@@ -124,7 +124,7 @@
 					create_ore = harvesting.resources[metal]
 					harvesting.resources[metal] = 0
 
-				for(var/i=1,i<=create_ore,i++)
+				for(var/i=1, i <= create_ore, i++)
 					var/oretype = ore_types[metal]
 					new oretype(src)
 
@@ -140,93 +140,56 @@
 /obj/machinery/mining/drill/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/machinery/mining/drill/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/screwdriver))
-		if(active) return
-		open = !open
-		user << "\blue You [open ? "open" : "close"] the maintenance panel." //TODO: Sprite.
+/obj/machinery/mining/drill/attackby(obj/item/O as obj, mob/user as mob)
+	if(!active)
+		if(default_deconstruction_screwdriver(user, O))
+			return
+		if(default_deconstruction_crowbar(user, O))
+			return
+		if(default_part_replacement(user, O))
+			return
+	if(!panel_open || active) return ..()
+
+	if(istype(O, /obj/item/weapon/cell))
+		if(cell)
+			user << "The drill already has a cell installed."
+		else
+			user.drop_item()
+			O.loc = src
+			cell = O
+			component_parts += O
+			user << "You install \the [O]."
 		return
-	else
-		if(!open || active) return ..()
-		if(istype(W,/obj/item/weapon/crowbar))
-			if(cell)
-				user << "You pry out \the [cell]."
-				cell.loc = get_turf(src)
-				cell = null
-			else if(storage)
-				user << "You slip the bolt and pry out \the [storage]."
-				storage.loc = get_turf(src)
-				storage = null
-			else if(cutter)
-				user << "You carefully detatch and pry out \the [cutter]."
-				cutter.loc = get_turf(src)
-				cutter = null
-			else if(cellmount)
-				user << "You yank out a few wires and pry out \the [cellmount]."
-				cellmount.loc = get_turf(src)
-				cellmount = null
-			else
-				user << "There's nothing inside the drilling rig to remove."
-			return
-		else if(istype(W,/obj/item/weapon/stock_parts/matter_bin))
-			if(storage)
-				user << "The drill already has a matter bin installed."
-			else
-				user.drop_item()
-				W.loc = src
-				storage = W
-				user << "You install \the [W]."
-			return
-		else if(istype(W,/obj/item/weapon/stock_parts/micro_laser))
-			if(cutter)
-				user << "The drill already has a cutting head installed."
-			else
-				user.drop_item()
-				W.loc = src
-				cutter = W
-				user << "You install \the [W]."
-			return
-		else if(istype(W,/obj/item/weapon/stock_parts/capacitor))
-			if(cellmount)
-				user << "The drill already has a cell capacitor installed."
-			else
-				user.drop_item()
-				W.loc = src
-				cellmount = W
-				user << "You install \the [W]."
-			return
-		else if(istype(W,/obj/item/weapon/cell))
-			if(cell)
-				user << "The drill already has a cell installed."
-			else
-				user.drop_item()
-				W.loc = src
-				cell = W
-				user << "You install \the [W]."
-			return
 	..()
+
 /obj/machinery/mining/drill/attack_hand(mob/user as mob)
 	check_supports()
 
-	if(need_player_check)
+	if (panel_open && cell)
+		user << "You take out \the [cell]."
+		cell.loc = get_turf(user)
+		component_parts -= cell
+		cell = null
+		return
+	else if(need_player_check)
 		user << "You hit the manual override and reset the drill's error checking."
 		need_player_check = 0
-		if(anchored) get_resource_field()
+		if(anchored)
+			get_resource_field()
 		update_icon()
 		return
-
-	else if(supported)
+	else if(supported && !panel_open)
 		if(use_cell_power())
 			active = !active
 			if(active)
-				user << "\blue You engage \the [src] and it lurches downwards, grinding noisily."
+				visible_message("<span class='notice'>\The [src] lurches downwards, grinding noisily.</span>")
 				need_update_field = 1
 			else
-				user << "\blue You disengage \the [src] and it shudders to a grinding halt."
+				visible_message("<span class='notice'>\The [src] shudders to a grinding halt.</span>")
 		else
-			user << "\blue The drill is unpowered."
+			user << "<span class='notice'>The drill is unpowered.</span>"
 	else
-		user << "\blue Turning on a piece of industrial machinery without sufficient bracing is a bad idea."
+		user << "<span class='notice'>Turning on a piece of industrial machinery without sufficient bracing or wires exposed is a bad idea.</span>"
 
 	update_icon()
 
@@ -240,6 +203,21 @@
 	else
 		icon_state = "mining_drill"
 	return
+
+/obj/machinery/mining/drill/RefreshParts()
+	..()
+	harvest_speed = 0
+	capacity = 0
+	charge_use = 50
+
+	for(var/obj/item/weapon/stock_parts/P in component_parts)
+		if(istype(P, /obj/item/weapon/stock_parts/micro_laser))
+			harvest_speed = P.rating
+		if(istype(P, /obj/item/weapon/stock_parts/matter_bin))
+			capacity = 200 * P.rating
+		if(istype(P, /obj/item/weapon/stock_parts/capacitor))
+			charge_use -= 10 * P.rating
+	cell = locate(/obj/item/weapon/cell) in component_parts
 
 /obj/machinery/mining/drill/proc/check_supports()
 
@@ -259,19 +237,11 @@
 
 /obj/machinery/mining/drill/proc/system_error(var/error)
 
-	if(error) src.visible_message("\red \The [src] flashes a '[error]' warning.")
+	if(error)
+		src.visible_message("<span class='notice'>\The [src] flashes a '[error]' warning.</span>")
 	need_player_check = 1
 	active = 0
 	update_icon()
-
-/obj/machinery/mining/drill/proc/get_harvest_capacity()
-	return (cutter ? cutter.rating : 0)
-
-/obj/machinery/mining/drill/proc/get_storage_capacity()
-	return 200 * (storage ? storage.rating : 0)
-
-/obj/machinery/mining/drill/proc/get_charge_use()
-	return 50 - (10 * (cellmount ? cellmount.rating : 0))
 
 /obj/machinery/mining/drill/proc/get_resource_field()
 
@@ -281,13 +251,13 @@
 	var/turf/T = get_turf(src)
 	if(!istype(T)) return
 
-	var/tx = T.x-2
-	var/ty = T.y-2
+	var/tx = T.x - 2
+	var/ty = T.y - 2
 	var/turf/mine_turf
-	for(var/iy=0,iy<5,iy++)
-		for(var/ix=0,ix<5,ix++)
-			mine_turf = locate(tx+ix,ty+iy,T.z)
-			if(mine_turf && istype(mine_turf) && mine_turf.has_resources)
+	for(var/iy = 0,iy < 5, iy++)
+		for(var/ix = 0, ix < 5, ix++)
+			mine_turf = locate(tx + ix, ty + iy, T.z)
+			if(mine_turf && mine_turf.has_resources)
 				resource_field += mine_turf
 
 	if(!resource_field.len)
@@ -295,9 +265,8 @@
 
 /obj/machinery/mining/drill/proc/use_cell_power()
 	if(!cell) return 0
-	var/req = get_charge_use()
-	if(cell.charge >= req)
-		cell.use(req)
+	if(cell.charge >= charge_use)
+		cell.use(charge_use)
 		return 1
 	return 0
 
@@ -312,9 +281,9 @@
 	if(B)
 		for(var/obj/item/weapon/ore/O in contents)
 			O.loc = B
-		usr << "\red You unload the drill's storage cache into the ore box."
+		usr << "<span class='notice'>You unload the drill's storage cache into the ore box.</span>"
 	else
-		usr << "\red You must move an ore box up to the drill before you can unload it."
+		usr << "<span class='notice'>You must move an ore box up to the drill before you can unload it.</span>"
 
 
 /obj/machinery/mining/brace
@@ -326,16 +295,16 @@
 /obj/machinery/mining/brace/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/wrench))
 
-		if(istype(get_turf(src),/turf/space))
-			user << "\blue You can't anchor something to empty space. Idiot."
+		if(istype(get_turf(src), /turf/space))
+			user << "<span class='notice'>You can't anchor something to empty space. Idiot.</span>"
 			return
 
 		if(connected && connected.active)
-			user << "\blue You can't unanchor the brace of a running drill!"
+			user << "<span class='notice'>You can't unanchor the brace of a running drill!</span>"
 			return
 
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		user << "\blue You [anchored ? "un" : ""]anchor the brace."
+		user << "<span class='notice'>You [anchored ? "un" : ""]anchor the brace.</span>"
 
 		anchored = !anchored
 		if(anchored)
@@ -347,18 +316,16 @@
 
 	var/turf/T = get_step(get_turf(src), src.dir)
 
-	if(!T.has_resources)
-		src.visible_message("\red The terrain near the brace is unsuitable!")
-		return
-
 	for(var/thing in T.contents)
-		if(istype(thing,/obj/machinery/mining/drill))
+		if(istype(thing, /obj/machinery/mining/drill))
 			connected = thing
 			break
 
-	if(!connected) return
+	if(!connected)
+		return
 
-	if(!connected.supports) connected.supports = list()
+	if(!connected.supports)
+		connected.supports = list()
 
 	icon_state = "mining_brace_active"
 

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -5,16 +5,13 @@
 	icon_state = "forensic0-old" //GET A BETTER SPRITE.
 	item_state = "electronic"
 	matter = list("metal" = 150)
-
 	origin_tech = "magnets=1;engineering=1"
 
 /obj/item/weapon/mining_scanner/attack_self(mob/user as mob)
-
 	user << "You begin sweeping \the [src] about, scanning for metal deposits."
 
-	if(!do_after(user,50)) return
-
-	if(!user || !src) return
+	if(!do_after(user, 50))
+		return
 
 	var/list/metals = list(
 		"surface minerals" = 0,
@@ -23,32 +20,30 @@
 		"exotic matter" = 0
 		)
 
-	for(var/turf/T in range(3,get_turf(user)))
+	for(var/turf/T in range(2, get_turf(user)))
 
 		if(!T.has_resources)
 			continue
 
 		for(var/metal in T.resources)
-
 			var/ore_type
 
 			switch(metal)
-				if("silicates" || "carbonaceous rock" || "iron") ore_type = "surface minerals"
-				if("gold" || "silver" || "diamond")              ore_type = "precious metals"
-				if("uranium")                                    ore_type = "nuclear fuel"
-				if("phoron" || "osmium" || "hydrogen")           ore_type = "exotic matter"
+				if("silicates", "carbonaceous rock", "iron")	ore_type = "surface minerals"
+				if("gold", "silver", "diamond")					ore_type = "precious metals"
+				if("uranium")									ore_type = "nuclear fuel"
+				if("phoron", "osmium", "hydrogen")				ore_type = "exotic matter"
 
 			if(ore_type) metals[ore_type] += T.resources[metal]
 
-	user << "\icon[src] \blue The scanner beeps and displays a readout."
+	user << "\icon[src] <span class='notice'>The scanner beeps and displays a readout.</span>"
 
 	for(var/ore_type in metals)
-
 		var/result = "no sign"
 
 		switch(metals[ore_type])
-			if(1 to 50) result = "trace amounts"
-			if(51 to 150) result = "significant amounts"
-			if(151 to INFINITY) result = "huge quantities"
+			if(1 to 25) result = "trace amounts"
+			if(26 to 75) result = "significant amounts"
+			if(76 to INFINITY) result = "huge quantities"
 
 		user << "- [result] of [ore_type]."


### PR DESCRIPTION
Drill is now a proper machine, with a circutboard, can be upgraded using RPED.
Scanner now has the same range as the drill.
Fixed a bug where scanner ignored all ores but silicates, gold, uranium, and phoron. Switch doesn't work with ||.
Braces used to be impossible to attach to a drill if the turf with the drill had no resources, even if the spot was valid. That was corrected.
Span classes and spacing.
