### PR TITLE
Research minor fixes, fix item design path definition, macro usage

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -324,8 +324,8 @@ other types of metals and chemistry for reagents).
 ///////////////////////////////////
 /////////Shield Generators/////////
 ///////////////////////////////////
-datum/design/circuit/shield
-	req_tech = list("bluespace" = 4, "phorontech" = 3)
+/datum/design/circuit/shield
+	req_tech = list(TECH_BLUESPACE = 4, TECH_PHORON = 3)
 	materials = list("$glass" = 2000, "sacid" = 20, "$phoron" = 10000, "$diamond" = 5000, "$gold" = 10000)
 
 /datum/design/item/medical


### PR DESCRIPTION
```
Fix research design item path definition, usage of TECH_* macros

code/modules/research/designs.dm:
    fixed path definition of `datum/design/circuit/shield`
    fixed req_tech variable to now use TECH_* macros
```

The fixes were that in `code/modules/research/designs.dm`, a leading `/` was added to `datum/design/circuit/shield`, and its `req_tech` variable was changed to use macros instead of strings.
