### PR TITLE
Window Verb Fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -334,6 +334,7 @@
 	//player-constructed windows
 	if (constructed)
 		anchored = 0
+		update_verbs()
 
 	if (start_dir)
 		set_dir(start_dir)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -159,8 +159,7 @@
 		tforce = I.throwforce
 	if(reinf) tforce *= 0.25
 	if(health - tforce <= 7 && !reinf)
-		anchored = 0
-		update_nearby_icons()
+		set_anchored(FALSE)
 		step(src, get_dir(AM, src))
 	take_damage(tforce)
 
@@ -244,15 +243,11 @@
 			playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 			user << (state == 1 ? "<span class='notice'>You have unfastened the window from the frame.</span>" : "<span class='notice'>You have fastened the window to the frame.</span>")
 		else if(reinf && state == 0)
-			anchored = !anchored
-			update_nearby_icons()
-			update_verbs()
+			set_anchored(!anchored)
 			playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 			user << (anchored ? "<span class='notice'>You have fastened the frame to the floor.</span>" : "<span class='notice'>You have unfastened the frame from the floor.</span>")
 		else if(!reinf)
-			anchored = !anchored
-			update_nearby_icons()
-			update_verbs()
+			set_anchored(!anchored)
 			playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 			user << (anchored ? "<span class='notice'>You have fastened the window to the floor.</span>" : "<span class='notice'>You have unfastened the window.</span>")
 	else if(istype(W, /obj/item/weapon/crowbar) && reinf && state <= 1)
@@ -277,8 +272,7 @@
 			user.do_attack_animation(src)
 			hit(W.force)
 			if(health <= 7)
-				anchored = 0
-				update_nearby_icons()
+				set_anchored(FALSE)
 				step(src, get_dir(user, src))
 		else
 			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
@@ -333,8 +327,7 @@
 
 	//player-constructed windows
 	if (constructed)
-		anchored = 0
-		update_verbs()
+		set_anchored(FALSE)
 
 	if (start_dir)
 		set_dir(start_dir)
@@ -370,6 +363,13 @@
 	if(dir & (dir - 1))
 		return 1
 	return 0
+
+/obj/structure/window/proc/set_anchored(var/new_anchored)
+	if(anchored == new_anchored)
+		return
+	anchored = new_anchored
+	update_verbs()
+	update_nearby_icons()
 
 //This proc is used to update the icons of nearby windows. It should not be confused with update_nearby_tiles(), which is an atmos proc!
 /obj/structure/window/proc/update_nearby_icons()


### PR DESCRIPTION
Adds a helper proc to ensure icons and verbs are updated properly on anchor state changes.
Based on https://github.com/PolarisSS13/Polaris/pull/1153.
