### PR TITLE
Makes install-byond.sh more robust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-#pretending we're C because otherwise ruby will initialize, even with "language: dm".
-language: c
+language: generic
 sudo: false
 
 env:

--- a/install-byond.sh
+++ b/install-byond.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
 set -e
-if [ -d "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin" ];
+if [ -f "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/DreamMaker" ];
 then
   echo "Using cached directory."
 else
   echo "Setting up BYOND."
   mkdir -p "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}"
   cd "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}"
+  echo "Installing DreamMaker to $PWD"
   curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
-  unzip byond.zip
+  unzip -o byond.zip
   cd byond
   make here
 fi


### PR DESCRIPTION
Adds a check to ensure DreamMaker exists in the cached folder, not merely that the folder exists.
Makes unrar output the destination folder of inflated files.
Partial port of https://github.com/d3athrow/vgstation13/pull/7906.
