### PR TITLE
Adjusts supermatter delamination behavior

### DIFF
--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -14,17 +14,6 @@
 /mob/living/singularity_pull(S)
 	step_towards(src, S)
 
-/mob/living/carbon/human/singularity_act()
-	var/gain = 20
-	if(mind)
-		if((mind.assigned_role == "Station Engineer") || (mind.assigned_role == "Chief Engineer"))
-			gain = 100
-		if(mind.assigned_role == "Assistant")
-			gain = rand(0, 300)
-	investigate_log(I_SINGULO,"has been consumed by a singularity", I_SINGULO)
-	gib()
-	return gain
-
 /mob/living/carbon/human/singularity_pull(S, current_size)
 	if(current_size >= STAGE_THREE)
 		var/list/handlist = list(l_hand, r_hand)
@@ -45,12 +34,8 @@
 		return 2
 
 /obj/singularity_pull(S, current_size)
-	if(simulated)
-		if(anchored)
-			if(current_size >= STAGE_FIVE)
-				step_towards(src, S)
-		else
-			step_towards(src, S)
+	if(simulated && !anchored)
+		step_towards(src, S)
 
 /obj/effect/beam/singularity_pull()
 	return
@@ -109,21 +94,6 @@
 				O.singularity_act(src, current_size)
 	ChangeTurf(get_base_turf_by_area(src))
 	return 2
-
-/turf/simulated/wall/singularity_pull(S, current_size)
-
-	if(!reinf_material)
-		if(current_size >= STAGE_FIVE)
-			if(prob(75))
-				dismantle_wall()
-			return
-		if(current_size == STAGE_FOUR)
-			if(prob(30))
-				dismantle_wall()
-	else
-		if(current_size >= STAGE_FIVE)
-			if(prob(30))
-				dismantle_wall()
 
 /turf/space/singularity_act()
 	return

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -382,15 +382,13 @@
 
 
 /obj/machinery/power/supermatter/proc/supermatter_pull()
-	for(var/atom/movable/AM in range(255, src))
-		if(AM.anchored)
-			continue
-		if(istype(AM, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = AM
+	for(var/atom/A in range(255, src))
+		A.singularity_pull(src, STAGE_FIVE)
+		if(istype(A, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = A
 			if(!H.lying)
 				H << "<span class='danger'>A strong gravitational force slams you to the ground!</span>"
 				H.Weaken(20)
-		step_towards(AM, src)
 
 
 /obj/machinery/power/supermatter/GotoAirflowDest(n) //Supermatter not pushed around by airflow

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -59,10 +59,9 @@
 	var/emergency_color = "#D9D900"
 
 	var/grav_pulling = 0
-	var/pull_radius = 14
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
-	var/pull_time = 100
-	var/explosion_power = 8
+	var/pull_time = 300
+	var/explosion_power = 6
 
 	var/emergency_issued = 0
 
@@ -97,8 +96,7 @@
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
-	message_admins("Supermatter exploded at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("Supermatter exploded at ([x],[y],[z])")
+	log_and_message_admins("Supermatter exploded at [x] [y] [z]")
 	anchored = 1
 	grav_pulling = 1
 	exploded = 1
@@ -112,7 +110,7 @@
 			var/rads = DETONATION_RADS * sqrt( 1 / (get_dist(mob, src) + 1) )
 			mob.apply_effect(rads, IRRADIATE)
 	spawn(pull_time)
-		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
+		explosion(get_turf(src), explosion_power, explosion_power * 1.25, explosion_power * 1.5, explosion_power * 1.75, 1)
 		qdel(src)
 		return
 
@@ -318,6 +316,7 @@
 		data["ambient_temp"] = round(env.temperature)
 		data["ambient_pressure"] = round(env.return_pressure())
 	data["detonating"] = grav_pulling
+	data["energy"] = power
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -383,16 +382,15 @@
 
 
 /obj/machinery/power/supermatter/proc/supermatter_pull()
-	//following is adapted from singulo code
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
-	// Let's just make this one loop.
-	for(var/atom/X in orange(pull_radius,src))
-		spawn()	X.singularity_pull(src, STAGE_FIVE)
-
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
-	return
+	for(var/atom/movable/AM in range(255, src))
+		if(AM.anchored)
+			continue
+		if(istype(AM, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = AM
+			if(!H.lying)
+				H << "<span class='danger'>A strong gravitational force slams you to the ground!</span>"
+				H.Weaken(20)
+		step_towards(AM, src)
 
 
 /obj/machinery/power/supermatter/GotoAirflowDest(n) //Supermatter not pushed around by airflow
@@ -413,8 +411,7 @@
 
 	gasefficency = 0.125
 
-	pull_radius = 5
-	pull_time = 45
+	pull_time = 150
 	explosion_power = 3
 
 /obj/machinery/power/supermatter/shard/announce_warning() //Shards don't get announcements

--- a/nano/templates/supermatter_crystal.tmpl
+++ b/nano/templates/supermatter_crystal.tmpl
@@ -22,4 +22,10 @@
 	<span class="itemContent">
 		{{:data.ambient_pressure}} kPa
 	</span>
+	<span class="itemLabel">
+		Relative EER:
+	</span>
+	<span class="itemContent">
+		{{:data.energy}}
+	</span>
 {{/if}}


### PR DESCRIPTION
- Do note that the reduction in explosion strength isn't as high as it might seem. I'd say it is approximately 20-30% weaker.

:cl:
tweak: Supermatter no longer pulls anchored objects. To compensate, pull radius was increased. It is currently limited by range() proc to approximately 32 tiles.
tweak: Supermatter delamination's explosion strength reduced slightly. This will hopefully motivate players to actually attempt repairs as it will be possible to complete them within 1-2 hours.
tweak: Supermatter spends more time (30 seconds compared to 10 seconds) in pulling mode before exploding during delamination.
add: Supermatter's UI now shows "Relative EER" (Energy Emission Ratio) value which represents how energised the supermatter is.
/:cl:
