### PR TITLE
Fixes (master)

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -15,6 +15,10 @@
 			// Override the current limb status and don't cause an explosion
 			E.droplimb(1,1)
 
+	for(var/obj/item/I in src)
+		drop_from_inventory(I)
+		I.throw_at(get_edge_target_turf(src,pick(alldirs)), rand(1,3), round(30/I.w_class))
+
 	..(species.gibbed_anim)
 	gibs(loc, viruses, dna, null, species.flesh_color, species.blood_color)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -9,7 +9,7 @@
 #define LIGHT_BROKEN 2
 #define LIGHT_BURNED 3
 
-
+#define LIGHT_BULB_TEMPERATURE 400 //K - used value for a 60W bulb
 
 /obj/item/light_fixture_frame
 	name = "light fixture frame"
@@ -487,11 +487,13 @@
 		var/mob/living/carbon/human/H = user
 
 		if(istype(H))
-
-			if(H.gloves)
+			if(H.species.heat_level_1 > LIGHT_BULB_TEMPERATURE)
+				prot = 1
+			else if(H.gloves)
 				var/obj/item/clothing/gloves/G = H.gloves
 				if(G.max_heat_protection_temperature)
-					prot = (G.max_heat_protection_temperature > 360)
+					if(G.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
+						prot = 1
 		else
 			prot = 1
 


### PR DESCRIPTION
- Fixes #8997. Gibbing a human now causes all items on and in their person to be thrown around.
- Fixes #8977. Species with a high enough heat_level_1 can remove lightbults.
