### PR TITLE
Fixes #10210

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -34,7 +34,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 	var/debug = 0
 	var/requires_power = 1
-	var/unlimited_power = 0
 	var/always_unpowered = 0	//this gets overriden to 1 for space in area/New()
 
 	var/power_equip = 1
@@ -349,7 +348,6 @@ area/space/atmosalert()
 	name = "\improper Centcom"
 	icon_state = "centcom"
 	requires_power = 0
-	unlimited_power = 1
 	lighting_use_dynamic = 0
 
 /area/centcom/control
@@ -388,7 +386,6 @@ area/space/atmosalert()
 	name = "\improper Mercenary Base"
 	icon_state = "syndie-ship"
 	requires_power = 0
-	unlimited_power = 1
 	lighting_use_dynamic = 0
 
 /area/syndicate_mothership/control
@@ -463,7 +460,6 @@ area/space/atmosalert()
 	name = "\improper Independant Station"
 	icon_state = "yellow"
 	requires_power = 0
-	unlimited_power = 1
 	flags = RAD_SHIELDED
 
 /area/syndicate_station/start

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -28,8 +28,7 @@ obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
 			user << "\red \A [charging] is already charging here."
 			return
 		// Checks to make sure he's not in space doing it, and that the area got proper power.
-		var/area/a = get_area(src)
-		if(!isarea(a) || (a.power_equip == 0 && !a.unlimited_power))
+		if(!powered())
 			user << "\red The [name] blinks red as you try to insert the item!"
 			return
 		if (istype(G, /obj/item/weapon/gun/energy/gun/nuclear) || istype(G, /obj/item/weapon/gun/energy/crossbow))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -189,9 +189,7 @@
 	..()
 
 	spawn(2)
-		var/area/A = get_area(src)
-		if(A && !A.requires_power)
-			on = 1
+		on = has_power()
 
 		switch(fitting)
 			if("tube")
@@ -398,7 +396,7 @@
 // true if area has power and lightswitch is on
 /obj/machinery/light/proc/has_power()
 	var/area/A = src.loc.loc
-	return A.lightswitch && A.power_light
+	return A.lightswitch && (!A.requires_power || A.power_light)
 
 /obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
 	if(flickering) return
@@ -570,8 +568,7 @@
 // called when area power state changes
 /obj/machinery/light/power_change()
 	spawn(10)
-		var/area/A = src.loc.loc
-		seton(A.lightswitch && A.power_light)
+		seton(has_power())
 
 // called when on fire
 


### PR DESCRIPTION
- Fixes #10210
-  Removes `unlimited_power` var. Redundant, only used in one place (rechargers) and what it did do is better served by power module procs.
