### PR TITLE
Eye runtime fixes.

### DIFF
--- a/code/modules/mob/freelook/ai/eye.dm
+++ b/code/modules/mob/freelook/ai/eye.dm
@@ -36,11 +36,13 @@
 	eyeobj.owner = src
 	eyeobj.name = "[src.name] (AI Eye)" // Give it a name
 	spawn(5)
-		eyeobj.loc = src.loc
+		if(eyeobj)
+			eyeobj.loc = src.loc
 
 /mob/living/silicon/ai/Del()
-	eyeobj.owner = null
-	del(eyeobj) // No AI, no Eye
+	if(eyeobj)
+		eyeobj.owner = null
+		del(eyeobj) // No AI, no Eye
 	..()
 
 /atom/proc/move_camera_by_click()

--- a/code/modules/mob/freelook/eye.dm
+++ b/code/modules/mob/freelook/eye.dm
@@ -36,7 +36,7 @@ mob/eye/Del()
 		ghost_darkness_images -= ghostimage
 		ghost_sightless_images -= ghostimage
 		del(ghostimage)
-		ghostimage = null;
+		ghostimage = null
 		updateallghostimages()
 	..()
 


### PR DESCRIPTION
Ensures the spawn in ai/New() doesn't attempt to update eyeobj if the AI was deleted before the timer.
