### PR TITLE
Bandaid fix for process scheduler bloating status tab

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -639,20 +639,20 @@
 
 	if(.)
 		if(statpanel("Status") && ticker && ticker.current_state != GAME_STATE_PREGAME)
-			statpanel("Status", "Station Time", worldtime2text())
-			statpanel("Status", "Round Duration", round_duration())
+			stat("Station Time", worldtime2text())
+			stat("Round Duration", round_duration())
 
 		if(client.holder)
 			if(statpanel("Status"))
-				statpanel("Status","Location:","([x], [y], [z])")
+				stat("Location:","([x], [y], [z])")
 			if(statpanel("Processes"))
-				statpanel("Processes","CPU:","[world.cpu]")
-				statpanel("Processes","Instances:","[world.contents.len]")
+				stat("CPU:","[world.cpu]")
+				stat("Instances:","[world.contents.len]")
 				if(processScheduler && processScheduler.getIsRunning())
 					for(var/datum/controller/process/P in processScheduler.processes)
-						statpanel("Processes",P.getStatName(), P.getTickTime())
+						stat(P.getStatName(), P.getTickTime())
 				else
-					statpanel("Processes","processScheduler is not running.")
+					stat("processScheduler is not running.")
 
 		if(listed_turf && client)
 			if(!TurfAdjacent(listed_turf))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -645,13 +645,14 @@
 		if(client.holder)
 			if(statpanel("Status"))
 				statpanel("Status","Location:","([x], [y], [z])")
-				statpanel("Status","CPU:","[world.cpu]")
-				statpanel("Status","Instances:","[world.contents.len]")
-			if(statpanel("Status") && processScheduler && processScheduler.getIsRunning())
-				for(var/datum/controller/process/P in processScheduler.processes)
-					statpanel("Status",P.getStatName(), P.getTickTime())
-			else
-				statpanel("Status","processScheduler is not running.")
+			if(statpanel("Processes"))
+				statpanel("Processes","CPU:","[world.cpu]")
+				statpanel("Processes","Instances:","[world.contents.len]")
+				if(processScheduler && processScheduler.getIsRunning())
+					for(var/datum/controller/process/P in processScheduler.processes)
+						statpanel("Processes",P.getStatName(), P.getTickTime())
+				else
+					statpanel("Processes","processScheduler is not running.")
 
 		if(listed_turf && client)
 			if(!TurfAdjacent(listed_turf))


### PR DESCRIPTION
The issues with it stem from tabulation. It seems to be overflowing. Until we get it fixed, we should move it so it doesn't interfere with admins/mobs/developers ability to play synthetics, xenos, and other things that have a heavy use of the status panel.

I really didn't want to do this, but this might be the best fix until someone else can figure out how to make tabs cooperate.
