### PR TITLE
Fixes #8661.

### DIFF
--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -41,4 +41,5 @@ var/global/list/empty_playable_ai_cores = list()
 			var/datum/game_mode/traitor/autotraitor/current_mode = ticker.mode
 			current_mode.possible_traitors.Remove(src)
 
+	ghostize(0)
 	del(src)


### PR DESCRIPTION
Fixes #8661.
Now ghosts the AI before it's deleted, setting the respawn timer.
