### PR TITLE
Fixes #12599

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -126,8 +126,6 @@
 		admins += src
 		holder.owner = src
 
-	. = ..()	//calls mob.Login()
-
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)
 	prefs = preferences_datums[ckey]
 	if(!prefs)
@@ -135,6 +133,8 @@
 		preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
+
+	. = ..()	//calls mob.Login()
 
 	if(custom_event_msg && custom_event_msg != "")
 		src << "<h1 class='alert'>Custom Event</h1>"


### PR DESCRIPTION
After #12573, players trying to connect to a mob will attempt to load their UI before preferences are loaded, causing runtimes and broken UIs.
