### PR TITLE
Holodeck stool icon fix.

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -46,8 +46,8 @@
 /obj/structure/holostool
 	name = "stool"
 	desc = "Apply butt."
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "stool"
+	icon = 'icons/obj/furniture.dmi'
+	icon_state = "stool_padded_preview"
 	anchored = 1.0
 	pressure_resistance = 15
 


### PR DESCRIPTION
Backports the icon state change from dev. Fixes #10515.
