### PR TITLE
Crew monitor balance and lag fixes.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -126,6 +126,7 @@
 #include "code\datums\ai_laws.dm"
 #include "code\datums\browser.dm"
 #include "code\datums\computerfiles.dm"
+#include "code\datums\crew.dm"
 #include "code\datums\datacore.dm"
 #include "code\datums\datumvars.dm"
 #include "code\datums\disease.dm"

--- a/code/datums/crew.dm
+++ b/code/datums/crew.dm
@@ -1,0 +1,74 @@
+var/global/datum/repository/crew/crew_repository = new()
+
+/datum/cache_entry
+	var/timestamp
+	var/data
+
+/datum/repository/crew
+	var/list/cache_data
+
+/datum/repository/crew/New()
+	cache_data = list()
+	..()
+
+/datum/repository/crew/proc/health_data(var/turf/T)
+	var/list/crewmembers = list()
+	if(!T)
+		return crewmembers
+
+	var/z_level = "[T.z]"
+	var/datum/cache_entry/cache_entry = cache_data[z_level]
+	if(!cache_entry)
+		cache_entry = new/datum/cache_entry
+		cache_data[z_level] = cache_entry
+
+	if(world.time < cache_entry.timestamp)
+		return cache_entry.data
+
+	var/tracked = scan()
+	for(var/obj/item/clothing/under/C in tracked)
+		var/turf/pos = get_turf(C)
+		if((C) && (C.has_sensor) && (pos) && (T && pos.z == T.z) && (C.sensor_mode != SUIT_SENSOR_OFF))
+			if(istype(C.loc, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = C.loc
+				if(H.w_uniform != C)
+					continue
+
+				var/list/crewmemberData = list("dead"=0, "oxy"=-1, "tox"=-1, "fire"=-1, "brute"=-1, "area"="", "x"=-1, "y"=-1, "ref" = "\ref[H]")
+
+				crewmemberData["sensor_type"] = C.sensor_mode
+				crewmemberData["name"] = H.get_authentification_name(if_no_id="Unknown")
+				crewmemberData["rank"] = H.get_authentification_rank(if_no_id="Unknown", if_no_job="No Job")
+				crewmemberData["assignment"] = H.get_assignment(if_no_id="Unknown", if_no_job="No Job")
+
+				if(C.sensor_mode >= SUIT_SENSOR_BINARY)
+					crewmemberData["dead"] = H.stat > UNCONSCIOUS
+
+				if(C.sensor_mode >= SUIT_SENSOR_VITAL)
+					crewmemberData["oxy"] = round(H.getOxyLoss(), 1)
+					crewmemberData["tox"] = round(H.getToxLoss(), 1)
+					crewmemberData["fire"] = round(H.getFireLoss(), 1)
+					crewmemberData["brute"] = round(H.getBruteLoss(), 1)
+
+				if(C.sensor_mode >= SUIT_SENSOR_TRACKING)
+					var/area/A = get_area(H)
+					crewmemberData["area"] = sanitize(A.name)
+					crewmemberData["x"] = pos.x
+					crewmemberData["y"] = pos.y
+
+				crewmembers[++crewmembers.len] = crewmemberData
+
+	crewmembers = sortByKey(crewmembers, "name")
+	cache_entry.timestamp = world.time + 5 SECONDS
+	cache_entry.data = crewmembers
+
+	return crewmembers
+
+/datum/repository/crew/proc/scan()
+	var/list/tracked = list()
+	for(var/mob/living/carbon/human/H in mob_list)
+		if(istype(H.w_uniform, /obj/item/clothing/under))
+			var/obj/item/clothing/under/C = H.w_uniform
+			if (C.has_sensor)
+				tracked |= C
+	return tracked

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -1,6 +1,5 @@
 /obj/nano_module/crew_monitor
 	name = "Crew monitor"
-	var/list/tracked = new
 
 /obj/nano_module/crew_monitor/Topic(href, href_list)
 	if(..()) return
@@ -26,51 +25,11 @@
 		return 1
 
 /obj/nano_module/crew_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	user.set_machine(src)
-	src.scan()
-
 	var/data[0]
 	var/turf/T = get_turf(src)
-	var/list/crewmembers = list()
-	for(var/obj/item/clothing/under/C in src.tracked)
-
-		var/turf/pos = get_turf(C)
-
-		if((C) && (C.has_sensor) && (pos) && (T && pos.z == T.z) && (C.sensor_mode != SUIT_SENSOR_OFF))
-			if(istype(C.loc, /mob/living/carbon/human))
-
-				var/mob/living/carbon/human/H = C.loc
-				if(H.w_uniform != C)
-					continue
-
-				var/list/crewmemberData = list("dead"=0, "oxy"=-1, "tox"=-1, "fire"=-1, "brute"=-1, "area"="", "x"=-1, "y"=-1, "ref" = "\ref[H]")
-
-				crewmemberData["sensor_type"] = C.sensor_mode
-				crewmemberData["name"] = H.get_authentification_name(if_no_id="Unknown")
-				crewmemberData["rank"] = H.get_authentification_rank(if_no_id="Unknown", if_no_job="No Job")
-				crewmemberData["assignment"] = H.get_assignment(if_no_id="Unknown", if_no_job="No Job")
-
-				if(C.sensor_mode >= SUIT_SENSOR_BINARY)
-					crewmemberData["dead"] = H.stat > 1
-
-				if(C.sensor_mode >= SUIT_SENSOR_VITAL)
-					crewmemberData["oxy"] = round(H.getOxyLoss(), 1)
-					crewmemberData["tox"] = round(H.getToxLoss(), 1)
-					crewmemberData["fire"] = round(H.getFireLoss(), 1)
-					crewmemberData["brute"] = round(H.getBruteLoss(), 1)
-
-				if(C.sensor_mode >= SUIT_SENSOR_TRACKING)
-					var/area/A = get_area(H)
-					crewmemberData["area"] = sanitize(A.name)
-					crewmemberData["x"] = pos.x
-					crewmemberData["y"] = pos.y
-
-				crewmembers[++crewmembers.len] = crewmemberData
-
-	crewmembers = sortByKey(crewmembers, "name")
 
 	data["isAI"] = user.isMobAI()
-	data["crewmembers"] = crewmembers
+	data["crewmembers"] = crew_repository.health_data(T)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
@@ -87,10 +46,4 @@
 		// should make the UI auto-update; doesn't seem to?
 		ui.set_auto_update(1)
 
-/obj/nano_module/crew_monitor/proc/scan()
-	for(var/mob/living/carbon/human/H in mob_list)
-		if(istype(H.w_uniform, /obj/item/clothing/under))
-			var/obj/item/clothing/under/C = H.w_uniform
-			if (C.has_sensor)
-				tracked |= C
 	return 1

--- a/html/changelogs/PsiOmegaDelta-CrewEfficiency.yml
+++ b/html/changelogs/PsiOmegaDelta-CrewEfficiency.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - tweak: "Crew monitors now update every 5th second instead of every other. Reduces lag and gives antags a larger window of opportunity to disable suit sensors if they have to harm someone."


### PR DESCRIPTION
Creates a central repository for crew data. This repository only updates data when requested and no more often than every 5th second, no matter how many times the data is requested.

Reduces any lag caused by having multiple crew monitor windows open and as a bonus gives antags a larger window of opportunity to disable sensors before detection of harm (as there is only one source that updates every 0-5 seconds instead of multiple sources that update every 0-2).

Changelog entry doesn't explicitly mention the fact that this is a change from X windows doing calls every 2 seconds to 1 datum doing it very 5 but it didn't feel relevant either. While the AI can technically have multiple crew monitor windows open I doubt it's common.
