### PR TITLE
Vending Machine Fixes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -210,7 +210,7 @@
 		return
 	else if (istype(W, /obj/item/weapon/card/emag))
 		src.emagged = 1
-		user << "You short out the product lock on [src]"
+		user << "You short out the product lock on \the [src]"
 		return
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		src.panel_open = !src.panel_open
@@ -230,7 +230,7 @@
 		W.loc = src
 		coin = W
 		categories |= CAT_COIN
-		user << "\blue You insert the [W] into the [src]"
+		user << "\blue You insert \the [W] into \the [src]"
 		nanomanager.update_uis(src)
 		return
 	else if(istype(W, /obj/item/weapon/wrench))
@@ -240,9 +240,9 @@
 			switch (anchored)
 				if (0)
 					anchored = 1
-					user.visible_message("[user] tightens the bolts securing \the [src] to the floor.", "You tighten the bolts securing \the [src] to the floor.")
+					user.visible_message("\The [user] tightens the bolts securing \the [src] to the floor.", "You tighten the bolts securing \the [src] to the floor.")
 				if (1)
-					user.visible_message("[user] unfastens the bolts securing \the [src] to the floor.", "You unfasten the bolts securing \the [src] to the floor.")
+					user.visible_message("\The [user] unfastens the bolts securing \the [src] to the floor.", "You unfasten the bolts securing \the [src] to the floor.")
 					anchored = 0
 		return
 
@@ -272,7 +272,7 @@
 	if(istype(cashmoney, /obj/item/weapon/spacecash/bundle))
 		// Bundles can just have money subtracted, and will work
 
-		visible_message("<span class='info'>[usr] inserts some cash into [src].</span>")
+		visible_message("<span class='info'>\The [usr] inserts some cash into \the [src].</span>")
 		var/obj/item/weapon/spacecash/bundle/cashmoney_bundle = cashmoney
 		cashmoney_bundle.worth -= currently_vending.price
 
@@ -287,7 +287,7 @@
 		// This is really dirty, but there's no superclass for all bills, so we
 		// just assume that all spacecash that's not something else is a bill
 
-		visible_message("<span class='info'>[usr] inserts a bill into [src].</span>")
+		visible_message("<span class='info'>\The [usr] inserts a bill into \the [src].</span>")
 		var/left = cashmoney.worth - currently_vending.price
 		usr.drop_from_inventory(cashmoney)
 		del(cashmoney)
@@ -306,7 +306,7 @@
  * successful, 0 if failed.
  */
 /obj/machinery/vending/proc/pay_with_ewallet(var/obj/item/weapon/spacecash/ewallet/wallet)
-	visible_message("<span class='info'>[usr] swipes [wallet] through [src].</span>")
+	visible_message("<span class='info'>\The [usr] swipes \the [wallet] through \the [src].</span>")
 	if(currently_vending.price > wallet.worth)
 		src.status_message = "Insufficient funds on chargecard."
 		src.status_error = 1
@@ -323,10 +323,10 @@
  * successful, 0 if failed
  */
 /obj/machinery/vending/proc/pay_with_card(var/obj/item/weapon/card/id/I, var/obj/item/ID_container)
-	if(ID_container)
-		visible_message("<span class='info'>[usr] swipes [ID_container] through [src].</span>")
+	if(I==ID_container || ID_container == null)
+		visible_message("<span class='info'>\The [usr] swipes \the [I] through \the [src].</span>")
 	else
-		visible_message("<span class='info'>[usr] swipes [I] through [src].</span>")
+		visible_message("<span class='info'>\The [usr] swipes \the [ID_container] through \the [src].</span>")
 	var/datum/money_account/customer_account = get_account(I.associated_account_number)
 	if (!customer_account)
 		src.status_message = "Error: Unable to access account. Please contact technical support if problem persists."
@@ -538,7 +538,7 @@
 			return
 		if(coin.string_attached)
 			if(prob(50))
