### PR TITLE
Fixes evidence bag boxes

### DIFF
--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -25,8 +25,10 @@
 	name = "evidence bag box"
 	desc = "A box claiming to contain evidence bags."
 	storage_slots = 6
+	can_hold = list(/obj/item/weapon/evidencebag)
 
 /obj/item/weapon/storage/box/evidence/New()
+	..()
 	for(var/i=0;i<storage_slots,i++)
 		new /obj/item/weapon/evidencebag(src)
 


### PR DESCRIPTION
- Evidence bag boxes no longer runtime on opening due to missing parent call
- It is now possible to properly place evidence bags back into the box.
