### PR TITLE
(probably) fixes an issue where the server hangs at roundstart if the IRC bot doesn't respond properly

### DIFF
--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -1,7 +1,8 @@
 /proc/send2irc(var/channel, var/msg)
 	if(config.use_irc_bot && config.irc_bot_host)
 		if(config.irc_bot_export)
-			world.Export("http://[config.irc_bot_host]:45678?[list2params(list(pwd=config.comms_password, chan=channel, mesg=msg))]")
+			spawn(-1) // spawn here prevents hanging in the case that the bot isn't reachable
+				world.Export("http://[config.irc_bot_host]:45678?[list2params(list(pwd=config.comms_password, chan=channel, mesg=msg))]")
 		else
 			if(config.use_lib_nudge)
 				var/nudge_lib


### PR DESCRIPTION
Bot32 was trying to read for five seconds then calling it a timeout and giving up; the server was taking longer than that. I've bumped its timeout up to twenty seconds, but this should prevent the server hanging regardless of timeouts.
