### PR TITLE
Fixes #12558

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -255,7 +255,7 @@
 	move_buckled()
 	
 /obj/structure/bed/roller/forceMove()
- 	..()
+	..()
 	move_buckled()
 
 /obj/structure/bed/roller/move_buckled()

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -274,7 +274,7 @@
 /obj/structure/bed/roller/buckle_mob()
 	. = ..()
 	if(.)
-		moved_event.register(src, src, /obj/structure/bed/proc/move_buckled)
+		moved_event.register(src, src, /obj/structure/bed/roller/proc/move_buckled)
 
 /obj/structure/bed/roller/unbuckle_mob()
 	moved_event.unregister(src, src)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -250,14 +250,6 @@
 	held = null
 
 
-/obj/structure/bed/roller/Move()
-	..()
-	move_buckled()
-	
-/obj/structure/bed/roller/forceMove()
-	..()
-	move_buckled()
-
 /obj/structure/bed/roller/proc/move_buckled()
 	if(buckled_mob)
 		if(buckled_mob.buckled == src)
@@ -277,6 +269,15 @@
 		density = 0
 		icon_state = "down"
 
+	return ..()
+
+/obj/structure/bed/roller/buckle_mob()
+	. = ..()
+	if(.)
+		moved_event.register(src, src, /obj/structure/bed/proc/move_buckled)
+
+/obj/structure/bed/roller/unbuckle_mob()
+	moved_event.unregister(src, src)
 	return ..()
 
 /obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -220,7 +220,7 @@
 		var/obj/item/roller_holder/RH = W
 		if(!RH.held)
 			user << "<span class='notice'>You collect the roller bed.</span>"
-			src.loc = RH
+			src.forceMove(RH)
 			RH.held = src
 			return
 
@@ -252,9 +252,16 @@
 
 /obj/structure/bed/roller/Move()
 	..()
+	move_buckled()
+	
+/obj/structure/bed/roller/forceMove()
+ 	..()
+	move_buckled()
+
+/obj/structure/bed/roller/move_buckled()
 	if(buckled_mob)
 		if(buckled_mob.buckled == src)
-			buckled_mob.loc = src.loc
+			buckled_mob.forceMove(src.loc)
 		else
 			buckled_mob = null
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -258,7 +258,7 @@
 	..()
 	move_buckled()
 
-/obj/structure/bed/roller/move_buckled()
+/obj/structure/bed/roller/proc/move_buckled()
 	if(buckled_mob)
 		if(buckled_mob.buckled == src)
 			buckled_mob.forceMove(src.loc)


### PR DESCRIPTION
Move() relocates the buckled mob to follow, but forceMove() didn't.
Also implements forceMove() in bed.dm
