### PR TITLE
Event manager tweaks.

### DIFF
--- a/code/controllers/Processes/event.dm
+++ b/code/controllers/Processes/event.dm
@@ -3,4 +3,13 @@
 	schedule_interval = 20 // every 2 seconds
 
 /datum/controller/process/event/doWork()
-	event_manager.process()
+	for(last_object in event_manager.active_events)
+		var/datum/event/E = last_object
+		E.process()
+		SCHECK
+
+	for(var/i = EVENT_LEVEL_MUNDANE to EVENT_LEVEL_MAJOR)
+		last_object = event_manager.event_containers[i]
+		var/list/datum/event_container/EC = last_object
+		EC.process()
+		SCHECK

--- a/code/modules/events/camera_damage.dm
+++ b/code/modules/events/camera_damage.dm
@@ -30,7 +30,7 @@
 	var/obj/machinery/camera/C = pick(cameranet.cameras)
 	if(is_valid_camera(C))
 		return C
-	return acquire_random_camera(remaining_attempts--)
+	return acquire_random_camera(remaining_attempts-1)
 
 /datum/event/camera_damage/proc/is_valid_camera(var/obj/machinery/camera/C)
 	// Only return a functional camera, not installed in a silicon, and that exists somewhere players have access

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -23,14 +23,6 @@
 /datum/event_manager/New()
 	allEvents = typesof(/datum/event) - /datum/event
 
-/datum/event_manager/proc/process()
-	for(var/datum/event/E in event_manager.active_events)
-		E.process()
-
-	for(var/i = EVENT_LEVEL_MUNDANE to EVENT_LEVEL_MAJOR)
-		var/list/datum/event_container/EC = event_containers[i]
-		EC.process()
-
 /datum/event_manager/proc/event_complete(var/datum/event/E)
 	if(!E.event_meta || !E.severity)	// datum/event is used here and there for random reasons, maintaining "backwards compatibility"
 		log_debug("Event of '[E.type]' with missing meta-data has completed.")


### PR DESCRIPTION
Moves the event manager processing into the process itself.
Ensures the last_object var is properly set in case of issues, making it easier to tell which event caused it.
Also fixes a potential risk of the camera damage event looping forever.
