### PR TITLE
Tweaks rig power usage when driven by AI.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -66,6 +66,7 @@
 	var/malfunction_delay = 0
 	var/electrified = 0
 	var/locked_down = 0
+	var/aimove_power_usage = 200							  // Power usage per tile traveled when suit is moved by AI in IIS. In joules.
 
 	var/seal_delay = SEAL_DELAY
 	var/sealing                                               // Keeps track of seal status independantly of canremove.
@@ -890,7 +891,7 @@
 			wearer_move_delay += 2
 			return wearer.buckled.relaymove(wearer,direction)
 
-	cell.use(200) //Arbitrary, TODO
+	cell.use(aimove_power_usage * CELLRATE)
 	wearer.Move(get_step(get_turf(wearer),direction),direction)
 
 // This returns the rig if you are contained inside one, but not if you are wearing it

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -79,6 +79,7 @@
 	armor = list(melee = 50, bullet = 15, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 30)
 	emp_protection = 40 //change this to 30 if too high.
 	slowdown = 0
+	aimove_power_usage = 50
 
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja


### PR DESCRIPTION
- You no longer require a portable fusion power plant to meet energy demands of RIG moved by AI.
- Old usage: 4000J (or even more?) / tile. New: 200J / tile. Controlled by variable, ninja suit has only 50J / tile.

:cl:
tweak: RIGs driven by AIs inside IIS now use massively less power. In other words, the AI can walk more than few tiles without fully draining the battery.
/:cl:
