### PR TITLE
VV marking datums no longer prevents GC.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -166,6 +166,7 @@
 #include "code\datums\recipe.dm"
 #include "code\datums\sun.dm"
 #include "code\datums\supplypacks.dm"
+#include "code\datums\weakref.dm"
 #include "code\datums\ai\ai.dm"
 #include "code\datums\extensions\extensions.dm"
 #include "code\datums\extensions\multitool\_multitool.dm"

--- a/code/controllers/Processes/garbage.dm
+++ b/code/controllers/Processes/garbage.dm
@@ -1,6 +1,5 @@
 // The time a datum was destroyed by the GC, or null if it hasn't been
 /datum/var/gcDestroyed
-
 #define GC_COLLECTIONS_PER_RUN 300
 #define GC_COLLECTION_TIMEOUT (30 SECONDS)
 #define GC_FORCE_DEL_PER_RUN 30
@@ -65,6 +64,9 @@ world/loop_checks = 0
 		testing("GC: [refID] old enough to test: GCd_at_time: [GCd_at_time] time_to_kill: [time_to_kill] current: [world.time]")
 		#endif
 		if(A && A.gcDestroyed == GCd_at_time) // So if something else coincidently gets the same ref, it's not deleted by mistake
+			#ifdef GC_FINDREF
+			LocateReferences(A)
+			#endif
 			// Something's still referring to the qdel'd object.  Kill it.
 			testing("GC: -- \ref[A] | [A.type] was unable to be GC'd and was deleted --")
 			logging["[A.type]"]++
@@ -87,29 +89,47 @@ world/loop_checks = 0
 #undef GC_COLLECTIONS_PER_TICK
 
 #ifdef GC_FINDREF
-/datum/controller/process/garbage_collector/proc/LookForRefs(var/datum/D, var/list/targ)
+
+/datum/controller/process/garbage_collector/proc/LocateReferences(var/atom/A)
+	testing("GC: Attempting to locate references to [A] | [A.type]. This is a potentially long-running operation.")
+	if(istype(A))
+		if(A.loc != null)
+			testing("GC: [A] | [A.type] is located in [A.loc] instead of null")
+		if(A.contents.len)
+			testing("GC: [A] | [A.type] has contents: [jointext(A.contents)]")
+	var/ref_count = 0
+	for(var/atom/atom)
+		ref_count += LookForRefs(atom, A)
+	for(var/datum/datum)	// This is strictly /datum, not subtypes.
+		ref_count += LookForRefs(datum, A)
+	for(var/client/client)
+		ref_count += LookForRefs(client, A)
+	var/message = "GC: References found to [A] | [A.type]: [ref_count]."
+	if(!ref_count)
+		message += " Has likely been supplied as an 'in list' argment to a proc."
+	testing(message)
+
+/datum/controller/process/garbage_collector/proc/LookForRefs(var/datum/D, var/datum/A)
 	. = 0
 	for(var/V in D.vars)
 		if(V == "contents")
 			continue
-		if(istype(D.vars[V], /atom))
-			var/atom/A = D.vars[V]
-			if(A in targ)
+		if(!islist(D.vars[V]))
+			if(D.vars[V] == A)
 				testing("GC: [A] | [A.type] referenced by [D] | [D.type], var [V]")
 				. += 1
-		else if(islist(D.vars[V]))
-			. += LookForListRefs(D.vars[V], targ, D, V)
+		else
+			. += LookForListRefs(D.vars[V], A, D, V)
 
-/datum/controller/process/garbage_collector/proc/LookForListRefs(var/list/L, var/list/targ, var/datum/D, var/V)
+/datum/controller/process/garbage_collector/proc/LookForListRefs(var/list/L, var/datum/A, var/datum/D, var/V)
 	. = 0
 	for(var/F in L)
-		if(istype(F, /atom))
-			var/atom/A = F
-			if(A in targ)
+		if(!islist(F))
+			if(F == A || L[F] == A)
 				testing("GC: [A] | [A.type] referenced by [D] | [D.type], list [V]")
 				. += 1
