### PR TITLE
Updates gridcheck behavior

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -3,25 +3,13 @@
 	if(announce)
 		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", new_sound = 'sound/AI/poweroff.ogg')
 
-	var/list/skipped_areas = list(/area/turret_protected/ai)
-
-	for(var/obj/machinery/power/smes/S in world)
-		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas || !(S.z in config.station_levels))
-			continue
-		S.last_charge			= S.charge
-		S.last_output_attempt	= S.output_attempt
-		S.last_input_attempt 	= S.input_attempt
-		S.charge = 0
-		S.inputting(0)
-		S.outputting(0)
-		S.update_icon()
-		S.power_change()
+	for(var/obj/machinery/power/smes/buildable/S in world)
+		S.energy_fail(rand(30,60))
 
 
 	for(var/obj/machinery/power/apc/C in world)
-		if(!C.is_critical && C.cell && (C.z in config.station_levels))
-			C.cell.charge = 0
+		if(!C.is_critical)
+			C.energy_fail(rand(60,120))
 
 /proc/power_restore(var/announce = 1)
 	var/list/skipped_areas = list(/area/turret_protected/ai)
@@ -35,7 +23,7 @@
 		var/area/current_area = get_area(S)
 		if(current_area.type in skipped_areas || isNotStationLevel(S.z))
 			continue
-		S.charge = S.last_charge
+		S.charge = S.capacity
 		S.output_attempt = S.last_output_attempt
 		S.input_attempt = S.last_input_attempt
 		S.update_icon()

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -1,15 +1,15 @@
 
-/proc/power_failure(var/announce = 1)
+/proc/power_failure(var/announce = 1, var/severity = 2)
 	if(announce)
 		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", new_sound = 'sound/AI/poweroff.ogg')
 
 	for(var/obj/machinery/power/smes/buildable/S in world)
-		S.energy_fail(rand(30,60))
+		S.energy_fail(rand(15 * severity,30 * severity))
 
 
 	for(var/obj/machinery/power/apc/C in world)
 		if(!C.is_critical)
-			C.energy_fail(rand(60,120))
+			C.energy_fail(rand(30 * severity,60 * severity))
 
 /proc/power_restore(var/announce = 1)
 	var/list/skipped_areas = list(/area/turret_protected/ai)

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -2,7 +2,7 @@
 	announceWhen		= 5
 
 /datum/event/grid_check/start()
-	power_failure(0)
+	power_failure(0, severity)
 
 /datum/event/grid_check/announce()
 	command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check", new_sound = 'sound/AI/poweroff.ogg')

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -1,15 +1,8 @@
 /datum/event/grid_check	//NOTE: Times are measured in master controller ticks!
 	announceWhen		= 5
 
-/datum/event/grid_check/setup()
-	endWhen = rand(30,120)
-
 /datum/event/grid_check/start()
 	power_failure(0)
 
 /datum/event/grid_check/announce()
-	if (prob(30))
-		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check", new_sound = 'sound/AI/poweroff.ogg')
-
-/datum/event/grid_check/end()
-	power_restore()
+	command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check", new_sound = 'sound/AI/poweroff.ogg')

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -37,6 +37,7 @@
 	var/input_pulsed = 0
 	var/output_cut = 0
 	var/output_pulsed = 0
+	var/failure_timer = 0			// Set by gridcheck event, temporarily disables the SMES.
 
 	var/open_hatch = 0
 	var/name_tag = null
@@ -116,6 +117,9 @@
 
 /obj/machinery/power/smes/process()
 	if(stat & BROKEN)	return
+	if(failure_timer)	// Disabled by gridcheck.
+		failure_timer--
+		return
 
 	//store machine state to see if we need to update the icon overlays
 	var/last_disp = chargedisplay()
@@ -311,6 +315,7 @@
 	data["outputLevel"] = output_level
 	data["outputMax"] = output_level_max
 	data["outputLoad"] = round(output_used)
+	data["failTime"] = failure_timer * 2
 
 	if(outputting)
 		data["outputting"] = 2			// smes is outputting
@@ -346,6 +351,9 @@
 	else if( href_list["online"] )
 		outputting(!output_attempt)
 		update_icon()
+	else if( href_list["reboot"] )
+		failure_timer = 0
+		update_icon()
 	else if( href_list["input"] )
 		switch( href_list["input"] )
 			if("min")
@@ -370,6 +378,8 @@
 
 	return 1
 
+/obj/machinery/power/smes/proc/energy_fail(var/duration)
+	failure_timer = max(failure_timer, duration)
 
 /obj/machinery/power/smes/proc/ion_act()
 	if(src.z in config.station_levels)
@@ -384,7 +394,7 @@
 			explosion(src.loc, -1, 0, 1, 3, 1, 0)
 			qdel(src)
 			return
-		if(prob(15)) //Power drain
+		else if(prob(15)) //Power drain
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(3, 1, src)
 			s.start()
@@ -392,11 +402,13 @@
 				emp_act(1)
 			else
 				emp_act(2)
-		if(prob(5)) //smoke only
+		else if(prob(5)) //smoke only
 			var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
 			smoke.set_up(3, 0, src.loc)
 			smoke.attach(src)
 			smoke.start()
+		else
+			energy_fail(rand(0, 30))
 
 /obj/machinery/power/smes/proc/inputting(var/do_input)
 	input_attempt = do_input
@@ -409,21 +421,26 @@
 		outputting = 0
 
 /obj/machinery/power/smes/emp_act(severity)
-	inputting(rand(0,1))
-	outputting(rand(0,1))
-	output_level = rand(0, output_level_max)
-	input_level = rand(0, input_level_max)
-	charge -= 1e6/severity
-	if (charge < 0)
-		charge = 0
+	if(prob(50))
+		inputting(rand(0,1))
+		outputting(rand(0,1))
+	if(prob(50))
+		output_level = rand(0, output_level_max)
+		input_level = rand(0, input_level_max)
+	if(prob(50))
+		charge -= 1e6/severity
+		if (charge < 0)
+			charge = 0
+	if(prob(50))
+		energy_fail(rand(0 + (severity * 30),30 + (severity * 30)))
 	update_icon()
 	..()
 
 
 /obj/machinery/power/smes/magical
-	name = "magical power storage unit"
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Magically produces power."
-	capacity = 9000000
+	name = "quantum power storage unit"
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Gains energy from quantum entanglement link."
+	capacity = 5000000
 	output_level = 250000
 	should_be_mapped = 1
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -93,7 +93,7 @@
 		s.start()
 		charge -= (output_level_max * SMESRATE)
 		if(prob(1)) // Small chance of overload occuring since grounding is disabled.
-			apcs_overload(5,10)
+			apcs_overload(5,10,20)
 
 	..()
 
@@ -214,6 +214,7 @@
 				h_user.Paralyse(5)
 			spawn(0)
 				empulse(src.loc, 2, 4)
+			apcs_overload(0, 5, 10)
 			charge = 0
 
 		if (36 to 60)
@@ -232,7 +233,8 @@
 			spawn(0)
 				empulse(src.loc, 8, 16)
 			charge = 0
-			apcs_overload(1, 10)
+			apcs_overload(1, 10, 20)
+			energy_fail(10)
 			src.ping("Caution. Output regulators malfunction. Uncontrolled discharge detected.")
 
 		if (61 to INFINITY)
@@ -247,7 +249,8 @@
 			spawn(0)
 				empulse(src.loc, 32, 64)
 			charge = 0
-			apcs_overload(5, 25)
+			apcs_overload(5, 25, 100)
+			energy_fail(30)
 			src.ping("Caution. Output regulators malfunction. Significant uncontrolled discharge detected.")
 
 			if (prob(50))
@@ -270,9 +273,9 @@
 
 
 // Proc: apcs_overload()
-// Parameters: 2 (failure_chance - chance to actually break the APC, overload_chance - Chance of breaking lights)
+// Parameters: 3 (failure_chance - chance to actually break the APC, overload_chance - Chance of breaking lights, reboot_chance - Chance of temporarily disabling the APC)
 // Description: Damages output powernet by power surge. Destroys few APCs and lights, depending on parameters.
-/obj/machinery/power/smes/buildable/proc/apcs_overload(var/failure_chance, var/overload_chance)
+/obj/machinery/power/smes/buildable/proc/apcs_overload(var/failure_chance, var/overload_chance, var/reboot_chance)
 	if (!src.powernet)
 		return
 
@@ -283,6 +286,8 @@
 				A.overload_lighting()
 			if (prob(failure_chance))
 				A.set_broken()
+			if(prob(reboot_chance))
+				A.energy_fail(rand(30,60))
 
 // Proc: update_icon()
 // Parameters: None

--- a/html/changelogs/atlantiscze-PR-11429.yml
+++ b/html/changelogs/atlantiscze-PR-11429.yml
@@ -1,0 +1,6 @@
+author: Atlantis
+
+delete-after: True
+
+changes: 
+  - rscadd: "Expanded gridcheck random event. Affected devices now show error UI and may be restarted manually before the event ends. All Z-levels are now affected equally."

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -1,3 +1,11 @@
+{{if data.failTime}}
+<div class='notice'>
+	<b><h3>SYSTEM FAILURE</h3></b>
+	<i>I/O regulators malfunction detected! Waiting for system reboot...</i><br>
+	Automatic reboot in {{:data.failTime}} seconds...
+	{{:helper.link('Reboot Now', 'refresh', {'reboot' : 1})}}<br><br><br>
+</div>
+{{else}}
 <div class='notice'>
 	{{if data.siliconUser}}
 		<div class="itemContentSmall">
@@ -178,4 +186,4 @@
 	{{/if}}
 
 </div>
-		
+{{/if}}

--- a/nano/templates/smes.tmpl
+++ b/nano/templates/smes.tmpl
@@ -1,3 +1,11 @@
+{{if data.failTime}}
+<div class='notice'>
+	<b><h3>SYSTEM FAILURE</h3></b>
+	<i>I/O regulators malfunction detected! Waiting for system reboot...</i><br>
+	Automatic reboot in {{:data.failTime}} seconds...
+	{{:helper.link('Reboot Now', 'refresh', {'reboot' : 1})}}<br><br><br>
+</div>
+{{else}}
 <div class="item">
 	<div class="itemLabel">
 		Stored Capacity:
@@ -87,3 +95,4 @@
 		</div>
 	</div>
 </div>
+{{/if}}


### PR DESCRIPTION
- Gridcheck random event is updated. Core behavior remains the same, but mechanism it uses to achieve power outage is changed.
- Both SMESs and APCs have new variable which is set by gridcheck. This variable decrements by 1 every tick, and until it is back to zero the APC/SMES won't work.
- SMESs are disabled for 60-120 seconds (random for each device). APCs for 120-240 seconds.
- Both SMESs and APCs show error UI with timer counting down until the device restarts (begins working again).
- Both SMEss and APCs may be manually restarted, on per-device basis, by clicking restart button in the UI. This is useful if you urgently need one or two devices back online, for example, medical treatment facilities, etc. This immediately skips the X second timer and restores the device to working state, while keeping the original intention of this event - allowing antagonists to use lack of power to enter areas they don't normally have access to.
- APCs affected by gridcheck have BSOD texture until they restart
- Power restoration is slightly less laggy as it doesn't happen with all APCs at once.
- (EDIT) - Gridcheck now affects all Z-levels, not just the station itself.

BONUS: Overloads that can be caused by attempting to modify charged SMES expanded, now they trigger the same effect gridcheck does, if the SMES is sufficiently charged, in addition to previous behavior.
