### PR TITLE
improve defines in table code

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -415,9 +415,16 @@
 	connections = dirs_to_corner_states(connection_dirs)
 
 #define CORNER_NONE 0
-#define CORNER_CLOCKWISE 1
+#define CORNER_COUNTERCLOCKWISE 1
 #define CORNER_DIAGONAL 2
-#define CORNER_COUNTERCLOCKWISE 4
+#define CORNER_CLOCKWISE 4
+
+/*
+  turn() is weird:
+    turn(icon, angle) turns icon by angle degrees clockwise
+    turn(matrix, angle) turns matrix by angle degrees clockwise
+    turn(dir, angle) turns dir by angle degrees counter-clockwise
+*/
 
 /proc/dirs_to_corner_states(list/dirs)
 	if(!istype(dirs)) return
@@ -430,14 +437,14 @@
 		if(dir in dirs)
 			. |= CORNER_DIAGONAL
 		if(turn(dir,45) in dirs)
-			. |= CORNER_CLOCKWISE
-		if(turn(dir,-45) in dirs)
 			. |= CORNER_COUNTERCLOCKWISE
+		if(turn(dir,-45) in dirs)
+			. |= CORNER_CLOCKWISE
 		ret[i] = "[.]"
 
 	return ret
 
 #undef CORNER_NONE
-#undef CORNER_EASTWEST
+#undef CORNER_COUNTERCLOCKWISE
 #undef CORNER_DIAGONAL
-#undef CORNER_NORTHSOUTH
+#undef CORNER_CLOCKWISE


### PR DESCRIPTION
the defines were inverted, this uninverts them
also fixes #undef of old names for things

no actual changes after comment removal and macro parsing, this is purely a preprocessor change - the values of `CORNER_COUNTERCLOCKWISE` and `CORNER_CLOCKWISE` have been flipped, and all usages have been flipped.
