### PR TITLE
Tweaks and fixes MKII

### DIFF
--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -48,7 +48,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 			if (evac)
 				emergency_shuttle_docked.Announce("The Emergency Shuttle has docked with the station. You have approximately [round(estimate_launch_time()/60,1)] minutes to board the Emergency Shuttle.")
 			else
-				priority_announcement.Announce("The scheduled Crew Transfer Shuttle has docked with the station. It will depart in approximately [round(emergency_shuttle.estimate_launch_time()/60,1)] minutes.")
+				priority_announcement.Announce("The scheduled Crew Transfer Shuttle to [dock_name] has docked with the station. It will depart in approximately [round(emergency_shuttle.estimate_launch_time()/60,1)] minutes.")
 
 		//arm the escape pods
 		if (evac)
@@ -94,7 +94,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	//reset the shuttle transit time if we need to
 	shuttle.move_time = SHUTTLE_TRANSIT_DURATION
 
-	priority_announcement.Announce("A crew transfer has been scheduled. The shuttle has been called. It will arrive in approximately [round(estimate_arrival_time()/60)] minutes.")
+	priority_announcement.Announce("A crew transfer to [dock_name] has been scheduled. The shuttle has been called. It will arrive in approximately [round(estimate_arrival_time()/60)] minutes.")
 
 //recalls the shuttle
 /datum/emergency_shuttle_controller/proc/recall()

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -33,7 +33,7 @@
 	if (!iswall(W) || !isturf(user.loc))
 		user << "<span class='warning'>You can't place this here!</span>"
 		return
-	
+
 	var/placement_dir = get_dir(user, W)
 	if (!(placement_dir in cardinal))
 		user << "<span class='warning'>You must stand directly in front of the wall you wish to place that on.</span>"
@@ -43,7 +43,7 @@
 	var/stuff_on_wall = 0
 	if (locate(/obj/structure/sign/poster) in W)
 		stuff_on_wall = 1
-	
+
 	//crude, but will cover most cases. We could do stuff like check pixel_x/y but it's not really worth it.
 	for (var/dir in cardinal)
 		var/turf/T = get_step(W, dir)
@@ -61,7 +61,7 @@
 
 	flick("poster_being_set", P)
 	//playsound(W, 'sound/items/poster_being_created.ogg', 100, 1) //why the hell does placing a poster make printer sounds?
-	
+
 	var/oldsrc = src //get a reference to src so we can delete it after detaching ourselves
 	src = null
 	spawn(17)
@@ -71,7 +71,7 @@
 			user << "<span class='notice'>You place the poster!</span>"
 		else
 			P.roll_and_drop(P.loc)
-	
+
 	qdel(oldsrc)	//delete it now to cut down on sanity checks afterwards. Agouri's code supports rerolling it anyway
 
 //############################## THE ACTUAL DECALS ###########################
@@ -90,11 +90,11 @@
 
 	if(!serial)
 		serial = rand(1, poster_designs.len) //use a random serial if none is given
-	
+
 	serial_number = serial
 	var/datum/poster/design = poster_designs[serial_number]
 	set_poster(design)
-	
+
 	switch (placement_dir)
 		if (NORTH)
 			pixel_x = 0
@@ -133,22 +133,22 @@
 
 
 /obj/structure/sign/poster/attack_hand(mob/user as mob)
+
 	if(ruined)
 		return
-	var/temp_loc = user.loc
-	switch(alert("Do I want to rip the poster from the wall?","You think...","Yes","No"))
-		if("Yes")
-			if(user.loc != temp_loc)
-				return
-			visible_message("<span class='warning'>[user] rips [src] in a single, decisive motion!</span>" )
-			playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
-			ruined = 1
-			icon_state = "poster_ripped"
-			name = "ripped poster"
-			desc = "You can't make out anything from the poster's original print. It's ruined."
-			add_fingerprint(user)
-		if("No")
+
+	if(alert("Do I want to rip the poster from the wall?","You think...","Yes","No") == "Yes")
+
+		if(ruined || !user.Adjacent(src))
 			return
