### PR TITLE
Fixes oversight in fire burnout check

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -295,7 +295,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 		//if the reaction is progressing too slow then it isn't self-sustaining anymore and burns out
 		if(zone) //be less restrictive with canister and tank reactions
-			if((!liquid_fuel || used_fuel <= FIRE_LIQUD_MIN_BURNRATE) && (!gas_fuel || used_fuel <= FIRE_GAS_MIN_BURNRATE*group_multiplier))
+			if((!liquid_fuel || used_fuel <= FIRE_LIQUD_MIN_BURNRATE) && (!gas_fuel || used_fuel <= FIRE_GAS_MIN_BURNRATE*zone.contents.len))
 				return 0
 
 


### PR DESCRIPTION
Fires now use the full zone size when considering the minimum amount of phoron/oxygen required to sustain a fire. When zburn() is called, a new gas_mix is created that has a group_multiplier equal to the number of fire tiles instead of the zone air's group_multiplier. While this is desirable for determining the amount of fuel and oxidizer participating in fire processing (see line 248), it causes fire to require less phoron/oxygen to burn than it should.
