### PR TITLE
Fixes for jetpacks and gas tanks

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -23,11 +23,9 @@
 	..()
 
 /obj/item/weapon/tank/jetpack/examine(mob/user)
-	if(!..(user, 0))
-		return
-
-	if(air_contents.gas["oxygen"] < 10)
-		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of oxygen!</span>"
+	. = ..()
+	if(air_contents.total_moles < 5)
+		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of gas!</span>"
 		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/jetpack/verb/toggle_rockets()
@@ -106,15 +104,6 @@
 /obj/item/weapon/tank/jetpack/carbondioxide/New()
 	..()
 	air_contents.adjust_gas("carbon_dioxide", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
-
-/obj/item/weapon/tank/jetpack/carbondioxide/examine(mob/user)
-	if(!..(user, 0))
-		return
-
-	if(air_contents.gas["carbon_dioxide"] < 10)
-		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of carbon dioxide!</span>"
-		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 	return
 
 /obj/item/weapon/tank/jetpack/rig

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -18,12 +18,16 @@
 	src.ion_trail = new /datum/effect/effect/system/ion_trail_follow()
 	src.ion_trail.set_up(src)
 
+/obj/item/weapon/tank/jetpack/Destroy()
+	qdel(ion_trail)
+	..()
+
 /obj/item/weapon/tank/jetpack/examine(mob/user)
 	if(!..(user, 0))
 		return
 
 	if(air_contents.gas["oxygen"] < 10)
-		user << text("\red <B>The meter on the [src.name] indicates you are almost out of air!</B>")
+		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of oxygen!</span>"
 		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/jetpack/verb/toggle_rockets()
@@ -101,18 +105,15 @@
 
 /obj/item/weapon/tank/jetpack/carbondioxide/New()
 	..()
-	src.ion_trail = new /datum/effect/effect/system/ion_trail_follow()
-	src.ion_trail.set_up(src)
-	//src.air_contents.carbon_dioxide = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	air_contents.adjust_gas("carbon_dioxide", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 	return
 
 /obj/item/weapon/tank/jetpack/carbondioxide/examine(mob/user)
-	if(!..(0))
+	if(!..(user, 0))
 		return
 
 	if(air_contents.gas["carbon_dioxide"] < 10)
-		user << text("\red <B>The meter on the [src.name] indicates you are almost out of carbon dioxide!</B>")
+		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of carbon dioxide!</span>"
 		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 	return
 

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -40,32 +40,24 @@
 	..()
 
 /obj/item/weapon/tank/examine(mob/user)
-	var/obj/icon = src
-	if (istype(src.loc, /obj/item/assembly))
-		icon = src.loc
-	if (!in_range(src, user))
-		if (icon == src) user << "\blue It's \a \icon[icon][src]! If you want any more information you'll need to get closer."
-		return
-
-	var/celsius_temperature = src.air_contents.temperature-T0C
-	var/descriptive
-
-	if (celsius_temperature < 20)
-		descriptive = "cold"
-	else if (celsius_temperature < 40)
-		descriptive = "room temperature"
-	else if (celsius_temperature < 80)
-		descriptive = "lukewarm"
-	else if (celsius_temperature < 100)
-		descriptive = "warm"
-	else if (celsius_temperature < 300)
-		descriptive = "hot"
-	else
-		descriptive = "furiously hot"
-
-	user << "\blue \The \icon[icon][src] feels [descriptive]"
-
-	return
+	. = ..(user, 0)
+	if(.)
+		var/celsius_temperature = air_contents.temperature - T0C
+		var/descriptive
+		switch(celsius_temperature)
+			if(300 to INFINITY)
+				descriptive = "furiously hot"
+			if(100 to 300)
+				descriptive = "hot"
+			if(80 to 100)
+				descriptive = "warm"
+			if(40 to 80)
+				descriptive = "lukewarm"
+			if(20 to 40)
+				descriptive = "room temperature"
+			else
+				descriptive = "cold"
+		user << "<span class='notice'>\The [src] feels [descriptive].</span>"
 
 /obj/item/weapon/tank/blob_act()
 	if(prob(50))


### PR DESCRIPTION
Jetpacks now GC; CO2 jetpacks no longer pointlessly create a datum that
is already created in the parent; jetpacks can be properly examined;
removes text() and adds spans and \the.

Gas tanks now properly show their description.
