### PR TITLE
Fixes beds occasionally buckling in odd directions

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -1,6 +1,7 @@
 /obj
 	var/can_buckle = 0
 	var/buckle_movable = 0
+	var/buckle_dir = 0
 	var/buckle_lying = -1 //bed-like behavior, forces mob.lying = buckle_lying if != -1
 	var/buckle_require_restraints = 0 //require people to be handcuffed before being able to buckle. eg: pipes
 	var/mob/living/buckled_mob = null
@@ -31,7 +32,7 @@
 
 	M.buckled = src
 	M.facing_dir = null
-	M.set_dir(dir)
+	M.set_dir(buckle_dir ? buckle_dir : dir)
 	M.update_canmove()
 	buckled_mob = M
 	post_buckle_mob(M)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -15,6 +15,7 @@
 	pressure_resistance = 15
 	anchored = 1
 	can_buckle = 1
+	buckle_dir = SOUTH
 	buckle_lying = 1
 	var/material/material
 	var/material/padding_material

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -4,6 +4,7 @@
 	icon_state = "chair_preview"
 	color = "#666666"
 	base_icon = "chair"
+	buckle_dir = 0
 	buckle_lying = 0 //force people to sit up in chairs when buckled
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 


### PR DESCRIPTION
Fixes beds buckling users in a direction that is not south after having been moved.

Can do similar for the surgery table in the same PR if people would like that.

Also, has buckling on a roller bed using a grab not triggering the post_mob_grab() proc been fixed already? I could not find any reason why mobs buckled in that way wouldn't get pixelshifted.
