### PR TITLE
Fixes a typo/mistake

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -202,7 +202,7 @@
 	category = "Medical"
 
 /datum/autolathe/recipe/syringegun_ammo
-	name = "syringe"
+	name = "syringe gun cartridge"
 	path = /obj/item/weapon/syringe_cartridge
 	category = "Arms and Ammunition"
 


### PR DESCRIPTION
Makes it so both a syringe and syringe gun cartridge aren't labelled as syringe. Aims to lessen confusion.
