### PR TITLE
Fixes holodeck runtime.

### DIFF
--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -291,7 +291,7 @@
 	if(HP.ambience)
 		linkedholodeck.forced_ambience = HP.ambience
 	else
-		linkedholodeck.forced_ambience = initial(linkedholodeck.ambience)
+		linkedholodeck.forced_ambience = list()
 
 	for(var/mob/living/M in mobs_in_area(linkedholodeck))
 		if(M.mind)


### PR DESCRIPTION
initial() doesn't work well with lists (or reference objects in general). Causes a null value.
