### PR TITLE
Refactors get_apc()

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -46,7 +46,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/used_environ = 0
 
 	var/has_gravity = 1
-	var/list/apc = list()
+	var/obj/machinery/power/apc/apc = null
 	var/no_air = null
 //	var/list/lights				// list of all lights on this area
 	var/list/all_doors = list()		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -156,7 +156,7 @@
 		init()
 	else
 		area = get_area(src)
-		area.apc |= src
+		area.apc = src
 		opened = 1
 		operating = 0
 		name = "[area.name] APC"
@@ -171,7 +171,7 @@
 	if(operating && malf && src.z in config.station_levels) //if (is_type_in_list(get_area(src), the_station_areas))
 		malf.hacked_apcs -= src
 
-	area.apc -= src
+	area.apc = null
 	area.power_light = 0
 	area.power_equip = 0
 	area.power_environ = 0
@@ -210,7 +210,7 @@
 	else
 		src.area = get_area_name(areastring)
 		name = "\improper [area.name] APC"
-	area.apc |= src
+	area.apc = src
 	update_icon()
 
 	make_terminal()

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -149,7 +149,6 @@
 			return C
 	return null
 
+
 /area/proc/get_apc()
-	var/obj/machinery/power/apc/FINDME = locate() in src
-	if (FINDME)
-		return FINDME
+	return apc


### PR DESCRIPTION
- Fixes #9536
- Area now has APC variable, instead of list. APC construction, etc. should have checks to allow one APC per area only, so situations with multi-APC areas are unlikely, unless adminbus occurs. Either way, with or without this commit, one of the APCs would be unoperational (no load)
- get_apc() no longer uses very laggy locate() in contents of area. In situations where get_apc() is called repeately this brings massive increase in performance (from 0.120 to 0.000, depending on area size and amount of things in contents of that area) as it now only returns the apc variable.
