### PR TITLE
Fixes airlocks losing air, again and again.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -409,12 +409,12 @@
 	set_opacity(0)
 	sleep(3)
 	src.density = 0
+	update_nearby_tiles()
 	sleep(7)
 	src.layer = open_layer
 	explosion_resistance = 0
 	update_icon()
 	set_opacity(0)
-	update_nearby_tiles()
 	operating = 0
 
 	if(autoclose)
@@ -436,12 +436,12 @@
 	src.density = 1
 	explosion_resistance = initial(explosion_resistance)
 	src.layer = closed_layer
+	update_nearby_tiles()
 	sleep(7)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)	//caaaaarn!
 	operating = 0
-	update_nearby_tiles()
 
 	//I shall not add a check every x ticks if a door has closed over some fire.
 	var/obj/fire/fire = locate() in loc


### PR DESCRIPTION
- Replaces #11123 - this PR fixes the issue itself, instead of using delays to work around the issue.
- update_nearby_tiles() is now being called right after density is changed, instead of sleeping for 0.7 seconds.
- Tested this in engineering shuttle dock airlock, which is one of few airlocks which don't have pump replenishing lost gas installed. Loss of air is minimal (few kilopascals, likely caused by airlocks opening at 5kPa as reaching pure vacuum would take too long) in comparsion to situation without this fix (where, once cycled out, you can't cycle back in without forcing the inner side of airlock)
