### PR TITLE
Fixes #11276

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -890,9 +890,9 @@
 				var/turf/T = loc
 				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 				if(L)
-					light_amount = min(10,L.lum_r + L.lum_g + L.lum_b) - 5 //hardcapped so it's not abused by having a ton of flashlights
+					light_amount = min(10,L.lum_r + L.lum_g + L.lum_b) - 2 //hardcapped so it's not abused by having a ton of flashlights
 				else
-					light_amount =  5
+					light_amount =  1
 			nutrition += light_amount
 			traumatic_shock -= light_amount
 


### PR DESCRIPTION
- Re-adjusts two values to take new lighting in account.
- For reference. Turf which has light fixture (large) on it, has light value of 6. An average half-lit turf has around 1.5. These values were obtained via in-game tests.
- Using old values, diona would die (without another light source such as flashlight) when standing on any other turf other than turf with light fixture, as diona required light level of 5 or larger to survive. Now they require 2 or larger. As a rule of thumb, if the turf is brightly lit to <b>clearly</b> see it's contents, it's probably safe to stay at for longer durations.
- Now it should be relatively similar to the old values before lighting changes.
