### PR TITLE
Mob bump fixes.

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -101,10 +101,12 @@
 	..(message, null, verb)
 
 /mob/living/bot/Bump(var/atom/A)
-	if(istype(A, /obj/machinery/door) && botcard)
+	if(on && botcard && istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
 		if(!istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/blast) && D.check_access(botcard))
 			D.open()
+	else
+		..()
 
 /mob/living/bot/proc/Emag(var/mob/user)
 	log_and_message_admins("emagged [src]")

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -11,6 +11,11 @@
 	is_ranged = 1
 	preparing_arrest_sounds = new()
 
+	a_intent = I_HURT
+	mob_bump_flag = HEAVY
+	mob_swap_flags = ALLMOBS
+	mob_push_flags = ALLMOBS|HEAVY
+
 	var/shot_delay = 4
 	var/last_shot = 0
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -717,7 +717,7 @@
 		drop_l_hand()
 		drop_r_hand()
 	else
-		density = 1
+		density = initial(density)
 
 	for(var/obj/item/weapon/grab/G in grabbed_by)
 		if(G.state >= GRAB_AGGRESSIVE)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -863,7 +863,7 @@ var/list/be_special_flags = list(
 #define ROBOT 8
 #define SLIME 16
 #define SIMPLE_ANIMAL 32
-
+#define HEAVY 64
 
 #define ALLMOBS (HUMAN|MONKEY|ALIEN|ROBOT|SLIME|SIMPLE_ANIMAL)
 


### PR DESCRIPTION
ED-209 is considered massive enough to not bump easily. Bots now also call the base Bump() code properly.
update_canmove() no longer unconditionally sets mob density to 1.
Fixes #10365. Fixes #10682.
