### PR TITLE
Meteor events are now direction biased.

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -13,6 +13,8 @@
 
 #define iscorgi(A) istype(A, /mob/living/simple_animal/corgi)
 
+#define isEye(A) istype(A, /mob/eye)
+
 #define ishuman(A) istype(A, /mob/living/carbon/human)
 
 #define isliving(A) istype(A, /mob/living)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -18,25 +18,27 @@
 //Meteor spawning global procs
 ///////////////////////////////
 
-/proc/spawn_meteors(var/number = 10, var/list/meteortypes)
-	for(var/i = 0; i < number; i++)
-		spawn_meteor(meteortypes)
+/proc/pick_meteor_start(var/startSide = pick(cardinal))
+	var/startLevel = pick(config.station_levels)
+	var/pickedstart = spaceDebrisStartLoc(startSide, startLevel)
 
-/proc/spawn_meteor(var/list/meteortypes)
-	var/turf/pickedstart
-	var/turf/pickedgoal
-	var/max_i = 10//number of tries to spawn meteor.
-	while (!istype(pickedstart, /turf/space))
-		var/startSide = pick(cardinal)
-		pickedstart = spaceDebrisStartLoc(startSide, 1)
-		pickedgoal = spaceDebrisFinishLoc(startSide, 1)
-		max_i--
-		if(max_i<=0)
-			return
+	return list(startLevel, pickedstart)
+
+/proc/spawn_meteors(var/number = 10, var/list/meteortypes, var/startSide)
+	for(var/i = 0; i < number; i++)
+		spawn_meteor(meteortypes, startSide)
+
+/proc/spawn_meteor(var/list/meteortypes, var/startSide)
+	var/start = pick_meteor_start(startSide)
+
+	var/startLevel = start[1]
+	var/turf/pickedstart = start[2]
+	var/turf/pickedgoal = spaceDebrisFinishLoc(startSide, startLevel)
+
 	var/Me = pickweight(meteortypes)
 	var/obj/effect/meteor/M = new Me(pickedstart)
 	M.dest = pickedgoal
-	M.z_original = 1
+	M.z_original = startLevel
 	spawn(0)
 		walk_towards(M, M.dest, 1)
 	return
@@ -95,7 +97,6 @@
 	var/dest
 	pass_flags = PASSTABLE
 	var/heavy = 0
-	var/meteorsound = 'sound/effects/meteorimpact.ogg'
 	var/z_original = 1
 
 	var/meteordrop = /obj/item/weapon/ore/iron
@@ -128,7 +129,6 @@
 /obj/effect/meteor/Bump(atom/A)
 	if(A)
 		ram_turf(get_turf(A))
-		playsound(src.loc, meteorsound, 40, 1)
 		get_hit()
 
 /obj/effect/meteor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
@@ -168,15 +168,15 @@
 		var/obj/item/O = new meteordrop(get_turf(src))
 		O.throw_at(dest, 5, 10)
 
-/obj/effect/meteor/proc/meteor_effect(var/sound=1)
-	if(sound)
+/obj/effect/meteor/proc/meteor_effect(var/effect=1)
+	if(effect)
 		for(var/mob/M in player_list)
 			var/turf/T = get_turf(M)
 			if(!T || T.z != src.z)
 				continue
 			var/dist = get_dist(M.loc, src.loc)
 			shake_camera(M, dist > 20 ? 3 : 5, dist > 20 ? 1 : 3)
-			M.playsound_local(src.loc, meteorsound, 50, 1, get_rand_frequency(), 10)
+
 
 ///////////////////////
 //Meteor types
@@ -189,7 +189,6 @@
 	pass_flags = PASSTABLE | PASSGRILLE
 	hits = 1
 	hitpwr = 3
-	meteorsound = 'sound/weapons/throwtap.ogg'
 	meteordrop = /obj/item/weapon/ore/glass
 
 //Medium-sized
@@ -219,7 +218,6 @@
 	icon_state = "flaming"
 	hits = 5
 	heavy = 1
-	meteorsound = 'sound/effects/bamf.ogg'
 	meteordrop = /obj/item/weapon/ore/phoron
 
 /obj/effect/meteor/flaming/meteor_effect()
@@ -249,7 +247,6 @@
 	hits = 30
 	hitpwr = 1
 	heavy = 1
-	meteorsound = 'sound/effects/bamf.ogg'
 	meteordrop = /obj/item/weapon/ore/phoron
 
 /obj/effect/meteor/tunguska/meteor_effect()

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -3,9 +3,12 @@
 	endWhen 		= 7
 	var/next_meteor = 6
 	var/waves = 1
+	var/start_side
 
 /datum/event/meteor_wave/setup()
 	waves = severity * rand(1,3)
+	start_side = pick(cardinal)
+	endWhen = worst_case_end()
 
 /datum/event/meteor_wave/announce()
 	switch(severity)
@@ -14,13 +17,17 @@
 		else
 			command_announcement.Announce("The station is now in a meteor shower.", "Meteor Alert")
 
-//meteor showers are lighter and more common,
 /datum/event/meteor_wave/tick()
 	if(waves && activeFor >= next_meteor)
-		spawn() spawn_meteors(severity * rand(1,2), get_meteors())
+		var/pick_side = prob(80) ? start_side : (prob(50) ? turn(start_side, 90) : turn(start_side, -90))
+
+		spawn() spawn_meteors(severity * rand(1,2), get_meteors(), pick_side)
 		next_meteor += rand(15, 30) / severity
 		waves--
-		endWhen = (waves ? next_meteor + 1 : activeFor + 15)
+		endWhen = worst_case_end()
+
+/datum/event/meteor_wave/proc/worst_case_end()
+	return activeFor + ((30 / severity) * waves) + 10
 
 /datum/event/meteor_wave/end()
 	switch(severity)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -290,7 +290,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!M || !M.client || M.shakecamera)
+	if(!M || !M.client || M.shakecamera || M.stat || isEye(M) || isAI(M))
 		return
 	M.shakecamera = 1
 	spawn(1)

--- a/html/changelogs/PsiOmegaDelta-BiasedMeteors.yml
+++ b/html/changelogs/PsiOmegaDelta-BiasedMeteors.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+
+changes: 
+  - tweak: "Meteor events now select a map edge to arrive from, with a probability for each individual wave to come from either neighboring edge. Meteors will never arrive from opposite the starting edge."


### PR DESCRIPTION
- When a meteor event triggers it now selects a main edge to arrive from, with a 20% probability for each individual wave of the event to come from either neighboring edge.
  Will never arrive from the opposite edge.
- The meteor event end time is now made more useful, and is based on a longest delay between meteor waves scenario, and is updated after each wave.
- The meteor event now supports multiple station Z-levels.
- Removes the meteor sounds, as they can rarely be heard over the explosions anyway.
