### PR TITLE
Gamemode fixes

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -109,6 +109,12 @@
 		M = whom
 		C = M.client
 		key = M.key
+	else if(istype(whom, /datum/mind))
+		var/datum/mind/D = whom
+		key = D.key
+		M = D.current
+		if(D.current)
+			C = D.current.client
 	else if(istype(whom, /datum))
 		var/datum/D = whom
 		return "*invalid:[D.type]*"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -143,7 +143,11 @@
 
 	if(href_list["add_antagonist"])
 		var/datum/antagonist/antag = all_antag_types[href_list["add_antagonist"]]
-		if(antag) antag.add_antagonist(src, 1, 1, 0, 1, 1) // Ignore equipment and role type for this.
+		if(antag) 
+			if(antag.add_antagonist(src, 1, 1, 0, 1, 1)) // Ignore equipment and role type for this.
+				log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
+			else
+				usr << "<span class='warning'>[src] could not be made into a [antag.role_text]!</span>"
 
 	else if(href_list["remove_antagonist"])
 		var/datum/antagonist/antag = all_antag_types[href_list["remove_antagonist"]]

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -59,20 +59,23 @@
 
 /datum/antagonist/proc/get_candidates(var/ghosts_only)
 	candidates = list() // Clear.
-	candidates = ticker.mode.get_players_for_role(role_type, id)
+	
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
-	for(var/datum/mind/player in candidates)
+	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
 		if(ghosts_only && !istype(player.current, /mob/dead))
-			candidates -= player
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!"
 		else if(player.special_role)
-			candidates -= player
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!"
 		else if (player in pending_antagonists)
-			candidates -= player
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They have already been selected for this role!"
 		else if(!can_become_antag(player))
-			candidates -= player
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!"
 		else if(player_is_antag(player))
-			candidates -= player
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!"
+		else
+			candidates += player
+
 	return candidates
 
 /datum/antagonist/proc/attempt_random_spawn()
@@ -108,6 +111,7 @@
 		return 0
 
 	//Grab candidates randomly until we have enough.
+	candidates = shuffle(candidates)
 	while(candidates.len && pending_antagonists.len < cur_max)
 		var/datum/mind/player = pick(candidates)
 		candidates -= player
@@ -118,6 +122,7 @@
 /datum/antagonist/proc/draft_antagonist(var/datum/mind/player)
 	//Check if the player can join in this antag role, or if the player has already been given an antag role.
 	if(!can_become_antag(player) || player.special_role)
+		log_debug("[player.key] was selected for [role_text] by lottery, but is not allowed to be that role.")
 		return 0
 
 	pending_antagonists |= player

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -64,15 +64,15 @@
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
 		if(ghosts_only && !istype(player.current, /mob/dead))
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!"
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
 		else if(player.special_role)
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!"
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!")
 		else if (player in pending_antagonists)
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: They have already been selected for this role!"
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They have already been selected for this role!")
 		else if(!can_become_antag(player))
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!"
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
 		else if(player_is_antag(player))
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!"
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
 		else
 			candidates += player
 

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -86,7 +86,7 @@
 			code_owner.store_memory("<B>Nuclear Bomb Code</B>: [code]", 0, 0)
 			code_owner.current << "The nuclear authorization code is: <B>[code]</B>"
 	else
-		message_admins("<spam class='danger'>Could not spawn nuclear bomb. Contact a developer.</span>")
+		message_admins("<span class='danger'>Could not spawn nuclear bomb. Contact a developer.</span>")
 		return
 
 	spawned_nuke = code

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -86,7 +86,7 @@
 			code_owner.store_memory("<B>Nuclear Bomb Code</B>: [code]", 0, 0)
 			code_owner.current << "The nuclear authorization code is: <B>[code]</B>"
 	else
-		world << "<spam class='danger'>Could not spawn nuclear bomb. Contact a developer.</span>"
+		message_admins("<spam class='danger'>Could not spawn nuclear bomb. Contact a developer.</span>")
 		return
 
 	spawned_nuke = code

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -2,9 +2,9 @@
 	if(player.current && jobban_isbanned(player.current, bantype))
 		return 0
 	if(!ignore_role)
-		if(player.assigned_role in protected_jobs)
+		if(player.assigned_role in restricted_jobs)
 			return 0
