### PR TITLE
Fixes #11047

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -2,7 +2,7 @@
 /mob/living/carbon/process_resist()
 
 	//drop && roll
-	if(on_fire)
+	if(on_fire && !buckled)
 		fire_stacks -= 1.2
 		Weaken(3)
 		spin(32,2)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -574,20 +574,11 @@ default behaviour is:
 	set name = "Resist"
 	set category = "IC"
 
-	if(can_resist())
+	if(!(stat || next_move > world.time))
 		next_move = world.time + 20
 		resist_grab()
-		if(!weakened && !restrained())
+		if(!weakened)
 			process_resist()
-
-/mob/living/proc/can_resist()
-	//need to allow !canmove, or otherwise neck grabs can't be resisted
-	//similar thing with weakened and pinning
-	if(stat)
-		return 0
-	if(next_move > world.time)
-		return 0
-	return 1
 
 /mob/living/proc/process_resist()
 	//Getting out of someone's inventory.

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -34,9 +34,6 @@
 /mob/living/captive_brain/emote(var/message)
 	return
 
-/mob/living/captive_brain/can_resist()
-	return !(stat || next_move > world.time)
-
 /mob/living/captive_brain/process_resist()
 	//Resisting control by an alien mind.
 	if(istype(src.loc,/mob/living/simple_animal/borer))


### PR DESCRIPTION
Allows resisting while restrained. Fixes #11047.
Also prevents stop-drop-and-roll while buckled. Removed the can_resist() proc because it was pointless, each of the different resist actions all have different requirements anyways.
