### PR TITLE
Refactor floodlights

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -267,7 +267,7 @@
 
 			if("cellremove")
 				if(open && cell && !usr.get_active_hand())
-					cell.updateicon()
+					cell.update_icon()
 					usr.put_in_active_hand(cell)
 					cell.add_fingerprint(usr)
 					cell = null

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -10,7 +10,7 @@
 	power_channel = EQUIP
 	var/obj/item/weapon/cell/charging = null
 	var/chargelevel = -1
-	
+
 /obj/machinery/cell_charger/update_icon()
 	icon_state = "ccharger[charging ? 1 : 0]"
 
@@ -27,11 +27,11 @@
 			chargelevel = newlevel
 	else
 		overlays.Cut()
-	
+
 /obj/machinery/cell_charger/examine(mob/user)
 	if(!..(user, 5))
 		return
-	
+
 	user << "There's [charging ? "a" : "no"] cell in the charger."
 	if(charging)
 		user << "Current charge: [charging.charge]"
@@ -71,7 +71,7 @@
 	if(charging)
 		usr.put_in_hands(charging)
 		charging.add_fingerprint(user)
-		charging.updateicon()
+		charging.update_icon()
 
 		src.charging = null
 		user.visible_message("[user] removes the cell from the charger.", "You remove the cell from the charger.")
@@ -84,7 +84,7 @@
 			return
 
 		charging.loc = src.loc
-		charging.updateicon()
+		charging.update_icon()
 		charging = null
 		update_icon()
 		user.visible_message("[user] removes the cell from the charger.", "You remove the cell from the charger.")
@@ -103,11 +103,11 @@
 	if((stat & (BROKEN|NOPOWER)) || !anchored)
 		update_use_power(0)
 		return
-	
+
 	if (charging && !charging.fully_charged())
 		charging.give(active_power_usage*CELLRATE)
 		update_use_power(2)
-		
+
 		update_icon()
 	else
 		update_use_power(1)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -7,28 +7,60 @@
 	density = 1
 	var/on = 0
 	var/obj/item/weapon/cell/high/cell = null
-	var/use = 5
+	var/use = 200 // 200W light
 	var/unlocked = 0
 	var/open = 0
 	var/brightness_on = 8		//can't remember what the maxed out value is
 
 /obj/machinery/floodlight/New()
 	src.cell = new(src)
+	cell.maxcharge = 1000
+	cell.charge = 1000 // 41minutes @ 200W
 	..()
 
-/obj/machinery/floodlight/proc/updateicon()
+/obj/machinery/floodlight/update_icon()
+	overlays.Cut()
 	icon_state = "flood[open ? "o" : ""][open && cell ? "b" : ""]0[on]"
 
 /obj/machinery/floodlight/process()
-	if(on)
-		if(cell.charge >= use)
-			cell.use(use)
-		else
-			on = 0
-			updateicon()
-			set_light(0)
-			src.visible_message("<span class='warning'>[src] shuts down due to lack of power!</span>")
-			return
+	if(!on)
+		return
+
+	if(!cell || (cell.charge < (use * CELLRATE)))
+		turn_off(1)
+		return
+
+	// If the cell is almost empty rarely "flicker" the light. Aesthetic only.
+	if((cell.percent() < 10) && prob(5))
+		set_light(brightness_on/2, brightness_on/4)
+		spawn(20)
+			if(on)
+				set_light(brightness_on, brightness_on/2)
+
+	cell.use(use*CELLRATE)
+
+
+// Returns 0 on failure and 1 on success
+/obj/machinery/floodlight/proc/turn_on(var/loud = 0)
+	if(!cell)
+		return 0
+	if(cell.charge < (use * CELLRATE))
+		return 0
+
+	on = 1
+	set_light(brightness_on, brightness_on / 2)
+	update_icon()
+	if(loud)
+		visible_message("\the [src] turns on.")
+	return 1
+
+/obj/machinery/floodlight/proc/turn_off(var/loud = 0)
+	on = 0
+	set_light(0, 0)
+	update_icon()
+	if(loud)
+		visible_message("\the [src] shuts down.")
+
 
 /obj/machinery/floodlight/attack_hand(mob/user as mob)
 	if(open && cell)
@@ -40,27 +72,20 @@
 			cell.loc = loc
 
 		cell.add_fingerprint(user)
-		cell.updateicon()
+		cell.update_icon()
 
 		src.cell = null
 		user << "You remove the power cell"
