### PR TITLE
Travis - Invalid changelog tags should now fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
   - (! grep 'step_[xy]' maps/**/*.dmm)
   - (! find nano/templates/ -type f -exec md5sum {} + | sort | uniq -D -w 32 | grep nano)
   - (  md5sum -c - <<< "0af969f671fba6cf9696c78cd175a14a *baystation12.int")
-  - DreamMaker baystation12.dme
   - python tools/GenerateChangelog/ss13_genchangelog.py html/changelog.html html/changelogs
+  - DreamMaker baystation12.dme

--- a/tools/GenerateChangelog/ss13_genchangelog.py
+++ b/tools/GenerateChangelog/ss13_genchangelog.py
@@ -126,6 +126,7 @@ if failed_cache_read and os.path.isfile(args.targetFile):
                 all_changelog_entries[date] = entry
         
 del_after = []
+errors = False
 print('Reading changelogs...')
 for fileName in glob.glob(os.path.join(args.ymlDir, "*.yml")):
     name, ext = os.path.splitext(os.path.basename(fileName))
@@ -146,6 +147,7 @@ for fileName in glob.glob(os.path.join(args.ymlDir, "*.yml")):
             if change not in author_entries:
                 (change_type, _) = dictToTuples(change)[0]
                 if change_type not in validPrefixes:
+                    errors = True
                     print('  {0}: Invalid prefix {1}'.format(fileName, change_type), file=sys.stderr)
                 author_entries += [change]
                 new += 1
@@ -208,3 +210,6 @@ if len(del_after):
         if os.path.isfile(fileName):
             print(' Deleting {0} (delete-after set)...'.format(fileName))
             os.remove(fileName)
+
+if errors:
+    sys.exit(1)


### PR DESCRIPTION
Use of invalid prefixes in changelogs should no longer silently fail in Travis.
