### PR TITLE
Adjusts names of two areas

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -914,7 +914,7 @@ area/space/atmosalert()
 	icon_state = "tcomsatcham"
 
 /area/server
-	name = "\improper Messaging Server Room"
+	name = "\improper Research Server Room"
 	icon_state = "server"
 
 //Crew
@@ -1826,7 +1826,7 @@ area/space/atmosalert()
 	ambience = list('sound/ambience/ambimalf.ogg')
 
 /area/turret_protected/ai_server_room
-	name = "AI Server Room"
+	name = "Messaging Server Room"
 	icon_state = "ai_server"
 
 /area/turret_protected/ai


### PR DESCRIPTION
- Messaging Server Room -> Research Server Room - That's the server room near toxins storage/misc. research. It has absolutely nothing to do with messaging, as it houses Research's servers only.
- AI Server Room -> Messaging Server Room - That's the actual server room that houses messaging server in central section of the station.
