### PR TITLE
Makes Travis treat build warnings as errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
   - cp config/example/* config/
   - scripts/dm.sh -DUNIT_TEST baystation12.dme
+  - grep "0 warnings" build_log.txt
   - DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt
   - grep "All Unit Tests Passed" log.txt
   - (! grep "runtime error:" log.txt)

--- a/code/modules/modular_computers/computers/item/modular_computer.dm
+++ b/code/modules/modular_computers/computers/item/modular_computer.dm
@@ -616,4 +616,4 @@
 			ui_updated_needed = 1
 
 	if(ui_updated_needed)
-		update_uis
+		update_uis()

--- a/scripts/dm.sh
+++ b/scripts/dm.sh
@@ -44,7 +44,7 @@ if [[ $DM == "" ]]; then
     exit 3
 fi
 
-"$DM" $dmepath.mdme
+"$DM" $dmepath.mdme > build_log.txt
 retval=$?
 
 mv $dmepath.mdme.dmb $dmepath.dmb


### PR DESCRIPTION
The DM build script now outputs the build log to a file which can then be reviewed from .travis.yml.
