### PR TITLE
Changes teleportation scroll and spellbook to be only usable by wizards

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -11,6 +11,10 @@
 	origin_tech = list(TECH_BLUESPACE = 4)
 
 /obj/item/weapon/teleportation_scroll/attack_self(mob/user as mob)
+	if((user.mind && !wizards.is_antagonist(user.mind)))
+		usr << "<span class='warning'>You stare at the scroll but cannot make sense of the markings!</span>"
+		return
+
 	user.set_machine(src)
 	var/dat = "<B>Teleportation Scroll:</B><BR>"
 	dat += "Number of uses: [src.uses]<BR>"

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -14,6 +14,10 @@
 /obj/item/weapon/spellbook/attack_self(mob/user = usr)
 	if(!user)
 		return
+	if((user.mind && !wizards.is_antagonist(user.mind)))
+		usr << "<span class='warning'>You stare at the book but cannot make sense of the markings!</span>"
+		return
+
 	user.set_machine(src)
 	var/dat
 	if(temp)

--- a/html/changelogs/Yoshax-stafffixes.yml
+++ b/html/changelogs/Yoshax-stafffixes.yml
@@ -2,4 +2,4 @@ author: Yoshax
 delete-after: True
 
 changes: 
-  - tweak: "Makes the special wizard projectile staffs, Animate, Change, Focus and any future ones only usable by wizards.."
+  - tweak: "Makes the special wizard projectile staffs, Animate, Change, Focus and any future ones only usable by wizards. Also makes it so only wizards can use spellbooks and teleportation scrolls."


### PR DESCRIPTION
Someone pointed this out after #9674 was merged. Didn't think of it. Changed for the same reason as the staffs, doesn't make sense random folks can use the teleport scroll or stuff.
