### PR TITLE
Sound environments

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -56,7 +56,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/air_doors_activated = 0
 	var/list/ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
 	var/sound/forced_ambience = null
-
+	var/sound_env = 2	//reverb preset for sounds played in this area, see sound datum reference for more
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()
@@ -807,6 +807,9 @@ area/space/atmosalert()
 
 
 //Hallway
+
+/area/hallway/primary/
+	sound_env = 12 //hallway
 
 /area/hallway/primary/fore
 	name = "\improper Fore Primary Hallway"

--- a/code/game/area/asteroid_areas.dm
+++ b/code/game/area/asteroid_areas.dm
@@ -3,6 +3,7 @@
 /area/mine
 	icon_state = "mining"
 	music = 'sound/ambience/song_game.ogg'
+	sound_env = 5 //stoneroom
 
 /area/mine/explored
 	name = "Mine"

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -53,34 +53,34 @@ var/const/FALLOFF_SOUNDS = 0.5
 	if(isturf(turf_source))
 		// 3D sounds, the technology is here!
 		var/turf/T = get_turf(src)
-		
+
 		//sound volume falloff with distance
 		var/distance = get_dist(T, turf_source)
-		
+
 		S.volume -= max(distance - world.view, 0) * 2 //multiplicative falloff to add on top of natural audio falloff.
-		
+
 		//sound volume falloff with pressure
 		var/pressure_factor = 1.0
-		
+
 		var/datum/gas_mixture/hearer_env = T.return_air()
 		var/datum/gas_mixture/source_env = turf_source.return_air()
-		
+
 		if (hearer_env && source_env)
 			var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
-			
+
 			if (pressure < ONE_ATMOSPHERE)
 				pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
 		else //in space
 			pressure_factor = 0
-		
+
 		if (distance <= 1)
 			pressure_factor = max(pressure_factor, 0.15)	//hearing through contact
-		
+
 		S.volume *= pressure_factor
-		
+
 		if (S.volume <= 0)
 			return	//no volume means no sound
-		
+
 		var/dx = turf_source.x - T.x // Hearing from the right/left
 		S.x = dx
 		var/dz = turf_source.y - T.y // Hearing from infront/behind
@@ -88,8 +88,11 @@ var/const/FALLOFF_SOUNDS = 0.5
 		// The y value is for above your head, but there is no ceiling in 2d spessmens.
 		S.y = 1
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
+
 	if(!is_global)
-		S.environment = 2
+		var/area/A = get_area(src)
+		S.environment = A.sound_env
+
 	src << S
 
 /client/proc/playtitlemusic()


### PR DESCRIPTION
Areas can now set their sound environments. Default is still 2 (room). For now only hallways and asteroid areas have different ones (hallway and stoneroom respectively)
