### PR TITLE
Makes the initial resist proc solely responsible for checking click delays.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -341,9 +341,6 @@
 	if(!req_breakout())
 		return
 
-	if(!escapee.canClick())
-		return
-
 	escapee.setClickCooldown(100)
 
 	//okay, so the closet is either welded or locked... resist!!!

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -155,9 +155,6 @@
 	return ..()
 
 /mob/living/carbon/escape_buckle()
-	if(!canClick())
-		return
-
 	setClickCooldown(100)
 	if(!buckled) return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -589,7 +589,7 @@ default behaviour is:
 	set name = "Resist"
 	set category = "IC"
 
-	if(!(stat || next_move > world.time))
+	if(!stat && canClick())
 		setClickCooldown(20)
 		resist_grab()
 		if(!weakened)


### PR DESCRIPTION
Because it sets the click cooldown itself downstream procs fail when they in turn check the click delay.
Fixes #11839. Fixes #12062. Fixes #12114.

:cl:
fix: Should again be possible to resist out of chairs, beds, and welded lockers.
/:cl:
