### PR TITLE
Gamestart cleanup.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -39,7 +39,6 @@ datum/controller/game_controller/proc/setup()
 
 	setup_objects()
 	setupgenetics()
-	setup_economy()
 	SetupXenoarch()
 
 	transfer_controller = new

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -2,10 +2,8 @@
 	data_core = new /obj/effect/datacore()
 	return 1
 
-/obj/effect/datacore/proc/manifest(var/nosleep = 0)
+/obj/effect/datacore/proc/manifest()
 	spawn()
-		if(!nosleep)
-			sleep(40)
 		for(var/mob/living/carbon/human/H in player_list)
 			manifest_inject(H)
 		return

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -110,11 +110,11 @@ var/global/datum/controller/gameticker/ticker
 	else
 		src.mode.announce()
 
+	current_state = GAME_STATE_PLAYING
 	create_characters() //Create player characters and transfer them
 	collect_minds()
 	equip_characters()
 	data_core.manifest()
-	current_state = GAME_STATE_PLAYING
 
 	callHook("roundstart")
 


### PR DESCRIPTION
- setup_economy() was called twice.
- Game state is set to playing just before creating characters, this ensures equipment such as headsets initialize properly.
- Removes the sleep in manifest creation. Prevents duplicate manifest entries from occurring if one joins within 4 seconds of round start.
