### PR TITLE
Fixes null reference runtimes when clicking screen objects in null space.

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1295,8 +1295,10 @@ var/mob/dview/dview_mob = new
 // call to generate a stack trace and print to runtime logs
 /proc/crash_with(msg)
 	CRASH(msg)
-	
+
 /proc/screen_loc2turf(scr_loc, turf/origin)
+	if(!origin)
+		return
 	var/tX = splittext(scr_loc, ",")
 	var/tY = splittext(tX[2], ":")
 	var/tZ = origin.z
@@ -1306,4 +1308,4 @@ var/mob/dview/dview_mob = new
 	tX = max(1, min(world.maxx, origin.x + (text2num(tX) - (world.view + 1))))
 	tY = max(1, min(world.maxy, origin.y + (text2num(tY) - (world.view + 1))))
 	return locate(tX, tY, tZ)
-	
+

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -351,5 +351,6 @@
 		C.swap_hand()
 	else
 		var/turf/T = screen_loc2turf(modifiers["screen-loc"], get_turf(usr))
-		T.Click(location, control, params)
+		if(T)
+			T.Click(location, control, params)
 	return 1


### PR DESCRIPTION
To clarify, while the user is in null space. The lobby screen is a good example.