-				user << "\blue You successfully pull the coin out before the [src] could swallow it."
+				user << "\blue You successfully pull the coin out before \the [src] could swallow it."
 			else
 				user << "\blue You weren't able to pull the coin out fast enough, the machine ate it, string and all."
 				del(coin)
@@ -567,7 +567,7 @@
 
 /obj/machinery/vending/proc/stock(var/datum/data/vending_product/R, var/mob/user)
 	if(src.panel_open)
-		user << "\blue You stock the [src] with \a [R.product_name]"
+		user << "\blue You stock \the [src] with \a [R.product_name]"
 		R.amount++
 
 	nanomanager.update_uis(src)
@@ -601,7 +601,7 @@
 		return
 
 	for(var/mob/O in hearers(src, null))
-		O.show_message("<span class='game say'><span class='name'>[src]</span> beeps, \"[message]\"",2)
+		O.show_message("<span class='game say'><span class='name'>\The [src]</span> beeps, \"[message]\"",2)
 	return
 
 /obj/machinery/vending/power_change()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -179,29 +179,16 @@
 	return
 
 /obj/machinery/vending/attackby(obj/item/weapon/W as obj, mob/user as mob)
+
+	var/obj/item/weapon/card/id/I = W.GetID()
+
 	if (currently_vending && vendor_account && !vendor_account.suspended)
 		var/paid = 0
 		var/handled = 0
-		if(istype(W, /obj/item/weapon/card/id))
-			var/obj/item/weapon/card/id/C = W
-			paid = pay_with_card(C)
+
+		if (I) //for IDs and PDAs and wallets with IDs
+			paid = pay_with_card(I,W)
 			handled = 1
-		else if (istype(W, /obj/item/device/pda))
-			var/obj/item/device/pda/C = W
-			if(C.id)
-				paid = pay_with_card(C.id,"\improper PDA")
-				handled = 1
-			else
-				user << "There is no ID in [C]"
-				return
-		else if (istype(W, /obj/item/weapon/storage/wallet))
-			var/obj/item/weapon/storage/wallet/C = W
-			if(C.front_id)
-				paid = pay_with_card(C.front_id,"wallet")
-				handled = 1
-			else
-				user << "There is no ID in [C]"
-				return
 		else if (istype(W, /obj/item/weapon/spacecash/ewallet))
 			var/obj/item/weapon/spacecash/ewallet/C = W
 			paid = pay_with_ewallet(C)
@@ -218,7 +205,7 @@
 			nanomanager.update_uis(src)
 			return // don't smack that machine with your 2 thalers
 
-	if (istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda) || istype(W, /obj/item/weapon/storage/wallet) || istype(W, /obj/item/weapon/spacecash/ewallet) || istype(W, /obj/item/weapon/spacecash))
+	if (I || istype(W, /obj/item/weapon/spacecash))
 		attack_hand(user)
 		return
 	else if (istype(W, /obj/item/weapon/card/emag))
@@ -319,7 +306,7 @@
  * successful, 0 if failed.
  */
 /obj/machinery/vending/proc/pay_with_ewallet(var/obj/item/weapon/spacecash/ewallet/wallet)
-	visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
+	visible_message("<span class='info'>[usr] swipes [wallet] through [src].</span>")
 	if(currently_vending.price > wallet.worth)
 		src.status_message = "Insufficient funds on chargecard."
 		src.status_error = 1
@@ -335,11 +322,11 @@
  * Takes payment for whatever is the currently_vending item. Returns 1 if
  * successful, 0 if failed
  */
-/obj/machinery/vending/proc/pay_with_card(var/obj/item/weapon/card/id/I, var/container_name = null)
-	if(container_name)
-		visible_message("<span class='info'>[usr] swipes \an [container_name] through [src].</span>")
+/obj/machinery/vending/proc/pay_with_card(var/obj/item/weapon/card/id/I, var/obj/item/ID_container)
+	if(ID_container)
+		visible_message("<span class='info'>[usr] swipes [ID_container] through [src].</span>")
 	else
