### PR TITLE
Prevents gun aiming from being triggered just by examining things, or talking on the radio

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -87,6 +87,7 @@
 	if(in_throw_mode)
 		if(isturf(A) || isturf(A.loc))
 			throw_item(A)
+			trigger_aiming(TARGET_CAN_CLICK)
 			return 1
 		throw_mode_off()
 
@@ -94,6 +95,7 @@
 
 	if(W == A) // Handle attack_self
 		W.attack_self(src)
+		trigger_aiming(TARGET_CAN_CLICK)
 		if(hand)
 			update_inv_l_hand(0)
 		else
@@ -116,6 +118,8 @@
 			if(ismob(A)) // No instant mob attacking
 				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			UnarmedAttack(A, 1)
+
+		trigger_aiming(TARGET_CAN_CLICK)
 		return 1
 
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
@@ -137,12 +141,16 @@
 				if(ismob(A)) // No instant mob attacking
 					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				UnarmedAttack(A, 1)
+
+			trigger_aiming(TARGET_CAN_CLICK)
 			return
 		else // non-adjacent click
 			if(W)
 				W.afterattack(A, src, 0, params) // 0: not Adjacent
 			else
 				RangedAttack(A, params)
+
+			trigger_aiming(TARGET_CAN_CLICK)
 	return 1
 
 /mob/proc/setClickCooldown(var/timeout)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -336,7 +336,7 @@
 		else		direction = WEST
 	if(direction != dir)
 		facedir(direction)
-		
+
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen1_full.dmi'
 	icon_state = "passage0"
@@ -352,4 +352,4 @@
 	else
 		var/turf/T = screen_loc2turf(modifiers["screen-loc"], get_turf(usr))
 		T.Click(location, control, params)
-	return 1 
+	return 1

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -23,6 +23,7 @@
 	owner = newowner
 	loc = null
 	verbs.Cut()
+	toggle_permission(TARGET_CAN_RADIO)
 
 /obj/aiming_overlay/proc/toggle_permission(var/perm)
 
@@ -201,6 +202,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		else
 			owner << "<span class='notice'>You will no longer aim rather than fire.</span>"
 			owner.client.remove_gun_icons()
+		owner.gun_setting_icon.icon_state = "gun[active]"
 
 /obj/aiming_overlay/proc/cancel_aiming(var/no_message = 0)
 	if(!aiming_with || !aiming_at)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -1,4 +1,8 @@
-/mob/living/proc/trigger_aiming(var/trigger_type)
+//as core click exists at the mob level
+/mob/proc/trigger_aiming(var/trigger_type)
+	return
+
+/mob/living/trigger_aiming(var/trigger_type)
 	if(!aimed.len)
 		return
 	for(var/obj/aiming_overlay/AO in aimed)
@@ -23,7 +27,3 @@
 	var/obj/item/weapon/gun/G = aiming_with
 	if(istype(G))
 		G.Fire(aiming_at, owner)
-
-/mob/living/ClickOn(var/atom/A, var/params)
-	. = ..()
-	trigger_aiming(TARGET_CAN_CLICK)

--- a/html/changelogs/HarpyEagle-gun-aiming.yml
+++ b/html/changelogs/HarpyEagle-gun-aiming.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - bugfix: "Examining objects/yourself no longer triggers the gun hostage/aiming system."

--- a/html/changelogs/Neerti-2016_aim_intent_changes.yml
+++ b/html/changelogs/Neerti-2016_aim_intent_changes.yml
@@ -1,0 +1,7 @@
+author: Neerti
+
+delete-after: True
+
+changes: 
+  - tweak: "The toggle to shoot if the target talks on the radio defaults to off."
+  - bugfix: "The aim intent icon now updates when clicked."


### PR DESCRIPTION
Looking at the floor no longer triggers gun aiming.

Also removed talking on the radio from triggering aiming (sorry Chinsky). It's occasionally been a minor source of confusion for people not expecting it, and honestly: If you can tell that they are talking into their radio (by seeing emote or whatever) you can just choose to shoot them yourself if you wish. If you can't tell, then why should the game make you shoot anyways? Removed the associated UI elements as they're no longer used, did this as a separate commit so it is easy to bring them back if it finds a new purpose.

:cl: HarpyEagle
bugfix: Examining the floor (or anything else for that matter) no longer triggers the gun hostage/aiming system. Same goes for facing a different direction.
/:cl:
