### PR TITLE
Status display alarms now clear properly on all mode changes.

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -28,6 +28,7 @@
 	var/message2 = ""	// message line 2
 	var/index1			// display index for scrolling messages or 0 if non-scrolling
 	var/index2
+	var/picture = null
 
 	var/frequency = 1435		// radio frequency
 
@@ -72,13 +73,13 @@
 
 // set what is displayed
 /obj/machinery/status_display/proc/update()
+	remove_display()
 	if(friendc && !ignore_friendc)
 		set_picture("ai_friend")
 		return 1
 
 	switch(mode)
 		if(STATUS_DISPLAY_BLANK)	//blank
-			remove_display()
 			return 1
 		if(STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME)				//emergency shuttle timer
 			if(emergency_shuttle.waiting_to_leave())
@@ -96,8 +97,6 @@
 				if(length(message2) > CHARS_PER_LINE)
 					message2 = "Error"
 				update_display(message1, message2)
-			else
-				remove_display()
 			return 1
 		if(STATUS_DISPLAY_MESSAGE)	//custom messages
 			var/line1
@@ -121,6 +120,9 @@
 				if(index2 > message2_len)
 					index2 -= message2_len
 			update_display(line1, line2)
+			return 1
+		if(STATUS_DISPLAY_ALERT)
+			set_picture(picture_state)
 			return 1
 		if(STATUS_DISPLAY_TIME)
 			message1 = "TIME"
@@ -150,9 +152,11 @@
 		index2 = 0
 
 /obj/machinery/status_display/proc/set_picture(state)
-	picture_state = state
 	remove_display()
-	overlays += image('icons/obj/status_display.dmi', icon_state=picture_state)
+	if(!picture || picture_state != state)
+		picture_state = state
+		picture = image('icons/obj/status_display.dmi', icon_state=picture_state)
+	overlays |= picture
 
 /obj/machinery/status_display/proc/update_display(line1, line2)
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
@@ -207,7 +211,7 @@
 
 		if("time")
 			mode = STATUS_DISPLAY_TIME
-
+	update()
 
 #undef CHARS_PER_LINE
 #undef FOND_SIZE


### PR DESCRIPTION
Previously one had to first set the display mode to Clear before the overlays would go away.
This corrects situations where, for example, the emergency shuttle ETA could be covered by a NT logo.
