### PR TITLE
Alters the round duration format, increases Stat inactivity timeout.

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -36,9 +36,12 @@ proc/round_duration()
 
 	var/mills = world.time // 1/10 of a second, not real milliseconds but whatever
 	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
-	var/mins = (mills % 36000) / 600
-	var/hours = mills / 36000
+	var/mins = round((mills % 36000) / 600)
+	var/hours = round(mills / 36000)
 
-	last_round_duration = "[round(hours)]h [round(mins)]m"
+	mins = mins < 10 ? add_zero(mins, 1) : mins
+	hours = hours < 10 ? add_zero(hours, 1) : hours
+
+	last_round_duration = "[hours]:[mins]"
 	next_duration_update = world.time + 1 MINUTES
 	return last_round_duration

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -635,7 +635,7 @@
 
 /mob/Stat()
 	..()
-	. = (client && client.inactivity < 1200)
+	. = (is_client_active(10 MINUTES))
 
 	if(.)
 		if(statpanel("Status") && ticker && ticker.current_state != GAME_STATE_PREGAME)


### PR DESCRIPTION
Round duration now has a similar format to round time, that is: 02:08 instead of 2h 8m
Stat inactivity timeout is now the intended 10 minutes instead of 1 minute.
