### PR TITLE
Amendments to light replacer

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -194,13 +194,13 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_packs/janitor
 	name = "Janitorial supplies"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
 					/obj/item/weapon/mop,
 					/obj/item/weapon/caution,
 					/obj/item/weapon/caution,
 					/obj/item/weapon/caution,
+					/obj/item/weapon/caution,
 					/obj/item/weapon/storage/bag/trash,
+					/obj/item/device/lightreplacer,
 					/obj/item/weapon/reagent_containers/spray/cleaner,
 					/obj/item/weapon/reagent_containers/glass/rag,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -15,7 +15,7 @@
 //
 // HOW TO REFILL THE DEVICE
 //
-// It will need to be manually refilled with lights.
+// It can be manually refilled or by clicking on a storage item containing lights.
 // If it's part of a robot module, it will charge when the Robot is inside a Recharge Station.
 //
 // EMAGGED FEATURES
@@ -41,7 +41,7 @@
 /obj/item/device/lightreplacer
 
 	name = "light replacer"
-	desc = "A device to automatically replace lights. Refill with working lightbulbs."
+	desc = "A device to automatically replace lights. Refill with working lightbulbs or sheets of glass."
 
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "lightreplacer0"
@@ -51,14 +51,13 @@
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_MAGNET = 3, TECH_MATERIAL = 2)
 
-	var/max_uses = 20
-	var/uses = 0
+	var/max_uses = 32
+	var/uses = 32
 	var/emagged = 0
 	var/failmsg = ""
 	var/charge = 0
 
 /obj/item/device/lightreplacer/New()
-	uses = max_uses / 2
 	failmsg = "The [name]'s refill light blinks red."
 	..()
 
@@ -73,8 +72,8 @@
 			user << "<span class='warning'>[src.name] is full.</span>"
 			return
 		else if(G.use(1))
-			AddUses(5)
-			user << "<span class='notice'>You insert a piece of glass into the [src.name]. You have [uses] lights remaining.</span>"
+			AddUses(16) //Autolathe converts 1 sheet into 16 lights.
+			user << "<span class='notice'>You insert a piece of glass into \the [src.name]. You have [uses] light\s remaining.</span>"
 			return
 		else
 			user << "<span class='warning'>You need one sheet of glass to replace lights.</span>"
@@ -84,14 +83,13 @@
 		if(L.status == 0) // LIGHT OKAY
 			if(uses < max_uses)
 				AddUses(1)
-				user << "You insert the [L.name] into the [src.name]. You have [uses] lights remaining."
+				user << "You insert \the [L.name] into \the [src.name]. You have [uses] light\s remaining."
 				user.drop_item()
 				qdel(L)
 				return
 		else
 			user << "You need a working light."
 			return
-
 
 /obj/item/device/lightreplacer/attack_self(mob/user)
 	/* // This would probably be a bit OP. If you want it though, uncomment the code.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -224,7 +224,7 @@
 //Set the stop_messages to stop it from printing messages
 /obj/item/weapon/storage/proc/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(!istype(W)) return //Not an item
-	
+
 	if(!usr.canUnEquip(W))
 		return 0
 
@@ -339,6 +339,21 @@
 
 	if(isrobot(user))
 		return //Robots can't interact with storage items.
+
+	if(istype(W, /obj/item/device/lightreplacer))
+		var/obj/item/device/lightreplacer/LP = W
+		var/amt_inserted = 0
+		var/turf/T = get_turf(user)
+		for(var/obj/item/weapon/light/L in src.contents)
+			if(L.status == 0)
+				if(LP.uses < LP.max_uses)
+					LP.AddUses(1)
+					amt_inserted++
+					remove_from_storage(L, T)
+					qdel(L)
+		if(amt_inserted)
+			user << "You inserted [amt_inserted] light\s into \the [LP.name]. You have [LP.uses] light\s remaining."
+			return
 
 	if(!can_be_inserted(W))
 		return

--- a/html/changelogs/Hubblenaut-dev.yml
+++ b/html/changelogs/Hubblenaut-dev.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Light replacers can be refilled by clicking on a storage item."
+  - tweak: "Light replacers now hold up to 32 light bulbs."
+  - tweak: "Light replacers can be obtained through janitorial supply crates."
+  - tweak: "A sheet of glass fills the light replacer by 16 bulbs."


### PR DESCRIPTION
- Filling light replacers with glass sheets will now fill it with 16 bulbs instead of 5 - the amount of bulbs that can be fabricated from a single sheet of glass at an autolathe.
- Light replacers can now be quickly refilled by using it to click on a storage item holding spare light bulbs.
- Light replacers now hold two times worth of a single sheet of glass of light bulbs - 32 bulbs
- Added light replacers to the janitorial supply crate - also lowered the amount of buckets in the supply crate from 3 to 1 and added a fourth warning sign to make it hold the exact equipment that can be found in the custodial office.
