### PR TITLE
Adds Hardsuit Module tab.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -46,6 +46,10 @@
 	var/obj/item/ai_card  // Reference to the MMI, posibrain, intellicard or pAI card previously holding the AI.
 	var/obj/item/ai_verbs/verb_holder
 
+/obj/item/rig_module/ai_container/process()
+	if(integrated_ai && loc)
+		integrated_ai.SetupStat(loc.get_rig())
+
 /obj/item/rig_module/ai_container/proc/update_verb_holder()
 	if(!verb_holder)
 		verb_holder = new(src)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -52,6 +52,8 @@
 	var/activate_string = "Activate"
 	var/deactivate_string = "Deactivate"
 
+	var/list/stat_rig_module/stat_modules = new()
+
 /obj/item/rig_module/examine()
 	..()
 	switch(damage)
@@ -126,7 +128,11 @@
 
 		charges = processed_charges
 
-	..()
+	stat_modules +=	new/stat_rig_module/activate(src)
+	stat_modules +=	new/stat_rig_module/deactivate(src)
+	stat_modules +=	new/stat_rig_module/engage(src)
+	stat_modules +=	new/stat_rig_module/select(src)
+	stat_modules +=	new/stat_rig_module/charge(src)
 
 // Called when the module is installed into a suit.
 /obj/item/rig_module/proc/installed(var/obj/item/weapon/rig/new_holder)
@@ -218,4 +224,111 @@
 // Called by holder rigsuit attackby()
 // Checks if an item is usable with this module and handles it if it is
 /obj/item/rig_module/proc/accepts_item(var/obj/item/input_device)
+	return 0
+
+/mob/living/carbon/human/Stat()
+	..()
+
+	if(istype(back,/obj/item/weapon/rig))
+		var/obj/item/weapon/rig/R = back
+		SetupStat(R)
+
+/mob/proc/SetupStat(var/obj/item/weapon/rig/R)
+	if(R && !R.canremove && R.installed_modules.len && statpanel("Hardsuit Modules"))
+		var/cell_status = R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "ERROR"
+		statpanel("Hardsuit Modules", "Suit charge", cell_status)
+		for(var/obj/item/rig_module/module in R.installed_modules)
+		{
+			for(var/stat_rig_module/SRM in module.stat_modules)
+				if(SRM.CanUse())
+					statpanel("Hardsuit Modules",SRM.module.interface_name,SRM)
+		}
+
+/stat_rig_module
+	parent_type = /atom/movable
+	var/module_mode = ""
+	var/obj/item/rig_module/module
+
+/stat_rig_module/New(var/obj/item/rig_module/module)
+	..()
+	src.module = module
+
+/stat_rig_module/proc/AddHref(var/list/href_list)
+	return
+
+/stat_rig_module/proc/CanUse()
+	return 0
+
+/stat_rig_module/Click()
+	..()
+	if(CanUse())
+		var/list/href_list = list(
+							"interact_module" = module.holder.installed_modules.Find(module),
+							"module_mode" = module_mode
+							)
+		AddHref(href_list)
+		module.holder.Topic(usr, href_list)
+
+/stat_rig_module/activate/New(var/obj/item/rig_module/module)
+	..()
+	name = module.activate_string
+	if(module.active_power_cost)
+		name += " ([module.active_power_cost*10]A)"
+	module_mode = "activate"
+
+/stat_rig_module/activate/CanUse()
+	return module.toggleable && !module.active
+
+/stat_rig_module/deactivate/New(var/obj/item/rig_module/module)
+	..()
+	name = module.deactivate_string
+	// Show cost despite being 0, if it means changing from an active cost.
+	if(module.active_power_cost || module.passive_power_cost)
+		name += " ([module.passive_power_cost*10]P)"
+
+	module_mode = "deactivate"
+
+/stat_rig_module/deactivate/CanUse()
+	return module.toggleable && module.active
+
+/stat_rig_module/engage/New(var/obj/item/rig_module/module)
+	..()
+	name = module.engage_string
+	if(module.use_power_cost)
+		name += " ([module.use_power_cost*10]E)"
+	module_mode = "engage"
+
+/stat_rig_module/engage/CanUse()
+	return module.usable
+
+/stat_rig_module/select/New()
+	..()
+	name = "Select"
+	module_mode = "select"
+
+/stat_rig_module/select/CanUse()
+	if(module.selectable)
+		name = module.holder.selected_module == module ? "Selected" : "Select"
+		return 1
+	return 0
+
+/stat_rig_module/charge/New()
+	..()
+	name = "Change Charge"
+	module_mode = "select_charge_type"
+
+/stat_rig_module/charge/AddHref(var/list/href_list)
+	var/charge_index = module.charges.Find(module.charge_selected)
+	if(!charge_index)
+		charge_index = 0
+	else
+		charge_index = charge_index == module.charges.len ? 1 : charge_index+1
+
+	href_list["charge_type"] = module.charges[charge_index]
+
+/stat_rig_module/charge/CanUse()
+	if(module.charges && module.charges.len)
+		var/datum/rig_charge/charge = module.charges[module.charge_selected]
+		name = "[charge.display_name] ([charge.charges]C) - Change"
+		return 1
 	return 0

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -776,6 +776,14 @@
 		return 0
 	wearer.Move(null,dir)*/
 
+/atom/proc/get_rig()
+	if(loc)
+		return loc.get_rig()
+	return null
+
+/obj/item/weapon/rig/get_rig()
+	return src
+
 #undef ONLY_DEPLOY
 #undef ONLY_RETRACT
 #undef SEAL_DELAY

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -35,7 +35,6 @@
 
 	var/locked = 0
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
-	var/mob/living/silicon/robot = null//Appears unused.
 	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
 
 	attackby(var/obj/item/O as obj, var/mob/user as mob)


### PR DESCRIPTION
Allows one to (de)activate, engage, select and change module charges from the new   "Hardsuit Modules" tab panel. Not as informative as NanoUI but allows for swifter access.
Basic idea similar to spells, made by popular nag.

Works for the suit operator, should hopefully work for any integrated AIs.
![New player tab.](https://www.dropbox.com/s/5y9xcyh5xatnk1t/RigModuleStatPanel.png?dl=1)
The numbers have different suffixes depending on source.
A is the cost while the module is Active. Displayed while passive.
P is the cost while the module is Passive. Displayed while active.
E is the cost of Engaging the module.
C is the number of remaining Charges for the currently selected source.
