### PR TITLE
Fixes NanoUI interaction.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -627,7 +627,7 @@ About the new airlock wires panel:
 				user << "<span class='warning'>Unable to interface: Connection refused.</span>"
 		return STATUS_CLOSE
 
-	return STATUS_INTERACTIVE
+	return ..()
 
 /obj/machinery/door/airlock/Topic(href, href_list, var/nowindow = 0)
 	if(..())

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -214,7 +214,7 @@
 		usr << "<span class='notice'>\The [src] has to be secured first!</span>"
 		return STATUS_CLOSE
 
-	return STATUS_INTERACTIVE
+	return ..()
 
 
 /obj/machinery/porta_turret/Topic(href, href_list, var/nowindow = 0)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -79,7 +79,7 @@
 	if(isLocked(user))
 		return STATUS_CLOSE
 
-	return STATUS_INTERACTIVE
+	return ..()
 
 /obj/machinery/turretid/attackby(obj/item/weapon/W, mob/user)
 	if(stat & BROKEN)

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -9,7 +9,7 @@
 	return list()
 
 /datum/topic_state/proc/can_use_topic(var/src_object, var/mob/user)
-	return STATUS_INTERACTIVE
+	return STATUS_CLOSE
 
 /mob/proc/shared_nano_interaction()
 	if (src.stat || !client)

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -1,4 +1,4 @@
-/var/global/datum/topic_state/default_state = new()
+/var/global/datum/topic_state/default/default_state = new()
 
 /datum/topic_state/default/href_list(var/mob/user)
 	return list()


### PR DESCRIPTION
A number of machinery objects were returning STATUS_INTERACTIVE instead of parent.
Fixes missing subtype definition for /var/global/datum/topic_state/default/default_state.
