### PR TITLE
Adjusts charge cost for energy type guns

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -22,6 +22,23 @@
 		viewers(user) << "\red <b>[user] is licking the electrodes of the [src.name]! It looks like \he's trying to commit suicide.</b>"
 		return (FIRELOSS)
 
+//currently only used by energy-type guns, that may change in the future.
+/obj/item/weapon/cell/device
+	name = "device power cell"
+	desc = "A small power cell designed to power handheld devices."
+	icon_state = "cell" //placeholder
+	w_class = 2
+	force = 0
+	throw_speed = 5
+	throw_range = 7
+	maxcharge = 1000
+	matter = list("metal" = 350, "glass" = 50)
+
+/obj/item/weapon/cell/device/variable/New(newloc, charge_amount)
+	..(newloc)
+	maxcharge = charge_amount
+	charge = maxcharge
+
 /obj/item/weapon/cell/crap
 	name = "\improper Nanotrasen brand rechargable AA battery"
 	desc = "You can't top the plasma top." //TOTALLY TRADEMARK INFRINGEMENT

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -594,6 +594,8 @@
 			user << "Close the panel first."
 		else if(cell)
 			user << "There is a power cell already installed."
+		else if(W.w_class != 3)
+			user << "\The [W] is too [W.w_class < 3? "small" : "large"] to fit here."
 		else
 			user.drop_item()
 			W.loc = src

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -442,18 +442,21 @@
 		if(cell)
 			user << "There is a power cell already installed."
 			return
-		else
-			if (stat & MAINT)
-				user << "<span class='warning'>There is no connector for your power cell.</span>"
-				return
-			user.drop_item()
-			W.loc = src
-			cell = W
-			user.visible_message(\
-				"<span class='warning'>[user.name] has inserted the power cell to [src.name]!</span>",\
-				"<span class='notice'>You insert the power cell.</span>")
-			chargecount = 0
-			update_icon()
+		if (stat & MAINT)
+			user << "<span class='warning'>There is no connector for your power cell.</span>"
+			return
+		if(W.w_class != 3)
+			user << "\The [W] is too [W.w_class < 3? "small" : "large"] to fit here."
+			return
+		
+		user.drop_item()
+		W.loc = src
+		cell = W
+		user.visible_message(\
+			"<span class='warning'>[user.name] has inserted the power cell to [src.name]!</span>",\
+			"<span class='notice'>You insert the power cell.</span>")
+		chargecount = 0
+		update_icon()
 	else if	(istype(W, /obj/item/weapon/screwdriver))	// haxing
 		if(opened)
 			if (cell)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -13,8 +13,8 @@
 	firemode_type = /datum/firemode/energy
 
 	var/obj/item/weapon/cell/power_supply //What type of power cell this uses
-	var/charge_cost = 100 //How much energy is needed to fire.
-	var/maxcharge = 1000 //the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
+	var/charge_cost = 200 //How much energy is needed to fire.
+	var/max_shots = 10 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
 	var/cell_type = null
 	var/projectile_type = /obj/item/projectile/beam/practice
 	var/modifystate
@@ -47,7 +47,7 @@
 	if(cell_type)
 		power_supply = new cell_type(src)
 	else
-		power_supply = new /obj/item/weapon/cell/device/variable(src, maxcharge)
+		power_supply = new /obj/item/weapon/cell/device/variable(src, max_shots*charge_cost)
 	if(self_recharge)
 		processing_objects.Add(src)
 	update_icon()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -14,7 +14,8 @@
 
 	var/obj/item/weapon/cell/power_supply //What type of power cell this uses
 	var/charge_cost = 100 //How much energy is needed to fire.
-	var/cell_type = /obj/item/weapon/cell
+	var/maxcharge = 1000 //the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
+	var/cell_type = null
 	var/projectile_type = /obj/item/projectile/beam/practice
 	var/modifystate
 	var/charge_meter = 1	//if set, the icon state will be chosen based on the current charge
@@ -45,7 +46,8 @@
 	..()
 	if(cell_type)
 		power_supply = new cell_type(src)
