### PR TITLE
Improved admin logging.

### DIFF
--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -4,7 +4,7 @@
 
 proc/log_and_message_admins(var/message as text, var/mob/user = usr)
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")
-	message_admins(user ? "[key_name(user)] [message]" : "EVENT [message]")
+	message_admins(user ? "[key_name_admin(user)] [message]" : "EVENT [message]")
 
 proc/log_and_message_admins_many(var/list/mob/users, var/message)
 	if(!users || !users.len)
@@ -16,10 +16,6 @@ proc/log_and_message_admins_many(var/list/mob/users, var/message)
 
 	log_admin("[english_list(user_keys)] [message]")
 	message_admins("[english_list(user_keys)] [message]")
-
-proc/admin_log_and_message_admins(var/message as text)
-	log_admin(usr ? "[key_name_admin(usr)] [message]" : "EVENT [message]")
-	message_admins(usr ? "[key_name_admin(usr)] [message]" : "EVENT [message]", 1)
 
 proc/admin_attack_log(var/mob/attacker, var/mob/victim, var/attacker_message, var/victim_message, var/admin_message)
 	if(victim)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -728,7 +728,7 @@ var/list/admin_verbs_mentor = list(
 
 	var/new_name = sanitizeSafe(input(src, "Enter new name. Leave blank or as is to cancel.", "[S.real_name] - Enter new silicon name", S.real_name))
 	if(new_name && new_name != S.real_name)
-		admin_log_and_message_admins("has renamed the silicon '[S.real_name]' to '[new_name]'")
+		log_and_message_admins("has renamed the silicon '[S.real_name]' to '[new_name]'")
 		S.SetName(new_name)
 	feedback_add_details("admin_verb","RAI") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -743,7 +743,7 @@ var/list/admin_verbs_mentor = list(
 
 	var/obj/nano_module/law_manager/L = new(S)
 	L.ui_interact(usr, state = admin_state)
-	admin_log_and_message_admins("has opened [S]'s law manager.")
+	log_and_message_admins("has opened [S]'s law manager.")
 	feedback_add_details("admin_verb","MSL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/change_human_appearance_admin()
@@ -756,7 +756,7 @@ var/list/admin_verbs_mentor = list(
 	var/mob/living/carbon/human/H = input("Select mob.", "Change Mob Appearance - Admin") as null|anything in human_mob_list
 	if(!H) return
 
-	admin_log_and_message_admins("is altering the appearance of [H].")
+	log_and_message_admins("is altering the appearance of [H].")
 	H.change_appearance(APPEARANCE_ALL, usr, usr, check_species_whitelist = 0, state = admin_state)
 	feedback_add_details("admin_verb","CHAA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -776,10 +776,10 @@ var/list/admin_verbs_mentor = list(
 
 	switch(alert("Do you wish for [H] to be allowed to select non-whitelisted races?","Alter Mob Appearance","Yes","No","Cancel"))
 		if("Yes")
-			admin_log_and_message_admins("has allowed [H] to change \his appearance, without whitelisting of races.")
+			log_and_message_admins("has allowed [H] to change \his appearance, without whitelisting of races.")
 			H.change_appearance(APPEARANCE_ALL, H.loc, check_species_whitelist = 0)
 		if("No")
-			admin_log_and_message_admins("has allowed [H] to change \his appearance, with whitelisting of races.")
+			log_and_message_admins("has allowed [H] to change \his appearance, with whitelisting of races.")
 			H.change_appearance(APPEARANCE_ALL, H.loc, check_species_whitelist = 1)
 	feedback_add_details("admin_verb","CMAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/icarus.dm
+++ b/code/modules/admin/verbs/icarus.dm
@@ -4,7 +4,7 @@
 	set category = "Fun"
 
 	var/turf/target = get_turf(src.mob)
-	admin_log_and_message_admins("has fired the Icarus point defense laser at [target.x]-[target.y]-[target.z]")
+	log_and_message_admins("has fired the Icarus point defense laser at [target.x]-[target.y]-[target.z]")
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -18,7 +18,7 @@
 	set category = "Fun"
 
 	var/turf/target = get_turf(src.mob)
-	admin_log_and_message_admins("has fired the Icarus main gun projectile at [target.x]-[target.y]-[target.z]")
+	log_and_message_admins("has fired the Icarus main gun projectile at [target.x]-[target.y]-[target.z]")
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -31,7 +31,7 @@
 	set desc = "Lets you chose the position of the Icarus in regards to the map."
 	set category = "Fun"
 
-	admin_log_and_message_admins("is changing the Icarus position.")
+	log_and_message_admins("is changing the Icarus position.")
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -193,41 +193,41 @@
 
 	if(href_list["toggle_report"])
 		report_at_round_end = !report_at_round_end
-		admin_log_and_message_admins("has [report_at_round_end ? "enabled" : "disabled"] the round end event report.")
+		log_and_message_admins("has [report_at_round_end ? "enabled" : "disabled"] the round end event report.")
 	else if(href_list["dec_timer"])
 		var/datum/event_container/EC = locate(href_list["event"])
 		var/decrease = 60 * (10 ** text2num(href_list["dec_timer"]))
 		EC.next_event_time -= decrease
-		admin_log_and_message_admins("decreased timer for [severity_to_string[EC.severity]] events by [decrease/600] minute(s).")
+		log_and_message_admins("decreased timer for [severity_to_string[EC.severity]] events by [decrease/600] minute(s).")
 	else if(href_list["inc_timer"])
 		var/datum/event_container/EC = locate(href_list["event"])
 		var/increase = 60 * (10 ** text2num(href_list["inc_timer"]))
 		EC.next_event_time += increase
-		admin_log_and_message_admins("increased timer for [severity_to_string[EC.severity]] events by [increase/600] minute(s).")
+		log_and_message_admins("increased timer for [severity_to_string[EC.severity]] events by [increase/600] minute(s).")
 	else if(href_list["select_event"])
 		var/datum/event_container/EC = locate(href_list["select_event"])
 		var/datum/event_meta/EM = EC.SelectEvent()
 		if(EM)
-			admin_log_and_message_admins("has queued the [severity_to_string[EC.severity]] event '[EM.name]'.")
+			log_and_message_admins("has queued the [severity_to_string[EC.severity]] event '[EM.name]'.")
 	else if(href_list["pause"])
 		var/datum/event_container/EC = locate(href_list["pause"])
 		EC.delayed = !EC.delayed
-		admin_log_and_message_admins("has [EC.delayed ? "paused" : "resumed"] countdown for [severity_to_string[EC.severity]] events.")
+		log_and_message_admins("has [EC.delayed ? "paused" : "resumed"] countdown for [severity_to_string[EC.severity]] events.")
 	else if(href_list["pause_all"])
 		config.allow_random_events = text2num(href_list["pause_all"])
-		admin_log_and_message_admins("has [config.allow_random_events ? "resumed" : "paused"] countdown for all events.")
+		log_and_message_admins("has [config.allow_random_events ? "resumed" : "paused"] countdown for all events.")
 	else if(href_list["interval"])
 		var/delay = input("Enter delay modifier. A value less than one means events fire more often, higher than one less often.", "Set Interval Modifier") as num|null
 		if(delay && delay > 0)
 			var/datum/event_container/EC = locate(href_list["interval"])
 			EC.delay_modifier = delay
-			admin_log_and_message_admins("has set the interval modifier for [severity_to_string[EC.severity]] events to [EC.delay_modifier].")
+			log_and_message_admins("has set the interval modifier for [severity_to_string[EC.severity]] events to [EC.delay_modifier].")
 	else if(href_list["stop"])
 		if(alert("Stopping an event may have unintended side-effects. Continue?","Stopping Event!","Yes","No") != "Yes")
 			return
 		var/datum/event/E = locate(href_list["stop"])
 		var/datum/event_meta/EM = E.event_meta
-		admin_log_and_message_admins("has stopped the [severity_to_string[EM.severity]] event '[EM.name]'.")
+		log_and_message_admins("has stopped the [severity_to_string[EM.severity]] event '[EM.name]'.")
 		E.kill()
 	else if(href_list["view_events"])
 		selected_event_container = locate(href_list["view_events"])
@@ -249,23 +249,23 @@
 			var/datum/event_meta/EM = locate(href_list["set_weight"])
 			EM.weight = weight
 			if(EM != new_event)
-				admin_log_and_message_admins("has changed the weight of the [severity_to_string[EM.severity]] event '[EM.name]' to [EM.weight].")
+				log_and_message_admins("has changed the weight of the [severity_to_string[EM.severity]] event '[EM.name]' to [EM.weight].")
 	else if(href_list["toggle_oneshot"])
 		var/datum/event_meta/EM = locate(href_list["toggle_oneshot"])
 		EM.one_shot = !EM.one_shot
 		if(EM != new_event)
-			admin_log_and_message_admins("has [EM.one_shot ? "set" : "unset"] the oneshot flag for the [severity_to_string[EM.severity]] event '[EM.name]'.")
+			log_and_message_admins("has [EM.one_shot ? "set" : "unset"] the oneshot flag for the [severity_to_string[EM.severity]] event '[EM.name]'.")
 	else if(href_list["toggle_enabled"])
 		var/datum/event_meta/EM = locate(href_list["toggle_enabled"])
 		EM.enabled = !EM.enabled
-		admin_log_and_message_admins("has [EM.enabled ? "enabled" : "disabled"] the [severity_to_string[EM.severity]] event '[EM.name]'.")
+		log_and_message_admins("has [EM.enabled ? "enabled" : "disabled"] the [severity_to_string[EM.severity]] event '[EM.name]'.")
 	else if(href_list["remove"])
 		if(alert("This will remove the event from rotation. Continue?","Removing Event!","Yes","No") != "Yes")
 			return
 		var/datum/event_meta/EM = locate(href_list["remove"])
 		var/datum/event_container/EC = locate(href_list["EC"])
 		EC.available_events -= EM
-		admin_log_and_message_admins("has removed the [severity_to_string[EM.severity]] event '[EM.name]'.")
+		log_and_message_admins("has removed the [severity_to_string[EM.severity]] event '[EM.name]'.")
 	else if(href_list["add"])
 		if(!new_event.name || !new_event.event_type)
 			return
@@ -273,12 +273,12 @@
 			return
 		new_event.severity = selected_event_container.severity
 		selected_event_container.available_events += new_event
-		admin_log_and_message_admins("has added \a [severity_to_string[new_event.severity]] event '[new_event.name]' of type [new_event.event_type] with weight [new_event.weight].")
+		log_and_message_admins("has added \a [severity_to_string[new_event.severity]] event '[new_event.name]' of type [new_event.event_type] with weight [new_event.weight].")
 		new_event = new
 	else if(href_list["clear"])
 		var/datum/event_container/EC = locate(href_list["clear"])
 		if(EC.next_event)
-			admin_log_and_message_admins("has dequeued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.")
+			log_and_message_admins("has dequeued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.")
 			EC.next_event = null
 
 	Interact(usr)


### PR DESCRIPTION
log_and_message_admins() (which sure needs a shorter name) now uses key_name_admin() instead of just key_name().
Replaces calls to admin_log_and_message_admins() which did this with log_and_message_admins() instead.
