### PR TITLE
Chops out "Security Cadet" from assistant Alt Titles.

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -10,7 +10,7 @@
 	selection_color = "#dddddd"
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
-	alt_titles = list("Technical Assistant","Medical Intern","Research Assistant","Security Cadet","Visitor")
+	alt_titles = list("Technical Assistant","Medical Intern","Research Assistant","Visitor")
 
 /datum/job/assistant/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0


### PR DESCRIPTION
Will remove the other "intern" alt titles if requested but this one in particular seemed to be pretty disliked in this thread: http://baystation12.net/forums/threads/discussion-suggestion-alt-titles.237/
