### PR TITLE
Fixes #9029.

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -1,14 +1,13 @@
 /var/global/sent_spiders_to_station = 0
 
 /datum/event/spider_infestation
-	announceWhen	= 400
-
+	announceWhen	= 90
 	var/spawncount = 1
 
 
 /datum/event/spider_infestation/setup()
-	announceWhen = rand(announceWhen, announceWhen + 50)
-	spawncount = rand(8, 12)	//spiderlings only have a 50% chance to grow big and strong
+	announceWhen = rand(announceWhen, announceWhen + 60)
+	spawncount = rand(4 * severity, 6 * severity)	//spiderlings only have a 50% chance to grow big and strong
 	sent_spiders_to_station = 0
 
 /datum/event/spider_infestation/announce()

--- a/html/changelogs/PsiOmegaDelta-ChitterChitter.yml
+++ b/html/changelogs/PsiOmegaDelta-ChitterChitter.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+changes:
+  - tweak: "The spider infestation event now makes an announcement much sooner."
+delete-after: false

--- a/html/changelogs/PsiOmegaDelta.yml
+++ b/html/changelogs/PsiOmegaDelta.yml
@@ -1,3 +1,0 @@
-author: PsiOmegaDelta
-changes: []
-delete-after: false


### PR DESCRIPTION
Fixes #9029.
Reduces the announcement message delay for spiders from 800-900 seconds to 180-300 seconds.
Number of spiders now based on severity, with a moderate level event spawning as many spiders as before.
