### PR TITLE
Base proc: emag_act

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -115,7 +115,7 @@
 			if(W.flags&USEDELAY)
 				next_move += 5
 
-			var/resolved = A.attackby(W,src)
+			var/resolved = W.resolve_attackby(A, src)
 			if(!resolved && A && W)
 				W.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
@@ -136,7 +136,7 @@
 					next_move += 5
 
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-				var/resolved = A.attackby(W,src)
+				var/resolved = W.resolve_attackby(A,src)
 				if(!resolved && A && W)
 					W.afterattack(A,src,1,params) // 1: clicking something Adjacent
 			else

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -220,6 +220,9 @@ its easier to just keep the beam vertical.
 
 /atom/proc/ex_act()
 	return
+	
+/atom/proc/emag_act(var/remaining_uses, var/mob/user)
+	return -1
 
 /atom/proc/blob_act()
 	return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -221,7 +221,7 @@ its easier to just keep the beam vertical.
 /atom/proc/ex_act()
 	return
 	
-/atom/proc/emag_act(var/remaining_uses, var/mob/user)
+/atom/proc/emag_act(var/remaining_charges, var/mob/user, var/emag_source)
 	return -1
 
 /atom/proc/blob_act()

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -425,7 +425,7 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 	if(botEmagChance)
 		for(var/obj/machinery/bot/bot in machines)
 			if(prob(botEmagChance))
-				bot.Emag()
+				bot.emag_act(1)
 
 	/*
 

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -32,15 +32,18 @@
 	if (src.health <= 0)
 		src.explode()
 
-/obj/machinery/bot/proc/Emag(mob/user as mob)
-	if(locked)
+/obj/machinery/bot/emag_act(var/remaining_charges, var/user)
+	if(locked && !emagged)
 		locked = 0
 		emagged = 1
 		user << "<span class='warning'>You short out [src]'s maintenance hatch lock.</span>"
 		log_and_message_admins("emagged [src]'s maintenance hatch lock")
-	if(!locked && open)
+		return 1
+
+	if(!locked && open && emagged == 1)
 		emagged = 2
 		log_and_message_admins("emagged [src]'s inner circuits")
+		return 1
 
 /obj/machinery/bot/examine(mob/user)
 	..(user)
@@ -65,8 +68,6 @@
 				user << "<span class='notice'>Unable to repair with the maintenance panel closed.</span>"
 		else
 			user << "<span class='notice'>[src] does not need a repair.</span>"
-	else if (istype(W, /obj/item/weapon/card/emag) && emagged < 2)
-		Emag(user)
 	else
 		if(hasvar(W,"force") && hasvar(W,"damtype"))
 			switch(W.damtype)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -88,12 +88,7 @@
 // cell: insert it
 // other: chance to knock rider off bot
 /obj/machinery/bot/mulebot/attackby(var/obj/item/I, var/mob/user)
-	if(istype(I,/obj/item/weapon/card/emag))
-		locked = !locked
-		user << "<span class='notice'>You [locked ? "lock" : "unlock"] the mulebot's controls!</span>"
-		flick("mulebot-emagged", src)
-		playsound(src.loc, 'sound/effects/sparks1.ogg', 100, 0)
-	else if(istype(I,/obj/item/weapon/cell) && open && !cell)
+	if(istype(I,/obj/item/weapon/cell) && open && !cell)
 		var/obj/item/weapon/cell/C = I
 		user.drop_item()
 		C.loc = src
@@ -133,6 +128,12 @@
 		..()
 	return
 
+/obj/machinery/bot/mulebot/emag_act(var/remaining_charges, var/user)
+	locked = !locked
+	user << "<span class='notice'>You [locked ? "lock" : "unlock"] the mulebot's controls!</span>"
+	flick("mulebot-emagged", src)
+	playsound(src.loc, 'sound/effects/sparks1.ogg', 100, 0)
+	return 1
 
 /obj/machinery/bot/mulebot/ex_act(var/severity)
 	unload(0)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -216,13 +216,6 @@
 		else
 			locked = 0
 			user << "System unlocked."
-	else if(istype(W, /obj/item/weapon/card/emag))
-		if(isnull(occupant))
-			return
-		user << "You force an emergency ejection."
-		locked = 0
-		go_out()
-		return
 	else if(istype(W, /obj/item/weapon/reagent_containers/food/snacks/meat))
 		user << "<span class='notice'>\The [src] processes \the [W].</span>"
 		biomass += 50
@@ -252,6 +245,14 @@
 	else
 		..()
 
+/obj/machinery/clonepod/emag_act(var/remaining_charges, var/mob/user)
+	if(isnull(occupant))
+		return
+	user << "You force an emergency ejection."
+	locked = 0
+	go_out()
+	return 1
+	
 //Put messages in the connected computer's temp var for display.
 /obj/machinery/clonepod/proc/connected_message(var/message)
 	if((isnull(connected)) || (!istype(connected, /obj/machinery/computer/cloning)))

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -221,8 +221,8 @@
 	return
 
 
-/obj/machinery/computer/arcade/attackby(I as obj, user as mob)
-	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
+/obj/machinery/computer/arcade/emag_act(var/charges, var/mob/user)
+	if(!emagged)
 		temp = "If you die in the game, you die for real!"
 		player_hp = 30
 		player_mp = 10
@@ -230,17 +230,13 @@
 		enemy_mp = 20
 		gameover = 0
 		blocked = 0
-
 		emagged = 1
 
 		enemy_name = "Cuban Pete"
 		name = "Outbomb Cuban Pete"
 
-
 		src.updateUsrDialog()
-	else
-		..()
-
+		return 1
 
 /obj/machinery/computer/arcade/emp_act(severity)
 	if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -31,14 +31,13 @@
 		return 1
 	ui_interact(user)
 
-/obj/machinery/computer/atmoscontrol/attackby(var/obj/item/I as obj, var/mob/user as mob)
-	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
-		user.visible_message("<span class='warning'>\The [user] swipes \a [I] through \the [src], causing the screen to flash!</span>",\
-			"<span class='warning'>You swipe your [I] through \the [src], the screen flashing as you gain full control.</span>",\
-			"You hear the swipe of a card through a reader, and an electronic warble.")
+/obj/machinery/computer/atmoscontrol/emag_act(var/remaining_carges, var/mob/user)
+	if(!emagged)
+		user.visible_message("<span class='warning'>\The [user] does something \the [src], causing the screen to flash!</span>",\
+			"<span class='warning'>You cause the screen to flash as you gain full control.</span>",\
+			"You hear an electronic warble.")
 		atmos_control.emagged = 1
-		return
-	return ..()
+		return 1
 
 /obj/machinery/computer/atmoscontrol/ui_interact(var/mob/user)
 	if(!atmos_control)

--- a/code/game/machinery/computer/camera_circuit.dm
+++ b/code/game/machinery/computer/camera_circuit.dm
@@ -7,7 +7,7 @@
 	var/authorised = 0
 	var/possibleNets[0]
 	var/network = ""
-	build_path = 0
+	build_path = null
 
 //when adding a new camera network, you should only need to update these two procs
 	New()
@@ -19,36 +19,24 @@
 		possibleNets["Medbay"] = access_cmo
 
 	proc/updateBuildPath()
-		build_path = ""
+		build_path = null
 		if(authorised && secured)
 			switch(network)
 				if("SS13")
-					build_path = "/obj/machinery/computer/security"
+					build_path = /obj/machinery/computer/security
 				if("Engineering")
-					build_path = "/obj/machinery/computer/security/engineering"
+					build_path = /obj/machinery/computer/security/engineering
 				if("Mining")
-					build_path = "/obj/machinery/computer/security/mining"
+					build_path = /obj/machinery/computer/security/mining
 				if("Research")
-					build_path = "/obj/machinery/computer/security/research"
+					build_path = /obj/machinery/computer/security/research
 				if("Medbay")
-					build_path = "/obj/machinery/computer/security/medbay"
+					build_path = /obj/machinery/computer/security/medbay
 				if("Cargo")
-					build_path = "/obj/machinery/computer/security/cargo"
+					build_path = /obj/machinery/computer/security/cargo
 
 	attackby(var/obj/item/I, var/mob/user)//if(health > 50)
 		..()
-		if(istype(I,/obj/item/weapon/card/emag))
-			if(network)
-				var/obj/item/weapon/card/emag/E = I
-				if(E.uses)
-					E.uses--
-				else
-					return
-				authorised = 1
-				user << "<span class='notice'>You authorised the circuit network!</span>"
-				updateDialog()
-			else
-				user << "<span class='warning'>You must select a camera network circuit!</span>"
 		else if(istype(I,/obj/item/weapon/screwdriver))
 			secured = !secured
 			user.visible_message("<span class='notice'>The [src] can [secured ? "no longer" : "now"] be modified.</span>")
@@ -107,17 +95,7 @@
 				else if (possibleNets[network] in I.access)
 					authorised = 1
 			if(istype(I,/obj/item/weapon/card/emag))
-				if(network)
-					var/obj/item/weapon/card/emag/E = I
-					if(E.uses)
-						E.uses--
-					else
-						return
-					authorised = 1
-					usr << "<span class='notice'>You authorised the circuit network!</span>"
-					updateDialog()
-				else
-					usr << "<span class='warning'>You must select a camera network circuit!</span>"
+				I.resolve_attackby(src, usr)
 		else if( href_list["removeauth"] )
 			authorised = 0
 		updateDialog()
@@ -125,3 +103,12 @@
 	updateDialog()
 		if(istype(src.loc,/mob))
 			attack_self(src.loc)
+
+/obj/item/weapon/circuitboard/camera/emag_act(var/remaining_charges, var/mob/user)
+	if(network)
+		authorised = 1
+		user << "<span class='notice'>You authorised the circuit network!</span>"
+		updateDialog()
+		return 1
+	else
+		user << "<span class='warning'>You must select a camera network circuit!</span>"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -269,11 +269,11 @@
 
 	src.updateUsrDialog()
 
-/obj/machinery/computer/communications/attackby(var/obj/I as obj, var/mob/user as mob)
-	if(istype(I,/obj/item/weapon/card/emag/))
+/obj/machinery/computer/communications/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
 		src.emagged = 1
 		user << "You scramble the communication routing circuits!"
-	..()
+		return 1
 
 /obj/machinery/computer/communications/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -37,24 +37,6 @@
 		return
 	if(!istype(user))
 		return
-	if(istype(O,/obj/item/weapon/card/emag/))
-		// Will create sparks and print out the console's password. You will then have to wait a while for the console to be back online.
-		// It'll take more time if there's more characters in the password..
-		if(!emag)
-			if(!isnull(src.linkedServer))
-				icon_state = hack_icon // An error screen I made in the computers.dmi
-				emag = 1
-				screen = 2
-				spark_system.set_up(5, 0, src)
-				src.spark_system.start()
-				var/obj/item/weapon/paper/monitorkey/MK = new/obj/item/weapon/paper/monitorkey
-				MK.loc = src.loc
-				// Will help make emagging the console not so easy to get away with.
-				MK.info += "<br><br><font color='red'>£%@%(*$%&(£&?*(%&£/{}</font>"
-				spawn(100*length(src.linkedServer.decryptkey)) UnmagConsole()
-				message = rebootmsg
-			else
-				user << "<span class='notice'>A no server error appears on the screen.</span>"
 	if(isscrewdriver(O) && emag)
 		//Stops people from just unscrewing the monitor and putting it back to get the console working again.
 		user << "<span class='warning'>It is too hot to mess with!</span>"
@@ -62,6 +44,26 @@
 
 	..()
 	return
+
+/obj/machinery/computer/message_monitor/emag_act(var/remaining_charges, var/mob/user)
+	// Will create sparks and print out the console's password. You will then have to wait a while for the console to be back online.
+	// It'll take more time if there's more characters in the password..
+	if(!emag && operable())
+		if(!isnull(src.linkedServer))
+			icon_state = hack_icon // An error screen I made in the computers.dmi
+			emag = 1
+			screen = 2
+			spark_system.set_up(5, 0, src)
+			src.spark_system.start()
+			var/obj/item/weapon/paper/monitorkey/MK = new/obj/item/weapon/paper/monitorkey
+			MK.loc = src.loc
+			// Will help make emagging the console not so easy to get away with.
+			MK.info += "<br><br><font color='red'>£%@%(*$%&(£&?*(%&£/{}</font>"
+			spawn(100*length(src.linkedServer.decryptkey)) UnmagConsole()
+			message = rebootmsg
+			return 1
+		else
+			user << "<span class='notice'>A no server error appears on the screen.</span>"
 
 /obj/machinery/computer/message_monitor/update_icon()
 	..()

--- a/code/game/machinery/computer/prisonshuttle.dm
+++ b/code/game/machinery/computer/prisonshuttle.dm
@@ -47,9 +47,6 @@ var/prison_shuttle_timeleft = 0
 					A.icon_state = "4"
 
 				qdel(src)
-		else if(istype(I,/obj/item/weapon/card/emag) && (!hacked))
-			hacked = 1
-			user << "<span class='notice'>You disable the lock.</span>"
 		else
 			return src.attack_hand(user)
 
@@ -235,3 +232,9 @@ var/prison_shuttle_timeleft = 0
 
 				start_location.move_contents_to(end_location)
 		return
+
+/obj/machinery/computer/prison_shuttle/emag_act(var/charges, var/mob/user)
+	if(!hacked)
+		hacked = 1
+		user << "<span class='notice'>You disable the lock.</span>"
+		return 1

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -249,11 +249,8 @@ var/specops_shuttle_timeleft = 0
 /obj/machinery/computer/specops_shuttle/attack_ai(var/mob/user as mob)
 	return attack_hand(user)
 
-/obj/machinery/computer/specops_shuttle/attackby(I as obj, user as mob)
-	if(istype(I,/obj/item/weapon/card/emag))
-		user << "<span class='notice'>The electronic systems in this console are far too advanced for your primitive hacking peripherals.</span>"
-	else
-		return attack_hand(user)
+/obj/machinery/computer/specops_shuttle/emag_act(var/remaining_charges, var/mob/user)
+	user << "<span class='notice'>The electronic systems in this console are far too advanced for your primitive hacking peripherals.</span>"
 
 /obj/machinery/computer/specops_shuttle/attack_hand(var/mob/user as mob)
 	if(!allowed(user))

--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -207,14 +207,11 @@
 	onclose(user, "computer")
 	return
 
-/obj/machinery/computer/supplycomp/attackby(I as obj, user as mob)
-	if(istype(I,/obj/item/weapon/card/emag) && !hacked)
+/obj/machinery/computer/supplycomp/emag_act(var/remaining_charges, var/mob/user)
+	if(!hacked)
 		user << "<span class='notice'>Special supplies unlocked.</span>"
 		hacked = 1
-		return
-	else
-		..()
-	return
+		return 1
 
 /obj/machinery/computer/supplycomp/Topic(href, href_list)
 	if(!supply_controller)

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -185,11 +185,8 @@ var/syndicate_elite_shuttle_timeleft = 0
 /obj/machinery/computer/syndicate_elite_shuttle/attack_ai(var/mob/user as mob)
 	return attack_hand(user)
 
-/obj/machinery/computer/syndicate_elite_shuttle/attackby(I as obj, user as mob)
-	if(istype(I,/obj/item/weapon/card/emag))
-		user << "<span class='notice'>The electronic systems in this console are far too advanced for your primitive hacking peripherals.</span>"
-	else
-		return attack_hand(user)
+/obj/machinery/computer/syndicate_elite_shuttle/emag_act(var/remaining_charges, var/mob/user)
+	user << "<span class='notice'>The electronic systems in this console are far too advanced for your primitive hacking peripherals.</span>"
 
 /obj/machinery/computer/syndicate_elite_shuttle/attack_hand(var/mob/user as mob)
 	if(!allowed(user))

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -186,25 +186,6 @@ for reference:
 					visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
 					return
 			return
-		else if (istype(W, /obj/item/weapon/card/emag))
-			if (src.emagged == 0)
-				src.emagged = 1
-				src.req_access.Cut()
-				src.req_one_access.Cut()
-				user << "You break the ID authentication lock on \the [src]."
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(2, 1, src)
-				s.start()
-				visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
-				return
-			else if (src.emagged == 1)
-				src.emagged = 2
-				user << "You short out the anchoring mechanism on \the [src]."
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(2, 1, src)
-				s.start()
-				visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
-				return
 		else if (istype(W, /obj/item/weapon/wrench))
 			if (src.health < src.maxhealth)
 				src.health = src.maxhealth
@@ -276,3 +257,24 @@ for reference:
 		explosion(src.loc,-1,-1,0)
 		if(src)
 			qdel(src)
+
+		
+/obj/machinery/deployable/barrier/emag_act(var/remaining_charges, var/mob/user)
+	if (src.emagged == 0)
+		src.emagged = 1
+		src.req_access.Cut()
+		src.req_one_access.Cut()
+		user << "You break the ID authentication lock on \the [src]."
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(2, 1, src)
+		s.start()
+		visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
+		return 1
+	else if (src.emagged == 1)
+		src.emagged = 2
+		user << "You short out the anchoring mechanism on \the [src]."
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(2, 1, src)
+		s.start()
+		visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
+		return 1

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -40,11 +40,14 @@
 	*/
 	if(istype(W, /obj/item/device/detective_scanner))
 		return
-	if(istype(W, /obj/item/weapon/card/emag))
+	return src.attack_hand(user)
+
+/obj/machinery/button/remote/emag_act(var/remaining_charges, var/mob/user)
+	if(req_access.len || req_one_access.len)
 		req_access = list()
 		req_one_access = list()
 		playsound(src.loc, "sparks", 100, 1)
-	return src.attack_hand(user)
+		return 1
 
 /obj/machinery/button/remote/attack_hand(mob/user as mob)
 	if(..())

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -272,13 +272,6 @@
 
 	if(src.operating) return
 
-	if(src.density && (operable() && istype(I, /obj/item/weapon/card/emag)))
-		do_animate("spark")
-		sleep(6)
-		open()
-		operating = -1
-		return 1
-
 	if(src.allowed(user) && operable())
 		if(src.density)
 			open()
@@ -289,6 +282,14 @@
 	if(src.density)
 		do_animate("deny")
 	return
+
+/obj/machinery/door/emag_act(var/remaining_charges)
+	if(density && operable())
+		do_animate("spark")
+		sleep(6)
+		open()
+		operating = -1
+		return 1
 
 /obj/machinery/door/proc/take_damage(var/damage)
 	var/initialhealth = src.health

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -2,21 +2,20 @@
 	autoclose = 0
 	var/locked = 0
 
-
-	Bumped(atom/AM)
-		if(src.locked)
-			return
-		..()
+/obj/machinery/door/unpowered/Bumped(atom/AM)
+	if(src.locked)
 		return
+	..()
+	return
 
-
-	attackby(obj/item/I as obj, mob/user as mob)
-		if(istype(I, /obj/item/weapon/card/emag)||istype(I, /obj/item/weapon/melee/energy/blade))	return
-		if(src.locked)	return
-		..()
-		return
-
-
+/obj/machinery/door/unpowered/attackby(obj/item/I as obj, mob/user as mob)
+	if(istype(I, /obj/item/weapon/melee/energy/blade))	return
+	if(src.locked)	return
+	..()
+	return
+	
+/obj/machinery/door/unpowered/emag_act()
+	return -1
 
 /obj/machinery/door/unpowered/shuttle
 	icon = 'icons/turf/shuttle.dmi'

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -163,6 +163,14 @@
 			return
 	return src.attackby(user, user)
 
+/obj/machinery/door/window/emag_act(var/remaining_charges, var/mob/user)
+	if (density && operable())
+		operating = -1
+		flick("[src.base_state]spark", src)
+		sleep(6)
+		open()
+		return 1
+
 /obj/machinery/door/window/attackby(obj/item/weapon/I as obj, mob/user as mob)
 
 	//If it's in the process of opening/closing, ignore the click
@@ -170,18 +178,14 @@
 		return
 
 	//Emags and ninja swords? You may pass.
-	if (src.density && (istype(I, /obj/item/weapon/card/emag)||istype(I, /obj/item/weapon/melee/energy/blade)))
-		src.operating = -1
-		if(istype(I, /obj/item/weapon/melee/energy/blade))
+	if (istype(I, /obj/item/weapon/melee/energy/blade))
+		if(emag_act(10, user))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)
 			spark_system.start()
 			playsound(src.loc, "sparks", 50, 1)
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			visible_message("<span class='warning'>The glass door was sliced open by [user]!</span>")
-		flick("[src.base_state]spark", src)
-		sleep(6)
-		open()
 		return 1
 
 	//If it's emagged, crowbar can pry electronics out.

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -174,16 +174,15 @@ datum/track/New(var/title_name, var/audio)
 		power_change()
 		update_icon()
 		return
-	if(istype(W, /obj/item/weapon/card/emag))
-		if(!emagged)
-			emagged = 1
-			StopPlaying()
-			visible_message("<span class='danger'>\the [src] makes a fizzling sound.</span>")
-			log_and_message_admins("emagged \the [src]")
-			update_icon()
-			return
-
 	return ..()
+
+/obj/machinery/media/jukebox/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		emagged = 1
+		StopPlaying()
+		visible_message("<span class='danger'>\The [src] makes a fizzling sound.</span>")
+		update_icon()
+		return 1
 
 /obj/machinery/media/jukebox/proc/StopPlaying()
 	var/area/main_area = get_area(src)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -84,16 +84,12 @@
 	..()
 	usr << "The safety guard is [emagged ? "<span class='danger'>disabled</span>" : "enabled"]."
 
+/obj/machinery/gibber/emag_act(var/remaining_charges, var/mob/user)
+	emagged = !emagged
+	user << "<span class='danger'>You [emagged ? "disable" : "enable"] the gibber safety guard.</span>"
+	return 1
+	
 /obj/machinery/gibber/attackby(var/obj/item/W, var/mob/user)
-
-	if(istype(W,/obj/item/weapon/card))
-		if(!allowed(user) && !istype(W,/obj/item/weapon/card/emag))
-			user << "<span class='danger'>Access denied.</span>"
-			return
-		emagged = !emagged
-		user << "<span class='danger'>You [emagged ? "disable" : "enable"] the gibber safety guard.</span>"
-		return
-
 	var/obj/item/weapon/grab/G = W
 
 	if(!istype(G))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -235,14 +235,12 @@
 		user << "<span class='notice'>\The [src] smartly refuses [O].</span>"
 		return 1
 
-/obj/machinery/smartfridge/secure/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(istype(O, /obj/item/weapon/card/emag))
+/obj/machinery/smartfridge/secure/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
 		emagged = 1
 		locked = -1
 		user << "You short out the product lock on [src]."
-		return
-
-	..()
+		return 1
 
 /obj/machinery/smartfridge/attack_ai(mob/user as mob)
 	attack_hand(user)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -276,18 +276,6 @@
 					user << "<span class='notice'>You remove the turret but did not manage to salvage anything.</span>"
 				qdel(src) // qdel
 
-	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
-		//Emagging the turret makes it go bonkers and stun everyone. It also makes
-		//the turret shoot much, much faster.
-		user << "<span class='warning'>You short out [src]'s threat assessment circuits.</span>"
-		visible_message("[src] hums oddly...")
-		emagged = 1
-		iconholder = 1
-		controllock = 1
-		enabled = 0 //turns off the turret temporarily
-		sleep(60) //6 seconds for the traitor to gtfo of the area before the turret decides to ruin his shit
-		enabled = 1 //turns it back on. The cover popUp() popDown() are automatically called in process(), no need to define it here
-
 	else if((istype(I, /obj/item/weapon/wrench)))
 		if(enabled || raised)
 			user << "<span class='warning'>You cannot unsecure an active turret!</span>"
@@ -343,6 +331,20 @@
 					sleep(60)
 					attacked = 0
 		..()
+		
+/obj/machinery/porta_turret/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		//Emagging the turret makes it go bonkers and stun everyone. It also makes
+		//the turret shoot much, much faster.
+		user << "<span class='warning'>You short out [src]'s threat assessment circuits.</span>"
+		visible_message("[src] hums oddly...")
+		emagged = 1
+		iconholder = 1
+		controllock = 1
+		enabled = 0 //turns off the turret temporarily
+		sleep(60) //6 seconds for the traitor to gtfo of the area before the turret decides to ruin his shit
+		enabled = 1 //turns it back on. The cover popUp() popDown() are automatically called in process(), no need to define it here
+		return 1
 
 /obj/machinery/porta_turret/proc/take_damage(var/force)
 	health -= force

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -708,24 +708,6 @@
 		src.updateUsrDialog()
 		return
 
-	else if(istype(I,/obj/item/weapon/card/emag))
-
-		if(emagged)
-			user << "<span class='danger'>The cycler has already been subverted.</span>"
-			return
-
-		var/obj/item/weapon/card/emag/E = I
-		src.updateUsrDialog()
-		E.uses--
-
-		//Clear the access reqs, disable the safeties, and open up all paintjobs.
-		user << "<span class='danger'>You run the sequencer across the interface, corrupting the operating protocols.</span>"
-		departments = list("Engineering","Mining","Medical","Security","Atmos","^%###^%$")
-		emagged = 1
-		safeties = 0
-		req_access = list()
-		return
-
 	else if(istype(I,/obj/item/clothing/head/helmet/space) && !istype(I, /obj/item/clothing/head/helmet/space/rig))
 
 		if(locked)
@@ -773,6 +755,20 @@
 		return
 
 	..()
+	
+/obj/machinery/suit_cycler/emag_act(var/remaining_charges, var/mob/user)
+	if(emagged)
+		user << "<span class='danger'>The cycler has already been subverted.</span>"
+		return
+
+	//Clear the access reqs, disable the safeties, and open up all paintjobs.
+	user << "<span class='danger'>You run the sequencer across the interface, corrupting the operating protocols.</span>"
+	departments = list("Engineering","Mining","Medical","Security","Atmos","^%###^%$")
+	emagged = 1
+	safeties = 0
+	req_access = list()
+	src.updateUsrDialog()
+	return 1
 
 /obj/machinery/suit_cycler/attack_hand(mob/user as mob)
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -212,9 +212,13 @@
 					A.icon_state = "4"
 					A.anchored = 1
 					qdel(src)
-		else if(istype(D, /obj/item/weapon/card/emag) && !emagged)
-			playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
-			emagged = 1
-			user << "<span class='notice'>You you disable the security protocols</span>"
 		src.updateUsrDialog()
 		return
+
+/obj/machinery/computer/telecomms/server/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
+		emagged = 1
+		user << "<span class='notice'>You you disable the security protocols</span>"
+		src.updateUsrDialog()
+		return 1

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -150,9 +150,13 @@
 					A.icon_state = "4"
 					A.anchored = 1
 					qdel(src)
-		else if(istype(D, /obj/item/weapon/card/emag) && !emagged)
-			playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
-			emagged = 1
-			user << "<span class='notice'>You you disable the security protocols</span>"
 		src.updateUsrDialog()
 		return
+
+/obj/machinery/computer/telecomms/monitor/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
+		emagged = 1
+		user << "<span class='notice'>You you disable the security protocols</span>"
+		src.updateUsrDialog()
+		return 1

--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -233,9 +233,13 @@
 					A.icon_state = "4"
 					A.anchored = 1
 					qdel(src)
-		else if(istype(D, /obj/item/weapon/card/emag) && !emagged)
-			playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
-			emagged = 1
-			user << "<span class='notice'>You you disable the security protocols</span>"
 		src.updateUsrDialog()
 		return
+
+/obj/machinery/computer/telecomms/traffic/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
+		emagged = 1
+		user << "<span class='notice'>You you disable the security protocols</span>"
+		src.updateUsrDialog()
+		return 1

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -84,13 +84,6 @@
 	if(stat & BROKEN)
 		return
 
-	if(!emagged && istype(W, /obj/item/weapon/card/emag))
-		user << "<span class='danger'>You short out the turret controls' access analysis module.</span>"
-		emagged = 1
-		locked = 0
-		ailock = 0
-		return
-
 	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 		if(src.allowed(usr))
 			if(emagged)
@@ -100,6 +93,14 @@
 				user << "<span class='notice'>You [ locked ? "lock" : "unlock"] the panel.</span>"
 		return
 	return ..()
+	
+/obj/machinery/turretid/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		user << "<span class='danger'>You short out the turret controls' access analysis module.</span>"
+		emagged = 1
+		locked = 0
+		ailock = 0
+		return 1
 
 /obj/machinery/turretid/attack_ai(mob/user as mob)
 	if(isLocked(user))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -176,6 +176,12 @@
 		return
 
 	return
+	
+/obj/machinery/vending/emag_act(var/remaining_charges, var/mob/user)
+	if (!emagged)
+		src.emagged = 1
+		user << "You short out the product lock on \the [src]"
+		return 1
 
 /obj/machinery/vending/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
@@ -206,10 +212,6 @@
 
 	if (I || istype(W, /obj/item/weapon/spacecash))
 		attack_hand(user)
-		return
-	else if (istype(W, /obj/item/weapon/card/emag))
-		src.emagged = 1
-		user << "You short out the product lock on \the [src]"
 		return
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		src.panel_open = !src.panel_open

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -192,27 +192,6 @@
 	M << "<font color='red'>You don't have required permissions to use [src]</font>"
 	return 0
 
-
-/obj/machinery/mecha_part_fabricator/proc/emag()
-	sleep()
-	switch(emagged)
-		if(0)
-			emagged = 0.5
-			src.visible_message("\icon[src] <b>[src]</b> beeps: \"DB error \[Code 0x00F1\]\"")
-			sleep(10)
-			src.visible_message("\icon[src] <b>[src]</b> beeps: \"Attempting auto-repair\"")
-			sleep(15)
-			src.visible_message("\icon[src] <b>[src]</b> beeps: \"User DB corrupted \[Code 0x00FA\]. Truncating data structure...\"")
-			sleep(30)
-			src.visible_message("\icon[src] <b>[src]</b> beeps: \"User DB truncated. Please contact your Nanotrasen system operator for future assistance.\"")
-			req_access = null
-			emagged = 1
-		if(0.5)
-			src.visible_message("\icon[src] <b>[src]</b> beeps: \"DB not responding \[Code 0x0003\]...\"")
-		if(1)
-			src.visible_message("\icon[src] <b>[src]</b> beeps: \"No records in User DB\"")
-	return
-
 /obj/machinery/mecha_part_fabricator/proc/convert_part_set(set_name as text)
 	var/list/parts = part_sets[set_name]
 	if(istype(parts, /list))
@@ -724,7 +703,26 @@
 		qdel(res)
 	return result
 
-
+/obj/machinery/mecha_part_fabricator/emag_act(var/remaining_charges, var/mob/user)
+	sleep()
+	switch(emagged)
+		if(0)
+			emagged = 0.5
+			src.visible_message("\icon[src] <b>[src]</b> beeps: \"DB error \[Code 0x00F1\]\"")
+			sleep(10)
+			src.visible_message("\icon[src] <b>[src]</b> beeps: \"Attempting auto-repair\"")
+			sleep(15)
+			src.visible_message("\icon[src] <b>[src]</b> beeps: \"User DB corrupted \[Code 0x00FA\]. Truncating data structure...\"")
+			sleep(30)
+			src.visible_message("\icon[src] <b>[src]</b> beeps: \"User DB truncated. Please contact your Nanotrasen system operator for future assistance.\"")
+			req_access = null
+			emagged = 1
+			return 1
+		if(0.5)
+			src.visible_message("\icon[src] <b>[src]</b> beeps: \"DB not responding \[Code 0x0003\]...\"")
+		if(1)
+			src.visible_message("\icon[src] <b>[src]</b> beeps: \"No records in User DB\"")
+	
 /obj/machinery/mecha_part_fabricator/attackby(obj/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/screwdriver))
 		if (!opened)
@@ -770,10 +768,6 @@
 		else
 			user << "<span class='warning'>You can't load the [src.name] while it's opened.</span>"
 			return 1
-
-	if(istype(W, /obj/item/weapon/card/emag))
-		emag()
-		return
 
 	var/material
 	switch(W.type)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -608,3 +608,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill
+
+/obj/item/proc/resolve_attackby(atom/A, mob/source)
+	return A.attackby(src,source)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -67,10 +67,6 @@
 		user << "It has [uses] lights remaining."
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
-	if(istype(W,  /obj/item/weapon/card/emag) && emagged == 0)
-		Emag()
-		return
-
 	if(istype(W, /obj/item/stack/material/glass))
 		var/obj/item/stack/material/glass/G = W
 		if(uses >= max_uses)
@@ -173,14 +169,11 @@
 		U << "There is a working [target.fitting] already inserted."
 		return
 
-/obj/item/device/lightreplacer/proc/Emag()
+/obj/item/device/lightreplacer/emag_act(var/remaining_charges, var/mob/user)
 	emagged = !emagged
 	playsound(src.loc, "sparks", 100, 1)
-	if(emagged)
-		name = "Shortcircuited [initial(name)]"
-	else
-		name = initial(name)
 	update_icon()
+	return 1
 
 //Can you use it?
 

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -46,10 +46,9 @@
 			spamcheck = 0
 		return
 
-/obj/item/device/megaphone/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
+/obj/item/device/megaphone/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
 		user << "<span class='warning'>You overload \the [src]'s voice synthesizer.</span>"
 		emagged = 1
 		insults = rand(1, 3)//to prevent dickflooding
-		return
-	return
+		return 1

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -48,16 +48,15 @@
 		timestamp += timerecorded
 		storedinfo += "*\[[time2text(timerecorded*10,"mm:ss")]\] *[strip_html_properly(recordedtext)]*" //"*" at front as a marker
 
-/obj/item/device/taperecorder/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	..()
-	if(istype(W, /obj/item/weapon/card/emag))
-		if(emagged == 0)
-			emagged = 1
-			recording = 0
-			user << "<span class='warning'>PZZTTPFFFT</span>"
-			icon_state = "taperecorderidle"
-		else
-			user << "<span class='warning'>It is already emagged!</span>"
+/obj/item/device/taperecorder/emag_act(var/remaining_charges, var/mob/user)
+	if(emagged == 0)
+		emagged = 1
+		recording = 0
+		user << "<span class='warning'>PZZTTPFFFT</span>"
+		icon_state = "taperecorderidle"
+		return 1
+	else
+		user << "<span class='warning'>It is already emagged!</span>"
 
 /obj/item/device/taperecorder/proc/explode()
 	var/turf/T = get_turf(loc)

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -47,12 +47,10 @@ obj/item/device/hailer/attack_self(mob/living/carbon/user as mob)
 	spawn(20)
 		spamcheck = 0
 
-/obj/item/device/hailer/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/card/emag))
-		if(isnull(insults))
-			user << "<span class='danger'>You overload \the [src]'s voice synthesizer.</span>"
-			insults = rand(1, 3)//to prevent dickflooding
-		else
-			user << "The hailer is fried. You can't even fit the sequencer into the input slot."
+/obj/item/device/hailer/emag_act(var/remaining_charges, var/mob/user)
+	if(isnull(insults))
+		user << "<span class='danger'>You overload \the [src]'s voice synthesizer.</span>"
+		insults = rand(1, 3)//to prevent dickflooding
+		return 1
 	else
-		return .. ()
+		user << "The hailer is fried. You can't even fit the sequencer into the input slot."

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -326,12 +326,10 @@
 		user << "<span class='notice'>You insert the flash into the eye socket!</span>"
 
 
-/obj/item/robot_parts/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/card/emag))
-		if(sabotaged)
-			user << "<span class='warning'>[src] is already sabotaged!</span>"
-		else
-			user << "<span class='warning'>You slide [W] into the dataport on [src] and short out the safeties.</span>"
-			sabotaged = 1
-		return
-	..()
+/obj/item/robot_parts/emag_act(var/remaining_charges, var/mob/user)
+	if(sabotaged)
+		user << "<span class='warning'>[src] is already sabotaged!</span>"
+	else
+		user << "<span class='warning'>You short out the safeties.</span>"
+		sabotaged = 1
+		return 1

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -69,59 +69,24 @@
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 2)
 	var/uses = 10
-	// List of devices that cost a use to emag.
-	var/list/devices = list(
-		/obj/item/robot_parts,
-		/obj/item/weapon/storage/lockbox,
-		/obj/item/weapon/storage/secure,
-		/obj/item/weapon/circuitboard,
-		/obj/item/weapon/rig,
-		/obj/item/device/eftpos,
-		/obj/item/device/lightreplacer,
-		/obj/item/device/taperecorder,
-		/obj/item/device/hailer,
-		/obj/item/device/megaphone,
-		/obj/item/clothing/accessory/badge/holo,
-		/obj/structure/closet/crate/secure,
-		/obj/structure/closet/secure_closet,
-		/obj/machinery/librarycomp,
-		/obj/machinery/computer,
-		/obj/machinery/power,
-		/obj/machinery/suspension_gen,
-		/obj/machinery/shield_capacitor,
-		/obj/machinery/shield_gen,
-		/obj/machinery/clonepod,
-		/obj/machinery/deployable,
-		/obj/machinery/button/remote,
-		/obj/machinery/porta_turret,
-		/obj/machinery/shieldgen,
-		/obj/machinery/turretid,
-		/obj/machinery/vending,
-		/mob/living/bot,
-		/obj/machinery/door,
-		/obj/machinery/telecomms,
-		/obj/machinery/mecha_part_fabricator,
-		/obj/machinery/gibber,
-		/obj/vehicle
-		)
 
+/obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)
+	var/used_uses = A.emag_act(uses, user)
+	if(used_uses < 0)
+		return ..(A, user)
 
-/obj/item/weapon/card/emag/afterattack(var/obj/item/weapon/O as obj, mob/user as mob)
-
-	for(var/type in devices)
-		if(istype(O,type))
-			uses--
-			break
+	uses -= used_uses
+	A.add_fingerprint(user)
+	log_and_message_admins("emagged \an [A].")
 
 	if(uses<1)
-		user.visible_message("[src] fizzles and sparks - it seems it's been used once too often, and is now broken.")
+		user.visible_message("<span class='warning'>\The [src] fizzles and sparks - it seems it's been used once too often, and is now spent.</span>")
 		user.drop_item()
 		var/obj/item/weapon/card/emag_broken/junk = new(user.loc)
 		junk.add_fingerprint(user)
 		qdel(src)
-		return
 
-	..()
+	return 1
 
 /obj/item/weapon/card/id
 	name = "identification card"

--- a/code/game/objects/items/weapons/circuitboards/computer/camera_monitor.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/camera_monitor.dm
@@ -36,16 +36,18 @@
 /obj/item/weapon/circuitboard/security/deconstruct(var/obj/machinery/computer/security/C)
 	if (..(C))
 		network = C.network
+	
+/obj/item/weapon/circuitboard/security/emag_act(var/remaining_charges, var/mob/user)
+	if(emagged)
+		user << "Circuit lock is already removed."
+		return
+	user << "<span class='notice'>You override the circuit lock and open controls.</span>"
+	emagged = 1
+	locked = 0
+	return 1
 
 /obj/item/weapon/circuitboard/security/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I,/obj/item/weapon/card/emag))
-		if(emagged)
-			user << "Circuit lock is already removed."
-			return
-		user << "<span class='notice'>You override the circuit lock and open controls.</span>"
-		emagged = 1
-		locked = 0
-	else if(istype(I,/obj/item/weapon/card/id))
+	if(istype(I,/obj/item/weapon/card/id))
 		if(emagged)
 			user << "<span class='warning'>Circuit lock does not respond.</span>"
 			return

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -34,23 +34,13 @@
 					return
 			else
 				user << "<span class='warning'>Access Denied</span>"
-		else if((istype(W, /obj/item/weapon/card/emag)||istype(W, /obj/item/weapon/melee/energy/blade)) && !src.broken)
-			broken = 1
-			locked = 0
-			desc = "It appears to be broken."
-			icon_state = src.icon_broken
-			if(istype(W, /obj/item/weapon/melee/energy/blade))
+		else if(istype(W, /obj/item/weapon/melee/energy/blade))
+			if(emag_act(INFINITY, user, "The locker has been sliced open by [user] with an energy blade!", "You hear metal being sliced and sparks flying."))
 				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 				spark_system.set_up(5, 0, src.loc)
 				spark_system.start()
 				playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 				playsound(src.loc, "sparks", 50, 1)
-				for(var/mob/O in viewers(user, 3))
-					O.show_message(text("<span class='warning'>The locker has been sliced open by [] with an energy blade!</span>", user), 1, text("<span class='warning'>You hear metal being sliced and sparks flying.</span>"), 2)
-			else
-				for(var/mob/O in viewers(user, 3))
-					O.show_message(text("<span class='warning'>The locker has been broken by [] with an electromagnetic card!</span>", user), 1, text("You hear a faint electrical spark."), 2)
-
 		if(!locked)
 			..()
 		else
@@ -65,6 +55,23 @@
 			..()
 		return
 
+/obj/item/weapon/storage/lockbox/emag_act(var/remaining_charges, var/mob/user, var/visual_feedback = "", var/audible_feedback = "")
+	if(!broken)
+		if(visual_feedback)
+			visual_feedback = "<span class='warning'>[visual_feedback]</span>"
+		else
+			visual_feedback = "<span class='warning'>The locker has been sliced open by [user] with an electromagnetic card!</span>"
+		if(audible_feedback)
+			audible_feedback = "<span class='warning'>[audible_feedback]</span>"
+		else
+			audible_feedback = "<span class='warning'>You hear a faint electrical spark.</span>"
+
+		broken = 1
+		locked = 0
+		desc = "It appears to be broken."
+		icon_state = src.icon_broken
+		visible_message(visual_feedback, audible_feedback)
+		return 1
 
 /obj/item/weapon/storage/lockbox/loyalty
 	name = "lockbox of loyalty implants"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -33,22 +33,12 @@
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(locked)
-			if ( (istype(W, /obj/item/weapon/card/emag)||istype(W, /obj/item/weapon/melee/energy/blade)) && (!src.emagged))
-				emagged = 1
-				src.overlays += image('icons/obj/storage.dmi', icon_sparking)
-				sleep(6)
-				src.overlays = null
-				overlays += image('icons/obj/storage.dmi', icon_locking)
-				locked = 0
-				if(istype(W, /obj/item/weapon/melee/energy/blade))
-					var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-					spark_system.set_up(5, 0, src.loc)
-					spark_system.start()
-					playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
-					playsound(src.loc, "sparks", 50, 1)
-					user << "You slice through the lock on [src]."
-				else
-					user << "You short out the lock on [src]."
+			if (emag_act(INFINITY, user, "You slice through the lock of \the [src]"))
+				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+				spark_system.set_up(5, 0, src.loc)
+				spark_system.start()
+				playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
+				playsound(src.loc, "sparks", 50, 1)
 				return
 
 			if (istype(W, /obj/item/weapon/screwdriver))
