### PR TITLE
Fixes observers being unable to see silicon antag status.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -141,6 +141,8 @@ Works together with spawning an observer, noted above.
 	var/client/C = U.client
 	for(var/mob/living/carbon/human/target in target_list)
 		C.images += target.hud_list[SPECIALROLE_HUD]
+	for(var/mob/living/silicon/target in target_list)
+		C.images += target.hud_list[SPECIALROLE_HUD]
 	return 1
 
 /mob/proc/ghostize(var/can_reenter_corpse = 1)


### PR DESCRIPTION
target_list contains mob/living mobs while the loop only considers living/carbon/human.
To make things a bit of a headache hud_list is defined separately for living/carbon/human and living/silicon, instead of directly on /living.

It is certainly possible to define hud_list at mob/living instead but adding an extra loop for silicons is the method that is least likely to break things, thus IMO the most appropriate for a master fix.
