### PR TITLE
Fixes the removal of all organs when admins use "Select Equipment"

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -555,7 +555,9 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	for (var/obj/item/I in M)
 		if (istype(I, /obj/item/weapon/implant))
 			continue
-		qdel(I)
+		M.drop_from_inventory(I)
+		if(I.loc != M)
+			qdel(I)
 	switch(dresscode)
 		if ("strip")
 			//do nothing


### PR DESCRIPTION
fixes #8884 

I pretty much just followed the same thing Zuh did here: https://github.com/Zuhayr/Baystation12/commit/93a63134b17468602d33d1a7ed4403c1586721e9
