### PR TITLE
Fixes portable generators going above their temperature limit

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -217,7 +217,8 @@
 	//limit temperature increase so that it cannot raise temperature above upper_limit,
 	//or if it is already above upper_limit, limit the increase to 0.
 	var/inc_limit = max(upper_limit - temperature, 0)
-	temperature += min(rand(-7 + bias, 7 + bias), inc_limit)
+	var/dec_limit = min(temperature - lower_limit, 0)
+	temperature += between(dec_limit, rand(-7 + bias, 7 + bias), inc_limit)
 
 	if (temperature > max_temperature)
 		overheat()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -214,7 +214,10 @@
 	else if (temperature > upper_limit)
 		bias = max(round((temperature - average)/TEMPERATURE_DIVISOR, 1), -TEMPERATURE_CHANGE_MAX)
 
-	temperature += rand(-7 + bias, 7 + bias)
+	//limit temperature increase so that it cannot raise temperature above upper_limit,
+	//or if it is already above upper_limit, limit the increase to 0.
+	var/inc_limit = max(upper_limit - temperature, 0)
+	temperature += min(rand(-7 + bias, 7 + bias), inc_limit)
 
 	if (temperature > max_temperature)
 		overheat()


### PR DESCRIPTION
While portable generators were biased so that they would reduce their temperature _on average_ when above their temperature limit, sometimes the random walk would cause them to wander above the danger temperature for extended periods of time even when set to a safe power level.

This prevents the temperature from randomly walking above upper_limit while still allowing the temperature to change smoothly.
