### PR TITLE
Supply shuttle and crate fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -37,10 +37,7 @@
 
 
 /obj/structure/closet/examine(mob/user)
-	if(get_dist(src, user) > 1)
-		return ..(user)
-
-	if(opened)
+	if(..(user, 1) && !opened)
 		var/content_size = 0
 		for(var/obj/item/I in src.contents)
 			if(!I.anchored)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -123,9 +123,6 @@ var/list/mechtoys = list(
 	var/comment = null
 
 /datum/controller/supply
-	var/processing = 1
-	var/processing_interval = 300
-	var/iteration = 0
 	//supply points
 	var/points = 50
 	var/points_per_process = 1
@@ -145,20 +142,14 @@ var/list/mechtoys = list(
 	New()
 		ordernum = rand(1,9000)
 
-	//Supply shuttle ticker - handles supply point regenertion and shuttle travelling between centcomm and the station
-	proc/process()
 		for(var/typepath in (typesof(/datum/supply_packs) - /datum/supply_packs))
 			var/datum/supply_packs/P = new typepath()
 			supply_packs[P.name] = P
 
-		spawn(0)
-			set background = 1
-			while(1)
-				if(processing)
-					iteration++
-					points += points_per_process
-
-				sleep(processing_interval)
+	// Supply shuttle ticker - handles supply point regeneration
+	// This is called by the process scheduler every thirty seconds
+	proc/process()
+		points += points_per_process
 
 	//To stop things being sent to centcomm which should not be sent to centcomm. Recursively checks for these types.
 	proc/forbidden_atoms_check(atom/A)
@@ -251,23 +242,30 @@ var/list/mechtoys = list(
 			var/datum/supply_order/SO = S
 			var/datum/supply_packs/SP = SO.object
 
-			var/atom/A = new SP.containertype(pickedloc)
+			var/obj/A = new SP.containertype(pickedloc)
 			A.name = "[SP.containername] [SO.comment ? "([SO.comment])":"" ]"
 
 			//supply manifest generation begin
 
-			var/obj/item/weapon/paper/manifest/slip = new /obj/item/weapon/paper/manifest(A)
-			slip.is_copy = 0
-			slip.info = "<h3>[command_name()] Shipping Manifest</h3><hr><br>"
-			slip.info +="Order #[SO.ordernum]<br>"
-			slip.info +="Destination: [station_name]<br>"
-			slip.info +="[shoppinglist.len] PACKAGES IN THIS SHIPMENT<br>"
-			slip.info +="CONTENTS:<br><ul>"
+			var/obj/item/weapon/paper/manifest/slip
+			if(!SP.contraband)
+				slip = new /obj/item/weapon/paper/manifest(A)
+				slip.is_copy = 0
+				slip.info = "<h3>[command_name()] Shipping Manifest</h3><hr><br>"
+				slip.info +="Order #[SO.ordernum]<br>"
+				slip.info +="Destination: [station_name]<br>"
+				slip.info +="[shoppinglist.len] PACKAGES IN THIS SHIPMENT<br>"
+				slip.info +="CONTENTS:<br><ul>"
 
 			//spawn the stuff, finish generating the manifest while you're at it
 			if(SP.access)
-				A:req_access = list()
-				A:req_access += text2num(SP.access)
+				if(isnum(SP.access))
+					A.req_access = list(SP.access)
+				else if(islist(SP.access))
+					var/list/L = SP.access // access var is a plain var, we need a list
+					A.req_access = L.Copy()
+				else
+					world << "<span class='danger'>Supply pack with invalid access restriction [SP.access] encountered!</span>"
 
 			var/list/contains
 			if(istype(SP,/datum/supply_packs/randomised))
@@ -283,12 +281,12 @@ var/list/mechtoys = list(
 				if(!typepath)	continue
 				var/atom/B2 = new typepath(A)
 				if(SP.amount && B2:amount) B2:amount = SP.amount
-				slip.info += "<li>[B2.name]</li>" //add the item to the manifest
+				if(slip) slip.info += "<li>[B2.name]</li>" //add the item to the manifest
 
 			//manifest finalisation
-			slip.info += "</ul><br>"
-			slip.info += "CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"
-			if (SP.contraband) slip.loc = null	//we are out of blanks for Form #44-D Ordering Illicit Drugs.
+			if(slip)
+				slip.info += "</ul><br>"
+				slip.info += "CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"
 
 		shoppinglist.Cut()
 		return

--- a/code/modules/reagents/dispenser/supply.dm
+++ b/code/modules/reagents/dispenser/supply.dm
@@ -144,7 +144,7 @@
 		_tname {\
 			name = _name ;\
 			containername = _cname ;\
-			containertype = /obj/structure/closet/crate/secure;\
+			containertype = /obj/structure/closet/crate;\
 			cost = _cost ;\
 			contains = list( _type , _type );\
 			group = "Reagent Cartridges"\


### PR DESCRIPTION
- Supply point generation no longer increases over time, leading to a total of around 45000 points generating after 150 minutes - the new figure is around 300 points over 150 minutes.
- Supply packs can have access set as either a number or a list; either is transferred to crates' req_access var correctly (and without `text2num()`)
- Non-secure reagent cartridge crates no longer use secure crates
- Closet/crate examine now calls ..() in all circumstances, not just when the user is more than one tile away
- Contraband crates no longer generate a manifest slip then give it to the GC
- Supply crate spawning no longer uses the `:` operator
