### PR TITLE
Makes flares brighter

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -132,7 +132,8 @@
 	name = "flare"
 	desc = "A red Nanotrasen issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = 2.0
-	brightness_on = 7 // Pretty bright.
+	brightness_on = 8 // Pretty bright.
+	light_power = 3
 	light_color = "#e58775"
 	icon_state = "flare"
 	item_state = "flare"

--- a/html/changelogs/HarpyEagle-flare-tweak.yml
+++ b/html/changelogs/HarpyEagle-flare-tweak.yml
@@ -1,0 +1,18 @@
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+
+author: HarpyEagle
+delete-after: True
+
+changes: 
+  - tweak: "Made flares brighter."


### PR DESCRIPTION
The lighting update was not very kind to flares, and given that they are a single use item that cannot be turned off they need a bit of a boost in order to have more of a purpose.
