### PR TITLE
Fixes adjustBrainLoss

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -30,7 +30,6 @@
 		var/obj/item/organ/brain/sponge = internal_organs_by_name["brain"]
 		if(sponge)
 			sponge.take_damage(amount)
-			sponge.damage = min(max(brainloss, 0),(maxHealth*2))
 			brainloss = sponge.damage
 		else
 			brainloss = 200

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -193,14 +193,15 @@ var/list/organ_cache = list()
 	W.damage += damage
 	W.time_inflicted = world.time
 
+//Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(amount, var/silent=0)
 	if(src.status & ORGAN_ROBOT)
-		src.damage += (amount * 0.8)
+		src.damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else
-		src.damage += amount
+		src.damage = between(0, src.damage + amount, max_damage)
 
 		//only show this if the organ is not robotic
-		if(owner && parent_organ)
+		if(owner && parent_organ && amount > 0)
 			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 			if(parent && !silent)
 				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)


### PR DESCRIPTION
adjustBrainLoss() was giving damage to the brain organ and then setting it back to brainloss, before brainloss could be updated, undoing the change. 

At the very least this appeared to break alkysine.
