### PR TITLE
qdel(reagent) adjustments.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -39,6 +39,7 @@
 	. = ..()
 	if(reagents)
 		qdel(reagents)
+		reagents = null
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
 	loc = null

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -100,10 +100,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	flags |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
 
-/obj/item/clothing/mask/smokable/Destroy()
-	..()
-	qdel(reagents)
-
 /obj/item/clothing/mask/smokable/process()
 	var/turf/location = get_turf(src)
 	smoketime--

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -146,11 +146,6 @@
 		new /obj/item/clothing/mask/smokable/cigarette(src)
 	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 
-/obj/item/weapon/storage/fancy/cigarettes/Destroy()
-	qdel(reagents)
-	..()
-
-
 /obj/item/weapon/storage/fancy/cigarettes/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
 	return
@@ -201,10 +196,6 @@
 	for(var/i = 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette/cigar(src)
 	create_reagents(15 * storage_slots)
-
-/obj/item/weapon/storage/fancy/cigar/Destroy()
-	qdel(reagents)
-	..()
 
 /obj/item/weapon/storage/fancy/cigar/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -17,6 +17,9 @@
 		germ_level++
 
 /mob/living/carbon/Destroy()
+	qdel(ingested)
+	qdel(touching)
+	// We don't qdel(bloodstr) because it's the same as qdel(reagents)
 	for(var/guts in internal_organs)
 		qdel(guts)
 	for(var/food in stomach_contents)


### PR DESCRIPTION
Attempts to ensure qdel(reagents) only occur once per Destroy() and that all the extra mob reagent sources are also handled.
