### PR TITLE
Can now expand monkey cubes.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1595,6 +1595,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube
 	name = "monkey cube"
 	desc = "Just add water!"
+	flags = 0
 	icon_state = "monkeycube"
 	bitesize = 12
 	filling_color = "#ADAC7F"


### PR DESCRIPTION
Apparently open containers don't call afterattack. Marks monkey cubes as closed. Fixes #12085.
:cl:
fix: Monkey cubes can now be expanded in sinks again.
/:cl:
