### PR TITLE
[DNM] Makes custom items use the host item's inhand sprites if none are provided, knife fixes

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -73,7 +73,7 @@
 	name = "knife"
 	desc = "Can cut through any food."
 	icon_state = "knife"
-	force_divisor = 0.2 // 12 when wielded with hardness 60 (steel)
+	force_divisor = 0.15 // 9 when wielded with hardness 60 (steel)
 
 /obj/item/weapon/material/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob)
 	if ((CLUMSY in user.mutations) && prob(50))

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -52,6 +52,7 @@
 	name = "kitchen knife"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "knife"
+	item_state = "knife"
 	desc = "A general purpose Chef's Knife made by SpaceCook Incorporated. Guaranteed to stay sharp for years to come."
 	flags = CONDUCT
 	sharp = 1
@@ -85,6 +86,7 @@
 	name = "butcher's cleaver"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "butch"
+	item_state = "butcher_knife"
 	desc = "A huge thing used for chopping and chopping up meat. This includes clowns and clown-by-products."
 	force_divisor = 0.25 // 15 when wielded with hardness 60 (steel)
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -57,7 +57,7 @@
 	flags = CONDUCT
 	sharp = 1
 	edge = 1
-	force_divisor = 0.15 // 9 when wielded with hardness 60 (steel)
+	force_divisor = 0.2 // 12 when wielded with hardness 60 (steel)
 	matter = list(DEFAULT_WALL_MATERIAL = 12000)
 	origin_tech = "materials=1"
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")


### PR DESCRIPTION
- Custom items will attempt to determine what item states and icons the host item uses for the in-hand overlays if none are provided in CUSTOM_ITEM_MOB for that custom item. This behaviour can be forced off by setting inherit_inhands to 0 in the custom item config.
- Swaps the force dividers for utensil knives and kitchen knives. Because why the hell does a utensil knife deal more damage than a large chef's knife?
- Fixes inhand icons for knife subtypes.
