### PR TITLE
Fixes #5945, de-copy-pastes parapens and sleepypens

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -33,7 +33,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/pen/paralysis,
+					/obj/item/weapon/pen/reagent/paralysis,
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
 	cost = 20
 	containertype = /obj/structure/closet/crate

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -34,3 +34,14 @@ proc/admin_attacker_log_many_victims(var/mob/attacker, var/list/mob/victims, var
 
 	for(var/mob/victim in victims)
 		admin_attack_log(attacker, victim, attacker_message, victim_message, admin_message)
+
+proc/admin_inject_log(mob/attacker, mob/victim, obj/item/weapon, reagents, amount_transferred, violent=0)
+	if(violent)
+		violent = "violently "
+	else
+		violent = ""
+	admin_attack_log(attacker,
+	                 victim,
+	                 "used \the [weapon] to [violent]inject - [reagents] - [amount_transferred]u transferred",
+	                 "was [violent]injected with \the [weapon] - [reagents] - [amount_transferred]u transferred",
+	                 "used \the [weapon] to [violent]inject [reagents] ([amount_transferred]u transferred) into")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -86,7 +86,7 @@ var/global/list/additional_antag_types = list()
 			new/datum/uplink_item(/obj/item/weapon/soap/syndie, 1, "Subversive Soap", "SP"),
 			new/datum/uplink_item(/obj/item/weapon/cane/concealed, 2, "Concealed Cane Sword", "CC"),
 			new/datum/uplink_item(/obj/item/weapon/cartridge/syndicate, 3, "Detomatix PDA Cartridge", "DC"),
-			new/datum/uplink_item(/obj/item/weapon/pen/paralysis, 3, "Paralysis Pen", "PP"),
+			new/datum/uplink_item(/obj/item/weapon/pen/reagent/paralysis, 3, "Paralysis Pen", "PP"),
 			new/datum/uplink_item(/obj/item/weapon/storage/box/syndie_kit/cigarette, 4, "Cigarette Kit", "BH"),
 			new/datum/uplink_item(/obj/item/weapon/storage/box/syndie_kit/toxin, 4, "Random Toxin - Beaker", "RT")
 			),

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -11,7 +11,7 @@
 
 			if("stealth")
 				new /obj/item/weapon/gun/energy/crossbow(src)
-				new /obj/item/weapon/pen/paralysis(src)
+				new /obj/item/weapon/pen/reagent/paralysis(src)
 				new /obj/item/device/chameleon(src)
 				return
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -51,66 +51,59 @@
 	msg_admin_attack("[user.name] ([user.ckey]) Used the [name] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 	return
 
+/*
+ * Reagent pens
+ */
+
+/obj/item/weapon/pen/reagent
+	flags = OPENCONTAINER
+	slot_flags = SLOT_BELT
+
+/obj/item/weapon/pen/reagent/New()
+	..()
+	create_reagents(30)
+
+/obj/item/weapon/pen/reagent/attack(mob/living/M as mob, mob/user as mob)
+
+	if(!istype(M))
+		return
+
+	. = ..()
+
+	if(M.can_inject(user,1))
+		if(reagents.total_volume)
+			if(M.reagents)
+				var/list/contained_reagents = list()
+				for(var/datum/reagent/R in reagents.reagent_list)
+					contained_reagents += R.name
+				M.attack_log += "\[[time_stamp()]\] <font color='orange'>Injected by [user.name] ([user.ckey]) with \the [src] (INTENT: [uppertext(user.a_intent)]) Reagents: [english_list(contained_reagents)]</font>"
+				user.attack_log += "\[[time_stamp()]\] <font color='orange'>Injected [M.name] ([M.ckey]) with \the [src] (INTENT: [uppertext(user.a_intent)]) Reagents: [english_list(contained_reagents)]</font>"
+				msg_admin_attack("[key_name_admin(user)] injected [key_name_admin(M)] with \the [src] (INTENT: [uppertext(user.a_intent)]) Reagents: [english_list(contained_reagents)]")
+				reagents.trans_to_mob(M, 30, CHEM_BLOOD)
+
 
 /*
  * Sleepy Pens
  */
-/obj/item/weapon/pen/sleepypen
+/obj/item/weapon/pen/reagent/sleepy
 	desc = "It's a black ink pen with a sharp point and a carefully engraved \"Waffle Co.\""
-	flags = OPENCONTAINER
-	slot_flags = SLOT_BELT
 	origin_tech = "materials=2;syndicate=5"
 
-
-/obj/item/weapon/pen/sleepypen/New()
-	var/datum/reagents/R = new/datum/reagents(30) //Used to be 300
-	reagents = R
-	R.my_atom = src
-	R.add_reagent("chloralhydrate", 22)	//Used to be 100 sleep toxin//30 Chloral seems to be fatal, reducing it to 22./N
+/obj/item/weapon/pen/reagent/sleepy/New()
 	..()
-	return
-
-
-/obj/item/weapon/pen/sleepypen/attack(mob/M as mob, mob/user as mob)
-	if(!(istype(M,/mob)))
-		return
-	..()
-	if(reagents.total_volume)
-		if(M.reagents) reagents.trans_to_mob(M, 50, CHEM_BLOOD) //used to be 150
-	return
+	reagents.add_reagent("chloralhydrate", 22)	//Used to be 100 sleep toxin//30 Chloral seems to be fatal, reducing it to 22./N
 
 
 /*
  * Parapens
  */
- /obj/item/weapon/pen/paralysis
-	flags = OPENCONTAINER
-	slot_flags = SLOT_BELT
+ /obj/item/weapon/pen/reagent/paralysis
 	origin_tech = "materials=2;syndicate=5"
 
-
-/obj/item/weapon/pen/paralysis/attack(mob/living/M as mob, mob/user as mob)
-
-	if(!(istype(M,/mob)))
-		return
-
+/obj/item/weapon/pen/reagent/paralysis/New()
 	..()
-
-
-	if(M.can_inject(user,1))
-		if(reagents.total_volume)
-			if(M.reagents) reagents.trans_to_mob(M, 50, CHEM_BLOOD)
-	return
-
-
-/obj/item/weapon/pen/paralysis/New()
-	var/datum/reagents/R = new/datum/reagents(50)
-	reagents = R
-	R.my_atom = src
-	R.add_reagent("zombiepowder", 10)
-	R.add_reagent("cryptobiolin", 15)
-	..()
-	return
+	reagents.add_reagent("zombiepowder", 10)
+	reagents.add_reagent("cryptobiolin", 15)
 
 /*
  * Chameleon pen

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -73,14 +73,9 @@
 	if(M.can_inject(user,1))
 		if(reagents.total_volume)
 			if(M.reagents)
-				var/list/contained_reagents = list()
-				for(var/datum/reagent/R in reagents.reagent_list)
-					contained_reagents += R.name
-				M.attack_log += "\[[time_stamp()]\] <font color='orange'>Injected by [user.name] ([user.ckey]) with \the [src] (INTENT: [uppertext(user.a_intent)]) Reagents: [english_list(contained_reagents)]</font>"
-				user.attack_log += "\[[time_stamp()]\] <font color='orange'>Injected [M.name] ([M.ckey]) with \the [src] (INTENT: [uppertext(user.a_intent)]) Reagents: [english_list(contained_reagents)]</font>"
-				msg_admin_attack("[key_name_admin(user)] injected [key_name_admin(M)] with \the [src] (INTENT: [uppertext(user.a_intent)]) Reagents: [english_list(contained_reagents)]")
-				reagents.trans_to_mob(M, 30, CHEM_BLOOD)
-
+				var/contained_reagents = reagents.get_reagents()
+				var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
+				admin_inject_log(user, M, src, contained_reagents, trans)
 
 /*
  * Sleepy Pens

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -19,17 +19,19 @@
 	reagents.add_reagent("tricordrazine", 30)
 	return
 
-/obj/item/weapon/reagent_containers/hypospray/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
 	if(!reagents.total_volume)
 		user << "<span class='warning'>[src] is empty.</span>"
 		return
 	if (!istype(M))
 		return
+	if(!M.can_inject(user, 1))
+		return
+
 	user << "<span class='notice'>You inject [M] with [src].</span>"
 	M << "<span class='notice'>You feel a tiny prick!</span>"
 
 	if(M.reagents)
-
 		var/contained = reagentlist()
 		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been injected with [name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to inject [M.name] ([M.key]). Reagents: [contained]</font>")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -33,11 +33,8 @@
 
 	if(M.reagents)
 		var/contained = reagentlist()
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been injected with [name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to inject [M.name] ([M.key]). Reagents: [contained]</font>")
-		msg_admin_attack("[user.name] ([user.ckey]) injected [M.name] ([M.key]) with [name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-
 		var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
+		admin_inject_log(user, M, src, contained, trans)
 		user << "<span class='notice'>[trans] units injected. [reagents.total_volume] units remaining in \the [src].</span>"
 
 	return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -219,10 +219,6 @@
 
 	proc/syringestab(mob/living/carbon/target as mob, mob/living/carbon/user as mob)
 
-		user.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [target.name] ([target.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>"
-		target.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>"
-		msg_admin_attack("[user.name] ([user.ckey]) attacked [target.name] ([target.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-
 		if(istype(target, /mob/living/carbon/human))
 
 			var/mob/living/carbon/human/H = target
@@ -244,6 +240,11 @@
 					O.show_message(text("\red <B>[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!</B>"), 1)
 				user.remove_from_mob(src)
 				qdel(src)
+
+				user.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [target.name] ([target.ckey]) with \the [src] (INTENT: HARM).</font>"
+				target.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [src.name] (INTENT: HARM).</font>"
+				msg_admin_attack("[key_name_admin(user)] attacked [key_name_admin(target)] with [src.name] (INTENT: HARM) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+
 				return
 
 			user.visible_message("<span class='danger'>[user] stabs [target] in \the [hit_area] with [src.name]!</span>")
@@ -255,7 +256,15 @@
 			user.visible_message("<span class='danger'>[user] stabs [target] with [src.name]!</span>")
 			target.take_organ_damage(3)// 7 is the same as crowbar punch
 
+
+
 		var/syringestab_amount_transferred = rand(0, (reagents.total_volume - 5)) //nerfed by popular demand
+		var/list/contained_reagents = list()
+		for(var/datum/reagent/R in reagents.reagent_list)
+			contained_reagents += R.name
+		user.attack_log += "\[[time_stamp()]\]<font color='red'> Stabbed [target.name] ([target.ckey]) with \the [src] (INTENT: HARM). Reagents: [english_list(contained_reagents)] ([syringestab_amount_transferred]u total)"
+		target.attack_log += "\[[time_stamp()]\]<font color='orange'> Stabbed by [user.name] ([user.ckey]) with \the [src] (INTENT: HARM). Reagents: [english_list(contained_reagents)] ([syringestab_amount_transferred]u total)"
+		msg_admin_attack("[key_name_admin(user)] stabbed [key_name_admin(target)] with \the [src] (INTENT: HARM). Reagents: [english_list(contained_reagents)] ([syringestab_amount_transferred]u total)")
 		reagents.trans_to_mob(target, syringestab_amount_transferred, CHEM_BLOOD)
 		break_syringe(target, user)
 

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -254,7 +254,7 @@
 			if(prob(75))
 				new_item = new /obj/item/weapon/pen(src.loc)
 			else
-				new_item = new /obj/item/weapon/pen/sleepypen(src.loc)
+				new_item = new /obj/item/weapon/pen/reagent/sleepy(src.loc)
 			if(prob(30))
 				apply_image_decorations = 1
 		if(16)


### PR DESCRIPTION
Fixes #5945.

Harm-syringes, hyposprays, parapens and sleepypens now all respect armour, and produce admin logs for transferred reagents if any are transferred.
