### PR TITLE
Fix #12373

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -373,7 +373,7 @@
 	if ((stat != DEAD || !( ticker )))
 		usr << "<span class='notice'><B>You must be dead to use this!</B></span>"
 		return
-	if (ticker.mode.deny_respawn) //BS12 EDIT
+	if (ticker.mode && ticker.mode.deny_respawn)
 		usr << "<span class='notice'>Respawn is disabled for this roundtype.</span>"
 		return
 	else if(!MayRespawn(1, config.respawn_delay))


### PR DESCRIPTION
fix #12373.

```
runtime error: Cannot read null.deny_respawn
proc name: Respawn (/mob/verb/abandon_mob)
  source file: mob.dm,376
  usr: (src)
  src: Damon Vasilyev (/mob/dead/observer)
  src.loc: the floor (125,141,1) (/turf/simulated/floor/tiled)
  call stack:
Damon Vasilyev (/mob/dead/observer): Respawn()
```
