### PR TITLE
Relative HUD element positioning.

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -13,110 +13,112 @@
 	Therefore, the top right corner (except during admin shenanigans) is at "15,15"
 */
 
+#define ui_entire_screen "WEST,SOUTH to EAST,NORTH"
+
 //Lower left, persistant menu
-#define ui_inventory "1:6,1:5"
+#define ui_inventory "WEST:6,SOUTH:5"
 
 //Lower center, persistant menu
-#define ui_sstore1 "3:10,1:5"
-#define ui_id "4:12,1:5"
-#define ui_belt "5:14,1:5"
-#define ui_back "6:14,1:5"
-#define ui_rhand "7:16,1:5"
-#define ui_lhand "8:16,1:5"
-#define ui_equip "7:16,2:5"
-#define ui_swaphand1 "7:16,2:5"
-#define ui_swaphand2 "8:16,2:5"
-#define ui_storage1 "9:18,1:5"
-#define ui_storage2 "10:20,1:5"
+#define ui_sstore1 "WEST+2:10,SOUTH:5"
+#define ui_id "WEST+3:12,SOUTH:5"
+#define ui_belt "WEST+4:14,SOUTH:5"
+#define ui_back "CENTER-2:14,SOUTH:5"
+#define ui_rhand "CENTER-1:16,SOUTH:5"
+#define ui_lhand "CENTER:16,SOUTH:5"
+#define ui_equip "CENTER-1:16,SOUTH+1:5"
+#define ui_swaphand1 "CENTER-1:16,SOUTH+1:5"
+#define ui_swaphand2 "CENTER:16,SOUTH+1:5"
+#define ui_storage1 "CENTER+1:16,SOUTH:5"
+#define ui_storage2 "CENTER+2:16,SOUTH:5"
 
-#define ui_alien_head "4:12,1:5"	//aliens
-#define ui_alien_oclothing "5:14,1:5"	//aliens
+#define ui_alien_head "CENTER-3:12,SOUTH:5"		//aliens
+#define ui_alien_oclothing "CENTER-2:14,SOUTH:5"//aliens
 
-#define ui_inv1 "7,1:5"			//borgs
-#define ui_inv2 "8,1:5"			//borgs
-#define ui_inv3 "9,1:5"			//borgs
-#define ui_borg_store "10,1:5"	//borgs
-#define ui_borg_inventory "6,1:5"//borgs
+#define ui_inv1 "CENTER-1,SOUTH:5"			//borgs
+#define ui_inv2 "CENTER,SOUTH:5"			//borgs
+#define ui_inv3 "CENTER+1,SOUTH:5"			//borgs
+#define ui_borg_store "CENTER+2,SOUTH:5"	//borgs
+#define ui_borg_inventory "CENTER-2,SOUTH:5"//borgs
 
-#define ui_monkey_mask "5:14,1:5"	//monkey
-#define ui_monkey_back "6:14,1:5"	//monkey
+#define ui_monkey_mask "WEST+4:14,SOUTH:5"	//monkey
+#define ui_monkey_back "WEST+5:14,SOUTH:5"	//monkey
 
-#define ui_construct_health "15:00,7:15" //same height as humans, hugging the right border
-#define ui_construct_purge "15:00,6:15"
-#define ui_construct_fire "14:16,8:13" //above health, slightly to the left
-#define ui_construct_pull "14:28,2:10" //above the zone_sel icon
+#define ui_construct_health "EAST:00,CENTER:15" //same height as humans, hugging the right border
+#define ui_construct_purge "EAST:00,CENTER-1:15"
+#define ui_construct_fire "EAST-1:16,CENTER+1:13" //above health, slightly to the left
+#define ui_construct_pull "EAST-1:28,SOUTH+1:10" //above the zone_sel icon
 
 //Lower right, persistant menu
