### PR TITLE
Fixes #9976

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -66,6 +66,8 @@
 	if(ismob(loc))
 		var/mob/m = loc
 		m.unEquip(src, 1)
+		m.update_inv_r_hand()
+		m.update_inv_l_hand()
 	return ..()
 
 /obj/item/device


### PR DESCRIPTION
Deleted items update their loc's inhand overlays if they are in a mob when GC'd. Fixes #9976.
