### PR TITLE
[Dev] Fixes bug with EAL random name proc

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -107,11 +107,12 @@
 	space_chance = 10
 
 /datum/language/machine/get_random_name()
+	var/new_name
 	if(prob(70))
-		name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"
+		new_name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"
 	else
-		name = pick(ai_names)
-	return name
+		new_name = pick(ai_names)
+	return new_name
 
 //Syllable Lists
 /*


### PR DESCRIPTION
BASICALLY without this, the language would continually rename itself whenever somebody randomed an IPC name (which the language would then be called)
