### PR TITLE
Fixes #11510

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -301,7 +301,7 @@
 		return splash_mob(target, amount, copy)
 	if(isturf(target))
 		return trans_to_turf(target, amount, multiplier, copy)
-	if(isobj(target))
+	if(isobj(target) && target.is_open_container())
 		return trans_to_obj(target, amount, multiplier, copy)
 	return 0
 


### PR DESCRIPTION
Splashing and external transfer now checks if the container is open. Fixes #11510. Should probably check that this does not adversely affect anything else, chances are there's some outdated code somewhere using trans_to() incorrectly.