-		power_supply.give(power_supply.maxcharge)
+	else
+		power_supply = new /obj/item/weapon/cell/device/variable(src, maxcharge)
 	if(self_recharge)
 		processing_objects.Add(src)
 	update_icon()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -43,7 +43,7 @@ obj/item/weapon/gun/energy/retro
 	w_class = 3
 	projectile_type = /obj/item/projectile/beam
 	origin_tech = null
-	charge_cost = 200 //to compensate a bit for self-recharging
+	max_shots = 5 //to compensate a bit for self-recharging
 	self_recharge = 1
 
 /obj/item/weapon/gun/energy/lasercannon
@@ -55,7 +55,8 @@ obj/item/weapon/gun/energy/retro
 	origin_tech = "combat=4;materials=3;powerstorage=3"
 	slot_flags = SLOT_BELT|SLOT_BACK
 	projectile_type = /obj/item/projectile/beam/heavylaser
-	charge_cost = 250
+	charge_cost = 400
+	max_shots = 5
 	fire_delay = 20
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
@@ -72,7 +73,8 @@ obj/item/weapon/gun/energy/retro
 	fire_sound = 'sound/weapons/laser3.ogg'
 	origin_tech = "combat=5;materials=3;magnets=2;syndicate=2"
 	projectile_type = /obj/item/projectile/beam/xray
-	charge_cost = 50
+	charge_cost = 100
+	max_shots = 20
 	fire_delay = 1
 
 /obj/item/weapon/gun/energy/sniperrifle
@@ -84,7 +86,8 @@ obj/item/weapon/gun/energy/retro
 	origin_tech = "combat=6;materials=5;powerstorage=4"
 	projectile_type = /obj/item/projectile/beam/sniper
 	slot_flags = SLOT_BACK
-	charge_cost = 250
+	charge_cost = 400
+	max_shots = 4
 	fire_delay = 35
 	force = 10
 	w_class = 4

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -4,8 +4,8 @@
 	icon_state = "energystun100"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	fire_sound = 'sound/weapons/Taser.ogg'
+	max_shots = 10
 
-	charge_cost = 100 //How much energy is needed to fire.
 	projectile_type = /obj/item/projectile/beam/stun
 	origin_tech = "combat=3;magnets=2"
 	modifystate = "energystun"

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -6,14 +6,14 @@
 	slot_flags = SLOT_BELT|SLOT_BACK
 	force = 10
 	fire_sound='sound/weapons/Laser.ogg'
-	charge_cost = 50
 	projectile_type = /obj/item/projectile/beam
 	sel_mode = 2
