### PR TITLE
AOOC rewrite: Two way communication

### DIFF
--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -35,6 +35,8 @@
 	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
 		player.current.verbs += /mob/proc/add_objectives
 
+	player.current.verbs += /mob/proc/aooc
+
 	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
 	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
 	and it otherwise has no bearing on your round.</span>"
@@ -63,6 +65,7 @@
 
 		if(!is_special_character(player))
 			player.current.verbs -= /mob/living/proc/write_ambition
+			player.current.verbs -= /mob/proc/aooc
 			player.ambitions = ""
 		return 1
 	return 0

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -35,7 +35,7 @@
 	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
 		player.current.verbs += /mob/proc/add_objectives
 
-	player.current.verbs += /mob/proc/aooc
+	player.current.client.verbs += /client/proc/aooc
 
 	player.current << "<span class='notice'>Once you decide on a goal to pursue, you can optionally display it to \
 	everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \
@@ -65,7 +65,7 @@
 
 		if(!is_special_character(player))
 			player.current.verbs -= /mob/living/proc/write_ambition
-			player.current.verbs -= /mob/proc/aooc
+			player.current.client.verbs -= /client/proc/aooc
 			player.ambitions = ""
 		return 1
 	return 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -82,7 +82,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/event_manager_panel,
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/empty_ai_core_toggle_latejoin,
-	/client/proc/aooc,
+	/mob/proc/aooc,
 	/client/proc/change_human_appearance_admin,	// Allows an admin to change the basic appearance of human-based mobs ,
 	/client/proc/change_human_appearance_self,	// Allows the human-based mob itself change its basic appearance ,
 	/client/proc/change_security_level,
@@ -289,6 +289,7 @@ var/list/admin_verbs_mod = list(
 	/client/proc/check_antagonists,
 	/client/proc/jobbans,
 	/client/proc/cmd_admin_subtle_message, // send an message to somebody as a 'voice in their head',
+	/mob/proc/aooc,
 	/datum/admins/proc/paralyze_mob
 )
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -82,7 +82,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/event_manager_panel,
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/empty_ai_core_toggle_latejoin,
-	/mob/proc/aooc,
+	/client/proc/aooc,
 	/client/proc/change_human_appearance_admin,	// Allows an admin to change the basic appearance of human-based mobs ,
 	/client/proc/change_human_appearance_self,	// Allows the human-based mob itself change its basic appearance ,
 	/client/proc/change_security_level,
@@ -289,7 +289,7 @@ var/list/admin_verbs_mod = list(
 	/client/proc/check_antagonists,
 	/client/proc/jobbans,
 	/client/proc/cmd_admin_subtle_message, // send an message to somebody as a 'voice in their head',
-	/mob/proc/aooc,
+	/client/proc/aooc,
 	/datum/admins/proc/paralyze_mob
 )
 

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -1,19 +1,22 @@
-/client/proc/aooc(msg as text)
+/mob/proc/aooc(msg as text)
 	set category = "OOC"
 	set name = "AOOC"
 	set desc = "Antagonist OOC"
 
-	if(!check_rights(R_ADMIN))	return
+	//if(!check_rights(R_ADMIN))	return
 
 	msg = sanitize(msg)
 	if(!msg)	return
-
 	var/display_name = src.key
-	if(holder && holder.fakekey)
-		display_name = holder.fakekey
-
+	if(usr.client.holder)
+		if(usr.client.holder.fakekey)
+			display_name = client.holder.fakekey
 	for(var/mob/M in mob_list)
-		if((M.mind && M.mind.special_role && M.client) || check_rights(R_ADMIN, 0, M))
-			M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
-
+		if(check_rights(R_ADMIN, 0, M) || check_rights(R_MOD, 0, M)) // What staff see
+			M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[get_options_bar(src, 0, 1, 1)]([admin_jump_link(usr, M.client.holder)]):</EM> <span class='message'>[msg]</span></span></font>"
+		else if((M.mind && M.mind.special_role && M.client))
+			if(usr.client.holder) // What players see if messenger is staff
+				M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[display_name]([usr.client.holder.rank]):</EM> <span class='message'>[msg]</span></span></font>"
+			else // Waht players see if the messenger is not staff
+				M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
 	log_ooc("(ANTAG) [key] : [msg]")

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -1,22 +1,25 @@
-/mob/proc/aooc(msg as text)
+/client/proc/aooc(msg as text)
 	set category = "OOC"
 	set name = "AOOC"
 	set desc = "Antagonist OOC"
 
 	//if(!check_rights(R_ADMIN))	return
 
+
+	if(isghost(src.mob) && !check_rights(R_ADMIN|R_MOD, 0))
+		src << "<span class='warning'>You cannot use AOOC while ghosting/observing!</span>"
+		return
+
 	msg = sanitize(msg)
 	if(!msg)	return
 	var/display_name = src.key
-	if(usr.client.holder)
-		if(usr.client.holder.fakekey)
-			display_name = client.holder.fakekey
+	if(holder)
+		if(holder.fakekey)
+			display_name = usr.client.holder.fakekey
+	var/player_display = holder ? "[display_name]([usr.client.holder.rank])" : display_name
 	for(var/mob/M in mob_list)
-		if(check_rights(R_ADMIN, 0, M) || check_rights(R_MOD, 0, M)) // What staff see
-			M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[get_options_bar(src, 0, 1, 1)]([admin_jump_link(usr, M.client.holder)]):</EM> <span class='message'>[msg]</span></span></font>"
-		else if((M.mind && M.mind.special_role && M.client))
-			if(usr.client.holder) // What players see if messenger is staff
-				M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[display_name]([usr.client.holder.rank]):</EM> <span class='message'>[msg]</span></span></font>"
-			else // Waht players see if the messenger is not staff
-				M << "<font color='#960018'><span class='ooc'>" + create_text_tag("aooc", "Antag-OOC:", M.client) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+		if(check_rights(R_ADMIN|R_MOD, 0, M)) // What staff see
+			M << "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[get_options_bar(src, 0, 1, 1)]([admin_jump_link(usr, M.client.holder)]):</EM> <span class='message'>[msg]</span></span></span>"
+		else if(M.mind && M.mind.special_role && M.client) // What players see
+			M << "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[player_display]:</EM> <span class='message'>[msg]</span></span></span>"
 	log_ooc("(ANTAG) [key] : [msg]")

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -24,6 +24,7 @@ em						{font-style: normal;font-weight: bold;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}
 .ooc .admin				{color: #b82e00;}
+.ooc .aooc				{color: #960018;}
 
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}


### PR DESCRIPTION
As has been requested by several staff members, AOOC has been rewritten to allow two way communication between antagonists and staff (mods, admins). Players can also speak to eachother, which opens up the possibility of metagame and is something new that will have to be monitored.

:cl:
add: Players who are active antags can now respond to AOOC
add: Mods have been given access to AOOC
/:cl:

Player sees top example, staff see bottom
![AOOC example](http://i.imgur.com/itoWUgW.png)
Ignore debug message in image. It's been removed
