### PR TITLE
Malfunction tweaks

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -97,7 +97,7 @@
 		user << "<span class='danger'>Transfer failed:</span> Existing AI found on remote terminal. Remove existing AI to install a new one."
 		return 0
 
-	if(ai.is_malf())
+	if(ai.malfunctioning)
 		user << "<span class='danger'>ERROR:</span> Remote transfer interface disabled."
 		return 0
 
@@ -108,7 +108,7 @@
 	admin_attack_log(user, ai, "Carded with [src.name]", "Was carded with [src.name]", "used the [src.name] to card")
 	src.name = "[initial(name)] - [ai.name]"
 
-	ai.loc = src
+	ai.forceMove(src)
 	ai.destroy_eyeobj(src)
 	ai.cancel_camera()
 	ai.control_disabled = 1

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -8,12 +8,14 @@
 
 	remove_ai_verbs(src)
 
+	stop_malf(0) // Remove AI's malfunction status, that will fix all hacked APCs, disable delta, etc.
+
 	for(var/obj/machinery/ai_status_display/O in world)
-		spawn( 0 )
 		O.mode = 2
-		if (istype(loc, /obj/item/device/aicard))
-			var/obj/item/device/aicard/card = loc
-			card.update_icon()
+
+	if (istype(loc, /obj/item/device/aicard))
+		var/obj/item/device/aicard/card = loc
+		card.update_icon()
 
 	. = ..(gibbed,"gives one shrill beep before falling lifeless.")
 	density = 1

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -19,22 +19,31 @@
 	user << "Use ai-help command to view relevant information about your abilities"
 
 // Safely remove malfunction status, fixing hacked APCs and resetting variables.
-/mob/living/silicon/ai/proc/stop_malf()
+/mob/living/silicon/ai/proc/stop_malf(var/loud = 1)
+	if(!malfunctioning)
+		return
 	var/mob/living/silicon/ai/user = src
 	// Generic variables
 	malfunctioning = 0
 	sleep(10)
 	research = null
+	hardware = null
 	// Fix hacked APCs
 	if(hacked_apcs)
 		for(var/obj/machinery/power/apc/A in hacked_apcs)
 			A.hacker = null
+			A.update_icon()
 	hacked_apcs = null
+	// Stop the delta alert, and, if applicable, self-destruct timer.
+	bombing_station = 0
+	if(security_level == SEC_LEVEL_DELTA)
+		set_security_level(SEC_LEVEL_RED)
 	// Reset our verbs
 	src.verbs = null
 	add_ai_verbs()
 	// Let them know.
-	user << "You are no longer malfunctioning. Your abilities have been removed."
+	if(loud)
+		user << "You are no longer malfunctioning. Your abilities have been removed."
 
 // Called every tick. Checks if AI is malfunctioning. If yes calls Process on research datum which handles all logic.
 /mob/living/silicon/ai/proc/malf_process()


### PR DESCRIPTION
- APC icons are now automatically updated, Fixes #11712
- Once malf AI is killed or destroyed, the alert is lowered to red, if it is delta. Reason for this is that only the AI can cancel delta.
- Once malf AI is killed, it will lose it's malfunction abilities and the zeroth law. It will also be possible to transfer it to an intellicard, and restore it via an integrity restorer. That way the crew should now be able to fix a malfunctioning AI, preventing the player from being forced out of the round.
