### PR TITLE
Fixes overdose not working for ingested reagents

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -39,7 +39,7 @@
 		return
 	if(!affects_dead && M.stat == DEAD)
 		return
-	if(overdose && (dose > overdose) && (location == CHEM_BLOOD))
+	if(overdose && (dose > overdose) && (location != CHEM_TOUCH))
 		overdose(M, alien)
 	var/removed = metabolism
 	if(ingest_met && (location == CHEM_INGEST))


### PR DESCRIPTION
I'm not sure what motivated that check however I cannot see a good reason why medicines delivered by pill or drunk from a glass should be exempt from overdose effects so I am considering this a fix.
