### PR TITLE
Extensions update

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -180,6 +180,7 @@
 #include "code\datums\extensions\extensions.dm"
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\cardborg.dm"
+#include "code\datums\extensions\interactive.dm"
 #include "code\datums\extensions\multitool\_multitool.dm"
 #include "code\datums\extensions\multitool\multitool.dm"
 #include "code\datums\extensions\multitool\store.dm"

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -58,7 +58,7 @@
 
 	if(multitool_mode && isobj(A))
 		var/obj/O = A
-		var/datum/extension/multitool/MT = get_extension(O, /datum/extension/multitool)
+		var/datum/extension/interactive/multitool/MT = get_extension(O, /datum/extension/interactive/multitool)
 		if(MT)
 			MT.interact(aiMulti, src)
 			return

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -1,44 +1,17 @@
 /datum/extension
 	var/datum/holder = null // The holder
-	var/list/host_predicates
-	var/list/user_predicates
 	var/expected_type = /datum
 	var/flags = EXTENSION_FLAG_NONE
 
-/datum/extension/New(var/datum/holder, var/host_predicates = list(), var/user_predicates = list(), var/additional_arguments = list())
+/datum/extension/New(var/datum/holder)
 	if(!istype(holder, expected_type))
 		CRASH("Invalid holder type. Expected [expected_type], was [holder.type]")
 	src.holder = holder
 	..()
 
-	src.host_predicates = host_predicates ? host_predicates : list()
-	src.user_predicates = user_predicates ? user_predicates : list()
-
 /datum/extension/Destroy()
 	holder = null
-	host_predicates.Cut()
-	user_predicates.Cut()
 	return ..()
-
-/datum/extension/proc/extension_status(var/mob/user)
-	if(!holder || !user)
-		return STATUS_CLOSE
-	if(!all_predicates_true(list(holder), host_predicates))
-		return STATUS_CLOSE
-	if(!all_predicates_true(list(user), user_predicates))
-		return STATUS_CLOSE
-	if(holder.CanUseTopic(usr, default_state) != STATUS_INTERACTIVE)
-		return STATUS_CLOSE
-
-	return STATUS_INTERACTIVE
-
-/datum/extension/proc/extension_act(var/href, var/list/href_list, var/mob/user)
-	return extension_status(user) == STATUS_CLOSE
-
-/datum/extension/Topic(var/href, var/list/href_list)
-	if(..())
-		return TRUE
-	return extension_act(href, href_list, usr)
 
 /datum
 	var/list/datum/extension/extensions
@@ -59,25 +32,34 @@
 	..(exclude)
 	//extensions = list()
 
-/proc/set_extension(var/datum/source, var/datum/extension/base_type, var/expansion_type, var/host_predicates, var/user_predicates, var/list/additional_argments)
+//Variadic - Additional positional arguments can be given. Named arguments might not work so well
+/proc/set_extension(var/datum/source, var/datum/extension/base_type, var/expansion_type)
 	if(!source.extensions)
 		source.extensions = list()
 	var/datum/extension/existing_extension = source.extensions[base_type]
 	if(istype(existing_extension))
 		qdel(existing_extension)
+
 	if(initial(base_type.flags) & EXTENSION_FLAG_IMMEDIATE)
-		source.extensions[base_type] = new expansion_type(source, host_predicates, user_predicates, additional_argments)
+		. = construct_extension_instance(expansion_type, source, args.Copy(4))
+		source.extensions[base_type] = .
 	else
-		source.extensions[base_type] = list(expansion_type, host_predicates, user_predicates, additional_argments)
+		var/list/extension_data = list(expansion_type, source)
+		if(args.len > 3)
+			extension_data += args.Copy(4)
+		source.extensions[base_type] = extension_data
 
 /proc/get_extension(var/datum/source, var/base_type)
 	if(!source.extensions)
 		return
-	var/list/expansion = source.extensions[base_type]
-	if(!expansion)
+	. = source.extensions[base_type]
+	if(!.)
 		return
