### PR TITLE
Observer pattern changes.

### DIFF
--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -94,7 +94,7 @@
 	return ..()
 
 /datum/scheduled_task/proc/pre_process()
-	task_triggered_event.raise_event(list(src))
+	task_triggered_event.raise_event(src)
 
 /datum/scheduled_task/proc/process()
 	if(procedure)

--- a/code/datums/observation/destroyed.dm
+++ b/code/datums/observation/destroyed.dm
@@ -11,5 +11,5 @@ var/decl/observ/destroyed/destroyed_event = new()
 	name = "Destroyed"
 
 /datum/Destroy()
-	destroyed_event.raise_event(list(src))
+	destroyed_event.raise_event(src)
 	. = ..()

--- a/code/datums/observation/destroyed.dm
+++ b/code/datums/observation/destroyed.dm
@@ -1,6 +1,13 @@
-var/datum/observ/destroyed/destroyed_event = new()
+//	Observer Pattern Implementation: Destroyed
+//		Registration type: /datum
+//
+//		Raised when: A /datum instance is destroyed.
+//
+//		Arguments that the called proc should expect:
+//			/datum/destroyed_instance: The instance that was destroyed.
+var/decl/observ/destroyed/destroyed_event = new()
 
-/datum/observ/destroyed
+/decl/observ/destroyed
 	name = "Destroyed"
 
 /datum/Destroy()

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -1,12 +1,21 @@
+//	Observer Pattern Implementation: Moved
+//		Registration type: /atom/movable
+//
+//		Raised when: An /atom/movable instance has moved.
+//
+//		Arguments that the called proc should expect:
+//			/atom/movable/moving_instance: The instance that moved
+//			/atom/old_loc: The loc before the move.
+//			/atom/new_loc: The loc after the move.
 #define CANCEL_MOVE_EVENT -55
 
-var/datum/observ/moved/moved_event = new()
+var/decl/observ/moved/moved_event = new()
 
-/datum/observ/moved
+/decl/observ/moved
 	name = "Moved"
 	expected_type = /atom/movable
 
-/datum/observ/moved/register(var/eventSource, var/datum/procOwner, var/proc_call)
+/decl/observ/moved/register(var/eventSource, var/datum/procOwner, var/proc_call)
 	. = ..()
 	var/atom/movable/child = eventSource
 	if(.)
@@ -19,7 +28,6 @@ var/datum/observ/moved/moved_event = new()
 /********************
 * Movement Handling *
 ********************/
-
 /atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)
 	if(T && T != loc)

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -15,38 +15,40 @@ var/decl/observ/moved/moved_event = new()
 	name = "Moved"
 	expected_type = /atom/movable
 
-/decl/observ/moved/register(var/eventSource, var/datum/procOwner, var/proc_call)
+/decl/observ/moved/register(var/atom/movable/mover, var/datum/listener, var/proc_call)
 	. = ..()
-	var/atom/movable/child = eventSource
-	if(.)
-		var/atom/movable/parent = child.loc
-		while(istype(parent) && !moved_event.is_listening(parent, child))
-			moved_event.register(parent, child, /atom/movable/proc/recursive_move)
-			child = parent
-			parent = child.loc
+
+	// Listen to the parent if possible.
+	if(. && istype(mover.loc, expected_type))
+		register(mover.loc, mover, /atom/movable/proc/recursive_move)
+
+/decl/observ/moved/unregister(var/atom/movable/mover, var/datum/listener, var/proc_call)
+	. = ..()
+
+	// Stop listening to the parent if we aren't being listened to.
+	if(. && !has_listeners(mover))
+		unregister(mover.loc, mover, /atom/movable/proc/recursive_move)
+
+// Handles the triggering of movement events by the parent.
+/atom/movable/proc/recursive_move(var/atom/movable/am, var/old_loc, var/new_loc)
+	moved_event.raise_event(src, old_loc, new_loc)
+
 
 /********************
 * Movement Handling *
 ********************/
-/atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
-	var/turf/T = get_turf(new_loc)
-	if(T && T != loc)
-		forceMove(T)
-
-/atom/movable/proc/recursive_move(var/atom/movable/am, var/old_loc, var/new_loc)
-	moved_event.raise_event(list(src, old_loc, new_loc))
 
 /atom/Entered(var/atom/movable/am, var/atom/old_loc)
 	. = ..()
 	if(. != CANCEL_MOVE_EVENT)
-		moved_event.raise_event(list(am, old_loc, am.loc))
+		moved_event.raise_event(am, old_loc, am.loc)
 
 /atom/movable/Entered(var/atom/movable/am, atom/old_loc)
 	. = ..()
-	if(. != CANCEL_MOVE_EVENT && moved_event.has_listeners(am) && !moved_event.is_listening(src, am))
+	if(. != CANCEL_MOVE_EVENT && moved_event.has_listeners(am))
 		moved_event.register(src, am, /atom/movable/proc/recursive_move)
 
 /atom/movable/Exited(var/atom/movable/am, atom/old_loc)
-	..()
-	if(moved_event.is_listening(src, am, /atom/movable/proc/recursive_move))
-		moved_event.unregister(src, am)
+	. = ..()
+	if(moved_event.has_listeners(am))
+		moved_event.unregister(src, am, /atom/movable/proc/recursive_move)

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -38,6 +38,11 @@ var/decl/observ/moved/moved_event = new()
 * Movement Handling *
 ********************/
 
+/atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
+	var/turf/T = get_turf(new_loc)
+	if(T && T != loc)
+		forceMove(T)
+
 /atom/Entered(var/atom/movable/am, var/atom/old_loc)
 	. = ..()
 	if(. != CANCEL_MOVE_EVENT)

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -1,61 +1,137 @@
-/datum/observ
-	var/name = "Unnamed Event"
-	var/expected_type = /datum
-	var/list/listeners_assoc
+//
+//	Observer Pattern Implementation
+//
+//	Implements a basic observer pattern with the following main procs:
+//
+//	/decl/observ/proc/is_listening(var/event_source, var/datum/proc_owner, var/proc_call)
+//		event_source: The instance which is generating events.
+//		proc_owner: The instance which may be listening to events by event_source
+//		proc_call: Optional. The specific proc to call when the event is raised.
+//
+//		Returns true if proc_owner is listening for events by event_source, and proc_call supplied is either null or the same proc that will be called when an event is raised.
+//
+//	/decl/observ/proc/has_listeners(var/event_source)
+//		event_source: The instance which is generating events.
+//
+//		Returns true if the given event_source has any listeners at all.
+//
+//	/decl/observ/proc/register(var/event_source, var/datum/proc_owner, var/proc_call)
+//		event_source: The instance you wish to receive events from.
+//		proc_owner: The instance/owner of the proc to call when an event is raised by the event_source.
+//		proc_call: The proc to call when an event is raised.
+//
+//		Calling register() multiple times using the same event_source and proc_owner will replace the current proc to be called with the supplied proc_call.
+//		As such, some care will have to be taken should you even conduct registrations for other instances/proc_owners than src in case other registrations have already been made.
+//		A call to register() does not override the proc_call provided in a register_global() call, these are fully separate.
+//
+//		When proc_call is called the first argument is always the source of the event (event_source).
+//		Additional arguments may or may not be supplied, see individual event definition files (destroyed.dm, moved.dm, etc.) for details.
+//
+//		The instance making the register() call is also responsible for calling unregister(), including when event_source is destroyed.
+//			This can be handled by listening to the event_source's destroyed event, unregistering in the proc_owner's Destroy() proc, etc.
+//
+//	/decl/observ/proc/unregister(var/event_source, var/datum/proc_owner)
+//		event_source: The instance you wish to stop receiving events from.
+//		proc_owner: The instance/owner of the proc which will no longer receive the events.
+//
+//		Calling unregister() multiple times with the same event_source and proc_owner is safe/will have no side-effect once a prior register() call has been undone.
+//
+//	/decl/observ/proc/register_global(var/datum/proc_owner, var/proc_call)
+//		proc_owner: The instance/owner of the proc to call when an event is raised by any and all sources.
+//		proc_call: The proc to call when an event is raised.
+//
+//		Calling register_global() multiple times using the same proc_owner will replace the current proc to be called with the supplied proc_call.
+//		As such, some care will have to be taken should you even conduct registrations for other instances/proc_owners than src in case other registrations have already been made.
+//		A call to register_global() does not override the proc_call provided in a register() call, these are fully separate.
+//
+//		The instance making the register() call is also responsible for calling unregister(), except for when event_sources are destroyed (as it isn't bound to any specific instance).
+//			This can for example be handled in the proc_owner's Destroy() proc.
+//
+//		For additional details see: /decl/observ/proc/register() above as details concerning which arguments proc_call will receive.
+//
+//	/decl/observ/proc/unregister_global(var/datum/proc_owner)
+//		proc_owner: The instance/owner of the proc which will no longer receive the events.
+//
+//		Calling unregister_global() multiple times with the same event_source and proc_owner is safe/will have no side-effect once a prior register_global() call has been undone.
+//
+//	/decl/observ/proc/raise_event(var/list/args = list())
+//		Should never be called unless implementing a new event type.
+//		The argument shall always be a list, and the first element shall always be the event_source instance belonging to the event.
+//		Beyond that there are no restrictions.
 
-/datum/observ/New()
+/decl/observ
+	var/name = "Unnamed Event" // The name of this event, used mainly for debug/VV purposes. The list of event managers can be reached through the "Debug Controller" verb, selecting the "Observation" entry.
+	var/expected_type = /datum // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
+	var/list/event_sources     // Associate list of event sources, each with their own associate list. This associate list contains an instance/proc pair to call when the event is raised.
+	var/list/global_listeners  // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
+
+/decl/observ/New()
 	all_observable_events.events += src
-	listeners_assoc = list()
+	event_sources = list()
 	..()
 
-/datum/observ/proc/is_listening(var/eventSource, var/datum/procOwner, var/proc_call)
-	var/listeners = listeners_assoc[eventSource]
+/decl/observ/proc/is_listening(var/event_source, var/datum/proc_owner, var/proc_call)
+	var/listeners = event_sources[event_source]
 	if(!listeners)
 		return FALSE
 
-	var/stored_proc_call = listeners[procOwner]
+	var/stored_proc_call = listeners[proc_owner]
 	return stored_proc_call && (!proc_call || stored_proc_call == proc_call)
 
