### PR TITLE
SMESs will no longer turn themselves off when they run out of power

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -146,10 +146,6 @@
 		charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
 
 		add_avail(output_used)				// add output to powernet (smes side)
-
-		if(output_used < 0.0001)			// either from no charge or set to 0
-			outputting(0)
-			investigate_log("lost power and turned <font color='red'>off</font>","singulo")
 	else if(output_attempt && output_level > 0)
 		outputting = 1
 	else


### PR DESCRIPTION
- Instead, they simply won't output until some power is regained.
- This prevents, for example, solar SMESs from shutting down when they reach zero charge when the array is shadowed by the station. The SMES simply won't output any power until the array begins generating again.

NOTE: This does not cause the SMES to magically generate power or something. The SMES simply won't change it's output setting when running out of power.
