### PR TITLE
Adds a new optional 'ambitions' system

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,6 +61,9 @@
 	//put this here for easier tracking ingame
 	var/datum/money_account/initial_account
 
+	//used for optional self-objectives that antagonists can give themselves, which are displayed at the end of the round.
+	var/ambitions
+
 /datum/mind/New(var/key)
 	src.key = key
 	..()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -107,7 +107,8 @@
 		for(var/datum/objective/objective in objectives)
 			output += "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
 			obj_count++
-
+	if(ambitions)
+		output += "<HR><B>Ambitions:</B> [ambitions]<br>"
 	recipient << browse(output,"window=memory")
 
 /datum/mind/proc/edit_memory()
@@ -141,7 +142,8 @@
 
 	else
 		out += "None."
-	out += "<br><a href='?src=\ref[src];obj_add=1'>\[add\]</a>"
+	out += "<br><a href='?src=\ref[src];obj_add=1'>\[add\]</a><br><br>"
+	out += "<b>Ambitions:</b> [ambitions ? ambitions : "None"] <a href='?src=\ref[src];amb_edit=\ref[src]'>\[edit\]</a></br>"
 	usr << browse(out, "window=edit_memory[src]")
 
 /datum/mind/Topic(href, href_list)
@@ -180,6 +182,17 @@
 		var/new_memo = sanitize(input("Write new memory", "Memory", memory) as null|message)
 		if (isnull(new_memo)) return
 		memory = new_memo
+
+	else if (href_list["amb_edit"])
+		var/datum/mind/mind = locate(href_list["amb_edit"])
+		if(!mind)
+			return
+		var/new_ambition = input("Enter a new ambition", "Memory", mind.ambitions) as null|message
+		if(isnull(new_ambition))
+			return
+		if(mind)
+			mind.ambitions = sanitize(new_ambition)
+			mind.current << "<span class='warning'>Your ambitions have been changed by higher powers, they are now: [mind.ambitions]</span>"
 
 	else if (href_list["obj_edit"] || href_list["obj_add"])
 		var/datum/objective/objective

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -35,6 +35,11 @@
 	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
 		player.current.verbs += /mob/proc/add_objectives
 
+	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
+	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
+	and it otherwise has no bearing on your round.</span>"
+	player.current.verbs += /mob/living/proc/write_ambition
+
 	// Handle only adding a mind and not bothering with gear etc.
 	if(nonstandard_role_type)
 		faction_members |= player
@@ -55,5 +60,9 @@
 		player.special_role = null
 		update_icons_removed(player)
 		BITSET(player.current.hud_updateflag, SPECIALROLE_HUD)
+
+		if(!is_special_character(player))
+			player.current.verbs -= /mob/living/proc/write_ambition
+			player.ambitions = ""
 		return 1
 	return 0

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -106,6 +106,11 @@
 
 	show_objectives(player)
 
+	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
+	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
+	and it otherwise has no bearing on your round.</span>"
+	player.current.verbs |= /mob/living/proc/write_ambition
+
 	// Clown clumsiness check, I guess downstream might use it.
 	if (player.current.mind)
 		if (player.current.mind.assigned_role == "Clown")

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -105,17 +105,6 @@
 		create_nuke()
 
 	show_objectives(player)
-
-	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
-	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
-	and it otherwise has no bearing on your round.</span>"
-	player.current.verbs |= /mob/living/proc/write_ambition
-
-	// Clown clumsiness check, I guess downstream might use it.
-	if (player.current.mind)
-		if (player.current.mind.assigned_role == "Clown")
-			player.current << "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself."
-			player.current.mutations.Remove(CLUMSY)
 	return 1
 
 /datum/antagonist/proc/set_antag_name(var/mob/living/player)

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -47,9 +47,8 @@
 			antagonist.create_objectives(src.mind,1)
 
 	src << "<b><font size=3>These objectives are completely voluntary. You are not required to complete them.</font></b>"
-
-
 	show_objectives(src.mind)
+
 /mob/living/proc/write_ambition()
 	set name = "Set Ambition"
 	set category = "IC"
@@ -57,15 +56,18 @@
 
 	if(!mind)
 		return
