### PR TITLE
Fixes

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -77,7 +77,7 @@
 		return
 	if (src.operating)
 		return
-	if (src.density && !issmall(M) && src.allowed(AM))
+	if (src.density && (!issmall(M) || ishuman(M)) && src.allowed(AM))
 		open()
 		if(src.check_access(null))
 			sleep(50)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -290,7 +290,7 @@
 						<a id='link[i]'
 						onmouseover='expand("item[i]","[M_job]","[M_name]","[M_rname]","--unused--","[M_key]","[M.lastKnownIP]",[is_antagonist],"\ref[M]")'
 						>
-						<span id='search><b>[i]'>[M_name] - [M_rname] - [M_key] ([M_job])</b></span>
+						<span id='search[i]'><b>[M_name] - [M_rname] - [M_key] ([M_job])</b></span>
 						</a>
 						<br><span id='item[i]'></span>
 					</td>

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -61,15 +61,13 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 		else
 			dat += "'#252536'>"
 		if(!isobserver(user))
-			dat += "<A href='?src=\ref[src];select=[i]'"
+			dat += "<A href='?src=\ref[src];select=[i]' style='display:block;text-decoration:none;'>"
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
 			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
-			if(!isobserver(user))
-				dat += ">"
 			dat += "<image src='[I.icon_state].png' style='border-style: none'>"
 		else
-			dat += "style='display:block;text-decoration:none;'>&nbsp;"
+			dat += "&nbsp;"
 
 		if(!isobserver(user))
 			dat += "</A>"

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -60,19 +60,22 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 			dat += "'#66CCFF'>"
 		else
 			dat += "'#252536'>"
-		dat += "<A href='?src=\ref[src];select=[i]'"
+		if(!isobserver(user))
+			dat += "<A href='?src=\ref[src];select=[i]'>"
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
 			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
-			dat += "><image src='[I.icon_state].png' style='border-style: none'>"
+			dat += "<image src='[I.icon_state].png' style='border-style: none'>"
 		else
 			dat += "style='display:block;text-decoration:none;'>&nbsp;"
 
-		dat += "</A></td>"
+		if(!isobserver(user))
+			dat += "</A>"
+		dat += "</td>"
 
 	dat += "</table><br>"
 
-	if(selected >= 0)
+	if(selected >= 0 && !isobserver(user))
 		dat += "<br><A href='?src=\ref[src];remove=0'>Remove Selected Piece</A>"
 	user << browse(dat,"window=boardgame;size=500x500")
 	onclose(usr, "boardgame")

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -61,10 +61,12 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 		else
 			dat += "'#252536'>"
 		if(!isobserver(user))
-			dat += "<A href='?src=\ref[src];select=[i]'>"
+			dat += "<A href='?src=\ref[src];select=[i]'"
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
 			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
+			if(!isobserver(user))
+				dat += ">"
 			dat += "<image src='[I.icon_state].png' style='border-style: none'>"
 		else
 			dat += "style='display:block;text-decoration:none;'>&nbsp;"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -144,11 +144,11 @@
 				return
 
 			if(!check_rights(R_ADMIN, 0))
+				var/datum/species/S = all_species[client.prefs.species]
 				if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
 					src << alert("You are currently not whitelisted to play [client.prefs.species].")
 					return 0
 
-				var/datum/species/S = all_species[client.prefs.species]
 				if(!(S.spawn_flags & CAN_JOIN))
 					src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
 					return 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -143,14 +143,14 @@
 				usr << "\red The round is either not ready, or has already finished..."
 				return
 
-			if(client.prefs.species != "Human" && !check_rights(R_ADMIN, 0))
-				if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
+			if(!check_rights(R_ADMIN, 0))
+				if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
 					src << alert("You are currently not whitelisted to play [client.prefs.species].")
 					return 0
 
 				var/datum/species/S = all_species[client.prefs.species]
-				if(!(S.spawn_flags & IS_WHITELISTED))
-					src << alert("Your current species,[client.prefs.species], is not available for play on the station.")
+				if(!(S.spawn_flags & CAN_JOIN))
+					src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
 					return 0
 
 			LateChoices()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -167,15 +167,14 @@
 				usr << "<span class='danger'>The station is currently exploding. Joining would go poorly.</span>"
 				return
 
-			if(client.prefs.species != "Human")
-				if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-					src << alert("You are currently not whitelisted to play [client.prefs.species].")
-					return 0
+			var/datum/species/S = all_species[client.prefs.species]
+			if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
+				src << alert("You are currently not whitelisted to play [client.prefs.species].")
+				return 0
 
-				var/datum/species/S = all_species[client.prefs.species]
-				if(!(S.spawn_flags & CAN_JOIN))
-					src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
-					return 0
+			if(!(S.spawn_flags & CAN_JOIN))
+				src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
+				return 0
 
 			AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
 			return


### PR DESCRIPTION
Allows small humans to bump windoors, fixes #11864. Changes latejoin checks to use the correct spawn flags, fixes #11801. Corrects a refactor artifact, fixes #11783. Changes the board game to not show topic links to observers, fixes #11776. Sorry for the messy commits.
