### PR TITLE
Can now click held mobs to view their inventory.

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -55,6 +55,10 @@ var/list/holder_mob_icon_cache = list()
 	var/obj/item/I = GetID()
 	return I ? I.GetAccess() : ..()
 
+/obj/item/weapon/holder/attack_self()
+	for(var/mob/M in contents)
+		M.show_inv(usr)
+
 /obj/item/weapon/holder/proc/sync(var/mob/living/M)
 	dir = 2
 	overlays.Cut()


### PR DESCRIPTION
:cl:
add: Can now click held mobs, such as Pun Pun, to view their inventory.
/:cl:

Fixes #11437 once and for all.
