### PR TITLE
Chameleon Glasses fix.

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -298,7 +298,7 @@
 	item_state = "glasses"
 	desc = "It looks like a plain set of mesons, but on closer inspection, it seems to have a small dial inside."
 	origin_tech = list(TECH_ILLEGAL = 3)
-	var/list/clothing_choices = list()
+	var/list/global/clothing_choices
 
 /obj/item/clothing/glasses/chameleon/New()
 	..()


### PR DESCRIPTION
Fixes #10942

The portion that generates the list just performs a null check, not a length check.
So we initialize it as null instead.
