### PR TITLE
Makes silicon subsystems more generic.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1469,6 +1469,7 @@
 #include "code\modules\modular_computers\file_system\program_events.dm"
 #include "code\modules\modular_computers\file_system\programs\_engineering.dm"
 #include "code\modules\modular_computers\file_system\programs\_medical.dm"
+#include "code\modules\modular_computers\file_system\programs\_program.dm"
 #include "code\modules\modular_computers\file_system\programs\card.dm"
 #include "code\modules\modular_computers\file_system\programs\comm.dm"
 #include "code\modules\modular_computers\file_system\programs\configurator.dm"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -90,11 +90,9 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	src.verbs |= ai_verbs_default
-	src.verbs |= silicon_subsystems
 
 /mob/living/silicon/ai/proc/remove_ai_verbs()
 	src.verbs -= ai_verbs_default
-	src.verbs -= silicon_subsystems
 
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
 	announcement = new()
@@ -434,7 +432,7 @@ var/list/ai_verbs_default = list(
 	if (href_list["switchcamera"])
 		switchCamera(locate(href_list["switchcamera"])) in cameranet.cameras
 	if (href_list["showalerts"])
-		subsystem_alarm_monitor()
+		open_subsystem(/datum/nano_module/alarm_monitor/all)
 	//Carn: holopad requests
 	if (href_list["jumptoholopad"])
 		var/obj/machinery/hologram/holopad/H = locate(href_list["jumptoholopad"])

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -24,4 +24,4 @@
 /mob/living/silicon/ai/proc/ai_checklaws()
 	set category = "AI Commands"
 	set name = "State Laws"
-	subsystem_law_manager()
+	open_subsystem(/datum/nano_module/law_manager)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -326,10 +326,10 @@ var/list/mob_hat_cache = list()
 	src << "Use <b>say ;Hello</b> to talk to other drones and <b>say Hello</b> to speak silently to your nearby fellows."
 
 /mob/living/silicon/robot/drone/add_robot_verbs()
-	src.verbs |= silicon_subsystems
+	return
 
 /mob/living/silicon/robot/drone/remove_robot_verbs()
-	src.verbs -= silicon_subsystems
+	return
 
 /mob/living/silicon/robot/drone/construction/welcome_drone()
 	src << "<b>You are a construction drone, an autonomous engineering and fabrication system.</b>."

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -51,4 +51,4 @@
 /mob/living/silicon/robot/proc/robot_checklaws()
 	set category = "Robot Commands"
 	set name = "State Laws"
-	subsystem_law_manager()
+	open_subsystem(/datum/nano_module/law_manager)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -234,7 +234,7 @@
 	if(new_sprites && new_sprites.len)
 		module_sprites = new_sprites.Copy()
 		//Custom_sprite check and entry
-		
+
 		if (custom_sprite == 1)
 			var/list/valid_states = icon_states(CUSTOM_ITEM_SYNTH)
 			if("[ckey]-[modtype]" in valid_states)
@@ -429,7 +429,7 @@
 
 // update the status screen display
 /mob/living/silicon/robot/Stat()
-	..()
+	. = ..()
 	if (statpanel("Status"))
 		show_cell_power()
 		show_jetpack_pressure()
@@ -779,7 +779,7 @@
 		return 1
 
 	if (href_list["showalerts"])
-		subsystem_alarm_monitor()
+		open_subsystem(/datum/nano_module/alarm_monitor/all)
 		return 1
 
 	if (href_list["mod"])
@@ -963,11 +963,9 @@
 
 /mob/living/silicon/robot/proc/add_robot_verbs()
 	src.verbs |= robot_verbs_default
-	src.verbs |= silicon_subsystems
 
 /mob/living/silicon/robot/proc/remove_robot_verbs()
 	src.verbs -= robot_verbs_default
-	src.verbs -= silicon_subsystems
 
 // Uses power from cyborg's cell. Returns 1 on success or 0 on failure.
 // Properly converts using CELLRATE now! Amount is in Joules.

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -150,10 +150,12 @@ var/global/list/robot_modules = list(
 	added_networks.Cut()
 
 /obj/item/weapon/robot_module/proc/add_subsystems(var/mob/living/silicon/robot/R)
-	R.verbs |= subsystems
+	for(var/subsystem_type in subsystems)
+		R.init_subsystem(subsystem_type)
 
 /obj/item/weapon/robot_module/proc/remove_subsystems(var/mob/living/silicon/robot/R)
-	R.verbs -= subsystems
+	for(var/subsystem_type in subsystems)
+		R.remove_subsystem(subsystem_type)
 
 /obj/item/weapon/robot_module/proc/apply_status_flags(var/mob/living/silicon/robot/R)
 	if(!can_be_pushed)
@@ -186,7 +188,7 @@ var/global/list/robot_modules = list(
 	name = "medical robot module"
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)
-	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
+	subsystems = list(/datum/nano_module/crew_monitor)
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/medical/surgeon
@@ -308,7 +310,7 @@ var/global/list/robot_modules = list(
 	name = "engineering robot module"
 	channels = list("Engineering" = 1)
 	networks = list(NETWORK_ENGINEERING)
-	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
+	subsystems = list(/datum/nano_module/power_monitor)
 	supported_upgrades = list(/obj/item/borg/upgrade/rcd)
 	sprites = list(
 					"Basic" = "Engineering",
@@ -387,7 +389,7 @@ var/global/list/robot_modules = list(
 	name = "security robot module"
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
-	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
+	subsystems = list(/datum/nano_module/crew_monitor)
 	can_be_pushed = 0
 	supported_upgrades = list(/obj/item/borg/upgrade/tasercooler)
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -166,7 +166,7 @@
 		show_emergency_shuttle_eta()
 		show_system_integrity()
 		show_malf_ai()
-	..()
+	. = ..()
 
 // this function displays the stations manifest in a separate window
 /mob/living/silicon/proc/show_station_manifest()

--- a/code/modules/mob/living/silicon/subystems.dm
+++ b/code/modules/mob/living/silicon/subystems.dm
@@ -1,141 +1,93 @@
 /mob/living/silicon
-	var/register_alarms = 1
-	var/datum/nano_module/alarm_monitor/all/alarm_monitor
-	var/datum/nano_module/atmos_control/atmos_control
-	var/datum/nano_module/crew_monitor/crew_monitor
-	var/datum/nano_module/law_manager/law_manager
-	var/datum/nano_module/power_monitor/power_monitor
-	var/datum/nano_module/rcon/rcon
-
-/mob/living/silicon/ai
-	var/datum/nano_module/computer_ntnetmonitor/ntnet_monitor
-
-/mob/living/silicon
 	var/list/silicon_subsystems = list(
-		/mob/living/silicon/proc/subsystem_alarm_monitor,
-		/mob/living/silicon/proc/subsystem_law_manager
+		/datum/nano_module/alarm_monitor/all,
+		/datum/nano_module/law_manager
 	)
 
-/mob/living/silicon/ai
-	silicon_subsystems = list(
-		/mob/living/silicon/proc/subsystem_alarm_monitor,
-		/mob/living/silicon/proc/subsystem_atmos_control,
-		/mob/living/silicon/proc/subsystem_crew_monitor,
-		/mob/living/silicon/proc/subsystem_law_manager,
-		/mob/living/silicon/proc/subsystem_power_monitor,
-		/mob/living/silicon/proc/subsystem_rcon,
-		/mob/living/silicon/ai/proc/subsystem_ntnet_monitor
-	)
+/mob/living/silicon/ai/New()
+	silicon_subsystems.Cut()
+	for(var/subtype in subtypesof(/datum/nano_module))
+		var/datum/nano_module/NM = subtype
+		if(initial(NM.adheres_to_NT_standard))
+			silicon_subsystems += NM
+	..()
 
 /mob/living/silicon/robot/syndicate
-	register_alarms = 0
-	silicon_subsystems = list(/mob/living/silicon/proc/subsystem_law_manager)
+	silicon_subsystems = list(
+		/datum/nano_module/law_manager
+	)
 
 /mob/living/silicon/Destroy()
-	qdel(alarm_monitor)
-	alarm_monitor = null
-
-	qdel(atmos_control)
-	atmos_control = null
-
-	qdel(crew_monitor)
-	crew_monitor = null
-
-	qdel(law_manager)
-	law_manager = null
-
-	qdel(power_monitor)
-	power_monitor = null
-
-	qdel(rcon)
-	rcon = null
-
-	return ..()
-
-/mob/living/silicon/ai/Destroy()
-	qdel(ntnet_monitor)
-	ntnet_monitor = null
-
-	return ..()
+	for(var/subsystem in silicon_subsystems)
+		remove_subsystem(subsystem)
+	silicon_subsystems.Cut()
+	. = ..()
 
 /mob/living/silicon/proc/init_subsystems()
-	alarm_monitor 	= new(src)
-	atmos_control 	= new(src)
-	crew_monitor 	= new(src)
-	law_manager 	= new(src)
-	power_monitor	= new(src)
-	rcon 			= new(src)
+	for(var/subsystem_type in silicon_subsystems)
+		init_subsystem(subsystem_type)
 
-	if(!register_alarms)
+	if(/datum/nano_module/alarm_monitor/all in silicon_subsystems)
+		for(var/datum/alarm_handler/AH in alarm_manager.all_handlers)
+			AH.register_alarm(src, /mob/living/silicon/proc/receive_alarm)
+			queued_alarms[AH] = list()	// Makes sure alarms remain listed in consistent order
+
+/mob/living/silicon/proc/init_subsystem(var/subsystem_type)
+	var/existing_entry = silicon_subsystems[subsystem_type]
+	if(existing_entry && !ispath(existing_entry))
+		return FALSE
+
+	var/ui_state = subsystem_type == /datum/nano_module/law_manager ? conscious_state : self_state
+	var/stat_silicon_subsystem/SSS = new(src, subsystem_type, ui_state)
+	silicon_subsystems[subsystem_type] = SSS
+	return TRUE
+
+/mob/living/silicon/proc/remove_subsystem(var/subsystem_type)
+	var/stat_silicon_subsystem/SSS = silicon_subsystems[subsystem_type]
+	if(!istype(SSS))
+		return FALSE
+
+	qdel(SSS)
+	silicon_subsystems -= subsystem_type
+	return TRUE
+
+/mob/living/silicon/proc/open_subsystem(var/subsystem_type)
+	var/stat_silicon_subsystem/SSS = silicon_subsystems[subsystem_type]
+	if(!istype(SSS))
+		return FALSE
+	SSS.Click()
+	return TRUE
+
+/mob/living/silicon/Stat()
+	. = ..()
+	if(!.)
 		return
+	if(!silicon_subsystems.len)
+		return
+	if(!statpanel("Subsystems"))
+		return
+	for(var/subsystem_type in silicon_subsystems)
+		var/stat_silicon_subsystem/SSS = silicon_subsystems[subsystem_type]
+		stat(SSS)
 
-	for(var/datum/alarm_handler/AH in alarm_manager.all_handlers)
-		AH.register_alarm(src, /mob/living/silicon/proc/receive_alarm)
-		queued_alarms[AH] = list()	// Makes sure alarms remain listed in consistent order
+/stat_silicon_subsystem
+	parent_type = /atom/movable
+	simulated = 0
+	var/ui_state
+	var/datum/nano_module/subsystem
 
-/mob/living/silicon/ai/init_subsystems()
+/stat_silicon_subsystem/New(var/mob/living/silicon/loc, var/subsystem_type, var/ui_state)
+	if(!istype(loc))
+		CRASH("Unexpected location. Expected /mob/living/silicon, was [loc.type].")
+	src.ui_state = ui_state
+	subsystem = new subsystem_type(loc)
+	name = subsystem.name
 	..()
-	ntnet_monitor = new(src)
 
-/********************
-*	Alarm Monitor	*
-********************/
-/mob/living/silicon/proc/subsystem_alarm_monitor()
-	set name = "Alarm Monitor"
-	set category = "Subystems"
+/stat_silicon_subsystem/Destroy()
+	qdel(subsystem)
+	subsystem = null
+	. = ..()
 
-	alarm_monitor.ui_interact(usr, state = self_state)
-
-/********************
-*	Atmos Control	*
-********************/
-/mob/living/silicon/proc/subsystem_atmos_control()
-	set category = "Subystems"
-	set name = "Atmospherics Control"
-
-	atmos_control.ui_interact(usr, state = self_state)
-
-/********************
-*	Crew Monitor	*
-********************/
-/mob/living/silicon/proc/subsystem_crew_monitor()
-	set category = "Subystems"
-	set name = "Crew Monitor"
-
-	crew_monitor.ui_interact(usr, state = self_state)
-
-/****************
-*	Law Manager	*
-****************/
-/mob/living/silicon/proc/subsystem_law_manager()
-	set name = "Law Manager"
-	set category = "Subystems"
-
-	law_manager.ui_interact(usr, state = conscious_state)
-
-/********************
-*	NTNet Monitor	*
-********************/
-/mob/living/silicon/ai/proc/subsystem_ntnet_monitor()
-	set name = "NTNet Monitoring"
-	set category = "Subystems"
-
-	ntnet_monitor.ui_interact(usr, state = conscious_state)
-
-/********************
-*	Power Monitor	*
-********************/
-/mob/living/silicon/proc/subsystem_power_monitor()
-	set category = "Subystems"
-	set name = "Power Monitor"
-
-	power_monitor.ui_interact(usr, state = self_state)
-
-/************
-*	RCON	*
-************/
-/mob/living/silicon/proc/subsystem_rcon()
-	set category = "Subystems"
-	set name = "RCON"
-
-	rcon.ui_interact(usr, state = self_state)
+/stat_silicon_subsystem/Click()
+	subsystem.ui_interact(usr, state = ui_state)

--- a/code/modules/mob/living/silicon/subystems.dm
+++ b/code/modules/mob/living/silicon/subystems.dm
@@ -8,7 +8,7 @@
 	silicon_subsystems.Cut()
 	for(var/subtype in subtypesof(/datum/nano_module))
 		var/datum/nano_module/NM = subtype
-		if(initial(NM.adheres_to_NT_standard))
+		if(initial(NM.available_to_ai))
 			silicon_subsystems += NM
 	..()
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -96,8 +96,7 @@
 /datum/computer_file/program/proc/run_program(var/mob/living/user)
 	if(can_run(user, 1))
 		if(nanomodule_path)
-			NM = new nanomodule_path(computer)	// Computer is passed here as it's (probably!) physical object. Some UI's perform get_turf() and passing program datum wouldn't go well with this.
-			NM.program = src					// Set the program reference to separate variable, instead.
+			NM = new nanomodule_path(computer, src)	// Computer is passed here as it's (probably!) physical object. Some UI's perform get_turf() and passing program datum wouldn't go well with this.
 		if(requires_ntnet && network_destination)
 			generate_network_log("Connection opened to [network_destination].")
 		program_state = PROGRAM_STATE_ACTIVE

--- a/code/modules/modular_computers/file_system/programs/_program.dm
+++ b/code/modules/modular_computers/file_system/programs/_program.dm
@@ -1,0 +1,20 @@
+/datum/computer_file/program/initial_data()
+	return get_header_data()
+
+/datum/computer_file/program/update_layout()
+	return TRUE
+
+/datum/nano_module/program
+	available_to_ai = FALSE
+	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
+
+/datum/nano_module/program/New(var/host, var/program)
+	src.program = program
+	..()
+
+/datum/nano_module/program/Topic(href, href_list)
+	// Calls forwarded to PROGRAM itself should begin with "PRG_"
+	// Calls forwarded to COMPUTER running the program should begin with "PC_"
+	if(program && program.Topic(href, href_list))
+		return TRUE
+	return ..()

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -7,7 +7,7 @@
 	requires_ntnet = 1
 	available_on_ntnet = 0
 	available_on_syndinet = 1
-	nanomodule_path = /datum/nano_module/computer_dos/
+	nanomodule_path = /datum/nano_module/program/computer_dos/
 	var/obj/machinery/ntnet_relay/target = null
 	var/dos_speed = 0
 	var/error = ""
@@ -36,11 +36,10 @@
 
 	..(forced)
 
-/datum/nano_module/computer_dos
+/datum/nano_module/program/computer_dos
 	name = "DoS Traffic Generator"
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/computer_dos/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/program/computer_dos/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!ntnet_global)
 		return
 	var/datum/computer_file/program/ntnet_dos/PRG = program

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -38,6 +38,7 @@
 
 /datum/nano_module/computer_dos
 	name = "DoS Traffic Generator"
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/computer_dos/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!ntnet_global)

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -58,6 +58,7 @@
 
 /datum/nano_module/revelation
 	name = "Revelation Virus"
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/revelation/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -7,7 +7,7 @@
 	requires_ntnet = 0
 	available_on_ntnet = 0
 	available_on_syndinet = 1
-	nanomodule_path = /datum/nano_module/revelation/
+	nanomodule_path = /datum/nano_module/program/revelation/
 	var/armed = 0
 
 /datum/computer_file/program/revelation/run_program(var/mob/living/user)
@@ -56,11 +56,10 @@
 	temp.armed = armed
 	return temp
 
-/datum/nano_module/revelation
+/datum/nano_module/program/revelation
 	name = "Revelation Virus"
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/revelation/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/program/revelation/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	var/list/data = list()
 	var/datum/computer_file/program/revelation/PRG = program
 	if(!istype(PRG))

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -10,6 +10,7 @@
 
 /datum/nano_module/card_mod
 	name = "ID card modification program"
+	adheres_to_NT_standard = FALSE
 	var/mod_mode = 1
 	var/is_centcom = 0
 	var/show_assignments = 0

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -1,24 +1,21 @@
 /datum/computer_file/program/card_mod
 	filename = "cardmod"
 	filedesc = "ID card modification program"
-	nanomodule_path = /datum/nano_module/card_mod
+	nanomodule_path = /datum/nano_module/program/card_mod
 	program_icon_state = "id"
 	extended_desc = "Program for programming employee ID cards to access parts of the station."
 	required_access = access_change_ids
 	requires_ntnet = 0
 	size = 8
 
-/datum/nano_module/card_mod
+/datum/nano_module/program/card_mod
 	name = "ID card modification program"
-	adheres_to_NT_standard = FALSE
 	var/mod_mode = 1
 	var/is_centcom = 0
 	var/show_assignments = 0
 
-/datum/nano_module/card_mod/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	var/list/data = list()
-	if(program)
-		data = program.get_header_data()
+/datum/nano_module/program/card_mod/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+	var/list/data = host.initial_data()
 
 	data["src"] = "\ref[src]"
 	data["station_name"] = station_name()
@@ -90,7 +87,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/card_mod/proc/format_jobs(list/jobs)
+/datum/nano_module/program/card_mod/proc/format_jobs(list/jobs)
 	var/obj/item/weapon/card/id/id_card = program.computer.card_slot.stored_card
 	var/list/formatted = list()
 	for(var/job in jobs)
@@ -101,8 +98,7 @@
 
 	return formatted
 
-/datum/nano_module/card_mod/proc/get_accesses(var/is_centcom = 0)
-
+/datum/nano_module/program/card_mod/proc/get_accesses(var/is_centcom = 0)
 	return null
 
 
@@ -113,7 +109,7 @@
 	var/mob/user = usr
 	var/obj/item/weapon/card/id/user_id_card = user.GetIdCard()
 	var/obj/item/weapon/card/id/id_card = computer.card_slot.stored_card
-	var/datum/nano_module/card_mod/module = NM
+	var/datum/nano_module/program/card_mod/module = NM
 	switch(href_list["action"])
 		if("switchm")
 			if(href_list["target"] == "mod")

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -32,6 +32,7 @@
 	var/datum/announcement/priority/crew_announcement = new
 	var/current_viewing_message_id = 0
 	var/current_viewing_message = null
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/comm/New()
 	..()

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -7,7 +7,7 @@
 	filename = "comm"
 	filedesc = "Command and communications program."
 	program_icon_state = "comm"
-	nanomodule_path = /datum/nano_module/comm
+	nanomodule_path = /datum/nano_module/program/comm
 	extended_desc = "Used to command and control the station. Can relay long-range communications."
 	required_access = access_heads
 	requires_ntnet = 1
@@ -22,7 +22,7 @@
 	temp.message_core.messages = message_core.messages.Copy()
 	return temp
 
-/datum/nano_module/comm
+/datum/nano_module/program/comm
 	name = "Command and communications program"
 	var/current_status = STATE_DEFAULT
 	var/msg_line1 = ""
@@ -32,16 +32,13 @@
 	var/datum/announcement/priority/crew_announcement = new
 	var/current_viewing_message_id = 0
 	var/current_viewing_message = null
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/comm/New()
+/datum/nano_module/program/comm/New()
 	..()
 	crew_announcement.newscast = 1
 
-/datum/nano_module/comm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	var/list/data = list()
-	if(program)
-		data = program.get_header_data()
+/datum/nano_module/program/comm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+	var/list/data = host.initial_data()
 
 	if(program)
 		data["emagged"] = program.computer_emagged
@@ -93,18 +90,18 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/comm/proc/is_autenthicated(var/mob/user)
+/datum/nano_module/program/comm/proc/is_autenthicated(var/mob/user)
 	if(program)
 		return program.can_run(user)
 	return 1
 
-/datum/nano_module/comm/proc/obtain_message_listener()
+/datum/nano_module/program/comm/proc/obtain_message_listener()
 	if(program)
 		var/datum/computer_file/program/comm/P = program
 		return P.message_core
 	return global_message_listener
 
-/datum/nano_module/comm/Topic(href, href_list)
+/datum/nano_module/program/comm/Topic(href, href_list)
 	if(..())
 		return 1
 	var/mob/user = usr
@@ -241,7 +238,7 @@
 
 	nanomanager.update_uis(src)
 
-/datum/nano_module/comm/proc/post_status(var/command, var/data1, var/data2)
+/datum/nano_module/program/comm/proc/post_status(var/command, var/data1, var/data2)
 
 	var/datum/radio_frequency/frequency = radio_controller.return_frequency(1435)
 

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -12,14 +12,13 @@
 	size = 4
 	available_on_ntnet = 0
 	requires_ntnet = 0
-	nanomodule_path = /datum/nano_module/computer_configurator/
+	nanomodule_path = /datum/nano_module/program/computer_configurator/
 
-/datum/nano_module/computer_configurator
+/datum/nano_module/program/computer_configurator
 	name = "NTOS Computer Configuration Tool"
 	var/obj/item/modular_computer/movable = null
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/computer_configurator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/program/computer_configurator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(program)
 		movable = program.computer
 	if(!istype(movable))

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -17,6 +17,7 @@
 /datum/nano_module/computer_configurator
 	name = "NTOS Computer Configuration Tool"
 	var/obj/item/modular_computer/movable = null
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/computer_configurator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(program)

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -7,7 +7,7 @@
 	requires_ntnet = 0
 	available_on_ntnet = 0
 	undeletable = 1
-	nanomodule_path = /datum/nano_module/computer_filemanager/
+	nanomodule_path = /datum/nano_module/program/computer_filemanager/
 	var/open_file
 	var/error
 
@@ -175,19 +175,13 @@
 	return t
 
 
-/datum/nano_module/computer_filemanager
+/datum/nano_module/program/computer_filemanager
 	name = "NTOS File Manager"
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/computer_filemanager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-
+/datum/nano_module/program/computer_filemanager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	var/datum/computer_file/program/filemanager/PRG
-	var/list/data = list()
-	if(program)
-		data = program.get_header_data()
-		PRG = program
-	else
-		return
+	var/list/data = program.get_header_data()
+	PRG = program
 
 	var/obj/item/weapon/computer_hardware/hard_drive/HDD
 	var/obj/item/weapon/computer_hardware/hard_drive/portable/RHDD

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -177,6 +177,7 @@
 
 /datum/nano_module/computer_filemanager
 	name = "NTOS File Manager"
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/computer_filemanager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -9,7 +9,7 @@
 	requires_ntnet = 1
 	requires_ntnet_feature = NTNET_SOFTWAREDOWNLOAD
 	available_on_ntnet = 0
-	nanomodule_path = /datum/nano_module/computer_ntnetdownload/
+	nanomodule_path = /datum/nano_module/program/computer_ntnetdownload/
 	ui_header = "downloader_finished.gif"
 	var/datum/computer_file/program/downloaded_file = null
 	var/hacked_download = 0
@@ -99,12 +99,11 @@
 		return 1
 	return 0
 
-/datum/nano_module/computer_ntnetdownload
+/datum/nano_module/program/computer_ntnetdownload
 	name = "Network Downloader"
 	var/obj/item/modular_computer/my_computer = null
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/computer_ntnetdownload/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/program/computer_ntnetdownload/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(program)
 		my_computer = program.computer
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -102,6 +102,7 @@
 /datum/nano_module/computer_ntnetdownload
 	name = "Network Downloader"
 	var/obj/item/modular_computer/my_computer = null
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/computer_ntnetdownload/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(program)

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -11,15 +11,12 @@
 
 /datum/nano_module/computer_ntnetmonitor
 	name = "NTNet Diagnostics and Monitoring"
+	available_to_ai = TRUE
 
 /datum/nano_module/computer_ntnetmonitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!ntnet_global)
 		return
-
-	var/list/data = list()
-	if(program)
-		data = program.get_header_data()
-
+	var/list/data = host.initial_data()
 
 	data["ntnetstatus"] = ntnet_global.check_function()
 	data["ntnetrelays"] = ntnet_global.relays.len
@@ -38,7 +35,8 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "ntnet_monitor.tmpl", "NTNet Diagnostics and Monitoring Tool", 575, 700, state = state)
-		ui.auto_update_layout = 1
+		if(host.update_layout())
+			ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -180,6 +180,7 @@
 
 /datum/nano_module/computer_chatclient
 	name = "NTNet Relay Chat Client"
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/computer_chatclient/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!ntnet_global || !ntnet_global.chat_channels)

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -9,7 +9,7 @@
 	network_destination = "NTNRC server"
 	ui_header = "ntnrc_idle.gif"
 	available_on_ntnet = 1
