### PR TITLE
The moved event again returns the correct result from parent.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1890,6 +1890,7 @@
 #include "code\modules\xgm\xgm_gas_data.dm"
 #include "code\modules\xgm\xgm_gas_mixture.dm"
 #include "code\unit_tests\equipment_tests.dm"
+#include "code\unit_tests\foundation_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
 #include "code\unit_tests\observation_tests.dm"

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -20,7 +20,8 @@ var/datum/observ/moved/moved_event = new()
 
 /atom/movable/Move()
 	var/old_loc = loc
-	if(..())
+	. = ..()
+	if(.)
 		moved_event.raise_event(list(src, old_loc, loc))
 
 /atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)

--- a/code/unit_tests/foundation_tests.dm
+++ b/code/unit_tests/foundation_tests.dm
@@ -1,0 +1,29 @@
+/*
+* Unit tests for built-in BYOND procs, to ensure overrides have not affected functionality.
+*/
+datum/unit_test/foundation
+	name = "FOUNDATION template"
+	async = 0
+
+datum/unit_test/foundation/step_shall_return_true_on_success
+	name = "FOUNDATION: step() shall return true on success"
+
+datum/unit_test/foundation/step_shall_return_true_on_success/start_test()
+	var/mob_step_result = TestStep(/mob)
+	var/obj_step_result = TestStep(/obj)
+
+	if(mob_step_result && obj_step_result)
+		pass("step() returned true.")
+	else
+		fail("step() did not return true: Mob result: [mob_step_result] - Obj result: [obj_step_result].")
+
+	return 1
+
+datum/unit_test/foundation/proc/TestStep(type_to_test)
+	var/turf/start = locate(20,20,1)
+	var/atom/movable/T = new type_to_test(start)
+
+	. = step(T, NORTH)
+	. = . && start.x == T.x
+	. = . && start.y + 1 == T.y
+	. = . && start.z == T.z


### PR DESCRIPTION
Fixes #12072.
Fixes #12075.
Fixes #12076.
Fixes #12078.
Fixes #12096.
