### PR TITLE
Fixes liquid fuel fire progress being affected by non-existant gas

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -274,10 +274,10 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		
 		//vapour fuels are extremely volatile! The reaction progress is a percentage of the total fuel (similar to old zburn).)
 		var/min_burn = 0.30*volume*group_multiplier/CELL_VOLUME //in moles - so that fires with very small gas concentrations burn out fast
-		var/gas_reaction_progress = max(min_burn, firelevel_ratio*gas_fuel)*FIRE_GAS_BURNRATE_MULT
+		var/gas_reaction_progress = min(max(min_burn, firelevel_ratio*gas_fuel)*FIRE_GAS_BURNRATE_MULT, gas_fuel)
 
 		//liquid fuels are not as volatile, and the reaction progress depends on the size of the area that is burning. Limit the burn rate to a certain amount per area.
-		var/liquid_reaction_progress = (firelevel_ratio*0.2 + 0.05)*fuel_area*FIRE_LIQUID_BURNRATE_MULT
+		var/liquid_reaction_progress = min((firelevel_ratio*0.2 + 0.05)*fuel_area*FIRE_LIQUID_BURNRATE_MULT, liquid_fuel)
 
 		var/total_reaction_progress = gas_reaction_progress + liquid_reaction_progress
 		var/used_fuel = min(total_reaction_progress, reaction_limit)


### PR DESCRIPTION
Fixes an issue with the rate of a liquid fuel-only fires being abnormally high.

When a fire is burning without any `gas_fuel`, it calculates a value for `gas_reaction_progress` and then clamps it to zero later on at line 305. The issue arises because it needs to be clamped earlier as each type of fuel burns based on the ratio `gas_reaction_progress/total_reaction_progress`, which is going to be incorrect until `gas_reaction_progress` is clamped to the actual amount of `gas_fuel` available to burn.

While the issue seems like it was present before #9936 it was not really visible until now.