-	nanomodule_path = /datum/nano_module/computer_chatclient/
+	nanomodule_path = /datum/nano_module/program/computer_chatclient/
 	var/last_message = null				// Used to generate the toolbar icon
 	var/username
 	var/datum/ntnet_conversation/channel = null
@@ -178,11 +178,10 @@
 		channel = null
 	..(forced)
 
-/datum/nano_module/computer_chatclient
+/datum/nano_module/program/computer_chatclient
 	name = "NTNet Relay Chat Client"
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/computer_chatclient/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/program/computer_chatclient/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!ntnet_global || !ntnet_global.chat_channels)
 		return
 

--- a/code/modules/modular_computers/file_system/programs/nttransfer.dm
+++ b/code/modules/modular_computers/file_system/programs/nttransfer.dm
@@ -10,7 +10,7 @@ var/global/nttransfer_uid = 0
 	requires_ntnet_feature = NTNET_PEERTOPEER
 	network_destination = "other device via P2P tunnel"
 	available_on_ntnet = 1
-	nanomodule_path = /datum/nano_module/computer_nttransfer/
+	nanomodule_path = /datum/nano_module/program/computer_nttransfer/
 
 	var/error = ""										// Error screen
 	var/server_password = ""							// Optional password to download the file.
@@ -87,14 +87,10 @@ var/global/nttransfer_uid = 0
 	download_completion = 0
 
 
