### PR TITLE
Fixes #9107.

### DIFF
--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -37,5 +37,4 @@
 		i++
 
 /obj/item/weapon/storage/donut_box/empty
-	icon_state = "donutbox0"
 	startswith = 0


### PR DESCRIPTION
Fixes #9107.
The empty donut box no longer uses a non-existing item state.
