### PR TITLE
Fixes #9664.

### DIFF
--- a/code/__HELPERS/datum_pool.dm
+++ b/code/__HELPERS/datum_pool.dm
@@ -29,7 +29,7 @@ var/global/list/GlobalPool = list()
 	if(!D)
 		// So the GC knows we're pooling this type.
 		if(!GlobalPool[get_type])
-			GlobalPool[get_type] = list(new get_type)
+			GlobalPool[get_type] = list()
 		if(islist(second_arg))
 			return new get_type (arglist(second_arg))
 		else
@@ -58,7 +58,10 @@ var/global/list/GlobalPool = list()
 		#ifdef DEBUG_ATOM_POOL
 		world << text("DEBUG_DATUM_POOL: PlaceInPool([]) exceeds []. Discarding.", D.type, ATOM_POOL_COUNT)
 		#endif
-		del(D)
+		if(garbage_collector)
+			garbage_collector.AddTrash(D)
+		else
+			del(D)
 		return
 
 	if(D in GlobalPool[D.type])

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -17,17 +17,20 @@
 	if(!target)
 		return
 	for(var/i = 1 to step_count)
+		if(!loc)
+			return
 		step_towards(src, target)
 		var/turf/T = get_turf(src)
-		reagents.touch_turf(T)
-		var/mob/M = locate() in T
-		if(M)
-			reagents.splash_mob(M, reagents.total_volume)
-			break
-		for(var/atom/A in T)
-			reagents.touch(A)
-		if(T == get_turf(target))
-			break
+		if(T && reagents)
+			reagents.touch_turf(T)
+			var/mob/M = locate() in T
+			if(M)
+				reagents.splash_mob(M, reagents.total_volume)
+				break
+			for(var/atom/A in T)
+				reagents.touch(A)
+			if(T == get_turf(target))
+				break
 		sleep(delay)
 	sleep(10)
 	qdel(src)


### PR DESCRIPTION
Fixes #9664.

Datum pool no longer creates a new object without arguments just for the sake of it when initializing pool lists.
Also bandaids an issue where water could be qdeled while being sprayed and reagents nulled, because someone calls spawn() qdel in new.
Datum pool now also adds excess pool objects on the trash pile instead of calling del directly.
