### PR TITLE
Corrects Wizard spell overlay positioning.

### DIFF
--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -1,3 +1,4 @@
+
 //////////////////////////
 //Movable Screen Objects//
 //   By RemieRichards	//
@@ -30,9 +31,10 @@
 
 	//Split X+Pixel_X up into list(X, Pixel_X)
 	var/list/screen_loc_X = text2list(screen_loc_params[1],":")
-
+	screen_loc_X[1] = encode_screen_X(text2num(screen_loc_X[1]))
 	//Split Y+Pixel_Y up into list(Y, Pixel_Y)
 	var/list/screen_loc_Y = text2list(screen_loc_params[2],":")
+	screen_loc_Y[1] = encode_screen_Y(text2num(screen_loc_Y[1]))
 
 	if(snap2grid) //Discard Pixel Values
 		screen_loc = "[screen_loc_X[1]],[screen_loc_Y[1]]"
@@ -42,8 +44,50 @@
 		var/pix_Y = text2num(screen_loc_Y[2]) - 16
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
-	moved = TRUE
+/obj/screen/movable/proc/encode_screen_X(X)
+	if(X > usr.client.view+1)
+		. = "EAST-[usr.client.view*2 + 1-X]"
+	else if(X < usr.client.view+1)
+		. = "WEST+[X-1]"
+	else
+		. = "CENTER"
 
+/obj/screen/movable/proc/decode_screen_X(X)
+	//Find EAST/WEST implementations
+	if(findtext(X,"EAST-"))
+		var/num = text2num(copytext(X,6)) //Trim EAST-
+		if(!num)
+			num = 0
+		. = usr.client.view*2 + 1 - num
+	else if(findtext(X,"WEST+"))
+		var/num = text2num(copytext(X,6)) //Trim WEST+
+		if(!num)
+			num = 0
+		. = num+1
+	else if(findtext(X,"CENTER"))
+		. = usr.client.view+1
+
+/obj/screen/movable/proc/encode_screen_Y(Y)
+	if(Y > usr.client.view+1)
+		. = "NORTH-[usr.client.view*2 + 1-Y]"
+	else if(Y < usr.client.view+1)
+		. = "SOUTH+[Y-1]"
+	else
+		. = "CENTER"
+
+/obj/screen/movable/proc/decode_screen_Y(Y)
+	if(findtext(Y,"NORTH-"))
+		var/num = text2num(copytext(Y,7)) //Trim NORTH-
+		if(!num)
+			num = 0
+		. = usr.client.view*2 + 1 - num
+	else if(findtext(Y,"SOUTH+"))
+		var/num = text2num(copytext(Y,7)) //Time SOUTH+
+		if(!num)
+			num = 0
+		. = num+1
+	else if(findtext(Y,"CENTER"))
+		. = usr.client.view+1
 
 //Debug procs
 /client/proc/test_movable_UI()


### PR DESCRIPTION
Includes some Destroy() cleanup, from the code I sto-borrowed from vg. Will have to backport that part to master.
Fixes the rest of  #11583. Fixes #11555.
