### PR TITLE
Various fixes.

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -342,11 +342,11 @@ var/global/datum/controller/occupations/job_master
 						else
 							permitted = 1
 
-						if(G.whitelisted && !is_alien_whitelisted(H, G.whitelisted))
+						if(G.whitelisted && (G.whitelisted != H.species.name || !is_alien_whitelisted(H, G.whitelisted)))
 							permitted = 0
 
 						if(!permitted)
-							H << "<span class='warning'>Your current job or whitelist status does not permit you to spawn with [thing]!</span>"
+							H << "<span class='warning'>Your current species, job or whitelist status does not permit you to spawn with [thing]!</span>"
 							continue
 
 						if(G.slot && !(G.slot in custom_equip_slots))

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -60,7 +60,7 @@ var/list/whitelist = list()
 		species = "[species]";
 	if(species == "human" || species == "Human")
 		return 1
-	if(check_rights(R_ADMIN, 0))
+	if(check_rights(R_ADMIN, 0, M))
 		return 1
 	if(!alien_whitelist)
 		return 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -126,6 +126,8 @@
 		admins += src
 		holder.owner = src
 
+	. = ..()	//calls mob.Login()
+
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)
 	prefs = preferences_datums[ckey]
 	if(!prefs)
@@ -133,8 +135,6 @@
 		preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-
-	. = ..()	//calls mob.Login()
 
 	if(custom_event_msg && custom_event_msg != "")
 		src << "<h1 class='alert'>Custom Event</h1>"

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -42,15 +42,15 @@ var/list/gear_datums = list()
 	S["gear"] << pref.gear
 
 /datum/category_item/player_setup_item/loadout/proc/valid_gear_choices(var/max_cost)
-	var/list/valid_gear_choices = list()
+	. = list()
+	var/mob/preference_mob = preference_mob()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
-		if(G.whitelisted && !is_alien_whitelisted(preference_mob(), G.whitelisted))
+		if(G.whitelisted && !is_alien_whitelisted(preference_mob, G.whitelisted))
 			continue
 		if(max_cost && G.cost > max_cost)
 			continue
-		valid_gear_choices += gear_name
-	return valid_gear_choices
+		. += gear_name
 
 /datum/category_item/player_setup_item/loadout/sanitize_character()
 	if(!islist(pref.gear))


### PR DESCRIPTION
Client Login() now calls ..() before setting up preferences, ensuring a mob has actually been assigned. Fixes #12560 (and probably other somehow subtle sanitation issues).
The alien whitelist proc now checks the rights of the supplied mob, not usr.
When granting xeno loadout gear the mob's current species must match the gear's whiteliste species.
