### PR TITLE
Unlimited Welder Fix

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -212,7 +212,7 @@
 		if(prob(5))
 			remove_fuel(1)
 
-		if(get_fuel() == 0)
+		if(get_fuel() < 1)
 			setWelding(0)
 
 	//I'm not sure what this does. I assume it has to do with starting fires...


### PR DESCRIPTION
Fixes a bug where welders can be used indefinitely. With this, the welder will not turn on unless it has at least 1u of welder fuel. 

Port of https://github.com/PolarisSS13/Polaris/pull/1028.
