### PR TITLE
Fixes #11661

### DIFF
--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -167,6 +167,7 @@
 	..()
 	temp_chem_holder = new()
 	temp_chem_holder.create_reagents(10)
+	temp_chem_holder.flags |= OPENCONTAINER
 	create_reagents(200)
 	if(mechanical)
 		connect()
@@ -623,7 +624,7 @@
 	set src in view(1)
 	if(usr.incapacitated())
 		return
-	
+
 	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
 		close_lid(usr)
 	return


### PR DESCRIPTION
Basically the issue was that the temporary reagent object in question was not an open
container, so when the hydrotray wanted to transfer reagents to it, it failed because it wasn't open.
