### PR TITLE
Removes the Traitor game mode.

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -46,7 +46,7 @@
 /datum/antagonist/proc/can_late_spawn()
 	if(!ticker)
 		return 0
-	if(!(id in ticker.mode.latejoin_antags))
+	if(!(id in ticker.mode.latejoin_antag_tags))
 		return 0
 	update_current_antag_max()
 	if(get_antag_count() >= cur_max)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -23,7 +23,7 @@ var/global/list/additional_antag_types = list()
 
 	var/list/antag_tags = list()             // Core antag templates to spawn.
 	var/list/antag_templates                 // Extra antagonist types to include.
-	var/list/latejoin_antags = list()        // Antags that may auto-spawn, latejoin or otherwise come in midround.
+	var/list/latejoin_antag_tags = list()        // Antags that may auto-spawn, latejoin or otherwise come in midround.
 	var/round_autoantag = 0                  // Will this round attempt to periodically spawn more antagonists?
 	var/antag_scaling_coeff = 5              // Coefficient for scaling max antagonists to player count.
 	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
@@ -42,6 +42,11 @@ var/global/list/additional_antag_types = list()
 	// This will probably break something.
 	name = capitalize(lowertext(name))
 	config_tag = lowertext(config_tag)
+
+	if(round_autoantag && !latejoin_antag_tags.len)
+		latejoin_antag_tags = antag_tags.Copy()
+	else if(!round_autoantag && latejoin_antag_tags.len)
+		round_autoantag = TRUE
 
 /datum/game_mode/Topic(href, href_list[])
 	if(..())

--- a/code/game/gamemodes/mixed/intrigue.dm
+++ b/code/game/gamemodes/mixed/intrigue.dm
@@ -6,9 +6,8 @@
 	required_enemies = 4
 	end_on_antag_death = 0
 	antag_tags = list(MODE_NINJA, MODE_TRAITOR)
-	round_autoantag = 1
 	require_all_templates = 1
-	latejoin_antags = list(MODE_TRAITOR)
+	latejoin_antag_tags = list(MODE_TRAITOR)
 
 /datum/game_mode/intrigue/New()
 	..()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -13,14 +13,7 @@
 	config_tag = "traitor"
 	required_players = 0
 	required_enemies = 1
-	end_on_antag_death = 1
 	antag_tags = list(MODE_TRAITOR)
-	antag_scaling_coeff = 8
-
-/datum/game_mode/traitor/auto
-	name = "autotraitor"
-	config_tag = "autotraitor"
-	round_autoantag = 1
 	antag_scaling_coeff = 5
 	end_on_antag_death = 0
-	latejoin_antags = list(MODE_TRAITOR)
+	latejoin_antag_tags = list(MODE_TRAITOR)


### PR DESCRIPTION
Traitor is dead, long live Auto-Traitor!

The `round_autoantag` and `latejoin_antags` are now automatically set based on their original values.
If `round_autoantag` is enabled but `latejoin_antags` is empty then `latejoin_antags` is populated with the core antag ids for the gamemode.
If `round_autoantag` is disabled but `latejoin_antags` is populated then `round_autoantag` is enabled.

Forum discussion: https://baystation12.net/forums/threads/remove-traitor-gamemode.1843/