-/datum/observ/proc/has_listeners(var/eventSource)
-	var/list/listeners = listeners_assoc[eventSource]
+/decl/observ/proc/has_listeners(var/event_source)
+	var/list/listeners = event_sources[event_source]
 	return listeners && listeners.len
 
-/datum/observ/proc/register(var/eventSource, var/datum/procOwner, var/proc_call)
-	if(!(eventSource && procOwner && procOwner))
+/decl/observ/proc/register(var/datum/event_source, var/datum/proc_owner, var/proc_call)
+	if(!(event_source && proc_owner && proc_call))
 		return FALSE
-	if(istype(eventSource, /datum/observ))
+	if(istype(event_source, /decl/observ))
 		return FALSE
 
-	if(!istype(eventSource, expected_type))
-		CRASH("Unexpected type. Expected [expected_type], was [eventSource]")
+	if(!istype(event_source, expected_type))
+		CRASH("Unexpected type. Expected [expected_type], was [event_source.type]")
 
-	var/listeners = listeners_assoc[eventSource]
+	var/listeners = event_sources[event_source]
 	if(!listeners)
 		listeners = list()
-		listeners_assoc[eventSource] = listeners
-	listeners[procOwner] = proc_call
-	destroyed_event.register(procOwner, src, /datum/observ/proc/unregister)
+		event_sources[event_source] = listeners
+	listeners[proc_owner] = proc_call
+
 	return TRUE
 
-/datum/observ/proc/unregister(var/eventSource, var/datum/procOwner)
-	if(!(eventSource && procOwner))
-		return FALSE
-	if(istype(eventSource, /datum/observ))
+/decl/observ/proc/unregister(var/event_source, var/datum/proc_owner)
+	if(!(event_source && proc_owner))
 		return FALSE
 
-	var/listeners = listeners_assoc[eventSource]
+	var/listeners = event_sources[event_source]
 	if(!listeners)
 		return FALSE
 
-	listeners -= procOwner
-	destroyed_event.unregister(procOwner, src)
+	listeners -= proc_owner
 	return TRUE
 
-/datum/observ/proc/raise_event(var/list/args = list())
+/decl/observ/proc/register_global(var/datum/proc_owner, var/proc_call)
+	if(!(proc_owner && proc_call))
+		return FALSE
+	if(!global_listeners)
+		global_listeners = list()
+
+	global_listeners[proc_owner] = proc_call
+	return TRUE
+
+/decl/observ/proc/unregister_global(var/datum/proc_owner)
+	if(!(proc_owner && global_listeners))
+		return FALSE
+
+	global_listeners -= proc_owner
+	return TRUE
+
+/decl/observ/proc/raise_event(var/list/args = list())
 	if(!args.len)
 		return
-	var/listeners = listeners_assoc[args[1]]
-	if(!listeners)
-		return
-	for(var/listener in listeners)
-		call(listener, listeners[listener])	(arglist(args))
+	var/listeners = event_sources[args[1]]
+	if(listeners)
+		for(var/listener in listeners)
+			call(listener, listeners[listener])(arglist(args))	// Sadly arglist() cannot be stored in a var for re-use
+	for(var/listener in global_listeners)
+		call(listener, global_listeners[listener])(arglist(args))

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -62,76 +62,241 @@
 /decl/observ
 	var/name = "Unnamed Event" // The name of this event, used mainly for debug/VV purposes. The list of event managers can be reached through the "Debug Controller" verb, selecting the "Observation" entry.
 	var/expected_type = /datum // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
-	var/list/event_sources     // Associate list of event sources, each with their own associate list. This associate list contains an instance/proc pair to call when the event is raised.
+	var/list/event_sources     // Associative list of event sources, each with their own associative list. This associative list contains an instance/proc pair to call when the event is raised.
 	var/list/global_listeners  // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
 
 /decl/observ/New()
 	all_observable_events.events += src
-	event_sources = list()
-	..()
+	return ..()
 
-/decl/observ/proc/is_listening(var/event_source, var/datum/proc_owner, var/proc_call)
-	var/listeners = event_sources[event_source]
-	if(!listeners)
+/decl/observ/Del()
+	all_observable_events.events -= src
+	return ..()
+
+/decl/observ/proc/is_listening(var/event_source, var/datum/listener, var/proc_call)
+	// Return whether there are global listeners unless the event source is given.
+	if (!event_source)
+		return !!global_listeners
+
+	// Return whether anything is listening to a source, if no listener is given.
+	if (!listener)
+		return global_listeners || (event_sources && event_source in event_sources)
+
+	// Return false if there are no sources or nothing is associated with that source.
+	if (!(event_sources && event_source in event_sources))
 		return FALSE
 
-	var/stored_proc_call = listeners[proc_owner]
-	return stored_proc_call && (!proc_call || stored_proc_call == proc_call)
+	// Get and check the listeners for the reuqested event.
+	var/listeners = event_sources[event_source]
+	if (!(listener in listeners))
+		return FALSE
+
+	// Return true unless a specific callback needs checked.
+	if (!proc_call)
+		return TRUE
+
+	// Check if the specific callback exists.
+	var/list/callback = listeners[listener]
+	if (istype(callback))
+		return proc_call in callback
+	return proc_call == callback
 
 /decl/observ/proc/has_listeners(var/event_source)
