### PR TITLE
Allows setting the URL for the IRC bot to report separately from the main SERVER config setting

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -86,6 +86,7 @@
 	var/guests_allowed = 1
 	var/debugparanoid = 0
 
+	var/serverurl
 	var/server
 	var/banappeals
 	var/wikiurl
@@ -364,6 +365,9 @@
 
 				if ("hostedby")
 					config.hostedby = value
+
+				if ("serverurl")
+					config.serverurl = value
 
 				if ("server")
 					config.server = value

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -26,6 +26,6 @@
 
 
 /hook/startup/proc/ircNotify()
-	send2mainirc("Server starting up on [config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]")
+	send2mainirc("Server starting up on byond://[config.serverurl ? config.serverurl : (config.server ? config.server : "[world.address]:[world.port]")]")
 	return 1
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -171,6 +171,10 @@ GUEST_BAN
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
 #SERVER server.net:port
 
+## set a server URL for the IRC bot to use; like SERVER, don't include the byond://
+## Unlike SERVER, this one shouldn't break auto-reconnect
+#SERVERURL server.net:port
+
 ## forum address
 # FORUMURL http://example.com
 


### PR DESCRIPTION
Adds a new configuration value, SERVERURL, for the IRC bot to use if set