-		updateicon()
+		update_icon()
 		return
 
 	if(on)
-		on = 0
-		user << "\blue You turn off the light"
-		set_light(0)
+		turn_off(1)
 	else
-		if(!cell)
-			return
-		if(cell.charge <= 0)
-			return
-		on = 1
-		user << "\blue You turn on the light"
-		set_light(brightness_on)
+		if(!turn_on(1))
+			user << "You try to turn on \the [src] but it does not work."
 
-	updateicon()
+	update_icon()
 
 
 /obj/machinery/floodlight/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -93,4 +118,4 @@
 				W.loc = src
 				cell = W
 				user << "You insert the power cell."
-	updateicon()
+	update_icon()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -51,7 +51,7 @@
 	set_light(brightness_on, brightness_on / 2)
 	update_icon()
 	if(loud)
-		visible_message("\the [src] turns on.")
+		visible_message("\The [src] turns on.")
 	return 1
 
 /obj/machinery/floodlight/proc/turn_off(var/loud = 0)
@@ -59,7 +59,17 @@
 	set_light(0, 0)
 	update_icon()
 	if(loud)
-		visible_message("\the [src] shuts down.")
+		visible_message("\The [src] shuts down.")
+
+/obj/machinery/floodlight/attack_ai(mob/user as mob)
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user))
+		return attack_hand(user)
+
+	if(on)
+		turn_off(1)
+	else
+		if(!turn_on(1))
+			user << "You try to turn on \the [src] but it does not work."
 
 
 /obj/machinery/floodlight/attack_hand(mob/user as mob)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -121,7 +121,7 @@
 			if("cellremove")
 				if(panel_open && cell && !usr.get_active_hand())
 					usr.visible_message("\blue [usr] removes \the [cell] from \the [src].", "\blue You remove \the [cell] from \the [src].")
-					cell.updateicon()
+					cell.update_icon()
 					usr.put_in_hands(cell)
 					cell.add_fingerprint(usr)
 					cell = null

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -5,56 +5,56 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "suitcooler0"
 	slot_flags = SLOT_BACK	//you can carry it on your back if you want, but it won't do anything unless attached to suit storage
-	
+
 	//copied from tank.dm
 	flags = CONDUCT
 	force = 5.0
 	throwforce = 10.0
 	throw_speed = 1
 	throw_range = 4
-	
+
 	origin_tech = "magnets=2;materials=2"
-	
+
 	var/on = 0				//is it turned on?
 	var/cover_open = 0		//is the cover open?
 	var/obj/item/weapon/cell/cell
 	var/max_cooling = 12				//in degrees per second - probably don't need to mess with heat capacity here
 	var/charge_consumption = 16.6		//charge per second at max_cooling
 	var/thermostat = T20C
-	
+
 	//TODO: make it heat up the surroundings when not in space
 
 /obj/item/device/suit_cooling_unit/New()
 	processing_objects |= src
-	
+
 	cell = new/obj/item/weapon/cell()	//comes with the crappy default power cell - high-capacity ones shouldn't be hard to find
 	cell.loc = src
 
 /obj/item/device/suit_cooling_unit/process()
-	if (!on || !cell) 
+	if (!on || !cell)
 		return
-	
+
 	if (!ismob(loc))
 		return
-	
+
 	if (!attached_to_suit(loc))		//make sure they have a suit and we are attached to it
 		return
-	
+
 	var/mob/living/carbon/human/H = loc
-	
+
 	var/efficiency = 1 - H.get_pressure_weakness()		//you need to have a good seal for effective cooling
 	var/env_temp = get_environment_temperature()		//wont save you from a fire
 	var/temp_adj = min(H.bodytemperature - max(thermostat, env_temp), max_cooling)
-	
+
 	if (temp_adj < 0.5)	//only cools, doesn't heat, also we don't need extreme precision
 		return
-	
+
 	var/charge_usage = (temp_adj/max_cooling)*charge_consumption
-	
+
 	H.bodytemperature -= temp_adj*efficiency
-	
+
 	cell.use(charge_usage)
-	
+
 	if(cell.charge <= 0)
 		turn_off()
 
@@ -70,22 +70,22 @@
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/space))
 		return 0	//space has no temperature, this just makes sure the cooling unit works in space
-	
+
 	var/datum/gas_mixture/environment = T.return_air()
 	if (!environment)
 		return 0
-	
+
 	return environment.temperature
 
 /obj/item/device/suit_cooling_unit/proc/attached_to_suit(mob/M)
-	if (!ishuman(M)) 
+	if (!ishuman(M))
 		return 0
-	
+
 	var/mob/living/carbon/human/H = M
-	
+
 	if (!H.wear_suit || H.s_store != src)
 		return 0
-	
+
 	return 1
 
 /obj/item/device/suit_cooling_unit/proc/turn_on()
@@ -93,7 +93,7 @@
 		return
 	if(cell.charge <= 0)
 		return
-	
+
 	on = 1
 	updateicon()
 
@@ -112,7 +112,7 @@
 			cell.loc = get_turf(loc)
 
 		cell.add_fingerprint(user)
-		cell.updateicon()
+		cell.update_icon()
 
 		user << "You remove the [src.cell]."
 		src.cell = null
@@ -149,7 +149,7 @@
 				user << "You insert the [cell]."
 		updateicon()
 		return
-	
+
 	return ..()
 
 /obj/item/device/suit_cooling_unit/proc/updateicon()
@@ -164,7 +164,7 @@
 /obj/item/device/suit_cooling_unit/examine(mob/user)
 	if(!..(user, 1))
 		return
-	
+
 	if (on)
 		if (attached_to_suit(src.loc))
 			user << "It's switched on and running."
@@ -172,13 +172,13 @@
 			user << "It's switched on, but not attached to anything."
 	else
 		user << "It is switched off."
-	
+
 	if (cover_open)
 		if(cell)
 			user << "The panel is open, exposing the [cell]."
 		else
 			user << "The panel is open."
-	
+
 	if (cell)
 		user << "The charge meter reads [round(cell.percent())]%."
 	else

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -73,7 +73,7 @@
 
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		if(bcell)
-			bcell.updateicon()
+			bcell.update_icon()
 			bcell.loc = get_turf(src.loc)
 			bcell = null
 			user << "<span class='notice'>You remove the cell from the [src].</span>"

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -194,7 +194,7 @@
 				wrapped = A.cell
 
 				A.cell.add_fingerprint(user)
-				A.cell.updateicon()
+				A.cell.update_icon()
 				A.cell.loc = src
 				A.cell = null
 
@@ -211,7 +211,7 @@
 				wrapped = A.cell
 
 				A.cell.add_fingerprint(user)
-				A.cell.updateicon()
+				A.cell.update_icon()
 				A.updateicon()
 				A.cell.loc = src
 				A.cell = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -746,7 +746,7 @@
 	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))
 		var/datum/robot_component/cell_component = components["power cell"]
 		if(cell)
-			cell.updateicon()
+			cell.update_icon()
 			cell.add_fingerprint(user)
 			user.put_in_active_hand(cell)
 			user << "You remove \the [cell]."

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -714,7 +714,7 @@
 		if(cell)
 			user.put_in_hands(cell)
 			cell.add_fingerprint(user)
-			cell.updateicon()
+			cell.update_icon()
 
 			src.cell = null
 			user.visible_message("<span class='warning'>[user.name] removes the power cell from [src.name]!</span>",\

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -8,7 +8,7 @@
 
 /obj/item/weapon/cell/initialize()
 	..()
-	updateicon()
+	update_icon()
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)
 
@@ -22,7 +22,7 @@
 
 	return use(cell_amt) / CELLRATE
 
-/obj/item/weapon/cell/proc/updateicon()
+/obj/item/weapon/cell/update_icon()
 	overlays.Cut()
 
 	if(charge < 0.01)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -159,7 +159,7 @@
 	else if(cell)
 		cell.loc = loc
 		cell.add_fingerprint(user)
-		cell.updateicon()
+		cell.update_icon()
 
 		icon_state = "suspension0"
 		cell = null


### PR DESCRIPTION
- Fixes #9543
- Removes ugly floodlight/proc/updateicon() and replaces it with proper floodlight/update_icon() which is standard on all objects/items. Does the same refactor for power cells and adjusts the proc call in relevant files (hence the amount of 1-line changes in various files)
- Makes floodlights properly use CELLRATE. Their load is 200 watts. Cell adjusted accordingly, it starts with 1k cell, which is enough for ~40 minutes (roughly)
- Floodlights with almost discharged cell (less than 10%) ocassionally "flicker", dimming for few seconds. This serves as indicator that the power cell is running low.
- Floodlight luminosity adjusted. They now shine slightly more, espicially closer to the floodlight.
