### PR TITLE
Improve formatting of admin announcements

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -750,7 +750,8 @@ proc/admin_notice(var/message, var/rights)
 	if(message)
 		if(!check_rights(R_SERVER,0))
 			message = sanitize(message, 500, extra = 0)
-		world << "\blue <b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>\n \t [message]"
+		message = replacetext(message, "\n", "<br>") // required since we're putting it in a <p> tag
+		world << "<span class=notice><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b><p style='text-indent: 50px'>[message]</p></span>"
 		log_admin("Announce: [key_name(usr)] : [message]")
 	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
Title.

![](https://i.imgur.com/RSYRPwz.png)
produces
![](https://i.imgur.com/wgqVM4Z.png)
instead of
![](https://i.imgur.com/ZGExfpi.png)
