### PR TITLE
Fixes runtime when attempting to latejoin into a deleted core

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -187,6 +187,11 @@
 	anchored = 1
 	state = 20//So it doesn't interact based on the above. Not really necessary.
 
+/obj/structure/AIcore/deactivated/Del()
+	if(src in empty_playable_ai_cores)
+		empty_playable_ai_cores -= src
+	..()
+
 /obj/structure/AIcore/deactivated/proc/load_ai(var/mob/living/silicon/ai/transfer, var/obj/item/device/aicard/card, var/mob/user)
 
 	if(!istype(transfer) || locate(/mob/living/silicon/ai) in src)


### PR DESCRIPTION
Title. Attempting to do this left you stranded on the lobby screen without admin intervention.
