### PR TITLE
Fixes #9158.

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -253,7 +253,7 @@ var/global/photo_count = 0
 	var/viewer = user
 	if(user.client)		//To make shooting through security cameras possible
 		viewer = user.client.eye
-	var/can_see = (dummy in viewers(world.view, viewer)) != null
+	var/can_see = (dummy in viewers(world.view, viewer))
 
 	dummy.loc = null
 	dummy = null	//Alas, nameless creature	//garbage collect it instead

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -255,8 +255,7 @@ var/global/photo_count = 0
 		viewer = user.client.eye
 	var/can_see = (dummy in viewers(world.view, viewer))
 
-	dummy.loc = null
-	dummy = null	//Alas, nameless creature	//garbage collect it instead
+	del(dummy)
 	return can_see
 
 /obj/item/device/camera/proc/captureimage(atom/target, mob/user, flag)


### PR DESCRIPTION
Neither the value True nor False are null. Removes breaking null check. Fixes #9158.
