### PR TITLE
Runtime fixes.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -164,7 +164,7 @@
 			a = get_area(src.loc)
 	else
 		var/error = dist_y/2 - dist_x
-		while(src && target &&((((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)) && dist_travelled < range) || (a.has_gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
+		while(src && target &&((((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)) && dist_travelled < range) || (a && a.has_gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dx)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -18,7 +18,8 @@
 
 /obj/Destroy()
 	processing_objects -= src
-	..()
+	nanomanager.close_uis(src)
+	return ..()
 
 /obj/Topic(href, href_list, var/nowindow = 0, var/datum/topic_state/state = default_state)
 	// Calling Topic without a corresponding window open causes runtime errors

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -106,6 +106,26 @@
 	return update_count
 
  /**
+  * Close all /nanoui uis attached to src_object
+  *
+  * @param src_object /obj|/mob The obj or mob which the uis are attached to
+  *
+  * @return int The number of uis close
+  */
+/datum/nanomanager/proc/close_uis(src_object)
+	var/src_object_key = "\ref[src_object]"
+	if (isnull(open_uis[src_object_key]) || !istype(open_uis[src_object_key], /list))
+		return 0
+
+	var/close_count = 0
+	for (var/ui_key in open_uis[src_object_key])
+		for (var/datum/nanoui/ui in open_uis[src_object_key][ui_key])
+			if(ui && ui.src_object && ui.user && ui.src_object.nano_host())
+				ui.close()
+				close_count++
+	return close_count
+
+ /**
   * Update /nanoui uis belonging to user
   *
   * @param user /mob The mob who owns the uis


### PR DESCRIPTION
NanoUI windows now close on Destroy(), preventing all sorts of qdel issues.
Adds a missing !null check in atoms_movable (a similar check is made only a few lines up).
