### PR TITLE
Refactoring of power_changed()

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -198,13 +198,6 @@
 	if(..(user, 1))
 		user << "A small gauge in the corner reads [round(last_flow_rate, 0.1)] L/s; [round(last_power_draw)] W"
 
-
-/obj/machinery/atmospherics/unary/vent_pump/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/binary/dp_vent_pump/receive_signal(datum/signal/signal)
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return 0

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -209,12 +209,6 @@ Thus, the two variables affect pump operation are set in New():
 
 	src.update_icon()
 
-/obj/machinery/atmospherics/binary/pump/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/binary/pump/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -72,12 +72,6 @@
 		return 0
 	return 1
 
-/obj/machinery/atmospherics/omni/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/omni/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(!istype(W, /obj/item/weapon/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -87,12 +87,6 @@
 /obj/machinery/atmospherics/trinary/filter/hide(var/i)
 	update_underlays()
 
-/obj/machinery/atmospherics/trinary/filter/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/trinary/filter/process()
 	..()
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -57,12 +57,6 @@
 /obj/machinery/atmospherics/trinary/mixer/hide(var/i)
 	update_underlays()
 
-/obj/machinery/atmospherics/trinary/mixer/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/trinary/mixer/New()
 	..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_MIXER

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -290,12 +290,6 @@
 	icon_state = "map_tvalve1"
 	state = 1
 
-/obj/machinery/atmospherics/tvalve/digital/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/tvalve/digital/update_icon()
 	..()
 	if(!powered())
@@ -429,12 +423,6 @@
 /obj/machinery/atmospherics/tvalve/mirrored/digital/bypass
 	icon_state = "map_tvalvem1"
 	state = 1
-
-/obj/machinery/atmospherics/tvalve/mirrored/digital/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
 
 /obj/machinery/atmospherics/tvalve/mirrored/digital/update_icon()
 	..()

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -42,12 +42,6 @@
 			return
 		add_underlay(T, node, dir)
 
-/obj/machinery/atmospherics/unary/outlet_injector/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/unary/outlet_injector/process()
 	..()
 

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -380,12 +380,6 @@
 	if(welded)
 		user << "It seems welded shut."
 
-/obj/machinery/atmospherics/unary/vent_pump/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/unary/vent_pump/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -246,12 +246,6 @@
 	update_icon()
 	return
 
-/obj/machinery/atmospherics/unary/vent_scrubber/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/unary/vent_scrubber/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -249,12 +249,6 @@
 	open = 1
 	icon_state = "map_valve1"
 
-/obj/machinery/atmospherics/valve/digital/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/valve/digital/update_icon()
 	..()
 	if(!powered())

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -144,16 +144,14 @@
 		else
 	return
 
-/obj/machinery/body_scanconsole/power_change()
-	..()
+/obj/machinery/body_scanconsole/update_icon()
 	if(stat & BROKEN)
 		icon_state = "body_scannerconsole-p"
+	else if (stat & NOPOWER)
+		spawn(rand(0, 15))
+			src.icon_state = "body_scannerconsole-p"
 	else
-		if (stat & NOPOWER)
-			spawn(rand(0, 15))
-				src.icon_state = "body_scannerconsole-p"
-		else
-			icon_state = initial(icon_state)
+		icon_state = initial(icon_state)
 
 /obj/machinery/body_scanconsole
 	var/obj/machinery/bodyscanner/connected

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -20,10 +20,6 @@
 	..()
 	update_icon()
 
-/obj/machinery/ai_slipper/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/ai_slipper/update_icon()
 	if (stat & NOPOWER || stat & BROKEN)
 		icon_state = "motion0"

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -832,11 +832,6 @@
 
 	return ..()
 
-/obj/machinery/alarm/power_change()
-	..()
-	spawn(rand(0,15))
-		update_icon()
-
 /obj/machinery/alarm/examine(mob/user)
 	..(user)
 	if (buildstage < 2)
@@ -1006,11 +1001,6 @@ FIRE ALARM
 		alarm()
 
 	return
-
-/obj/machinery/firealarm/power_change()
-	..()
-	spawn(rand(0,15))
-		update_icon()
 
 /obj/machinery/firealarm/attack_hand(mob/user as mob)
 	if(user.stat || stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -78,15 +78,6 @@
 	if(icon_keyboard)
 		overlays += image(icon, icon_keyboard, overlay_layer)
 
-/obj/machinery/computer/power_change()
-	..()
-	update_icon()
-	if(stat & NOPOWER)
-		set_light(0)
-	else
-		set_light(light_range_on, light_power_on)
-
-
 /obj/machinery/computer/proc/set_broken()
 	stat |= BROKEN
 	update_icon()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -56,10 +56,6 @@
 /obj/machinery/button/remote/proc/trigger()
 	return
 
-/obj/machinery/button/remote/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/button/remote/update_icon()
 	if(stat & NOPOWER)
 		icon_state = "doorctrl-p"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1085,12 +1085,10 @@ About the new airlock wires panel:
 	..()
 
 /obj/machinery/door/airlock/power_change() //putting this is obj/machinery/door itself makes non-airlock doors turn invisible for some reason
-	..()
+	. = ..()
 	if(stat & NOPOWER)
 		// If we lost power, disable electrification
-		// Keeping door lights on, runs on internal battery or something.
 		electrified_until = 0
-	update_icon()
 
 /obj/machinery/door/airlock/proc/prison_open()
 	if(arePowerSystemsOn())

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -82,13 +82,6 @@
 	return
 
 
-// has the door power situation changed, if so update icon.
-/obj/machinery/door_timer/power_change()
-	..()
-	update_icon()
-	return
-
-
 // open/closedoor checks if door_timer has power, if so it checks if the
 // linked door is open/closed (by density) then opens it/closes it.
 

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -39,13 +39,10 @@ var/list/doppler_arrays = list()
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='game say'><span class='name'>[src]</span> states coldly, \"[message]\"</span>",2)
 
-
-/obj/machinery/doppler_array/power_change()
-	..()
+/obj/machinery/doppler_array/update_icon()
 	if(stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"
+	else if( !(stat & NOPOWER) )
+		icon_state = initial(icon_state)
 	else
-		if( !(stat & NOPOWER) )
-			icon_state = initial(icon_state)
-		else
-			icon_state = "[initial(icon_state)]-off"
+		icon_state = "[initial(icon_state)]-off"

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -37,9 +37,8 @@
 	wifi_receiver = null
 	return ..()
 
-/obj/machinery/flasher/power_change()
-	..()
-	if ( !(stat & NOPOWER) )
+/obj/machinery/flasher/update_icon()
+	if ( !(stat & (BROKEN|NOPOWER)) )
 		icon_state = "[base_state]1"
 //		src.sd_SetLuminosity(2)
 	else

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -32,7 +32,7 @@
 	use_power = lit ? 2 : 1
 	update_icon()
 
-//TODO maybe ... soft lighting
+//maybe add soft lighting? Maybe, though not everything needs it
 /obj/machinery/holosign/update_icon()
 	if (!lit || (stat & (BROKEN|NOPOWER)))
 		icon_state = "sign_off"

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -7,7 +7,7 @@
 	layer = 4
 	use_power = 1
 	idle_power_usage = 2
-	active_power_usage = 4
+	active_power_usage = 70
 	anchored = 1
 	var/lit = 0
 	var/id = null
@@ -32,17 +32,12 @@
 	use_power = lit ? 2 : 1
 	update_icon()
 
+//TODO maybe ... soft lighting
 /obj/machinery/holosign/update_icon()
-	if (!lit)
+	if (!lit || (stat & (BROKEN|NOPOWER)))
 		icon_state = "sign_off"
 	else
 		icon_state = on_icon
-
-/obj/machinery/holosign/power_change()
-	if (stat & NOPOWER)
-		lit = 0
-		use_power = 0
-	update_icon()
 
 /obj/machinery/holosign/surgery
 	name = "surgery holosign"

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -48,10 +48,6 @@
 			location.hotspot_expose(1000,500,1)
 	return 1
 
-/obj/machinery/igniter/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/igniter/proc/ignite()
 	use_power(50)
 	on = !on
@@ -96,10 +92,6 @@
 	else
 		icon_state = "migniter-p"
 //		src.sd_SetLuminosity(0)
-
-/obj/machinery/sparker/power_change()
-	..()
-	update_icon()
 
 /obj/machinery/sparker/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/screwdriver))

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -44,14 +44,14 @@ datum/track/New(var/title_name, var/audio)
 	. = ..()
 
 /obj/machinery/media/jukebox/power_change()
-	if(!powered(power_channel) || !anchored)
+	. = ..()
+	if(!anchored)
 		stat |= NOPOWER
 	else
 		stat &= ~NOPOWER
 
 	if(stat & (NOPOWER|BROKEN) && playing)
 		StopPlaying()
-	update_icon()
 
 /obj/machinery/media/jukebox/update_icon()
 	overlays.Cut()

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -177,12 +177,6 @@
 	if(src.shoot_inventory && prob(2))
 		src.throw_item()
 
-/obj/machinery/smartfridge/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/smartfridge/update_icon()
 	if(stat & (BROKEN|NOPOWER))
 		icon_state = icon_off

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -212,14 +212,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 /obj/machinery/newscaster/power_change()
 	if(isbroken) //Broken shit can't be powered.
 		return
-	..()
+	. = ..()
 	if( !(stat & NOPOWER) )
 		src.ispowered = 1
-		src.update_icon()
 	else
-		spawn(rand(0, 15))
-			src.ispowered = 0
-			src.update_icon()
+		src.ispowered = 0
 
 
 /obj/machinery/newscaster/ex_act(severity)

--- a/code/game/machinery/records_scanner.dm
+++ b/code/game/machinery/records_scanner.dm
@@ -27,8 +27,7 @@ obj/machinery/scanner/New()
 		return
 	use_power(50)
 
-/obj/machinery/scanner/power_change()
-	..()
+/obj/machinery/scanner/update_icon()
 	if(stat & NOPOWER)
 		spawn(rand(0, 15))
 			icon_state = "scanner_off"

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -53,10 +53,6 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	light_range = 0
 	var/datum/announcement/announcement = new
 
-/obj/machinery/requests_console/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/requests_console/update_icon()
 	if(stat & NOPOWER)
 		if(icon_state != "req_comp_off")

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -43,7 +43,7 @@ var/list/ai_status_emotions = list(
 		if(istype(M, /obj/machinery/ai_status_display))
 			var/obj/machinery/ai_status_display/AISD = M
 			AISD.emotion = emote
-			AISD.update()
+			AISD.update_icon()
 		//if Friend Computer, change ALL displays
 		else if(istype(M, /obj/machinery/status_display))
 
@@ -76,30 +76,22 @@ var/list/ai_status_emotions = list(
 /obj/machinery/ai_status_display/process()
 	return
 
-/obj/machinery/ai_status_display/proc/update()
-	if(mode==0) //Blank
+/obj/machinery/ai_status_display/update_icon()
+	if(stat & (NOPOWER|BROKEN))
 		overlays.Cut()
 		return
 
-	if(mode==1)	// AI emoticon
-		var/datum/ai_emotion/ai_emotion = ai_status_emotions[emotion]
-		set_picture(ai_emotion.overlay)
-		return
-
-	if(mode==2)	// BSOD
-		set_picture("ai_bsod")
-		return
+	switch(mode)
+		if(0) //Blank
+			overlays.Cut()
+		if(1) // AI emoticon
+			var/datum/ai_emotion/ai_emotion = ai_status_emotions[emotion]
+			set_picture(ai_emotion.overlay)
+		if(2) // BSOD
+			set_picture("ai_bsod")
 
 /obj/machinery/ai_status_display/proc/set_picture(var/state)
 	picture_state = state
 	if(overlays.len)
 		overlays.Cut()
 	overlays += image('icons/obj/status_display.dmi', icon_state=picture_state)
-
-/obj/machinery/ai_status_display/power_change()
-	..()
-	if(stat & NOPOWER)
-		if(overlays.len)
-			overlays.Cut()
-	else
-		update()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -58,17 +58,18 @@
 
 
 /obj/machinery/suit_storage_unit/power_change()
-	..()
-	if( !(stat & NOPOWER) )
-		src.ispowered = 1
-		src.update_icon()
-	else
-		spawn(rand(0, 15))
-			src.ispowered = 0
-			src.islocked = 0
-			src.isopen = 1
-			src.dump_everything()
+	. = ..()
+	if(.)
+		if( !(stat & NOPOWER) )
+			src.ispowered = 1
 			src.update_icon()
+		else
+			spawn(rand(0, 15))
+				src.ispowered = 0
+				src.islocked = 0
+				src.isopen = 1
+				src.dump_everything()
+				src.update_icon()
 
 
 /obj/machinery/suit_storage_unit/ex_act(severity)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -377,8 +377,7 @@
 	src.add_fingerprint(usr)
 	return
 
-/obj/machinery/teleport/station/power_change()
-	..()
+/obj/machinery/teleport/station/update_icon()
 	if(stat & NOPOWER)
 		icon_state = "controller-p"
 

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -184,9 +184,9 @@
 	update_icon()
 
 /obj/machinery/turretid/power_change()
-	..()
-	updateTurrets()
-	update_icon()
+	. = ..()
+	if(.)
+		updateTurrets()
 
 /obj/machinery/turretid/update_icon()
 	..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -613,16 +613,14 @@
 		O.show_message("<span class='game say'><span class='name'>\The [src]</span> beeps, \"[message]\"</span>",2)
 	return
 
-/obj/machinery/vending/power_change()
-	..()
+/obj/machinery/vending/update_icon()
 	if(stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"
+	else if( !(stat & NOPOWER) )
+		icon_state = initial(icon_state)
 	else
-		if( !(stat & NOPOWER) )
-			icon_state = initial(icon_state)
-		else
-			spawn(rand(0, 15))
-				src.icon_state = "[initial(icon_state)]-off"
+		spawn(rand(0, 15))
+			src.icon_state = "[initial(icon_state)]-off"
 
 //Oh no we're malfunctioning!  Dump out some product and break.
 /obj/machinery/vending/proc/malfunction()

--- a/code/game/mecha/mech_sensor.dm
+++ b/code/game/mecha/mech_sensor.dm
@@ -57,12 +57,6 @@
 /obj/machinery/mech_sensor/proc/enabled()
 	return on && !(stat & NOPOWER)
 
-/obj/machinery/mech_sensor/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/mech_sensor/update_icon(var/safety = 0)
 	if (enabled())
 		icon_state = "airlock_sensor_standby"

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -152,7 +152,7 @@
 			target.brightness_range = L2.brightness_range
 			target.brightness_power = L2.brightness_power
 			target.brightness_color = L2.brightness_color
-			target.on = target.has_power()
+			target.on = target.powered()
 			target.update()
 			qdel(L2)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -554,7 +554,7 @@
 				return
 
 /obj/machinery/button/windowtint/power_change()
-	..()
+	. = ..()
 	if(active && !powered(power_channel))
 		toggle_tint()
 

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -167,9 +167,8 @@
 	..()
 
 /obj/machinery/computer/HolodeckControl/power_change()
-	var/oldstat
-	..()
-	if (stat != oldstat && active && (stat & NOPOWER))
+	. = ..()
+	if (. && active && (stat & NOPOWER))
 		emergencyShutdown()
 
 /obj/machinery/computer/HolodeckControl/process()

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -162,9 +162,7 @@
 /obj/machinery/modular_computer/power_change()
 	if(battery_powered)
 		return
-	else
-		..()
-		update_icon()
+	..()
 
 /obj/machinery/modular_computer/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(cpu)

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -120,8 +120,8 @@
 
 
 /obj/machinery/power/am_control_unit/power_change()
-	..()
-	if(stat & NOPOWER && active)
+	. = ..()
+	if((stat & NOPOWER) && active)
 		toggle_power()
 	return
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -210,11 +210,6 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/power/generator/power_change()
-	..()
-	updateicon()
-
-
 /obj/machinery/power/generator/verb/rotate_clock()
 	set category = "Object"
 	set name = "Rotate Generator (Clockwise)"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -198,7 +198,7 @@
 	..()
 
 	spawn(2)
-		on = has_power()
+		on = powered()
 
 		switch(fitting)
 			if("tube")
@@ -325,7 +325,7 @@
 				brightness_range = L.brightness_range
 				brightness_power = L.brightness_power
 				brightness_color = L.brightness_color
-				on = has_power()
+				on = powered()
 				update()
 
 				user.drop_item()	//drop the item to update overlays and such
@@ -387,7 +387,7 @@
 			return
 
 		user << "You stick \the [W] into the light socket!"
-		if(has_power() && (W.flags & CONDUCT))
+		if(powered() && (W.flags & CONDUCT))
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(3, 1, src)
 			s.start()
@@ -398,7 +398,7 @@
 
 // returns whether this light has power
 // true if area has power and lightswitch is on
-/obj/machinery/light/proc/has_power()
+/obj/machinery/light/powered()
 	var/area/A = get_area(src)
 	return A && A.lightswitch && (!A.requires_power || A.power_light)
 
@@ -568,7 +568,7 @@
 // called when area power state changes
 /obj/machinery/light/power_change()
 	spawn(10)
-		seton(has_power())
+		seton(powered())
 
 // called when on fire
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -60,9 +60,9 @@
 /obj/machinery/power/proc/disconnect_terminal() // machines without a terminal will just return, no harm no fowl.
 	return
 
-// returns true if the area has power on given channel (or doesn't require power).
-// defaults to power_channel
-/obj/machinery/proc/powered(var/chan = -1) // defaults to power_channel
+// returns true if the area has power on given channel (or doesn't require power), defaults to power_channel. 
+// May also optionally specify an area, otherwise defaults to src.loc.loc
+/obj/machinery/proc/powered(var/chan = -1, var/area/check_area = null)
 
 	if(!src.loc)
 		return 0
@@ -72,12 +72,13 @@
 	//if(!use_power)
 	//	return 1
 
-	var/area/A = src.loc.loc		// make sure it's in an area
-	if(!A || !isarea(A))
+	if(!check_area)
+		check_area = src.loc.loc		// make sure it's in an area
+	if(!check_area || !isarea(check_area))
 		return 0					// if not, then not powered
 	if(chan == -1)
 		chan = power_channel
-	return A.powered(chan)			// return power status of the area
+	return check_area.powered(chan)			// return power status of the area
 
 // increment the power usage stats for an area
 /obj/machinery/proc/use_power(var/amount, var/chan = -1) // defaults to power_channel
@@ -88,15 +89,19 @@
 		chan = power_channel
 	A.use_power(amount, chan)
 
-/obj/machinery/proc/power_change()		// called whenever the power settings of the containing area change
-										// by default, check equipment channel & set flag
-										// can override if needed
+// called whenever the power settings of the containing area change
+// by default, check equipment channel & set flag can override if needed
+/obj/machinery/proc/power_change()
+	var/oldstat = stat
+
 	if(powered(power_channel))
 		stat &= ~NOPOWER
 	else
-
 		stat |= NOPOWER
-	return
+
+	. = (stat != oldstat)
+	if(.)
+		update_icon()
 
 // connect the machine to a powernet if a node cable is present on the turf
 /obj/machinery/power/proc/connect_to_network()

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -138,7 +138,7 @@
 		strength_change()
 
 /obj/machinery/particle_accelerator/control_box/power_change()
-	..()
+	. = ..()
 	if(stat & NOPOWER)
 		active = 0
 		update_use_power(0)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -502,11 +502,6 @@ var/list/solars_list = list()
 	update_icon()
 
 
-/obj/machinery/power/solar_control/power_change()
-	..()
-	update_icon()
-
-
 /obj/machinery/power/solar_control/proc/broken()
 	stat |= BROKEN
 	update_icon()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -45,9 +45,9 @@
 	else if(operating == -1)
 		movedir = backwards
 	else operating = 0
-	update()
+	update_icon()
 
-/obj/machinery/conveyor/proc/update()
+/obj/machinery/conveyor/update_icon()
 	if(stat & BROKEN)
 		icon_state = "conveyor-broken"
 		operating = 0
@@ -117,7 +117,7 @@
 // also propagate inoperability to any connected conveyor with the same ID
 /obj/machinery/conveyor/proc/broken()
 	stat |= BROKEN
-	update()
+	update_icon()
 
 	var/obj/machinery/conveyor/C = locate() in get_step(src, dir)
 	if(C)
@@ -136,7 +136,7 @@
 		return
 	operable = op
 
-	update()
+	update_icon()
 	var/obj/machinery/conveyor/C = locate() in get_step(src, stepdir)
 	if(C)
 		C.set_operable(stepdir, id, op)
@@ -146,10 +146,6 @@
 	set src in view()
 	src.broken()
 */
-
-/obj/machinery/conveyor/power_change()
-	..()
-	update()
 
 // the conveyor control switch
 //
@@ -176,7 +172,7 @@
 	..(loc)
 	if(!id)
 		id = newid
-	update()
+	update_icon()
 
 	spawn(5)		// allow map load
 		conveyors = list()
@@ -186,7 +182,7 @@
 
 // update the icon depending on the position
 
-/obj/machinery/conveyor_switch/proc/update()
+/obj/machinery/conveyor_switch/update_icon()
 	if(position<0)
 		icon_state = "switch-rev"
 	else if(position>0)
@@ -225,13 +221,13 @@
 		position = 0
 
 	operated = 1
-	update()
+	update_icon()
 
 	// find any switches with same id as this one, and set their positions to match us
 	for(var/obj/machinery/conveyor_switch/S in world)
 		if(S.id == src.id)
 			S.position = position
-			S.update()
+			S.update_icon()
 
 
 /obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
@@ -254,13 +250,13 @@
 		position = 0
 
 	operated = 1
-	update()
+	update_icon()
 
 	// find any switches with same id as this one, and set their positions to match us
 	for(var/obj/machinery/conveyor_switch/S in world)
 		if(S.id == src.id)
 			S.position = position
-			S.update()
+			S.update_icon()
 
 
 

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -40,8 +40,8 @@
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
 
-/obj/machinery/keycard_auth/power_change()
-	..()
+//icon_state gets set everwhere besides here, that needs to be fixed sometime
+/obj/machinery/keycard_auth/update_icon()
 	if(stat &NOPOWER)
 		icon_state = "auth_off"
 

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -173,13 +173,12 @@
 		qdel(shield_tile)
 
 /obj/machinery/shieldgen/power_change()
-	..()
-	if(!active) return
+	. = ..()
+	if(!. || !active) return
 	if (stat & NOPOWER)
 		collapse_shields()
 	else
 		create_shields()
-	update_icon()
 
 /obj/machinery/shieldgen/process()
 	if (!active || (stat & NOPOWER))

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -136,11 +136,9 @@
 
 	updateDialog()
 
-/obj/machinery/shield_capacitor/power_change()
+/obj/machinery/shield_capacitor/update_icon()
 	if(stat & BROKEN)
 		icon_state = "broke"
-	else
-		..()
 
 /obj/machinery/shield_capacitor/verb/rotate()
 	set name = "Rotate capacitor clockwise"


### PR DESCRIPTION
Many, many machines want to update icons when power changes anyways, now it's done from the base power_changed(). Adds missing update_icons() in various places, where old code used to do it from power_changed()

Lights no longer have a separate proc with the exact same meaning as powered(). Cleaned up lightswitch.dm a bit. Light fixtures no longer have a separate snowflake proc with the exact same meaning as powered()