-	if(istype(expansion))
-		var/expansion_type = expansion[1]
-		expansion = new expansion_type(source, expansion[2], expansion[3], expansion[4])
-		source.extensions[base_type] = expansion
-	return expansion
+	if(islist(.)) //a list, so it's expecting to be lazy-loaded
+		var/list/extension_data = .
+		. = construct_extension_instance(extension_data[1], extension_data[2], extension_data.Copy(3))
+		source.extensions[base_type] = .
+
+/proc/construct_extension_instance(var/extension_type, var/datum/source, var/list/arguments)
+	arguments = list(source) + arguments
+	return new extension_type(arglist(arguments))

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -60,6 +60,11 @@
 		. = construct_extension_instance(extension_data[1], extension_data[2], extension_data.Copy(3))
 		source.extensions[base_type] = .
 
+//Fast way to check if it has an extension, also doesn't trigger instantiation of lazy loaded extensions
+/proc/has_extension(var/datum/source, var/base_type)
+	return (source.extensions && source.extensions[base_type])
+
 /proc/construct_extension_instance(var/extension_type, var/datum/source, var/list/arguments)
 	arguments = list(source) + arguments
 	return new extension_type(arglist(arguments))
+

--- a/code/datums/extensions/interactive.dm
+++ b/code/datums/extensions/interactive.dm
@@ -1,0 +1,35 @@
+//Extensions that can be interacted with via Topic
+/datum/extension/interactive
+	var/list/host_predicates
+	var/list/user_predicates
+
+/datum/extension/interactive/New(var/datum/holder, var/host_predicates = list(), var/user_predicates = list())
+	..()
+
+	src.host_predicates = host_predicates ? host_predicates : list()
+	src.user_predicates = user_predicates ? user_predicates : list()
+
+/datum/extension/interactive/Destroy()
+	host_predicates.Cut()
+	user_predicates.Cut()
+	return ..()
+
+/datum/extension/interactive/proc/extension_status(var/mob/user)
+	if(!holder || !user)
+		return STATUS_CLOSE
+	if(!all_predicates_true(list(holder), host_predicates))
+		return STATUS_CLOSE
+	if(!all_predicates_true(list(user), user_predicates))
+		return STATUS_CLOSE
+	if(holder.CanUseTopic(usr, default_state) != STATUS_INTERACTIVE)
+		return STATUS_CLOSE
+
+	return STATUS_INTERACTIVE
+
+/datum/extension/interactive/proc/extension_act(var/href, var/list/href_list, var/mob/user)
+	return extension_status(user) == STATUS_CLOSE
+
+/datum/extension/interactive/Topic(var/href, var/list/href_list)
+	if(..())
+		return TRUE
+	return extension_act(href, href_list, usr)

--- a/code/datums/extensions/interactive.dm
+++ b/code/datums/extensions/interactive.dm
@@ -21,7 +21,7 @@
 		return STATUS_CLOSE
 	if(!all_predicates_true(list(user), user_predicates))
 		return STATUS_CLOSE
-	if(holder.CanUseTopic(usr, default_state) != STATUS_INTERACTIVE)
+	if(holder.CanUseTopic(user, default_state) != STATUS_INTERACTIVE)
 		return STATUS_CLOSE
 
 	return STATUS_INTERACTIVE

--- a/code/datums/extensions/multitool/circuitboards/circuitboards.dm
+++ b/code/datums/extensions/multitool/circuitboards/circuitboards.dm
@@ -1,4 +1,4 @@
-/datum/extension/multitool/circuitboards/extension_status(var/mob/user)
+/datum/extension/interactive/multitool/circuitboards/extension_status(var/mob/user)
 	if(isAI(user)) // No remote AI access
 		return STATUS_CLOSE
 

--- a/code/datums/extensions/multitool/circuitboards/stationalert.dm
+++ b/code/datums/extensions/multitool/circuitboards/stationalert.dm
@@ -1,4 +1,4 @@
-/datum/extension/multitool/circuitboards/stationalert/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
+/datum/extension/interactive/multitool/circuitboards/stationalert/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
 	var/obj/item/weapon/circuitboard/stationalert/SA = holder
 	. += "<b>Alarm Sources</b><br>"
 	. += "<table>"
@@ -12,7 +12,7 @@
 		. += "</tr>"
 	. += "</table>"
 
-/datum/extension/multitool/circuitboards/stationalert/on_topic(href, href_list, user)
+/datum/extension/interactive/multitool/circuitboards/stationalert/on_topic(href, href_list, user)
 	var/obj/item/weapon/circuitboard/stationalert/SA = holder
 	if(href_list["add"])
 		var/datum/alarm_handler/AH = locate(href_list["add"]) in alarm_manager.all_handlers

--- a/code/datums/extensions/multitool/items/cable.dm
+++ b/code/datums/extensions/multitool/items/cable.dm
@@ -1,8 +1,8 @@
 /obj/item/stack/cable_coil/New()
-	set_extension(src, /datum/extension/multitool, /datum/extension/multitool/items/cable)
+	set_extension(src, /datum/extension/interactive/multitool, /datum/extension/interactive/multitool/items/cable)
 	..()
 
-/datum/extension/multitool/items/cable/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
+/datum/extension/interactive/multitool/items/cable/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
 	var/obj/item/stack/cable_coil/cable_coil = holder
 	. += "<b>Available Colors</b><br>"
 	. += "<table>"
@@ -16,7 +16,7 @@
 		. += "</tr>"
 	. += "</table>"
 
-/datum/extension/multitool/items/cable/on_topic(href, href_list, user)
+/datum/extension/interactive/multitool/items/cable/on_topic(href, href_list, user)
 	var/obj/item/stack/cable_coil/cable_coil = holder
 	if(href_list["select_color"] && href_list["select_color"] in possible_cable_coil_colours)
 		cable_coil.set_cable_color(href_list["select_color"], user)

--- a/code/datums/extensions/multitool/items/items.dm
+++ b/code/datums/extensions/multitool/items/items.dm
@@ -1,4 +1,4 @@
-/datum/extension/multitool/items/extension_status(var/mob/user)
+/datum/extension/interactive/multitool/items/extension_status(var/mob/user)
 	if(isAI(user)) // No remote AI access
 		return STATUS_CLOSE
 

--- a/code/datums/extensions/multitool/machinery/cloning.dm
+++ b/code/datums/extensions/multitool/machinery/cloning.dm
@@ -1,11 +1,11 @@
-/datum/extension/multitool/cryo/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
+/datum/extension/interactive/multitool/cryo/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
 	. += buffer(M)
 	. += "<HR><b>Connected Cloning Pods:</b><br>"
 	var/obj/machinery/computer/cloning/C = holder
 	for(var/atom/cloning_pod in C.pods)
 		. += "[cloning_pod.name]<br>"
 
-/datum/extension/multitool/cryo/receive_buffer(var/obj/item/device/multitool/M, var/atom/buffer, var/mob/user)
+/datum/extension/interactive/multitool/cryo/receive_buffer(var/obj/item/device/multitool/M, var/atom/buffer, var/mob/user)
 	var/obj/machinery/clonepod/P = buffer
 	var/obj/machinery/computer/cloning/C = holder
 

--- a/code/datums/extensions/multitool/multitool.dm
+++ b/code/datums/extensions/multitool/multitool.dm
@@ -1,8 +1,8 @@
-/datum/extension/multitool
+/datum/extension/interactive/multitool
 	var/window_x = 370
 	var/window_y = 470
 
-/datum/extension/multitool/proc/interact(var/obj/item/device/multitool/M, var/mob/user)
+/datum/extension/interactive/multitool/proc/interact(var/obj/item/device/multitool/M, var/mob/user)
 	if(extension_status(user) != STATUS_INTERACTIVE)
 		return
 
@@ -15,13 +15,13 @@
 	else
 		close_window(usr)
 
-/datum/extension/multitool/proc/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
+/datum/extension/interactive/multitool/proc/get_interact_window(var/obj/item/device/multitool/M, var/mob/user)
 	return
 
-/datum/extension/multitool/proc/close_window(var/mob/user)
+/datum/extension/interactive/multitool/proc/close_window(var/mob/user)
 	user << browse(null, "window=multitool")
 
-/datum/extension/multitool/proc/buffer(var/obj/item/device/multitool/multitool)
+/datum/extension/interactive/multitool/proc/buffer(var/obj/item/device/multitool/multitool)
 	. += "<b>Buffer Memory:</b><br>"
 	var/buffer_name = multitool.get_buffer_name()
 	if(buffer_name)
@@ -29,12 +29,12 @@
 	else
 		. += "No connection stored in the buffer."
 
-/datum/extension/multitool/extension_status(var/mob/user)
+/datum/extension/interactive/multitool/extension_status(var/mob/user)
 	if(!user.get_multitool())
 		return STATUS_CLOSE
 	. = ..()
 
-/datum/extension/multitool/extension_act(href, href_list, var/mob/user)
+/datum/extension/interactive/multitool/extension_act(href, href_list, var/mob/user)
 	if(..())
 		close_window(usr)
 		return TRUE
@@ -56,15 +56,15 @@
 			close_window(user)
 	return MT_NOACTION ? FALSE : TRUE
 
-/datum/extension/multitool/proc/on_topic(href, href_list, user)
+/datum/extension/interactive/multitool/proc/on_topic(href, href_list, user)
 	return MT_NOACTION
 
-/datum/extension/multitool/proc/send_buffer(var/obj/item/device/multitool/M, var/atom/buffer, var/mob/user)
+/datum/extension/interactive/multitool/proc/send_buffer(var/obj/item/device/multitool/M, var/atom/buffer, var/mob/user)
 	if(M.get_buffer() == buffer && buffer)
 		receive_buffer(M, buffer, user)
 	else if(!buffer)
 		user << "<span class='warning'>Unable to acquire data from the buffered object. Purging from memory.</span>"
 	return MT_REFRESH
 
-/datum/extension/multitool/proc/receive_buffer(var/obj/item/device/multitool/M, var/atom/buffer, var/mob/user)
+/datum/extension/interactive/multitool/proc/receive_buffer(var/obj/item/device/multitool/M, var/atom/buffer, var/mob/user)
 	return

--- a/code/datums/extensions/multitool/store.dm
+++ b/code/datums/extensions/multitool/store.dm
@@ -1,4 +1,4 @@
-/datum/extension/multitool/store/interact(var/obj/item/device/multitool/M, var/mob/user)
+/datum/extension/interactive/multitool/store/interact(var/obj/item/device/multitool/M, var/mob/user)
 	if(CanUseTopic(user) != STATUS_INTERACTIVE)
 		return
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -45,7 +45,7 @@
 	var/biomass = CLONE_BIOMASS * 3
 
 /obj/machinery/clonepod/New()
-	set_extension(src, /datum/extension/multitool, /datum/extension/multitool/store)
+	set_extension(src, /datum/extension/interactive/multitool, /datum/extension/interactive/multitool/store)
 	..()
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/clonepod(src)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -18,7 +18,7 @@
 
 /obj/machinery/computer/cloning/initialize()
 	..()
-	set_extension(src, /datum/extension/multitool, /datum/extension/multitool/cryo, list(/proc/is_operable))
+	set_extension(src, /datum/extension/interactive/multitool, /datum/extension/interactive/multitool/cryo, list(/proc/is_operable))
 	updatemodules()
 
 /obj/machinery/computer/cloning/Destroy()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -62,7 +62,7 @@
 		return ..(A, user)
 
 	var/obj/O = A
-	var/datum/extension/multitool/MT = get_extension(O, /datum/extension/multitool)
+	var/datum/extension/interactive/multitool/MT = get_extension(O, /datum/extension/interactive/multitool)
 	if(!MT)
 		return ..(A, user)
 

