### PR TITLE
Antag tweaks.

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -48,7 +48,6 @@
 #define MODE_LOYALIST "loyalist"
 #define MODE_MALFUNCTION "malf"
 #define MODE_TRAITOR "traitor"
-#define MODE_AUTOTRAITOR "autotraitor"
 
 #define DEFAULT_TELECRYSTAL_AMOUNT 25
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -66,8 +66,6 @@
 	var/list/global_objectives =   list()   // Universal objectives if any.
 	var/list/candidates =          list()   // Potential candidates.
 	var/list/faction_members =     list()   // Semi-antags (in-round revs, borer thralls)
-	
-	var/allow_latejoin = 0					//Determines whether or not the game mode will allow for the template to spawn try_latespawn
 
 	// ID card stuff.
 	var/default_access = list()

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -44,7 +44,9 @@
 	return (flags & ANTAG_VOTABLE)
 
 /datum/antagonist/proc/can_late_spawn()
-	if(!(allow_latejoin))
+	if(!ticker)
+		return 0
+	if(!(id in ticker.mode.latejoin_antags))
 		return 0
 	update_current_antag_max()
 	if(get_antag_count() >= cur_max)

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -44,7 +44,7 @@ var/datum/antagonist/mercenary/mercs
 	player.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(player.back), slot_in_backpack)
 	player.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/cyanide(player), slot_in_backpack)
 
-	var/obj/item/device/radio/uplink/U = new(player.loc, player.mind, DEFAULT_TELECRYSTAL_AMOUNT)
+	var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, DEFAULT_TELECRYSTAL_AMOUNT)
 	player.put_in_hands(U)
 
 	player.update_icons()

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -5,10 +5,6 @@ var/datum/antagonist/traitor/traitors
 	id = MODE_TRAITOR
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Internal Affairs Agent", "Head of Security", "Captain")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
-	
-/datum/antagonist/traitor/auto
-	id = MODE_AUTOTRAITOR
-	allow_latejoin = 1
 
 /datum/antagonist/traitor/New()
 	..()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -23,6 +23,7 @@ var/global/list/additional_antag_types = list()
 
 	var/list/antag_tags = list()             // Core antag templates to spawn.
 	var/list/antag_templates                 // Extra antagonist types to include.
+	var/list/latejoin_antags = list()        // Antags that may auto-spawn, latejoin or otherwise come in midround.
 	var/round_autoantag = 0                  // Will this round attempt to periodically spawn more antagonists?
 	var/antag_scaling_coeff = 5              // Coefficient for scaling max antagonists to player count.
 	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
@@ -278,17 +279,23 @@ var/global/list/additional_antag_types = list()
 	return
 
 /datum/game_mode/proc/declare_completion()
+	set waitfor = FALSE
 
-	var/is_antag_mode = (antag_templates && antag_templates.len)
 	check_victory()
-	if(is_antag_mode)
-		sleep(10)
-		for(var/datum/antagonist/antag in antag_templates)
-			sleep(10)
-			antag.check_victory()
-			antag.print_player_summary()
-		sleep(10)
-		print_ownerless_uplinks()
+	sleep(2)
+	for(var/datum/antagonist/antag in antag_templates)
+		antag.check_victory()
+		antag.print_player_summary()
+		sleep(2)
+	for(var/antag_type in all_antag_types)
+		var/datum/antagonist/antag = all_antag_types[antag_type]
+		if(!antag.current_antagonists.len || (antag in antag_templates))
+			continue
+		sleep(2)
+		antag.print_player_summary()
+	sleep(2)
+
+	print_ownerless_uplinks()
 
 	var/clients = 0
 	var/surviving_humans = 0

--- a/code/game/gamemodes/mixed/intrigue.dm
+++ b/code/game/gamemodes/mixed/intrigue.dm
@@ -1,11 +1,15 @@
 /datum/game_mode/intrigue
 	name = "Ninja & Traitor"
-	round_description = "Crewmembers are contacted by external elements while another infiltrates the colony."
 	extended_round_description = "Traitors and a ninja spawn during this round."
 	config_tag = "intrigue"
 	required_players = 15
 	required_enemies = 4
 	end_on_antag_death = 0
-	antag_tags = list(MODE_NINJA, MODE_AUTOTRAITOR)
+	antag_tags = list(MODE_NINJA, MODE_TRAITOR)
 	round_autoantag = 1
 	require_all_templates = 1
+	latejoin_antags = list(MODE_TRAITOR)
+
+/datum/game_mode/intrigue/New()
+	..()
+	round_description = "Crewmembers are contacted by external elements while another infiltrates \the [station_name()]."

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -20,6 +20,7 @@
 /datum/game_mode/traitor/auto
 	name = "autotraitor"
 	config_tag = "autotraitor"
-	antag_tags = list(MODE_AUTOTRAITOR)
 	round_autoantag = 1
 	antag_scaling_coeff = 5
+	end_on_antag_death = 0
+	latejoin_antags = list(MODE_TRAITOR)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -84,6 +84,8 @@
 		M.r_hand.update_held_icon()
 
 /obj/item/Destroy()
+	qdel(hidden_uplink)
+	hidden_uplink = null
 	if(ismob(loc))
 		var/mob/m = loc
 		m.drop_from_inventory(src)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -192,16 +192,18 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 // Includes normal radio uplink, multitool uplink,
 // implant uplink (not the implant tool) and a preset headset uplink.
 
-/obj/item/device/radio/uplink/New()
-	hidden_uplink = new(src)
+/obj/item/device/radio/uplink/New(var/loc, var/owner)
+	..()
+	hidden_uplink = new(src, owner)
 	icon_state = "radio"
 
 /obj/item/device/radio/uplink/attack_self(mob/user as mob)
 	if(hidden_uplink)
 		hidden_uplink.trigger(user)
 
-/obj/item/device/multitool/uplink/New()
-	hidden_uplink = new(src)
+/obj/item/device/multitool/uplink/New(var/loc, var/owner)
+	..()
+	hidden_uplink = new(src, owner)
 
 /obj/item/device/multitool/uplink/attack_self(mob/user as mob)
 	if(hidden_uplink)

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -209,7 +209,7 @@ datum/ghosttrap/pai/transfer_personality(var/mob/candidate, var/mob/living/silic
 	object = "wizard familiar"
 	pref_check = MODE_WIZARD
 	ghost_trap_message = "They are occupying a familiar now."
-	ghost_trap_role = "familiar"
+	ghost_trap_role = "Wizard Familiar"
 	ban_checks = list(MODE_WIZARD)
 
 /datum/ghosttrap/familiar/welcome_candidate(var/mob/target)


### PR DESCRIPTION
The game mode now defines which antags may late-join/spawn (as opposed to the antag template itself).
The round end summary now includes all antag types with players.
Corrects antag panel spawned mercenary uplinks not being connected to the proper owner.
Also renames the wizard familiar trap from "familiar" to "Wizard Familiar" for consistency with other ghost traps.

Removes the auto-traitor subtype. Fixes #12643.
