### PR TITLE
qdel shield generators no longer runtime every tick until hard deleted.

### DIFF
--- a/code/modules/shieldgen/sheldwallgen.dm
+++ b/code/modules/shieldgen/sheldwallgen.dm
@@ -80,10 +80,10 @@
 	return 1
 
 /obj/machinery/shieldwallgen/process()
-	spawn(100)
-		power()
-		if(power)
-			storedpower -= 2500 //the generator post itself uses some power
+	power()
+	if(power)
+		storedpower -= 2500 //the generator post itself uses some power
+
 	if(storedpower >= max_stored_power)
 		storedpower = max_stored_power
 	if(storedpower <= 0)


### PR DESCRIPTION
Caused by a spawn() in process() doesn't seem like it did much except delay power consumption by 10 seconds.
