### PR TITLE
Syringe gun logs, logging helper reorganization

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -195,7 +195,6 @@
 #include "code\datums\wires\wires.dm"
 #include "code\defines\obj.dm"
 #include "code\defines\obj\weapon.dm"
-#include "code\defines\procs\admin.dm"
 #include "code\defines\procs\announce.dm"
 #include "code\defines\procs\AStar.dm"
 #include "code\defines\procs\dbcore.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -796,6 +796,7 @@
 #include "code\js\byjax.dm"
 #include "code\js\menus.dm"
 #include "code\modules\admin\admin.dm"
+#include "code\modules\admin\admin_attack_log.dm"
 #include "code\modules\admin\admin_investigate.dm"
 #include "code\modules\admin\admin_memo.dm"
 #include "code\modules\admin\admin_ranks.dm"

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -93,3 +93,60 @@
 	if(dir & DOWN) comps += "DOWN"
 	
 	return english_list(comps, nothing_text="0", and_text="|", comma_text="|")
+
+//more or less a logging utility
+/proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/highlight_special_characters = 1)
+	var/mob/M
+	var/client/C
+	var/key
+
+	if(!whom)	return "*null*"
+	if(istype(whom, /client))
+		C = whom
+		M = C.mob
+		key = C.key
+	else if(ismob(whom))
+		M = whom
+		C = M.client
+		key = M.key
+	else if(istype(whom, /datum))
+		var/datum/D = whom
+		return "*invalid:[D.type]*"
+	else
+		return "*invalid*"
+
+	. = ""
+
+	if(key)
+		if(include_link && C)
+			. += "<a href='?priv_msg=\ref[C]'>"
+
+		if(C && C.holder && C.holder.fakekey && !include_name)
+			. += "Administrator"
+		else
+			. += key
+
+		if(include_link)
+			if(C)	. += "</a>"
+			else	. += " (DC)"
+	else
+		. += "*no key*"
+
+	if(include_name && M)
+		var/name
+
+		if(M.real_name)
+			name = M.real_name
+		else if(M.name)
+			name = M.name
+
+
+		if(include_link && is_special_character(M) && highlight_special_characters)
+			. += "/(<font color='#FFA500'>[name]</font>)" //Orange
+		else
+			. += "/([name])"
+
+	return .
+
+/proc/key_name_admin(var/whom, var/include_name = 1)
+	return key_name(whom, 1, include_name)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -489,64 +489,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	if(M < 0)
 		return -M
 
-
-/proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/highlight_special_characters = 1)
-	var/mob/M
-	var/client/C
-	var/key
-
-	if(!whom)	return "*null*"
-	if(istype(whom, /client))
-		C = whom
-		M = C.mob
-		key = C.key
-	else if(ismob(whom))
-		M = whom
-		C = M.client
-		key = M.key
-	else if(istype(whom, /datum))
-		var/datum/D = whom
-		return "*invalid:[D.type]*"
-	else
-		return "*invalid*"
-
-	. = ""
-
-	if(key)
-		if(include_link && C)
-			. += "<a href='?priv_msg=\ref[C]'>"
-
-		if(C && C.holder && C.holder.fakekey && !include_name)
-			. += "Administrator"
-		else
-			. += key
-
-		if(include_link)
-			if(C)	. += "</a>"
-			else	. += " (DC)"
-	else
-		. += "*no key*"
-
-	if(include_name && M)
-		var/name
-
-		if(M.real_name)
-			name = M.real_name
-		else if(M.name)
-			name = M.name
-
-
-		if(include_link && is_special_character(M) && highlight_special_characters)
-			. += "/(<font color='#FFA500'>[name]</font>)" //Orange
-		else
-			. += "/([name])"
-
-	return .
-
-/proc/key_name_admin(var/whom, var/include_name = 1)
-	return key_name(whom, 1, include_name)
-
-
 // returns the turf located at the map edge in the specified direction relative to A
 // used for mass driver
 /proc/get_edge_target_turf(var/atom/A, var/direction)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -20,6 +20,10 @@ var/global/floorIsLava = 0
 				var/msg = rendered
 				C << msg
 
