### PR TITLE
[READY]Assorted modular computer tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -161,9 +161,9 @@
 #define NTNET_SYSTEMCONTROL 4		// Control of various systems, RCon, air alarm control, etc.
 
 // NTNet transfer speeds, used when downloading/uploading a file/program.
-#define NTNETSPEED_LOWSIGNAL 0.025	// GQ/s transfer speed when the device is wirelessly connected and on Low signal
-#define NTNETSPEED_HIGHSIGNAL 0.1	// GQ/s transfer speed when the device is wirelessly connected and on High signal
-#define NTNETSPEED_ETHERNET 0.5		// GQ/s transfer speed when the device is using wired connection
+#define NTNETSPEED_LOWSIGNAL 0.1	// GQ/s transfer speed when the device is wirelessly connected and on Low signal
+#define NTNETSPEED_HIGHSIGNAL 0.5	// GQ/s transfer speed when the device is wirelessly connected and on High signal
+#define NTNETSPEED_ETHERNET 1		// GQ/s transfer speed when the device is using wired connection
 
 // Program bitflags
 #define PROGRAM_ALL 7

--- a/code/modules/modular_computers/computers/item/modular_computer.dm
+++ b/code/modules/modular_computers/computers/item/modular_computer.dm
@@ -30,6 +30,11 @@
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 	var/light_strength = 0
 
+	// Damage of the chassis. If the chassis takes too much damage it will break apart.
+	var/damage = 0				// Current damage level
+	var/broken_damage = 50		// Damage level at which the computer ceases to operate
+	var/max_damage = 100		// Damage level at which the computer breaks apart.
+
 	// Important hardware (must be installed for computer to work)
 	var/obj/item/weapon/computer_hardware/processor_unit/processor_unit				// CPU. Without it the computer won't run. Better CPUs can run more programs at once.
 	var/obj/item/weapon/computer_hardware/network_card/network_card					// Network Card component of this computer. Allows connection to NTNet
@@ -126,6 +131,13 @@
 		user << "You emag \the [src]. It's screen briefly shows a \"OVERRIDE ACCEPTED: New software downloads available.\" message."
 		return 1
 
+/obj/item/modular_computer/examine(var/mob/user)
+	..()
+	if(damage > broken_damage)
+		user << "<span class='danger'>It is heavily damaged!</span>"
+	else if(damage)
+		user << "It is damaged."
+
 /obj/item/modular_computer/New()
 	processing_objects.Add(src)
 	update_icon()
@@ -135,7 +147,7 @@
 	kill_program(1)
 	processing_objects.Remove(src)
 	for(var/obj/item/weapon/computer_hardware/CH in src.get_all_components())
-		qdel(CH)
+		uninstall_component(null, CH)
 	return ..()
 
 /obj/item/modular_computer/update_icon()
@@ -204,9 +216,27 @@
 	else
 		turn_on(user)
 
+/obj/item/modular_computer/proc/break_apart()
+	visible_message("\The [src] breaks apart!")
+	var/turf/newloc = get_turf(src)
+	new /obj/item/stack/material/steel(newloc, round(steel_sheet_cost/2))
+	for(var/obj/item/weapon/computer_hardware/H in get_all_components())
+		uninstall_component(null, H)
+		H.forceMove(newloc)
+		if(prob(25))
+			H.take_damage(rand(10,30))
+	relay_qdel()
+	qdel()
+
 /obj/item/modular_computer/proc/turn_on(var/mob/user)
 	var/issynth = issilicon(user) // Robots and AIs get different activation messages.
-	if(processor_unit && ((battery_module && battery_module.battery.charge) || check_power_override())) // Battery-run and charged or non-battery but powered by APC.
+	if(damage > broken_damage)
+		if(issynth)
+			user << "You send an activation signal to \the [src], but it responds with an error code. It must be damaged."
+		else
+			user << "You press the power button, but the computer fails to boot up, displaying variety of errors before shutting down again."
+		return
+	if(processor_unit && ((battery_module && battery_module.battery.charge && battery_module.check_functionality()) || check_power_override())) // Battery-run and charged or non-battery but powered by APC.
 		if(issynth)
 			user << "You send an activation signal to \the [src], turning it on"
 		else