-		if(config.protect_roles_from_antagonist && (player.assigned_role in restricted_jobs))
+		if(config.protect_roles_from_antagonist && (player.assigned_role in protected_jobs))
 			return 0
 	return 1
 

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -135,10 +135,10 @@ datum/antagonist/revolutionary/finalize(var/datum/mind/target)
 	world << text
 
 // This is a total redefine because headrevs are greeted differently to subrevs.
-/datum/antagonist/revolutionary/add_antagonist(var/datum/mind/player)
+/datum/antagonist/revolutionary/add_antagonist(var/datum/mind/player, var/ignore_role)
 	if((player in current_antagonists) || (player in head_revolutionaries))
 		return 0
-	if(!can_become_antag(player))
+	if(!can_become_antag(player, ignore_role))
 		return 0
 	current_antagonists |= player
 	player.current << "<span class='danger'><font size=3>You are a Revolutionary!</font></span>"
@@ -167,11 +167,6 @@ datum/antagonist/revolutionary/finalize(var/datum/mind/target)
 			player.current << "<span class='danger'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</span>"
 		if(show_message)
 			player.current.visible_message("[player.current] looks like they just remembered their real allegiance!")
-
-/datum/antagonist/revolutionary/can_become_antag(var/datum/mind/player)
-	return ..() && istype(player) && \
-		istype(player.current, /mob/living/carbon/human) && \
-		!(player.assigned_role in command_positions)
 
 // Used by RP-rev.
 /mob/living/carbon/human/proc/convert_to_rev(mob/M as mob in oview(src))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -511,32 +511,26 @@ var/global/list/additional_antag_types = list()
 	if(!antag_template)
 		return candidates
 
-	var/roletext
 	// Assemble a list of active players without jobbans.
 	for(var/mob/new_player/player in player_list)
 		if( player.client && player.ready )
-			if(!(jobban_isbanned(player, "Syndicate") || jobban_isbanned(player, antag_template.bantype)))
-				players += player
-
-	// Shuffle the players list so that it becomes ping-independent.
-	players = shuffle(players)
+			players += player
 
 	// Get a list of all the people who want to be the antagonist for this round
 	for(var/mob/new_player/player in players)
 		if(!role || (player.client.prefs.be_special & role))
-			log_debug("[player.key] had [roletext] enabled, so we are drafting them.")
+			log_debug("[player.key] had [antag_id] enabled, so we are drafting them.")
 			candidates += player.mind
 			players -= player
 
 	// If we don't have enough antags, draft people who voted for the round.
 	if(candidates.len < required_enemies)
-		for(var/key in round_voters)
-			for(var/mob/new_player/player in players)
-				if(player.ckey == key)
-					log_debug("[player.key] voted for this round, so we are drafting them.")
-					candidates += player.mind
-					players -= player
-					break
+		for(var/mob/new_player/player in players)
+			if(player.ckey in round_voters)
+				log_debug("[player.key] voted for this round, so we are drafting them.")
+				candidates += player.mind
+				players -= player
+				break
 
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than required_enemies
 							//			required_enemies if the number of people with that role set to yes is less than recomended_enemies,
@@ -569,12 +563,14 @@ var/global/list/additional_antag_types = list()
 			if(antag)
 				antag_templates |= antag
 
+	/*
 	if(antag_templates && antag_templates.len)
 		for(var/datum/antagonist/antag in antag_templates)
 			if(antag.flags & (ANTAG_OVERRIDE_JOB|ANTAG_RANDSPAWN))
 				continue
 			antag_templates -= antag
 			world << "<span class='danger'>[antag.role_text_plural] are invalid for additional roundtype antags!</span>"
+	*/
 
 	newscaster_announcements = pick(newscaster_standard_feeds)
 


### PR DESCRIPTION
-  Fixes antag datum not respecting restricted_jobs depending on config. Fixes #10657
-  Fixes revs being unspawnable. The player has not been spawned yet they can't be a
  /mob/living/carbon/human. Also fixes spawning revs via traitor panel.
- Adds logging for admin spawning antags
- Fixes certain antag roles from being unspawnable. No idea why that check was there but it basically meant that antags without `ANTAG_OVERRIDE_JOB|ANTAG_RANDSPAWN` cannot be spawned at round start.
- Also adds more debug messages and feedback about why someone is not eligible for antag role.
