### PR TITLE
Makes objects without moues opacity not appear via alt-click.

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -29,6 +29,10 @@
 	else if(istype(target,/obj/effect/decal/cleanable))
 		user << "<span class='notice'>You scrub \the [target.name] out.</span>"
 		del(target)
+	else if(istype(target,/turf))
+		user << "<span class='notice'>You scrub \the [target.name] clean.</span>"
+		var/turf/T = target
+		T.clean()
 	else
 		user << "<span class='notice'>You clean \the [target.name].</span>"
 		target.clean_blood()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -823,6 +823,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 		else
 			statpanel(listed_turf.name, null, listed_turf)
 			for(var/atom/A in listed_turf)
+				if(!A.mouse_opacity)
+					continue
 				if(A.invisibility > see_invisible)
 					continue
 				if(is_type_in_list(A, shouldnt_see))


### PR DESCRIPTION
Prevents clicking objects you should not be able to click.
Based on https://github.com/tgstation/-tg-station/pull/8982.
