### PR TITLE
Add autohiss/purr on a per-client toggle

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1206,6 +1206,7 @@
 #include "code\modules\mob\language\outsider.dm"
 #include "code\modules\mob\language\station.dm"
 #include "code\modules\mob\language\synthetic.dm"
+#include "code\modules\mob\living\autohiss.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\default_language.dm"
 #include "code\modules\mob\living\life.dm"

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -36,9 +36,9 @@
 			src << "Auto-hiss is now OFF."
 
 /datum/species
-	var/autohiss_basic_map = null
-	var/autohiss_extra_map = null
-	var/autohiss_exempt = null
+	var/list/autohiss_basic_map = null
+	var/list/autohiss_extra_map = null
+	var/list/autohiss_exempt = null
 
 /datum/species/unathi
 	autohiss_basic_map = list(

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -1,0 +1,89 @@
+
+#define AUTOHISS_OFF 0
+#define AUTOHISS_SR 1
+#define AUTOHISS_SRX 2
+
+#define AUTOHISS_NUM 3
+
+
+/mob/living/proc/handle_autohiss(message, datum/language/L)
+	return message // no autohiss at this level
+
+/mob/living/carbon/human/handle_autohiss(message, datum/language/L)
+	if(!client || client.autohiss_mode == AUTOHISS_OFF) // no need to process if there's no client or they have autohiss off
+		return message
+	return species.handle_autohiss(message, L, client.autohiss_mode)
+
+/client
+	var/autohiss_mode = 0
+
+/client/verb/toggle_autohiss()
+	set name = "Toggle Auto-Hiss"
+	set desc = "Toggle automatic hissing as Unathi and r-rolling as Taj"
+	set category = "OOC"
+
+	autohiss_mode = (autohiss_mode + 1) % AUTOHISS_NUM
+	switch(autohiss_mode)
+		if(AUTOHISS_OFF)
+			src << "Auto-hiss is now OFF."
+		if(AUTOHISS_SR)
+			src << "Auto-hiss is now ON for 's' (Unathi) and 'r' (Tajara)."
+		if(AUTOHISS_SRX)
+			src << "Auto-hiss is now ON for 's', 'x' (Unathi) and 'r' (Tajara)."
+		else
+			soft_assert(0, "invalid autohiss value [autohiss_mode]")
+			autohiss_mode = AUTOHISS_OFF
+			src << "Auto-hiss is now OFF."
+
+/datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
+	return message
+
+/datum/species/unathi/handle_autohiss(message, datum/language/lang, mode)
+	if(lang.name == "Sinta'unathi") // Sinta'unathi has no autohiss
+		return message
+
+	. = list()
+	while(length(message))
+		var/i = findtext(message, "s")
+		var/j = findtext(message, "x")
+		if(!i && !j)
+			. += message
+			break
+		if(!j || (i && j && i<j)) // s only, or s first
+			. += copytext(message, 1, i+1)
+			for(var/a = 1 to rand(1,3))
+				. += "s"
+			message = copytext(message, i+1)
+		else // x first
+			if(mode == AUTOHISS_SRX)
+				. += copytext(message, 1, j)
+				switch(copytext(message, j, j+1))
+					if("x")
+						. += pick("ks", "kss", "ksss")
+					if("X")
+						. += pick("Ks", "Kss", "Ksss")
+			else
+				. += copytext(message, 1, j+1)
+			message = copytext(message, j+1)
+	return list2text(.)
+
+/datum/species/tajaran/handle_autohiss(message, datum/language/lang, mode)
+	if(lang.name == "Siik'tajr") // Siik'tajr has no autopurr
+		return message
+
+	. = list()
+	while(length(message))
+		var/i = findtext(message, "r")
+		if(!i)
+			. += message
+			break
+		. += copytext(message, 1, i+1)
+		for(var/a = 1 to rand(1,3))
+			. += "r"
+		message = copytext(message, i+1)
+	return list2text(.)
+
+#undef AUTOHISS_OFF
+#undef AUTOHISS_SR
+#undef AUTOHISS_SRX
+#undef AUTOHISS_NUM

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -15,7 +15,7 @@
 	return species.handle_autohiss(message, L, client.autohiss_mode)
 
 /client
-	var/autohiss_mode = 0
+	var/autohiss_mode = AUTOHISS_OFF
 
 /client/verb/toggle_autohiss()
 	set name = "Toggle Auto-Hiss"
@@ -88,8 +88,6 @@
 			. += pick(map[min_char])
 		message = copytext(message, min_index + 1)
 
-	for(var/x = 1 to length(.))
-		world.log << "[x]: [.[x]]"
 	return list2text(.)
 
 #undef AUTOHISS_OFF

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -1,7 +1,7 @@
 
 #define AUTOHISS_OFF 0
-#define AUTOHISS_SR 1
-#define AUTOHISS_SRX 2
+#define AUTOHISS_BASIC 1
+#define AUTOHISS_FULL 2
 
 #define AUTOHISS_NUM 3
 
@@ -26,64 +26,73 @@
 	switch(autohiss_mode)
 		if(AUTOHISS_OFF)
 			src << "Auto-hiss is now OFF."
-		if(AUTOHISS_SR)
-			src << "Auto-hiss is now ON for 's' (Unathi) and 'r' (Tajara)."
-		if(AUTOHISS_SRX)
-			src << "Auto-hiss is now ON for 's', 'x' (Unathi) and 'r' (Tajara)."
+		if(AUTOHISS_BASIC)
+			src << "Auto-hiss is now BASIC."
+		if(AUTOHISS_FULL)
+			src << "Auto-hiss is now FULL."
 		else
 			soft_assert(0, "invalid autohiss value [autohiss_mode]")
 			autohiss_mode = AUTOHISS_OFF
 			src << "Auto-hiss is now OFF."
 
+/datum/species
+	var/autohiss_basic_map = null
+	var/autohiss_extra_map = null
+	var/autohiss_exempt = null
+
+/datum/species/unathi
+	autohiss_basic_map = list(
+			"s" = list("ss", "sss", "ssss")
+		)
+	autohiss_extra_map = list(
+			"x" = list("ks", "kss", "ksss")
+		)
+	autohiss_exempt = list("Sinta'unathi")
+
+/datum/species/tajaran
+	autohiss_basic_map = list(
+			"r" = list("rr", "rrr", "rrrr")
+		)
+	autohiss_exempt = list("Siik'tajr")
+
+
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
-	return message
-
-/datum/species/unathi/handle_autohiss(message, datum/language/lang, mode)
-	if(lang.name == "Sinta'unathi") // Sinta'unathi has no autohiss
+	if(!autohiss_basic_map)
+		return message
+	if(autohiss_exempt && (lang.name in autohiss_exempt))
 		return message
 
-	. = list()
-	while(length(message))
-		var/i = findtext(message, "s")
-		var/j = findtext(message, "x")
-		if(!i && !j)
-			. += message
-			break
-		if(!j || (i && j && i<j)) // s only, or s first
-			. += copytext(message, 1, i+1)
-			for(var/a = 1 to rand(1,3))
-				. += "s"
-			message = copytext(message, i+1)
-		else // x first
-			if(mode == AUTOHISS_SRX)
-				. += copytext(message, 1, j)
-				switch(copytext(message, j, j+1))
-					if("x")
-						. += pick("ks", "kss", "ksss")
-					if("X")
-						. += pick("Ks", "Kss", "Ksss")
-			else
-				. += copytext(message, 1, j+1)
-			message = copytext(message, j+1)
-	return list2text(.)
-
-/datum/species/tajaran/handle_autohiss(message, datum/language/lang, mode)
-	if(lang.name == "Siik'tajr") // Siik'tajr has no autopurr
-		return message
+	var/map = autohiss_basic_map.Copy()
+	if(mode == AUTOHISS_FULL && autohiss_extra_map)
+		map |= autohiss_extra_map
 
 	. = list()
+
 	while(length(message))
-		var/i = findtext(message, "r")
-		if(!i)
+		var/min_index = 10000 // if the message is longer than this, the autohiss is the least of your problems
+		var/min_char = null
+		for(var/char in map)
+			var/i = findtext(message, char)
+			if(!i) // no more of this character anywhere in the string, don't even bother searching next time
+				map -= char
+			else if(i < min_index)
+				min_index = i
+				min_char = char
+		if(!min_char) // we didn't find any of the mapping characters
 			. += message
 			break
-		. += copytext(message, 1, i+1)
-		for(var/a = 1 to rand(1,3))
-			. += "r"
-		message = copytext(message, i+1)
+		. += copytext(message, 1, min_index)
+		if(copytext(message, min_index, min_index+1) == uppertext(min_char))
+			. += capitalize(pick(map[min_char]))
+		else
+			. += pick(map[min_char])
+		message = copytext(message, min_index + 1)
+
+	for(var/x = 1 to length(.))
+		world.log << "[x]: [.[x]]"
 	return list2text(.)
 
 #undef AUTOHISS_OFF
-#undef AUTOHISS_SR
-#undef AUTOHISS_SRX
+#undef AUTOHISS_BASIC
+#undef AUTOHISS_FULL
 #undef AUTOHISS_NUM

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -182,6 +182,8 @@ proc/get_radio_key_from_channel(var/channel)
 	message = trim_left(message)
 
 	if(!(speaking && (speaking.flags & NO_STUTTER)))
+		message = handle_autohiss(message, speaking)
+
 		var/list/handle_s = handle_speech_problems(message, verb)
 		message = handle_s[1]
 		verb = handle_s[2]

--- a/html/changelogs/GinjaNinja32-autohiss.yml
+++ b/html/changelogs/GinjaNinja32-autohiss.yml
@@ -1,0 +1,5 @@
+author: GinjaNinja32
+delete-after: True
+changes:
+  - rscadd: "Added an auto-hiss system for those who would prefer the game do their sss or rrr for them. Activate via Toggle Auto-Hiss in the OOC tab."
+  - rscadd: "Auto-hiss system in 'basic' mode will extend 's' for Unathi and 'r' for Tajara. 'Full' mode adds 'x' to 'ks' for Unathi, and is identical to 'basic' mode for Tajara."


### PR DESCRIPTION
see title
It has three modes:
- Off: The autohiss/purr does nothing to the input string. This is the default, and behaves identically to current behaviour.
- SR: The autohiss/purr will extend 's' (for Unathi) and 'r' (for Taj) between one and three characters each
- SRX: As SR, but Unathi gain 'x' -> 'ks', 'kss', 'ksss'.

Sinta'unathi is unaffected for Unathi. Siik'tajr is unaffected for Tajara. Any language with the `NO_STUTTER` flag (currently just noise language IIRC) is also unaffected.

Codewise, based on constructing a list of strings then `list2text()`ing the list, since that should be faster than repeated concatenation.