+
+		visible_message("<span class='warning'>[user] rips [src] in a single, decisive motion!</span>" )
+		playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
+		ruined = 1
+		icon_state = "poster_ripped"
+		name = "ripped poster"
+		desc = "You can't make out anything from the poster's original print. It's ruined."
+		add_fingerprint(user)
 
 /obj/structure/sign/poster/proc/roll_and_drop(turf/newloc)
 	var/obj/item/weapon/contraband/poster/P = new(src, serial_number)

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -142,7 +142,7 @@
 		if(ruined || !user.Adjacent(src))
 			return
 
-		visible_message("<span class='warning'>[user] rips [src] in a single, decisive motion!</span>" )
+		visible_message("<span class='warning'>\The [user] rips \the [src] in a single, decisive motion!</span>" )
 		playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
 		ruined = 1
 		icon_state = "poster_ripped"

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -14,6 +14,7 @@
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.25 // 5 when thrown with weight 20 (steel)
 	var/loaded      //Descriptive string for currently loaded food object.
+	var/scoop_food = 1
 
 /obj/item/weapon/material/kitchen/utensil/New()
 	..()
@@ -80,6 +81,7 @@
 	desc = "A knife for eating with. Can cut through any food."
 	icon_state = "knife"
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
+	scoop_food = 0
 
 // Identical to the tactical knife but nowhere near as stabby.
 // Kind of like the toy esword compared to the real thing.

--- a/code/global.dm
+++ b/code/global.dm
@@ -29,6 +29,7 @@ var/diary               = null
 var/href_logfile        = null
 var/station_name        = "NSS Exodus"
 var/station_short       = "Exodus"
+var/const/dock_name     = "N.A.S. Crescent"
 var/const/boss_name     = "Central Command"
 var/const/boss_short    = "Centcomm"
 var/const/company_name  = "NanoTrasen"

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -12,20 +12,18 @@
 
 /obj/item/clothing/mask/breath/proc/adjust_mask(mob/user)
 	if(user.canmove && !user.stat)
-		if(!src.hanging)
-			src.hanging = !src.hanging
-			gas_transfer_coefficient = 1 //gas is now escaping to the turf and vice versa
-			item_flags &= ~(AIRTIGHT)
-			body_parts_covered = ~(FACE)
+		src.hanging = !src.hanging
+		if (src.hanging)
+			gas_transfer_coefficient = 1
+			body_parts_covered = body_parts_covered & ~FACE
+			item_flags = item_flags & ~AIRTIGHT
 			icon_state = "breathdown"
 			user << "Your mask is now hanging on your neck."
-
 		else
-			src.hanging = !src.hanging
 			gas_transfer_coefficient = initial(gas_transfer_coefficient)
-			item_flags |= AIRTIGHT
-			body_parts_covered |= FACE
-			icon_state = "breath"
+			body_parts_covered = initial(body_parts_covered)
+			item_flags = initial(item_flags)
+			icon_state = initial(icon_state)
 			user << "You pull the mask up to cover your face."
 		update_clothing_icon()
 

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -5,19 +5,19 @@
 */
 
 /datum/language
