### PR TITLE
Engineering alarm monitors now include camera alarms.

### DIFF
--- a/code/modules/nano/modules/alarm_monitor.dm
+++ b/code/modules/nano/modules/alarm_monitor.dm
@@ -9,7 +9,7 @@
 
 /datum/nano_module/alarm_monitor/engineering/New()
 	..()
-	alarm_handlers = list(atmosphere_alarm, fire_alarm, power_alarm)
+	alarm_handlers = list(atmosphere_alarm, camera_alarm, fire_alarm, power_alarm)
 
 /datum/nano_module/alarm_monitor/security/New()
 	..()

--- a/html/changelogs/PsiOmegaDelta-CameraAlerts.yml
+++ b/html/changelogs/PsiOmegaDelta-CameraAlerts.yml
@@ -1,0 +1,5 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - tweak: "Engineering alarm consoles now display camera alerts."
+  


### PR DESCRIPTION
Perhaps cameras now will be repaired.
