### PR TITLE
Grabs no longer endless loop runtime.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -155,7 +155,7 @@ var/list/slot_equipment_priority = list( \
 			Target = loc
 
 		remove_from_mob(W)
-		if(!W) return 1 // self destroying objects (tk, grabs)
+		if(!(W && W.loc)) return 1 // self destroying objects (tk, grabs)
 
 		W.forceMove(Target)
 		update_icons()

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -226,7 +226,7 @@
 				beacon_freq = freq
 		if("screw")
 			screwloose = !screwloose
-			usr << "<span class='notice>You twiddle the screw.</span>"
+			usr << "<span class='notice'>You twiddle the screw.</span>"
 		if("oddbutton")
 			oddbutton = !oddbutton
 			usr << "<span class='notice'>You press the weird button.</span>"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -277,9 +277,9 @@
 						qdel(MED)
 					for(var/mob/M in viewers(src, null))
 						if ((M.client && !( M.blinded )))
-							M.show_message("<span class='notice>[user] applies the [MED] on [src].</span>")
+							M.show_message("<span class='notice'>[user] applies the [MED] on [src].</span>")
 		else
-			user << "<span class='notice>\The [src] is dead, medical items won't bring it back to life.</span>"
+			user << "<span class='notice'>\The [src] is dead, medical items won't bring it back to life.</span>"
 	if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
 		if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch))
 			harvest(user)
@@ -300,7 +300,7 @@
 			usr << "<span class='danger>This weapon is ineffective, it does no damage.</span>"
 			for(var/mob/M in viewers(src, null))
 				if ((M.client && !( M.blinded )))
-					M.show_message("<span class='notice>[user] gently taps [src] with the [O].</span>")
+					M.show_message("<span class='notice'>[user] gently taps [src] with \the [O].</span>")
 
 /mob/living/simple_animal/movement_delay()
 	var/tally = 0 //Incase I need to add stuff other than "speed" later

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -24,7 +24,7 @@
 	assailant = user
 	affecting = victim
 
-	if(affecting.anchored)
+	if(affecting.anchored || !assailant.Adjacent(victim))
 		qdel(src)
 		return
 
@@ -36,7 +36,6 @@
 	hud.master = src
 
 /obj/item/weapon/grab/Destroy()
-	//make sure the grabbed_by list doesn't fill up with nulls
 	if(affecting)
 		affecting.grabbed_by -= src
 		affecting = null
@@ -45,6 +44,7 @@
 			assailant.client.screen -= hud
 		assailant = null
 	qdel(hud)
+	hud = null
 	..()
 
 //Used by throw code to hand over the mob, instead of throwing the grab. The grab is then deleted by the throw code.
@@ -68,6 +68,9 @@
 
 /obj/item/weapon/grab/process()
 	confirm()
+	if(!assailant)
+		qdel(src)
+		return
 
 	if(assailant.client)
 		assailant.client.screen -= hud
@@ -227,8 +230,5 @@
 
 
 /obj/item/weapon/grab/dropped()
+	loc = null
 	qdel(src)
-
-/obj/item/weapon/grab/Destroy()
-	qdel(hud)
-	..()

--- a/code/modules/nano/modules/law_manager.dm
+++ b/code/modules/nano/modules/law_manager.dm
@@ -147,7 +147,7 @@
 				R << "<span class='danger'>Law Notice</span>"
 				R.laws.show_laws(R)
 		if(usr != owner)
-			usr << "<span class='notice>Laws displayed.</span>"
+			usr << "<span class='notice'>Laws displayed.</span>"
 		return 1
 
 	return 0


### PR DESCRIPTION
**Edit:** Having thought about it, the main issue is this:
- Mob drops an item which destroys itself on drop, for example the grab object occupying one's hands.
- Currently, when an item destroys itself and the loc is a mob, it tells the mob to drop the item
- Goto 1

On other servers item.loc has already been set to the new destination by the time the mob tells the item that it has been dropped.
Solved in this case by having items that destroy themselves null their loc on drop, breaking the chain.
