### PR TITLE
Ensures event sources are cleaned up properly on destroy.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -221,6 +221,7 @@
 #include "code\datums\observation\moved.dm"
 #include "code\datums\observation\observation.dm"
 #include "code\datums\observation\task_triggered.dm"
+#include "code\datums\observation\~cleanup.dm"
 #include "code\datums\repositories\cameras.dm"
 #include "code\datums\repositories\crew.dm"
 #include "code\datums\repositories\repository.dm"

--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -1,0 +1,70 @@
+var/list/global_listen_count = list()
+var/list/event_sources_count = list()
+var/list/event_listen_count = list()
+
+/decl/observ/destroyed/raise_event()
+	. = ..()
+	if(!.)
+		return
+	var/source = args[1]
+
+	if(global_listen_count[source])
+		cleanup_global_listener(source, global_listen_count[source])
+	if(event_sources_count[source])
+		cleanup_source_listeners(source, event_sources_count[source])
+	if(event_listen_count[source])
+		cleanup_event_listener(source, event_listen_count[source])
+
+
+/decl/observ/register(var/datum/event_source, var/datum/listener, var/proc_call)
+	. = ..()
+	if(.)
+		event_sources_count[event_source] += 1
+		event_listen_count[listener] += 1
+
+/decl/observ/unregister(var/datum/event_source, var/datum/listener, var/proc_call)
+	. = ..()
+	if(.)
+		event_sources_count[event_source] -= 1
+		event_listen_count[listener] -= 1
+
+/decl/observ/register_global(var/datum/listener, var/proc_call)
+	. = ..()
+	if(.)
+		global_listen_count[listener] += 1
+
+/decl/observ/unregister_global(var/datum/listener, var/proc_call)
+	. = ..()
+	if(.)
+		global_listen_count[listener] -= 1
+
+/decl/observ/destroyed/proc/cleanup_global_listener(listener, listen_count)
+	global_listen_count -= listener
+	for(var/entry in all_observable_events.events)
+		var/decl/observ/event = entry
+		if(event.unregister_global(listener))
+			log_debug("[event] - [listener] was deleted while still registered to global events.")
+			if(!(--listen_count))
+				return
+
+/decl/observ/destroyed/proc/cleanup_source_listeners(event_source, source_listener_count)
+	event_sources_count -= event_source
+	for(var/entry in all_observable_events.events)
+		var/decl/observ/event = entry
+		var/proc_owners = event.event_sources[event_source]
+		if(proc_owners)
+			for(var/proc_owner in proc_owners)
+				if(event.unregister(event_source, proc_owner))
+					log_debug("[event] - [event_source] was deleted while still being listened to by [proc_owner].")
+					if(!(--source_listener_count))
+						return
+
+/decl/observ/destroyed/proc/cleanup_event_listener(listener, listener_count)
+	event_listen_count -= listener
+	for(var/entry in all_observable_events.events)
+		var/decl/observ/event = entry
+		for(var/event_source in event.event_sources)
+			if(event.unregister(event_source, listener))
+				log_debug("[event] - [listener] was deleted while still listening to [event_source].")
+				if(!(--listener_count))
+					return

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -1,29 +1,54 @@
 /proc/is_listening_to_movement(var/atom/movable/listening_to, var/listener)
 	return moved_event.is_listening(listening_to, listener)
 
-datum/unit_test/observation
+/datum/unit_test/observation
 	name = "OBSERVATION template"
 	async = 0
 	var/list/received_moves
 
-datum/unit_test/observation/start_test()
+/datum/unit_test/observation/start_test()
 	if(!received_moves)
 		received_moves = list()
 	received_moves.Cut()
 
-datum/unit_test/observation/proc/receive_move(var/atom/movable/am, var/old_loc, var/new_loc)
+	sanity_check_events("Pre-Test")
+	. = conduct_test()
+	sanity_check_events("Post-Test")
+
+/datum/unit_test/observation/proc/sanity_check_events(var/phase)
+	for(var/entry in all_observable_events.events)
+		var/decl/observ/event = entry
+		if(null in event.global_listeners)
+			fail("[phase]: [event] - The global listeners list contains a null entry.")
+
+		for(var/event_source in event.event_sources)
+			for(var/list_of_listeners in event.event_sources[event_source])
+				if(isnull(list_of_listeners))
+					fail("[phase]: [event] - The event source list contains a null entry.")
+				else
+					for(var/listener in list_of_listeners)
+						if(isnull(listener))
+							fail("[event] - The event source listener list contains a null entry.")
+						else
+							for(var/proc_call in list_of_listeners[listener])
+								if(isnull(proc_call))
+									fail("[phase]: [event] - [listener]- The proc call list contains a null entry.")
+
+/datum/unit_test/observation/proc/conduct_test()
+	return 0
+
+/datum/unit_test/observation/proc/receive_move(var/atom/movable/am, var/old_loc, var/new_loc)
 	received_moves[++received_moves.len] =  list(am, old_loc, new_loc)
 
-datum/unit_test/observation/proc/dump_received_moves()
+/datum/unit_test/observation/proc/dump_received_moves()
 	for(var/entry in received_moves)
 		var/list/l = entry
 		log_unit_test("[l[1]] - [l[2]] - [l[3]]")
 
-datum/unit_test/observation/global_listeners_shall_receive_events
+/datum/unit_test/observation/global_listeners_shall_receive_events
 	name = "OBSERVATION: Global listeners shall receive events"
 
-datum/unit_test/observation/global_listeners_shall_receive_events/start_test()
-	..()
+/datum/unit_test/observation/global_listeners_shall_receive_events/conduct_test()
 	var/turf/start = locate(20,20,1)
 	var/turf/target = locate(20,21,1)
 	var/mob/living/carbon/human/H = new(start)
@@ -46,11 +71,10 @@ datum/unit_test/observation/global_listeners_shall_receive_events/start_test()
 	qdel(H)
 	return 1
 
-datum/unit_test/observation/moved_observer_shall_register_on_follow
+/datum/unit_test/observation/moved_observer_shall_register_on_follow
 	name = "OBSERVATION: Moved - Observer Shall Register on Follow"
 
-datum/unit_test/observation/moved_observer_shall_register_on_follow/start_test()
-	..()
+/datum/unit_test/observation/moved_observer_shall_register_on_follow/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/mob/dead/observer/O = new(T)
@@ -65,11 +89,10 @@ datum/unit_test/observation/moved_observer_shall_register_on_follow/start_test()
 	qdel(O)
 	return 1
 
-datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow
+/datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow
 	name = "OBSERVATION: Moved - Observer Shall Unregister on NoFollow"
 
-datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow/start_test()
-	..()
+/datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/mob/dead/observer/O = new(T)
@@ -85,11 +108,10 @@ datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow/start_te
 	qdel(O)
 	return 1
 
-datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners
+/datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners
 	name = "OBSERVATION: Moved - Shall Not Register on Enter Without Listeners"
 
-datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/start_test()
-	..()
+/datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/obj/structure/closet/C = new(T)
@@ -104,11 +126,10 @@ datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/
 	qdel(H)
 	return 1
 
-datum/unit_test/observation/moved_shall_register_recursively_on_new_listener
+/datum/unit_test/observation/moved_shall_register_recursively_on_new_listener
 	name = "OBSERVATION: Moved - Shall Register Recursively on New Listener"
 
-datum/unit_test/observation/moved_shall_register_recursively_on_new_listener/start_test()
-	..()
+/datum/unit_test/observation/moved_shall_register_recursively_on_new_listener/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/obj/structure/closet/C = new(T)
@@ -128,11 +149,10 @@ datum/unit_test/observation/moved_shall_register_recursively_on_new_listener/sta
 	qdel(O)
 	return 1
 
-datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener
+/datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener
 	name = "OBSERVATION: Moved - Shall Register Recursively with Existing Listener"
 
-datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener/start_test()
-	..()
+/datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/living/carbon/human/H = new(T)
 	var/obj/structure/closet/C = new(T)
@@ -153,11 +173,10 @@ datum/unit_test/observation/moved_shall_register_recursively_with_existing_liste
 
 	return 1
 
-datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop
+/datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop
 	name = "OBSERVATION: Moved - Shall Only Trigger Once For Recursive Drop"
 
-datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop/start_test()
-	..()
+/datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/obj/mecha/mech = new(T)
 	var/obj/item/weapon/wrench/held_item = new(T)
@@ -200,11 +219,10 @@ datum/unit_test/observation/moved_shall_only_trigger_for_recursive_drop/start_te
 
 	return 1
 
-datum/unit_test/observation/moved_shall_not_unregister_recursively_one
+/datum/unit_test/observation/moved_shall_not_unregister_recursively_one
 	name = "OBSERVATION: Moved - Shall Not Unregister Recursively - One"
 
