### PR TITLE
Of bruises and bandages

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -11,14 +11,8 @@
 	var/heal_burn = 0
 
 /obj/item/stack/medical/attack(mob/living/carbon/M as mob, mob/user as mob)
-	if (!istype(M))
-		user << "\red \The [src] cannot be applied to [M]!"
-		return 1
-
-	if ( ! (istype(user, /mob/living/carbon/human) || \
-			istype(user, /mob/living/silicon) || \
-			istype(user, /mob/living/carbon/monkey)) )
-		user << "\red You don't have the dexterity to do this!"
+	if(!istype(M))
+		user << "<span class='warning'>\The [src] cannot be applied to [M].</span>"
 		return 1
 
 	if (istype(M, /mob/living/carbon/human))
@@ -27,29 +21,25 @@
 
 		if(affecting.display_name == "head")
 			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
-				user << "\red You can't apply [src] through [H.head]!"
+				user << "<span class='warning'>You can't apply [src] through [H.head].</span>"
 				return 1
 		else
 			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
-				user << "\red You can't apply [src] through [H.wear_suit]!"
+				user << "<span class='warning'>You can't apply [src] through [H.wear_suit].</span>"
 				return 1
 
 		if(affecting.status & ORGAN_ROBOT)
-			user << "\red This isn't useful at all on a robotic limb.."
+			user << "<span class='warning'>This isn't useful at all on a robotic limb.</span>"
 			return 1
 
-		H.UpdateDamageIcon()
-
 	else
-
-		M.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
-		user.visible_message( \
-			"\blue [M] has been applied with [src] by [user].", \
-			"\blue You apply \the [src] to [M]." \
-		)
+		M.heal_organ_damage((heal_brute / 2), (heal_burn / 2))
+		user.visible_message("<span class='notice'>[M] has been applied with [src] by [user].</span>", "<span class='notice'>You apply \the [src] to [M].</span>")
 		use(1)
+		return 1
 
-	M.updatehealth()
+	return 0
+
 /obj/item/stack/medical/bruise_pack
 	name = "roll of gauze"
 	singular_name = "gauze length"
@@ -67,29 +57,37 @@
 
 		if(affecting.open == 0)
 			if(!affecting.bandage())
-				user << "\red The wounds on [M]'s [affecting.display_name] have already been bandaged."
+				user << "<span class='warning'>The wounds on [M]'s [affecting.display_name] have already been bandaged.</span>"
 				return 1
 			else
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
+				var/list/bleed = list()
+				var/list/bruise = list()
+				var/list/scratch = list()
+				for(var/datum/wound/W in affecting.wounds)
+					if(W.internal)
 						continue
-					if (W.current_stage <= W.max_bleeding_stage)
-						user.visible_message( 	"\blue [user] bandages [W.desc] on [M]'s [affecting.display_name].", \
-										"\blue You bandage [W.desc] on [M]'s [affecting.display_name]." )
-						//H.add_side_effect("Itch")
-					else if (istype(W,/datum/wound/bruise))
-						user.visible_message( 	"\blue [user] places bruise patch over [W.desc] on [M]'s [affecting.display_name].", \
-										"\blue You place bruise patch over [W.desc] on [M]'s [affecting.display_name]." )
+					if(W.current_stage <= W.max_bleeding_stage)
+						bleed += "\a [W.desc]"
+					else if(istype(W, /datum/wound/bruise))
+						bruise += "\a [W.desc]"
 					else
-						user.visible_message( 	"\blue [user] places bandaid over [W.desc] on [M]'s [affecting.display_name].", \
-										"\blue You place bandaid over [W.desc] on [M]'s [affecting.display_name]." )
+						scratch += "\a [W.desc]"
+				if(bleed.len)
+					var/mes = "[bleed.len == 1 ? "a bandage" : "bandages"] over [english_list(bleed)] on [M]'s [affecting.display_name]"
+					user.visible_message("<span class='notice'>[user] places [mes].</span>", "<span class='notice'>You place [mes].</span>")
+				if(bruise.len)
+					var/mes = "[bruise.len == 1 ? "a bruise patch" : "bruise patches"] over [english_list(bruise)] on [M]'s [affecting.display_name]"
+					user.visible_message("<span class='notice'>[user] places [mes].</span>", "<span class='notice'>You place [mes].</span>")
+				if(scratch.len)
+					var/mes = "[scratch.len == 1 ? "a bandaid" : "bandaids"] over [english_list(scratch)] on [M]'s [affecting.display_name]"
+					user.visible_message("<span class='notice'>[user] places [mes].</span>", "<span class='notice'>You place [mes].</span>")
 				use(1)
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))
 					return
 			else
