### PR TITLE
Prevents supermatter/singularity from pulling anchored items

### DIFF
--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -45,6 +45,8 @@
 
 /obj/item/singularity_pull(S, current_size)
 	spawn(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
+		if(anchored)
+			return
 		if(current_size >= STAGE_FOUR)
 			//throw_at(S, 14, 3)
 			step_towards(src,S)

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -44,17 +44,18 @@
 	return
 
 /obj/item/singularity_pull(S, current_size)
-	spawn(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
-		if(anchored)
-			return
-		if(current_size >= STAGE_FOUR)
-			//throw_at(S, 14, 3)
-			step_towards(src,S)
-			sleep(1)
-			step_towards(src,S)
-		else if(current_size > STAGE_ONE)
-			step_towards(src,S)
-		else ..()
+	set waitfor = 0
+	if(anchored)
+		return
+	sleep(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
+	if(current_size >= STAGE_FOUR)
+		//throw_at(S, 14, 3)
+		step_towards(src,S)
+		sleep(1)
+		step_towards(src,S)
+	else if(current_size > STAGE_ONE)
+		step_towards(src,S)
+	else ..()
 
 /obj/machinery/atmospherics/pipe/singularity_pull()
 	return


### PR DESCRIPTION
- Delaminating SM/Singulo no longer pulls anchored items (obj/item/), such as, intercoms.
