### PR TITLE
Adds diona 'split' command

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -319,7 +319,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 This function restores the subjects blood to max.
 */
 /mob/living/carbon/human/proc/restore_blood()
-	if(!species.flags & NO_BLOOD)
+	if(!(species.flags & NO_BLOOD))
 		var/blood_volume = vessel.get_reagent_amount("blood")
 		vessel.add_reagent("blood",560.0-blood_volume)
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -219,3 +219,40 @@
 		M << "\green You hear a strange, alien voice in your head... \italic [msg]"
 		src << "\green You said: \"[msg]\" to [M]"
 	return
+
+/mob/living/carbon/human/proc/diona_split_nymph()
+	set name = "Split"
+	set desc = "Split your humanoid form into its constituent nymphs."
+	set category = "Abilities"
+
+	var/turf/T = get_turf(src)
+
+	var/mob/living/carbon/alien/diona/S = new(T)
+	S.set_dir(dir)
+	if(mind)
+		mind.transfer_to(S)
+
+	message_admins("\The [src] has split into nymphs; player now controls [key_name_admin(S)]")
+	log_admin("\The [src] has split into nymphs; player now controls [key_name(S)]")
+
+	var/nymphs = 1
+
+	for(var/mob/living/carbon/alien/diona/D in src)
+		nymphs++
+		D.loc = T
+		D.set_dir(pick(NORTH, SOUTH, EAST, WEST))
+
+	if(nymphs < 5)
+		for(var/i in nymphs to 4)
+			var/mob/M = new /mob/living/carbon/alien/diona(T)
+			M.set_dir(pick(NORTH, SOUTH, EAST, WEST))
+
+
+	for(var/obj/item/W in src)
+		drop_from_inventory(W)
+
+	visible_message("<span class='warning'>\The [src] quivers slightly, then splits apart with a wet slithering noise.</span>")
+
+	del(src)
+
+

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -168,6 +168,10 @@
 		"r_foot" = list("path" = /obj/item/organ/external/diona/foot/right)
 		)
 
+	inherent_verbs = list(
+		/mob/living/carbon/human/proc/diona_split_nymph
+		)
+
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
 


### PR DESCRIPTION
Title. Allows dionaea to split into nymphs on command. Any merged player nymphs will count towards these five, and extra clientless nymphs will be spawned if there are not 5 or more.
