### PR TITLE
Changes Human and Skrell max_age

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -154,7 +154,7 @@
 	name_language = null
 
 	min_age = 19
-	max_age = 80
+	max_age = 90
 
 	spawn_flags = CAN_JOIN | IS_WHITELISTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -12,7 +12,7 @@
 	secondary_langs = list(LANGUAGE_SOL_COMMON)
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 17
-	max_age = 110
+	max_age = 100
 
 	spawn_flags = CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR


### PR DESCRIPTION
Changes skrell max_age to 90, as per Paradoxon's specification. Fixes #12704
Human max_age changed to 100, as per ThatOneGuy via IRC.
