### PR TITLE
Fixes #10621

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -563,6 +563,7 @@
 	adj_drowsy = -3
 	adj_sleepy = -2
 	adj_temp = 25
+	overdose = 45
 
 	glass_icon_state = "hot_coffee"
 	glass_name = "cup of coffee"
@@ -572,9 +573,13 @@
 	..()
 	if(alien == IS_DIONA)
 		return
-	M.make_jittery(5)
 	if(adj_temp > 0)
 		holder.remove_reagent("frostoil", 10 * removed)
+
+/datum/reagent/drink/coffee/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien == IS_DIONA)
+		return
+	M.make_jittery(5)
 
 /datum/reagent/drink/coffee/icecoffee
 	name = "Iced Coffee"


### PR DESCRIPTION
Coffee now adds jittery as an overdose effect. Set overdose so that drinking two full cups in one go (60 units) will result in 150 jitteriness.
