### PR TITLE
[DNM][WIP] Adds more coloured lights

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -302,22 +302,30 @@
 /obj/machinery/alarm/update_icon()
 	if(wiresexposed)
 		icon_state = "alarmx"
+		set_light(0)
 		return
 	if((stat & (NOPOWER|BROKEN)) || shorted)
 		icon_state = "alarmp"
+		set_light(0)
 		return
 
 	var/icon_level = danger_level
 	if (alarm_area.atmosalm)
 		icon_level = max(icon_level, 1)	//if there's an atmos alarm but everything is okay locally, no need to go past yellow
 
+	var/new_color = null
 	switch(icon_level)
 		if (0)
 			icon_state = "alarm0"
+			new_color = "#03A728"
 		if (1)
 			icon_state = "alarm2" //yes, alarm2 is yellow alarm
+			new_color = "#EC8B2F"
 		if (2)
 			icon_state = "alarm1"
+			new_color = "#DA0205"
+	
+	set_light(l_range = 2, l_power = 1, l_color = new_color)
 
 /obj/machinery/alarm/receive_signal(datum/signal/signal)
 	if(stat & (NOPOWER|BROKEN))
@@ -888,8 +896,11 @@ FIRE ALARM
 	var/last_process = 0
 	var/wiresexposed = 0
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
+	var/seclevel
 
 /obj/machinery/firealarm/update_icon()
+	overlays.Cut()
+
 	if(wiresexposed)
 		switch(buildstage)
 			if(2)
@@ -898,17 +909,28 @@ FIRE ALARM
 				icon_state="fire_b1"
 			if(0)
 				icon_state="fire_b0"
-
+		set_light(0)
 		return
 
 	if(stat & BROKEN)
 		icon_state = "firex"
+		set_light(0)
 	else if(stat & NOPOWER)
 		icon_state = "firep"
-	else if(!src.detecting)
-		icon_state = "fire1"
+		set_light(0)
 	else
-		icon_state = "fire0"
+		if(!src.detecting)
+			icon_state = "fire1"
+			set_light(l_range = 2, l_power = 1, l_color = "#ff0000")
+		else
+			icon_state = "fire0"
+			switch(seclevel)
+				if("green")	set_light(l_range = 2, l_power = 1, l_color = "#00ff00")
+				if("blue")	set_light(l_range = 2, l_power = 1, l_color = "#1024A9")
+				if("red")	set_light(l_range = 4, l_power = 2, l_color = "#ff0000") //similar to small lightbulb
+				if("delta")	set_light(l_range = 4, l_power = 2, l_color = "#FF6633")
+		
+		src.overlays += image('icons/obj/monitors.dmi', "overlay_[seclevel]")
 
 /obj/machinery/firealarm/fire_act(datum/gas_mixture/air, temperature, volume)
 	if(src.detecting)
@@ -1120,14 +1142,14 @@ FIRE ALARM
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 
+/obj/machinery/firealarm/proc/set_security_level(var/newlevel)
+	if(seclevel != newlevel)
+		seclevel = newlevel
+		update_icon()
+
 /obj/machinery/firealarm/initialize()
 	if(z in config.contact_levels)
-		if(security_level)
-			src.overlays += image('icons/obj/monitors.dmi', "overlay_[get_security_level()]")
-		else
-			src.overlays += image('icons/obj/monitors.dmi', "overlay_green")
-
-	update_icon()
+		set_security_level(security_level? get_security_level() : "green")
 
 /*
 FIRE ALARM CIRCUIT

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -7,11 +7,19 @@
 	var/list/light_sources
 
 /atom/proc/set_light(l_range, l_power, l_color)
-	if(l_power != null) light_power = l_power
-	if(l_range != null) light_range = l_range
-	if(l_color != null) light_color = l_color
+	. = 0 //make it less costly if nothing's changed
 
-	update_light()
+	if(l_power != null && l_power != light_power)
+		light_power = l_power
+		. = 1
+	if(l_range != null && l_range != light_range)
+		light_range = l_range
+		. = 1
+	if(l_color != null && l_color != light_color)
+		light_color = l_color
+		. = 1
+
+	if(.) update_light()
 
 /atom/proc/update_light()
 	if(!light_power || !light_range)

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -25,46 +25,31 @@
 			if(SEC_LEVEL_GREEN)
 				security_announcement_down.Announce("[config.alert_desc_green]", "Attention! Security level lowered to green")
 				security_level = SEC_LEVEL_GREEN
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_green")
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
 					security_announcement_up.Announce("[config.alert_desc_blue_upto]", "Attention! Security level elevated to blue")
 				else
 					security_announcement_down.Announce("[config.alert_desc_blue_downto]", "Attention! Security level lowered to blue")
 				security_level = SEC_LEVEL_BLUE
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_blue")
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
 					security_announcement_up.Announce("[config.alert_desc_red_upto]", "Attention! Code red!")
 				else
 					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Attention! Code red!")
 				security_level = SEC_LEVEL_RED
-
 				/*	- At the time of commit, setting status displays didn't work properly
 				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
 				if(CC)
 					CC.post_status("alert", "redalert")*/
-
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_red")
-
 			if(SEC_LEVEL_DELTA)
 				security_announcement_up.Announce("[config.alert_desc_delta]", "Attention! Delta security level reached!", new_sound = 'sound/effects/siren.ogg')
 				security_level = SEC_LEVEL_DELTA
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_delta")
-	else
-		return
+
+		var/newlevel = get_security_level()
+		for(var/obj/machinery/firealarm/FA in machines)
+			if(FA.z in config.contact_levels)
+				FA.set_security_level(newlevel)
+
 
 /proc/get_security_level()
 	switch(security_level)


### PR DESCRIPTION
- Adds coloured lighting to air alarms and fire alarms. Fire alarm light colour reflects the current alert state, unless the alarm has been set off. On red or delta, fire alarms more red light (similar to a small lightbulb) for added impact.

TODO
- Add lighting to the ERT shuttle. Have a red light that goes green when the shuttle arrives at the Exodus.
- Add general toggleable light fixture type that can be set to specific presets or cycle between them.
