### PR TITLE
Slime temperature damage calculation change

### DIFF
--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -54,11 +54,13 @@
 
 	if(bodytemperature < (T0C + 5)) // start calculating temperature damage etc
 
-		if(bodytemperature <= (T0C - 50)) // hurt temperature
-			if(bodytemperature <= 50) // sqrting negative numbers is bad
+		if(bodytemperature <= hurt_temperature)
+			if(bodytemperature <= die_temperature)
 				adjustToxLoss(200)
 			else
-				adjustToxLoss(round(sqrt(bodytemperature)) * 2)
+				// could be more fancy, but doesn't worth the complexity: when the slimes goes into a cold area
+				// the damage is mostly determined by how fast its body cools
+				adjustToxLoss(30)
 
 	updatehealth()
 

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -49,6 +49,9 @@
 	var/SStun = 0 // NPC stun variable. Used to calm them down when they are attacked while feeding, or they will immediately re-attach
 	var/Discipline = 0 // if a slime has been hit with a freeze gun, or wrestled/attacked off a human, they become disciplined and don't attack anymore for a while. The part about freeze gun is a lie
 
+	var/hurt_temperature = T0C-50 // slime keeps taking damage when its bodytemperature is below this
+	var/die_temperature = 50 // slime dies instantly when its bodytemperature is below this
+
 	///////////TIME FOR SUBSPECIES
 
 	var/colour = "grey"


### PR DESCRIPTION
If I read the code well, currently the damage-temperature curve is not continuous and isn't monotone.

![slime_dam](https://cloud.githubusercontent.com/assets/1443881/12378687/6800872a-bd46-11e5-9f24-dbd0f9a22dec.png)

The new funtion maybe not the best, because it makes the damage much larger in the intermediate region. My primary goal was to show that the function currently is weird.

I don't know how good is the compiler with constant expressions, maybe it's better the calculate the 200/sqrt(hurt_temperature-did_temperature) by hand.
