### PR TITLE
Fixes camera wires

### DIFF
--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -58,7 +58,7 @@ var/const/CAMERA_WIRE_NOTHING2 = 32
 			C.setViewRange(new_range)
 
 		if(CAMERA_WIRE_POWER)
-			C.deactivate(null) // Deactivate the camera
+			C.kick_viewers() // Kicks anyone watching the camera
 
 		if(CAMERA_WIRE_LIGHT)
 			C.light_disabled = !C.light_disabled


### PR DESCRIPTION
Seems like pulsing was mistakenly set to deactivate the camera during the wire datum update, instead of kicking viewers as it's supposed to do.

Original behaviour [here](https://github.com/Baystation12/Baystation12/blob/2d1de6330a9bcf655a0f466942d738d865743472/code/game/machinery/camera/wires.dm#L90).
