### PR TITLE
pAI id card correction.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -7,6 +7,8 @@
 	pass_flags = 1
 	mob_size = MOB_SMALL
 
+	idcard_type = /obj/item/weapon/card/id
+
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null
 


### PR DESCRIPTION
pAIs now have a basic id card, not a synth one, which ensures they no longer have all-access.
