### PR TITLE
Robolimb fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -236,7 +236,7 @@
 /mob/living/carbon/human/proc/get_damageable_organs()
 	var/list/obj/item/organ/external/parts = list()
 	for(var/obj/item/organ/external/O in organs)
-		if(O.brute_dam + O.burn_dam < O.max_damage)
+		if(O.is_damageable())
 			parts += O
 	return parts
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -118,8 +118,12 @@
 		else if(E.is_malfunctioning())
 
 			if(E.body_part == HAND_LEFT)
+				if(!l_hand)
+					continue
 				drop_from_inventory(l_hand)
 			else
+				if(!r_hand)
+					continue
 				drop_from_inventory(r_hand)
 
 			emote("me", 1, "drops what they were holding, their [E.name] malfunctioning!")

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -175,15 +175,16 @@ var/list/organ_cache = list()
 	W.time_inflicted = world.time
 
 /obj/item/organ/proc/take_damage(amount, var/silent=0)
-	if(src.robotic == 2)
+	if(src.status & ORGAN_ROBOT)
 		src.damage += (amount * 0.8)
 	else
 		src.damage += amount
 
-	if(owner && parent_organ)
-		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
-		if(parent && !silent)
-			owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
+		//only show this if the organ is not robotic
+		if(owner && parent_organ)
+			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+			if(parent && !silent)
+				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
 /obj/item/organ/proc/robotize() //Being used to make robutt hearts, etc
 	robotic = 2

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -138,6 +138,9 @@
 			   DAMAGE PROCS
 ****************************************************/
 
+/obj/item/organ/external/proc/is_damageable(var/additional_damage = 0)
+	return (vital || brute_dam + burn_dam + additional_damage < max_damage)
+
 /obj/item/organ/external/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())
 	if((brute <= 0) && (burn <= 0))
 		return 0
@@ -177,7 +180,7 @@
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
 	// Non-vital organs are limited to max_damage. You can't kill someone by bludeonging their arm all the way to 200 -- you can
 	// push them faster into paincrit though, as the additional damage is converted into shock.
-	if(vital || (brute_dam + burn_dam + brute + burn) < max_damage || !config.limbs_can_break)
+	if(is_damageable(brute + burn) || !config.limbs_can_break)
 		if(brute)
 			if(can_cut)
 				createwound( CUT, brute )

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -8,7 +8,10 @@ mob/var/next_pain_time = 0
 // partname is the name of a body part
 // amount is a num from 1 to 100
 mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0)
-	if(stat >= 2) return
+	if(stat >= 1) 
+		return
+	if(species && species.flags & NO_PAIN)
+		return
 	if(analgesic > 40)
 		return
 	if(world.time < next_pain_time && !force)
@@ -48,10 +51,10 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 // message is the custom message to be displayed
 // flash_strength is 0 for weak pain flash, 1 for strong pain flash
 mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
-	if(stat >= 1) return
-
-	if(species && species.flags & NO_PAIN) return
-
+	if(stat >= 1) 
+		return
+	if(species && species.flags & NO_PAIN) 
+		return
 	if(reagents.has_reagent("tramadol"))
 		return
 	if(reagents.has_reagent("oxycodone"))
@@ -79,7 +82,7 @@ mob/living/carbon/human/proc/handle_pain()
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in organs)
-		if(E.status & ORGAN_DEAD) continue
+		if(E.status & (ORGAN_DEAD|ORGAN_ROBOT)) continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,
 		// but also sometimes use one of the less damaged ones
@@ -91,6 +94,7 @@ mob/living/carbon/human/proc/handle_pain()
 
 	// Damage to internal organs hurts a lot.
 	for(var/obj/item/organ/I in internal_organs)
+		if(I.status & (ORGAN_DEAD|ORGAN_ROBOT)) continue
 		if(I.damage > 2) if(prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
 			src.custom_pain("You feel a sharp pain in your [parent.name]", 1)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -10,7 +10,7 @@ mob/var/next_pain_time = 0
 mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0)
 	if(stat >= 1) 
 		return
-	if(species && species.flags & NO_PAIN)
+	if(species && (species.flags & NO_PAIN))
 		return
 	if(analgesic > 40)
 		return
@@ -53,7 +53,7 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 	if(stat >= 1) 
 		return
-	if(species && species.flags & NO_PAIN) 
+	if(species.flags & NO_PAIN) 
 		return
 	if(reagents.has_reagent("tramadol"))
 		return
@@ -74,7 +74,7 @@ mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping
 
-	if(species && species.flags & NO_PAIN) return
+	if(species.flags & NO_PAIN) return
 
 	if(stat >= 2) return
 	if(analgesic > 70)


### PR DESCRIPTION
- Fixes #9460
- Fixes robot limbs spamming malfunctioning messages and spark effects endlessly if one arm is malfunctioning while holding an item in the other arm.
- Fixes robotic organs causing pain messages and fixes pain() not checking if the species has NO_PAIN.
