### PR TITLE
Inflatables now lose deflate verb when it's used

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -111,6 +111,7 @@
 	if(isobserver(usr)) //to stop ghosts from deflating
 		return
 
+	verbs -= /obj/structure/inflatable/verb/hand_deflate
 	deflate()
 
 /obj/structure/inflatable/attack_generic(var/mob/user, var/damage, var/attack_verb)


### PR DESCRIPTION
Makes it easier to deflate several in a row when using verb in tabs and prevents double-deflating.
