### PR TITLE
Inventory updates

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -239,198 +239,124 @@
 /obj/item/proc/equipped(var/mob/user, var/slot)
 	return
 
+//Defines which slots correspond to which slot flags
+var/list/global/slot_flags_enumeration = list(
+	"[slot_wear_mask]" = SLOT_MASK,
+	"[slot_back]" = SLOT_BACK,
+	"[slot_wear_suit]" = SLOT_OCLOTHING,
+	"[slot_gloves]" = SLOT_GLOVES,
+	"[slot_shoes]" = SLOT_FEET,
+	"[slot_belt]" = SLOT_BELT,
+	"[slot_glasses]" = SLOT_EYES,
+	"[slot_head]" = SLOT_HEAD,
+	"[slot_l_ear]" = SLOT_EARS|SLOT_TWOEARS,
+	"[slot_r_ear]" = SLOT_EARS|SLOT_TWOEARS,
+	"[slot_w_uniform]" = SLOT_ICLOTHING,
+	"[slot_wear_id]" = SLOT_ID,
+	"[slot_tie]" = SLOT_TIE,
+	)
+
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 //If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
 //Set disable_warning to 1 if you wish it to not give you outputs.
+//Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
 /obj/item/proc/mob_can_equip(M as mob, slot, disable_warning = 0)
 	if(!slot) return 0
 	if(!M) return 0
 
-	if(ishuman(M))
-		//START HUMAN
-		var/mob/living/carbon/human/H = M
-		var/list/mob_equip = list()
-		if(H.species.hud && H.species.hud.equip_slots)
-			mob_equip = H.species.hud.equip_slots
+	if(!ishuman(M)) return 0
+	
+	var/mob/living/carbon/human/H = M
+	var/list/mob_equip = list()
+	if(H.species.hud && H.species.hud.equip_slots)
+		mob_equip = H.species.hud.equip_slots
 
-		if(H.species && !(slot in mob_equip))
+	if(H.species && !(slot in mob_equip))
+		return 0
+	
+	//First check if the item can be equipped to the desired slot.
+	if("[slot]" in slot_flags_enumeration)
+		var/req_flags = slot_flags_enumeration["[slot]"]
+		if(!(req_flags & slot_flags))
 			return 0
+	
+	//Next check that the slot is free
+	if(H.get_equipped_item(slot))
+		return 0
+	
+	//Next check if the slot is accessible.
+	var/mob/_user = disable_warning? null : H
+	if(!H.slot_is_accessible(slot, src, _user))
+		return 0
+	
+	//Lastly, check special rules for the desired slot.
+	switch(slot)
+		if(slot_l_ear, slot_r_ear)
+			var/slot_other_ear = (slot == slot_l_ear)? slot_r_ear : slot_l_ear
+			if( (w_class > 1) && !(slot_flags & SLOT_EARS) )
+				return 0
+			if( (slot_flags & SLOT_TWOEARS) && H.get_equipped_item(slot_other_ear) )
+				return 0
+		if(slot_wear_id)
+			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+				if(!disable_warning)
+					H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
+				return 0
+		if(slot_l_store, slot_r_store)
+			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+				if(!disable_warning)
+					H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
+				return 0
+			if(slot_flags & SLOT_DENYPOCKET)
+				return 0
+			if( w_class > 2 && !(slot_flags & SLOT_POCKET) )
+				return 0
+		if(slot_s_store)
+			if(!H.wear_suit && (slot_wear_suit in mob_equip))
+				if(!disable_warning)
+					H << "<span class='warning'>You need a suit before you can attach this [name].</span>"
+				return 0
+			if(!H.wear_suit.allowed)
+				if(!disable_warning)
+					usr << "<span class='warning'>You somehow have a suit with no defined allowed items for suit storage, stop that.</span>"
+				return 0
+			if( !(istype(src, /obj/item/device/pda) || istype(src, /obj/item/weapon/pen) || is_type_in_list(src, H.wear_suit.allowed)) )
+				return 0
+		if(slot_handcuffed)
+			if(!istype(src, /obj/item/weapon/handcuffs))
+				return 0
+		if(slot_legcuffed)
+			if(!istype(src, /obj/item/weapon/legcuffs))
+				return 0
+		if(slot_in_backpack) //used entirely for equipping spawned mobs or at round start
+			var/allow = 0
+			if(H.back && istype(H.back, /obj/item/weapon/storage/backpack))
+				var/obj/item/weapon/storage/backpack/B = H.back
+				if(B.contents.len < B.storage_slots && w_class <= B.max_w_class)
+					allow = 1
+			if(!allow)
+				return 0
+		if(slot_tie)
+			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+				if(!disable_warning)
+					H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
+				return 0
+			var/obj/item/clothing/under/uniform = H.w_uniform
+			if(uniform.accessories.len && !uniform.can_attach_accessory(src))
+				if (!disable_warning)
+					H << "<span class='warning'>You already have an accessory of this type attached to your [uniform].</span>"
+				return 0
+	return 1
 
