### PR TITLE
Renames the rig mounted taser.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -135,8 +135,8 @@
 	suit_overlay_active = "mounted-taser"
 	suit_overlay_inactive = "mounted-taser"
 
-	interface_name = "mounted energy gun"
-	interface_desc = "A shoulder-mounted cell-powered energy gun."
+	interface_name = "mounted taser"
+	interface_desc = "A shoulder-mounted cell-powered taser."
 
 	gun_type = /obj/item/weapon/gun/energy/taser/mounted
 


### PR DESCRIPTION
Was previously called an energy gun, same as the actual mounted energy gun, which could be mildly confusing.
Port of https://github.com/PolarisSS13/Polaris/pull/127.
