### PR TITLE
Backports fix for areas not venting when both airlock doors are forced open

### DIFF
--- a/code/ZAS/Controller.dm
+++ b/code/ZAS/Controller.dm
@@ -281,8 +281,8 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 	var/direct = !(block & ZONE_BLOCKED)
 	var/space = !istype(B)
 
-	if(direct && !space)
-		if(min(A.zone.contents.len, B.zone.contents.len) <= 10 || equivalent_pressure(A.zone,B.zone) || current_cycle == 0)
+	if(!space)
+		if(min(A.zone.contents.len, B.zone.contents.len) < ZONE_MIN_SIZE || (direct && (equivalent_pressure(A.zone,B.zone) || current_cycle == 0)))
 			merge(A.zone,B.zone)
 			return
 

--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -33,3 +33,5 @@ Notes for people who used ZAS before:
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2
 #define BLOCKED 3
+
+#define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct


### PR DESCRIPTION
Because I'm tired of seeing it happen and admins doing work-arounds like deleting walls when there is a fix. Backports #9718