-		if(islist(F))
-			. += LookForListRefs(F, targ, D, "[F] in list [V]")
+		else
+			. += LookForListRefs(F, A, D, "[F] in list [V]")
 #endif
 
 /datum/controller/process/garbage_collector/proc/AddTrash(datum/A)

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -1,0 +1,31 @@
+/datum
+	var/weakref
+
+/datum/Destroy()
+	weakref = null // Clear this reference to ensure it's kept for as brief duration as possible.
+	. = ..()
+
+//obtain a weak reference to a datum
+/proc/weakref(datum/D)
+	if(D.gcDestroyed)
+		return
+	if(!D.weakref)
+		D.weakref = new /datum/weakref(D)
+	return D.weakref
+
+/datum/weakref
+	var/ref
+
+/datum/weakref/New(datum/D)
+	ref = "\ref[D]"
+
+/datum/weakref/Destroy()
+	// A weakref datum should not be manually destroyed as it is a shared resource,
+	//  rather it should be automatically collected by the BYOND GC when all references are gone.
+	return 0
+
+/datum/weakref/proc/resolve()
+	var/datum/D = locate(ref)
+	if(D && D.weakref == src)
+		return D
+	return null

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -125,7 +125,7 @@
 							return
 
 			if("marked datum")
-				current = holder.marked_datum
+				current = holder.marked_datum()
 				if(!current)
 					switch(alert("You do not currently have a marked datum; do you want to pass null instead?",, "Yes", "Cancel"))
 						if("Yes")

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -6,12 +6,16 @@ var/list/admin_datums = list()
 	var/rights = 0
 	var/fakekey			= null
 
-	var/datum/marked_datum
+	var/datum/weakref/marked_datum_weak
 
 	var/admincaster_screen = 0	//See newscaster.dm under machinery for a full description
 	var/datum/feed_message/admincaster_feed_message = new /datum/feed_message   //These two will act as holders.
 	var/datum/feed_channel/admincaster_feed_channel = new /datum/feed_channel
 	var/admincaster_signature	//What you'll sign the newsfeeds as
+	
+/datum/admins/proc/marked_datum()
+	if(marked_datum_weak)
+		return marked_datum_weak.resolve()
 
 /datum/admins/New(initial_rank = "Temporary Admin", initial_rights = 0, ckey)
 	if(!ckey)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1606,6 +1606,7 @@
 				where = "onfloor"
 
 		if ( where == "inmarked" )
+			var/marked_datum = marked_datum()
 			if ( !marked_datum )
 				usr << "You don't have any object marked. Abandoning spawn."
 				return
@@ -1623,7 +1624,7 @@
 					if ("relative")
 						target = locate(loc.x + X,loc.y + Y,loc.z + Z)
 			if ( "inmarked" )
-				target = marked_datum
+				target = marked_datum()
 
 		if(target)
 			for (var/path in paths)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -27,20 +27,20 @@ var/list/VVckey_edit = list("key", "ckey")
 		src.modify_variables(ticker)
 		feedback_add_details("admin_verb","ETV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/mod_list_add_ass() //haha
-
+/client/proc/mod_list_add_ass()
 	var/class = "text"
-	if(src.holder && src.holder.marked_datum)
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
-	else
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+	if(src.holder)
+		var/datum/marked_datum = holder.marked_datum()
+		if(marked_datum)
+			class_input += "marked datum ([marked_datum.type])"
 
+	class = input("What kind of variable?","Variable Type") as null|anything in class_input
 	if(!class)
 		return
 
-	if(holder.marked_datum && class == "marked datum ([holder.marked_datum.type])")
+	var/datum/marked_datum = holder.marked_datum()
+	if(marked_datum && class == "marked datum ([marked_datum.type])")
 		class = "marked datum"
 
 	var/var_value = null
@@ -69,7 +69,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			var_value = input("Pick icon:","Icon") as null|icon
 
 		if("marked datum")
-			var_value = holder.marked_datum
+			var_value = holder.marked_datum()
 
 	if(!var_value) return
 
@@ -79,17 +79,18 @@ var/list/VVckey_edit = list("key", "ckey")
 /client/proc/mod_list_add(var/list/L, atom/O, original_name, objectvar)
 
 	var/class = "text"
-	if(src.holder && src.holder.marked_datum)
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
-	else
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+	if(src.holder)
+		var/datum/marked_datum = holder.marked_datum()
+		if(marked_datum)
+			class_input += "marked datum ([marked_datum.type])"
 
+	class = input("What kind of variable?","Variable Type") as null|anything in class_input
 	if(!class)
 		return
 
-	if(holder.marked_datum && class == "marked datum ([holder.marked_datum.type])")
+	var/datum/marked_datum = holder.marked_datum()
+	if(marked_datum && class == "marked datum ([marked_datum.type])")
 		class = "marked datum"
 
 	var/var_value = null
@@ -118,7 +119,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			var_value = input("Pick icon:","Icon") as icon
 
 		if("marked datum")
-			var_value = holder.marked_datum
+			var_value = holder.marked_datum()
 
 	if(!var_value) return
 
@@ -244,17 +245,21 @@ var/list/VVckey_edit = list("key", "ckey")
 			usr << "If a direction, direction is: [dir]"
 
 	var/class = "text"
-	if(src.holder && src.holder.marked_datum)
-		class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])", "DELETE FROM LIST")
-	else
-		class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "DELETE FROM LIST")
+	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+
+	if(src.holder)
+		var/datum/marked_datum = holder.marked_datum()
+		if(marked_datum)
+			class_input += "marked datum ([marked_datum.type])"
+
+	class_input += "DELETE FROM LIST"
+	class = input("What kind of variable?","Variable Type",default) as null|anything in class_input
 
 	if(!class)
 		return
 