@@ -224,6 +254,10 @@
 /obj/item/modular_computer/process()
 	if(!enabled) // The computer is turned off
 		last_power_usage = 0
+		return 0
+
+	if(damage > broken_damage)
+		shutdown_computer()
 		return 0
 
 	if(active_program && active_program.requires_ntnet && !get_ntnet_status(active_program.requires_ntnet_feature)) // Active program requires NTNet to run but we've just lost connection. Crash.
@@ -379,11 +413,12 @@
 		var/mob/user = usr
 		if(hard_drive)
 			P = hard_drive.find_file_by_name(prog)
-			P.computer = src
 
 		if(!P || !istype(P)) // Program not found or it's not executable program.
 			user << "<span class='danger'>\The [src]'s screen shows \"I/O ERROR - Unable to run program\" warning.</span>"
 			return
+
+		P.computer = src
 
 		if(!P.is_supported_by_hardware(hardware_flag, 1, user))
 			return
@@ -407,9 +442,9 @@
 		update_uis()
 
 // Used in following function to reduce copypaste
-/obj/item/modular_computer/proc/power_failure()
+/obj/item/modular_computer/proc/power_failure(var/malfunction = 0)
 	if(enabled) // Shut down the computer
-		visible_message("<span class='danger'>\The [src]'s screen flickers \"BATTERY CRITICAL\" warning as it shuts down unexpectedly.</span>")
+		visible_message("<span class='danger'>\The [src]'s screen flickers \"BATTERY [malfunction ? "MALFUNCTION" : "CRITICAL"]\" warning as it shuts down unexpectedly.</span>")
 		if(active_program)
 			active_program.event_powerfailure(0)
 		for(var/datum/computer_file/program/PRG in idle_threads)
@@ -429,6 +464,9 @@
 			power_usage += H.power_usage
 
 	if(battery_module)
+		if(!battery_module.check_functionality())
+			power_failure(1)
+			return
 		battery_module.battery.use(power_usage * CELLRATE)
 
 	last_power_usage = power_usage
@@ -450,10 +488,9 @@
 		user << "You insert \the [I] into \the [src]."
 		return
 	if(istype(W, /obj/item/weapon/paper))
-		var/obj/item/weapon/paper/P = W
 		if(!nano_printer)
 			return
-		nano_printer.load_paper(P)
+		nano_printer.attackby(W, user)
 	if(istype(W, /obj/item/weapon/computer_hardware))
 		var/obj/item/weapon/computer_hardware/C = W
 		if(C.hardware_size <= max_hardware_size)
@@ -469,6 +506,21 @@
 		src.visible_message("\The [src] has been disassembled by [user].")
 		relay_qdel()
 		qdel(src)
+		return
+	if(istype(W, /obj/item/weapon/weldingtool))
+		var/obj/item/weapon/weldingtool/WT = W
+		if(!WT.isOn())
+			user << "\The [W] is off."
+			return
+
+		if(!damage)
+			user << "\The [src] does not require repairs."
+			return
+
+		user << "You begin repairing damage to \the [src]..."
+		if(WT.remove_fuel(round(damage/75)) && do_after(usr, damage/10))
+			damage = 0
+			user << "You repair \the [src]."
 		return
 
 	if(istype(W, /obj/item/weapon/screwdriver))
@@ -580,13 +632,14 @@
 		found = 1
 		critical = 1
 	if(found)
-		user << "You remove \the [H] from \the [src]."
+		if(user)
+			user << "You remove \the [H] from \the [src]."
 		H.forceMove(get_turf(src))
 		H.holder2 = null
 	if(critical && enabled)
-		user << "<span class='danger'>\The [src]'s screen freezes for few seconds and then displays an \"HARDWARE ERROR: Critical component disconnected. Please verify component connection and reboot the device. If the problem persists contact technical support for assistance.\" warning.</span>"
-		kill_program(1)
-		enabled = 0
+		if(user)
+			user << "<span class='danger'>\The [src]'s screen freezes for few seconds and then displays an \"HARDWARE ERROR: Critical component disconnected. Please verify component connection and reboot the device. If the problem persists contact technical support for assistance.\" warning.</span>"
+		shutdown_computer()
 		update_icon()
 
 
