### PR TITLE
Fire tweaks

### DIFF
--- a/code/setup.dm
+++ b/code/setup.dm
@@ -131,17 +131,17 @@
 #define PHORON_FLASHPOINT                  (T0C +  246) //519 K - autoignite temperature in air if that ever gets implemented.
 
 //These control the mole ratio of oxidizer and fuel used in the combustion reaction
-#define FIRE_REACTION_OXIDIZER_AMOUNT	3
+#define FIRE_REACTION_OXIDIZER_AMOUNT	3 //should be greater than the fuel amount if fires are going to spread much
 #define FIRE_REACTION_FUEL_AMOUNT		2
 
 //These control the speed at which fire burns
 #define FIRE_GAS_BURNRATE_MULT			1
-#define FIRE_LIQUID_BURNRATE_MULT		0.5
+#define FIRE_LIQUID_BURNRATE_MULT		1
 
 //If the fire is burning slower than this rate then the reaction is going too slow to be self sustaining and the fire burns itself out.
 //This ensures that fires don't grind to a near-halt while still remaining active forever.
-#define FIRE_GAS_MIN_BURNRATE				0.1
-#define FIRE_LIQUD_MIN_BURNRATE				0.05
+#define FIRE_GAS_MIN_BURNRATE			0.01
+#define FIRE_LIQUD_MIN_BURNRATE			0.01
 
 //How many moles of fuel are contained within one solid/liquid fuel volume unit
 #define LIQUIDFUEL_AMOUNT_TO_MOL		1  //mol/volume unit

--- a/html/changelogs/HarpyEagle-fire.yml
+++ b/html/changelogs/HarpyEagle-fire.yml
@@ -1,0 +1,4 @@
+author: HarpyEagle
+delete-after: True
+changes: 
+  - rscadd: "Re-implemented fuel fires. Tweaked fire behaviour overall."


### PR DESCRIPTION
Adjusts how fires process. Attempts to make liquid fuel fires burn slowly, depending on how much fuel there is. Gas fires burn erupt into a huge fireball and burns quicker. Tried to make fires burn slow enough that there is a point to firefighting, In the end they still don't last more than a few minutes though.

Also made fire color depend on firelevel as well as air temperature so that the slow-burning fuel fires aren't always deep red.

Fixes #8754. Now both gas and liquid fires die out when they are burning too slowly. A fire tile still gets created and is deleted the next tick though. However the fire does not adjust gasses or add heat if the condition is met, and it looks pretty cool, so unintended feature.

![dff590d9b3d829151bcb37fab99942fd](https://cloud.githubusercontent.com/assets/242428/7695254/a28d3b6e-fdba-11e4-9465-e45e46466169.gif)
