### PR TITLE
More #10285 fixes.

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -7,7 +7,7 @@
 /datum/reagents/New(var/max = 100, atom/A = null)
 	maximum_volume = max
 	my_atom = A
-	
+
 	//I dislike having these here but map-objects are initialised before world/New() is called. >_>
 	if(!chemical_reagents_list)
 		//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
@@ -270,7 +270,7 @@
 	if(!target || !istype(target))
 		return
 
-	amount = min(amount, total_volume, target.get_free_space() / multiplier)
+	amount = max(0, min(amount, total_volume, target.get_free_space() / multiplier))
 
 	if(!amount)
 		return
@@ -290,9 +290,9 @@
 
 /* Holder-to-atom and similar procs */
 
-//The general proc for applying reagents to things. This proc assumes the reagents are being applied externally, 
+//The general proc for applying reagents to things. This proc assumes the reagents are being applied externally,
 //not directly injected into the contents. It first calls touch, then the appropriate trans_to_*() or splash_mob().
-//If for some reason touch effects are bypassed (e.g. injecting stuff directly into a reagent container or person), 
+//If for some reason touch effects are bypassed (e.g. injecting stuff directly into a reagent container or person),
 //call the appropriate trans_to_*() proc.
 /datum/reagents/proc/trans_to(var/atom/target, var/amount = 1, var/multiplier = 1, var/copy = 0)
 	touch(target) //First, handle mere touch effects


### PR DESCRIPTION
Adds another sanity check to trans_to_holder to avoid runtime issues.
This code only exists on dev-freeze, thus is separate from the prior master-targeting fix.
