### PR TITLE
Removes the need for spawn() in New() procs.

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -54,9 +54,6 @@
 	air2.volume = ATMOS_DEFAULT_VOLUME_FILTER
 	air3.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
-	if(radio_controller)
-		initialize()
-
 /obj/machinery/atmospherics/trinary/filter/update_icon()
 	if(istype(src, /obj/machinery/atmospherics/trinary/filter/m_filter))
 		icon_state = "m"

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -73,9 +73,6 @@
 	if (!id_tag)
 		assign_uid()
 		id_tag = num2text(uid)
-	if(ticker && ticker.current_state == 3)//if the game is running
-		src.initialize()
-		src.broadcast_status()
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume
 	name = "Large Air Vent"
@@ -259,11 +256,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/initialize()
 	..()
 
-	//some vents work his own spesial way
+	//some vents work his own special way
 	radio_filter_in = frequency==1439?(RADIO_FROM_AIRALARM):null
 	radio_filter_out = frequency==1439?(RADIO_TO_AIRALARM):null
 	if(frequency)
 		set_frequency(frequency)
+		src.broadcast_status()
 
 /obj/machinery/atmospherics/unary/vent_pump/receive_signal(datum/signal/signal)
 	if(stat & (NOPOWER|BROKEN))

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -42,9 +42,6 @@
 	if (!id_tag)
 		assign_uid()
 		id_tag = num2text(uid)
-	if(ticker && ticker.current_state == 3)//if the game is running
-		src.initialize()
-		src.broadcast_status()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_icon(var/safety = 0)
 	if(!check_icon_cache())
@@ -121,6 +118,7 @@
 	radio_filter_out = frequency==initial(frequency)?(RADIO_TO_AIRALARM):null
 	if (frequency)
 		set_frequency(frequency)
+		src.broadcast_status()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/process()
 	..()

--- a/code/TriDimension/Pipes.dm
+++ b/code/TriDimension/Pipes.dm
@@ -45,8 +45,6 @@ obj/machinery/atmospherics/pipe/zpipe/New()
 			initialize_directions = EAST
 		if(SOUTHWEST)
 			initialize_directions = SOUTH
-	initialize()
-
 
 obj/machinery/atmospherics/pipe/zpipe/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -38,6 +38,10 @@
 
 	..()
 
+
+/atom/movable/proc/initialize()
+	return
+
 /atom/movable/Bump(var/atom/A, yes)
 	if(src.throwing)
 		src.throw_impact(A)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -14,6 +14,11 @@
 	var/moved_recently = 0
 	var/mob/pulledby = null
 
+/atom/movable/New()
+	..()
+	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
+		initialize()
+
 /atom/movable/Del()
 	if(isnull(gcDestroyed) && loc)
 		testing("GC: -- [type] was deleted via del() rather than qdel() --")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -1,11 +1,5 @@
 var/global/datum/controller/gameticker/ticker
 
-#define GAME_STATE_PREGAME		1
-#define GAME_STATE_SETTING_UP	2
-#define GAME_STATE_PLAYING		3
-#define GAME_STATE_FINISHED		4
-
-
 /datum/controller/gameticker
 	var/const/restart_timeout = 600
 	var/current_state = GAME_STATE_PREGAME

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -118,8 +118,6 @@
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 		update_icon()
-		if(ticker && ticker.current_state == 3)//if the game is running
-			src.initialize()
 		return
 
 	first_run()

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -67,12 +67,6 @@
 /obj/machinery/air_sensor/initialize()
 	set_frequency(frequency)
 
-/obj/machinery/air_sensor/New()
-	..()
-
-	if(radio_controller)
-		set_frequency(frequency)
-
 obj/machinery/air_sensor/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src,frequency)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -9,12 +9,6 @@
 	var/circuit = null //The path to the circuit board type. If circuit==null, the computer can't be disassembled.
 	var/processing = 0
 
-/obj/machinery/computer/New()
-	..()
-	if(ticker)
-		initialize()
-
-
 /obj/machinery/computer/initialize()
 	power_change()
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -58,10 +58,9 @@
 	icon_state = "cart-s"
 	access_security = 1
 
-/obj/item/weapon/cartridge/security/New()
+/obj/item/weapon/cartridge/security/initialize()
+	radio = new /obj/item/radio/integrated/beepsky(src)
 	..()
-	spawn(5)
-		radio = new /obj/item/radio/integrated/beepsky(src)
 
 /obj/item/weapon/cartridge/detective
 	name = "\improper D.E.T.E.C.T. cartridge"
@@ -102,6 +101,7 @@
 /obj/item/weapon/cartridge/signal
 	name = "generic signaler cartridge"
 	desc = "A data cartridge with an integrated radio signaler module."
