### PR TITLE
Attempts to fix SPACE magazine + minor corrections

### DIFF
--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -4,6 +4,7 @@
 	var/stored_data = "" 			// Stored data in string format.
 	filetype = "DAT"
 	var/block_size = 250
+	var/do_not_edit = 0				// Whether the user will be reminded that the file probably shouldn't be edited.
 
 /datum/computer_file/data/clone()
 	var/datum/computer_file/data/temp = ..()

--- a/code/modules/modular_computers/file_system/news_article.dm
+++ b/code/modules/modular_computers/file_system/news_article.dm
@@ -3,13 +3,14 @@
 /datum/computer_file/data/news_article
 	filetype = "XNML"
 	filename = "Unknown News Entry"
-	block_size = 1000 // Results in smaller files
-	var/server_file_path 			// File path to HTML file that will be loaded on server start. Example: "space_magazine_1.html". Must be in /news_articles/ server folder.
+	block_size = 1000 		// Results in smaller files
+	do_not_edit = 1			// Editing the file breaks most formatting due to some HTML tags not being accepted as input from average user.
+	var/server_file_path 	// File path to HTML file that will be loaded on server start. Example: '/news_articles/space_magazine_1.html'. Use the /news_articles/ folder!
 
 /datum/computer_file/data/news_article/New(var/load_from_file = 0)
 	..()
 	if(server_file_path && load_from_file)
-		stored_data = file2text("news_articles/[server_file_path]")
+		stored_data = file2text(server_file_path)
 	calculate_size()
 
 
@@ -17,4 +18,4 @@
 
 /datum/computer_file/data/news_article/space/vol_one
 	filename = "SPACE Magazine vol. 1"
-	server_file_path = "space_magazine_1.html"
+	server_file_path = 'news_articles/space_magazine_1.html'

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -83,8 +83,12 @@
 		var/datum/computer_file/data/F = HDD.find_file_by_name(open_file)
 		if(!F || !istype(F))
 			return 1
+		if(F.do_not_edit && (alert("WARNING: This file is not compatible with editor. Editing it may result in permanently corrupted formatting or damaged data consistency. Edit anyway?", "Incompatible File", "No", "Yes") == "No"))
+			return 1
 		// 16384 is the limit for file length in characters. Currently, papers have value of 2048 so this is 8 times as long, since we can't edit parts of the file independently.
-		var/newtext = sanitize(html_decode(input(usr, "Editing file [open_file]. You may use most tags used in paper formatting:", "Text Editor", F.stored_data) as message), 16384)
+		var/newtext = sanitize(html_decode(input(usr, "Editing file [open_file]. You may use most tags used in paper formatting:", "Text Editor", F.stored_data) as message|null), 16384)
+		if(!newtext)
+			return
 		if(F)
 			var/datum/computer_file/data/backup = F.clone()
 			HDD.remove_file(F)


### PR DESCRIPTION
- (Theoretically) Fixes #12505
- Adds a warning that prevents users from accidentally editing XNML files (that contain HTML tags that are not allowed to be inputted by players). Players can still edit the file, but now they know it will break the formatting.
- Adds support for "Cancel" button when editing text file via the file browser.
