### PR TITLE
Minor Travis performance tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ addons:
       - libc6-i386
       - libgcc1:i386
       - libstdc++6:i386
-      - python
-      - python-pip
   
 install:
   - pip install --user PyYaml -q
@@ -33,7 +31,7 @@ script:
   - (! find nano/templates/ -type f -exec md5sum {} + | sort | uniq -D -w 32 | grep nano)
   - md5sum -c - <<< "0af969f671fba6cf9696c78cd175a14a *baystation12.int"
   - md5sum -c - <<< "88490b460c26947f5ec1ab1bb9fa9f17 *html/changelogs/example.yml"
-  - python tools/GenerateChangelog/ss13_genchangelog.py html/changelog.html html/changelogs
+  - python tools/GenerateChangelog/ss13_genchangelog.py html/changelog.html html/changelogs --dry-run
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
   - DreamMaker baystation12.dme
 


### PR DESCRIPTION
No longer asking Travis to install existing Python packages.
The changelog generator no longer writes its output to file, shaving off several microseconds.