-		visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
+		visible_message("<span class='info'>[usr] swipes [I] through [src].</span>")
 	var/datum/money_account/customer_account = get_account(I.associated_account_number)
 	if (!customer_account)
 		src.status_message = "Error: Unable to access account. Please contact technical support if problem persists."

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -186,6 +186,22 @@
 			var/obj/item/weapon/card/id/C = W
 			paid = pay_with_card(C)
 			handled = 1
+		else if (istype(W, /obj/item/device/pda))
+			var/obj/item/device/pda/C = W
+			if(C.id)
+				paid = pay_with_card(C.id,"\improper PDA")
+				handled = 1
+			else
+				user << "There is no ID in [C]"
+				return
+		else if (istype(W, /obj/item/weapon/storage/wallet))
+			var/obj/item/weapon/storage/wallet/C = W
+			if(C.front_id)
+				paid = pay_with_card(C.front_id,"wallet")
+				handled = 1
+			else
+				user << "There is no ID in [C]"
+				return
 		else if (istype(W, /obj/item/weapon/spacecash/ewallet))
 			var/obj/item/weapon/spacecash/ewallet/C = W
 			paid = pay_with_ewallet(C)
@@ -202,7 +218,10 @@
 			nanomanager.update_uis(src)
 			return // don't smack that machine with your 2 thalers
 
-	if (istype(W, /obj/item/weapon/card/emag))
+	if (istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda) || istype(W, /obj/item/weapon/storage/wallet) || istype(W, /obj/item/weapon/spacecash/ewallet) || istype(W, /obj/item/weapon/spacecash))
+		attack_hand(user)
+		return
+	else if (istype(W, /obj/item/weapon/card/emag))
 		src.emagged = 1
 		user << "You short out the product lock on [src]"
 		return
@@ -316,8 +335,11 @@
  * Takes payment for whatever is the currently_vending item. Returns 1 if
  * successful, 0 if failed
  */
-/obj/machinery/vending/proc/pay_with_card(var/obj/item/weapon/card/id/I)
-	visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
+/obj/machinery/vending/proc/pay_with_card(var/obj/item/weapon/card/id/I, var/container_name = null)
+	if(container_name)
+		visible_message("<span class='info'>[usr] swipes \an [container_name] through [src].</span>")
+	else
+		visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
 	var/datum/money_account/customer_account = get_account(I.associated_account_number)
 	if (!customer_account)
 		src.status_message = "Error: Unable to access account. Please contact technical support if problem persists."

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -1,5 +1,5 @@
 /obj/item/device/eftpos
-	name = "EFTPOS scanner"
+	name = "\improper EFTPOS scanner"
 	desc = "Swipe your ID card to make purchases electronically."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "eftpos"
@@ -110,11 +110,13 @@
 	else
 		user << browse(null,"window=eftpos")
 
-/obj/item/device/eftpos/attackby(O as obj, user as mob)
-	if(istype(O, /obj/item/weapon/card))
+/obj/item/device/eftpos/attackby(obj/item/O as obj, user as mob)
+
+	var/obj/item/weapon/card/id/I = O.GetID()
+
+	if(I)
 		if(linked_account)
-			var/obj/item/weapon/card/I = O
-			scan_card(I)
+			scan_card(I, O)
 		else
 			usr << "\icon[src]<span class='warning'>Unable to connect to linked account.</span>"
 	else if (istype(O, /obj/item/weapon/spacecash/ewallet))
@@ -124,7 +126,7 @@
 				if(transaction_locked && !transaction_paid)
 					if(transaction_amount <= E.worth)
 						playsound(src, 'sound/machines/chime.ogg', 50, 1)
-						src.visible_message("\icon[src] The [src] chimes.")
+						src.visible_message("\icon[src] \The [src] chimes.")
 						transaction_paid = 1
 
 						//transfer the money
@@ -141,7 +143,7 @@
 						T.time = worldtime2text()
 						linked_account.transaction_log.Add(T)
 					else
