### PR TITLE
IPC Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,8 +8,8 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if(O.status & ORGAN_ROBOT)
-			continue //robot limbs don't count towards shock and crit
+		if(O.status & ORGAN_ROBOT && !O.vital)
+			continue //*non-vital* robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -94,7 +94,7 @@
 
 /obj/item/organ/optical_sensor
 	name = "optical sensor"
-	organ_tag = "eyes"
+	organ_tag = "optics"
 	parent_organ = "head"
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "camera"


### PR DESCRIPTION
You should now be able to put an IPC down with four lethal egun shots to the chest/groin. Fixes #11381.

Damage to synthetic extremities, such as head, arms, and legs, still result only in the loss of the functionality of those body parts, as intended.

Fixes #11380
