### PR TITLE
Ambition system tweaks

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -193,6 +193,7 @@
 		if(mind)
 			mind.ambitions = sanitize(new_ambition)
 			mind.current << "<span class='warning'>Your ambitions have been changed by higher powers, they are now: [mind.ambitions]</span>"
+		log_and_message_admins("made [key_name(mind.current)]'s ambitions be '[mind.ambitions]'.")
 
 	else if (href_list["obj_edit"] || href_list["obj_add"])
 		var/datum/objective/objective

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -190,10 +190,16 @@
 		var/new_ambition = input("Enter a new ambition", "Memory", mind.ambitions) as null|message
 		if(isnull(new_ambition))
 			return
+		new_ambition = sanitize(new_ambition)
 		if(mind)
-			mind.ambitions = sanitize(new_ambition)
-			mind.current << "<span class='warning'>Your ambitions have been changed by higher powers, they are now: [mind.ambitions]</span>"
-		log_and_message_admins("made [key_name(mind.current)]'s ambitions be '[mind.ambitions]'.")
+			if(new_ambition)
+				mind.current << "<span class='warning'>Your ambitions have been changed by higher powers, they are now: [mind.ambitions]</span>"
+				log_and_message_admins("made [key_name(mind.current)]'s ambitions be '[mind.ambitions]'.")
+			else
+				mind.current << "<span class='warning'>Your ambitions have been unmade by higher powers.</span>"
+				log_and_message_admins("has cleared [key_name(mind.current)]'s ambitions.")
+		else
+			usr << "<span class='warning'>The mind has ceased to be.</span>"
 
 	else if (href_list["obj_edit"] || href_list["obj_add"])
 		var/datum/objective/objective

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -32,14 +32,10 @@
 	if(faction_verb && player.current)
 		player.current.verbs |= faction_verb
 
-	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
-		player.current.verbs += /mob/proc/add_objectives
-
-	player.current.client.verbs += /client/proc/aooc
-
-	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
-	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
-	and it otherwise has no bearing on your round.</span>"
+	spawn(1 SECOND) //Added a delay so that this should pop up at the bottom and not the top of the text flood the new antag gets.
+		player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
+			everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
+			and it otherwise has no bearing on your round.</span>"
 	player.current.verbs += /mob/living/proc/write_ambition
 
 	// Handle only adding a mind and not bothering with gear etc.

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -31,6 +31,11 @@
 
 	if(faction_verb && player.current)
 		player.current.verbs |= faction_verb
+		
+	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
+		player.current.verbs += /mob/proc/add_objectives
+
+	player.current.client.verbs += /client/proc/aooc
 
 	spawn(1 SECOND) //Added a delay so that this should pop up at the bottom and not the top of the text flood the new antag gets.
 		player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -71,6 +71,7 @@
 		src << "<span class='notice'>You've set your goal to be '[new_ambitions]'.</span>"
 	else
 		src << "<span class='notice'>You leave your ambitions behind.</span>"
+	log_and_message_admins("has set their ambitions to now be: [new_ambitions].")
 
 //some antagonist datums are not actually antagonists, so we might want to avoid
 //sending them the antagonist meet'n'greet messages.

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -9,7 +9,7 @@
 		text += get_special_objective_text(P)
 		if(P.ambitions)
 			text += "<br>Their goals for today were..."
-			text += "<br><b>[P.ambitions]</b>"
+			text += "<br><span class='notice'>[P.ambitions]</span>"
 		if(!global_objectives.len && P.objectives && P.objectives.len)
 			var/failed
 			var/num = 1


### PR DESCRIPTION
Setting ambitions, with the verb or with admin powers, is now logged.
Round-end text changed to be blue instead of bolded, for better readability.
Makes the ambition system known to the antag at the bottom of the chat log instead of before the 'you are a X' prompt.
