### PR TITLE
Make it possible to eat mice from hand

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -122,6 +122,10 @@
 #define GLUT_SMALLER 2    // Eat anything smaller than we are
 #define GLUT_ANYTHING 3   // Eat anything, ever
 
+// Devour speeds, returned by can_devour()
+#define DEVOUR_SLOW 1
+#define DEVOUR_FAST 2
+
 #define TINT_NONE 0
 #define TINT_MODERATE 1
 #define TINT_HEAVY 2

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -69,6 +69,18 @@ var/list/holder_mob_icon_cache = list()
 /obj/item/weapon/holder/attack_self()
 	for(var/mob/M in contents)
 		M.show_inv(usr)
+		
+/obj/item/weapon/holder/attack(mob/target, mob/user)
+	// Devour on click on self with holder
+	if(target == user && istype(user,/mob/living/carbon))
+		var/mob/living/carbon/M = user
+		
+		for(var/mob/victim in src.contents)
+			M.devour(victim)
+
+		update_state()
+
+	..()
 
 /obj/item/weapon/holder/proc/sync(var/mob/living/M)
 	dir = 2

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -446,3 +446,12 @@
 	user << browse(dat, text("window=mob[];size=325x500", name))
 	onclose(user, "mob[name]")
 	return
+	
+/**
+ *  Return FALSE if victim can't be devoured, DEVOUR_FAST if they can be devoured quickly, DEVOUR_SLOW for slow devour
+ */
+/mob/living/carbon/proc/can_devour(mob/victim)
+	if((FAT in mutations) && issmall(victim))
+		return DEVOUR_FAST
+	
+	return FALSE

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -62,3 +62,25 @@
 	else
 		src << "You do not have enough chemicals stored to reproduce."
 		return
+		
+/**
+ *  Attempt to devour victim
+ *
+ *  Returns TRUE on success, FALSE on failure
+ */
+/mob/living/carbon/proc/devour(mob/victim)
+	var/can_eat = can_devour(victim)
+	if(!can_eat)
+		return FALSE
+	
+	src.visible_message("<span class='danger'>\The [src] is attempting to devour \the [victim]!</span>")
+	if(can_eat == DEVOUR_FAST)
+		if(!do_mob(src, victim, 30)) return FALSE
+	else
+		if(!do_mob(src, victim, 100)) return FALSE
+	src.visible_message("<span class='danger'>\The [src] devours \the [victim]!</span>")
+	admin_attack_log(src, victim, "Devoured.", "Was devoured by.", "devoured")
+	victim.forceMove(src)
+	src.stomach_contents.Add(victim)
+	
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1473,3 +1473,14 @@
 		return PULSE_NONE
 	else
 		return H.pulse
+		
+/mob/living/carbon/human/can_devour(mob/victim)		
+	if(src.species.gluttonous && (iscarbon(victim) || isanimal(victim)))
+		if(src.species.gluttonous == GLUT_TINY && (victim.mob_size <= MOB_TINY) && !ishuman(victim)) // Anything MOB_TINY or smaller
+			return DEVOUR_SLOW
+		else if(src.species.gluttonous == GLUT_SMALLER && (src.mob_size > victim.mob_size)) // Anything we're larger than
+			return DEVOUR_SLOW
+		else if(src.species.gluttonous == GLUT_ANYTHING) // Eat anything ever
+			return DEVOUR_FAST
+	
+	..()

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -204,7 +204,7 @@
 		for(var/mob/M in src)
 			if(M in stomach_contents)
 				stomach_contents.Remove(M)
-				M.loc = loc
+				M.forceMove(loc)
 		src.visible_message("\red <B>[src] hurls out the contents of their stomach!</B>")
 	return
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -320,7 +320,8 @@
 
 	//clicking on yourself while grabbing them
 	if(M == assailant && state >= GRAB_AGGRESSIVE)
-		devour(affecting, assailant)
+		if(assailant.devour(affecting))
+			qdel(src)
 
 /obj/item/weapon/grab/dropped()
 	loc = null

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -145,30 +145,3 @@
 	step_to(attacker, target)
 	attacker.set_dir(EAST) //face the victim
 	target.set_dir(SOUTH) //face up
-
-/obj/item/weapon/grab/proc/devour(mob/target, mob/user)
-	var/can_eat
-	if((FAT in user.mutations) && issmall(target))
-		can_eat = 1
-	else
-		var/mob/living/carbon/human/H = user
-		if(istype(H) && H.species.gluttonous && (iscarbon(target) || isanimal(target)))
-			if(H.species.gluttonous == GLUT_TINY && (target.mob_size <= MOB_TINY) && !ishuman(target)) // Anything MOB_TINY or smaller
-				can_eat = 1
-			else if(H.species.gluttonous == GLUT_SMALLER && (H.mob_size > target.mob_size)) // Anything we're larger than
-				can_eat = 1
-			else if(H.species.gluttonous == GLUT_ANYTHING) // Eat anything ever
-				can_eat = 2
-
-	if(can_eat)
-		var/mob/living/carbon/attacker = user
-		user.visible_message("<span class='danger'>[user] is attempting to devour [target]!</span>")
-		if(can_eat == 2)
-			if(!do_mob(user, target, 30)) return
-		else
-			if(!do_mob(user, target, 100)) return
-		user.visible_message("<span class='danger'>[user] devours [target]!</span>")
-		admin_attack_log(attacker, target, "Devoured.", "Was devoured by.", "devoured")
-		target.loc = user
-		attacker.stomach_contents.Add(target)
-		qdel(src)

--- a/html/changelogs/Daranz - eat-hand-mice.yml
+++ b/html/changelogs/Daranz - eat-hand-mice.yml
@@ -1,0 +1,4 @@
+author: Daranz
+delete-after: True
+changes: 
+  - rscadd: "Mice and other small critters can now be eaten from hand. As a member of species eligible to eat mice, scoop a mouse and click on your character with the hand holding the mouse. The old method of eating from grab remains available both for unscoopable and scoopable creatures."


### PR DESCRIPTION
This adds the ability to click on yourself with a holder (ie, what you get when you scoop up a mouse or other critter) and devour it in the same way you can devour small creatures from a grab.

Included is a refactor that takes devouring out of grabs and makes it into a mob proc. 
