### PR TITLE
Adds req_access to medical RIG

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -203,6 +203,8 @@
 
 /obj/item/weapon/rig/medical/equipped
 
+	req_access = list(access_medical_equip)
+
 	initial_modules = list(
 		/obj/item/rig_module/chem_dispenser/injector,
 		/obj/item/rig_module/maneuvering_jets,


### PR DESCRIPTION
Rescue suit now requires access_medical_equip, a small oversight from a long time ago. Also provides the suit some security for sitting in the open.
