### PR TITLE
Adds Icon Caching for some Mob HUD Icons

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -32,6 +32,8 @@
 	var/temperature_alert = 0
 	var/in_stasis = 0
 	var/heartbeat = 0
+	var/global/ol_cache = 0
+	var/global/list/overlays_cache = list()
 
 /mob/living/carbon/human/Life()
 
@@ -1082,6 +1084,33 @@
 		return 1
 
 	proc/handle_regular_hud_updates()
+		if(!ol_cache)
+			overlays_cache.len = 23
+			overlays_cache[1] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage1")
+			overlays_cache[2] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage2")
+			overlays_cache[3] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage3")
+			overlays_cache[4] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage4")
+			overlays_cache[5] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage5")
+			overlays_cache[6] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage6")
+			overlays_cache[7] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage7")
+			overlays_cache[8] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage8")
+			overlays_cache[9] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage9")
+			overlays_cache[10] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage10")
+			overlays_cache[11] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay1")
+			overlays_cache[12] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay2")
+			overlays_cache[13] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay3")
+			overlays_cache[14] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay4")
+			overlays_cache[15] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay5")
+			overlays_cache[16] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay6")
+			overlays_cache[17] = image('icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay7")
+			overlays_cache[18] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay1")
+			overlays_cache[19] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay2")
+			overlays_cache[20] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay3")
+			overlays_cache[21] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay4")
+			overlays_cache[22] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay5")
+			overlays_cache[23] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay6")
+			ol_cache = 1
+
 		if(hud_updateflag) // update our mob's hud overlays, AKA what others see flaoting above our head
 			handle_hud_list()
 
@@ -1100,32 +1129,32 @@
 
 		if(damageoverlay.overlays)
 			damageoverlay.overlays = list()
-
+		
 		if(stat == UNCONSCIOUS)
 			//Critical damage passage overlay
 			if(health <= 0)
 				var/image/I
 				switch(health)
 					if(-20 to -10)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage1")
+						I = overlays_cache[1]
 					if(-30 to -20)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage2")
+						I = overlays_cache[2]
 					if(-40 to -30)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage3")
+						I = overlays_cache[3]
 					if(-50 to -40)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage4")
+						I = overlays_cache[4]
 					if(-60 to -50)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage5")
+						I = overlays_cache[5]
 					if(-70 to -60)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage6")
+						I = overlays_cache[6]
 					if(-80 to -70)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage7")
+						I = overlays_cache[7]
 					if(-90 to -80)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage8")
+						I = overlays_cache[8]
 					if(-95 to -90)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage9")
+						I = overlays_cache[9]
 					if(-INFINITY to -95)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "passage10")
+						I = overlays_cache[10]
 				damageoverlay.overlays += I
 		else
 			//Oxygen damage overlay
@@ -1133,19 +1162,19 @@
 				var/image/I
 				switch(oxyloss)
 					if(10 to 20)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay1")
+						I = overlays_cache[11]
 					if(20 to 25)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay2")
+						I = overlays_cache[12]
 					if(25 to 30)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay3")
+						I = overlays_cache[13]
 					if(30 to 35)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay4")
+						I = overlays_cache[14]
 					if(35 to 40)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay5")
+						I = overlays_cache[15]
 					if(40 to 45)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay6")
+						I = overlays_cache[16]
 					if(45 to INFINITY)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "oxydamageoverlay7")
+						I = overlays_cache[17]
 				damageoverlay.overlays += I
 
 			//Fire and Brute damage overlay (BSSR)
@@ -1155,17 +1184,17 @@
 				var/image/I
 				switch(hurtdamage)
 					if(10 to 25)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay1")
+						I = overlays_cache[18]
 					if(25 to 40)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay2")
+						I = overlays_cache[19]
 					if(40 to 55)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay3")
+						I = overlays_cache[20]
 					if(55 to 70)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay4")
+						I = overlays_cache[21]
 					if(70 to 85)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay5")
+						I = overlays_cache[22]
 					if(85 to INFINITY)
-						I = image("icon" = 'icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay6")
+						I = overlays_cache[23]
 				damageoverlay.overlays += I
 
 		if( stat == DEAD )

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -32,7 +32,7 @@
 	var/temperature_alert = 0
 	var/in_stasis = 0
 	var/heartbeat = 0
-	var/global/overlays_cache
+	var/global/list/overlays_cache = null
 
 /mob/living/carbon/human/Life()
 
@@ -1084,7 +1084,6 @@
 
 	proc/handle_regular_hud_updates()
 		if(!overlays_cache)
-			overlays_cache = list()
 			overlays_cache.len = 23
 			overlays_cache[1] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage1")
 			overlays_cache[2] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage2")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -32,8 +32,7 @@
 	var/temperature_alert = 0
 	var/in_stasis = 0
 	var/heartbeat = 0
-	var/global/ol_cache = 0
-	var/global/list/overlays_cache = list()
+	var/global/overlays_cache
 
 /mob/living/carbon/human/Life()
 
@@ -1084,7 +1083,8 @@
 		return 1
 
 	proc/handle_regular_hud_updates()
-		if(!ol_cache)
+		if(!overlays_cache)
+			overlays_cache = list()
 			overlays_cache.len = 23
 			overlays_cache[1] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage1")
 			overlays_cache[2] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage2")
@@ -1109,7 +1109,6 @@
 			overlays_cache[21] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay4")
 			overlays_cache[22] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay5")
 			overlays_cache[23] = image('icons/mob/screen1_full.dmi', "icon_state" = "brutedamageoverlay6")
-			ol_cache = 1
 
 		if(hud_updateflag) // update our mob's hud overlays, AKA what others see flaoting above our head
 			handle_hud_list()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1084,6 +1084,7 @@
 
 	proc/handle_regular_hud_updates()
 		if(!overlays_cache)
+			overlays_cache = list()
 			overlays_cache.len = 23
 			overlays_cache[1] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage1")
 			overlays_cache[2] = image('icons/mob/screen1_full.dmi', "icon_state" = "passage2")


### PR DESCRIPTION
Adds partial caching for some of the smaller HUD additions of the mobs to allow for less processing needed to constantly update the icons when needed.

Code has been tested on a live server for several weeks prior to it's shutdown, so it should work as great as it has worked for us.
