### PR TITLE
Tweaks door crushing

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -4,7 +4,7 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
                        // It's a conversion constant. power_used*CELLRATE = charge_provided, or charge_used/CELLRATE = power_provided
 
 // Doors!
-#define DOOR_CRUSH_DAMAGE 20
+#define DOOR_CRUSH_DAMAGE 80
 #define ALIEN_SELECT_AFK_BUFFER  1    // How many minutes that a person can be AFK before not being allowed to be an alien.
 
 // Channel numbers for power.

--- a/html/changelogs/atlantiscze-doorcrushing.yml
+++ b/html/changelogs/atlantiscze-doorcrushing.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: atlantiscze
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: Being crushed by door will now push you out of the door, preventing door crush spam. To compensate, damage caused by door crushing has been increased.


### PR DESCRIPTION
- Airlocks that crush you will now also push you from the airlock in random direction. This prevents crush-stunlocking. This idea has been borrowed from PR that's open at Polaris.
- To compensate, damage from crushing airlock has been doubled. It's capable of breaking a bone now, but shouldn't outright kill you unless you enter the airlock repeatedly. The airlock also uses extra power when crushing something.

:cl:
tweak: Being crushed by door will now push you out of the door, preventing door crush spam. To compensate, damage caused by door crushing has been increased.
/:cl:
