### PR TITLE
Adds the missing cargo department to the world Topic() manifest request.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -183,6 +183,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				"eng" = engineering_positions,
 				"med" = medical_positions,
 				"sci" = science_positions,
+				"car" = cargo_positions,
 				"civ" = civilian_positions,
 				"bot" = nonhuman_positions
 			)


### PR DESCRIPTION
Blame the manifest code for existing in 3 places.
