### PR TITLE
Loadout tweaks.

### DIFF
--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -222,9 +222,9 @@
 /proc/isLeap(y)
 	return ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
 
-/proc/atomtype2nameassoclist(var/atom_types)
+/proc/atomtype2nameassoclist(var/atom_type)
 	. = list()
-	for(var/atom_type in typesof(atom_types))
-		var/atom/A = atom_type
-		.[initial(A.name)] = atom_type
+	for(var/sub_atom_type in typesof(atom_type))
+		var/atom/A = sub_atom_type
+		.[initial(A.name)] = sub_atom_type
 	. = sortAssoc(.)

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -221,3 +221,10 @@
 
 /proc/isLeap(y)
 	return ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
+
+/proc/atomtype2nameassoclist(var/atom_types)
+	. = list()
+	for(var/atom_type in typesof(atom_types))
+		var/atom/A = atom_type
+		.[initial(A.name)] = atom_type
+	. = sortAssoc(.)

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -28,7 +28,7 @@ var/datum/antagonist/raider/raiders
 		/obj/item/clothing/under/serviceoveralls,
 		/obj/item/clothing/under/captain_fly,
 		/obj/item/clothing/under/det,
-		/obj/item/clothing/under/brown,
+		/obj/item/clothing/under/color/brown,
 		)
 
 	var/list/raider_shoes = list(

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -77,7 +77,7 @@ var/datum/antagonist/wizard/wizards
 		return 0
 
 	wizard_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(wizard_mob), slot_l_ear)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(wizard_mob), slot_w_uniform)
+	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/under/color/lightpurple(wizard_mob), slot_w_uniform)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(wizard_mob), slot_shoes)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -733,7 +733,7 @@
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 		if("blue wizard")
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(M), slot_w_uniform)
+			M.equip_to_slot_or_del(new /obj/item/clothing/under/color/lightpurple(M), slot_w_uniform)
 			M.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(M), slot_wear_suit)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(M), slot_shoes)
 			M.equip_to_slot_or_del(new /obj/item/device/radio/headset(M), slot_l_ear)
@@ -745,7 +745,7 @@
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box(M), slot_in_backpack)
 
 		if("red wizard")
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(M), slot_w_uniform)
+			M.equip_to_slot_or_del(new /obj/item/clothing/under/color/lightpurple(M), slot_w_uniform)
 			M.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/red(M), slot_wear_suit)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(M), slot_shoes)
 			M.equip_to_slot_or_del(new /obj/item/device/radio/headset(M), slot_l_ear)
@@ -757,7 +757,7 @@
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box(M), slot_in_backpack)
 
 		if("marisa wizard")
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(M), slot_w_uniform)
+			M.equip_to_slot_or_del(new /obj/item/clothing/under/color/lightpurple(M), slot_w_uniform)
 			M.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/marisa(M), slot_wear_suit)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal/marisa(M), slot_shoes)
 			M.equip_to_slot_or_del(new /obj/item/device/radio/headset(M), slot_l_ear)

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -48,7 +48,10 @@
 	var/list/valid_paths
 
 /datum/gear_tweak/path/New(var/list/valid_paths)
-	src.valid_paths = valid_paths
+	if(istype(valid_paths))
+		src.valid_paths = valid_paths
+	else	// If it wasn't a list, attempt to treat it as a type
+		src.valid_paths = atomtype2nameassoclist(valid_paths)
 	..()
 
 /datum/gear_tweak/path/get_contents(var/metadata)

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -50,8 +50,10 @@
 /datum/gear_tweak/path/New(var/list/valid_paths)
 	if(istype(valid_paths))
 		src.valid_paths = valid_paths
-	else	// If it wasn't a list, attempt to treat it as a type
+	else if(ispath(valid_paths))
 		src.valid_paths = atomtype2nameassoclist(valid_paths)
+	else
+		CRASH("[valid_paths] is of an unhandled type.")
 	..()
 
 /datum/gear_tweak/path/get_contents(var/metadata)

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -18,88 +18,12 @@
 	path = /obj/item/clothing/under/blackjumpskirt
 
 /datum/gear/uniform/jumpsuit
-	display_name = "jumpsuit, rainbow"
-	path = /obj/item/clothing/under/rainbow
-
-/datum/gear/uniform/jumpsuit/black
-	display_name = "jumpsuit, black"
-	path = /obj/item/clothing/under/color/black
-
-/datum/gear/uniform/jumpsuit/blackfemale
-	display_name = "jumpsuit, female-black"
-	path = /obj/item/clothing/under/color/blackf
-
-/datum/gear/uniform/jumpsuit/blue
-	display_name = "jumpsuit, blue"
-	path = /obj/item/clothing/under/color/blue
-
-/datum/gear/uniform/jumpsuit/green
-	display_name = "jumpsuit, green"
-	path = /obj/item/clothing/under/color/green
-
-/datum/gear/uniform/jumpsuit/grey
-	display_name = "jumpsuit, grey"
+	display_name = "generic jumpsuits"
 	path = /obj/item/clothing/under/color/grey
 
-/datum/gear/uniform/jumpsuit/pink
-	display_name = "jumpsuit, pink"
-	path = /obj/item/clothing/under/color/pink
-
-/datum/gear/uniform/jumpsuit/white
-	display_name = "jumpsuit, white"
-	path = /obj/item/clothing/under/color/white
-
-/datum/gear/uniform/jumpsuit/yellow
-	display_name = "jumpsuit, yellow"
-	path = /obj/item/clothing/under/color/yellow
-
-/datum/gear/uniform/jumpsuit/lightblue
-	display_name = "jumpsuit, lightblue"
-	path = /obj/item/clothing/under/lightblue
-
-/datum/gear/uniform/jumpsuit/red
-	display_name = "jumpsuit, red"
-	path = /obj/item/clothing/under/color/red
-
-/datum/gear/uniform/jumpsuit/aqua
-	display_name = "jumpsuit, aqua"
-	path = /obj/item/clothing/under/aqua
-
-/datum/gear/uniform/jumpsuit/purple
-	display_name = "jumpsuit, purple"
-	path = /obj/item/clothing/under/purple
-
-/datum/gear/uniform/jumpsuit/lightpurple
-	display_name = "jumpsuit, lightpurple"
-	path = /obj/item/clothing/under/lightpurple
-
-/datum/gear/uniform/jumpsuit/lightgreen
-	display_name = "jumpsuit, lightgreen"
-	path = /obj/item/clothing/under/lightgreen
-
-/datum/gear/uniform/jumpsuit/lightbrown
-	display_name = "jumpsuit, lightbrown"
-	path = /obj/item/clothing/under/lightbrown
-
-/datum/gear/uniform/jumpsuit/brown
-	display_name = "jumpsuit, brown"
-	path = /obj/item/clothing/under/brown
-
-/datum/gear/uniform/jumpsuit/yellowgreen
-	display_name = "jumpsuit, yellowgreen"
-	path = /obj/item/clothing/under/yellowgreen
-
-/datum/gear/uniform/jumpsuit/darkblue
-	display_name = "jumpsuit, darkblue"
-	path = /obj/item/clothing/under/darkblue
-
-/datum/gear/uniform/jumpsuit/lightred
-	display_name = "jumpsuit, lightred"
-	path = /obj/item/clothing/under/lightred
-
-/datum/gear/uniform/jumpsuit/darkred
-	display_name = "jumpsuit, darkred"
-	path = /obj/item/clothing/under/darkred
+/datum/gear/uniform/jumpsuit/New()
+	..()
+	gear_tweaks += new/datum/gear_tweak/path(/obj/item/clothing/under/color)
 
 /datum/gear/uniform/skirt
 	display_name = "plaid skirt, blue"

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -69,77 +69,77 @@
 	item_state = "psyche"
 	worn_state = "psyche"
 
-/obj/item/clothing/under/lightblue
+/obj/item/clothing/under/color/lightblue
 	name = "lightblue jumpsuit"
 	desc = "A lightblue jumpsuit."
 	icon_state = "lightblue"
 	item_state = "b_suit"
 	worn_state = "lightblue"
 
