### PR TITLE
Fixes and Tweaks

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -290,7 +290,7 @@ datum/controller/vote
 					if(check_rights(R_ADMIN|R_MOD, 0))
 						question = "End the shift?"
 						choices.Add("Initiate Crew Transfer", "Continue The Round")
-						if (config.allow_extra_antags)
+						if (config.allow_extra_antags && !antag_add_finished)
 							choices.Add("Add Antagonist")
 					else
 						if (get_security_level() == "red" || get_security_level() == "delta")
@@ -301,7 +301,7 @@ datum/controller/vote
 							initiator_key << "The crew transfer button has been disabled!"
 						question = "End the shift?"
 						choices.Add("Initiate Crew Transfer", "Continue The Round")
-						if (config.allow_extra_antags)
+						if (config.allow_extra_antags && !antag_add_finished)
 							choices.Add("Add Antagonist")
 				if("add_antagonist")
 					if(!config.allow_extra_antags)

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -63,7 +63,7 @@ datum/controller/vote
 
 	proc/autoaddantag()
 		disallow_none = 1
-		initiate_vote("addantag","the server", 1)
+		initiate_vote("add_antagonist","the server", 1)
 		log_debug("The server has called an add antag vote.")
 
 	proc/reset()

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -381,19 +381,19 @@ datum/controller/vote
 					. += "[choices[i]]"
 				. += "</td><td>"
 				if(current_high_votes[C.ckey] == i)
-					. += "<b><a href='?src=\ref[src];high_vote=[i]'>High</a></b>"
+					. += "<b><a href='?src=\ref[src];high_vote=[i]'>First</a></b>"
 				else
-					. += "<a href='?src=\ref[src];high_vote=[i]'>High</a>"
+					. += "<a href='?src=\ref[src];high_vote=[i]'>First</a>"
 				. += "</td><td>"
 				if(current_med_votes[C.ckey] == i)
-					. += "<b><a href='?src=\ref[src];med_vote=[i]'>Medium</a></b>"
+					. += "<b><a href='?src=\ref[src];med_vote=[i]'>Second</a></b>"
 				else
-					. += "<a href='?src=\ref[src];med_vote=[i]'>Medium</a>"
+					. += "<a href='?src=\ref[src];med_vote=[i]'>Second</a>"
 				. += "</td><td>"
 				if(current_low_votes[C.ckey] == i)
-					. += "<b><a href='?src=\ref[src];low_vote=[i]'>Low</a></b>"
+					. += "<b><a href='?src=\ref[src];low_vote=[i]'>Third</a></b>"
 				else
-					. += "<a href='?src=\ref[src];low_vote=[i]'>Low</a>"
+					. += "<a href='?src=\ref[src];low_vote=[i]'>Third</a>"
 				. += "</td><td align = 'center'>[votepercent]%</td>"
 				if (additional_text.len >= i)
 					. += additional_text[i]

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -51,7 +51,6 @@ datum/controller/vote
 	proc/autotransfer()
 		initiate_vote("crew_transfer","the server", 1)
 		log_debug("The server has called a crew transfer vote")
-		antag_add_finished = 0 // reset this so that players can vote in another antag
 
 	proc/autogamemode()
 		initiate_vote("gamemode","the server", 1)
@@ -205,6 +204,7 @@ datum/controller/vote
 					else if(.[1] == "Add Antagonist")
 						spawn(10)
 							initiate_vote("add_antagonist", "the server", 1)
+							antag_add_finished = 1 // only one round end add antag per round
 				if("add_antagonist")
 					if(isnull(.[1]) || .[1] == "None")
 						antag_add_finished = 1

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -223,18 +223,19 @@ datum/controller/vote
 								world << "The random antag in [i]\th place is [.[i]]."
 						var/antag_type = antag_names_to_ids[.[1]]
 						if(ticker.current_state >= 2)
-							var/list/antag_choices = list(all_antag_types[antag_type], all_antag_types[antag_names_to_ids[.[2]]], all_antag_types[antag_names_to_ids[.[3]]])
-							if(!ticker.attempt_late_antag_spawn(antag_choices))
-								world << "<b>No antags were added.</b>"
-								antag_add_finished = 1
-								if(auto_add_antag)
+							spawn(0) // break off so we don't hang the vote process
+								var/list/antag_choices = list(all_antag_types[antag_type], all_antag_types[antag_names_to_ids[.[2]]], all_antag_types[antag_names_to_ids[.[3]]])
+								if(!ticker.attempt_late_antag_spawn(antag_choices))
+									world << "<b>No antags were added.</b>"
+									antag_add_finished = 1
+									if(auto_add_antag)
+										auto_add_antag = 0
+										spawn(10)
+											autotransfer();
+								else if(auto_add_antag)
 									auto_add_antag = 0
-									spawn(10)
-										autotransfer();
-							else if(auto_add_antag)
-								auto_add_antag = 0
-								// the buffer will already have an hour added to it, so we'll give it one more
-								transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
+									// the buffer will already have an hour added to it, so we'll give it one more
+									transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
 						else
 							additional_antag_types |= antag_type
 				if("map")

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -229,7 +229,8 @@ datum/controller/vote
 								antag_add_finished = 1
 								if(auto_add_antag)
 									auto_add_antag = 0
-									autotransfer();
+									spawn(10)
+										autotransfer();
 							else if(auto_add_antag)
 								auto_add_antag = 0
 								// the buffer will already have an hour added to it, so we'll give it one more

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -104,7 +104,7 @@
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
-		if(ghosts_only && !isghost(player.current))
+		if(ghosts_only && !(!player.current || isghost(player.current) || player.current.stat == DEAD || !player.current.client))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
 		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -190,7 +190,7 @@
 	if(!(flags & ANTAG_OVERRIDE_JOB) && (!player.current || istype(player.current, /mob/new_player)))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
 		return 0
-	if(isghost(player.current) && !(player in ticker.antag_pool))
+	if(ticker.current_state >= 2 && (isghost(player.current) || player.current.stat == DEAD || !player.current.client) && !(player in ticker.antag_pool))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they are a ghost not in the antag pool.")
 		return 0
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -190,6 +190,9 @@
 	if(!(flags & ANTAG_OVERRIDE_JOB) && (!player.current || istype(player.current, /mob/new_player)))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
 		return 0
+	if(isghost(player.current) && !(player in ticker.antag_pool))
+		log_debug("[player.key] was selected for [role_text] by lottery, but they are a ghost not in the antag pool.")
+		return 0
 
 	pending_antagonists |= player
 	log_debug("[player.key] has been selected for [role_text] by lottery.")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -478,7 +478,7 @@ var/global/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker/proc/attempt_late_antag_spawn(var/list/antag_choices)
 	var/datum/antagonist/antag = antag_choices[1]
-	while(antag_choices.len && antag && antag in all_antag_types)
+	while(antag_choices.len && antag)
 		var/needs_ghost = antag.flags & (ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB)
 		if (needs_ghost)
 			looking_for_antags = 1
@@ -511,6 +511,6 @@ var/global/datum/controller/gameticker/ticker
 			antag_choices -= antag
 			if(length(antag_choices))
 				antag = antag_choices[1]
-				if(antag && antag in all_antag_types)
+				if(antag)
 					world << "Attempting to spawn [antag.role_text_plural]."
 	return 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -480,19 +480,21 @@ var/global/datum/controller/gameticker/ticker
 	var/datum/antagonist/antag = antag_choices[1]
 	while(antag_choices.len)
 		var/needs_ghost = antag.flags & (ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB)
-		antag.update_current_antag_max()
-		antag.build_candidate_list(needs_ghost)
 		if (needs_ghost)
 			looking_for_antags = 1
 			antag_pool.Cut()
-			world << "<b>A ghost is needed to spawn \a [antag.role_text].</b>\nGhosts may enter the antag pool by using the toggle-add-antag-candidacy verb. You have 30 seconds to enter the pool."
+			world << "<b>A ghost is needed to spawn \a [antag.role_text].</b>\nGhosts may enter the antag pool by making sure their [antag.role_text] preference is set to high, then using the toggle-add-antag-candidacy verb. You have 30 seconds to enter the pool."
 			sleep(300)
 			looking_for_antags = 0
+			antag.update_current_antag_max()
+			antag.build_candidate_list(needs_ghost)
 			for(var/datum/mind/candidate in antag.candidates)
 				if(!(candidate in antag_pool))
 					antag.candidates -= candidate
 					log_debug("[candidate.key] was not in the antag pool and could not be selected.")
 		else
+			antag.update_current_antag_max()
+			antag.build_candidate_list(needs_ghost)
 			for(var/datum/mind/candidate in antag.candidates)
 				if(isghost(candidate.current))
 					antag.candidates -= candidate
