### PR TITLE
Fixes #11621

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -33,7 +33,9 @@
 					for(var/T in temp_tech)
 						files.UpdateTech(T, temp_tech[T])
 						user << "\The [loaded_item] had level [temp_tech[T]] in [T]."
-					loaded_item = null
+				else
+					user << "\The [loaded_item] was not reliable enough to advance research."
+				loaded_item = null
 				for(var/obj/I in contents)
 					for(var/mob/M in I.contents)
 						M.death()


### PR DESCRIPTION
- Fixes #11621 by ensuring reference to analyzed object is nulled even if the analyzed object is not reliable enough
- Adds feedback message that warns the user that analyzed item wasn't reliable enough.
