### PR TITLE
Fixes cryogenic showers

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -144,7 +144,7 @@
 /datum/reagent/cryoxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
 		M.adjustCloneLoss(-30 * removed)
-		M.adjustOxyLoss(-3 * removed)
+		M.adjustOxyLoss(-30 * removed)
 		M.heal_organ_damage(30 * removed, 30 * removed)
 		M.adjustToxLoss(-30 * removed)
 


### PR DESCRIPTION
Changes shower temperature settings to use more reasonable temperature values, because the old ones were just a bit too silly, and also made cryomachinery pointless. A menu is now shown when adjusting shower temperature.

Also fixes an apparent typo in clonexadone affect_blood. If you compare with cryoxodone the typo is readily apparent.
