### PR TITLE
Teleport anomaly fix.

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
@@ -34,7 +34,7 @@
 				sparks.set_up(3, 0, get_turf(M))
 				sparks.start()
 				//
-				M.loc = pick(orange(get_turf(T), 50))
+				M.Move(pick(trange(50, get_turf(holder))))
 				sparks = new /datum/effect/effect/system/spark_spread()
 				sparks.set_up(3, 0, get_turf(M))
 				sparks.start()

--- a/html/changelogs/PsiOmegaDelta-ArtifactTele-150516.yml
+++ b/html/changelogs/PsiOmegaDelta-ArtifactTele-150516.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - bugfix: "Teleporter artifacts should no longer teleport mobs inside objects."


### PR DESCRIPTION
It should no longer teleport mobs inside other atoms.

Based on the dangerous assumption that touch-based teleportation actually works as intended.
