### PR TITLE
Shortens cryosleep timer

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -168,7 +168,7 @@
 	var/disallow_occupant_types = list()
 
 	var/mob/occupant = null       // Person waiting to be despawned.
-	var/time_till_despawn = 18000 // 30 minutes-ish safe period before being despawned.
+	var/time_till_despawn = 9000  // Down to 15 minutes //30 minutes-ish is too long
 	var/time_entered = 0          // Used to keep track of the safe period.
 	var/obj/item/device/radio/intercom/announce //
 


### PR DESCRIPTION
Halves the duration from 30 to 15 minutes. It isn't that much of an issue these days but this reduces the risk of a cryo-queue.

Port of https://github.com/PolarisSS13/Polaris/pull/1390.
