### PR TITLE
Hull shields should no longer prevent the departure shuttle from leaving

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -911,6 +911,9 @@ About the new airlock wires panel:
 	health -= crush_damage
 	healthcheck()
 
+/obj/effect/energy_field/airlock_crush(var/crush_damage)
+	Stress(crush_damage)
+
 /obj/structure/closet/airlock_crush(var/crush_damage)
 	..()
 	damage(crush_damage)


### PR DESCRIPTION
If hull shields are left alone by the crew (due to being, for example, all dead) the departure shuttle is unable to leave.
This should destroy any shields faster than they can regenerate, thus ensuring a safe and pleasant departure.