+	max_shots = 10
 	
 	firemodes = list(
 		list(name="stun", projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg'),
 		list(name="lethal", projectile_type=/obj/item/projectile/beam, fire_sound='sound/weapons/Laser.ogg'),
-		list(name="DESTROY", projectile_type=/obj/item/projectile/beam/pulse, fire_sound='sound/weapons/pulse.ogg', fire_delay=25, charge_cost=100),
+		list(name="DESTROY", projectile_type=/obj/item/projectile/beam/pulse, fire_sound='sound/weapons/pulse.ogg', fire_delay=25, charge_cost=400),
 		)
 
 /obj/item/weapon/gun/energy/pulse_rifle/mounted
@@ -27,6 +27,7 @@
 	fire_delay = 25
 	fire_sound='sound/weapons/pulse.ogg'
 	projectile_type=/obj/item/projectile/beam/pulse
+	charge_cost=400
 
 /obj/item/weapon/gun/energy/pulse_rifle/destroyer/attack_self(mob/living/user as mob)
 	user << "<span class='warning'>[src.name] has three settings, and they are all DESTROY.</span>"
@@ -37,4 +38,4 @@
 	desc = "It's not the size of the gun, it's the size of the hole it puts through people."
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	icon_state = "m1911-p"
-	cell_type = /obj/item/weapon/cell/crap
+	max_shots = 5

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -9,7 +9,8 @@
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
-	charge_cost = 100
+	charge_cost = 300
+	max_shots = 10
 	projectile_type = /obj/item/projectile/ion
 
 /obj/item/weapon/gun/energy/ionrifle/emp_act(severity)
@@ -29,7 +30,7 @@
 	item_state = "decloner"
 	fire_sound = 'sound/weapons/pulse3.ogg'
 	origin_tech = "combat=5;materials=4;powerstorage=3"
-	charge_cost = 100
+	max_shots = 10
 	projectile_type = /obj/item/projectile/energy/declone
 
 /obj/item/weapon/gun/energy/floragun
@@ -39,6 +40,7 @@
 	item_state = "floramut"
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	charge_cost = 100
+	max_shots = 10
 	projectile_type = /obj/item/projectile/energy/floramut
 	origin_tech = "materials=2;biotech=3;powerstorage=3"
 	modifystate = "floramut"
@@ -65,7 +67,6 @@
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = 4
 	projectile_type = /obj/item/projectile/meteor
-	charge_cost = 100
 	cell_type = /obj/item/weapon/cell/potato
 	self_recharge = 1
 	recharge_time = 5 //Time it takes for shots to recharge (in ticks)
@@ -110,7 +111,7 @@
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	w_class = 4.0
-	charge_cost = 200
+	max_shots = 5
 	projectile_type = /obj/item/projectile/change
 	origin_tech = null
 	self_recharge = 1
@@ -127,7 +128,7 @@
 	name = "staff of animation"
 	desc = "An artefact that spits bolts of life-force which causes objects which are hit by it to animate and come to life! This magic doesn't affect machines."
 	projectile_type = /obj/item/projectile/animate
-	charge_cost = 100
+	max_shots = 10
 
 obj/item/weapon/gun/energy/staff/focus
 	name = "mental focus"
@@ -140,11 +141,11 @@ obj/item/weapon/gun/energy/staff/focus
 	/*
 	attack_self(mob/living/user as mob)
 		if(projectile_type == "/obj/item/projectile/forcebolt")
-			charge_cost = 200
+			charge_cost = 400
 			user << "<span class='warning'>The [src.name] will now strike a small area.</span>"
 			projectile_type = "/obj/item/projectile/forcebolt/strong"
 		else
-			charge_cost = 100
+			charge_cost = 200
 			user << "<span class='warning'>The [src.name] will now strike only a single person.</span>"
 			projectile_type = "/obj/item/projectile/forcebolt"
 	*/

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -4,9 +4,8 @@
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	fire_sound = 'sound/weapons/Taser.ogg'
-	charge_cost = 100
+	max_shots = 5
 	projectile_type = /obj/item/projectile/beam/stun
-	cell_type = /obj/item/weapon/cell/crap
 
 /obj/item/weapon/gun/energy/taser/mounted
 	name = "mounted taser gun"
@@ -15,7 +14,7 @@
 
 /obj/item/weapon/gun/energy/taser/mounted/cyborg
 	name = "taser gun"
-	cell_type = /obj/item/weapon/cell/secborg
+	max_shots = 6
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 
 
@@ -26,9 +25,8 @@
 	item_state = "stunrevolver"
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 	origin_tech = "combat=3;materials=3;powerstorage=2"
-	charge_cost = 125
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
-	cell_type = /obj/item/weapon/cell
+	max_shots = 8
 
 
 /obj/item/weapon/gun/energy/crossbow
@@ -43,7 +41,7 @@
 	silenced = 1
 	fire_sound = 'sound/weapons/Genhit.ogg'
 	projectile_type = /obj/item/projectile/energy/bolt
-	cell_type = /obj/item/weapon/cell/crap
+	max_shots = 5
 	self_recharge = 1
 	charge_meter = 0
 


### PR DESCRIPTION
- Adds a type of smaller power cell for powering devices. Not used by many things at the moment, but it's one step closer to a more coherent picture of power cells, instead of seemingly car-battery sized cells being used for everything.
- Adjusts charge costs for various energy guns so that mounted energy guns drain 80% of a default rig's power cell in 40 shots, and mounted laser cannons drain the same in 20 shots. Handheld guns are unaffected. Laser cannon capacity increased from 4 to 5. Makes it easier to balance charge costs for purposes outside of shot capacity.
