### PR TITLE
Fixes projectiles ignoring their specified target zone

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -95,7 +95,7 @@
 		return 1
 
 	firer = user
-	def_zone = user.zone_sel.selecting
+	def_zone = target_zone
 
 	if(user == target) //Shooting yourself
 		user.bullet_act(src, target_zone)


### PR DESCRIPTION
Only affected shooting yourself with the CLUMSY disability, but still incorrect behaviour regardless.
