### PR TITLE
Makes crit oxyloss and malf AI timer run in gametime instead of realtime.

### DIFF
--- a/code/controllers/verbs.dm
+++ b/code/controllers/verbs.dm
@@ -62,7 +62,7 @@
 		usr.client.debug_variables(antag)
 		message_admins("Admin [key_name_admin(usr)] is debugging the [antag.role_text] template.")
 
-/client/proc/debug_controller(controller in list("Master","Failsafe","Ticker","Lighting","Air","Jobs","Sun","Radio","Supply","Shuttles","Emergency Shuttle","Configuration","pAI", "Cameras", "Transfer Controller", "Gas Data","Event","Plants","Alarm","Nano"))
+/client/proc/debug_controller(controller in list("Master","Failsafe","Ticker","Ticker Process","Lighting","Air","Jobs","Sun","Radio","Supply","Shuttles","Emergency Shuttle","Configuration","pAI", "Cameras", "Transfer Controller", "Gas Data","Event","Plants","Alarm","Nano"))
 	set category = "Debug"
 	set name = "Debug Controller"
 	set desc = "Debug the various periodic loop controllers for the game (be careful!)"
@@ -78,6 +78,9 @@
 		if("Ticker")
 			debug_variables(ticker)
 			feedback_add_details("admin_verb","DTicker")
+		if("Ticker Process")
+			debug_variables(tickerProcess)
+			feedback_add_details("admin_verb","DTickerProcess")
 		if("Lighting")
 			debug_variables(lighting_controller)
 			feedback_add_details("admin_verb","DLighting")

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -27,7 +27,7 @@ var/datum/antagonist/rogue_ai/malf
 	hacked_apcs |= apc
 
 /datum/antagonist/rogue_ai/proc/update_takeover_time()
-	hack_time -= ((hacked_apcs.len/6)*tickerProcess.getLastTickerTimeDuration())
+	hack_time -= ((hacked_apcs.len/6)*2.0)
 
 /datum/antagonist/rogue_ai/tick()
 	if(revealed && hacked_apcs.len >= 3)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -2,7 +2,7 @@
 
 //NOTE: Breathing happens once per FOUR TICKS, unless the last breath fails. In which case it happens once per ONE TICK! So oxyloss healing is done once per 4 ticks while oxyloss damage is applied once per tick!
 #define HUMAN_MAX_OXYLOSS 1 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
-#define HUMAN_CRIT_MAX_OXYLOSS ( (tickerProcess.getLastTickerTimeDuration()) / 6) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 50HP to get through, so (1/6)*last_tick_duration per second. Breaths however only happen every 4 ticks.
+#define HUMAN_CRIT_MAX_OXYLOSS ( 2.0 / 6) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 50HP to get through, so (1/6)*last_tick_duration per second. Breaths however only happen every 4 ticks. last_tick_duration = ~2.0 on average
 
 #define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 4 //Amount of damage applied when your body temperature passes the 400K point


### PR DESCRIPTION
Hardcrit oxyloss and the malf AI timer now accumulate/count down in game time instead of in realtime. This means that the in-game time for crit and malf AI countdown to happen is no longer tied to something that is completely OOC.

Also adds in a quick way to debug the new ticker process.
