### PR TITLE
Fixes the RIG grenade launcher icon

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -21,7 +21,7 @@
 	name = "mounted grenade launcher"
 	desc = "A shoulder-mounted micro-explosive dispenser."
 	selectable = 1
-	icon_state = "grenade"
+	icon_state = "grenadelauncher"
 
 	interface_name = "integrated grenade launcher"
 	interface_desc = "Discharges loaded grenades against the wearer's location."


### PR DESCRIPTION
:cl: Mark9013100
fix: Fixes the RIG grenade launcher icon.
/:cl:

Port of https://github.com/PolarisSS13/Polaris/pull/1063
