### PR TITLE
Clean server start.

### DIFF
--- a/code/ZAS/Controller.dm
+++ b/code/ZAS/Controller.dm
@@ -98,7 +98,7 @@ Class Procs:
 	set background = 1
 	#endif
 
-	world << "<span class='danger'>Processing Geometry...</span>"
+	admin_notice("<span class='danger'>Processing Geometry...</span>", R_DEBUG)
 	sleep(-1)
 
 	var/start_time = world.timeofday
@@ -109,14 +109,14 @@ Class Procs:
 		simulated_turf_count++
 		S.update_air_properties()
 
-	world << {"<span class='danger'>Geometry initialized in [round(0.1*(world.timeofday-start_time),0.1)] seconds.</b></span>
+	admin_notice({"<span class='danger'>Geometry initialized in [round(0.1*(world.timeofday-start_time),0.1)] seconds.</b></span>
 <span class='info'>
 Total Simulated Turfs: [simulated_turf_count]
 Total Zones: [zones.len]
 Total Edges: [edges.len]
 Total Active Edges: [active_edges.len ? "<span class='danger'>[active_edges.len]</span>" : "None"]
 Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_count]</font>
-</span>"}
+</span>"}, R_DEBUG)
 
 
 //	spawn Start()

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -26,7 +26,7 @@ datum/controller/game_controller/New()
 		job_master = new /datum/controller/occupations()
 		job_master.SetupOccupations()
 		job_master.LoadJobs("config/jobs.txt")
-		world << "<span class='danger'>Job setup complete</span>"
+		admin_notice("<span class='danger'>Job setup complete</span>", R_DEBUG)
 
 	if(!syndicate_code_phrase)		syndicate_code_phrase	= generate_code_phrase()
 	if(!syndicate_code_response)	syndicate_code_response	= generate_code_phrase()
@@ -46,17 +46,17 @@ datum/controller/game_controller/proc/setup()
 
 
 datum/controller/game_controller/proc/setup_objects()
-	world << "<span class='danger'>Initializing objects</span>"
+	admin_notice("<span class='danger'>Initializing objects</span>", R_DEBUG)
 	sleep(-1)
 	for(var/atom/movable/object in world)
 		object.initialize()
 
-	world << "<span class='danger'>Initializing pipe networks</span>"
+	admin_notice("<span class='danger'>Initializing pipe networks</span>", R_DEBUG)
 	sleep(-1)
 	for(var/obj/machinery/atmospherics/machine in machines)
 		machine.build_network()
 
-	world << "<span class='danger'>Initializing atmos machinery.</span>"
+	admin_notice("<span class='danger'>Initializing atmos machinery.</span>", R_DEBUG)
 	sleep(-1)
 	for(var/obj/machinery/atmospherics/unary/U in machines)
 		if(istype(U, /obj/machinery/atmospherics/unary/vent_pump))
@@ -77,5 +77,5 @@ datum/controller/game_controller/proc/setup_objects()
 	//Set up spawn points.
 	populate_spawn_points()
 
-	world << "<span class='danger'>Initializations complete.</span>"
+	admin_notice("<span class='danger'>Initializations complete.</span>", R_DEBUG)
 	sleep(-1)

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -1,3 +1,8 @@
+proc/admin_notice(var/message, var/rights)
+	for(var/mob/M in mob_list)
+		if(check_rights(rights, 0, M))
+			M << message
+
 proc/log_and_message_admins(var/message as text, var/mob/user = usr)
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")
 	message_admins(user ? "[key_name(user)] [message]" : "EVENT [message]")

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -55,8 +55,7 @@ proc/admin_proc()
 	if(!check_rights(R_ADMIN)) return
 	world << "you have enough rights!"
 
-NOTE: it checks usr! not src! So if you're checking somebody's rank in a proc which they did not call
-you will have to do something like if(client.holder.rights & R_ADMIN) yourself.
+NOTE: It checks usr by default. Supply the "user" argument if you wish to check for a specific mob.
 */
 /proc/check_rights(rights_required, show_msg=1, var/mob/user = usr)
 	if(user && user.client)

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -3,7 +3,7 @@ proc/createRandomZlevel()
 		return
 
 	var/list/potentialRandomZlevels = list()
-	world << "\red \b Searching for away missions..."
+	admin_notice("\red \b Searching for away missions...", R_DEBUG)
 	var/list/Lines = file2list("maps/RandomZLevels/fileList.txt")
 	if(!Lines.len)	return
 	for (var/t in Lines)
@@ -35,7 +35,7 @@ proc/createRandomZlevel()
 
 
 	if(potentialRandomZlevels.len)
-		world << "\red \b Loading away mission..."
+		admin_notice("\red \b Loading away mission...", R_DEBUG)
 
 		var/map = pick(potentialRandomZlevels)
 		var/file = file(map)
@@ -48,8 +48,8 @@ proc/createRandomZlevel()
 				continue
 			awaydestinations.Add(L)
 
-		world << "\red \b Away mission loaded."
+		admin_notice("\red \b Away mission loaded.", R_DEBUG)
 
 	else
-		world << "\red \b No away missions found."
+		admin_notice("\red \b No away missions found.", R_DEBUG)
 		return

--- a/code/modules/random_map/mining_distribution.dm
+++ b/code/modules/random_map/mining_distribution.dm
@@ -62,13 +62,13 @@ Deep minerals:
 			deep_count++
 	// Sanity check.
 	if(surface_count < MIN_SURFACE_COUNT)
-		world << "<span class='danger'>Insufficient surface minerals. Rerolling...</span>"
+		admin_notice("<span class='danger'>Insufficient surface minerals. Rerolling...</span>", R_DEBUG)
 		return 0
 	else if(rare_count < MIN_RARE_COUNT)
-		world << "<span class='danger'>Insufficient rare minerals. Rerolling...</span>"
+		admin_notice("<span class='danger'>Insufficient rare minerals. Rerolling...</span>", R_DEBUG)
 		return 0
 	else if(deep_count < MIN_DEEP_COUNT)
-		world << "<span class='danger'>Insufficient deep minerals. Rerolling...</span>"
+		admin_notice("<span class='danger'>Insufficient deep minerals. Rerolling...</span>", R_DEBUG)
 		return 0
 	else
 		return 1
@@ -112,7 +112,7 @@ Deep minerals:
 
 	// Infinite loop check!
 	if(iteration>=iterate_before_fail)
-		world << "<span class='danger'>Iteration count exceeded, aborting.</span>"
+		admin_notice("<span class='danger'>Iteration count exceeded, aborting.</span>", R_DEBUG)
 		return
 
 	var/isize = input_size

--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -58,12 +58,12 @@ var/global/list/random_maps = list()
 	if(seed) rand_seed(seed)
 
 	var/start_time = world.timeofday
-	world << "<span class='danger'>Generating [descriptor].</span>"
+	admin_notice("<span class='danger'>Generating [descriptor].</span>", R_DEBUG)
 	for(var/i = 0;i<max_attempts;i++)
 		if(generate())
-			world << "<span class='danger'>[capitalize(descriptor)] generation completed in [round(0.1*(world.timeofday-start_time),0.1)] seconds.</span>"
+			admin_notice("<span class='danger'>[capitalize(descriptor)] generation completed in [round(0.1*(world.timeofday-start_time),0.1)] seconds.</span>", R_DEBUG)
 			return
-	world << "<span class='danger'>[capitalize(descriptor)] generation failed in [round(0.1*(world.timeofday-start_time),0.1)] seconds: could not produce sane map.</span>"
+	admin_notice("<span class='danger'>[capitalize(descriptor)] generation failed in [round(0.1*(world.timeofday-start_time),0.1)] seconds: could not produce sane map.</span>", R_DEBUG)
 
 /datum/random_map/proc/within_bounds(var/val)
 	return (val>0) && (val<=raw_map_size)
@@ -169,5 +169,5 @@ var/global/list/random_maps = list()
 	for(var/i = 0, i < max_secret_rooms, i++)
 		if(make_mining_asteroid_secret())
 			rooms_placed++
-	world << "<span class='danger'>Placed [rooms_placed] secrets.</span>"
+	admin_notice("<span class='danger'>Placed [rooms_placed] secrets.</span>", R_DEBUG)
 	return 1


### PR DESCRIPTION
Server start messages concerning initialization, object generation, etc. is now only propagated to users with R_DEBUG access.

Basically based on what players on other servers see on server-start-join, and I liked it.
![Server Start](https://www.dropbox.com/s/md468mjr3wvsbi8/ServerStart.png?dl=1)
