### PR TITLE
Renames Track-With-Camera to Follow-With-Camera

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -132,11 +132,11 @@
 
 /mob/living/silicon/ai/proc/ai_camera_track(var/target_name in trackable_mobs())
 	set category = "AI Commands"
-	set name = "Track With Camera"
+	set name = "Follow With Camera"
 	set desc = "Select who you would like to track."
 
 	if(src.stat == 2)
-		src << "You can't track with camera because you are dead!"
+		src << "You can't follow [target_name] with cameras because you are dead!"
 		return
 	if(!target_name)
 		src.cameraFollow = null


### PR DESCRIPTION
Title. This means both AIs and ghosts can get space-completion for following a specific mob from 'fol', rather than AIs needing 'tra' and ghosts needing 'fol'.
