### PR TITLE
Drag a living slime over a dead one and it takes no damage from extinguisher

### DIFF
--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -28,6 +28,9 @@
 			for(var/atom/A in T)
 				if(!ismob(A) && A.simulated) // Mobs are handled differently
 					reagents.touch(A)
+				// choosing the first one breaks with dead mobs: 
+				// there can be more than one dead mob on the same tile
+				// or a dead with an alive one
 				else if(ismob(A) && !M)
 					M = A
 			if(M)


### PR DESCRIPTION
It's because the code at the comment assumes only one mob per tile.

Pull request, because I don't know how to reference code in an issue.
