### PR TITLE
Removes secret-mode player requirements

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -12,7 +12,6 @@
 		certain though... there is never just one of them. Good luck."
 	config_tag = "changeling"
 	required_players = 2
-	required_players_secret = 10
 	required_enemies = 1
 	end_on_antag_death = 1
 	antag_scaling_coeff = 10

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -4,7 +4,6 @@
 	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
 	required_players = 5
-	required_players_secret = 15
 	required_enemies = 3
 	end_on_antag_death = 1
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/epidemic/epidemic.dm
+++ b/code/game/gamemodes/epidemic/epidemic.dm
@@ -2,7 +2,6 @@
 	name = "epidemic"
 	config_tag = "epidemic"
 	required_players = 1
-	required_players_secret = 15
 	round_description = "A deadly epidemic is spreading on the station. Find a cure as fast as possible, and keep your distance to anyone who speaks in a hoarse voice!"
 
 	var/cruiser_arrival

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -10,7 +10,6 @@ var/global/list/additional_antag_types = list()
 	var/probability = 0
 
 	var/required_players = 0                 // Minimum players for round to start if voted in.
-	var/required_players_secret = 0          // Minimum number of players for that game mode to be chose in Secret
 	var/required_enemies = 0                 // Minimum antagonists for round to start.
 	var/newscaster_announcements = null
 	var/end_on_antag_death = 0               // Round will end when all antagonists are dead.
@@ -147,12 +146,8 @@ var/global/list/additional_antag_types = list()
 		if((player.client)&&(player.ready))
 			playerC++
 
-	if(master_mode=="secret")
-		if(playerC < required_players_secret)
-			return 0
-	else
-		if(playerC < required_players)
-			return 0
+	if(playerC < required_players)
+		return 0
 
 	if(!(antag_templates && antag_templates.len))
 		return 1

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -8,7 +8,6 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	name = "heist"
 	config_tag = "heist"
 	required_players = 15
-	required_players_secret = 25
 	required_enemies = 4
 	round_description = "An unidentified bluespace signature has slipped past the Icarus and is approaching the station!"
 	end_on_antag_death = 1

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -4,7 +4,6 @@
 	extended_round_description = "The AI will attempt to hack the APCs around the station in order to gain as much control as possible."
 	config_tag = "malfunction"
 	required_players = 2
-	required_players_secret = 7
 	required_enemies = 1
 	end_on_antag_death = 0
 	auto_recall_shuttle = 0

--- a/code/game/gamemodes/meme/meme.dm
+++ b/code/game/gamemodes/meme/meme.dm
@@ -6,7 +6,6 @@
 	name = "Memetic Anomaly"
 	config_tag = "meme"
 	required_players = 3
-	required_players_secret = 10
 	restricted_jobs = list("AI", "Cyborg")
 	recommended_enemies = 2 // need at least a meme and a host
 	votable = 0 // temporarily disable this mode for voting

--- a/code/game/gamemodes/mixed/bughunt.dm
+++ b/code/game/gamemodes/mixed/bughunt.dm
@@ -3,7 +3,6 @@
 	round_description = "A mercenary strike force is approaching the station to eradicate a xenomorph infestation!"
 	config_tag = "bughunt"
 	required_players = 15
-	required_players_secret = 25
 	required_enemies = 1
 	end_on_antag_death = 1
 	antag_tags = list(MODE_XENOMORPH, MODE_DEATHSQUAD)

--- a/code/game/gamemodes/mixed/conflux.dm
+++ b/code/game/gamemodes/mixed/conflux.dm
@@ -4,7 +4,6 @@
 	extended_round_description = "Cultists and wizards spawn during this round."
 	config_tag = "conflux"
 	required_players = 15
-	required_players_secret = 15
 	required_enemies = 5
 	end_on_antag_death = 1
 	antag_tags = list(MODE_WIZARD, MODE_CULTIST)

--- a/code/game/gamemodes/mixed/paranoia.dm
+++ b/code/game/gamemodes/mixed/paranoia.dm
@@ -4,7 +4,6 @@
 	extended_round_description = "Rampant AIs, renegades and changelings spawn in this mode."
 	config_tag = "paranoia"
 	required_players = 2
-	required_players_secret = 7
 	required_enemies = 1
 	end_on_antag_death = 1
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -4,7 +4,6 @@
 	extended_round_description = "Traitors and changelings both spawn during this mode."
 	config_tag = "traitorling"
 	required_players = 10
-	required_players_secret = 15
 	required_enemies = 5
 	end_on_antag_death = 1
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/uprising.dm
+++ b/code/game/gamemodes/mixed/uprising.dm
@@ -4,7 +4,6 @@
 	round_description = "Some crewmembers are attempting to start a revolution while a cult plots in the shadows!"
 	extended_round_description = "Cultists and revolutionaries spawn in this round."
 	required_players = 15
-	required_players_secret = 15
 	required_enemies = 3
 	end_on_antag_death = 1
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_CULTIST)

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -10,7 +10,6 @@
 		only hope this unknown assassin isn't here for you."
 	config_tag = "ninja"
 	required_players = 1
-	required_players_secret = 10
 	required_enemies = 1
 	end_on_antag_death = 1
 	antag_tags = list(MODE_NINJA)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -9,7 +9,6 @@ var/list/nuke_disks = list()
 	round_description = "A mercenary strike force is approaching the station!"
 	config_tag = "mercenary"
 	required_players = 15
-	required_players_secret = 25 // 25 players - 5 players to be the nuke ops = 20 players remaining
 	required_enemies = 1
 	end_on_antag_death = 1
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -4,7 +4,6 @@
 	round_description = "Some crewmembers are attempting to start a revolution!"
 	extended_round_description = "Revolutionaries - Remove the heads of staff from power. Convert other crewmembers to your cause using the 'Convert Bourgeoise' verb. Protect your leaders."
 	required_players = 4
-	required_players_secret = 15
 	required_enemies = 3
 	auto_recall_shuttle = 1
 	end_on_antag_death = 1

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -4,7 +4,6 @@
 	extended_round_description = "A powerful entity capable of manipulating the elements around him, most commonly referred to as a 'wizard', has infiltrated the station. They have a wide variety of powers and spells available to them that makes your own simple moral self tremble with fear and excitement. Ultimately, their purpose is unknown. However, it is up to you and your crew to decide if their powers can be used for good or if their arrival foreshadows the destruction of the entire station."
 	config_tag = "wizard"
 	required_players = 1
-	required_players_secret = 10
 	required_enemies = 1
 	end_on_antag_death = 1
 	antag_tags = list(MODE_WIZARD)

--- a/html/changelogs/TheWelp - secretRemove.yml
+++ b/html/changelogs/TheWelp - secretRemove.yml
@@ -1,0 +1,6 @@
+author: TheWelp
+
+delete-after: True
+
+changes: 
+  - rscdel: "Removed increased player requirements for secret rounds."


### PR DESCRIPTION
The reasoning behind this is to allow secret rounds to have a higher variety of game modes, especially during lower population games.

The gist of the changes was removing required_players_secret and all code that references it. The requirements for secret will instead be equal to their regular game-mode counterparts. 
