### PR TITLE
Fixes Snapwalk's Limb Augment item being removable through the inventory panel

### DIFF
--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1131,6 +1131,7 @@
 	icon_state = "parker_eliza_arms"
 	item_state = "parker_eliza_arms"
 	item_color = "parker_eliza_arms"
+	canremove = 0
 
 
 ////////////// Accessories /////

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1131,6 +1131,7 @@
 	icon_state = "parker_eliza_arms"
 	item_state = "parker_eliza_arms"
 	item_color = "parker_eliza_arms"
+	body_parts_covered = 0 //technicially it's underneath everything
 	canremove = 0
 
 


### PR DESCRIPTION
I haven't heard of any incidents on the server about this, but it's probably best to prevent them from being removed.
