### PR TITLE
Tweak/refactor of droplimb mechanics

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1,6 +1,12 @@
 /****************************************************
 				EXTERNAL ORGANS
 ****************************************************/
+
+//These control the damage thresholds for the various ways of removing limbs
+#define DROPLIMB_THRESHOLD_EDGE 5
+#define DROPLIMB_THRESHOLD_TEAROFF 2
+#define DROPLIMB_THRESHOLD_DESTROY 1
+
 /obj/item/organ/external
 	name = "external"
 	min_broken_damage = 30
@@ -233,6 +239,7 @@
 		//If we can't inflict the full amount of damage, spread the damage in other ways
 		//How much damage can we actually cause?
 		var/can_inflict = max_damage * config.organ_health_multiplier - (brute_dam + burn_dam)
+		var/spillover = 0
 		if(can_inflict)
 			if (brute > 0)
 				//Inflict all burte damage we can
@@ -244,16 +251,17 @@
 				//How much mroe damage can we inflict
 				can_inflict = max(0, can_inflict - brute)
 				//How much brute damage is left to inflict
-				brute = max(0, brute - temp)
+				spillover += max(0, brute - temp)
 
 			if (burn > 0 && can_inflict)
 				//Inflict all burn damage we can
 				createwound(BURN, min(burn,can_inflict))
 				//How much burn damage is left to inflict
-				burn = max(0, burn - can_inflict)
+				spillover += max(0, burn - can_inflict)
+		
 		//If there are still hurties to dispense
-		if (burn || brute)
-			owner.shock_stage += (brute+burn) * config.organ_damage_spillover_multiplier
+		if (spillover)
+			owner.shock_stage += spillover * config.organ_damage_spillover_multiplier
 
 	// sync the organ's damage with its wounds
 	src.update_damages()
@@ -262,26 +270,30 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
 		if(!cannot_amputate && config.limbs_can_break && (brute_dam + burn_dam) >= (max_damage * config.organ_health_multiplier))
-			var/threshold = max_damage
-			var/dropped
-			if((burn >= threshold) && prob(burn/3))
-				dropped = 1
-				droplimb(0,DROPLIMB_BURN)
-			if(!dropped && prob(brute))
-				var/edge_eligible = 0
-				if(edge)
-					if(istype(used_weapon,/obj/item))
-						var/obj/item/W = used_weapon
-						if(W.w_class >= w_class)
-							edge_eligible = 1
-					else
+			//organs can come off in three cases
+			//1. If the damage source is edge_eligible and the brute damage dealt exceeds the edge threshold, then the organ is cut off.
+			//2. If the damage amount dealt exceeds the disintegrate threshold, the organ is completely obliterated.
+			//3. If the organ has already reached or would be put over it's max damage amount (currently redundant),
+			//   and the brute damage dealt exceeds the tearoff threshold, the organ is torn off.
+			
+			//Check edge eligibility
+			var/edge_eligible = 0
+			if(edge)
+				if(istype(used_weapon,/obj/item))
+					var/obj/item/W = used_weapon
+					if(W.w_class >= w_class)
 						edge_eligible = 1
+				else
+					edge_eligible = 1
 
-				if(brute >= threshold || (edge_eligible && brute >= threshold/3))
-					if(edge)
-						droplimb(0,DROPLIMB_EDGE)
-					else
-						droplimb(0,DROPLIMB_BLUNT)
+			if(edge_eligible && brute >= max_damage / DROPLIMB_THRESHOLD_EDGE && prob(brute))
+				droplimb(0, DROPLIMB_EDGE)
+			else if(burn >= max_damage / DROPLIMB_THRESHOLD_DESTROY && prob(burn/3))
+				droplimb(0, DROPLIMB_BURN)
+			else if(brute >= max_damage / DROPLIMB_THRESHOLD_DESTROY && prob(brute))
+				droplimb(0, DROPLIMB_BLUNT)
+			else if(brute >= max_damage / DROPLIMB_THRESHOLD_TEAROFF && prob(brute/3))
+				droplimb(0, DROPLIMB_EDGE)
 
 	return update_icon()
 


### PR DESCRIPTION
Slight refactor of limb removal due to damage, and adjusts limb removal mechanics.
- Limb removal due to edge damage sources is more permissive.
- Allows non-edge damage sources to tear limbs off (with lower probability)

Thresholds with this PR:

| Body Part | Edge | Tear-Off | Disintegrate/Destroy |
| --- | --- | --- | --- |
| Head | 15 | 37.5 | 75 |
| Arms/Legs | 10 | 25 | 50 |
| Hands/Feet | 6 | 15 | 30 |

Remember that in order to remove limbs, the organ has to reach full damage and the probability also scales with damage, so low damage edge sources (e.g. hatchets) are still harder to remove limbs with. 

This PR increases the variety of edge sources that can delimb. While I guess it is subjective, I felt that preventing things like hatchets and switchblades from removing arms and legs was a little too restrictive. As well, this PR provides a middle ground between slicing off a limb (with edge) and _completely destroying it outright_, something I felt that was lacking.
