### PR TITLE
Magboots can be worn over shoes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -357,6 +357,7 @@ BLIND     // can't see anything
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
 	force = 2
+	var/overshoes = 0
 	species_restricted = list("exclude","Unathi","Tajara")
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/shoes.dmi')
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -1,30 +1,71 @@
 /obj/item/clothing/shoes/magboots
-	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle."
+	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
 	species_restricted = null
 	force = 3
+	overshoes = 1
 	var/magpulse = 0
 	var/icon_base = "magboots"
 	icon_action_button = "action_blank"
 	action_button_name = "Toggle the magboots"
+	var/obj/item/clothing/shoes/shoes = null	//Undershoes
+	var/mob/living/carbon/human/wearer = null	//For shoe procs
+	
+/obj/item/clothing/shoes/magboots/proc/set_slowdown()
+	slowdown = shoes? max(SHOES_SLOWDOWN, shoes.slowdown): SHOES_SLOWDOWN	//So you can't put on magboots to make you walk faster.
+	if (magpulse)
+		slowdown += 3
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
 	if(magpulse)
 		flags &= ~NOSLIP
-		slowdown = SHOES_SLOWDOWN
 		magpulse = 0
+		set_slowdown()
 		force = 3
 		if(icon_base) icon_state = "[icon_base]0"
 		user << "You disable the mag-pulse traction system."
 	else
 		flags |= NOSLIP
-		slowdown = 2
 		magpulse = 1
+		set_slowdown()
 		force = 5
 		if(icon_base) icon_state = "[icon_base]1"
 		user << "You enable the mag-pulse traction system."
 	user.update_inv_shoes()	//so our mob-overlays update
+
+/obj/item/clothing/shoes/magboots/mob_can_equip(mob/user)
+	var/mob/living/carbon/human/H = user
+	
+	if(H.shoes)
+		shoes = H.shoes
+		if(shoes.overshoes)
+			user << "You are unable to wear \the [src] as \the [H.shoes] are in the way."
+			shoes = null
+			return 0
+		H.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
+		shoes.loc = src
+
+	if(!..())
+		if(shoes) 	//Put the old shoes back on if the check fails.
+			if(H.equip_to_slot_if_possible(shoes, slot_shoes))
+				src.shoes = null
+		return 0
+
+	if (shoes)
+		user << "You slip \the [src] on over \the [shoes]."
+	set_slowdown()
+	wearer = H
+	return 1
+
+/obj/item/clothing/shoes/magboots/dropped()
+	..()
+	var/mob/living/carbon/human/H = wearer
+	if(shoes)
+		if(!H.equip_to_slot_if_possible(shoes, slot_shoes))
+			shoes.loc = get_turf(src)
+		src.shoes = null
+	wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	..(user)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -96,10 +96,7 @@
 			helmet.canremove = 0
 
 	if(boots)
-		if(H.shoes)
-			M << "You are unable to deploy your suit's magboots as \the [H.shoes] are in the way."
-		else if (H.equip_to_slot_if_possible(boots, slot_shoes))
-			M << "Your suit's boots deploy with a hiss."
+		if (H.equip_to_slot_if_possible(boots, slot_shoes))
 			boots.canremove = 0
 
 	if(tank)
@@ -115,18 +112,18 @@
 	var/mob/living/carbon/human/H
 
 	if(helmet)
+		helmet.canremove = 1
 		H = helmet.loc
 		if(istype(H))
 			if(helmet && H.head == helmet)
-				helmet.canremove = 1
 				H.drop_from_inventory(helmet)
 				helmet.loc = src
 
 	if(boots)
+		boots.canremove = 1
 		H = boots.loc
 		if(istype(H))
 			if(boots && H.shoes == boots)
-				boots.canremove = 1
 				H.drop_from_inventory(boots)
 				boots.loc = src
 

--- a/html/changelogs/Techhead-VoidsuitsMagbootsAndTanks.yml
+++ b/html/changelogs/Techhead-VoidsuitsMagbootsAndTanks.yml
@@ -1,0 +1,6 @@
++author: Techhead
+ +delete-after: True
+ +changes: 
++  - rscadd: "Voidsuits can have tanks inserted into the storage slot."
++  - rscadd: "Voidsuits display helpful information on their contents on examine."
++  - rscadd: "Magboots can be equipped over other shoes. Except other magboots."


### PR DESCRIPTION
Equipping magboots or a voidsuit with magboots installed will place them
over any existing shoes. Existing shoes are replaced on feet when magboots
are unequipped. Magboots cannot be worn over other magboots.
Fixes #9125
Changelog for this and my previous voidsuit changes included.
