### PR TITLE
Fixes #9753.

### DIFF
--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -1,12 +1,19 @@
+/mob/proc/on_mob_jump()
+	return
+
+/mob/dead/observer/on_mob_jump()
+	following = null
+
 /client/proc/Jump(var/area/A in return_sorted_areas())
 	set name = "Jump to Area"
 	set desc = "Area to jump to"
 	set category = "Admin"
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 
 	if(config.allow_admin_jump)
+		usr.on_mob_jump()
 		usr.loc = pick(get_area_turfs(A))
 
 		log_admin("[key_name(usr)] jumped to [A]")
@@ -18,12 +25,13 @@
 /client/proc/jumptoturf(var/turf/T in world)
 	set name = "Jump to Turf"
 	set category = "Admin"
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 	if(config.allow_admin_jump)
 		log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
 		message_admins("[key_name_admin(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]", 1)
+		usr.on_mob_jump()
 		usr.loc = T
 		feedback_add_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
@@ -34,7 +42,7 @@
 	set category = "Admin"
 	set name = "Jump to Mob"
 
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 
@@ -46,6 +54,7 @@
 			var/turf/T = get_turf(M)
 			if(T && isturf(T))
 				feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+				A.on_mob_jump()
 				A.loc = T
 			else
 				A << "This mob is not located in the game world."
@@ -56,13 +65,14 @@
 	set category = "Admin"
 	set name = "Jump to Coordinate"
 
-	if (!holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 
 	if (config.allow_admin_jump)
 		if(src.mob)
 			var/mob/A = src.mob
+			A.on_mob_jump()
 			A.x = tx
 			A.y = ty
 			A.z = tz
@@ -76,7 +86,7 @@
 	set category = "Admin"
 	set name = "Jump to Key"
 
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 
@@ -91,6 +101,7 @@
 		var/mob/M = selection:mob
 		log_admin("[key_name(usr)] jumped to [key_name(M)]")
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
+		usr.on_mob_jump()
 		usr.loc = M.loc
 		feedback_add_details("admin_verb","JK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
@@ -100,12 +111,13 @@
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 	if(config.allow_admin_jump)
 		log_admin("[key_name(usr)] teleported [key_name(M)]")
 		message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
+		M.on_mob_jump()
 		M.loc = get_turf(usr)
 		feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
@@ -116,7 +128,7 @@
 	set name = "Get Key"
 	set desc = "Key to teleport"
 
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 
@@ -134,6 +146,7 @@
 		log_admin("[key_name(usr)] teleported [key_name(M)]")
 		message_admins("[key_name_admin(usr)] teleported [key_name(M)]", 1)
 		if(M)
+			M.on_mob_jump()
 			M.loc = get_turf(usr)
 			feedback_add_details("admin_verb","GK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
@@ -142,12 +155,13 @@
 /client/proc/sendmob(var/mob/M in sortmobs())
 	set category = "Admin"
 	set name = "Send Mob"
-	if(!src.holder)
+	if(!check_rights(R_ADMIN, user = src))
 		src << "Only administrators may use this command."
 		return
 	var/area/A = input(usr, "Pick an area.", "Pick an area") in return_sorted_areas()
 	if(A)
 		if(config.allow_admin_jump)
+			M.on_mob_jump()
 			M.loc = pick(get_area_turfs(A))
 			feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
Fixes #9753.
Being admin jumped or jumping to another location now cancels ghost tracking.
Also adds proper permission checks.