-#define ui_dropbutton "11:22,1:5"
-#define ui_drop_throw "14:28,2:7"
-#define ui_pull_resist "13:26,2:7"
-#define ui_acti "13:26,1:5"
-#define ui_movi "12:24,1:5"
-#define ui_zonesel "14:28,1:5"
-#define ui_acti_alt "14:28,1:5" //alternative intent switcher for when the interface is hidden (F12)
+#define ui_dropbutton "EAST-4:22,SOUTH:5"
+#define ui_drop_throw "EAST-1:28,SOUTH+1:7"
+#define ui_pull_resist "EAST-2:26,SOUTH+1:7"
+#define ui_acti "EAST-2:26,SOUTH:5"
+#define ui_movi "EAST-3:24,SOUTH:5"
+#define ui_zonesel "EAST-1:28,SOUTH:5"
+#define ui_acti_alt "EAST-1:28,SOUTH:5" //alternative intent switcher for when the interface is hidden (F12)
 
-#define ui_borg_pull "12:24,2:7"
-#define ui_borg_module "13:26,2:7"
-#define ui_borg_panel "14:28,2:7"
+#define ui_borg_pull "EAST-3:24,SOUTH+1:7"
+#define ui_borg_module "EAST-2:26,SOUTH+1:7"
+#define ui_borg_panel "EAST-1:28,SOUTH+1:7"
 
 //Gun buttons
-#define ui_gun1 "13:26,3:7"
-#define ui_gun2 "14:28, 4:7"
-#define ui_gun3 "13:26,4:7"
-#define ui_gun_select "14:28,3:7"
-#define ui_gun4 "12:24,3:7"
+#define ui_gun1 "EAST-2:26,SOUTH+2:7"
+#define ui_gun2 "EAST-1:28, SOUTH+3:7"
+#define ui_gun3 "EAST-2:26,SOUTH+3:7"
+#define ui_gun_select "EAST-1:28,SOUTH+2:7"
+#define ui_gun4 "EAST-3:24,SOUTH+2:7"
 
 //Upper-middle right (damage indicators)
-#define ui_toxin "14:28,13:27"
-#define ui_fire "14:28,12:25"
-#define ui_oxygen "14:28,11:23"
-#define ui_pressure "14:28,10:21"
+#define ui_toxin "EAST-1:28,NORTH-2:27"
+#define ui_fire "EAST-1:28,NORTH-3:25"
+#define ui_oxygen "EAST-1:28,NORTH-4:23"
+#define ui_pressure "EAST-1:28,NORTH-5:21"
 
-#define ui_alien_toxin "14:28,13:25"
-#define ui_alien_fire "14:28,12:25"
-#define ui_alien_oxygen "14:28,11:25"
+#define ui_alien_toxin "EAST-1:28,NORTH-2:25"
+#define ui_alien_fire "EAST-1:28,NORTH-3:25"
+#define ui_alien_oxygen "EAST-1:28,NORTH-4:25"
 
 //Middle right (status indicators)
-#define ui_nutrition "14:28,5:11"
-#define ui_temp "14:28,6:13"
-#define ui_health "14:28,7:15"
-#define ui_internal "14:28,8:17"
+#define ui_nutrition "EAST-1:28,CENTER-2:11"
+#define ui_temp "EAST-1:28,CENTER-1:13"
+#define ui_health "EAST-1:28,CENTER:15"
+#define ui_internal "EAST-1:28,CENTER+1:17"
 									//borgs
-#define ui_borg_health "14:28,6:13" //borgs have the health display where humans have the pressure damage indicator.
-#define ui_alien_health "14:28,6:13" //aliens have the health display where humans have the pressure damage indicator.
+#define ui_borg_health "EAST-1:28,CENTER-1:13" //borgs have the health display where humans have the pressure damage indicator.
+#define ui_alien_health "EAST-1:28,CENTER-1:13" //aliens have the health display where humans have the pressure damage indicator.
 
 //Pop-up inventory
-#define ui_shoes "2:8,1:5"
+#define ui_shoes "WEST+1:8,SOUTH:5"
 
