### PR TITLE
Chemical logging improvements

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1383,6 +1383,7 @@
 #include "code\modules\random_map\random_map.dm"
 #include "code\modules\reagents\Chemistry-Colours.dm"
 #include "code\modules\reagents\Chemistry-Holder.dm"
+#include "code\modules\reagents\Chemistry-Logging.dm"
 #include "code\modules\reagents\Chemistry-Machinery.dm"
 #include "code\modules\reagents\Chemistry-Readme.dm"
 #include "code\modules\reagents\Chemistry-Reagents-Antidepressants.dm"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,7 +79,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/allow_character_respawn,    /* Allows a ghost to respawn */
 	/client/proc/event_manager_panel,
-	/client/proc/empty_ai_core_toggle_latejoin
+	/client/proc/empty_ai_core_toggle_latejoin,
+	/client/proc/view_chemical_reaction_logs
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -363,6 +363,7 @@ datum
 									for(var/S in C.secondary_results)
 										add_reagent(S, C.result_amount * C.secondary_results[S] * multiplier)
 
+								log_chemical_reaction(my_atom, C, multiplier)
 								var/list/seen = viewers(4, get_turf(my_atom))
 								for(var/mob/M in seen)
 									M << "\blue \icon[my_atom] The solution begins to bubble."

--- a/code/modules/reagents/Chemistry-Logging.dm
+++ b/code/modules/reagents/Chemistry-Logging.dm
@@ -1,0 +1,28 @@
+
+/var/list/chemical_reaction_logs = list()
+
+/proc/log_chemical_reaction(atom/A, datum/chemical_reaction/R, multiplier)
+	if(!A || !R)
+		return
+
+	var/turf/T = get_turf(A)
+	var/logstr = "[usr ? key_name(usr) : "EVENT"] mixed [R.name] ([R.result]) (x[multiplier]) in \the [A] at [T ? "[T.x],[T.y],[T.z]" : "*null*"]"
+
+	chemical_reaction_logs += "\[[time_stamp()]\] [logstr]"
+
+	if(R.log_is_important)
+		message_admins(logstr)
+	log_admin(logstr)
+
+/client/proc/view_chemical_reaction_logs()
+	set name = "Show Chemical Reactions"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/html = ""
+	for(var/entry in chemical_reaction_logs)
+		html += "[entry]<br>"
+
+	usr << browse(html, "window=chemlogs")

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -31,6 +31,8 @@ datum
 			result = null
 			required_reagents = list("water" = 1, "potassium" = 1)
 			result_amount = 2
+			log_is_important = 1
+
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/datum/effect/effect/system/reagents_explosion/e = new()
 				e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
@@ -344,6 +346,8 @@ datum
 			result = "nitroglycerin"
 			required_reagents = list("glycerol" = 1, "pacid" = 1, "sacid" = 1)
 			result_amount = 2
+			log_is_important = 1
+
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/datum/effect/effect/system/reagents_explosion/e = new()
 				e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -17,6 +17,8 @@ datum
 		var/list/secondary_results = list()		//additional reagents produced by the reaction
 		var/requires_heating = 0
 
+		var/log_is_important = 0 // If this reaction should be considered important for logging. Important recipes message admins when mixed, non-important ones just log to file.
+
 		proc
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				return
@@ -169,6 +171,7 @@ datum
 			result = "pacid"
 			required_reagents = list("sacid" = 1, "chlorine" = 1, "potassium" = 1)
 			result_amount = 3
+			log_is_important = 1
 
 		synaptizine
 			name = "Synaptizine"
@@ -456,6 +459,7 @@ datum
 			result = "chloralhydrate"
 			required_reagents = list("ethanol" = 1, "chlorine" = 3, "water" = 1)
 			result_amount = 1
+			log_is_important = 1
 
 		potassium_chloride
 			name = "Potassium Chloride"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -170,10 +170,7 @@
 
 					if(istype(target,/mob/living))
 						var/mob/living/M = target
-						var/list/injected = list()
-						for(var/datum/reagent/R in src.reagents.reagent_list)
-							injected += R.name
-						var/contained = english_list(injected)
+						var/contained = reagents.get_reagents()
 						M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been injected with [src.name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
 						user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to inject [M.name] ([M.key]). Reagents: [contained]</font>")
 						msg_admin_attack("[user.name] ([user.ckey]) injected [M.name] ([M.key]) with [src.name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
@@ -181,6 +178,13 @@
 					src.reagents.reaction(target, INGEST)
 				if(ismob(target) && target == user)
 					src.reagents.reaction(target, INGEST)
+
+				if(!ismob(target) && !istype(target, /obj/item/weapon/reagent_containers/glass)) // It's not a mob (which is logged above) and it's not a beaker or similar (which is a fairly normal thing to inject into)
+					usr = user
+					var/contained = reagents.get_reagents()
+					user.attack_log += "\[[time_stamp()]\] <font color='red'>Injected \the [target] with \the [src]. Reagents: [contained]</font>"
+					log_and_message_admins("injected \the [target] with \the [src]. Reagents: [contained]")
+
 				spawn(5)
 					var/datum/reagent/blood/B
 					for(var/datum/reagent/blood/d in src.reagents.reagent_list)


### PR DESCRIPTION
- Recipes can be marked as "important"; important recipes will message admins when mixed. Chloral and polyacid have been marked as important.
- A list of reactions, who mixed them, how much was mixed, what it was mixed in, and where that object was is available via Show-Chemical-Reactions, requiring R_ADMIN. This information is also passed to `log_admin()`.
- Injecting food or drinks (but not beakers) with reagents now causes logs.