-/obj/item/clothing/under/aqua
+/obj/item/clothing/under/color/aqua
 	name = "aqua jumpsuit"
 	desc = "An aqua jumpsuit."
 	icon_state = "aqua"
 	item_state = "b_suit"
 	worn_state = "aqua"
 
-/obj/item/clothing/under/purple
+/obj/item/clothing/under/color
 	name = "purple jumpsuit"
-	desc = "A purple jumpsuit."
+	desc = "The latest in space fashion."
 	icon_state = "purple"
 	item_state = "p_suit"
 	worn_state = "purple"
 
-/obj/item/clothing/under/lightpurple
+/obj/item/clothing/under/color/lightpurple
 	name = "lightpurple jumpsuit"
 	desc = "A lightpurple jumpsuit."
 	icon_state = "lightpurple"
 	item_state = "p_suit"
 	worn_state = "lightpurple"
 
-/obj/item/clothing/under/lightgreen
+/obj/item/clothing/under/color/lightgreen
 	name = "lightgreen jumpsuit"
 	desc = "A lightgreen jumpsuit."
 	icon_state = "lightgreen"
 	item_state = "g_suit"
 	worn_state = "lightgreen"
 
-/obj/item/clothing/under/lightbrown
+/obj/item/clothing/under/color/lightbrown
 	name = "lightbrown jumpsuit"
 	desc = "A lightbrown jumpsuit."
 	icon_state = "lightbrown"
 	item_state = "lb_suit"
 	worn_state = "lightbrown"
 
-/obj/item/clothing/under/brown
+/obj/item/clothing/under/color/brown
 	name = "brown jumpsuit"
 	desc = "A brown jumpsuit."
 	icon_state = "brown"
 	item_state = "lb_suit"
 	worn_state = "brown"
 
-/obj/item/clothing/under/yellowgreen
+/obj/item/clothing/under/color/yellowgreen
 	name = "yellowgreen jumpsuit"
 	desc = "A yellowgreen jumpsuit."
 	icon_state = "yellowgreen"
 	item_state = "y_suit"
 	worn_state = "yellowgreen"
 
-/obj/item/clothing/under/darkblue
+/obj/item/clothing/under/color/darkblue
 	name = "darkblue jumpsuit"
 	desc = "A darkblue jumpsuit."
 	icon_state = "darkblue"
 	item_state = "b_suit"
 	worn_state = "darkblue"
 
-/obj/item/clothing/under/lightred
+/obj/item/clothing/under/color/lightred
 	name = "lightred jumpsuit"
 	desc = "Alightred jumpsuit."
 	icon_state = "lightred"
 	item_state = "r_suit"
 	worn_state = "lightred"
 
-/obj/item/clothing/under/darkred
+/obj/item/clothing/under/color/darkred
 	name = "darkred jumpsuit"
 	desc = "A darkred jumpsuit."
 	icon_state = "darkred"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -135,7 +135,7 @@
 	worn_state = "johnny"
 	item_state = "johnny"
 
-/obj/item/clothing/under/rainbow
+/obj/item/clothing/under/color/rainbow
 	name = "rainbow"
 	icon_state = "rainbow"
 	item_state = "rainbow"

--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -6,13 +6,13 @@ datum/unit_test/loadout_test_shall_have_name_cost_path/start_test()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
 
-		if(G.display_name)
+		if(!G.display_name)
 			log_unit_test("[G]: Missing display name.")
 			failed = 1
-		else if(G.cost)
-			log_unit_test("[G]: Missing cost.")
+		else if(G.cost <= 0)
+			log_unit_test("[G]: Invalid cost.")
 			failed = 1
-		else if(G.path)
+		else if(!G.path)
 			log_unit_test("[G]: Missing path definition.")
 			failed = 1
 

--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -3,17 +3,17 @@ datum/unit_test/loadout_test_shall_have_name_cost_path
 
 datum/unit_test/loadout_test_shall_have_name_cost_path/start_test()
 	var/failed = 0
-	for(var/geartype in subtypesof(/datum/gear))
-		var/datum/gear/G = geartype
+	for(var/gear_name in gear_datums)
+		var/datum/gear/G = gear_datums[gear_name]
 
-		if(!initial(G.display_name))
-			log_unit_test("[G]: Loadout - Missing display name.")
+		if(G.display_name)
+			log_unit_test("[G]: Missing display name.")
 			failed = 1
