### PR TITLE
Visualnets now override the Move-procs

### DIFF
--- a/code/modules/mob/observer/freelook/update_triggers.dm
+++ b/code/modules/mob/observer/freelook/update_triggers.dm
@@ -20,6 +20,16 @@
 		updateVisibility(src)
 	. = ..()
 
+/atom/movable/Move()
+	. = ..()
+	if(opacity && .)
+		updateVisibility(src)
+
+/atom/movable/forceMove()
+	. = ..()
+	if(opacity && .)
+		updateVisibility(src)
+
 // DOORS
 
 // Simply updates the visibility of the area when it opens/closes/destroyed.

--- a/code/modules/mob/observer/freelook/visualnet.dm
+++ b/code/modules/mob/observer/freelook/visualnet.dm
@@ -11,8 +11,6 @@
 /datum/visualnet/New()
 	..()
 	visual_nets += src
-	spawn(1)
-		moved_event.register_global(src, /datum/visualnet/proc/update_visibility)
 
 /datum/visualnet/Destroy()
 	visual_nets -= src
@@ -22,7 +20,6 @@
 	for(var/chunk in chunks)
 		qdel(chunk)
 	chunks.Cut()
-	moved_event.unregister_global(src, /datum/visualnet/proc/update_visibility)
 	. = ..()
 
 // Checks if a chunk has been Generated in x, y, z.


### PR DESCRIPTION
As opposed to listening to the Moved events globally.
Cuts down a fair amount on event registrations and raised events.
