### PR TITLE
Fixes #10494.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -578,7 +578,6 @@
 		if(keyslot.syndie)
 			src.syndie = 1
 
-
 	for (var/ch_name in src.channels)
 		if(!radio_controller)
 			sleep(30) // Waiting for the radio_controller to be created.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -182,7 +182,7 @@
 	aiCamera = new/obj/item/device/camera/siliconcam/robot_camera(src)
 
 	laws = new /datum/ai_laws/syndicate_override
-	module = new /obj/item/weapon/robot_module/syndicate(src)
+	new /obj/item/weapon/robot_module/syndicate(src)
 
 	radio.keyslot = new /obj/item/device/encryptionkey/syndicate(radio)
 	radio.recalculateChannels()
@@ -263,7 +263,7 @@
 		return
 
 	var/module_type = robot_modules[modtype]
-	module = new module_type(src)
+	new module_type(src)
 
 	hands.icon_state = lowertext(modtype)
 	feedback_inc("cyborg_[lowertext(modtype)]",1)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -39,6 +39,8 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/New(var/mob/living/silicon/robot/R)
 	..()
+	R.module = src
+
 	add_camera_networks(R)
 	add_languages(R)
 	add_subsystems(R)
@@ -69,7 +71,7 @@ var/global/list/robot_modules = list(
 	synths = null
 	emag = null
 	jetpack = null
-	..()
+	return ..()
 
 /obj/item/weapon/robot_module/emp_act(severity)
 	if(modules)


### PR DESCRIPTION
Assigns the selected module before updating radio channels, ensuring said channels update correctly. Fixes #10494.
