### PR TITLE
Fixes #10136

### DIFF
--- a/code/game/machinery/computer3/computers/camera.dm
+++ b/code/game/machinery/computer3/computers/camera.dm
@@ -56,7 +56,7 @@
 	name = "Security Camera Network Main Key"
 	var/title = "Station"
 	var/desc = "Connects to station security cameras."
-	var/list/networks = list("SS13")
+	var/networks = list("ALL") // A little workaround as it is not possible to place station_networks here
 	var/screen = "cameras"
 
 	execute(var/datum/file/source)
@@ -76,58 +76,65 @@
 						return
 		computer.Crash(MISSING_PROGRAM)
 
+/datum/file/camnet_key/New()
+	for(var/N in networks)
+		if(N == "ALL")
+			networks = station_networks
+			break
+	return ..()
+
 /datum/file/camnet_key/mining
 	name = "Mining Camera Network Key"
 	title = "mining station"
 	desc = "Connects to mining security cameras."
-	networks = list("MINE")
+	networks = list(NETWORK_MINE)
 	screen = "miningcameras"
 
 /datum/file/camnet_key/research
 	name = "Research Camera Network Key"
 	title = "research"
-	networks = list("RD")
+	networks = list(NETWORK_RESEARCH)
 
 /datum/file/camnet_key/bombrange
 	name = "R&D Bomb Range Camera Network Key"
 	title = "bomb range"
 	desc = "Monitors the bomb range."
-	networks = list("Toxins")
+	networks = list(NETWORK_RESEARCH)
 
 /datum/file/camnet_key/xeno
 	name = "R&D Misc. Research Camera Network Key"
 	title = "special research"
-	networks = list("Misc")
+	networks = list(NETWORK_RESEARCH)
 
 /datum/file/camnet_key/singulo
 	name = "Singularity Camera Network Key"
 	title = "singularity"
-	networks = list("Singularity")
+	networks = list(NETWORK_ENGINE)
 
 /datum/file/camnet_key/entertainment
 	name = "Entertainment Channel Encryption Key"
 	title = "entertainment"
 	desc = "Damn, I hope they have /tg/thechannel on here."
-	networks = list("thunder")
+	networks = list(NETWORK_THUNDER)
 	screen = "entertainment"
 
 /datum/file/camnet_key/creed
 	name = "Special Ops Camera Encryption Key"
 	title = "special ops"
 	desc = "Connects to special ops secure camera feeds."
-	networks = list("CREED")
+	networks = list(NETWORK_ERT)
 
 /datum/file/camnet_key/prison
 	name = "Prison Camera Network Key"
 	title = "prison"
 	desc = "Monitors the prison."
-	networks = list("Prison")
+	networks = list(NETWORK_SECURITY)
 
 /datum/file/camnet_key/syndicate
 	name = "Camera Network Key"
 	title = "%!#BUFFER OVERFLOW"
 	desc = "Connects to security cameras."
-	networks = list("SS13")
+	networks = list("ALL")
 	hidden_file = 1
 
 

--- a/code/game/machinery/computer3/laptop.dm
+++ b/code/game/machinery/computer3/laptop.dm
@@ -106,12 +106,16 @@
 	pixel_x			= 2
 	pixel_y			= -3
 	show_keyboard	= 0
+	active_power_usage = 200 // Stationary consoles we use on station have 300, laptops are probably slightly more power efficient
+	idle_power_usage = 100
 
 	var/obj/item/device/laptop/portable = null
 
 	New(var/L, var/built = 0)
 		if(!built && !battery)
 			battery = new /obj/item/weapon/cell(src)
+			battery.maxcharge = 500
+			battery.charge = 500
 		..(L,built)
 
 	verb/close_computer()

--- a/code/game/machinery/computer3/lapvend.dm
+++ b/code/game/machinery/computer3/lapvend.dm
@@ -202,11 +202,11 @@
 	if (network == 3)
 		newlap.spawn_parts += (/obj/item/part/computer/networking/cable)
 	if (power == 1)
-		qdel(newlap.battery)
-		newlap.battery = new /obj/item/weapon/cell/high(newlap)
+		newlap.battery.maxcharge = 1000
+		newlap.battery.charge = 1000
 	if (power == 2)
-		qdel(newlap.battery)
-		newlap.battery = new /obj/item/weapon/cell/super(newlap)
+		newlap.battery.maxcharge = 1750
+		newlap.battery.charge = 1750
 
 	newlap.spawn_parts()
 


### PR DESCRIPTION
- Quick fix for #10136, laptops now use the #define-d values rather than hardcoded strings. Camera net keys work again properly.
- I also adjusted laptop's power usage. With how it used to be, you could buy laptop and let it run for whole shift, never having to recharge even with weakest cell. Right now, it lasts about 10 minutes on worst cell, and almost one hour on the best one. Actual power usage (in watts) is slightly lower than stationbound consoles.
