### PR TITLE
Of garbage and references

### DIFF
--- a/code/controllers/Processes/garbage.dm
+++ b/code/controllers/Processes/garbage.dm
@@ -103,10 +103,10 @@ world/loop_checks = 0
 		if(V == "contents")
 			continue
 		if(istype(D.vars[V], /atom))
-			for(var/atom/A in targ)
-				if(D.vars[V] == A)
-					testing("GC: [A] | [A.type] referenced by [D] | [D.type], var [V]")
-					. += 1
+			var/atom/A = D.vars[V]
+			if(A in targ)
+				testing("GC: [A] | [A.type] referenced by [D] | [D.type], var [V]")
+				. += 1
 		else if(islist(D.vars[V]))
 			. += LookForListRefs(D.vars[V], targ, D, V)
 
@@ -114,10 +114,10 @@ world/loop_checks = 0
 	. = 0
 	for(var/F in L)
 		if(istype(F, /atom))
-			for(var/atom/A in targ)
-				if(F == A)
-					testing("GC: [A] | [A.type] referenced by [D] | [D.type], list [V]")
-					. += 1
+			var/atom/A = F
+			if(A in targ)
+				testing("GC: [A] | [A.type] referenced by [D] | [D.type], list [V]")
+				. += 1
 		if(islist(F))
 			. += LookForListRefs(F, targ, D, "[F] in list [V]")
 #endif


### PR DESCRIPTION
Adds an alternate reference searcher that needs a "GC_FINDREF" define during compile to be turned on.

When it's compiled, whenever an atom is to be hard deleted, it will look through all atoms and datums, through their vars, looking for the references to our atom(s).

The process is slow, taking around three minutes (on my machine) per tick, and is only intended for catching references that are put into weird places.

Example log:

```
## TESTING: GC: Searching references for the circuit board (cyborg recharging station) | /obj/item/weapon/circuitboard/recharge_station
## TESTING: GC: Searching references for the micro-manipulator | /obj/item/weapon/stock_parts/manipulator
## TESTING: GC: Searching references for the micro-manipulator | /obj/item/weapon/stock_parts/manipulator
## TESTING: GC: Searching references for the capacitor | /obj/item/weapon/stock_parts/capacitor
## TESTING: GC: Searching references for the capacitor | /obj/item/weapon/stock_parts/capacitor
## TESTING: GC: Searching references for the high-capacity power cell | /obj/item/weapon/cell/high
## TESTING: GC: Searching references for the cable coil | /obj/item/stack/cable_coil
## TESTING: GC: Searching references for the cyborg recharging station | /obj/machinery/recharge_station
## TESTING: GC: the high-capacity power cell | /obj/item/weapon/cell/high referenced by the cyborg recharging station | /obj/machinery/recharge_station, var cell
## TESTING: GC: the circuit board (cyborg recharging station) | /obj/item/weapon/circuitboard/recharge_station referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: the micro-manipulator | /obj/item/weapon/stock_parts/manipulator referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: the micro-manipulator | /obj/item/weapon/stock_parts/manipulator referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: the capacitor | /obj/item/weapon/stock_parts/capacitor referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: the capacitor | /obj/item/weapon/stock_parts/capacitor referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: the high-capacity power cell | /obj/item/weapon/cell/high referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: the cable coil | /obj/item/stack/cable_coil referenced by the cyborg recharging station | /obj/machinery/recharge_station, list component_parts
## TESTING: GC: -- [0x2003533] | /obj/item/weapon/circuitboard/recharge_station was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003534] | /obj/item/weapon/stock_parts/manipulator was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003535] | /obj/item/weapon/stock_parts/manipulator was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003536] | /obj/item/weapon/stock_parts/capacitor was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003537] | /obj/item/weapon/stock_parts/capacitor was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003538] | /obj/item/weapon/cell/high was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003539] | /obj/item/stack/cable_coil was unable to be GC'd and was deleted --
## TESTING: GC: -- [0x2003532] | /obj/machinery/recharge_station was unable to be GC'd and was deleted --
```
