### PR TITLE
Fixes a non-existant chemical stopping hearts

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -36,5 +36,5 @@
 // Chemistry lists.
 var/list/tachycardics  = list("coffee", "inaprovaline", "hyperzine", "nitroglycerin", "thirteenloko", "nicotine") // Increase heart rate.
 var/list/bradycardics  = list("neurotoxin", "cryoxadone", "clonexadone", "space_drugs", "stoxin")                 // Decrease heart rate.
-var/list/heartstopper  = list("potassium_phorochloride", "zombie_powder") // This stops the heart.
+var/list/heartstopper  = list("potassium_chlorophoride", "zombie_powder") // This stops the heart.
 var/list/cheartstopper = list("potassium_chloride")                       // This stops the heart when overdose is met. -- c = conditional


### PR DESCRIPTION
In the current code, "potassium_chlorophoride" is creatable, but "potassium_phorochloride" is a nonexistant chemical, and "potassium_chlorophoride" doesn't actually stop the heart, even though it states it does in the chemicals description. Stumbled across this while testing out some heart stopping chemicals and noticed that potassium_chlorophoride didn't actually stop the heart and found this error.
