### PR TITLE
Adds an add-antag option to transfer votes

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -51,6 +51,7 @@ datum/controller/vote
 	proc/autotransfer()
 		initiate_vote("crew_transfer","the server", 1)
 		log_debug("The server has called a crew transfer vote")
+		antag_add_finished = 0 // reset this so that players can vote in another antag
 
 	proc/autogamemode()
 		initiate_vote("gamemode","the server", 1)
@@ -164,21 +165,19 @@ datum/controller/vote
 				else
 					i++
 
-			if(mode == "gamemode" && (firstChoice == "Extended" || ticker.hide_mode == 0)) // Announce Extended gamemode, but not other gamemodes
+			if(mode != "gamemode" || (firstChoice == "Extended" || ticker.hide_mode == 0)) // Announce unhidden gamemodes or other results, but not other gamemodes
 				text += "<b>Vote Result: [firstChoice]</b>"
 				if(secondChoice)
 					text += "\nSecond place: [secondChoice]"
 				if(thirdChoice)
 					text += ", third place: [thirdChoice]"
-			else if(mode != "gamemode")
-				text += "<b>Vote Result: [firstChoice]</b>"
 			else
-				text += "<b>The vote has ended.</b>" // What will be shown if it is a gamemode vote that isn't extended
+				text += "<b>The vote has ended.</b>" // What will be shown if it is a gamemode vote that was hidden
 
 		else
 			text += "<b>Vote Result: Inconclusive - No Votes!</b>"
 			if(mode == "add_antagonist")
-				antag_add_failed = 1
+				antag_add_finished = 1
 		log_vote(text)
 		world << "<font color='purple'>[text]</font>"
 		return list(firstChoice, secondChoice, thirdChoice)
@@ -203,11 +202,22 @@ datum/controller/vote
 				if("crew_transfer")
 					if(.[1] == "Initiate Crew Transfer")
 						init_shift_change(null, 1)
+					else if(.[1] == "Add Antagonist")
+						initiate_vote("add_antagonist", "the server", 1)
+						antag_add_finished = 1
 				if("add_antagonist")
 					if(isnull(.[1]) || .[1] == "None")
-						antag_add_failed = 1
+						antag_add_finished = 1
 					else
-						additional_antag_types |= antag_names_to_ids[.[1]]
+						var/antag_type = antag_names_to_ids[.[1]]
+						if(ticker.current_state >= 2)
+							var/datum/antagonist/antag = all_antag_types[antag_type]
+							var/datum/antagonist/antag2 = all_antag_types[antag_names_to_ids[.[2]]]
+							var/datum/antagonist/antag3 = all_antag_types[antag_names_to_ids[.[3]]]
+							if(!ticker.attempt_late_antag_spawn(antag, antag2, antag3))
+								world << "No antags were added."
+						else
+							additional_antag_types |= antag_type
 				if("map")
 					var/datum/map/M = all_maps[.[1]]
 					fdel("use_map")
@@ -291,8 +301,10 @@ datum/controller/vote
 							initiator_key << "The crew transfer button has been disabled!"
 						question = "End the shift?"
 						choices.Add("Initiate Crew Transfer", "Continue The Round")
+						if (config.allow_extra_antags)
+							choices.Add("Add Antagonist")
 				if("add_antagonist")
-					if(!config.allow_extra_antags || ticker.current_state >= 2)
+					if(!config.allow_extra_antags)
 						return 0
 					for(var/antag_type in all_antag_types)
 						var/datum/antagonist/antag = all_antag_types[antag_type]
@@ -420,7 +432,7 @@ datum/controller/vote
 				. += "<font color='grey'>Map (Disallowed)</font>"
 			. += "</li><li>"
 			//extra antagonists
-			if(!antag_add_failed && config.allow_extra_antags)
+			if(!antag_add_finished && config.allow_extra_antags)
 				. += "<a href='?src=\ref[src];vote=add_antagonist'>Add Antagonist Type</a>"
 			else
 				. += "<font color='grey'>Add Antagonist (Disallowed)</font>"

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -203,8 +203,8 @@ datum/controller/vote
 					if(.[1] == "Initiate Crew Transfer")
 						init_shift_change(null, 1)
 					else if(.[1] == "Add Antagonist")
