### PR TITLE
Ports confused movement from Polaris, with fixes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -111,10 +111,10 @@ default behaviour is:
 			..()
 			if (!istype(AM, /atom/movable) || AM.anchored)
 				if(confused && prob(50) && m_intent=="run")
-					Paralyse(1)
+					Weaken(1)
 					playsound(loc, "punch", 25, 1, -1)
 					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")
-					src.take_organ_damage(5)
+					src.apply_damage(5, BRUTE)
 				return
 			if (!now_pushing)
 				now_pushing = 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -111,7 +111,7 @@ default behaviour is:
 			..()
 			if (!istype(AM, /atom/movable) || AM.anchored)
 				if(confused && prob(50) && m_intent=="run")
-					Weaken(1)
+					Weaken(2)
 					playsound(loc, "punch", 25, 1, -1)
 					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")
 					src.apply_damage(5, BRUTE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -109,22 +109,26 @@ default behaviour is:
 		now_pushing = 0
 		spawn(0)
 			..()
-			if (!istype(AM, /atom/movable))
+			if (!istype(AM, /atom/movable) || AM.anchored)
+				if(confused && prob(50) && m_intent=="run")
+					Paralyse(1)
+					playsound(loc, "punch", 25, 1, -1)
+					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")
+					src.take_organ_damage(5)
 				return
 			if (!now_pushing)
 				now_pushing = 1
 
-				if (!AM.anchored)
-					var/t = get_dir(src, AM)
-					if (istype(AM, /obj/structure/window))
-						for(var/obj/structure/window/win in get_step(AM,t))
-							now_pushing = 0
-							return
-					step(AM, t)
-					if(ishuman(AM) && AM:grabbed_by)
-						for(var/obj/item/weapon/grab/G in AM:grabbed_by)
-							step(G:assailant, get_dir(G:assailant, AM))
-							G.adjust_position()
+				var/t = get_dir(src, AM)
+				if (istype(AM, /obj/structure/window))
+					for(var/obj/structure/window/win in get_step(AM,t))
+						now_pushing = 0
+						return
+				step(AM, t)
+				if(ishuman(AM) && AM:grabbed_by)
+					for(var/obj/item/weapon/grab/G in AM:grabbed_by)
+						step(G:assailant, get_dir(G:assailant, AM))
+						G.adjust_position()
 				now_pushing = 0
 			return
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -286,8 +286,8 @@
 			//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
 			move_delay = world.time + tickcomp
 			//drunk driving
-			if(mob.confused && prob(75))
-				direct = pick(cardinal)
+			if(mob.confused && prob(20)) //vehicles tend to keep moving in the same direction
+				direct = turn(direct, pick(90, -90))
 			return mob.buckled.relaymove(mob,direct)
 
 		if(istype(mob.machine, /obj/machinery))
@@ -310,9 +310,9 @@
 				else if(mob.confused)
 					switch(mob.m_intent)
 						if("run")
-							if(prob(75))	direct = pick(cardinal)
+							if(prob(50))	direct = turn(direct, pick(90, -90))
 						if("walk")
-							if(prob(25))	direct = pick(cardinal)
+							if(prob(25))	direct = turn(direct, pick(90, -90))
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)
 
@@ -351,13 +351,17 @@
 							M.animate_movement = 2
 							return
 
-		else if(mob.confused)
-			switch(mob.m_intent)
-				if("run")
-					if(prob(75))	step(mob, pick(cardinal))
-				if("walk")
-					if(prob(25))	step(mob, pick(cardinal))
-		else
+		else 
+			if(mob.confused)
+				switch(mob.m_intent)
+					if("run")
+						if(prob(75))
+							direct = turn(direct, pick(90, -90))
+							n = get_step(mob, direct)
+					if("walk")
+						if(prob(25))
+							direct = turn(direct, pick(90, -90))
+							n = get_step(mob, direct)
 			. = mob.SelfMove(n, direct)
 
 		for (var/obj/item/weapon/grab/G in mob)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -286,7 +286,7 @@
 			//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
 			move_delay = world.time + tickcomp
 			//drunk driving
-			if(mob.confused)
+			if(mob.confused && prob(75))
 				direct = pick(cardinal)
 			return mob.buckled.relaymove(mob,direct)
 
@@ -307,8 +307,12 @@
 					if((!l_hand || l_hand.is_stump()) && (!r_hand || r_hand.is_stump()))
 						return // No hands to drive your chair? Tough luck!
 				//drunk wheelchair driving
-				if(mob.confused)
-					direct = pick(cardinal)
+				else if(mob.confused)
+					switch(mob.m_intent)
+						if("run")
+							if(prob(75))	direct = pick(cardinal)
+						if("walk")
+							if(prob(25))	direct = pick(cardinal)
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)
 
@@ -348,7 +352,11 @@
 							return
 
 		else if(mob.confused)
-			step(mob, pick(cardinal))
+			switch(mob.m_intent)
+				if("run")
+					if(prob(75))	step(mob, pick(cardinal))
+				if("walk")
+					if(prob(25))	step(mob, pick(cardinal))
 		else
 			. = mob.SelfMove(n, direct)
 


### PR DESCRIPTION
Port of https://github.com/PolarisSS13/Polaris/pull/698

Despite the stated intent of randomly changing the direction of movement, what was implemented was a % chance of moving randomly or _not moving at all_. Also made confused movement cause you to randomly turn left/right instead of completely random, and adjusted with the values for confused driving and wheelchair rolling.

:cl: Hubblenaut/HarpyEagle
tweak: Confused movement is a little less random. It is now easier to get to where you want to when confused, especially while walking.
rscadd: People running into solid objects while confused can be knocked over.
/:cl:
