### PR TITLE
add a sleep inbetween disabling and enabling hardware mode

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -161,6 +161,7 @@
 	spawn(5) // And wait a half-second, since it sounds like you can do this too fast.
 		if(src)
 			winset(src, null, "command=\".configure graphics-hwmode off\"")
+			sleep(2) // wait a bit more, possibly fixes hardware mode not re-activating right
 			winset(src, null, "command=\".configure graphics-hwmode on\"")
 
 	log_client_to_db()


### PR DESCRIPTION
i've been seeing HW mode not always re-enabling, hopefully this'll fix it.
