### PR TITLE
Invisible / Missing Growth State Fix

### DIFF
--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -36,7 +36,9 @@
 			if(age >= seed.get_trait(TRAIT_MATURATION))
 				overlay_stage = seed.growth_stages
 			else
-				var/maturation = round(seed.get_trait(TRAIT_MATURATION)/seed.growth_stages)
+				var/maturation = seed.get_trait(TRAIT_MATURATION)/seed.growth_stages
+				if(maturation < 1)
+					maturation = 1
 				overlay_stage = maturation ? max(1,round(age/maturation)) : 1
 			var/ikey = "[seed.get_trait(TRAIT_PLANT_ICON)]-[overlay_stage]"
 			var/image/plant_overlay = plant_controller.plant_icon_cache["[ikey]-[seed.get_trait(TRAIT_PLANT_COLOUR)]"]


### PR DESCRIPTION
Fixes a number of plants seeming to randomly have invisible plant growth states.
- This was caused by overly-rounded math resulting in attempts to call growth states that do not exist.
- Fixes https://github.com/Baystation12/Baystation12/issues/8541
  - Was closed without actually being corrected
