### PR TITLE
Admins will no longer see stars when viewing faxes.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1478,7 +1478,7 @@
 		var/obj/item/fax = locate(href_list["AdminFaxView"])
 		if (istype(fax, /obj/item/weapon/paper))
 			var/obj/item/weapon/paper/P = fax
-			P.show_content(usr)
+			P.show_content(usr,1)
 		else if (istype(fax, /obj/item/weapon/photo))
 			var/obj/item/weapon/photo/H = fax
 			H.show(usr)


### PR DESCRIPTION
If an admin wasn't human / ghosting / or a silicon mob they would see garbled text.
This uses the "force view" setting to 1 bypassing the check. (http://bit.ly/1JP04vu)

Fixes #10050
