### PR TITLE
Fixes #9525.

### DIFF
--- a/code/modules/mob/freelook/eye.dm
+++ b/code/modules/mob/freelook/eye.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/mob/eye.dmi'
 	icon_state = "default-eye"
 	alpha = 127
+	density = 0
 
 	var/sprint = 10
 	var/cooldown = 0


### PR DESCRIPTION
Fixes #9525.
The Eye mob is no longer as dense. Should no longer block mobs, doors, or anything else.