-		switch(slot)
-			if(slot_l_hand)
-				if(H.l_hand)
-					return 0
-				return 1
-			if(slot_r_hand)
-				if(H.r_hand)
-					return 0
-				return 1
-			if(slot_wear_mask)
-				if(H.wear_mask)
-					return 0
-				if(H.head && !(H.head.canremove) && (H.head.flags & HEADCOVERSMOUTH))
-					if(!disable_warning)
-						H << "<span class='warning'>\The [H.head] is in the way.</span>"
-					return 0
-				if( !(slot_flags & SLOT_MASK) )
-					return 0
-				return 1
-			if(slot_back)
-				if(H.back)
-					return 0
-				if( !(slot_flags & SLOT_BACK) )
-					return 0
-				return 1
-			if(slot_wear_suit)
-				if(H.wear_suit)
-					return 0
-				if( !(slot_flags & SLOT_OCLOTHING) )
-					return 0
-				return 1
-			if(slot_gloves)
-				if(H.gloves)
-					return 0
-				if( !(slot_flags & SLOT_GLOVES) )
-					return 0
-				return 1
-			if(slot_shoes)
-				if(H.shoes)
-					return 0
-				if( !(slot_flags & SLOT_FEET) )
-					return 0
-				return 1
-			if(slot_belt)
-				if(H.belt)
-					return 0
-				if(!H.w_uniform && (slot_w_uniform in mob_equip))
-					if(!disable_warning)
-						H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
-					return 0
-				if( !(slot_flags & SLOT_BELT) )
-					return
-				return 1
-			if(slot_glasses)
-				if(H.glasses)
-					return 0
-				if(H.head && !(H.head.canremove) && (H.head.flags & HEADCOVERSEYES))
-					if(!disable_warning)
-						H << "<span class='warning'>\The [H.head] is in the way.</span>"
-					return 0
-				if( !(slot_flags & SLOT_EYES) )
-					return 0
-				return 1
-			if(slot_head)
-				if(H.head)
-					return 0
-				if( !(slot_flags & SLOT_HEAD) )
-					return 0
-				return 1
-			if(slot_l_ear)
-				if(H.l_ear)
-					return 0
-				if( (w_class > 1) && !(slot_flags & SLOT_EARS) )
-					return 0
-				if( (slot_flags & SLOT_TWOEARS) && H.r_ear )
-					return 0
-				return 1
-			if(slot_r_ear)
-				if(H.r_ear)
-					return 0
-				if( (w_class > 1) && !(slot_flags & SLOT_EARS) )
-					return 0
-				if( (slot_flags & SLOT_TWOEARS) && H.l_ear )
-					return 0
-				return 1
-			if(slot_w_uniform)
-				if(H.w_uniform)
-					return 0
-				if(H.wear_suit && (H.wear_suit.body_parts_covered & src.body_parts_covered))
-					if(!disable_warning)
-						H << "<span class='warning'>\The [H.wear_suit] is in the way.</span>"
-					return 0
-				if( !(slot_flags & SLOT_ICLOTHING) )
-					return 0
-				return 1
-			if(slot_wear_id)
-				if(H.wear_id)
-					return 0
-				if(!H.w_uniform && (slot_w_uniform in mob_equip))
-					if(!disable_warning)
-						H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
-					return 0
-				if( !(slot_flags & SLOT_ID) )
-					return 0
-				return 1
-			if(slot_l_store)
-				if(H.l_store)
-					return 0
-				if(!H.w_uniform && (slot_w_uniform in mob_equip))
-					if(!disable_warning)
-						H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
-					return 0
-				if(slot_flags & SLOT_DENYPOCKET)
-					return 0
-				if( w_class <= 2 || (slot_flags & SLOT_POCKET) )
-					return 1
-			if(slot_r_store)
-				if(H.r_store)
-					return 0
-				if(!H.w_uniform && (slot_w_uniform in mob_equip))
-					if(!disable_warning)
-						H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
-					return 0
-				if(slot_flags & SLOT_DENYPOCKET)
-					return 0
-				if( w_class <= 2 || (slot_flags & SLOT_POCKET) )
-					return 1
-				return 0
-			if(slot_s_store)
-				if(H.s_store)
-					return 0
-				if(!H.wear_suit && (slot_wear_suit in mob_equip))
-					if(!disable_warning)
-						H << "<span class='warning'>You need a suit before you can attach this [name].</span>"
-					return 0
-				if(!H.wear_suit.allowed)
-					if(!disable_warning)
-						usr << "<span class='warning'>You somehow have a suit with no defined allowed items for suit storage, stop that.</span>"
-					return 0
-				if( istype(src, /obj/item/device/pda) || istype(src, /obj/item/weapon/pen) || is_type_in_list(src, H.wear_suit.allowed) )
-					return 1
-				return 0
-			if(slot_handcuffed)
-				if(H.handcuffed)
-					return 0
-				if(!istype(src, /obj/item/weapon/handcuffs))
-					return 0
-				return 1
-			if(slot_legcuffed)
-				if(H.legcuffed)
-					return 0
-				if(!istype(src, /obj/item/weapon/legcuffs))
-					return 0
-				return 1
-			if(slot_in_backpack)
-				if (H.back && istype(H.back, /obj/item/weapon/storage/backpack))
-					var/obj/item/weapon/storage/backpack/B = H.back
-					if(B.contents.len < B.storage_slots && w_class <= B.max_w_class)
-						return 1
-				return 0
-			if(slot_tie)
-				if(!H.w_uniform && (slot_w_uniform in mob_equip))
-					if(!disable_warning)
-						H << "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>"
-					return 0
-				var/obj/item/clothing/under/uniform = H.w_uniform
-				if(uniform.accessories.len && !uniform.can_attach_accessory(src))
-					if (!disable_warning)
-						H << "<span class='warning'>You already have an accessory of this type attached to your [uniform].</span>"
-					return 0
-				if( !(slot_flags & SLOT_TIE) )
-					return 0
-				return 1
-		return 0 //Unsupported slot
-		//END HUMAN
+/obj/item/proc/mob_can_unequip(mob/M, slot, disable_warning = 0)
+	if(!slot) return 0
+	if(!M) return 0
+	
+	if(!canremove)
+		return 0
+	if(!M.slot_is_accessible(slot, src, disable_warning? null : M))
+		return 0
+	return 1
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -147,11 +147,8 @@
 
 	src.throwing = 0
 	if (src.loc == user)
