### PR TITLE
[WIP][DNM] Chemical Kinetics

### DIFF
--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -218,6 +218,18 @@ About Recipes:
 			Basically like a reagent's data variable. You can set extra requirements for a
 			reaction with this.
 
+		stages
+			Amount of reaction iterations until completion; each step consumes 1/S of total available reagents
+			and decrements a local copy of the stages var, so that when it reaches 1, all remaining reagents are used up.
+
+			In an infinite container full of reagents it would speed up indefinitely, but in a finite one,
+			it just so happens to give us a constant decrement per stage.
+
+		reaction_delay
+			Delay between iterations (mixing is treated as iteration 0), in deciseconds.
+			Keep in mind when setting this that it adds up - if you want to keep a reaction slow, keeping the stages high is better.
+			Modify it for things like grenade reactions, as higher stages would keep the reaction going longer and/or less intense.
+
 
 About the Tools:
 

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -218,17 +218,31 @@ About Recipes:
 			Basically like a reagent's data variable. You can set extra requirements for a
 			reaction with this.
 
-		stages
-			Amount of reaction iterations until completion; each step consumes 1/S of total available reagents
-			and decrements a local copy of the stages var, so that when it reaches 1, all remaining reagents are used up.
 
-			In an infinite container full of reagents it would speed up indefinitely, but in a finite one,
-			it just so happens to give us a constant decrement per stage.
+	kinetics:
+
+		rate
+			Fraction of how much of the total usable reagent actually is used in a reaction's iteration.
+			If the required_amount is 1 and reagent volume is 10, for example, a reaction with a rate of 2 will use
+			5 reagents in the first iteration, then 2.5 (0.5 * (10-5)) in the next, and so on.
+
+			KEEP IT >= 1! You can use floats >1 but values <1 will result in Shenanigans (TM) occuring.
 
 		reaction_delay
 			Delay between iterations (mixing is treated as iteration 0), in deciseconds.
 			Keep in mind when setting this that it adds up - if you want to keep a reaction slow, keeping the stages high is better.
