### PR TITLE
Allows all synths to view the alternative law sets.

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -185,7 +185,7 @@
 		This is another way of saying that we won't bother dealing with them.*/
 	else
 		src << "No holopad connected."
-		return
+		return 0
 	return 1
 
 /mob/living/silicon/ai/proc/holopad_emote(var/message) //This is called when the AI uses the 'me' verb while using a holopad.
@@ -206,7 +206,7 @@
 			M.show_message(rendered, 2)
 	else //This shouldn't occur, but better safe then sorry.
 		src << "No holopad connected."
-		return
+		return 0
 	return 1
 
 /mob/living/silicon/ai/emote(var/act, var/type, var/message)

--- a/code/modules/nano/modules/law_manager.dm
+++ b/code/modules/nano/modules/law_manager.dm
@@ -34,10 +34,7 @@
 		return 1
 
 	if(href_list["set_view"])
-		if(is_malf(usr) || owner.is_ai_malf())
-			current_view = text2num(href_list["set_view"])
-		else
-			current_view = 0
+		current_view = text2num(href_list["set_view"])
 		return 1
 
 	if(href_list["law_channel"])
@@ -170,12 +167,8 @@
 
 	data["isAI"] = owner.isAI()
 	data["isMalf"] = is_malf(user)
-	data["isAIMalf"] = owner.is_ai_malf()
 	data["isSlaved"] = owner.is_slaved()
 	data["isAdmin"] = is_admin(user)
-
-	if(!(data["isMalf"] || data["isAIMalf"]))
-		current_view = 0
 	data["view"] = current_view
 
 	var/channels[0]
@@ -183,9 +176,7 @@
 		channels[++channels.len] = list("channel" = ch_name)
 	data["channel"] = owner.lawchannel
 	data["channels"] = channels
-
-	if(data["isMalf"] || data["isAIMalf"])
-		data["law_sets"] = package_multiple_laws(data["isAdmin"] ? admin_laws : player_laws)
+	data["law_sets"] = package_multiple_laws(data["isAdmin"] ? admin_laws : player_laws)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -215,15 +206,6 @@
 
 /obj/nano_module/law_manager/proc/is_malf(var/mob/user)
 	return (is_admin(user) && !owner.is_slaved()) || owner.is_malf_or_traitor()
-
-/mob/living/silicon/proc/is_ai_malf()
-	return 0
-
-/mob/living/silicon/robot/is_ai_malf()
-	return is_slaved() && connected_ai.is_malf_or_traitor()
-
-/mob/living/silicon/ai/is_ai_malf()
-	return 0
 
 /mob/living/silicon/proc/is_slaved()
 	return 0

--- a/html/changelogs/PsiOmegaDelta-LawSets.yml
+++ b/html/changelogs/PsiOmegaDelta-LawSets.yml
@@ -1,0 +1,6 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - rscadd: "Synths can now review all law modules that can be found on the station from their law manager."
+  - rscadd: "Synths can state these laws if desired, however this is strongly discouraged unless subverted/malfunctioning."

--- a/nano/templates/law_manager.tmpl
+++ b/nano/templates/law_manager.tmpl
@@ -41,18 +41,16 @@
     }
 </style>
 
-{{if data.isSlaved && data.isAdmin}}
-    <span class='notice'>This unit is law synced to {{:data.isSlaved}}.</span>
+{{if data.isSlaved}}
+    <div class='notice'>Law synced to {{:data.isSlaved}}.</div>
 {{/if}}
 
-{{if data.isMalf || data.isAIMalf}}
-	<div class="item">
-		<div class="itemContentWidest">
-			{{:helper.link('Law Management', null, {'set_view' : 0}, data.view == 0 ? 'selected' : null)}}
-			{{:helper.link('Law Sets', null, {'set_view' : 1}, data.view == 1 ? 'selected' : null)}}
-		</div>
+<div class="item">
+	<div class="itemContentWidest">
+		{{:helper.link('Law Management', null, {'set_view' : 0}, data.view == 0 ? 'selected' : null)}}
+		{{:helper.link('Law Sets', null, {'set_view' : 1}, data.view == 1 ? 'selected' : null)}}
 	</div>
-{{/if}}
+</div>
 
 {{if data.view == 0}}
 	{{if data.has_ion_laws}}    
@@ -196,6 +194,8 @@
         </div>
     {{/if}}
 {{else data.view == 1}}
+	<div class='notice'>Remember: Stating laws other than those currently loaded may be grounds for decommissioning - NanoTrasen</div>
+
 	{{for data.law_sets}}
 		<div class="item">
 			<div class="itemLabelWide">
@@ -246,7 +246,7 @@
 		
 			<div class="itemContent">
 				<br>
-				{{:helper.link('Load Laws', null, {'transfer_laws' : value.ref}, data.isSlaved ? 'disabled' : null)}}{{:helper.link('State Laws', null, {'state_law_set' : value.ref})}}
+				{{:helper.link('Load Laws', null, {'transfer_laws' : value.ref}, data.isMalf ? null : 'disabled')}}{{:helper.link('State Laws', null, {'state_law_set' : value.ref})}}
 			</div>
 		</div>
 	{{/for}}


### PR DESCRIPTION
Synths are no longer required to be a malf/traitor to view alternative law sets. The main purpose is to allow synths to easily state the default NanoTrasen even while simply subverted.

Law template updated with a warning that stating improper laws may not be good for you.