-		//canremove==0 means that object may not be removed. You can still wear it. This only applies to clothing. /N
-		if(!src.canremove)
+		if(!user.unEquip(src))
 			return
-		else
-			user.u_equip(src)
 	else
 		if(isliving(src.loc))
 			return
@@ -160,7 +157,6 @@
 	if(src.loc == user)
 		src.pickup(user)
 	return
-
 
 /obj/item/attack_ai(mob/user as mob)
 	if (istype(src.loc, /obj/item/weapon/robot_module))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -30,7 +30,7 @@
 
 	if (ishuman(usr) || issmall(usr)) //so monkeys can take off their backpacks -- Urist
 
-		if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
+		if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech. why?
 			return
 
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
@@ -44,18 +44,21 @@
 		//there's got to be a better way of doing this.
 		if (!(src.loc == usr) || (src.loc && src.loc.loc == usr))
 			return
-
-		if (!( usr.restrained() ) && !( usr.stat ))
-			switch(over_object.name)
-				if("r_hand")
-					usr.u_equip(src)
-					usr.put_in_r_hand(src)
-				if("l_hand")
-					usr.u_equip(src)
-					usr.put_in_l_hand(src)
-			src.add_fingerprint(usr)
+		
+		if (( usr.restrained() ) || ( usr.stat ))
 			return
