### PR TITLE
Makes the mining asteroid airless again.

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -3,6 +3,7 @@
 	name = "impassable rock"
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rock-dark"
+	blocks_air = 1
 
 /turf/simulated/mineral //wall piece
 	name = "Rock"


### PR DESCRIPTION
This turf surrounds the edges of the map.

air was "leaking" through it from off the map filling the zones that touch it with air.

fixes: #11365
