### PR TITLE
Anti ban-evasion through dll detection

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -91,6 +91,8 @@ var/list/IClog     = list()
 var/list/OOClog    = list()
 var/list/adminlog  = list()
 
+var/list/client/clientcidcheck = list()
+
 var/list/powernets = list()
 
 var/Debug2 = 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -169,7 +169,15 @@
 		if(config.aggressive_changelog)
 			src.changes()
 
-
+	if(isnull(clientcidcheck[ckey]))
+		clientcidcheck[ckey] = computer_id
+		src << link("byond://[world.internet_address]:[world.port]")
+	else
+		var/oldcid = clientcidcheck[ckey]
+		clientcidcheck[ckey] = null //reset so if they connect from another computer or a laptop or something later on, they don't get this message.
+		if(oldcid != computer_id)
+			src << "Your client is failing to report a stable computer id. Please remove wsock32.dll from c:/program files/byond/bin and reconnect."
+			del(src)
 
 	//////////////
 	//DISCONNECT//


### PR DESCRIPTION
This is currently untested. I have no idea if this works or not, so don't pull it until it's tested.

This should detect the dll file used to ban-evade, and prevent them from joining. 

Credit to MrStonedOne for the code.
