### PR TITLE
More MayRespawn checks.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -620,6 +620,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 1
 
 mob/dead/observer/MayRespawn(var/feedback = 0)
+	if(!client || !mind)
+		return 0
+	if(mind.current && mind.current.stat != DEAD)
+		if(feedback)
+			src << "<span class='warning'>Your non-dead body prevent you from respawning.</span>"
+		return 0
 	if(config.antag_hud_restricted && has_enabled_antagHUD == 1)
 		if(feedback)
 			src << "<span class='warning'>antagHUD restrictions prevent you from respawning.</span>"

--- a/html/changelogs/PsiOmegaDelta-MayRespawn.yml
+++ b/html/changelogs/PsiOmegaDelta-MayRespawn.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - bugfix: "Astral projecting mobs, such as wizards or cultists, may no longer respawn as something else while their body lives."


### PR DESCRIPTION
Main fix: Astral projecting wizards/cultists may no longer respawn as something else.
