### PR TITLE
Cleans up living/say broadcast and verb logic

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -42,5 +42,3 @@
 #define INNATE       64  // All mobs can be assumed to speak and understand this language. (audible emotes)
 #define NO_TALK_MSG  128 // Do not show the "\The [speaker] talks into \the [radio]" message
 #define NO_STUTTER   256 // No stuttering, slurring, or other speech problems
-#define COMMON_VERBS 512 // Robots will apply regular verbs to this
-

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -25,7 +25,7 @@
 	speech_verb = "says"
 	whisper_verb = "whispers"
 	key = "0"
-	flags = RESTRICTED | COMMON_VERBS
+	flags = RESTRICTED
 	syllables = list("blah","blah","blah","bleh","meh","neh","nah","wah")
 
 //TODO flag certain languages to use the mob-type specific say_quote and then get rid of these.

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -161,19 +161,13 @@ proc/get_radio_key_from_channel(var/channel)
 	else
 		speaking = get_default_language()
 
-	if (speaking)
-		// This is broadcast to all mobs with the language,
-		// irrespective of distance or anything else.
-		if(speaking.flags & HIVEMIND)
-			speaking.broadcast(src,trim(message))
-			return 1
-		//If we've gotten this far, keep going!
-		if(speaking.flags & COMMON_VERBS)
-			verb = say_quote(message)
-		else
-			verb = speaking.get_spoken_verb(copytext(message, length(message)))
-	else
-		verb = say_quote(message)
+	// This is broadcast to all mobs with the language,
+	// irrespective of distance or anything else.
+	if(speaking && (speaking.flags & HIVEMIND))
+		speaking.broadcast(src,trim(message))
+		return 1
+
+	verb = say_quote(message, speaking)
 
 	if(is_muzzled())
 		src << "<span class='danger'>You're muzzled and cannot speak!</span>"


### PR DESCRIPTION
Human say_quote() will use the language to obtain a speech verb while silicon say_quote() will use synth speech verbs, so passing the language to say_quote eliminates the need for the extra language flag. 

This has the side-effect that silicons will always use their synth speech verbs regardless of language, however. Either way though, if silicons are going to have some special logic for what verb they use then is should probably go in silicon/say_quote instead of in living/say.
- [x] DNM because I need to test this.
