### PR TITLE
Adds a helper proc to check if mouse drops are valid.

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -5,6 +5,16 @@
 	recieving object instead, so that's the default action.  This allows you to drag
 	almost anything into a trash can.
 */
+
+/atom/proc/CanMouseDrop(atom/over, var/mob/user = usr)
+	if(!user || !over)
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	if(!src.Adjacent(user) || !over.Adjacent(user))
+		return FALSE // should stop you from dragging through windows
+	return TRUE
+
 /atom/MouseDrop(atom/over)
 	if(!usr || !over) return
 	if(!Adjacent(usr) || !over.Adjacent(usr)) return // should stop you from dragging through windows

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -36,16 +36,17 @@
 			overlays += filling
 
 /obj/machinery/iv_drip/MouseDrop(over_object, src_location, over_location)
-	..()
+	if(!CanMouseDrop(over_object))
+		return
 
 	if(attached)
-		visible_message("[src.attached] is detached from \the [src]")
+		visible_message("\The [attached] is detached from \the [src]")
 		src.attached = null
 		src.update_icon()
 		return
 
-	if(in_range(src, usr) && ishuman(over_object) && get_dist(over_object, src) <= 1)
-		visible_message("[usr] attaches \the [src] to \the [over_object].")
+	if(ishuman(over_object))
+		visible_message("\The [usr] attaches \the [src] to \the [over_object].")
 		src.attached = over_object
 		src.update_icon()
 


### PR DESCRIPTION
Used by the IV drop for now. Fixes #10107.
