### PR TITLE
Fix a problem with captain's medal

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -28,10 +28,17 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/captain(H), slot_back)
 			if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_cap(H), slot_back)
 			if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
-		var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/captain(H), slot_w_uniform) 
 		if(H.age>49)
-			U.accessories += new /obj/item/clothing/accessory/medal/gold/captain(U)
-		H.equip_to_slot_or_del(U, slot_w_uniform)
+			// Since we can have something other than the default uniform at this  
+			// point, check if we can actually attach the medal
+			var/obj/item/clothing/uniform = H.w_uniform
+			var/obj/item/clothing/accessory/medal/gold/captain/medal = new()
+			
+			if(uniform && uniform.can_attach_accessory(medal))
+				uniform.attach_accessory(null, medal)
+			else
+				qdel(medal)
 		H.equip_to_slot_or_del(new /obj/item/device/pda/captain(H), slot_belt)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/caphat(H), slot_head)

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -18,12 +18,7 @@
 		var/obj/item/clothing/accessory/A = I
 		if(can_attach_accessory(A))
 			user.drop_item()
-			accessories += A
-			A.on_attached(src, user)
-			src.verbs |= /obj/item/clothing/proc/removetie_verb
-			if(istype(loc, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = loc
-				H.update_inv_w_uniform()
+			attach_accessory(user, A)
 			return
 		else
 			user << "<span class='warning'>You cannot attach more accessories of this type to [src].</span>"
@@ -68,6 +63,18 @@
 	if(accessories.len)
 		for(var/obj/item/clothing/accessory/A in accessories)
 			user << "\A [A] is attached to it."
+
+/**
+ *  Attach accessory A to src
+ *
+ *  user is the user doing the attaching. Can be null, such as when attaching
+ *  items on spawn
+ */
+/obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
+	accessories += A
+	A.on_attached(src, user)
+	src.verbs |= /obj/item/clothing/proc/removetie_verb
+	update_clothing_icon()
 
 /obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory/A)
 	if(!(A in accessories))

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -47,8 +47,9 @@
 	loc = has_suit
 	has_suit.overlays += get_inv_overlay()
 
-	user << "<span class='notice'>You attach \the [src] to \the [has_suit].</span>"
-	src.add_fingerprint(user)
+	if(user)
+		user << "<span class='notice'>You attach \the [src] to \the [has_suit].</span>"
+		src.add_fingerprint(user)
 
 /obj/item/clothing/accessory/proc/on_removed(var/mob/user)
 	if(!has_suit)


### PR DESCRIPTION
Sufficiently old captains get a medal of captaincy on spawn. It is supposed to be attached to the captain's uniform. Problem is, it is impossible to remove and does not initially show up correctly on the inventory icon. This solves both the problems.