-#define ui_iclothing "1:6,2:7"
-#define ui_oclothing "2:8,2:7"
-#define ui_gloves "3:10,2:7"
+#define ui_iclothing "WEST:6,SOUTH+1:7"
+#define ui_oclothing "WEST+1:8,SOUTH+1:7"
+#define ui_gloves "WEST+2:10,SOUTH+1:7"
 
-#define ui_glasses "1:6,3:9"
-#define ui_mask "2:8,3:9"
-#define ui_l_ear "3:10,3:9"
-#define ui_r_ear "3:10,4:11"
+#define ui_glasses "WEST:6,SOUTH+2:9"
+#define ui_mask "WEST+1:8,SOUTH+2:9"
+#define ui_l_ear "WEST+2:10,SOUTH+2:9"
+#define ui_r_ear "WEST+2:10,SOUTH+3:11"
 
-#define ui_head "2:8,4:11"
+#define ui_head "WEST+1:8,SOUTH+3:11"
 
 //Intent small buttons
-#define ui_help_small "12:8,1:1"
-#define ui_disarm_small "12:15,1:18"
-#define ui_grab_small "12:32,1:18"
-#define ui_harm_small "12:39,1:1"
+#define ui_help_small "EAST-3:8,SOUTH:1"
+#define ui_disarm_small "EAST-3:15,SOUTH:18"
+#define ui_grab_small "EAST-3:32,SOUTH:18"
+#define ui_harm_small "EAST-3:39,SOUTH:1"
 
 //#define ui_swapbutton "6:-16,1:5" //Unused
 
 //#define ui_headset "SOUTH,8"
-#define ui_hand "6:14,1:5"
-#define ui_hstore1 "5,5"
+#define ui_hand "CENTER-1:14,SOUTH:5"
+#define ui_hstore1 "CENTER-2,CENTER-2"
 //#define ui_resist "EAST+1,SOUTH-1"
 #define ui_sleep "EAST+1, NORTH-13"
 #define ui_rest "EAST+1, NORTH-14"
 
 
-#define ui_iarrowleft "SOUTH-1,11"
-#define ui_iarrowright "SOUTH-1,13"
+#define ui_iarrowleft "SOUTH-1,EAST-4"
+#define ui_iarrowright "SOUTH-1,EAST-2"
 
-#define ui_spell_master "14:16,14:16"
-#define ui_genetic_master "14:16,12:16"
+#define ui_spell_master "EAST-1:16,NORTH-1:16"
+#define ui_genetic_master "EAST-1:16,NORTH-3:16"

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -32,7 +32,7 @@
 	mymob.flash.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.flash.icon_state = "blank"
 	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = "1,1 to 15,15"
+	mymob.flash.screen_loc = ui_entire_screen
 	mymob.flash.layer = 17
 
 	mymob.fire = new /obj/screen()

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -41,14 +41,14 @@ var/list/global_huds = list(
 /datum/global_hud/New()
 	//420erryday psychedellic colours screen overlay for when you are high
 	druggy = new /obj/screen()
-	druggy.screen_loc = "WEST,SOUTH to EAST,NORTH"
+	druggy.screen_loc = ui_entire_screen
 	druggy.icon_state = "druggy"
 	druggy.layer = 17
 	druggy.mouse_opacity = 0
 
 	//that white blurry effect you get when you eyes are damaged
 	blurry = new /obj/screen()
-	blurry.screen_loc = "WEST,SOUTH to EAST,NORTH"
+	blurry.screen_loc = ui_entire_screen
 	blurry.icon_state = "blurry"
 	blurry.layer = 17
 	blurry.mouse_opacity = 0
@@ -74,21 +74,21 @@ var/list/global_huds = list(
 	//welding mask overlay black/dither
 	darkMask = newlist(/obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen)
 	O = darkMask[1]
-	O.screen_loc = "3,3 to 5,13"
+	O.screen_loc = "WEST+2,SOUTH+2 to WEST+4,NORTH-2"
 	O = darkMask[2]
-	O.screen_loc = "5,3 to 10,5"
+	O.screen_loc = "WEST+4,SOUTH+2 to EAST-5,SOUTH+4"
 	O = darkMask[3]
-	O.screen_loc = "6,11 to 10,13"
+	O.screen_loc = "WEST+5,NORTH-4 to EAST-5,NORTH-2"
 	O = darkMask[4]
-	O.screen_loc = "11,3 to 13,13"
+	O.screen_loc = "EAST-4,SOUTH+2 to EAST-2,NORTH-2"
 	O = darkMask[5]
-	O.screen_loc = "1,1 to 15,2"
+	O.screen_loc = "WEST,SOUTH to EAST,SOUTH+1"
 	O = darkMask[6]
-	O.screen_loc = "1,3 to 2,15"
+	O.screen_loc = "WEST,SOUTH+2 to WEST+1,NORTH"
 	O = darkMask[7]
-	O.screen_loc = "14,3 to 15,15"
+	O.screen_loc = "EAST-1,SOUTH+2 to EAST,NORTH"
 	O = darkMask[8]
-	O.screen_loc = "3,14 to 13,15"
+	O.screen_loc = "WEST+2,NORTH-1 to EAST-2,NORTH"
 
 	for(i = 1, i <= 4, i++)
 		O = vimpaired[i]

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -318,7 +318,7 @@
 	mymob.flash.icon = ui_style
 	mymob.flash.icon_state = "blank"
 	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = "1,1 to 15,15"
+	mymob.flash.screen_loc = ui_entire_screen
 	mymob.flash.layer = 17
 	hud_elements |= mymob.flash
 

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -240,7 +240,7 @@
 	mymob.flash.icon = ui_style
 	mymob.flash.icon_state = "blank"
 	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = "1,1 to 15,15"
+	mymob.flash.screen_loc = ui_entire_screen
 	mymob.flash.layer = 17
 
 	mymob.zone_sel = new /obj/screen/zone_sel()

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -121,7 +121,7 @@
 	mymob.flash.icon = 'icons/mob/screen1.dmi'
 	mymob.flash.icon_state = "blank"
 	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = "1,1 to 15,15"
+	mymob.flash.screen_loc = ui_entire_screen
 	mymob.flash.layer = 17
 
 	if(constructtype)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -143,7 +143,7 @@ var/obj/screen/robot_inventory
 	mymob.flash.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.flash.icon_state = "blank"
 	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = "1,1 to 15,15"
+	mymob.flash.screen_loc = ui_entire_screen
 	mymob.flash.layer = 17
 
 	mymob.zone_sel = new /obj/screen/zone_sel()

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -79,7 +79,7 @@
 
 					//Blind the AI
 					updateicon()
-					src.blind.screen_loc = "1,1 to 15,15"
+					src.blind.screen_loc = ui_entire_screen
 					if (src.blind.layer!=18)
 						src.blind.layer = 18
 					src.sight = src.sight&~SEE_TURFS

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -6,12 +6,12 @@
 	flash = new /obj/screen()
 	flash.icon_state = "blank"
 	flash.name = "flash"
-	flash.screen_loc = "1,1 to 15,15"
+	flash.screen_loc = ui_entire_screen
 	flash.layer = 17
 	blind = new /obj/screen()
 	blind.icon_state = "black"
 	blind.name = " "
-	blind.screen_loc = "1,1 to 15,15"
+	blind.screen_loc = ui_entire_screen
 	blind.layer = 0
 	client.screen.Add( blind, flash )
 


### PR DESCRIPTION
HUD positions are now relative the client view screen edges instead of using absolute positions.
We don't currently use custom client view ranges, but this potentially makes it more reasonable to implement (an example is a certain new short sighted species of ours).
Port of https://github.com/d3athrow/vgstation13/pull/5984.

Normal view:
![Before](https://www.dropbox.com/s/cq4uid8rvoqqjrz/Before.png?dl=1)

Extended view:
![After](https://www.dropbox.com/s/2b0msrjqbrxm9zx/After.png?dl=1)
