### PR TITLE
Fixes Windoors, Disposal Bins and Shield capacitor icons.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -410,12 +410,11 @@
 
 	close_door_at = 0
 	do_animate("closing")
-	sleep(3)
-	src.density = 1
+	density = 1
 	explosion_resistance = initial(explosion_resistance)
-	src.layer = closed_layer
+	layer = closed_layer
 	update_nearby_tiles()
-	sleep(7)
+	sleep(10)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)	//caaaaarn!

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -114,8 +114,8 @@
 		return 0
 	if (!ticker)
 		return 0
-
-	operating = 1
+	if(!operating )
+		operating = 1
 	flick(text("[]opening", src.base_state), src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
 	density = 0
@@ -128,8 +128,9 @@
 	return 1
 
 /obj/machinery/door/window/close()
-	if (src.operating)
+	if (operating)
 		return 0
+
 	operating = 1
 	flick(text("[]closing", src.base_state), src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
@@ -139,7 +140,8 @@
 	update_nearby_tiles()
 
 	sleep(10)
-	src.operating = 0
+	operating = 0
+
 	return 1
 
 /obj/machinery/door/window/take_damage(var/damage)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -24,6 +24,12 @@
 		src.base_state = src.icon_state
 	return
 
+/obj/machinery/door/window/update_icon()
+	if(density)
+		icon_state = base_state
+	else
+		icon_state = "[base_state]open"
+
 /obj/machinery/door/window/proc/shatter(var/display_message = 1)
 	new /obj/item/weapon/material/shard(src.loc)
 	var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(src.loc)
@@ -104,22 +110,19 @@
 		return 1
 
 /obj/machinery/door/window/open()
-	if (src.operating == 1) //doors can still open when emag-disabled
+	if (operating == 1) //doors can still open when emag-disabled
 		return 0
 	if (!ticker)
 		return 0
-	if(!src.operating) //in case of emag
-		src.operating = 1
+
+	operating = 1
 	flick(text("[]opening", src.base_state), src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	src.icon_state = text("[]open", src.base_state)
-	sleep(10)
-
+	density = 0
+	update_icon()
 	explosion_resistance = 0
-	src.density = 0
-//	src.sd_SetOpacity(0)	//TODO: why is this here? Opaque windoors? ~Carn
 	update_nearby_tiles()
-
+	sleep(10)
 	if(operating == 1) //emag again
 		src.operating = 0
 	return 1
@@ -127,19 +130,15 @@
 /obj/machinery/door/window/close()
 	if (src.operating)
 		return 0
-	src.operating = 1
+	operating = 1
 	flick(text("[]closing", src.base_state), src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	src.icon_state = src.base_state
-
-	src.density = 1
+	density = 1
+	update_icon()
 	explosion_resistance = initial(explosion_resistance)
-//	if(src.visible)
-//		SetOpacity(1)	//TODO: why is this here? Opaque windoors? ~Carn
 	update_nearby_tiles()
 
 	sleep(10)
-
 	src.operating = 0
 	return 1
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -40,7 +40,7 @@
 			trunk.linked = src	// link the pipe trunk to self
 
 		air_contents = new/datum/gas_mixture(PRESSURE_TANK_VOLUME)
-		update()
+		update_icon()
 
 /obj/machinery/disposal/Destroy()
 	eject()
@@ -103,7 +103,7 @@
 		for(var/obj/item/O in T.contents)
 			T.remove_from_storage(O,src)
 		T.update_icon()
-		update()
+		update_icon()
 		return
 
 	var/obj/item/weapon/grab/G = I
@@ -140,7 +140,7 @@
 			continue
 		M.show_message("[user.name] places \the [I] into the [src].", 3)
 
-	update()
+	update_icon()
 
 // mouse drop another mob or self
 //
@@ -191,7 +191,7 @@
 			continue
 		C.show_message(msg, 3)
 
-	update()
+	update_icon()
 	return
 
 // attempt to move while inside
@@ -209,7 +209,7 @@
 		user.client.eye = user.client.mob
 		user.client.perspective = MOB_PERSPECTIVE
 	user.forceMove(src.loc)
-	update()
+	update_icon()
 	return
 
 // ai as human but can't flush
@@ -231,7 +231,7 @@
 		interact(user, 0)
 	else
 		flush = !flush
-		update()
+		update_icon()
 	return
 
 // user interaction
@@ -299,12 +299,12 @@
 				mode = 1
 			else
 				mode = 0
-			update()
+			update_icon()
 
 		if(!isAI(usr))
 			if(href_list["handle"])
 				flush = text2num(href_list["handle"])
-				update()
+				update_icon()
 
 			if(href_list["eject"])
 				eject()
@@ -319,13 +319,12 @@
 	for(var/atom/movable/AM in src)
 		AM.forceMove(src.loc)
 		AM.pipe_eject(0)
-	update()
+	update_icon()
 
 // update the icon & overlays to reflect mode & status
-/obj/machinery/disposal/proc/update()
+/obj/machinery/disposal/update_icon()
 	overlays.Cut()
 	if(stat & BROKEN)
-		icon_state = "disposal-broken"
 		mode = 0
 		flush = 0
 		return
@@ -373,7 +372,7 @@
 		update_use_power(1)
 	else if(air_contents.return_pressure() >= SEND_PRESSURE)
 		mode = 2 //if full enough, switch to ready mode
-		update()
+		update_icon()
 	else
 		src.pressurize() //otherwise charge
 
@@ -429,14 +428,14 @@
 	flush = 0
 	if(mode == 2)	// if was ready,
 		mode = 1	// switch to charging
-	update()
+	update_icon()
 	return
 
 
 // called when area power changes
 /obj/machinery/disposal/power_change()
 	..()	// do default setting/reset of stat NOPOWER bit
-	update()	// update icon
+	update_icon()	// update icon
 	return
 
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -381,7 +381,7 @@
 /obj/machinery/disposal/deliveryChute/interact()
 	return
 
-/obj/machinery/disposal/deliveryChute/update()
+/obj/machinery/disposal/deliveryChute/update_icon()
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(var/atom/movable/AM) //Go straight into the chute
@@ -423,7 +423,7 @@
 	flush = 0
 	if(mode == 2)	// if was ready,
 		mode = 1	// switch to charging
-	update()
+	update_icon()
 	return
 
 /obj/machinery/disposal/deliveryChute/attackby(var/obj/item/I, var/mob/user)

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -26,7 +26,7 @@
 				possible_gen.owned_capacitor = src
 				break
 	..()
-	
+
 /obj/machinery/shield_capacitor/emag_act(var/remaining_charges, var/mob/user)
 	if(prob(75))
 		src.locked = !src.locked
@@ -137,8 +137,7 @@
 	updateDialog()
 
 /obj/machinery/shield_capacitor/update_icon()
-	if(stat & BROKEN)
-		icon_state = "broke"
+	icon_state = "capacitor"
 
 /obj/machinery/shield_capacitor/verb/rotate()
 	set name = "Rotate capacitor clockwise"


### PR DESCRIPTION
- Windoor update_icon() implemented, overriding default update_icon() for airlocks.
- Disposal Bin code slightly refactored. proc/update() renamed to /update_icon() to bring it in line with all other objects. Refactors uses of update() to update_icon().
- Shield Capacitor update_icon() no longer updates to nonexistant icon state.
- Fixes #12745
