### PR TITLE
Forces hardware acceleration.

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -156,6 +156,13 @@
 		add_admin_verbs()
 		admin_memo_show()
 
+	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
+	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)
+	spawn(5) // And wait a half-second, since it sounds like you can do this too fast.
+		if(src)
+			winset(src, null, "command=\".configure graphics-hwmode off\"")
+			winset(src, null, "command=\".configure graphics-hwmode on\"")
+
 	log_client_to_db()
 
 	send_resources()


### PR DESCRIPTION
Most likely also fixes the hickup where BYOND still rending lights are blobs of light despite having hardware acceleration enabled.
Ports https://github.com/ParadiseSS13/Paradise/pull/1690. Fixes #10147 as much as it can be fixed I believe.

Seems a bit scary that this is possible tho.
