### PR TITLE
Spawn fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1485,6 +1485,7 @@
 #include "code\modules\reagents\dispenser\_defines.dm"
 #include "code\modules\reagents\dispenser\cartridge.dm"
 #include "code\modules\reagents\dispenser\cartridge_presets.dm"
+#include "code\modules\reagents\dispenser\cartridge_spawn.dm"
 #include "code\modules\reagents\dispenser\dispenser2.dm"
 #include "code\modules\reagents\dispenser\dispenser_presets.dm"
 #include "code\modules\reagents\dispenser\supply.dm"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -997,18 +997,18 @@ var/global/floorIsLava = 0
 
 	return 0
 
-/datum/admins/proc/spawn_fruit()
+/datum/admins/proc/spawn_fruit(seedtype in plant_controller.seeds)
 	set category = "Debug"
 	set desc = "Spawn the product of a seed."
 	set name = "Spawn Fruit"
 
 	if(!check_rights(R_SPAWN))	return
 
-	var/seedtype = input("Select a seed type", "Spawn Fruit") as null|anything in plant_controller.seeds
 	if(!seedtype || !plant_controller.seeds[seedtype])
 		return
 	var/datum/seed/S = plant_controller.seeds[seedtype]
 	S.harvest(usr,0,0,1)
+	log_admin("[key_name(usr)] spawned [seedtype] fruit at ([usr.x],[usr.y],[usr.z])")
 
 /datum/admins/proc/spawn_custom_item()
 	set category = "Debug"
@@ -1050,17 +1050,17 @@ var/global/floorIsLava = 0
 		for(var/datum/custom_item/item in current_items)
 			usr << "- name: [item.name] icon: [item.item_icon] path: [item.item_path] desc: [item.item_desc]"
 
-/datum/admins/proc/spawn_plant()
+/datum/admins/proc/spawn_plant(seedtype in plant_controller.seeds)
 	set category = "Debug"
 	set desc = "Spawn a spreading plant effect."
 	set name = "Spawn Plant"
 
 	if(!check_rights(R_SPAWN))	return
 
-	var/seedtype = input("Select a seed type", "Spawn Plant") as null|anything in plant_controller.seeds
 	if(!seedtype || !plant_controller.seeds[seedtype])
 		return
 	new /obj/effect/plant(get_turf(usr), plant_controller.seeds[seedtype])
+	log_admin("[key_name(usr)] spawned [seedtype] vines at ([usr.x],[usr.y],[usr.z])")
 
 /datum/admins/proc/spawn_atom(var/object as text)
 	set category = "Debug"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -123,7 +123,8 @@ var/list/admin_verbs_spawn = list(
 	/client/proc/FireLaser,
 	/client/proc/FireCannons,
 	/client/proc/ChangeIcarusPosition,
-	/client/proc/virus2_editor
+	/client/proc/virus2_editor,
+	/client/proc/spawn_chemdisp_cartridge
 	)
 var/list/admin_verbs_server = list(
 	/client/proc/Set_Holiday,

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -30,19 +30,23 @@
 	if(!is_open_container())
 		user << "The cap is sealed."
 
-/obj/item/weapon/reagent_containers/chem_disp_cartridge/verb/setLabel(L as text)
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/verb/verb_set_label(L as text)
 	set name = "Set Cartridge Label"
 	set category = "Object"
 	set src in view(usr, 1)
+
+	setLabel(L, usr)
+
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/proc/setLabel(L, mob/user = null)
 	if(L)
-		if(usr)
-			usr << "<span class='notice'>You set the label on \the [src] to '[L]'.</span>"
+		if(user)
+			user << "<span class='notice'>You set the label on \the [src] to '[L]'.</span>"
 
 		label = L
 		name = "[initial(name)] - '[L]'"
 	else
-		if(usr)
-			usr << "<span class='notice'>You clear the label on \the [src].</span>"
+		if(user)
+			user << "<span class='notice'>You clear the label on \the [src].</span>"
 		label = ""
 		name = initial(name)
 

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,0 +1,13 @@
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in chemical_reagents_list)
+	set name = "Spawn Chemical Dispenser Cartridge"
+	set category = "Admin"
+
+	var/obj/item/weapon/reagent_containers/chem_disp_cartridge/C
+	switch(size)
+		if("small") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge/small(usr.loc)
+		if("medium") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge/medium(usr.loc)
+		if("large") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge(usr.loc)
+	C.reagents.add_reagent(reagent, C.volume)
+	var/datum/reagent/R = chemical_reagents_list[reagent]
+	C.setLabel(R.name)
+	log_admin("[key_name(usr)] spawned a [size] reagent container containing [reagent] at ([usr.x],[usr.y],[usr.z])")


### PR DESCRIPTION
Fixes spawning a chem dispenser spamming the log with label settings
Fixes Spawn-Fruit and Spawn-Plant not being usable from hotbar
Fixes Spawn-Fruit and Spawn-Plant not producing admin logs (file only)
Allows spawning dispenser cartridges with different sizes and reagents
