### PR TITLE
Buffs pike's health pool/chance of breaking windows.

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -35,13 +35,17 @@
 
 	var/i = 1
 	while (i <= num_groups)
+		var/group_size = rand(group_size_min, group_size_max)
 		if(prob(96))
-			var/group_size = rand(group_size_min, group_size_max)
 			for (var/j = 1, j <= group_size, j++)
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
+			i++
 		else
-			spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i]))
-		i++
+			group_size = round(group_size/6)
+
+			for(var/j = 1, j <= group_size, j++)
+				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i+j]))
+			i += group_size
 
 /datum/event/carp_migration/end()
 	for(var/mob/living/simple_animal/hostile/C in spawned_carp)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -41,6 +41,7 @@
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
 			i++
 		else
+			group_size = max(1,round(group_size/6))
 			group_size = min(spawn_locations.len-i+1,group_size)
 			for(var/j = 1, j <= group_size, j++)
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i+j]))

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -37,7 +37,7 @@
 	while (i <= num_groups)
 		var/group_size = rand(group_size_min, group_size_max)
 		for (var/j = 1, j <= group_size, j++)
-			if(prob(95)) //5% chance of SHERK
+			if(prob(96)) //5% chance of SHERK
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
 			else
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i]))

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -42,7 +42,7 @@
 			i++
 		else
 			group_size = round(group_size/6)
-
+			group_size = min(spawn_locations.len-i+1,group_size)
 			for(var/j = 1, j <= group_size, j++)
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i+j]))
 			i += group_size

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -35,12 +35,12 @@
 
 	var/i = 1
 	while (i <= num_groups)
-		var/group_size = rand(group_size_min, group_size_max)
-		for (var/j = 1, j <= group_size, j++)
-			if(prob(96)) //5% chance of SHERK
+		if(prob(96))
+			var/group_size = rand(group_size_min, group_size_max)
+			for (var/j = 1, j <= group_size, j++)
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
-			else
-				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i]))
+		else
+			spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i]))
 		i++
 
 /datum/event/carp_migration/end()

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -41,7 +41,6 @@
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
 			i++
 		else
-			group_size = round(group_size/6)
 			group_size = min(spawn_locations.len-i+1,group_size)
 			for(var/j = 1, j <= group_size, j++)
 				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i+j]))

--- a/code/modules/mob/living/simple_animal/hostile/pike.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pike.dm
@@ -14,11 +14,11 @@
 
 	pixel_x = -16
 
-	health = 75
-	maxHealth = 75
+	health = 150
+	maxHealth = 150
 
 	harm_intent_damage = 5
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 
-	break_stuff_probability = 25
+	break_stuff_probability = 35


### PR DESCRIPTION
This is for two reasons: 
#1 I noticed that pikes were basically treated the same as carp. Where it would normally take 1 shot now took 3 (and roughly 5 with this health pool). They are basically over and done with in a few seconds.
#2 they kill other carp. While this is thematically cool and an interesting dynamic between carp and pikes, it makes migrations so much easier as each pike will kill roughly 5-6 carp, and in the case of the smallest carp migration, that is everything except the pike, basically nullifying the migration at all.

This update doubles their health and increases their breaking chances by 10% in an aim to offset the carp-killing they do through the danger they possess by themselves.

I've also made them a bit rarer as well.
