### PR TITLE
[Important] Alters turf/Enter() density check.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -78,7 +78,7 @@
 
 	..()
 
-	if (!mover || !mover.density || !isturf(mover.loc))
+	if (!mover || !isturf(mover.loc) || isobserver(mover))
 		return 1
 
 	//First, check objects to block exit that are not on the border


### PR DESCRIPTION
Things are breaking down in hilarious ways without it, with things moving through solid objects when they definitely shouldn't.
Instead makes it an observer check.
