### PR TITLE
Adds armor penetration system

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -5,6 +5,7 @@
 	var/active_w_class
 	sharp = 0
 	edge = 0
+	armor_penetration = 50
 	flags = NOBLOODY
 
 /obj/item/weapon/melee/energy/proc/activate(mob/living/user)
@@ -173,7 +174,8 @@
 	name = "energy blade"
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
-	force = 70.0//Normal attacks deal very high damage.
+	force = 40 //Normal attacks deal very high damage - about the same as wielded fire axe
+	armor_penetration = 100
 	sharp = 1
 	edge = 1
 	anchored = 1    // Never spawned outside of inventory, should be fine.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,7 +13,7 @@
 
 	var/damtype = "brute"
 	var/force = 0
-	var/armorpen = 0
+	var/armor_penetration = 0
 
 /obj/Destroy()
 	processing_objects -= src

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,6 +13,7 @@
 
 	var/damtype = "brute"
 	var/force = 0
+	var/armorpen = 0
 
 /obj/Destroy()
 	processing_objects -= src

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -227,7 +227,7 @@ emp_act
 	else
 		visible_message("\red <B>[src] has been attacked in the [hit_area] with [I.name] by [user]!</B>")
 
-	var/armor = run_armor_check(affecting, "melee", I.armorpen, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].")
+	var/armor = run_armor_check(affecting, "melee", I.armor_penetration, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].")
 	var/weapon_sharp = is_sharp(I)
 	var/weapon_edge = has_edge(I)
 	if ((weapon_sharp || weapon_edge) && prob(getarmor(target_zone, "melee")))
@@ -342,7 +342,7 @@ emp_act
 		var/hit_area = affecting.name
 
 		src.visible_message("\red [src] has been hit in the [hit_area] by [O].")
-		var/armor = run_armor_check(affecting, "melee", O.armorpen, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].") //I guess "melee" is the best fit here
+		var/armor = run_armor_check(affecting, "melee", O.armor_penetration, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].") //I guess "melee" is the best fit here
 
 		if(armor < 2)
 			apply_damage(throw_damage, dtype, zone, armor, is_sharp(O), has_edge(O), O)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -227,7 +227,7 @@ emp_act
 	else
 		visible_message("\red <B>[src] has been attacked in the [hit_area] with [I.name] by [user]!</B>")
 
-	var/armor = run_armor_check(affecting, "melee", "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].")
+	var/armor = run_armor_check(affecting, "melee", I.armorpen, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].")
 	var/weapon_sharp = is_sharp(I)
 	var/weapon_edge = has_edge(I)
 	if ((weapon_sharp || weapon_edge) && prob(getarmor(target_zone, "melee")))
@@ -342,7 +342,7 @@ emp_act
 		var/hit_area = affecting.name
 
 		src.visible_message("\red [src] has been hit in the [hit_area] by [O].")
-		var/armor = run_armor_check(affecting, "melee", "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].") //I guess "melee" is the best fit here
+		var/armor = run_armor_check(affecting, "melee", O.armorpen, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].") //I guess "melee" is the best fit here
 
 		if(armor < 2)
 			apply_damage(throw_damage, dtype, zone, armor, is_sharp(O), has_edge(O), O)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -10,24 +10,33 @@
 	1 - halfblock
 	2 - fullblock
 */
-/mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/absorb_text = null, var/soften_text = null)
+/mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/armour_pen = 0, var/absorb_text = null, var/soften_text = null)
 	var/armor = getarmor(def_zone, attack_flag)
 	var/absorb = 0
+	
+	//Roll armour
 	if(prob(armor))
 		absorb += 1
 	if(prob(armor))
 		absorb += 1
+	
+	//Roll penetration
+	if(prob(armour_pen))
+		absorb -= 1
+	if(prob(armour_pen))
+		absorb -= 1
+	
 	if(absorb >= 2)
 		if(absorb_text)
 			show_message("[absorb_text]")
 		else
-			show_message("\red Your armor absorbs the blow!")
+			show_message("<span class='warning'>Your armor absorbs the blow!</span>")
 		return 2
 	if(absorb == 1)
 		if(absorb_text)
 			show_message("[soften_text]",4)
 		else
-			show_message("\red Your armor softens the blow!")
+			show_message("<span class='warning'>Your armor softens the blow!</span>")
 		return 1
 	return 0
 
@@ -64,7 +73,7 @@
 		return
 
 	//Armor
-	var/absorb = run_armor_check(def_zone, P.check_armour)
+	var/absorb = run_armor_check(def_zone, P.check_armour, P.armorpen)
 	var/proj_sharp = is_sharp(P)
 	var/proj_edge = has_edge(P)
 	if ((proj_sharp || proj_edge) && prob(getarmor(def_zone, P.check_armour)))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -73,7 +73,7 @@
 		return
 
 	//Armor
-	var/absorb = run_armor_check(def_zone, P.check_armour, P.armorpen)
+	var/absorb = run_armor_check(def_zone, P.check_armour, P.armor_penetration)
 	var/proj_sharp = is_sharp(P)
 	var/proj_edge = has_edge(P)
 	if ((proj_sharp || proj_edge) && prob(getarmor(def_zone, P.check_armour)))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -11,6 +11,9 @@
 	2 - fullblock
 */
 /mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/armour_pen = 0, var/absorb_text = null, var/soften_text = null)
+	if(armour_pen >= 100)
+		return 0 //might as well just skip the processing
+
 	var/armor = getarmor(def_zone, attack_flag)
 	var/absorb = 0
 	

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,8 +9,7 @@
 	force = 10
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
-	projectile_type = /obj/item/projectile/beam
-	fire_delay = 1 //rapid fire
+	projectile_type = /obj/item/projectile/beam/midlaser
 
 /obj/item/weapon/gun/energy/laser/mounted
 	self_recharge = 1

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -23,10 +23,15 @@
 	check_armour = "laser"
 	eyeblur = 2
 
