### PR TITLE
Fix mech fabricators not syncing

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -502,7 +502,7 @@
 		src.updateUsrDialog()
 		sleep(30) //only sleep if called by user
 	var/found = 0
-	for(var/obj/machinery/computer/rdconsole/RDC in get_area(src))
+	for(var/obj/machinery/computer/rdconsole/RDC in get_area_all_atoms(get_area(src)))
 		if(!RDC.sync)
 			continue
 		found++


### PR DESCRIPTION
`get_area()` returns `area.master` these days, but `area.master` has no contents itself—the contents are all in the light level subareas. Fortunately, `get_area_all_atoms()` provides the same functionality. 

I'm not sure how many other places use the `for(var/item in get_area())` convention, but if any do, they'll need the same fix applied to them, or funny things will happen.

Related bug: #9058. 
