### PR TITLE
Fixes rlimb assignment for hands/feet in chargen

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1447,7 +1447,7 @@ datum/preferences
 							rlimb_data[limb] = choice
 							organ_data[limb] = "cyborg"
 							if(second_limb)
-								organ_data[second_limb] = choice
+								rlimb_data[second_limb] = choice
 								organ_data[second_limb] = "cyborg"
 							if(third_limb && organ_data[third_limb] == "amputated")
 								organ_data[third_limb] = null


### PR DESCRIPTION
An easy fix for a small typo that caused rlimbs not to be assigned to
second_limb (hands/feet). I'm surprised the bug went unnoticed this
long.
