### PR TITLE
Fixes IPCs being knocked unconscious when hit in the head with a melee weapon

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -169,42 +169,6 @@
 		src.add_fingerprint(user)
 		return
 
-	//I consider this worthless but it isn't my code so whatever.  Remove or uncomment.
-	/*attack(mob/M as mob, mob/living/user as mob)
-		if ((CLUMSY in user.mutations) && prob(50))
-			user << "<span class='warning'>The [src] slips out of your hand and hits your head.</span>"
-			user.take_organ_damage(10)
-			user.Paralyse(2)
-			return
-
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
-
-		log_attack("<font color='red'>[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>")
-
-		var/t = user:zone_sel.selecting
-		if (t == "head")
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if (H.stat < 2 && H.health < 50 && prob(90))
-				// ******* Check
-					if (istype(H, /obj/item/clothing/head) && H.flags & 8 && prob(80))
-						H << "<span class='warning'>The helmet protects you from being hit hard in the head!</span>"
-						return
-					var/time = rand(2, 6)
-					if (prob(75))
-						H.Paralyse(time)
-					else
-						H.Stun(time)
-					if(H.stat != 2)	H.stat = 1
-					for(var/mob/O in viewers(H, null))
-						O.show_message(text("<span class='warning'><B>[] has been knocked unconscious!</B></span>", H), 1, "<span class='warning'>You hear someone fall.</span>", 2)
-				else
-					H << text("<span class='warning'>[] tried to knock you unconcious!</span>",user)
-					H.eye_blurry += 3
-
-		return*/
-
 // -----------------------------
 //        Secure Safe
 // -----------------------------

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -695,6 +695,28 @@
 			number += 2
 	return number
 
+//Used by various things that knock people out by applying blunt trauma to the head.
+//Checks that the species has a "head" (brain containing organ) and that hit_zone refers to it.
+/mob/living/carbon/human/proc/headcheck(var/target_zone, var/brain_tag = "brain")
+	if(!species.has_organ[brain_tag])
+		return 0
+	
+	var/obj/item/organ/affecting = internal_organs_by_name[brain_tag]
+	
+	target_zone = check_zone(target_zone)
+	if(!affecting || affecting.parent_organ != target_zone)
+		return 0
+	
+	//if the parent organ is significantly larger than the brain organ, then hitting it is not guaranteed
+	var/obj/item/organ/parent = get_organ(target_zone)
+	if(!parent)
+		return 0
+	
+	if(parent.w_class > affecting.w_class + 1)
+		return prob(100 / 2**(parent.w_class - affecting.w_class - 1))
+	
+	return 1
+
 /mob/living/carbon/human/IsAdvancedToolUser(var/silent)
 	if(species.has_fine_manipulation)
 		return 1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -257,29 +257,32 @@ emp_act
 					H.bloody_hands(src)
 
 		if(!stat)
+			if(headcheck(hit_area))
+				//Harder to score a stun but if you do it lasts a bit longer
+				if(prob(effective_force))
+					apply_effect(20, PARALYZE, armor)
+					visible_message("<span class='danger'>[src] [species.knockout_message]</span>")
+			else
+				//Easier to score a stun but lasts less time
+				if(prob(effective_force + 10))
+					apply_effect(6, WEAKEN, armor)
+					visible_message("<span class='danger'>[src] has been knocked down!</span>")
+		
+		//Apply blood
+		if(bloody)
 			switch(hit_area)
-				if("head")//Harder to score a stun but if you do it lasts a bit longer
-					if(prob(effective_force))
-						apply_effect(20, PARALYZE, armor)
-						visible_message("\red <B>[src] has been knocked unconscious!</B>")
-					if(bloody)//Apply blood
-						if(wear_mask)
-							wear_mask.add_blood(src)
-							update_inv_wear_mask(0)
-						if(head)
-							head.add_blood(src)
-							update_inv_head(0)
-						if(glasses && prob(33))
-							glasses.add_blood(src)
-							update_inv_glasses(0)
-
-				if("chest")//Easier to score a stun but lasts less time
-					if(prob((effective_force + 10)))
-						apply_effect(6, WEAKEN, armor)
-						visible_message("\red <B>[src] has been knocked down!</B>")
-
-					if(bloody)
-						bloody_body(src)
+				if("head")
+					if(wear_mask)
+						wear_mask.add_blood(src)
+						update_inv_wear_mask(0)
+					if(head)
+						head.add_blood(src)
+						update_inv_head(0)
+					if(glasses && prob(33))
+						glasses.add_blood(src)
+						update_inv_glasses(0)
+				if("chest")
+					bloody_body(src)
 
 	if(Iforce > 10 || Iforce >= 5 && prob(33))
 		forcesay(hit_appends)	//forcesay checks stat already

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -58,6 +58,7 @@
 	var/dusted_anim = "dust-h"
 	var/death_sound
 	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
