### PR TITLE
Devouring-related fixes and tweaks 

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -117,6 +117,11 @@
 #define MOB_TINY 		5
 #define MOB_MINISCULE	1
 
+// Gluttony levels. 
+#define GLUT_TINY 1       // Eat anything tiny and smaller
+#define GLUT_SMALLER 2    // Eat anything smaller than we are
+#define GLUT_ANYTHING 3   // Eat anything, ever
+
 #define TINT_NONE 0
 #define TINT_MODERATE 1
 #define TINT_HEAVY 2

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1283,7 +1283,7 @@
 			if(M.loc != src)
 				stomach_contents.Remove(M)
 				continue
-			if(istype(M, /mob/living/carbon) && stat != 2)
+			if(iscarbon(M)|| isanimal(M))
 				if(M.stat == 2)
 					M.death(1)
 					stomach_contents.Remove(M)

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -26,7 +26,7 @@
 	cold_level_3 = 0
 
 	eyes = "vox_eyes_s"
-	gluttonous = 2
+	gluttonous = GLUT_SMALLER
 
 	breath_type = "nitrogen"
 	poison_type = "oxygen"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -121,7 +121,7 @@
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
 	var/holder_type
-	var/gluttonous                // Can eat some mobs. 1 = eat MOB_TINY and below, 2 = eat anything we're larger than, 3 = eat anything
+	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	                              // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -121,7 +121,7 @@
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
 	var/holder_type
-	var/gluttonous                // Can eat some mobs. 1 for mice, 2 for monkeys, 3 for people.
+	var/gluttonous                // Can eat some mobs. 1 = eat MOB_TINY and below, 2 = eat anything we're larger than, 3 = eat anything
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	                              // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -30,7 +30,7 @@
 	mob_size = MOB_SMALL
 	holder_type = /obj/item/weapon/holder/human
 	short_sighted = 1
-	gluttonous = 1
+	gluttonous = GLUT_TINY
 
 	spawn_flags = CAN_JOIN | IS_WHITELISTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_EYE_COLOR

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -28,7 +28,7 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	primitive_form = "Stok"
 	darksight = 3
-	gluttonous = 1
+	gluttonous = GLUT_TINY
 	slowdown = 0.5
 	brute_mod = 0.8
 	num_alternate_languages = 2
@@ -87,7 +87,7 @@
 	slowdown = -0.5
 	brute_mod = 1.15
 	burn_mod =  1.15
-	gluttonous = 1
+	gluttonous = GLUT_TINY
 	num_alternate_languages = 2
 	secondary_langs = list("Siik'tajr")
 	name_language = "Siik'tajr"

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -11,7 +11,7 @@
 
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
-	gluttonous = 3
+	gluttonous = GLUT_ANYTHING
 
 	eyes = "blank_eyes"
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -158,9 +158,9 @@
 		var/mob/living/carbon/attacker = user
 		user.visible_message("<span class='danger'>[user] is attempting to devour [target]!</span>")
 		if(can_eat == 2)
-			if(!do_mob(user, target)||!do_after(user, 30)) return
+			if(!do_mob(user, target, 30)) return
 		else
-			if(!do_mob(user, target)||!do_after(user, 100)) return
+			if(!do_mob(user, target, 100)) return
 		user.visible_message("<span class='danger'>[user] devours [target]!</span>")
 		admin_attack_log(attacker, target, "Devoured.", "Was devoured by.", "devoured")
 		target.loc = user

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -146,11 +146,13 @@
 		can_eat = 1
 	else
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && H.species.gluttonous)
-			if(H.species.gluttonous == 2)
-				can_eat = 2
-			else if((H.mob_size > target.mob_size) && !ishuman(target) && (iscarbon(target) || isanimal(target)))
+		if(istype(H) && H.species.gluttonous && (iscarbon(target) || isanimal(target)))
+			if(H.species.gluttonous == 1 && (target.mob_size <= MOB_TINY) && !ishuman(target)) // Anything MOB_TINY or smaller
 				can_eat = 1
+			else if(H.species.gluttonous == 2 && (H.mob_size > target.mob_size)) // Anything we're larger than
+				can_eat = 1
+			else if(H.species.gluttonous == 3) // Eat anything ever
+				can_eat = 2
 
 	if(can_eat)
 		var/mob/living/carbon/attacker = user

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -160,6 +160,7 @@
 		else
 			if(!do_mob(user, target)||!do_after(user, 100)) return
 		user.visible_message("<span class='danger'>[user] devours [target]!</span>")
+		admin_attack_log(attacker, target, "Devoured.", "Was devoured by.", "devoured")
 		target.loc = user
 		attacker.stomach_contents.Add(target)
 		qdel(src)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -149,7 +149,7 @@
 		if(istype(H) && H.species.gluttonous)
 			if(H.species.gluttonous == 2)
 				can_eat = 2
-			else if((H.mob_size > target.mob_size) && !ishuman(target) && iscarbon(target))
+			else if((H.mob_size > target.mob_size) && !ishuman(target) && (iscarbon(target) || isanimal(target)))
 				can_eat = 1
 
 	if(can_eat)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -147,11 +147,11 @@
 	else
 		var/mob/living/carbon/human/H = user
 		if(istype(H) && H.species.gluttonous && (iscarbon(target) || isanimal(target)))
-			if(H.species.gluttonous == 1 && (target.mob_size <= MOB_TINY) && !ishuman(target)) // Anything MOB_TINY or smaller
+			if(H.species.gluttonous == GLUT_TINY && (target.mob_size <= MOB_TINY) && !ishuman(target)) // Anything MOB_TINY or smaller
 				can_eat = 1
-			else if(H.species.gluttonous == 2 && (H.mob_size > target.mob_size)) // Anything we're larger than
+			else if(H.species.gluttonous == GLUT_SMALLER && (H.mob_size > target.mob_size)) // Anything we're larger than
 				can_eat = 1
-			else if(H.species.gluttonous == 3) // Eat anything ever
+			else if(H.species.gluttonous == GLUT_ANYTHING) // Eat anything ever
 				can_eat = 2
 
 	if(can_eat)


### PR DESCRIPTION
- `simple_animal`s can now be devoured (from grab) by species that were supposed to be able to do so (resolves #11796)
- `gluttony` levels revised slightly: previously, `gluttony` level of 2 entitled you to eat anything, meaning Vox could eat whole people. Now, Vox's level of gluttony allows them to eat anything smaller than them. Tajara, Unathi, and Resomi can now eat `simple_animal`s that are `TINY` or smaller (includes mice, etc.). Xenomorphs can eat anything. I believe this is in line with the intended behavior.
- Devouring now generates attack logs. Since you can kill people this way, I figured attack logs would be useful for admins.
