### PR TITLE
APC event tweak.

### DIFF
--- a/code/modules/events/apc_damage.dm
+++ b/code/modules/events/apc_damage.dm
@@ -45,10 +45,5 @@
 	return pick(apcs)
 
 /datum/event/apc_damage/proc/is_valid_apc(var/obj/machinery/power/apc/apc)
-	// Type must be exactly a basic APC.
-	// This generally prevents affecting APCs in critical areas (AI core, engine room, etc.) as they often use higher capacity subtypes.
-	if(apc.type != /obj/machinery/power/apc)
-		return 0
-
 	var/turf/T = get_turf(apc)
-	return !apc.emagged && T && (T.z in config.player_levels)
+	return !apc.is_critical && !apc.emagged && T && (T.z in config.player_levels)


### PR DESCRIPTION
The APC event now instead checks for the new is_critical flag instead of making assumptions based on type.