+proc/admin_notice(var/message, var/rights)
+	for(var/mob/M in mob_list)
+		if(check_rights(rights, 0, M))
+			M << message
 
 ///////////////////////////////////////////////////////////////////////////////////////////////Panels
 

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -1,7 +1,6 @@
-proc/admin_notice(var/message, var/rights)
-	for(var/mob/M in mob_list)
-		if(check_rights(rights, 0, M))
-			M << message
+/mob/var/lastattacker = null
+/mob/var/lastattacked = null
+/mob/var/attack_log = list( )
 
 proc/log_and_message_admins(var/message as text, var/mob/user = usr)
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")
@@ -23,10 +22,12 @@ proc/admin_log_and_message_admins(var/message as text)
 	message_admins(usr ? "[key_name_admin(usr)] [message]" : "EVENT [message]", 1)
 
 proc/admin_attack_log(var/mob/attacker, var/mob/victim, var/attacker_message, var/victim_message, var/admin_message)
-	victim.attack_log += text("\[[time_stamp()]\] <font color='orange'>[key_name(attacker)] - [victim_message]</font>")
-	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>[key_name(victim)] - [attacker_message]</font>")
+	if(victim)
+		victim.attack_log += text("\[[time_stamp()]\] <font color='orange'>[key_name(attacker)] - [victim_message]</font>")
+	if(attacker)
+		attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>[key_name(victim)] - [attacker_message]</font>")
 
-	msg_admin_attack("[key_name(attacker)] [admin_message] [key_name(victim)] (INTENT: [uppertext(attacker.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[attacker.x];Y=[attacker.y];Z=[attacker.z]'>JMP</a>)")
+	msg_admin_attack("[key_name(attacker)] [admin_message] [key_name(victim)] (INTENT: [attacker? uppertext(attacker.a_intent) : "N/A"]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[attacker.x];Y=[attacker.y];Z=[attacker.z]'>JMP</a>)")
 
 proc/admin_attacker_log_many_victims(var/mob/attacker, var/list/mob/victims, var/attacker_message, var/victim_message, var/admin_message)
 	if(!victims || !victims.len)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -48,9 +48,6 @@
 	var/use_me = 1 //Allows all mobs to use the me verb by default, will have to manually specify they cannot
 	var/damageoverlaytemp = 0
 	var/computer_id = null
-	var/lastattacker = null
-	var/lastattacked = null
-	var/attack_log = list( )
 	var/already_placed = 0.0
 	var/obj/machinery/machine = null
 	var/other_mobs = null

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -50,9 +50,11 @@
 		if(speed >= 10 && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
-			if(L.can_inject())
-				if(syringe.reagents)
-					syringe.reagents.trans_to_mob(L, 15, CHEM_BLOOD)
+			if(L.can_inject() && syringe.reagents)
+				var/reagent_log = syringe.reagents.get_reagents()
+				syringe.reagents.trans_to_mob(L, 15, CHEM_BLOOD)
+				admin_inject_log(thrower, L, src, reagent_log, 15, violent=1)
+
 		syringe.break_syringe(iscarbon(hit_atom)? hit_atom : null)
 		syringe.update_icon()
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -241,12 +241,10 @@
 	return 0
 
 /datum/reagents/proc/get_reagents()
-	var/res = ""
+	. = list()
 	for(var/datum/reagent/current in reagent_list)
-		if (res != "") res += ","
-		res += "[current.id]([current.volume])"
-
-	return res
+		. += "[current.id] ([current.volume])"
+	return english_list(., "EMPTY", "", ", ", ", ")
 
 /* Holder-to-holder and similar procs */
 


### PR DESCRIPTION
- Fixes #9053 
- Improves reagent contents log formatting
- moves admin attack logging procs out of defines/procs and into admin_attack_log.dm in the admin module. I considered moving it into the general logging helpers file but it seemed to fit better in the admin module, as logging.dm seems to be mostly system-level stuff.
- moves key_name() out of unsorted helpers and into logging helpers.
