### PR TITLE
Fix speed and add rotate()

### DIFF
--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -96,7 +96,7 @@
 			adjust_speed(0, -get_acceleration())
 
 
-/obj/effect/map/ship/rotate(var/direction)
+/obj/effect/map/ship/proc/rotate(var/direction)
 	var/matrix/M = matrix()
 	M.Turn(dir2angle(direction))
 	src.transform = M //Rotate ship

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -71,7 +71,7 @@
 /obj/effect/map/ship/proc/get_brake_path()
 	if(!get_acceleration())
 		return INFINITY
-	return max(abs(speed[1]),abs(speed[2]))/get_acceleration()
+	return get_speed()/get_acceleration()
 
 #define SIGN(X) (X == 0 ? 0 : (X > 0 ? 1 : -1))
 /obj/effect/map/ship/proc/decelerate()

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -8,7 +8,6 @@
 	var/last_burn = 0
 	var/list/last_movement = list(0,0)
 	var/fore_dir = NORTH
-	var/standart_icon
 
 	var/obj/effect/map/current_sector
 	var/obj/machinery/computer/helm/nav_control
@@ -50,6 +49,11 @@
 			res |= NORTH
 		else
 			res |= SOUTH
+
+	var/matrix/M = matrix()
+	M.Turn([dir2angle(res))
+	src.transform = M //Rotate ship
+
 	return res
 
 /obj/effect/map/ship/proc/adjust_speed(n_x, n_y)
@@ -106,8 +110,3 @@
 		var/turf/newloc = locate(x + deltas[1], y + deltas[2], z)
 		if(newloc)
 			Move(newloc)
-		rotate()
-
-/obj/effect/map/ship/proc/rotate()
-	var/direct = get_heading()
-	src.icon = turn(src.standart_icon,dir2angle(direct))

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -8,6 +8,7 @@
 	var/last_burn = 0
 	var/list/last_movement = list(0,0)
 	var/fore_dir = NORTH
+	var/standart_icon
 
 	var/obj/effect/map/current_sector
 	var/obj/machinery/computer/helm/nav_control
@@ -23,6 +24,7 @@
 			nav_control = H
 			break
 	processing_objects.Add(src)
+	standart_icon = icon
 
 /obj/effect/map/ship/relaymove(mob/user, direction)
 	accelerate(direction)
@@ -98,9 +100,14 @@
 	if(!is_still())
 		var/list/deltas = list(0,0)
 		for(var/i=1, i<=2, i++)
-			if(speed[i] && world.time > last_movement[i] + default_delay - speed[i])
+			if(speed[i] && world.time > last_movement[i] + default_delay - abs(speed[i]))
 				deltas[i] = speed[i] > 0 ? 1 : -1
 				last_movement[i] = world.time
 		var/turf/newloc = locate(x + deltas[1], y + deltas[2], z)
 		if(newloc)
 			Move(newloc)
+		rotate()
+
+/obj/effect/map/ship/proc/rotate()
+	var/direct = get_heading()
+	src.icon = turn(src.standart_icon,dir2angle(direct))

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -23,7 +23,6 @@
 			nav_control = H
 			break
 	processing_objects.Add(src)
-	standart_icon = icon
 
 /obj/effect/map/ship/relaymove(mob/user, direction)
 	accelerate(direction)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -8,6 +8,7 @@
 	var/last_burn = 0
 	var/list/last_movement = list(0,0)
 	var/fore_dir = NORTH
+	var/rotate = 1 //For proc rotate
 
 	var/obj/effect/map/current_sector
 	var/obj/machinery/computer/helm/nav_control
@@ -48,11 +49,6 @@
 			res |= NORTH
 		else
 			res |= SOUTH
-
-	var/matrix/M = matrix()
-	M.Turn(dir2angle(res))
-	src.transform = M //Rotate ship
-
 	return res
 
 /obj/effect/map/ship/proc/adjust_speed(n_x, n_y)
@@ -99,6 +95,12 @@
 		if(direction & SOUTH)
 			adjust_speed(0, -get_acceleration())
 
+
+/obj/effect/map/ship/rotate(var/direction)
+	var/matrix/M = matrix()
+	M.Turn(dir2angle(direction))
+	src.transform = M //Rotate ship
+
 /obj/effect/map/ship/process()
 	if(!is_still())
 		var/list/deltas = list(0,0)
@@ -109,3 +111,5 @@
 		var/turf/newloc = locate(x + deltas[1], y + deltas[2], z)
 		if(newloc)
 			Move(newloc)
+		if(rotate)	
+			rotate(get_heading())

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -51,7 +51,7 @@
 			res |= SOUTH
 
 	var/matrix/M = matrix()
-	M.Turn([dir2angle(res))
+	M.Turn(dir2angle(res))
 	src.transform = M //Rotate ship
 
 	return res

--- a/html/changelogs/Dennok-PR-8879.yml
+++ b/html/changelogs/Dennok-PR-8879.yml
@@ -1,0 +1,6 @@
+author: Dennok
+delete-after: True
+
+changes:
+  - bugfix: "Fix don't correct process() delay calculation."
+  - rscadd: "Added a rotate() proc to ship, and rotate var for don't rotatable ships."


### PR DESCRIPTION
If move NORTH and EAST  speed[i] be + and "last_movement[i] + default_delay - speed[i]" decrease but if move SOUTH and WEST  speed[i] be - and "last_movement[i] + default_delay - speed[i]" increase. abs(speed[i]) Fix it. "last_movement[i] + default_delay -abs(speed[i])" always decrease.

rotate() rotate ship icon in move dir.(Don't need a make additional dir sprites)
