### PR TITLE
Fixes wound max_bleeding_stage oddness

### DIFF
--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -36,9 +36,8 @@
 	var/list/stages
 	// internal wounds can only be fixed through surgery
 	var/internal = 0
-	// maximum stage at which bleeding should still happen, counted from the right rather than the left of the list
-	// 1 means all stages except the last should bleed
-	var/max_bleeding_stage = 1
+	// maximum stage at which bleeding should still happen. Beyond this stage bleeding is prevented.
+	var/max_bleeding_stage = 0
 	// one of CUT, BRUISE, BURN
 	var/damage_type = CUT
 	// whether this wound needs a bandage/salve to heal at all
@@ -63,8 +62,6 @@
 			damage_list += stages[V]
 
 		src.damage = damage
-
-		max_bleeding_stage = src.desc_list.len - max_bleeding_stage
 
 		// initialize with the appropriate stage
 		src.init_stage(damage)
@@ -248,8 +245,9 @@
 /** CUTS **/
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage
-	// All cuts have max_bleeding_stage set to the stage that bears the wound type's name.
-	max_bleeding_stage = 2
+	// Minor cuts have max_bleeding_stage set to the stage that bears the wound type's name.
+	// The major cut types have the max_bleeding_stage set to the clot stage.
+	max_bleeding_stage = 3
 	stages = list("ugly ripped cut" = 20, "ripped cut" = 10, "cut" = 5, "healing cut" = 2, "small scab" = 0)
 	damage_type = CUT
 
@@ -264,17 +262,17 @@
 	damage_type = CUT
 
 /datum/wound/cut/gaping
-	max_bleeding_stage = 2
+	max_bleeding_stage = 3
 	stages = list("gaping wound" = 50, "large blood soaked clot" = 25, "large clot" = 15, "small angry scar" = 5, "small straight scar" = 0)
 	damage_type = CUT
 
 /datum/wound/cut/gaping_big
-	max_bleeding_stage = 2
+	max_bleeding_stage = 3
 	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large clot" = 20, "large angry scar" = 10, "large straight scar" = 0)
 	damage_type = CUT
 
 datum/wound/cut/massive
-	max_bleeding_stage = 2
+	max_bleeding_stage = 3
 	stages = list("massive wound" = 70, "massive healing wound" = 50, "large clot" = 20, "massive angry scar" = 10,  "massive jagged scar" = 0)
 	damage_type = CUT
 
@@ -282,7 +280,7 @@ datum/wound/cut/massive
 /datum/wound/bruise
 	stages = list("monumental bruise" = 80, "huge bruise" = 50, "large bruise" = 30,
 				  "moderate bruise" = 20, "small bruise" = 10, "tiny bruise" = 5)
-	max_bleeding_stage = 3
+	max_bleeding_stage = 3 //only large bruise and above can bleed.
 	autoheal_cutoff = 30
 	damage_type = BRUISE
 
@@ -312,7 +310,7 @@ datum/wound/cut/massive
 	internal = 1
 	stages = list("severed artery" = 30, "cut artery" = 20, "damaged artery" = 10, "bruised artery" = 5)
 	autoheal_cutoff = 5
-	max_bleeding_stage = 0	//all stages bleed. It's called internal bleeding after all.
+	max_bleeding_stage = 4	//all stages bleed. It's called internal bleeding after all.
 
 /** EXTERNAL ORGAN LOSS **/
 /datum/wound/lost_limb
@@ -324,7 +322,7 @@ datum/wound/cut/massive
 	switch(losstype)
 		if(DROPLIMB_EDGE, DROPLIMB_BLUNT)
 			damage_type = CUT
-			max_bleeding_stage = 2
+			max_bleeding_stage = 3 //clotted stump and above can bleed.
 			stages = list(
 				"ripped stump" = damage_amt*1.3,
 				"bloody stump" = damage_amt, 

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -246,7 +246,7 @@
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage
 	// Minor cuts have max_bleeding_stage set to the stage that bears the wound type's name.
-	// The major cut types have the max_bleeding_stage set to the clot stage.
+	// The major cut types have the max_bleeding_stage set to the clot stage (which is accordingly given the "blood soaked" descriptor).
 	max_bleeding_stage = 3
 	stages = list("ugly ripped cut" = 20, "ripped cut" = 10, "cut" = 5, "healing cut" = 2, "small scab" = 0)
 	damage_type = CUT
@@ -257,23 +257,23 @@
 	damage_type = CUT
 
 /datum/wound/cut/flesh
-	max_bleeding_stage = 3
+	max_bleeding_stage = 4
 	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "fresh skin" = 0)
 	damage_type = CUT
 
 /datum/wound/cut/gaping
 	max_bleeding_stage = 3
