### PR TITLE
Fire Extinguishers

### DIFF
--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -30,7 +30,7 @@
 				else if(ismob(A) && !M)
 					M = A
 			if(M)
-				reagents.trans_to(M, reagents.total_volume)
+				reagents.splash(M, reagents.total_volume)
 				break
 			if(T == get_turf(target))
 				break

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "extinguish"
 	mouse_opacity = 0
+	pass_flags = PASSTABLE | PASSGRILLE
 
 /obj/effect/effect/water/New(loc)
 	..()
@@ -53,4 +54,3 @@
 	name = "chemicals"
 	icon = 'icons/obj/chempuff.dmi'
 	icon_state = ""
-	pass_flags = PASSTABLE | PASSGRILLE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -61,6 +61,12 @@
 		name = "[material.display_name] [initial(name)]"
 		desc += " It's made of [material.use_name]."
 
+/obj/structure/bed/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(istype(mover) && mover.checkpass(PASSTABLE))
+		return 1
+	else
+		return ..()
+
 /obj/structure/bed/ex_act(severity)
 	switch(severity)
 		if(1.0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -218,23 +218,23 @@
 		else if (on_fire)
 			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			if (M.on_fire)
-				M.visible_message("<span class='warning'>[M] tries to pat out [src]'s flames, but to no avail!</span>", \
+				M.visible_message("<span class='warning'>[M] tries to pat out [src]'s flames, but to no avail!</span>",
 				"<span class='warning'>You try to pat out [src]'s flames, but to no avail! Put yourself out first!</span>")
 			else
-				M.visible_message("<span class='warning'>[M] tries to pat out [src]'s flames!</span>", \
+				M.visible_message("<span class='warning'>[M] tries to pat out [src]'s flames!</span>",
 				"<span class='warning'>You try to pat out [src]'s flames! Hot!</span>")
 				if(do_mob(M, src, 15))
 					if (prob(10) && (M.fire_stacks <= 0))
-						src.fire_stacks -= 2
+						M.fire_stacks -= 0.5
 						M.fire_stacks += 1
 					M.IgniteMob()
 					if (M.on_fire)
-						M.visible_message("<span class='danger'>The fire spreads from [src] to [M]!</span>", \
+						M.visible_message("<span class='danger'>The fire spreads from [src] to [M]!</span>",
 						"<span class='danger'>The fire spreads to you as well!</span>")
 					else
-						src.fire_stacks -= 3 //Less effective than stop, drop, and roll
+						src.fire_stacks -= 1 //Less effective than stop, drop, and roll
 						if (src.fire_stacks <= 0)
-							M.visible_message("<span class='warning'>[M] successfully pats out [src]'s flames.</span>", \
+							M.visible_message("<span class='warning'>[M] successfully pats out [src]'s flames.</span>",
 							"<span class='warning'>You successfully pat out [src]'s flames.</span>")
 							src.ExtinguishMob()
 							src.fire_stacks = 0

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -143,26 +143,26 @@
 		environment.add_thermal_energy(-removed_heat)
 		if (prob(5))
 			T.visible_message("<span class='warning'>The water sizzles as it lands on \the [T]!</span>")
-	else
-		if(volume >= 3)
-			if(T.wet >= 1)
+	
+	else if(volume >= 10)
+		if(T.wet >= 1)
+			return
+		T.wet = 1
+		if(T.wet_overlay)
+			T.overlays -= T.wet_overlay
+			T.wet_overlay = null
+		T.wet_overlay = image('icons/effects/water.dmi',T,"wet_floor")
+		T.overlays += T.wet_overlay
+
+		spawn(800) // This is terrible and needs to be changed when possible.
+			if(!T || !istype(T))
 				return
-			T.wet = 1
+			if(T.wet >= 2)
+				return
+			T.wet = 0
 			if(T.wet_overlay)
 				T.overlays -= T.wet_overlay
 				T.wet_overlay = null
-			T.wet_overlay = image('icons/effects/water.dmi',T,"wet_floor")
-			T.overlays += T.wet_overlay
-
-			spawn(800) // This is terrible and needs to be changed when possible.
-				if(!T || !istype(T))
-					return
-				if(T.wet >= 2)
-					return
-				T.wet = 0
-				if(T.wet_overlay)
-					T.overlays -= T.wet_overlay
-					T.wet_overlay = null
 
 /datum/reagent/water/touch_obj(var/obj/O)
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
@@ -184,7 +184,7 @@
 /datum/reagent/water/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(istype(M, /mob/living/carbon/slime))
 		var/mob/living/carbon/slime/S = M
-		S.adjustToxLoss(15 * removed) // Babies have 150 health, adults have 200; So, 10 units and 13.5
+		S.adjustToxLoss(8 * removed) // Babies have 150 health, adults have 200; So, 10 units and 13.5
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null


### PR DESCRIPTION
Makes fire extinguishers actually effective at putting out mob fires. Before this PR each spray of an extinguisher is barely able to match stop-drop-and-roll. Doubles the amount of water extinguishers carry and quadruples the amount of water sprayed with each use. To keep slimes balanced, the amount of damage taken by water per unit has been halved.

Refactors extinguisher.dm a little to make pushing chairs incrementally less horrible.

Also adjusts patting out fires to be on the same level as stop-drop-and-roll, and fixes #9585 by making beds/chairs allow PASSTABLE and allowing water spray to pass over tables through grilles.
