### PR TITLE
Changes SM alerts to Engineering frequency

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -47,6 +47,7 @@
 	var/damage_archived = 0
 	var/safe_alert = "Crystaline hyperstructure returning to safe operating levels."
 	var/safe_warned = 0
+	var/public_alert = 0 //Stick to Engineering frequency except for big warnings when integrity bad
 	var/warning_point = 100
 	var/warning_alert = "Danger! Crystal hyperstructure instability!"
 	var/emergency_point = 700
@@ -88,7 +89,7 @@
 
 /obj/machinery/power/supermatter/New()
 	. = ..()
-	radio = new (src)
+	radio = new /obj/item/device/radio{channels=list("Engineering")}(src)
 
 
 /obj/machinery/power/supermatter/Del()
@@ -126,7 +127,7 @@
 	integrity = round(100 - integrity * 100)
 	integrity = integrity < 0 ? 0 : integrity
 	var/alert_msg = " Integrity at [integrity]%"
-
+	
 	if(damage > emergency_point)
 		alert_msg = emergency_alert + alert_msg
 		lastwarning = world.timeofday - WARNING_DELAY * 4
@@ -141,7 +142,15 @@
 	else
 		alert_msg = null
 	if(alert_msg)
-		radio.autosay(alert_msg, "Supermatter Monitor")
+		radio.autosay(alert_msg, "Supermatter Monitor", "Engineering")
+		//Public alerts
+		if((damage > emergency_point) && !public_alert)
+			radio.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor")
+			public_alert = 1
+		else if(safe_warned && public_alert)
+			radio.autosay(alert_msg, "Supermatter Monitor")
+			public_alert = 0
+		
 
 /obj/machinery/power/supermatter/process()
 


### PR DESCRIPTION
As per complete landslide vote in http://www.baystation12.net/forums/viewtopic.php?f=5&t=12462.

Supermatter now broadcast alert messages over Engineering frequency except under two circumstances, which are:

One alert when the crystal becomes critical (Below 30% integrity) so medbay and other appropriate departments can prepare/evac impending doom.

When the crystal recovers to tell people to stop panicking.
