### PR TITLE
Fixes and tweaks involving robot grippers

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -97,6 +97,11 @@
 		/obj/item/stack/material
 		)
 
+/obj/item/weapon/gripper/examine(mob/user)
+	..()
+	if(wrapped)
+		user << "It is holding \a [wrapped]."
+		
 /obj/item/weapon/gripper/attack_self(mob/user as mob)
 	if(wrapped)
 		return wrapped.attack_self(user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -26,8 +26,6 @@
 
 	var/obj/item/wrapped = null // Item currently being held.
 
-	var/force_holder = null //
-
 // VEEEEERY limited version for mining borgs. Basically only for swapping cells and upgrading the drills.
 /obj/item/weapon/gripper/miner
 	name = "drill maintenance gripper"
@@ -126,13 +124,7 @@
 	//update_icon()
 
 /obj/item/weapon/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(wrapped) 	//The force of the wrapped obj gets set to zero during the attack() and afterattack().
-		force_holder = wrapped.force
-		wrapped.force = 0.0
-		wrapped.attack(M,user)
-		if(deleted(wrapped))
-			wrapped = null
-		return 1
+	// Don't fall through and smack people with gripper, instead just no-op
 	return 0
 
 /obj/item/weapon/gripper/afterattack(var/atom/target, var/mob/living/user, proximity, params)
@@ -150,14 +142,17 @@
 		//Temporary put wrapped into user so target's attackby() checks pass.
 		wrapped.loc = user
 
+		//The force of the wrapped obj gets set to zero during the attack() and afterattack().
+		var/force_holder = wrapped.force
+		wrapped.force = 0.0
+		
 		//Pass the attack on to the target. This might delete/relocate wrapped.
 		var/resolved = target.attackby(wrapped,user)
 		if(!resolved && wrapped && target)
 			wrapped.afterattack(target,user,1)
 
-		//wrapped's force was set to zero.  This resets it to the value it had before.
 		wrapped.force = force_holder
-		force_holder = null
+
 		//If wrapped was neither deleted nor put into target, put it back into the gripper.
 		if(wrapped && user && (wrapped.loc == user))
 			wrapped.loc = src

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -120,7 +120,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		return 0
 	if(!istype(O, /obj/item/stack/material))
 		user << "<span class='notice'>You cannot insert this item into \the [src]!</span>"
-		return 1
+		return 0
 	if(stat)
 		return 1
 

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -118,6 +118,8 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		return 1
 	if(O.is_open_container())
 		return 0
+	if(is_robot_module(O))
+		return 0
 	if(!istype(O, /obj/item/stack/material))
 		user << "<span class='notice'>You cannot insert this item into \the [src]!</span>"
 		return 0

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -117,7 +117,7 @@
 		return 1
 	if(!istype(O, /obj/item/stack/material))
 		user << "<span class='notice'>You cannot insert this item into \the [src]!</span>"
-		return 1
+		return 0
 	if(stat)
 		return 1
 

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -115,6 +115,8 @@
 	if(!linked_console)
 		user << "<span class='notice'>\The [src] must be linked to an R&D console first!</span>"
 		return 1
+	if(is_robot_module(O))
+		return 0
 	if(!istype(O, /obj/item/stack/material))
 		user << "<span class='notice'>You cannot insert this item into \the [src]!</span>"
 		return 0


### PR DESCRIPTION
This a bunch of things related to robot grippers:
- Sheet loader now properly feeds protolathes and circuit imprinters. (resolves #11843)
- Gripper-held items are now properly applied when clicking a mob. I'd like someone to look closely at 0916fba—I don't know why it was calling `attack()` the way it did it, but maybe I'm missing something. (also #11843)
- Protolathe and circuit imprinter now properly reject sheets from robot matter synthesizers (engiborg, drones, etc.). (resolves #11430)
- Grippers now tell you what (if anything) is in them when you examine them. 
