### PR TITLE
Airlocks can now crush more things.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -869,18 +869,22 @@ About the new airlock wires panel:
 	return 1
 
 /atom/movable/proc/airlock_crush(var/crush_damage)
-	return
+	return 0
 
 /obj/machinery/portable_atmospherics/canister/airlock_crush(var/crush_damage)
+	. = ..()
 	health -= crush_damage
 	healthcheck()
 
 /obj/structure/closet/airlock_crush(var/crush_damage)
+	..()
 	damage(crush_damage)
 	for(var/atom/movable/AM in src)
 		AM.airlock_crush()
+	return 1
 
 /mob/living/airlock_crush(var/crush_damage)
+	. = ..()
 	adjustBruteLoss(crush_damage)
 	SetStunned(5)
 	SetWeakened(5)
@@ -888,12 +892,13 @@ About the new airlock wires panel:
 	T.add_blood(src)
 
 /mob/living/carbon/airlock_crush(var/crush_damage)
-	..()
+	. = ..()
 	if (!(species && (species.flags & NO_PAIN)))
 		emote("scream")
 
 /mob/living/silicon/robot/airlock_crush(var/crush_damage)
 	adjustBruteLoss(crush_damage)
+	return 0
 
 /obj/machinery/door/airlock/close(var/forced=0)
 	if(!can_close(forced))
@@ -911,7 +916,8 @@ About the new airlock wires panel:
 
 	for(var/turf/turf in locs)
 		for(var/atom/movable/AM in turf)
-			AM.airlock_crush(DOOR_CRUSH_DAMAGE)
+			if(AM.airlock_crush(DOOR_CRUSH_DAMAGE))
+				take_damage(DOOR_CRUSH_DAMAGE)
 
 	use_power(360)	//360 W seems much more appropriate for an actuator moving an industrial door capable of crushing people
 	if(istype(src, /obj/machinery/door/airlock/glass))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -862,6 +862,9 @@ About the new airlock wires panel:
 /obj/machinery/door/blocks_airlock()
 	return 0
 
+/obj/machinery/mech_sensor/blocks_airlock()
+	return 0
+
 /mob/living/blocks_airlock()
 	return 1
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -881,12 +881,6 @@ About the new airlock wires panel:
 	adjustBruteLoss(crush_damage)
 	SetStunned(5)
 	SetWeakened(5)
-	var/obj/effect/stop/S
-	S = new /obj/effect/stop
-	S.victim = src
-	S.loc = loc
-	spawn(20)
-		qdel(S)
 	var/turf/T = get_turf(src)
 	T.add_blood(src)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -388,7 +388,9 @@
 
 
 /obj/machinery/door/proc/open(var/forced = 0)
-	if(!can_open(forced)) return
+	if(!can_open(forced))
+		return
+	operating = 1
 
 	do_animate("opening")
 	icon_state = "door0"
@@ -401,8 +403,7 @@
 	update_icon()
 	SetOpacity(0)
 	update_nearby_tiles()
-
-	if(operating)	operating = 0
+	operating = 0
 
 	if(autoclose)
 		close_door_at = next_close_time()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -497,6 +497,9 @@
 /obj/mecha/proc/dynabsorbdamage(damage,damage_type)
 	return damage*(listgetindex(damage_absorption,damage_type) || 1)
 
+/obj/mecha/airlock_crush(var/crush_damage)
+	take_damage(crush_damage)
+	check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 
 /obj/mecha/proc/update_health()
 	if(src.health > 0)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -498,8 +498,10 @@
 	return damage*(listgetindex(damage_absorption,damage_type) || 1)
 
 /obj/mecha/airlock_crush(var/crush_damage)
+	..()
 	take_damage(crush_damage)
 	check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
+	return 1
 
 /obj/mecha/proc/update_health()
 	if(src.health > 0)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -160,16 +160,19 @@
 					A.ex_act(severity++)
 				qdel(src)
 
+/obj/structure/closet/proc/damage(var/damage)
+	health -= damage
+	if(health <= 0)
+		for(var/atom/movable/A in src)
+			A.loc = src.loc
+		qdel(src)
+
 /obj/structure/closet/bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		return
 
-	health -= Proj.damage
 	..()
-	if(health <= 0)
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.loc
-		qdel(src)
+	damage(Proj.damage)
 
 	return
 

--- a/html/changelogs/PsiOmegaDelta-AirlockPressure.yml
+++ b/html/changelogs/PsiOmegaDelta-AirlockPressure.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+changes:
+  - rscadd: "Beware. Airlocks can now crush more things than just mobs."
+delete-after: True


### PR DESCRIPTION
Airlocks can now crush mobs, canisters, closets, and mechas.
Airlocks are also blocked by dense objects in general.
Fixes #8983.
