### PR TITLE
Gives turret density = 1

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -9,7 +9,7 @@
 	icon_state = "turretCover"
 	anchored = 1
 
-	density = 0
+	density = 1
 	use_power = 1				//this turret uses and requires power
 	idle_power_usage = 50		//when inactive, this turret takes up constant 50 Equipment power
 	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power


### PR DESCRIPTION
No more walking over turrets.
(Watch as I somehow fucked this up.)
Fixes https://github.com/Baystation12/Baystation12/issues/10760
