### PR TITLE
Removes the bullshit ling meta message

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -463,7 +463,6 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 			// sending display messages
 			C << "<span class='notice'>We have regenerated.</span>"
-			C.visible_message("<span class='warning'>[src] appears to wake from the dead, having healed all wounds.</span>")
 
 
 	feedback_add_details("changeling_powers","FD")


### PR DESCRIPTION
The only thing it does is makes idiots go THIS GUY ROSE FROM THE DEAD LOOK LOOK HE IS AN ALIEN TOSS HIM OUT OF AN AIRLOCK when he didn't have any visible wounds and wasn't obviously dead in the first place. They still appear dead while regenerating, so a careful observation is your friend here.
