### PR TITLE
Fixes #8913

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -325,7 +325,8 @@
 		var/id = href_list["write"]
 		//var/t = strip_html_simple(input(usr, "What text do you wish to add to " + (id=="end" ? "the end of the paper" : "field "+id) + "?", "[name]", null),8192) as message
 
-		var/textlimit = MAX_PAPER_MESSAGE_LEN - length(info)
+		var/textlimit = MAX_BOOK_MESSAGE_LEN - length(strip_html_properly(info, 0))
+
 		if(textlimit <= 0)
 			usr << "<span class='info'>You're trying to find a free place on paper, but can't!</span>"
 			return


### PR DESCRIPTION
Increases the limit, and now this limit on the size of the text without html tags

Note to the merger with dev: remove the second parameter in strip_html_properly() call

Edit: Probably parse an infinite number of html tags - bad, as in this embodiment, they are  not counted. Someone has another idea?