+/obj/item/projectile/beam/midlaser
+	damage = 40
+	armorpen = 10
+
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 60
+	armorpen = 30
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
@@ -35,7 +40,8 @@
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"
-	damage = 30
+	damage = 25
+	armorpen = 50
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer
@@ -45,6 +51,7 @@
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
+	armorpen = 30
 
 	muzzle_type = /obj/effect/projectile/laser_pulse/muzzle
 	tracer_type = /obj/effect/projectile/laser_pulse/tracer
@@ -122,7 +129,8 @@
 /obj/item/projectile/beam/sniper
 	name = "sniper beam"
 	icon_state = "xray"
-	damage = 60
+	damage = 50
+	armorpen = 10
 	stun = 3
 	weaken = 3
 	stutter = 3

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -25,13 +25,13 @@
 
 /obj/item/projectile/beam/midlaser
 	damage = 40
-	armorpen = 10
+	armor_penetration = 10
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 60
-	armorpen = 30
+	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
@@ -41,7 +41,7 @@
 	name = "xray beam"
 	icon_state = "xray"
 	damage = 25
-	armorpen = 50
+	armor_penetration = 50
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer
@@ -51,7 +51,7 @@
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
-	armorpen = 30
+	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser_pulse/muzzle
 	tracer_type = /obj/effect/projectile/laser_pulse/tracer
@@ -130,7 +130,7 @@
 	name = "sniper beam"
 	icon_state = "xray"
 	damage = 50
-	armorpen = 10
+	armor_penetration = 10
 	stun = 3
 	weaken = 3
 	stutter = 3

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -119,7 +119,8 @@
 
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
-	damage = 60
+	damage = 50
+	armorpen = 15
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -139,20 +140,23 @@
 
 /* "Rifle" rounds */
 
-/obj/item/projectile/bullet/rifle/a762
-	damage = 30
+/obj/item/projectile/bullet/rifle
+	armorpen = 20
 	penetrating = 1
+
+/obj/item/projectile/bullet/rifle/a762
+	damage = 25
+
+/obj/item/projectile/bullet/rifle/a556
+	damage = 35
 
 /obj/item/projectile/bullet/rifle/a145
 	damage = 80
 	stun = 3
 	weaken = 3
 	penetrating = 5
+	armorpen = 50
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
-
-/obj/item/projectile/bullet/rifle/a556
-	damage = 40
-	penetrating = 1
 
 /* Miscellaneous */
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -155,7 +155,7 @@
 	stun = 3
 	weaken = 3
 	penetrating = 5
-	armor_penetration = 50
+	armor_penetration = 80
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
 
 /* Miscellaneous */

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -120,7 +120,7 @@
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	damage = 50
-	armorpen = 15
+	armor_penetration = 15
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -141,7 +141,7 @@
 /* "Rifle" rounds */
 
 /obj/item/projectile/bullet/rifle
-	armorpen = 20
+	armor_penetration = 20
 	penetrating = 1
 
 /obj/item/projectile/bullet/rifle/a762
@@ -155,7 +155,7 @@
 	stun = 3
 	weaken = 3
 	penetrating = 5
-	armorpen = 50
+	armor_penetration = 50
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
 
 /* Miscellaneous */

--- a/html/changelogs/HarpyEagle-armourpen.yml
+++ b/html/changelogs/HarpyEagle-armourpen.yml
@@ -1,0 +1,34 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: HarpyEagle
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - rscadd: "Adds armour penetration mechanic for projectiles and melee weapons."
+  - rscadd: "Laser carbines, LWAP, and shotgun now have a small amount of armour penetration, ballistic rifles (not SMGs) have moderate amounts, laser cannon has high armour penetration, and the PTR mostly ignores body armour."
+  - tweak: "Shotgun slugs and Z8/STS damage has been lowered slightly to accomodate for their higher penetration. In general ballistics deal less damage but have higher penetration than comparable laser weapons. Notable exception: X-Ray lasers have had their damage lowered slightly but gain very high armour penetration."
+  - rscadd: "Energy swords now have very high armour penetration. Ninja blades do less damage but ignore armour completely."


### PR DESCRIPTION
Modifies the armour system to allow objects to specify an armour penetration value. This is intended to provide designers with more design space when creating new types of weapons and projectiles.

The effect that armour penetration value has on the average damage absorbed by armour is described by the following graph. The lines are a bit wavy because the data was obtained empirically using [this script](http://hastebin.com/izaligonoy.py).
![screenshot 2015-06-17 20 19 12](https://cloud.githubusercontent.com/assets/242428/8221529/cc7c03f8-152d-11e5-817b-04e17299e481.png)

Valid values for armour penetration are 0 to 100, mirroring the values for armour, however anything over 50 is probably going to be OP. The purple line represents no armour penetration, and is a straight line from 0 to 100. Grey is 100% armour penetration, which ignores armour completely.

I tried a bunch of different schemes for armour penetration, and ended up settling on this one because it meshes very well with the existing armour system, and has a decent spread of effectiveness.
- Laser carbines now have their old fire rate but gain a small amount of armour penetration to differentiate them from energuns.
- Shotgun slugs are no longer identical to .357. The former does slightly less damage but has a small amount of armour penetration.
- Most 'rifle' type ballistic weapons have a moderate amount of armour penetration, damage reduced slightly to compensate.
- Laser cannons have high armour penetration, PTR rounds have higher. 

In general, beam weapons do more damage than ballistics while having lower armour penetration.
