### PR TITLE
Fixes #9685.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -620,9 +620,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 1
 
 mob/dead/observer/MayRespawn(var/feedback = 0)
-	if(!client || !mind)
+	if(!client)
 		return 0
-	if(mind.current && mind.current.stat != DEAD)
+	if(mind && mind.current && mind.current.stat != DEAD)
 		if(feedback)
 			src << "<span class='warning'>Your non-dead body prevent you from respawning.</span>"
 		return 0


### PR DESCRIPTION
Observers straight from the lobby do not have minds, while observers that once lived do.
Re-arranges the MayRespawn() logic to handle both these situations.
