### PR TITLE
Fix a problem with solar control computers not connecting to powernets

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -360,9 +360,8 @@ var/list/solars_list = list()
 
 /obj/machinery/power/solar_control/initialize()
 	..()
-	if(!powernet) return
+	if(!connect_to_network()) return
 	set_panels(cdir)
-	connect_to_network()
 
 /obj/machinery/power/solar_control/update_icon()
 	if(stat & BROKEN)


### PR DESCRIPTION
There is an issue which causes newly-constructed solar control computers to fail to connect to a powernet, despite being built right on top of a cable node. The control computer's `powernet` remains set to `null` until the cables are replaced to force an update. 

This change makes the solar control computers try to connect to a powernet in `initialize()` to correct this problem. Other functionality should remain the same. 
