### PR TITLE
Revert "IAA cartridge tweak"

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -79,7 +79,6 @@
 	name = "\improper P.R.O.V.E. cartridge"
 	icon_state = "cart-s"
 	access_security = 1
-	access_status_display = 1
 
 /obj/item/weapon/cartridge/clown
 	name = "\improper Honkworks 5.0 cartridge"


### PR DESCRIPTION
Reverts Baystation12/Baystation12#10860
Added access to status displays, not crew records as claimed by the un-edited original PR.
