### PR TITLE
Adjusts malfunctioning limb stance damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -72,7 +72,18 @@
 		var/obj/item/organ/external/E = organs_by_name[limb_tag]
 		if(!E || (E.status & (ORGAN_DESTROYED|ORGAN_DEAD)))
 			stance_damage += 2 // let it fail even if just foot&leg
-		else if (E.is_malfunctioning() || E.is_broken() || !E.is_usable())
+		else if (E.is_malfunctioning())
+			//malfunctioning only happens intermittently so treat it as a missing limb when it procs
+			stance_damage += 2
+			if(prob(10))
+				visible_message("\The [src]'s [E.name] [pick("twitches", "shudders")] and sparks!")
+				var/datum/effect/effect/system/spark_spread/spark_system = new ()
+				spark_system.set_up(5, 0, src)
+				spark_system.attach(src)
+				spark_system.start()
+				spawn(10)
+					qdel(spark_system)
+		else if (E.is_broken() || !E.is_usable())
 			stance_damage += 1
 		else if (E.is_dislocated())
 			stance_damage += 0.5


### PR DESCRIPTION
Since malfunctioning only happens intermittently, it counts as a missing limb when it procs. Also added an occasional effect for malfunctioning robot legs, similar to that for robot arms.
