### PR TITLE
Can use items on roller/optable people on help intent

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -110,7 +110,6 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 
 	if (user.a_intent == I_HELP)
 		user << "<span class='warning'>You can't see any useful way to use [tool] on [M].</span>"
-		return 1
 	return 0
 
 proc/sort_surgeries()


### PR DESCRIPTION
Failing to find a valid surgery step now doesn't prevent attack() from running its course.
This does allow you to mutilate patient if you get step wrong, but also now you don't have to pull patient off the table to apply bandages / injections etc.
Visible indications (on examine) of surgery state (incision -> open incision) should help with getting lost in surgery.
Fixes confirmed parts of #11881
