### PR TITLE
Fixes #10516

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -137,6 +137,11 @@
 	interact(mob/user as mob)
 		return //HTML MENU FOR WIRES GOES HERE
 
+/obj/item/device/assembly/nano_host()
+    if(istype(loc, /obj/item/device/assembly_holder))
+        return loc.nano_host()
+    return ..()
+
 /*
 	var/small_icon_state = null//If this obj will go inside the assembly use this for icons
 	var/list/small_icon_state_overlays = null//Same here


### PR DESCRIPTION
If contained, assemblies now return the host holder when the Topic check is made. Fixes #10516
