### PR TITLE
Fixes carbon fire_act()

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -372,8 +372,8 @@
 
 /mob/living/carbon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
-	var/temp_inc = max(BODYTEMP_HEATING_MAX*(1-get_heat_protection()), 0)
-	bodytemperature = min(bodytemperature + temp_inc, exposed_temperature)
+	var/temp_inc = max(min(BODYTEMP_HEATING_MAX*(1-get_heat_protection()), exposed_temperature - bodytemperature), 0)
+	bodytemperature += temp_inc
 
 /mob/living/carbon/can_use_hands()
 	if(handcuffed)


### PR DESCRIPTION
Caused fire to actually cool down the mob if the mob was already hotter than the exposed temperature.
