### PR TITLE
Humans health hud now shows "DEAD" instead of crit while dead.

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -76,8 +76,14 @@
 	drop_r_hand()
 	drop_l_hand()
 
+	//TODO:  Change death state to health_dead for all these icon files.  This is a stop gap.
+	 
 	if(healths)
-		healths.icon_state = "health6"
+		if("health7" in icon_states(healths.icon))
+			healths.icon_state = "health7"
+		else
+			healths.icon_state = "health6"
+			log_debug("[src] ([src.type]) died but does not have a valid health7 icon_state (using health6 instead). report this error to Ccomp5950 or your nearest Developer")
 
 	timeofdeath = world.time
 	if(mind) mind.store_memory("Time of death: [worldtime2text()]", 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1157,7 +1157,7 @@
 					I = overlays_cache[23]
 			damageoverlay.overlays += I
 
-		if(healths)
+		if(healths  && stat != DEAD) // They are dead, let death() handle their hud update on this.
 			if (analgesic > 100)
 				healths.icon_state = "health_numb"
 			else


### PR DESCRIPTION
mob/death() was setting the icon state for the health hud to health6 which for 90% of mobs is crit

health7 is dead.

Todo:  Change icon_states for all mobs to be health_dead instead of health6 or health7 or whatever.

:cl:
bugfix: Mobs will now have the correct health indicator when they die.  X_X
/:cl:
