### PR TITLE
Fixes #12613

### DIFF
--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -46,8 +46,6 @@
 		silent = 0
 	else
 		updatehealth()
-		handle_stunned()
-		handle_weakened()
 		if(health <= 0)
 			death()
 			blinded = 1
@@ -55,7 +53,6 @@
 			return 1
 
 		if(paralysis && paralysis > 0)
-			handle_paralysed()
 			blinded = 1
 			stat = UNCONSCIOUS
 			if(halloss > 0)

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -157,8 +157,6 @@
 					src << "\red All systems restored."
 					emp_damage -= 1
 
-		//Other
-		handle_statuses()
 	return 1
 
 /mob/living/carbon/brain/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -696,9 +696,6 @@
 			animate_tail_reset()
 			adjustHalLoss(-3)
 
-		if(paralysis)
-			AdjustParalysis(-1)
-
 		else if(sleeping)
 			speech_problem_flag = 1
 			handle_dreams()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -642,6 +642,7 @@
 
 	return //TODO: DEFERRED
 
+//DO NOT CALL handle_statuses() from this proc, it's called from living/Life() as long as this returns a true value.
 /mob/living/carbon/human/handle_regular_status_updates()
 	if(!handle_some_updates())
 		return 0
@@ -739,9 +740,6 @@
 			dizziness = max(0, dizziness - 3)
 			jitteriness = max(0, jitteriness - 3)
 			adjustHalLoss(-1)
-
-		//Other
-		handle_statuses()
 
 		if (drowsyness)
 			drowsyness--

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -112,14 +112,11 @@
 	else
 		if (src.paralysis || src.stunned || src.weakened || (status_flags && FAKEDEATH)) //Stunned etc.
 			if (src.stunned > 0)
-				AdjustStunned(-1)
 				src.stat = 0
 			if (src.weakened > 0)
-				AdjustWeakened(-1)
 				src.lying = 0
 				src.stat = 0
 			if (src.paralysis > 0)
-				AdjustParalysis(-1)
 				src.blinded = 0
 				src.lying = 0
 				src.stat = 0

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -47,7 +47,7 @@
 	// human/handle_regular_status_updates() needs a cleanup, as blindness should be handled in handle_disabilities()
 	if(handle_regular_status_updates()) // Status & health update, are we dead or alive etc.
 		handle_disabilities() // eye, ear, brain damages
-		handle_status_effects() //all special effects, stunned, weakened, jitteryness, hallucination, sleeping, etc
+		handle_statuses() //all special effects, stunned, weakened, jitteryness, hallucination, sleeping, etc
 
 	handle_actions()
 
@@ -93,19 +93,55 @@
 			stat = CONSCIOUS
 		return 1
 
-//this updates all special effects: stunned, sleeping, weakened, druggy, stuttering, etc..
-/mob/living/proc/handle_status_effects()
-	if(paralysis)
-		paralysis = max(paralysis-1,0)
+/mob/living/proc/handle_statuses()
+	handle_stunned()
+	handle_weakened()
+	handle_paralysed()
+	handle_stuttering()
+	handle_silent()
+	handle_drugged()
+	handle_slurring()
+
+/mob/living/proc/handle_stunned()
 	if(stunned)
-		stunned = max(stunned-1,0)
+		AdjustStunned(-1)
 		if(!stunned)
 			update_icons()
+	return stunned
 
+/mob/living/proc/handle_weakened()
 	if(weakened)
 		weakened = max(weakened-1,0)
 		if(!weakened)
 			update_icons()
+	return weakened
+
+/mob/living/proc/handle_stuttering()
+	if(stuttering)
+		stuttering = max(stuttering-1, 0)
+	return stuttering
+
+/mob/living/proc/handle_silent()
+	if(silent)
+		silent = max(silent-1, 0)
+	return silent
+
+/mob/living/proc/handle_drugged()
+	if(druggy)
+		druggy = max(druggy-1, 0)
+	return druggy
+
+/mob/living/proc/handle_slurring()
+	if(slurring)
+		slurring = max(slurring-1, 0)
+	return slurring
+
+/mob/living/proc/handle_paralysed()
+	if(paralysis)
+		AdjustParalysis(-1)
+		if(!paralysis)
+			update_icons()
+	return paralysis
 
 /mob/living/proc/handle_disabilities()
 	//Eyes

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -996,49 +996,6 @@ mob/proc/yank_out_object()
 			anchored = 0
 	return 1
 
-/mob/living/proc/handle_statuses()
-	handle_stunned()
-	handle_weakened()
-	handle_stuttering()
-	handle_silent()
-	handle_drugged()
-	handle_slurring()
-
-/mob/living/proc/handle_stunned()
-	if(stunned)
-		AdjustStunned(-1)
-	return stunned
-
-/mob/living/proc/handle_weakened()
-	if(weakened)
-		weakened = max(weakened-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-	return weakened
-
-/mob/living/proc/handle_stuttering()
-	if(stuttering)
-		stuttering = max(stuttering-1, 0)
-	return stuttering
-
-/mob/living/proc/handle_silent()
-	if(silent)
-		silent = max(silent-1, 0)
-	return silent
-
-/mob/living/proc/handle_drugged()
-	if(druggy)
-		druggy = max(druggy-1, 0)
-	return druggy
-
-/mob/living/proc/handle_slurring()
-	if(slurring)
-		slurring = max(slurring-1, 0)
-	return slurring
-
-/mob/living/proc/handle_paralysed() // Currently only used by simple_animal.dm, treated as a special case in other mobs
-	if(paralysis)
-		AdjustParalysis(-1)
-	return paralysis
-
 //Check for brain worms in head.
 /mob/proc/has_brain_worms()
 


### PR DESCRIPTION
`handle_statuses()` is now called from `living/Life()` instead of from `handle_regular_status_updates()`, replacing the call from handle_status_effects().

Also moves the various handle_*() procs to living/life.dm.

Tested with humans, didn't test other mobs.

I plan to move the code which handles the _effects_ of each of these statuses out of `handle_regular_status_updates()` in the future as well.