-	var/name = "an unknown language" // Fluff name of language if any.
-	var/desc = "A language."         // Short description for 'Check Languages'.
-	var/speech_verb = "says"         // 'says', 'hisses', 'farts'.
-	var/ask_verb = "asks"            // Used when sentence ends in a ?
-	var/exclaim_verb = "exclaims"    // Used when sentence ends in a !
-	var/whisper_verb                 // Optional. When not specified speech_verb + quietly/softly is used instead.
-	var/signlang_verb = list()       // list of emotes that might be displayed if this language has NONVERBAL or SIGNLANG flags
-	var/colour = "body"              // CSS style to use for strings in this language.
-	var/key = "x"                    // Character used to speak in language eg. :o for Unathi.
-	var/flags = 0                    // Various language flags.
-	var/native                       // If set, non-native speakers will have trouble speaking.
-	var/list/syllables               // Used when scrambling text for a non-speaker.
-	var/list/space_chance = 55       // Likelihood of getting a space in the random scramble string
+	var/name = "an unknown language"  // Fluff name of language if any.
+	var/desc = "A language."          // Short description for 'Check Languages'.
+	var/speech_verb = "says"          // 'says', 'hisses', 'farts'.
+	var/ask_verb = "asks"             // Used when sentence ends in a ?
+	var/exclaim_verb = "exclaims"     // Used when sentence ends in a !
+	var/whisper_verb = "whispers"     // Optional. When not specified speech_verb + quietly/softly is used instead.
+	var/signlang_verb = list("signs") // list of emotes that might be displayed if this language has NONVERBAL or SIGNLANG flags
+	var/colour = "body"               // CSS style to use for strings in this language.
+	var/key = "x"                     // Character used to speak in language eg. :o for Unathi.
+	var/flags = 0                     // Various language flags.
+	var/native                        // If set, non-native speakers will have trouble speaking.
+	var/list/syllables                // Used when scrambling text for a non-speaker.
+	var/list/space_chance = 55        // Likelihood of getting a space in the random scramble string
 
 /datum/language/proc/get_random_name(var/gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	if(!syllables || !syllables.len)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,7 +8,7 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if(O.status & ORGAN_ROBOT && !O.vital)
+		if((O.status & ORGAN_ROBOT) && !O.vital)
 			continue //*non-vital* robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -89,15 +89,20 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/proc/get_icon(var/skeletal)
 
-	var/gender
+	var/gender = "f"
+	if(owner && owner.gender == MALE)
+		gender = "m"
+
 	if(force_icon)
-		mob_icon = new /icon(force_icon, "[icon_name]")
+		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")
 	else
 		if(!dna)
-			mob_icon = new /icon('icons/mob/human_races/r_human.dmi', "[icon_name][gendered_icon ? "_f" : ""]")
+			mob_icon = new /icon('icons/mob/human_races/r_human.dmi', "[icon_name][gendered_icon ? "_[gender]" : ""]")
 		else
 
-			if(gendered_icon)
+			if(!gendered_icon)
+				gender = null
+			else
 				if(dna.GetUIState(DNA_UI_GENDER))
 					gender = "f"
 				else

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -1,6 +1,20 @@
 /mob/living/var/obj/aiming_overlay/aiming
 /mob/living/var/list/aimed = list()
 
+/mob/verb/toggle_gun_mode()
+	set name = "Toggle Gun Mode"
+	set desc = "Begin or stop aiming."
+	set category = "IC"
+
+	if(isliving(src))
+		var/mob/living/M = src
+		if(!M.aiming)
+			M.aiming = new(src)
+		M.aiming.toggle_active()
+	else
+		src << "<span class='warning'>This verb may only be used by living mobs, sorry.</span>"
+	return
+
 /mob/living/proc/stop_aiming(var/obj/item/thing, var/no_message = 0)
 	if(!aiming)
 		aiming = new(src)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -105,11 +105,11 @@
 	if (bitecount==0)
 		return
 	else if (bitecount==1)
-		user << "\blue \The [src] was bitten by someone!"
+		user << "<span class='notice'>\The [src] was bitten by someone!</span>"
 	else if (bitecount<=3)
-		user << "\blue \The [src] was bitten [bitecount] times!"
+		user << "<span class='notice'>\The [src] was bitten [bitecount] time\s!</span>"
 	else
-		user << "\blue \The [src] was bitten multiple times!"
+		user << "<span class='notice'>\The [src] was bitten multiple times!</span>"
 
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/storage))
@@ -124,12 +124,12 @@
 				U.create_reagents(5)
 
 			if (U.reagents.total_volume > 0)
-				user << "\red You already have something on your [U]."
+				user << "<span class='warning'>You already have something on your [U].</span>"
 				return
 
 			user.visible_message( \
-				"[user] scoops up some [src] with \the [U]!", \
-				"\blue You scoop up some [src] with \the [U]!" \
+				"\The [user] scoops up some [src] with \the [U]!", \
+				"<span class='notice'>You scoop up some [src] with \the [U]!</span>" \
 			)
 
 			src.bitecount++
@@ -154,7 +154,7 @@
 			if (W.w_class >= src.w_class || is_robot_module(W))
 				return
 
