### PR TITLE
Voting system changes.

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -147,20 +147,18 @@ datum/controller/vote
 				if(length(winners[i]) > 0)
 					secondChoice = pick(winners[i])
 					winners[i] -= secondChoice
+				else if(i == 3)
+					break
 				else
-					if(i == 3)
-						break
-					else
-						i++
+					i++
 			while(isnull(thirdChoice))
 				if(length(winners[i]) > 0)
 					thirdChoice = pick(winners[i])
 					winners[i] -= thirdChoice
+				else if(i == 3)
+					break
 				else
-					if(i == 3)
-						break
-					else
-						i++
+					i++
 
 			if((mode == "gamemode" && firstChoice == "Extended") || ticker.hide_mode == 0) // Announce Extended gamemode, but not other gamemodes
 				text += "<b>Vote Result: [firstChoice]</b>"

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -160,13 +160,16 @@ datum/controller/vote
 				else
 					i++
 
-			if((mode == "gamemode" && firstChoice == "Extended") || ticker.hide_mode == 0) // Announce Extended gamemode, but not other gamemodes
+			if(mode == "gamemode" && (firstChoice == "Extended" || ticker.hide_mode == 0)) // Announce Extended gamemode, but not other gamemodes
+				text += "<b>Vote Result: [firstChoice]</b>"
+				if(secondChoice)
+					text += "\nSecond place: [secondChoice]"
+				if(thirdChoice)
+					text += ", third place: [thirdChoice]"
+			else if(mode != "gamemode")
 				text += "<b>Vote Result: [firstChoice]</b>"
 			else
-				if(mode != "gamemode")
-					text += "<b>Vote Result: [firstChoice]</b>"
-				else
-					text += "<b>The vote has ended.</b>" // What will be shown if it is a gamemode vote that isn't extended
+				text += "<b>The vote has ended.</b>" // What will be shown if it is a gamemode vote that isn't extended
 
 		else
 			text += "<b>Vote Result: Inconclusive - No Votes!</b>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -449,11 +449,12 @@ var/global/list/additional_antag_types = list()
 		// If we don't have enough antags, draft people who voted for the round.
 		if(candidates.len < required_enemies)
 			for(var/mob/new_player/player in players)
-				if(player.ckey in round_voters)
-					log_debug("[player.key] voted for this round, so we are drafting them.")
+				if(!role || !(role in player.client.prefs.never_be_special_role))
+					log_debug("[player.key] has not selected never for this role, so we are drafting them.")
 					candidates += player.mind
 					players -= player
-					break
+					if(candidates.len == required_enemies || players.len == 0)
+						break
 
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than required_enemies
 							//			required_enemies if the number of people with that role set to yes is less than recomended_enemies,

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -26,6 +26,7 @@ var/global/datum/controller/gameticker/ticker
 	var/list/availablefactions = list()	  // list of factions with openings
 
 	var/pregame_timeleft = 0
+	var/gamemode_voted = 0
 
 	var/delay_end = 0	//if set to nonzero, the round will not restart on it's own
 
@@ -44,7 +45,21 @@ var/global/datum/controller/gameticker/ticker
 	'sound/music/clouds.s3m',\
 	'sound/music/space_oddity.ogg') //Ground Control to Major Tom, this song is cool, what's going on?
 	do
-		pregame_timeleft = 180
+		if(!gamemode_voted)
+			pregame_timeleft = 180
+		else
+			pregame_timeleft = 15
+			if(!isnull(secondary_mode))
+				master_mode = secondary_mode
+				secondary_mode = null
+				world << "Trying to start the second top game mode..."
+			else if(!isnull(tertiary_mode))
+				master_mode = tertiary_mode
+				tertiary_mode = null
+				world << "Trying to start the third top game mode..."
+			else
+				master_mode = "extended"
+				world << "Forcing the game mode to extended..."
 		world << "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>"
 		world << "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds"
 		while(current_state == GAME_STATE_PREGAME)
@@ -53,7 +68,8 @@ var/global/datum/controller/gameticker/ticker
 				vote.process()
 			if(round_progressing)
 				pregame_timeleft--
-			if(pregame_timeleft == config.vote_autogamemode_timeleft)
+			if(pregame_timeleft == config.vote_autogamemode_timeleft && !gamemode_voted)
+				gamemode_voted = 1
 				if(!vote.time_remaining)
 					vote.autogamemode()	//Quit calling this over and over and over and over.
 					while(vote.time_remaining)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -53,13 +53,17 @@ var/global/datum/controller/gameticker/ticker
 				master_mode = secondary_mode
 				secondary_mode = null
 				world << "Trying to start the second top game mode..."
+				if(!hide_mode)
+					world << "<b>The game mode is now: [master_mode]</b>"
 			else if(!isnull(tertiary_mode))
 				master_mode = tertiary_mode
 				tertiary_mode = null
 				world << "Trying to start the third top game mode..."
+				if(!hide_mode)
+					world << "<b>The game mode is now: [master_mode]</b>"
 			else
 				master_mode = "extended"
-				world << "Forcing the game mode to extended..."
+				world << "<b>Forcing the game mode to extended...</b>"
 		world << "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>"
 		world << "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds"
 		while(current_state == GAME_STATE_PREGAME)

--- a/code/global.dm
+++ b/code/global.dm
@@ -40,6 +40,8 @@ var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 544)
 
 var/round_progressing = 1
 var/master_mode       = "extended" // "extended"
