### PR TITLE
Un-breaks hats, semi-fixes #9873, partially reverts #9937

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -698,8 +698,10 @@ proc/get_damage_icon_part(damage_state, body_part)
 		
 		//Determine the state to use
 		var/t_state = head.icon_state
-		if(head.item_state)
-			t_state = head.item_state
+		if(istype(head, /obj/item/weapon/paper))
+			/* I don't like this, but bandaid to fix half the hats in the game
+			   being completely broken without re-breaking paper hats */
+			t_state = "paper"
 		
 		//Create the image
 		var/image/standing = image(icon = t_icon, icon_state = t_state)


### PR DESCRIPTION
Title. A lot of hats have item_state set for inhands, this change broke a significant number of hats in the game. Bandaid fix to get working hats pending a proper fix (probably renaming the states in the dmi).
#9873, #9937.