@@ -636,16 +689,16 @@
 		nanomanager.update_uis(src)
 
 /obj/item/modular_computer/proc/check_update_ui_need()
-	var/ui_updated_needed = 0
+	var/ui_update_needed = 0
 	if(battery_module)
 		var/batery_percent = battery_module.battery.percent()
-		if(last_battery_percent != batery_percent) //Let's update UI on percent chandge
-			ui_updated_needed = 1
+		if(last_battery_percent != batery_percent) //Let's update UI on percent change
+			ui_update_needed = 1
 			last_battery_percent = batery_percent
 
 	if(worldtime2text() != last_world_time)
 		last_world_time = worldtime2text()
-		ui_updated_needed = 1
+		ui_update_needed = 1
 
 	if(idle_threads.len)
 		var/list/current_header_icons = list()
@@ -658,13 +711,51 @@
 
 		else if(!listequal(last_header_icons, current_header_icons))
 			last_header_icons = current_header_icons
-			ui_updated_needed = 1
+			ui_update_needed = 1
 		else
 			for(var/x in last_header_icons|current_header_icons)
 				if(last_header_icons[x]!=current_header_icons[x])
 					last_header_icons = current_header_icons
-					ui_updated_needed = 1
+					ui_update_needed = 1
 					break
 
-	if(ui_updated_needed)
+	if(ui_update_needed)
 		update_uis()
+
+/obj/item/modular_computer/proc/take_damage(var/amount, var/component_probability, var/damage_casing = 1, var/randomize = 1)
+	if(randomize)
+		// 75%-125%, rand() works with integers, apparently.
+		amount *= (rand(75, 125) / 100.0)
+	amount = round(amount)
+	if(damage_casing)
+		damage += amount
+		damage = between(0, damage, max_damage)
+
+	if(component_probability)
+		for(var/obj/item/weapon/computer_hardware/H in get_all_components())
+			if(prob(component_probability))
+				H.take_damage(round(amount / 2))
+
+	if(damage >= max_damage)
+		break_apart()
+
+// Stronger explosions cause serious damage to internal components
+// Minor explosions are mostly mitigitated by casing.
+/obj/item/modular_computer/ex_act(var/severity)
+	take_damage(rand(100,200) / severity, 30 / severity)
+
+// EMPs are similar to explosions, but don't cause physical damage to the casing. Instead they screw up the components
+/obj/item/modular_computer/emp_act(var/severity)
+	take_damage(rand(100,200) / severity, 50 / severity, 0)
+
+// "Stun" weapons can cause minor damage to components (short-circuits?)
+// "Burn" damage is equally strong against internal components and exterior casing
+// "Brute" damage mostly damages the casing.
+/obj/item/modular_computer/bullet_act(var/obj/item/projectile/Proj)
+	switch(Proj.damage_type)
+		if(BRUTE)
+			take_damage(Proj.damage, Proj.damage / 2)
+		if(HALLOSS)
+			take_damage(Proj.damage, Proj.damage / 3, 0)
+		if(BURN)
+			take_damage(Proj.damage, Proj.damage / 1.5)

--- a/code/modules/modular_computers/computers/item/modular_computer.dm
+++ b/code/modules/modular_computers/computers/item/modular_computer.dm
@@ -28,7 +28,7 @@
 	var/icon_state_menu = "menu"							// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/max_hardware_size = 0								// Maximal hardware size. Currently, tablets have 1, laptops 2 and consoles 3. Limits what hardware types can be installed.
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
-
+	var/light_strength = 0
 
 	// Important hardware (must be installed for computer to work)
 	var/obj/item/weapon/computer_hardware/processor_unit/processor_unit				// CPU. Without it the computer won't run. Better CPUs can run more programs at once.
@@ -116,7 +116,9 @@
 
 	overlays.Cut()
 	if(!enabled)
+		set_light(0)
 		return
+	set_light(light_strength)
 	if(active_program)
 		overlays.Add(active_program.program_icon_state ? active_program.program_icon_state : icon_state_menu)
 	else

--- a/code/modules/modular_computers/computers/item/modular_computer.dm
+++ b/code/modules/modular_computers/computers/item/modular_computer.dm
@@ -59,6 +59,22 @@
 
 	proc_eject_id(usr)
 
+// Eject ID card from computer, if it has ID slot with card inside.
+/obj/item/modular_computer/verb/eject_usb()
+	set name = "Eject Portable Device"
+	set category = "Object"
+	set src in view(1)
+
+	if(usr.incapacitated() || !istype(usr, /mob/living))
+		usr << "<span class='warning'>You can't do that.</span>"
+		return
+
+	if(!Adjacent(usr))
+		usr << "<span class='warning'>You can't reach it.</span>"
+		return
+
+	proc_eject_usb(usr)
+
 /obj/item/modular_computer/proc/proc_eject_id(mob/user)
 	if(!user)
 		user = usr
@@ -81,6 +97,17 @@
 	card_slot.stored_card = null
 	update_uis()
 	user << "You remove the card from \the [src]"
+
+/obj/item/modular_computer/proc/proc_eject_usb(mob/user)
+	if(!user)
+		user = usr
+
+	if(!portable_drive)
+		user << "There is no portable device connected to \the [src]."
+		return
+
+	uninstall_component(user, portable_drive)
+	update_uis()
 
 /obj/item/modular_computer/attack_ghost(var/mob/observer/ghost/user)
 	if(enabled)

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -11,10 +11,10 @@
 	var/obj/machinery/modular_computer/machinery_computer = null
 
 /obj/item/modular_computer/processor/Destroy()
+	. = ..()
 	if(machinery_computer && (machinery_computer.cpu == src))
 		machinery_computer.cpu = null
 	machinery_computer = null
-	return ..()
 
 // Due to how processes work, we'd receive two process calls - one from machinery type and one from our own type.
 // Since we want this to be in-sync with machinery (as it's hidden type for machinery-based computers) we'll ignore
@@ -24,6 +24,12 @@
 		..()
 	else
 		return
+
+/obj/item/modular_computer/processor/examine(var/mob/user)
+	if(damage > broken_damage)
+		user << "<span class='danger'>It is heavily damaged!</span>"
+	else if(damage)
+		user << "It is damaged."
 
 // Power interaction is handled by our machinery part, due to machinery having APC connection.
 /obj/item/modular_computer/processor/handle_power()
@@ -40,6 +46,8 @@
 	hardware_flag = machinery_computer.hardware_flag
 	max_hardware_size = machinery_computer.max_hardware_size
 	steel_sheet_cost = machinery_computer.steel_sheet_cost
+	max_damage = machinery_computer._max_damage
+	broken_damage = machinery_computer._break_damage
 
 /obj/item/modular_computer/processor/relay_qdel()
 	qdel(machinery_computer)
@@ -110,7 +118,7 @@
 
 /obj/item/modular_computer/processor/get_all_components()
 	var/list/all_components = ..()
-	if(machinery_computer.tesla_link)
+	if(machinery_computer && machinery_computer.tesla_link)
 		all_components.Add(machinery_computer.tesla_link)
 	return all_components
 

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -7,3 +7,4 @@
 	hardware_flag = PROGRAM_TABLET
 	max_hardware_size = 1
 	w_class = 2
+	light_strength = 2					// Same as PDAs

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -20,7 +20,7 @@
 	var/screen_icon_screensaver = "standby"							// Icon state overlay when the computer is powered, but not 'switched on'.
 	var/max_hardware_size = 0										// Maximal hardware size. Currently, tablets have 1, laptops 2 and consoles 3. Limits what hardware types can be installed.
 	var/steel_sheet_cost = 10										// Amount of steel sheets refunded when disassembling an empty frame of this computer.
-
+	var/light_strength = 0											// Light luminosity when turned on
 	var/base_active_power_usage = 100								// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
 	var/base_idle_power_usage = 10									// Power usage when the computer is idle and screen is off (currently only applies to laptops)
 
@@ -42,7 +42,9 @@
 	if(!cpu || !cpu.enabled)
 		if (!(stat & NOPOWER) || battery_powered)
 			overlays.Add(screen_icon_screensaver)
+		set_light(0)
 		return
+	set_light(light_strength)
 	if(cpu.active_program)
 		overlays.Add(cpu.active_program.program_icon_state ? cpu.active_program.program_icon_state : screen_icon_state_menu)
 	else

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -59,6 +59,15 @@
 	if(cpu)
 		cpu.eject_id()
 
+// Eject ID card from computer, if it has ID slot with card inside.
+/obj/machinery/modular_computer/verb/eject_usb()
+	set name = "Eject Portable Device"
+	set category = "Object"
+	set src in view(1)
+
+	if(cpu)
+		cpu.eject_usb()
+
 /obj/machinery/modular_computer/New()
 	..()
 	cpu = new(src)

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -15,6 +15,8 @@
 	max_hardware_size = 3
 	steel_sheet_cost = 20
 	light_strength = 4
+	_max_damage = 300
+	_break_damage = 150
 
 /obj/machinery/modular_computer/console/buildable/New()
 	..()

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -14,6 +14,7 @@
 	base_active_power_usage = 500
 	max_hardware_size = 3
 	steel_sheet_cost = 20
+	light_strength = 4
 
 /obj/machinery/modular_computer/console/buildable/New()
 	..()

--- a/code/modules/modular_computers/computers/machinery/modular_laptop.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_laptop.dm
@@ -60,6 +60,7 @@
 	base_idle_power_usage = 25
 	base_active_power_usage = 200
 	max_hardware_size = 2
+	light_strength = 3
 
 /obj/machinery/modular_computer/laptop/buildable/New()
 	..()

--- a/code/modules/modular_computers/computers/machinery/modular_laptop.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_laptop.dm
@@ -61,6 +61,8 @@
 	base_active_power_usage = 200
 	max_hardware_size = 2
 	light_strength = 3
+	_max_damage = 200
+	_break_damage = 100
 
 /obj/machinery/modular_computer/laptop/buildable/New()
 	..()

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -5,7 +5,7 @@
 	desc = "A standard power cell, commonly seen in high-end portable microcomputers or low-end laptops. It's rating is 750."
 	icon_state = "battery_normal"
 	critical = 1
-
+	malfunction_probability = 1
 	var/battery_rating = 750
 	var/obj/item/weapon/cell/battery = null
 
@@ -50,7 +50,9 @@
 	hardware_size = 1
 	battery_rating = 1000000
 
-
+/obj/item/weapon/computer_hardware/battery_module/diagnostics(var/mob/user)
+	..()
+	user << "Internal battery charge: [battery.charge]/[battery.maxcharge] CU"
 
 /obj/item/weapon/computer_hardware/battery_module/New()
 	battery = new/obj/item/weapon/cell(src)

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -49,12 +49,21 @@
 	icon_state = "hdd_micro"
 	hardware_size = 1
 
+/obj/item/weapon/computer_hardware/hard_drive/diagnostics(var/mob/user)
+	..()
+	// 999 is a byond limit that is in place. It's unlikely someone will reach that many files anyway, since you would sooner run out of space.
+	user << "NT-NFS File Table Status: [stored_files.len]/999"
+	user << "Storage capacity: [used_capacity]/[max_capacity]GQ"
+
 // Use this proc to add file to the drive. Returns 1 on success and 0 on failure. Contains necessary sanity checks.
 /obj/item/weapon/computer_hardware/hard_drive/proc/store_file(var/datum/computer_file/F)
 	if(!F || !istype(F))
 		return 0
 
 	if(!can_store_file(F.size))
+		return 0
+
+	if(!check_functionality())
 		return 0
 
 	if(!stored_files)
@@ -82,6 +91,9 @@
 		return 0
 
 	if(!stored_files)
+		return 0
+
+	if(!check_functionality())
 		return 0
 
 	if(F in stored_files)
@@ -124,6 +136,9 @@
 
 // Tries to find the file by filename. Returns null on failure
 /obj/item/weapon/computer_hardware/hard_drive/proc/find_file_by_name(var/filename)
+	if(!check_functionality())
+		return null
+
 	if(!filename)
 		return null
 

--- a/code/modules/modular_computers/hardware/hardware.dm
+++ b/code/modules/modular_computers/hardware/hardware.dm
@@ -3,12 +3,51 @@
 	desc = "Unknown Hardware"
 	icon = 'icons/obj/modular_components.dmi'
 	var/obj/item/modular_computer/holder2 = null
-	var/power_usage = 0 	// If the hardware uses extra power, change this.
-	var/enabled = 1			// If the hardware is turned off set this to 0.
-	var/critical = 1		// Prevent disabling for important component, like the HDD.
-	var/hardware_size = 1	// Limits which devices can contain this component. 1: Tablets/Laptops/Consoles, 2: Laptops/Consoles, 3: Consoles only
+	var/power_usage = 0 			// If the hardware uses extra power, change this.
+	var/enabled = 1					// If the hardware is turned off set this to 0.
+	var/critical = 1				// Prevent disabling for important component, like the HDD.
+	var/hardware_size = 1			// Limits which devices can contain this component. 1: Tablets/Laptops/Consoles, 2: Laptops/Consoles, 3: Consoles only
+	var/damage = 0					// Current damage level
+	var/max_damage = 100			// Maximal damage level.
+	var/damage_malfunction = 20		// "Malfunction" threshold. When damage exceeds this value the hardware piece will semi-randomly fail and do !!FUN!! things
+	var/damage_failure = 50			// "Failure" threshold. When damage exceeds this value the hardware piece will not work at all.
+	var/malfunction_probability = 10// Chance of malfunction when the component is damaged
+
+/obj/item/weapon/computer_hardware/attackby(var/obj/item/W as obj, var/mob/living/user as mob)
+	// Multitool. Runs diagnostics
+	if(istype(W, /obj/item/device/multitool))
+		user << "***** DIAGNOSTICS REPORT *****"
+		diagnostics(user)
+		user << "******************************"
+		return 1
+	// Nanopaste. Repair all damage if present for a single unit.
+	var/obj/item/stack/S = W
+	if(istype(S, /obj/item/stack/nanopaste))
+		if(!damage)
+			user << "\The [src] doesn't seem to require repairs."
+			return 1
+		if(S.use(1))
+			user << "You apply a bit of \the [W] to \the [src]. It immediately repairs all damage."
+			damage = 0
+		return 1
+	// Cable coil. Works as repair method, but will probably require multiple applications and more cable.
+	if(istype(S, /obj/item/stack/cable_coil))
+		if(!damage)
+			user << "\The [src] doesn't seem to require repairs."
+			return 1
+		if(S.use(1))
+			user << "You patch up \the [src] with a bit of \the [W]."
+			take_damage(-10)
+		return 1
+	return ..()
+
+
+// Called on multitool click, prints diagnostic information to the user.
+/obj/item/weapon/computer_hardware/proc/diagnostics(var/mob/user)
+	user << "Hardware Integrity Test... (Corruption: [damage]/[max_damage]) [damage > damage_failure ? "FAIL" : damage > damage_malfunction ? "WARN" : "PASS"]"
 
 /obj/item/weapon/computer_hardware/New(var/obj/L)
+	w_class = hardware_size
 	if(istype(L, /obj/machinery/modular_computer))
 		var/obj/machinery/modular_computer/C = L
 		if(C.cpu)
@@ -20,4 +59,31 @@
 
 /obj/item/weapon/computer_hardware/Destroy()
 	holder2 = null
