### PR TITLE
Removes Stat() sleep.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -291,7 +291,7 @@
 			user.listed_turf = null
 		else
 			user.listed_turf = T
-			user.client.statpanel = T.name
+			user.client.statpanel = "Turf"
 	return
 
 /mob/proc/TurfAdjacent(var/turf/T)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -658,17 +658,17 @@
 			if(!TurfAdjacent(listed_turf))
 				listed_turf = null
 			else
-				statpanel(listed_turf.name, null, listed_turf)
-				for(var/atom/A in listed_turf)
-					if(!A.mouse_opacity)
-						continue
-					if(A.invisibility > see_invisible)
-						continue
-					if(is_type_in_list(A, shouldnt_see))
-						continue
-					statpanel(listed_turf.name, null, A)
+				if(statpanel("Turf"))
+					stat("\icon[listed_turf]", listed_turf.name)
+					for(var/atom/A in listed_turf)
+						if(!A.mouse_opacity)
+							continue
+						if(A.invisibility > see_invisible)
+							continue
+						if(is_type_in_list(A, shouldnt_see))
+							continue
+						stat(A)
 
-	sleep(4) //Prevent updating the stat panel for the next .4 seconds, prevents clientside latency from updates
 
 // facing verbs
 /mob/proc/canface()


### PR DESCRIPTION
Fixes a Stat() runtime that occasionally occur if the client was logged out when the sleep() was done sleeping.
Fixes delays when using alt+Turf click.

Makes the alt+Turf click panel only update when viewed instead. Seems like the better performance fix option for panels in general.
Makes the alt+Turf click panel always use the "Turf" name, consistency.
