### PR TITLE
Fix vendors eating items and not increasing item count

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -528,9 +528,9 @@
 		nanomanager.update_uis(src)
 
 /obj/machinery/vending/proc/stock(var/datum/data/vending_product/R, var/mob/user)
-	if(src.panel_open)
-		user << "<span class='notice'>You insert \the [src] in the product receptor.</span>"
-		R.amount++
+
+	user << "<span class='notice'>You insert \the [src] in the product receptor.</span>"
+	R.amount++
 
 	nanomanager.update_uis(src)
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -241,9 +241,8 @@
 
 		for(var/datum/data/vending_product/R in product_records)
 			if(istype(W, R.product_path))
-				stock(R, user)
-				qdel(W)
-				return
+				stock(W, R, user)
+				return 1
 		..()
 
 /**
@@ -527,10 +526,17 @@
 		currently_vending = null
 		nanomanager.update_uis(src)
 
-/obj/machinery/vending/proc/stock(var/datum/data/vending_product/R, var/mob/user)
+/**
+ * Add item to the machine
+ *
+ * Checks if item is vendable in this machine should be performed before
+ * calling. W is the item being inserted, R is the associated vending_product entry.
+ */	
+/obj/machinery/vending/proc/stock(obj/item/weapon/W, var/datum/data/vending_product/R, var/mob/user)
 
-	user << "<span class='notice'>You insert \the [src] in the product receptor.</span>"
+	user << "<span class='notice'>You insert \the [W] in the product receptor.</span>"
 	R.amount++
+	qdel(W)
 
 	nanomanager.update_uis(src)
 


### PR DESCRIPTION
Per #10808 vendors are supposed to accept items without having their panels open, so now they do that properly.

Resolves #12335.
