### PR TITLE
Removes dufflebag storage slot limit.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -156,7 +156,6 @@
 		)
 	slowdown = 1
 	max_storage_space = 38
-	storage_slots = 12
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie
 	name = "black dufflebag"


### PR DESCRIPTION
Fixes  #12561.
Small and large sized webbings all appear to have the appropriate number of slots (3 vs 5 respectively).
