### PR TITLE
Muzzle-flash lighting effect for guns

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -57,6 +57,7 @@
 	var/fire_sound_text = "gunshot"
 	var/recoil = 0		//screen shake
 	var/silenced = 0
+	var/muzzle_flash = 3
 	var/accuracy = 0   //accuracy is measured in tiles. +1 accuracy means that everything is effectively one tile closer for the purpose of miss chance, -1 means the opposite. launchers are not supported, at the moment.
 	var/scoped_accuracy = null
 
@@ -244,6 +245,12 @@
 				"<span class='warning'>You fire \the [src]!</span>",
 				"You hear a [fire_sound_text]!"
 				)
+
+		if(muzzle_flash)
+			var/turf/T_user = get_turf(user)
+			var/turf/T_target = get_turf(target)
+			var/obj/effect/effect/smoke/illumination/I = new /obj/effect/effect/smoke/illumination(get_step(T_user, get_dir(T_user,T_target)), brightness=muzzle_flash, lifetime=8)
+			I.alpha = 0
 
 	if(recoil)
 		spawn()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -18,7 +18,7 @@
 	var/projectile_type = /obj/item/projectile/beam/practice
 	var/modifystate
 	var/charge_meter = 1	//if set, the icon state will be chosen based on the current charge
-	
+
 	//self-recharging
 	var/self_recharge = 0	//if set, the weapon will recharge itself
 	var/use_external_power = 0 //if set, the weapon will look for an external power source to draw from, otherwise it recharges magically
@@ -33,7 +33,7 @@
 		modifystate = isnull(current_mode.modifystate)? initial(modifystate) : current_mode.modifystate
 		charge_cost = isnull(current_mode.charge_cost)? initial(charge_cost) : current_mode.charge_cost
 		fire_sound = isnull(current_mode.fire_sound)? initial(fire_sound) : current_mode.fire_sound
-		
+
 		update_icon()
 		update_held_icon()
 
@@ -60,15 +60,15 @@
 		charge_tick++
 		if(charge_tick < recharge_time) return 0
 		charge_tick = 0
-		
+
 		if(!power_supply || power_supply.charge >= power_supply.maxcharge)
 			return 0 // check if we actually need to recharge
-		
+
 		if(use_external_power)
 			var/obj/item/weapon/cell/external = get_external_power_supply()
 			if(!external || !external.use(charge_cost)) //Take power from the borg...
 				return 0
-		
+
 		power_supply.give(charge_cost) //... to recharge the shot
 		update_icon()
 	return 1
@@ -93,16 +93,22 @@
 					return suit.cell
 	return null
 
+/obj/item/weapon/gun/energy/examine(mob/user)
+	..(user)
+	var/shots_remaining = round(power_supply.charge / charge_cost)
+	user << "Has [shots_remaining] shot\s remaining."
+	return
+
 /obj/item/weapon/gun/energy/update_icon()
 	if(charge_meter)
 		var/ratio = power_supply.charge / power_supply.maxcharge
-		
+
 		//make sure that rounding down will not give us the empty state even if we have charge for a shot left.
 		if(power_supply.charge < charge_cost)
 			ratio = 0
 		else
 			ratio = max(round(ratio, 0.25) * 100, 25)
-		
+
 		if(modifystate)
 			icon_state = "[modifystate][ratio]"
 		else

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -7,6 +7,7 @@
 
 	var/release_force = 0
 	var/throw_distance = 10
+	muzzle_flash = 0
 	fire_sound_text = "a launcher firing"
 
 //This normally uses a proc on projectiles and our ammo is not strictly speaking a projectile.

--- a/html/changelogs/RavingManiac-dev.yml
+++ b/html/changelogs/RavingManiac-dev.yml
@@ -1,0 +1,5 @@
+author: RavingManiac
+delete-after: true
+changes:
+  - rscadd: "Muzzle-flash lighting effect for guns"
+  - rscadd: "Energy guns now display shots remaining on examine"


### PR DESCRIPTION
An illumination effect is spawned on the tile into which the gun fires. Doesn't apply to launchers and silenced weapons.

Energy guns also now display shots remaining on examine.
