### PR TITLE
Pathogenic Isolator List Naming Fix

### DIFF
--- a/nano/templates/pathogenic_isolator.tmpl
+++ b/nano/templates/pathogenic_isolator.tmpl
@@ -81,7 +81,7 @@
       {{if data.database}}
         {{for data.database}}
           <div class='itemContent'>
-            <div class='highlight fixedLeft'>{{:data.name}}</div>
+            <div class='highlight fixedLeft'>{{:value.name}}</div>
             {{:helper.link('Details', 'circle-arrow-s', { 'entry' : 1, 'view' : value.record }, null, 'fixedLeft')}}
           </div>
         {{/for}}


### PR DESCRIPTION
Now the Pathogenic Isolator will properly name all virus strains on the List screen, instead of writing "unidentified".
