### PR TITLE
Fixes and cleanup

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -234,8 +234,9 @@ var/list/mob/living/forced_ambiance_list = new
 		L.lastarea = get_area(L.loc)
 	var/area/newarea = get_area(L.loc)
 	var/area/oldarea = L.lastarea
-	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && (L.m_intent == "run")) // Being ready when you change areas gives you a chance to avoid falling all together.
-		thunk(L)
+	if(oldarea.has_gravity != newarea.has_gravity)
+		if(newarea.has_gravity == 1 && L.m_intent == "run") // Being ready when you change areas allows you to avoid falling.
+			thunk(L)
 		L.update_floating( L.Check_Dense_Object() )
 
 	L.lastarea = newarea

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -237,7 +237,7 @@ var/list/mob/living/forced_ambiance_list = new
 	if(oldarea.has_gravity != newarea.has_gravity)
 		if(newarea.has_gravity == 1 && L.m_intent == "run") // Being ready when you change areas allows you to avoid falling.
 			thunk(L)
-		L.update_floating( L.Check_Dense_Object() )
+		L.update_floating()
 
 	L.lastarea = newarea
 	play_ambience(L)
@@ -273,7 +273,7 @@ var/list/mob/living/forced_ambiance_list = new
 	for(var/mob/M in A)
 		if(has_gravity)
 			thunk(M)
-		M.update_floating( M.Check_Dense_Object() )
+		M.update_floating()
 
 /area/proc/thunk(mob)
 	if(istype(get_turf(mob), /turf/space)) // Can't fall onto nothing.

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -29,6 +29,7 @@
 	M.facing_dir = null
 	M.set_dir(buckle_dir ? buckle_dir : dir)
 	M.update_canmove()
+	M.update_floating()
 	buckled_mob = M
 	post_buckle_mob(M)
 	return 1
@@ -39,6 +40,7 @@
 		buckled_mob.buckled = null
 		buckled_mob.anchored = initial(buckled_mob.anchored)
 		buckled_mob.update_canmove()
+		buckled_mob.update_floating()
 		buckled_mob = null
 
 		post_buckle_mob(.)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,16 +73,6 @@
 	// Works similarly to worn sprite_sheets, except the alternate sprites are used when the clothing/refit_for_species() proc is called.
 	var/list/sprite_sheets_obj = list()
 
-/obj/item/equipped()
-	..()
-	var/mob/M = loc
-	if(!istype(M))
-		return
-	if(M.l_hand)
-		M.l_hand.update_held_icon()
-	if(M.r_hand)
-		M.r_hand.update_held_icon()
-
 /obj/item/Destroy()
 	qdel(hidden_uplink)
 	hidden_uplink = null
@@ -257,7 +247,15 @@
 	layer = SCREEN_LAYER+0.01
 	if(user.client)	user.client.screen |= src
 	if(user.pulling == src) user.stop_pulling()
-	return
+	
+	//Update two-handing status
+	var/mob/M = loc
+	if(!istype(M))
+		return
+	if(M.l_hand)
+		M.l_hand.update_held_icon()
+	if(M.r_hand)
+		M.r_hand.update_held_icon()
 
 //Defines which slots correspond to which slot flags
 var/list/global/slot_flags_enumeration = list(

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -113,7 +113,7 @@
 	unwielded_force_divisor = 0.65 // 14 when unwielded based on above
 	thrown_force_divisor = 1.5 // 20 when thrown with weight 15 (glass)
 	throw_speed = 3
-	edge = 1
+	edge = 0
 	sharp = 1
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -33,6 +33,7 @@
 
 /obj/structure/bed/chair/post_buckle_mob()
 	update_icon()
+	return ..()
 
 /obj/structure/bed/chair/update_icon()
 	..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -80,10 +80,6 @@
 		dirtoverlay.alpha = min((dirt - 50) * 5, 255)
 
 /turf/simulated/Entered(atom/A, atom/OL)
-	if(movement_disabled && usr.ckey != movement_disabled_exception)
-		usr << "<span class='danger'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
-
 	if (istype(A,/mob/living))
 		var/mob/living/M = A
 		if(M.lying)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -14,9 +14,6 @@
 	update_starlight()
 	..()
 
-/turf/space/is_space()
-	return 1
-
 // override for space turfs, since they should never hide anything
 /turf/space/levelupdate()
 	for(var/obj/O in src)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -62,15 +62,8 @@
 // Ported from unstable r355
 
 /turf/space/Entered(atom/movable/A as mob|obj)
-	if(movement_disabled)
-		usr << "<span class='warning'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
 	..()
-	if ((!(A) || src != A.loc))	return
-
-	inertial_drift(A)
-
-	if(ticker && ticker.mode)
+	if(A && A.loc == src && ticker && ticker.mode)
 
 		// Okay, so let's make it so that people can travel z levels but not nuke disks!
 		// if(ticker.mode.name == "mercenary")	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -134,7 +134,7 @@ var/const/enterloopsanity = 100
 			M.lastarea = get_area(M.loc)
 		if(M.lastarea.has_gravity == 0)
 			inertial_drift(M)
-		else if(is_space())
+		else if(!is_space())
 			M.inertia_dir = 0
 			M.make_floating(0)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -72,9 +72,6 @@
 	return 1
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	if(movement_disabled && usr.ckey != movement_disabled_exception)
-		usr << "<span class='warning'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
 
 	..()
 
@@ -118,9 +115,6 @@
 var/const/enterloopsanity = 100
 /turf/Entered(atom/atom as mob|obj)
 
-	if(movement_disabled)
-		usr << "<span class='warning'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
 	..()
 
 	if(!istype(atom, /atom/movable))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -130,13 +130,14 @@ var/const/enterloopsanity = 100
 
 	if(ismob(A))
 		var/mob/M = A
-		if(!M.lastarea)
-			M.lastarea = get_area(M.loc)
-		if(M.lastarea.has_gravity == 0)
+		if(!M.check_solid_ground())
 			inertial_drift(M)
-		else if(!is_space())
+			//we'll end up checking solid ground again but we still need to check the other things. 
+			//Ususally most people aren't in space anyways so hopefully this is acceptable.
+			M.update_floating()
+		else
 			M.inertia_dir = 0
-			M.make_floating(0)
+			M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
 
 	var/objects = 0
 	if(A && (A.flags & PROXMOVE))
@@ -156,19 +157,17 @@ var/const/enterloopsanity = 100
 /turf/proc/is_plating()
 	return 0
 
-/turf/proc/inertial_drift(atom/movable/A as mob|obj)
+/turf/proc/inertial_drift(atom/movable/A)
 	if(!(A.last_move))	return
 	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
 		var/mob/M = A
-		if(M.Allow_Spacemove(1)) //if this mob can control their own movement in space then they shouldn't drift
+		if(M.Allow_Spacemove(1)) //if this mob can control their own movement in space then they shouldn't be drifting
 			M.inertia_dir  = 0
 			return
 		spawn(5)
-			if((M && !(M.anchored) && !(M.pulledby) && (M.loc == src)))
-				if(M.inertia_dir)
-					step(M, M.inertia_dir)
-					return
-				M.inertia_dir = M.last_move
+			if(M && !(M.anchored) && !(M.pulledby) && (M.loc == src))
+				if(!M.inertia_dir)
+					M.inertia_dir = M.last_move
 				step(M, M.inertia_dir)
 	return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -160,7 +160,7 @@ var/const/enterloopsanity = 100
 	if(!(A.last_move))	return
 	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
 		var/mob/M = A
-		if(M.Process_Spacemove(1))
+		if(M.Allow_Spacemove(1)) //if this mob can control their own movement in space then they shouldn't drift
 			M.inertia_dir  = 0
 			return
 		spawn(5)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -48,9 +48,6 @@
 /turf/ex_act(severity)
 	return 0
 
-/turf/proc/is_space()
-	return 0
-
 /turf/proc/is_intact()
 	return 0
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -1,3 +1,4 @@
+//Note that despite the use of the NOSLIP flag, magboots are still hardcoded to prevent spaceslipping in Check_Shoegrip().
 /obj/item/clothing/shoes/magboots
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
@@ -33,6 +34,7 @@
 		user << "You enable the mag-pulse traction system."
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()
+	user.update_floating() //kind of yuck
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -55,8 +57,14 @@
 	if (shoes)
 		user << "You slip \the [src] on over \the [shoes]."
 	set_slowdown()
-	wearer = H
+	wearer = H //TODO clean this up
 	return 1
+
+/obj/item/clothing/shoes/magboots/equipped()
+	..()
+	var/mob/M = src.loc
+	if(istype(M))
+		M.update_floating( M.Check_Dense_Object() ) //yuck
 
 /obj/item/clothing/shoes/magboots/dropped()
 	..()
@@ -65,6 +73,7 @@
 		if(!H.equip_to_slot_if_possible(shoes, slot_shoes))
 			shoes.forceMove(get_turf(src))
 		src.shoes = null
+	wearer.update_floating( wearer.Check_Dense_Object() ) //yuck
 	wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -9,8 +9,15 @@
 	var/magpulse = 0
 	var/icon_base = "magboots"
 	action_button_name = "Toggle Magboots"
-	var/obj/item/clothing/shoes/shoes = null	//Undershoes
-	var/mob/living/carbon/human/wearer = null	//For shoe procs
+
+	//For covering shoes when worn
+	var/obj/item/clothing/shoes/shoes = null
+	var/mob/wearer = null
+
+/obj/item/clothing/shoes/magboots/Destroy()
+	shoes = null
+	wearer = null
+	. = ..()
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	slowdown = shoes? max(SHOES_SLOWDOWN, shoes.slowdown): SHOES_SLOWDOWN	//So you can't put on magboots to make you walk faster.
@@ -37,44 +44,48 @@
 	user.update_floating()
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user)
-	var/mob/living/carbon/human/H = user
-
-	if(H.shoes)
-		shoes = H.shoes
-		if(shoes.overshoes)
-			user << "You are unable to wear \the [src] as \the [H.shoes] are in the way."
-			shoes = null
-			return 0
-		H.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
-		shoes.forceMove(src)
-
 	if(!..())
 		if(shoes) 	//Put the old shoes back on if the check fails.
