### PR TITLE
Replaces engine N2 canisters with room temperature variants

### DIFF
--- a/maps/exodus-1.dmm
+++ b/maps/exodus-1.dmm
@@ -4508,7 +4508,7 @@
 "bIJ" = (/turf/simulated/wall,/area/rnd/storage)
 "bIK" = (/obj/structure/sign/redcross{desc = "The Star of Life, a symbol of Medical Aid."; icon_state = "lifestar"; name = "Medbay"; pixel_x = 32},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/plating,/area/maintenance/engineering)
 "bIL" = (/obj/item/device/radio/intercom{dir = 2; pixel_y = 22},/obj/effect/floor_decal/corner/purple/diagonal{dir = 4},/obj/machinery/modular_computer/console/preset/research,/turf/simulated/floor/tiled/white,/area/crew_quarters/heads/hor)
-"bIM" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,/turf/simulated/floor/plating,/area/engineering/engine_room)
+"bIM" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/nitrogen,/turf/simulated/floor/plating,/area/engineering/engine_room)
 "bIN" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/wall/r_wall,/area/rnd/mixing)
 "bIO" = (/obj/machinery/atmospherics/unary/freezer{dir = 2; icon_state = "freezer_1"; use_power = 1; power_setting = 20; set_temperature = 73},/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/turf/simulated/floor/tiled/dark,/area/server)
 "bIP" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor/tiled,/area/rnd/storage)


### PR DESCRIPTION
- Makes it slightly safer for new players, which often accidentally open the release valve, resulting in uninhabitable engine room.
