### PR TITLE
Basic encryption hack popup only shows suitable APCs

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -163,12 +163,14 @@
 
 	command_announcement.Announce(fulltext)
 
-// Proc: get_all_apcs()
+// Proc: get_unhacked_apcs()
 // Parameters: None
-// Description: Returns a list of all APCs
-/proc/get_all_apcs()
+// Description: Returns a list of all unhacked APCs
+/proc/get_unhacked_apcs(var/mob/living/silicon/ai/user)
 	var/list/H = list()
 	for(var/obj/machinery/power/apc/A in machines)
+		if(A.hacker && A.hacker == user)
+			continue
 		H.Add(A)
 	return H
 

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -38,7 +38,7 @@
 // END RESEARCH DATUMS
 // BEGIN ABILITY VERBS
 
-/datum/game_mode/malfunction/verb/basic_encryption_hack(obj/machinery/power/apc/A as obj in get_all_apcs())
+/datum/game_mode/malfunction/verb/basic_encryption_hack(obj/machinery/power/apc/A as obj in get_unhacked_apcs(src))
 	set category = "Software"
 	set name = "Basic Encryption Hack"
 	set desc = "10 CPU - Basic encryption hack that allows you to overtake APCs on the station."


### PR DESCRIPTION
Unfortunately, there is no way to make it work for right-click menu.
