### PR TITLE
Fixes the mining rig camera not properly showing up on the station camera list.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/head/helmet/space/rig/ert
 	light_overlay = "helmet_light_dual"
-	camera_networks = list("ERT")
+	camera_networks = list(NETWORK_ERT)
 
 /obj/item/weapon/rig/ert
 	name = "ERT-C hardsuit control module"

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -40,7 +40,7 @@
 
 	airtight = 0
 	seal_delay = 5 //not being vaccum-proof has an upside I guess
-	
+
 	helm_type = /obj/item/clothing/head/lightrig/hacker
 	chest_type = /obj/item/clothing/suit/lightrig/hacker
 	glove_type = /obj/item/clothing/gloves/lightrig/hacker

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -1,23 +1,23 @@
 /obj/item/clothing/head/helmet/space/rig/industrial
-	camera_networks = list("Mine")
+	camera_networks = list(NETWORK_MINE)
 
 /obj/item/clothing/head/helmet/space/rig/ce
-	camera_networks = list("Engineering")
+	camera_networks = list(NETWORK_ENGINEERING)
 
 /obj/item/clothing/head/helmet/space/rig/eva
 	light_overlay = "helmet_light_dual"
-	camera_networks = list("Engineering")
+	camera_networks = list(NETWORK_ENGINEERING)
 
 /obj/item/clothing/head/helmet/space/rig/hazmat
 	light_overlay = "hardhat_light"
-	camera_networks = list("Research")
+	camera_networks = list(NETWORK_RESEARCH)
 
 /obj/item/clothing/head/helmet/space/rig/medical
-	camera_networks = list("Medbay")
+	camera_networks = list(NETWORK_MEDICAL)
 
 /obj/item/clothing/head/helmet/space/rig/hazard
 	light_overlay = "helmet_light_dual"
-	camera_networks = list("Security")
+	camera_networks = list(NETWORK_SECURITY)
 
 /obj/item/weapon/rig/industrial
 	name = "industrial suit control module"


### PR DESCRIPTION
Was using "Mine" instead of "MINE. Corrected by replacing all networks with the defined presets.
