### PR TITLE
Rubber bullets and beanbags now check melee armour instead of bullet armour

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -110,6 +110,7 @@
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
+	check_armour = "melee"
 	damage = 10
 	agony = 40
 	embed = 0
@@ -123,6 +124,7 @@
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
+	check_armour = "melee"
 	damage = 20
 	agony = 60
 	embed = 0

--- a/html/changelogs/HarpyEagle-rubberbullets.yml
+++ b/html/changelogs/HarpyEagle-rubberbullets.yml
@@ -1,0 +1,20 @@
+################################
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+author: HarpyEagle
+delete-after: True
+changes: 
+  - tweak: "Rubber bullets and beanbags now are now resisted by melee armour."


### PR DESCRIPTION
See tin. Arguably should have been this way from the beginning, for the same reason that tasers were made less effective versus spacesuits. In particular cultists are harder to stun.

This was brought up in the rubber bullet discussion thread but really is only tangentially related to that discussion. 
