### PR TITLE
Refactors mob HUD initialization.

### DIFF
--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -1,3 +1,6 @@
+/mob/living/carbon/alien/instantiate_hud(var/datum/hud/HUD)
+	HUD.larva_hud()
+
 /datum/hud/proc/larva_hud()
 
 	src.adding = list()

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -253,26 +253,9 @@ datum/hud/New(mob/owner)
 	var/ui_color = mymob.client.prefs.UI_style_color
 	var/ui_alpha = mymob.client.prefs.UI_style_alpha
 
-	if(ishuman(mymob))
-		human_hud(ui_style, ui_color, ui_alpha, mymob) // Pass the player the UI style chosen in preferences
-	else if(isrobot(mymob))
-		robot_hud()
-	else if(issmall(mymob))
-		monkey_hud(ui_style, ui_color, ui_alpha)
-	else if(isbrain(mymob))
-		brain_hud(ui_style)
-	else if(isalien(mymob))
-		larva_hud()
-	else if(isslime(mymob))
-		slime_hud()
-	else if(isAI(mymob))
-		ai_hud()
-	else if(isobserver(mymob))
-		ghost_hud()
-	else
-		mymob.instantiate_hud(src)
+	mymob.instantiate_hud(src, ui_style, ui_color, ui_alpha)
 
-/mob/proc/instantiate_hud(var/datum/hud/HUD)
+/mob/proc/instantiate_hud(var/datum/hud/HUD, var/ui_style, var/ui_color, var/ui_alpha)
 	return
 
 //Triggered when F12 is pressed (Unless someone changed something in the DMF)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -1,5 +1,10 @@
-/datum/hud/proc/human_hud(var/ui_style='icons/mob/screen1_White.dmi', var/ui_color = "#ffffff", var/ui_alpha = 255, var/mob/living/carbon/human/target)
+/mob/living/carbon/human/instantiate_hud(var/datum/hud/HUD, var/ui_style, var/ui_color, var/ui_alpha)
+	if(species == /datum/species/monkey)
+		HUD.monkey_hud(ui_style, ui_color, ui_alpha)
+	else
+		HUD.human_hud(ui_style, ui_color, ui_alpha, src)
 
+/datum/hud/proc/human_hud(var/ui_style='icons/mob/screen1_White.dmi', var/ui_color = "#ffffff", var/ui_alpha = 255, var/mob/living/carbon/human/target)
 	var/datum/hud_data/hud_data
 	if(!istype(target))
 		hud_data = new()

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -2,8 +2,14 @@
 /datum/hud/proc/unplayer_hud()
 	return
 
+/mob/dead/observer/instantiate_hud(var/datum/hud/HUD)
+	HUD.ghost_hud()
+
 /datum/hud/proc/ghost_hud()
 	return
+
+/mob/living/carbon/brain/instantiate_hud(var/datum/hud/HUD)
+	HUD.brain_hud()
 
 /datum/hud/proc/brain_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
 	mymob.blind = new /obj/screen()
@@ -12,6 +18,9 @@
 	mymob.blind.name = " "
 	mymob.blind.screen_loc = "1,1"
 	mymob.blind.layer = 0
+
+/mob/living/silicon/ai/instantiate_hud(var/datum/hud/HUD)
+	HUD.ai_hud()
 
 /datum/hud/proc/ai_hud()
 	return
@@ -33,6 +42,9 @@
 	mymob.client.screen = null
 
 	mymob.client.screen += list(blobpwrdisplay, blobhealthdisplay)
+
+/mob/living/carbon/slime/instantiate_hud(var/datum/hud/HUD)
+	HUD.slime_hud()
 
 /datum/hud/proc/slime_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
 

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -1,5 +1,7 @@
 var/obj/screen/robot_inventory
 
+/mob/living/silicon/robot/instantiate_hud(var/datum/hud/HUD)
+	HUD.robot_hud()
 
 /datum/hud/proc/robot_hud()
 


### PR DESCRIPTION
Mainly because of human monkeys, which should get their hud because they are monkeys not because they are small (otherwise, those poor Resomi). And also because not all small mobs should have the monkey HUD.
Fixes #11583 (except for the wizard part. I hate wizards).
