### PR TITLE
Adds the ability to have random lobby screens.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -6,6 +6,8 @@ var/list/gamemode_cache = list()
 
 	var/nudge_script_path = "nudge.py"  // where the nudge.py script is located
 
+	var/list/lobby_screens = list("title") // Which lobby screens are available
+
 	var/log_ooc = 0						// log OOC channel
 	var/log_access = 0					// log login/logout
 	var/log_say = 0						// log client say
@@ -693,6 +695,9 @@ var/list/gamemode_cache = list()
 					var/list/values = text2list(value, " ")
 					if(values.len > 0)
 						language_prefixes = values
+
+				if ("lobby_screens")
+					config.lobby_screens = text2list(value, ";")
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -1,5 +1,22 @@
+/var/obj/effect/lobby_image = new/obj/effect/lobby_image()
 
-/var/atom/movable/lobby_image = new /atom/movable{icon = 'icons/misc/title.dmi'; icon_state = "title"; screen_loc = "1,1"; name = "Baystation12"}
+/obj/effect/lobby_image
+	name = "Baystation12"
+	desc = "This shouldn't be read"
+	icon = 'icons/misc/title.dmi'
+	screen_loc = "WEST,SOUTH"
+
+/obj/effect/lobby_image/initialize()
+	var/list/known_icon_states = icon_states(icon)
+	for(var/lobby_screen in config.lobby_screens)
+		if(!(lobby_screen in known_icon_states))
+			error("Lobby screen '[lobby_screen]' did not exist in the icon set [icon].")
+			config.lobby_screens -= lobby_screen
+
+	if(config.lobby_screens.len)
+		icon_state = pick(config.lobby_screens)
+	else
+		icon_state = known_icon_states[1]
 
 /mob/new_player
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -385,3 +385,7 @@ STARLIGHT 0
 
 ## Default language prefix keys, separated with spaces. Only single character keys are supported. If unset, defaults to , # and - 
 # DEFAULT_LANGUAGE_PREFIXES , # -
+
+## A ; separated list of lobby screens to randomly pick from. The listed screens must exist as icon states in '/icons/misc/title.dmi'.
+## Defaults to 'title' if left unset.
+# LOBBY_SCREENS title


### PR DESCRIPTION
A random lobby screen is now picked at server start (or as objects are initialized to be precise), and presented to all players. Sadly in our case we currently only have one every day lobby screen.
Port of https://github.com/PolarisSS13/Polaris/pull/321, with added sanity checking.
