### PR TITLE
Stops sampling from being a means of fighting vines

### DIFF
--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -61,6 +61,7 @@
 	var/list/neighbors = list()
 	var/obj/effect/plant/parent
 	var/datum/seed/seed
+	var/sampled = 0
 	var/floor = 0
 	var/spread_chance = 40
 	var/spread_distance = 3
@@ -234,11 +235,18 @@
 	plant_controller.add_plant(src)
 
 	if(istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/weapon/scalpel))
+		if(sampled)
+			user << "<span class='warning'>\The [src] has already been sampled recently.</span>"
+			return
+		if(!is_mature())
+			user << "<span class='warning'>\The [src] is not mature enough to yield a sample yet.</span>"
+			return
 		if(!seed)
-			user << "There is nothing to take a sample from."
+			user << "<span class='warning'>There is nothing to take a sample from.</span>"
 			return
 		seed.harvest(user,0,1)
-		health -= (rand(3,5)*10)
+		health -= (rand(3,5)*5)
+		sampled = 1
 	else
 		..()
 		if(W.force)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -69,6 +69,12 @@
 		last_tick = world.time
 		update_neighbors()
 
+	if(sampled)
+		//Should be between 2-7 for given the default range of values for TRAIT_PRODUCTION
+		var/chance = max(1, round(30/seed.get_trait(TRAIT_PRODUCTION)))
+		if(prob(chance))
+			sampled = 0
+
 	if(is_mature() && neighbors.len && prob(spread_chance))
 		//spread to 1-3 adjacent turfs depending on yield trait.
 		var/max_spread = between(1, round(seed.get_trait(TRAIT_YIELD)*3/14), 3)


### PR DESCRIPTION
All it does is mean that anywhere that vines spawn will be littered with hundreds of seed packets, and vines are often dealt with pretty fast anyways.

Vines can now only be sampled once mature, can only be sampled periodically, and take less damage from sampling.
