### PR TITLE
Adjusts threshold for limb removal due to damage

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -214,17 +214,21 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
 		if(!cannot_amputate && config.limbs_can_break && (brute_dam + burn_dam) >= (max_damage * config.organ_health_multiplier))
-			var/threshold = max_damage/3
+			var/threshold = max_damage
 			var/dropped
 			if((burn >= threshold) && prob(burn/3))
 				dropped = 1
 				droplimb(0,DROPLIMB_BURN)
 			if(!dropped && prob(brute))
-				if(brute >= threshold)
-					if((sharp || edge) && istype(used_weapon,/obj/item))
-						var/obj/item/W = used_weapon
-						if(W.w_class >= 3)
-							droplimb(0,DROPLIMB_EDGE)
+				var/edge_eligible = 0
+				if(edge && istype(used_weapon,/obj/item))
+					var/obj/item/W = used_weapon
+					if(W.w_class >= 3)
+						edge_eligible = 1
+				
+				if(brute >= threshold || (edge_eligible && brute >= threshold/3))
+					if((sharp || edge))
+						droplimb(0,DROPLIMB_EDGE)
 					else
 						droplimb(0,DROPLIMB_BLUNT)
 


### PR DESCRIPTION
Tweaks the droplimb damage threshold following earlier discussion. 

Mechanically this makes edge damage sources more likely to remove limbs than non-edge damage sources, which is kind of the point of edge. It also addresses an inconsistency (possible oversight?) where sharp or edge brute sources were subject to a w_class restriction when removing limbs, but blunt sources were not.

Aesthetically this makes completely destroying a limb require much more damage than cutting it off.