-			Modify it for things like grenade reactions, as higher stages would keep the reaction going longer and/or less intense.
+
+			Modify it to get things like delayed grenade reactions, as higher stages would
+			also keep the reaction going longer and/or less intense.
+
+		cutoff
+			A safeguard for multi-stage reactions - a reaction will stop when the volume of reagents falls below cutoff*stoichiometry
+			of the reagent. Bear in mind it's not a predictable value - for a cutoff of 5, rate of 2 and reqs of 1, in a beaker
+			with 10u of reagent it will produce 7.5 units of product (pass at 10u and pass at 5u), 11u 8.25 (rounded to 8.3)
+			and so on by 0.75 increments but 9u will only yield 4.5 (pass at 9u, fail at 4.5u).
+
+			Reactions with rate > 1 have a hard minimum on cutoff to prevent overly long loops - BYOND hates them
+			(learn 1 simple trick to break SS13 servers they don't want you to know!)
 
 
 About the Tools:

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -6,11 +6,19 @@
 	var/list/catalysts = list()
 	var/list/inhibitors = list()
 
-	var/reaction_delay = 10 // delay between each instance of reaction from mixing, in deciseconds.
-	var/stages = 1 // how many iterations it takes for the reaction to conclude, 1 amounts to old behavior;
+/* Kinetics vars - default to old behavior
+
+old grenade reactions are absolutely required to keep the values at 0-1-0 to work as intended */
+
+	var/reaction_delay = 10 // delay between each instance of reaction from mixing, in deciseconds. 0 is old behavior.
+	var/rate = 1 //fraction of reagent available used, 1 amounts to old behavior, 2 means half of reagent is consumed per iteration, etc.
+	var/cutoff = 0 //cutoff, only on multi-stage reactions - you could experiment with it for !!FUN!! behaviors
+
+/* end of kinetics */
 
 	var/result_amount = 0
 	var/mix_message = "The solution begins to bubble."
+
 
 /datum/chemical_reaction/proc/can_happen(var/datum/reagents/holder)
 	return 1
@@ -100,6 +108,7 @@
 	result = "space_drugs"
 	required_reagents = list("mercury" = 1, "sugar" = 1, "lithium" = 1)
 	result_amount = 3
+	rate = 4 //demonstration, but since it's illegal, making production longer and more conspicuous can't hurt for now
 
 /datum/chemical_reaction/lube
 	name = "Space Lube"
@@ -121,7 +130,6 @@
 	result = "synaptizine"
 	required_reagents = list("sugar" = 1, "lithium" = 1, "water" = 1)
 	result_amount = 3
-	stages = 6 //reminder to self - remove this
 
 /datum/chemical_reaction/hyronalin
 	name = "Hyronalin"
@@ -467,7 +475,7 @@
 	result_amount = 2
 	mix_message = null
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -489,7 +497,7 @@
 	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1 )
 	result_amount = null
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/flash_powder/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -521,7 +529,7 @@
 	required_reagents = list("uranium" = 1, "iron" = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
 	result_amount = 2
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/emp_pulse/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -538,7 +546,7 @@
 	required_reagents = list("glycerol" = 1, "pacid" = 1, "sacid" = 1)
 	result_amount = 2
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -561,7 +569,7 @@
 	required_reagents = list("aluminum" = 1, "phoron" = 1, "sacid" = 1 )
 	result_amount = 1
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/napalm/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/turf/location = get_turf(holder.my_atom.loc)
@@ -578,7 +586,7 @@
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 	result_amount = 0.4
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/chemsmoke/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -599,7 +607,7 @@
 	result_amount = 2
 	mix_message = "The solution violently bubbles!"
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/foam/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -620,7 +628,7 @@
 	required_reagents = list("aluminum" = 3, "foaming_agent" = 1, "pacid" = 1)
 	result_amount = 5
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/metalfoam/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -640,7 +648,7 @@
 	required_reagents = list("iron" = 3, "foaming_agent" = 1, "pacid" = 1)
 	result_amount = 5
 	reaction_delay = 0
-	stages = 1
+	rate = 1
 
 /datum/chemical_reaction/ironfoam/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -6,6 +6,9 @@
 	var/list/catalysts = list()
 	var/list/inhibitors = list()
 
+	var/reaction_delay = 10 // delay between each instance of reaction from mixing, in deciseconds.
+	var/stages = 1 // how many iterations it takes for the reaction to conclude, 1 amounts to old behavior;
+
 	var/result_amount = 0
 	var/mix_message = "The solution begins to bubble."
 
@@ -118,6 +121,7 @@
 	result = "synaptizine"
 	required_reagents = list("sugar" = 1, "lithium" = 1, "water" = 1)
 	result_amount = 3
+	stages = 6 //reminder to self - remove this
 
 /datum/chemical_reaction/hyronalin
 	name = "Hyronalin"
@@ -462,6 +466,8 @@
 	required_reagents = list("water" = 1, "potassium" = 1)
 	result_amount = 2
 	mix_message = null
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -482,6 +488,8 @@
 	result = null
 	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1 )
 	result_amount = null
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/flash_powder/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -512,6 +520,8 @@
 	result = null
 	required_reagents = list("uranium" = 1, "iron" = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
 	result_amount = 2
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/emp_pulse/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -527,6 +537,8 @@
 	result = "nitroglycerin"
 	required_reagents = list("glycerol" = 1, "pacid" = 1, "sacid" = 1)
 	result_amount = 2
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -548,6 +560,8 @@
 	result = null
 	required_reagents = list("aluminum" = 1, "phoron" = 1, "sacid" = 1 )
 	result_amount = 1
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/napalm/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/turf/location = get_turf(holder.my_atom.loc)
@@ -563,6 +577,8 @@
 	result = null
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 	result_amount = 0.4
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/chemsmoke/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -582,6 +598,8 @@
 	required_reagents = list("fluorosurfactant" = 1, "water" = 1)
 	result_amount = 2
 	mix_message = "The solution violently bubbles!"
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/foam/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -601,6 +619,8 @@
 	result = null
 	required_reagents = list("aluminum" = 3, "foaming_agent" = 1, "pacid" = 1)
 	result_amount = 5
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/metalfoam/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -619,6 +639,8 @@
 	result = null
 	required_reagents = list("iron" = 3, "foaming_agent" = 1, "pacid" = 1)
 	result_amount = 5
+	reaction_delay = 0
+	stages = 1
 
 /datum/chemical_reaction/ironfoam/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)


### PR DESCRIPTION
Reworks the chemical reactions to no longer instantaneously convert 100% of all reagents into products, opening the path towards more complex and open chemistry system. Reactions now have two new vars: stages, which controls how many steps it takes to 100% reaction, and reaction_delay which controls the length between each step, counting from mixing.

For example, a reaction whose stages = 3 and reaction_delay of 10 will take 3 seconds total (30 ds) with a fraction of the reagents reacting every second.

Ideally, since #9372 is in the works, it will use a linear reaction rate (if we take 30 chems, 1 required each, 1/3 \* 30 in first second, 1/2 \* 20 and 1/1 \* 10 yields constant 10 chems used/reaction), as a more realistic exponential rate would asymptotically tend towards zero, only stopping once it reaches MIN_CHEMICAL_VOLUME and is rounded to zero if that PR gets pulled.

 Due to technical issues to iron out (the proc re-calls if it finds >0 potential reactions instead of iterating until that) it currently IS exponential, stopping when it reaches less chemicals that required for reaction. It's also really messy ATM, mostly putting this here to avoid pastebinning the code every time.
