### PR TITLE
Fixes records unintentionally referencing each other.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -48,7 +48,7 @@
 		else
 			assignment = "Unassigned"
 
-		var/id = add_zero(num2hex(rand(1, 1.6777215E7)), 6)	//this was the best they could come up with? A large random number? *sigh*
+		var/id = generate_record_id()
 		var/icon/front = new(get_id_photo(H), dir = SOUTH)
 		var/icon/side = new(get_id_photo(H), dir = WEST)
 		//General Record
@@ -136,8 +136,10 @@
 		locked += L
 	return
 
+/proc/generate_record_id()
+	return add_zero(num2hex(rand(1, 65535)), 4)	//no point generating higher numbers because of the limitations of num2hex
 
-proc/get_id_photo(var/mob/living/carbon/human/H)
+/proc/get_id_photo(var/mob/living/carbon/human/H)
 	var/icon/preview_icon = null
 
 	var/g = "m"

--- a/code/defines/procs/records.dm
+++ b/code/defines/procs/records.dm
@@ -5,7 +5,7 @@
 	var/icon/side = new(get_id_photo(dummy), dir = WEST)
 	var/datum/data/record/G = new /datum/data/record()
 	G.fields["name"] = "New Record"
-	G.fields["id"] = text("[]", add_zero(num2hex(rand(1, 1.6777215E7)), 6))
+	G.fields["id"] = generate_record_id()
 	G.fields["rank"] = "Unassigned"
 	G.fields["real_rank"] = "Unassigned"
 	G.fields["sex"] = "Male"

--- a/code/game/machinery/records_scanner.dm
+++ b/code/game/machinery/records_scanner.dm
@@ -88,7 +88,7 @@ obj/machinery/scanner/attack_hand(mob/living/carbon/human/user)
 	G.fields["rank"] = "Unassigned"
 	G.fields["real_rank"] = G.fields["rank"]
 	G.fields["name"] = mname
-	G.fields["id"] = text("[]", add_zero(num2hex(rand(1, 1.6777215E7)), 6))
+	G.fields["id"] = generate_record_id()
 	M.fields["name"] = G.fields["name"]
 	M.fields["id"] = G.fields["id"]
 	S.fields["name"] = G.fields["name"]


### PR DESCRIPTION
Because of the limitations of BYOND's bitwise operators (which affect both the old and new implementations of num2hex()), you cannot use numbers larger than 2^16 with that proc.
Manual port of https://github.com/PolarisSS13/Polaris/pull/430. Cherry picking not possible due to datacore relocation, split, etc.
