### PR TITLE
Newmalf Fixes

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -163,14 +163,13 @@
 
 	command_announcement.Announce(fulltext)
 
-// Proc: get_unhacked_apcs()
+// Proc: get_all_apcs()
 // Parameters: None
-// Description: Returns a list of APCs that are not yet hacked.
-/proc/get_unhacked_apcs()
+// Description: Returns a list of all APCs
+/proc/get_all_apcs()
 	var/list/H = list()
 	for(var/obj/machinery/power/apc/A in machines)
-		if(!A.hacker)
-			H.Add(A)
+		H.Add(A)
 	return H
 
 

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -38,7 +38,7 @@
 // END RESEARCH DATUMS
 // BEGIN ABILITY VERBS
 
-/datum/game_mode/malfunction/verb/basic_encryption_hack(obj/machinery/power/apc/A as obj in get_unhacked_apcs())
+/datum/game_mode/malfunction/verb/basic_encryption_hack(obj/machinery/power/apc/A as obj in get_all_apcs())
 	set category = "Software"
 	set name = "Basic Encryption Hack"
 	set desc = "10 CPU - Basic encryption hack that allows you to overtake APCs on the station."

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -769,7 +769,7 @@ var/list/ai_verbs_default = list(
 	// Off-Station APCs should not count towards CPU generation.
 	for(var/obj/machinery/power/apc/A in hacked_apcs)
 		if(A.z in config.station_levels)
-			cpu_gain += 0.002
+			cpu_gain += 0.004
 			cpu_storage += 10
 
 	research.max_cpu = cpu_storage + override_CPUStorage

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -830,7 +830,7 @@ var/list/ai_verbs_default = list(
 		if(src.research)
 			stat(null, "Available CPU: [src.research.stored_cpu] TFlops")
 			stat(null, "Maximal CPU: [src.research.max_cpu] TFlops")
-			stat(null, "CPU generation rate: [src.research.cpu_increase_per_tick] TFlops/s")
+			stat(null, "CPU generation rate: [src.research.cpu_increase_per_tick * 10] TFlops/s")
 			stat(null, "Current research focus: [src.research.focus ? src.research.focus.name : "None"]")
 			if(src.research.focus)
 				stat(null, "Research completed: [round(src.research.focus.invested, 0.1)]/[round(src.research.focus.price)]")


### PR DESCRIPTION
- Attempting to hack already hacked APC now correctly produces "You already control this APC" message. Fixes #10498
- Fixes incorrectly displayed CPU increase. Value displayed was per decisecond, not per second.
- Increases CPU income from hacked APCs according to feedback and observations on live server.
