### PR TITLE
Non-admin devs can now toggle debug logs.

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -33,7 +33,7 @@
 		game_log("DEBUG", text)
 
 	for(var/client/C in admins)
-		if(C.is_preference_enabled(/datum/client_preference/admin/show_debug_logs))
+		if(C.is_preference_enabled(/datum/client_preference/debug/show_debug_logs))
 			C << "DEBUG: [text]"
 
 /proc/log_game(text)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -158,7 +158,7 @@ var/const/FALLOFF_SOUNDS = 0.5
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music)	return
 	if(is_preference_enabled(/datum/client_preference/play_lobby_music))
-		src << sound(ticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS
+		src << sound(ticker.login_music, repeat = 1, wait = 0, volume = 85, channel = 1) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -54,7 +54,7 @@ var/list/_client_preferences_by_type
 
 /datum/client_preference/play_lobby_music/toggled(var/mob/preference_mob, var/enabled)
 	if(enabled)
-		preference_mob << sound(ticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1)
+		preference_mob << sound(ticker.login_music, repeat = 1, wait = 0, volume = 85, channel = 1)
 	else
 		preference_mob << sound(null, repeat = 0, wait = 0, volume = 85, channel = 1)
 
@@ -131,20 +131,6 @@ var/list/_client_preferences_by_type
 /datum/client_preference/admin/may_toggle(var/mob/preference_mob)
 	return check_rights(R_ADMIN, 0, preference_mob)
 
-/datum/client_preference/admin/show_attack_logs
-	description = "Attack Log Messages"
-	key = "CHAT_ATTACKLOGS"
-	enabled_description = "Show"
-	disabled_description = "Hide"
-	enabled_by_default = FALSE
-
-/datum/client_preference/admin/show_debug_logs
-	description = "Debug Log Messages"
-	key = "CHAT_DEBUGLOGS"
-	enabled_description = "Show"
-	disabled_description = "Hide"
-	enabled_by_default = FALSE
-
 /datum/client_preference/admin/show_chat_prayers
 	description = "Chat Prayers"
 	key = "CHAT_PRAYER"
@@ -159,3 +145,24 @@ var/list/_client_preferences_by_type
 	key = "SOUND_ADMINHELP"
 	enabled_description = "Hear"
 	disabled_description = "Silent"
+
+/datum/client_preference/admin/show_attack_logs
+	description = "Attack Log Messages"
+	key = "CHAT_ATTACKLOGS"
+	enabled_description = "Show"
+	disabled_description = "Hide"
+	enabled_by_default = FALSE
+
+/********************
+* Debug Preferences *
+********************/
+
+/datum/client_preference/debug/may_toggle(var/mob/preference_mob)
+	return check_rights(R_ADMIN|R_DEBUG, 0, preference_mob)
+
+/datum/client_preference/debug/show_debug_logs
+	description = "Debug Log Messages"
+	key = "CHAT_DEBUGLOGS"
+	enabled_description = "Show"
+	disabled_description = "Hide"
+	enabled_by_default = FALSE


### PR DESCRIPTION
On Bay devs do have administrator rights currently, but this isn't necessarily true downstream (or forever).
