### PR TITLE
Reimplements old xenobiology slime colors

### DIFF
--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -16,55 +16,60 @@ var/global/list/cached_icons = list()
 	volume = 60
 	unacidable = 0
 	flags = OPENCONTAINER
-	var/paint_type = "red"
+	var/paint_hex = "#FE191A"
 
-	afterattack(turf/simulated/target, mob/user, proximity)
-		if(!proximity) return
-		if(istype(target) && reagents.total_volume > 5)
-			user.visible_message("<span class='warning'>\The [target] has been splashed with something by [user]!</span>")
-			reagents.trans_to_turf(target, 5)
-		else
-			return ..()
+/obj/item/weapon/reagent_containers/glass/paint/afterattack(turf/simulated/target, mob/user, proximity)
+	if(!proximity) return
+	if(istype(target) && reagents.total_volume > 5)
+		user.visible_message("<span class='warning'>\The [target] has been splashed with something by [user]!</span>")
+		reagents.trans_to_turf(target, 5)
+	else
+		return ..()
 
-	New()
-		if(paint_type && lentext(paint_type) > 0)
-			name = paint_type + " " + name
-		..()
-		reagents.add_reagent("water", volume*3/5)
-		reagents.add_reagent("plasticide", volume/5)
-		if(paint_type == "white") //why don't white crayons exist
-			reagents.add_reagent("aluminum", volume/5)
-		else if (paint_type == "black")
-			reagents.add_reagent("carbon", volume/5)
-		else
-			reagents.add_reagent("crayon_dust_[paint_type]", volume/5)
-		reagents.handle_reactions()
+/obj/item/weapon/reagent_containers/glass/paint/New()
+	..()
+	if(paint_hex && lentext(paint_hex) > 0)
+		reagents.add_reagent("paint", volume, paint_hex)
 
-	red
-		icon_state = "paint_red"
-		paint_type = "red"
+/obj/item/weapon/reagent_containers/glass/paint/red
+	name = "red paint bucket"
+	icon_state = "paint_red"
+	paint_hex = "#FE191A"
 
-	yellow
-		icon_state = "paint_yellow"
-		paint_type = "yellow"
+/obj/item/weapon/reagent_containers/glass/paint/yellow
+	name = "yellow paint bucket"
+	icon_state = "paint_yellow"
+	paint_hex = "#FDFE7D"
 
-	green
-		icon_state = "paint_green"
-		paint_type = "green"
+/obj/item/weapon/reagent_containers/glass/paint/green
+	name = "green paint bucket"
+	icon_state = "paint_green"
+	paint_hex = "#18A31A"
 
-	blue
-		icon_state = "paint_blue"
-		paint_type = "blue"
+/obj/item/weapon/reagent_containers/glass/paint/blue
+	name = "blue paint bucket"
+	icon_state = "paint_blue"
+	paint_hex = "#247CFF"
 
-	purple
-		icon_state = "paint_violet"
-		paint_type = "purple"
+/obj/item/weapon/reagent_containers/glass/paint/purple
+	name = "purple paint bucket"
+	icon_state = "paint_violet"
+	paint_hex = "#CC0099"
 
-	black
-		icon_state = "paint_black"
-		paint_type = "black"
+/obj/item/weapon/reagent_containers/glass/paint/black
+	name = "black paint bucket"
+	icon_state = "paint_black"
+	paint_hex = "#333333"
 
-	white
-		icon_state = "paint_white"
-		paint_type = "white"
+/obj/item/weapon/reagent_containers/glass/paint/white
+	name = "white paint bucket"
+	icon_state = "paint_white"
+	paint_hex = "#F0F8FF"
 
+/obj/item/weapon/reagent_containers/glass/paint/random
+	name = "odd paint bucket"
+	icon_state = "paint_neutral"
+
+/obj/item/weapon/reagent_containers/glass/paint/random/New()
+	paint_hex = rgb(rand(1,255),rand(1,255),rand(1,255))
+	..()

--- a/code/modules/mob/living/carbon/metroid/items.dm
+++ b/code/modules/mob/living/carbon/metroid/items.dm
@@ -217,18 +217,19 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
 
