### PR TITLE
Some fixes related to storage item HUDs

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -150,21 +150,38 @@
 	return
 
 /obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
+	// Don't try to transfer reagents to lighters
+	if(istype(W, /obj/item/clothing/mask/smokable/cigarette))
 		var/obj/item/clothing/mask/smokable/cigarette/C = W
-		if(!istype(C)) return // what
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
-		..()
+	..()
 
 /obj/item/weapon/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M, /mob))
 		return
-
-	if(M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
-		var/obj/item/clothing/mask/smokable/cigarette/W = new /obj/item/clothing/mask/smokable/cigarette(user)
-		reagents.trans_to_obj(W, (reagents.total_volume/contents.len))
-		user.equip_to_slot_if_possible(W, slot_wear_mask)
+		
+	if(M == user && user.zone_sel.selecting == "mouth")
+		// Find ourselves a cig. Note that we could be full of lighters.
+		var/obj/item/clothing/mask/smokable/cigarette/cig = null		
+		for(var/obj/item/clothing/mask/smokable/cigarette/C in contents)
+			cig = C
+			break
+		
+		if(cig == null)
+			user << "<span class='notice'>Looks like the packet is out of cigarettes.</span>"
+			return
+		
+		// Instead of running equip_to_slot_if_possible() we check here first,
+		// to avoid dousing cig with reagents if we're not going to equip it
+		if(!cig.mob_can_equip(user, slot_wear_mask))
+			return 
+			
+		// We call remove_from_storage first to manage the reagent transfer and 
+		// UI updates.
+		remove_from_storage(cig, null)
+		user.equip_to_slot(cig, slot_wear_mask)
+		
 		reagents.maximum_volume = 15 * contents.len
-		contents.len--
 		user << "<span class='notice'>You take a cigarette out of the pack.</span>"
 		update_icon()
 	else

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -143,6 +143,7 @@
 	for(var/i = 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette(src)
 	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	flags |= OPENCONTAINER
 
 /obj/item/weapon/storage/fancy/cigarettes/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -233,21 +233,6 @@
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 		..()
 
-/obj/item/weapon/storage/fancy/cigar/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M, /mob))
-		return
-
-	if(M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
-		var/obj/item/clothing/mask/smokable/cigarette/cigar/W = new /obj/item/clothing/mask/smokable/cigarette/cigar(user)
-		reagents.trans_to_obj(W, (reagents.total_volume/contents.len))
-		user.equip_to_slot_if_possible(W, slot_wear_mask)
-		reagents.maximum_volume = 15 * contents.len
-		contents.len--
-		user << "<span class='notice'>You take a cigar out of the case.</span>"
-		update_icon()
-	else
-		..()
-
 /*
  * Vial Box
  */

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -600,13 +600,13 @@
 		return
 
 	if(istype(O,/obj/item/weapon/storage/bag/plants))
+		var/obj/item/weapon/storage/bag/plants/bag = O
 		var/failed = 1
 		for(var/obj/item/G in O.contents)
 			if(!G.reagents || !G.reagents.total_volume)
 				continue
 			failed = 0
-			O.contents -= G
-			G.loc = src
+			bag.remove_from_storage(G, src)
 			holdingitems += G
 			if(holdingitems && holdingitems.len >= limit)
 				break


### PR DESCRIPTION
## Hud fixes

There were some problems with the inventory bar on the HUD not updating in certain circumstances.
- Plant bags now properly update HUD when emptied into All-in-one grinder (fixes #6298)
- Cigarette packets now properly update HUD when player takes a cigarette out via the mouth targeting method (target mouth, click on own mob with packet in hand). 
## Relatedly
- Cigar boxes no longer allow removal of cigars via the mouth targeting method. Internally, this means deleting a bunch of duplicate code, since the cigar way of handling this appeared to be largely copy & paste of the cigarette method. On the user side, who the hell takes cigars out of a box with their mouth, this made no sense at all. 
- Cigarette packets are now open containers. This was needed to make them accept injections of reagents via syringes. This functionality was supposed to be in place, but didn't work. It works now, even if it's still a bunch of messy code in places.
## Changelog

:cl: Daranz
bugfix: HUD glitches with the plant bag and cigarette packets are now fixed.
/:cl:
