### PR TITLE
Makes custom items use the host item's inhand sprites if none are provided, knife fixes

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -61,7 +61,7 @@
 	attack_verb = list("attacked", "poked")
 	edge = 0
 	sharp = 0
-	force_divisor = 0.25 //5 when wielded with weight 20 (steel)
+	force_divisor = 0.1 //2 when wielded with weight 20 (steel)
 
 /obj/item/weapon/material/kitchen/utensil/spoon/plastic
 	default_material = "plastic"
@@ -71,9 +71,9 @@
  */
 /obj/item/weapon/material/kitchen/utensil/knife
 	name = "knife"
-	desc = "Can cut through any food."
+	desc = "A knife for eating with. Can cut through any food."
 	icon_state = "knife"
-	force_divisor = 0.2 // 12 when wielded with hardness 60 (steel)
+	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
 
 /obj/item/weapon/material/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob)
 	if ((CLUMSY in user.mutations) && prob(50))
@@ -100,7 +100,7 @@
 	name = "rolling pin"
 	desc = "Used to knock out the Bartender."
 	icon_state = "rolling_pin"
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked") //I think the rollingpin attackby will end up ignoring this anyway.
+	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	default_material = "wood"
 	force_divisor = 0.7 // 10 when wielded with weight 15 (wood)
 	thrown_force_divisor = 1 // as above

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -20,6 +20,7 @@
 /datum/custom_item
 	var/assoc_key
 	var/character_name
+	var/inherit_inhands = 1 //if unset, and inhands are not provided, then the inhand overlays will be invisible.
 	var/item_icon
 	var/item_desc
 	var/name
@@ -44,9 +45,20 @@
 	if(item_desc)
 		item.desc = item_desc
 	if(item_icon)
-		item.icon = CUSTOM_ITEM_OBJ
-		item.icon_state = item_icon
-		if(istype(item, /obj/item))
+		if(!istype(item))
+			item.icon = CUSTOM_ITEM_OBJ
+			item.icon_state = item_icon
+			return
+		else 
+			if(inherit_inhands)
+				apply_inherit_inhands(item)
+			else
+				item.item_state_slots = null
+				item.item_icons = null
+			
+			item.icon = CUSTOM_ITEM_OBJ
+			item.icon_state = item_icon
+			item.item_state = null
 			item.icon_override = CUSTOM_ITEM_MOB
 
 	// Kits are dumb so this is going to have to be hardcoded/snowflake.
@@ -66,6 +78,48 @@
 
 	return item
 
+/datum/custom_item/proc/apply_inherit_inhands(var/obj/item/item)
+	var/list/new_item_icons = list()
+	var/list/new_item_state_slots = list()
+	
+	var/list/available_states = icon_states(CUSTOM_ITEM_MOB)
+	
+	//If l_hand or r_hand are not present, preserve them using item_icons/item_state_slots
+	//Then use icon_override to make every other slot use the custom sprites by default.
+	//This has to be done before we touch any of item's vars
+	if(!("[item_icon]_l" in available_states))
+		new_item_state_slots[slot_l_hand_str] = get_state(item, slot_l_hand_str, "_l")
+		new_item_icons[slot_l_hand_str] = get_icon(item, slot_l_hand_str, 'icons/mob/items/lefthand.dmi')
+	if(!("[item_icon]_r" in available_states))
+		new_item_state_slots[slot_r_hand_str] = get_state(item, slot_r_hand_str, "_r")
+		new_item_icons[slot_r_hand_str] = get_icon(item, slot_r_hand_str, 'icons/mob/items/righthand.dmi')
+	
+	item.item_state_slots = new_item_state_slots
+	item.item_icons = new_item_icons
+
+//this has to mirror the way update_inv_*_hand() selects the state
+/datum/custom_item/proc/get_state(var/obj/item/item, var/slot_str, var/hand_str)
+	var/t_state
+	if(item.item_state_slots && item.item_state_slots[slot_str])
+		t_state = item.item_state_slots[slot_str]
+	else if(item.item_state)
+		t_state = item.item_state
+	else
+		t_state = item.icon_state
+	if(item.icon_override)
+		t_state += hand_str
+	return t_state
+
+//this has to mirror the way update_inv_*_hand() selects the icon
+/datum/custom_item/proc/get_icon(var/obj/item/item, var/slot_str, var/icon/hand_icon)
+	var/icon/t_icon
+	if(item.icon_override)
+		t_icon = item.icon_override
+	else if(item.item_icons && (slot_str in item.item_icons))
+		t_icon = item.item_icons[slot_str]
+	else
+		t_icon = hand_icon
+	return t_icon
 
 // Parses the config file into the custom_items list.
 /hook/startup/proc/load_custom_items()
@@ -107,6 +161,8 @@
 				current_data.name = field_data
 			if("item_icon")
 				current_data.item_icon = field_data
+			if("inherit_inhands")
+				current_data.inherit_inhands = text2num(field_data)
 			if("item_desc")
 				current_data.item_desc = field_data
 			if("req_access")

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -842,11 +842,11 @@ var/global/list/damage_icon_parts = list()
 
 		//determine icon to use
 		var/icon/t_icon
-		if(r_hand.icon_override)
+		if(r_hand.item_icons && (slot_r_hand_str in r_hand.item_icons))
+			t_icon = r_hand.item_icons[slot_r_hand_str]
+		else if(r_hand.icon_override)
 			t_state += "_r"
 			t_icon = r_hand.icon_override
-		else if(r_hand.item_icons && (slot_r_hand_str in r_hand.item_icons))
-			t_icon = r_hand.item_icons[slot_r_hand_str]
 		else
 			t_icon = INV_R_HAND_DEF_ICON
 
@@ -874,11 +874,11 @@ var/global/list/damage_icon_parts = list()
 
 		//determine icon to use
 		var/icon/t_icon
-		if(l_hand.icon_override)
+		if(l_hand.item_icons && (slot_l_hand_str in l_hand.item_icons))
+			t_icon = l_hand.item_icons[slot_l_hand_str]
+		else if(l_hand.icon_override)
 			t_state += "_l"
 			t_icon = l_hand.icon_override
-		else if(l_hand.item_icons && (slot_l_hand_str in l_hand.item_icons))
-			t_icon = l_hand.item_icons[slot_l_hand_str]
 		else
 			t_icon = INV_L_HAND_DEF_ICON
 


### PR DESCRIPTION
- Custom items will attempt to determine what item states and icons the host item uses for the in-hand overlays if none are provided in CUSTOM_ITEM_MOB for that custom item. This behaviour can be forced off by setting inherit_inhands to 0 in the custom item config.
- item_icons takes precedence over icon_override for inhands only.
- Fixes knife item_states, force dividers for utensils

Seems to work alright.
