### PR TITLE
Observers can now view radio settings, admins can alter them.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -178,21 +178,7 @@
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/heads/hop
-/*
-/obj/item/device/radio/headset/headset_mine
-	name = "mining radio headset"
-	desc = "Headset used by miners. How useless. To access the mining channel, use :d."
-	icon_state = "mine_headset"
-	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/headset_mine
 
-/obj/item/device/radio/headset/heads/qm
-	name = "quartermaster's headset"
-	desc = "The headset of the man who control your toiletpaper supply. To access the cargo channel, use :q. For mining, use :d."
-	icon_state = "cargo_headset"
-	item_state = "headset"
-	keyslot2 = new /obj/item/device/encryptionkey/heads/qm
-*/
 /obj/item/device/radio/headset/headset_cargo
 	name = "supply radio headset"
 	desc = "A headset used by the QM and their slaves."

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -83,6 +83,8 @@ var/global/list/default_medbay_channels = list(
 	for (var/ch_name in channels)
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 
+/obj/item/device/radio/attack_ghost(mob/user)
+	interact(user)
 
 /obj/item/device/radio/attack_self(mob/user as mob)
 	user.set_machine(src)
@@ -143,8 +145,14 @@ var/global/list/default_medbay_channels = list(
 	if(!(freq in internal_channels))
 		return 0
 
-	var/obj/item/weapon/card/id/I = user.GetIdCard()
-	return has_access(list(), internal_channels[freq], I ? I.GetAccess() : list())
+	return user.has_internal_radio_channel_access(internal_channels[freq])
+
+/mob/proc/has_internal_radio_channel_access(var/list/req_one_accesses)
+	var/obj/item/weapon/card/id/I = GetIdCard()
+	return has_access(list(), req_one_accesses, I ? I.GetAccess() : list())
+
+/mob/dead/observer/has_internal_radio_channel_access(var/list/req_one_accesses)
+	return can_admin_interact()
 
 /obj/item/device/radio/proc/text_wires()
 	if (b_stat)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -657,6 +657,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/canface()
 	return 1
 
+/mob/dead/observer/proc/can_admin_interact()
+	return check_rights(R_ADMIN, 0, src)
+
 /mob/dead/observer/verb/toggle_ghostsee()
 	set name = "Toggle Ghost Vision"
 	set desc = "Toggles your ability to see things only ghosts can see, like other ghosts"

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -10,7 +10,7 @@
 	return STATUS_CLOSE // By default no mob can do anything with NanoUI
 
 /mob/dead/observer/default_can_use_topic()
-	if(check_rights(R_ADMIN, 0, src))
+	if(can_admin_interact())
 		return STATUS_INTERACTIVE				// Admins are more equal
 	return STATUS_UPDATE						// Ghosts can view updates
 


### PR DESCRIPTION
I may or may not rewrite the client toggles as we're out (using all 16 flags) and I wanted to make admin observer world interaction such a toggle :|
