### PR TITLE
Eye mobs are now listed in the observer tracking list.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -444,6 +444,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/sortmobs()
 	var/list/moblist = list()
 	var/list/sortmob = sortAtom(mob_list)
+	for(var/mob/eye/M in sortmob)
+		moblist.Add(M)
 	for(var/mob/living/silicon/ai/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/living/silicon/pai/M in sortmob)

--- a/html/changelogs/PsiOmegaDelta-EyeTracking.yml
+++ b/html/changelogs/PsiOmegaDelta-EyeTracking.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - rscadd: "AI eyes can now be found in the observer follow list."


### PR DESCRIPTION
Fixes #9636.

Listing eyes near AIs, as that will be the main source of them.
