### PR TITLE
Fixes #9155

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -43,6 +43,13 @@
 			node = target
 			break
 
+	//copied from pipe construction code since heaters/freezers don't use fittings and weren't doing this check - this all really really needs to be refactored someday.
+	//check that there are no incompatible pipes/machinery in our own location
+	for(var/obj/machinery/atmospherics/M in src.loc)
+		if(M != src && (M.initialize_directions & node_connect) && M.check_connect_types(M,src))	// matches at least one direction on either type of pipe & same connection type
+			node = null
+			break
+
 	update_icon()
 
 /obj/machinery/atmospherics/unary/freezer/update_icon()

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -39,9 +39,17 @@
 
 	var/node_connect = dir
 
+	//check that there is something to connect to
 	for(var/obj/machinery/atmospherics/target in get_step(src, node_connect))
 		if(target.initialize_directions & get_dir(target, src))
 			node = target
+			break
+
+	//copied from pipe construction code since heaters/freezers don't use fittings and weren't doing this check - this all really really needs to be refactored someday.
+	//check that there are no incompatible pipes/machinery in our own location
+	for(var/obj/machinery/atmospherics/M in src.loc)
+		if(M != src && (M.initialize_directions & node_connect) && M.check_connect_types(M,src))	// matches at least one direction on either type of pipe & same connection type
+			node = null
 			break
 
 	update_icon()


### PR DESCRIPTION
Heaters and freezers now check if there are other machines in their turf that have the same connection dirs.

Since the check was being done in pipe fitting's attackby() heaters and freezers and weren't doing this check. Another thing that will probably need to be moved into atmos machine initialization someday.
