### PR TITLE
Upgrades default suit cooler cell

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -26,8 +26,7 @@
 
 /obj/item/device/suit_cooling_unit/New()
 	processing_objects |= src
-
-	cell = new/obj/item/weapon/cell()	//comes with the crappy default power cell - high-capacity ones shouldn't be hard to find
+	cell = new/obj/item/weapon/cell/high()	//comes not with the crappy default power cell - because this is dedicated EVA equipment
 	cell.loc = src
 
 /obj/item/device/suit_cooling_unit/process()


### PR DESCRIPTION
Considering suit coolers are dedicated EVA equipment instead of emergency equipment, it's strange that they come equipped with a cell that lasts a handful of minutes in operation instead of a duration more comparable to an oxygen tank's.

This upgrades their default cell so that <s>FBPs</s> IPCs can grab, combine, and go just like other crewmembers.
Port of https://github.com/PolarisSS13/Polaris/pull/1469.
