### PR TITLE
Fixes radio chatter/dsay

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -286,10 +286,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	for (var/mob/R in receive)
 
 	  /* --- Loop through the receivers and categorize them --- */
-
-		if (!R.is_preference_enabled(/datum/client_preference/holder/hear_radio))
-			continue
-
 		if(istype(R, /mob/new_player)) // we don't want new players to hear messages. rare but generates runtimes.
 			continue
 
@@ -489,10 +485,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	for (var/mob/R in receive)
 
 	  /* --- Loop through the receivers and categorize them --- */
-
-		if(!R.is_preference_enabled(/datum/client_preference/holder/hear_radio)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
-			continue
-
 		// --- Check for compression ---
 		if(compression > 0)
 

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -8,17 +8,17 @@
 /datum/category_item/player_setup_item/player_global/settings/load_preferences(var/savefile/S)
 	S["lastchangelog"]	>> pref.lastchangelog
 	S["default_slot"]	>> pref.default_slot
-	S["preferences"]		>> pref.preferences
+	S["preferences"]	>> pref.preferences
 
 /datum/category_item/player_setup_item/player_global/settings/save_preferences(var/savefile/S)
 	S["lastchangelog"]	<< pref.lastchangelog
 	S["default_slot"]	<< pref.default_slot
-	S["preferences"]		<< pref.preferences
+	S["preferences"]	<< pref.preferences
 
 /datum/category_item/player_setup_item/player_global/settings/sanitize_preferences()
+	var/mob/pref_mob = preference_mob()
 	if(!istype(pref.preferences, /list))
 		pref.preferences = list()
-		var/mob/pref_mob = preference_mob()
 		for(var/cp in get_client_preferences())
 			var/datum/client_preference/client_pref = cp
 			if(!client_pref.enabled_by_default || !client_pref.may_toggle(pref_mob))
@@ -26,7 +26,8 @@
 			pref.preferences += client_pref.key
 
 	for(var/preference in pref.preferences)
-		if(!get_client_preference_by_key(preference))
+		var/datum/client_preference/client_pref = get_client_preference_by_key(preference)
+		if(!client_pref || !client_pref.may_toggle(pref_mob))
 			pref.preferences -= preference
 
 	pref.lastchangelog	= sanitize_text(pref.lastchangelog, initial(pref.lastchangelog))

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -153,9 +153,3 @@ var/list/_client_preferences_by_type
 	key = "SOUND_ADMINHELP"
 	enabled_description = "Hear"
 	disabled_description = "Silent"
-
-/datum/client_preference/holder/hear_radio
-	description = "Radio chatter"
-	key = "CHAT_RADIO"
-	enabled_description = "Show"
-	disabled_description = "Hide"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -54,7 +54,7 @@
 			src << "<span class='danger'>Deadchat is globally muted.</span>"
 			return
 
-	if(is_preference_enabled(/datum/client_preference/show_dsay))
+	if(!is_preference_enabled(/datum/client_preference/show_dsay))
 		usr << "<span class='danger'>You have deadchat muted.</span>"
 		return
 


### PR DESCRIPTION
Was an old admin setting that allowed them to filter out radio traffic.
Fixed by removing it, as it would be disabled by default for non-holders. Fixes #12327.

Adds missing !, restoring the ability to use/hear dsay.
