### PR TITLE
Changes ED-209 Construction to work with new armor vests

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -84,7 +84,7 @@
 				lasercolor = "r"
 			else if( istype(W, /obj/item/clothing/suit/bluetag) )
 				lasercolor = "b"
-			if( lasercolor || istype(W, /obj/item/clothing/suit/armor/vest) )
+			if( lasercolor || istype(W, /obj/item/clothing/suit/storage/vest) )
 				user.drop_item()
 				del(W)
 				build_step++


### PR DESCRIPTION
Changes ED-209 construction to accept any type of the newer armor vests
rather than the old mostly deprecated armor vests.
