### PR TITLE
Fixes

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -55,6 +55,7 @@
 	if(!..())
 		return 0
 
+	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	A.attack_generic(src,rand(5,6),"bitten")
 
 /*
@@ -75,6 +76,9 @@
 		if (Victim == A)
 			Feedstop()
 		return
+
+	//should have already been set if we are attacking a mob, but it doesn't hurt and will cover attacking non-mobs too
+	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 	var/mob/living/M = A
 	if (istype(M))
@@ -144,6 +148,7 @@
 		custom_emote(1,"[friendly] [A]!")
 		return
 
+	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/damage = rand(melee_damage_lower, melee_damage_upper)
 	if(A.attack_generic(src,damage,attacktext,environment_smash) && loc && attack_sound)
 		playsound(loc, attack_sound, 50, 1, 1)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -21,6 +21,8 @@
 	return
 
 /obj/effect/spider/attackby(var/obj/item/weapon/W, var/mob/user)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+
 	if(W.attack_verb.len)
 		visible_message("<span class='warning'>\The [src] have been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]</span>")
 	else

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -344,7 +344,7 @@
 				if(E.damage > 10)
 					E.damage += rand(4,10)
 			if(FLASH_PROTECTION_REDUCED)
-				H << "<span class='danger'>Your equipment intensify the welder's glow. Your eyes itch and burn severely.</span>"
+				H << "<span class='danger'>Your equipment intensifies the welder's glow. Your eyes itch and burn severely.</span>"
 				H.eye_blurry += rand(12,20)
 				E.damage += rand(12, 16)
 		if(safety<FLASH_PROTECTION_MAJOR)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -200,11 +200,11 @@
 	desc = "This sheet is special platinum-glass alloy designed to withstand large temperatures"
 	singular_name = "borosilicate glass sheet"
 	icon_state = "sheet-phoronglass"
-	default_type = "borosilicate glass"
+	default_type = "phglass"
 
 /obj/item/stack/material/glass/phoronrglass
 	name = "reinforced borosilicate glass"
 	desc = "This sheet is special platinum-glass alloy designed to withstand large temperatures. It is reinforced with few rods."
 	singular_name = "reinforced borosilicate glass sheet"
 	icon_state = "sheet-phoronrglass"
-	default_type = "reinforced borosilicate glass"
+	default_type = "rphglass"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -480,7 +480,7 @@ var/list/name_to_material
 	rod_product = null
 
 /material/glass/phoron
-	name = "borosilicate glass"
+	name = "phglass"
 	display_name = "borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronglass
 	flags = MATERIAL_BRITTLE
@@ -492,7 +492,7 @@ var/list/name_to_material
 	rod_product = /obj/item/stack/material/glass/phoronrglass
 
 /material/glass/phoron/reinforced
-	name = "reinforced borosilicate glass"
+	name = "rphglass"
 	display_name = "reinforced borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronrglass
 	stack_origin_tech = list(TECH_MATERIAL = 5)

--- a/code/modules/mining/alloys.dm
+++ b/code/modules/mining/alloys.dm
@@ -27,7 +27,7 @@
 	product = /obj/item/stack/material/steel
 
 /datum/alloy/borosilicate
-	metaltag = "borosilicate glass"
+	metaltag = "phglass"
 	requires = list(
 		"platinum" = 1,
 		"sand" = 2

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -321,6 +321,8 @@
 			else
 				if(!Atkcool)
 					a_intent = I_GRAB
+					if(invalidFeedTarget(Target))
+						a_intent = I_HURT //just glomp them instead
 					UnarmedAttack(Target)
 
 		else if(Target in view(7, src))

--- a/code/modules/mob/living/carbon/metroid/powers.dm
+++ b/code/modules/mob/living/carbon/metroid/powers.dm
@@ -16,11 +16,18 @@
 
 /mob/living/carbon/slime/proc/invalidFeedTarget(var/mob/living/M)
 	if (!M || !istype(M))
-		return "This subject is incomparable..."
+		return "This subject is incompatible..."
 	if (istype(M, /mob/living/carbon/slime)) // No cannibalism... yet
 		return "I cannot feed on other slimes..."
 	if (!Adjacent(M))
 		return "This subject is too far away..."
+	if (issilicon(M))
+		return "This subject does not have an edible life energy..."
+	if (ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species.flags & (NO_POISON|NO_SCAN))
+			//they can't take clone or tox damage, then for the most part they aren't affected by being fed on - and presumably feeding on them would not affect the slime either
+			return "This subject does not have an edible life energy..."
 	if (istype(M, /mob/living/carbon) && M.getCloneLoss() >= M.maxHealth * 1.5 || istype(M, /mob/living/simple_animal) && M.stat == DEAD)
 		return "This subject does not have an edible life energy..."
 	for(var/mob/living/carbon/slime/met in view())

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -85,11 +85,11 @@
 
 //this is largely hacky and bad :(	-Pete
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel/attackby(var/obj/item/A as obj, mob/user as mob)
-	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))
+	if(w_class > 3 && (istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/pickaxe/plasmacutter)))
 		user << "<span class='notice'>You begin to shorten the barrel of \the [src].</span>"
 		if(loaded.len)
 			for(var/i in 1 to max_shells)
-				afterattack(user, user)	//will this work? //it will. we call it twice, for twice the FUN
+				Fire(user, user)	//will this work? //it will. we call it twice, for twice the FUN
 				playsound(user, fire_sound, 50, 1)
 			user.visible_message("<span class='danger'>The shotgun goes off!</span>", "<span class='danger'>The shotgun goes off in your face!</span>")
 			return

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -53,7 +53,7 @@
 		return
 	if(!affects_dead && M.stat == DEAD)
 		return
-	if(overdose && (dose > overdose) && (location != CHEM_TOUCH))
+	if(overdose && (volume > overdose) && (location != CHEM_TOUCH))
 		overdose(M, alien)
 	var/removed = metabolism
 	if(ingest_met && (location == CHEM_INGEST))

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -76,6 +76,7 @@
 
 /obj/effect/cleanable/wizard_mark/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/weapon/nullrod) || istype(I, /obj/item/weapon/spellbook))
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		src.visible_message("\The [src] fades away!")
 		qdel(src)
 		return


### PR DESCRIPTION
Fixes #10904, Easy fix.
Fixes #12436, or at least the mentioned cleanables. Dunno what drib is.
Fixes #11520, makes overdosing based off of the current volume instead of the total amount metabolized.

Adds click cooldowns for slimes and a few other mobs when attacking non-mob atoms. Should fix part of #12300

Fixes #12575 - Slimes no longer attempt to feed on IPCs, they just glomp them.

Did not do any testing.
