### PR TITLE
Adds more coloured lights

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -7,11 +7,19 @@
 	var/list/light_sources
 
 /atom/proc/set_light(l_range, l_power, l_color)
-	if(l_power != null) light_power = l_power
-	if(l_range != null) light_range = l_range
-	if(l_color != null) light_color = l_color
+	. = 0 //make it less costly if nothing's changed
 
-	update_light()
+	if(l_power != null && l_power != light_power)
+		light_power = l_power
+		. = 1
+	if(l_range != null && l_range != light_range)
+		light_range = l_range
+		. = 1
+	if(l_color != null && l_color != light_color)
+		light_color = l_color
+		. = 1
+
+	if(.) update_light()
 
 /atom/proc/update_light()
 	if(!light_power || !light_range)

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -25,46 +25,31 @@
 			if(SEC_LEVEL_GREEN)
 				security_announcement_down.Announce("[config.alert_desc_green]", "Attention! Security level lowered to green")
 				security_level = SEC_LEVEL_GREEN
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_green")
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
 					security_announcement_up.Announce("[config.alert_desc_blue_upto]", "Attention! Security level elevated to blue")
 				else
 					security_announcement_down.Announce("[config.alert_desc_blue_downto]", "Attention! Security level lowered to blue")
 				security_level = SEC_LEVEL_BLUE
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_blue")
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
 					security_announcement_up.Announce("[config.alert_desc_red_upto]", "Attention! Code red!")
 				else
 					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Attention! Code red!")
 				security_level = SEC_LEVEL_RED
-
 				/*	- At the time of commit, setting status displays didn't work properly
 				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
 				if(CC)
 					CC.post_status("alert", "redalert")*/
-
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_red")
-
 			if(SEC_LEVEL_DELTA)
 				security_announcement_up.Announce("[config.alert_desc_delta]", "Attention! Delta security level reached!", new_sound = 'sound/effects/siren.ogg')
 				security_level = SEC_LEVEL_DELTA
-				for(var/obj/machinery/firealarm/FA in machines)
-					if(FA.z in config.contact_levels)
-						FA.overlays = list()
-						FA.overlays += image('icons/obj/monitors.dmi', "overlay_delta")
-	else
-		return
+
+		var/newlevel = get_security_level()
+		for(var/obj/machinery/firealarm/FA in machines)
+			if(FA.z in config.contact_levels)
+				FA.set_security_level(newlevel)
+
 
 /proc/get_security_level()
 	switch(security_level)


### PR DESCRIPTION
- Adds coloured lighting to air alarms and fire alarms. Fire alarm light colour reflects the current alert state, unless the alarm has been set off. On red or delta, fire alarms more red light (similar to a small lightbulb) for added impact.

TODO
- ~~Add lighting to the ERT shuttle. Have a red light that goes green when the shuttle arrives at the Exodus.~~

[Going to red alert](http://i.gyazo.com/33cf9d10de5d13d84469901512cf96bf.gif) (please excuse the poor frame rate).
