### PR TITLE
Fixes certain modes not sending the 'A round of [x] has ended' notification at round-end

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -280,6 +280,7 @@
 
 /datum/game_mode/cult/declare_completion()
 	if(config.objectives_disabled)
+		..()
 		return 1
 	if(!check_cult_victory())
 		feedback_set_details("round_end_result","win - cult win")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -243,6 +243,7 @@ var/global/list/turf/synd_spawn = list()
 
 /datum/game_mode/nuclear/declare_completion()
 	if(config.objectives_disabled)
+		..()
 		return
 	var/disk_rescued = 1
 	for(var/obj/item/weapon/disk/nuclear/D in world)

--- a/code/game/gamemodes/revolution/anti_revolution.dm
+++ b/code/game/gamemodes/revolution/anti_revolution.dm
@@ -191,6 +191,7 @@
 					feedback_add_details("head_objective","[objective.type]|FAIL")
 				count++
 		break // just print once
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -353,7 +353,7 @@
 		else if(finished == 2)
 			feedback_set_details("round_end_result","loss - rev heads killed")
 			world << "\red <FONT size = 3><B> The heads of staff managed to stop the revolution!</B></FONT>"
-		..()
+	..()
 	return 1
 
 /datum/game_mode/proc/auto_declare_completion_revolution()

--- a/code/game/gamemodes/revolution/rp-revolution.dm
+++ b/code/game/gamemodes/revolution/rp-revolution.dm
@@ -270,6 +270,8 @@
 			text += "[head_mind.key] (character destroyed)"
 
 		world << text
+
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -146,7 +146,7 @@
 		else if(finished == 2)
 			feedback_set_details("round_end_result","loss - revolution stopped")
 			world << "\red <FONT size = 3><B> The heads of staff managed to stop the revolution!</B></FONT>"
-		..()
+	..()
 	return 1
 
 /datum/game_mode/revolution/proc/is_convertible(mob/M)


### PR DESCRIPTION
Title. The notification is sent in `/datum/game_mode/declare_completion()`, this PR adds the required `..()` calls to ensure it is always called.
