### PR TITLE
Limb reattachment heals missing limbs now

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -191,6 +191,7 @@
 			for(var/datum/wound/lost_limb/W in parent.wounds)
 				parent.wounds -= W
 				qdel(W)
+				break
 			parent.update_damages()
 
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -174,11 +174,11 @@
 
 /obj/item/organ/external/replaced(var/mob/living/carbon/human/target)
 	owner = target
+	forceMove(owner)
 	if(istype(owner))
 		owner.organs_by_name[limb_name] = src
 		owner.organs |= src
 		for(var/obj/item/organ/organ in src)
-			organ.loc = owner
 			organ.replaced(owner,src)
 
 	if(parent_organ)
@@ -187,6 +187,12 @@
 			if(!parent.children)
 				parent.children = list()
 			parent.children.Add(src)
+			//Remove all stump wounds since limb is not missing anymore
+			for(var/datum/wound/lost_limb/W in parent.wounds)
+				parent.wounds -= W
+				qdel(W)
+			parent.update_damages()
+
 
 /obj/item/organ/external/robotize()
 	..()
@@ -715,7 +721,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	removed(null, ignore_children)
 	victim.traumatic_shock += 60
 
-	wounds.Cut()
 	if(parent_organ)
 		var/datum/wound/lost_limb/W = new (src, disintegrate, clean)
 		if(clean)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -32,7 +32,6 @@
 		"<span class='notice'>You have attached [target]'s [E.name] to the [E.amputation_point].</span>")
 		user.drop_from_inventory(E)
 		E.replaced(target)
-		E.loc = target
 		target.update_body()
 		target.updatehealth()
 		target.UpdateDamageIcon()


### PR DESCRIPTION
Changes to limb reattachment - now when limb is attached, wound from it not being there is removed. Because you know, it's there now. No more bleeding stumps with limbs already attached.

Also fixes limbs instahealing when cut / reattached. Wounds used to be Cut() to prevent fantom wounds but, it's not needed anymore because whole limb is removed.
Also moved moving organs inside replaced() since it was called next to it anyway, and not like you can replace  organ without moving it to human. Also forceMove()
