### PR TITLE
Gives the medical equipment access a name.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -333,6 +333,8 @@
 			return "Gateway"
 		if(access_sec_doors)
 			return "Security"
+		if(access_medical_equip)
+			return "Medical Equipment"
 
 /proc/get_centcom_access_desc(A)
 	switch(A)


### PR DESCRIPTION
Required for guest passes to list the entry. Fixes  #10780.