-	stages = list("gaping wound" = 50, "large blood soaked clot" = 25, "large clot" = 15, "small angry scar" = 5, "small straight scar" = 0)
+	stages = list("gaping wound" = 50, "large blood soaked clot" = 25, "blood soaked clot" = 15, "small angry scar" = 5, "small straight scar" = 0)
 	damage_type = CUT
 
 /datum/wound/cut/gaping_big
 	max_bleeding_stage = 3
-	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large clot" = 20, "large angry scar" = 10, "large straight scar" = 0)
+	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large blood soaked clot" = 25, "large angry scar" = 10, "large straight scar" = 0)
 	damage_type = CUT
 
 datum/wound/cut/massive
 	max_bleeding_stage = 3
-	stages = list("massive wound" = 70, "massive healing wound" = 50, "large clot" = 20, "massive angry scar" = 10,  "massive jagged scar" = 0)
+	stages = list("massive wound" = 70, "massive healing wound" = 50, "massive blood soaked clot" = 25, "massive angry scar" = 10,  "massive jagged scar" = 0)
 	damage_type = CUT
 
 /** BRUISES **/

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -270,12 +270,12 @@
 
 /datum/wound/cut/gaping_big
 	max_bleeding_stage = 2
-	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large angry scar" = 10, "large straight scar" = 0)
+	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large clot" = 20, "large angry scar" = 10, "large straight scar" = 0)
 	damage_type = CUT
 
 datum/wound/cut/massive
 	max_bleeding_stage = 2
-	stages = list("massive wound" = 70, "massive healing wound" = 50, "massive angry scar" = 10,  "massive jagged scar" = 0)
+	stages = list("massive wound" = 70, "massive healing wound" = 50, "large clot" = 20, "massive angry scar" = 10,  "massive jagged scar" = 0)
 	damage_type = CUT
 
 /** BRUISES **/

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -248,6 +248,7 @@
 /** CUTS **/
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage
+	// All cuts have max_bleeding_stage set to the stage that bears the wound type's name.
 	max_bleeding_stage = 2
 	stages = list("ugly ripped cut" = 20, "ripped cut" = 10, "cut" = 5, "healing cut" = 2, "small scab" = 0)
 	damage_type = CUT
@@ -258,7 +259,7 @@
 	damage_type = CUT
 
 /datum/wound/cut/flesh
-	max_bleeding_stage = 4
+	max_bleeding_stage = 3
 	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "fresh skin" = 0)
 	damage_type = CUT
 
@@ -279,7 +280,7 @@ datum/wound/cut/massive
 
 /** BRUISES **/
 /datum/wound/bruise
-	stages = list("monumental bruise" = 80, "huge bruise" = 50, "large bruise" = 30,\
+	stages = list("monumental bruise" = 80, "huge bruise" = 50, "large bruise" = 30,
 				  "moderate bruise" = 20, "small bruise" = 10, "tiny bruise" = 5)
 	max_bleeding_stage = 3
 	autoheal_cutoff = 30
@@ -323,7 +324,7 @@ datum/wound/cut/massive
 	switch(losstype)
 		if(DROPLIMB_EDGE, DROPLIMB_BLUNT)
 			damage_type = CUT
-			max_bleeding_stage = 3
+			max_bleeding_stage = 2
 			stages = list(
 				"ripped stump" = damage_amt*1.3,
 				"bloody stump" = damage_amt, 
@@ -332,7 +333,6 @@ datum/wound/cut/massive
 				)
 		if(DROPLIMB_BURN)
 			damage_type = BURN
-			max_bleeding_stage = 1
 			stages = list(
 				"ripped charred stump" = damage_amt*1.3,
 				"charred stump" = damage_amt,


### PR DESCRIPTION
Originally a fix for "Doctor places a bandaid on Patient's flesh wound" which is kind of silly.
- Fixes some odd max_bleeding_stage values given to `/datum/wound/cut/flesh` that led to people treating flesh wounds with a bandaid. Also fixed the bleeding stage for stumps, so that "bloody stump" counts as a bleeding stage.
- Adds missing clot stages to gaping_big and massive cuts. Without the clot stages the jump between the next two stages was abnormally large, and the values given for max_bleeding_stage did not make
  much sense.
- Lastly, attempts to prevent futher max_bleeding_stage confusion by making the var no longer switch itself around in New(). Instead, the value given refers directly to the index of the maximum
  bleeding stage. This should also make wound datums more friendly to initial(), if that's ever needed.
