### PR TITLE
Change of random virus targets.

### DIFF
--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -4,12 +4,12 @@ datum/event/viral_infection
 datum/event/viral_infection/setup()
 	announceWhen = rand(0, 3000)
 	endWhen = announceWhen + 1
-	
+
 	//generate 1-3 viruses. This way there's an upper limit on how many individual diseases need to be cured if many people are initially infected
 	var/num_diseases = rand(1,3)
 	for (var/i=0, i < num_diseases, i++)
 		var/datum/disease2/disease/D = new /datum/disease2/disease
-		
+
 		var/strength = 1 //whether the disease is of the greater or lesser variety
 		if (severity >= EVENT_LEVEL_MAJOR && prob(75))
 			strength = 2
@@ -24,7 +24,7 @@ datum/event/viral_infection/announce()
 		level = pick("one", "two", "three", "four")
 	else
 		level = "five"
-	
+
 	if (severity == EVENT_LEVEL_MAJOR || prob(60))
 		command_announcement.Announce("Confirmed outbreak of level [level] biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak5.ogg')
 
@@ -33,8 +33,10 @@ datum/event/viral_infection/start()
 
 	var/list/candidates = list()	//list of candidate keys
 	for(var/mob/living/carbon/human/G in player_list)
-		if(G.client && G.stat != DEAD)
-			candidates += G
+		if(G.stat != DEAD && G.is_client_active(5))
+			var/turf/T = get_turf(G)
+			if(T.z in config.station_levels)
+				candidates += G
 	if(!candidates.len)	return
 	candidates = shuffle(candidates)//Incorporating Donkie's list shuffle
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -587,3 +587,7 @@ proc/is_blind(A)
 
 	eyeobj.setLoc(C)
 	return 1
+
+// Returns true if the mob has a client which has been active in the last given X minutes.
+/mob/proc/is_client_active(var/active = 1)
+	return client && client.inactivity < active MINUTES

--- a/html/changelogs/PsiOmegaDelta-GoingViral.yml
+++ b/html/changelogs/PsiOmegaDelta-GoingViral.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - bugfix: "The virus event will now only infect mobs on the station, currently controlled by player that has been active in the last 5 minutes."


### PR DESCRIPTION
The random virus event will now only infect mobs on station and which currently have a player that has been active in the last 5 minutes.
A stopgap solution until a more indepth discussion about the random virus event is concluded.
