### PR TITLE
Makes grab eye attacking respect species lore better

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,3 +1,9 @@
+/mob/living/carbon/human/proc/get_unarmed_attack(var/mob/living/carbon/human/target, var/hit_zone)
+	for(var/datum/unarmed_attack/u_attack in species.unarmed_attacks)
+		if(u_attack.is_usable(src, target, hit_zone))
+			return u_attack
+	return null
+
 /mob/living/carbon/human/attack_hand(mob/living/carbon/M as mob)
 
 	var/mob/living/carbon/human/H = M
@@ -178,13 +184,7 @@
 				miss_type = 2
 
 			// See what attack they use
-			var/datum/unarmed_attack/attack = null
-			for(var/datum/unarmed_attack/u_attack in H.species.unarmed_attacks)
-				if(!u_attack.is_usable(H, src, hit_zone))
-					continue
-				else
-					attack = u_attack
-					break
+			var/datum/unarmed_attack/attack = H.get_unarmed_attack(src, hit_zone)
 			if(!attack)
 				return 0
 

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -9,11 +9,15 @@
 /datum/unarmed_attack/diona
 	attack_verb = list("lashed", "bludgeoned")
 	attack_noun = list("tendril")
+	eye_attack_text = "a tendril"
+	eye_attack_text_victim = "a tendril"
 	damage = 5
 
 /datum/unarmed_attack/claws
 	attack_verb = list("scratched", "clawed", "slashed")
 	attack_noun = list("claws")
+	eye_attack_text = "claws"
+	eye_attack_text_victim = "sharp claws"
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	damage = 5

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -8,8 +8,11 @@
 	var/shredding = 0 // Calls the old attack_alien() behavior on objects/mobs when on harm intent.
 	var/sharp = 0
 	var/edge = 0
+	
+	var/eye_attack_text
+	var/eye_attack_text_victim
 
-/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user)
+/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 	if(user.restrained())
 		return 0
 
@@ -78,6 +81,13 @@
 	user.visible_message("<span class='warning'>[user] [pick(attack_verb)] [target] in the [affecting.name]!</span>")
 	playsound(user.loc, attack_sound, 25, 1, -1)
 
+/datum/unarmed_attack/proc/handle_eye_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target)
+	var/obj/item/organ/eyes/eyes = target.internal_organs_by_name["eyes"]
+	eyes.take_damage(rand(3,4), 1)
+	
+	user.visible_message("<span class='danger'>[user] presses \his [eye_attack_text] into [target]'s [eyes.name]!</span>")
+	target << "<span class='danger'>You experience[(target.species.flags & NO_PAIN)? "" : " immense pain as you feel" ] [eye_attack_text_victim] being pressed into your [eyes.name][(target.species.flags & NO_PAIN)? "." : "!"]</span>"
+
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -97,6 +107,8 @@
 /datum/unarmed_attack/punch
 	attack_verb = list("punched")
 	attack_noun = list("fist")
+	eye_attack_text = "fingers"
+	eye_attack_text_victim = "digits"
 	damage = 0
 
 /datum/unarmed_attack/punch/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -351,6 +351,11 @@
 				if(I_HURT)
 
 					if(hit_zone == "eyes")
+						var/mob/living/carbon/human/H = affecting
+						var/datum/unarmed_attack/attack = H.get_unarmed_attack(src, hit_zone)
+						if(!attack)
+							return
+						
 						if(state < GRAB_NECK)
 							assailant << "<span class='warning'>You require a better grab to do this.</span>"
 							return
@@ -362,16 +367,11 @@
 						if(!affecting.has_eyes())
 							assailant << "<span class='danger'>You cannot locate any eyes on [affecting]!</span>"
 							return
-						assailant.visible_message("<span class='danger'>[assailant] pressed \his fingers into [affecting]'s eyes!</span>")
-						affecting << "<span class='danger'>You experience immense pain as you feel digits being pressed into your eyes!</span>"
-						assailant.attack_log += text("\[[time_stamp()]\] <font color='red'>Pressed fingers into the eyes of [affecting.name] ([affecting.ckey])</font>")
-						affecting.attack_log += text("\[[time_stamp()]\] <font color='orange'>Had fingers pressed into their eyes by [assailant.name] ([assailant.ckey])</font>")
-						msg_admin_attack("[key_name(assailant)] has pressed his fingers into [key_name(affecting)]'s eyes.")
-						var/obj/item/organ/eyes/eyes = affecting:internal_organs_by_name["eyes"]
-						eyes.damage += rand(3,4)
-						if (eyes.damage >= eyes.min_broken_damage)
-							if(affecting.stat != 2)
-								affecting << "\red You go blind!"
+						assailant.attack_log += text("\[[time_stamp()]\] <font color='red'>Attacked [affecting.name]'s eyes using grab ([affecting.ckey])</font>")
+						affecting.attack_log += text("\[[time_stamp()]\] <font color='orange'>Had eyes attacked by [assailant.name]'s grab ([assailant.ckey])</font>")
+						msg_admin_attack("[key_name(assailant)] attacked [key_name(affecting)]'s eyes using a grab action.")
+						
+						attack.handle_eye_attack(assailant, affecting)
 					else if(hit_zone != "head")
 						if(state < GRAB_NECK)
 							assailant << "<span class='warning'>You require a better grab to do this.</span>"

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -79,6 +79,12 @@
 		owner.b_eyes ? owner.b_eyes : 0
 		)
 
+/obj/item/organ/eyes/take_damage()
+	var/oldbroken = is_broken()
+	..()
+	if(is_broken() && !oldbroken && owner && !owner.stat)
+		owner << "<span class='danger'>You go blind!</span>"
+
 /obj/item/organ/eyes/process() //Eye damage replaces the old eye_stat var.
 	..()
 	if(!owner)


### PR DESCRIPTION
Makes grab eye pressing less hardcoded, it now produces different messages based on the attack type used. 

For the purposes of this fix I restricted my self to changing the log messages only, however I think it would make sense if the damage dealt depended on if the attack is sharp or something. Out of scope though.
