### PR TITLE
Make power-restoring admin secrets also cancel grid check effects

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -17,12 +17,15 @@
 	if(announce)
 		command_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
 	for(var/obj/machinery/power/apc/C in world)
-		if(C.cell && (C.z in config.station_levels))
-			C.cell.charge = C.cell.maxcharge
+		if(C.z in config.station_levels)
+			C.failure_timer = 0
+			if(C.cell)
+				C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in world)
 		var/area/current_area = get_area(S)
 		if(current_area.type in skipped_areas || isNotStationLevel(S.z))
 			continue
+		S.failure_timer = 0
 		S.charge = S.capacity
 		S.update_icon()
 		S.power_change()
@@ -34,6 +37,7 @@
 	for(var/obj/machinery/power/smes/S in world)
 		if(isNotStationLevel(S.z))
 			continue
+		S.failure_timer = 0
 		S.charge = S.capacity
 		S.output_level = S.output_level_max
 		S.output_attempt = 1

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -17,13 +17,12 @@
 	if(announce)
 		command_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
 	for(var/obj/machinery/power/apc/C in world)
-		if(C.z in config.station_levels)
-			C.failure_timer = 0
-			if(C.cell)
-				C.cell.charge = C.cell.maxcharge
+		C.failure_timer = 0
+		if(C.cell)
+			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in world)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas || isNotStationLevel(S.z))
+		if(current_area.type in skipped_areas)
 			continue
 		S.failure_timer = 0
 		S.charge = S.capacity
@@ -35,8 +34,6 @@
 	if(announce)
 		command_announcement.Announce("All SMESs on [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
 	for(var/obj/machinery/power/smes/S in world)
-		if(isNotStationLevel(S.z))
-			continue
 		S.failure_timer = 0
 		S.charge = S.capacity
 		S.output_level = S.output_level_max


### PR DESCRIPTION
"Power all SMES" and "Make All Areas Powered" admin secrets now also restore power to SMESes and APCs affected by grid check or (admin secret-inflicted) power failures.

This is chiefly helpful in local debugging, when you end up letting the grid_check event run, and want to quickly undo it. 
