### PR TITLE
Resist code cleanup, plus fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1063,6 +1063,7 @@
 #include "code\modules\mob\living\carbon\carbon_defines.dm"
 #include "code\modules\mob\living\carbon\carbon_powers.dm"
 #include "code\modules\mob\living\carbon\give.dm"
+#include "code\modules\mob\living\carbon\resist.dm"
 #include "code\modules\mob\living\carbon\shock.dm"
 #include "code\modules\mob\living\carbon\viruses.dm"
 #include "code\modules\mob\living\carbon\alien\alien.dm"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -316,10 +316,6 @@
 		return 0 //closed but not welded...
 	return 1
 
-/obj/structure/closet/secure_closet/req_breakout()
-	if(!opened && locked) return 1
-	return ..() //It's a secure closet, but isn't locked.
-
 /obj/structure/closet/proc/mob_breakout(var/mob/living/escapee)
 	var/breakout_time = 2 //2 minutes by default
 
@@ -329,7 +325,7 @@
 	//okay, so the closet is either welded or locked... resist!!!
 	escapee.next_move = world.time + 100
 	escapee.last_special = world.time + 100
-	escapee << "\red You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)"
+	escapee << "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)</span>"
 	
 	visible_message("<span class='danger'>The [src] begins to shake violently!</span>")
 	playsound(src.loc, 'sound/effects/grillehit.ogg', 100, 1)
@@ -351,23 +347,6 @@
 
 /obj/structure/closet/proc/break_open()
 	welded = 0
-	update_icon()
-	//Do this to prevent contents from being opened into nullspace (read: bluespace)
-	if(istype(loc, /obj/structure/bigDelivery))
-		var/obj/structure/bigDelivery/BD = loc
-		BD.unwrap()
-	open()
-
-/obj/structure/closet/secure_closet/break_open()
-	desc += " It appears to be broken."
-	icon_state = icon_off
-	spawn()
-		flick(icon_broken, src)
-		sleep(10)
-		flick(icon_broken, src)
-		sleep(10)
-	broken = 1
-	locked = 0
 	update_icon()
 	//Do this to prevent contents from being opened into nullspace (read: bluespace)
 	if(istype(loc, /obj/structure/bigDelivery))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -132,3 +132,25 @@
 			overlays += "welded"
 	else
 		icon_state = icon_opened
+
+
+/obj/structure/closet/secure_closet/req_breakout()
+	if(!opened && locked) return 1
+	return ..() //It's a secure closet, but isn't locked.
+
+/obj/structure/closet/secure_closet/break_open()
+	desc += " It appears to be broken."
+	icon_state = icon_off
+	spawn()
+		flick(icon_broken, src)
+		sleep(10)
+		flick(icon_broken, src)
+		sleep(10)
+	broken = 1
+	locked = 0
+	update_icon()
+	//Do this to prevent contents from being opened into nullspace (read: bluespace)
+	if(istype(loc, /obj/structure/bigDelivery))
+		var/obj/structure/bigDelivery/BD = loc
+		BD.unwrap()
+	open()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -524,3 +524,4 @@
 	Stun(stun_duration)
 	Weaken(Floor(stun_duration/2))
 	return 1
+

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -10,12 +10,16 @@
 		fire_stacks -= 2 //reduced
 		Weaken(3)
 		spin(32,2)
-		visible_message("<span class='danger'>[src] rolls on the floor, trying to put themselves out!</span>", \
-			"<span class='notice'>You stop, drop, and roll!</span>")
+		visible_message(
+			"<span class='danger'>[src] rolls on the floor, trying to put themselves out!</span>",
+			"<span class='notice'>You stop, drop, and roll!</span>"
+			)
 		sleep(30)
 		if(fire_stacks <= 0)
-			visible_message("<span class='danger'>[src] has successfully extinguished themselves!</span>", \
-				"<span class='notice'>You extinguish yourself.</span>")
+			visible_message(
+				"<span class='danger'>[src] has successfully extinguished themselves!</span>",
+				"<span class='notice'>You extinguish yourself.</span>"
+				)
 			ExtinguishMob()
 		return
 	
@@ -46,14 +50,18 @@
 		breakouttime = HC.breakouttime
 		displaytime = breakouttime / 600 //Minutes
 	
