### PR TITLE
Re-decouples NanoUI modules.

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -16,6 +16,9 @@
 	machinery_computer = null
 	return ..()
 
+/obj/item/modular_computer/processor/nano_host()
+	return machinery_computer.nano_host()
+
 // Due to how processes work, we'd receive two process calls - one from machinery type and one from our own type.
 // Since we want this to be in-sync with machinery (as it's hidden type for machinery-based computers) we'll ignore
 // non-relayed process calls.

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -25,6 +25,13 @@
 	if(comp && istype(comp))
 		computer = comp
 
+/datum/computer_file/program/Destroy()
+	computer = null
+	. = ..()
+
+/datum/computer_file/program/nano_host()
+	return computer.nano_host()
+
 /datum/computer_file/program/clone()
 	var/datum/computer_file/program/temp = ..()
 	temp.required_access = required_access
@@ -96,7 +103,7 @@
 /datum/computer_file/program/proc/run_program(var/mob/living/user)
 	if(can_run(user, 1))
 		if(nanomodule_path)
-			NM = new nanomodule_path(computer, src)	// Computer is passed here as it's (probably!) physical object. Some UI's perform get_turf() and passing program datum wouldn't go well with this.
+			NM = new nanomodule_path(src, new /datum/topic_manager/program(src), src)
 		if(requires_ntnet && network_destination)
 			generate_network_log("Connection opened to [network_destination].")
 		program_state = PROGRAM_STATE_ACTIVE

--- a/code/modules/modular_computers/file_system/programs/_program.dm
+++ b/code/modules/modular_computers/file_system/programs/_program.dm
@@ -9,3 +9,20 @@
 
 /datum/nano_module/program
 	available_to_ai = FALSE
+	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
+
+/datum/nano_module/program/New(var/host, var/topic_manager, var/program)
+	..()
+	src.program = program
+
+/datum/topic_manager/program
+	var/datum/program
+
+/datum/topic_manager/program/New(var/datum/program)
+	..()
+	src.program = program
+
+// Calls forwarded to PROGRAM itself should begin with "PRG_"
+// Calls forwarded to COMPUTER running the program should begin with "PC_"
+/datum/topic_manager/program/Topic(href, href_list)
+	return program && program.Topic(href, href_list)

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -2,29 +2,23 @@
 	var/name
 	var/datum/host
 	var/available_to_ai = TRUE
-	var/datum/computer_file/program/program = null	// Program-Based computer program that runs this nano module. Defaults to null.
+	var/datum/topic_manager/topic_manager
 
-/datum/nano_module/New(var/host, var/program)
-	src.program = program
-	// Machinery-based computers wouldn't work w/o this as nano will assume they're items inside containers.
-	if(istype(host, /obj/item/modular_computer/processor))
-		var/obj/item/modular_computer/processor/H = host
-		src.host = H.machinery_computer
-	else
-		src.host = host
-
-/datum/nano_module/Topic(href, href_list)
-	// Calls forwarded to PROGRAM itself should begin with "PRG_"
-	// Calls forwarded to COMPUTER running the program should begin with "PC_"
-	if(program && program.Topic(href, href_list))
-		return TRUE
-	return ..()
+/datum/nano_module/New(var/datum/host, var/topic_manager)
+	..()
+	src.host = host.nano_host()
+	src.topic_manager = topic_manager
 
 /datum/nano_module/nano_host()
 	return host ? host : src
 
 /datum/nano_module/proc/can_still_topic(var/datum/topic_state/state = default_state)
 	return CanUseTopic(usr, state) == STATUS_INTERACTIVE
+
+/datum/nano_module/Topic(href, href_list)
+	if(topic_manager && topic_manager.Topic(href, href_list))
+		return TRUE
+	. = ..()
 
 /datum/proc/initial_data()
 	return list()


### PR DESCRIPTION
Base NanoUI modules again have no other required dependency beyond having a host.
It should be do-able to remove the program dependency for the /program subtype as well, utilizing a similar pattern as the `initial_data()` proc, but I'm not prepared to spend the effort.

Program and non-program modules have been tested, both by suspending, exiting, and shutting down.
Modular computer header display updates have been tested, using the alarm monitor running in the background and causing an alarm.