-
-
-
-/datum/nano_module/computer_nttransfer
+/datum/nano_module/program/computer_nttransfer
 	name = "NTNet P2P Transfer Client"
-	adheres_to_NT_standard = FALSE
 
-/datum/nano_module/computer_nttransfer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/program/computer_nttransfer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!program)
 		return
 	var/datum/computer_file/program/nttransfer/PRG = program

--- a/code/modules/modular_computers/file_system/programs/nttransfer.dm
+++ b/code/modules/modular_computers/file_system/programs/nttransfer.dm
@@ -92,6 +92,7 @@ var/global/nttransfer_uid = 0
 
 /datum/nano_module/computer_nttransfer
 	name = "NTNet P2P Transfer Client"
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/computer_nttransfer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(!program)

--- a/code/modules/nano/modules/alarm_monitor.dm
+++ b/code/modules/nano/modules/alarm_monitor.dm
@@ -2,10 +2,14 @@
 	name = "Alarm monitor"
 	var/list_cameras = 0						// Whether or not to list camera references. A future goal would be to merge this with the enginering/security camera console. Currently really only for AI-use.
 	var/list/datum/alarm_handler/alarm_handlers // The particular list of alarm handlers this alarm monitor should present to the user.
+	adheres_to_NT_standard = FALSE
 
 /datum/nano_module/alarm_monitor/New()
 	..()
 	alarm_handlers = list()
