### PR TITLE
Cargo now sorts under their own department in manifests.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -17,6 +17,7 @@
 	var/list/eng = new()
 	var/list/med = new()
 	var/list/sci = new()
+	var/list/car = new()
 	var/list/civ = new()
 	var/list/bot = new()
 	var/list/misc = new()
@@ -67,6 +68,9 @@
 		if(real_rank in science_positions)
 			sci[name] = rank
 			department = 1
+		if(real_rank in cargo_positions)
+			car[name] = rank
+			department = 1
 		if(real_rank in civilian_positions)
 			civ[name] = rank
 			department = 1
@@ -99,6 +103,11 @@
 		dat += "<tr><th colspan=3>Science</th></tr>"
 		for(name in sci)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[sci[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+	if(car.len > 0)
+		dat += "<tr><th colspan=3>Cargo</th></tr>"
+		for(name in car)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[car[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 	if(civ.len > 0)
 		dat += "<tr><th colspan=3>Civilian</th></tr>"

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -72,6 +72,7 @@ var/global/ManifestJSON
 	var/eng[0]
 	var/med[0]
 	var/sci[0]
+	var/car[0]
 	var/civ[0]
 	var/bot[0]
 	var/misc[0]
@@ -113,6 +114,12 @@ var/global/ManifestJSON
 			department = 1
 			if(depthead && sci.len != 1)
 				sci.Swap(1,sci.len)
+				
+		if(real_rank in cargo_positions)
+			car[++car.len] = list("name" = name, "rank" = rank, "active" = isactive)
+			department = 1
+			if(depthead && car.len != 1)
+				car.Swap(1,car.len)
 
 		if(real_rank in civilian_positions)
 			civ[++civ.len] = list("name" = name, "rank" = rank, "active" = isactive)
@@ -134,6 +141,7 @@ var/global/ManifestJSON
 		"eng" = eng,\
 		"med" = med,\
 		"sci" = sci,\
+		"car" = car,\
 		"civ" = civ,\
 		"bot" = bot,\
 		"misc" = misc\

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -86,6 +86,12 @@ var/list/science_positions = list(
 )
 
 //BS12 EDIT
+var/list/cargo_positions = list(
+	"Quartermaster",
+	"Cargo Technician",
+	"Shaft Miner"
+)
+
 var/list/civilian_positions = list(
 	"Head of Personnel",
 	"Bartender",
@@ -93,9 +99,6 @@ var/list/civilian_positions = list(
 	"Chef",
 	"Janitor",
 	"Librarian",
-	"Quartermaster",
-	"Cargo Technician",
-	"Shaft Miner",
 	"Lawyer",
 	"Chaplain",
 	"Assistant"

--- a/html/changelogs/PsiOmegaDelta-Cargonia.yml
+++ b/html/changelogs/PsiOmegaDelta-Cargonia.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+delete-after: true
+changes:
+  - tweak: "Cargo now sorts under its own department on station manifests."

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -555,6 +555,12 @@ th.sci {
     color: #ffffff;
 }
 
+th.car {
+    background: #bb9040;
+    font-weight: bold;
+    color: #ffffff;
+}
+
 th.civ {
     background: #a32800;
     font-weight: bold;

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -347,6 +347,16 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         {{/if}}
                     {{/for}}
                 {{/if}}
+				{{if data.manifest.car.length}}
+                    <tr><th colspan="3" class="car">Cargo</th></tr>
+                    {{for data.manifest["car"]}}
+                        {{if value.rank == "Quartermaster"}}
+                            <tr><td><span class="good">{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
+                        {{else}}
+                            <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
+                        {{/if}}
+                    {{/for}}
+                {{/if}}
                 {{if data.manifest.civ.length}}
                     <tr><th colspan="3" class="civ">Civilian</th></tr>
                     {{for data.manifest["civ"]}}


### PR DESCRIPTION
Cargonia now has its own section in station manifests. To avoid clutter the Head of Personnel isn't included in the department listing but this is easily changed.

A change like this should not require a change in these many places tho..
