### PR TITLE
Fixes #10357

### DIFF
--- a/code/setup.dm
+++ b/code/setup.dm
@@ -877,8 +877,8 @@ var/list/be_special_flags = list(
 #define DOOR_OPEN_LAYER 2.7		//Under all objects if opened. 2.7 due to tables being at 2.6
 #define DOOR_CLOSED_LAYER 3.1	//Above most items if closed
 #define LIGHTING_LAYER 11
-#define OBFUSCATION_LAYER 14	//Where images covering the view for eyes are put
-#define SCREEN_LAYER 17			//Mob HUD/effects layer
+#define OBFUSCATION_LAYER 21	//Where images covering the view for eyes are put
+#define SCREEN_LAYER 22			//Mob HUD/effects layer
 
 
 /////////////////


### PR DESCRIPTION
- Adjusts layer defines.
- Screen Layer (UI) is now 22. That should mean i will be above all else. This also prevents laser fire from overlapping the UI.
- Obfuscation Layer (AI's "cameraless zones") is now 21. That makes it above laser fire effects, fixing #10357
