### PR TITLE
Fixes supply beacons.

### DIFF
--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -100,8 +100,10 @@
 	..()
 
 /obj/machinery/power/supply_beacon/process()
-	if(!use_power || expended)
+	if(expended)
 		return PROCESS_KILL
+	if(!use_power)
+		return
 	if(draw_power(500) < 500)
 		deactivate()
 		return


### PR DESCRIPTION
Just because it's not active doesn't mean you kill the process, this removes the item from processing later when it is activated.

Fixes #11925
