### PR TITLE
Fixes #12763

### DIFF
--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -12,6 +12,7 @@
 	..()
 
 /obj/item/organ/external/chest/ipc
+	gendered_icon = 0
 	dislocated = -1
 	encased = null
 /obj/item/organ/external/chest/ipc/New()
@@ -19,6 +20,7 @@
 	..()
 
 /obj/item/organ/external/groin/ipc
+	gendered_icon = 0
 	dislocated = -1
 /obj/item/organ/external/groin/ipc/New()
 	robotize("Morpheus Cyberkinetics")


### PR DESCRIPTION
Fixes #12763

icon_state = "torso_m", yet ipc.dmi has only "torso"
