### PR TITLE
Ports table pixel placement from /tg/

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -111,7 +111,7 @@
 			setMoveCooldown(10) //getting something out of a backpack
 
 		if(W)
-			var/resolved = W.resolve_attackby(A, src)
+			var/resolved = W.resolve_attackby(A, src, params)
 			if(!resolved && A && W)
 				W.afterattack(A, src, 1, params) // 1 indicates adjacency
 		else
@@ -134,7 +134,7 @@
 
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-				var/resolved = W.resolve_attackby(A,src)
+				var/resolved = W.resolve_attackby(A,src, params)
 				if(!resolved && A && W)
 					W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
 			else

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -24,12 +24,12 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
-/obj/item/proc/resolve_attackby(atom/A, mob/user)
+/obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
 	add_fingerprint(user)
-	return A.attackby(src, user)
+	return A.attackby(src, user, click_params)
 
 // No comment
-/atom/proc/attackby(obj/item/W, mob/user)
+/atom/proc/attackby(obj/item/W, mob/user, var/click_params)
 	return
 
 /atom/movable/attackby(obj/item/W, mob/user)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1371,7 +1371,7 @@
 /mob/living/carbon/human/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W in organs)
 		return
-	..()
+	. = ..()
 
 /mob/living/carbon/human/reset_view(atom/A, update_hud = 1)
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -799,7 +799,7 @@ default behaviour is:
 /mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W in internal_organs)
 		return
-	..()
+	. = ..()
 
 /mob/living/touch_map_edge()
 

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -1,6 +1,3 @@
-#define CELLS 8
-#define CELLSIZE (32/CELLS)
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Food.
 ////////////////////////////////////////////////////////////////////////////////
@@ -18,22 +15,3 @@
 		src.pixel_x = rand(-6.0, 6) //Randomizes postion
 		src.pixel_y = rand(-6.0, 6)
 
-/obj/item/weapon/reagent_containers/food/afterattack(atom/A, mob/user, proximity, params)
-	if(center_of_mass.len && proximity && params && istype(A, /obj/structure/table))
-		//Places the item on a grid
-		var/list/mouse_control = params2list(params)
-
-		var/mouse_x = text2num(mouse_control["icon-x"])
-		var/mouse_y = text2num(mouse_control["icon-y"])
-
-		if(!isnum(mouse_x) || !isnum(mouse_y))
-			return
-
-		var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
-		var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
-
-		pixel_x = (CELLSIZE * (0.5 + cell_x)) - center_of_mass["x"]
-		pixel_y = (CELLSIZE * (0.5 + cell_y)) - center_of_mass["y"]
-
-#undef CELLS
-#undef CELLSIZE

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -70,7 +70,7 @@
 	return
 
 
-/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/table/attackby(obj/item/W, mob/user, var/click_params)
 	if (!W) return
 
 	// Handle harm intent grabbing/tabling.
@@ -131,7 +131,15 @@
 		user << "<span class='warning'>There's nothing to put \the [W] on! Try adding plating to \the [src] first.</span>"
 		return
 
-	user.drop_item(src.loc)
+	// Placing stuff on tables
+	if(user.drop_from_inventory(W, src.loc))
+		var/list/click_data = params2list(click_params)
+		//Center the icon where the user clicked.
+		if(!click_data || !click_data["icon-x"] || !click_data["icon-y"])
+			return
+		//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
+		W.pixel_x = Clamp(text2num(click_data["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
+		W.pixel_z = Clamp(text2num(click_data["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
 	return
 
 /obj/structure/table/attack_tk() // no telehulk sorry

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -137,9 +137,19 @@
 		//Center the icon where the user clicked.
 		if(!click_data || !click_data["icon-x"] || !click_data["icon-y"])
 			return
+
+		//Food is special, apparently
+		var/center_x = 16
+		var/center_y = 16
+		if(istype(W, /obj/item/weapon/reagent_containers/food))
+			var/obj/item/weapon/reagent_containers/food/F = W
+			if(F.center_of_mass.len)
+				center_x = F.center_of_mass["x"]
+				center_y = F.center_of_mass["y"]
+
 		//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
-		W.pixel_x = Clamp(text2num(click_data["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
-		W.pixel_z = Clamp(text2num(click_data["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
+		W.pixel_x = Clamp(text2num(click_data["icon-x"]) - center_x, -(world.icon_size/2), world.icon_size/2)
+		W.pixel_z = Clamp(text2num(click_data["icon-y"]) - center_y, -(world.icon_size/2), world.icon_size/2)
 	return
 
 /obj/structure/table/attack_tk() // no telehulk sorry

--- a/html/changelogs/HarpyEagle-pixel-placement.yml
+++ b/html/changelogs/HarpyEagle-pixel-placement.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - rscadd: "Items can now be positioned on tables by clicking."


### PR DESCRIPTION
Port of https://github.com/tgstation/-tg-station/pull/7833 (partial), https://github.com/tgstation/-tg-station/pull/8021 by RemieRichards

Lifted the code from -tg-station's latest master since the feature itself is pretty small, and I didn't want to look though a massive PR. Consequently, I didn't update every single attackby() prototype because it's optional and I can't be bothered.

Also fixes carbon and human/drop_from_inventory() returning incorrect values which was breaking things including this port.

I was debating whether or not to keep grid alignment, ditched it for simplicity - it shouldn't be hard to align things manually with most click delays gone.
