### PR TITLE
Allow admins to drag-drop ghosts into mobs.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1255,3 +1255,28 @@ var/global/floorIsLava = 0
 //ALL DONE
 //*********************************************************************************************************
 //
+
+/datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)
+	if(!istype(frommob))
+		return //Extra sanity check to make sure only observers are shoved into things
+
+	//Same as assume-direct-control perm requirements.
+	if (!check_rights(R_VAREDIT,0) || !check_rights(R_ADMIN|R_DEBUG,0))
+		return 0
+	if (!frommob.ckey)
+		return 0
+	var/question = ""
+	if (tomob.ckey)
+		question = "This mob already has a user ([tomob.key]) in control of it! "
+	question += "Are you sure you want to place [frommob.name]([frommob.key]) in control of [tomob.name]?"
+	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
+	if (ask != "Yes")
+		return 1
+	if(tomob.client) //No need to ghostize if there is no client
+		tomob.ghostize(0)
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
+	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
+	feedback_add_details("admin_verb","CGD")
+	tomob.ckey = frommob.ckey
+	qdel(frommob)
+	return 1

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -482,6 +482,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 
+//This is called when a ghost is drag clicked to something.
+/mob/dead/observer/MouseDrop(atom/over)
+	if (isobserver(usr) && usr.client && usr.client.holder && isliving(over))
+		if (usr.client.holder.cmd_ghost_drag(src,over))
+			return
+
+	return ..()
+
 //Used for drawing on walls with blood puddles as a spooky ghost.
 /mob/dead/verb/bloody_doodle()
 


### PR DESCRIPTION
This functions the same way as editing the ckey in vv.
Has the same permission check as assume-direct-control or var edit.
The admin in question will be asked whether or not to complete the ghost transfer.
If the target mob is already owned by another ckey the popup will include a warning and ghostize the owner if the admin still proceeds.

All the cool kids are doing it: https://github.com/tgstation/-tg-station/pull/8957, https://github.com/ParadiseSS13/Paradise/pull/813
