### PR TITLE
Prevents APC wires from being displayed to the AI.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -738,7 +738,7 @@
 	if(!user)
 		return
 
-	if(wiresexposed /*&& (!istype(user, /mob/living/silicon))*/) //Commented out the typecheck to allow engiborgs to repair damaged apcs.
+	if(wiresexposed && !istype(user, /mob/living/silicon/ai))
 		wires.Interact(user)
 
 	return ui_interact(user)


### PR DESCRIPTION
Restores and makes the mob type check more specific. Fixes #10559.
