### PR TITLE
Masks work with internals again

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -274,7 +274,7 @@
 					else
 
 						var/no_mask
-						if(!(C.wear_mask && C.wear_mask.flags & AIRTIGHT))
+						if(!(C.wear_mask && C.wear_mask.item_flags & AIRTIGHT))
 							var/mob/living/carbon/human/H = C
 							if(!(H.head && H.head.item_flags & AIRTIGHT))
 								no_mask = 1


### PR DESCRIPTION
Minor oversight; masks were being checked for the `AIRTIGHT` flag in the wrong place.
