### PR TITLE
Fixes #9731 and #9469

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -152,12 +152,12 @@
 			icon_state = initial(icon_state) +"_locked"
 			playsound(src.loc, 'sound/items/Screwdriver2.ogg', 50, 1)
 			spawn(0.001) //Otherwise det_time is erroneously set to 0 after this
-			if(istimer(detonator.a_left)) //Make sure description reflects that the timer has been reset
-				var/obj/item/device/assembly/timer/T = detonator.a_left
-				det_time = 10*T.time
-			if(istimer(detonator.a_right))
-				var/obj/item/device/assembly/timer/T = detonator.a_right
-				det_time = 10*T.time
+				if(istimer(detonator.a_left)) //Make sure description reflects that the timer has been reset
+					var/obj/item/device/assembly/timer/T = detonator.a_left
+					det_time = 10*T.time
+				if(istimer(detonator.a_right))
+					var/obj/item/device/assembly/timer/T = detonator.a_right
+					det_time = 10*T.time
 			return
 
 		playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -151,6 +151,13 @@
 		if(!has_reagents)
 			icon_state = initial(icon_state) +"_locked"
 			playsound(src.loc, 'sound/items/Screwdriver2.ogg', 50, 1)
+			spawn(0.001) //Otherwise det_time is erroneously set to 0 after this
+			if(istimer(detonator.a_left)) //Make sure description reflects that the timer has been reset
+				var/obj/item/device/assembly/timer/T = detonator.a_left
+				det_time = 10*T.time
+			if(istimer(detonator.a_right))
+				var/obj/item/device/assembly/timer/T = detonator.a_right
+				det_time = 10*T.time
 			return
 
 		playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -151,7 +151,7 @@
 		if(!has_reagents)
 			icon_state = initial(icon_state) +"_locked"
 			playsound(src.loc, 'sound/items/Screwdriver2.ogg', 50, 1)
-			spawn(0.001) //Otherwise det_time is erroneously set to 0 after this
+			spawn(0) //Otherwise det_time is erroneously set to 0 after this
 				if(istimer(detonator.a_left)) //Make sure description reflects that the timer has been reset
 					var/obj/item/device/assembly/timer/T = detonator.a_left
 					det_time = 10*T.time

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -5,6 +5,7 @@
 	desc = "A hand made chemical grenade."
 	w_class = 2.0
 	force = 2.0
+	det_time = null
 	var/stage = 0
 	var/state = 0
 	var/path = 0
@@ -25,6 +26,7 @@
 				detonator.detached()
 				usr.put_in_hands(detonator)
 				detonator=null
+				det_time = null
 				stage=0
 				icon_state = initial(icon_state)
 			else if(beakers.len)
@@ -60,6 +62,12 @@
 			user.remove_from_mob(det)
 			det.loc = src
 			detonator = det
+			if(istimer(detonator.a_left))
+				var/obj/item/device/assembly/timer/T = detonator.a_left
+				det_time = 10*T.time
+			if(istimer(detonator.a_right))
+				var/obj/item/device/assembly/timer/T = detonator.a_right
+				det_time = 10*T.time
 			icon_state = initial(icon_state) +"_ass"
 			name = "unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]"
 			stage = 1

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -47,6 +47,8 @@
 		if(det_time > 1)
 			user << "The timer is set to [det_time/10] seconds."
 			return
+		if(det_time == null)
+			return
 		user << "\The [src] is set for instant detonation."
 
 
@@ -89,16 +91,16 @@
 /obj/item/weapon/grenade/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isscrewdriver(W))
 		switch(det_time)
-			if ("1")
+			if (1)
 				det_time = 10
 				user << "<span class='notice'>You set the [name] for 1 second detonation time.</span>"
-			if ("10")
+			if (10)
 				det_time = 30
 				user << "<span class='notice'>You set the [name] for 3 second detonation time.</span>"
-			if ("30")
+			if (30)
 				det_time = 50
 				user << "<span class='notice'>You set the [name] for 5 second detonation time.</span>"
-			if ("50")
+			if (50)
 				det_time = 1
 				user << "<span class='notice'>You set the [name] for instant detonation.</span>"
 		add_fingerprint(user)


### PR DESCRIPTION
Timers on normal grenades can now be changed between instant detonation or 1, 3, or 5 second delay with a screwdriver as intended, and chem grenades with timers show the timer's setting properly.
