### PR TITLE
Fixes corpses and unconscious people still showing typing indicators.

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -5,14 +5,17 @@ mob/var/typing
 mob/var/last_typed
 mob/var/last_typed_time
 
-var/global/image/typing_indicator
+mob/var/obj/effect/decal/typing_indicator
 
 /mob/proc/set_typing_indicator(var/state)
 
 	if(!typing_indicator)
-		typing_indicator = image('icons/mob/talk.dmi',null,"typing")
+		typing_indicator = new
+		typing_indicator.icon = 'icons/mob/talk.dmi'
+		typing_indicator.icon_state = "typing"
 
-	if(client)
+	if(client && !stat)
+		typing_indicator.invisibility  = invisibility
 		if(client.prefs.toggles & SHOW_TYPING)
 			overlays -= typing_indicator
 		else


### PR DESCRIPTION
Indicator also has same visibility as the owner, so no magicaly sensing where someone is going to talk soon (chat bubbles works well enough)
Since images do not have visibility, had to make it an object decal. Also since it's set per mob, it's no longer global. Shouldn't really be much of an issue, since it's only created when mob tries to speak (so ~60 objects total on high-usual load)