-			user << "\red You slip [W] inside [src]."
+			user << "<span class='warning'>You slip \the [W] inside \the [src].</span>"
 			user.remove_from_mob(W)
 			W.dropped(user)
 			add_fingerprint(user)
@@ -163,15 +163,15 @@
 
 		if (has_edge(W))
 			if (!can_slice_here)
-				user << "\red You cannot slice [src] here! You need a table or at least a tray to do it."
+				user << "<span class='warning'>You cannot slice \the [src] here! You need a table or at least a tray to do it.</span>"
 				return
 
 			var/slices_lost = 0
 			if (W.w_class > 3)
-				user.visible_message("\blue [user] crudely slices \the [src] with [W]!", "\blue You crudely slice \the [src] with your [W]!")
+				user.visible_message("<span class='notice'>\The [user] crudely slices \the [src] with [W]!</span>", "<span class='notice'>You crudely slice \the [src] with your [W]!</span>")
 				slices_lost = rand(1,min(1,round(slices_num/2)))
 			else
-				user.visible_message("\blue [user] slices \the [src]!", "\blue You slice \the [src]!")
+				user.visible_message("<span class='notice'>\The [user] slices \the [src]!</span>", "<span class='notice'>You slice \the [src]!</span>")
 
 			var/reagents_per_slice = reagents.total_volume/slices_num
 			for(var/i=1 to (slices_num-slices_lost))
@@ -474,7 +474,7 @@
 	..()
 	new/obj/effect/decal/cleanable/egg_smudge(src.loc)
 	src.reagents.splash(hit_atom, reagents.total_volume)
-	src.visible_message("\red [src.name] has been squashed.","\red You hear a smack.")
+	src.visible_message("<span class='warning'>\The [src] has been squashed!</span>","<span class='warning'>You hear a smack.</span>")
 	qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -483,10 +483,10 @@
 		var/clr = C.colourName
 
 		if(!(clr in list("blue","green","mime","orange","purple","rainbow","red","yellow")))
-			usr << "\blue The egg refuses to take on this color!"
+			usr << "<span class='notice'>The egg refuses to take on this color!</span>"
 			return
 
-		usr << "\blue You color \the [src] [clr]"
+		usr << "<span class='notice'>You color \the [src] [clr]</span>"
 		icon_state = "egg-[clr]"
 	else
 		..()
@@ -1114,7 +1114,7 @@
 		bitesize = 0.1 //this snack is supposed to be eating during looooong time. And this it not dinner food! --rastaf0
 	On_Consume()
 		if(prob(unpopped))	//lol ...what's the point?
-			usr << "\red You bite down on an un-popped kernel!"
+			usr << "<span class='warning'>You bite down on an un-popped kernel!</span>"
 			unpopped = max(0, unpopped-1)
 		..()
 
@@ -2674,7 +2674,7 @@
 	if( open && pizza )
 		user.put_in_hands( pizza )
 
-		user << "\red You take the [src.pizza] out of the [src]."
+		user << "<span class='warning'>You take \the [src.pizza] out of \the [src].</span>"
 		src.pizza = null
 		update_icon()
 		return
@@ -2688,7 +2688,7 @@
 		boxes -= box
 
 		user.put_in_hands( box )
-		user << "\red You remove the topmost [src] from your hand."
+		user << "<span class='warning'>You remove the topmost [src] from your hand.</span>"
 		box.update_icon()
 		update_icon()
 		return
@@ -2727,11 +2727,11 @@
 				box.update_icon()
 				update_icon()
 
-				user << "\red You put the [box] ontop of the [src]!"
+				user << "<span class='warning'>You put \the [box] ontop of \the [src]!</span>"
 			else
-				user << "\red The stack is too high!"
+				user << "<span class='warning'>The stack is too high!</span>"
 		else
-			user << "\red Close the [box] first!"
+			user << "<span class='warning'>Close \the [box] first!</span>"
 
 		return
 
@@ -2744,9 +2744,9 @@
 
 			update_icon()
 
-			user << "\red You put the [I] in the [src]!"
+			user << "<span class='warning'>You put \the [I] in \the [src]!</span>"
 		else