-				user << "<span class='notice'>The [affecting.display_name] is cut open, you'll need more than a bandage!</span>"
+				user << "<span class='warning'>The [affecting.display_name] is cut open, you'll need more than a bandage.</span>"
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
@@ -110,18 +108,17 @@
 
 		if(affecting.open == 0)
 			if(!affecting.salve())
-				user << "\red The wounds on [M]'s [affecting.display_name] have already been salved."
+				user << "<span class='warning'>The wounds on [M]'s [affecting.display_name] have already been salved.</span>"
 				return 1
 			else
-				user.visible_message( 	"\blue [user] salves wounds on [M]'s [affecting.display_name].", \
-										"\blue You salve wounds on [M]'s [affecting.display_name]." )
+				user.visible_message("<span class='notice'>[user] salves wounds on [M]'s [affecting.display_name].</span>", "<span class='notice'>You salve wounds on [M]'s [affecting.display_name].</span>" )
 				use(1)
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))
 					return
 			else
-				user << "<span class='notice'>The [affecting.display_name] is cut open, you'll need more than a bandage!</span>"
+				user << "<span class='warning'>The [affecting.display_name] is cut open, you'll need more than a bandage.</span>"
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -144,31 +141,39 @@
 			var/disinfected = affecting.disinfect()
 
 			if(!(bandaged || disinfected))
-				user << "\red The wounds on [M]'s [affecting.display_name] have already been treated."
+				user << "<span class='warning'>The wounds on [M]'s [affecting.display_name] have already been treated.</span>"
 				return 1
 			else
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
+				var/list/bleed = list()
+				var/list/bruise = list()
+				var/list/scratch = list()
+				for(var/datum/wound/W in affecting.wounds)
+					if(W.internal)
 						continue
-					if (W.current_stage <= W.max_bleeding_stage)
-						user.visible_message( 	"\blue [user] cleans [W.desc] on [M]'s [affecting.display_name] and seals edges with bioglue.", \
-										"\blue You clean and seal [W.desc] on [M]'s [affecting.display_name]." )
-						//H.add_side_effect("Itch")
-					else if (istype(W,/datum/wound/bruise))
-						user.visible_message( 	"\blue [user] places medicine patch over [W.desc] on [M]'s [affecting.display_name].", \
-										"\blue You place medicine patch over [W.desc] on [M]'s [affecting.display_name]." )
+					if(W.current_stage <= W.max_bleeding_stage)
+						bleed += "\a [W.desc]"
+					else if(istype(W, /datum/wound/bruise))
+						bruise += "\a [W.desc]"
 					else
-						user.visible_message( 	"\blue [user] smears some bioglue over [W.desc] on [M]'s [affecting.display_name].", \
-										"\blue You smear some bioglue over [W.desc] on [M]'s [affecting.display_name]." )
-				if (bandaged)
-					affecting.heal_damage(heal_brute,0)
+						scratch += "\a [W.desc]"
+				if(bleed.len)
+					var/mes = "[english_list(bleed)] on [M]'s [affecting.display_name]"
+					user.visible_message("<span class='notice'>[user] cleans [mes] and seals edges with bioglue.</span>", "<span class='notice'>You clean and seal [mes].</span>")
+				if(bruise.len)
+					var/mes = "[bruise.len == 1 ? "a medicine patch" : "medicine patches"] over [english_list(bruise)] on [M]'s [affecting.display_name]"
+					user.visible_message("<span class='notice'>[user] places [mes].</span>", "<span class='notice'>You place [mes].</span>")
+				if(scratch.len)
+					var/mes = "some bioglue over [english_list(scratch)] on [M]'s [affecting.display_name]"
+					user.visible_message("<span class='notice'>[user] smears [mes].</span>", "<span class='notice'>You smear [mes].</span>")
+				if(bandaged)
+					affecting.heal_damage(heal_brute, 0)
 				use(1)
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))
 					return
 			else
-				user << "<span class='notice'>The [affecting.display_name] is cut open, you'll need more than a bandage!</span>"
+				user << "<span class='warning'>The [affecting.display_name] is cut open, you'll need more than a bandage.</span>"
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -177,7 +182,6 @@
 	icon_state = "burnkit"
 	heal_burn = 12
 	origin_tech = "biotech=1"
-
 
 /obj/item/stack/medical/advanced/ointment/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
@@ -189,12 +193,11 @@
 
 		if(affecting.open == 0)
 			if(!affecting.salve())
