### PR TITLE
Fixes several jobs not spawning with their prefered lootbag.

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -23,6 +23,12 @@
 /datum/job/proc/equip(var/mob/living/carbon/human/H)
 	return 1
 
+/datum/job/proc/equip_backpack(var/mob/living/carbon/human/H)
+	switch(H.backbag)
+		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
+		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
+
 /datum/job/proc/equip_survival(var/mob/living/carbon/human/H)
 	if(!H)	return 0
 	H.species.equip_survival_gear(H,0)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -13,8 +13,12 @@
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		return 1
-	
+
 	equip_survival(var/mob/living/carbon/human/H)
+		if(!H)	return 0
+		return 1
+
+	equip_backpack(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		return 1
 
@@ -39,5 +43,9 @@
 		return 1
 
 	equip_survival(var/mob/living/carbon/human/H)
+		if(!H)	return 0
+		return 1
+
+	equip_backpack(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		return 1

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -393,6 +393,7 @@ var/global/datum/controller/occupations/job_master
 							spawn_in_storage += thing
 			//Equip job items.
 			job.equip(H)
+			job.equip_backpack(H)
 			job.equip_survival(H)
 			job.apply_fingerprints(H)
 


### PR DESCRIPTION
Added a proc that spawns it for those jobs that didn't put a bag on in their 'equip' proc. There's just too many of those to move thme out in override for that proc and some jobs (like miners) depend on knowing if bag is there or not. It won't spawn second bag if first one is there anyway.

fixes #10132
