### PR TITLE
Antagonist summary printout now prefers assignment over special role.

### DIFF
--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -45,7 +45,7 @@
 	return text
 
 /datum/antagonist/proc/print_player_lite(var/datum/mind/ply)
-	var/role = ply.special_role ? "\improper[ply.special_role]" : "\improper[ply.assigned_role]"
+	var/role = ply.assigned_role ? "\improper[ply.assigned_role]" : "\improper[ply.special_role]"
 	var/text = "<br><b>[ply.name]</b> (<b>[ply.key]</b>) as \a <b>[role]</b> ("
 	if(ply.current)
 		if(ply.current.stat == DEAD)


### PR DESCRIPTION
As antags are listed under relevant headings, i.e. "The traitors were", this seems more reasonable. Fixes #10817.
