### PR TITLE
Polishes the knifing mechanic

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -34,23 +34,6 @@ attacked_by() will handle hitting/missing/logging as it does now, and will call 
 
 	if(!istype(M) || (can_operate(M) && do_surgery(M,user,src))) return 0
 
-	// Knifing
-	if(edge)
-		for(var/obj/item/weapon/grab/G in M.grabbed_by)
-			if(G.assailant == user && G.state >= GRAB_NECK && world.time >= (G.last_action + 20))
-				//TODO: better alternative for applying damage multiple times? Nice knifing sound?
-				M.apply_damage(20, BRUTE, "head", 0, sharp=sharp, edge=edge)
-				M.apply_damage(20, BRUTE, "head", 0, sharp=sharp, edge=edge)
-				M.apply_damage(20, BRUTE, "head", 0, sharp=sharp, edge=edge)
-				M.adjustOxyLoss(60) // Brain lacks oxygen immediately, pass out
-				flick(G.hud.icon_state, G.hud)
-				G.last_action = world.time
-				user.visible_message("<span class='danger'>[user] slit [M]'s throat open with \the [name]!</span>")
-				user.attack_log += "\[[time_stamp()]\]<font color='red'> Knifed [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
-				M.attack_log += "\[[time_stamp()]\]<font color='orange'> Got knifed by [user.name] ([user.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
-				msg_admin_attack("[key_name(user)] knifed [key_name(M)] with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])" )
-				return
-
 	/////////////////////////
 	user.lastattacked = M
 	M.lastattacker = user
@@ -60,6 +43,12 @@ attacked_by() will handle hitting/missing/logging as it does now, and will call 
 		M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [user.name] ([user.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
 		msg_admin_attack("[key_name(user)] attacked [key_name(M)] with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])" )
 	/////////////////////////
+
+	// Attacking someone with a weapon while they are neck-grabbed
+	if(user.a_intent == I_HURT)
+		for(var/obj/item/weapon/grab/G in M.grabbed_by)
+			if(G.assailant == user && G.state >= GRAB_NECK)
+				M.attack_throat(src, G, user)
 
 	var/power = force
 	if(HULK in user.mutations)
@@ -72,7 +61,7 @@ attacked_by() will handle hitting/missing/logging as it does now, and will call 
 
 		// Handle striking to cripple.
 		var/dislocation_str
-		if(user.a_intent == "disarm")
+		if(user.a_intent == I_DISARM)
 			dislocation_str = H.attack_joint(src, user, def_zone)
 		if(H.attacked_by(src, user, def_zone) && hitsound)
 			playsound(loc, hitsound, 50, 1, -1)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -121,3 +121,6 @@
 
 /mob/living/bot/proc/explode()
 	qdel(src)
+
+/mob/living/bot/attack_throat()
+	return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -246,3 +246,53 @@
 
 	//Scale quadratically so that single digit numbers of fire stacks don't burn ridiculously hot.
 	return round(FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE*(fire_stacks/FIRE_MAX_FIRESUIT_STACKS)**2)
+
+//If simple_animals are ever moved under carbon, then this can probably be moved to carbon as well
+/mob/living/proc/attack_throat(obj/item/W, obj/item/weapon/grab/G, mob/user)
+	
+	// Knifing
+	if(!W.edge || !W.force || W.damtype != BRUTE) return //unsuitable weapon
+	
+	user.visible_message("<span class='danger'>\The [user] begins to slit [src]'s throat with \the [W]!</span>")
+	
+	user.next_move = world.time + 20 //also should prevent user from triggering this repeatedly
+	if(!do_after(user, 20))
+		return
+	if(!(G && G.assailant == user && G.affecting == src)) //check that we still have a grab
+		return
+	
+	var/damage_mod = 1
+	//presumably, if they are wearing a helmet that stops pressure effects, then it probably covers the throat as well
+	var/obj/item/clothing/head/helmet = get_equipped_item(slot_head)
+	if(istype(helmet) && (helmet.body_parts_covered & HEAD) && (helmet.flags & STOPPRESSUREDAMAGE))
+		//we don't do an armor_check here because this is not an impact effect like a weapon swung with momentum, that either penetrates or glances off.
+		damage_mod = 1.0 - (helmet.armor["melee"]/100)
+	
+	var/total_damage = 0
+	for(var/i in 1 to 3)
+		var/damage = min(W.force*1.5, 20)*damage_mod
+		apply_damage(damage, W.damtype, "head", 0, sharp=W.sharp, edge=W.edge)
+		total_damage += damage
+	
+	var/oxyloss = total_damage
+	if(total_damage >= 40) //threshold to make someone pass out
+		oxyloss = 60 // Brain lacks oxygen immediately, pass out
+	
+	adjustOxyLoss(min(oxyloss, 100 - getOxyLoss())) //don't put them over 100 oxyloss
+	
+	if(total_damage)
+		if(oxyloss >= 40)
+			user.visible_message("<span class='danger'>\The [user] slit [src]'s throat open with \the [W]!</span>")
+		else
+			user.visible_message("<span class='danger'>\The [user] cut [src]'s neck with \the [W]!</span>")
+		
+		if(W.hitsound)
+			playsound(loc, W.hitsound, 50, 1, -1)
+	
+	G.last_action = world.time
+	flick(G.hud.icon_state, G.hud)
+	
+	user.attack_log += "\[[time_stamp()]\]<font color='red'> Knifed [name] ([ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])</font>"
+	src.attack_log += "\[[time_stamp()]\]<font color='orange'> Got knifed by [user.name] ([user.ckey]) with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])</font>"
+	msg_admin_attack("[key_name(user)] knifed [key_name(src)] with [W.name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(W.damtype)])" )
+	return

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -126,6 +126,9 @@
 	updatehealth()
 	return 1*/
 
+/mob/living/silicon/attack_throat()
+	return
+
 /proc/islinked(var/mob/living/silicon/robot/bot, var/mob/living/silicon/ai/ai)
 	if(!istype(bot) || !istype(ai))
 		return 0
@@ -345,4 +348,3 @@
 
 /mob/living/silicon/proc/is_malf_or_traitor()
 	return is_traitor() || is_malf()
-


### PR DESCRIPTION
- Fixes weirdness with knifing where attempting to knife someone before `world.time >= (G.last_action + 20)` could be met, would just attack them instead, which was very unintuitive from a UX perspective. Instead, attempting to knife someone now properly induces a delay.
- Knifing damage scales with weapon force and an attempted measure of throat protection. In practice this means knifing someone wearing a sealed hardsuit helmet, voidsuit helmet, or trying to cut someone's throat with wirecutters will require several attempts before the victim passes out.
- Knifing checks harm intent, in case you just wanted to beat on the victim for some reason.
- Prevents knifing bots or silicons.
