### PR TITLE
Guestpass machine tweaks.

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -47,6 +47,6 @@
 
 #define attack_animation(A) if(istype(A)) A.do_attack_animation(src)
 
-#define sequential_id uniqueness_repository.Generate(/datum/uniqueness_generator/id_sequential, type)
+#define sequential_id(key) uniqueness_repository.Generate(/datum/uniqueness_generator/id_sequential, key)
 
-#define random_id(min_id,max_id) uniqueness_repository.Generate(/datum/uniqueness_generator/id_random, type, min_id, max_id)
+#define random_id(key,min_id,max_id) uniqueness_repository.Generate(/datum/uniqueness_generator/id_random, key, min_id, max_id)

--- a/code/datums/repositories/unique.dm
+++ b/code/datums/repositories/unique.dm
@@ -21,37 +21,37 @@ var/datum/repository/unique/uniqueness_repository = new()
 	return
 
 /datum/uniqueness_generator/id_sequential
-	var/list/ids_by_type
+	var/list/ids_by_key
 
 /datum/uniqueness_generator/id_sequential/New()
 	..()
-	ids_by_type = list()
+	ids_by_key = list()
 
-/datum/uniqueness_generator/id_sequential/Generate(var/type, var/default_id = 100)
-	var/id = ids_by_type[type]
+/datum/uniqueness_generator/id_sequential/Generate(var/key, var/default_id = 100)
+	var/id = ids_by_key[key]
 	if(id)
 		id++
 	else
 		id = default_id
 
-	ids_by_type[type] = id
+	ids_by_key[key] = id
 	. = id
 
 /datum/uniqueness_generator/id_random
-	var/list/ids_by_type
+	var/list/ids_by_key
 
 /datum/uniqueness_generator/id_random/New()
 	..()
-	ids_by_type = list()
+	ids_by_key = list()
 
-/datum/uniqueness_generator/id_random/Generate(var/type, var/min, var/max)
-	var/list/ids = ids_by_type[type]
+/datum/uniqueness_generator/id_random/Generate(var/key, var/min, var/max)
+	var/list/ids = ids_by_key[key]
 	if(!ids)
 		ids = list()
-		ids_by_type[type] = ids
+		ids_by_key[key] = ids
 
 	if(ids.len >= (max - min) + 1)
-		error("Random ID limit reached for type [type].")
+		error("Random ID limit reached for key [key].")
 		ids.Cut()
 
 	if(ids.len >= 0.6 * ((max-min) + 1)) // if more than 60% of possible ids used

--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -24,7 +24,7 @@
 	verbs += /mob/living/carbon/alien/diona/proc/merge
 
 /mob/living/carbon/alien/diona/put_in_hands(var/obj/item/W) // No hands.
-	W.loc = get_turf(src)
+	W.forceMove(get_turf(src))
 	return 1
 
 /mob/living/carbon/alien/diona/proc/wear_hat(var/obj/item/new_hat)

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -78,5 +78,5 @@
 	..()
 
 /obj/item/device/mmi/digital/posibrain/PickName()
-	src.brainmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[random_id(100,999)]"
+	src.brainmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[random_id(type,100,999)]"
 	src.brainmob.real_name = src.brainmob.name

--- a/code/modules/mob/living/carbon/brain/robot.dm
+++ b/code/modules/mob/living/carbon/brain/robot.dm
@@ -7,7 +7,7 @@
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3, TECH_DATA = 4)
 
 /obj/item/device/mmi/digital/robot/PickName()
-	src.brainmob.name = "[pick(list("ADA","DOS","GNU","MAC","WIN"))]-[random_id(1000,9999)]"
+	src.brainmob.name = "[pick(list("ADA","DOS","GNU","MAC","WIN"))]-[random_id(type,1000,9999)]"
 	src.brainmob.real_name = src.brainmob.name
 
 /obj/item/device/mmi/digital/robot/transfer_identity(var/mob/living/carbon/H)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -141,7 +141,7 @@ var/list/mob_hat_cache = list()
 	name = real_name
 
 /mob/living/silicon/robot/drone/updatename()
-	real_name = "maintenance drone ([random_id(100, 999)])"
+	real_name = "maintenance drone ([random_id(type,100,999)])"
 	name = real_name
 
 /mob/living/silicon/robot/drone/updateicon()
@@ -342,7 +342,7 @@ var/list/mob_hat_cache = list()
 	flavor_text = "It's a bulky construction drone stamped with a Sol Central glyph."
 
 /mob/living/silicon/robot/drone/construction/updatename()
-	real_name = "construction drone ([random_id(100, 999)])"
+	real_name = "construction drone ([random_id(type,100,999)])"
 	name = real_name
 
 /proc/too_many_active_drones()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -247,5 +247,5 @@
 		src << "<span class='notice'>You need to disable a module first!</span>"
 
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W) // No hands.
-	W.loc = get_turf(src)
+	W.forceMove(get_turf(src))
 	return 1

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -66,7 +66,7 @@
 	verbs += /mob/living/proc/hide
 
 	if(name == initial(name))
-		name = "[name] ([sequential_id])"
+		name = "[name] ([sequential_id(/mob/living/simple_animal/mouse)])"
 	real_name = name
 
 	if(!body_color)


### PR DESCRIPTION
Can no longer href-exploit to grant permissions which are not on the issuing id.
The first 9999 guest passes should now have unique ids.
Changes a number of .loc to forceMove().
Adds a little chime when a guest pass is successfully printed.

Also makes unique number generation a little less abstract, in that a key has to be supplied manually (previously referred to as type, while not strictly necessary).