-	..()
+	return ..()
+
+// Handles damage checks
+/obj/item/weapon/computer_hardware/proc/check_functionality()
+	// Too damaged to work at all.
+	if(damage > damage_failure)
+		return 0
+	// Still working. Well, sometimes...
+	if(damage > damage_malfunction)
+		if(prob(malfunction_probability))
+			return 0
+	// Good to go.
+	return 1
+
+/obj/item/weapon/computer_hardware/examine(var/mob/user)
+	. = ..()
+	if(damage > damage_failure)
+		user << "<span class='danger'>It seems to be severely damaged!</span>"
+	else if(damage > damage_malfunction)
+		user << "<span class='notice'>It seems to be damaged!</span>"
+	else if(damage)
+		user << "It seems to be slightly damaged."
+
+// Damages the component. Contains necessary checks. Negative damage "heals" the component.
+/obj/item/weapon/computer_hardware/proc/take_damage(var/amount)
+	damage += round(amount) 					// We want nice rounded numbers here.
+	damage = between(0, damage, max_damage)		// Clamp the value.
+

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -1,27 +1,32 @@
 /obj/item/weapon/computer_hardware/nano_printer
 	name = "nano printer"
-	desc = "Small integrated printer with scanner and paper recycling module."
+	desc = "Small integrated printer with paper recycling module."
 	power_usage = 50
 	critical = 0
 	icon_state = "printer"
 	hardware_size = 1
 	var/stored_paper = 5
 	var/max_paper = 10
-	var/obj/item/weapon/paper/P = null	// Currently stored paper for scanning.
 
+/obj/item/weapon/computer_hardware/nano_printer/diagnostics(var/mob/user)
+	..()
+	user << "Paper buffer level: [stored_paper]/[max_paper]"
 
 /obj/item/weapon/computer_hardware/nano_printer/proc/print_text(var/text_to_print, var/paper_title = null)
 	if(!stored_paper)
 		return 0
+	if(!enabled)
+		return 0
+	if(!check_functionality())
+		return 0
 
-	// Recycle stored paper
-	if(P)
-		stored_paper++
-		qdel(P)
-		P = null
+	var/obj/item/weapon/paper/P = new/obj/item/weapon/paper(get_turf(holder2))
 
-	P = new/obj/item/weapon/paper(get_turf(holder2))
-	P.info = text_to_print
+	// Damaged printer causes the resulting paper to be somewhat harder to read.
+	if(damage > damage_malfunction)
+		P.info = stars(text_to_print, 100-malfunction_probability)
+	else
+		P.info = text_to_print
 	if(paper_title)
 		P.name = paper_title
 	P.update_icon()
@@ -29,34 +34,18 @@
 	P = null
 	return 1
 
-/obj/item/weapon/computer_hardware/nano_printer/proc/load_paper(var/obj/item/weapon/paper/paper)
-	if(!paper || !istype(paper))
-		return 0
+/obj/item/weapon/computer_hardware/nano_printer/attackby(obj/item/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/paper))
+		if(stored_paper >= max_paper)
+			user << "You try to add \the [W] into [src], but it's paper bin is full"
+			return
 
-	// We already have paper loaded, recycle it.
-	if(P && try_recycle_paper())
-		P = paper
-		P.forceMove(holder2)
-
-/obj/item/weapon/computer_hardware/nano_printer/proc/try_recycle_paper()
-	if(!P)
-		return 0
-
-	if(stored_paper >= max_paper)
-		return 0
-
-	qdel(P)
-	P = null
-	return 1
+		user << "You insert \the [W] into [src]."
+		qdel(W)
+		stored_paper++
 
 /obj/item/weapon/computer_hardware/nano_printer/Destroy()
 	if(holder2 && (holder2.nano_printer == src))
 		holder2.nano_printer = null
-	if(P)
-		if(holder2)
-			P.forceMove(get_turf(holder2))
-		else
-			qdel(P)
-		P = null
 	holder2 = null
 	..()

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -60,7 +60,11 @@ var/global/ntnet_card_uid = 1
 	if(holder2)
 		var/turf/T = get_turf(holder2)
 		if((T && istype(T)) && T.z in config.station_levels)
-			return 2
+			// Computer is on station. Low/High signal depending on what type of network card you have
+			if(long_range)
+				return 2
+			else
+				return 1
 
 	if(long_range) // Computer is not on station, but it has upgraded network card. Low signal.
 		return 1

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -11,6 +11,18 @@ var/global/ntnet_card_uid = 1
 	var/identification_string = "" 	// Identification string, technically nickname seen in the network. Can be set by user.
 	var/long_range = 0
 	var/ethernet = 0 // Hard-wired, therefore always on, ignores NTNet wireless checks.
