### PR TITLE
Fixes various actions occuring instantly

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -623,7 +623,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 
 	else return get_step(ref, base_dir)
 
-/proc/do_mob(var/mob/user, var/mob/target, var/delay, var/numticks = 5, var/needhand = 1) //This is quite an ugly solution but i refuse to use the old request system.
+/proc/do_mob(var/mob/user, var/mob/target, var/delay = 30, var/numticks = 5, var/needhand = 1) //This is quite an ugly solution but i refuse to use the old request system.
 	if(!user || !target)	return 0
 	if(numticks == 0)		return 0
 


### PR DESCRIPTION
As of v0.1.18 `do_mob()` had a default duration of 3 seconds. It seems that disappeared somewhere, causing various actions (such as feeding other people food and drinks) to have no delay.
