### PR TITLE
Refactors /obj/item/apc_frame to /obj/item/frame/apc

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -1,19 +1,19 @@
 // APC HULL
 
-/obj/item/apc_frame
+/obj/item/frame/apc
 	name = "\improper APC frame"
 	desc = "Used for repairing or building APCs"
 	icon = 'icons/obj/apc_repair.dmi'
 	icon_state = "apc_frame"
 	flags = CONDUCT
 
-/obj/item/apc_frame/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/frame/apc/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	if (istype(W, /obj/item/weapon/wrench))
 		new /obj/item/stack/material/steel( get_turf(src.loc), 2 )
 		qdel(src)
 
-/obj/item/apc_frame/proc/try_build(turf/on_wall)
+/obj/item/frame/apc/try_build(turf/on_wall)
 	if (get_dist(on_wall,usr)>1)
 		return
 	var/ndir = get_dir(usr,on_wall)

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -74,7 +74,7 @@
 	recipes += new/datum/stack_recipe("grenade casing", /obj/item/weapon/grenade/chem_grenade)
 	recipes += new/datum/stack_recipe("light fixture frame", /obj/item/frame/light, 2)
 	recipes += new/datum/stack_recipe("small light fixture frame", /obj/item/frame/light/small, 1)
-	recipes += new/datum/stack_recipe("apc frame", /obj/item/apc_frame, 2)
+	recipes += new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2)
 	recipes += new/datum/stack_recipe("air alarm frame", /obj/item/frame/air_alarm, 2)
 	recipes += new/datum/stack_recipe("fire alarm frame", /obj/item/frame/fire_alarm, 2)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -596,14 +596,14 @@
 					"<span class='notice'>You disassembled the broken APC frame.</span>",\
 					"You hear welding.")
 			else
-				new /obj/item/apc_frame(loc)
+				new /obj/item/frame/apc(loc)
 				user.visible_message(\
 					"<span class='warning'>[src] has been cut from the wall by [user.name] with the weldingtool.</span>",\
 					"<span class='notice'>You cut the APC frame from the wall.</span>",\
 					"You hear welding.")
 			qdel(src)
 			return
-	else if (istype(W, /obj/item/apc_frame) && opened && emagged)
+	else if (istype(W, /obj/item/frame/apc) && opened && emagged)
 		emagged = 0
 		if (opened==2)
 			opened = 1
@@ -612,7 +612,7 @@
 			"<span class='notice'>You replace the damaged APC frontal panel with a new one.</span>")
 		qdel(W)
 		update_icon()
-	else if (istype(W, /obj/item/apc_frame) && opened && ((stat & BROKEN) || hacker))
+	else if (istype(W, /obj/item/frame/apc) && opened && ((stat & BROKEN) || hacker))
 		if (has_electronics)
 			user << "<span class='warning'>You cannot repair this APC until you remove the electronics still inside.</span>"
 			return

--- a/maps/exodus-1.dmm
+++ b/maps/exodus-1.dmm
@@ -4249,7 +4249,7 @@
 "bDK" = (/obj/structure/disposalpipe/segment,/obj/machinery/door/airlock/glass_medical{id_tag = "GeneticsDoor"; name = "Genetics Laboratory"; req_access = list(9)},/turf/simulated/floor{icon_state = "white"},/area/medical/medbay2)
 "bDL" = (/turf/simulated/floor{icon_state = "white"},/area/medical/genetics_cloning)
 "bDM" = (/obj/machinery/disposal,/obj/structure/disposalpipe/trunk,/obj/item/device/radio/intercom{broadcasting = 0; name = "Station Intercom (General)"; pixel_y = 20},/turf/simulated/floor{icon_state = "white"},/area/medical/genetics_cloning)
-"bDN" = (/obj/item/apc_frame,/obj/effect/decal/cleanable/dirt,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/plating,/area/medical/genetics)
+"bDN" = (/obj/item/frame/apc,/obj/effect/decal/cleanable/dirt,/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/plating,/area/medical/genetics)
 "bDO" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/plating,/area/medical/genetics)
 "bDP" = (/obj/machinery/door/firedoor,/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "acute1"; name = "EMT Storage Privacy Shutters"; opacity = 0},/obj/machinery/light_switch{pixel_x = 22; pixel_y = 0},/turf/simulated/floor{tag = "icon-whitebluefull"; icon_state = "whitebluefull"},/area/medical/sleeper)
 "bDQ" = (/obj/structure/table/standard,/obj/item/device/mmi,/obj/item/device/mmi,/obj/item/device/mmi,/turf/simulated/floor,/area/assembly/robotics)


### PR DESCRIPTION
- This fixes broken APC frame placement on walls - #9537 
- Alternative would be adding snowflake check into wall code for this specific frame type, which is something i wanted to avoid.
