### PR TITLE
Stack splitting and cable merging fixes.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -252,6 +252,7 @@
 	var/orig_amount = src.amount
 	if (transfer && src.use(transfer))
 		var/obj/item/stack/newstack = new src.type(loc, transfer)
+		newstack.color = color
 		if (prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(newstack)
 			if(blood_DNA)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -613,6 +613,12 @@ obj/structure/cable/proc/cableColor(var/colorC)
 // Items usable on a cable coil :
 //   - Wirecutters : cut them duh !
 //   - Cable coil : merge cables
+/obj/item/stack/cable_coil/proc/can_merge(var/obj/item/stack/cable_coil/C)
+	return color == C.color
+
+/obj/item/stack/cable_coil/cyborg/can_merge()
+	return 1
+
 /obj/item/stack/cable_coil/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if( istype(W, /obj/item/weapon/wirecutters) && src.get_amount() > 1)
@@ -623,6 +629,11 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		return
 	else if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
+
+		if(!can_merge(C))
+			user << "These coils do not go together."
+			return
+
 		if(C.get_amount() >= get_max_amount())
 			user << "The coil is too long, you cannot add any more cable to it."
 			return

--- a/html/changelogs/PsiOmegaDelta-StackFixes.yml
+++ b/html/changelogs/PsiOmegaDelta-StackFixes.yml
@@ -1,0 +1,6 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - bugfix: "Split stacks no longer lose their coloring."
+  - tweak: "Can no longer merge cables of different colors."


### PR DESCRIPTION
Split stacks will now keep the same color. No more red cables from coils of other colors.
Can now only join cables of the same color together, unless you are a borg (due to how the cyborg coil is synthesized and can change color).
