### PR TITLE
Adds access_hydroponics for chefs

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -38,7 +38,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	access = list(access_hydroponics, access_bar, access_kitchen)
-	minimal_access = list(access_kitchen)
+	minimal_access = list(access_kitchen, access_hydroponics)
 	alt_titles = list("Cook")
 
 


### PR DESCRIPTION
Chefs can already access hydroponics from within the kitchen, it's silly they can't open the door connecting garden storage and hydroponics and have to walk all the way through the bar, into the hallway, through the garden just to get over there.
