### PR TITLE
Round Duration display

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -12,7 +12,7 @@ proc/worldtime2text(time = world.time)
 
 proc/worlddate2text()
 	return num2text((text2num(time2text(world.timeofday, "YYYY"))+544)) + "-" + time2text(world.timeofday, "MM-DD")
-	
+
 proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")
 
@@ -27,3 +27,18 @@ proc/isDay(var/month, var/day)
 		// Uncomment this out when debugging!
 		//else
 			//return 1
+
+var/next_duration_update = 0
+var/last_round_duration = 0
+proc/round_duration()
+	if(last_round_duration && world.time < next_duration_update)
+		return last_round_duration
+
+	var/mills = world.time // 1/10 of a second, not real milliseconds but whatever
+	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
+	var/mins = (mills % 36000) / 600
+	var/hours = mills / 36000
+
+	last_round_duration = "[round(hours)]h [round(mins)]m"
+	next_duration_update = world.time + 1 MINUTES
+	return last_round_duration

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -189,7 +189,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Station Time: [worldtime2text()]")
 		if(emergency_shuttle)
 			var/eta_status = emergency_shuttle.get_status_panel_eta()
 			if(eta_status)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -149,12 +149,6 @@
 /mob/living/silicon/proc/show_malf_ai()
 	return 0
 
-
-// this function displays the station time in the status panel
-/mob/living/silicon/proc/show_station_time()
-	stat(null, "Station Time: [worldtime2text()]")
-
-
 // this function displays the shuttles ETA in the status panel if the shuttle has been called
 /mob/living/silicon/proc/show_emergency_shuttle_eta()
 	if(emergency_shuttle)
@@ -166,7 +160,6 @@
 // This adds the basic clock, shuttle recall timer, and malf_ai info to all silicon lifeforms
 /mob/living/silicon/Stat()
 	if(statpanel("Status"))
-		show_station_time()
 		show_emergency_shuttle_eta()
 		show_system_integrity()
 		show_malf_ai()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -638,6 +638,10 @@
 	. = (client && client.inactivity < 1200)
 
 	if(.)
+		if(statpanel("Status") && ticker && ticker.current_state != GAME_STATE_PREGAME)
+			statpanel("Status", "Station Time", worldtime2text())
+			statpanel("Status", "Round Duration", round_duration())
+
 		if(client.holder)
 			if(statpanel("Status"))
 				statpanel("Status","Location:","([x], [y], [z])")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -67,12 +67,7 @@
 	Stat()
 		..()
 
-		statpanel("Status")
-		if (client.statpanel == "Status" && ticker)
-			if (ticker.current_state != GAME_STATE_PREGAME)
-				stat(null, "Station Time: [worldtime2text()]")
-		statpanel("Lobby")
-		if(client.statpanel=="Lobby" && ticker)
+		if(statpanel("Lobby") && ticker)
 			if(ticker.hide_mode)
 				stat("Game Mode:", "Secret")
 			else
@@ -387,16 +382,11 @@
 			global_announcer.autosay("A new[rank ? " [rank]" : " visitor" ] [join_message ? join_message : "has arrived on the station"].", "Arrivals Announcement Computer")
 
 	proc/LateChoices()
-		var/mills = world.time // 1/10 of a second, not real milliseconds but whatever
-		//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
-		var/mins = (mills % 36000) / 600
-		var/hours = mills / 36000
-
 		var/name = client.prefs.be_random_name ? "friend" : client.prefs.real_name
 
 		var/dat = "<html><body><center>"
 		dat += "<b>Welcome, [name].<br></b>"
-		dat += "Round Duration: [round(hours)]h [round(mins)]m<br>"
+		dat += "Round Duration: [round_duration()]<br>"
 
 		if(emergency_shuttle) //In case Nanotrasen decides reposess CentComm's shuttles.
 			if(emergency_shuttle.going_to_centcom()) //Shuttle is going to centcomm, not recalled

--- a/html/changelogs/PsiOmegaDelta-RoundDuration.yml
+++ b/html/changelogs/PsiOmegaDelta-RoundDuration.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - rscadd: "Station time and duration now available in the Status tab."

--- a/html/changelogs/Yoshax-emptypls.xml
+++ b/html/changelogs/Yoshax-emptypls.xml
@@ -1,5 +1,0 @@
-author: Yoshax
-delete-after: True
-
-changes: 
-  - tweak: "Makes hyposprays start empty instead of filled with Tricord."


### PR DESCRIPTION
The stat panel now displays station time along with current round duration.
Also moves all instances of showing station time to the Mob/Stat() proc.
