### PR TITLE
Fixes #12184

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -135,7 +135,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 //Transfers blood from reagents to vessel, respecting blood types compatability.
 /mob/living/carbon/human/inject_blood(var/datum/reagent/blood/injected, var/amount)
 
-	if(!(species.flags & NO_BLOOD))
+	if(species.flags & NO_BLOOD)
 		reagents.add_reagent("blood", amount, injected.data)
 		reagents.update_total()
 		return


### PR DESCRIPTION
Basically the problem was that there was a NO_BLOOD check that was
backwards and it would just add more blood to the mob's reagents and would attempt to find a blood vessel in species with NO_BLOOD and wouldn't find one, returning normally.
