### PR TITLE
dm.sh will again return error code on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ Thumbs.db
 *.backup
 data/
 cfg/
-
+build_log.txt

--- a/scripts/dm.sh
+++ b/scripts/dm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 dmepath=""
 retval=1
 
@@ -47,8 +49,10 @@ fi
 "$DM" $dmepath.mdme | tee build_log.txt
 retval=$?
 
-mv $dmepath.mdme.dmb $dmepath.dmb
-mv $dmepath.mdme.rsc $dmepath.rsc
+if [[ $retval == 0 ]]; then
+    mv $dmepath.mdme.dmb $dmepath.dmb
+    mv $dmepath.mdme.rsc $dmepath.rsc
+fi
 
 rm $dmepath.mdme
 


### PR DESCRIPTION
the `tee` call was returning 0 causing the whole pipe to return 0, pipefail makes the furthest right command that failed's return code be used
