### PR TITLE
Shuttle docking announcements are sent to the main IRC channel.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -178,6 +178,7 @@ var/list/gamemode_cache = list()
 	var/irc_bot_export = 0 // whether the IRC bot in use is a Bot32 (or similar) instance; Bot32 uses world.Export() instead of nudge.py/libnudge
 	var/main_irc = ""
 	var/admin_irc = ""
+	var/announce_shuttle_dock_to_irc = FALSE
 	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
 	var/use_overmap = 0
@@ -611,6 +612,9 @@ var/list/gamemode_cache = list()
 
 				if("admin_irc")
 					config.admin_irc = value
+
+				if("announce_shuttle_dock_to_irc")
+					config.announce_shuttle_dock_to_irc = TRUE
 
 				if("python_path")
 					if(value)

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -45,10 +45,15 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 		if (autopilot)
 			set_launch_countdown(SHUTTLE_LEAVETIME)	//get ready to return
 
+			var/estimated_time = 0
 			if (evac)
-				emergency_shuttle_docked.Announce("The Emergency Shuttle has docked with the station. You have approximately [round(estimate_launch_time()/60,1)] minutes to board the Emergency Shuttle.")
+				estimated_time = round(emergency_shuttle.estimate_launch_time()/60,1)
+				emergency_shuttle_docked.Announce("The Emergency Shuttle has docked with the station. You have approximately [estimated_time] minute\s to board the Emergency Shuttle.")
 			else
-				priority_announcement.Announce("The scheduled Crew Transfer Shuttle to [dock_name] has docked with the station. It will depart in approximately [round(emergency_shuttle.estimate_launch_time()/60,1)] minutes.")
+				estimated_time = round(estimate_launch_time()/60,1)
+				priority_announcement.Announce("The scheduled Crew Transfer Shuttle to [dock_name] has docked with the station. It will depart in approximately [estimated_time] minute\s.")
+			if(config.announce_shuttle_dock_to_irc)
+				send2mainirc("The shuttle has docked with the station. It will depart in approximately [estimated_time] minute\s.")
 
 		//arm the escape pods
 		if (evac)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -391,3 +391,6 @@ STARLIGHT 0
 ## A ; separated list of lobby screens to randomly pick from. The listed screens must exist as icon states in '/icons/misc/title.dmi'.
 ## Defaults to 'title' if left unset.
 # LOBBY_SCREENS title
+
+## Uncomment this line to announce shuttle dock announcements to the main IRC channel, if MAIN_IRC has also been setup.
+# ANNOUNCE_SHUTTLE_DOCK_TO_IRC


### PR DESCRIPTION
Gives players on IRC a few minutes to prepare for a new round, if so desired.
Comes with a configuration setting which defaults to disabled.
