### PR TITLE
Corrects comment, multiz stub, no-zone default

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -46,17 +46,17 @@
 				air_master.connect(sim, src)
 
 /*
-	Simple heuristic for determining if removing the turf from it's zone may possibly partition the zone (A very bad thing).
+	Simple heuristic for determining if removing the turf from it's zone will not partition the zone (A very bad thing).
 	Instead of analyzing the entire zone, we only check the nearest 3x3 turfs surrounding the src turf.
-	This implementation may produce false positives but it (hopefully) will not produce any false negatives.
+	This implementation may produce false negatives but it (hopefully) will not produce any false postiives.
 */
 
 /turf/simulated/proc/can_safely_remove_from_zone()
 	#ifdef ZLEVELS
-	return 1 //not sure how to generalize this to multiz at the moment.
+	return 0 //TODO generalize this to multiz.
 	#else
 	
-	if(!zone) return 0
+	if(!zone) return 1
 	
 	var/check_dirs = get_zone_neighbours(src)
 	var/unconnected_dirs = check_dirs


### PR DESCRIPTION
At some point while writing that proc it was renamed to `can_safely_remove_from_zone()` from something more confusing and its return value was inverted to produce 1 if it is safe to remove the turf, and 0 otherwise, but the comment, stub, and no-zone default were left unchanged.