+	var/qdeled = 0
 
 /obj/item/weapon/cartridge/signal/science
 	name = "\improper Signal Ace 2 cartridge"
@@ -110,10 +110,9 @@
 	access_reagent_scanner = 1
 	access_atmos = 1
 
-/obj/item/weapon/cartridge/signal/New()
-	..()
-	spawn(5)
-		radio = new /obj/item/radio/integrated/signal(src)
+/obj/item/weapon/cartridge/signal/initialize()
+    radio = new /obj/item/radio/integrated/signal(src)
+    ..()
 
 /obj/item/weapon/cartridge/signal/Destroy()
 	qdel(radio)
@@ -125,10 +124,9 @@
 	icon_state = "cart-q"
 	access_quartermaster = 1
 
-/obj/item/weapon/cartridge/quartermaster/New()
+/obj/item/weapon/cartridge/quartermaster/initialize()
+	radio = new /obj/item/radio/integrated/mule(src)
 	..()
-	spawn(5)
-		radio = new /obj/item/radio/integrated/mule(src)
 
 /obj/item/weapon/cartridge/head
 	name = "\improper Easy-Record DELUXE"
@@ -143,10 +141,8 @@
 	access_janitor = 1
 	access_security = 1
 
-/obj/item/weapon/cartridge/hop/New()
-	..()
-	spawn(5)
-		radio = new /obj/item/radio/integrated/mule(src)
+/obj/item/weapon/cartridge/hop/initialize()
+	radio = new /obj/item/radio/integrated/mule(src)
 
 /obj/item/weapon/cartridge/hos
 	name = "\improper R.O.B.U.S.T. DELUXE"
@@ -154,10 +150,9 @@
 	access_status_display = 1
 	access_security = 1
 
-/obj/item/weapon/cartridge/hos/New()
+/obj/item/weapon/cartridge/hos/initialize()
+	radio = new /obj/item/radio/integrated/beepsky(src)
 	..()
-	spawn(5)
-		radio = new /obj/item/radio/integrated/beepsky(src)
 
 /obj/item/weapon/cartridge/ce
 	name = "\improper Power-On DELUXE"
@@ -180,10 +175,9 @@
 	access_reagent_scanner = 1
 	access_atmos = 1
 
-/obj/item/weapon/cartridge/rd/New()
+/obj/item/weapon/cartridge/rd/initialize()
+	radio = new /obj/item/radio/integrated/signal(src)
 	..()
-	spawn(5)
-		radio = new /obj/item/radio/integrated/signal(src)
 
 /obj/item/weapon/cartridge/captain
 	name = "\improper Value-PAK cartridge"

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -217,12 +217,10 @@
 	var/last_transmission
 	var/datum/radio_frequency/radio_connection
 
-	New()
-		..()
-		if(radio_controller)
-			initialize()
-
 	initialize()
+		if(!radio_controller)
+			return
+
 		if (src.frequency < 1441 || src.frequency > 1489)
 			src.frequency = sanitize_frequency(src.frequency)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -42,8 +42,6 @@
 /obj/item/device/radio/New()
 	..()
 	wires = new(src)
-	if(radio_controller)
-		initialize()
 
 /obj/item/device/radio/Destroy()
 	qdel(wires)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -61,9 +61,6 @@
 	else
 		return null
 
-/atom/movable/proc/initialize()
-	return
-
 /obj/proc/updateUsrDialog()
 	if(in_use)
 		var/is_in_use = 0

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -308,12 +308,6 @@ var/list/solars_list = list()
 /obj/machinery/power/solar_control/drain_power()
 	return -1
 
-/obj/machinery/power/solar_control/New()
-	..()
-	if(ticker)
-		initialize()
-	connect_to_network()
-
 /obj/machinery/power/solar_control/Destroy()
 	for(var/obj/machinery/power/solar/M in connected_panels)
 		M.unset_control()
@@ -368,6 +362,7 @@ var/list/solars_list = list()
 	..()
 	if(!powernet) return
 	set_panels(cdir)
+	connect_to_network()
 
 /obj/machinery/power/solar_control/update_icon()
 	if(stat & BROKEN)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1,5 +1,10 @@
 #define DEBUG
 
+#define GAME_STATE_PREGAME		1
+#define GAME_STATE_SETTING_UP	2
+#define GAME_STATE_PLAYING		3
+#define GAME_STATE_FINISHED		4
+
 // Math constants.
 #define M_E     2.71828183
 #define M_PI    3.14159265


### PR DESCRIPTION
It causes massive headaches with qdel(), as references to objects can suddenly be created after soft-deletion.
The old master controller is responsible for calling initialize() on every atom/movable at round start.
Base atom/movable/New() responsible for calling initialize() after round start.
