### PR TITLE
Synth say fixes.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -128,7 +128,6 @@ proc/get_radio_key_from_channel(var/channel)
 	return verb
 
 /mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="")
-
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
 			src << "\red You cannot speak in IC (Muted)."
@@ -171,7 +170,7 @@ proc/get_radio_key_from_channel(var/channel)
 		// irrespective of distance or anything else.
 		if(speaking.flags & HIVEMIND)
 			speaking.broadcast(src,trim(message))
-			return
+			return 1
 		//If we've gotten this far, keep going!
 		if(speaking.flags & COMMON_VERBS)
 			verb = say_quote(message)
@@ -188,11 +187,11 @@ proc/get_radio_key_from_channel(var/channel)
 		verb = handle_s[2]
 
 	if(!message || message == "")
-		return
+		return 0
 
 	var/list/obj/item/used_radios = new
 	if(handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name))
-		return
+		return 1
 
 	var/list/handle_v = handle_speech_sound()
 	var/sound/speech_sound = handle_v[1]

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -78,6 +78,8 @@
 
 	for(var/datum/ai_law/law in laws.laws_to_state())
 		can_state = statelaw("[prefix][law.get_index()]. [law.law]")
+		if(!can_state)
+			break
 
 	if(!can_state)
 		src << "<span class='danger'>[method]: Unable to state laws. Communication method unavailable.</span>"

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -37,4 +37,4 @@
 			else if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)
 				if(M.client) M << "<b>[src]</b> transmits, \"[message]\""
 		return 1
-	..(message)
+	return ..(message, 0)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,3 +1,6 @@
+/mob/living/silicon/say(var/message, var/sanitize = 1)
+	return ..(sanitize ? sanitize(message) : message)
+
 /mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	log_say("[key_name(src)] : [message]")
 


### PR DESCRIPTION
Adds synth message sanitizing. Fixes #10667.
Makes sure say() code again return expected values, however broken radio communication no longer stops the statement of laws. Fixes #10675.
