### PR TITLE
Loadout gear is now only stored into storage where it fits.

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -434,20 +434,23 @@ var/global/datum/controller/occupations/job_master
 					captain_announcement.Announce("All hands, Captain [H.real_name] on deck!", new_sound=announce_sound)
 
 			//Deferred item spawning.
-			if(spawn_in_storage && spawn_in_storage.len)
-				var/obj/item/weapon/storage/B
-				for(var/obj/item/weapon/storage/S in H.contents)
-					B = S
-					break
+			for(var/thing in spawn_in_storage)
+				var/datum/gear/G = gear_datums[thing]
+				var/metadata = H.client.prefs.gear[G.display_name]
+				var/item = G.spawn_item(null, metadata)
 
-				if(!isnull(B))
-					for(var/thing in spawn_in_storage)
-						H << "<span class='notice'>Placing \the [thing] in your [B.name]!</span>"
-						var/datum/gear/G = gear_datums[thing]
-						var/metadata = H.client.prefs.gear[G.display_name]
-						G.spawn_item(B, metadata)
-				else
-					H << "<span class='danger'>Failed to locate a storage object on your mob, either you spawned with no arms and no backpack or this is a bug.</span>"
+				var/atom/placed_in = H.equip_to_storage(item)
+				if(placed_in)
+					H << "<span class='notice'>Placing \the [item] in your [placed_in.name]!</span>"
+					continue
+				if(H.equip_to_appropriate_slot(item))
+					H << "<span class='notice'>Placing \the [item] in your inventory!</span>"
+					continue
+				if(H.put_in_hands(item))
+					H << "<span class='notice'>Placing \the [item] in your hands!</span>"
+					continue
+				H << "<span class='danger'>Failed to locate a storage object on your mob, either you spawned with no arms and no backpack or this is a bug.</span>"
+				qdel(item)
 
 		if(istype(H)) //give humans wheelchairs, if they need them.
 			var/obj/item/organ/external/l_foot = H.get_organ("l_foot")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -85,14 +85,13 @@ var/list/slot_equipment_priority = list( \
 		var/obj/item/weapon/storage/backpack = src.back
 		if(backpack.can_be_inserted(newitem, 1))
 			newitem.forceMove(src.back)
-			return 1
+			return backpack
 
 	// Try to place it in any item that can store stuff, on the mob.
 	for(var/obj/item/weapon/storage/S in src.contents)
 		if(S.can_be_inserted(newitem, 1))
 			newitem.forceMove(S)
-			return 1
-	return 0
+			return S
 
 //These procs handle putting s tuff in your hand. It's probably best to use these rather than setting l_hand = ...etc
 //as they handle all relevant stuff like adding it to the player's screen and updating their overlays.


### PR DESCRIPTION
The equip_to_storage() proc now also returns the used container, for convenience.
Fixes #12816 proper.
