### PR TITLE
Reworks character creation language selection

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -74,7 +74,7 @@ datum/preferences
 	var/b_eyes = 0						//Eye color
 	var/species = "Human"               //Species datum to use.
 	var/species_preview                 //Used for the species selection window.
-	var/language = "None"				//Secondary language
+	var/list/alternate_languages = list() //Secondary language(s)
 	var/list/gear						//Custom/fluff item loadout.
 
 		//Some faction information.
@@ -132,9 +132,12 @@ datum/preferences
 	var/metadata = ""
 	var/slot_name = ""
 
+	var/client/client = null
+
 /datum/preferences/New(client/C)
 	b_type = pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 	if(istype(C))
+		client = C
 		if(!IsGuestKey(C.key))
 			load_path(C.ckey)
 			if(load_preferences())
@@ -307,7 +310,7 @@ datum/preferences
 	dat += "(<a href='?_src_=prefs;preference=all;task=random'>&reg;</A>)"
 	dat += "<br>"
 	dat += "Species: <a href='?src=\ref[user];preference=species;task=change'>[species]</a><br>"
-	dat += "Secondary Language:<br><a href='byond://?src=\ref[user];preference=language;task=input'>[language]</a><br>"
+
 	dat += "Blood Type: <a href='byond://?src=\ref[user];preference=b_type;task=input'>[b_type]</a><br>"
 	dat += "Skin Tone: <a href='?_src_=prefs;preference=s_tone;task=input'>[-s_tone + 35]/220<br></a>"
 	//dat += "Skin pattern: <a href='byond://?src=\ref[user];preference=skin_style;task=input'>Adjust</a><br>"
@@ -380,6 +383,25 @@ datum/preferences
 		dat += "\[...\]<br><br>"
 	else
 		dat += "<br><br>"
+
+
+	dat += "<b>Languages</b><br>"
+	var/datum/species/S = all_species[species]
+	if(S.language)
+		dat += "- [S.language]<br>"
+	if(S.default_language && S.default_language != S.language)
+		dat += "- [S.default_language]<br>"
+	if(S.num_alternate_languages)
+		if(alternate_languages.len)
+			for(var/i = 1 to alternate_languages.len)
+				var/lang = alternate_languages[i]
+				dat += "- [lang] - <a href='byond://?src=\ref[user];preference=language;remove=[i]'>remove</a><br>"
+
+		if(alternate_languages.len < S.num_alternate_languages)
+			dat += "- <a href='byond://?src=\ref[user];preference=language;add=1'>add</a> ([S.num_alternate_languages - alternate_languages.len] remaining)<br>"
+	else
+		dat += "- [species] cannot choose secondary languages.<br>"
+	dat += "<br><br>"
 
 	var/list/undies = gender == MALE ? underwear_m : underwear_f
 
@@ -1126,6 +1148,32 @@ datum/preferences
 				if(gear_name == choice)
 					gear -= gear_name
 					break
+	else if(href_list["preference"] == "language")
+		if(href_list["remove"])
+			var/index = text2num(href_list["remove"])
+			alternate_languages.Cut(index, index+1)
+		if(href_list["add"])
+			var/datum/species/S = all_species[species]
+			if(alternate_languages.len >= S.num_alternate_languages)
+				alert(user, "You have already selected the maximum number of alternate languages for this species!")
+			else
+				var/list/available_languages = S.secondary_langs.Copy()
+				for(var/L in all_languages)
+					var/datum/language/lang = all_languages[L]
+					if(!(lang.flags & RESTRICTED) && (!config.usealienwhitelist || is_alien_whitelisted(user, L) || !(lang.flags & WHITELISTED)))
+						available_languages |= L
+
+				// make sure we don't let them waste slots on the default languages
+				available_languages -= S.language
+				available_languages -= S.default_language
+				available_languages -= alternate_languages
+
+				if(!available_languages.len)
+					alert(user, "There are no additional languages available to select.")
+				else
+					var/new_lang = input("Select an additional language", "Character Generation", null) as null|anything in available_languages
+					if(new_lang)
+						alternate_languages |= new_lang
 
 	switch(href_list["task"])
 		if("change")
@@ -1135,6 +1183,7 @@ datum/preferences
 				if(!choice) return
 				species_preview = choice
 				SetSpecies(user)
+				alternate_languages = list() // Reset their alternate languages. Todo: attempt to just fix it instead?
 
 		if("random")
 			switch(href_list["preference"])
@@ -1242,29 +1291,6 @@ datum/preferences
 						b_hair = 0//hex2num(copytext(new_hair, 6, 8))
 
 						s_tone = 0