-	/*afterattack(obj/target, mob/user , flag)
-		if(istype(target, /obj/item/slime_extract))
-			if(target.enhanced == 1)
-				user << "<span class='warning'> This extract has already been enhanced!</span>"
-				return ..()
-			if(target.Uses == 0)
-				user << "<span class='warning'> You can't enhance a used extract!</span>"
-				return ..()
-			user <<"You apply the enhancer. It now has triple the amount of uses."
-			target.Uses = 3
-			target.enahnced = 1
-			qdel(src)*/
+/obj/item/weapon/slimesteroid2/afterattack(obj/target, mob/user , flag)
+	if(istype(target, /obj/item/slime_extract))
+		var/obj/item/slime_extract/extract = target
+		if(extract.enhanced == 1)
+			user << "<span class='warning'> This extract has already been enhanced!</span>"
+			return ..()
+		if(extract.Uses == 0)
+			user << "<span class='warning'> You can't enhance a used extract!</span>"
+			return ..()
+		user <<"You apply the enhancer. It now has triple the amount of uses."
+		extract.Uses = 3
+		extract.enhanced = 1
+		qdel(src)
 
 /obj/effect/golemrune
 	anchored = 1
@@ -239,45 +240,45 @@
 	unacidable = 1
 	layer = TURF_LAYER
 
-	New()
-		..()
-		processing_objects.Add(src)
+/obj/effect/golemrune/New()
+	..()
+	processing_objects.Add(src)
 
-	process()
-		var/mob/observer/ghost/ghost
-		for(var/mob/observer/ghost/O in src.loc)
-			if(!O.client)	continue
-			if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
-			ghost = O
-			break
-		if(ghost)
-			icon_state = "golem2"
-		else
-			icon_state = "golem"
+/obj/effect/golemrune/process()
+	var/mob/observer/ghost/ghost
+	for(var/mob/observer/ghost/O in src.loc)
+		if(!O.client)	continue
+		if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
+		ghost = O
+		break
+	if(ghost)
+		icon_state = "golem2"
+	else
+		icon_state = "golem"
 
-	attack_hand(mob/living/user as mob)
-		var/mob/observer/ghost/ghost
-		for(var/mob/observer/ghost/O in src.loc)
-			if(!O.client)	continue
-			if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
-			ghost = O
-			break
-		if(!ghost)
-			user << "The rune fizzles uselessly. There is no spirit nearby."
-			return
-		var/mob/living/carbon/human/G = new(src.loc)
-		G.set_species("Golem")
-		G.key = ghost.key
-		G << "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost."
-		qdel(src)
+/obj/effect/golemrune/attack_hand(mob/living/user as mob)
+	var/mob/observer/ghost/ghost
+	for(var/mob/observer/ghost/O in src.loc)
+		if(!O.client)	continue
+		if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
+		ghost = O
+		break
+	if(!ghost)
+		user << "The rune fizzles uselessly. There is no spirit nearby."
+		return
+	var/mob/living/carbon/human/G = new(src.loc)
+	G.set_species("Golem")
+	G.key = ghost.key
+	G << "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost."
+	qdel(src)
 
 
-	proc/announce_to_ghosts()
-		for(var/mob/observer/ghost/G in player_list)
-			if(G.client)
-				var/area/A = get_area(src)
-				if(A)
-					G << "Golem rune created in [A.name]."
+/obj/effect/golemrune/proc/announce_to_ghosts()
+	for(var/mob/observer/ghost/G in player_list)
+		if(G.client)
+			var/area/A = get_area(src)
+			if(A)
+				G << "Golem rune created in [A.name]."
 
 /mob/living/carbon/slime/has_eyes()
 	return 0

--- a/code/modules/mob/living/carbon/metroid/subtypes.dm
+++ b/code/modules/mob/living/carbon/metroid/subtypes.dm
@@ -36,11 +36,11 @@
 			slime_mutation[4] = "blue"
 		if("dark purple")
 			slime_mutation[1] = "purple"
-			slime_mutation[2] = "purple"
+			slime_mutation[2] = "sepia"
 			slime_mutation[3] = "orange"
 			slime_mutation[4] = "orange"
 		if("yellow")
