### PR TITLE
Fix for runtime in skills computer

### DIFF
--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -277,7 +277,11 @@ What a mess.*/
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
 					P.info += "</TT>"
-					P.name = "Employment Record ([active1.fields["name"]])"
+					if(active1)
+						P.name = "Employment Record ([active1.fields["name"]])"
+					else
+						P.name = "Employment Record (Unknown/Invald Entry)"
+						log_debug("[usr] ([usr.ckey]) attempted to print a null employee record, this should be investigated.")
 					printing = null
 //RECORD DELETE
 			if ("Delete All Records")


### PR DESCRIPTION
#10306

I couldn't replicate it, but I'd imagine it could occur if an entry was somehow deleted after bringing it up on the display screen. This would probably fix it anyway (there was a mismatch between the line reported in the issue and the code on the file which I also wasn't able to trace down the source of). 
