### PR TITLE
Changes cyborg HUD to not display a superfluous empty row

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -210,7 +210,7 @@ var/obj/screen/robot_inventory
 		if(!r.robot_modules_background)
 			return
 
-		var/display_rows = round((r.module.modules.len) / 8) +1 //+1 because round() returns floor of number
+		var/display_rows = -round(-(r.module.modules.len) / 8)
 		r.robot_modules_background.screen_loc = "CENTER-4:16,SOUTH+1:7 to CENTER+3:16,SOUTH+[display_rows]:7"
 		r.client.screen += r.robot_modules_background
 


### PR DESCRIPTION
Title. Modules with precisely 8, 16, 24 etc items were showing an extra row, this changes it from floor(X/8)+1 to just ceil(X/8).
