### PR TITLE
Fixes pressure overshoot when filling nearly empty tanks

### DIFF
--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -427,10 +427,19 @@
 //If set, sink_volume_mod adjusts the effective output volume used in the calculation. This is useful when the output gas_mixture is
 //part of a pipenetwork, and so it's volume isn't representative of the actual volume since the gas will be shared across the pipenetwork when it processes.
 /proc/calculate_transfer_moles(datum/gas_mixture/source, datum/gas_mixture/sink, var/pressure_delta, var/sink_volume_mod=0)
-	//Make the approximation that the sink temperature is unchanged after transferring gas
-	var/air_temperature = (sink.temperature > 0)? sink.temperature : source.temperature
-	var/output_volume = (sink.volume * sink.group_multiplier) + sink_volume_mod
+	if(source.temperature == 0 || source.total_moles == 0) return 0
 
+	var/output_volume = (sink.volume * sink.group_multiplier) + sink_volume_mod
+	var/source_total_moles = source.total_moles * source.group_multiplier
+
+	var/air_temperature = source.temperature
+	if(sink.total_moles > 0 && sink.temperature > 0)
+		//estimate the final temperature of the sink after transfer
+		var/estimate_moles = pressure_delta*output_volume/(sink.temperature * R_IDEAL_GAS_EQUATION)
+		var/sink_heat_capacity = sink.heat_capacity()
+		var/transfer_heat_capacity = source.heat_capacity()*estimate_moles/source_total_moles
+		air_temperature = (sink.temperature*sink_heat_capacity  + source.temperature*transfer_heat_capacity) / (sink_heat_capacity + transfer_heat_capacity)
+	
 	//get the number of moles that would have to be transfered to bring sink to the target pressure
 	return pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 


### PR DESCRIPTION
This PR proposes two fixes for the pressure overshoot that occurs when filling very cold, nearly empty tanks with very hot gas.

Alternate 1 proposes estimating the transfer amount assuming that the sink temperature remains unchanged, and then using that estimate to obtain an estimate for the final sink temperature. This is then used to obtain a final transfer amount in predictor-corrector fashion.

Alternate 2 proposes comparing the amount of gas in the sink mix to an arbitrarily number. If the amount is small enough, the source temperature is used. Otherwise the sink temperature is used.

Marked DNM until a consensus can be reached about which one is better.
