### PR TITLE
Wizards can no longer de-jaunt in turfs with dense objects.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -388,3 +388,11 @@
 
 /turf/proc/process()
 	return PROCESS_KILL
+
+/turf/proc/contains_dense_objects()
+	if(density)
+		return 1
+	for(var/atom/A in src)
+		if(A.density && !(A.flags & ON_BORDER))
+			return 1
+	return 0

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -119,10 +119,8 @@
 		H << "<span class='warning'>You cannot use your teleporter on this Z-level.</span>"
 		return 0
 
-	for(var/atom/A in T)
-		if(A.density && !(A.flags & ON_BORDER))
-			H << "<span class='warning'>You cannot teleport to a location with solid objects.</span>"
-			return 0
+	if(T.contains_dense_objects())
+		H << "<span class='warning'>You cannot teleport to a location with solid objects.</span>"
 
 	phase_out(H,get_turf(H))
 	H.loc = T

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -189,7 +189,11 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	if(silenced > 0)
 		return
 
-	if(user.z == 2 && spell_flags & Z2NOCAST) //Certain spells are not allowed on the centcomm zlevel
+	var/turf/Turf = get_turf(user)
+	if(!Turf)
+		user << "<span class='warning'>You cannot cast spells in null space!</span>"
+
+	if(spell_flags & Z2NOCAST && (Turf.z in config.admin_levels)) //Certain spells are not allowed on the centcomm zlevel
 		return 0
 
 	if(spell_flags & CONSTRUCT_CHECK)

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -36,7 +36,7 @@
 			target.monkeyizing=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
 			sleep(duration)
-			mobloc = get_turf(target.loc)
+			mobloc = holder.last_valid_turf
 			animation.loc = mobloc
 			jaunt_steam(mobloc)
 			target.canmove = 0
@@ -75,6 +75,11 @@
 	var/reappearing = 0
 	density = 0
 	anchored = 1
+	var/turf/last_valid_turf
+
+/obj/effect/dummy/spell_jaunt/New(var/location)
+	..()
+	last_valid_turf = get_turf(location)
 
 /obj/effect/dummy/spell_jaunt/Destroy()
 	// Eject contents if deleted somehow
@@ -87,6 +92,9 @@
 	var/turf/newLoc = get_step(src,direction)
 	if(!(newLoc.flags & NOJAUNT))
 		loc = newLoc
+		var/turf/T = get_turf(loc)
+		if(!T.contains_dense_objects())
+			last_valid_turf = T
 	else
 		user << "<span class='warning'>Some strange aura is blocking the way!</span>"
 	src.canmove = 0

--- a/html/changelogs/PsiOmegaDelta-SolidTeleportation.yml
+++ b/html/changelogs/PsiOmegaDelta-SolidTeleportation.yml
@@ -1,4 +1,5 @@
 author: PsiOmegaDelta
 changes:
   - tweak: "Ninjas can no longer teleport unto turfs that contain solid objects."
+  - tweak: "Wizards can no longer etheral jaunt unto turfs that contain solid objects."
 delete-after: true


### PR DESCRIPTION
Wizards can no longer de-jaunt in turfs with dense objects, instead they are moved back to the last turf without such objects (or the start turf if necessary).
Does not take into account solid objects that may have moved unto this turf between the wizard entering it and the spell ending.

Also fixes an exploit where wizards could cast CentCom restricted spells by hiding inside objects, such as lockers or coffins.
