### PR TITLE
Restores the ability to interact with turfs in the alt+click list.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -703,7 +703,7 @@
 				listed_turf = null
 			else
 				if(statpanel("Turf"))
-					stat("\icon[listed_turf]", listed_turf.name)
+					stat(listed_turf)
 					for(var/atom/A in listed_turf)
 						if(!A.mouse_opacity)
 							continue


### PR DESCRIPTION
A minor consequence is that AIs (or their view to be precise) that go too far away from selected turfs will no longer have it listed until they return within range.