-						initiate_vote("add_antagonist", "the server", 1)
-						antag_add_finished = 1
+						spawn(10)
+							initiate_vote("add_antagonist", "the server", 1)
 				if("add_antagonist")
 					if(isnull(.[1]) || .[1] == "None")
 						antag_add_finished = 1
@@ -293,6 +293,8 @@ datum/controller/vote
 					if(check_rights(R_ADMIN|R_MOD, 0))
 						question = "End the shift?"
 						choices.Add("Initiate Crew Transfer", "Continue The Round")
+						if (config.allow_extra_antags)
+							choices.Add("Add Antagonist")
 					else
 						if (get_security_level() == "red" || get_security_level() == "delta")
 							initiator_key << "The current alert status is too high to call for a crew transfer!"

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -214,7 +214,8 @@ datum/controller/vote
 							var/datum/antagonist/antag = all_antag_types[antag_type]
 							var/datum/antagonist/antag2 = all_antag_types[antag_names_to_ids[.[2]]]
 							var/datum/antagonist/antag3 = all_antag_types[antag_names_to_ids[.[3]]]
-							if(!ticker.attempt_late_antag_spawn(antag, antag2, antag3))
+							var/list/antag_choices = list(antag, antag2, antag3)
+							if(!ticker.attempt_late_antag_spawn(antag_choices))
 								world << "No antags were added."
 						else
 							additional_antag_types |= antag_type

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -211,10 +211,7 @@ datum/controller/vote
 					else
 						var/antag_type = antag_names_to_ids[.[1]]
 						if(ticker.current_state >= 2)
-							var/datum/antagonist/antag = all_antag_types[antag_type]
-							var/datum/antagonist/antag2 = all_antag_types[antag_names_to_ids[.[2]]]
-							var/datum/antagonist/antag3 = all_antag_types[antag_names_to_ids[.[3]]]
-							var/list/antag_choices = list(antag, antag2, antag3)
+							var/list/antag_choices = list(all_antag_types[antag_type], all_antag_types[antag_names_to_ids[.[2]]], all_antag_types[antag_names_to_ids[.[3]]])
 							if(!ticker.attempt_late_antag_spawn(antag_choices))
 								world << "No antags were added."
 						else

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -1,4 +1,4 @@
-var/global/antag_add_failed // Used in antag type voting.
+var/global/antag_add_finished // Used in antag type voting.
 var/global/list/additional_antag_types = list()
 
 /datum/game_mode

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -439,7 +439,7 @@ var/global/list/additional_antag_types = list()
 				continue
 			if(!role || (role in player.client.prefs.be_special_role))
 				log_debug("[player.key] had [antag_id] enabled, so we are drafting them.")
-				candidates |= player.mind
+				candidates += player.mind
 	else
 		// Assemble a list of active players without jobbans.
 		for(var/mob/new_player/player in player_list)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -479,6 +479,7 @@ var/global/datum/controller/gameticker/ticker
 // there's probably already some list of procs for latespawning antags like this that I can't figure out
 /datum/controller/gameticker/proc/attempt_late_antag_spawn(var/list/antag_choices)
 	var/datum/antagonist/antag = antag_choices[1]
+	var/datum/mind/lucky_guy
 	while(antag_choices.len)
 		var/list/candidates = list()
 		var/move_to_spawn = 0
@@ -489,19 +490,23 @@ var/global/datum/controller/gameticker/ticker
 			preserve_appearence = 0
 			antag_pool.Cut()
 			world << "<b>A ghost is needed to spawn \a [antag.role_text].</b>\nGhosts may enter the antag pool by using the toggle-add-antag-candidacy verb. You have 15 seconds to enter the pool."