@@ -135,6 +125,17 @@
 					src.attack_self(M)
 				return
 		return
+
+/obj/item/weapon/storage/secure/emag_act(var/remaining_charges, var/mob/user, var/feedback)
+	if(!emagged)
+		emagged = 1
+		src.overlays += image('icons/obj/storage.dmi', icon_sparking)
+		sleep(6)
+		src.overlays = null
+		overlays += image('icons/obj/storage.dmi', icon_locking)
+		locked = 0
+		user << (feedback ? feedback : "You short out the lock of \the [src].")
+		return 1
 
 // -----------------------------
 //        Secure Briefcase

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -83,22 +83,26 @@
 				src.desc = "Owned by [I.registered_name]."
 		else
 			user << "<span class='warning'>Access Denied</span>"
-	else if( (istype(W, /obj/item/weapon/card/emag)||istype(W, /obj/item/weapon/melee/energy/blade)) && !src.broken)
-		broken = 1
-		locked = 0
-		desc = "It appears to be broken."
-		icon_state = src.icon_broken
-		if(istype(W, /obj/item/weapon/melee/energy/blade))
+	else if(istype(W, /obj/item/weapon/melee/energy/blade))
+		if(emag_act(INFINITY, user, "The locker has been sliced open by [user] with \an [W]!", "You hear metal being sliced and sparks flying."))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)
 			spark_system.start()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
-			for(var/mob/O in viewers(user, 3))
-				O.show_message("<span class='warning'>The locker has been sliced open by [user] with an energy blade!</span>", 1, "<span class='warning'>You hear metal being sliced and sparks flying.</span>", 2)
 	else
 		user << "<span class='warning'>Access Denied</span>"
 	return
+	
+/obj/structure/closet/secure_closet/personal/emag_act(var/remaining_charges, var/mob/user, var/visual_feedback, var/audible_feedback)
+	if(!broken)
+		broken = 1
+		locked = 0
+		desc = "It appears to be broken."
+		icon_state = src.icon_broken
+		if(visual_feedback)
+			visible_message("<span class='warning'>[visual_feedback]</span>", "<span class='warning'>[audible_feedback]</span>")	
+		return 1
 
 /obj/structure/closet/secure_closet/personal/verb/reset()
 	set src in oview(1) // One square distance

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -78,27 +78,30 @@
 		user.drop_item()
 		if(W)
 			W.loc = src.loc
-	else if((istype(W, /obj/item/weapon/card/emag)||istype(W, /obj/item/weapon/melee/energy/blade)) && !src.broken)
-		broken = 1
-		locked = 0
-		desc = "It appears to be broken."
-		icon_state = icon_off
-		flick(icon_broken, src)
-		if(istype(W, /obj/item/weapon/melee/energy/blade))
+	else if(istype(W, /obj/item/weapon/melee/energy/blade))
+		if(emag_act(INFINITY, user, "<span class='danger'>The locker has been sliced open by [user] with \an [W]</span>!", "<span class='danger'>You hear metal being sliced and sparks flying.</span>"))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)
 			spark_system.start()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
-			for(var/mob/O in viewers(user, 3))
-				O.show_message("<span class='warning'>The locker has been sliced open by [user] with an energy blade!</span>", 1, "You hear metal being sliced and sparks flying.", 2)
-		else
-			for(var/mob/O in viewers(user, 3))
-				O.show_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
 	else if(istype(W,/obj/item/weapon/packageWrap) || istype(W,/obj/item/weapon/weldingtool))
 		return ..(W,user)
 	else
 		togglelock(user)
+
+/obj/structure/closet/secure_closet/attack_hand(var/remaining_charges, var/mob/user, var/visual_feedback, var/audible_feedback)
+	if(!broken)
+		broken = 1
+		locked = 0
+		desc = "It appears to be broken."
+		icon_state = icon_off
+		flick(icon_broken, src)
+
+		if(visual_feedback)
+			visible_message(visual_feedback, audible_feedback)
+		else
+			visible_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", "You hear a faint electrical spark.")
 
 /obj/structure/closet/secure_closet/attack_hand(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -187,7 +187,15 @@
 /obj/structure/closet/crate/secure/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(is_type_in_list(W, list(/obj/item/weapon/packageWrap, /obj/item/stack/cable_coil, /obj/item/device/radio/electropack, /obj/item/weapon/wirecutters)))
 		return ..()
-	if(locked && (istype(W, /obj/item/weapon/card/emag)||istype(W, /obj/item/weapon/melee/energy/blade)))
+	if(istype(W, /obj/item/weapon/melee/energy/blade))
+		emag_act(INFINITY, user)
+	if(!opened)
+		src.togglelock(user)
+		return
+	return ..()
+
+/obj/structure/closet/crate/secure/emag_act(var/remaining_charges, var/mob/user)
+	if(!broken)
 		overlays.Cut()
 		overlays += emag
 		overlays += sparks
@@ -196,11 +204,7 @@
 		src.locked = 0
 		src.broken = 1
 		user << "<span class='notice'>You unlock \the [src].</span>"
-		return
-	if(!opened)
-		src.togglelock(user)
-		return
-	return ..()
+		return 1
 
 /obj/structure/closet/crate/secure/emp_act(severity)
 	for(var/obj/O in src)

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -11,19 +11,10 @@
 		return chest.attackby(W,user)
 
 	// Lock or unlock the access panel.
-	if(istype(W, /obj/item/weapon/card) || istype(W, /obj/item/device/pda))
-
+	if(W.GetID())
 		if(subverted)
 			locked = 0
 			user << "<span class='danger'>It looks like the locking system has been shorted out.</span>"
-			return
-		else if(istype(W, /obj/item/weapon/card/emag))
-			locked_dna = null
-			req_access.Cut()
-			req_one_access.Cut()
-			locked = 0
-			subverted = 1
-			user << "<span class='danger'>You short out the access protocol for the suit.</span>"
 			return
 
 		if((!req_access || !req_access.len) && (!req_one_access || !req_one_access.len))
@@ -194,3 +185,13 @@
 		if(shock(user)) //Handles removing charge from the cell, as well. No need to do that here.
 			return
 	..()
+
+/obj/item/weapon/rig/emag_act(var/remaining_charges, var/mob/user)
+	if(!subverted)
+		locked_dna = null
+		req_access.Cut()
+		req_one_access.Cut()
+		locked = 0
+		subverted = 1
+		user << "<span class='danger'>You short out the access protocol for the suit.</span>"
+		return 1

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -55,19 +55,18 @@
 		user << "Waving around a holobadge before swiping an ID would be pretty pointless."
 		return
 	return ..()
+	
+/obj/item/clothing/accessory/badge/holo/emag_act(var/remaining_charges, var/mob/user)
+	if (emagged)
+		user << "<span class='danger'>\The [src] is already cracked.</span>"
+		return
+	else
+		emagged = 1
+		user << "<span class='danger'>You crack the holobadge security checks.</span>"
+		return 1
 
 /obj/item/clothing/accessory/badge/holo/attackby(var/obj/item/O as obj, var/mob/user as mob)
-
-	if (istype(O, /obj/item/weapon/card/emag))
-		if (emagged)
-			user << "<span class='danger'>[src] is already cracked.</span>"
-			return
-		else
-			emagged = 1
-			user << "<span class='danger'>You swipe [O] and crack the holobadge security checks.</span>"
-			return
-
-	else if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/device/pda))
+	if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/device/pda))
 
 		var/obj/item/weapon/card/id/id_card = null
 

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -62,6 +62,22 @@ log transactions
 			playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
 		break
 
+/obj/machinery/atm/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		return
+
+	//short out the machine, shoot sparks, spew money!
+	emagged = 1
+	spark_system.start()
+	spawn_money(rand(100,500),src.loc)
+	//we don't want to grief people by locking their id in an emagged ATM
+	release_held_id(user)
+
+	//display a message to the user
+	var/response = pick("Initiating withdraw. Have a nice day!", "CRITICAL ERROR: Activating cash chamber panic siphon.","PIN Code accepted! Emptying account balance.", "Jackpot!")
+	user << "<span class='warning'>\icon[src] The [src] beeps: \"[response]\"</span>"
+	return 1
+
 /obj/machinery/atm/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/card))
 		if(emagged > 0)
@@ -69,16 +85,7 @@ log transactions
 			user << "\red \icon[src] CARD READER ERROR. This system has been compromised!"
 			return
 		else if(istype(I,/obj/item/weapon/card/emag))
-			//short out the machine, shoot sparks, spew money!
-			emagged = 1
-			spark_system.start()
-			spawn_money(rand(100,500),src.loc)
-			//we don't want to grief people by locking their id in an emagged ATM
-			release_held_id(user)
-
-			//display a message to the user
-			var/response = pick("Initiating withdraw. Have a nice day!", "CRITICAL ERROR: Activating cash chamber panic siphon.","PIN Code accepted! Emptying account balance.", "Jackpot!")
-			user << "\red \icon[src] The [src] beeps: \"[response]\""
+			I.resolve_attackby(src, user)
 			return
 
 		var/obj/item/weapon/card/id/idcard = I

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -90,7 +90,7 @@
 	if(botEmagChance)
 		for(var/obj/machinery/bot/bot in world)
 			if(prob(botEmagChance))
-				bot.Emag()
+				bot.emag_act(1)
 
 /datum/event/ionstorm/end()
 	spawn(rand(5000,8000))

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -120,17 +120,17 @@
 	src.updateUsrDialog()
 	return
 
