### PR TITLE
Type definition typo fix.

### DIFF
--- a/code/game/objects/items/weapons/grenades/anti_photon_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/anti_photon_grenade.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/grenade/anti_photon
 	desc = "An experimental device for temporarily removing light in a limited area."
-	name = "pgoton disruption grenade"
+	name = "photon disruption grenade"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "emp"
 	item_state = "emp"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -316,7 +316,7 @@
 	desc = "A box containing 5 experimental photon disruption grenades."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/anti_photon/New()
+/obj/item/weapon/storage/box/anti_photons/New()
 		..()
 		new /obj/item/weapon/grenade/anti_photon(src)
 		new /obj/item/weapon/grenade/anti_photon(src)


### PR DESCRIPTION
Not sure how it happened, but this fixes a typo for the anti-photon grenades box.
