### PR TITLE
Generalizes Eye vision refresh on mob login, and other tweaks.

### DIFF
--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -19,4 +19,4 @@
 		for(var/obj/machinery/ai_status_display/O in machines) //change status
 			O.mode = 1
 			O.emotion = "Neutral"
-	src.view_core()
+

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -45,5 +45,8 @@
 		client.eye = src
 		client.perspective = MOB_PERSPECTIVE
 
+	if(eyeobj)
+		eyeobj.possess(src)
+
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")


### PR DESCRIPTION
Fixes issues like the camera MIU, /obj/item/clothing/mask/ai, not updating as expected on relog.
Adds an obfuscation underlay to complicate in-memory hacks to remove camera static.
Adding an eye to a visualnet no longer causes a force update (they can wait for as long as other eyes have to for a refresh).