+
+/datum/nano_module/alarm_monitor/all
+	adheres_to_NT_standard = TRUE
 
 /datum/nano_module/alarm_monitor/all/New()
 	..()

--- a/code/modules/nano/modules/alarm_monitor.dm
+++ b/code/modules/nano/modules/alarm_monitor.dm
@@ -2,14 +2,14 @@
 	name = "Alarm monitor"
 	var/list_cameras = 0						// Whether or not to list camera references. A future goal would be to merge this with the enginering/security camera console. Currently really only for AI-use.
 	var/list/datum/alarm_handler/alarm_handlers // The particular list of alarm handlers this alarm monitor should present to the user.
-	adheres_to_NT_standard = FALSE
+	available_to_ai = FALSE
 
 /datum/nano_module/alarm_monitor/New()
 	..()
 	alarm_handlers = list()
 
 /datum/nano_module/alarm_monitor/all
-	adheres_to_NT_standard = TRUE
+	available_to_ai = TRUE
 
 /datum/nano_module/alarm_monitor/all/New()
 	..()
@@ -72,10 +72,7 @@
 		return 1
 
 /datum/nano_module/alarm_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	var/data[0]
-
-	if(program)
-		data = program.get_header_data()
+	var/list/data = host.initial_data()
 
 	var/categories[0]
 	for(var/datum/alarm_handler/AH in alarm_handlers)
