### PR TITLE
Ninjas can no longer teleport unto turfs that contain solid objects.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -120,7 +120,7 @@
 		return 0
 
 	for(var/atom/A in T)
-		if(A.density)
+		if(A.density && !(A.flags & ON_BORDER))
 			H << "<span class='warning'>You cannot teleport to a location with solid objects.</span>"
 			return 0
 

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -119,6 +119,11 @@
 		H << "<span class='warning'>You cannot use your teleporter on this Z-level.</span>"
 		return 0
 
+	for(var/atom/A in T)
+		if(A.density)
+			H << "<span class='warning'>You cannot teleport to a location with solid objects.</span>"
+			return 0
+
 	phase_out(H,get_turf(H))
 	H.loc = T
 	phase_in(H,get_turf(H))

--- a/html/changelogs/PsiOmegaDelta-SolidTeleportation.yml
+++ b/html/changelogs/PsiOmegaDelta-SolidTeleportation.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+changes:
+  - tweak: "Ninjas can no longer teleport unto turfs that contain solid objects."
+delete-after: true


### PR DESCRIPTION
Related to #10087.
It is no longer possible for ninjas to teleport to turfs containing solid objects.

This does have another side-effect besides being unable to teleport untop of an AI (or other mobs, something to consider). Ninjas can no longer teleport on top of doors, meaning they need to have mesons or similar tech enabled to let them through into other areas. May or may not be desirable.