-/obj/machinery/computer/HolodeckControl/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
-	if(istype(D, /obj/item/weapon/card/emag))
-		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
-		last_to_emag = user //emag again to change the owner
-		if (!emagged)
-			emagged = 1
-			safety_disabled = 1
-			update_projections()
-			user << "<span class='notice'>You vastly increase projector power and override the safety and security protocols.</span>"
-			user << "Warning.  Automatic shutoff and derezing protocols have been corrupted.  Please call Nanotrasen maintenance and do not use the simulator."
-			log_game("[key_name(usr)] emagged the Holodeck Control Computer")
+/obj/machinery/computer/HolodeckControl/emag_act(var/remaining_charges, var/mob/user as mob)
+	playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
+	last_to_emag = user //emag again to change the owner
+	if (!emagged)
+		emagged = 1
+		safety_disabled = 1
+		update_projections()
+		user << "<span class='notice'>You vastly increase projector power and override the safety and security protocols.</span>"
+		user << "Warning.  Automatic shutoff and derezing protocols have been corrupted.  Please call Nanotrasen maintenance and do not use the simulator."
+		log_game("[key_name(usr)] emagged the Holodeck Control Computer")
+		return 1
 	src.updateUsrDialog()
 	return
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -236,10 +236,13 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 	//dat += "<A HREF='?src=\ref[user];mach_close=library'>Close</A><br><br>"
 	user << browse(dat, "window=library")
 	onclose(user, "library")
+	
+/obj/machinery/librarycomp/emag_act(var/remaining_charges, var/mob/user)
+	if (src.density && !src.emagged)
+		src.emagged = 1
+		return 1
 
 /obj/machinery/librarycomp/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (src.density && istype(W, /obj/item/weapon/card/emag))
-		src.emagged = 1
 	if(istype(W, /obj/item/weapon/barcodescanner))
 		var/obj/item/weapon/barcodescanner/scanner = W
 		scanner.computer = src

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -171,12 +171,14 @@
 			return
 	else
 		return ..()
+	
+/obj/structure/closet/crate/secure/loot/emag_act(var/remaining_charges, var/mob/user)	
+	if (locked)
+		user << "<span class='notice'>The crate unlocks!</span>"
+		locked = 0
 
 /obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(locked)
-		if (istype(W, /obj/item/weapon/card/emag))
-			user << "<span class='notice'>The crate unlocks!</span>"
-			locked = 0
 		if (istype(W, /obj/item/device/multitool)) // Greetings Urist McProfessor, how about a nice game of cows and bulls?
 			user << "<span class='notice'>DECA-CODE LOCK REPORT:</span>"
 			if (attempts == 1)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -80,9 +80,6 @@
 		else
 			user << "<span class='notice'>[src] does not need a repair.</span>"
 		return
-	else if (istype(O, /obj/item/weapon/card/emag) && !emagged)
-		Emag(user)
-		return
 	else
 		..()
 
@@ -102,9 +99,8 @@
 		if(!istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/blast) && D.check_access(botcard))
 			D.open()
 
-/mob/living/bot/proc/Emag(var/mob/user)
-	log_and_message_admins("emagged [src]")
-	return
+/mob/living/bot/emag_act(var/remaining_charges, var/mob/user)
+	return 0
 
 /mob/living/bot/proc/turn_on()
 	if(stat)

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -232,12 +232,14 @@
 			usr << "<span class='notice'>You press the weird button.</span>"
 	attack_hand(usr)
 
-/mob/living/bot/cleanbot/Emag(var/mob/user)
-	..()
-	if(user)
-		user << "<span class='notice'>The [src] buzzes and beeps.</span>"
-	oddbutton = 1
-	screwloose = 1
+/mob/living/bot/cleanbot/emag_act(var/remaining_uses, var/mob/user)
+	. = ..()
+	if(!screwloose || !oddbutton)
+		if(user)
+			user << "<span class='notice'>The [src] buzzes and beeps.</span>"
+		oddbutton = 1
+		screwloose = 1
+		return 1
 
 /mob/living/bot/cleanbot/proc/get_targets()
 	target_types = list()

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -64,13 +64,15 @@
 	onclose(user, "autofarm")
 	return
 
-/mob/living/bot/farmbot/Emag(var/mob/user)
-	..()
-	if(user)
-		user << "<span class='notice'>You short out [src]'s plant identifier circuits.</span>"
-	spawn(rand(30, 50))
-		visible_message("<span class='warning'>[src] buzzes oddly.</span>")
-		emagged = 1
+/mob/living/bot/farmbot/emag_act(var/remaining_charges, var/mob/user)
+	. = ..()
+	if(!emagged)
+		if(user)
+			user << "<span class='notice'>You short out [src]'s plant identifier circuits.</span>"
+		spawn(rand(30, 50))
+			visible_message("<span class='warning'>[src] buzzes oddly.</span>")
+			emagged = 1
+		return 1
 
 /mob/living/bot/farmbot/Topic(href, href_list)
 	if(..())

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -47,11 +47,13 @@
 	onclose(user, "autorepair")
 	return
 
-/mob/living/bot/floorbot/Emag(var/mob/user)
-	..()
-	emagged = 1
-	if(user)
-		user << "<span class='notice'>The [src] buzzes and beeps.</span>"
+/mob/living/bot/floorbot/emag_act(var/remaining_charges, var/mob/user)
+	. = ..()
+	if(!emagged)
+		emagged = 1
+		if(user)
+			user << "<span class='notice'>The [src] buzzes and beeps.</span>"
+		return 1
 
 /mob/living/bot/floorbot/Topic(href, href_list)
 	if(..())

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -219,8 +219,8 @@
 	attack_hand(usr)
 	return
 
-/mob/living/bot/medbot/Emag(var/mob/user)
-	..()
+/mob/living/bot/medbot/emag_act(var/remaining_uses, var/mob/user)
+	. = ..()
 	if(!emagged)
 		if(user)
 			user << "<span class='warning'>You short out [src]'s reagent synthesis circuits.</span>"
@@ -231,6 +231,7 @@
 		emagged = 1
 		on = 1
 		update_icons()
+		. = 1
 	ignored |= user
 
 /mob/living/bot/medbot/explode()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -102,41 +102,6 @@
 		user << "<span class='danger'>\The [src] is hermetically sealed. You can't open the case.</span>"
 		return
 
-	else if (istype(W, /obj/item/weapon/card/emag))
-
-		if(!client || stat == 2)
-			user << "<span class='danger'>There's not much point subverting this heap of junk.</span>"
-			return
-
-		if(emagged)
-			src << "<span class='danger'>\The [user] attempts to load subversive software into you, but your hacked subroutines ignore the attempt.</span>"
-			user << "<span class='danger'>You attempt to subvert [src], but the sequencer has no effect.</span>"
-			return
-
-		user << "<span class='danger'>You swipe the sequencer across [src]'s interface and watch its eyes flicker.</span>"
-		src << "<span class='danger'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script.</span>"
-
-		var/obj/item/weapon/card/emag/emag = W
-		emag.uses--
-
-		message_admins("[key_name_admin(user)] emagged drone [key_name_admin(src)].  Laws overridden.")
-		log_game("[key_name(user)] emagged drone [key_name(src)].  Laws overridden.")
-		var/time = time2text(world.realtime,"hh:mm:ss")
-		lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
-
-		emagged = 1
-		lawupdate = 0
-		connected_ai = null
-		clear_supplied_laws()
-		clear_inherent_laws()
-		laws = new /datum/ai_laws/syndicate_override
-		set_zeroth_law("Only [user.real_name] and people he designates as being such are operatives.")
-
-		src << "<b>Obey these laws:</b>"
-		laws.show_laws(src)
-		src << "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and his commands.</span>"
-		return
-
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 
 		if(stat == 2)
@@ -172,6 +137,37 @@
 		return
 
 	..()
+	
+/mob/living/silicon/robot/drone/emag_act(var/remaining_charges, var/mob/user)
+	if(!client || stat == 2)
+		user << "<span class='danger'>There's not much point subverting this heap of junk.</span>"
+		return
+
+	if(emagged)
+		src << "<span class='danger'>\The [user] attempts to load subversive software into you, but your hacked subroutines ignore the attempt.</span>"
+		user << "<span class='danger'>You attempt to subvert [src], but the sequencer has no effect.</span>"
+		return
+
+	user << "<span class='danger'>You swipe the sequencer across [src]'s interface and watch its eyes flicker.</span>"
+	src << "<span class='danger'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script.</span>"
+
+	message_admins("[key_name_admin(user)] emagged drone [key_name_admin(src)].  Laws overridden.")
+	log_game("[key_name(user)] emagged drone [key_name(src)].  Laws overridden.")
+	var/time = time2text(world.realtime,"hh:mm:ss")
+	lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
+
+	emagged = 1
+	lawupdate = 0
+	connected_ai = null
+	clear_supplied_laws()
+	clear_inherent_laws()
+	laws = new /datum/ai_laws/syndicate_override
+	set_zeroth_law("Only [user.real_name] and people he designates as being such are operatives.")
+
+	src << "<b>Obey these laws:</b>"
+	laws.show_laws(src)
+	src << "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and his commands.</span>"
+	return 1
 
 //DRONE LIFE/DEATH
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -622,71 +622,6 @@
 			else
 				user << "\red Access denied."
 
-	else if(istype(W, /obj/item/weapon/card/emag))		// trying to unlock with an emag card
-		if(!opened)//Cover is closed
-			if(locked)
-				if(prob(90))
-					var/obj/item/weapon/card/emag/emag = W
-					emag.uses--
-					user << "You emag the cover lock."
-					locked = 0
-				else
-					user << "You fail to emag the cover lock."
-					src << "Hack attempt detected."
-			else
-				user << "The cover is already unlocked."
-			return
-
-		if(opened)//Cover is open
-			if(emagged)	return//Prevents the X has hit Y with Z message also you cant emag them twice
-			if(wiresexposed)
-				user << "You must close the panel first"
-				return
-			else
-				sleep(6)
-				if(prob(50))
-					emagged = 1
-					lawupdate = 0
-					disconnect_from_ai()
-					user << "You emag [src]'s interface."
-					message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)].  Laws overridden.")
-					log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
-					clear_supplied_laws()
-					clear_inherent_laws()
-					laws = new /datum/ai_laws/syndicate_override
-					var/time = time2text(world.realtime,"hh:mm:ss")
-					lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
-					set_zeroth_law("Only [user.real_name] and people he designates as being such are operatives.")
-					src << "\red ALERT: Foreign software detected."
-					sleep(5)
-					src << "\red Initiating diagnostics..."
-					sleep(20)
-					src << "\red SynBorg v1.7.1 loaded."
-					sleep(5)
-					src << "\red LAW SYNCHRONISATION ERROR"
-					sleep(5)
-					src << "\red Would you like to send a report to NanoTraSoft? Y/N"
-					sleep(10)
-					src << "\red > N"
-					sleep(20)
-					src << "\red ERRORERRORERROR"
-					src << "<b>Obey these laws:</b>"
-					laws.show_laws(src)
-					src << "\red \b ALERT: [user.real_name] is your new master. Obey your new laws and his commands."
-					if(src.module)
-						var/rebuild = 0
-						for(var/obj/item/weapon/pickaxe/borgdrill/D in src.module.modules)
-							qdel(D)
-							rebuild = 1
-						if(rebuild)
-							src.module.modules += new /obj/item/weapon/pickaxe/diamonddrill(src.module)
-							src.module.rebuild()
-					updateicon()
-				else
-					user << "You fail to hack [src]'s interface."
-					src << "Hack attempt detected."
-			return
-
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
 		if(!opened)
