### PR TITLE
Fix Say ":i " not working

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -114,9 +114,11 @@
 				used_radios += R
 
 		if("intercom")
-			for(var/obj/item/device/radio/intercom/I in view(1, null))
-				I.talk_into(src, message, null, verb, speaking)
-				used_radios += I
+			if(!src.restrained())
+				for(var/obj/item/device/radio/intercom/I in view(1, null))
+					I.talk_into(src, message, null, verb, speaking)
+					I.add_fingerprint(src)
+					used_radios += I
 		if("whisper")
 			whisper_say(message, speaking, alt_name)
 			return

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -115,7 +115,7 @@
 
 		if("intercom")
 			for(var/obj/item/device/radio/intercom/I in view(1, null))
-				I.talk_into(src, message, verb, speaking)
+				I.talk_into(src, message, null, verb, speaking)
 				used_radios += I
 		if("whisper")
 			whisper_say(message, speaking, alt_name)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -115,7 +115,7 @@
 
 		if("intercom")
 			if(!src.restrained())
-				for(var/obj/item/device/radio/intercom/I in view(1, null))
+				for(var/obj/item/device/radio/intercom/I in view(1))
 					I.talk_into(src, message, null, verb, speaking)
 					I.add_fingerprint(src)
 					used_radios += I


### PR DESCRIPTION
Speaking into intercoms via Say :i now actually works, without needing to manually turn on the intercom microphone. Actually, it didn't work even with the microphone on—the microphone would just pick up the mumbling. 

Because it's now possible to talk into intercoms without touching them, bbc8ad6 makes intercoms receive fingerprints when you Say :i into them, and makes it impossible to talk into them when restrained. I figured the latter would be a logical, since otherwise, handcuffed people could run up to a intercom and call for help, even after you've removed their headset. 
