### PR TITLE
"Junior Officer" alt-title

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -96,7 +96,6 @@
 	economic_modifier = 5
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels)
 	minimal_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels)
-	alt_titles = list("Forensic Technician")
 	minimal_player_age = 3
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -135,6 +134,7 @@
 	spawn_positions = 4
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
+	alt_titles = list("Junior Officer")
 	economic_modifier = 4
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks)


### PR DESCRIPTION
Adds "Junior Officer" as an alternative job title to Security Officers.

Pros:
- replaces "Security Cadet" as a title that signalizes lesser experience,
- opens up roleplay possibilities,
- gives no potential room for slot abuse,
- gives a reason for a character to make mistakes, allowing for some antag opportunities!

Cons:
- gives a reason for a character to make mistakes.

Also: removes duplicated line in Detective's code.