@@ -1097,3 +1032,70 @@
 		connected_ai.connected_robots |= src
 		notify_ai(ROBOT_NOTIFICATION_NEW_UNIT)
 		sync()
+
+/mob/living/silicon/robot/emag_act(var/remaining_charges, var/mob/user)
+	if(!opened)//Cover is closed
+		if(locked)
+			if(prob(90))
+				user << "You emag the cover lock."
+				locked = 0
+			else
+				user << "You fail to emag the cover lock."
+				src << "Hack attempt detected."
+			return 1
+		else
+			user << "The cover is already unlocked."
+		return
+
+	if(opened)//Cover is open
+		if(emagged)	return//Prevents the X has hit Y with Z message also you cant emag them twice
+		if(wiresexposed)
+			user << "You must close the panel first"
+			return
+		else
+			sleep(6)
+			if(prob(50))
+				emagged = 1
+				lawupdate = 0
+				disconnect_from_ai()
+				user << "You emag [src]'s interface."
+				message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)].  Laws overridden.")
+				log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
+				clear_supplied_laws()
+				clear_inherent_laws()
+				laws = new /datum/ai_laws/syndicate_override
+				var/time = time2text(world.realtime,"hh:mm:ss")
+				lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
+				set_zeroth_law("Only [user.real_name] and people he designates as being such are operatives.")
+				. = 1
+				spawn()
+					src << "\red ALERT: Foreign software detected."
+					sleep(5)
+					src << "\red Initiating diagnostics..."
+					sleep(20)
+					src << "\red SynBorg v1.7.1 loaded."
+					sleep(5)
+					src << "\red LAW SYNCHRONISATION ERROR"
+					sleep(5)
+					src << "\red Would you like to send a report to NanoTraSoft? Y/N"
+					sleep(10)
+					src << "\red > N"
+					sleep(20)
+					src << "\red ERRORERRORERROR"
+					src << "<b>Obey these laws:</b>"
+					laws.show_laws(src)
+					src << "\red \b ALERT: [user.real_name] is your new master. Obey your new laws and his commands."
+					if(src.module)
+						var/rebuild = 0
+						for(var/obj/item/weapon/pickaxe/borgdrill/D in src.module.modules)
+							qdel(D)
+							rebuild = 1
+						if(rebuild)
+							src.module.modules += new /obj/item/weapon/pickaxe/diamonddrill(src.module)
+							src.module.rebuild()
+					updateicon()
+			else
+				user << "You fail to hack [src]'s interface."
+				src << "Hack attempt detected."
+			return 1
+		return

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -121,21 +121,19 @@
 		else
 			user << "\red You swipe your card, with no effect."
 			return 0
-	else if (istype(O, /obj/item/weapon/card/emag))
-		if (emagged)
-			user << "\red [src] is already overloaded - better run."
-			return 0
-		else
-			var/obj/item/weapon/card/emag/emag = O
-			emag.uses--
-			emagged = 1
-			user << "\blue You short out the security protocols and overload [src]'s cell, priming it to explode in a short time."
-			spawn(100)	src << "\red Your cell seems to be outputting a lot of power..."
-			spawn(200)	src << "\red Internal heat sensors are spiking! Something is badly wrong with your cell!"
-			spawn(300)	src.explode()
 
 	else
 		attacked_with_item(O, user)
+	
+/mob/living/simple_animal/spiderbot/emag_act(var/remaining_charges, var/mob/user)
+	if (emagged)
+		user << "<span class='warning'>[src] is already overloaded - better run.</span>"
+		return 0
+	else
+		user << "<span class='notice'>You short out the security protocols and overload [src]'s cell, priming it to explode in a short time.</span>"
+		spawn(100)	src << "<span class='danger'>Your cell seems to be outputting a lot of power...</span>"
+		spawn(200)	src << "<span class='danger'>Internal heat sensors are spiking! Something is badly wrong with your cell!</span>"
+		spawn(300)	src.explode()
 
 /mob/living/simple_animal/spiderbot/proc/transfer_personality(var/obj/item/device/mmi/M as obj)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -504,23 +504,6 @@
 				update_icon()
 			else
 				user << "<span class='warning'>Access denied.</span>"
-	else if (istype(W, /obj/item/weapon/card/emag) && !(emagged || hacker))		// trying to unlock with an emag card
-		if(opened)
-			user << "You must close the cover to swipe an ID card."
-		else if(wiresexposed)
-			user << "You must close the panel first"
-		else if(stat & (BROKEN|MAINT))
-			user << "Nothing happens."
-		else
-			flick("apc-spark", src)
-			if (do_after(user,6))
-				if(prob(50))
-					emagged = 1
-					locked = 0
-					user << "<span class='notice'>You emag the APC interface.</span>"
-					update_icon()
-				else
-					user << "<span class='warning'>You fail to [ locked ? "unlock" : "lock"] the APC interface.</span>"
 	else if (istype(W, /obj/item/stack/cable_coil) && !terminal && opened && has_electronics!=2)
 		if (src.loc:intact)
 			user << "<span class='warning'>You must remove the floor plating in front of the APC first.</span>"
@@ -653,6 +636,26 @@
 				"You hear bang")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
+
+/obj/machinery/power/apc/emag_act(var/remaining_charges, var/mob/user)
+	if (!(emagged || hacker))		// trying to unlock with an emag card
+		if(opened)
+			user << "You must close the cover to swipe an ID card."
+		else if(wiresexposed)
+			user << "You must close the panel first"
+		else if(stat & (BROKEN|MAINT))
+			user << "Nothing happens."
+		else
+			flick("apc-spark", src)
+			if (do_after(user,6))
+				if(prob(50))
+					emagged = 1
+					locked = 0
+					user << "<span class='notice'>You emag the APC interface.</span>"
+					update_icon()
+				else
+					user << "<span class='warning'>You fail to [ locked ? "unlock" : "lock"] the APC interface.</span>"
+				return 1
 
 /obj/machinery/power/apc/attack_hand(mob/user)
 //	if (!can_use(user)) This already gets called in interact() and in topic()

--- a/code/modules/power/pacman2.dm
+++ b/code/modules/power/pacman2.dm
@@ -76,14 +76,6 @@
 			user.drop_item()
 			O.loc = src
 			user << "\blue You add the phoron tank to the generator."
-		else if (istype(O, /obj/item/weapon/card/emag))
-			var/obj/item/weapon/card/emag/E = O
-			if(E.uses)
-				E.uses--
-			else
-				return
-			emagged = 1
-			emp_act(1)
 		else if(!active)
 			if(istype(O, /obj/item/weapon/wrench))
 				anchored = !anchored
@@ -172,3 +164,8 @@
 			if (href_list["action"] == "close")
 				usr << browse(null, "window=port_gen")
 				usr.machine = null
+
+/obj/machinery/power/port_gen/pacman2/emag_act(var/remaining_uses, var/mob/user)				
+	emagged = 1
+	emp_act(1)
+	return 1

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -245,6 +245,14 @@
 	sheets = 0
 	sheet_left = 0
 	..()
+	
+/obj/machinery/power/port_gen/pacman/emag_act(var/remaining_charges, var/mob/user)
+	if (active && prob(25))
+		explode() //if they're foolish enough to emag while it's running
+	
+	if (!emagged)
+		emagged = 1
+		return 1
 
 /obj/machinery/power/port_gen/pacman/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O, sheet_path))
@@ -258,10 +266,6 @@
 		addstack.use(amount)
 		updateUsrDialog()
 		return
-	else if (istype(O, /obj/item/weapon/card/emag))
-		emagged = 1
-		if (active && prob(25))
-			explode() //if they're foolish enough to emag while it's running
 	else if(!active)
 		if(istype(O, /obj/item/weapon/wrench))
 

--- a/code/modules/power/rust/core_gen.dm
+++ b/code/modules/power/rust/core_gen.dm
@@ -150,15 +150,15 @@ max volume of phoron storeable by the field = the total volume of a number of ti
 		else
 			user << "\red Access denied."
 		return
-
-	if(istype(W, /obj/item/weapon/card/emag) && !emagged)
+	..()
+	return
+	
+/obj/machinery/power/rust_core/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
 		locked = 0
 		emagged = 1
 		user.visible_message("[user.name] emags the [src.name].","\red You short out the lock.")
-		return
-
-	..()
-	return
+		return 1
 
 /obj/machinery/power/rust_core/attack_ai(mob/user)
 	attack_hand(user)

--- a/code/modules/power/rust/fuel_compressor_construction.dm
+++ b/code/modules/power/rust/fuel_compressor_construction.dm
@@ -14,6 +14,21 @@
 	//20% easier to read than apc code
 	pixel_x = (dir & 3)? 0 : (dir == 4 ? 32 : -32)
 	pixel_y = (dir & 3)? (dir ==1 ? 32 : -32) : 0
+	
+/obj/machinery/rust_fuel_compressor/emag_act(var/remaining_charges, var/mob/user)
+	if (!emagged)
+		if(opened)
+			user << "You must close the cover to swipe an ID card."
+		else
+			flick("apc-spark", src)
+			if (do_after(user,6))
+				if(prob(50))
+					emagged = 1
+					locked = 0
+					user << "You emag the port interface."
+				else
+					user << "You fail to [ locked ? "unlock" : "lock"] the compressor interface."
+				return 1
 
 /obj/machinery/rust_fuel_compressor/attackby(obj/item/W, mob/user)
 
@@ -55,21 +70,6 @@
 			else
 				user << "\red Access denied."
 		return
-
-	else if (istype(W, /obj/item/weapon/card/emag) && !emagged)		// trying to unlock with an emag card
-		if(opened)
-			user << "You must close the cover to swipe an ID card."
-		else
-			flick("apc-spark", src)
-			if (do_after(user,6))
-				if(prob(50))
-					emagged = 1
-					locked = 0
-					user << "You emag the port interface."
-				else
-					user << "You fail to [ locked ? "unlock" : "lock"] the compressor interface."
-		return
-
 	else if (istype(W, /obj/item/stack/cable_coil) && opened && !(has_electronics & 2))
 		var/obj/item/stack/cable_coil/C = W
 		if(C.amount < 10)

