### PR TITLE
Adds antag datum flag that is used to exlude the type from random selection.

### DIFF
--- a/code/game/antagonist/_antagonist_setup.dm
+++ b/code/game/antagonist/_antagonist_setup.dm
@@ -26,6 +26,7 @@
 #define ANTAG_RANDSPAWN         256 // Potentially randomly spawns due to events.
 #define ANTAG_VOTABLE           512 // Can be voted as an additional antagonist before roundstart.
 #define ANTAG_SET_APPEARANCE   1024 // Causes antagonists to use an appearance modifier on spawn.
+#define ANTAG_RANDOM_EXCEPTED  2048 // If a game mode randomly selects antag types, antag types with this flag should be excluded.
 
 // Globals.
 var/global/list/all_antag_types = list()

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -48,3 +48,11 @@
 
 /datum/antagonist/proc/is_latejoin_template()
 	return (flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
+
+/proc/all_random_antag_types()
+	// No caching as the ANTAG_RANDOM_EXCEPTED flag can be added/removed mid-round.
+	var/list/antag_candidates = all_antag_types.Copy()
+	for(var/datum/antagonist/antag in antag_candidates)
+		if(antag.flags & ANTAG_RANDOM_EXCEPTED)
+			antag_candidates -= antag
+	return antag_candidates

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -7,7 +7,7 @@ var/datum/antagonist/deathsquad/deathsquad
 	role_text_plural = "Death Commandos"
 	welcome_text = "You work in the service of Central Command Asset Protection, answering directly to the Board of Directors."
 	landmark_id = "Commando"
-	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_HAS_NUKE | ANTAG_HAS_LEADER
+	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_HAS_NUKE | ANTAG_HAS_LEADER | ANTAG_RANDOM_EXCEPTED
 	default_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
 	antaghud_indicator = "huddeathsquad"
 

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -9,7 +9,7 @@ var/datum/antagonist/ert/ert
 	welcome_text = "As member of the Emergency Response Team, you answer only to your leader and CentComm officials."
 	leader_welcome_text = "As leader of the Emergency Response Team, you answer only to CentComm, and have authority to override the Captain where it is necessary to achieve your mission goals. It is recommended that you attempt to cooperate with the captain where possible, however."
 	landmark_id = "Response Team"
-	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME
+	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 	antaghud_indicator = "hudloyalist"
 
 	hard_cap = 5

--- a/code/game/gamemodes/calamity/calamity.dm
+++ b/code/game/gamemodes/calamity/calamity.dm
@@ -11,16 +11,14 @@
 	event_delay_mod_major = 0.75
 
 /datum/game_mode/calamity/create_antagonists()
+	var/list/antag_candidates = all_random_antag_types()
 
-	//Let's not modify global lists for trivial reasons, even if it seems harmless right now.
-	var/list/antag_candidates = all_antag_types.Copy()
-	
 	var/grab_antags = round(num_players()/ANTAG_TYPE_RATIO)+1
 	while(antag_candidates.len && antag_tags.len < grab_antags)
 		var/antag_id = pick(antag_candidates)
 		antag_candidates -= antag_id
 		antag_tags |= antag_id
-	
+
 	..()
 
 /datum/game_mode/calamity/check_victory()


### PR DESCRIPTION
Death Commando, Mercenary Commando (inherits from death commando), and the ERT antag types added to the exclude list. Fixes  #11416.
