### PR TITLE
Preferences now store client key instead of the client itself.

### DIFF
--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -25,11 +25,6 @@
 				continue
 			pref.preferences += client_pref.key
 
-	for(var/preference in pref.preferences)
-		var/datum/client_preference/client_pref = get_client_preference_by_key(preference)
-		if(!client_pref || !client_pref.may_toggle(pref_mob))
-			pref.preferences -= preference
-
 	pref.lastchangelog	= sanitize_text(pref.lastchangelog, initial(pref.lastchangelog))
 	pref.default_slot	= sanitize_integer(pref.default_slot, 1, config.character_slots, initial(pref.default_slot))
 
@@ -51,7 +46,7 @@
 		. += "</tr>"
 
 	. += "</table>"
-	return jointext(., null)
+	return jointext(., "")
 
 /datum/category_item/player_setup_item/player_global/settings/OnTopic(var/href,var/list/href_list, var/mob/user)
 	var/mob/pref_mob = preference_mob()

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -226,13 +226,13 @@
 /datum/category_item/player_setup_item/Topic(var/href,var/list/href_list)
 	if(..())
 		return 1
-	var/mob/user = usr
-	if(!user.client)
+	var/mob/pref_mob = preference_mob()
+	if(!pref_mob || !pref_mob.client)
 		return 1
 
-	. = OnTopic(href, href_list, user)
+	. = OnTopic(href, href_list, usr)
 	if(. == TOPIC_REFRESH)
-		user.client.prefs.ShowChoices(user)
+		pref_mob.client.prefs.ShowChoices(usr)
 
 /datum/category_item/player_setup_item/CanUseTopic(var/mob/user)
 	return 1
@@ -241,5 +241,4 @@
 	return TOPIC_NOACTION
 
 /datum/category_item/player_setup_item/proc/preference_mob()
-	if(pref && pref.client && pref.client.mob)
-		return pref.client.mob
+    return get_mob_by_key(pref.client_ckey)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -106,7 +106,7 @@ datum/preferences
 	// OOC Metadata:
 	var/metadata = ""
 
-	var/client/client = null
+	var/client_ckey = null
 
 	var/savefile/loaded_preferences
 	var/savefile/loaded_character
@@ -121,7 +121,7 @@ datum/preferences
 	gear = list()
 
 	if(istype(C))
-		client = C
+		client_ckey = C.ckey
 		if(!IsGuestKey(C.key))
 			load_path(C.ckey)
 			load_preferences()
@@ -187,6 +187,12 @@ datum/preferences
 
 /datum/preferences/proc/ShowChoices(mob/user)
 	if(!user || !user.client)	return
+
+	if(!get_mob_by_key(client_ckey))
+		user << "<span class='danger'>No mob exists for the given client!</span>"
+		close_load_dialog(user)
+		return
+
 	var/dat = "<html><body><center>"
 
 	if(path)


### PR DESCRIPTION
For reasons unbeknown to me, the client var is reset when the client logs outs and thus the preference mob cease to be.
Now stores the client key, and acquires the appropriate mob based on that, if possible.
Also removes the sanitation check because the holder isn't set before the preferences are created.

Fixes #12341. I honestly cannot say why this client issue only appears here.