-				user << "\red The wounds on [M]'s [affecting.display_name] have already been salved."
+				user << "<span class='warning'>The wounds on [M]'s [affecting.display_name] have already been salved.</span>"
 				return 1
 			else
-				user.visible_message( 	"\blue [user] covers wounds on [M]'s [affecting.display_name] with regenerative membrane.", \
-										"\blue You cover wounds on [M]'s [affecting.display_name] with regenerative membrane." )
-				affecting.heal_damage(0,heal_burn)
+				user.visible_message("<span class='notice'>[user] covers wounds on [M]'s [affecting.display_name] with regenerative membrane.</span>", "<span class='notice'>You cover wounds on [M]'s [affecting.display_name] with regenerative membrane.</span>" )
+				affecting.heal_damage(0, heal_burn)
 				use(1)
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
@@ -218,27 +221,27 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 		var/limb = affecting.display_name
-		if(!((affecting.name == "l_arm") || (affecting.name == "r_arm") || (affecting.name == "l_leg") || (affecting.name == "r_leg")))
-			user << "\red You can't apply a splint there!"
+		if(!(affecting.name == "l_arm" || affecting.name == "r_arm" || affecting.name == "l_leg" || affecting.name == "r_leg"))
+			user << "<span class='warning'>You can't apply a splint there.</span>"
 			return
 		if(affecting.status & ORGAN_SPLINTED)
-			user << "\red [M]'s [limb] is already splinted!"
+			user << "<span class='warning'>[M]'s [limb] is already splinted.</span>"
 			return
-		if (M != user)
-			user.visible_message("\red [user] starts to apply \the [src] to [M]'s [limb].", "\red You start to apply \the [src] to [M]'s [limb].", "\red You hear something being wrapped.")
+		if(M != user)
+			user.visible_message("<span class='notice'>[user] starts to apply \the [src] to [M]'s [limb].</span>", "<span class='notice'>You start to apply \the [src] to [M]'s [limb]...</span>", "<span class='notice'>You hear something being wrapped.</span>")
 		else
 			if((!user.hand && affecting.name == "r_arm") || (user.hand && affecting.name == "l_arm"))
-				user << "\red You can't apply a splint to the arm you're using!"
+				user << "<span class='warning'>You can't apply a splint to the arm you're using!</span>"
 				return
-			user.visible_message("\red [user] starts to apply \the [src] to their [limb].", "\red You start to apply \the [src] to your [limb].", "\red You hear something being wrapped.")
+			user.visible_message("<span class='notice'>[user] starts to apply \the [src] to their [limb].</span>", "<span class='notice'>You start to apply \the [src] to your [limb]...</span>", "<span class='notice'>You hear something being wrapped.</span>")
 		if(do_after(user, 50))
-			if (M != user)
-				user.visible_message("\red [user] finishes applying \the [src] to [M]'s [limb].", "\red You finish applying \the [src] to [M]'s [limb].", "\red You hear something being wrapped.")
+			if(M != user)
+				user.visible_message("<span class='notice'>[user] finishes applying \the [src] to [M]'s [limb].</span>", "<span class='notice'>You finish applying \the [src] to [M]'s [limb].</span>", "<span class='notice'>You hear something being wrapped.</span>")
 			else
 				if(prob(25))
-					user.visible_message("\red [user] successfully applies \the [src] to their [limb].", "\red You successfully apply \the [src] to your [limb].", "\red You hear something being wrapped.")
+					user.visible_message("<span class='notice'>[user] successfully applies \the [src] to their [limb].</span>", "<span class='notice'>You successfully apply \the [src] to your [limb].</span>", "<span class='notice'>You hear something being wrapped.</span>")
 				else
-					user.visible_message("\red [user] fumbles \the [src].", "\red You fumble \the [src].", "\red You hear something being wrapped.")
+					user.visible_message("<span class='warning'>[user] fumbles \the [src].</span>", "<span class='warning'>You fumble \the [src].</span>", "<span class='notice'>You hear something being wrapped.</span>")
 					return
 			affecting.status |= ORGAN_SPLINTED
 			use(1)


### PR DESCRIPTION
Fixes #8210
Medicine stacks will now give less messages, they clump up all wounds of the same level, so you get a maximum of three messages per click, usually just one instead of one wound = one line.
For example:
`You clean and seal an ugly ripped cut and a ripped cut on Kelenius's right arm.`
`You clean and seal an ugly ripped cut and a cut on Kelenius's left arm.`
`You clean and seal a cut, a cut, and a cut on Kelenius's left arm.`
(That's for three clicks)
Code cleanup, spanclasses, spacing, stuff.
