### PR TITLE
Adds issue template.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### Brief description of the issue
+
+#### What you expected to happen
+
+#### What actually happened
+
+#### Steps to reproduce
+
+#### Additional info:
+ - **Server Revision**: Found using the "Show Server Revision" verb under the OOC tab.
+ - **Game ID**: This is a random string that is generated for each round, displayed when you login/relog to the server.
+If you know the id for the round the reported issue occured, please list it here.
+ - Anything else you may wish to add.


### PR DESCRIPTION
As according to https://github.com/blog/2111-issue-and-pull-request-templates.
Template based on https://baystation12.net/forums/threads/issue-tracker-report-template.110/.

Does not include the map/runtime templates. I suspect they risk confusing people, or be left to clutter the issue ticket.

How it should turn out when parsed as Markdown:
#### Brief description of the issue
#### What you expected to happen
#### What actually happened
#### Steps to reproduce
#### Additional info:
- **Server Revision**: Found using the "Show Server Revision" verb under the OOC tab.
- **Game ID**: This is a random string that is generated for each round, displayed when you login/relog to the server.
  If you know the id for the round the reported issue occured, please list it here.
- Anything else you may wish to add.
