### PR TITLE
Meteors no longer impact with each other.

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -131,6 +131,9 @@
 		playsound(src.loc, meteorsound, 40, 1)
 		get_hit()
 
+/obj/effect/meteor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	return istype(mover, /obj/effect/meteor) ? 1 : ..()
+
 /obj/effect/meteor/proc/ram_turf(var/turf/T)
 	//first bust whatever is in the turf
 	for(var/atom/A in T)
@@ -200,7 +203,7 @@
 
 //Large-sized
 /obj/effect/meteor/big
-	name = "big meteor"
+	name = "large meteor"
 	icon_state = "large"
 	hits = 6
 	heavy = 1


### PR DESCRIPTION
This increases the number of meteors which survive to reach the station, as there is some tendency for them to spawn on the same location (but not necessarily fly in the same direction).

Partial port of https://github.com/d3athrow/vgstation13/pull/5696.