-
-				if("language")
-					var/languages_available
-					var/list/new_languages = list("None")
-					var/datum/species/S = all_species[species]
-
-					if(config.usealienwhitelist)
-						for(var/L in all_languages)
-							var/datum/language/lang = all_languages[L]
-							if((!(lang.flags & RESTRICTED)) && (is_alien_whitelisted(user, L)||(!( lang.flags & WHITELISTED ))||(S && (L in S.secondary_langs))))
-								new_languages += lang
-
-								languages_available = 1
-
-						if(!(languages_available))
-							alert(user, "There are not currently any available secondary languages.")
-					else
-						for(var/L in all_languages)
-							var/datum/language/lang = all_languages[L]
-							if(!(lang.flags & RESTRICTED))
-								new_languages += lang.name
-
-					language = input("Please select a secondary language", "Character Generation", null) in new_languages
 
 				if("metadata")
 					var/new_metadata = input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , metadata)  as message|null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -107,8 +107,19 @@
 	S["gender"]				>> gender
 	S["age"]				>> age
 	S["species"]			>> species
-	S["language"]			>> language
 	S["spawnpoint"]			>> spawnpoint
+
+	S["language"]			>> alternate_languages
+	if(isnull(alternate_languages))
+		alternate_languages = list()
+	if(!islist(alternate_languages))
+		if(client)
+			// Warn them that we just broke their languages
+			client << "<span class='danger'>Your current character slot's languages list has been updated from an old version, and may not be what you expect.</span>"
+		if(alternate_languages in all_languages)
+			alternate_languages = list(alternate_languages)
+		else
+			alternate_languages = list()
 
 	//colors to be consolidated into hex strings (requires some work with dna code)
 	S["hair_red"]			>> r_hair
@@ -200,7 +211,7 @@
 	if(isnum(undershirt))
 		undershirt = undershirt_t[undershirt_t[undershirt]]
 
-	if(isnull(language)) language = "None"
+	if(isnull(alternate_languages)) alternate_languages = list()
 	if(isnull(spawnpoint)) spawnpoint = "Arrivals Shuttle"
 	if(isnull(nanotrasen_relation)) nanotrasen_relation = initial(nanotrasen_relation)
 	if(!real_name) real_name = random_name(gender)
@@ -265,7 +276,7 @@
 	S["gender"]				<< gender
 	S["age"]				<< age
 	S["species"]			<< species
-	S["language"]			<< language
+	S["language"]			<< alternate_languages
 	S["hair_red"]			<< r_hair
 	S["hair_green"]			<< g_hair
 	S["hair_blue"]			<< b_hair

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -114,12 +114,22 @@
 		alternate_languages = list()
 	if(!islist(alternate_languages))
 		if(client)
-			// Warn them that we just broke their languages
+			// Warn them that we (probably) just broke their languages
 			client << "<span class='danger'>Your current character slot's languages list has been updated from an old version, and may not be what you expect.</span>"
+
 		if(alternate_languages in all_languages)
 			alternate_languages = list(alternate_languages)
 		else
 			alternate_languages = list()
+
+		// try to give them their species language
+		var/datum/species/SP = all_species[species]
+		if(SP)
+			alternate_languages |= SP.language
+			alternate_languages |= SP.default_language
+
+		// remove the Galcom that most races have as default_language
+		alternate_languages -= "Galactic Common"
 
 	//colors to be consolidated into hex strings (requires some work with dna code)
 	S["hair_red"]			>> r_hair

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -73,7 +73,7 @@
 	whisper_verb = "whispers"
 	colour = "solcom"
 	key = "1"
-	flags = RESTRICTED
+	flags = WHITELISTED
 
 	//syllables are at the bottom of the file
 

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -5,6 +5,7 @@
 	deform = 'icons/mob/human_races/r_def_vox.dmi'
 	default_language = "Vox-pidgin"
 	language = "Galactic Common"
+	num_alternate_languages = 1
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/strong)
 	rarity_value = 2
 	blurb = "The Vox are the broken remnants of a once-proud race, now reduced to little more than \
@@ -65,7 +66,7 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H.back), slot_in_backpack)
 		H.internal = H.r_hand
 	H.internals.icon_state = "internal1"
-		
+
 
 /datum/species/vox/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
 	if(!H.mind || !H.mind.special_role) // Pariah check.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -34,9 +34,10 @@
 	// Language/culture vars.
 	var/default_language = "Galactic Common" // Default language is used when 'say' is used without modifiers.
 	var/language = "Galactic Common"         // Default racial language, if any.
-	var/secondary_langs = list()             // The names of secondary languages that are available to this species.
+	var/list/secondary_langs = list()        // The names of secondary languages that are available to this species.
 	var/list/speech_sounds                   // A list of sounds to potentially play when speaking.
 	var/list/speech_chance                   // The likelihood of a speech sound playing.
+	var/num_alternate_languages = 0          // How many secondary languages are available to select at character creation
 
 	// Combat vars.
 	var/total_health = 100                   // Point at which the mob will enter crit.

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1,7 +1,6 @@
 /datum/species/human
 	name = "Human"
 	name_plural = "Humans"
-	language = "Sol Common"
 	primitive_form = "Monkey"
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
 	blurb = "Humanity originated in the Sol system, and over the last five centuries has spread \
@@ -9,6 +8,8 @@
 	While the central Sol government maintains control of its far-flung people, powerful corporate \
 	interests, rampant cyber and bio-augmentation and secretive factions make life on most human \
 	worlds tumultous at best."
