### PR TITLE
Fixes #9706

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -167,8 +167,8 @@
 			return
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom)
-	..()
 	if(seed) seed.thrown_at(src,hit_atom)
+	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/attackby(var/obj/item/weapon/W, var/mob/user)
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -229,7 +229,8 @@
 			for(var/mob/living/M in T.contents)
 				apply_special_effect(M)
 			splatter(T,thrown)
-		origin_turf.visible_message("<span class='danger'>The [thrown.name] explodes!</span>")
+		if(origin_turf)
+			origin_turf.visible_message("<span class='danger'>The [thrown.name] explodes!</span>")
 		qdel(thrown)
 		return
 
@@ -242,7 +243,8 @@
 
 	if(get_trait(TRAIT_JUICY) && splatted)
 		splatter(origin_turf,thrown)
-		origin_turf.visible_message("<span class='danger'>The [thrown.name] splatters against [target]!</span>")
+		if(origin_turf)
+			origin_turf.visible_message("<span class='danger'>The [thrown.name] splatters against [target]!</span>")
 		qdel(thrown)
 
 /datum/seed/proc/handle_environment(var/turf/current_turf, var/datum/gas_mixture/environment, var/light_supplied, var/check_only)


### PR DESCRIPTION
- Adds checks whether the turf exists. This should prevent runtimes.
- Moves ..() call in food/snacks/grown after seed.thrown_at() call. I believe this was causing the runtime in first place.

I did a brief check and it seems to work, but re-check by someone who understands xenoflora more than me would be welcome.