-			spawn(150)
-				looking_for_antags = 0
-				for(var/mob/observer/ghost/player in antag_pool)
-					if(antag.role_type in player.client.prefs.be_special_role && antag.can_become_antag(player.mind))
-						candidates += player.mind
+			sleep(150)
+			looking_for_antags = 0
+			for(var/mob/observer/ghost/player in antag_pool)
+				if(antag.role_type in player.client.prefs.be_special_role)
+					candidates += player.mind
+					log_debug("[player.key] had [antag.role_text] enabled and are in the antag pool, so we are drafting them.")
 		else
 			for(var/mob/living/player in player_list)
-				if(antag.role_type in player.client.prefs.be_special_role && antag.can_become_antag(player.mind))
+				if(antag.role_type in player.client.prefs.be_special_role)
 					candidates += player.mind
-		var/lucky_guy = pick(candidates)
-		while(!antag.add_antagonist(lucky_guy, 0, 0, move_to_spawn, 0, preserve_appearence) && candidates.len)
-			candidates -= lucky_guy // not so lucky
+					log_debug("[player.key] had [antag.role_text] enabled, so we are drafting them.")
+		if(candidates.len)
 			lucky_guy = pick(candidates)
+			while(!antag.add_antagonist(lucky_guy, 0, 0, move_to_spawn, 0, preserve_appearence) && candidates.len)
+				log_debug("[lucky_guy.key] was selected, but could not be \a [antag.role_text].")
+				candidates -= lucky_guy // not so lucky
+				lucky_guy = pick(candidates)
 		if(!candidates.len) // couldn't add any one :(
 			world << "Could not add \a [antag.role_text]."
 			antag_choices -= antag
@@ -510,6 +515,7 @@ var/global/datum/controller/gameticker/ticker
 				world << "Attempting to spawn \a [antag.role_text]."
 			else
 				return 0
-		else
+		else if(lucky_guy)
+			log_debug("[lucky_guy.key] was selected to be \a [antag.role_text].")
 			return 1
 	return 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -34,6 +34,9 @@ var/global/datum/controller/gameticker/ticker
 
 	var/round_end_announced = 0 // Spam Prevention. Announce round end only once.
 
