### PR TITLE
Fixes Anomaly Analyzer reading the wrong variable

### DIFF
--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -181,7 +181,7 @@
 				out += " have been detected "
 
 				//how the artifact does it's effect
-				switch(A.my_effect.effect_type)
+				switch(A.my_effect.effect)
 					if(1)
 						out += " emitting in an ambient energy field."
 					if(2)
@@ -224,7 +224,7 @@
 						out += "low level radiation"
 
 				//how the artifact does it's effect
-				switch(A.secondary_effect.effect_type)
+				switch(A.secondary_effect.effect)
 					if(1)
 						out += " emitting in an ambient energy field."
 					if(2)


### PR DESCRIPTION
Anomaly analyzer erroneously read the wrong variable for the effect's range (touch, aura or pulse).
Port of https://github.com/PolarisSS13/Polaris/pull/1221.
