### PR TITLE
Fixes #12459.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/_program.dm
+++ b/code/modules/modular_computers/file_system/programs/_program.dm
@@ -1,7 +1,7 @@
-/datum/computer_file/program/initial_data()
-	return get_header_data()
+/obj/machinery/modular_computer/initial_data()
+	return cpu ? cpu.get_header_data() : ..()
 
-/datum/computer_file/program/update_layout()
+/obj/machinery/modular_computer/update_layout()
 	return TRUE
 
 /datum/nano_module/program

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -179,8 +179,8 @@
 	name = "NTOS File Manager"
 
 /datum/nano_module/program/computer_filemanager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+	var/list/data = host.initial_data()
 	var/datum/computer_file/program/filemanager/PRG
-	var/list/data = program.get_header_data()
 	PRG = program
 
 	var/obj/item/weapon/computer_hardware/hard_drive/HDD


### PR DESCRIPTION
Moves the header acquirement to the appropriate host type, the one program I tested with of course happened to use the old method. Fixes #12459.
