### PR TITLE
Stops spamming of retract message for pAIs

### DIFF
--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -9,6 +9,7 @@
 			for (var/mob/M in viewers(T))
 				M.show_message("\red The data cable rapidly retracts back into its spool.", 3, "\red You hear a click and the sound of wire spooling rapidly.", 2)
 			qdel(src.cable)
+			src.cable = null
 
 	handle_regular_hud_updates()
 


### PR DESCRIPTION
Whenever a pAI walks away from their cable it ends up spamming the chat while it gets deleted. This will stop this (and probably fix a qdel issue as well)