-	var/list/listeners = event_sources[event_source]
-	return listeners && listeners.len
+	return is_listening(event_source)
 
-/decl/observ/proc/register(var/datum/event_source, var/datum/proc_owner, var/proc_call)
-	if(!(event_source && proc_owner && proc_call))
+/decl/observ/proc/register(var/datum/event_source, var/datum/listener, var/proc_call)
+	// Sanity checking.
+	if (!(event_source && listener && proc_call))
 		return FALSE
-	if(istype(event_source, /decl/observ))
+	if (istype(event_source, /decl/observ))
 		return FALSE
 
-	if(!istype(event_source, expected_type))
+	// Crash if the event source is the wrong type.
+	if (!istype(event_source, expected_type))
 		CRASH("Unexpected type. Expected [expected_type], was [event_source.type]")
 
-	var/listeners = event_sources[event_source]
-	if(!listeners)
+	// Perform some setup.
+	if (!event_sources)
+		event_sources = list()
+
+	var/list/listeners = event_sources[event_source]
+	if (!listeners)
 		listeners = list()
 		event_sources[event_source] = listeners
-	listeners[proc_owner] = proc_call
 
+	// If no callbacks are set or the callback is set to the value we want, return true..
+	var/list/callbacks = listeners[listener]
+	if (!callbacks || callbacks == proc_call)
+		listeners[listener] = proc_call
+		return TRUE
+
+	// Otherwise, make sure the callbacks are a list.
+	if (!istype(callbacks))
+		callbacks = list(callbacks)
+		listeners[listener] = callbacks
+
+	// Add the callback, and return true.
+	callbacks |= proc_call
 	return TRUE
 
-/decl/observ/proc/unregister(var/event_source, var/datum/proc_owner)
-	if(!(event_source && proc_owner))
+/decl/observ/proc/unregister(var/event_source, var/datum/listener, var/proc_call)
+	// Sanity.
+	if (!(event_sources && event_source && listener && event_source in event_sources))
 		return FALSE
 
-	var/listeners = event_sources[event_source]
-	if(!listeners)
+	// Return false if nothing is listening for this event.
+	var/list/listeners = event_sources[event_source]
+	if (!listeners)
 		return FALSE
 
-	listeners -= proc_owner
+	// Remove all callbacks if no specific one is given.
+	if (!proc_call)
+		listeners -= listener
+
+		// Perform some cleanup and return true.
+		if (!listeners.len)
+			event_sources -= event_source
+		if (!event_sources.len)
+			event_sources = null
+		return TRUE
+
+	// See if we can find the callback.
+	var/list/callbacks = listeners[listener]
+	if (istype(callbacks) && callbacks.len)
+		var/index = callbacks.Find(proc_call)
+		if (!index)
+			return FALSE
+
+		callbacks.Cut(index, index + 1)
+	else if (callbacks)
+		if(callbacks != proc_call)
+			return FALSE
+
+		callbacks = null
+	else
+		return FALSE
+
+	// If we made it to here, we found the callback and need to tidy up.
+	if (!(callbacks && callbacks.len))
+		listeners -= listener
+	if (!listeners.len)
+		event_sources -= event_source
+	if (!event_sources.len)
+		event_sources = null
+
+	// We found it, so return true.
 	return TRUE
 
-/decl/observ/proc/register_global(var/datum/proc_owner, var/proc_call)
-	if(!(proc_owner && proc_call))
+/decl/observ/proc/register_global(var/datum/listener, var/proc_call)
+	// Sanity.
+	if (!(listener && proc_call))
 		return FALSE
-	if(!global_listeners)
+
+	// Set up the global listeners if needed.
+	if (!global_listeners)
 		global_listeners = list()
 
-	global_listeners[proc_owner] = proc_call
+	// If no callbacks are set or the callback is set to the value we want, return true..
+	var/list/callbacks = global_listeners[listener]
+	if (!callbacks || callbacks == proc_call)
+		global_listeners[listener] = proc_call
+		return TRUE
+
+	// Otherwise, make sure the callbacks are a list.
+	if (!istype(callbacks))
+		callbacks = list(callbacks)
+		global_listeners[listener] = callbacks
+
+	// Add the callback and return true.
+	callbacks |= proc_call
 	return TRUE
 
-/decl/observ/proc/unregister_global(var/datum/proc_owner)
-	if(!(proc_owner && global_listeners))
+/decl/observ/proc/unregister_global(var/datum/listener, var/proc_call)
+	// Return false unless the listener is set as a global listener.
+	if (!(global_listeners && listener && listener in global_listeners))
 		return FALSE
 
-	global_listeners -= proc_owner
+	// Remove all callbacks if no specific one is given.
+	if (!proc_call)
+		global_listeners -= listener
+
+		// Perform some cleanup and return true.
+		if (!global_listeners.len)
+			global_listeners = null
+		return TRUE
+
+	// See if we can find the callback.
+	var/list/callbacks = global_listeners[listener]
+	if (istype(callbacks) && callbacks.len)
+		var/index = callbacks.Find(proc_call)
+		if (!index)
+			return FALSE
+
+		callbacks.Cut(index, index + 1)
+	else if (callbacks)
+		if(callbacks != proc_call)
+			return FALSE
+
+		callbacks = null
+	else
+		return FALSE
+
+	// If we made it to here, we found the callback and need to tidy up.
+	if (!(callbacks && callbacks.len))
+		global_listeners -= listener
+	if (!global_listeners.len)
+		global_listeners = null
+
+	// We found it, so return true.
 	return TRUE
 
