### PR TITLE
Reduces wizard subjugate duration

### DIFF
--- a/code/modules/spells/targeted/subjugate.dm
+++ b/code/modules/spells/targeted/subjugate.dm
@@ -11,9 +11,9 @@
 
 	max_targets = 1
 
-	amt_dizziness = 300
-	amt_confused = 300
-	amt_stuttering = 300
+	amt_dizziness = 100
+	amt_confused = 100
+	amt_stuttering = 100
 
 	compatible_mobs = list(/mob/living/carbon/human)
 


### PR DESCRIPTION
Reduces wizard subjugate duration to one third of previous duration. General agreement in this thread: http://baystation12.net/forums/threads/vote-remove-wizard-subjugate.1007/

Because a robeless spell shouldn't take you out of the round for as long as the respawn timer lasts.
