### PR TITLE
Fixes #8987, lost edges from merged zones

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -50,7 +50,7 @@ atom/proc/c_airblock(turf/other)
 	#ifdef ZASDBG
 	ASSERT(isturf(other))
 	#endif
-	return !CanPass(null, other, 0, 0) + 2*!CanPass(null, other, 1.5, 1)
+	return (AIR_BLOCKED*!CanPass(null, other, 0, 0))|(ZONE_BLOCKED*!CanPass(null, other, 1.5, 1))
 
 
 turf/c_airblock(turf/other)

--- a/code/ZAS/Controller.dm
+++ b/code/ZAS/Controller.dm
@@ -154,7 +154,18 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		#ifdef ZASDBG
 		var/updated = 0
 		#endif
+		
+		//defer updating of self-zone-blocked turfs until after all other turfs have been updated.
+		//this hopefully ensures that non-self-zone-blocked turfs adjacent to self-zone-blocked ones
+		//have valid zones when the self-zone-blocked turfs update.
+		var/list/deferred = list()
+		
 		for(var/turf/T in updating)
+			//check if the turf is self-zone-blocked
+			if(T.c_airblock(T) & ZONE_BLOCKED)
+				deferred += T
+				continue
+			
 			T.update_air_properties()
 			T.post_update_air_properties()
 			T.needs_air_update = 0
@@ -163,6 +174,15 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 			updated++
 			#endif
 			//sleep(1)
+
+		for(var/turf/T in deferred)
+			T.update_air_properties()
+			T.post_update_air_properties()
+			T.needs_air_update = 0
+			#ifdef ZASDBG
+			T.overlays -= mark
+			updated++
+			#endif
 
 		#ifdef ZASDBG
 		if(updated != updating.len)
@@ -307,7 +327,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 
 /datum/controller/air_system/proc/mark_edge_sleeping(connection_edge/E)
 	#ifdef ZASDBG