+var/secondary_mode    = "extended"
+var/tertiary_mode     = "extended"
 var/secret_force_mode = "secret"   // if this is anything but "secret", the secret rotation will forceably choose this mode.
 
 var/host = null //only here until check @ code\modules\ghosttrap\trap.dm:112 is fixed

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -4,17 +4,24 @@
 
 /datum/category_item/player_setup_item/antagonism/candidacy/load_character(var/savefile/S)
 	S["be_special"]	>> pref.be_special_role
+	S["never_be_special"] >> pref.never_be_special_role
 
 /datum/category_item/player_setup_item/antagonism/candidacy/save_character(var/savefile/S)
 	S["be_special"]	<< pref.be_special_role
+	S["never_be_special"] << pref.never_be_special_role
 
 /datum/category_item/player_setup_item/antagonism/candidacy/sanitize_character()
 	if(!istype(pref.be_special_role))
 		pref.be_special_role = list()
+	if(!istype(pref.never_be_special_role))
+		pref.never_be_special_role = list()
 
 	for(var/role in pref.be_special_role)
 		if(!(role in valid_special_roles()))
 			pref.be_special_role -= role
+	for(var/role in pref.never_be_special_role)
+		if(!(role in valid_special_roles()))
+			pref.never_be_special_role -= role
 
 /datum/category_item/player_setup_item/antagonism/candidacy/content(var/mob/user)
 	. += "<b>Special Role Availability:</b><br>"
@@ -25,9 +32,11 @@
 		if(jobban_isbanned(preference_mob(), antag.bantype))
 			. += "<span class='danger'>\[BANNED\]</span><br>"
 		else if(antag.role_type in pref.be_special_role)
-			. += "<b>Yes</b> / <a href='?src=\ref[src];del_special=[antag.role_type]'>No</a></br>"
+			. += "<b>High</b> / <a href='?src=\ref[src];del_special=[antag.role_type]'>Low</a> / <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
+		else if(antag.role_type in pref.never_be_special_role)
+			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> / <a href='?src=\ref[src];del_special=[antag.role_type]'>Low</a> / <b>Never</b></br>"
 		else
-			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>Yes</a> / <b>No</b></br>"
+			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> / <b>Low</b> / <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
 		. += "</td></tr>"
 
 	var/list/ghost_traps = get_ghost_traps()
@@ -40,9 +49,11 @@
 		if(banned_from_ghost_role(preference_mob(), ghost_trap))
 			. += "<span class='danger'>\[BANNED\]</span><br>"
 		else if(ghost_trap.pref_check in pref.be_special_role)
-			. += "<b>Yes</b> / <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>No</a></br>"
+			. += "<b>High</b> / <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Low</a> / <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
+		else if(ghost_trap.pref_check in pref.never_be_special_role)
+			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> / <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Low</a> / <b>Never</b></br>"
 		else
-			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>Yes</a> / <b>No</b></br>"
+			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> / <b>Low</b> / <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
 		. += "</td></tr>"
 	. += "</table>"
 
@@ -57,10 +68,17 @@
 		if(!(href_list["add_special"] in valid_special_roles()))
 			return TOPIC_HANDLED
 		pref.be_special_role |= href_list["add_special"]
+		pref.never_be_special_role -= href_list["add_special"]
 		return TOPIC_REFRESH
 
 	if(href_list["del_special"])
 		pref.be_special_role -= href_list["del_special"]
+		pref.never_be_special_role -= href_list["del_special"]
+		return TOPIC_REFRESH
+
+	if(href_list["add_never"])
+		pref.be_special_role -= href_list["add_never"]
+		pref.never_be_special_role |= href_list["add_never"]
 		return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -17,6 +17,7 @@ datum/preferences
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
+	var/list/never_be_special_role = list()
 	var/list/be_special_role = list()		//Special role selection
 	var/UI_style = "Midnight"
 	var/UI_style_color = "#ffffff"

--- a/html/changelogs/mustafakalash-PR-12589.yml
+++ b/html/changelogs/mustafakalash-PR-12589.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mkalash
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "New voting system allows players to chose three options: high, medium, and low"
+  - rscadd: "Players can set individual antag roles to 'never' and will not be selected to antag by the game mode"
+  - tweak: "Players who do not vote for the game mode, but have not selected never, are candidates"
+  - rscadd: "The game will try the top three voted game modes before forcing extended without revote"


### PR DESCRIPTION
Discussion thread: https://baystation12.net/forums/threads/suggestion-new-voting-system-antag-opt-in-change.1737/

Please comment on my coding style, I'm trying to learn best practices!

Goal: reduce lobby time, prevent people absolutely against antagging from having to beg admins for a role change.

Implementation:
- Three vote choices: 1 high (3 votes), 1 medium (2 votes), and 1 low (1 vote)
- Should the highest voted game mode fail to start, the server will try to start the second place game mode after 15 seconds
- If the second and third choices both fail, then the game mode will be forced to extended
- Maximum lobby time, not including vote delay: 225 seconds
- Antag roles get three choices: high, low, never
- High and low are almost equivalent to yes and no, respectively
  - Those who have selected low can be selected by lottery, regardless of vote
- Players who chose never will never be selected by lottery
  - They still can be antagged by in-game means (rev/cult/etc.) 

Screenshots:
![vote panel](http://i.imgur.com/2Uf6fUi.png)
![preference panel](http://i.imgur.com/UUIMxqb.png)
![lobby log](http://i.imgur.com/ysurwPh.png?1)
Note that wizard did not start because I had set wizard to 'never', so there were no candidates

:cl:
tweak: New voting system allows players to chose three options: high, medium, and low
add: Players can set individual antag roles to 'never' and will not be selected to antag by the game mode
tweak: Players who do not vote for the game mode, but have not selected never, are candidates
add: The game will try the top three voted game modes before forcing extended without revote
/:cl:
