### PR TITLE
Fixes cyborgs showing up as AIs in radio output for AIs.

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -617,7 +617,7 @@
 	if(buildstage != 2)
 		return STATUS_CLOSE
 
-	if(aidisabled && user.isAI())
+	if(aidisabled && user.isMobAI())
 		user << "<span class='warning'>AI control for \the [src] interface has been disabled.</span>"
 		return STATUS_CLOSE
 

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -93,6 +93,6 @@
 /datum/topic_state/air_alarm/href_list(var/mob/user)
 	var/list/extra_href = list()
 	extra_href["remote_connection"] = 1
-	extra_href["remote_access"] = user && (user.isAI() || atmos_control.allowed(user) || atmos_control.emagged || air_alarm.rcon_setting == RCON_YES || (air_alarm.alarm_area.atmosalm && air_alarm.rcon_setting == RCON_AUTO))
+	extra_href["remote_access"] = user && (user.isMobAI() || atmos_control.allowed(user) || atmos_control.emagged || air_alarm.rcon_setting == RCON_YES || (air_alarm.alarm_area.atmosalm && air_alarm.rcon_setting == RCON_AUTO))
 
 	return extra_href

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -86,10 +86,10 @@
 /mob/living/silicon/isSilicon()
 	return 1
 
-/mob/proc/isAI()
+/mob/proc/isMobAI()
 	return 0
 
-/mob/living/silicon/ai/isAI()
+/mob/living/silicon/ai/isMobAI()
 	return 1
 
 /mob/proc/isSynthetic()


### PR DESCRIPTION
Also fixes pAIs and non-carbon non-robot non-AI non-pAI mobs doing the same.
Fixes #8518.
