### PR TITLE
Fixes #8696

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -189,7 +189,7 @@
 		var/obj/item/stack/stack = eating
 		stack.use(max(1, round(total_used/mass_per_sheet))) // Always use at least 1 to prevent infinite materials.
 	else
-		user.drop_item(O)
+		user.remove_from_mob(O)
 		del(O)
 
 	updateUsrDialog()

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -125,7 +125,7 @@
 	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
 		user << "You attach \the [W] into the assembly inner circuits."
 		upgrades += W
-		user.drop_item(W)
+		user.remove_from_mob(W)
 		W.loc = src
 		return
 

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -11,7 +11,7 @@ obj/machinery/seed_extractor/attackby(var/obj/item/O as obj, var/mob/user as mob
 	// Fruits and vegetables.
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown) || istype(O, /obj/item/weapon/grown))
 
-		user.drop_item(O)
+		user.remove_from_mob(O)
 
 		var/datum/seed/new_seed_type
 		if(istype(O, /obj/item/weapon/grown))

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -21,8 +21,7 @@
 	if (can_hang && !coat)
 		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
 		coat = W
-		user.drop_item(src)
-		coat.loc = src
+		user.drop_from_inventory(coat, src)
 		update_icon()
 	else
 		user << "<span class='notice'>You cannot hang [W] on [src]</span>"

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -61,7 +61,7 @@
 					user << "\red Unwield the axe first."
 					return
 				fireaxe = O
-				user.drop_item(O)
+				user.remove_from_mob(O)
 				src.contents += O
 				user << "\blue You place the fire axe back in the [src.name]."
 				update_icon()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -431,7 +431,7 @@
 		user.visible_message("<span class='danger'>The [src] was sliced apart by [user]!</span>")
 		destroy()
 
-	user.drop_item(src)
+	user.drop_item(src.loc)
 	return
 
 /obj/structure/table/proc/straight_table_check(var/direction)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -277,7 +277,7 @@
 		del(W)
 		return
 	else if (istype(W, /obj/item) && get_dist(src,user)<2)
-		user.drop_item(src)
+		user.drop_item(src.loc)
 		visible_message("<span class='notice'>[user] dunks [W] into the [src]!</span>", 3)
 		return
 

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -225,7 +225,7 @@
 /obj/machinery/seed_storage/proc/add(var/obj/item/seeds/O as obj)
 	if (istype(O.loc, /mob))
 		var/mob/user = O.loc
-		user.drop_item(O)
+		user.remove_from_mob(O)
 	else if(istype(O.loc,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = O.loc
 		S.remove_from_storage(O, src)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -165,7 +165,7 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/drop_r_hand(var/atom/Target)
 	return drop_from_inventory(r_hand, Target)
 
-//Drops the item in our active hand.
+//Drops the item in our active hand. TODO: rename this to drop_active_hand or something
 /mob/proc/drop_item(var/atom/Target)
 	if(hand)	return drop_l_hand(Target)
 	else		return drop_r_hand(Target)

--- a/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
+++ b/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
@@ -14,9 +14,8 @@
 		if(held_container)
 			user << "\red You must remove the [held_container] first."
 		else
-			user.drop_item(src)
 			held_container = W
-			held_container.loc = src
+			user.drop_from_inventory(held_container, src)
 			user << "\blue You put the [held_container] onto the [src]."
 			var/image/I = image("icon"=W, "layer"=FLOAT_LAYER)
 			underlays += I

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -377,9 +377,9 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("\blue [user] has transplanted \the [tool] into [target]'s [affected.name].", \
 		"\blue You have transplanted \the [tool] into [target]'s [affected.name].")
-		user.drop_item(tool)
 		var/obj/item/organ/O = tool
 		if(istype(O))
+			user.remove_from_mob(O)
 			O.replaced(target,affected)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
Items were being placed _inside_ the table.

Fixes #8696, and updates other usages of drop_item() where appropriate.
