### PR TITLE
Allows small zones to merge even if zone-blocked

### DIFF
--- a/code/ZAS/Controller.dm
+++ b/code/ZAS/Controller.dm
@@ -281,8 +281,8 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 	var/direct = !(block & ZONE_BLOCKED)
 	var/space = !istype(B)
 
-	if(direct && !space)
-		if(equivalent_pressure(A.zone,B.zone) || current_cycle == 0)
+	if(!space)
+		if(min(A.zone.contents.len, B.zone.contents.len) < ZONE_MIN_SIZE || (direct && (equivalent_pressure(A.zone,B.zone) || current_cycle == 0)))
 			merge(A.zone,B.zone)
 			return
 

--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -33,3 +33,5 @@ Notes for people who used ZAS before:
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2
 #define BLOCKED 3
+
+#define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct


### PR DESCRIPTION
This is actually an idea I've had for a while now. The reasoning behind it is that ZAS does not handle small zones very well, in the sense that small zones act as impediments to airflow and can result in air flow behaviour that is unrealistic and unintuitive. 

While I've had the idea for a while, it was only recently made possible by #9456 which stopped airlocks from blindly partitioning zones. The result is that air flow should be more responsive in cases such as bolting external airlock doors open. It also happens to fix #9235.
