### PR TITLE
Misc fixes.

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -49,6 +49,9 @@
 /obj/machinery/computer/med_data/attack_hand(mob/user as mob)
 	if(..())
 		return
+	ui_interact(user)
+
+/obj/machinery/computer/med_data/ui_interact(mob/user)
 	var/dat
 	if (src.temp)
 		dat = text("<TT>[src.temp]</TT><BR><BR><A href='?src=\ref[src];temp=1'>Clear Screen</A>")

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -56,6 +56,9 @@
 /obj/machinery/computer/secure_data/attack_hand(mob/user as mob)
 	if(..())
 		return
+	ui_interact(user)
+
+/obj/machinery/computer/secure_data/ui_interact(user)
 	if (src.z > 6)
 		user << "<span class='warning'>Unable to establish a connection:</span> You're too far away from the station!"
 		return

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -39,6 +39,9 @@
 /obj/machinery/computer/skills/attack_hand(mob/user as mob)
 	if(..())
 		return
+	ui_interact(user)
+
+/obj/machinery/computer/skills/ui_interact(mob/user as mob)
 	if (src.z > 6)
 		user << "<span class='danger'>Unable to establish a connection:</span> You're too far away from the station!"
 		return

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -23,18 +23,18 @@
 	alarm_monitor.register_alarm(src, /obj/machinery/computer/station_alert/update_icon)
 	..()
 	if(monitor_type)
-		register(new monitor_type(src))
+		register_monitor(new monitor_type(src))
 
 /obj/machinery/computer/station_alert/Destroy()
 	. = ..()
-	unregister()
+	unregister_monitor()
 
 /obj/machinery/computer/station_alert/proc/register_monitor(var/datum/nano_module/alarm_monitor/monitor)
 	if(monitor.host != src)
 		return
 
 	alarm_monitor = monitor
-	alarm_monitor.register(src, /obj/machinery/computer/station_alert/update_icon)
+	alarm_monitor.register_alarm(src, /obj/machinery/computer/station_alert/update_icon)
 
 /obj/machinery/computer/station_alert/proc/unregister_monitor()
 	if(alarm_monitor)
@@ -43,22 +43,17 @@
 		alarm_monitor = null
 
 /obj/machinery/computer/station_alert/attack_ai(mob/user)
-	add_fingerprint(user)
-	if(stat & (BROKEN|NOPOWER))
-		return
-	interact(user)
-	return
+	ui_interact(user)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
-	add_fingerprint(user)
-	if(stat & (BROKEN|NOPOWER))
-		return
-	interact(user)
-	return
+	ui_interact(user)
 
-/obj/machinery/computer/station_alert/interact(mob/user)
+/obj/machinery/computer/station_alert/ui_interact(mob/user)
 	if(alarm_monitor)
 		alarm_monitor.ui_interact(user)
+
+/obj/machinery/computer/station_alert/nano_container()
+	return alarm_monitor
 
 /obj/machinery/computer/station_alert/update_icon()
 	icon_screen = initial(icon_screen)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -45,11 +45,19 @@
 	return 1
 
 /obj/proc/CouldUseTopic(var/mob/user)
-	if(!isAI(user) && src.Adjacent(user))
-		// We are -probably- in physical contact with the object, better than how Topics() previously did it and always applied fingerprints.
-		add_fingerprint(user)
+	user.AddTopicPrint(src)
+
+/mob/proc/AddTopicPrint(var/obj/target)
+	target.add_hiddenprint(src)
+
+/mob/living/AddTopicPrint(var/obj/target)
+	if(Adjacent(target))
+		target.add_fingerprint(src)
 	else
-		add_hiddenprint(user)
+		target.add_hiddenprint(src)
+
+/mob/living/silicon/ai/AddTopicPrint(var/obj/target)
+	target.add_hiddenprint(src)
 
 /obj/proc/CouldNotUseTopic(var/mob/user)
 	// Nada


### PR DESCRIPTION
The station alert console no longer uses the old interact proc() to open the window interface.
Makes the records computers use the ui_interact proc to show the window.
This fixes https://github.com/PolarisSS13/Polaris/issues/537.

The station alert console now registers alarms using the correct procs.

The proper fingerprint type should now be applied during Topic() call (this means that admin observer object NanoUI interactions now have a degree of logging).
