### PR TITLE
Adds a reconnect button to the file menu.

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -973,6 +973,15 @@ menu "menu"
 		is-disabled = false
 		saved-params = "is-checked"
 	elem 
+		name = "&Reconnect"
+		command = ".reconnect"
+		category = "&File"
+		is-checked = false
+		can-check = false
+		group = ""
+		is-disabled = false
+		saved-params = "is-checked"
+	elem 
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"


### PR DESCRIPTION
This uses the client side command .reconnect (that can only be used from interfaces).
Port of https://github.com/tgstation/-tg-station/pull/12412.

Will at least save me some time when BYOND decides it's time to keep resetting my connection again.
:cl:
add: Adds a reconnect button to the file menu.
/:cl:
