### PR TITLE
Replaces certain uses of shock_stage with halloss

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -114,10 +114,6 @@ var/list/gamemode_cache = list()
 
 	var/organ_health_multiplier = 1
 	var/organ_regeneration_multiplier = 1
-	
-	//Paincrit knocks someone down once they hit 60 shock_stage, so by default make it so that close to 100 additional damage needs to be dealt,
-	//so that it's similar to HALLOSS. Lowered it a bit since hitting paincrit takes much longer to wear off than a halloss stun.
-	var/organ_damage_spillover_multiplier = 0.5
 
 	var/bones_can_break = 0
 	var/limbs_can_break = 0
@@ -674,8 +670,6 @@ var/list/gamemode_cache = list()
 					config.organ_health_multiplier = value / 100
 				if("organ_regeneration_multiplier")
 					config.organ_regeneration_multiplier = value / 100
-				if("organ_damage_spillover_multiplier")
-					config.organ_damage_spillover_multiplier = value / 100
 				if("bones_can_break")
 					config.bones_can_break = value
 				if("limbs_can_break")

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -99,7 +99,7 @@
 			if(child.dislocated == 1)
 				child.undislocate()
 	if(owner)
-		owner.shock_stage += 20
+		owner.apply_effect(20, AGONY)
 		for(var/obj/item/organ/external/limb in owner.organs)
 			if(limb.dislocated == 2)
 				return
@@ -209,7 +209,7 @@
 				burn = max(0, burn - can_inflict)
 		//If there are still hurties to dispense
 		if (burn || brute)
-			owner.shock_stage += (brute+burn) * config.organ_damage_spillover_multiplier
+			owner.apply_effect( (brute+burn)*config.organ_damage_spillover_multiplier, AGONY )
 
 	// sync the organ's damage with its wounds
 	src.update_damages()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -209,7 +209,7 @@
 				burn = max(0, burn - can_inflict)
 		//If there are still hurties to dispense
 		if (burn || brute)
-			owner.apply_effect( (brute+burn)*config.organ_damage_spillover_multiplier, AGONY )
+			owner.apply_effect((brute+burn), AGONY)
 
 	// sync the organ's damage with its wounds
 	src.update_damages()


### PR DESCRIPTION
After taking a look over traumatic shock code again, using `shock_stage` the way it was seemed kind of out of place. Unlike halloss, `shock_stage` is more of a counter that triggers when a certain `traumatic_shock` level is reached, instead of an accumulated damage var.

While using `shock_stage` did have the intended effect, my impression is that it's much harder to recover from `shock_stage` induced paincrit than it is to recover from reaching a high enough halloss. Plus halloss seems to fit the job better.
