### PR TITLE
Species economy modifier now defaults to human if missing.

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -53,7 +53,11 @@
 			if(COMPANY_OPPOSED)		loyalty = 0.70
 
 	//give them an account in the station database
-	var/money_amount = (rand(5,50) + rand(5, 50)) * loyalty * economic_modifier * (H.species ? economic_species_modifier[H.species.type] : 2)
+	var/species_modifier = (H.species ? economic_species_modifier[H.species.type] : 2)
+	if(species_modifier == 0)
+		species_modifier = economic_species_modifier[/datum/species/human]
+	
+	var/money_amount = (rand(5,50) + rand(5, 50)) * loyalty * economic_modifier * species_modifier
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null)
 	if(H.mind)
 		var/remembered_info = ""

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -52,6 +52,7 @@
 												/datum/species/skrell	= 12,
 												/datum/species/tajaran	= 7,
 												/datum/species/unathi	= 7,
+												/datum/species/diona	= 5,
 												/datum/species/vox		= 1
 											)
 


### PR DESCRIPTION
Also adds a x5 entry for diona.
Fixes  #11891.
