### PR TITLE
Adds AFK marker/duration in Who.

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -41,6 +41,8 @@
 
 			if(is_special_character(C.mob))
 				entry += " - <b><font color='red'>Antagonist</font></b>"
+			if(C.is_afk())
+				entry += " (AFK - [C.inactivity2text()])"
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 			Lines += entry
 	else


### PR DESCRIPTION
Seen by staff, similar to the AFK marker in staffwho.
Based on https://github.com/PolarisSS13/Polaris/pull/1197.
