### PR TITLE
Surgical kits can now contain their equipment.

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -71,11 +71,17 @@ proc/isemptylist(list/list)
 			return 1
 	return 0
 
-//Empties the list by setting the length to 0. Hopefully the elements get garbage collected
-proc/clearlist(list/list)
-	if(istype(list))
-		list.len = 0
-	return
+/proc/instances_of_type_in_list(var/atom/A, var/list/L)
+	var/instances = 0
+	for(var/type in L)
+		if(istype(A, type))
+			instances++
+	return instances
+
+//Empties the list by .Cut(). Setting lenght = 0 has been confirmed to leak references.
+proc/clearlist(var/list/L)
+	if(islist(L))
+		L.Cut()
 
 //Removes any null entries from the list
 proc/listclearnulls(list/list)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -598,32 +598,33 @@
 	icon_state = "light"
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
 	item_state = "syringe_kit"
-	storage_slots=21
-	can_hold = list(/obj/item/weapon/light/tube, /obj/item/weapon/light/bulb)
-	max_storage_space = 42	//holds 21 items of w_class 2
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
+	
+/obj/item/weapon/storage/box/lights/New()
+	..()
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/lights/bulbs/New()
-	..()
 	for(var/i = 0; i < 21; i++)
 		new /obj/item/weapon/light/bulb(src)
+	..()
 
 /obj/item/weapon/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	icon_state = "lighttube"
 
 /obj/item/weapon/storage/box/lights/tubes/New()
-	..()
 	for(var/i = 0; i < 21; i++)
 		new /obj/item/weapon/light/tube(src)
+	..()
 
 /obj/item/weapon/storage/box/lights/mixed
 	name = "box of replacement lights"
 	icon_state = "lightmixed"
 
 /obj/item/weapon/storage/box/lights/mixed/New()
-	..()
 	for(var/i = 0; i < 14; i++)
 		new /obj/item/weapon/light/tube(src)
 	for(var/i = 0; i < 7; i++)
 		new /obj/item/weapon/light/bulb(src)
+	..()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -130,8 +130,7 @@
 
 /obj/item/weapon/storage/firstaid/surgery
 	name = "surgery kit"
-	desc = "Contains tools for surgery."
-	storage_slots = 10
+	desc = "Contains tools for surgery. Has precise foam fitting for safe transport."
 
 /obj/item/weapon/storage/firstaid/surgery/New()
 	..()
@@ -146,7 +145,8 @@
 	new /obj/item/weapon/bonegel(src)
 	new /obj/item/weapon/FixOVein(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
-	return
+
+	make_exact_fit()
 
 /*
  * Pill Bottles

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -235,12 +235,12 @@
 	if(can_hold.len)
 		if(!is_type_in_list(W, can_hold))
 			if(!stop_messages && ! istype(W, /obj/item/weapon/hand_labeler))
-				usr << "<span class='notice'>[src] cannot hold [W].</span>"
+				usr << "<span class='notice'>[src] cannot hold \the [W].</span>"
 			return 0
 		var/max_instances = can_hold[W.type]
 		if(max_instances && instances_of_type_in_list(W, contents) >= max_instances)
 			if(!stop_messages && !istype(W, /obj/item/weapon/hand_labeler))
-				usr << "<span class='notice'>[src] has no more space for an additional [W].</span>"
+				usr << "<span class='notice'>[src] has no more space specifically for \the [W].</span>"
 			return 0
 
 	if(cant_hold.len && is_type_in_list(W, cant_hold))
@@ -460,9 +460,9 @@
 	max_w_class = 0
 	max_storage_space = 0
 	for(var/obj/item/I in src)
+		can_hold[I.type]++
 		max_w_class = max(I.w_class, max_w_class)
 		max_storage_space += I.get_storage_cost()
-		can_hold[I.type] = ++can_hold[I.type]
 
 //Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
 //Returns -1 if the atom was not found on container.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -51,10 +51,10 @@
 		//there's got to be a better way of doing this.
 		if (!(src.loc == usr) || (src.loc && src.loc.loc == usr))
 			return
-		
+
 		if (( usr.restrained() ) || ( usr.stat ))
 			return
-		
+
 		if ((src.loc == usr) && !usr.unEquip(src))
 			return
 
@@ -232,12 +232,16 @@
 			usr << "<span class='notice'>[src] is full, make some space.</span>"
 		return 0 //Storage item is full
 
-	if(can_hold.len && !is_type_in_list(W, can_hold))
-		if(!stop_messages)
-			if (istype(W, /obj/item/weapon/hand_labeler))
-				return 0
-			usr << "<span class='notice'>[src] cannot hold [W].</span>"
-		return 0
+	if(can_hold.len)
+		if(!is_type_in_list(W, can_hold))
+			if(!stop_messages && ! istype(W, /obj/item/weapon/hand_labeler))
+				usr << "<span class='notice'>[src] cannot hold [W].</span>"
+			return 0
+		var/max_instances = can_hold[W.type]
+		if(max_instances && instances_of_type_in_list(W, contents) >= max_instances)
+			if(!stop_messages && !istype(W, /obj/item/weapon/hand_labeler))
+				usr << "<span class='notice'>[src] has no more space for an additional [W].</span>"
+			return 0
 
 	if(cant_hold.len && is_type_in_list(W, cant_hold))
 		if(!stop_messages)
@@ -448,6 +452,17 @@
 		if(istype(A,/obj/))
 			var/obj/O = A
 			O.hear_talk(M, text, verb, speaking)
+
+/obj/item/weapon/storage/proc/make_exact_fit()
+	storage_slots = contents.len
+
+	can_hold.Cut()
+	max_w_class = 0
+	max_storage_space = 0
+	for(var/obj/item/I in src)
+		max_w_class = max(I.w_class, max_w_class)
+		max_storage_space += I.get_storage_cost()
+		can_hold[I.type] = ++can_hold[I.type]
 
 //Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
 //Returns -1 if the atom was not found on container.


### PR DESCRIPTION
The surgical kit can now contain the equipment it came with. It can also not contain more items of a given type than it was spawned with.
This means that even if the storage container otherwise has sufficient space it can, for example, still only ever contain 1 surgical saw.

Fixes #11298. Fixes #11297.
