### PR TITLE
Abandoned crates again use unique digits for their codes

### DIFF
--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -16,6 +16,7 @@
 
 	for(var/i in 1 to codelen)
 		code += pick(digits)
+		digits -= code[code.len]
 
 	generate_loot()
 


### PR DESCRIPTION
Restores the property of abandoned crate codes being composed of unique digits. Without unique digits opening the crates was made a bit harder than it should have been.
