### PR TITLE
Items again have their loc set just before dropped() is called.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -218,7 +218,7 @@ var/list/slot_equipment_priority = list( \
 	drop_from_inventory(I)
 	return 1
 
-//Attemps to remove an object on a mob.  Will not move it to another area or such, just removes from the mob.
+//Attemps to remove an object on a mob.
 /mob/proc/remove_from_mob(var/obj/O)
 	src.u_equip(O)
 	if (src.client)
@@ -227,6 +227,7 @@ var/list/slot_equipment_priority = list( \
 	O.screen_loc = null
 	if(istype(O, /obj/item))
 		var/obj/item/I = O
+		I.loc = src.loc
 		I.dropped(src)
 	return 1
 


### PR DESCRIPTION
Fixes #9299.
Fixes #9406.
