### PR TITLE
Travis change:  Faster Unit Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ language: c
 sudo: false
 
 env:
-  BYOND_MAJOR="509"
-  BYOND_MINOR="1318"
-  MACRO_COUNT=1048
+  global:
+    BYOND_MAJOR="509"
+    BYOND_MINOR="1318"
+    MACRO_COUNT=1048
+  matrix:
+    - MODE="-UNIT_TEST_FAST"
+    - MODE="-_JUST_COMPILE"
   
 cache:
   directories:
@@ -41,8 +45,4 @@ script:
   - python tools/GenerateChangelog/ss13_genchangelog.py html/changelog.html html/changelogs
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
   - cp config/example/* config/
-  - scripts/dm.sh -DUNIT_TEST baystation12.dme
-  - DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt
-  - grep "All Unit Tests Passed" log.txt
-  - (! grep "runtime error:" log.txt)
-  - (! grep 'Process scheduler caught exception processing' log.txt)
+  - scripts/dm.sh ${MODE} baystation12.dme

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -16,6 +16,8 @@
 //
 
 
+#ifndef UNIT_TEST_NO_ZAS
+// We don't run this code if there is no ZAS checks.  Usually this is because of a test map to speed up other unit_test
 
 datum/unit_test/human_breath
 	name = "MOB: Human Suffocates in Space"
@@ -30,6 +32,11 @@ datum/unit_test/human_breath/start_test()
 
 	if(!istype(T, /turf/space))	//If the above isn't a space turf then we force it to find one will most likely pick 1,1,1
 		T = locate(/turf/space)
+		if(!istype(T, /turf/space))
+			fail("Unable to locate /turf/space.")
+			async = 0
+			return 0
+
 
 	H = new(T)
 
@@ -53,6 +60,7 @@ datum/unit_test/human_breath/check_result()
 	return 1	// return 1 to show we're done and don't want to recheck the result.
 
 // ============================================================================
+#endif
 
 //#define BRUTE     "brute"
 //#define BURN      "fire"

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -127,6 +127,8 @@ proc/initialize_unit_tests()
 
 		if(isnull(d.start_test()))		// Start the test.
 			d.fail("Test Runtimed")
+			continue
+
 		if(d.async)				// If it's async then we'll need to check back on it later.
 			async_test.Add(d)
 		total_unit_tests++

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -1,3 +1,4 @@
+#ifndef UNIT_TEST_NO_ZAS
 /*
  *
  *  Zas Unit Tests.
@@ -27,6 +28,7 @@ datum/unit_test/zas_area_test/start_test()
 
 	if(isnull(test))
 		fail("Check Runtimed")
+		return 0
 
 	if(test["result"] == SUCCESS)
 		pass(test["msg"])
@@ -219,3 +221,4 @@ datum/unit_test/zas_supply_shuttle_moved/check_result()
 #undef UT_NORMAL_COLD
 #undef SUCCESS
 #undef FAILURE
+#endif

--- a/maps/testmap/test-10x10.dmm
+++ b/maps/testmap/test-10x10.dmm
@@ -1,0 +1,21 @@
+"a" = (/turf/simulated/wall/iron,/area/quartermaster/storage)
+"b" = (/obj/machinery/power/smes/magical,/obj/structure/cable/pink{dir = 8},/turf/simulated/floor/fixed,/area/quartermaster/storage)
+"c" = (/obj/machinery/power/apc/super,/obj/machinery/power/terminal,/obj/structure/cable/pink{dir = 4},/turf/simulated/floor/fixed,/area/quartermaster/storage)
+"d" = (/obj/machinery/light/built,/turf/simulated/floor/fixed,/area/quartermaster/storage)
+"e" = (/turf/simulated/floor/fixed,/area/quartermaster/storage,/obj/effect/landmark{name = "tdome1"})
+"f" = (/obj/effect/landmark/start,/turf/simulated/floor/fixed,/area/quartermaster/storage)
+
+
+(1,1,1) = {"
+aaaaaaaaaa
+abcdeeedea
+aeeeeeeeea
+adeeeeeeda
+aeeeeeeeea
+aeeeeeeeea
+adeeeeeeda
+aeeeeeeeea
+afedeeedea
+aaaaaaaaaa
+"}
+

--- a/scripts/dm.sh
+++ b/scripts/dm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 dmepath=""
 retval=1
+UNIT_TEST=0
 
 for var; do
     if [[ $var != -* && $var == *.dme ]]; then
@@ -27,13 +27,26 @@ fi
 
 for var; do
     arg=$(echo $var | sed -r 's/^.{2}//')
-    if [[ $var == -D* ]]; then
+    if [[ $var == -UNIT_TEST_FAST ]]; then
+	sed -i '1s/^/#define MAP_OVERRIDE\n/' $dmepath.mdme
+	sed -i '1s/^/#define UNIT_TEST\n/' $dmepath.mdme
+	sed -i '1s/^/#define UNIT_TEST_NO_ZAS\n/' $dmepath.mdme
+	grep -v "\.dmm" $dmepath.mdme > $dmepath.mdme_nomap
+	mv $dmepath.mdme_nomap $dmepath.mdme
+	sed -i 's!// BEGIN_INCLUDE!// BEGIN_INCLUDE\n#include "maps/testmap/test-10x10.dmm"!' $dmepath.mdme
+	UNIT_TEST=1
+    elif [[ $var == -UNIT_TEST ]]; then
+	sed -i '1s/^/#define UNIT_TEST\n/' $dmepath.mdme
+	UNIT_TEST=1
+    elif [[ $var == -R ]]; then
+	grep -v "\.dmm" $dmepath.mdme > $dmepath.mdme
+    elif [[ $var == -D* ]]; then
         sed -i '1s!^!#define '$arg'\n!' $dmepath.mdme
     elif [[ $var == -I* ]]; then
         sed -i 's!// BEGIN_INCLUDE!// BEGIN_INCLUDE\n#include "'$arg'"!' $dmepath.mdme
     elif [[ $var == -M* ]]; then
         sed -i '1s/^/#define MAP_OVERRIDE\n/' $dmepath.mdme
-        sed -i 's!// BEGIN_INCLUDE!// BEGIN_INCLUDE\n#include "_maps\\'$arg'.dm"!' $dmepath.mdme
+        sed -i 's!// BEGIN_INCLUDE!// BEGIN_INCLUDE\n#include "maps\\'$arg'.dmm"!' $dmepath.mdme
     fi
 done
 
@@ -44,12 +57,19 @@ if [[ $DM == "" ]]; then
     exit 3
 fi
 
+set -ev
 "$DM" $dmepath.mdme
-retval=$?
-
+set +ve
 mv $dmepath.mdme.dmb $dmepath.dmb
 mv $dmepath.mdme.rsc $dmepath.rsc
 
 rm $dmepath.mdme
 
-exit $retval
+if [[ $UNIT_TEST -eq 1 ]];then
+    set -ev
+    DreamDaemon $dmepath.dmb -invisible -trusted -core 2>&1 | tee log.txt
+    grep -q "All Unit Tests Passed" log.txt
+    (! grep "runtime error:" log.txt)
+    (! grep 'Process scheduler caught exception processing' log.txt)
+    set +ve
+fi


### PR DESCRIPTION
Forces Travis to not run test that require a full map.
But also compiles the version with the full map (but not run unit tests against it).

SInce we're using a unit test with only a 10x10 map the game server starts up instantly.  We may need to revisit this if doing so causes runtimes later on.

Includes a 10x10 test map, I've not used it for anything but unit testing so no idea if APC's and Lights are wired correctly.

Moves the unit testing into dm.sh you can either use -UNIT_TEST or -UNIT_TEST_FAST the option -_JUST_COMPILE is a dummy option and is only shown for pretty output in travis's website.

Without worrying about ZAS or other slow unit tests this runs in 2 minutes or so.
