### PR TITLE
Fixes the EMP cell drain.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -136,8 +136,8 @@
 		var/mob/living/silicon/robot/R = loc
 		severity *= R.cell_emp_mult
 
-	// Lose 1/2, 1/4, 1/8 of the current charge per hit or 1/4, 1/8, 1/24 of the max charge per hit, whichever is highest
-	charge -= max(charge / (2 / severity), maxcharge/(4 / severity))
+	// Lose 1/2, 1/4, 1/6 of the current charge per hit or 1/4, 1/8, 1/12 of the max charge per hit, whichever is highest
+	charge -= max(charge / (2 * severity), maxcharge/(4 * severity))
 	if (charge < 0)
 		charge = 0
 	..()


### PR DESCRIPTION
The math is now corrected, using \* instead of / (minor difference).
Second degree EMPs should thus no longer fully drain cells.
