### PR TITLE
Fixes virus infectionchance oversight

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -118,7 +118,7 @@
 	//uniqueID = rand(0,10000)
 	var/datum/disease2/effectholder/holder = pick(effects)
 	holder.minormutate()
-	infectionchance = min(50,infectionchance + rand(0,10))
+	//infectionchance = min(50,infectionchance + rand(0,10))
 
 /datum/disease2/disease/proc/majormutate()
 	uniqueID = rand(0,10000)


### PR DESCRIPTION
Miniature pointed this one out.

Fixes an oversight in minormutate() that would cause minor viruses to become extremely infectious after spreading to another person.
