### PR TITLE
Fixes  #8490.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1272,10 +1272,12 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 	equipment = 0
 	environ = 0
 	update()
+	update_icon()
 
 	spawn(600)
 		update_channels()
 		update()
+		update_icon()
 	..()
 
 /obj/machinery/power/apc/ex_act(severity)


### PR DESCRIPTION
Fixes  #8490.
Now properly calls update icon on EMP effect changes.
