### PR TITLE
Fixes nuclear authentication disk

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -22,7 +22,11 @@ var/list/nuke_disks = list()
 //delete all nuke disks not on a station zlevel
 /datum/game_mode/nuclear/proc/check_nuke_disks()
 	for(var/obj/item/weapon/disk/nuclear/N in nuke_disks)
-		if(isNotStationLevel(N.z)) qdel(N)
+		var/turf/T = get_turf(T)
+		if(!T || !isNotStationLevel(T.z))
+			log_and_message_admins("Nuclear authentication disk has left the station Z level.")
+			qdel(N)
+
 
 //checks if L has a nuke disk on their person
 /datum/game_mode/nuclear/proc/check_mob(mob/living/L)


### PR DESCRIPTION
- Nuclear disk will now only delete itself when it actualy leaves station Z. Being in container of some kind no longer causes it to be deleted.
