### PR TITLE
Fixes condiment placement

### DIFF
--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -14,12 +14,12 @@
 
 /obj/item/weapon/reagent_containers/food/New()
 	..()
-	if (isnull(center_of_mass) && !pixel_x && !pixel_y)
+	if (center_of_mass.len && !pixel_x && !pixel_y)
 		src.pixel_x = rand(-6.0, 6) //Randomizes postion
 		src.pixel_y = rand(-6.0, 6)
 
 /obj/item/weapon/reagent_containers/food/afterattack(atom/A, mob/user, proximity, params)
-	if(proximity && params && istype(A, /obj/structure/table) && center_of_mass.len)
+	if(center_of_mass.len && proximity && params && istype(A, /obj/structure/table))
 		//Places the item on a grid
 		var/list/mouse_control = params2list(params)
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -45,7 +45,8 @@
 
 			var/trans = reagents.trans_to_obj(target, amount_per_transfer_from_this)
 			user << "<span class='notice'>You add [trans] units of the condiment to \the [target].</span>"
-		else(..())
+		else
+			..()
 
 	feed_sound(var/mob/user)
 		playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -45,6 +45,7 @@
 
 			var/trans = reagents.trans_to_obj(target, amount_per_transfer_from_this)
 			user << "<span class='notice'>You add [trans] units of the condiment to \the [target].</span>"
+		else(..())
 
 	feed_sound(var/mob/user)
 		playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)


### PR DESCRIPTION
Condiments couldn't be placed on a grid and small condiments weren't centered on the turf despite intended. Fixed.
Food will also now spawn with randomized pixelshifts again, which was disabled by the same bug.

Food placement will also now first check for existing center_of_mass-list before doing a type-check.

Port of https://github.com/PolarisSS13/Polaris/pull/1090.
