### PR TITLE
Fixes #10215

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1259,6 +1259,7 @@
 #include "code\modules\mob\living\silicon\pai\software_modules.dm"
 #include "code\modules\mob\living\silicon\robot\analyzer.dm"
 #include "code\modules\mob\living\silicon\robot\component.dm"
+#include "code\modules\mob\living\silicon\robot\custom_sprites.dm"
 #include "code\modules\mob\living\silicon\robot\death.dm"
 #include "code\modules\mob\living\silicon\robot\emote.dm"
 #include "code\modules\mob\living\silicon\robot\examine.dm"

--- a/code/modules/mob/living/silicon/robot/custom_sprites.dm
+++ b/code/modules/mob/living/silicon/robot/custom_sprites.dm
@@ -1,0 +1,29 @@
+
+//list(ckey = real_name,) 
+//Since the ckey is used as the icon_state, the current system will only permit a single custom robot sprite per ckey.
+//While it might be possible for a ckey to use that custom sprite for several real_names, it seems rather pointless to support it.
+var/list/robot_custom_icons
+
+/hook/startup/proc/load_robot_custom_sprites()
+	var/config_file = file2text("config/custom_sprites.txt")
+	var/list/lines = text2list(config_file, "\n")
+
+	robot_custom_icons = list()
+	for(var/line in lines)
+		//split entry into ckey and real_name
+		var/split_idx = findtext(line, "-") //this works if ckey cannot contain dashes, and findtext starts from the beginning
+		if(!split_idx || split_idx == length(line))
+			continue //bad entry
+		
+		var/ckey = copytext(line, 1, split_idx)
+		var/real_name = copytext(line, split_idx+1)
+		
+		robot_custom_icons[ckey] = real_name
+
+/mob/living/silicon/robot/proc/set_custom_sprite()
+	var/rname = robot_custom_icons[ckey]
+	if(rname && rname == real_name)
+		custom_sprite = 1
+		icon = 'icons/mob/custom-synthetic.dmi'
+		if(icon_state == "robot")
+			icon_state = "[ckey]-Standard"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -302,23 +302,7 @@
 		camera.c_tag = changed_name
 
 	if(!custom_sprite) //Check for custom sprite
-		var/file = file2text("config/custom_sprites.txt")
-		var/lines = text2list(file, "\n")
-
-		for(var/line in lines)
-		// split & clean up
-			var/list/Entry = text2list(line, "-")
-			for(var/i = 1 to Entry.len)
-				Entry[i] = trim(Entry[i])
-
-			if(Entry.len < 2)
-				continue;
-
-			if(Entry[1] == src.ckey && Entry[2] == src.real_name) //They're in the list? Custom sprite time, var and icon change required
-				custom_sprite = 1
-				icon = 'icons/mob/custom-synthetic.dmi'
-				if(icon_state == "robot")
-					icon_state = "[src.ckey]-Standard"
+		set_custom_sprite()
 
 	//Flavour text.
 	if(client)


### PR DESCRIPTION
- Robot custom sprite config entries are now split at the first dash, instead of at every dash.
- The config is parsed once at startup.
