### PR TITLE
Re-adds missing bot check.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -103,6 +103,13 @@
 			bumpopen(M)
 		return
 
+	if(istype(AM, /obj/machinery/bot))
+		var/obj/machinery/bot/bot = AM
+		if(src.check_access(bot.botcard))
+			if(density)
+				open()
+		return
+
 	if(istype(AM, /mob/living/bot))
 		var/mob/living/bot/bot = AM
 		if(src.check_access(bot.botcard))


### PR DESCRIPTION
Not all bots are of the type /mob/living/bot yet. Re-adds the /obj/machinery/bot-type check on airlock bump.
Fixes #10507.
