### PR TITLE
Fixes area power initialization

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -88,17 +88,22 @@ datum/controller/game_controller/proc/setup()
 
 
 datum/controller/game_controller/proc/setup_objects()
-	world << "\red \b Initializing objects"
+	world << "<span class='danger>Initializing objects</span>"
 	sleep(-1)
 	for(var/atom/movable/object in world)
 		object.initialize()
+	
+	world << "<span class='danger>Initializing areas</span>"
+	sleep(-1)
+	for(var/area/area in all_areas)
+		area.initialize()
 
-	world << "\red \b Initializing pipe networks"
+	world << "<span class='danger>Initializing pipe networks</span>"
 	sleep(-1)
 	for(var/obj/machinery/atmospherics/machine in machines)
 		machine.build_network()
 
-	world << "\red \b Initializing atmos machinery."
+	world << "<span class='danger>Initializing atmos machinery.</span>"
 	sleep(-1)
 	for(var/obj/machinery/atmospherics/unary/U in machines)
 		if(istype(U, /obj/machinery/atmospherics/unary/vent_pump))

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -21,14 +21,13 @@
 		luminosity = 1
 		lighting_use_dynamic = 0
 
-	//If an APC is present it will set these, otherwise they stay off.
-	power_light = 0
-	power_equip = 0
-	power_environ = 0
-
 	..()
 
-//	spawn(15)
+/area/proc/initialize()
+	if(!requires_power || !(locate(/obj/machinery/power/apc) in apc))
+		power_light = 0
+		power_equip = 0
+		power_environ = 0
 	power_change()		// all machines set to current power level, also updates lighting icon
 	InitializeLighting()
 


### PR DESCRIPTION
Power channels start on when objects initialize, then are turned off and area machines notified from area initialization if an APC is not found.

Didn't notice any issues with vent pumps or scrubbers, and the genetics lab is still properly unpowered.