-/decl/observ/proc/raise_event(var/list/args = list())
-	if(!args.len)
+/decl/observ/proc/raise_event()
+	// Sanity
+	if (!args.len)
 		return
-	var/listeners = event_sources[args[1]]
-	if(listeners)
-		for(var/listener in listeners)
-			call(listener, listeners[listener])(arglist(args))	// Sadly arglist() cannot be stored in a var for re-use
-	for(var/listener in global_listeners)
-		call(listener, global_listeners[listener])(arglist(args))
+
+	// Call the global listeners, if they exist.
+	if (global_listeners)
+		for (var/datum/listener in global_listeners)
+			var/list/callback = global_listeners[listener]
+
+			// If it's not a list, the callback is used as the procedure name.
+			if (!istype(callback))
+				try
+					world << call(listener, callback)(arglist(args))
+				catch (var/exception/e)
+					error(e.desc)
+					unregister_global(listener, callback)
+				continue
+
+			// Otherwise, call each procedure on the object with the arguments.
+			for (var/proc_call in callback)
+				try
+					call(listener, proc_call)(arglist(args))
+				catch (var/exception/e)
+					error(e.desc)
+					unregister_global(listener, proc_call)
+
+	// Call the listeners for this specific event source, if they exist.
+	var/source = args[1]
+	if (event_sources && source in event_sources)
+		var/listeners = event_sources[source]
+		for (var/datum/listener in listeners)
+			var/list/callback = listeners[listener]
+
+			// If it's not a list, the callback is used as the procedure name.
+			if (!istype(callback))
+				try
+					call(listener, callback)(arglist(args))
+				catch (var/exception/e)
+					error(e.desc)
+					unregister(source, listener, callback)
+				continue
+
+			// Otherwise, call each procedure on the object with the arguments.
+			for (var/proc_call in callback)
+				try
+					call(listener, proc_call)(arglist(args))
+				catch (var/exception/e)
+					error(e.desc)
+					unregister(source, listener, proc_call)

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -60,30 +60,26 @@
 //		Beyond that there are no restrictions.
 
 /decl/observ
-	var/name = "Unnamed Event" // The name of this event, used mainly for debug/VV purposes. The list of event managers can be reached through the "Debug Controller" verb, selecting the "Observation" entry.
-	var/expected_type = /datum // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
-	var/list/event_sources     // Associative list of event sources, each with their own associative list. This associative list contains an instance/proc pair to call when the event is raised.
-	var/list/global_listeners  // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
+	var/name = "Unnamed Event"          // The name of this event, used mainly for debug/VV purposes. The list of event managers can be reached through the "Debug Controller" verb, selecting the "Observation" entry.
+	var/expected_type = /datum          // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
+	var/list/event_sources = list()     // Associative list of event sources, each with their own associative list. This associative list contains an instance/proc pair to call when the event is raised.
+	var/list/global_listeners = list()  // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
 
 /decl/observ/New()
 	all_observable_events.events += src
-	return ..()
-
-/decl/observ/Del()
-	all_observable_events.events -= src
-	return ..()
+	. = ..()
 
 /decl/observ/proc/is_listening(var/event_source, var/datum/listener, var/proc_call)
 	// Return whether there are global listeners unless the event source is given.
 	if (!event_source)
-		return !!global_listeners
+		return !!global_listeners.len
 
 	// Return whether anything is listening to a source, if no listener is given.
 	if (!listener)
-		return global_listeners || (event_sources && event_source in event_sources)
+		return global_listeners.len || event_source in event_sources
 
-	// Return false if there are no sources or nothing is associated with that source.
-	if (!(event_sources && event_source in event_sources))
+	// Return false if nothing is associated with that source.
+	if (!(event_source in event_sources))
 		return FALSE
 
 	// Get and check the listeners for the reuqested event.
@@ -97,9 +93,10 @@
 
 	// Check if the specific callback exists.
 	var/list/callback = listeners[listener]
-	if (istype(callback))
-		return proc_call in callback
-	return proc_call == callback
+	if (!callback)
+		return FALSE
+
+	return proc_call in callback
 
 /decl/observ/proc/has_listeners(var/event_source)
 	return is_listening(event_source)
@@ -115,24 +112,16 @@
 	if (!istype(event_source, expected_type))
 		CRASH("Unexpected type. Expected [expected_type], was [event_source.type]")
 
-	// Perform some setup.
-	if (!event_sources)
-		event_sources = list()
-
+	// Setup the listeners for this source if needed.
 	var/list/listeners = event_sources[event_source]
 	if (!listeners)
 		listeners = list()
 		event_sources[event_source] = listeners
 
-	// If no callbacks are set or the callback is set to the value we want, return true..
+	// Make sure the callbacks are a list.
 	var/list/callbacks = listeners[listener]
-	if (!callbacks || callbacks == proc_call)
-		listeners[listener] = proc_call
-		return TRUE
-
-	// Otherwise, make sure the callbacks are a list.
-	if (!istype(callbacks))
-		callbacks = list(callbacks)
+	if (!callbacks)
+		callbacks = list()
 		listeners[listener] = callbacks
 
 	// Add the callback, and return true.