-			if(H.equip_to_slot_if_possible(shoes, slot_shoes))
-				src.shoes = null
+			if(user.equip_to_slot_if_possible(shoes, slot_shoes, disable_warning = 1))
+				shoes.forceMove(get_turf(user)) //well if that fails then drop them on the floor
+			shoes = null
 		return 0
+
+/obj/item/clothing/shoes/magboots/proc/cover_shoes(obj/item/clothing/shoes/S, mob/user)
+	if(S.overshoes)
+		user << "You are unable to wear \the [src] as \the [S] are in the way."
+		return 0
+
+	shoes = S
+	user.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
+	shoes.forceMove(src)
 
 	if (shoes)
 		user << "You slip \the [src] on over \the [shoes]."
 	set_slowdown()
-	wearer = H //TODO clean this up
+	wearer = user
 	return 1
 
+//This gets called only if the item is successfully equipped, luckily for us
 /obj/item/clothing/shoes/magboots/equipped()
 	..()
 	var/mob/M = src.loc
 	if(istype(M))
 		M.update_floating()
 
+		var/obj/item/clothing/shoes/S = M.get_equipped_item(slot_shoes)
+		if(istype(S))
+			cover_shoes(S, M)
+
 /obj/item/clothing/shoes/magboots/dropped()
 	..()
-	var/mob/living/carbon/human/H = wearer
 	if(shoes)
-		if(!H.equip_to_slot_if_possible(shoes, slot_shoes))
+		if(!wearer || !wearer.equip_to_slot_if_possible(shoes, slot_shoes))
 			shoes.forceMove(get_turf(src))
 		src.shoes = null
-	wearer.update_floating()
-	wearer = null
+	if(wearer)
+		wearer.update_floating()
+		wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	..(user)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -34,7 +34,7 @@
 		user << "You enable the mag-pulse traction system."
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()
-	user.update_floating() //kind of yuck
+	user.update_floating()
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -64,7 +64,7 @@
 	..()
 	var/mob/M = src.loc
 	if(istype(M))
-		M.update_floating( M.Check_Dense_Object() ) //yuck
+		M.update_floating()
 
 /obj/item/clothing/shoes/magboots/dropped()
 	..()
@@ -73,7 +73,7 @@
 		if(!H.equip_to_slot_if_possible(shoes, slot_shoes))
 			shoes.forceMove(get_turf(src))
 		src.shoes = null
-	wearer.update_floating( wearer.Check_Dense_Object() ) //yuck
+	wearer.update_floating()
 	wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -845,9 +845,14 @@
 	if(!wearer.lastarea)
 		wearer.lastarea = get_area(wearer.loc)
 
-	if((istype(wearer.loc, /turf/space)) || (wearer.lastarea.has_gravity == 0))
-		if(!wearer.Allow_Spacemove(0))
+	if(!wearer.check_solid_ground())
+		var/allowmove = wearer.Allow_Spacemove(0)
+		if(!allowmove)
 			return 0
+		else if(allowmove == -1 && wearer.handle_spaceslipping()) //Check to see if we slipped
+			return 0
+		else
+			wearer.inertia_dir = 0 //If not then we can reset inertia and move
 
 	if(malfunctioning)
 		direction = pick(cardinal)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -846,7 +846,7 @@
 		wearer.lastarea = get_area(wearer.loc)
 
 	if((istype(wearer.loc, /turf/space)) || (wearer.lastarea.has_gravity == 0))
-		if(!wearer.Process_Spacemove(0))
+		if(!wearer.Allow_Spacemove(0))
 			return 0
 
 	if(malfunctioning)

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -81,26 +81,13 @@ note dizziness decrements automatically in the mob's Life() proc.
 /mob/var/is_floating = 0
 /mob/var/floatiness = 0
 
-/mob/proc/update_floating(var/dense_object=0)
+/mob/proc/update_floating()
 
-	if(anchored||buckled)
+	if(anchored || buckled || check_solid_ground())
 		make_floating(0)
 		return
 
-	var/turf/turf = get_turf(src)
-	if(!istype(turf,/turf/space))
-		var/area/A = turf.loc
-		if(istype(A) && A.has_gravity)
-			make_floating(0)
-			return
-		else if (Check_Shoegrip())
-			make_floating(0)
-			return
-		else
-			make_floating(1)
-			return
-
-	if(dense_object && Check_Shoegrip())
+	if(Check_Shoegrip() && Check_Dense_Object())
 		make_floating(0)
 		return
 
@@ -108,10 +95,6 @@ note dizziness decrements automatically in the mob's Life() proc.
 	return
 
 /mob/proc/make_floating(var/n)
-	if(buckled)
-		if(is_floating)
-			stop_floating()
-		return
 	floatiness = n
 
 	if(floatiness && !is_floating)

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -13,7 +13,7 @@
 
 	//First, check if we can breathe at all
 	if(health < config.health_threshold_crit && !(CE_STABLE in chem_effects)) //crit aka circulatory shock
-		losebreath++
+		losebreath = max(2, losebreath + 1)
 
 	if(losebreath>0) //Suffocating so do not take a breath
 		losebreath--

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -68,7 +68,7 @@
 
 	return (tally+config.human_delay)
 
-/mob/living/carbon/human/Process_Spacemove(var/check_drift = 0)
+/mob/living/carbon/human/Allow_Spacemove(var/check_drift = 0)
 	//Can we act?
 	if(restrained())	return 0
 
@@ -89,9 +89,7 @@
 			return 1
 
 	//If no working jetpack then use the other checks
-	if(..())
-		return 1
-	return 0
+	. = ..()
 
 
 /mob/living/carbon/human/slip_chance(var/prob_slip = 5)

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -140,7 +140,7 @@
 	..()
 
 /mob/living/carbon/slime/Allow_Spacemove()
-	return 2
+	return 1
 
 /mob/living/carbon/slime/Stat()
 	..()

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -139,7 +139,7 @@
 
 	..()
 
-/mob/living/carbon/slime/Process_Spacemove()
+/mob/living/carbon/slime/Allow_Spacemove()
 	return 2
 
 /mob/living/carbon/slime/Stat()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,10 +6,10 @@
 /mob/living/silicon/robot/Allow_Spacemove()
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
-			if(J && istype(J, /obj/item/weapon/tank/jetpack))
-				if(J.allow_thrust(0.01))	return 1
-	if(..())	return 1
-	return 0
+			if(J && J.allow_thrust(0.01))
+				return 1
+	. = ..()
+
 
  //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -3,7 +3,7 @@
 		return 0
 	..(prob_slip)
 
-/mob/living/silicon/robot/Process_Spacemove()
+/mob/living/silicon/robot/Allow_Spacemove()
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
 			if(J && istype(J, /obj/item/weapon/tank/jetpack))

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -64,7 +64,7 @@
 
 	wizardy_spells = list(/spell/aoe_turf/conjure/forcewall)
 
