### PR TITLE
Closed a security loophole

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -4,7 +4,7 @@ var/list/forbidden_varedit_object_types = list(
 										/datum/feedback_variable			//Prevents people messing with feedback gathering
 									)
 
-var/list/VVlocked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "bound_x", "bound_y", "step_x", "step_y", "force_ending")
+var/list/VVlocked = list("vars", "holder", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "bound_x", "bound_y", "step_x", "step_y", "force_ending")
 var/list/VVicon_edit_lock = list("icon", "icon_state", "overlays", "underlays")
 var/list/VVckey_edit = list("key", "ckey")
 


### PR DESCRIPTION
Prevents people from modifying the holder var to steal admin ranks

Once again, excuse the branch name. Using browser github, so I can't remove any merge commits.
