### PR TITLE
Fixes the broken Antag Uplink.

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -140,8 +140,8 @@ nanoui is used to open and update nano browser uis
   * @return nothing
   */
 /datum/nanoui/proc/update_status(var/push_update = 0)
-	src_object = src_object.nano_host()
-	var/new_status = src_object.CanUseTopic(user, state)
+	var/obj/host = src_object.nano_host()
+	var/new_status = host.CanUseTopic(user, state)
 	if(master_ui)
 		new_status = min(new_status, master_ui.status)
 


### PR DESCRIPTION
NanoUI re-assigns src_object, rather than merely acquiring the host, causing ui_interact() updates to be called on the wrong object.
Fixes #11607.