@@ -502,7 +504,10 @@ var/global/datum/controller/gameticker/ticker
 			antag.finalize_spawn()
 			return 1
 		else
-			world << "Failed to find enough [antag.role_text_plural]."
+			if(antag.initial_spawn_req > 1)
+				world << "Failed to find enough [antag.role_text_plural]."
+			else
+				world << "Failed to find a [antag.role_text]."
 			antag_choices -= antag
 			if(length(antag_choices))
 				antag = antag_choices[1]

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -478,7 +478,7 @@ var/global/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker/proc/attempt_late_antag_spawn(var/list/antag_choices)
 	var/datum/antagonist/antag = antag_choices[1]
-	while(antag_choices.len)
+	while(antag_choices.len && antag && antag in all_antag_types)
 		var/needs_ghost = antag.flags & (ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB)
 		if (needs_ghost)
 			looking_for_antags = 1
@@ -502,8 +502,6 @@ var/global/datum/controller/gameticker/ticker
 		if(length(antag.candidates) >= antag.initial_spawn_req)
 			antag.attempt_spawn()
 			antag.finalize_spawn()
-			// the buffer will already have an hour added to it, so we'll give it one more
-			transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
 			return 1
 		else
 			if(antag.initial_spawn_req > 1)
@@ -513,5 +511,6 @@ var/global/datum/controller/gameticker/ticker
 			antag_choices -= antag
 			if(length(antag_choices))
 				antag = antag_choices[1]
-				world << "Attempting to spawn [antag.role_text_plural]."
+				if(antag && antag in all_antag_types)
+					world << "Attempting to spawn [antag.role_text_plural]."
 	return 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -502,6 +502,8 @@ var/global/datum/controller/gameticker/ticker
 		if(length(antag.candidates) >= antag.initial_spawn_req)
 			antag.attempt_spawn()
 			antag.finalize_spawn()
+			// the buffer will already have an hour added to it, so we'll give it one more
+			transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
 			return 1
 		else
 			if(antag.initial_spawn_req > 1)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -938,7 +938,7 @@ proc/admin_notice(var/message, var/rights)
 			for(var/datum/antagonist/antag in ticker.mode.antag_templates)
 				if(antag.is_antagonist(M))
 					return 2
-		else if(M.special_role)
+		if(M.special_role)
 			return 1
 
 	if(isrobot(character))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1927,7 +1927,7 @@ mob/living/silicon/ai/can_centcom_reply()
 		return "|<A HREF='?[source];adminplayerobservejump=\ref[eyeobj]'>EYE</A>"
 
 /mob/observer/ghost/extra_admin_link(var/source)
-	if(mind && mind.current)
+	if(mind && (mind.current && !isghost(mind.current)))
 		return "|<A HREF='?[source];adminplayerobservejump=\ref[mind.current]'>BDY</A>"
 
 /proc/admin_jump_link(var/atom/target, var/source)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -711,6 +711,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			usr << "You have left the antag pool."
 		else
 			ticker.antag_pool += src.mind
-			usr << "You have joined the antag pool."
+			usr << "You have joined the antag pool. Make sure you have the needed role set to high!"
 	else
 		usr << "The game is not currently looking for antags."

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -693,7 +693,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return "|<a href='byond://?src=\ref[ghost];track=\ref[eyeobj]'>eye</a>"
 
 /mob/observer/ghost/extra_ghost_link(var/atom/ghost)
-	if(mind && mind.current)
+	if(mind && (mind.current && !isghost(mind.current)))
 		return "|<a href='byond://?src=\ref[ghost];track=\ref[mind.current]'>body</a>"
 
 /proc/ghost_follow_link(var/atom/target, var/atom/ghost)


### PR DESCRIPTION
The midround add antag proc will wait to build the candidate list until after the 30 second period for ghosts, to give them a chance to set their prefs.

Renames the vote choices: high :arrow_right: first, medium :arrow_right: second, low :arrow_right: third.

Removes erroneous 'body' follow links from observers that don't actually have bodies.

Crew transfer add antag option will not displayed if it is not allowed due to failing.

If a crew transfer add antag fails, another transfer vote will immediately start without an add antag option.

Successful crew transfer add antag votes will add two hours till the next vote instead of one.

Adds "random" to the add antag vote.

Fixes #12801, #12853 , adds check for ghosts in the drafting process.

Prevents the vote process from hanging.

Fixes #12846.
