### PR TITLE
Fixes #9169.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -188,8 +188,8 @@
 //Standard robots use config for crit, which is somewhat excessive for these guys.
 //Drones killed by damage will gib.
 /mob/living/silicon/robot/drone/handle_regular_status_updates()
-
-	if((health <= -35 || (master_fabricator && src.z != master_fabricator.z)) && src.stat != 2)
+	var/turf/T = get_turf(src)
+	if((!T || health <= -35 || (master_fabricator && T.z != master_fabricator.z)) && src.stat != DEAD)
 		timeofdeath = world.time
 		death() //Possibly redundant, having trouble making death() cooperate.
 		gib()


### PR DESCRIPTION
#9169.

Drones can now survive entering chargers and being picked up.