+	var/knockout_message = "has been knocked unconscious!"
 
 	// Environment tolerance/life processes vars.
 	var/reagent_tag                                   //Used for metabolizing reagents.

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -256,6 +256,8 @@
 	brute_mod = 1.875 // 100% * 1.875 * 0.8 (robolimbs) ~= 150%
 	burn_mod = 1.875  // So they take 50% extra damage from brute/burn overall.
 	show_ssd = "flashing a 'system offline' glyph on their monitor"
+	death_message = "gives one shrill beep before falling lifeless."
+	knockout_message = "encounters a hardware fault and suddenly reboots!"
 
 	warning_low_pressure = 50
 	hazard_low_pressure = 0

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -91,15 +91,15 @@
 	var/damage = 20
 	var/obj/item/clothing/hat = attacker.head
 	if(istype(hat))
-		damage += hat.force * 10
+		damage += hat.force * 3
 	
 	var/armor = target.run_armor_check("head", "melee")
-	target.apply_damage(damage*rand(90, 110)/100, BRUTE, "head", armor)
-	attacker.apply_damage(10*rand(90, 110)/100, BRUTE, "head", attacker.run_armor_check("head", "melee"))
+	target.apply_damage(damage, BRUTE, "head", armor)
+	attacker.apply_damage(10, BRUTE, "head", attacker.run_armor_check("head", "melee"))
 	
-	if(!armor && prob(damage))
+	if(!armor && target.headcheck("head") && prob(damage))
 		target.apply_effect(20, PARALYZE)
-		target.visible_message("<span class='danger'>[target] has been knocked unconscious!</span>")
+		target.visible_message("<span class='danger'>[target] [target.species.knockout_message]</span>")
 	
 	playsound(attacker.loc, "swing_hit", 25, 1, -1)
 	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Headbutted [target.name] ([target.ckey])</font>")

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -45,7 +45,7 @@
 
 	force = 15 //Smashing bottles over someoen's head hurts.
 
-	var/obj/item/organ/external/affecting = user.zone_sel.selecting //Find what the player is aiming at
+	var/affecting = user.zone_sel.selecting //Find what the player is aiming at
 
 	var/armor_block = 0 //Get the target's armour values for normal attack damage.
 	var/armor_duration = 0 //The more force the bottle has, the longer the duration.
@@ -58,12 +58,11 @@
 	target.apply_damage(force, BRUTE, affecting, armor_block, sharp=0)
 
 	// You are going to knock someone out for longer if they are not wearing a helmet.
-	if(affecting == "head" && istype(target, /mob/living/carbon/))
-
+	var/mob/living/carbon/human/H = target
+	if(istype(H) && H.headcheck(affecting))
 		//Display an attack message.
-		for(var/mob/O in viewers(user, null))
-			if(target != user) O.show_message(text("\red <B>[target] has been hit over the head with a bottle of [src.name], by [user]!</B>"), 1)
-			else O.show_message(text("\red <B>[target] hit \himself with a bottle of [src.name] on the head!</B>"), 1)
+		var/obj/item/organ/O = H.get_organ(affecting)
+		user.visible_message("<span class='danger'>[user] smashes [src] into [H]'s [O.name]!</span>")
 		//Weaken the target for the duration that we calculated and divide it by 5.
 		if(armor_duration)
 			target.apply_effect(min(armor_duration, 10) , WEAKEN, armor_block) // Never weaken more than a flash!


### PR DESCRIPTION
- Replaces the hardcoded def_zones with a headcheck() proc to handle species who have "brains" are located in non-standard places. This proc returns 1 if the given target zone refers to a body part that contains a brain.
- If the brain is located in an organ that is much larger than it, then headcheck() will return 1 with some probability. For IPCs, who have their posis in their chest, this probability will be 25%. This balances the fact that the chest is usually easier to hit than the head.
