### PR TITLE
Destroying a camera now also cuts wires randomly.

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -278,6 +278,11 @@ var/const/POWER = 8
 	var/r = rand(1, wires.len)
 	CutWireIndex(r)
 
+/datum/wires/proc/RandomCutAll(var/probability = 10)
+	for(var/i = 1; i < MAX_FLAG && i < (1 << wire_count); i += i)
+		if(prob(probability))
+			CutWireIndex(i)
+
 /datum/wires/proc/CutAll()
 	for(var/i = 1; i < MAX_FLAG && i < (1 << wire_count); i += i)
 		CutWireIndex(i)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -226,6 +226,8 @@
 //Used when someone breaks a camera
 /obj/machinery/camera/proc/destroy()
 	stat |= BROKEN
+	wires.RandomCutAll()
+
 	kick_viewers()
 	triggerCameraAlarm()
 	update_icon()

--- a/html/changelogs/PsiOmegaDelta-RandomWireBreaking.yml
+++ b/html/changelogs/PsiOmegaDelta-RandomWireBreaking.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes:
+  - tweak: "Destroying a camera by brute force now has a chance to break the wiring within."


### PR DESCRIPTION
The wire datum has been given an additional proc for this task.