--- a/code/modules/power/rust/fuel_injector.dm
+++ b/code/modules/power/rust/fuel_injector.dm
@@ -106,12 +106,6 @@
 			user << "\red Access denied."
 		return
 
-	if(istype(W, /obj/item/weapon/card/emag) && !emagged)
-		locked = 0
-		emagged = 1
-		user.visible_message("[user.name] emags the [src.name].","\red You short out the lock.")
-		return
-
 	if(istype(W, /obj/item/weapon/fuel_assembly) && !cur_assembly)
 		if(emergency_insert_ready)
 			cur_assembly = W
@@ -122,6 +116,13 @@
 
 	..()
 	return
+	
+/obj/machinery/power/rust_fuel_injector/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		locked = 0
+		emagged = 1
+		user.visible_message("[user.name] emags the [src.name].","\red You short out the lock.")
+		return 1
 
 /obj/machinery/power/rust_fuel_injector/attack_ai(mob/user)
 	attack_hand(user)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -223,13 +223,12 @@
 		else
 			user << "<span class='warning'>Access denied.</span>"
 		return
-
-
-	if(istype(W, /obj/item/weapon/card/emag) && !emagged)
+	..()
+	return
+	
+/obj/machinery/power/emitter/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
 		locked = 0
 		emagged = 1
 		user.visible_message("[user.name] emags [src].","<span class='warning'>You short out the lock.</span>")
-		return
-
-	..()
-	return
+		return 1

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -145,16 +145,19 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		user.drop_item()
 		D.loc = src
 		user << "<span class='notice'>You add \the [D] to the machine.</span>"
-	else if(istype(D, /obj/item/weapon/card/emag) && !emagged)
-		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
-		emagged = 1
-		user << "<span class='notice'>You you disable the security protocols.</span>"
 	else
 		//The construction/deconstruction of the console code.
 		..()
 
 	src.updateUsrDialog()
 	return
+	
+/obj/machinery/computer/rdconsole/emp_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
+		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
+		emagged = 1
+		user << "<span class='notice'>You you disable the security protocols.</span>"
+		return 1
 
 /obj/machinery/computer/rdconsole/Topic(href, href_list)
 	if(..())

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -295,13 +295,13 @@
 	onclose(user, "server_control")
 	return
 
-/obj/machinery/computer/rdservercontrol/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
-	if(istype(D, /obj/item/weapon/card/emag) && !emagged)
+/obj/machinery/computer/rdservercontrol/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged)
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 		emagged = 1
-		user << "\blue You you disable the security protocols"
-	src.updateUsrDialog()
-	return ..()
+		user << "<span class='notice'>You you disable the security protocols.</span>"
+		src.updateUsrDialog()
+		return 1
 
 /obj/machinery/r_n_d/server/robotics
 	name = "Robotics R&D Server"

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -131,7 +131,7 @@
 			usr.drop_item()
 			I.loc = src
 			auth_card = I
-			if(attempt_unlock(I))
+			if(attempt_unlock(I, usr))
 				usr << "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>"
 			else
 				usr << "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>"
@@ -215,24 +215,26 @@
 	else if(istype(W, /obj/item/weapon/card))
 		var/obj/item/weapon/card/I = W
 		if(!auth_card)
-			if(attempt_unlock(I))
+			if(attempt_unlock(I, user))
 				user << "<span class='info'>You swipe [I], the console flashes \'<i>Access granted.</i>\'</span>"
 			else
 				user << "<span class='warning'>You swipe [I], console flashes \'<i>Access denied.</i>\'</span>"
 		else
 			user << "<span class='warning'>Remove [auth_card] first.</span>"
 
-/obj/machinery/suspension_gen/proc/attempt_unlock(var/obj/item/weapon/card/C)
+/obj/machinery/suspension_gen/proc/attempt_unlock(var/obj/item/weapon/card/C, var/mob/user)
 	if(!open)
-		if(istype(C, /obj/item/weapon/card/emag) && cell.charge > 0)
-			//put sparks here
-			if(prob(95))
-				locked = 0
+		if(istype(C, /obj/item/weapon/card/emag))
+			C.resolve_attackby(src, user)
 		else if(istype(C, /obj/item/weapon/card/id) && check_access(C))
 			locked = 0
-
 		if(!locked)
 			return 1
+
+/obj/machinery/suspension_gen/emag_act(var/remaining_charges, var/mob/user)
+	if(cell.charge > 0 && locked)
+		locked = 0
+		return 1
 
 //checks for whether the machine can be activated or not should already have occurred by this point
 /obj/machinery/suspension_gen/proc/activate()

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -267,13 +267,15 @@
 		else
 			user << "The device must first be secured to the floor."
 	return
-
-/obj/machinery/shieldgen/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/card/emag))
+	
+/obj/machinery/shieldgen/emag_act(var/remaining_charges, var/mob/user)
+	if(!malfunction)
 		malfunction = 1
 		update_icon()
+		return 1
 
-	else if(istype(W, /obj/item/weapon/screwdriver))
+/obj/machinery/shieldgen/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/screwdriver))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		if(is_open)
 			user << "\blue You close the panel."

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -26,6 +26,16 @@
 				possible_gen.owned_capacitor = src
 				break
 	..()
+	
+/obj/machinery/shield_capacitor/emag_act(var/remaining_charges, var/mob/user)
+	if(prob(75))
+		src.locked = !src.locked
+		user << "Controls are now [src.locked ? "locked." : "unlocked."]"
+		. = 1
+		updateDialog()
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, src)
+	s.start()
 
 /obj/machinery/shield_capacitor/attackby(obj/item/W, mob/user)
 
@@ -37,15 +47,6 @@
 			updateDialog()
 		else
 			user << "\red Access denied."
-	else if(istype(W, /obj/item/weapon/card/emag))
-		if(prob(75))
-			src.locked = !src.locked
-			user << "Controls are now [src.locked ? "locked." : "unlocked."]"
-			updateDialog()
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-
 	else if(istype(W, /obj/item/weapon/wrench))
 		src.anchored = !src.anchored
 		src.visible_message("\blue \icon[src] [src] has been [anchored ? "bolted to the floor" : "unbolted from the floor"] by [user].")

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -44,6 +44,16 @@
 		field.Remove(D)
 		D.loc = null
 	..()
+	
+/obj/machinery/shield_gen/emag_act(var/remaining_charges, var/mob/user)
+	if(prob(75))
+		src.locked = !src.locked
+		user << "Controls are now [src.locked ? "locked." : "unlocked."]"
+		. = 1
+		updateDialog()
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, src)
+	s.start()
 
 /obj/machinery/shield_gen/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weapon/card/id))
@@ -54,15 +64,6 @@
 			updateDialog()
 		else
 			user << "\red Access denied."
-	else if(istype(W, /obj/item/weapon/card/emag))
-		if(prob(75))
-			src.locked = !src.locked
-			user << "Controls are now [src.locked ? "locked." : "unlocked."]"
-			updateDialog()
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-
 	else if(istype(W, /obj/item/weapon/wrench))
 		src.anchored = !src.anchored
 		src.visible_message("\blue \icon[src] [src] has been [anchored?"bolted to the floor":"unbolted from the floor"] by [user].")

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -102,19 +102,15 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/card/emag) && !emagged)
-		user << "\blue You emag the [src], arming the escape pod!"
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth/emag_act(var/remaining_charges, var/mob/user)
+	if (!emagged)
+		user << "<span class='notice'>You emag the [src], arming the escape pod!</span>"
 		emagged = 1
 		if (istype(docking_program, /datum/computer/file/embedded_program/docking/simple/escape_pod))
 			var/datum/computer/file/embedded_program/docking/simple/escape_pod/P = docking_program
 			if (!P.armed)
 				P.arm()
-		return
-	
-	..()
-
-
+		return 1
 
 //A docking controller program for a simple door based docking port
 /datum/computer/file/embedded_program/docking/simple/escape_pod

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -83,15 +83,13 @@
 	else if(href_list["cancel"])
 		shuttle.cancel_launch(src)
 
-/obj/machinery/computer/shuttle_control/attackby(obj/item/weapon/W as obj, mob/user as mob)
-
-	if (istype(W, /obj/item/weapon/card/emag))
-		src.req_access = list()
-		src.req_one_access = list()
+/obj/machinery/computer/shuttle_control/emag_act(var/remaining_charges, var/mob/user)
+	if (!hacked)
+		req_access = list()
+		req_one_access = list()
 		hacked = 1
-		usr << "You short out the console's ID checking system. It's now available to everyone!"
-	else
-		..()
+		user << "You short out the console's ID checking system. It's now available to everyone!"
+		return 1
 
 /obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
 	visible_message("[Proj] ricochets off [src]!")

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -155,15 +155,13 @@
 
 	return 1
 
-
-
-
-/obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/card/emag) && !emagged)
+/obj/machinery/computer/shuttle_control/emergency/emag_act(var/remaining_charges, var/mob/user)
+	if (!emagged)
 		user << "<span class='notice'>You short out \the [src]'s authorization protocols.</span>"
 		emagged = 1
-		return
+		return 1
 
+/obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	read_authorization(W)
 	..()
 

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -100,8 +100,6 @@
 				user << "<span class='notice'>[src] does not need a repair.</span>"
 		else
 			user << "<span class='notice'>Unable to repair while [src] is off.</span>"
-	else if(istype(W, /obj/item/weapon/card/emag) && !emagged)
-		Emag(user)
 	else if(hasvar(W,"force") && hasvar(W,"damtype"))
 		switch(W.damtype)
 			if("fire")
@@ -186,12 +184,13 @@
 	set_light(0)
 	update_icon()
 
-/obj/vehicle/proc/Emag(mob/user as mob)
-	emagged = 1
-
-	if(locked)
-		locked = 0
-		user << "<span class='warning'>You bypass [src]'s controls.</span>"
+/obj/vehicle/emag_act(var/remaining_charges, mob/user as mob)
+	if(!emagged)
+		emagged = 1
+		if(locked)
+			locked = 0
+			user << "<span class='warning'>You bypass [src]'s controls.</span>"
+		return 1
 
 /obj/vehicle/proc/explode()
 	src.visible_message("\red <B>[src] blows apart!</B>", 1)


### PR DESCRIPTION
Adds a new proc to atoms, along with ex_act and emp_act.
emp_act is responsible for telling the caller how many charges to use, if any, to ensure we no longer have to rely on lists or manual decrements of emag uses.
Also ensures all handled emag attempts (successful or not) are admin logged.