+	malfunction_probability = 1
+
+/obj/item/weapon/computer_hardware/network_card/diagnostics(var/mob/user)
+	..()
+	user << "NIX Unique ID: [identification_id]"
+	user << "NIX User Tag: [identification_string]"
+	user << "Supported protocols:"
+	user << "511.m SFS (Subspace) - Standard Frequency Spread"
+	if(long_range)
+		user << "511.n WFS/HB (Subspace) - Wide Frequency Spread/High Bandiwdth"
+	if(ethernet)
+		user << "OpenEth (Physical Connection) - Physical network connection port"
 
 /obj/item/weapon/computer_hardware/network_card/New(var/l)
 	..(l)
@@ -27,7 +39,7 @@ var/global/ntnet_card_uid = 1
 
 /obj/item/weapon/computer_hardware/network_card/wired
 	name = "wired NTNet network card"
-	desc = "An advanced network card for usage with NTNet. This one uses wired connection."
+	desc = "An advanced network card for usage with standard NTNet frequencies. This one also supports wired connection."
 	ethernet = 1
 	power_usage = 100 // Better range but higher power usage.
 	icon_state = "netcard_ethernet"
@@ -49,6 +61,9 @@ var/global/ntnet_card_uid = 1
 		return 0
 
 	if(!enabled)
+		return 0
+
+	if(!check_functionality())
 		return 0
 
 	if(ethernet) // Computer is connected via wired connection.

--- a/code/modules/modular_computers/hardware/processor_unit.dm
+++ b/code/modules/modular_computers/hardware/processor_unit.dm
@@ -8,6 +8,7 @@
 	hardware_size = 2
 	power_usage = 50
 	critical = 1
+	malfunction_probability = 1
 
 	var/max_idle_programs = 2 // 2 idle, + 1 active = 3 as said in description.
 


### PR DESCRIPTION
This PR will finish some parts of modular computers that weren't fully finished during main release.

Full list of planned changes:
- [X] Boost NTNet connectivity speeds, according to feedback from players.
- [X] Make active computers emit light.
- [x] Add a way of disconnecting "USB" data crystals without having to use screwdriver
- [X] Make simple damage system for components. Components may take damage. Once components exceed certain amount of damage they will semi-randomly stop working. This is most apparent with NTNet network card (which causes connectivity losses randomly) and battery (which sometimes causes the computer to simply shut down). If components take too much damage they will stop working completely. Components may be fully repaired with one unit of nanopaste, or patched up with pieces of cable.
- [x] Related to above - implement ex_act, emp_act, and bullet_act properly. Allow computers to be shot apart with guns, or damaged by EMPs.
- [x] Related to above - implement ways of repairing damaged computers/components. For computers it's probably going to be welding tool, for components nanopaste or wires.
- [x] Add possibility to actually load paper into nano printer.
- [X] Adjust w_class of modular computer components. For now i went with having w_class same as component size, so tablet components will be tiny, while console components will be normal sized. 

And possibly more, if i can think of anything else.

:cl:
rscadd: Modular computers may now be damaged by gunfire, EMPs and similar threats. This includes the computer's chassis, and components.
rscadd: Damaged components may be repaired using nanopaste or cable coil. Damaged chassis can be repaired with welder. You can use multitool on a component to get diagnostic report.
tweak: NTNet speeds increased, with advanced network cards being buffed considerably.
tweak: Data crystals may now be disconnected without a screwdriver, via the rightclick menu.
tweak: You can now load paper into the nano printer, by clicking it (or the computer it is installed in) with paper pieces.
tweak: Component weights re-adjusted. For now they will have weight depending on what device are they intended for (tablet+: tiny, laptop+: small, console:normal)
tweak: Modular computers now glow when turned on. Tablet has equal light intensity as PDA, while console is comparable to a light bulb. This light is not colored.
/:cl:

Also possibly fixes qdel() issues and runtime error during explosions.
