### PR TITLE
Forensics: the Unmangling

### DIFF
--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -21,20 +21,20 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 	var/item_multiplier = istype(src,/obj/item)?1.2:1
 	var/suit_coverage = 0
 	if(M.wear_suit)
-		fibertext = "Material from \a [M.wear_suit]."
+		fibertext = "Material from \a [initial(M.wear_suit)]."
 		if(prob(10*item_multiplier) && !(fibertext in suit_fibers))
 			suit_fibers += fibertext
 		suit_coverage = M.wear_suit.body_parts_covered
 
 	if(M.w_uniform && (M.w_uniform.body_parts_covered & ~suit_coverage))
-		fibertext = "Fibers from \a [M.w_uniform]."
+		fibertext = "Fibers from \a [initial(M.w_uniform.name)]."
 		if(prob(15*item_multiplier) && !(fibertext in suit_fibers))
 			suit_fibers += fibertext
 
 	if(M.gloves && (M.gloves.body_parts_covered & ~suit_coverage))
-		fibertext = "Material from a pair of [M.gloves.name]."
+		fibertext = "Material from a pair of [initial(M.gloves.name)]."
 		if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
-			suit_fibers += "Material from a pair of [M.gloves.name]."
+			suit_fibers += "Material from a pair of [initial(M.gloves.name)]."
 
 /datum/data/record/forensic
 	name = "forensic data"


### PR DESCRIPTION
Fiber names use initial name of clothing, to stop mangled gloves showing up as such instead of just gloves. Also chamsuits because those are holograms.
