### PR TITLE
Adds optional objectives to configuration.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -188,3 +188,8 @@
 #define CAPTURE_MODE_REGULAR 0 //Regular polaroid camera mode
 #define CAPTURE_MODE_ALL 1 //Admin camera mode
 #define CAPTURE_MODE_PARTIAL 3 //Simular to regular mode, but does not do dummy check
+
+//objectives
+#define CONFIG_OBJECTIVE_NONE 2
+#define CONFIG_OBJECTIVE_VERB 1
+#define CONFIG_OBJECTIVE_ALL  0

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -473,11 +473,19 @@ var/list/gamemode_cache = list()
 
 				if ("objectives_disabled")
 					if(!value)
-						log_misc("Incorrect objective disabled definition: [value]")
-						config.objectives_disabled = 2
+						log_misc("Could not find value for objectives_disabled in configuration.")
+						config.objectives_disabled = CONFIG_OBJECTIVE_NONE
 					else
-						config.objectives_disabled = text2num(value)
-
+						switch(value)
+							if("none")
+								config.objectives_disabled = CONFIG_OBJECTIVE_NONE
+							if("verb")
+								config.objectives_disabled = CONFIG_OBJECTIVE_VERB
+							if("all")
+								config.objectives_disabled = CONFIG_OBJECTIVE_ALL
+							else
+								log_misc("Incorrect objective disabled definition: [value]")
+								config.objectives_disabled = CONFIG_OBJECTIVE_NONE
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist = 1
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -472,7 +472,11 @@ var/list/gamemode_cache = list()
 					config.ninjas_allowed = 1
 
 				if ("objectives_disabled")
-					config.objectives_disabled = 1
+					if(!value)
+						log_misc("Incorrect objective disabled definition: [value]")
+						config.objectives_disabled = 2
+					else
+						config.objectives_disabled = text2num(value)
 
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist = 1

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -32,7 +32,7 @@
 	if(faction_verb && player.current)
 		player.current.verbs |= faction_verb
 
-	if(config.objectives_disabled == 1)
+	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
 		player.current.verbs += /mob/proc/add_objectives
 
 	// Handle only adding a mind and not bothering with gear etc.

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -32,6 +32,9 @@
 	if(faction_verb && player.current)
 		player.current.verbs |= faction_verb
 
+	if(config.objectives_disabled == 1)
+		player.current.verbs += /mob/proc/add_objectives
+
 	// Handle only adding a mind and not bothering with gear etc.
 	if(nonstandard_role_type)
 		faction_members |= player

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -1,14 +1,14 @@
-/datum/antagonist/proc/create_global_objectives()
-	if(config.objectives_disabled)
+/datum/antagonist/proc/create_global_objectives(var/override=0)
+	if(config.objectives_disabled && !override)
 		return 0
 	if(global_objectives && global_objectives.len)
 		return 0
 	return 1
 
-/datum/antagonist/proc/create_objectives(var/datum/mind/player)
-	if(config.objectives_disabled)
+/datum/antagonist/proc/create_objectives(var/datum/mind/player, var/override=0)
+	if(config.objectives_disabled && !override)
 		return 0
-	if(create_global_objectives() || global_objectives.len)
+	if(create_global_objectives(override) || global_objectives.len)
 		player.objectives |= global_objectives
 	return 1
 
@@ -17,7 +17,7 @@
 
 /datum/antagonist/proc/check_victory()
 	var/result = 1
-	if(config.objectives_disabled)
+	if(config.objectives_disabled > 1)
 		return 1
 	if(global_objectives && global_objectives.len)
 		for(var/datum/objective/O in global_objectives)
@@ -30,3 +30,23 @@
 			world << "<span class='danger'><font size = 3>[loss_text]</font></span>"
 			if(loss_feedback_tag) feedback_set_details("round_end_result","[loss_feedback_tag]")
 
