### PR TITLE
Modular computer fixes

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -80,6 +80,7 @@
 		return
 	..()
 	machinery_computer.update_icon()
+	machinery_computer.use_power = 0
 	return
 
 // Tesla links only work on machinery types, so we'll override the default try_install_component() proc
@@ -94,6 +95,7 @@
 		// Consoles don't usually have internal power source, so we can't disable tesla link in them.
 		if(istype(machinery_computer, /obj/machinery/modular_computer/console))
 			L.critical = 1
+			L.enabled = 1
 		found = 1
 	..(user, H, found)
 

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -16,25 +16,16 @@
 
 /datum/nano_module/computer_configurator
 	name = "NTOS Computer Configuration Tool"
-	var/obj/machinery/modular_computer/stationary = null
 	var/obj/item/modular_computer/movable = null
 
 /datum/nano_module/computer_configurator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(program)
-		stationary = program.computer
 		movable = program.computer
-
-	if(!istype(stationary))
-		stationary = null
 	if(!istype(movable))
 		movable = null
 
-	if(istype(movable, /obj/item/modular_computer/processor))
-		var/obj/item/modular_computer/processor/P = movable
-		stationary = P.machinery_computer
-
 	// No computer connection, we can't get data from that.
-	if(!movable && !stationary)
+	if(!movable)
 		return 0
 
 	var/list/data = list()
@@ -42,27 +33,15 @@
 	if(program)
 		data = program.get_header_data()
 
-	var/list/hardware = list()
-	if(stationary)
-		if(stationary.cpu)
-			movable = stationary.cpu
-			hardware.Add(stationary.tesla_link)
-		else
-			return
+	var/list/hardware = movable.get_all_components()
 
-	if(movable)
-		hardware.Add(movable.network_card)
-		hardware.Add(movable.hard_drive)
-		hardware.Add(movable.card_slot)
-		hardware.Add(movable.nano_printer)
-		hardware.Add(movable.battery_module)
-		data["disk_size"] = movable.hard_drive.max_capacity
-		data["disk_used"] = movable.hard_drive.used_capacity
-		data["power_usage"] = movable.last_power_usage
-		data["battery_exists"] = movable.battery_module ? 1 : 0
-		if(movable.battery_module)
-			data["battery_rating"] = movable.battery_module.battery.maxcharge
-			data["battery_percent"] = round(movable.battery_module.battery.percent())
+	data["disk_size"] = movable.hard_drive.max_capacity
+	data["disk_used"] = movable.hard_drive.used_capacity
+	data["power_usage"] = movable.last_power_usage
+	data["battery_exists"] = movable.battery_module ? 1 : 0
+	if(movable.battery_module)
+		data["battery_rating"] = movable.battery_module.battery.maxcharge
+		data["battery_percent"] = round(movable.battery_module.battery.percent())
 
 	var/list/all_entries[0]
 	for(var/obj/item/weapon/computer_hardware/H in hardware)


### PR DESCRIPTION
- Tesla link is now correctly enabled when being installed into a console. Fixes #11974
- Tesla link now correctly stops using power when the computer shuts down.
- Configurator program now uses much better method to obtain list of components. This method takes into account possible hardware additions in the future.
