### PR TITLE
Overhauls forceMove() 

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1884,6 +1884,7 @@
 #include "code\unit_tests\loadout_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
+#include "code\unit_tests\movement_tests.dm"
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\test_obj.dm"
 #include "code\unit_tests\unique_tests.dm"

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -23,6 +23,8 @@
 
 #define ismouse(A) istype(A, /mob/living/simple_animal/mouse)
 
+#define ismovable(A) istype(A, /atom/movable)
+
 #define isnewplayer(A) istype(A, /mob/new_player)
 
 #define isobj(A) istype(A, /obj)

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -27,7 +27,7 @@ var/decl/observ/moved/moved_event = new()
 
 /atom/Entered(var/atom/movable/am, var/atom/old_loc)
 	. = ..()
-	if(. != CANCEL_MOVE_EVENT)
+	if(. != CANCEL_MOVE_EVENT && !isarea(src))
 		moved_event.raise_event(am, old_loc, am.loc)
 
 /atom/movable/Entered(var/atom/movable/am, atom/old_loc)
@@ -38,3 +38,16 @@ var/decl/observ/moved/moved_event = new()
 /atom/movable/Exited(var/atom/movable/am, atom/old_loc)
 	. = ..()
 	moved_event.unregister(src, am, /atom/movable/proc/recursive_move)
+
+// Entered() typically lifts the moved event, but in the case of null-space we'll have to handle it.
+/atom/movable/Move()
+	var/old_loc = loc
+	. = ..()
+	if(. && !loc)
+		moved_event.raise_event(src, old_loc, null)
+
+/atom/movable/forceMove(atom/destination, var/special_event)
+	var/old_loc = loc
+	. = ..()
+	if(. && !loc && !special_event)
+		moved_event.raise_event(src, old_loc, null)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -25,6 +25,12 @@
 	//Detective Work, used for the duplicate data points kept in the scanners
 	var/list/original_atom
 
+/atom/Destroy()
+	if(reagents)
+		qdel(reagents)
+		reagents = null
+	. = ..()
+
 /atom/proc/reveal_blood()
 	return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -78,7 +78,7 @@
 
 	..()
 
-	if (!mover || !isturf(mover.loc))
+	if (!mover || !mover.density || !isturf(mover.loc))
 		return 1
 
 	//First, check objects to block exit that are not on the border

--- a/code/unit_tests/movement_tests.dm
+++ b/code/unit_tests/movement_tests.dm
@@ -1,0 +1,64 @@
+/datum/unit_test/movement
+	name = "MOVEMENT template"
+	async = 0
+	disabled = 0
+
+/datum/unit_test/movement/force_move_shall_trigger_crossed_when_entering_turf
+	name = "MOVEMENT - Force Move Shall Trigger Crossed When Entering Turf"
+
+/datum/unit_test/movement/force_move_shall_trigger_crossed_when_entering_turf/start_test()
+	var/turf/start = locate(20,20,1)
+	var/turf/target = locate(20,21,1)
+
+	var/obj/mover = new /obj/test(start, 1)
+	var/obj/test/crossed_obj/crossed = new(target, 1)
+
+	mover.forceMove(target)
+
+	if(!crossed.crossers)
+		fail("The target object was never crossed.")
+	else if(crossed.crossers.len != 1)
+		fail("The target object was crossed [crossed.crossers.len] times, expected 1.")
+	else
+		pass("The target was crossed 1 time.")
+
+	qdel(target)
+	qdel(crossed)
+	return TRUE
+
+/datum/unit_test/movement/force_move_shall_trigger_entered
+	name = "MOVEMENT - Force Move Shall Trigger Entered"
+
+/datum/unit_test/movement/force_move_shall_trigger_entered/start_test()
+	var/turf/start = locate(20,20,1)
+	var/obj/mover = new /obj/test(start, 1)
+	var/obj/test/entered_obj/target = new(start, 1)
+
+	mover.forceMove(target)
+
+	if(!target.enterers)
+		fail("The target object was never entered.")
+	else if(target.enterers.len != 1)
+		fail("The target object was entered [target.enterers.len] times, expected 1.")
+	else
+		pass("The target was entered 1 time.")
+
+	qdel(mover)
+	qdel(target)
+	return TRUE
+
+/obj/test/crossed_obj
+	var/list/crossers
+
+/obj/test/crossed_obj/Crossed(var/crosser)
+	if(!crossers)
+		crossers = list()
+	crossers += crosser
+
+/obj/test/entered_obj
+	var/list/enterers
+
+/obj/test/entered_obj/Entered(var/enterer)
+	if(!enterers)
+		enterers = list()
+	enterers += enterer


### PR DESCRIPTION
This ensures the Exited() proc is called properly during Destroy().
Moves the reagents qdel() to a more appropriate location while I'm at it.
