### PR TITLE
Reduce smoking pipes w_class to 1

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -324,6 +324,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A pipe, for smoking. Probably made of meershaum or something."
 	icon_state = "pipeoff"
 	item_state = "pipeoff"
+	w_class = 1
 	icon_on = "pipeon"  //Note - these are in masks.dmi
 	icon_off = "pipeoff"
 	smoketime = 0


### PR DESCRIPTION
Smoking pipes shouldn't have w_class 3 no matter how you look at it, reduced to w_class 1 to make it more sensible.
