### PR TITLE
Partially reverts #12433

### DIFF
--- a/code/modules/modular_computers/file_system/programs/_program.dm
+++ b/code/modules/modular_computers/file_system/programs/_program.dm
@@ -4,17 +4,8 @@
 /obj/machinery/modular_computer/update_layout()
 	return TRUE
 
+/obj/item/modular_computer/update_layout()
+	return TRUE
+
 /datum/nano_module/program
 	available_to_ai = FALSE
-	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
-
-/datum/nano_module/program/New(var/host, var/program)
-	src.program = program
-	..()
-
-/datum/nano_module/program/Topic(href, href_list)
-	// Calls forwarded to PROGRAM itself should begin with "PRG_"
-	// Calls forwarded to COMPUTER running the program should begin with "PC_"
-	if(program && program.Topic(href, href_list))
-		return TRUE
-	return ..()

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -2,14 +2,23 @@
 	var/name
 	var/datum/host
 	var/available_to_ai = TRUE
+	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
 
-/datum/nano_module/New(var/host)
+/datum/nano_module/New(var/host, var/program)
+	src.program = program
 	// Machinery-based computers wouldn't work w/o this as nano will assume they're items inside containers.
 	if(istype(host, /obj/item/modular_computer/processor))
 		var/obj/item/modular_computer/processor/H = host
 		src.host = H.machinery_computer
 	else
 		src.host = host
+
+/datum/nano_module/Topic(href, href_list)
+	// Calls forwarded to PROGRAM itself should begin with "PRG_"
+	// Calls forwarded to COMPUTER running the program should begin with "PC_"
+	if(program && program.Topic(href, href_list))
+		return TRUE
+	return ..()
 
 /datum/nano_module/nano_host()
 	return host ? host : src


### PR DESCRIPTION
- Moves some modular computer specific things back to /datum/nano_module/. This ensures computers can operate correctly with things (rcon, power monitor, ...) that aren't modular computer exclusive (such as downloader program, etc.)
- Fixes #12481
- Fixes #12459 (properly)