-	return
+		
+		if ((src.loc == usr) && !usr.unEquip(src))
+			return
+
+		switch(over_object.name)
+			if("r_hand")
+				usr.u_equip(src)
+				usr.put_in_r_hand(src)
+			if("l_hand")
+				usr.u_equip(src)
+				usr.put_in_l_hand(src)
+		src.add_fingerprint(usr)
 
 
 /obj/item/weapon/storage/proc/return_inv()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -464,17 +464,18 @@ BLIND     // can't see anything
 		if (!(src.loc == usr))
 			return
 
-		if (!( usr.restrained() ) && !( usr.stat ))
-			switch(over_object.name)
-				if("r_hand")
-					usr.u_equip(src)
-					usr.put_in_r_hand(src)
-				if("l_hand")
-					usr.u_equip(src)
-					usr.put_in_l_hand(src)
-			src.add_fingerprint(usr)
+		if (( usr.restrained() ) || ( usr.stat ))
 			return
-	return
+		
+		if (!usr.unEquip(src))
+			return
+		
+		switch(over_object.name)
+			if("r_hand")
+				usr.put_in_r_hand(src)
+			if("l_hand")
+				usr.put_in_l_hand(src)
+		src.add_fingerprint(usr)
 
 /obj/item/clothing/under/examine(mob/user)
 	..(user)

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -5,7 +5,7 @@
 	item_state = "balaclava"
 	flags = BLOCKHAIR
 	flags_inv = HIDEFACE
