### PR TITLE
Language renames by maintainer requests

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -29,7 +29,7 @@
 #define LANGUAGE_SIIK_MAAS "Siik'maas"
 #define LANGUAGE_SIIK_TAJR "Siik'tajr"
 #define LANGUAGE_SKRELLIAN "Skrellian"
-#define LANGUAGE_RESOMI "Resomi"
+#define LANGUAGE_RESOMI "Schechi"
 #define LANGUAGE_ROOTSPEAK "Rootspeak"
 #define LANGUAGE_TRADEBAND "Tradeband"
 #define LANGUAGE_GUTTER "Gutter"

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -35,7 +35,7 @@
 	)
 
 /datum/language/tajaran
-	name = LANGUAGE_SIIK_TAJR
+	name = LANGUAGE_SIIK_MAAS
 	desc = "The traditionally employed tongue of Ahdomai, composed of expressive yowls and chirps. Native to the Tajaran."
 	speech_verb = "mrowls"
 	ask_verb = "mrowls"

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -47,13 +47,13 @@
 	autohiss_extra_map = list(
 			"x" = list("ks", "kss", "ksss")
 		)
-	autohiss_exempt = list("Sinta'unathi")
+	autohiss_exempt = list(LANGUAGE_UNATHI)
 
 /datum/species/tajaran
 	autohiss_basic_map = list(
 			"r" = list("rr", "rrr", "rrrr")
 		)
-	autohiss_exempt = list("Siik'tajr")
+	autohiss_exempt = list(LANGUAGE_SIIK_MAAS)
 
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -146,7 +146,7 @@ var/list/ai_verbs_default = list(
 	add_language(LANGUAGE_EAL, 1)
 	add_language(LANGUAGE_SOL_COMMON, 0)
 	add_language(LANGUAGE_UNATHI, 0)
-	add_language(LANGUAGE_SIIK_TAJR, 0)
+	add_language(LANGUAGE_SIIK_MAAS, 0)
 	add_language(LANGUAGE_SKRELLIAN, 0)
 	add_language(LANGUAGE_RESOMI, 0)
 	add_language(LANGUAGE_TRADEBAND, 1)

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -468,13 +468,13 @@
 		// 	Sol Common, Tradeband and Gutter are added with New() and are therefore the current default, always active languages
 		user.translator_on = !user.translator_on
 		if(user.translator_on)
-			user.add_language("Sinta'unathi")
-			user.add_language("Siik'tajr")
-			user.add_language("Skrellian")
+			user.add_language(LANGUAGE_UNATHI)
+			user.add_language(LANGUAGE_SIIK_MAAS)
+			user.add_language(LANGUAGE_SKRELLIAN)
 		else
-			user.remove_language("Sinta'unathi")
-			user.remove_language("Siik'tajr")
-			user.remove_language("Skrellian")
+			user.remove_language(LANGUAGE_UNATHI)
+			user.remove_language(LANGUAGE_SIIK_MAAS)
+			user.remove_language(LANGUAGE_SKRELLIAN)
 
 	is_active(mob/living/silicon/pai/user)
 		return user.translator_on

--- a/sql/migrate/V002__Update_tajlang.sql
+++ b/sql/migrate/V002__Update_tajlang.sql
@@ -1,0 +1,1 @@
+UPDATE whitelist SET race="siik'maas" WHERE race="siik'tajr";


### PR DESCRIPTION
Removed random floating language name texts and replaced with defines.
:cl:
tweak: Changed Tajarian language name (from Siik'tajr to Siik'maas)
tweak: Changed Resomi language name (from Resomi to Schechi)
/:cl:
