### PR TITLE
Fixes a pair of null.z runtimes

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -16,15 +16,15 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			explosion_rec(epicenter, power)
 			return
 
+		var/start = world.timeofday
+		epicenter = get_turf(epicenter)
+		if(!epicenter) return
+
 ///// Z-Level Stuff
 		if(z_transfer && (devastation_range > 0 || heavy_impact_range > 0))
 			//transfer the explosion in both directions
 			explosion_z_transfer(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
 ///// Z-Level Stuff
-
-		var/start = world.timeofday
-		epicenter = get_turf(epicenter)
-		if(!epicenter) return
 
 		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
 		//playsound(epicenter, 'sound/effects/explosionfar.ogg', 100, 1, round(devastation_range*2,1) )

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -102,7 +102,8 @@
 	grav_pulling = 1
 	exploded = 1
 	for(var/mob/living/mob in living_mob_list)
-		if(loc.z == mob.loc.z)
+		var/turf/T = get_turf(mob)
+		if(T && (loc.z == T.z))
 			if(istype(mob, /mob/living/carbon/human))
 				//Hilariously enough, running into a closet should make you get hit the hardest.
 				var/mob/living/carbon/human/H = mob


### PR DESCRIPTION
Fixes explosions with multiz maps breaking if the epicenter is null
Fixes supermatter trying to irradiate mobs in nullspace crashing the proc

Should fix #9693.