-			user << "\red You try to push the [I] through the lid but it doesn't work!"
+			user << "<span class='warning'>You try to push \the [I] through the lid but it doesn't work!</span>"
 		return
 
 	if( istype(I, /obj/item/weapon/pen/) )

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -119,31 +119,31 @@
 	// Eating with forks
 	if(istype(W,/obj/item/weapon/material/kitchen/utensil))
 		var/obj/item/weapon/material/kitchen/utensil/U = W
+		if(U.scoop_food)
+			if(!U.reagents)
+				U.create_reagents(5)
 
-		if(!U.reagents)
-			U.create_reagents(5)
+			if (U.reagents.total_volume > 0)
+				user << "\red You already have something on your [U]."
+				return
 
-		if (U.reagents.total_volume > 0)
-			user << "\red You already have something on your [U]."
+			user.visible_message( \
+				"[user] scoops up some [src] with \the [U]!", \
+				"\blue You scoop up some [src] with \the [U]!" \
+			)
+
+			src.bitecount++
+			U.overlays.Cut()
+			U.loaded = "[src]"
+			var/image/I = new(U.icon, "loadedfood")
+			I.color = src.filling_color
+			U.overlays += I
+
+			reagents.trans_to_obj(U, min(reagents.total_volume,5))
+
+			if (reagents.total_volume <= 0)
+				qdel(src)
 			return
-
-		user.visible_message( \
-			"[user] scoops up some [src] with \the [U]!", \
-			"\blue You scoop up some [src] with \the [U]!" \
-		)
-
-		src.bitecount++
-		U.overlays.Cut()
-		U.loaded = "[src]"
-		var/image/I = new(U.icon, "loadedfood")
-		I.color = src.filling_color
-		U.overlays += I
-
-		reagents.trans_to_obj(U, min(reagents.total_volume,5))
-
-		if (reagents.total_volume <= 0)
-			qdel(src)
-		return
 
 	if (is_sliceable())
 		//these are used to allow hiding edge items in food that is not on a table/tray

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -28,9 +28,9 @@
 		emergency_shuttle.departed = 1
 
 		if (emergency_shuttle.evac)
-			priority_announcement.Announce("The Emergency Shuttle has left the station. Estimate [round(emergency_shuttle.estimate_arrival_time()/60,1)] minutes until the shuttle docks at [boss_name].")
+			priority_announcement.Announce("The Emergency Shuttle has left the station. Estimate [round(emergency_shuttle.estimate_arrival_time()/60,1)] minutes until the shuttle docks at [dock_name].")
 		else
-			priority_announcement.Announce("The Crew Transfer Shuttle has left the station. Estimate [round(emergency_shuttle.estimate_arrival_time()/60,1)] minutes until the shuttle docks at [boss_name].")
+			priority_announcement.Announce("The Crew Transfer Shuttle has left the station. Estimate [round(emergency_shuttle.estimate_arrival_time()/60,1)] minutes until the shuttle docks at [dock_name].")
 
 /datum/shuttle/ferry/emergency/can_launch(var/user)
 	if (istype(user, /obj/machinery/computer/shuttle_control/emergency))
@@ -185,7 +185,7 @@
 			else if (!shuttle.location)
 				shuttle_status = "Standing-by at [station_name]."
 			else
-				shuttle_status = "Standing-by at [boss_name]."
+				shuttle_status = "Standing-by at [dock_name]."
 		if(WAIT_LAUNCH, FORCE_LAUNCH)
 			shuttle_status = "Shuttle has recieved command and will depart shortly."
 		if(WAIT_ARRIVE)


### PR DESCRIPTION
Adds an entry to define the name of the main shuttle dock destination.
Can no longer rip posters multiple times.
The toggle aim mode shortcut should again work.
Adds whisper and sign language verbs.
Makes it possible to not scoop food with objects such as knives.*
Breath masks are no longer airtight when they simple hang around someone's neck.
Fixes some icons for neuter/plural gendered mobs.

Ports https://github.com/PolarisSS13/Polaris/pull/767.
Ports https://github.com/PolarisSS13/Polaris/pull/778.

*As I wrote this PR I wonder if it wouldn't be more general to check if the item has the sharp property, and not scoop if so.
