### PR TITLE
Fixes defer_powernet_rebuild + optimizations

### DIFF
--- a/code/controllers/Processes/lighting.dm
+++ b/code/controllers/Processes/lighting.dm
@@ -4,23 +4,24 @@
 	lighting_controller.initializeLighting()
 
 /datum/controller/process/lighting/doWork()
-	lighting_controller.lights_workload_max = \
-		max(lighting_controller.lights_workload_max, lighting_controller.lights.len)
+	if(!lighting_processing_killed)
+		lighting_controller.lights_workload_max = \
+			max(lighting_controller.lights_workload_max, lighting_controller.lights.len)
 
-	for(var/datum/light_source/L in lighting_controller.lights)
-		if(L && L.check())
-			lighting_controller.lights.Remove(L)
+		for(var/datum/light_source/L in lighting_controller.lights)
+			if(L && L.check())
+				lighting_controller.lights.Remove(L)
 
-		scheck()
+			scheck()
 
-	lighting_controller.changed_turfs_workload_max = \
-		max(lighting_controller.changed_turfs_workload_max, lighting_controller.changed_turfs.len)
+		lighting_controller.changed_turfs_workload_max = \
+			max(lighting_controller.changed_turfs_workload_max, lighting_controller.changed_turfs.len)
 
-	for(var/turf/T in lighting_controller.changed_turfs)
-		if(T && T.lighting_changed)
-			T.shift_to_subarea()
+		for(var/turf/T in lighting_controller.changed_turfs)
+			if(T && T.lighting_changed)
+				T.shift_to_subarea()
 
-		scheck()
+			scheck()
 
-	if(lighting_controller.changed_turfs && lighting_controller.changed_turfs.len)
-		lighting_controller.changed_turfs.len = 0 // reset the changed list
+		if(lighting_controller.changed_turfs && lighting_controller.changed_turfs.len)
+			lighting_controller.changed_turfs.len = 0 // reset the changed list

--- a/code/controllers/Processes/lighting.dm
+++ b/code/controllers/Processes/lighting.dm
@@ -4,24 +4,23 @@
 	lighting_controller.initializeLighting()
 
 /datum/controller/process/lighting/doWork()
-	if(!lighting_processing_killed)
-		lighting_controller.lights_workload_max = \
-			max(lighting_controller.lights_workload_max, lighting_controller.lights.len)
+	lighting_controller.lights_workload_max = \
+		max(lighting_controller.lights_workload_max, lighting_controller.lights.len)
 
-		for(var/datum/light_source/L in lighting_controller.lights)
-			if(L && L.check())
-				lighting_controller.lights.Remove(L)
+	for(var/datum/light_source/L in lighting_controller.lights)
+		if(L && L.check())
+			lighting_controller.lights.Remove(L)
 
-			scheck()
+		scheck()
 
-		lighting_controller.changed_turfs_workload_max = \
-			max(lighting_controller.changed_turfs_workload_max, lighting_controller.changed_turfs.len)
+	lighting_controller.changed_turfs_workload_max = \
+		max(lighting_controller.changed_turfs_workload_max, lighting_controller.changed_turfs.len)
 
-		for(var/turf/T in lighting_controller.changed_turfs)
-			if(T && T.lighting_changed)
-				T.shift_to_subarea()
+	for(var/turf/T in lighting_controller.changed_turfs)
+		if(T && T.lighting_changed)
+			T.shift_to_subarea()
 
-			scheck()
+		scheck()
 
-		if(lighting_controller.changed_turfs && lighting_controller.changed_turfs.len)
-			lighting_controller.changed_turfs.len = 0 // reset the changed list
+	if(lighting_controller.changed_turfs && lighting_controller.changed_turfs.len)
+		lighting_controller.changed_turfs.len = 0 // reset the changed list

--- a/code/controllers/Processes/pipenet.dm
+++ b/code/controllers/Processes/pipenet.dm
@@ -3,13 +3,14 @@
 	schedule_interval = 20 // every 2 seconds
 
 /datum/controller/process/pipenet/doWork()
-	for(var/datum/pipe_network/pipeNetwork in pipe_networks)
-		if(istype(pipeNetwork) && !pipeNetwork.disposed)
-			pipeNetwork.process()
-			scheck()
-			continue
+	if(!pipe_processing_killed)
+		for(var/datum/pipe_network/pipeNetwork in pipe_networks)
+			if(istype(pipeNetwork) && !pipeNetwork.disposed)
+				pipeNetwork.process()
+				scheck()
+				continue
 
-		pipe_networks.Remove(pipeNetwork)
+			pipe_networks.Remove(pipeNetwork)
 
 /datum/controller/process/pipenet/getStatName()
 	return ..()+"([pipe_networks.len])"

--- a/code/controllers/Processes/powernet.dm
+++ b/code/controllers/Processes/powernet.dm
@@ -3,13 +3,14 @@
 	schedule_interval = 20 // every 2 seconds
 
 /datum/controller/process/powernet/doWork()
-	for(var/datum/powernet/powerNetwork in powernets)
-		if(istype(powerNetwork) && !powerNetwork.disposed)
-			powerNetwork.reset()
-			scheck()
-			continue
+	if(!defer_powernet_rebuild)
+		for(var/datum/powernet/powerNetwork in powernets)
+			if(istype(powerNetwork) && !powerNetwork.disposed)
+				powerNetwork.reset()
+				scheck()
+				continue
 
-		powernets.Remove(powerNetwork)
+			powernets.Remove(powerNetwork)
 
 	// This is necessary to ensure powersinks are always the first devices that drain power from powernet.
 	// Otherwise APCs or other stuff go first, resulting in bad things happening.

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -9,6 +9,7 @@ var/global/last_tick_duration = 0
 
 var/global/air_processing_killed = 0
 var/global/pipe_processing_killed = 0
+var/global/lighting_processing_killed = 0
 
 datum/controller/game_controller
 	var/list/shuttle_list	                    // For debugging and VV

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -11,7 +11,6 @@
 	deny_respawn = 1
 
 /datum/game_mode/meteor/post_setup()
-	defer_powernet_rebuild = 2//Might help with the lag
 	..()
 
 /datum/game_mode/meteor/process()

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -337,14 +337,15 @@
 
 /obj/machinery/power/supermatter/proc/supermatter_pull()
 	//following is adapted from singulo code
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
+	defer_powernet_rebuild = 1
+	lighting_processing_killed = 1
 	// Let's just make this one loop.
 	for(var/atom/X in orange(pull_radius,src))
 		X.singularity_pull(src, STAGE_FIVE)
 
-	if(defer_powernet_rebuild != 2)
+	spawn(20)
 		defer_powernet_rebuild = 0
+		lighting_processing_killed = 0
 	return
 
 


### PR DESCRIPTION
Fixes the defer_powernet_rebuild variable that was used in the code but seemed to have no actual reason to exist.

Also adds (or fixes) lighting_processing_killed, and pipe_processing_killed which can also be used wherever needed.

Applied some of them to the existing explosion code and the supermatter pull code in the hopes that they alleviate some of the lag.

And yeah I have no idea what's up with explosion.dm, shouldn't matter though.
