### PR TITLE
Both enabled and disabled preferences are now stored.

### DIFF
--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -1,29 +1,52 @@
 /datum/preferences
-	var/preferences = null
+	var/preferences_enabled = null
+	var/preferences_disabled = null
 
 /datum/category_item/player_setup_item/player_global/settings
 	name = "Settings"
 	sort_order = 2
 
 /datum/category_item/player_setup_item/player_global/settings/load_preferences(var/savefile/S)
-	S["lastchangelog"]	>> pref.lastchangelog
-	S["default_slot"]	>> pref.default_slot
-	S["preferences"]	>> pref.preferences
+	S["lastchangelog"]        >> pref.lastchangelog
+	S["default_slot"]	      >> pref.default_slot
+	S["preferences"]          >> pref.preferences_enabled
+	S["preferences_disabled"] >> pref.preferences_disabled
 
 /datum/category_item/player_setup_item/player_global/settings/save_preferences(var/savefile/S)
-	S["lastchangelog"]	<< pref.lastchangelog
-	S["default_slot"]	<< pref.default_slot
-	S["preferences"]	<< pref.preferences
+	S["lastchangelog"]        << pref.lastchangelog
+	S["default_slot"]         << pref.default_slot
+	S["preferences"]          << pref.preferences_enabled
+	S["preferences_disabled"] << pref.preferences_disabled
 
 /datum/category_item/player_setup_item/player_global/settings/sanitize_preferences()
 	var/mob/pref_mob = preference_mob()
-	if(!istype(pref.preferences, /list))
-		pref.preferences = list()
-		for(var/cp in get_client_preferences())
-			var/datum/client_preference/client_pref = cp
-			if(!client_pref.enabled_by_default || !client_pref.may_toggle(pref_mob))
-				continue
-			pref.preferences += client_pref.key
+
+	// Ensure our preferences are lists.
+	if(!istype(pref.preferences_enabled, /list))
+		pref.preferences_enabled = list()
+	if(!istype(pref.preferences_disabled, /list))
+		pref.preferences_disabled = list()
+
+	// Arrange preferences that have never been enabled/disabled.
+	var/list/client_preference_keys = list()
+	for(var/cp in get_client_preferences())
+		var/datum/client_preference/client_pref = cp
+		client_preference_keys += client_pref.key
+		if((client_pref.key in pref.preferences_enabled) || (client_pref.key in pref.preferences_disabled))
+			continue
+
+		if(client_pref.enabled_by_default  && client_pref.may_toggle(pref_mob))
+			pref.preferences_enabled += client_pref.key
+		else
+			pref.preferences_disabled += client_pref.key
+
+	// Clean out preferences that no longer exist.
+	for(var/key in pref.preferences_enabled)
+		if(!(key in client_preference_keys))
+			pref.preferences_enabled -= key
+	for(var/key in pref.preferences_disabled)
+		if(!(key in client_preference_keys))
+			pref.preferences_disabled -= key
 
 	pref.lastchangelog	= sanitize_text(pref.lastchangelog, initial(pref.lastchangelog))
 	pref.default_slot	= sanitize_integer(pref.default_slot, 1, config.character_slots, initial(pref.default_slot))
@@ -64,7 +87,7 @@
 		var/datum/client_preference/cp = get_client_preference_by_type(preference)
 		preference = cp.key
 
-	return (preference in prefs.preferences)
+	return (preference in prefs.preferences_enabled)
 
 /client/proc/set_preference(var/preference, var/set_preference)
 	var/datum/client_preference/cp
@@ -77,12 +100,14 @@
 		return FALSE
 
 	var/enabled
-	if(set_preference && !(preference in prefs.preferences))
-		prefs.preferences += preference
+	if(set_preference && !(preference in prefs.preferences_enabled))
+		prefs.preferences_enabled  += preference
+		prefs.preferences_disabled -= preference
 		enabled = TRUE
 		. = TRUE
-	else if(!set_preference && (preference in prefs.preferences))
-		prefs.preferences -= preference
+	else if(!set_preference && (preference in prefs.preferences_enabled))
+		prefs.preferences_enabled  -= preference
+		prefs.preferences_disabled |= preference
 		enabled = FALSE
 		. = TRUE
 	if(.)

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -241,4 +241,11 @@
 	return TOPIC_NOACTION
 
 /datum/category_item/player_setup_item/proc/preference_mob()
-    return get_mob_by_key(pref.client_ckey)
+	if(!pref.client)
+		for(var/client/C)
+			if(C.ckey == pref.client_ckey)
+				pref.client = C
+				break
+
+	if(pref.client)
+		return pref.client.mob

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -106,6 +106,7 @@ datum/preferences
 	// OOC Metadata:
 	var/metadata = ""
 
+	var/client/client = null
 	var/client_ckey = null
 
 	var/savefile/loaded_preferences
@@ -121,6 +122,7 @@ datum/preferences
 	gear = list()
 
 	if(istype(C))
+		client = C
 		client_ckey = C.ckey
 		if(!IsGuestKey(C.key))
 			load_path(C.ckey)


### PR DESCRIPTION
The purpose is to ensure that new preferences that are in neither list get the appropriate enabled/disabled setting without having to utilize the savefile update path.

Also attempts to optimize the acquirement of the preference mob.
