### PR TITLE
Vent crawling now explicitly checks for equipped items.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -221,17 +221,20 @@ var/list/slot_equipment_priority = list( \
 	if(!I) //If there's nothing to drop, the drop is automatically successful.
 		return 1
 
-	var/slot
-	for(var/s in slot_back to slot_tie) //kind of worries me
-		if(get_equipped_item(s) == I)
-			slot = s
-			break
-
+	var/slot = get_inventory_slot(I)
 	if(slot && !I.mob_can_unequip(src, slot))
 		return 0
 
 	drop_from_inventory(I)
 	return 1
+
+/mob/proc/get_inventory_slot(obj/item/I)
+	var/slot
+	for(var/s in slot_back to slot_tie) //kind of worries me
+		if(get_equipped_item(s) == I)
+			slot = s
+			break
+	return slot
 
 //Attemps to remove an object on a mob.
 /mob/proc/remove_from_mob(var/obj/O)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -656,27 +656,15 @@ default behaviour is:
 	set category = "IC"
 
 	resting = !resting
-	src << "\blue You are now [resting ? "resting" : "getting up"]"
+	src << "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>"
 
 /mob/living/proc/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	if(istype(carried_item, /obj/item/weapon/implant))
-		return 1
-	if(istype(carried_item, /obj/item/clothing/mask/facehugger))
-		return 1
-	return 0
-
-/mob/living/carbon/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	if(carried_item in internal_organs)
-		return 1
-	return ..()
-
-/mob/living/carbon/human/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	if(carried_item in organs)
-		return 1
-	return ..()
+	return isnull(get_inventory_slot(carried_item))
 
 /mob/living/simple_animal/spiderbot/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	return carried_item != held_item
+	if(carried_item == held_item)
+		return 0
+	return ..()
 
 /mob/living/proc/handle_ventcrawl(var/obj/machinery/atmospherics/unary/vent_pump/vent_found = null, var/ignore_items = 0) // -- TLE -- Merged by Carn
 	if(stat)


### PR DESCRIPTION
Fixes #10991.

Note to self: Consider making an item -> slot associative list on dev.
