### PR TITLE
Fixes #9221.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -106,7 +106,6 @@
 
 	if(loc)
 		loc.Exited(src)
-	loc = null
 
 	if(prob(30))
 		explosion(get_turf(loc), 0, 0, 1, 3)
@@ -460,6 +459,8 @@
 
 
 /obj/mecha/proc/setInternalDamage(int_dam_flag)
+	if(!pr_internal_damage) return
+
 	internal_damage |= int_dam_flag
 	pr_internal_damage.start()
 	log_append_to_last("Internal damage of type [int_dam_flag].",1)


### PR DESCRIPTION
Fixes #9221.
Removes a premature loc = null change.
Also fixes an issue occurring when the impact of an ion bullet would wreck a mech before triggering the EMP.
This would cause null runtimes as a now removed object would be accessed.
