### PR TITLE
Adds full atmospherics reset admin verb

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -901,6 +901,7 @@
 #include "code\modules\admin\verbs\diagnostics.dm"
 #include "code\modules\admin\verbs\dice.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
+#include "code\modules\admin\verbs\grief_fixers.dm"
 #include "code\modules\admin\verbs\mapping.dm"
 #include "code\modules\admin\verbs\massmodvar.dm"
 #include "code\modules\admin\verbs\modifyvariables.dm"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -88,7 +88,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/change_security_level,
 	/client/proc/view_chemical_reaction_logs,
 	/client/proc/makePAI,
-	/datum/admins/proc/paralyze_mob
+	/datum/admins/proc/paralyze_mob,
+	/client/proc/fixatmos
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -1,0 +1,51 @@
+/client/proc/fixatmos()
+	set category = "Admin"
+	set name = "Fix Atmospheric Issues"
+
+	if(!src.holder)
+		src << "Only administrators may use this command."
+		return
+
+
+	if(alert("WARNING: Executing this command will perform a full reset of atmosphere. All pipelines will lose any gas that may be in them, and all zones will be reset to contain air mix as on roundstart. The supermatter engine will also be stopped (to prevent overheat due to removal of coolant). Do not use unless the station is suffering serious atmospheric issues due to grief or bug.", "Full Atmosphere Reboot", "No", "Yes") == "No")
+		return
+	feedback_add_details("admin_verb","FA")
+
+	log_and_message_admins("Full atmosphere reset initiated by [usr].")
+	world << "<span class = 'danger'>Initiating restart of atmosphere. The server may lag a bit.</span>"
+	sleep(10)
+	var/current_time = world.timeofday
+
+	// Depower the supermatter, as it would quickly blow up once we remove all gases from the pipes.
+	for(var/obj/machinery/power/supermatter/S in machines)
+		S.power = 0
+	usr << "\[1/5\] - Supermatter depowered"
+
+	// Remove all gases from all pipenets
+	for(var/datum/pipe_network/PN in pipe_networks)
+		for(var/datum/gas_mixture/G in PN.gases)
+			G.gas = list()
+			G.update_values()
+
+	usr << "\[2/5\] - All pipenets purged of gas."
+
+	// Delete all zones.
+	for(var/zone/Z in world)
+		Z.c_invalidate()
+
+	usr << "\[3/5\] - All ZAS Zones removed."
+
+	for(var/turf/simulated/T in world)
+		T.air = null
+		T.overlays.Remove(gas_data.unsorted_overlays)
+		T.zone = null
+
+	usr << "\[4/5\] - All turfs reset to roundstart values."
+
+	qdel(air_master)
+	air_master = new
+	air_master.Setup()
+	spawn air_master.Start()
+
+	usr << "\[5/5\] - ZAS Rebooted"
+	world << "<span class = 'danger'>Atmosphere restart completed in <b>[(world.timeofday - current_time)/10]</b> seconds.</span>"

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -1,11 +1,8 @@
 /client/proc/fixatmos()
 	set category = "Admin"
-	set name = "Fix Atmospheric Issues"
+	set name = "Fix Atmospherics Grief"
 
-	if(!src.holder)
-		src << "Only administrators may use this command."
-		return
-
+	if(!check_rights(R_ADMIN|R_DEBUG)) return
 
 	if(alert("WARNING: Executing this command will perform a full reset of atmosphere. All pipelines will lose any gas that may be in them, and all zones will be reset to contain air mix as on roundstart. The supermatter engine will also be stopped (to prevent overheat due to removal of coolant). Do not use unless the station is suffering serious atmospheric issues due to grief or bug.", "Full Atmosphere Reboot", "No", "Yes") == "No")
 		return
@@ -35,9 +32,13 @@
 
 	usr << "\[3/5\] - All ZAS Zones removed."
 
+	var/list/unsorted_overlays = list()
+	for(var/id in gas_data.tile_overlay)
+		unsorted_overlays |= gas_data.tile_overlay[id]
+
 	for(var/turf/simulated/T in world)
 		T.air = null
-		T.overlays.Remove(gas_data.unsorted_overlays)
+		T.overlays.Remove(unsorted_overlays)
 		T.zone = null
 
 	usr << "\[4/5\] - All turfs reset to roundstart values."

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -11,8 +11,6 @@
 	var/list/molar_mass = list()
 	//Tile overlays.  /images, created from references to 'icons/effects/tile_effects.dmi'
 	var/list/tile_overlay = list()
-	//Tile overlays as above, but in unsorted list.
-	var/list/unsorted_overlays = list()
 	//Overlay limits.  There must be at least this many moles for the overlay to appear.
 	var/list/overlay_limit = list()
 	//Flags.
@@ -41,9 +39,7 @@
 		gas_data.name[gas.id] = gas.name
 		gas_data.specific_heat[gas.id] = gas.specific_heat
 		gas_data.molar_mass[gas.id] = gas.molar_mass
-		if(gas.tile_overlay)
-			gas_data.tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
-			gas_data.unsorted_overlays += gas_data.tile_overlay[gas.id]
+		if(gas.tile_overlay) gas_data.tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
 		if(gas.overlay_limit) gas_data.overlay_limit[gas.id] = gas.overlay_limit
 		gas_data.flags[gas.id] = gas.flags
 

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -11,6 +11,8 @@
 	var/list/molar_mass = list()
 	//Tile overlays.  /images, created from references to 'icons/effects/tile_effects.dmi'
 	var/list/tile_overlay = list()
+	//Tile overlays as above, but in unsorted list.
+	var/list/unsorted_overlays = list()
 	//Overlay limits.  There must be at least this many moles for the overlay to appear.
 	var/list/overlay_limit = list()
 	//Flags.
@@ -39,7 +41,9 @@
 		gas_data.name[gas.id] = gas.name
 		gas_data.specific_heat[gas.id] = gas.specific_heat
 		gas_data.molar_mass[gas.id] = gas.molar_mass
-		if(gas.tile_overlay) gas_data.tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
+		if(gas.tile_overlay)
+			gas_data.tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
+			gas_data.unsorted_overlays += gas_data.tile_overlay[gas.id]
 		if(gas.overlay_limit) gas_data.overlay_limit[gas.id] = gas.overlay_limit
 		gas_data.flags[gas.id] = gas.flags
 


### PR DESCRIPTION
- Adds "Fix Atmospheric Problems" verb, that is accessible to server admins.
- This verb will perform full reset of atmosphere. Unlike reboot-zas this fixes any possible griefs or bugs, by completely purging all existing gases and resetting them to roundstart values.

Important note: As this would cause active supermatter engine to delaminate very quickly (since all coolant would disappear), any active supermatter crystal will be depowered to prevent this from happening.
