### PR TITLE
Modifications to actor verb, orion trail, and board game.

### DIFF
--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -48,6 +48,9 @@ var/datum/antagonist/actor/actor
 	if(!MayRespawn(1))
 		return
 
+	var/choice = alert("Are you sure you'd like to join as an actor?", "Confirmation","Yes", "No")
+	if(choice != "Yes")
+		return
 
 	if(istype(usr,/mob/dead/observer) || istype(usr,/mob/new_player))
 		if(actor.current_antagonists.len >= actor.hard_cap)

--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -85,6 +85,8 @@
 	view = ORION_VIEW_MAIN
 
 /obj/machinery/computer/arcade/orion_trail/attack_hand(mob/user)
+	if(..())
+		return
 	var/dat = ""
 	if(event == null)
 		newgame()

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -89,19 +89,22 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 			dat += "'#66CCFF'>"
 		else
 			dat += "'#252536'>"
-		dat += "<A href='?src=\ref[src];select=[i];person=\ref[user]'"
+		if(!isobserver(user))
+			dat += "<A href='?src=\ref[src];select=[i]' style='display:block;text-decoration:none;'>"
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
 			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
-			dat += "><image src='[I.icon_state].png' style='border-style: none'>"
+			dat += "<image src='[I.icon_state].png' style='border-style: none'>"
 		else
-			dat += "style='display:block;text-decoration:none;'>&nbsp;"
+			dat += "&nbsp;"
 
-		dat += "</A></td>"
+		if(!isobserver(user))
+			dat += "</A>"
+		dat += "</td>"
 
 	dat += "</table><br>"
 
-	if(selected >= 0)
+	if(selected >= 0 && !isobserver(user))
 		dat += "<br><A href='?src=\ref[src];remove=0'>Remove Selected Piece</A>"
 	user << browse(dat,"window=boardgame;size=500x500")
 	onclose(usr, "boardgame")

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -1,8 +1,3 @@
-/*TODO:
-	implement icon loading that is efficient using browse_rsc
-	implement being able to move pieces
-*/
-
 /obj/item/weapon/board
 	name = "board"
 	desc = "A standard 12' checkerboard. Well used."
@@ -14,12 +9,25 @@
 	var/board = list()
 	var/selected = -1
 
+/obj/item/weapon/board/New()
+	..()
+	var i
+	for(i = 0; i < 12; i++)
+		new /obj/item/weapon/checker(src.loc)
+		new /obj/item/weapon/checker/red(src.loc)
+
 /obj/item/weapon/board/examine(mob/user, var/distance = -1)
 	if(in_range(user,src))
 		user.set_machine(src)
 		interact(user)
 		return
 	..()
+
+/obj/item/weapon/board/attack_hand(mob/living/carbon/human/M as mob)
+	if(M.machine == src)
+		..()
+	else
+		src.examine(M)
 
 obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 	if(I.w_class != 1) //only small stuff

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -30,28 +30,49 @@
 		src.examine(M)
 
 obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
+	if(!addPiece(I,user))
+		..()
+
+/obj/item/weapon/board/proc/addPiece(obj/item/I as obj, mob/user as mob, var/tile = 0)
 	if(I.w_class != 1) //only small stuff
 		user.show_message("<span class='warning'>\The [I] is too big to be used as a board piece.</span>")
-		return
+		return 0
 	if(num == 64)
 		user.show_message("<span class='warning'>\The [src] is already full!</span>")
-		return
+		return 0
+	if(tile > 0 && board["[tile]"])
+		user.show_message("<span class='warning'>That space is already filled!</span>")
+		return 0
+	if(!user.Adjacent(src))
+		return 0
+
 	user.drop_from_inventory(I)
 	I.forceMove(src)
 	num++
 
+
 	if(!board_icons["[I.icon] [I.icon_state]"])
 		board_icons["[I.icon] [I.icon_state]"] = new /icon(I.icon,I.icon_state)
 
-	var i;
-	for(i=0;i<64;i++)
-		if(!board["[i]"])
-			board["[i]"] = I
-			break
+	if(tile == 0)
+		var i;
+		for(i=0;i<64;i++)
+			if(!board["[i]"])
+				board["[i]"] = I
+				break
+	else
+		board["[tile]"] = I
 
 	src.updateDialog()
 
+	return 1
+
+
 /obj/item/weapon/board/interact(mob/user as mob)
+	if(user.incapacitated(INCAPACITATION_DISABLED) || (!isAI(user) && !user.Adjacent(src))) //can't see if you arent conscious. If you are not an AI you can't see it unless you are next to it, either.
+		user << browse(null, "window=boardgame")
+		user.unset_machine()
+		return
 
 	var/dat = "<HTML>"
 	dat += "<table border='0'>"
@@ -68,7 +89,7 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 			dat += "'#66CCFF'>"
 		else
 			dat += "'#252536'>"
-		dat += "<A href='?src=\ref[src];select=[i]'"
+		dat += "<A href='?src=\ref[src];select=[i];person=\ref[user]'"
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
 			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
@@ -86,42 +107,61 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 	onclose(usr, "boardgame")
 
 /obj/item/weapon/board/Topic(href, href_list)
-	if(href_list["select"])
-		var/s = href_list["select"]
-		var/obj/item/I = board["[s]"]
-		if(selected >= 0)
-			if(I) //cant put items on other items.
-				return
+	if(!usr.Adjacent(src))
+		usr.unset_machine()
+		usr << browse(null, "window=boardgame")
+		return
+
+	if(!usr.incapacitated()) //you can't move pieces if you can't move
+		if(href_list["select"])
+			var/s = href_list["select"]
+			var/obj/item/I = board["[s]"]
+			if(selected >= 0)
+				//check to see if clicked on tile is currently selected one
+				if(text2num(s) == selected)
+					selected = 0 //deselect it
+					return
+
+				if(I) //cant put items on other items.
+					return
 
 			//put item in new spot.
-			I = board["[selected]"]
+				I = board["[selected]"]
+				board["[selected]"] = null
+				board -= "[selected]"
+				board -= null
+				board["[s]"] = I
+				selected = -1
+			else
+				if(I)
+					selected = text2num(s)
+				else
+					var/mob/living/carbon/human/H = locate(href_list["person"])
+					if(!istype(H))
+						return
+					var/obj/item/O = H.get_active_hand()
+					if(!O)
+						return
+					addPiece(O,H,text2num(s))
+		if(href_list["remove"])
+			var/obj/item/I = board["[selected]"]
 			board["[selected]"] = null
 			board -= "[selected]"
 			board -= null
-			board["[s]"] = I
+			I.forceMove(src.loc)
+			num--
 			selected = -1
-		else
-			if(I)
-				selected = text2num(s)
-	if(href_list["remove"])
-		var/obj/item/I = board["[selected]"]
-		board["[selected]"] = null
-		board -= "[selected]"
-		board -= null
-		I.forceMove(src.loc)
-		num--
-		selected = -1
-		var j
-		for(j=0;j<64;j++)
-			if(board["[j]"])
-				var/obj/item/K = board["[j]"]
-				if(K.icon == I.icon && cmptext(K.icon_state,I.icon_state))
-					src.updateDialog()
-					return
-		//Didn't find it in use, remove it and allow GC to delete it.
-		board_icons["[I.icon] [I.icon_state]"] = null
-		board_icons -= "[I.icon] [I.icon_state]"
-		board_icons -= null
+			var j
+			for(j=0;j<64;j++)
+				if(board["[j]"])
+					var/obj/item/K = board["[j]"]
+					if(K.icon == I.icon && cmptext(K.icon_state,I.icon_state))
+						src.updateDialog()
+						return
+			//Didn't find it in use, remove it and allow GC to delete it.
+			board_icons["[I.icon] [I.icon_state]"] = null
+			board_icons -= "[I.icon] [I.icon_state]"
+			board_icons -= null
 	src.updateDialog()
 
 /obj/item/weapon/checker/


### PR DESCRIPTION
Orion Trail only works when power is on now.
'Join as Actor' verb will now prompt you to make sure.
Clicking on the boardgame will now firstly make you view it. Clicking on it again while you are already viewing it will make you pick it up. IMO a less awkward way to use it. You can still examine the board to view it.
Boardgame now spawns 12 red and black checkers along with the board itself (24 in all). This is done in the New() proc.
