### PR TITLE
Change Exotic Seeds crate access to Xenobio-only

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -393,9 +393,9 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/seeds/random,
 					/obj/item/seeds/kudzuseed)
 	cost = 15
-	containertype = /obj/structure/closet/crate/hydroponics
+	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Exotic Seeds crate"
-	access = access_hydroponics
+	access = access_xenobiology
 	group = "Hydroponics"
 
 /datum/supply_packs/medical


### PR DESCRIPTION
Only allows Xenobiologists/Xenobotanists/RD to access the exotic seeds crate, which contains stuff that regular Botanists shouldn't have, including exotic seeds which can, among other things, fill a room with phoron, devour people, or contain the deadliest poisons on the station.

:cl:
tweak: The exotic seeds crate is now access restricted to xenobiologists.
/:cl:
