### PR TITLE
Admins can now toggle OOC and LOOC separately from each other.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -185,6 +185,7 @@ var/list/gamemode_cache = list()
 	var/ninjas_allowed = 0
 	var/abandon_allowed = 1
 	var/ooc_allowed = 1
+	var/looc_allowed = 1
 	var/dooc_allowed = 1
 	var/dsay_allowed = 1
 
@@ -398,6 +399,7 @@ var/list/gamemode_cache = list()
 
 				if ("disable_ooc")
 					config.ooc_allowed = 0
+					config.looc_allowed = 0
 
 				if ("disable_entry")
 					config.enter_allowed = 0

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -85,8 +85,8 @@
 		return
 
 	if(!holder)
-		if(!config.ooc_allowed)
-			src << "<span class='danger'>OOC is globally muted.</span>"
+		if(!config.looc_allowed)
+			src << "<span class='danger'>LOOC is globally muted.</span>"
 			return
 		if(!config.dooc_allowed && (mob.stat == DEAD))
 			usr << "<span class='danger'>OOC for dead mobs has been turned off.</span>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -747,20 +747,43 @@ var/global/floorIsLava = 0
 	set category = "Server"
 	set desc="Globally Toggles OOC"
 	set name="Toggle OOC"
+
+	if(!check_rights(R_ADMIN))
+		return
+
 	config.ooc_allowed = !(config.ooc_allowed)
 	if (config.ooc_allowed)
 		world << "<B>The OOC channel has been globally enabled!</B>"
 	else
 		world << "<B>The OOC channel has been globally disabled!</B>"
-	log_admin("[key_name(usr)] toggled OOC.")
-	message_admins("[key_name_admin(usr)] toggled OOC.", 1)
+	log_and_message_admins("toggled OOC.")
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/togglelooc()
+	set category = "Server"
+	set desc="Globally Toggles LOOC"
+	set name="Toggle LOOC"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.looc_allowed = !(config.looc_allowed)
+	if (config.looc_allowed)
+		world << "<B>The LOOC channel has been globally enabled!</B>"
+	else
+		world << "<B>The LOOC channel has been globally disabled!</B>"
+	log_and_message_admins("toggled LOOC.")
+	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
 /datum/admins/proc/toggledsay()
 	set category = "Server"
 	set desc="Globally Toggles DSAY"
 	set name="Toggle DSAY"
+
+	if(!check_rights(R_ADMIN))
+		return
+
 	config.dsay_allowed = !(config.dsay_allowed)
 	if (config.dsay_allowed)
 		world << "<B>Deadchat has been globally enabled!</B>"
@@ -774,6 +797,10 @@ var/global/floorIsLava = 0
 	set category = "Server"
 	set desc="Toggle Dead OOC."
 	set name="Toggle Dead OOC"
+
+	if(!check_rights(R_ADMIN))
+		return
+
 	config.dooc_allowed = !( config.dooc_allowed )
 	log_admin("[key_name(usr)] toggled Dead OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.", 1)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -58,6 +58,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	/client/proc/secrets,
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
+	/datum/admins/proc/togglelooc,		/*toggles looc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggledsay,		/*toggles dsay on/off for everyone*/
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/

--- a/html/changelogs/PsiOmegaDelta-LOOCToggle.yml
+++ b/html/changelogs/PsiOmegaDelta-LOOCToggle.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - rscadd: "Admins can now toggle OOC/LOOC separately."
+  

--- a/html/changelogs/PsiOmegaDelta.yml
+++ b/html/changelogs/PsiOmegaDelta.yml
@@ -1,3 +1,0 @@
-author: PsiOmegaDelta
-changes: []
-delete-after: false


### PR DESCRIPTION
In terms of server configuration OOC/LOOC are still considered the same setting, unless someone really wants another config flag for it.
Observers still cannot use either OOC or LOOC if DOOC is toggled, no separate toggle for that.

Also includes what I think are correct permission checks for OOC toggling.
