### PR TITLE
Adjusts how reagents_explosion applies bombcap.

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -739,23 +739,23 @@ steam.start() -- spawns the effect
 			var/light = -1
 			var/flash = -1
 
-			// Clamp all values to max_explosion_range
+			// Clamp all values to fractions of max_explosion_range, following the same pattern as for tank transfer bombs
 			if (round(amount/12) > 0)
-				devastation = min (max_explosion_range, devastation + round(amount/12))
+				devastation = min (max_explosion_range*0.25, devastation + amount/12)
 
 			if (round(amount/6) > 0)
-				heavy = min (max_explosion_range, heavy + round(amount/6))
+				heavy = min (max_explosion_range*0.5, heavy + amount/6)
 
 			if (round(amount/3) > 0)
-				light = min (max_explosion_range, light + round(amount/3))
+				light = min (max_explosion_range, light + amount/3)
 
-			if (flash && flashing_factor)
-				flash += (round(amount/4) * flashing_factor)
+			if (flashing && flashing_factor)
+				flash = min (max_explosion_range*1.5, ((amount/4) * flashing_factor))
 
 			for(var/mob/M in viewers(8, location))
 				M << "\red The solution violently explodes."
 
-			explosion(location, devastation, heavy, light, flash)
+			explosion(location, round(devastation), round(heavy), round(light), round(flash))
 
 	proc/holder_damage(var/atom/holder)
 		if(holder)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -734,28 +734,34 @@ steam.start() -- spawns the effect
 					M.Weaken(rand(1,5))
 			return
 		else
-			var/devastation = -1
+			var/devst = -1
 			var/heavy = -1
 			var/light = -1
 			var/flash = -1
 
 			// Clamp all values to fractions of max_explosion_range, following the same pattern as for tank transfer bombs
 			if (round(amount/12) > 0)
-				devastation = min (max_explosion_range*0.25, devastation + amount/12)
+				devst = devst + amount/12
 
 			if (round(amount/6) > 0)
-				heavy = min (max_explosion_range*0.5, heavy + amount/6)
+				heavy = heavy + amount/6
 
 			if (round(amount/3) > 0)
-				light = min (max_explosion_range, light + amount/3)
+				light = light + amount/3
 
 			if (flashing && flashing_factor)
-				flash = min (max_explosion_range*1.5, ((amount/4) * flashing_factor))
+				flash = (amount/4) * flashing_factor
 
 			for(var/mob/M in viewers(8, location))
 				M << "\red The solution violently explodes."
 
-			explosion(location, round(devastation), round(heavy), round(light), round(flash))
+			explosion(
+				location, 
+				round(min(devst, BOMBCAP_DVSTN_RADIUS)), 
+				round(min(heavy, BOMBCAP_HEAVY_RADIUS)), 
+				round(min(light, BOMBCAP_LIGHT_RADIUS)), 
+				round(min(flash, BOMBCAP_FLASH_RADIUS))
+				)
 
 	proc/holder_damage(var/atom/holder)
 		if(holder)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -261,19 +261,22 @@
 		if(!istype(src.loc,/obj/item/device/transfer_valve))
 			message_admins("Explosive tank rupture! last key to touch the tank was [src.fingerprintslast].")
 			log_game("Explosive tank rupture! last key to touch the tank was [src.fingerprintslast].")
-		//world << "\blue[x],[y] tank is exploding: [pressure] kPa"
+
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react()
 		air_contents.react()
 		air_contents.react()
+
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-		range = min(range, max_explosion_range)		// was 8 - - - Changed to a configurable define -- TLE
-		var/turf/epicenter = get_turf(loc)
 
-		//world << "\blue Exploding Pressure: [pressure] kPa, intensity: [range]"
-
-		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
+		explosion(
+			get_turf(loc), 
+			round(min(BOMBCAP_DVSTN_RADIUS, range*0.25)), 
+			round(min(BOMBCAP_HEAVY_RADIUS, range*0.50)), 
+			round(min(BOMBCAP_LIGHT_RADIUS, range*1.00)), 
+			round(min(BOMBCAP_FLASH_RADIUS, range*1.50)), 
+			)
 		del(src)
 
 	else if(pressure > TANK_RUPTURE_PRESSURE)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -773,3 +773,8 @@ var/list/be_special_flags = list(
 #define ROBOT_NOTIFICATION_NEW_NAME 2
 #define ROBOT_NOTIFICATION_NEW_MODULE 3
 #define ROBOT_NOTIFICATION_MODULE_RESET 4
+
+#define BOMBCAP_DVSTN_RADIUS (max_explosion_range/4)
+#define BOMBCAP_HEAVY_RADIUS (max_explosion_range/2)
+#define BOMBCAP_LIGHT_RADIUS max_explosion_range
+#define BOMBCAP_FLASH_RADIUS (max_explosion_range*1.5)


### PR DESCRIPTION
Makes reagents_explosion apply bombcap in the same manner as tank transfer valves.

Also fixed reagents_explosion/start() checking the flash var instead of the flashing var.

Fixes #8280