-	body_parts_covered = FACE
+	body_parts_covered = FACE|HEAD
 	w_class = 2
 	sprite_sheets = list(
 		"Tajara" = 'icons/mob/species/tajaran/helmet.dmi',

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -15,26 +15,34 @@
 
 	var/hanging = 0
 
-	verb/toggle()
+/obj/item/clothing/mask/breath/proc/adjust_mask(mob/user)
+	if(user.canmove && !user.stat)
+		if(!src.hanging)
+			src.hanging = !src.hanging
+			gas_transfer_coefficient = 1 //gas is now escaping to the turf and vice versa
+			flags &= ~(MASKCOVERSMOUTH | AIRTIGHT)
+			body_parts_covered = 0
+			icon_state = "breathdown"
+			user << "Your mask is now hanging on your neck."
+
+		else
+			src.hanging = !src.hanging
+			gas_transfer_coefficient = initial(gas_transfer_coefficient)
+			flags |= MASKCOVERSMOUTH | AIRTIGHT
+			body_parts_covered = initial(body_parts_covered)
+			icon_state = "breath"
+			user << "You pull the mask up to cover your face."
+		update_clothing_icon()
+
+/obj/item/clothing/mask/breath/attack_self(mob/user)
+	adjust_mask(user)
+
+/obj/item/clothing/mask/breath/verb/toggle()
 		set category = "Object"
 		set name = "Adjust mask"
 		set src in usr
 
-		if(usr.canmove && !usr.stat && !usr.restrained())
-			if(!src.hanging)
-				src.hanging = !src.hanging
-				gas_transfer_coefficient = 1 //gas is now escaping to the turf and vice versa
-				flags &= ~(MASKCOVERSMOUTH | AIRTIGHT)
-				icon_state = "breathdown"
-				usr << "Your mask is now hanging on your neck."
-
-			else
-				src.hanging = !src.hanging
-				gas_transfer_coefficient = 0.10
-				flags |= MASKCOVERSMOUTH | AIRTIGHT
-				icon_state = "breath"
-				usr << "You pull the mask up to cover your face."
-			update_clothing_icon()
+		adjust_mask(usr)
 
 /obj/item/clothing/mask/breath/medical
 	desc = "A close-fitting sterile mask that can be connected to an air supply."

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -58,6 +58,10 @@ var/list/slot_equipment_priority = list( \
 		slot_r_store\
 	)
 
+//Checks if a given slot can be accessed at this time, either to equip or unequip I
+/mob/proc/slot_is_accessible(var/slot, var/obj/item/I, mob/user=null)
+	return 1
+
 //puts the item "W" into an appropriate slot in a human's inventory
 //returns 0 if it cannot, 1 if successful
 /mob/proc/equip_to_appropriate_slot(obj/item/W)
@@ -143,7 +147,8 @@ var/list/slot_equipment_priority = list( \
 		W.dropped()
 		return 0
 
-// Removes an item from inventory and places it in the target atom
+// Removes an item from inventory and places it in the target atom.
+// If canremove or other conditions need to be checked then use unEquip instead.
 /mob/proc/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W)
 		if(!Target)
@@ -201,7 +206,13 @@ var/list/slot_equipment_priority = list( \
 	if(!I) //If there's nothing to drop, the drop is automatically successful.
 		return 1
 
-	if(!I.canremove && !force)
+	var/slot
+	for(var/s in slot_back to slot_tie) //kind of worries me
+		if(get_equipped_item(s) == I)
+			slot = s
+			break
+
+	if(slot && !I.mob_can_unequip(src, slot))
 		return 0
 
 	remove_from_mob(I)
@@ -219,6 +230,15 @@ var/list/slot_equipment_priority = list( \
 		I.dropped(src)
 	return 1
 
+
+//Returns the item equipped to the specified slot, if any.
+/mob/proc/get_equipped_item(var/slot)
+	switch(slot)
+		if(slot_l_hand) return l_hand
+		if(slot_r_hand) return r_hand
+		if(slot_back) return back
+		if(slot_wear_mask) return wear_mask
+	return null
 
 //Outdated but still in use apparently. This should at least be a human proc.
 /mob/proc/get_equipped_items()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -201,7 +201,7 @@ var/list/slot_equipment_priority = list( \
 		update_inv_wear_mask(0)
 	return
 
-//This differs from remove_from_mob() in that it checks canremove first.
+//This differs from remove_from_mob() in that it checks if the item can be unequipped first.
 /mob/proc/unEquip(obj/item/I, force = 0) //Force overrides NODROP for things like wizarditis and admin undress.
 	if(!I) //If there's nothing to drop, the drop is automatically successful.
 		return 1
@@ -215,7 +215,7 @@ var/list/slot_equipment_priority = list( \
 	if(slot && !I.mob_can_unequip(src, slot))
 		return 0
 
-	remove_from_mob(I)
+	drop_from_inventory(I)
 	return 1
 
 //Attemps to remove an object on a mob.  Will not move it to another area or such, just removes from the mob.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -608,7 +608,7 @@ It can still be worn/put on as normal.
 	if ((source.restrained() || source.stat)) return //Source restrained or unconscious / dead
 
 	var/slot_to_process
-	var/strip_item //this will tell us which item we will be stripping - if any.
+	var/obj/item/strip_item //this will tell us which item we will be stripping - if any.
 
 	switch(place)	//here we go again...
 		if("mask")
@@ -790,17 +790,21 @@ It can still be worn/put on as normal.
 							target.internals.icon_state = "internal1"
 	if(slot_to_process)
 		if(strip_item) //Stripping an item from the mob
-			var/obj/item/W = strip_item
-			target.remove_from_mob(W)
-			W.add_fingerprint(source)
-			if(slot_to_process == slot_l_store) //pockets! Needs to process the other one too. Snowflake code, wooo! It's not like anyone will rewrite this anytime soon. If I'm wrong then... CONGRATULATIONS! ;)
-				if(target.r_store)
-					target.remove_from_mob(target.r_store) //At this stage l_store is already processed by the code above, we only need to process r_store.
-		else
-			if(item && target.has_organ_for_slot(slot_to_process)) //Placing an item on the mob
-				if(item.mob_can_equip(target, slot_to_process, 0))
-					source.remove_from_mob(item)
-					target.equip_to_slot_if_possible(item, slot_to_process, 0, 1, 1)
+			if(strip_item.mob_can_unequip(target, slot_to_process, 0))
+				target.drop_from_inventory(strip_item)
+				source.put_in_hands(strip_item)
+				strip_item.add_fingerprint(source)
+				if(slot_to_process == slot_l_store) //pockets! Needs to process the other one too. Snowflake code, wooo! It's not like anyone will rewrite this anytime soon. If I'm wrong then... CONGRATULATIONS! ;)
+					if(target.r_store)
+						target.drop_from_inventory(target.r_store) //At this stage l_store is already processed by the code above, we only need to process r_store.
+			else
+				source << "<span class='warning'>You fail to remove \the [strip_item] from [target]!</span>"
+		else if(item) 
+			if(target.has_organ_for_slot(slot_to_process) && item.mob_can_equip(target, slot_to_process, 0)) //Placing an item on the mob
+				source.drop_from_inventory(item)
+				target.equip_to_slot_if_possible(item, slot_to_process, 0, 1, 1)
+			else
+				source << "<span class='warning'>You fail to place \the [item] on [target]!</span>"
 
 	if(source && target)
 		if(source.machine == target)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -317,6 +317,48 @@ This saves us from having to call add_fingerprint() any time something is put in
 
 	return 1
 
+//Checks if a given slot can be accessed at this time, either to equip or unequip I
+/mob/living/carbon/human/slot_is_accessible(var/slot, var/obj/item/I, mob/user=null)
+	var/obj/item/covering = null
+	var/check_flags = 0
+	
+	switch(slot)
+		if(slot_wear_mask)
+			covering = src.head
+			check_flags = HEADCOVERSMOUTH
+		if(slot_glasses)
+			covering = src.head
+			check_flags = HEADCOVERSEYES
+		if(slot_gloves, slot_w_uniform)
+			covering = src.wear_suit
+	
+	if(covering)
+		if((covering.body_parts_covered & I.body_parts_covered) || (covering.flags & check_flags))
+			user << "<span class='warning'>\The [covering] is in the way.</span>"
+			return 0
+	return 1
+
+/mob/living/carbon/human/get_equipped_item(var/slot)
+	switch(slot)
+		if(slot_wear_suit) return wear_suit
+		if(slot_gloves) return gloves
+		if(slot_shoes) return shoes
+		if(slot_belt) return belt
+		if(slot_glasses) return glasses
+		if(slot_head) return head
+		if(slot_l_ear) return l_ear
+		if(slot_r_ear) return r_ear
+		if(slot_w_uniform) return w_uniform
+		if(slot_wear_id) return wear_id
+		if(slot_l_store) return l_store
+		if(slot_r_store) return r_store
+		if(slot_s_store) return s_store
+		if(slot_handcuffed) return handcuffed
+		if(slot_legcuffed) return legcuffed
+	return ..()
+
+///Bizarre equip effect system below
+
 /*
 	MouseDrop human inventory menu
 */

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -482,11 +482,7 @@ var/global/list/damage_icon_parts = list()
 		overlays_standing[UNIFORM_LAYER]	= standing
 	else
 		overlays_standing[UNIFORM_LAYER]	= null
-		// This really, really seems like it should not be mixed in the middle of display code...
-		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY
-		for( var/obj/item/thing in list(r_store, l_store, wear_id, belt) )
-			if(thing)
-				remove_from_mob(thing)
+
 	if(update_icons)   update_icons()
 
 /mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -192,6 +192,7 @@
 #define NOBLOODY           512  // Used for items if they don't want to get a blood overlay.
 #define NODELAY            8192 // 1 second attack-by delay skipped (Can be used once every 0.2s). Most objects have a 1s attack-by delay, which doesn't require a flag.
 
+//Use these flags to indicate if an item obscures the specified slots from view, whereas body_parts_covered seems to be used to indicate what body parts the item protects.
 #define GLASSESCOVERSEYES 256
 #define    MASKCOVERSEYES 256 // Get rid of some of the other retardation in these flags.
 #define    HEADCOVERSEYES 256 // Feel free to reallocate these numbers for other purposes.


### PR DESCRIPTION
This was going to involve a lot more refactoring and cleanup of inventory code but then I ended up realizing that the things that I was going to refactor (mainly the equip effect stuff) would probably be time better spent rewriting inventory code altogether, as opposed to adding even more stupid giant switch statements to connect slots to the appropriate vars.

This PR refactors and cleans up mob_can_equip(), and various things related to deciding whether an item can be equipped or unequipped are moved out to their own procs.

As well, the existing system where masks and jumpsuits cannot be put on while wearing a suit that blocks them is expanded on, and now items that block putting on a mask, jumpsuit or other item also block removing those items. 

For example, this prevents being able to accidentally take off your mask while wearing a voidsuit but not being able to put it on back again without toggling your helmet (which was actually what started this whole PR). As well, you can no longer strip someone down without removing them from their rig first. I decided to leave headsets unaffected for gameplay reasons, although support for them would be fairly simple to add.
