### PR TITLE
Travis.yml change to check for duplicate nanoUI templates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ install:
 script:
   - shopt -s globstar
   - (! grep 'step_[xy]' maps/**/*.dmm)
+  - (! find nano/templates/ -type f -exec md5sum {} + | sort | uniq -D -w 32 | grep nano)
   - DreamMaker baystation12.dme


### PR DESCRIPTION
The way nanoUI works having two templates with same MD5 hash means
that one won't be sent to the clients as the resource sending function
in byond uses MD5hash and MD5hash only to determine if someone has a file.

This bug doesn't show up in Windows for some reason but is something we'd want
to watch out for.