-/mob/living/simple_animal/familiar/pike/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/familiar/pike/Allow_Spacemove(var/check_drift = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/familiar/horror

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -43,9 +43,6 @@
 	if(istype(L))
 		owner = L
 
-/mob/living/simple_animal/hostile/scarybat/Allow_Spacemove(var/check_drift = 0)
-	return ..()	//No drifting in space for space carp!	//original comments do not steal
-
 /mob/living/simple_animal/hostile/scarybat/FindTarget()
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -43,7 +43,7 @@
 	if(istype(L))
 		owner = L
 
-/mob/living/simple_animal/hostile/scarybat/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/scarybat/Allow_Spacemove(var/check_drift = 0)
 	return ..()	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/hostile/scarybat/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -112,7 +112,7 @@
 		target_mob = M
 	..()
 
-/mob/living/simple_animal/hostile/bear/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/bear/Allow_Spacemove(var/check_drift = 0)
 	return	//No drifting in space for space bears!
 
 /mob/living/simple_animal/hostile/bear/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -112,9 +112,6 @@
 		target_mob = M
 	..()
 
-/mob/living/simple_animal/hostile/bear/Allow_Spacemove(var/check_drift = 0)
-	return	//No drifting in space for space bears!
-
 /mob/living/simple_animal/hostile/bear/FindTarget()
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -38,7 +38,7 @@
 
 	faction = "carp"
 
-/mob/living/simple_animal/hostile/carp/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/carp/Allow_Spacemove(var/check_drift = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/hostile/carp/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -32,7 +32,7 @@
 
 	faction = "faithless"
 
-/mob/living/simple_animal/hostile/faithless/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/faithless/Allow_Spacemove(var/check_drift = 0)
 	return 1
 
 /mob/living/simple_animal/hostile/faithless/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -58,7 +58,7 @@
 	ion_trail.set_up(src)
 	ion_trail.start()
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(var/check_drift = 0)
 	return 1
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/ListTargets()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -99,7 +99,7 @@
 	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
 	speed = 0
 
-/mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/syndicate/melee/space/Allow_Spacemove(var/check_drift = 0)
 	return
 
 /mob/living/simple_animal/hostile/syndicate/ranged
@@ -129,7 +129,7 @@
 	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
 	speed = 0
 
-/mob/living/simple_animal/hostile/syndicate/ranged/space/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/syndicate/ranged/space/Allow_Spacemove(var/check_drift = 0)
 	return
 
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -99,9 +99,6 @@
 	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
 	speed = 0
 
-/mob/living/simple_animal/hostile/syndicate/melee/space/Allow_Spacemove(var/check_drift = 0)
-	return
-
 /mob/living/simple_animal/hostile/syndicate/ranged
 	ranged = 1
 	rapid = 1
@@ -128,11 +125,6 @@
 	minbodytemp = 0
 	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
 	speed = 0
-
-/mob/living/simple_animal/hostile/syndicate/ranged/space/Allow_Spacemove(var/check_drift = 0)
-	return
-
-
 
 /mob/living/simple_animal/hostile/viscerator
 	name = "viscerator"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -237,13 +237,13 @@
 		return
 
 	//if(istype(mob.loc, /turf/space) || (mob.flags & NOGRAV))
-	//	if(!mob.Process_Spacemove(0))	return 0
+	//	if(!mob.Allow_Spacemove(0))	return 0
 
 	if(!mob.lastarea)
 		mob.lastarea = get_area(mob.loc)
 
 	if((istype(mob.loc, /turf/space)) || (mob.lastarea.has_gravity == 0))
-		if(!mob.Process_Spacemove(0))	return 0
+		if(!mob.Allow_Spacemove(0))	return 0
 
 	if(isobj(mob.loc) || ismob(mob.loc))//Inside an object, tell it we moved
 		var/atom/O = mob.loc
@@ -453,11 +453,11 @@
 /mob/proc/Post_Incorpmove()
 	return
 
-///Process_Spacemove
+///Allow_Spacemove
 ///Called by /client/Move()
 ///For moving in space
 ///Return 1 for movement 0 for none
-/mob/proc/Process_Spacemove(var/check_drift = 0)
+/mob/proc/Allow_Spacemove(var/check_drift = 0)
 
 	if(!Check_Dense_Object()) //Nothing to push off of so end here
 		update_floating(0)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -242,8 +242,14 @@
 	if(!mob.lastarea)
 		mob.lastarea = get_area(mob.loc)
 
-	if((istype(mob.loc, /turf/space)) || (mob.lastarea.has_gravity == 0))
-		if(!mob.Allow_Spacemove(0))	return 0
+	if(!mob.check_solid_ground())
+		var/allowmove = mob.Allow_Spacemove(0)
+		if(!allowmove)
+			return 0
+		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
+			return 0
+		else
+			mob.inertia_dir = 0 //If not then we can reset inertia and move
 
 	if(isobj(mob.loc) || ismob(mob.loc))//Inside an object, tell it we moved
 		var/atom/O = mob.loc
@@ -453,32 +459,33 @@
 /mob/proc/Post_Incorpmove()
 	return
 
-///Allow_Spacemove
-///Called by /client/Move()
-///For moving in space
-///Return 1 for movement 0 for none
+// Checks whether this mob is allowed to move in space
+// Return 1 for movement, 0 for none, 
+// -1 to allow movement but with a chance of slipping
 /mob/proc/Allow_Spacemove(var/check_drift = 0)
-
 	if(!Check_Dense_Object()) //Nothing to push off of so end here
-		update_floating(0)
 		return 0
-
-	update_floating(1)
 
 	if(restrained()) //Check to see if we can do things
 		return 0
 
-	//Check to see if we slipped
-	if(prob(slip_chance(5)) && !buckled)
-		src << "<span class='warning'>You slipped!</span>"
-		src.inertia_dir = src.last_move
-		step(src, src.inertia_dir)
+	return -1
+
+//Checks if a mob has solid ground to stand on
+//If there's no gravity then there's no up or down so naturally you can't stand on anything.
+//For the same reason lattices in space don't count - those are things you grip, presumably.
+/mob/proc/check_solid_ground()
+	if(istype(loc, /turf/space))
 		return 0
-	//If not then we can reset inertia and move
-	inertia_dir = 0
+
+	if(!lastarea)
+		lastarea = get_area(loc)
+	if(!lastarea.has_gravity)
+		return 0
+
 	return 1
 
-/mob/proc/Check_Dense_Object() //checks for anything to push off in the vicinity. also handles magboots on gravity-less floors tiles
+/mob/proc/Check_Dense_Object() //checks for anything to push off or grip in the vicinity. also handles magboots on gravity-less floors tiles
 
 	var/shoegrip = Check_Shoegrip()
 
@@ -499,6 +506,15 @@
 	return 0
 
 /mob/proc/Check_Shoegrip()
+	return 0
+
+//return 1 if slipped, 0 otherwise
+/mob/proc/handle_spaceslipping()
+	if(prob(slip_chance(5)) && !buckled)
+		src << "<span class='warning'>You slipped!</span>"
+		src.inertia_dir = src.last_move
+		step(src, src.inertia_dir)
+		return 1
 	return 0
 
 /mob/proc/slip_chance(var/prob_slip = 5)

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -13,6 +13,8 @@
 	var/damage = 0
 	// ticks of bleeding left.
 	var/bleed_timer = 0
+	// Above this amount wounds you will need to treat the wound to stop bleeding, regardless of bleed_timer
+	var/bleed_threshold = 30
 	// amount of damage the current wound type requires(less means we need to apply the next healing stage)
 	var/min_damage = 0
 
@@ -187,7 +189,7 @@
 			return 0	//incompatible damage types
 
 		if (src.amount > 1)
-			return 0
+			return 0	//merged wounds cannot be worsened.
 
 		//with 1.5*, a shallow cut will be able to carry at most 30 damage,
 		//37.5 for a deep cut
@@ -208,8 +210,8 @@
 		if (bandaged||clamped)
 			return 0
 
-		if (wound_damage() <= 30 && bleed_timer <= 0)
-			return 0	//Bleed timer has run out. Wounds with more than 30 damage don't stop bleeding on their own.
+		if (bleed_timer <= 0 && wound_damage() <= bleed_threshold)
+			return 0	//Bleed timer has run out. Once a wound is big enough though, you'll need a bandage to stop it
 
 		return 1
 
@@ -264,8 +266,9 @@
 	return null //no wound
 
 /** CUTS **/
-/datum/wound/cut/bleeding()
-	return ..() && wound_damage() >= 5
+/datum/wound/cut
+	bleed_threshold = 5
+	damage_type = CUT
 
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage
@@ -273,40 +276,34 @@
 	// The major cut types have the max_bleeding_stage set to the clot stage (which is accordingly given the "blood soaked" descriptor).
 	max_bleeding_stage = 3
 	stages = list("ugly ripped cut" = 20, "ripped cut" = 10, "cut" = 5, "healing cut" = 2, "small scab" = 0)
-	damage_type = CUT
 
 /datum/wound/cut/deep
 	max_bleeding_stage = 3
 	stages = list("ugly deep ripped cut" = 25, "deep ripped cut" = 20, "deep cut" = 15, "clotted cut" = 8, "scab" = 2, "fresh skin" = 0)
-	damage_type = CUT
 
 /datum/wound/cut/flesh
 	max_bleeding_stage = 4
 	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "fresh skin" = 0)
-	damage_type = CUT
 
 /datum/wound/cut/gaping
 	max_bleeding_stage = 3
 	stages = list("gaping wound" = 50, "large blood soaked clot" = 25, "blood soaked clot" = 15, "small angry scar" = 5, "small straight scar" = 0)
-	damage_type = CUT
 
 /datum/wound/cut/gaping_big
 	max_bleeding_stage = 3
 	stages = list("big gaping wound" = 60, "healing gaping wound" = 40, "large blood soaked clot" = 25, "large angry scar" = 10, "large straight scar" = 0)
-	damage_type = CUT
 
 datum/wound/cut/massive
 	max_bleeding_stage = 3
 	stages = list("massive wound" = 70, "massive healing wound" = 50, "massive blood soaked clot" = 25, "massive angry scar" = 10,  "massive jagged scar" = 0)
-	damage_type = CUT
 
 /** PUNCTURES **/
+/datum/wound/puncture
+	bleed_threshold = 5
+	damage_type = PIERCE
+
 /datum/wound/puncture/can_worsen(damage_type, damage)
-	return 0
-/datum/wound/puncture/can_merge(var/datum/wound/other)
-	return 0
-/datum/wound/puncture/bleeding()
-	return ..() && wound_damage() >= 5
+	return 0 //puncture wounds cannot be enlargened
 
 /datum/wound/puncture/small
 	max_bleeding_stage = 2
@@ -334,41 +331,36 @@ datum/wound/puncture/massive
 	damage_type = PIERCE
 
 /** BRUISES **/
-/datum/wound/bruise/bleeding()
-	return ..() && wound_damage() >= 20
-
 /datum/wound/bruise
 	stages = list("monumental bruise" = 80, "huge bruise" = 50, "large bruise" = 30,
 				  "moderate bruise" = 20, "small bruise" = 10, "tiny bruise" = 5)
+	bleed_threshold = 20
 	max_bleeding_stage = 3 //only large bruise and above can bleed.
 	autoheal_cutoff = 30
 	damage_type = BRUISE
 
 /** BURNS **/
 /datum/wound/burn
+	damage_type = BURN
 	max_bleeding_stage = 0
+
 /datum/wound/burn/bleeding()
 	return 0
 
 /datum/wound/burn/moderate
 	stages = list("ripped burn" = 10, "moderate burn" = 5, "healing moderate burn" = 2, "fresh skin" = 0)
-	damage_type = BURN
 
 /datum/wound/burn/large
 	stages = list("ripped large burn" = 20, "large burn" = 15, "healing large burn" = 5, "fresh skin" = 0)
-	damage_type = BURN
 
 /datum/wound/burn/severe
 	stages = list("ripped severe burn" = 35, "severe burn" = 30, "healing severe burn" = 10, "burn scar" = 0)
-	damage_type = BURN
 
 /datum/wound/burn/deep
 	stages = list("ripped deep burn" = 45, "deep burn" = 40, "healing deep burn" = 15,  "large burn scar" = 0)
-	damage_type = BURN
 
 /datum/wound/burn/carbonised
 	stages = list("carbonised area" = 50, "healing carbonised area" = 20, "massive burn scar" = 0)
-	damage_type = BURN
 
 /** INTERNAL BLEEDING **/
 /datum/wound/internal_bleeding

--- a/html/changelogs/HarpyEagle-fixes.yml
+++ b/html/changelogs/HarpyEagle-fixes.yml
@@ -1,0 +1,9 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - bugfix: "Rewrote how the floating animation is updated, the animation now correctly updates when leaving space, activating/deactivating magboots, and buckling/unbuckling."
+  - bugfix: "Examining people in crit now again indicates that they are not breathing."
+  - bugfix: "Fixed spears giving slashing cuts and not puncture wounds."
+  - bugfix: "Fixed wounds not bleeding when they are supposed to."


### PR DESCRIPTION
- Fixes examining people in crit not indicating that they aren't breathing
- Fixes spears having edge
- Fixes wounds not bleeding when they are supposed to, introduced by 1eab45ea43d77e552b907f85beaf653269215658. In the bleeding() overrides, `||` needed to be used instead of `&&`. Cleaned up the whole thing instead using a bleed_threshold var.

Also fixes floating animation not being set/reset correctly when: 
- leaving a space turf without magboots on
- exiting a gravity-less area
- activating/deactivating magboots or equipping/unequipping them, 
- buckling or unbuckling in space. 

Pretty much rewrote it along with cleaning up space movement handling.

Classic case of code being edited by dozens of people dozens of times without anyone really agreeing what each proc was meant to be used for. I guess it is not all that surprising that making sure floating was properly updated was such a pain, given the state of the code it had to be integrated with.

Cleaned up magboot shoe covering as well because it was also pretty horrible, plus a few other things.
