### PR TITLE
Fixes #9894

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -381,7 +381,9 @@ datum/controller/vote
 				if(usr.client.holder)
 					initiate_vote("custom",usr.key)
 			else
-				submit_vote(usr.ckey, round(text2num(href_list["vote"])))
+				var/t = round(text2num(href_list["vote"]))
+				if(t) // It starts from 1, so there's no problem
+					submit_vote(usr.ckey, t)
 		usr.vote()
 
 


### PR DESCRIPTION
It called submit_vote with null as the number, which reduced the vote count of the thing you voted for by 1 but didn't add to any votes and didn't move your vote.
