### PR TITLE
Evidence bag box no longer rely on storage slots.

### DIFF
--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -18,7 +18,7 @@
 
 /obj/item/weapon/storage/box/evidence/New()
 	..()
-	for(var/i=0;i<storage_slots,i++)
+	for(var/i = 1 to 7)
 		new /obj/item/weapon/evidencebag(src)
 
 /obj/item/weapon/storage/box/fingerprints


### PR DESCRIPTION
Instead simply straight up creates 7 evidence bags. Fixes #12330.
<s>Storage slots are not strictly necessary, they only appear to limit the max number of items even if there's otherwise enough capacity for them.</s>
Storage slots are updated to a required minimum in a spawn() somewhere.
