### PR TITLE
Change Topic() 'status' command to make more sense

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -104,7 +104,8 @@ var/world_topic_spam_protect_time = world.timeofday
 				n++
 		return n
 
-	else if (T == "status")
+	else if (copytext(T,1,7) == "status")
+		var/input[] = params2list(T)
 		var/list/s = list()
 		s["version"] = game_version
 		s["mode"] = master_mode
@@ -113,21 +114,37 @@ var/world_topic_spam_protect_time = world.timeofday
 		s["vote"] = config.allow_vote_mode
 		s["ai"] = config.allow_ai
 		s["host"] = host ? host : null
-		s["players"] = list()
 		s["stationtime"] = worldtime2text()
-		var/n = 0
-		var/admins = 0
 
-		for(var/client/C in clients)
-			if(C.holder)
-				if(C.holder.fakekey)
-					continue	//so stealthmins aren't revealed by the hub
-				admins++
-			s["player[n]"] = C.key
-			n++
-		s["players"] = n
+		if(input["status"] == "2")
+			var/list/players = list()
+			var/list/admins = list()
 
-		s["admins"] = admins
+			for(var/client/C in clients)
+				if(C.holder)
+					if(C.holder.fakekey)
+						continue
+					admins[C.key] = C.holder.rank
+				players += C.key
+
+			s["players"] = players.len
+			s["playerlist"] = list2params(players)
+			s["admins"] = admins.len
+			s["adminlist"] = list2params(admins)
+		else
+			var/n = 0
+			var/admins = 0
+
+			for(var/client/C in clients)
+				if(C.holder)
+					if(C.holder.fakekey)
+						continue	//so stealthmins aren't revealed by the hub
+					admins++
+				s["player[n]"] = C.key
+				n++
+
+			s["players"] = n
+			s["admins"] = admins
 
 		return list2params(s)
 


### PR DESCRIPTION
Title.
Current format returns `"player0=Key&player1=Other&player2=Someone&players=3&admins=2"`.
This PR changes it so that passing `"status=2"` will return `"players=3&playerlist=Key%26Other%26Someone&admins=2&adminlist=Key%3dHost%26Other%3dGame%2bMaster"`
Passing just `"status"` returns the old format for compatibility.

The format of the `playerlist` and `adminlist` entries are embedded query strings; when de-URL-encoded, the above example becomes:

```
players = "3"
playerlist = "Key&Other&Someone"
admins = "2"
adminlist = "Key=Host&Other=Game+Master"
```
