### PR TITLE
Adjusts preference defaults.

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -104,7 +104,7 @@
 
 	//play the recieving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
-	if(is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))
+	if(C.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))
 		C << 'sound/effects/adminhelp.ogg'
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -19,8 +19,6 @@
 	S["preferences_disabled"] << pref.preferences_disabled
 
 /datum/category_item/player_setup_item/player_global/settings/sanitize_preferences()
-	var/mob/pref_mob = preference_mob()
-
 	// Ensure our preferences are lists.
 	if(!istype(pref.preferences_enabled, /list))
 		pref.preferences_enabled = list()
@@ -35,7 +33,7 @@
 		if((client_pref.key in pref.preferences_enabled) || (client_pref.key in pref.preferences_disabled))
 			continue
 
-		if(client_pref.enabled_by_default  && client_pref.may_toggle(pref_mob))
+		if(client_pref.enabled_by_default)
 			pref.preferences_enabled += client_pref.key
 		else
 			pref.preferences_disabled += client_pref.key


### PR DESCRIPTION
They are no longer affected by whether clients are allowed to toggle them.
Worked fine for those who were always staff or non-staff, not so much for those in a transient state.

Also corrects AdminPMs checking the sender's ping-settings, not the receiver's. Fixes #12406.