-	if(!src.mind.special_role)
+	if(!is_special_character(mind))
 		src << "<span class='warning'>While you may perhaps have goals, this verb's meant to only be visible \
 		to antagonists.  Please make a bug report!</span>"
 		return
 	var/new_ambitions = input(src, "Write a short sentence of what your character hopes to accomplish \
 	today as an antagonist.  Remember that this is purely optional.  It will be shown at the end of the \
 	round for everybody else.", "Ambitions", mind.ambitions) as null|message
+	if(isnull(new_ambitions))
+		return
 	new_ambitions = sanitize(new_ambitions)
+	mind.ambitions = new_ambitions
 	if(new_ambitions)
-		mind.ambitions = new_ambitions
-		src << "<span class='notice'>You've set your goal to be '[new_ambitions]'.<span>"
-
+		src << "<span class='notice'>You've set your goal to be '[new_ambitions]'.</span>"
+	else
+		src << "<span class='notice'>You leave your ambitions behind.</span>"

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -50,3 +50,22 @@
 
 
 	show_objectives(src.mind)
+/mob/living/proc/write_ambition()
+	set name = "Set Ambition"
+	set category = "IC"
+	set src = usr
+
+	if(!mind)
+		return
+	if(!src.mind.special_role)
+		src << "<span class='warning'>While you may perhaps have goals, this verb's meant to only be visible \
+		to antagonists.  Please make a bug report!</span>"
+		return
+	var/new_ambitions = input(src, "Write a short sentence of what your character hopes to accomplish \
+	today as an antagonist.  Remember that this is purely optional.  It will be shown at the end of the \
+	round for everybody else.", "Ambitions", mind.ambitions) as null|message
+	new_ambitions = sanitize(new_ambitions)
+	if(new_ambitions)
+		mind.ambitions = new_ambitions
+		src << "<span class='notice'>You've set your goal to be '[new_ambitions]'.<span>"
+

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -7,6 +7,9 @@
 	for(var/datum/mind/P in current_antagonists)
 		text += print_player_full(P)
 		text += get_special_objective_text(P)
+		if(P.ambitions)
+			text += "<br>Their goals for today were..."
+			text += "<br><b>[P.ambitions]</b>"
 		if(!global_objectives.len && P.objectives && P.objectives.len)
 			var/failed
 			var/num = 1

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -904,22 +904,26 @@ proc/admin_notice(var/message, var/rights)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////ADMIN HELPER PROCS
 
-/proc/is_special_character(mob/M as mob) // returns 1 for specail characters and 2 for heroes of gamemode
+/proc/is_special_character(var/character) // returns 1 for special characters and 2 for heroes of gamemode
 	if(!ticker || !ticker.mode)
 		return 0
-	if (!istype(M))
-		return 0
+	var/datum/mind/M
+	if (ismob(character))
+		var/mob/C = character
+		M = C.mind
+	else if(istype(character, /datum/mind))
+		M = character
 
-	if(M.mind)
+	if(M)
 		if(ticker.mode.antag_templates && ticker.mode.antag_templates.len)
 			for(var/datum/antagonist/antag in ticker.mode.antag_templates)
-				if(antag.is_antagonist(M.mind))
+				if(antag.is_antagonist(M))
 					return 2
-		else if(M.mind.special_role)
+		else if(M.special_role)
 			return 1
 
-	if(isrobot(M))
-		var/mob/living/silicon/robot/R = M
+	if(isrobot(character))
+		var/mob/living/silicon/robot/R = character
 		if(R.emagged)
 			return 1
 


### PR DESCRIPTION
Antagonists can set custom objective-like goals for themselves, which everyone can see at the end of the round. This otherwise has no impact on the round. Admins can review and edit ambitions in the same manner as objectives.

![Antag ambitions](https://camo.githubusercontent.com/aa5d15d6bc027fe262378b01b8d4e598060a1ef2/687474703a2f2f7075752e73682f6e506276422f346263353632666162642e706e67)
![Antag Notice](https://camo.githubusercontent.com/ff02f12e435269368b9e2957cf09be4fd5a85e56/687474703a2f2f7075752e73682f6e506255372f623436363336353233322e706e67)
![Antag Summary](https://camo.githubusercontent.com/3a9bc2038a5e58d4bbbea85d730d966ab76d5054/687474703a2f2f7075752e73682f6e506258462f396630393036316338322e706e67)
Port of https://github.com/PolarisSS13/Polaris/pull/1231.