@@ -141,7 +130,7 @@
 
 /decl/observ/proc/unregister(var/event_source, var/datum/listener, var/proc_call)
 	// Sanity.
-	if (!(event_sources && event_source && listener && event_source in event_sources))
+	if (!(event_source && listener && event_source in event_sources))
 		return FALSE
 
 	// Return false if nothing is listening for this event.
@@ -156,35 +145,24 @@
 		// Perform some cleanup and return true.
 		if (!listeners.len)
 			event_sources -= event_source
-		if (!event_sources.len)
-			event_sources = null
 		return TRUE
 
-	// See if we can find the callback.
+	// See if the listener is registered.
 	var/list/callbacks = listeners[listener]
-	if (istype(callbacks) && callbacks.len)
-		var/index = callbacks.Find(proc_call)
-		if (!index)
-			return FALSE
-
-		callbacks.Cut(index, index + 1)
-	else if (callbacks)
-		if(callbacks != proc_call)
-			return FALSE
-
-		callbacks = null
-	else
+	if (!callbacks)
 		return FALSE
 
-	// If we made it to here, we found the callback and need to tidy up.
-	if (!(callbacks && callbacks.len))
+	// See if the callback exists.
+	var/index = callbacks.Find(proc_call)
+	if (!index)
+		return FALSE
+
+	// Remove the callback and do some cleanup.
+	callbacks.Cut(index, index + 1)
+	if (!callbacks.len)
 		listeners -= listener
 	if (!listeners.len)
 		event_sources -= event_source
-	if (!event_sources.len)
-		event_sources = null
-
-	// We found it, so return true.
 	return TRUE
 
 /decl/observ/proc/register_global(var/datum/listener, var/proc_call)
@@ -192,19 +170,10 @@
 	if (!(listener && proc_call))
 		return FALSE
 
-	// Set up the global listeners if needed.
-	if (!global_listeners)
-		global_listeners = list()
-
-	// If no callbacks are set or the callback is set to the value we want, return true..
+	// Make sure the callbacks are setup.
 	var/list/callbacks = global_listeners[listener]
-	if (!callbacks || callbacks == proc_call)
-		global_listeners[listener] = proc_call
-		return TRUE
-
-	// Otherwise, make sure the callbacks are a list.
-	if (!istype(callbacks))
-		callbacks = list(callbacks)
+	if (!callbacks)
+		callbacks = list()
 		global_listeners[listener] = callbacks
 
 	// Add the callback and return true.
@@ -213,41 +182,28 @@
 
 /decl/observ/proc/unregister_global(var/datum/listener, var/proc_call)
 	// Return false unless the listener is set as a global listener.
-	if (!(global_listeners && listener && listener in global_listeners))
+	if (!(listener && listener in global_listeners))
 		return FALSE
 
 	// Remove all callbacks if no specific one is given.
 	if (!proc_call)
 		global_listeners -= listener
-
-		// Perform some cleanup and return true.
-		if (!global_listeners.len)
-			global_listeners = null
 		return TRUE
 
-	// See if we can find the callback.
+	// See if the listener is registered.
 	var/list/callbacks = global_listeners[listener]
-	if (istype(callbacks) && callbacks.len)
-		var/index = callbacks.Find(proc_call)
-		if (!index)
-			return FALSE
-
-		callbacks.Cut(index, index + 1)
-	else if (callbacks)
-		if(callbacks != proc_call)
-			return FALSE
-
-		callbacks = null
-	else
+	if (!callbacks)
 		return FALSE
 
-	// If we made it to here, we found the callback and need to tidy up.
-	if (!(callbacks && callbacks.len))
-		global_listeners -= listener
-	if (!global_listeners.len)
-		global_listeners = null
+	// See if the callback exists.
+	var/index = callbacks.Find(proc_call)
+	if (!index)
+		return FALSE
 
-	// We found it, so return true.
+	// Remove the callback and perform cleanup.
+	callbacks.Cut(index, index + 1)
+	if (!callbacks.len)
+		global_listeners -= listener
 	return TRUE
 
 /decl/observ/proc/raise_event()
@@ -255,46 +211,27 @@
 	if (!args.len)
 		return
 
-	// Call the global listeners, if they exist.
-	if (global_listeners)
-		for (var/datum/listener in global_listeners)
-			var/list/callback = global_listeners[listener]
+	// Call the global listeners.
+	for (var/datum/listener in global_listeners)
+		var/list/callbacks = global_listeners[listener]
+		for (var/proc_call in callbacks)
 
-			// If it's not a list, the callback is used as the procedure name.
-			if (!istype(callback))
-				try
-					world << call(listener, callback)(arglist(args))
-				catch (var/exception/e)
-					error(e.desc)
-					unregister_global(listener, callback)
-				continue
-
-			// Otherwise, call each procedure on the object with the arguments.
-			for (var/proc_call in callback)
-				try
-					call(listener, proc_call)(arglist(args))
-				catch (var/exception/e)
-					error(e.desc)
-					unregister_global(listener, proc_call)
+			// If the callback crashes, record the error and remove it.
+			try
+				call(listener, proc_call)(arglist(args))
+			catch (var/exception/e)
+				error(e.desc)
+				unregister_global(listener, proc_call)
 
 	// Call the listeners for this specific event source, if they exist.
 	var/source = args[1]
-	if (event_sources && source in event_sources)
-		var/listeners = event_sources[source]
+	if (source in event_sources)
+		var/list/listeners = event_sources[source]
 		for (var/datum/listener in listeners)
-			var/list/callback = listeners[listener]
+			var/list/callbacks = listeners[listener]
+			for (var/proc_call in callbacks)
 
-			// If it's not a list, the callback is used as the procedure name.
-			if (!istype(callback))
-				try
-					call(listener, callback)(arglist(args))
-				catch (var/exception/e)
-					error(e.desc)
-					unregister(source, listener, callback)
-				continue
-
-			// Otherwise, call each procedure on the object with the arguments.
-			for (var/proc_call in callback)
+				// If the callback crashes, record the error and remove it.
 				try
 					call(listener, proc_call)(arglist(args))
 				catch (var/exception/e)

--- a/code/datums/observation/task_triggered.dm
+++ b/code/datums/observation/task_triggered.dm
@@ -1,5 +1,13 @@
-var/datum/observ/task_triggered/task_triggered_event = new()
+//
+//	Observer Pattern Implementation: Scheduled task triggered
+//		Registration type: /datum/scheduled_task
+//
+//		Raised when: When a scheduled task reaches its trigger time.
+//
+//		Arguments that the called proc should expect:
+//			/datum/scheduled_task/task: The task that reached its trigger time.
+var/decl/observ/task_triggered/task_triggered_event = new()
 
-/datum/observ/task_triggered
+/decl/observ/task_triggered
 	name = "Task Triggered"
 	expected_type = /datum/scheduled_task

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -137,7 +137,7 @@ var/const/enterloopsanity = 100
 		else if(is_space())
 			M.inertia_dir = 0
 			M.make_floating(0)
-	..()
+
 	var/objects = 0
 	if(A && (A.flags & PROXMOVE))
 		for(var/atom/movable/thing in range(1))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -326,7 +326,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	stop_following()
 	following = target
-	moved_event.register(following, src, /atom/movable/proc/move_to_destination)
+	moved_event.register(following, src, /mob/dead/observer/proc/move_to_destination)
 	destroyed_event.register(following, src, /mob/dead/observer/proc/stop_following)
 
 	src << "<span class='notice'>Now following \the [following]</span>"
@@ -339,12 +339,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		destroyed_event.unregister(following, src)
 		following = null
 
-/mob/dead/observer/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
+/mob/dead/observer/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)
 	if(check_holy(T))
 		usr << "<span class='warning'>You cannot follow something standing on holy grounds!</span>"
 		return
-	..()
+	if(T && T != loc)
+		forceMove(T)
 
 /mob/proc/check_holy(var/turf/T)
 	return 0

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -326,7 +326,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	stop_following()
 	following = target
-	moved_event.register(following, src, /mob/dead/observer/proc/move_to_destination)
+	moved_event.register(following, src, /atom/movable/proc/move_to_destination)
 	destroyed_event.register(following, src, /mob/dead/observer/proc/stop_following)
 
 	src << "<span class='notice'>Now following \the [following]</span>"
@@ -339,13 +339,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		destroyed_event.unregister(following, src)
 		following = null
 
-/mob/dead/observer/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
+/mob/dead/observer/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)
 	if(check_holy(T))
 		usr << "<span class='warning'>You cannot follow something standing on holy grounds!</span>"
 		return
-	if(T && T != loc)
-		forceMove(T)
+	..()
 
 /mob/proc/check_holy(var/turf/T)
 	return 0

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -186,7 +186,7 @@ datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop/start_te
 
 	var/list/event = received_moves[1]
 	if(event[1] != held_item || event[2] != held_mob || event[3] != mech)
-		fail("Unepected move event received. Expected [held_item], was [event[1]]. Expected [held_mob], was [event[2]]. Expected [mech], was [event[3]]")
+		fail("Unexpected move event received. Expected [held_item], was [event[1]]. Expected [held_mob], was [event[2]]. Expected [mech], was [event[3]]")
 	else if(!(held_item in mech.dropped_items))
 		fail("Expected \the [held_item] to be in the mechs' dropped item list")
 	else
@@ -200,3 +200,52 @@ datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop/start_te
 
 	return 1
 
+datum/unit_test/observation/moved_shall_not_unregister_recursively_one
+	name = "OBSERVATION: Moved - Shall Not Unregister Recursively - One"
+
+datum/unit_test/observation/moved_shall_not_unregister_recursively_one/start_test()
+	..()
+	var/turf/T = locate(20,20,1)
+	var/mob/dead/observer/one = new(T)
+	var/mob/dead/observer/two = new(T)
+	var/mob/dead/observer/three = new(T)
+
+	two.ManualFollow(one)
+	three.ManualFollow(two)
+
+	two.stop_following()
+	if(is_listening_to_movement(two, three))
+		pass("Observer three is still following observer two.")
+	else
+		fail("Observer three is no longer following observer two.")
+
+	qdel(one)
+	qdel(two)
+	qdel(three)
+
+	return 1
+
+datum/unit_test/observation/moved_shall_not_unregister_recursively_two
+	name = "OBSERVATION: Moved - Shall Not Unregister Recursively - Two"
+
+datum/unit_test/observation/moved_shall_not_unregister_recursively_two/start_test()
+	..()
+	var/turf/T = locate(20,20,1)
+	var/mob/dead/observer/one = new(T)
+	var/mob/dead/observer/two = new(T)
+	var/mob/dead/observer/three = new(T)
+
+	two.ManualFollow(one)
+	three.ManualFollow(two)
+
+	three.stop_following()
+	if(is_listening_to_movement(one, two))
+		pass("Observer two is still following observer one.")
+	else
+		fail("Observer two is no longer following observer one.")
+
+	qdel(one)
+	qdel(two)
+	qdel(three)
+
+	return 1

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -104,10 +104,10 @@ datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/
 	qdel(H)
 	return 1
 
-datum/unit_test/observation/moved_shall_registers_recursively_on_new_listener
+datum/unit_test/observation/moved_shall_register_recursively_on_new_listener
 	name = "OBSERVATION: Moved - Shall Register Recursively on New Listener"
 
-datum/unit_test/observation/moved_shall_registers_recursively_on_new_listener/start_test()
+datum/unit_test/observation/moved_shall_register_recursively_on_new_listener/start_test()
 	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
@@ -128,10 +128,10 @@ datum/unit_test/observation/moved_shall_registers_recursively_on_new_listener/st
 	qdel(O)
 	return 1
 
-datum/unit_test/observation/moved_shall_registers_recursively_with_existing_listener
+datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener
 	name = "OBSERVATION: Moved - Shall Register Recursively with Existing Listener"
 
-datum/unit_test/observation/moved_shall_registers_recursively_with_existing_listener/start_test()
+datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener/start_test()
 	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -19,10 +19,38 @@ datum/unit_test/observation/proc/dump_received_moves()
 		var/list/l = entry
 		log_unit_test("[l[1]] - [l[2]] - [l[3]]")
 
+datum/unit_test/observation/global_listeners_shall_receive_events
+	name = "OBSERVATION: Global listeners shall receive events"
+
+datum/unit_test/observation/global_listeners_shall_receive_events/start_test()
+	..()
+	var/turf/start = locate(20,20,1)
+	var/turf/target = locate(20,21,1)
+	var/mob/living/carbon/human/H = new(start)
+
+	moved_event.register_global(src, /datum/unit_test/observation/proc/receive_move)
+	H.forceMove(target)
+
+	if(received_moves.len != 1)
+		fail("Expected 1 raised moved event, were [received_moves.len].")
+		dump_received_moves()
+		return 1
+
+	var/list/event = received_moves[1]
+	if(event[1] != H || event[2] != start || event[3] != target)
+		fail("Unepected move event received. Expected [H], was [event[1]]. Expected [start], was [event[2]]. Expected [target], was [event[3]]")
+	else
+		pass("Received the expected move event.")
+
+	moved_event.unregister_global(src)
+	qdel(H)
+	return 1
+
 datum/unit_test/observation/moved_observer_shall_register_on_follow
 	name = "OBSERVATION: Moved - Observer Shall Register on Follow"
 
 datum/unit_test/observation/moved_observer_shall_register_on_follow/start_test()
+	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/mob/dead/observer/O = new(T)
@@ -41,6 +69,7 @@ datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow
 	name = "OBSERVATION: Moved - Observer Shall Unregister on NoFollow"
 
 datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow/start_test()
+	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/mob/dead/observer/O = new(T)
@@ -60,6 +89,7 @@ datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners
 	name = "OBSERVATION: Moved - Shall Not Register on Enter Without Listeners"
 
 datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/start_test()
+	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/obj/structure/closet/C = new(T)
@@ -78,6 +108,7 @@ datum/unit_test/observation/moved_shall_registers_recursively_on_new_listener
 	name = "OBSERVATION: Moved - Shall Register Recursively on New Listener"
 
 datum/unit_test/observation/moved_shall_registers_recursively_on_new_listener/start_test()
+	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/obj/structure/closet/C = new(T)
@@ -101,6 +132,7 @@ datum/unit_test/observation/moved_shall_registers_recursively_with_existing_list
 	name = "OBSERVATION: Moved - Shall Register Recursively with Existing Listener"
 
 datum/unit_test/observation/moved_shall_registers_recursively_with_existing_listener/start_test()
+	..()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/obj/structure/closet/C = new(T)
@@ -160,6 +192,7 @@ datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop/start_te
 	else
 		pass("One one moved event with expected arguments raised.")
 
+	moved_event.unregister(held_item, src)
 	qdel(mech)
 	qdel(held_item)
 	qdel(held_mob)

--- a/code/world.dm
+++ b/code/world.dm
@@ -25,6 +25,9 @@ var/global/datum/global_init/init = new ()
 
 	qdel(src) //we're done
 
+/datum/global_init/Destroy()
+	return 1
+
 /var/game_id = null
 /proc/generate_gameid()
 	if(game_id != null)


### PR DESCRIPTION
Adds additional unit tests.
Renames variables in hopes of making things more clear.
Adds general comments for those who wish to use the observer pattern.
Changes the definition from /datum/ to /decl/ to clarify that only one instance of each observation type should ever be created.
