### PR TITLE
AI restrictions and rejuvenation.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -678,16 +678,20 @@ var/list/ai_verbs_default = list(
 	set desc = "Augment visual feed with internal sensor overlays"
 	toggle_sensor_mode()
 
-/mob/living/silicon/ai/proc/check_unable(var/flags = 0)
+/mob/living/silicon/ai/proc/check_unable(var/flags = 0, var/feedback = 1)
 	if(stat == DEAD)
-		src << "<span class='warning'>You are dead!</span>"
+		if(feedback) src << "<span class='warning'>You are dead!</span>"
+		return 1
+
+	if(aiRestorePowerRoutine)
+		if(feedback) src << "<span class='warning'>You lack power!</span>"
 		return 1
 
 	if((flags & AI_CHECK_WIRELESS) && src.control_disabled)
-		src << "<span class='warning'>Wireless control is disabled!</span>"
+		if(feedback) src << "<span class='warning'>Wireless control is disabled!</span>"
 		return 1
 	if((flags & AI_CHECK_RADIO) && src.aiRadio.disabledAi)
-		src << "<span class='warning'>System Error - Transceiver Disabled!</span>"
+		if(feedback) src << "<span class='warning'>System Error - Transceiver Disabled!</span>"
 		return 1
 	return 0
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/ai/Life()
-	if (src.stat == 2)
+	if (src.stat == DEAD)
 		return
 	else //I'm not removing that shitton of tabs, unneeded as they are. -- Urist
 		//Being dead doesn't mean your temperature never changes
@@ -33,8 +33,8 @@
 			aiRestorePowerRoutine = 0 // Necessary if AI activated it's APU AFTER losing primary power.
 			adjustOxyLoss(-1)
 
-		// Handle EMP-stun
-		handle_stunned()
+		handle_stunned()	// Handle EMP-stun
+		lying = 0			// Handle lying down
 
 		malf_process()
 
@@ -176,3 +176,4 @@
 /mob/living/silicon/ai/rejuvenate()
 	..()
 	add_ai_verbs(src)
+

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -21,7 +21,7 @@
 /mob/living/silicon/ai/shared_nano_interaction()
 	if(lacks_power())
 		return STATUS_CLOSE
-	if (check_unable(1))
+	if (check_unable(1, 0))
 		return STATUS_CLOSE
 	return ..()
 


### PR DESCRIPTION
Ensures the AI cannot use Topic()s while unpowered.
Ensures the AI is properly rejuvenated by the AI verb, as a functional AI will now never be lying down.
