### PR TITLE
Can no longer use utensils to eat if you lack the means.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1221,6 +1221,7 @@
 #include "code\modules\mob\living\carbon\human\human_damage.dm"
 #include "code\modules\mob\living\carbon\human\human_defense.dm"
 #include "code\modules\mob\living\carbon\human\human_defines.dm"
+#include "code\modules\mob\living\carbon\human\human_helpers.dm"
 #include "code\modules\mob\living\carbon\human\human_movement.dm"
 #include "code\modules\mob\living\carbon\human\human_organs.dm"
 #include "code\modules\mob\living\carbon\human\human_powers.dm"

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -34,10 +34,8 @@
 		else
 			return ..()
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(!H.can_eat(src))
-			return
+	if(!M.can_eat(src))
+		return
 
 	if (reagents.total_volume > 0)
 		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -34,6 +34,11 @@
 		else
 			return ..()
 
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.can_eat(src))
+			return
+
 	if (reagents.total_volume > 0)
 		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		if(M == user)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -1,0 +1,11 @@
+/mob/living/carbon/human/proc/can_eat(var/food, var/feedback = 1)
+	if(!check_has_mouth())
+		if(feedback)
+			src << "Where do you intend to put \the [food]? You don't have a mouth!"
+		return 0
+	var/obj/item/blocked = check_mouth_coverage()
+	if(blocked)
+		if(feedback)
+			src << "<span class='warning'>\The [blocked] is in the way!</span>"
+		return 0
+	return 1

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -1,11 +1,37 @@
-/mob/living/carbon/human/proc/can_eat(var/food, var/feedback = 1)
-	if(!check_has_mouth())
-		if(feedback)
+#define HUMAN_EATING_NO_ISSUE		0
+#define HUMAN_EATING_NO_MOUTH		1
+#define HUMAN_EATING_BLOCKED_MOUTH	2
+
+/mob/living/carbon/human/can_eat(var/food, var/feedback = 1)
+	var/status = can_eat_status()
+	if(status == HUMAN_EATING_NO_ISSUE)
+		return 1
+	if(feedback)
+		if(status == HUMAN_EATING_NO_MOUTH)
 			src << "Where do you intend to put \the [food]? You don't have a mouth!"
-		return 0
+		else if(status == HUMAN_EATING_BLOCKED_MOUTH)
+			src << "<span class='warning'>\The [blocked] is in the way!</span>"
+	return 0
+
+/mob/living/carbon/human/can_force_feed(var/feeder, var/food, var/feedback = 1)
+	var/status = can_eat_status()
+	if(status == HUMAN_EATING_NO_ISSUE)
+		return 1
+	if(feedback)
+		if(status == HUMAN_EATING_NO_MOUTH)
+			feeder << "Where do you intend to put \the [food]? \The [src] doesn't have a mouth!"
+		else if(status == HUMAN_EATING_BLOCKED_MOUTH)
+			feeder << "<span class='warning'>\The [blocked] is in the way!</span>"
+	return 0
+
+/mob/living/carbon/human/proc/can_eat_status()
+	if(!check_has_mouth())
+		return HUMAN_EATING_NO_MOUTH
 	var/obj/item/blocked = check_mouth_coverage()
 	if(blocked)
-		if(feedback)
-			src << "<span class='warning'>\The [blocked] is in the way!</span>"
-		return 0
-	return 1
+		return HUMAN_EATING_BLOCKED_MOUTH
+	return HUMAN_EATING_NO_ISSUE
+
+#undef HUMAN_EATING_NO_ISSUE
+#undef HUMAN_EATING_NO_MOUTH
+#undef HUMAN_EATING_BLOCKED_MOUTH

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -14,6 +14,11 @@
 	emote_see = list("jiggles", "bounces in place")
 	var/colour = "grey"
 
+/mob/living/simple_animal/slime/can_force_feed(var/feeder, var/food, var/feedback)
+	if(feedback)
+		feeder << "Where do you intend to put \the [food]? \The [src] doesn't have a mouth!"
+	return 0
+
 /mob/living/simple_animal/adultslime
 	name = "pet slime"
 	desc = "A lovable, domesticated slime."

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -619,6 +619,12 @@ proc/is_blind(A)
 /mob/proc/is_client_active(var/active = 1)
 	return client && client.inactivity < active MINUTES
 
+/mob/proc/can_eat()
+	return 1
+
+/mob/proc/can_force_feed()
+	return 1
+
 #define SAFE_PERP -50
 /mob/living/proc/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest)
 	if(stat == DEAD)
@@ -644,7 +650,7 @@ proc/is_blind(A)
 	// A proper	CentCom id is hard currency.
 	else if(id && istype(id, /obj/item/weapon/card/id/centcom))
 		return SAFE_PERP
-	
+
 	if(check_access && !access_obj.allowed(src))
 		threatcount += 4
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -45,12 +45,7 @@
 		if(M == user)								//If you're eating it yourself
 			if(istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
-				if(!H.check_has_mouth())
-					user << "Where do you intend to put \the [src]? You don't have a mouth!"
-					return
-				var/obj/item/blocked = H.check_mouth_coverage()
-				if(blocked)
-					user << "<span class='warning'>\The [blocked] is in the way!</span>"
+				if(!H.can_eat(src))
 					return
 
 			if (fullness <= 50)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -43,10 +43,8 @@
 	if(istype(M, /mob/living/carbon))
 		var/fullness = M.nutrition + (M.reagents.get_reagent_amount("nutriment") * 25)
 		if(M == user)								//If you're eating it yourself
-			if(istype(M,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(!H.can_eat(src))
-					return
+			if(!M.can_eat(src))
+				return
 
 			if (fullness <= 50)
 				M << "<span class='danger'>You hungrily chew out a piece of [src] and gobble it!</span>"
@@ -60,35 +58,22 @@
 				M << "<span class='danger'>You cannot force any more of [src] to go down your throat.</span>"
 				return 0
 		else
-			if(istype(M,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(!H.check_has_mouth())
-					user << "Where do you intend to put \the [src]? \The [H] doesn't have a mouth!"
-					return
-				var/obj/item/blocked = H.check_mouth_coverage()
-				if(blocked)
-					user << "<span class='warning'>\The [blocked] is in the way!</span>"
-					return
-
-			if(!istype(M, /mob/living/carbon/slime))		//If you're feeding it to someone else.
-
-				if (fullness <= (550 * (1 + M.overeatduration / 1000)))
-					user.visible_message("<span class='danger'>[user] attempts to feed [M] [src].</span>")
-				else
-					user.visible_message("<span class='danger'>[user] cannot force anymore of [src] down [M]'s throat.</span>")
-					return 0
-
-				if(!do_mob(user, M)) return
-
-				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [src.name] by [user.name] ([user.ckey]) Reagents: [reagentlist(src)]</font>")
-				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Fed [src.name] by [M.name] ([M.ckey]) Reagents: [reagentlist(src)]</font>")
-				msg_admin_attack("[key_name(user)] fed [key_name(M)] with [src.name] Reagents: [reagentlist(src)] (INTENT: [uppertext(user.a_intent)])")
-
-				user.visible_message("<span class='danger'>[user] feeds [M] [src].</span>")
-
-			else
-				user << "This creature does not seem to have a mouth!"
+			if(!M.can_force_feed(user, src))
 				return
+
+			if (fullness <= (550 * (1 + M.overeatduration / 1000)))
+				user.visible_message("<span class='danger'>[user] attempts to feed [M] [src].</span>")
+			else
+				user.visible_message("<span class='danger'>[user] cannot force anymore of [src] down [M]'s throat.</span>")
+				return 0
+
+			if(!do_mob(user, M)) return
+
+			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [src.name] by [user.name] ([user.ckey]) Reagents: [reagentlist(src)]</font>")
+			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Fed [src.name] by [M.name] ([M.ckey]) Reagents: [reagentlist(src)]</font>")
+			msg_admin_attack("[key_name(user)] fed [key_name(M)] with [src.name] Reagents: [reagentlist(src)] (INTENT: [uppertext(user.a_intent)])")
+
+			user.visible_message("<span class='danger'>[user] feeds [M] [src].</span>")
 
 		if(reagents)								//Handle ingestion of the reagent.
 			playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), 1)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -19,16 +19,8 @@
 
 	attack(mob/M as mob, mob/user as mob, def_zone)
 		if(M == user)
-
-			if(istype(M, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(!H.check_has_mouth())
-					user << "Where do you intend to put \the [src]? You don't have a mouth!"
-					return
-				var/obj/item/blocked = H.check_mouth_coverage()
-				if(blocked)
-					user << "<span class='warning'>\The [blocked] is in the way!</span>"
-					return
+			if(!M.can_eat(src))
+				return
 
 			M << "<span class='notice'>You swallow \the [src].</span>"
 			M.drop_from_inventory(src) //icon update
@@ -38,14 +30,7 @@
 			return 1
 
 		else if(istype(M, /mob/living/carbon/human))
-
-			var/mob/living/carbon/human/H = M
-			if(!H.check_has_mouth())
-				user << "Where do you intend to put \the [src]? \The [H] doesn't have a mouth!"
-				return
-			var/obj/item/blocked = H.check_mouth_coverage()
-			if(blocked)
-				user << "<span class='warning'>\The [blocked] is in the way!</span>"
+			if(!M.can_force_feed(user, src))
 				return
 
 			user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>")


### PR DESCRIPTION
Humanoid mobs can no longer eat when missing a mouth or when their mouth is blocked when using utensils, same as when eating food directly.
Fixes  #11333.