+	num_alternate_languages = 2
+	secondary_langs = list("Sol Common")
 
 	flags = CAN_JOIN | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
@@ -17,13 +18,14 @@
 	name_plural = "Unathi"
 	icobase = 'icons/mob/human_races/r_lizard.dmi'
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
-	language = "Sinta'unathi"
 	tail = "sogtail"
 	tail_animation = 'icons/mob/species/unathi/tail.dmi'
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	primitive_form = "Stok"
 	darksight = 3
 	gluttonous = 1
+	num_alternate_languages = 2
+	secondary_langs = list("Sinta'unathi")
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the \
 	Uuosa-Eso system, which roughly translates to 'burning mother'.<br/><br/>Coming from a harsh, radioactive \
@@ -69,13 +71,14 @@
 	name_plural = "Tajaran"
 	icobase = 'icons/mob/human_races/r_tajaran.dmi'
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
-	language = "Siik'tajr"
 	tail = "tajtail"
 	tail_animation = 'icons/mob/species/tajaran/tail.dmi'
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
 	slowdown = -1
 	brute_mod = 1.2
+	num_alternate_languages = 2
+	secondary_langs = list("Siik'tajr")
 
 	blurb = "The Tajaran race is a species of feline-like bipeds hailing from the planet of Ahdomai in the \
 	S'randarr system. They have been brought up into the space age by the Humans and Skrell, and have been \
@@ -116,7 +119,6 @@
 	icobase = 'icons/mob/human_races/r_skrell.dmi'
 	deform = 'icons/mob/human_races/r_def_skrell.dmi'
 	eyes = "skrell_eyes_s"
-	language = "Skrellian"
 	primitive_form = "Neara"
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	blurb = "An amphibious species, Skrell come from the star system known as Qerr'Vallis, which translates to 'Star of \
@@ -124,6 +126,8 @@
 	of the Qerr'Katish, a caste within their society which keeps the empire of the Skrell running smoothly. Skrell are \
 	herbivores on the whole and tend to be co-operative with the other species of the galaxy, although they rarely reveal \
 	the secrets of their empire to their allies."
+	num_alternate_languages = 2
+	secondary_langs = list("Skrellian")
 
 	flags = CAN_JOIN | IS_WHITELISTED | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR
 
@@ -147,6 +151,7 @@
 	siemens_coefficient = 0.3
 	eyes = "blank_eyes"
 	show_ssd = "completely quiescent"
+	num_alternate_languages = 1
 
 
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
@@ -251,6 +256,7 @@
 	language = "Encoded Audio Language"
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2
+	num_alternate_languages = 1 // potentially could be 2?
 
 	eyes = "blank_eyes"
 	brute_mod = 1.875 // 100% * 1.875 * 0.8 (robolimbs) ~= 150%

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -439,12 +439,12 @@
 
 		new_character.lastarea = get_area(loc)
 
-		var/datum/language/chosen_language
-		if(client.prefs.language)
-			chosen_language = all_languages["[client.prefs.language]"]
-		if(chosen_language)
-			if(is_alien_whitelisted(src, client.prefs.language) || !config.usealienwhitelist || !(chosen_language.flags & WHITELISTED) || (new_character.species && (chosen_language.name in new_character.species.secondary_langs)))
-				new_character.add_language("[client.prefs.language]")
+		for(var/lang in client.prefs.alternate_languages)
+			var/datum/language/chosen_language = all_languages[lang]
+			if(chosen_language)
+				if(!config.usealienwhitelist || !(chosen_language.flags & WHITELISTED) || is_alien_whitelisted(src, lang) || has_admin_rights() \
+					|| (new_character.species && (chosen_language.name in new_character.species.secondary_langs)))
+					new_character.add_language(lang)
 
 		if(ticker.random_players)
 			new_character.gender = pick(MALE, FEMALE)

--- a/html/changelogs/GinjaNinja32-languages.yml
+++ b/html/changelogs/GinjaNinja32-languages.yml
@@ -1,0 +1,5 @@
+author: GinjaNinja32
+delete-after: True
+
+changes:
+  - rscadd: "Changed language selection to allow multiple language selections, changed humans/unathi/tajarans/skrell to not automatically gain their racial language, instead adding it to the selectable languages for that species. Old slots will warn when loaded that the languages may not be what you expect."


### PR DESCRIPTION
Humans, Tajarans, Skrell and Unathi do not automatically get their racial language any more, instead gaining an additional selectable language (and the ability to select their racial language). Vox, Dionaea and IPCs still automatically get their racial languages, for various reasons.

This enables, for example, a human who does _not_ know Sol Common, perhaps instead knowing just Galactic Common, or both Tradeband and Gutter. (or Tradeband/Gutter plus a whitelisted non-human language, or two whitelisted non-human languages, or...)

![](https://i.imgur.com/rY7aq5s.png)
![](https://i.imgur.com/7JdocGf.png)

Old character slots will output a warning on load that the languages may not be what the player expects (and in most, if not all cases, they won't be).
