### PR TITLE
Slowdown tweaks.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -144,10 +144,10 @@
 	if(pulling)
 		if(istype(pulling, /obj))
 			var/obj/O = pulling
-			. += O.w_class / 2
+			. += O.w_class / 5
 		else if(istype(pulling, /mob))
 			var/mob/M = pulling
-			. += M.mob_size / 5
+			. += M.mob_size / MOB_MEDIUM
 		else
 			. += 1
 


### PR DESCRIPTION
Pulling items now gives you a w_class / 5 slowdown instead of w_class / 2.
Pulling a normal sized mob gives you a  -1 slowdown instead of -4. Smaller/larger mob pull speed penalties adjusted similarly.
