### PR TITLE
Changes how Topic() calls apply fingerprints.

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -46,7 +46,11 @@
 
 /obj/proc/CouldUseTopic(var/mob/user)
 	var/atom/host = nano_host()
-	host.add_hiddenprint(user)
+	if(!isAI(user) && host.Adjacent(user))
+		// We are -probably- in physical contact with the object, better than how Topics() previously did it and always applied fingerprints.
+		host.add_fingerprint(user)
+	else
+		host.add_hiddenprint(user)
 
 /obj/proc/CouldNotUseTopic(var/mob/user)
 	// Nada


### PR DESCRIPTION
Now applies fingerprints if the user is adjacent to a physical object, otherwise applies a hidden fingerprint.
CouldUseTopic() is only called when a user has successfully interacted with an object interface/UI, not during basic refresh.
