### PR TITLE
Ninjas teleporter:  Checks Z levels and distance.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -121,6 +121,11 @@
 
 	if(T.contains_dense_objects())
 		H << "<span class='warning'>You cannot teleport to a location with solid objects.</span>"
+		return 0
+
+	if(T.z != H.z || get_dist(T, get_turf(H)) > world.view)
+		H << "<span class='warning'>You cannot teleport to such a distant object.</span>"
+		return 0
 
 	phase_out(H,get_turf(H))
 	H.forceMove(T)


### PR DESCRIPTION
Ninjas are able to use a camera console and teleport across the map.  This resolves that.

Plus Bonus return added where it was missing.

Kudos to EmpororJon for reporting it.  https://github.com/PolarisSS13/Polaris/issues/501 
