### PR TITLE
Fixes #11262

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -49,7 +49,7 @@
 		breath = environment.remove_volume(volume_needed)
 		handle_chemical_smoke(environment) //handle chemical smoke while we're at it
 	
-	if(breath)
+	if(breath && breath.total_moles)
 		//handle mask filtering
 		if(istype(wear_mask, /obj/item/clothing/mask) && breath)
 			var/obj/item/clothing/mask/M = wear_mask

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -967,7 +967,7 @@
 
 	if(L && !L.is_bruised())
 		src.custom_pain("You feel a stabbing pain in your chest!", 1)
-		L.damage = L.min_bruised_damage
+		L.bruise()
 
 /*
 /mob/living/carbon/human/verb/simulate()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -370,6 +370,12 @@
 		if(status_flags & GODMODE)
 			return
 
+		//exposure to extreme pressures can rupture lungs
+		if(breath && (breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5))
+			if(!is_lung_ruptured() && prob(5))
+				rupture_lung()
+
+		//check if we actually need to process breath
 		if(!breath || (breath.total_moles == 0) || suiciding)
 			failed_last_breath = 1
 			if(suiciding)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -206,6 +206,9 @@ var/list/organ_cache = list()
 			if(parent && !silent)
 				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
+/obj/item/organ/proc/bruise()
+	damage = max(damage, min_bruised_damage)
+
 /obj/item/organ/proc/robotize() //Being used to make robutt hearts, etc
 	robotic = 2
 	src.status &= ~ORGAN_BROKEN

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -172,10 +172,12 @@
 
 		affected.createwound(BRUISE, 20)
 		affected.fracture()
-
-		/*if (prob(40)) //TODO: ORGAN REMOVAL UPDATE.
-			user.visible_message("\red A rib pierces the lung!")
-			target.rupture_lung()*/
+		
+		if(affected.internal_organs && affected.internal_organs.len)
+			if(prob(40))
+				var/obj/item/organ/O = pick(affected.internal_organs) //TODO weight by organ size
+				user.visible_message("<span class='danger'>A wayward piece of [target]'s [affected.encased] pierces \his [O.name]!</span>")
+				O.bruise()
 
 /datum/surgery_step/open_encased/mend
 	allowed_tools = list(


### PR DESCRIPTION
Re-adds check for extreme pressure in breathing code.

Breathing in space (or unsimulated turfs in general) should produce a temporary gas_mix with the turf's air values, so handle_breath() should be able to distinguish between vacuum (being passed gas mix with no gas content) and not breathing (being passed null).

Also re-adds and generalizes a removed check in surgery code.