@@ -102,7 +99,7 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "alarm_monitor.tmpl", "Alarm Monitoring Console", 800, 800, state = state)
-		if(program) // This is necessary to ensure the status bar remains updated along with rest of the UI.
+		if(host.update_layout()) // This is necessary to ensure the status bar remains updated along with rest of the UI.
 			ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -30,11 +30,8 @@
 		return 1
 
 /datum/nano_module/atmos_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
-	var/data[0]
+	var/list/data = host.initial_data()
 	var/alarms[0]
-
-	if(program)
-		data = program.get_header_data()
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : machines))
@@ -44,7 +41,7 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "atmos_control.tmpl", src.name, 625, 625, state = state)
-		if(program) // This is necessary to ensure the status bar remains updated along with rest of the UI.
+		if(host.update_layout()) // This is necessary to ensure the status bar remains updated along with rest of the UI.
 			ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -16,9 +16,7 @@
 		return 1
 
 /datum/nano_module/crew_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	var/data[0]
-	if(program)
-		data = program.get_header_data()
+	var/list/data = host.initial_data()
 	var/turf/T = get_turf(nano_host())
 
 	data["isAI"] = isAI(user)

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -1,5 +1,6 @@
 /datum/nano_module/appearance_changer
 	name = "Appearance Editor"
+	adheres_to_NT_standard = FALSE
 	var/flags = APPEARANCE_ALL_HAIR
 	var/mob/living/carbon/human/owner = null
 	var/list/valid_species = list()

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -1,6 +1,6 @@
 /datum/nano_module/appearance_changer
 	name = "Appearance Editor"
