### PR TITLE
Gives IPC brains a little longer to process their name.

### DIFF
--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -145,7 +145,7 @@
 	robotize()
 	stored_mmi = new /obj/item/device/mmi/digital/posibrain(src)
 	..()
-	spawn(1)
+	spawn(30)
 		if(owner)
 			stored_mmi.name = "positronic brain ([owner.name])"
 			stored_mmi.brainmob.real_name = owner.name


### PR DESCRIPTION
Resolves #12227

Players don't have names yet when this code runs, so we wait a little longer and then run it.

If someone dies within 3 seconds they deserve to ramain nameless.
