### PR TITLE
Using more energy than a cell has stored now drains the cell.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -42,10 +42,8 @@
 	if(rigged && amount > 0)
 		explode()
 		return 0
-
-	if(charge < amount)	return 0
-	charge = (charge - amount)
-	return 1
+	charge = max(0, charge - amount)
+	return charge
 
 // recharge the cell
 /obj/item/weapon/cell/proc/give(var/amount)

--- a/html/changelogs/PsiOmegaDelta-BatteryDepletion.yml
+++ b/html/changelogs/PsiOmegaDelta-BatteryDepletion.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - bugfix: "Cells now drain when using more charge than what is available."


### PR DESCRIPTION
Fixes #9252.

Alternative solution to the issue in question:
`cell.use(max(cell.charge, amount))`