-						usr << "\icon[src]<span class='warning'>The charge card doesn't have that much money!</span>"
+						usr << "\icon[src]<span class='warning'>\The [O] doesn't have that much money!</span>"
 			else
 				usr << "\icon[src]<span class='warning'>Connected account has been suspended.</span>"
 		else
@@ -225,10 +227,13 @@
 
 	src.attack_self(usr)
 
-/obj/item/device/eftpos/proc/scan_card(var/obj/item/weapon/card/I)
+/obj/item/device/eftpos/proc/scan_card(var/obj/item/weapon/card/I, var/obj/item/ID_container)
 	if (istype(I, /obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/C = I
-		visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
+		if(I==ID_container || ID_container == null)
+			usr.visible_message("<span class='info'>\The [usr] swipes a card through \the [src].</span>")
+		else
+			usr.visible_message("<span class='info'>\The [usr] swipes \the [ID_container] through \the [src].</span>")
 		if(transaction_locked && !transaction_paid)
 			if(linked_account)
 				if(!linked_account.suspended)
@@ -242,7 +247,7 @@
 						if(!D.suspended)
 							if(transaction_amount <= D.money)
 								playsound(src, 'sound/machines/chime.ogg', 50, 1)
-								src.visible_message("\icon[src] The [src] chimes.")
+								src.visible_message("\icon[src] \The [src] chimes.")
 								transaction_paid = 1
 
 								//transfer the money
@@ -283,13 +288,13 @@
 	else if (istype(I, /obj/item/weapon/card/emag))
 		if(transaction_locked)
 			if(transaction_paid)
-				usr << "\icon[src]<span class='info'>You stealthily swipe [I] through [src].</span>"
+				usr << "\icon[src]<span class='info'>You stealthily swipe \the [I] through \the [src].</span>"
 				transaction_locked = 0
 				transaction_paid = 0
 			else
-				visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
+				usr.visible_message("<span class='info'>\The [usr] swipes a card through \the [src].</span>")
 				playsound(src, 'sound/machines/chime.ogg', 50, 1)
-				src.visible_message("\icon[src] The [src] chimes.")
+				src.visible_message("\icon[src] \The [src] chimes.")
 				transaction_paid = 1
 	else
 		..()

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -57,6 +57,15 @@ should be listed in the changelog upon commit though. Thanks. -->
 <!-- DO NOT REMOVE, MOVE, OR COPY THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>7 April 2015</h2>
+	<h3 class='author'>RavingManiac updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='tweak'>You can now pay vending machines without removing your ID from your PDA or wallet. Clicking on the vending machine with your ID/PDA/wallet/cash also brings up the menu now instead of attacking the vending machine.</li>
+	</ul>
+</div>
+
+
+<div class='commit sansserif'>
 	<h2 class='date'>24 February 2015</h2>
 	<h3 class='author'>Zuhayr updated:</h3>
 	<ul class='changes bgimages16'>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -60,7 +60,7 @@ should be listed in the changelog upon commit though. Thanks. -->
 	<h2 class='date'>7 April 2015</h2>
 	<h3 class='author'>RavingManiac updated:</h3>
 	<ul class='changes bgimages16'>
-		<li class='tweak'>You can now pay vending machines without removing your ID from your PDA or wallet. Clicking on the vending machine with your ID/PDA/wallet/cash also brings up the menu now instead of attacking the vending machine.</li>
+		<li class='tweak'>You can now pay vending machines and EFTPOS scanners without removing your ID from your PDA or wallet. Clicking on the vending machine with your ID/PDA/wallet/cash also brings up the menu now instead of attacking the vending machine.</li>
 	</ul>
 </div>
 


### PR DESCRIPTION
Player can now pay vending machines and EFTPOS scanners without removing ID from PDA or wallet. Clicking on the vending machine with ID/PDA/wallet/cash also brings up the menu instead of attacking the vending machine.
