### PR TITLE
[BOTANY] Fixes plant nutrient storage unit check

### DIFF
--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -101,7 +101,7 @@
 				if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS))
 					if(seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) < 0.05)
 						dat += "<td>Low</td>"
-					else if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) > 0.2)
+					else if(seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0.2)
 						dat += "<td>High</td>"
 					else
 						dat += "<td>Norm</td>"


### PR DESCRIPTION
Reported only high, low or none with previous version

Simple replacement of the correct variable to add "Norm" to the list of reportable variables, as originally intended.
