### PR TITLE
Garbage/qdel changes.

### DIFF
--- a/code/controllers/Processes/garbage.dm
+++ b/code/controllers/Processes/garbage.dm
@@ -85,14 +85,8 @@ var/list/delayed_garbage = list()
 /proc/qdel(var/datum/A)
 	if(!A)
 		return
-	if(istype(A, /list))
-		var/list/L = A
-		for(var/E in L)
-			qdel(E)
-		return
-
 	if(!istype(A))
-		//warning("qdel() passed object of type [A.type]. qdel() can only handle /datum types.")
+		warning("qdel() passed object of type [A.type]. qdel() can only handle /datum types.")
 		del(A)
 		if(garbage_collector)
 			garbage_collector.dels++

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -23,18 +23,6 @@
 	//Detective Work, used for the duplicate data points kept in the scanners
 	var/list/original_atom
 
-/atom/Destroy()
-	. = ..()
-	density = 0
-	set_opacity(0)
-
-	if(reagents)
-		qdel(reagents)
-		reagents = null
-	for(var/atom/movable/AM in contents)
-		qdel(AM)
-	invisibility = 101
-
 /atom/proc/assume_air(datum/gas_mixture/giver)
 	return null
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -31,8 +31,15 @@
 
 /atom/movable/Destroy()
 	. = ..()
-
+	if(reagents)
+		qdel(reagents)
+	for(var/atom/movable/AM in contents)
+		qdel(AM)
 	loc = null
+	if (pulledby)
+		if (pulledby.pulling == src)
+			pulledby.pulling = null
+		pulledby = null
 
 /atom/movable/proc/initialize()
 	return


### PR DESCRIPTION
Moves atom/Destroy() into atom/movable/Destroy(). Is now a /tg/ copy-paste.
Means deleting turfs no longer wipes everything on that turf and that pulling is canceled on qdel().
qdel no longer willingly accepts lists.
