### PR TITLE
Projectile visual bug fixes

### DIFF
--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -11,8 +11,8 @@
 	if(istype(M))
 		transform = M
 
-/obj/effect/projectile/proc/activate()
-	spawn(3)
+/obj/effect/projectile/proc/activate(var/kill_delay = 3)
+	spawn(kill_delay)
 		qdel(src)	//see effect_system.dm - sets loc to null and lets GC handle removing these effects
 
 	return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -296,25 +296,26 @@
 		before_move()
 		Move(location.return_turf())
 
-		if(first_step)
-			muzzle_effect(effect_transform)
-			first_step = 0
-		else
-			tracer_effect(effect_transform)
-
 		if(!bumped && !isturf(original))
 			if(loc == get_turf(original))
 				if(!(original in permutated))
 					if(Bump(original))
 						return
 
+		if(first_step)
+			muzzle_effect(effect_transform)
+			first_step = 0
+		else if(!bumped)
+			tracer_effect(effect_transform)
+
 		if(!hitscan)
 			sleep(step_delay)	//add delay between movement iterations if it's not a hitscan weapon
 
 /obj/item/projectile/proc/process_step(first_step = 0)
-
+	return
 
 /obj/item/projectile/proc/before_move()
+	return
 
 /obj/item/projectile/proc/setup_trajectory()
 	// trajectory dispersion
@@ -355,7 +356,10 @@
 			P.set_transform(M)
 			P.pixel_x = location.pixel_x
 			P.pixel_y = location.pixel_y
-			P.activate()
+			if(!hitscan)
+				P.activate(step_delay)	//if not a hitscan projectile, remove after a single delay
+			else
+				P.activate()
 
 /obj/item/projectile/proc/impact_effect(var/matrix/M)
 	if(ispath(tracer_type))

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -8,6 +8,7 @@
 	eyeblur = 4
 	var/frequency = 1
 	hitscan = 1
+	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer

--- a/html/changelogs/Loganbacca-projectilefixes.yml
+++ b/html/changelogs/Loganbacca-projectilefixes.yml
@@ -1,0 +1,4 @@
+author: Loganbacca
+delete-after: True
+changes: 
+  - bugfix: "Fixed visual bugs with projectile effects."


### PR DESCRIPTION
- Fixes #10065 
- Fixed visible beam projectile
- Fixed additional tracers overlaying impact effects
- Added a delay option for non-hitscan beams so multiple tracers aren't rendered on screen at the same time

Video of fixes in action: http://puu.sh/iTZeA/c36a5b7398.mp4

Firing the (captains) laser pistol at the start shows what can be done by making a projectile type that is non-hitscan and adding some modified laser effect icons. No code tweaks other that the projectile type definition (note: this change to the captains laser pistol is not in this PR, it is only for demonstration purposes in the video).
