### PR TITLE
Intent menu appears on zoom

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -259,11 +259,11 @@ datum/hud/New(mob/owner)
 	if(!hud_used)
 		usr << "\red This mob type does not use a HUD."
 		return
-		
+
 	if(!ishuman(src))
 		usr << "\red Inventory hiding is currently only supported for human mobs, sorry."
 		return
-	
+
 	if(!client) return
 	if(client.view != world.view)
 		return
@@ -325,7 +325,7 @@ datum/hud/New(mob/owner)
 		return
 	if(client.view != world.view)
 		return
-	
+
 	if(hud_used.hud_shown)
 		hud_used.hud_shown = 0
 		if(src.hud_used.adding)
@@ -337,6 +337,7 @@ datum/hud/New(mob/owner)
 		if(src.hud_used.item_action_list)
 			src.client.screen -= src.hud_used.item_action_list
 		src.client.screen -= src.internals
+		src.client.screen += src.hud_used.action_intent		//we want the intent swticher visible
 	else
 		hud_used.hud_shown = 1
 		if(src.hud_used.adding)

--- a/html/changelogs/RavingManiac-master.yml
+++ b/html/changelogs/RavingManiac-master.yml
@@ -2,4 +2,5 @@ author: RavingManiac
 delete-after: True
 
 changes: 
-  - tweak: "Candles now burn for about 30 mintutes."
+  - tweak: "Candles now burn for about 30 minutes."
+  - tweak: "Intent menu now appears while zooming with a sniper rifle."


### PR DESCRIPTION
Given that help/grab/disarm/harm intent affects firing, figured it'd make sense for the menu to appear while zooming.
