### PR TITLE
PAPs now use external pressure when pumping in.

### DIFF
--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/portable_atmospherics/powered/pump/New()
 	..()
-	cell = new/obj/item/weapon/cell(src)
+	cell = new/obj/item/weapon/cell/apc(src)
 
 	var/list/air_mix = StandardAirMix()
 	src.air_contents.adjust_multi("oxygen", air_mix["oxygen"], "nitrogen", air_mix["nitrogen"])
@@ -78,7 +78,7 @@
 			output_volume = environment.volume * environment.group_multiplier
 			air_temperature = environment.temperature? environment.temperature : air_contents.temperature
 		else
-			pressure_delta = target_pressure - air_contents.return_pressure()
+			pressure_delta = environment.return_pressure() - target_pressure
 			output_volume = air_contents.volume * air_contents.group_multiplier
 			air_temperature = air_contents.temperature? air_contents.temperature : environment.temperature
 

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -20,7 +20,7 @@
 
 /obj/machinery/portable_atmospherics/powered/scrubber/New()
 	..()
-	cell = new/obj/item/weapon/cell(src)
+	cell = new/obj/item/weapon/cell/apc(src)
 
 /obj/machinery/portable_atmospherics/powered/scrubber/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/html/changelogs/Techhead-PAPin.yml
+++ b/html/changelogs/Techhead-PAPin.yml
@@ -1,0 +1,4 @@
+author: Techhead
+delete-after: True
+changes: 
+  - bugfix: "Portable air pumps now fill based on external/airtank pressure when pumping in."


### PR DESCRIPTION
This allows Portable Air Pumps to be effectively used for draining rooms and air tanks.

Also, default cells in pumps and scrubbers changed from 1k basic cells to 5k heavy-duty cells.
