### PR TITLE
Fixes #9139.

### DIFF
--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -141,10 +141,11 @@
 			if("finalise_create_account")
 				var/account_name = href_list["holder_name"]
 				var/starting_funds = max(text2num(href_list["starting_funds"]), 0)
-				create_account(account_name, starting_funds, src)
 
 				starting_funds = Clamp(starting_funds, 0, station_account.money)	// Not authorized to put the station in debt.
-				starting_funds = min(starting_funds, fund_cap)						// Not authrorized to give more than the fund cap.
+				starting_funds = min(starting_funds, fund_cap)						// Not authorized to give more than the fund cap.
+
+				create_account(account_name, starting_funds, src)
 				if(starting_funds > 0)
 					//subtract the money
 					station_account.money -= starting_funds


### PR DESCRIPTION
Fixes #9139.
Arranges the order at which starting funds is set and account creation is done.
