### PR TITLE
Fixes #9927

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -154,14 +154,19 @@
 		user << "<span class='warning'>The crate appears to be broken.</span>"
 		return
 	if(src.allowed(user))
-		src.locked = !src.locked
-		for(var/mob/O in viewers(user, 3))
-			if((O.client && !( O.blinded )))
-				O << "<span class='notice'>The crate has been [locked ? null : "un"]locked by [user].</span>"
-		overlays.Cut()
-		overlays += locked ? redlight : greenlight
+		set_locked(!locked, user)
 	else
 		user << "<span class='notice'>Access Denied</span>"
+
+/obj/structure/closet/crate/secure/proc/set_locked(var/newlocked, mob/user = null)
+	if(locked == newlocked) return
+	
+	locked = newlocked
+	if(user)
+		for(var/mob/O in viewers(user, 3))
+			O.show_message( "<span class='notice'>The crate has been [locked ? null : "un"]locked by [user].</span>", 1)
+	overlays.Cut()
+	overlays += locked ? redlight : greenlight
 
 /obj/structure/closet/crate/secure/verb/verb_togglelock()
 	set src in oview(1) // One square distance

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -4,8 +4,8 @@
 	icon_state = "securecrate"
 	icon_opened = "securecrateopen"
 	icon_closed = "securecrate"
-	var/code = null
-	var/lastattempt = null
+	var/list/code = list()
+	var/list/lastattempt = list()
 	var/attempts = 10
 	var/codelen = 4
 	locked = 1
@@ -14,12 +14,12 @@
 	..()
 	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 
-	code = ""
-	for(var/i = 0, i < codelen, i++)
-		var/dig = pick(digits)
-		code += dig
-		digits -= dig  // Player can enter codes with matching digits, but there are never matching digits in the answer
+	for(var/i in 1 to codelen)
+		code += pick(digits)
 
+	generate_loot()
+
+/obj/structure/closet/crate/secure/loot/proc/generate_loot()
 	var/loot = rand(1, 100)
 	switch(loot)
 		if(1 to 5) // Common things go, 5%
@@ -145,58 +145,60 @@
 			new/obj/item/clothing/head/bearpelt(src)
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user as mob)
-	if(locked)
-		user << "<span class='notice'>The crate is locked with a Deca-code lock.</span>"
-		var/input = input(usr, "Enter [codelen] digits.", "Deca-Code Lock", "") as text
-		if(in_range(src, user))
-			if (input == code)
-				user << "<span class='notice'>The crate unlocks!</span>"
-				locked = 0
-				overlays.Cut()
-				overlays += greenlight
-			else if (input == null || length(input) != codelen)
-				user << "<span class='notice'>You leave the crate alone.</span>"
-			else
-				user << "<span class='warning'>A red light flashes.</span>"
-				lastattempt = input
-				attempts--
-				if (attempts == 0)
-					user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
-					var/turf/T = get_turf(src.loc)
-					explosion(T, 0, 0, 0, 1)
-					del(src)
-					return
-		else
-			user << "<span class='notice'>You attempt to interact with the device using a hand gesture, but it appears this crate is from before the DECANECT came out.</span>"
-			return
+	if(!locked)
+		return
+
+	user << "<span class='notice'>The crate is locked with a Deca-code lock.</span>"
+	var/input = input(user, "Enter [codelen] digits.", "Deca-Code Lock", "") as text
+	if(!Adjacent(user))
+		return
+
+	if(input == null || length(input) != codelen)
+		user << "<span class='notice'>You leave the crate alone.</span>"
+	else if(check_input(input))
+		user << "<span class='notice'>The crate unlocks!</span>"
+		playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
+		set_locked(0)
 	else
-		return ..()
+		visible_message("<span class='warning'>A red light on \the [src]'s control panel flashes briefly.</span>")
+		attempts--
+		if (attempts == 0)
+			user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
+			var/turf/T = get_turf(src.loc)
+			explosion(T, 0, 0, 1, 2)
+			del(src)
+
+/obj/structure/closet/crate/secure/loot/proc/check_input(var/input)
+	if(length(input) != codelen)
+		return 0
+	
+	. = 1
+	lastattempt.Cut()
+	for(var/i in 1 to codelen)
+		var/guesschar = copytext(input, i, i+1)
+		lastattempt += guesschar
+		if(guesschar != code[i])
+			. = 0
 
 /obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(locked)
-		if (istype(W, /obj/item/weapon/card/emag))
-			user << "<span class='notice'>The crate unlocks!</span>"
-			locked = 0
 		if (istype(W, /obj/item/device/multitool)) // Greetings Urist McProfessor, how about a nice game of cows and bulls?
-			user << "<span class='notice'>DECA-CODE LOCK REPORT:</span>"
+			user << "<span class='notice'>DECA-CODE LOCK ANALYSIS:</span>"
 			if (attempts == 1)
-				user << "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>"
+				user << "<span class='warning'>* Anti-Tamper system will activate on the next failed access attempt.</span>"
 			else
-				user << "<span class='notice'>* Anti-Tamper Bomb will activate after [src.attempts] failed access attempts.</span>"
-			if (lastattempt != null)
-				var/list/guess = list()
+				user << "<span class='notice'>* Anti-Tamper system will activate after [src.attempts] failed access attempts.</span>"
+			if(lastattempt.len)
 				var/bulls = 0
 				var/cows = 0
-				for(var/i = 1, i < codelen + 1, i++)
-					var/a = copytext(lastattempt, i, i+1) // Stuff the code into the list
-					guess += a
-					guess[a] = i
-				for(var/i in guess) // Go through list and count matches
-					var/a = findtext(code, i)
-					if(a == guess[i])
+				
+				var/list/code_contents = code.Copy()
+				for(var/i in 1 to codelen)
+					if(lastattempt[i] == code[i])
 						++bulls
-					else if(a)
+					else if(lastattempt[i] in code_contents)
 						++cows
+					code_contents -= lastattempt[i]
 				user << "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>"
-		else ..()
-	else ..()
+			return
+	..()

--- a/html/changelogs/HarpyEagle-decacode.yml
+++ b/html/changelogs/HarpyEagle-decacode.yml
@@ -1,0 +1,18 @@
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+
+author: HarpyEagle
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes wrong information being reported when analyzing locked abandoned crates with a multitool."


### PR DESCRIPTION
- Decacode crates now report results correctly when a multitool is used on them.
- Decacode crates now support lock codes with repeated symbols.
- Uses the proper animation when emagged.
- Cleanup.