-			slime_mutation[1] = "metal"
+			slime_mutation[1] = "bluespace"
 			slime_mutation[2] = "metal"
 			slime_mutation[3] = "orange"
 			slime_mutation[4] = "orange"

--- a/code/modules/mob/living/carbon/metroid/subtypes.dm
+++ b/code/modules/mob/living/carbon/metroid/subtypes.dm
@@ -31,7 +31,7 @@
 		//Tier 3
 		if("dark blue")
 			slime_mutation[1] = "purple"
-			slime_mutation[2] = "purple"
+			slime_mutation[2] = "cerulean"
 			slime_mutation[3] = "blue"
 			slime_mutation[4] = "blue"
 		if("dark purple")
@@ -46,7 +46,7 @@
 			slime_mutation[4] = "orange"
 		if("silver")
 			slime_mutation[1] = "metal"
-			slime_mutation[2] = "metal"
+			slime_mutation[2] = "pyrite"
 			slime_mutation[3] = "blue"
 			slime_mutation[4] = "blue"
 		//Tier 4

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1066,7 +1066,7 @@
 	var/list/possible_mobs = list(
 							/mob/living/simple_animal/cat,
 							/mob/living/simple_animal/cat/kitten,
-							/mob/living/simple_naimal/corgi,
+							/mob/living/simple_animal/corgi,
 							/mob/living/simple_animal/corgi/puppy,
 							/mob/living/simple_animal/cow,
 							/mob/living/simple_animal/chick,
@@ -1357,9 +1357,45 @@
 	result = null
 	required_reagents = list("phoron" = 1)
 	required = /obj/item/slime_extract/bluespace
+	reaction_sound = 'sound/effects/teleport.ogg'
 
 /datum/chemical_reaction/slime/teleport/on_reaction(var/datum/reagents/holder)
+	var/list/turfs = list()
+	for(var/turf/T in orange(holder.my_atom,6))
+		turfs += T
 	for(var/atom/movable/a in viewers(holder.my_atom,2))
+		a.forceMove(pick(turfs))
+	..()
+
+//pyrite
+/datum/chemical_reaction/slime/paint
+	name = "Slime Paint"
+	id = "m_paint"
+	result = null
+	required_reagents = list("phoron" = 1)
+	required = /obj/item/slime_extract/pyrite
+
+/datum/chemical_reaction/slime/paint/on_reaction(var/datum/reagents/holder)
+	var/color = pick("red","white","black","yellow","green","blue","purple")
+	var/type = text2path("/obj/item/weapon/reagent_containers/glass/paint/[color]")
+	if(!ispath(type))
+		CRASH("Invalid path in slime paint reaction.")
+		return
+
+	new type(get_turf(holder.my_atom))
+	..()
+
+//cerulean
+/datum/chemical_reaction/slime/extract_enhance
+	name = "Extract Enhancer"
+	id = "m_enhance"
+	result = null
+	required_reagents = list("phoron" = 1)
+	required = /obj/item/slime_extract/cerulean
+
+/datum/chemical_reaction/slime/extract_enhance/on_reaction(var/datum/reagents/holder)
+	new /obj/item/weapon/slimesteroid2(get_turf(holder.my_atom))
+	..()
 
 
 /* Food */

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1353,7 +1353,7 @@
 //Bluespace
 /datum/chemical_reaction/slime/teleport
 	name = "Slime Teleport"
-	id = "m_tele"
+	id = "m_blink"
 	result = null
 	required_reagents = list("phoron" = 1)
 	required = /obj/item/slime_extract/bluespace
@@ -1364,6 +1364,8 @@
 	for(var/turf/T in orange(holder.my_atom,6))
 		turfs += T
 	for(var/atom/movable/a in viewers(holder.my_atom,2))
+		if(!a.simulated)
+			continue
 		a.forceMove(pick(turfs))
 	..()
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1378,13 +1378,7 @@
 	required = /obj/item/slime_extract/pyrite
 
 /datum/chemical_reaction/slime/paint/on_reaction(var/datum/reagents/holder)
-	var/color = pick("red","white","black","yellow","green","blue","purple")
-	var/type = text2path("/obj/item/weapon/reagent_containers/glass/paint/[color]")
-	if(!ispath(type))
-		CRASH("Invalid path in slime paint reaction.")
-		return
-
-	new type(get_turf(holder.my_atom))
+	new /obj/item/weapon/reagent_containers/glass/paint/random(get_turf(holder.my_atom))
 	..()
 
 //cerulean

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1055,7 +1055,7 @@
 	P.loc = get_turf(holder.my_atom)
 	..()
 
-//Gold - removed
+//Gold
 /datum/chemical_reaction/slime/crit
 	name = "Slime Crit"
 	id = "m_tele"
@@ -1063,7 +1063,20 @@
 	required_reagents = list("phoron" = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/gold
-	mix_message = "The slime core fizzles disappointingly."
+	var/list/possible_mobs = list(
+							/mob/living/simple_animal/cat,
+							/mob/living/simple_animal/cat/kitten,
+							/mob/living/simple_naimal/corgi,
+							/mob/living/simple_animal/corgi/puppy,
+							/mob/living/simple_animal/cow,
+							/mob/living/simple_animal/chick,
+							/mob/living/simple_animal/chicken
+							)
+
+/datum/chemical_reaction/slime/crit/on_reaction(var/datum/reagents/holder)
+	var/type = pick(possible_mobs)
+	new type(get_turf(holder.my_atom))
+	..()
 
 //Silver
 /datum/chemical_reaction/slime/bork
@@ -1310,6 +1323,44 @@
 	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
 	Z.loc = get_turf(holder.my_atom)
 	Z.announce_to_ghosts()
+
+//Sepia
+/datum/chemical_reaction/slime/film
+	name = "Slime Film"
+	id = "m_film"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 2
+	required = /obj/item/slime_extract/sepia
+
+/datum/chemical_reaction/slime/film/on_reaction(var/datum/reagents/holder)
+	for(var/i in 1 to result_amount)
+		new /obj/item/device/camera_film(get_turf(holder.my_atom))
+	..()
+
+/datum/chemical_reaction/slime/camera
+	name = "Slime Camera"
+	id = "m_camera"
+	result = null
+	required_reagents = list("phoron" = 1)
+	result_amount = 1
+	required = /obj/item/slime_extract/sepia
+
+/datum/chemical_reaction/slime/camera/on_reaction(var/datum/reagents/holder)
+	new /obj/item/device/camera(get_turf(holder.my_atom))
+	..()
+
+//Bluespace
+/datum/chemical_reaction/slime/teleport
+	name = "Slime Teleport"
+	id = "m_tele"
+	result = null
+	required_reagents = list("phoron" = 1)
+	required = /obj/item/slime_extract/bluespace
+
+/datum/chemical_reaction/slime/teleport/on_reaction(var/datum/reagents/holder)
+	for(var/atom/movable/a in viewers(holder.my_atom,2))
+
 
 /* Food */
 

--- a/html/changelogs/TheWelp - xenobioQOL.yml
+++ b/html/changelogs/TheWelp - xenobioQOL.yml
@@ -1,4 +1,4 @@
 author: TheWelp
 delete-after: True
 changes: 
-  - rscadd: "Reimplements old xenobiology slimes. Includes Pyrite, Gold, Cerulean, Bluespace and Sepia"
+  - rscadd: "Ports more of TG's slimes. Includes Pyrite, Gold, Cerulean, Bluespace and Sepia"

--- a/html/changelogs/TheWelp - xenobioQOL.yml
+++ b/html/changelogs/TheWelp - xenobioQOL.yml
@@ -1,0 +1,4 @@
+author: TheWelp
+delete-after: True
+changes: 
+  - rscadd: "Reimplements old xenobiology slimes. Includes Pyrite, Gold, Cerulean, Bluespace and Sepia"


### PR DESCRIPTION
Reasons behind this:
They still existed on the wiki.
They all seem pretty harmless. Creating paint, cameras, etc.
The only exception being the bluespace slime, but then again xenobotany exists and can do the same thing better and faster.

Gold reworked to spit out dumb animals. Kittens, corgis, chicks n cows.
