### PR TITLE
Antag spawner now uses the starting location list...

### DIFF
--- a/code/game/antagonist/antagonist_place.dm
+++ b/code/game/antagonist/antagonist_place.dm
@@ -23,5 +23,5 @@
 /datum/antagonist/proc/place_mob(var/mob/living/mob)
 	if(!starting_locations || !starting_locations.len)
 		return
-	var/turf/T = pick_mobless_turf_if_exists(mob)		
+	var/turf/T = pick_mobless_turf_if_exists(starting_locations)
 	mob.forceMove(T)


### PR DESCRIPTION
..instead of the mob. Someone (might just maybe potentially be me, who knows) cleaned up the code a bit too quickly. Fixes #11284.
