### PR TITLE
Fixes #9447.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1321,6 +1321,7 @@
 #include "code\modules\nano\interaction\contained.dm"
 #include "code\modules\nano\interaction\default.dm"
 #include "code\modules\nano\interaction\inventory.dm"
+#include "code\modules\nano\interaction\inventory_deep.dm"
 #include "code\modules\nano\interaction\physical.dm"
 #include "code\modules\nano\interaction\self.dm"
 #include "code\modules\nano\interaction\zlevel.dm"

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -131,7 +131,7 @@
 	if(!target)
 		if(ai_card)
 			if(istype(ai_card,/obj/item/device/aicard))
-				ai_card.attack_self(H)
+				ai_card.ui_interact(H, state = deep_inventory_state)
 			else
 				eject_ai(H)
 		update_verb_holder()

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -234,7 +234,7 @@
 		SetupStat(R)
 
 /mob/proc/SetupStat(var/obj/item/weapon/rig/R)
-	if(R && !R.canremove && R.installed_modules.len && statpanel("Hardsuit Modules"))
+	if(src == usr && R && !R.canremove && R.installed_modules.len && statpanel("Hardsuit Modules"))
 		var/cell_status = R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "ERROR"
 		statpanel("Hardsuit Modules", "Suit charge", cell_status)
 		for(var/obj/item/rig_module/module in R.installed_modules)

--- a/code/modules/nano/interaction/inventory_deep.dm
+++ b/code/modules/nano/interaction/inventory_deep.dm
@@ -1,0 +1,10 @@
+/*
+	This state checks if src_object is contained anywhere in the user's inventory, including bags, etc.
+*/
+/var/global/datum/topic_state/deep_inventory_state/deep_inventory_state = new()
+
+/datum/topic_state/deep_inventory_state/can_use_topic(var/src_object, var/mob/user)
+	if(!user.contains(src_object))
+		return STATUS_CLOSE
+
+	return user.shared_nano_interaction()

--- a/nano/templates/aicard.tmpl
+++ b/nano/templates/aicard.tmpl
@@ -1,0 +1,97 @@
+<!--
+Title: inteliCard interface
+Used In File(s): \code\game\objects\items\devices\aicard.dm
+ -->
+ 
+ <style type="text/css">
+    table.borders   {
+        width:95%; 
+        margin-left:2.4%; 
+        margin-right:2.4%;
+    }
+
+    table.borders, table.borders tr {
+        border: 1px solid White;
+    }
+    
+    td.law_index {
+        width: 50px;
+    }
+    
+    td.state {
+        width: 63px;
+		text-align:center; 
+    }
+    
+    td.add {
+        width: 36px;
+    }
+    
+    td.edit {
+        width: 36px;
+		text-align:center; 
+    }
+    
+    td.delete {
+        width: 53px;
+		text-align:center; 
+    }
+    
+    td.law_type {
+        width: 65px;
+    }
+    
+    td.position {
+        width: 37px;
+    }
+</style>
+ 
+{{if data.has_ai}}
+    <div class="item">
+        <div class="itemLabelNarrow">
+            Integrity:
+        </div>
+        <div class="itemContentWide">
+            {{:data.integrity}}%
+        </div>
+    </div>
+    
+    {{if data.has_laws}}    
+		<table class='borders'>
+		<tr><td class='law_index'>Index</td><td>Law</td></tr>
+    
+		<div class="itemLabelNarrow">
+			Laws:
+		</div>
+		{{for data.laws}}
+			<tr><td valign="top">{{:value.index}}.</td><td>{{:value.law}}</td></tr>
+		{{/for}}
+		</table>
+    {{else}}
+        <span class='notice'>No laws found.</span>
+	{{/if}}
+    
+    {{if data.operational}}    
+        <table>
+            <tr>
+                <td><span class='itemLabelWidest'>Radio Subspace Transceiver</span></td>
+                <td>{{:helper.link("Enabled", null, {'radio' : 0}, data.radio ? 'selected' : null)}}</td>
+                <td>{{:helper.link("Disabled", null, {'radio' : 1}, data.radio ? null : 'redButton' )}}</td>
+            </tr>
+            <tr><td><span class='itemLabelWidest'>Wireless Interface</span></td>
+                <td>{{:helper.link("Enabled", null, {'wireless' : 0}, data.wireless ? 'selected' : null)}}</td>
+                <td>{{:helper.link("Disabled", null, {'wireless' : 1}, data.wireless ? null : 'redButton' )}}</td>
+            </tr>
+            {{if data.flushing}}
+                <tr><td><span class='notice'>AI wipe in progress...</span></td></tr>
+            {{else}}
+                <tr>
+                    <td><span class='itemLabelWidest'>Wipe AI</span></td>
+                    <td>{{:helper.link("Wipe", 'radiation', {'wipe' : 1}, null, 'redButton')}}</td>
+                </tr>
+            {{/if}}
+        </table>
+    {{/if}}
+{{else}}
+    Stored AI: <span class='notice'>No AI detected.</span>
+{{/if}}


### PR DESCRIPTION
Fixes #9447.
The inteliCard now has a NanoUI interface, allowing one to utilize custom CanUseTopic() checks depending on context, in-hand or in-rig.
This makes it possible to properly access a rigs internal inteliCard, and alter the settings.

Also fixes a runtime in the rig SetupStat() because BYOND has expectations of when statpanel can be called apparently.

This was actually less work than trying to figure out how the rig suit handled its internal synths...
