### PR TITLE
[WIP] Private AI frequency is now random per round.

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -242,8 +242,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Ensure the frequency is within bounds of what it should be sending/recieving at
 /proc/sanitize_frequency(var/f)
 	f = round(f)
-	f = max(1441, f) // 144.1
-	f = min(1489, f) // 148.9
+	f = max(PUBLIC_LOW_FREQ, f) // 144.1
+	f = min(PUBLIC_HIGH_FREQ, f) // 148.9
 	if ((f % 2) == 0) //Ensure the last digit is an odd number
 		f += 1
 	return f

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -97,12 +97,14 @@ On the map:
 1455 for AI access
 */
 
-var/const/BOT_FREQ = 1447
+var/const/PUBLIC_LOW_FREQ = 1441
+var/const/PUBLIC_HIGH_FREQ = 1489
+
+var/const/BOT_FREQ	= 1447
 var/const/COMM_FREQ = 1353
-var/const/ERT_FREQ = 1345
-var/const/AI_FREQ = 1343
-var/const/DTH_FREQ = 1341
-var/const/SYND_FREQ = 1213
+var/const/ERT_FREQ	= 1345
+var/const/DTH_FREQ	= 1341
+var/const/SYND_FREQ	= 1213
 
 // department channels
 var/const/PUB_FREQ = 1459
@@ -113,20 +115,22 @@ var/const/SCI_FREQ = 1351
 var/const/SRV_FREQ = 1349
 var/const/SUP_FREQ = 1347
 
-var/list/radiochannels = list(
-	"Common"		= PUB_FREQ,
-	"Science"		= SCI_FREQ,
-	"Command"		= COMM_FREQ,
-	"Medical"		= MED_FREQ,
-	"Engineering"	= ENG_FREQ,
-	"Security" 		= SEC_FREQ,
-	"Response Team" = ERT_FREQ,
-	"Special Ops" 	= DTH_FREQ,
-	"Mercenary" 	= SYND_FREQ,
-	"Supply" 		= SUP_FREQ,
-	"Service" 		= SRV_FREQ,
-	"AI Private"	= AI_FREQ
-)
+var/list/radiochannels
+/hook/startup/proc/radio_channel_setup()
+	radiochannels = list(
+		"Common"		= PUB_FREQ,
+		"Science"		= SCI_FREQ,
+		"Command"		= COMM_FREQ,
+		"Medical"		= MED_FREQ,
+		"Engineering"	= ENG_FREQ,
+		"Security" 		= SEC_FREQ,
+		"Response Team" = ERT_FREQ,
+		"Special Ops" 	= DTH_FREQ,
+		"Mercenary" 	= SYND_FREQ,
+		"Supply" 		= SUP_FREQ,
+		"Service" 		= SRV_FREQ,
+		"AI Private"	= get_ai_frequency()
+	)
 
 // central command channels, i.e deathsquid & response teams
 var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
