### PR TITLE
Fixes the start_timer() hook reporting a runtime.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,3 +69,5 @@ script:
   - grep "All Unit Tests Passed" log.txt
   - (! grep "runtime error:" log.txt)
   - (! grep 'Process scheduler caught exception processing' log.txt)
+  - (! grep "WARNING:" log.txt)
+  - (! grep "ERROR:" log.txt)

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -34,6 +34,7 @@ var/round_start_time = 0
 
 /hook/roundstart/proc/start_timer()
 	round_start_time = world.time
+	return 1
 
 #define round_duration_in_ticks (round_start_time ? world.time - round_start_time : 0)
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -447,6 +447,9 @@ var/world_topic_spam_protect_time = world.timeofday
 	return 1
 
 /world/proc/load_mode()
+	if(!fexists("data/mode.txt"))
+		return
+
 	var/list/Lines = file2list("data/mode.txt")
 	if(Lines.len)
 		if(Lines[1])


### PR DESCRIPTION
Now returns 1 for great success.
