### PR TITLE
Relocates Cult/Occult languages to unused keys.

### DIFF
--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -90,7 +90,7 @@
 	ask_verb = "intones"
 	exclaim_verb = "chants"
 	colour = "cult"
-	key = "n"
+	key = "f"
 	flags = RESTRICTED
 	space_chance = 100
 	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
@@ -108,5 +108,5 @@
 	ask_verb = "intones"
 	exclaim_verb = "chants"
 	colour = "cult"
-	key = "m"
+	key = "y"
 	flags = RESTRICTED | HIVEMIND


### PR DESCRIPTION
Now uses ~~j and k~~ ~~y and u~~ ~~r and y~~ f and y. Fixes #10799.
