### PR TITLE
limb fixes

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -61,7 +61,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 10000)
 	flags = CONDUCT
 	force = 15.0
-	w_class = 2.0
+	w_class = 3
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("drilled")
 
@@ -82,7 +82,7 @@
 	force = 10.0
 	sharp = 1
 	edge = 1
-	w_class = 2.0
+	w_class = 1
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 5
@@ -136,7 +136,7 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	flags = CONDUCT
 	force = 15.0
-	w_class = 2.0
+	w_class = 3
 	throwforce = 9.0
 	throw_speed = 3
 	throw_range = 5

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -234,7 +234,7 @@
 						edge_eligible = 1
 
 				if(brute >= threshold || (edge_eligible && brute >= threshold/3))
-					if((sharp || edge))
+					if(edge)
 						droplimb(0,DROPLIMB_EDGE)
 					else
 						droplimb(0,DROPLIMB_BLUNT)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -846,7 +846,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	owner.update_body()
 
 /obj/item/organ/external/proc/get_damage()	//returns total damage
-	return max(brute_dam + burn_dam - perma_injury, perma_injury)	//could use health?
+	return max(brute_dam + burn_dam - perma_injury, perma_injury)	//could use max_damage?
 
 /obj/item/organ/external/proc/has_infected_wound()
 	for(var/datum/wound/W in wounds)
@@ -994,7 +994,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "upper body"
 	limb_name = "chest"
 	icon_name = "torso"
-	health = 100
+	max_damage = 100
 	min_broken_damage = 35
 	body_part = UPPER_TORSO
 	vital = 1
@@ -1010,7 +1010,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "lower body"
 	limb_name = "groin"
 	icon_name = "groin"
-	health = 100
+	max_damage = 100
 	min_broken_damage = 35
 	body_part = LOWER_TORSO
 	vital = 1
@@ -1024,7 +1024,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	limb_name = "l_arm"
 	name = "left arm"
 	icon_name = "l_arm"
-	health = 50
+	max_damage = 50
 	min_broken_damage = 30
 	body_part = ARM_LEFT
 	parent_organ = "chest"
@@ -1044,7 +1044,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	limb_name = "l_leg"
 	name = "left leg"
 	icon_name = "l_leg"
-	health = 50
+	max_damage = 50
 	min_broken_damage = 30
 	body_part = LEG_LEFT
 	icon_position = LEFT
@@ -1066,7 +1066,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	limb_name = "l_foot"
 	name = "left foot"
 	icon_name = "l_foot"
-	health = 30
 	min_broken_damage = 15
 	body_part = FOOT_LEFT
 	icon_position = LEFT
@@ -1093,7 +1092,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	limb_name = "l_hand"
 	name = "left hand"
 	icon_name = "l_hand"
-	health = 30
 	min_broken_damage = 15
 	body_part = HAND_LEFT
 	parent_organ = "l_arm"
@@ -1118,7 +1116,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	limb_name = "head"
 	icon_name = "head"
 	name = "head"
-	health = 75
+	max_damage = 75
 	min_broken_damage = 35
 	body_part = HEAD
 	vital = 1

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -228,9 +228,12 @@
 				droplimb(0,DROPLIMB_BURN)
 			if(!dropped && prob(brute))
 				var/edge_eligible = 0
-				if(edge && istype(used_weapon,/obj/item))
-					var/obj/item/W = used_weapon
-					if(W.w_class >= 3)
+				if(edge)
+					if(istype(used_weapon,/obj/item))
+						var/obj/item/W = used_weapon
+						if(W.w_class >= w_class)
+							edge_eligible = 1
+					else
 						edge_eligible = 1
 
 				if(brute >= threshold || (edge_eligible && brute >= threshold/3))
@@ -996,6 +999,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "torso"
 	max_damage = 100
 	min_broken_damage = 35
+	w_class = 5
 	body_part = UPPER_TORSO
 	vital = 1
 	amputation_point = "spine"
@@ -1012,6 +1016,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "groin"
 	max_damage = 100
 	min_broken_damage = 35
+	w_class = 5
 	body_part = LOWER_TORSO
 	vital = 1
 	parent_organ = "chest"
@@ -1026,6 +1031,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "l_arm"
 	max_damage = 50
 	min_broken_damage = 30
+	w_class = 3
 	body_part = ARM_LEFT
 	parent_organ = "chest"
 	joint = "left elbow"
@@ -1046,6 +1052,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "l_leg"
 	max_damage = 50
 	min_broken_damage = 30
+	w_class = 3
 	body_part = LEG_LEFT
 	icon_position = LEFT
 	parent_organ = "groin"
@@ -1067,6 +1074,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "left foot"
 	icon_name = "l_foot"
 	min_broken_damage = 15
+	w_class = 2
 	body_part = FOOT_LEFT
 	icon_position = LEFT
 	parent_organ = "l_leg"
@@ -1093,6 +1101,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "left hand"
 	icon_name = "l_hand"
 	min_broken_damage = 15
+	w_class = 2
 	body_part = HAND_LEFT
 	parent_organ = "l_arm"
 	joint = "left wrist"
@@ -1118,6 +1127,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "head"
 	max_damage = 75
 	min_broken_damage = 35
+	w_class = 3
 	body_part = HEAD
 	vital = 1
 	parent_organ = "chest"

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -162,7 +162,7 @@
 		burn *= bumod //~2/3 damage for ROBOLIMBS
 
 	// High brute damage or sharp objects may damage internal organs
-	if(internal_organs && ((brute_dam >= max_damage) || (sharp && brute >= 5) || brute >= 10) && prob(5))
+	if(internal_organs && (brute_dam >= max_damage || (((sharp && brute >= 5) || brute >= 10) && prob(5))))
 		// Damage an internal organ
 		if(internal_organs && internal_organs.len)
 			var/obj/item/organ/I = pick(internal_organs)


### PR DESCRIPTION
- Fixes internal organs inside external organs only being damaged with `prob(5)` even when `brute_damage >= max_damage`
- Sharp no longer causes DROPLIMB_EDGE, so bullets explode limbs like they were meant to.
- Sets w_class for external organs. Chest/groin -> 5, head/arms/legs -> 3, hands/feet ->2. The `w_class` requirement for edge weapons now checks if  the weapon's `w_class` is `>=` the organ's `w_class`.
- Also makes the surgical saw and surgical drill `w_class = 3`, and the scalpel `w_class = 1`.
- The above two points mean that surgical saws can now again remove heads, arms, and legs. Hatchets and the like can only remove hands and feet.
