### PR TITLE
Admin dice

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -815,6 +815,7 @@
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"
+#include "code\modules\admin\verbs\dice.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\icarus.dm"
 #include "code\modules\admin\verbs\mapping.dm"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -110,7 +110,8 @@ var/list/admin_verbs_fun = list(
 	/client/proc/cmd_admin_add_random_ai_law,
 	/client/proc/make_sound,
 	/client/proc/toggle_random_events,
-	/client/proc/editappear
+	/client/proc/editappear,
+	/client/proc/roll_dices
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_fruit,
@@ -255,6 +256,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_debug_tog_aliens,
 	/client/proc/air_report,
 	/client/proc/enable_debug_verbs,
+	/client/proc/roll_dices,
 	/proc/possess,
 	/proc/release
 	)

--- a/code/modules/admin/verbs/dice.dm
+++ b/code/modules/admin/verbs/dice.dm
@@ -1,0 +1,24 @@
+/client/proc/roll_dices()
+	set category = "Fun"
+	set name = "Roll Dice"
+	if(!check_rights(R_FUN))
+		return
+
+	var/sum = input("How many times should we throw?") as num
+	var/side = input("Select the number of sides.") as num
+	if(!side)
+		side = 6
+	if(!sum)
+		sum = 2
+
+	var/dice = num2text(sum) + "d" + num2text(side)
+
+	if(alert("Do you want to inform the world about your game?",,"Yes", "No") == "Yes")
+		world << "<h2 style=\"color:#A50400\">The dice have been rolled by Gods!</h2>"
+
+	var/result = roll(dice)
+
+	if(alert("Do you want to inform the world about the result?",,"Yes", "No") == "Yes")
+		world << "<h2 style=\"color:#A50400\">Gods rolled [dice], result is [result]</h2>"
+
+	message_admins("[key_name_admin(src)] rolled dice [dice], result is [result]", 1)


### PR DESCRIPTION
Made in a separate PR, as it is quite useless thing.
Adds "Roll Dice" button to admins with +FUN. It allows you to roll custom dice with optional message to players. 
![sshot-338](https://cloud.githubusercontent.com/assets/4064061/7551170/61bd67b0-f687-11e4-8a42-1d86996cf451.png)

Inspired by Discworld
