### PR TITLE
Adjusts rig stealth module costs.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -16,8 +16,8 @@
 	disruptable = 1
 	disruptive = 0
 
-	use_power_cost = 5
-	active_power_cost = 1
+	use_power_cost = 50
+	active_power_cost = 10
 	passive_power_cost = 0
 	module_cooldown = 30
 

--- a/html/changelogs/PsiOmegaDelta-StealthFixes.yml
+++ b/html/changelogs/PsiOmegaDelta-StealthFixes.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - tweak: "The rig stealth module now requires as much power to run as the energy blade module."


### PR DESCRIPTION
Activation and active power costs were previously a tenth of the same costs for a mere energy blade.
Now costs matches that of an energy blade.