-	src << "\red You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)"
-	visible_message("\red <B>[src] attempts to remove \the [HC]!</B>")
+	visible_message(
+		"<span class='danger'>[src] attempts to remove \the [HC]!</span>",
+		"<span class='warning'>You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)</span>"
+		)
 
 	if(do_after(src, breakouttime))
 		if(!handcuffed || buckled)
 			return
-		visible_message("\red <B>[src] manages to remove the handcuffs!</B>")
-		src << "\blue You successfully remove \the [handcuffed]."
+		visible_message(
+			"<span class='danger'>[src] manages to remove \the [handcuffed]!</span>",
+			"<span class='notice'>You successfully remove \the [handcuffed].</span>"
+			)
 		drop_from_inventory(handcuffed)
 
 /mob/living/carbon/proc/escape_legcuffs()
@@ -76,15 +84,17 @@
 		breakouttime = HC.breakouttime
 		displaytime = breakouttime / 600 //Minutes
 	
-	src << "\red You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)"
-	visible_message( "\red <B>[usr] attempts to remove \the [HC]!</B>" )
+	visible_message( 
+		"<span class='danger'>[usr] attempts to remove \the [HC]!</span>", 
+		"<span class='warning'>You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)</span>"
+		)
 
 	if(do_after(src, breakouttime))
 		if(!legcuffed || buckled)
 			return 
 		visible_message(
-			"\red <B>[src] manages to remove the legcuffs!</B>", 
-			"\blue You successfully remove \the [legcuffed]."
+			"<span class='danger'>[src] manages to remove \the [legcuffed]!</span>", 
+			"<span class='notice'>You successfully remove \the [legcuffed].</span>"
 			)
 		
 		drop_from_inventory(legcuffed)
@@ -96,16 +106,18 @@
 		return 1
 
 /mob/living/carbon/proc/break_handcuffs()
-	src << "\red You attempt to break your handcuffs. (This will take around 5 seconds and you need to stand still)"
-	visible_message(text("\red <B>[] is trying to break the handcuffs!</B>", src))
+	visible_message(
+		"<span class='danger'>[src] is trying to break \the [handcuffed]!</span>",
+		"<span class='warning'>You attempt to break your [handcuffed.name]. (This will take around 5 seconds and you need to stand still)</span>"
+		)
 	
 	if(do_after(src, 50))
 		if(!handcuffed || buckled)
 			return
 		
 		visible_message(
-			"\red <B>[src] manages to break the handcuffs!</B>", 
-			"\red You successfully break your handcuffs."
+			"<span class='danger'>[src] manages to break \the [handcuffed]!</span>", 
+			"<span class='warning'>You successfully break your [handcuffed.name].</span>"
 			)
 		
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
@@ -117,16 +129,16 @@
 		update_inv_handcuffed()
 
 /mob/living/carbon/proc/break_legcuffs()
-	src << "\red You attempt to break your legcuffs. (This will take around 5 seconds and you need to stand still)"
-	visible_message("\red <B>[src] is trying to break the legcuffs!</B>")
+	src << "<span class='warning'>You attempt to break your legcuffs. (This will take around 5 seconds and you need to stand still)</span>"
+	visible_message("<span class='danger'>[src] is trying to break the legcuffs!</span>")
 
 	if(do_after(src, 50))
 		if(!legcuffed || buckled)
 			return
 		
 		visible_message(
-			"\red <B>[src] manages to break the legcuffs!</B>",
-			"\red You successfully break your legcuffs."
+			"<span class='danger'>[src] manages to break the legcuffs!</span>",
+			"<span class='warning'>You successfully break your legcuffs.</span>"
 			)
 		
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
@@ -149,8 +161,10 @@
 	else
 		next_move = world.time + 100
 		last_special = world.time + 100
-		src << "\red You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)"
-		visible_message("\red <B>[usr] attempts to unbuckle themself!</B>")
+		visible_message(
+			"<span class='danger'>[usr] attempts to unbuckle themself!</span>",
+			"<span class='warning'>You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)</span>"
+			)
 
 		if(do_after(usr, 1200))
 			if(!buckled)

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -1,9 +1,5 @@
 