-		else if(!initial(G.cost))
-			log_unit_test("[G]: Loadout - Missing cost.")
+		else if(G.cost)
+			log_unit_test("[G]: Missing cost.")
 			failed = 1
-		else if(!initial(G.path))
-			log_unit_test("[G]: Loadout - Missing path definition.")
+		else if(G.path)
+			log_unit_test("[G]: Missing path definition.")
 			failed = 1
 
 	if(failed)
@@ -21,3 +21,30 @@ datum/unit_test/loadout_test_shall_have_name_cost_path/start_test()
 	else
 		pass("All /datum/gear definitions had correct settings.")
 	return  1
+
+datum/unit_test/loadout_test_shall_have_valid_icon_states
+	name = "LOADOUT: Entries shall have valid icon states"
+
+datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
+	var/failed = FALSE
+	for(var/gear_name in gear_datums)
+		var/datum/gear/G = gear_datums[gear_name]
+		if(!type_has_valid_icon_state(G.path))
+			log_unit_test("[G]: [G.path] has a missing icon state.")
+			failed = TRUE
+		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
+			for(var/path_name in p.valid_paths)
+				var/path_type = p.valid_paths[path_name]
+				if(!type_has_valid_icon_state(path_type))
+					log_unit_test("[G]: [path_type] has a missing icon state.")
+					failed = TRUE
+
+	if(failed)
+		fail("One or more /datum/gear definitions had paths with invalid icon states.")
+	else
+		pass("All /datum/gear definitions had correct icon states.")
+	return  1
+
+/proc/type_has_valid_icon_state(var/atom/type)
+	var/atom/A = type
+	return (initial(A.icon_state) in icon_states(initial(A.icon)))

--- a/code/unit_tests/movement_tests.dm
+++ b/code/unit_tests/movement_tests.dm
@@ -1,7 +1,6 @@
 /datum/unit_test/movement
 	name = "MOVEMENT template"
 	async = 0
-	disabled = 0
 
 /datum/unit_test/movement/force_move_shall_trigger_crossed_when_entering_turf
 	name = "MOVEMENT - Force Move Shall Trigger Crossed When Entering Turf"

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -2116,7 +2116,7 @@
 "OJ" = (/obj/effect/landmark{name = "endgame_exit"},/turf/unsimulated/beach/sand,/area/beach)
 "OK" = (/obj/machinery/chem_master,/turf/unsimulated/floor{icon_state = "vault"; dir = 1},/area/rescue_base/base)
 "OL" = (/obj/structure/bed/chair/office/light{dir = 4},/turf/unsimulated/floor{icon_state = "dark"},/area/rescue_base/base)
-"OM" = (/obj/structure/table/standard,/obj/item/clothing/under/rainbow,/obj/item/clothing/glasses/sunglasses,/obj/item/clothing/head/collectable/petehat{pixel_y = 5},/turf/unsimulated/beach/sand,/area/beach)
+"OM" = (/obj/structure/table/standard,/obj/item/clothing/under/color/rainbow,/obj/item/clothing/glasses/sunglasses,/obj/item/clothing/head/collectable/petehat{pixel_y = 5},/turf/unsimulated/beach/sand,/area/beach)
 "ON" = (/obj/structure/table/reinforced,/obj/item/weapon/board,/turf/unsimulated/floor{icon_state = "dark"},/area/rescue_base/base)
 "OO" = (/obj/structure/table/reinforced,/obj/item/weapon/stamp/centcomm,/obj/item/weapon/pen,/turf/unsimulated/floor{icon_state = "dark"},/area/rescue_base/base)
 "OP" = (/obj/structure/bed/chair/office/light{dir = 8},/turf/unsimulated/floor{icon_state = "dark"},/area/rescue_base/base)


### PR DESCRIPTION
Adds tests to ensure loadout items always have valid icon states. 
The path gear tweaker can now accept a type to initialize as an associative name/type list, if no specific filtering is needed
Loadout jumpsuits now utilize the path gear tweaker.

Partially based on https://github.com/PolarisSS13/Polaris/pull/1363.
