### PR TITLE
Ghosts can now follow hivemind speech.

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -17,7 +17,7 @@
 	var/flags = 0                    // Various language flags.
 	var/native                       // If set, non-native speakers will have trouble speaking.
 	var/list/syllables               // Used when scrambling text for a non-speaker.
-	var/list/space_chance = 55       // Likelihood of getting a space in the random scramble string.
+	var/list/space_chance = 55       // Likelihood of getting a space in the random scramble string
 
 /datum/language/proc/get_random_name(var/gender, name_count=2, syllable_count=4)
 	if(!syllables || !syllables.len)
@@ -112,9 +112,11 @@
 /mob/new_player/hear_broadcast()
 	return
 
-/mob/dead/hear_broadcast(var/datum/language/language, var/speaker, var/speaker_name, var/message)
-	var/msg = "<i><span class='game say'>[language.name], <span class='name'>[speaker_name]</span> ([ghost_follow_link(speaker, src)]) [message]</span></i>"
-	src << msg
+/mob/dead/observer/hear_broadcast(var/datum/language/language, var/mob/speaker, var/speaker_name, var/message)
+	if(speaker.name == speaker_name || antagHUD)
+		src << "<i><span class='game say'>[language.name], <span class='name'>[speaker_name]</span> ([ghost_follow_link(speaker, src)]) [message]</span></i>"
+	else
+		src << "<i><span class='game say'>[language.name], <span class='name'>[speaker_name]</span> [message]</span></i>"
 
 /datum/language/proc/check_special_condition(var/mob/other)
 	return 1

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -101,11 +101,20 @@
 	log_say("[key_name(speaker)] : ([name]) [message]")
 
 	if(!speaker_mask) speaker_mask = speaker.name
-	var/msg = "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span> [format_message(message, get_spoken_verb(message))]</span></i>"
-
 	for(var/mob/player in player_list)
-		if(istype(player,/mob/dead) || ((src in player.languages) && check_special_condition(player)))
-			player << msg
+		player.hear_broadcast(src, speaker, speaker_mask, format_message(message, get_spoken_verb(message)))
+
+/mob/proc/hear_broadcast(var/datum/language/language, var/speaker, var/message)
+	if((language in languages) && language.check_special_condition(src))
+		var/msg = "<i><span class='game say'>[language.name], <span class='name'>[speaker]</span> [message]</span></i>"
+		src << msg
+
+/mob/new_player/hear_broadcast()
+	return
+
+/mob/dead/hear_broadcast(var/datum/language/language, var/speaker, var/speaker_name, var/message)
+	var/msg = "<i><span class='game say'>[language.name], <span class='name'>[speaker_name]</span> ([ghost_follow_link(speaker, src)]) [message]</span></i>"
+	src << msg
 
 /datum/language/proc/check_special_condition(var/mob/other)
 	return 1

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -22,7 +22,7 @@
 
 	for (var/mob/M in dead_mob_list)
 		if(!istype(M,/mob/new_player) && !istype(M,/mob/living/carbon/brain)) //No meta-evesdropping
-			M.show_message("[message_start] [message_body]", 2)
+			M.show_message("[message_start] ([ghost_follow_link(speaker, M)]) [message_body]", 2)
 
 	for (var/mob/living/S in living_mob_list)
 

--- a/html/changelogs/PsiOmegaDelta-HiveTracking.yml
+++ b/html/changelogs/PsiOmegaDelta-HiveTracking.yml
@@ -1,0 +1,6 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - rscadd: "Observers can now follow both the AI and its eye upon speech."
+  - rscadd: "Observers can now follow both observers and their body, if they ever had one, upon speech."
+  - rscadd: "Observers can now follow hivemind speakers."

--- a/html/changelogs/PsiOmegaDelta-HiveTracking.yml
+++ b/html/changelogs/PsiOmegaDelta-HiveTracking.yml
@@ -3,4 +3,4 @@ delete-after: True
 changes: 
   - rscadd: "Observers can now follow both the AI and its eye upon speech."
   - rscadd: "Observers can now follow both observers and their body, if they ever had one, upon speech."
-  - rscadd: "Observers can now follow hivemind speakers."
+  - rscadd: "Observers can now follow hivemind speakers if the speaker is not using an alias or antagHUD is enabled."


### PR DESCRIPTION
Ghosts can now follow hivemind speech with the same targets as for normal speech (separate links for mob and eye if any, etc.).