@@ -140,6 +144,9 @@ var/list/DEPT_FREQS = list(SCI_FREQ, MED_FREQ, ENG_FREQ, SEC_FREQ, SUP_FREQ, SRV
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1
 
+/proc/get_ai_frequency()
+	return 1343
+
 /proc/frequency_span_class(var/frequency)
 	// Antags!
 	if (frequency in ANTAG_FREQS)
@@ -151,7 +158,7 @@ var/list/DEPT_FREQS = list(SCI_FREQ, MED_FREQ, ENG_FREQ, SEC_FREQ, SUP_FREQ, SRV
 	else if(frequency == COMM_FREQ)
 		return "comradio"
 	// AI private channel
-	else if(frequency == AI_FREQ)
+	else if(frequency == get_ai_frequency())
 		return "airadio"
 	// department radio formatting (poorly optimized, ugh)
 	else if(frequency == SEC_FREQ)

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -139,7 +139,7 @@ var/datum/antagonist/traitor/traitors
 	if(istype(R,/obj/item/device/radio))
 		// generate list of radio freqs
 		var/obj/item/device/radio/target_radio = R
-		var/freq = 1441
+		var/freq = PUBLIC_LOW_FREQ
 		var/list/freqlist = list()
 		while (freq <= 1489)
 			if (freq < 1451 || freq > PUB_FREQ)

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -56,13 +56,13 @@
 	id = "Receiver A"
 	network = "tcommsat"
 	autolinkers = list("receiverA") // link to relay
-	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ)
 
+/obj/machinery/telecomms/receiver/preset_right/New()
+	freq_listening = list(get_ai_frequency(), SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ)
 	//Common and other radio frequencies for people to freely use
-	New()
-		for(var/i = 1441, i < 1489, i += 2)
-			freq_listening |= i
-		..()
+	for(var/i = PUBLIC_LOW_FREQ, i < PUBLIC_HIGH_FREQ, i += 2)
+		freq_listening |= i
+	..()
 
 /obj/machinery/telecomms/receiver/preset_cent
 	id = "CentComm Receiver"
@@ -87,7 +87,7 @@
 	autolinkers = list("processor2", "supply", "service", "unused")
 
 /obj/machinery/telecomms/bus/preset_two/New()
-	for(var/i = 1441, i < 1489, i += 2)
+	for(var/i = PUBLIC_LOW_FREQ, i < PUBLIC_HIGH_FREQ, i += 2)
 		if(i == PUB_FREQ)
 			continue
 		freq_listening |= i
@@ -102,8 +102,11 @@
 /obj/machinery/telecomms/bus/preset_four
 	id = "Bus 4"
 	network = "tcommsat"
-	freq_listening = list(ENG_FREQ, AI_FREQ, PUB_FREQ)
 	autolinkers = list("processor4", "engineering", "common")
+
+/obj/machinery/telecomms/bus/preset_four/New()
+	freq_listening = list(ENG_FREQ, get_ai_frequency(), PUB_FREQ)
+	..()
 
 /obj/machinery/telecomms/bus/preset_cent
 	id = "CentComm Bus"
@@ -168,8 +171,11 @@
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
-	freq_listening = list(PUB_FREQ, AI_FREQ) // AI Private and Common
 	autolinkers = list("common")
+
+/obj/machinery/telecomms/server/presets/common/New()
+	freq_listening = list(PUB_FREQ, get_ai_frequency()) // AI Private and Common
+	..()
 
 // "Unused" channels, AKA all others.
 /obj/machinery/telecomms/server/presets/unused
@@ -178,8 +184,8 @@
 	autolinkers = list("unused")
 
 /obj/machinery/telecomms/server/presets/unused/New()
-	for(var/i = 1441, i < 1489, i += 2)
-		if(i == AI_FREQ || i == PUB_FREQ)
+	for(var/i = PUBLIC_LOW_FREQ, i < PUBLIC_HIGH_FREQ, i += 2)
+		if(i in radiochannels)
 			continue
 		freq_listening |= i
 	..()

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -221,7 +221,7 @@
 		if(!radio_controller)
 			return
 
-		if (src.frequency < 1441 || src.frequency > 1489)
+		if (src.frequency < PUBLIC_LOW_FREQ || src.frequency > PUBLIC_HIGH_FREQ)
 			src.frequency = sanitize_frequency(src.frequency)
 
 		set_frequency(frequency)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -13,7 +13,7 @@
 	var/translate_hive = 0
 	var/obj/item/device/encryptionkey/keyslot1 = null
 	var/obj/item/device/encryptionkey/keyslot2 = null
-	maxf = 1489
+	maxf = PUBLIC_HIGH_FREQ
 
 	var/ks1type = /obj/item/device/encryptionkey
 	var/ks2type = null

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -59,7 +59,7 @@
 		if(frequency < 1200 || frequency > 1600)
 			frequency = sanitize_frequency(frequency, maxf)
 	// The max freq is higher than a regular headset to decrease the chance of people listening in, if you use the higher channels.
-	else if (frequency < 1441 || frequency > maxf)
+	else if (frequency < PUBLIC_LOW_FREQ || frequency > maxf)
 		//world.log << "[src] ([type]) has a frequency of [frequency], sanitizing."
 		frequency = sanitize_frequency(frequency, maxf)
 


### PR DESCRIPTION
All to make the life of meta gamers more difficult.
- [ ] Properly define the upper and lower public frequency span.
- [ ] Define a list utilized public frequencies.
- [ ] Ensure telecom equipment can handle the random AI channel.
- [ ] Make all unused frequencies and the AI private channel use the same radio CSS.
- [ ] Cleanup intercom mapping and rotations while I'm changing things around anyway.
