### PR TITLE
Logs population every 10 minutes instead of irregularly.

### DIFF
--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -98,7 +98,7 @@ proc/statistic_cycle()
 		return
 	while(1)
 		sql_poll_population()
-		sleep(600)
+		sleep(6000)
 
 //This proc is used for feedback. It is executed at round end.
 proc/sql_commit_feedback()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -163,7 +163,6 @@ var/global/datum/controller/gameticker/ticker
 	for(var/obj/multiz/ladder/L in world) L.connect() //Lazy hackfix for ladders. TODO: move this to an actual controller. ~ Z
 
 	if(config.sql_enabled)
-		spawn(3000)
 		statistic_cycle() // Polls population totals regularly and stores them in an SQL DB -- TLE
 
 	return 1


### PR DESCRIPTION
Previously, there were two types of delays that would control when population is tracked.
gameticker.dm would call a statistics cycle proc, while statistics.dm would call population poll proc.

I have removed the delay in the gameticker.dm. This allows statistics.dm to control when population of the server is stored in the database.
I believe the previous setup existed because admins and player storing procs were called seperately. This was changed in my previous edit here #9248. Where admins and players are now called in the same proc, so only one delay is needed.

I have tested this and it seems to work, storing population numbers in about 10 minute intervals: https://i.imgur.com/LSavEJ7.png

I also attempted to remove the delay in statistics.dm and focused on the delay in gameticker.dm
But this caused an infinite loop, lagged out the server, and created 150,000 rows of data in 2 hours, instead of about 144 per day: https://i.imgur.com/xZeBb1Y.png (This method does the opposite, placing a delay in statistics.dm and not gameticker.dm).

tl;dr Makes mysql server log player population every 10 minutes, instead of irregularly.
