### PR TITLE
Reflex runtime fix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -374,6 +374,8 @@
 	yo = targloc.y - curloc.y
 	xo = targloc.x - curloc.x
 	target = targloc
+	original = target
+	starting = curloc
 
 	//plot the initial trajectory
 	setup_trajectory()

--- a/code/modules/projectiles/targeting.dm
+++ b/code/modules/projectiles/targeting.dm
@@ -236,7 +236,7 @@
 	if(!I.aim_targets.len)
 		del(I.aim_targets)
 	var/mob/living/T = I.loc //Remove the targeting icons
-	if(T && ismob(T) && !I.aim_targets)
+	if(T && ismob(T) && !I.aim_targets && T.client)
 		T.client.remove_gun_icons()
 	if(!targeted_by.len)
 		del target_locked //Remove the overlay


### PR DESCRIPTION
- Fixes #8738 
- Fixed runtime when stopping aiming at a target which has lost its connected client

I'm not sure what caused the line changes in projectile.dm, I'm using Sublime Text on Linux for editing now so I'm assuming it's related to that? Any tricks I need to know about the line endings? 
From what I can tell they were dos line endings originally, and should still be in this PR. All I used was pure git for committing, no third party tools.