+	var/list/antag_pool = list()
+	var/looking_for_antags = 0
+
 /datum/controller/gameticker/proc/pregame()
 	login_music = pick(\
 	/*'sound/music/halloween/skeletons.ogg',\
@@ -472,3 +475,41 @@ var/global/datum/controller/gameticker/ticker
 		log_game("[i]s[total_antagonists[i]].")
 
 	return 1
+
+// there's probably already some list of procs for latespawning antags like this that I can't figure out
+/datum/controller/gameticker/proc/attempt_late_antag_spawn(var/list/antag_choices)
+	var/datum/antagonist/antag = antag_choices[1]
+	while(antag_choices.len)
+		var/list/candidates = list()
+		var/move_to_spawn = 0
+		var/preserve_appearence = 1
+		if (antag.flags & (ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB))
+			looking_for_antags = 1
+			move_to_spawn = 1
+			preserve_appearence = 0
+			antag_pool.Cut()
+			world << "<b>A ghost is needed to spawn \a [antag.role_text].</b>\nGhosts may enter the antag pool by using the toggle-add-antag-candidacy verb. You have 15 seconds to enter the pool."
+			spawn(150)
+				looking_for_antags = 0
+				for(var/mob/observer/ghost/player in antag_pool)
+					if(antag.role_type in player.client.prefs.be_special_role && antag.can_become_antag(player.mind))
+						candidates += player.mind
+		else
+			for(var/mob/living/player in player_list)
+				if(antag.role_type in player.client.prefs.be_special_role && antag.can_become_antag(player.mind))
+					candidates += player.mind
+		var/lucky_guy = pick(candidates)
+		while(!antag.add_antagonist(lucky_guy, 0, 0, move_to_spawn, 0, preserve_appearence) && candidates.len)
+			candidates -= lucky_guy // not so lucky
+			lucky_guy = pick(candidates)
+		if(!candidates.len) // couldn't add any one :(
+			world << "Could not add \a [antag.role_text]."
+			antag_choices -= antag
+			if(antag_choices.len)
+				antag = antag_choices[1]
+				world << "Attempting to spawn \a [antag.role_text]."
+			else
+				return 0
+		else
+			return 1
+	return 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -489,12 +489,12 @@ var/global/datum/controller/gameticker/ticker
 			sleep(300)
 			looking_for_antags = 0
 			for(var/datum/mind/candidate in antag.candidates)
-				if(!candidate in antag_pool)
+				if(!(candidate in antag_pool))
 					antag.candidates -= candidate
 					log_debug("[candidate.key] was not in the antag pool and could not be selected.")
 		else
 			for(var/datum/mind/candidate in antag.candidates)
-				if(isghost(candidate))
+				if(isghost(candidate.current))
 					antag.candidates -= candidate
 					log_debug("[candidate.key] is a ghost and can not be selected.")
 		if(length(antag.candidates) >= antag.initial_spawn_req)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -61,7 +61,10 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 					name = capitalize(pick(first_names_female)) + " " + capitalize(pick(last_names))
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
-
+	else
+		spawn(10) // wait for the observer mob to receive the client's key
+			mind = new /datum/mind(key)
+			mind.current = src
 	if(!T)	T = pick(latejoin | latejoin_cryo | latejoin_gateway)			//Safety in case we cannot find the body's position
 	forceMove(T)
 

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -703,11 +703,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = "Toggles whether or not you will be considered a candidate by an add-antag vote."
 	set category = "Ghost"
 	if(ticker.looking_for_antags)
-		if(src in ticker.antag_pool)
-			ticker.antag_pool -= src
+		if(src.mind in ticker.antag_pool)
+			ticker.antag_pool -= src.mind
 			usr << "You have left the antag pool."
 		else
-			ticker.antag_pool += src
+			ticker.antag_pool += src.mind
 			usr << "You have joined the antag pool."
 	else
-		usr << "The game is no currently looking for antags."
+		usr << "The game is not currently looking for antags."

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -697,3 +697,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if((!target) || (!ghost)) return
 	. = "<a href='byond://?src=\ref[ghost];track=\ref[target]'>follow</a>"
 	. += target.extra_ghost_link(ghost)
+
+/mob/observer/ghost/verb/toggle_antag_pool()
+	set name = "Toggle Add-Antag Candidacy"
+	set desc = "Toggles whether or not you will be considered a candidate by an add-antag vote."
+	set category = "Ghost"
+	if(ticker.looking_for_antags)
+		if(src in ticker.antag_pool)
+			ticker.antag_pool -= src
+			usr << "You have left the antag pool."
+		else
+			ticker.antag_pool += src
+			usr << "You have joined the antag pool."
+	else
+		usr << "The game is no currently looking for antags."

--- a/html/changelogs/mustafakalash-PR-12754.yml
+++ b/html/changelogs/mustafakalash-PR-12754.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mkalash
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Add antagonist vote now works midround"
+  - rscadd: "Ghosts can join a pool to be selected for off-station antag roles by add antag votes"
+  - rscadd: "Add antagonist option added to the crew transfer vote"


### PR DESCRIPTION
[Thread](https://baystation12.net/forums/threads/brainstorm-add-antag-on-transfer-vote.1823).
# Features
- Add-antag vote will fire only once if it is selected instead of transfer, without a 'none' option
- Voting add-antag will add an hour before the next transfer vote
- Players may vote to add-antag again on the next transfer vote
- If an off-station antag is chosen, players will be warned that ghosts may use an 'toggle-add-antag-candidacy' verb in order to be selected as an antag
- Otherwise, the antag will be chosen from in-game players
- The vote will try the top three votes until one antag successfully adds
- No antag will be added if the top three antag choices fail to add
# Todo
- [x] Tweak add-antag vote to work midround
- [x] Make a system for ghosts to be selected for off-station antags
- [x] Refactor the concept into actually viable code
- [x] Make sure in-round antags can spawn
- [x] Make sure off-station antags can spawn from ghosts
