### PR TITLE
Atmos machine fixes, scrubber hibernation

### DIFF
--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -130,7 +130,7 @@
 	var/total_specific_power = 0		//the power required to remove one mole of filterable gas
 	for (var/g in filtering)
 		var/ratio = source.gas[g]/total_filterable_moles //this converts the specific power per mole of pure gas to specific power per mole of scrubbed gas
-		total_specific_power = specific_power_gas[g]*ratio
+		total_specific_power += specific_power_gas[g]*ratio
 
 	//Figure out how much of each gas to filter
 	if (isnull(total_transfer_moles))

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -85,6 +85,9 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 	return node.pipe_color
 
 /obj/machinery/atmospherics/process()
+	last_flow_rate = 0
+	last_power_draw = 0
+	
 	build_network()
 
 /obj/machinery/atmospherics/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)


### PR DESCRIPTION
- Fixes #9600
- Fixes scrubber power usage
- Copies over a system analogous to Ccomp's vent pump hibernation for scrubbers.
