### PR TITLE
Removes oxygen_agent_b and volatile_fuel gases

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -40,7 +40,7 @@
 	..()
 	switch(filter_type)
 		if(0) //removing hydrocarbons
-			filtered_out = list("phoron", "oxygen_agent_b")
+			filtered_out = list("phoron")
 		if(1) //removing O2
 			filtered_out = list("oxygen")
 		if(2) //removing N2
@@ -95,10 +95,10 @@
 
 /obj/machinery/atmospherics/trinary/filter/process()
 	..()
-	
+
 	last_power_draw = 0
 	last_flow_rate = 0
-	
+
 	if((stat & (NOPOWER|BROKEN)) || !use_power)
 		return
 
@@ -206,7 +206,6 @@
 		switch(filter_type)
 			if(0) //removing hydrocarbons
 				filtered_out += "phoron"
-				filtered_out += "oxygen_agent_b"
 			if(1) //removing O2
 				filtered_out += "oxygen"
 			if(2) //removing N2

--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -21,11 +21,11 @@
 /decl/xgm_gas/phoron
 	id = "phoron"
 	name = "Phoron"
-	
+
 	//Note that this has a significant impact on TTV yield.
 	//Because it is so high, any leftover phoron soaks up a lot of heat and drops the yield pressure.
 	specific_heat = 200	// J/(mol*K)
-	
+
 	//Hypothetical group 14 (same as carbon), period 8 element.
 	//Using multiplicity rule, it's atomic number is 162
 	//and following a N/Z ratio of 1.5, the molar mass of a monatomic gas is:
@@ -35,14 +35,6 @@
 	overlay_limit = 0.7
 	flags = XGM_GAS_FUEL | XGM_GAS_CONTAMINANT
 
-/decl/xgm_gas/volatile_fuel
-	id = "volatile_fuel"
-	name = "Volatile Fuel"
-	specific_heat = 253	// J/(mol*K)	C8H18 gasoline. Isobaric, but good enough.
-	molar_mass = 0.114	// kg/mol. 		same.
-
-	flags = XGM_GAS_FUEL
-
 /decl/xgm_gas/sleeping_agent
 	id = "sleeping_agent"
 	name = "Sleeping Agent"
@@ -51,9 +43,3 @@
 
 	tile_overlay = "sleeping_agent"
 	overlay_limit = 1
-
-/decl/xgm_gas/oxygen_agent_b
-	id = "oxygen_agent_b"
-	name = "Oxygen Agent-B"	//what is this?
-	specific_heat = 300	// J/(mol*K)
-	molar_mass = 0.032	// kg/mol

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -69,7 +69,7 @@
 	var/datum/radio_frequency/radio_connection
 
 	var/list/TLV = list()
-	var/list/trace_gas = list("sleeping_agent", "volatile_fuel") //list of other gases that this air alarm is able to detect
+	var/list/trace_gas = list("sleeping_agent") //list of other gases that this air alarm is able to detect
 
 	var/danger_level = 0
 	var/pressure_dangerlevel = 0

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -17,7 +17,7 @@
 	var/minrate = 0
 	var/maxrate = 10 * ONE_ATMOSPHERE
 
-	var/list/scrubbing_gas = list("phoron", "carbon_dioxide", "sleeping_agent", "oxygen_agent_b")
+	var/list/scrubbing_gas = list("phoron", "carbon_dioxide", "sleeping_agent")
 
 /obj/machinery/portable_atmospherics/powered/scrubber/New()
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -58,7 +58,7 @@
 /datum/reagent/toxin/phoron/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return
-	T.assume_gas("volatile_fuel", volume, T20C)
+	T.assume_gas("phoron", volume, T20C)
 	remove_self(volume)
 
 /datum/reagent/toxin/cyanide //Fast and Lethal

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -667,7 +667,7 @@
 /datum/chemical_reaction/napalm/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/turf/location = get_turf(holder.my_atom.loc)
 	for(var/turf/simulated/floor/target_tile in range(0,location))
-		target_tile.assume_gas("volatile_fuel", created_volume, 400+T0C)
+		target_tile.assume_gas("phoron", created_volume, 400+T0C)
 		spawn (0) target_tile.hotspot_expose(700, 400)
 	holder.del_reagent("napalm")
 	return


### PR DESCRIPTION
- oxygen_agent_b wasn't used at all, except for filters which, for some reason filtered it in addition to phoron
- volatile_fuel was only used in two chemistry reactions as reaction result, it was replaced with gaseous phoron.

As a note for those who may say "Why remove it?" - it is not supported by most atmospherics machinery, such as most filters or scrubbers. Air alarms don't register it properly (they just show something is wrong, but don't display what it is, etc.
- Fixes #11855 
