### PR TITLE
Adds sanity checks for stripping.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -224,6 +224,10 @@
 
 
 /mob/living/carbon/human/show_inv(mob/user as mob)
+	// TODO :  Change to incapacitated() on merge.
+	if(user.stat || user.lying || user.resting || user.buckled)
+		return
+
 	var/obj/item/clothing/under/suit = null
 	if (istype(w_uniform, /obj/item/clothing/under))
 		suit = w_uniform

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -3,6 +3,11 @@
 	if(!slot_to_strip || !istype(user))
 		return
 
+	// TODO :  Change to incapacitated() on merge.
+	if(user.stat || user.lying || user.resting || user.buckled)
+		user << browse(null, text("window=mob[src.name]"))
+		return
+
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip))
 
 	switch(slot_to_strip)


### PR DESCRIPTION
Mobs can no longer strip other mobs while prone, unconscious, or buckled down. Fixes #10553.
