### PR TITLE
The id modification console now only operate on NT access permissions.

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -94,12 +94,12 @@ var/list/cargo_positions = list(
 
 var/list/civilian_positions = list(
 	"Head of Personnel",
+	"Internal Affairs Agent",
 	"Bartender",
 	"Gardener",
 	"Chef",
 	"Janitor",
 	"Librarian",
-	"Lawyer",
 	"Chaplain",
 	"Assistant"
 )

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -224,12 +224,7 @@
 	return 1
 
 /datum/computer_file/program/card_mod/proc/remove_nt_access(var/obj/item/weapon/card/id/id_card)
-	var/known_access_rights = get_access_ids(ACCESS_TYPE_STATION|ACCESS_TYPE_CENTCOM)
-
-	for(var/access in id_card.access)
-		if(access in known_access_rights)
-			id_card.access -= access
+	id_card.access -= get_access_ids(ACCESS_TYPE_STATION|ACCESS_TYPE_CENTCOM)
 
 /datum/computer_file/program/card_mod/proc/apply_access(var/obj/item/weapon/card/id/id_card, var/list/accesses)
-	for(var/access in accesses)
-		id_card.access |= access
+	id_card.access |= accesses


### PR DESCRIPTION
This means that it will not purge special antag permissions when applying assignments.
