### PR TITLE
Welding tool bugfixes

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -261,6 +261,8 @@
 
 //Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob. This should probably be renamed to use()
 /obj/item/weapon/weldingtool/proc/remove_fuel(var/amount = 1, var/mob/M = null)
+	if(!welding)
+		return 0
 	if(get_fuel() >= amount)
 		reagents.remove_reagent("fuel", amount)
 		if(M)
@@ -291,7 +293,7 @@
 	var/turf/T = get_turf(src)
 	//If we're turning it on
 	if(set_welding && !welding)
-		if (remove_fuel(1))
+		if (get_fuel() > 0)
 			if(M)
 				M << "<span class='notice'>You switch the [src] on.</span>"
 			else if(T)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -227,8 +227,11 @@
 		if(istype(W, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = W
 			if(!WT.remove_fuel(0,user))
-				user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
-				return
+				if(!WT.isOn())
+					return
+				else
+					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+					return
 			new /obj/item/stack/material/steel(src.loc)
 			for(var/mob/M in viewers(src))
 				M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 3, "You hear welding.", 2)
@@ -246,8 +249,11 @@
 	else if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if(!WT.remove_fuel(0,user))
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
-			return
+			if(!WT.isOn())
+				return
+			else
+				user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+				return
 		src.welded = !src.welded
 		src.update_icon()
 		for(var/mob/M in viewers(src))


### PR DESCRIPTION
`remove_fuel` once again checks for the welding tool being on. Because it's also called in the proc that turns the tool on, I changed that to only look at the welder's fuel instead of using `remove_fuel`. This should have very little effect, though I can implement the fix differently if it's important for whatever reason.
