### PR TITLE
Cleanables

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -16,7 +16,7 @@
 
 
 /obj/structure/janitorialcart/New()
-	create_reagents(100)
+	create_reagents(180)
 
 
 /obj/structure/janitorialcart/examine(mob/user)
@@ -39,7 +39,7 @@
 			if(reagents.total_volume < 1)
 				user << "<span class='warning'>[src] is out of water!</span>"
 			else
-				reagents.trans_to_obj(I, 5)	//
+				reagents.trans_to_obj(I, I.reagents.maximum_volume)
 				user << "<span class='notice'>You wet [I] in [src].</span>"
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 				return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -79,6 +79,10 @@
 			dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
 		dirtoverlay.alpha = min((dirt - 50) * 5, 255)
 
+/turf/simulated/remove_cleanables()
+	dirt = 0
+	. = ..()
+
 /turf/simulated/Entered(atom/A, atom/OL)
 	if(movement_disabled && usr.ckey != movement_disabled_exception)
 		usr << "<span class='danger'>Movement is admin-disabled.</span>" //This is to identify lag problems

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -43,6 +43,7 @@
 
 /turf/Destroy()
 	turfs -= src
+	remove_cleanables()
 	..()
 
 /turf/ex_act(severity)
@@ -219,18 +220,18 @@ var/const/enterloopsanity = 100
 	return 0
 
 //expects an atom containing the reagents used to clean the turf
-/turf/proc/clean(atom/source, mob/user)
+/turf/proc/clean(atom/source, mob/user = null)
 	if(source.reagents.has_reagent("water", 1) || source.reagents.has_reagent("cleaner", 1))
 		clean_blood()
-		if(istype(src, /turf/simulated))
-			var/turf/simulated/T = src
-			T.dirt = 0
-		for(var/obj/effect/O in src)
-			if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
-				qdel(O)
+		remove_cleanables()
 	else
 		user << "<span class='warning'>\The [source] is too dry to wash that.</span>"
 	source.reagents.trans_to_turf(src, 1, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
+
+/turf/proc/remove_cleanables()
+	for(var/obj/effect/O in src)
+		if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+			qdel(O)
 
 /turf/proc/update_blood_overlays()
 	return


### PR DESCRIPTION
Fixes #12179, mop is now filled with a single click.

Destroying a turf removes all cleanables from it. Fixes the annoying dirt marks left hanging over space turfs whenever parts of maintenance get blown up.
