### PR TITLE
Restores the Tajara reagent tag.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -122,6 +122,8 @@
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
 
+	reagent_tag = IS_TAJARA
+
 	heat_discomfort_level = 292
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",


### PR DESCRIPTION
:cl: Yoshax
fix: Tajara should now react appropriately to various chemical reagents, such as coffee.
/:cl:

Port of https://github.com/PolarisSS13/Polaris/pull/1023.