-/mob/living/carbon/resist()
-	//need to allow !canmove, or otherwise neck grabs can't be resisted
-	//so just check weakened instead.
-	if(stat || weakened || next_move > world.time) 
-		return 
+/mob/living/carbon/process_resist()
 	
 	//drop && roll
 	if(on_fire)

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -1,0 +1,160 @@
+
+/mob/living/carbon/resist()
+	//need to allow !canmove, or otherwise neck grabs can't be resisted
+	//so just check weakened instead.
+	if(stat || weakened || next_move > world.time) 
+		return 
+	
+	//drop && roll
+	if(on_fire)
+		fire_stacks -= 2 //reduced
+		Weaken(3)
+		spin(32,2)
+		visible_message("<span class='danger'>[src] rolls on the floor, trying to put themselves out!</span>", \
+			"<span class='notice'>You stop, drop, and roll!</span>")
+		sleep(30)
+		if(fire_stacks <= 0)
+			visible_message("<span class='danger'>[src] has successfully extinguished themselves!</span>", \
+				"<span class='notice'>You extinguish yourself.</span>")
+			ExtinguishMob()
+		return
+	
+	if(handcuffed)
+		spawn() escape_handcuffs()
+	else if(legcuffed)
+		spawn() escape_legcuffs()
+	
+	..()
+
+/mob/living/carbon/proc/escape_handcuffs()
+	if(!(last_special <= world.time)) return
+	
+	next_move = world.time + 100
+	last_special = world.time + 100
+
+	if(can_break_cuffs()) //Don't want to do a lot of logic gating here.
+		break_handcuffs()
+		return
+	
+	var/obj/item/weapon/handcuffs/HC = handcuffed
+	
+	//A default in case you are somehow handcuffed with something that isn't an obj/item/weapon/handcuffs type
+	var/breakouttime = 1200 
+	var/displaytime = 2 //Minutes to display in the "this will take X minutes."
+	//If you are handcuffed with actual handcuffs... Well what do I know, maybe someone will want to handcuff you with toilet paper in the future...
+	if(istype(HC))
+		breakouttime = HC.breakouttime
+		displaytime = breakouttime / 600 //Minutes
+	
+	src << "\red You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)"
+	visible_message("\red <B>[src] attempts to remove \the [HC]!</B>")
+
+	if(do_after(src, breakouttime))
+		if(!handcuffed || buckled)
+			return
+		visible_message("\red <B>[src] manages to remove the handcuffs!</B>")
+		src << "\blue You successfully remove \the [handcuffed]."
+		drop_from_inventory(handcuffed)
+
+/mob/living/carbon/proc/escape_legcuffs()
+	if(!(last_special <= world.time)) return
+	
+	next_move = world.time + 100
+	last_special = world.time + 100
+
+	if(can_break_cuffs()) //Don't want to do a lot of logic gating here.
+		break_legcuffs()
+		return
+
+	var/obj/item/weapon/legcuffs/HC = legcuffed
+	
+	//A default in case you are somehow legcuffed with something that isn't an obj/item/weapon/legcuffs type
+	var/breakouttime = 1200
+	var/displaytime = 2 //Minutes to display in the "this will take X minutes."
+	//If you are legcuffed with actual legcuffs... Well what do I know, maybe someone will want to legcuff you with toilet paper in the future...
+	if(istype(HC))
+		breakouttime = HC.breakouttime
+		displaytime = breakouttime / 600 //Minutes
+	
+	src << "\red You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)"
+	visible_message( "\red <B>[usr] attempts to remove \the [HC]!</B>" )
+
+	if(do_after(src, breakouttime))
+		if(!legcuffed || buckled)
+			return 
+		visible_message(
+			"\red <B>[src] manages to remove the legcuffs!</B>", 
+			"\blue You successfully remove \the [legcuffed]."
+			)
+		
+		drop_from_inventory(legcuffed)
+		legcuffed = null
+		update_inv_legcuffed()
+
+/mob/living/carbon/proc/can_break_cuffs()
+	if(HULK in mutations)
+		return 1
+
+/mob/living/carbon/proc/break_handcuffs()
+	src << "\red You attempt to break your handcuffs. (This will take around 5 seconds and you need to stand still)"
+	visible_message(text("\red <B>[] is trying to break the handcuffs!</B>", src))
+	
+	if(do_after(src, 50))
+		if(!handcuffed || buckled)
+			return
+		
+		visible_message(
+			"\red <B>[src] manages to break the handcuffs!</B>", 
+			"\red You successfully break your handcuffs."
+			)
+		
+		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+		
+		del(handcuffed)
+		handcuffed = null
+		if(buckled && buckled.buckle_require_restraints)
+			buckled.unbuckle_mob()
+		update_inv_handcuffed()
+
+/mob/living/carbon/proc/break_legcuffs()
+	src << "\red You attempt to break your legcuffs. (This will take around 5 seconds and you need to stand still)"
+	visible_message("\red <B>[src] is trying to break the legcuffs!</B>")
+
+	if(do_after(src, 50))
+		if(!legcuffed || buckled)
+			return
+		
+		visible_message(
+			"\red <B>[src] manages to break the legcuffs!</B>",
+			"\red You successfully break your legcuffs."
+			)
+		
+		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+		
+		del(legcuffed)
+		legcuffed = null
+		update_inv_legcuffed()
+
+/mob/living/carbon/human/can_break_cuffs()
+	if(species.can_shred(src,1))
+		return 1
+	return ..()
+
+/mob/living/carbon/escape_buckle()
+	if(!buckled) return
+	if(!(last_special <= world.time)) return
+
+	if(!restrained())
+		..()
+	else
+		next_move = world.time + 100
+		last_special = world.time + 100
+		src << "\red You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)"
+		visible_message("\red <B>[usr] attempts to unbuckle themself!</B>")
+
+		if(do_after(usr, 1200))
+			if(!buckled)
+				return
+			visible_message("<span class='danger'>[usr] manages to unbuckle themself!</span>",
+							"<span class='notice'>You successfully unbuckle yourself.</span>")
+			buckled.user_unbuckle_mob(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -460,13 +460,20 @@
 	set name = "Resist"
 	set category = "IC"
 
+	if(can_resist())
+		next_move = world.time + 20
+		process_resist()
+
+/mob/living/proc/can_resist()
 	//need to allow !canmove, or otherwise neck grabs can't be resisted
 	//so just check weakened instead.
-	if(stat || weakened || next_move > world.time)
-		return
+	if(stat || weakened)
+		return 0
+	if(next_move > world.time)
+		return 0
+	return 1
 
-	next_move = world.time + 20
-
+/mob/living/proc/process_resist()
 	//Getting out of someone's inventory.
 	if(istype(src.loc, /obj/item/weapon/holder))
 		escape_inventory(src.loc)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -460,284 +460,77 @@
 	set name = "Resist"
 	set category = "IC"
 
-	if(usr.stat || !isliving(usr) || usr.next_move > world.time)
+	//need to allow !canmove, or otherwise neck grabs can't be resisted
+	//so just check weakened instead.
+	if(stat || weakened || next_move > world.time)
 		return
 
-	usr.next_move = world.time + 20
-
-	var/mob/living/L = usr
+	next_move = world.time + 20
 
 	//Getting out of someone's inventory.
-	if(istype(src.loc,/obj/item/weapon/holder))
-		var/obj/item/weapon/holder/H = src.loc //Get our item holder.
-		var/mob/M = H.loc                      //Get our mob holder (if any).
-
-		if(istype(M))
-			M.drop_from_inventory(H)
-			M << "[H] wriggles out of your grip!"
-			src << "You wriggle out of [M]'s grip!"
-		else if(istype(H.loc,/obj/item))
-			src << "You struggle free of [H.loc]."
-			H.loc = get_turf(H)
-
-		if(istype(M))
-			for(var/atom/A in M.contents)
-				if(istype(A,/mob/living/simple_animal/borer) || istype(A,/obj/item/weapon/holder))
-					return
-
-		M.status_flags &= ~PASSEMOTES
+	if(istype(src.loc, /obj/item/weapon/holder))
+		escape_inventory(src.loc)
 		return
 
-	//Resisting control by an alien mind.
-	if(istype(src.loc,/mob/living/simple_animal/borer))
-		var/mob/living/simple_animal/borer/B = src.loc
-		var/mob/living/captive_brain/H = src
-
-		H << "<span class='danger'>You begin doggedly resisting the parasite's control (this will take approximately sixty seconds).</span>"
-		B.host << "<span class='danger'>You feel the captive mind of [src] begin to resist your control.</span>"
-
-		spawn(rand(200,250)+B.host.brainloss)
-
-			if(!B || !B.controlling)
-				return
-
-			B.host.adjustBrainLoss(rand(5,10))
-			H << "<span class='danger'>With an immense exertion of will, you regain control of your body!</span>"
-			B.host << "<span class='danger'>You feel control of the host brain ripped from your grasp, and retract your probosci before the wild neural impulses can damage you.</span>"
-
-			B.detatch()
-
-			verbs -= /mob/living/carbon/proc/release_control
-			verbs -= /mob/living/carbon/proc/punish_host
-			verbs -= /mob/living/carbon/proc/spawn_larvae
-
-			return
-
 	//resisting grabs (as if it helps anyone...)
-	if ((!( L.stat ) && !( L.restrained() )))
-		var/resisting = 0
-		for(var/obj/O in L.requests)
-			L.requests.Remove(O)
-			del(O)
-			resisting++
-		for(var/obj/item/weapon/grab/G in usr.grabbed_by)
-			resisting++
-			switch(G.state)
-				if(GRAB_PASSIVE)
-					del(G)
-				if(GRAB_AGGRESSIVE)
-					if(prob(60)) //same chance of breaking the grab as disarm
-						L.visible_message("<span class='warning'>[L] has broken free of [G.assailant]'s grip!</span>")
-						del(G)
-				if(GRAB_NECK)
-					//If the you move when grabbing someone then it's easier for them to break free. Same if the affected mob is immune to stun.
-					if (((world.time - G.assailant.l_move_time < 30 || !L.stunned) && prob(15)) || prob(3))
-						L.visible_message("<span class='warning'>[L] has broken free of [G.assailant]'s headlock!</span>")
-						del(G)
-		if(resisting)
-			L.visible_message("<span class='danger'>[L] resists!</span>")
-
+	if (!restrained())
+		resist_grab()
 
 	//unbuckling yourself
-	if(L.buckled && (L.last_special <= world.time) )
-		if(iscarbon(L))
-			var/mob/living/carbon/C = L
-			if( C.handcuffed )
-				C.next_move = world.time + 100
-				C.last_special = world.time + 100
-				C << "\red You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)"
-				for(var/mob/O in viewers(L))
-					O.show_message("\red <B>[usr] attempts to unbuckle themself!</B>", 1)
-				spawn(0)
-					if(do_after(usr, 1200))
-						if(!C.buckled)
-							return
-						for(var/mob/O in viewers(C))
-							O.show_message("\red <B>[usr] manages to unbuckle themself!</B>", 1)
-						C << "\blue You successfully unbuckle yourself."
-						C.buckled.user_unbuckle_mob(C)
-		else
-			L.buckled.user_unbuckle_mob(L)
+	if(buckled)
+		spawn() escape_buckle()
 
 	//Breaking out of a locker?
-	else if( src.loc && (istype(src.loc, /obj/structure/closet)) )
-		var/breakout_time = 2 //2 minutes by default
+	if( src.loc && (istype(src.loc, /obj/structure/closet)) )
+		var/obj/structure/closet/C = loc
+		spawn() C.mob_breakout(src)
 
-		var/obj/structure/closet/C = L.loc
-		if(C.opened)
-			return //Door's open... wait, why are you in it's contents then?
-		if(istype(L.loc, /obj/structure/closet/secure_closet))
-			var/obj/structure/closet/secure_closet/SC = L.loc
-			if(!SC.locked && !SC.welded)
-				return //It's a secure closet, but isn't locked. Easily escapable from, no need to 'resist'
-		else
-			if(!C.welded)
-				return //closed but not welded...
-		//	else Meh, lets just keep it at 2 minutes for now
-		//		breakout_time++ //Harder to get out of welded lockers than locked lockers
+/mob/living/proc/escape_inventory(obj/item/weapon/holder/H)
+	if(H != src.loc) return
+	
+	var/mob/M = H.loc //Get our mob holder (if any).
 
-		//okay, so the closet is either welded or locked... resist!!!
-		usr.next_move = world.time + 100
-		L.last_special = world.time + 100
-		L << "\red You lean on the back of \the [C] and start pushing the door open. (this will take about [breakout_time] minutes)"
-		for(var/mob/O in viewers(usr.loc))
-			O.show_message("\red <B>The [L.loc] begins to shake violently!</B>", 1)
+	if(istype(M))
+		M.drop_from_inventory(H)
+		M << "[H] wriggles out of your grip!"
+		src << "You wriggle out of [M]'s grip!"
+	else if(istype(H.loc,/obj/item))
+		src << "You struggle free of [H.loc]."
+		H.loc = get_turf(H)
 
+	if(istype(M))
+		for(var/atom/A in M.contents)
+			if(istype(A,/mob/living/simple_animal/borer) || istype(A,/obj/item/weapon/holder))
+				return
 
-		spawn(0)
-			if(do_after(usr,(breakout_time*60*10))) //minutes * 60seconds * 10deciseconds
-				if(!C || !L || L.stat != CONSCIOUS || L.loc != C || C.opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
-					return
+	M.status_flags &= ~PASSEMOTES
 
-				//Perform the same set of checks as above for weld and lock status to determine if there is even still a point in 'resisting'...
-				if(istype(L.loc, /obj/structure/closet/secure_closet))
-					var/obj/structure/closet/secure_closet/SC = L.loc
-					if(!SC.locked && !SC.welded)
-						return
-				else
-					if(!C.welded)
-						return
+/mob/living/proc/escape_buckle()
+	if(buckled)
+		buckled.user_unbuckle_mob(src)
 
-				//Well then break it!
-				if(istype(usr.loc, /obj/structure/closet/secure_closet))
-					var/obj/structure/closet/secure_closet/SC = L.loc
-					SC.desc = "It appears to be broken."
-					SC.icon_state = SC.icon_off
-					flick(SC.icon_broken, SC)
-					sleep(10)
-					flick(SC.icon_broken, SC)
-					sleep(10)
-					SC.broken = 1
-					SC.locked = 0
-					SC.update_icon()
-					usr << "\red You successfully break out!"
-					for(var/mob/O in viewers(L.loc))
-						O.show_message("\red <B>\the [usr] successfully broke out of \the [SC]!</B>", 1)
-					if(istype(SC.loc, /obj/structure/bigDelivery)) //Do this to prevent contents from being opened into nullspace (read: bluespace)
-						var/obj/structure/bigDelivery/BD = SC.loc
-						BD.attack_hand(usr)
-					SC.open()
-				else
-					C.welded = 0
-					C.update_icon()
-					usr << "\red You successfully break out!"
-					for(var/mob/O in viewers(L.loc))
-						O.show_message("\red <B>\the [usr] successfully broke out of \the [C]!</B>", 1)
-					if(istype(C.loc, /obj/structure/bigDelivery)) //nullspace ect.. read the comment above
-						var/obj/structure/bigDelivery/BD = C.loc
-						BD.attack_hand(usr)
-					C.open()
-
-	//drop && roll or breaking out of handcuffs
-	else if(iscarbon(L))
-		var/mob/living/carbon/CM = L
-		if(CM.on_fire && CM.canmove)
-			CM.fire_stacks -= 5
-			CM.Weaken(3)
-			CM.spin(32,2)
-			CM.visible_message("<span class='danger'>[CM] rolls on the floor, trying to put themselves out!</span>", \
-				"<span class='notice'>You stop, drop, and roll!</span>")
-			sleep(30)
-			if(fire_stacks <= 0)
-				CM.visible_message("<span class='danger'>[CM] has successfully extinguished themselves!</span>", \
-					"<span class='notice'>You extinguish yourself.</span>")
-				ExtinguishMob()
-			return
-		if(CM.handcuffed && CM.canmove && (CM.last_special <= world.time))
-			CM.next_move = world.time + 100
-			CM.last_special = world.time + 100
-
-			var/can_break_cuffs
-			if(HULK in usr.mutations)
-				can_break_cuffs = 1
-			else if(istype(CM,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = CM
-				if(H.species.can_shred(H,1))
-					can_break_cuffs = 1
-
-			if(can_break_cuffs) //Don't want to do a lot of logic gating here.
-				usr << "\red You attempt to break your handcuffs. (This will take around 5 seconds and you need to stand still)"
-				for(var/mob/O in viewers(CM))
-					O.show_message(text("\red <B>[] is trying to break the handcuffs!</B>", CM), 1)
-				spawn(0)
-					if(do_after(CM, 50))
-						if(!CM.handcuffed || CM.buckled)
-							return
-						for(var/mob/O in viewers(CM))
-							O.show_message(text("\red <B>[] manages to break the handcuffs!</B>", CM), 1)
-						CM << "\red You successfully break your handcuffs."
-						CM.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-						del(CM.handcuffed)
-						CM.handcuffed = null
-						if(buckled && buckled.buckle_require_restraints)
-							buckled.unbuckle_mob()
-						CM.update_inv_handcuffed()
-			else
-				var/obj/item/weapon/handcuffs/HC = CM.handcuffed
-				var/breakouttime = 1200 //A default in case you are somehow handcuffed with something that isn't an obj/item/weapon/handcuffs type
-				var/displaytime = 2 //Minutes to display in the "this will take X minutes."
-				if(istype(HC)) //If you are handcuffed with actual handcuffs... Well what do I know, maybe someone will want to handcuff you with toilet paper in the future...
-					breakouttime = HC.breakouttime
-					displaytime = breakouttime / 600 //Minutes
-				CM << "\red You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)"
-				for(var/mob/O in viewers(CM))
-					O.show_message( "\red <B>[usr] attempts to remove \the [HC]!</B>", 1)
-				spawn(0)
-					if(do_after(CM, breakouttime))
-						if(!CM.handcuffed || CM.buckled)
-							return // time leniency for lag which also might make this whole thing pointless but the server
-						for(var/mob/O in viewers(CM))//                                         lags so hard that 40s isn't lenient enough - Quarxink
-							O.show_message("\red <B>[CM] manages to remove the handcuffs!</B>", 1)
-						CM << "\blue You successfully remove \the [CM.handcuffed]."
-						CM.drop_from_inventory(CM.handcuffed)
-
-		else if(CM.legcuffed && CM.canmove && (CM.last_special <= world.time))
-			CM.next_move = world.time + 100
-			CM.last_special = world.time + 100
-
-			var/can_break_cuffs
-			if(HULK in usr.mutations)
-				can_break_cuffs = 1
-			else if(istype(CM,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = CM
-				if(H.species.can_shred(H,1))
-					can_break_cuffs = 1
-
-			if(can_break_cuffs) //Don't want to do a lot of logic gating here.
-				usr << "\red You attempt to break your legcuffs. (This will take around 5 seconds and you need to stand still)"
-				for(var/mob/O in viewers(CM))
-					O.show_message(text("\red <B>[] is trying to break the legcuffs!</B>", CM), 1)
-				spawn(0)
-					if(do_after(CM, 50))
-						if(!CM.legcuffed || CM.buckled)
-							return
-						for(var/mob/O in viewers(CM))
-							O.show_message(text("\red <B>[] manages to break the legcuffs!</B>", CM), 1)
-						CM << "\red You successfully break your legcuffs."
-						CM.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-						del(CM.legcuffed)
-						CM.legcuffed = null
-						CM.update_inv_legcuffed()
-			else
-				var/obj/item/weapon/legcuffs/HC = CM.legcuffed
-				var/breakouttime = 1200 //A default in case you are somehow legcuffed with something that isn't an obj/item/weapon/legcuffs type
-				var/displaytime = 2 //Minutes to display in the "this will take X minutes."
-				if(istype(HC)) //If you are legcuffed with actual legcuffs... Well what do I know, maybe someone will want to legcuff you with toilet paper in the future...
-					breakouttime = HC.breakouttime
-					displaytime = breakouttime / 600 //Minutes
-				CM << "\red You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)"
-				for(var/mob/O in viewers(CM))
-					O.show_message( "\red <B>[usr] attempts to remove \the [HC]!</B>", 1)
-				spawn(0)
-					if(do_after(CM, breakouttime))
-						if(!CM.legcuffed || CM.buckled)
-							return // time leniency for lag which also might make this whole thing pointless but the server
-						for(var/mob/O in viewers(CM))//                                         lags so hard that 40s isn't lenient enough - Quarxink
-							O.show_message("\red <B>[CM] manages to remove the legcuffs!</B>", 1)
-						CM << "\blue You successfully remove \the [CM.legcuffed]."
-						CM.drop_from_inventory(CM.legcuffed)
-						CM.legcuffed = null
-						CM.update_inv_legcuffed()
+/mob/living/proc/resist_grab()
+	var/resisting = 0
+	for(var/obj/O in requests)
+		requests.Remove(O)
+		del(O)
+		resisting++
+	for(var/obj/item/weapon/grab/G in grabbed_by)
+		resisting++
+		switch(G.state)
+			if(GRAB_PASSIVE)
+				del(G)
+			if(GRAB_AGGRESSIVE)
+				if(prob(60)) //same chance of breaking the grab as disarm
+					visible_message("<span class='warning'>[src] has broken free of [G.assailant]'s grip!</span>")
+					del(G)
+			if(GRAB_NECK)
+				//If the you move when grabbing someone then it's easier for them to break free. Same if the affected mob is immune to stun.
+				if (((world.time - G.assailant.l_move_time < 30 || !stunned) && prob(15)) || prob(3))
+					visible_message("<span class='warning'>[src] has broken free of [G.assailant]'s headlock!</span>")
+					del(G)
+	if(resisting)
+		visible_message("<span class='danger'>[src] resists!</span>")
 
 /mob/living/verb/lay_down()
 	set name = "Rest"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -492,10 +492,10 @@
 
 	if(istype(M))
 		M.drop_from_inventory(H)
-		M << "[H] wriggles out of your grip!"
-		src << "You wriggle out of [M]'s grip!"
+		M << "<span class='warning'>[H] wriggles out of your grip!</span>"
+		src << "<span class='warning'>You wriggle out of [M]'s grip!</span>"
 	else if(istype(H.loc,/obj/item))
-		src << "You struggle free of [H.loc]."
+		src << "<span class='warning'>You struggle free of [H.loc].</span>"
 		H.loc = get_turf(H)
 
 	if(istype(M))

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -33,3 +33,27 @@
 
 /mob/living/captive_brain/emote(var/message)
 	return
+
+/mob/living/captive_brain/resist()
+	//Resisting control by an alien mind.
+	if(istype(src.loc,/mob/living/simple_animal/borer))
+		var/mob/living/simple_animal/borer/B = src.loc
+		var/mob/living/captive_brain/H = src
+
+		H << "<span class='danger'>You begin doggedly resisting the parasite's control (this will take approximately sixty seconds).</span>"
+		B.host << "<span class='danger'>You feel the captive mind of [src] begin to resist your control.</span>"
+
+		spawn(rand(200,250)+B.host.brainloss)
+			if(!B || !B.controlling) return
+
+			B.host.adjustBrainLoss(rand(5,10))
+			H << "<span class='danger'>With an immense exertion of will, you regain control of your body!</span>"
+			B.host << "<span class='danger'>You feel control of the host brain ripped from your grasp, and retract your probosci before the wild neural impulses can damage you.</span>"
+			B.detatch()
+			verbs -= /mob/living/carbon/proc/release_control
+			verbs -= /mob/living/carbon/proc/punish_host
+			verbs -= /mob/living/carbon/proc/spawn_larvae
+		
+		return
+	
+	..()

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -34,7 +34,10 @@
 /mob/living/captive_brain/emote(var/message)
 	return
 
-/mob/living/captive_brain/resist()
+/mob/living/captive_brain/can_resist()
+	return !(stat || next_move > world.time)
+
+/mob/living/captive_brain/process_resist()
 	//Resisting control by an alien mind.
 	if(istype(src.loc,/mob/living/simple_animal/borer))
 		var/mob/living/simple_animal/borer/B = src.loc

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -96,7 +96,7 @@
 		affecting.loc = assailant.loc
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(1)
+		affecting.Stun(3)
 		if(isliving(affecting))
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -15,13 +15,15 @@
 	var/tag_x
 
 	attack_hand(mob/user as mob)
+		unwrap()
+
+	proc/unwrap()
 		if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
 			wrapped.loc = (get_turf(src.loc))
 			if(istype(wrapped, /obj/structure/closet))
 				var/obj/structure/closet/O = wrapped
 				O.welded = 0
 		del(src)
-		return
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(istype(W, /obj/item/device/destTagger))

--- a/html/changelogs/HarpyEagle-NeckgrabFix.yml
+++ b/html/changelogs/HarpyEagle-NeckgrabFix.yml
@@ -1,0 +1,5 @@
+author: HarpyEagle
+delete-after: True
+
+changes: 
+  - bugfix: "Neck-grabbing someone now stuns them properly."


### PR DESCRIPTION
Went to fix #8922 and couldn't resist cleaning up the code a bit (pun not intended).
- Moves various pieces around to new procs, subtypes, or other objects where appropriate. Removes the need for typechecks on usr. Span classes.
- Bonus, breaking out of a closet now makes sounds.
- Fixes #8922
- Fixes #9044. I guess `stunned` ticks down in Life sometime after grabs are processed so `Stun(1)` has no effect whatsoever.
