### PR TITLE
Fixes #10403

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -76,7 +76,8 @@
 	return candidates
 
 /datum/antagonist/proc/attempt_random_spawn()
-	attempt_spawn(flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
+	build_candidate_list(flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
+	attempt_spawn()
 	finalize_spawn()
 
 /datum/antagonist/proc/attempt_late_spawn(var/datum/mind/player)
@@ -90,16 +91,17 @@
 		add_antagonist(player,0,1,0,1,1)
 	return
 
+/datum/antagonist/proc/build_candidate_list(var/ghosts_only)
+	// Get the raw list of potential players.
+	update_current_antag_max()
+	candidates = get_candidates(ghosts_only)
+
 //Selects players that will be spawned in the antagonist role from the potential candidates
 //Selected players are added to the pending_antagonists lists.
 //Attempting to spawn an antag role with ANTAG_OVERRIDE_JOB should be done before jobs are assigned,
 //so that they do not occupy regular job slots. All other antag roles should be spawned after jobs are
 //assigned, so that job restrictions can be respected.
-/datum/antagonist/proc/attempt_spawn(var/ghosts_only)
-
-	// Get the raw list of potential players.
-	update_current_antag_max()
-	candidates = get_candidates(ghosts_only)
+/datum/antagonist/proc/attempt_spawn(var/rebuild_candidates = 1)
 
 	// Update our boundaries.
 	if(!candidates.len)
@@ -115,7 +117,7 @@
 
 /datum/antagonist/proc/draft_antagonist(var/datum/mind/player)
 	//Check if the player can join in this antag role, or if the player has already been given an antag role.
-	if(can_become_antag(player) && !player.special_role)
+	if(!can_become_antag(player) || player.special_role)
 		return 0
 
 	pending_antagonists |= player

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -245,10 +245,8 @@ var/global/list/additional_antag_types = list()
 	if(!(antag_templates && antag_templates.len))
 		return 1
 
-	// Attempt to mark folks down as ready to go. Don't finalize until post setup.
 	var/datum/antagonist/main_antags = antag_templates[1]
-	var/list/candidates = main_antags.get_candidates()
-	if(candidates.len >= required_enemies)
+	if(main_antags.candidates.len >= required_enemies)
 		return 1
 	return 0
 
@@ -263,10 +261,12 @@ var/global/list/additional_antag_types = list()
 			EMajor.delay_modifier = event_delay_mod_major
 
 /datum/game_mode/proc/pre_setup()
-	//antag roles that replace jobs need to be assigned before the job controller hands out jobs.
 	for(var/datum/antagonist/antag in antag_templates)
+		antag.build_candidate_list() //compile a list of all eligible candidates
+		
+		//antag roles that replace jobs need to be assigned before the job controller hands out jobs.
 		if(antag.flags & ANTAG_OVERRIDE_JOB)
-			antag.attempt_spawn()
+			antag.attempt_spawn() //select antags to be spawned
 
 ///post_setup()
 /datum/game_mode/proc/post_setup()
@@ -284,8 +284,8 @@ var/global/list/additional_antag_types = list()
 	//Assign all antag types for this game mode. Any players spawned as antags earlier should have been removed from the pending list, so no need to worry about those.
 	for(var/datum/antagonist/antag in antag_templates)
 		if(!(antag.flags & ANTAG_OVERRIDE_JOB))
-			antag.attempt_spawn()
-		antag.finalize_spawn()
+			antag.attempt_spawn() //select antags to be spawned
+		antag.finalize_spawn() //actually spawn antags
 		if(antag.is_latejoin_template())
 			latejoin_templates |= antag
 


### PR DESCRIPTION
`can_start()` no longer attempts to rebuild the antag candidate lists but instead reads the existing lists that are now built in `pre_setup()`

Also fixes an issue that came up in testing (the cultists not being spawned) which was due to an inverted check.