-	adheres_to_NT_standard = FALSE
+	available_to_ai = FALSE
 	var/flags = APPEARANCE_ALL_HAIR
 	var/mob/living/carbon/human/owner = null
 	var/list/valid_species = list()
@@ -92,12 +92,11 @@
 	return 0
 
 /datum/nano_module/appearance_changer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-
 	if(!owner || !owner.species)
 		return
 
 	generate_data(check_whitelist, whitelist, blacklist)
-	var/data[0]
+	var/list/data = host.initial_data()
 
 	data["specimen"] = owner.species.name
 	data["gender"] = owner.gender

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -2,6 +2,7 @@
 	var/name
 	var/host
 	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
+	var/adheres_to_NT_standard = TRUE
 
 /datum/nano_module/New(var/host)
 	// Machinery-based computers wouldn't work w/o this as nano will assume they're items inside containers.

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -1,8 +1,7 @@
 /datum/nano_module
 	var/name
-	var/host
-	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
-	var/adheres_to_NT_standard = TRUE
+	var/datum/host
+	var/available_to_ai = TRUE
 
 /datum/nano_module/New(var/host)
 	// Machinery-based computers wouldn't work w/o this as nano will assume they're items inside containers.
@@ -18,9 +17,8 @@
 /datum/nano_module/proc/can_still_topic(var/datum/topic_state/state = default_state)
 	return CanUseTopic(usr, state) == STATUS_INTERACTIVE
 
