### PR TITLE
Fixes #10355

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -25,7 +25,7 @@
 	botcard.access = botcard_access.Copy()
 
 	access_scanner = new /obj(src)
-	access_scanner.req_access = req_access.Copy()
+	access_scanner.req_one_access = req_access.Copy()
 
 /mob/living/bot/Life()
 	..()

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -16,6 +16,7 @@
 
 	var/obj/access_scanner = null
 	var/list/req_access = list()
+	var/list/req_one_access = list()
 
 /mob/living/bot/New()
 	..()
@@ -25,7 +26,8 @@
 	botcard.access = botcard_access.Copy()
 
 	access_scanner = new /obj(src)
-	access_scanner.req_one_access = req_access.Copy()
+	access_scanner.req_access = req_access.Copy()
+	access_scanner.req_one_access = req_one_access.Copy()
 
 /mob/living/bot/Life()
 	..()

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -4,7 +4,7 @@
 	icon_state = "secbot0"
 	maxHealth = 50
 	health = 50
-	req_access = list(access_security, access_forensics_lockers)
+	req_one_access = list(access_security, access_forensics_lockers)
 	botcard_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
 
 	var/mob/target


### PR DESCRIPTION
- Bots can now be unlocked when you have one of the required accesses, instead of requiring all of them.
- In other words, security officers can once again unlock beepsky. I believe no other bot uses more than one access level for unlocking.
