### PR TITLE
Tweaks space vines

### DIFF
--- a/code/modules/hydroponics/seed_mobs.dm
+++ b/code/modules/hydroponics/seed_mobs.dm
@@ -13,7 +13,7 @@
 	spawn(75)
 		if(!host.ckey && !host.client)
 			host.death()  // This seems redundant, but a lot of mobs don't
-			host.stat = 2 // handle death() properly. Better safe than etc.
+			host.stat = DEAD // handle death() properly. Better safe than etc.
 			host.visible_message("<span class='danger'>[host] is malformed and unable to survive. It expires pitifully, leaving behind some seeds.</span>")
 
 			var/total_yield = rand(1,3)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,7 +1,7 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
-/proc/spacevine_infestation()
+/proc/spacevine_infestation(var/potency_min=70, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
@@ -15,8 +15,15 @@
 			var/turf/simulated/floor/T = pick(turfs)
 			var/datum/seed/seed = plant_controller.create_random_seed(1)
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
-			seed.set_trait(TRAIT_POTENCY,rand(70,100)) // Guarantee a wide spread and powerful effects.
-			new /obj/effect/plant(T,seed)
+			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
+			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
+			
+			//make vine zero start off fully matured
+			var/obj/effect/plant/vine = new(T,seed)
+			vine.health = vine.max_health
+			vine.mature_time = 0
+			vine.process()
+			
 			message_admins("<span class='notice'>Event: Spacevines spawned at [T.loc] ([T.x],[T.y],[T.z])</span>")
 
 /obj/effect/dead_plant
@@ -57,6 +64,7 @@
 	var/spread_chance = 40
 	var/spread_distance = 3
 	var/evolve_chance = 2
+	var/mature_time		//minimum maturation time
 	var/last_tick = 0
 	var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/plant
 
@@ -112,6 +120,7 @@
 	if(max_growth > 2 && prob(50))
 		max_growth-- //Ensure some variation in final sprite, makes the carpet of crap look less wonky.
 
+	mature_time = world.time + seed.get_trait(TRAIT_MATURATION) + 15 //prevent vines from maturing until at least a few seconds after they've been created.
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
 	spread_distance = ((growth_type>0) ? round(spread_chance*0.6) : round(spread_chance*0.3))
 	update_icon()
@@ -256,4 +265,4 @@
 		die_off()
 
 /obj/effect/plant/proc/is_mature()
-	return (health >= (max_health/3))
+	return (health >= (max_health/3) && world.time > mature_time)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -70,7 +70,10 @@
 		update_neighbors()
 
 	if(is_mature() && neighbors.len && prob(spread_chance))
-		for(var/i=1,i<=seed.get_trait(TRAIT_YIELD),i++)
+		//spread to 1-3 adjacent turfs depending on yield trait.
+		var/max_spread = between(1, round(seed.get_trait(TRAIT_YIELD)*3/14), 3)
+		
+		for(var/i in 1 to max_spread)
 			if(prob(spread_chance))
 				sleep(rand(3,5))
 				if(!neighbors.len)

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -7,8 +7,11 @@
 	if(!istype(M))
 		return
 
-	if(!buckled_mob && !M.buckled && !M.anchored && (M.small || prob(round(seed.get_trait(TRAIT_POTENCY)/2))))
-		entangle(M)
+	if(!buckled_mob && !M.buckled && !M.anchored && (M.small || prob(round(seed.get_trait(TRAIT_POTENCY)/6))))
+		//wait a tick for the Entered() proc that called HasProximity() to finish (and thus the moving animation),
+		//so we don't appear to teleport from two tiles away when moving into a turf adjacent to vines.
+		spawn(1)
+			entangle(M)
 
 /obj/effect/plant/attack_hand(mob/user as mob)
 	// Todo, cause damage.
@@ -60,13 +63,11 @@
 	if(buckled_mob)
 		return
 
-	if(!Adjacent(victim))
+	if(victim.buckled)
 		return
 
-	victim.buckled = src
-	victim.update_canmove()
-	buckled_mob = victim
-	if(!victim.anchored && !victim.buckled && victim.loc != get_turf(src))
+	//grabbing people
+	if(!victim.anchored && Adjacent(victim) && victim.loc != get_turf(src))
 		var/can_grab = 1
 		if(istype(victim, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = victim
@@ -75,4 +76,9 @@
 		if(can_grab)
 			src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")
 			victim.loc = src.loc
-	victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
+	
+	//entangling people
+	if(victim.loc == src.loc)
+		buckle_mob(victim)
+		victim.set_dir(pick(cardinal))
+		victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"


### PR DESCRIPTION
It should no longer be possible for vines to mature almost right after they are created. Now they have to wait 2.5 seconds (on average). This has a fairly big impact on how hard it is to deal with vines.

I spent the most of an evening playing around with different ways to balance vines, and IMO they are now much closer to how I think they should have been. Since new vines don't spring up every second, the vine health mechanic actually matters now. Clearing vines is now less about how well you can play whack-a-mole, and more about the damage output you can deal to the vines. The tools you bring matter a lot more.

Alone and with only a hatchet I was just barely able to keep vines (passive/harmless and with roughly average growth rate traits) at bay in a 3 tile wide hallway. With a weldingtool and fuel pack I was able to make very, _very_ slow progress by myself (at times moving only a single tile in per several minutes). With a fireaxe I was able to make a several tiles of progress a minute. Vines grow somewhat slowly but clear slowly as well, requring players to hack away at each vine a few times.

In addition:
- Reduced the rate that vines will entangle people. Previously if you were pulled into a mass of vines you would be entangled the instant you freed yourself, a big issue since freeing yourself also took several clicks. Hopefully this alleviates that and makes being trapped by vines a difficult situation instead of trapped forever. Now you have to be completely surrounded by vines in order for moving to be a nearly guaranteed entangle. Just approaching the edge of a vine mass will sometimes entangle but not always. Travelling through a solid mass of vines with a suitable cutting implement is difficult but possible. Getting through with your bare hands is nearly impossible.
- Vines now only entangle people on the same turf. They can still pull you into their turf, and entangle you there. This makes sure that it is always clear _which_ vine object is entangling you or someone you wish to rescue, instead of having to guess at which of the possibly 9 vine objects it could be.
- Adds the possibility of adjusting growth rate and potency for different level space vine events. The events in rotation has been left unchanged.
