### PR TITLE
Droplimb fixes

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -744,7 +744,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 					I.loc = get_turf(src)
 			qdel(src)
 		if(DROPLIMB_BLUNT)
-			var/obj/effect/decal/cleanable/blood/gibs/gore = new owner.species.single_gib_type(get_turf(victim))
+			var/obj/effect/decal/cleanable/blood/gibs/gore = new victim.species.single_gib_type(get_turf(victim))
 			if(victim.species.flesh_color)
 				gore.fleshcolor = victim.species.flesh_color
 			if(victim.species.blood_color)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1,6 +1,12 @@
 /****************************************************
 				EXTERNAL ORGANS
 ****************************************************/
+
+//These control the damage thresholds for the various ways of removing limbs
+#define DROPLIMB_THRESHOLD_EDGE 5
+#define DROPLIMB_THRESHOLD_TEAROFF 2
+#define DROPLIMB_THRESHOLD_DESTROY 1
+
 /obj/item/organ/external
 	name = "external"
 	min_broken_damage = 30
@@ -235,6 +241,7 @@
 		//If we can't inflict the full amount of damage, spread the damage in other ways
 		//How much damage can we actually cause?
 		var/can_inflict = max_damage * config.organ_health_multiplier - (brute_dam + burn_dam)
+		var/spillover = 0
 		if(can_inflict)
 			if (brute > 0)
 				//Inflict all burte damage we can
@@ -246,16 +253,17 @@
 				//How much mroe damage can we inflict
 				can_inflict = max(0, can_inflict - brute)
 				//How much brute damage is left to inflict
-				brute = max(0, brute - temp)
+				spillover += max(0, brute - temp)
 
 			if (burn > 0 && can_inflict)
 				//Inflict all burn damage we can
 				createwound(BURN, min(burn,can_inflict))
 				//How much burn damage is left to inflict
-				burn = max(0, burn - can_inflict)
+				spillover += max(0, burn - can_inflict)
+		
 		//If there are still hurties to dispense
-		if (burn || brute)
-			owner.shock_stage += (brute+burn) * config.organ_damage_spillover_multiplier
+		if (spillover)
+			owner.shock_stage += spillover * config.organ_damage_spillover_multiplier
 
 	// sync the organ's damage with its wounds
 	src.update_damages()
@@ -264,26 +272,30 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
 		if(!cannot_amputate && config.limbs_can_break && (brute_dam + burn_dam) >= (max_damage * config.organ_health_multiplier))
-			var/threshold = max_damage
-			var/dropped
-			if((burn >= threshold) && prob(burn/3))
-				dropped = 1
-				droplimb(0,DROPLIMB_BURN)
-			if(!dropped && prob(brute))
-				var/edge_eligible = 0
-				if(edge)
-					if(istype(used_weapon,/obj/item))
-						var/obj/item/W = used_weapon
-						if(W.w_class >= w_class)
-							edge_eligible = 1
-					else
+			//organs can come off in three cases
+			//1. If the damage source is edge_eligible and the brute damage dealt exceeds the edge threshold, then the organ is cut off.
+			//2. If the damage amount dealt exceeds the disintegrate threshold, the organ is completely obliterated.
+			//3. If the organ has already reached or would be put over it's max damage amount (currently redundant),
+			//   and the brute damage dealt exceeds the tearoff threshold, the organ is torn off.
+			
+			//Check edge eligibility
+			var/edge_eligible = 0
+			if(edge)
+				if(istype(used_weapon,/obj/item))
+					var/obj/item/W = used_weapon
+					if(W.w_class >= w_class)
 						edge_eligible = 1
+				else
+					edge_eligible = 1
 
-				if(brute >= threshold || (edge_eligible && brute >= threshold/3))
-					if(edge)
-						droplimb(0,DROPLIMB_EDGE)
-					else
-						droplimb(0,DROPLIMB_BLUNT)
+			if(edge_eligible && brute >= max_damage / DROPLIMB_THRESHOLD_EDGE && prob(brute))
+				droplimb(0, DROPLIMB_EDGE)
+			else if(burn >= max_damage / DROPLIMB_THRESHOLD_DESTROY && prob(burn/3))
+				droplimb(0, DROPLIMB_BURN)
+			else if(brute >= max_damage / DROPLIMB_THRESHOLD_DESTROY && prob(brute))
+				droplimb(0, DROPLIMB_BLUNT)
+			else if(brute >= max_damage / DROPLIMB_THRESHOLD_TEAROFF && prob(brute/3))
+				droplimb(0, DROPLIMB_EDGE)
 
 	return update_icon()
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -707,11 +707,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	wounds.Cut()
 	if(parent)
-		var/datum/wound/W
-		if(clean || max_damage < 50)
-			W = new/datum/wound/lost_limb/small(max_damage/2)
-		else
-			W = new/datum/wound/lost_limb(max_damage)
+		var/datum/wound/lost_limb/W = new (src, disintegrate, clean)
 		parent.children -= src
 		if(clean)
 			parent.wounds |= W

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -315,12 +315,32 @@ datum/wound/cut/massive
 
 /** EXTERNAL ORGAN LOSS **/
 /datum/wound/lost_limb
-    damage_type = CUT
-    stages = list("ripped stump" = 65, "bloody stump" = 50, "clotted stump" = 25, "scarred stump" = 0)
-    max_bleeding_stage = 3
 
-    can_merge(var/datum/wound/other)
-        return 0 //cannot be merged
+/datum/wound/lost_limb/New(var/obj/item/organ/external/lost_limb, var/losstype, var/clean)
+	var/damage_amt = lost_limb.max_damage
+	if(clean) damage_amt /= 2
+	
+	switch(losstype)
+		if(DROPLIMB_EDGE, DROPLIMB_BLUNT)
+			damage_type = CUT
+			max_bleeding_stage = 3
+			stages = list(
+				"ripped stump" = damage_amt*1.3,
+				"bloody stump" = damage_amt, 
+				"clotted stump" = damage_amt*0.5, 
+				"scarred stump" = 0
+				)
+		if(DROPLIMB_BURN)
+			damage_type = BURN
+			max_bleeding_stage = 1
+			stages = list(
+				"ripped charred stump" = damage_amt*1.3,
+				"charred stump" = damage_amt,
+				"scarred stump" = damage_amt*0.5,
+				"scarred stump" = 0
+				)
+	
+	..(damage_amt)
 
-/datum/wound/lost_limb/small
-    stages = list("ripped hole" = 40, "bloody hole" = 30, "clotted hole" = 15, "scarred hole" = 0)
+/datum/wound/lost_limb/can_merge(var/datum/wound/other)
+	return 0 //cannot be merged


### PR DESCRIPTION
- Fixes droplimb not respecting damage type (has implications for things like bleed timers, etc)
- Fixes runtime with DROPLIMB_BLUNT
