### PR TITLE
Personal AI resting fix

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -398,6 +398,9 @@
 	canmove = 0
 	icon_state = "[chassis]"
 
+	//stop resting
+	resting = 0
+
 /mob/living/silicon/pai/start_pulling(var/atom/movable/AM)
 
 	if(istype(AM,/obj/item))


### PR DESCRIPTION
Fixes #11000

Added `resting = 0` into `/mob/living/silicon/pai/proc/close_up()` to make the pAI stop resting when it collapses back into the handheld device.
