### PR TITLE
belts no longer drop when dragged to /obj/screen

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -43,7 +43,6 @@
 	..()
 
 /obj/item/weapon/storage/MouseDrop(obj/over_object as obj)
-
 	if(!canremove)
 		return
 
@@ -66,8 +65,9 @@
 
 		if (( usr.restrained() ) || ( usr.stat ))
 			return
+	
 
-		if ((src.loc == usr) && !usr.unEquip(src))
+		if ((src.loc == usr) && !(istype(over_object, /obj/screen)) && !usr.unEquip(src))
 			return
 
 		switch(over_object.name)


### PR DESCRIPTION
Fixes #11860

I can't think of any time an /obj/item/weapon/storage needs to be unequiped when drug to /obj/screen.

The usr.unequp() is what is responsible for this issue.
