### PR TITLE
Light switches now glow

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -7,10 +7,12 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light1"
 	anchored = 1.0
+	use_power = 1
+	idle_power_usage = 20
+	power_channel = LIGHT
 	var/on = 1
 	var/area/area = null
 	var/otherarea = null
-	//	luminosity = 1
 
 /obj/machinery/light_switch/New()
 	..()
@@ -31,8 +33,12 @@
 /obj/machinery/light_switch/proc/updateicon()
 	if(stat & NOPOWER)
 		icon_state = "light-p"
+		set_light(0)
+		layer = OBJ_LAYER
 	else
 		icon_state = "light[on]"
+		set_light(2, 1.5, on ? "#82FF4C" : "#F86060")
+		layer = LIGHTING_LAYER+0.1
 
 /obj/machinery/light_switch/examine(mob/user)
 	if(..(user, 1))


### PR DESCRIPTION
- Adds a relatively weak light to light switches (slightly weaker than a light bulb), so it is not that hard to find them when the room is dark. Colour can be red or green depending on whether the light switch is turned on or off.
- Increases light switch power usage to 20 Watts. For comparsion, a light bulb has 60 so it feels apropriate.
- Light switches now run off LIGHT APC channel rather than EQUIP.
