### PR TITLE
Fixes #9965

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -211,9 +211,9 @@
 	else if(charge.charges < chems_to_use)
 		chems_to_use = charge.charges
 
-	var/mob/living/target_mob
+	var/mob/living/carbon/target_mob
 	if(target)
-		if(istype(target,/mob/living))
+		if(istype(target,/mob/living/carbon))
 			target_mob = target
 		else
 			return 0


### PR DESCRIPTION
- Hardsuit injectors now only work on carbon-based mobs. This prevents injecting of AIs, Robots and other silicon-based mobs.
