### PR TITLE
Fixes backup power test light

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -41,7 +41,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 	(A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
 	((A.lights && haspower) ? "The door bolt lights are on." : "The door bolt lights are off!"),
 	((haspower) ? "The test light is on." : "The test light is off!"),
-	((A.backupPowerCablesCut()) ? "The backup power light is off!" : "The backup power light is on."),
+	((A.backup_power_lost_until) ? "The backup power light is off!" : "The backup power light is on."),
 	((A.aiControlDisabled==0 && !A.emagged && haspower)? "The 'AI control allowed' light is on." : "The 'AI control allowed' light is off."),
 	((A.safe==0 && haspower)? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."),
 	((A.normalspeed==0 && haspower)? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),


### PR DESCRIPTION
Backup power test light will now also be offline when only momentarily unavailable, as initially intended.
