### PR TITLE
More check_eye() fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1233,7 +1233,7 @@
 				damageoverlay.overlays += I
 
 		if( stat == DEAD )
-			sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
+			sight = SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF
 			see_in_dark = 8
 			if(!druggy)		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 			if(healths)		healths.icon_state = "health7"	//DEAD healthmeter
@@ -1256,7 +1256,7 @@
 					*/
 
 		else
-			sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
+			sight = SEE_SELF
 			see_in_dark = species.darksight
 			see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
 
@@ -1411,7 +1411,7 @@
 				if(viewflags < 0)
 					reset_view(null, 0)
 				else if(viewflags)
-					sight |= viewflags
+					sight = viewflags //when viewing from a machine, use only the sight flags that the machine provides
 			else
 				var/isRemoteObserve = 0
 				if((mRemote in mutations) && remoteview_target)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1256,7 +1256,7 @@
 					*/
 
 		else
-			sight = SEE_SELF
+			sight = species.vision_flags
 			see_in_dark = species.darksight
 			see_invisible = see_in_dark>2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
 
@@ -1265,29 +1265,23 @@
 				see_in_dark = 8
 				if(!druggy)		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
-			if(seer==1)
+			if(seer)
 				var/obj/effect/rune/R = locate() in loc
 				if(R && R.word1 == cultwords["see"] && R.word2 == cultwords["hell"] && R.word3 == cultwords["join"])
 					see_invisible = SEE_INVISIBLE_OBSERVER
 				else
-					see_invisible = SEE_INVISIBLE_LIVING
 					seer = 0
 
-			var/tmp/glasses_processed = 0
+			var/equipped_glasses = glasses
 			var/obj/item/weapon/rig/rig = back
 			if(istype(rig) && rig.visor)
 				if(!rig.helmet || (head && rig.helmet == head))
 					if(rig.visor && rig.visor.vision && rig.visor.active && rig.visor.vision.glasses)
-						glasses_processed = 1
-						process_glasses(rig.visor.vision.glasses)
+						equipped_glasses = rig.visor.vision.glasses
+			if(equipped_glasses)
+				process_glasses(equipped_glasses)
 
-			if(glasses && !glasses_processed)
-				glasses_processed = 1
-				process_glasses(glasses)
-
-			if(!glasses_processed && (species.vision_flags > 0))
-				sight |= species.vision_flags
-			if(!seer && !glasses_processed)
+			if(!seer)
 				see_invisible = SEE_INVISIBLE_LIVING
 
 			if(healths)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -37,7 +37,7 @@
 	var/list/unarmed_attacks = null          // For empty hand harm-intent attack
 	var/brute_mod = 1                        // Physical damage multiplier.
 	var/burn_mod = 1                         // Burn damage multiplier.
-	var/vision_flags = 0                     // Same flags as glasses.
+	var/vision_flags = SEE_SELF              // Same flags as glasses.
 
 	// Death vars.
 	var/gibber_type = /obj/effect/gibspawner/human

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -42,7 +42,7 @@
 	breath_type = null
 	poison_type = null
 
-	vision_flags = SEE_MOBS
+	vision_flags = SEE_SELF|SEE_MOBS
 
 	has_organ = list(
 		"heart" =           /datum/organ/internal/heart,

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -388,8 +388,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/check_eye(var/mob/user as mob)
 	if (!camera)
-		return null
-	user.reset_view(camera)
+		return -1
 	return 0
 
 /mob/living/silicon/ai/restrained()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -124,7 +124,6 @@
 /mob/living/silicon/pai/check_eye(var/mob/user as mob)
 	if (!src.current)
 		return -1
-	user.reset_view(src.current)
 	return 0
 
 /mob/living/silicon/pai/blob_act()

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -53,11 +53,10 @@
 
 /obj/machinery/computer/helm/check_eye(var/mob/user as mob)
 	if (!manual_control)
-		return null
+		return -1
 	if (!get_dist(user, src) > 1 || user.blinded || !linked )
-		return null
-	user.reset_view(linked)
-	return 1
+		return -1
+	return 0
 
 /obj/machinery/computer/helm/attack_hand(var/mob/user as mob)
 	if(..())
@@ -67,6 +66,8 @@
 
 	if(!isAI(user))
 		user.set_machine(src)
+		if(linked)
+			user.reset_view(linked)
 
 	ui_interact(user)
 


### PR DESCRIPTION
- Fixes AIs and pAIs no longer reset_view() every time check_eye() is called.
- Fixes infinite recursion with the overmap helm console
- Fixes the sight flags from glasses being retained when looking through cameras.
