### PR TITLE
Fixes #9548

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -91,7 +91,7 @@
 
 /obj/item/device/aicard/proc/grab_ai(var/mob/living/silicon/ai/ai, var/mob/living/user)
 	if(!ai.client)
-		user << "<span class='danger'>ERROR:</span> [name] data core is offline. Unable to download."
+		user << "<span class='danger'>ERROR:</span> AI [ai.name] is offline. Unable to download."
 		return 0
 
 	if(carded_ai)
@@ -112,7 +112,6 @@
 	ai.cancel_camera()
 	ai.control_disabled = 1
 	ai.aiRestorePowerRoutine = 0
-	ai.aiRadio.disabledAi = 1
 	carded_ai = ai
 
 	if(ai.client)


### PR DESCRIPTION
- AI's name is now correctly displayed when the AI is clientless while being grabbed with intellicard.
- AI's wireless radio is no longer automatically muted when the AI is transferred to intellicard. It may still be muted from the UI if the intellicard's owner wants it. Reason for this is that many people who grab the AI without malicious intent tend to forget about this. If someone wants to intentionally disable AI's communication they may use the intellicard UI to do so, as with enabling/disabling wireless control.
