### PR TITLE
Make cloners announce cloning completion with a ding. 

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -182,6 +182,8 @@
 			return
 
 		else if((occupant.health >= heal_level) && (!eject_wait))
+			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+			src.audible_message("\The [src] signals that the cloning process is complete.")
 			connected_message("Cloning Process Complete.")
 			locked = 0
 			go_out()


### PR DESCRIPTION
This makes cloners go 'DING!', using the microwave oven ding sound effect, upon discharging a completed clone.

This should help absentminded doctors remember to shove the poor clone in a cryo tube. 
