### PR TITLE
Fixes #10550

### DIFF
--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -48,13 +48,15 @@
 				victim.verbs -= V
 
 		var/mob/dead/observer/ghost = victim.ghostize(0)
-		ghost.spell_list = victim.spell_list//If they have spells, transfer them. Now we basically have a backup mob.
+		ghost.spell_list += victim.spell_list//If they have spells, transfer them. Now we basically have a backup mob.
 
 		caster.mind.transfer_to(victim)
-		victim.spell_list = list() //clear those out
+		for(var/spell/S in victim.spell_list) //get rid of spells the new way
+			victim.remove_spell(S) //This will make it so that players will not get the HUD and all that spell bugginess that caused copies of spells and stuff of that nature.
+
 		for(var/spell/S in caster.spell_list)
 			victim.add_spell(S) //Now they are inside the victim's body - this also generates the HUD
-		caster.spell_list = list() //clean that out as well
+			caster.remove_spell(S) //remove the spells from the caster
 
 		if(victim.mind.special_verbs.len)//To add all the special verbs for the original caster.
 			for(var/V in caster.mind.special_verbs)//Not too important but could come into play.


### PR DESCRIPTION
From what I could tell the bugs were caused by spells not being properly removed from players in the mindswap spell.

Before the code would simply do X.spell_list = list() to clear the spells from the victim and the caster and replace them onto the new target. While this worked before, the new spell HUD system doesn't appreciate it as the spell buttons aren't removed from players.

What this means is that the player could press the button to activate the spell and cause all kinds of fuckery (Like the spell being casted by someone else because add_spell set a new caster, victims getting copies of the same spell, shared cooldown, etc).