+
+/mob/proc/add_objectives()
+	set name = "Get Objectives"
+	set desc = "Recieve optional objectives."
+	set category = "OOC"
+
+	src.verbs -= /mob/proc/add_objectives
+
+	if(!src.mind)
+		return
+
+	for(var/tag in all_antag_types) //we do all of them in case an admin adds an antagonist via the PP. Those do not show up in gamemode.
+		var/datum/antagonist/antagonist = all_antag_types[tag]
+		if(antagonist && antagonist.is_antagonist(src.mind))
+			antagonist.create_objectives(src.mind,1)
+
+	src << "<b><font size=3>These objectives are completely voluntary. You are not required to complete them.</font></b>"
+
+
+	show_objectives(src.mind)

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -1,12 +1,12 @@
 /datum/antagonist/proc/create_global_objectives(var/override=0)
-	if(config.objectives_disabled && !override)
+	if(config.objectives_disabled != CONFIG_OBJECTIVE_ALL && !override)
 		return 0
 	if(global_objectives && global_objectives.len)
 		return 0
 	return 1
 
 /datum/antagonist/proc/create_objectives(var/datum/mind/player, var/override=0)
-	if(config.objectives_disabled && !override)
+	if(config.objectives_disabled != CONFIG_OBJECTIVE_ALL && !override)
 		return 0
 	if(create_global_objectives(override) || global_objectives.len)
 		player.objectives |= global_objectives
@@ -17,7 +17,7 @@
 
 /datum/antagonist/proc/check_victory()
 	var/result = 1
-	if(config.objectives_disabled > 1)
+	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE)
 		return 1
 	if(global_objectives && global_objectives.len)
 		for(var/datum/objective/O in global_objectives)

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -146,7 +146,7 @@ var/datum/antagonist/raider/raiders
 	var/win_msg = ""
 
 	//No objectives, go straight to the feedback.
-	if(config.objectives_disabled || !global_objectives.len)
+	if(config.objectives_disabled > 1 || !global_objectives.len)
 		return
 
 	var/success = global_objectives.len

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -146,7 +146,7 @@ var/datum/antagonist/raider/raiders
 	var/win_msg = ""
 
 	//No objectives, go straight to the feedback.
-	if(config.objectives_disabled > 1 || !global_objectives.len)
+	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !global_objectives.len)
 		return
 
 	var/success = global_objectives.len

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -568,7 +568,7 @@ proc/get_nt_opposed()
 
 	if(!player || !player.current) return
 
-	if(config.objectives_disabled > 1 || !player.objectives.len)
+	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
 		show_generic_antag_text(player)
 		return
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -568,7 +568,7 @@ proc/get_nt_opposed()
 
 	if(!player || !player.current) return
 
-	if(config.objectives_disabled)
+	if(config.objectives_disabled > 1 || !player.objectives.len)
 		show_generic_antag_text(player)
 		return
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -32,7 +32,8 @@ var/list/nuke_disks = list()
 	return 0
 
 /datum/game_mode/nuclear/declare_completion()
-	if(config.objectives_disabled)
+	var/datum/antagonist/merc = all_antag_types[MODE_MERCENARY]
+	if(config.objectives_disabled > 1 || (merc && !merc.global_objectives.len))
 		..()
 		return
 	var/disk_rescued = 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -33,7 +33,7 @@ var/list/nuke_disks = list()
 
 /datum/game_mode/nuclear/declare_completion()
 	var/datum/antagonist/merc = all_antag_types[MODE_MERCENARY]
-	if(config.objectives_disabled > 1 || (merc && !merc.global_objectives.len))
+	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || (merc && !merc.global_objectives.len))
 		..()
 		return
 	var/disk_rescued = 1

--- a/html/changelogs/TheWelp - optionalObjectives.yml
+++ b/html/changelogs/TheWelp - optionalObjectives.yml
@@ -1,0 +1,4 @@
+author: TheWelp
+delete-after: True
+changes: 
+  - rscadd: "Added verb to antagonists to recieve objectives. Located in the OOC tab and gained whenever the person becomes an antagonist."


### PR DESCRIPTION
In the config the OBJECTIVES_DISABLED has three settings:
0 - do not disable objectives (default)
1 - objectives can be gained through a verb
2 - no objectives period

Didn't mess with any of the objectives themselves, just the ability to get them.