-datum/unit_test/observation/moved_shall_not_unregister_recursively_one/start_test()
-	..()
+/datum/unit_test/observation/moved_shall_not_unregister_recursively_one/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/dead/observer/one = new(T)
 	var/mob/dead/observer/two = new(T)
@@ -225,11 +243,10 @@ datum/unit_test/observation/moved_shall_not_unregister_recursively_one/start_tes
 
 	return 1
 
-datum/unit_test/observation/moved_shall_not_unregister_recursively_two
+/datum/unit_test/observation/moved_shall_not_unregister_recursively_two
 	name = "OBSERVATION: Moved - Shall Not Unregister Recursively - Two"
 
-datum/unit_test/observation/moved_shall_not_unregister_recursively_two/start_test()
-	..()
+/datum/unit_test/observation/moved_shall_not_unregister_recursively_two/conduct_test()
 	var/turf/T = locate(20,20,1)
 	var/mob/dead/observer/one = new(T)
 	var/mob/dead/observer/two = new(T)
@@ -249,3 +266,79 @@ datum/unit_test/observation/moved_shall_not_unregister_recursively_two/start_tes
 	qdel(three)
 
 	return 1
+
+/datum/unit_test/observation/sanity_global_listeners_shall_not_leave_null_entries_when_destroyed
+	name = "OBSERVATION: Sanity - Global listeners shall not leave null entries when destroyed"
+
+/datum/unit_test/observation/sanity_global_listeners_shall_not_leave_null_entries_when_destroyed/conduct_test()
+	var/turf/T = locate(20,20,1)
+	var/mob/M = new(T)
+
+	moved_event.register_global(M, /datum/unit_test/observation/proc/receive_move)
+	qdel(M)
+
+	if(null in moved_event.global_listeners)
+		fail("The global listener list contains a null entry.")
+	else
+		pass("The global listener list does not contain a null entry.")
+
+	return 1
+
+/datum/unit_test/observation/sanity_event_sources_shall_not_leave_null_entries_when_destroyed
+	name = "OBSERVATION: Sanity - Event sources shall not leave null entries when destroyed"
+
+/datum/unit_test/observation/sanity_event_sources_shall_not_leave_null_entries_when_destroyed/conduct_test()
+	var/turf/T = locate(20,20,1)
+	var/mob/event_source = new(T)
+	event_source.real_name = "Event Source"
+	event_source.name = "Event Source"
+	var/mob/listener = new(T)
+	listener.real_name = "Event Listener"
+	listener.name = "Event Listener"
+
+	moved_event.register(event_source, listener, /atom/movable/proc/recursive_move)
+	qdel(event_source)
+
+	if(null in moved_event.event_sources)
+		fail("The event source list contains a null entry.")
+	else
+		pass("The event source list does not contain a null entry.")
+
+	qdel(listener)
+	return 1
+
+/datum/unit_test/observation/sanity_event_listeners_shall_not_leave_null_entries_when_destroyed
+	name = "OBSERVATION: Sanity - Event listeners shall not leave null entries when destroyed"
+
+/datum/unit_test/observation/sanity_event_listeners_shall_not_leave_null_entries_when_destroyed/conduct_test()
+	var/turf/T = locate(20,20,1)
+	var/mob/event_source = new(T)
+	event_source.real_name = "Event Source"
+	event_source.name = "Event Source"
+	var/mob/listener = new(T)
+	listener.real_name = "Event Listener"
+	listener.name = "Event Listener"
+
+	moved_event.register(event_source, listener, /atom/movable/proc/recursive_move)
+	qdel(listener)
+
+	var/listeners = moved_event.event_sources[event_source]
+	if(listeners && (null in listeners))
+		fail("The event source listener list contains a null entry.")
+	else
+		pass("The event source listener list does not contain a null entry.")
+
+	qdel(event_source)
+	return 1
+
+/proc/test_unit()
+	var/turf/T = locate(20,20,1)
+	var/mob/event_source = new(T)
+	event_source.real_name = "Event Source"
+	event_source.name = "Event Source"
+	var/mob/listener = new(T)
+	listener.real_name = "Event Listener"
+	listener.name = "Event Listener"
+
+	moved_event.register(event_source, listener, /atom/movable/proc/recursive_move)
+	qdel(listener)


### PR DESCRIPTION
Registration/Unregistration should now only return TRUE strictly when something change.
This is utilized to keep a count of active registrations and then using them to cleanup in the Destruction phase to minimize the overhead.

The intention is to both avoid filling various lists with NULL entries and prevention of a clean GC.
