### PR TITLE
Server date and revision.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -149,6 +149,7 @@
 #include "code\datums\diseases\advance\symptoms\weight.dm"
 #include "code\datums\helper_datums\construction_datum.dm"
 #include "code\datums\helper_datums\events.dm"
+#include "code\datums\helper_datums\getrev.dm"
 #include "code\datums\helper_datums\global_iterator.dm"
 #include "code\datums\helper_datums\teleport.dm"
 #include "code\datums\helper_datums\topic_input.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -90,6 +90,7 @@
 	var/banappeals
 	var/wikiurl
 	var/forumurl
+	var/githuburl
 
 	//Alert level description
 	var/alert_desc_green = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
@@ -375,6 +376,9 @@
 
 				if ("forumurl")
 					config.forumurl = value
+
+				if ("githuburl")
+					config.githuburl = value
 
 				if ("guest_jobban")
 					config.guest_jobban = 1

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -1,0 +1,39 @@
+var/global/datum/getrev/revdata = new()
+
+/datum/getrev
+	var/revision
+	var/date
+	var/showinfo
+
+/datum/getrev/New()
+	var/list/head_log = file2list(".git/logs/HEAD", "\n")
+	for(var/line=head_log.len, line>=1, line--)
+		if(head_log[line])
+			var/list/last_entry = text2list(head_log[line], " ")
+			if(last_entry.len < 2)	continue
+			revision = last_entry[2]
+			// Get date/time
+			if(last_entry.len >= 5)
+				var/unix_time = text2num(last_entry[5])
+				if(unix_time)
+					date = unix2date(unix_time)
+			break
+	world.log << "Running revision:"
+	world.log << date
+	world.log << revision
+	return
+
+client/verb/showrevinfo()
+	set category = "OOC"
+	set name = "Show Server Revision"
+	set desc = "Check the current server code revision"
+
+	if(revdata.revision)
+		src << "<b>Server revision:</b> [revdata.date]"
+		if(config.githuburl)
+			src << "<a href='[config.githuburl]/commit/[revdata.revision]'>[revdata.revision]</a>"
+		else
+			src << revdata.revision
+	else
+		src << "Revision unknown"
+	return

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -177,6 +177,9 @@ GUEST_BAN
 ## Wiki address
 # WIKIURL http://example.com
 
+## GitHub address
+# GITHUBURL https://github.com/example-user/example-repository
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://example.com
 

--- a/html/changelogs/PsiOmegaDelta-ServerRevision.yml
+++ b/html/changelogs/PsiOmegaDelta-ServerRevision.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - rscadd: "You can now review the server revision date and hash by using the 'Show Server Revision' verb in the OOC category."


### PR DESCRIPTION
Can now see the current git revision and date:
- In the Dream Daemon log output.
- By using the "Show Server Revision" client verb which also links you to the commit in question.

Required for this to work fully:
- For the .git folder to be accessible from the root .dmb folder by simply being placed there, using soft links, or otherwise.
- The GITHUBURL setting in config.txt: 
  `GITHUBURL https://github.com/Baystation12/Baystation12`
