### PR TITLE
Change callproc to allow clicking on atoms to select them as arguments

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -1,4 +1,6 @@
+//// VERBS
 
+// standard callproc, select target
 /client/proc/callproc()
 	set category = "Debug"
 	set name = "Advanced ProcCall"
@@ -33,6 +35,7 @@
 
 	callproc_targetpicked(targetselected, target)
 
+// right click verb
 /client/proc/callproc_target(atom/A in range(world.view))
 	set category = "Debug"
 	set name = "Advanced ProcCall Target"
@@ -42,38 +45,84 @@
 
 	callproc_targetpicked(1, A)
 
-/client/proc/callproc_targetpicked(hastarget, datum/target)
+/datum/admins
+	var/datum/callproc/callproc = null // if the user has a callproc datum, it goes here
 
+/client/proc/callproc_targetpicked(hastarget, datum/target)
 	// this needs checking again here because VV's 'Call Proc' option directly calls this proc with the target datum
 	if(!check_rights(R_DEBUG)) return
 	if(config.debugparanoid && !check_rights(R_ADMIN)) return
 
-	var/returnval = null
+	if(!holder.callproc)
+		holder.callproc = new(src)
+	holder.callproc.callproc(hastarget, target)
 
-	var/procname = input("Proc name", "Proc") as null|text
-	if(!procname) return
+#define CANCEL -1
+#define WAITING 0
+#define DONE 1
+
+/datum/callproc
+	var/client/C
+	var/datum/target
+	var/hastarget
+	var/procname
+	var/list/arguments
+	var/waiting_for_click = 0
+
+/datum/callproc/New(client/C)
+	..()
+	src.C = C
+
+/datum/callproc/proc/clear()
+	target = null
+	hastarget = null
+	procname = null
+	arguments = null
+	waiting_for_click = 0
+
+/datum/callproc/proc/callproc(hastarget, datum/target)
+	src.target = target
+	src.hastarget = hastarget
+
+	procname = input("Proc name", "Proc") as null|text
+	if(!procname)
+		clear()
+		return
 
 	if(hastarget)
 		if(!target)
 			usr << "Your callproc target no longer exists."
+			clear()
 			return
 		if(!hascall(target, procname))
 			usr << "\The [target] has no call [procname]()"
+			clear()
 			return
 
-	var/list/arguments = list()
+	arguments = list()
+	do_args()
+
+/datum/callproc/proc/do_args()
+	switch(get_args())
+		if(WAITING)
+			return
+		if(DONE)
+			finalise()
+	clear()
+
+/datum/callproc/proc/get_args()
 	var/done = 0
 	var/current = null
 
 	while(!done)
 		if(hastarget && !target)
 			usr << "Your callproc target no longer exists."
-			return
+			return CANCEL
 		switch(input("Type of [arguments.len+1]\th variable", "argument [arguments.len+1]") as null|anything in list(
 				"finished", "null", "text", "num", "type", "obj reference", "mob reference",
-				"area/turf reference", "icon", "file", "client", "mob's area", "marked datum"))
+				"area/turf reference", "icon", "file", "client", "mob's area", "marked datum", "click on atom"))
 			if(null)
-				return
+				return CANCEL
 
 			if("finished")
 				done = 1
@@ -83,35 +132,35 @@
 
 			if("text")
 				current = input("Enter text for [arguments.len+1]\th argument") as null|text
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("num")
 				current = input("Enter number for [arguments.len+1]\th argument") as null|num
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("type")
 				current = input("Select type for [arguments.len+1]\th argument") as null|anything in typesof(/obj, /mob, /area, /turf)
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("obj reference")
 				current = input("Select object for [arguments.len+1]\th argument") as null|obj in world
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("mob reference")
 				current = input("Select mob for [arguments.len+1]\th argument") as null|mob in world
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("area/turf reference")
 				current = input("Select area/turf for [arguments.len+1]\th argument") as null|area|turf in world
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("icon")
 				current = input("Provide icon for [arguments.len+1]\th argument") as null|icon
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("client")
 				current = input("Select client for [arguments.len+1]\th argument") as null|anything in clients
-				if(isnull(current)) return
+				if(isnull(current)) return CANCEL
 
 			if("mob's area")
 				var/mob/M = input("Select mob to take area for [arguments.len+1]\th argument") as null|mob in world
@@ -122,18 +171,50 @@
 						if("Yes")
 							; // do nothing
 						if("Cancel")
-							return
+							return CANCEL
 
 			if("marked datum")
-				current = holder.marked_datum()
+				current = C.holder.marked_datum()
 				if(!current)
 					switch(alert("You do not currently have a marked datum; do you want to pass null instead?",, "Yes", "Cancel"))
 						if("Yes")
 							; // do nothing
 						if("Cancel")
-							return
+							return CANCEL
+
+			if("click on atom")
+				waiting_for_click = 1
+				C.verbs += /client/proc/cancel_callproc_select
+				C << "Click an atom to select it. Click an atom then click 'cancel', or use the Cancel-Callproc-Select verb to cancel selecting a target by click."
+				return WAITING
+
 		if(!done)
 			arguments += current
+
+	return DONE
+
+/client/proc/cancel_callproc_select()
+	set name = "Cancel Callproc Select"
+	set category = "Admin"
+
+	verbs -= /client/proc/cancel_callproc_select
+	if(holder && holder.callproc && holder.callproc.waiting_for_click)
+		holder.callproc.waiting_for_click = 0
+		holder.callproc.do_args()
+
+/client/Click(atom/A)
+	if(holder && holder.callproc && holder.callproc.waiting_for_click)
+		if(alert("Do you want to select \the [A] as the [holder.callproc.arguments.len+1]\th argument?",, "Yes", "No") == "Yes")
+			holder.callproc.arguments += A
+
+		holder.callproc.waiting_for_click = 0
+		verbs -= /client/proc/cancel_callproc_select
+		holder.callproc.do_args()
+	else
+		return ..()
+
+/datum/callproc/proc/finalise()
+	var/returnval
 
 	if(hastarget)
 		if(!target)
@@ -150,3 +231,7 @@
 
 	usr << "<span class='info'>[procname]() returned: [isnull(returnval) ? "null" : returnval]</span>"
 	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+#undef CANCEL
+#undef WAITING
+#undef DONE

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -136,7 +136,10 @@
 //		src << "<span class='notice'>[msg]</span>"
 //		return
 
-	send2adminirc("PlayerPM to [sender] from [key_name(src)]: [html_decode(msg)]")
+	var/rank = "Player"
+	if(holder)
+		rank = holder.rank
+	send2adminirc("[rank]PM to [sender] from [key_name(src)]: [html_decode(msg)]")
 
 	src << "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "", src) + " to <span class='name'>IRC-[sender]</span>: <span class='message'>[msg]</span></span></span>"
 


### PR DESCRIPTION
So much nicer than either selecting from a list or VV>mark datum.

Also changes IRC message replies to use the actual rank of the sender, if they have one (no more "PlayerPM" from people who have admin ranks)
