### PR TITLE
Admin observers now have an all access id.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -193,6 +193,15 @@
 /mob/proc/GetIdCard()
 	return null
 
+var/obj/item/weapon/card/id/all_access/ghost_all_access
+/mob/dead/observer/GetIdCard()
+	if(!is_admin(src))
+		return
+
+	if(!ghost_all_access)
+		ghost_all_access = new()
+	return ghost_all_access
+
 /mob/living/bot/GetIdCard()
 	return botcard
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -257,3 +257,15 @@ var/const/NO_EMAG_ACT = -50
 /obj/item/weapon/card/id/centcom/ERT/New()
 	..()
 	access |= get_all_station_access()
+
+/obj/item/weapon/card/id/all_access
+	name = "\improper Administrator's spare ID"
+	desc = "The spare ID of the Lord of Lords himself."
+	icon_state = "data"
+	item_state = "tdgreen"
+	registered_name = "Administrator"
+	assignment = "Administrator"
+/obj/item/weapon/card/id/all_access/New()
+	access = get_access_ids()
+	..()
+    


### PR DESCRIPTION
Gives them further control over modular computers, among other things.
