### PR TITLE
Fix ID computer not modifying manifest

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -160,6 +160,8 @@
 						computer.visible_message("<span class='notice'>[computer] prints out paper.</span>")
 		if("eject")
 			if(computer && computer.card_slot)
+				if(id_card)
+					data_core.manifest_modify(id_card.registered_name, id_card.assignment)
 				computer.proc_eject_id(user)
 		if("terminate")
 			if(computer && can_run(user, 1))


### PR DESCRIPTION
Untested, but it's the same code as pre-modular-computer, and it compiles.
