### PR TITLE
Reset view tweak.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -186,6 +186,7 @@
 
 /mob/proc/reset_view(atom/A)
 	if (client)
+		A = A ? A : eyeobj
 		if (istype(A, /atom/movable))
 			client.perspective = EYE_PERSPECTIVE
 			client.eye = A


### PR DESCRIPTION
If a client controlled mob owns an eye and the view is reset to null the view is instead reset to the eye.
