### PR TITLE
Fixes #6077

### DIFF
--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -55,8 +55,9 @@
 			ui.push_data(data)
 			return ui
 		else
-			//testing("nanomanager/try_update_ui mob [user.name] [src_object:name] [ui_key] [force_open] - forcing opening of ui")
-			ui.close()
+			ui.reinitialise(new_initial_data=data)
+			return ui
+
 	return null
 
  /**
@@ -164,10 +165,10 @@
 	else if (isnull(open_uis[src_object_key][ui.ui_key]) || !istype(open_uis[src_object_key][ui.ui_key], /list))
 		open_uis[src_object_key][ui.ui_key] = list();
 
-	ui.user.open_uis.Add(ui)
+	ui.user.open_uis |= ui
 	var/list/uis = open_uis[src_object_key][ui.ui_key]
-	uis.Add(ui)
-	processing_uis.Add(ui)
+	uis |= ui
+	processing_uis |= ui
 	//testing("nanomanager/ui_opened mob [ui.user.name] [ui.src_object:name] [ui.ui_key] - user.open_uis [ui.user.open_uis.len] | uis [uis.len] | processing_uis [processing_uis.len]")
 
  /**

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -408,6 +408,18 @@ nanoui is used to open and update nano browser uis
 	nanomanager.ui_opened(src)
 
  /**
+  * Reinitialise this UI, potentially with a different template and/or initial data
+  *
+  * @return nothing
+  */
+/datum/nanoui/proc/reinitialise(template, new_initial_data)
+	if(template)
+		add_template("main", template)
+	if(new_initial_data)
+		set_initial_data(new_initial_data)
+	open()
+
+ /**
   * Close this UI
   *
   * @return nothing


### PR DESCRIPTION
Fixes #6077.

Updates nanomanager's handling of opening UIs so that it can be called multiple times, changes force_open to simply ignore that the UI is open and try to open it again. Causes a slight flicker if the UI is open, but the window does not move or change size.

Bonus feature: NanoUI template swapping without closing the window.
