### PR TITLE
Partially reverts #10456.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -18,13 +18,11 @@
 	if(requires_power)
 		luminosity = 0
 	else
+		power_light = 0
+		power_equip = 0
+		power_environ = 0
 		luminosity = 1
 		lighting_use_dynamic = 0
-
-	//If an APC is present it will set these, otherwise they stay off.
-	power_light = 0
-	power_equip = 0
-	power_environ = 0
 
 	..()
 


### PR DESCRIPTION
It caused some equipment to start as and remain offline, in particular vents and scrubbers. Unfixes  #9594.
