### PR TITLE
Fixes overbloated closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -24,9 +24,39 @@
 
 /obj/structure/closet/initialize()
 	if(!opened)		// if closed, any item at the crate's loc is put in the contents
-		for(var/obj/item/I in src.loc)
+		var/obj/item/I
+		for(I in src.loc)
 			if(I.density || I.anchored || I == src) continue
 			I.loc = src
+		// adjust locker size to hold all items with 5 units of free store room
+		var/content_size = 0
+		for(I in src.contents)
+			content_size += Ceiling(I.w_class/2)
+		if(content_size > storage_capacity-5)
+			storage_capacity = content_size + 5
+
+
+/obj/structure/closet/examine(mob/user)
+	if(get_dist(src, user) > 1)
+		return ..(user)
+
+	if(opened)
+		var/content_size = 0
+		for(var/obj/item/I in src.contents)
+			if(!I.anchored)
+				content_size += Ceiling(I.w_class/2)
+		if(!content_size)
+			user << "It is empty."
+		else if(storage_capacity > content_size*4)
+			user << "It is barely filled."
+		else if(storage_capacity > content_size*2)
+			user << "It is less than half full."
+		else if(storage_capacity > content_size)
+			user << "There is still some free space."
+		else
+			user << "It is full."
+
+
 
 /obj/structure/closet/alter_health()
 	return get_turf(src)
@@ -329,25 +359,25 @@
 	escapee.next_move = world.time + 100
 	escapee.last_special = world.time + 100
 	escapee << "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)</span>"
-	
+
 	visible_message("<span class='danger'>The [src] begins to shake violently!</span>")
 
 	breakout = 1 //can't think of a better way to do this right now.
 	for(var/i in 1 to (6*breakout_time * 2)) //minutes * 6 * 5seconds * 2
 		playsound(src.loc, 'sound/effects/grillehit.ogg', 100, 1)
 		animate_shake()
-		
+
 		if(!do_after(escapee, 50)) //5 seconds
 			breakout = 0
 			return
-		if(!escapee || escapee.stat || escapee.loc != src) 
+		if(!escapee || escapee.stat || escapee.loc != src)
 			breakout = 0
 			return //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 		//Perform the same set of checks as above for weld and lock status to determine if there is even still a point in 'resisting'...
 		if(!req_breakout())
 			breakout = 0
 			return
-	
+
 	//Well then break it!
 	breakout = 0
 	escapee << "<span class='warning'>You successfully break out!</span>"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -166,7 +166,7 @@
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"
-	req_access = list(access_security)
+	req_access = list(access_brig)
 	icon_state = "sec1"
 	icon_closed = "sec"
 	icon_locked = "sec1"


### PR DESCRIPTION
Adjusts security officer equipment access so IA agents and Detectives no longer have tribial access to them.
Lockers will check how much storage is used up and will adjust their capacity it is too small. There will always be a minimum of 5 units of free storage in a closet.
Examining an opened locker from up close will now also give people a rough estimation of how filled it is.
