### PR TITLE
'fixes' spacestation13.com's server banner

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -112,6 +112,9 @@ var/world_topic_spam_protect_time = world.timeofday
 		s["vote"] = config.allow_vote_mode
 		s["ai"] = config.allow_ai
 		s["host"] = host ? host : null
+
+		// This is dumb, but spacestation13.com's banners break if player count isn't the 8th field of the reply, so... this has to go here.
+		s["players"] = 0
 		s["stationtime"] = worldtime2text()
 
 		if(input["status"] == "2")


### PR DESCRIPTION
they appear to just use the 8th field of the reply for the player count, rather than parsing the reply; this moves player count back to being the 8th entry
