### PR TITLE
Round start timer now remains at 0 until the round actually starts.

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -30,11 +30,20 @@ proc/isDay(var/month, var/day)
 
 var/next_duration_update = 0
 var/last_round_duration = 0
-proc/round_duration()
+var/round_start_time = 0
+
+/hook/roundstart/proc/start_timer()
+	round_start_time = world.time
+
+#define round_duration_in_ticks (round_start_time ? world.time - round_start_time : 0)
+
+/proc/round_duration_as_text()
+	if(!round_start_time)
+		return "00:00"
 	if(last_round_duration && world.time < next_duration_update)
 		return last_round_duration
 
-	var/mills = world.time // 1/10 of a second, not real milliseconds but whatever
+	var/mills = round_duration_in_ticks // 1/10 of a second, not real milliseconds but whatever
 	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
 	var/mins = round((mills % 36000) / 600)
 	var/hours = round(mills / 36000)

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -12,6 +12,6 @@ datum/controller/transfer_controller/Destroy()
 
 datum/controller/transfer_controller/proc/process()
 	currenttick = currenttick + 1
-	if (world.time >= timerbuffer - 600)
+	if (round_duration_in_ticks >= timerbuffer - 1 MINUTE)
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -398,7 +398,7 @@
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
-		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
+		dat += "Round Duration: <B>[round_duration_as_text()]</B><BR>"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if (!emergency_shuttle.online())
 			dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -671,7 +671,7 @@
 	if(.)
 		if(statpanel("Status") && ticker && ticker.current_state != GAME_STATE_PREGAME)
 			stat("Station Time", worldtime2text())
-			stat("Round Duration", round_duration())
+			stat("Round Duration", round_duration_as_text())
 
 		if(client.holder)
 			if(statpanel("Status"))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -385,7 +385,7 @@
 
 	var/dat = "<html><body><center>"
 	dat += "<b>Welcome, [name].<br></b>"
-	dat += "Round Duration: [round_duration()]<br>"
+	dat += "Round Duration: [round_duration_as_text()]<br>"
 
 	if(emergency_shuttle) //In case Nanotrasen decides reposess CentComm's shuttles.
 		if(emergency_shuttle.going_to_centcom()) //Shuttle is going to centcomm, not recalled

--- a/code/world.dm
+++ b/code/world.dm
@@ -175,7 +175,7 @@ var/world_topic_spam_protect_time = world.timeofday
 		// This is dumb, but spacestation13.com's banners break if player count isn't the 8th field of the reply, so... this has to go here.
 		s["players"] = 0
 		s["stationtime"] = worldtime2text()
-		s["roundduration"] = round_duration()
+		s["roundduration"] = round_duration_as_text()
 
 		if(input["status"] == "2")
 			var/list/players = list()


### PR DESCRIPTION
The transfer vote should thus now happen after 3 hours of gameplay, instead of after 3 hours of uptime.
