### PR TITLE
The silicon law manager now only requires the host to be conscious.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1338,6 +1338,7 @@
 #include "code\modules\nano\nanoui.dm"
 #include "code\modules\nano\interaction\admin.dm"
 #include "code\modules\nano\interaction\base.dm"
+#include "code\modules\nano\interaction\conscious.dm"
 #include "code\modules\nano\interaction\contained.dm"
 #include "code\modules\nano\interaction\default.dm"
 #include "code\modules\nano\interaction\inventory.dm"

--- a/code/modules/mob/living/silicon/subystems.dm
+++ b/code/modules/mob/living/silicon/subystems.dm
@@ -76,7 +76,7 @@
 	set name = "Law Manager"
 	set category = "Subystems"
 
-	law_manager.ui_interact(usr, state = self_state)
+	law_manager.ui_interact(usr, state = conscious_state)
 
 /********************
 *	Power Monitor	*

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -14,7 +14,7 @@
 /mob/proc/shared_nano_interaction()
 	if (src.stat || !client)
 		return STATUS_CLOSE						// no updates, close the interface
-	else if (restrained() || lying || stat || stunned || weakened)
+	else if (restrained() || lying || stat || stunned || weakened)	// TODO: Change to incapaciated() on merge
 		return STATUS_UPDATE					// update only (orange visibility)
 	return STATUS_INTERACTIVE
 

--- a/code/modules/nano/interaction/conscious.dm
+++ b/code/modules/nano/interaction/conscious.dm
@@ -1,0 +1,7 @@
+/*
+	This state only checks if user is conscious.
+*/
+/var/global/datum/topic_state/conscious_state/conscious_state = new()
+
+/datum/topic_state/conscious_state/can_use_topic(var/src_object, var/mob/user)
+	return user.stat == CONSCIOUS ? STATUS_INTERACTIVE : STATUS_CLOSE


### PR DESCRIPTION
This should mean that the law manager is available for carded AIs, even with the wireless interface disabled. Fixes #11139.
