### PR TITLE
fix wingrille spawners allowing initial ZAS init to expand zones through them

### DIFF
--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -13,6 +13,10 @@
 	var/win_path = /obj/structure/window/basic
 	var/activated
 
+// stops ZAS expanding zones past us, the windows will block the zone anyway
+/obj/effect/wingrille_spawn/CanPass()
+	return 0
+
 /obj/effect/wingrille_spawn/attack_hand()
 	attack_generic()
 


### PR DESCRIPTION
Avoids windows that look out onto a non-spaaaaaace airless area losing air at startup