--- a/code/game/objects/items/weapons/circuitboards/computer/station_alert.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/station_alert.dm
@@ -5,7 +5,7 @@
 
 /obj/item/weapon/circuitboard/stationalert/New()
 	alarm_handlers = new()
-	set_extension(src, /datum/extension/multitool, /datum/extension/multitool/circuitboards/stationalert)
+	set_extension(src, /datum/extension/interactive/multitool, /datum/extension/interactive/multitool/circuitboards/stationalert)
 	..()
 
 /obj/item/weapon/circuitboard/stationalert/construct(var/obj/machinery/computer/station_alert/SA)

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -160,19 +160,30 @@
 
 /spell/moghes_blessing/choose_targets(mob/user = usr)
 	var/list/hands = list()
-	if(user.l_hand && !findtext(user.l_hand.name,"Moghes Blessing"))
-		hands += user.l_hand
-	if(user.r_hand && !findtext(user.r_hand.name,"Moghes Blessing"))
-		hands += user.r_hand
+	for(var/obj/item/I in list(user.l_hand, user.r_hand))
+		//make sure it's not already blessed
+		if(istype(I) && !has_extension(I, /datum/extension/moghes_blessing))
+			hands += I
 	return hands
 
 /spell/moghes_blessing/cast(var/list/targets, mob/user)
 	for(var/obj/item/I in targets)
-		I.name = "[I.name] (Moghes Blessing)"
-		I.force += 10
-		I.throwforce += 7
-		I.color = "#663300"
+		set_extension(I, /datum/extension/moghes_blessing, /datum/extension/moghes_blessing)
 
+/datum/extension/moghes_blessing
+	expected_type = /obj/item
+	flags = EXTENSION_FLAG_IMMEDIATE
+
+/datum/extension/moghes_blessing/New(var/datum/holder)
+	..(holder)
+	apply_blessing(holder)
+
+/datum/extension/moghes_blessing/proc/apply_blessing(obj/item/I)
+	I.name += " of Moghes"
+	I.desc += "<BR>It has been imbued with the memories of Moghes."
+	I.force += 10
+	I.throwforce += 14
+	I.color = "#663300"
 
 //DIONA
 /spell/aoe_turf/conjure/grove/gestalt

--- a/code/unit_tests/expansions_tests.dm
+++ b/code/unit_tests/expansions_tests.dm
@@ -20,9 +20,9 @@
 		log_unit_test("[exp]/([exp.type]) was not strictly of the type /datum/extension.")
 		number_of_failures++
 
-	var/datum/extension/multitool/multi = get_extension(expansion_obj, /datum/extension/multitool)
-	if(multi.type != /datum/extension/multitool/cryo)
-		log_unit_test("[exp]/([exp.type]) was not strictly of the type /datum/extension/multitool/cryo.")
+	var/datum/extension/interactive/multitool/multi = get_extension(expansion_obj, /datum/extension/interactive/multitool)
+	if(multi.type != /datum/extension/interactive/multitool/cryo)
+		log_unit_test("[exp]/([exp.type]) was not strictly of the type /datum/extension/interactive/multitool/cryo.")
 		number_of_failures++
 	else
 		if(multi.host_predicates.len != 2)
@@ -45,5 +45,5 @@
 
 /obj/test/extensions/New()
 	set_extension(src, /datum/extension, /datum/extension)
-	set_extension(src, /datum/extension/multitool, /datum/extension/multitool/cryo, list(/proc/is_operable, /proc/is_operable))
+	set_extension(src, /datum/extension/interactive/multitool, /datum/extension/interactive/multitool/cryo, list(/proc/is_operable, /proc/is_operable))
 	..()


### PR DESCRIPTION
Aims to simplify extension use a little bit.
- Moves Topic-specific stuff into the extension/interactive subtype
- No more need to pack or unpack argument lists because of lazy-loading, interactive extension can just define more constructor parameters instead of messing with an additional_arguments list.
- Adds the option to set an extension using an instance, in case you want it instantiated right away.
- Removes Moghes' blessing hack (didn't test this part though)
