### PR TITLE
Makes special wizard projectile staffs only usable by wizards

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -117,6 +117,13 @@
 	self_recharge = 1
 	charge_meter = 0
 
+/obj/item/weapon/gun/energy/staff/special_check(var/mob/user)
+	if((user.mind && !wizards.is_antagonist(user.mind)))
+		usr << "<span class='warning'>You focus your mind on \the [src], but nothing happens!</span>"
+		return 0
+
+	return ..()
+
 /obj/item/weapon/gun/energy/staff/handle_click_empty(mob/user = null)
 	if (user)
 		user.visible_message("*fizzle*", "<span class='danger'>*fizzle*</span>")

--- a/html/changelogs/Yoshax-stafffixes.yml
+++ b/html/changelogs/Yoshax-stafffixes.yml
@@ -1,0 +1,5 @@
+author: Yoshax
+delete-after: True
+
+changes: 
+  - tweak: "Makes the special wizard projectile staffs, Animate, Change, Focus and any future ones only usable by wizards.."


### PR DESCRIPTION
Odd that random folks can use these magic staffs without any training or magical ability or stuff and it only results in bad stuffs. So changing it!
