### PR TITLE
Rig weapon fixes

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -85,7 +85,7 @@
 	desc = "A shoulder-mounted battery-powered laser cannon mount."
 	selectable = 1
 	usable = 1
-	use_power_cost = 10
+	module_cooldown = 0
 
 	engage_string = "Configure"
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -57,6 +57,7 @@ obj/item/weapon/gun/energy/retro
 	fire_delay = 20
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
+	name = "mounted laser cannon"
 	self_recharge = 1
 	use_external_power = 1
 	recharge_time = 10

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -35,6 +35,7 @@
 		user.update_inv_r_hand()
 
 /obj/item/weapon/gun/energy/gun/mounted
+	name = "mounted energy gun"
 	self_recharge = 1
 	use_external_power = 1
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -9,10 +9,12 @@
 	cell_type = /obj/item/weapon/cell/crap
 
 /obj/item/weapon/gun/energy/taser/mounted
+	name = "mounted taser gun"
 	self_recharge = 1
 	use_external_power = 1
 
 /obj/item/weapon/gun/energy/taser/mounted/cyborg
+	name = "taser gun"
 	cell_type = /obj/item/weapon/cell/secborg
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 


### PR DESCRIPTION
Fixes #8673.

Removes twin cooldowns on rig weapons; the cooldown is entirely handled by the internal `/obj/item/weapon/gun/energy` object now.

Renames mounted weapon variants so the messages say "You fire the mounted laser cannon!" etc.
