### PR TITLE
Shooting and machine/structure penetration tweaks

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -126,12 +126,7 @@
 	//decide whether to aim or shoot normally
 	var/aiming = 0
 	if(user && user.client && !(A in aim_targets))
-		var/client/C = user.client
-		//If help intent is on and we have clicked on an eligible target, switch to aim mode automatically
-		if(user.a_intent == I_HELP && isliving(A) && !C.gun_mode)
-			C.ToggleGunMode()
-
-		if(C.gun_mode)
+		if(user.client.gun_mode)
 			aiming = PreFire(A,user,params) //They're using the new gun system, locate what they're aiming at.
 
 	if (!aiming)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -53,7 +53,7 @@
 	else if(istype(A, /obj/structure/girder))
 		chance = 100
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		chance = 25
+		chance = damage
 
 	if(prob(chance))
 		if(A.opacity)


### PR DESCRIPTION
- Removed auto-switching to hostage mode when shooting while on help intent. It seemed to mostly just confuse people and it's main reason for existing went away once the hostage mode shortcut was added.
- Adjusts bullet penetration chance for default machines and structures, now scales with projectile damage.