-/datum/nano_module/Topic(href, href_list)
-	// Calls forwarded to PROGRAM itself should begin with "PRG_"
-	// Calls forwarded to COMPUTER running the program should begin with "PC_"
-	if(program)
-		program.Topic(href, href_list)
-	return ..()
+/datum/proc/initial_data()
+	return list()
+
+/datum/proc/update_layout()
+	return FALSE

--- a/code/modules/nano/modules/power_monitor.dm
+++ b/code/modules/nano/modules/power_monitor.dm
@@ -17,9 +17,7 @@
 // If PC is not null header template is loaded. Use PC.get_header_data() to get relevant nanoui data from it. All data entries begin with "PC_...."
 // In future it may be expanded to other modular computer devices.
 /datum/nano_module/power_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	var/list/data = list()
-	if(program)
-		data = program.get_header_data()
+	var/list/data = host.initial_data()
 
 	var/list/sensors = list()
 	// Focus: If it remains null if no sensor is selected and UI will display sensor list, otherwise it will display sensor reading.
@@ -41,7 +39,7 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "power_monitor.tmpl", "Power Monitoring Console", 800, 500, state = state)
-		if(program) // This is necessary to ensure the status bar remains updated along with rest of the UI.
+		if(host.update_layout()) // This is necessary to ensure the status bar remains updated along with rest of the UI.
 			ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/nano/modules/rcon.dm
+++ b/code/modules/nano/modules/rcon.dm
@@ -9,9 +9,7 @@
 
 /datum/nano_module/rcon/ui_interact(mob/user, ui_key = "rcon", datum/nanoui/ui=null, force_open=1, var/datum/topic_state/state = default_state)
 	FindDevices() // Update our devices list
-	var/data[0]
-	if(program)
-		data = program.get_header_data()
+	var/list/data = host.initial_data()
 
 	// SMES DATA (simplified view)
 	var/list/smeslist[0]
@@ -43,7 +41,7 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "rcon.tmpl", "RCON Console", 600, 400, state = state)
-		if(program) // This is necessary to ensure the status bar remains updated along with rest of the UI.
+		if(host.update_layout()) // This is necessary to ensure the status bar remains updated along with rest of the UI.
 			ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()


### PR DESCRIPTION
Will no longer have to define a proc for each desired NanoUI module

AIs will now automatically load all NT standard modules.
silicon/robot subtypes populate their modules from a list, which should be easy to modify. Robot modules with custom view work in a similar manner.