-	if(holder.marked_datum && class == "marked datum ([holder.marked_datum.type])")
+	var/datum/marked_datum = holder.marked_datum()
+	if(marked_datum && class == "marked datum ([marked_datum.type])")
 		class = "marked datum"
 
 	var/original_var
@@ -336,7 +341,9 @@ var/list/VVckey_edit = list("key", "ckey")
 				L[L.Find(variable)] = new_var
 
 		if("marked datum")
-			new_var = holder.marked_datum
+			new_var = holder.marked_datum()
+			if(!new_var)
+				return
 			if(assoc)
 				L[assoc_key] = new_var
 			else
@@ -497,12 +504,12 @@ var/list/VVckey_edit = list("key", "ckey")
 			if(dir)
 				usr << "If a direction, direction is: [dir]"
 
-		if(src.holder && src.holder.marked_datum)
-			class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
-		else
-			class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+		var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+		if(src.holder)
+			var/datum/marked_datum = holder.marked_datum()
+			if(marked_datum)
+				class_input += "marked datum ([marked_datum.type])"
+		class = input("What kind of variable?","Variable Type",default) as null|anything in class_input
 
 		if(!class)
 			return
@@ -514,7 +521,8 @@ var/list/VVckey_edit = list("key", "ckey")
 	else
 		original_name = O:name
 
-	if(holder.marked_datum && class == "marked datum ([holder.marked_datum.type])")
+	var/datum/marked_datum = holder.marked_datum()
+	if(marked_datum && class == "marked datum ([marked_datum.type])")
 		class = "marked datum"
 
 	switch(class)
@@ -580,7 +588,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			O.vars[variable] = var_new
 
 		if("marked datum")
-			O.vars[variable] = holder.marked_datum
+			O.vars[variable] = holder.marked_datum()
 
 	world.log << "### VarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]"
 	log_admin("[key_name(src)] modified [original_name]'s [variable] to [O.vars[variable]]")

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -223,7 +223,7 @@
 			usr << "This can only be done to instances of type /datum"
 			return
 
-		src.holder.marked_datum = D
+		src.holder.marked_datum_weak = weakref(D)
 		href_list["datumrefresh"] = href_list["mark_object"]
 
 	else if(href_list["rotatedatum"])

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -48,7 +48,7 @@
 						</tr></table>
 						<div align='center'>
 							<b><font size='1'>[replacetext("[D.type]", "/", "/<wbr>")]</font></b>
-							[holder.marked_datum == D ? "<br/><font size='1' color='red'><b>Marked Object</b></font>" : ""]
+							[holder.marked_datum() == D ? "<br/><font size='1' color='red'><b>Marked Object</b></font>" : ""]
 						</div>
 					</td>
 					<td width='50%'>


### PR DESCRIPTION
Utilizes a weak reference datum, which only stores the ref and acquires the datum on request.
Sadly does nothing to prevent the hidden 5 minute reference caused by many admin procs.