-	ASSERT(istype(E)
+	ASSERT(istype(E))
 	#endif
 	if(E.sleeping) return
 	active_edges.Remove(E)
@@ -315,7 +335,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 
 /datum/controller/air_system/proc/mark_edge_active(connection_edge/E)
 	#ifdef ZASDBG
-	ASSERT(istype(E)
+	ASSERT(istype(E))
 	#endif
 	if(!E.sleeping) return
 	active_edges.Add(E)

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -59,7 +59,8 @@
 		#endif
 		if(zone)
 			var/zone/z = zone
-			if(locate(/obj/machinery/door/airlock) in src) //Hacky, but prevents normal airlocks from rebuilding zones all the time
+			
+			if(s_block & ZONE_BLOCKED) //Hacky, but prevents normal airlocks from rebuilding zones all the time
 				z.remove(src)
 			else
 				z.rebuild()

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -46,6 +46,7 @@
 				air_master.connect(sim, src)
 
 /turf/simulated/update_air_properties()
+
 	if(zone && zone.invalid)
 		c_copy_air()
 		zone = null //Easier than iterating through the list at the zone.
@@ -120,8 +121,10 @@
 				//Might have assigned a zone, since this happens for each direction.
 				if(!zone)
 
-					//if((block & ZONE_BLOCKED) || (r_block & ZONE_BLOCKED && !(s_block & ZONE_BLOCKED)))
-					if(((block & ZONE_BLOCKED) && !(r_block & ZONE_BLOCKED)) || (r_block & ZONE_BLOCKED && !(s_block & ZONE_BLOCKED)))
+					//We do not merge if 
+					//    they are blocking us and we are not blocking them, or if
+					//    we are blocking them and not blocking ourselves - this prevents tiny zones from forming on doorways.
+					if(((block & ZONE_BLOCKED) && !(r_block & ZONE_BLOCKED)) || ((r_block & ZONE_BLOCKED) && !(s_block & ZONE_BLOCKED)))
 						#ifdef ZASDBG
 						if(verbose) world << "[d] is zone blocked."
 						//dbg(zone_blocked, d)

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -105,6 +105,13 @@ Class Procs:
 		#ifdef ZASDBG
 		T.dbg(merged)
 		#endif
+	
+	//rebuild the old zone's edges so that the will be possesed by the new zone
+	for(var/connection_edge/E in edges)
+		if(E.contains_zone(into))
+			continue //don't need to rebuild this edge
+		for(var/turf/T in E.connecting_turfs)
+			air_master.mark_for_update(T)
 
 /zone/proc/c_invalidate()
 	invalid = 1

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -922,30 +922,6 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 					refined_trg -= B
 					continue moving
 
-	var/list/doors = new/list()
-
-	if(toupdate.len)
-		for(var/turf/simulated/T1 in toupdate)
-			for(var/obj/machinery/door/D2 in T1)
-				doors += D2
-			/*if(T1.parent)
-				air_master.groups_to_rebuild += T1.parent
-			else
-				air_master.tiles_to_update += T1*/
-
-	if(fromupdate.len)
-		for(var/turf/simulated/T2 in fromupdate)
-			for(var/obj/machinery/door/D2 in T2)
-				doors += D2
-			/*if(T2.parent)
-				air_master.groups_to_rebuild += T2.parent
-			else
-				air_master.tiles_to_update += T2*/
-
-	for(var/obj/O in doors)
-		O:update_nearby_tiles(1)
-
-
 
 proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 	if(!original)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -227,12 +227,6 @@
 		if(S.zone) S.zone.rebuild()
 
 	if(ispath(N, /turf/simulated/floor))
-		//if the old turf had a zone, connect the new turf to it as well - Cael
-		//Adjusted by SkyMarshal 5/10/13 - The air master will handle the addition of the new turf.
-		//if(zone)
-		//	zone.RemoveTurf(src)
-		//	if(!zone.CheckStatus())
-		//		zone.SetStatus(ZONE_ACTIVE)
 
 		var/turf/simulated/W = new N( locate(src.x, src.y, src.z) )
 		//W.Assimilate_Air()
@@ -249,7 +243,7 @@
 			W.RemoveLattice()
 
 		if(air_master)
-			air_master.mark_for_update(src)
+			air_master.mark_for_update(src) //handle the addition of the new turf.
 
 		for(var/turf/space/S in range(W,1))
 			S.update_starlight()
@@ -258,10 +252,6 @@
 		return W
 
 	else
-		//if(zone)
-		//	zone.RemoveTurf(src)
-		//	if(!zone.CheckStatus())
-		//		zone.SetStatus(ZONE_ACTIVE)
 
 		var/turf/W = new N( locate(src.x, src.y, src.z) )
 		W.lighting_lumcount += old_lumcount


### PR DESCRIPTION
- Fixes the occurrence of tiny door zones when a zone is rebuilt, but deferring the update of self-zone-blocked turfs. Fixes #8987.
- Fixes edges from being lost when a zone is merged.
- Replaces the locate(/obj/machinery/door/airlock) hack in `/turf/simulated/update_air_properties()`. This is probably the most contentious change, and I'd like some feedback on it.

The only reason this hack ever worked is because airlocks block zones, and as such are likely to be at the edges of a zone. If a turf is at the edge, it can be removed without rebuilding the zone as there is no risk of accidentally partitioning the zone (unless the zone is 1-turf wide somewhere but I guess you just can't win them all). 

Since not necessarily all airlocks can block zones (it's now controlled by a door var), it made sense to me to just check the flag itself.

This assumption fails if a turf blocks zones from itself but not other turfs for some weird reason (I'm not aware of anything that does this at the moment). Or if there are large groups of adjacent doors (large enough that some turfs are not at an edge... so a 5-door cross at the very smallest). It is safer than just checking for the existence of an airlock, though.
