### PR TITLE
Aghosted mobs no longer act as SSD

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -398,8 +398,10 @@ var/list/admin_verbs_mentor = list(
 		var/mob/body = mob
 		var/mob/dead/observer/ghost = body.ghostize(1)
 		ghost.admin_ghosted = 1
-		if(body && !body.key)
-			body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
+		if(body)
+			body.aghosted = ghost
+			if(!body.key)
+				body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
 		feedback_add_details("admin_verb","O") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -216,6 +216,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			return
 	mind.current.ajourn=0
 	mind.current.key = key
+	mind.current.aghosted = null
 	if(!admin_ghosted)
 		announce_ghost_joinleave(mind, 0, "They now occupy their body again.")
 	return 1

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -257,7 +257,7 @@
 			var/show_ssd
 			var/mob/living/carbon/human/H = src
 			if(istype(H)) show_ssd = H.species.show_ssd
-			if(show_ssd && (!client || !key || player_logged))
+			if(show_ssd && !client && !aghosted)
 				M.visible_message("<span class='notice'>[M] shakes [src] trying to wake [t_him] up!</span>", \
 				"<span class='notice'>You shake [src], but they do not respond... Maybe they have S.S.D?</span>")
 			else if(lying || src.sleeping)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -941,8 +941,8 @@
 		if(status_flags & GODMODE)	return 0
 
 		//SSD check, if a logged player is awake put them back to sleep!
-		if(sleeping < 2 && species.show_ssd && (!client || !key || player_logged))
-			sleeping = 2
+		if(species.show_ssd && !client && !aghosted)
+			Sleeping(2)
 
 		if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 			blinded = 1
@@ -1002,10 +1002,8 @@
 				adjustHalLoss(-3)
 				if (mind)
 					//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of stoxin or similar.
-					if(player_logged)
-						sleeping = max(sleeping-1, 2)
-					else
-						sleeping = max(sleeping-1, 0)
+					if(client || sleeping > 3)
+						AdjustSleeping(-1)
 				blinded = 1
 				stat = UNCONSCIOUS
 				animate_tail_reset()

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -5,6 +5,5 @@
 	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)
 	mind.active = 1		//indicates that the mind is currently synced with a client
 	//If they're SSD, remove it so they can wake back up.
-	player_logged = 0
 	update_antag_icons(mind)
 	return .

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -1,8 +1,6 @@
 /mob/living/Logout()
 	..()
-	if (mind)
-		if(!key)	//key and mind have become seperated. I believe this is for when a staff member aghosts.
+	if (mind)	
+		//Per BYOND docs key remains set if the player DCs, becomes null if switching bodies.
+		if(!key)	//key and mind have become seperated. 
 			mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
-		//This tags a player as SSD. See appropriate life.dm files for furthering SSD effects such as falling asleep.
-		if(mind.active)
-			player_logged = 1 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -214,8 +214,8 @@
 
 	var/stance_damage = 0 //Whether this mob's ability to stand has been affected
 
-	//SSD var, changed it up some so people can have special things happen for different mobs when SSD.
-	var/player_logged = 0
+	//Indicates if a clientless mob is actually an admin aghosting
+	var/mob/dead/observer/aghosted = null
 
 	var/turf/listed_turf = null  	//the current turf being examined in the stat panel
 	var/list/shouldnt_see = list()	//list of objects that this mob shouldn't see in the stat panel. this silliness is needed because of AI alt+click and cult blood runes


### PR DESCRIPTION
Whoever wrote `player_logged` had some misconceptions about what `!key` means. Since it did not actually serve the purpose of determining if a player is aghosted and did not serve any other purpose, I replaced it with a much more direct implementation that uses an `aghosted` var instead. Since there is no way ATM to obtain the ghost mob of a player if you only have the original mob I figured it would be handy if it held a reference to the ghosted admin's observer mob.

Changed SSD checks to only look at client since regardless of what `key` gets set to I think we probably don't want players being told a mob is SSD if there is some client controlling it.

Note that as per BYOND docs (!client && key) will tell you if a player is disconnected.
