### PR TITLE
Corrects CanUseObjTopic base proc

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -43,6 +43,7 @@
 	return O.allowed(src)
 
 /mob/proc/CanUseObjTopic()
+	return 1
 
 /obj/proc/CouldUseTopic(var/mob/user)
 	var/atom/host = nano_host()


### PR DESCRIPTION
Now returns 1 instead of 0. Potentially fixes #10849.
