### PR TITLE
Clothing overlay display fix

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -2,6 +2,10 @@
 #define ONLY_RETRACT 2
 #define SEAL_DELAY 30
 
+#define UPDATE_CHESTPIECE \
+if (chest && hides_uniform)
+
+
 /*
  * Defines the behavior of hardsuits/rigs/power armour.
  */
@@ -23,6 +27,8 @@
 	siemens_coefficient = 0.2
 	permeability_coefficient = 0.1
 	unacidable = 1
+
+	var/hides_uniform = 1 	//used to determinate if uniform should be visible whenever the suit is sealed or not
 
 	var/interface_path = "hardsuit.tmpl"
 	var/ai_interface_path = "hardsuit.tmpl"
@@ -300,12 +306,18 @@
 		update_component_sealed()
 	update_icon(1)
 
+
 /obj/item/weapon/rig/proc/update_component_sealed()
 	for(var/obj/item/piece in list(helmet,boots,gloves,chest))
 		if(canremove)
 			piece.item_flags &= ~(STOPPRESSUREDAMAGE|AIRTIGHT)
 		else
 			piece.item_flags |=  (STOPPRESSUREDAMAGE|AIRTIGHT)
+	if (hides_uniform && chest)
+		if(canremove)
+			chest.flags_inv &= ~(HIDEJUMPSUIT)
+		else
+			chest.flags_inv |= HIDEJUMPSUIT
 	update_icon(1)
 
 /obj/item/weapon/rig/process()
@@ -495,6 +507,7 @@
 		wearer.update_inv_gloves()
 		wearer.update_inv_head()
 		wearer.update_inv_wear_suit()
+		wearer.update_inv_w_uniform()
 		wearer.update_inv_back()
 	return
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -2,10 +2,6 @@
 #define ONLY_RETRACT 2
 #define SEAL_DELAY 30
 
-#define UPDATE_CHESTPIECE \
-if (chest && hides_uniform)
-
-
 /*
  * Defines the behavior of hardsuits/rigs/power armour.
  */

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -41,7 +41,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags_inv =          HIDEJUMPSUIT|HIDETAIL
+	// HIDEJUMPSUIT no longer needed, see "hides_uniform" and "update_component_sealed()" in rig.dm
+	flags_inv =          HIDETAIL
 	item_flags =              STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
 	slowdown = 0
 	//will reach 10 breach damage after 25 laser carbine blasts, 3 revolver hits, or ~1 PTR hit. Completely immune to smg or sts hits.
@@ -75,7 +76,6 @@
 		if(module.active && module.activates_on_touch)
 			if(module.engage(A))
 				return 1
-
 	return 0
 
 //Rig pieces for non-spacesuit based rigs

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -39,6 +39,8 @@
 	helm_type = null
 	boot_type = null
 
+	hides_uniform = 0
+
 /obj/item/weapon/rig/internalaffairs/equipped
 
 	req_access = list(access_lawyer)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -270,6 +270,10 @@ This saves us from having to call add_fingerprint() any time something is put in
 			src.wear_suit = W
 			if(wear_suit.flags_inv & HIDESHOES)
 				update_inv_shoes(0)
+			if(wear_suit.flags_inv & HIDEGLOVES)
+				update_inv_gloves(0)
+			if(wear_suit.flags_inv & HIDEJUMPSUIT)
+				update_inv_w_uniform(0)
 			W.equipped(src, slot)
 			update_inv_wear_suit(redraw_mob)
 		if(slot_w_uniform)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -460,7 +460,7 @@ var/global/list/damage_icon_parts = list()
 //vvvvvv UPDATE_INV PROCS vvvvvv
 
 /mob/living/carbon/human/update_inv_w_uniform(var/update_icons=1)
-	if(w_uniform && istype(w_uniform, /obj/item/clothing/under) )
+	if(w_uniform && istype(w_uniform, /obj/item/clothing/under) && !(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT))
 		w_uniform.screen_loc = ui_iclothing
 
 		//determine state to use
@@ -529,7 +529,7 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons()
 
 /mob/living/carbon/human/update_inv_gloves(var/update_icons=1)
-	if(gloves)
+	if(gloves && !(wear_suit && wear_suit.flags_inv & HIDEGLOVES))
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
 
@@ -774,7 +774,9 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[SUIT_LAYER]	= null
 		update_tail_showing(0)
+		update_inv_w_uniform(0)
 		update_inv_shoes(0)
+		update_inv_gloves(0)
 
 	update_collar(0)
 

--- a/html/changelogs/Irrationalist-hide-clothes-fix.yml
+++ b/html/changelogs/Irrationalist-hide-clothes-fix.yml
@@ -1,0 +1,6 @@
+author: Irrationalist
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed clothing (gloves and jumpsuits) hidden from description on examination, but are still being displayed on character anyway."


### PR DESCRIPTION
Fixes the small issue stated [here](https://baystation12.net/forums/threads/the-little-things-4-with-a-vengance.9/page-20#post-29363)

To produce it:

> 1. Spawn with a jumpsuit
> 2. Put on a spacesuit
> 3. Roll down your jumpsuit
> 4. Observe your character's sprite, the rolled-down jumpsuit can be seen poking out

Fixes clothing (gloves and jumpsuits) hidden by other clothes from examination, but were still
being displayed on their wearer's sprite.
