### PR TITLE
Refactored slipping code a little.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1365,10 +1365,6 @@
 	if(update_hud)
 		handle_regular_hud_updates()
 
-/mob/living/carbon/human/Check_Shoegrip()
-	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))  //magboots + dense_object = no floating
-		return 1
-	return 0
 
 /mob/living/carbon/human/can_stand_overridden()
 	if(wearing_rig && wearing_rig.ai_can_move_suit(check_for_ai = 1))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -87,18 +87,9 @@
 	return 0
 
 
-/mob/living/carbon/human/Process_Spaceslipping(var/prob_slip = 5)
-	//If knocked out we might just hit it and stop.  This makes it possible to get dead bodies and such.
-
-	if(species.flags & NO_SLIP)
-		return
-
-	if(stat)
-		prob_slip = 0 // Changing this to zero to make it line up with the comment, and also, make more sense.
-
-	//Do we have magboots or such on if so no slip
-	if(istype(shoes, /obj/item/clothing/shoes/magboots) && (shoes.item_flags & NOSLIP))
-		prob_slip = 0
+/mob/living/carbon/human/slip_chance(var/prob_slip = 5)
+	if(!..())
+		return 0
 
 	//Check hands and mod slip
 	if(!l_hand)	prob_slip -= 2
@@ -106,5 +97,11 @@
 	if (!r_hand)	prob_slip -= 2
 	else if(r_hand.w_class <= 2)	prob_slip -= 1
 
-	prob_slip = round(prob_slip)
-	return(prob_slip)
+	return prob_slip
+
+/mob/living/carbon/human/Check_Shoegrip()
+	if(species.flags & NO_SLIP)
+		return 1
+	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))  //magboots + dense_object = no floating
+		return 1
+	return 0

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -38,8 +38,6 @@
 	//stuff in the stomach
 	handle_stomach()
 
-	update_gravity(mob_has_gravity())
-
 	update_pulling()
 
 	for(var/obj/item/weapon/grab/G in src)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -248,7 +248,7 @@ var/list/mob_hat_cache = list()
 	..()
 
 //DRONE MOVEMENT.
-/mob/living/silicon/robot/drone/Process_Spaceslipping(var/prob_slip)
+/mob/living/silicon/robot/drone/slip_chance(var/prob_slip)
 	return 0
 
 //CONSOLE PROCS

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/robot/Process_Spaceslipping(var/prob_slip)
+/mob/living/silicon/robot/slip_chance(var/prob_slip)
 	if(module && module.no_slip)
 		return 0
 	..(prob_slip)


### PR DESCRIPTION
Moved human Check_Shoegrip() override to human_movement. Parent is in mob_movement, makes sense to keep them in line imo.

Renamed Process_Spaceslipping to slip_chance because it doesn't do any kind of processing. And I hate naming of these procs.
Refactored human slip_chance override to use parent proc instead of doing same checks all over again.

Removed update_gravity (and its only call in life()) and mob_has_gravity(). First one was called precisely once and did /nothing/. Mob-level proc just returns and it is never overriden anywhere. Second one is just a call for has_gravity, meaningless and used only once in that removed line.

Refactored Check_Dense_Object (god I hate these names) to be less, for lack fo better word, retarded.
Instead of weird var for keeping number of dense objects (that is never used, check only used as binary true/false), it now just returns value when it finds a suitabl object.
Used trange and orange instead of oview to avoid fuckery in non-lit places.
