### PR TITLE
The AI can now toggle hologram eye tracking.

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -146,21 +146,14 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/process()
 	for (var/mob/living/silicon/ai/master in masters)
-		var/active_ai = (master && !master.stat && master.client && master.eyeobj)//If there is an AI attached, it's not incapacitated, it has a client, and the client eye is centered on the projector.
+		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
 		if((stat & NOPOWER) || !active_ai)
 			clear_holo(master)
 			continue
 
-		if((HOLOPAD_MODE == RANGE_BASED && (get_dist(master.eyeobj, src) > holo_range)))
+		if(!(masters[master] in view(src)))
 			clear_holo(master)
 			continue
-
-		if(HOLOPAD_MODE == AREA_BASED)
-			var/area/holo_area = get_area(src)
-			var/area/eye_area = get_area(master.eyeobj)
-			if(eye_area != holo_area)
-				clear_holo(master)
-				continue
 
 		use_power(power_per_hologram)
 	return 1
@@ -169,8 +162,21 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(masters[user])
 		step_to(masters[user], user.eyeobj) // So it turns.
 		var/obj/effect/overlay/H = masters[user]
-		H.loc = get_turf(user.eyeobj)
+		H.forceMove(get_turf(user.eyeobj))
 		masters[user] = H
+
+		if(!(H in view(src)))
+			clear_holo(user)
+			return 0
+
+		if((HOLOPAD_MODE == RANGE_BASED && (get_dist(user.eyeobj, src) > holo_range)))
+			clear_holo(user)
+
+		if(HOLOPAD_MODE == AREA_BASED)
+			var/area/holo_area = get_area(src)
+			var/area/hologram_area = get_area(H)
+			if(hologram_area != holo_area)
+				clear_holo(user)
 	return 1
 
 /*

--- a/code/modules/mob/freelook/ai/eye.dm
+++ b/code/modules/mob/freelook/ai/eye.dm
@@ -18,7 +18,7 @@
 			ai.ai_cancel_tracking()
 
 		//Holopad
-		if(ai.holo)
+		if(ai.holo && ai.hologram_follow)
 			ai.holo.move_hologram(ai)
 		return 1
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -23,7 +23,8 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/sensor_mode,
 	/mob/living/silicon/ai/proc/show_laws_verb,
 	/mob/living/silicon/ai/proc/toggle_acceleration,
-	/mob/living/silicon/ai/proc/toggle_camera_light
+	/mob/living/silicon/ai/proc/toggle_camera_light,
+	/mob/living/silicon/ai/proc/toggle_hologram_movement
 )
 
 //Not sure why this is necessary...
@@ -61,6 +62,7 @@ var/list/ai_verbs_default = list(
 	var/control_disabled = 0
 	var/datum/announcement/priority/announcement
 	var/obj/machinery/ai_powersupply/psupply = null // Backwards reference to AI's powersupply object.
+	var/hologram_follow = 1 //This is used for the AI eye, to determine if a holopad's hologram should follow it or not
 
 	//NEWMALF VARIABLES
 	var/malfunctioning = 0						// Master var that determines if AI is malfunctioning.
@@ -203,6 +205,7 @@ var/list/ai_verbs_default = list(
 /mob/living/silicon/ai/Destroy()
 	ai_list -= src
 	qdel(eyeobj)
+	eyeobj = null
 	..()
 
 /mob/living/silicon/ai/proc/setup_icon()
@@ -643,6 +646,14 @@ var/list/ai_verbs_default = list(
 	set category = "AI Commands"
 	set desc = "Augment visual feed with internal sensor overlays"
 	toggle_sensor_mode()
+
+/mob/living/silicon/ai/proc/toggle_hologram_movement()
+	set name = "Toggle Hologram Movement"
+	set category = "AI Commands"
+	set desc = "Toggles hologram movement based on moving with your virtual eye."
+
+	hologram_follow = !hologram_follow
+	usr << "<span class='info'>Your hologram will now [hologram_follow ? "follow" : "no longer follow"] you.</span>"
 
 /mob/living/silicon/ai/proc/check_unable(var/flags = 0, var/feedback = 1)
 	if(stat == DEAD)

--- a/html/changelogs/PsiOmegaDelta-HoloMovement.yml
+++ b/html/changelogs/PsiOmegaDelta-HoloMovement.yml
@@ -1,0 +1,4 @@
+author: Neerti
+delete-after: True
+changes: 
+  - rscadd: "The AI can now toggle whether its hologram will move towards the center of its view using the 'Toggle Hologram Movement' verb."


### PR DESCRIPTION
Allows the AI to use the "Toggle Hologram Movement" verb to toggle whether the hologram should follow the AI eye or not.
Also adds a check to ensure that the holopad can see the hologram, otherwise it shuts down.
Partial port of PolarisSS13/Polaris#11.
