### PR TITLE
Fixes traitors being unable to be marked as owners of agent ids.

### DIFF
--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -11,7 +11,7 @@
 	access = syndicate_access.Copy()
 
 /obj/item/weapon/card/id/syndicate/Destroy()
-	registered_user = null
+	unset_registered_user(registered_user)
 	return ..()
 
 /obj/item/weapon/card/id/syndicate/prevent_tracking()
@@ -27,7 +27,7 @@
 
 /obj/item/weapon/card/id/syndicate/attack_self(mob/user as mob)
 	// We use the fact that registered_name is not unset should the owner be vaporized, to ensure the id doesn't magically become unlocked.
-	if(!registered_user && !registered_name && register_user(user))
+	if(!registered_user && register_user(user))
 		user << "<span class='notice'>The microscanner marks you as its owner, preventing others from accessing its internals.</span>"
 	if(registered_user == user)
 		switch(alert("Would you like edit the ID, or show it?","Show or Edit?", "Edit","Show"))


### PR DESCRIPTION
Removes a unnecessary check during owner-assignment, allowing even id cards that have been spawned on floors to find a new owner.

:cl:
fix: Agent ids can now be assigned an owner even after having been dropped on the floor.
/:cl:
