### PR TITLE
Life and Vision tweaks.

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -31,8 +31,6 @@
 	BITSET(hud_updateflag, STATUS_HUD)
 	BITSET(hud_updateflag, LIFE_HUD)
 
-	handle_hud_list()
-
 	//Handle species-specific deaths.
 	species.handle_death(src)
 	animate_tail_stop()
@@ -68,7 +66,8 @@
 	if(wearing_rig)
 		wearing_rig.notify_ai("<span class='danger'>Warning: user death event. Mobility control passed to integrated intelligence system.</span>")
 
-	return ..(gibbed,species.death_message)
+	. = ..(gibbed,species.death_message)
+	handle_hud_list()
 
 /mob/living/carbon/human/proc/ChangeToHusk()
 	if(HUSK in mutations)	return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1413,7 +1413,7 @@
 /mob/living/carbon/human/proc/handle_hud_list()
 	if (BITTEST(hud_updateflag, HEALTH_HUD))
 		var/image/holder = hud_list[HEALTH_HUD]
-		if(stat == 2)
+		if(stat == DEAD)
 			holder.icon_state = "hudhealth-100" 	// X_X
 		else
 			var/percentage_health = RoundHealth((health-config.health_threshold_crit)/(maxHealth-config.health_threshold_crit)*100)
@@ -1421,11 +1421,12 @@
 		hud_list[HEALTH_HUD] = holder
 
 	if (BITTEST(hud_updateflag, LIFE_HUD))
-		var/image/holder = hud_list[STATUS_HUD]
+		var/image/holder = hud_list[LIFE_HUD]
 		if(stat == DEAD)
 			holder.icon_state = "huddead"
 		else
 			holder.icon_state = "hudhealthy"
+		hud_list[LIFE_HUD] = holder
 
 	if (BITTEST(hud_updateflag, STATUS_HUD))
 		var/foundVirus = 0
@@ -1438,13 +1439,10 @@
 				break
 
 		var/image/holder = hud_list[STATUS_HUD]
-		var/image/holder2 = hud_list[STATUS_HUD_OOC]
-		if(stat == 2)
+		if(stat == DEAD)
 			holder.icon_state = "huddead"
-			holder2.icon_state = "huddead"
 		else if(status_flags & XENO_HOST)
 			holder.icon_state = "hudxeno"
-			holder2.icon_state = "hudxeno"
 		else if(foundVirus)
 			holder.icon_state = "hudill"
 		else if(has_brain_worms())
@@ -1453,13 +1451,20 @@
 				holder.icon_state = "hudbrainworm"
 			else
 				holder.icon_state = "hudhealthy"
-			holder2.icon_state = "hudbrainworm"
 		else
 			holder.icon_state = "hudhealthy"
-			if(virus2.len)
-				holder2.icon_state = "hudill"
-			else
-				holder2.icon_state = "hudhealthy"
+
+		var/image/holder2 = hud_list[STATUS_HUD_OOC]
+		if(stat == DEAD)
+			holder2.icon_state = "huddead"
+		else if(status_flags & XENO_HOST)
+			holder2.icon_state = "hudxeno"
+		else if(has_brain_worms())
+			holder2.icon_state = "hudbrainworm"
+		else if(virus2.len)
+			holder2.icon_state = "hudill"
+		else
+			holder2.icon_state = "hudhealthy"
 
 		hud_list[STATUS_HUD] = holder
 		hud_list[STATUS_HUD_OOC] = holder2
@@ -1598,8 +1603,6 @@
 			remoteview_target = null
 			reset_view(null, 0)
 
-	eye_blind =  0
-	blinded = 0
 	update_equipment_vision()
 	species.handle_vision(src)
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -167,8 +167,8 @@
 		update_dead_sight()
 	else
 		sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		see_in_dark = 2
-		see_invisible = SEE_INVISIBLE_LIVING
+		see_in_dark = initial(see_in_dark)
+		see_invisible = initial(see_invisible)
 
 /mob/living/proc/update_dead_sight()
 	sight |= SEE_TURFS

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -43,6 +43,8 @@
 	for(var/obj/item/weapon/grab/G in src)
 		G.process()
 
+	blinded = 0 // Placing this here just show how out of place it is.
+	// human/handle_regular_status_updates() needs a cleanup, as blindness should be handled in handle_disabilities()
 	if(handle_regular_status_updates()) // Status & health update, are we dead or alive etc.
 		handle_disabilities() // eye, ear, brain damages
 		handle_status_effects() //all special effects, stunned, weakened, jitteryness, hallucination, sleeping, etc
@@ -51,8 +53,7 @@
 
 	update_canmove()
 
-	if(client)
-		handle_regular_hud_updates()
+	handle_regular_hud_updates()
 
 /mob/living/proc/handle_breathing()
 	return
@@ -180,7 +181,6 @@
 /mob/living/proc/handle_hud_icons()
 	handle_hud_icons_health()
 	handle_hud_glasses()
-	return
 
 /mob/living/proc/handle_hud_icons_health()
 	return

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,4 +1,5 @@
 /mob/living
+	see_in_dark = 2
 	see_invisible = SEE_INVISIBLE_LIVING
 
 	//Health and life related vars

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -27,6 +27,7 @@
 	show_stat_health = 1
 	faction = "cult"
 	supernatural = 1
+	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	var/nullblock = 0
 
@@ -249,16 +250,6 @@
 	set_light(2, -2, l_color = "#FFFFFF")
 
 ////////////////HUD//////////////////////
-
-// We override mob/living/update_sight() so constructs don't get their vision reset to the default of /mob/living
-
-/mob/living/simple_animal/construct/update_sight()
-        if(stat == DEAD)
-                update_dead_sight()
-        else
-                sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
-                see_in_dark = initial(see_in_dark)
-                see_invisible = initial(see_invisible)
 
 /mob/living/simple_animal/construct/Life()
 	. = ..()


### PR DESCRIPTION
Relocates the blindness reset to as late as possible without causing issues (beyond its positioning). Fixes #11865.
handle_regular_hud_updates() no longer quits early with no client around.
Re-arranges mob HUD updates. Among other things dead humans now do their final update after death, not just before it.
Also actually updates the LIFE_HUD overlay (used by silicons). Fixes mobs never appearing to be dead when they should be.
