### PR TITLE
Refactors wipe_core(), extends function to pAIs

### DIFF
--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -31,15 +31,4 @@ var/global/list/empty_playable_ai_cores = list()
 	global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
 
 	//Handle job slot/tater cleanup.
-	var/job = mind.assigned_role
-
-	job_master.FreeRole(job)
-
-	if(mind.objectives.len)
-		qdel(mind.objectives)
-		mind.special_role = null
-
-	clear_antag_roles(mind)
-
-	ghostize(0)
-	qdel(src)
+	clear_client()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -296,6 +296,34 @@
 		return
 
 	close_up()
+	
+	
+/mob/living/silicon/pai/verb/delete_personality()
+	set name = "Delete Personality"
+	set category = "OOC"
+	set desc = "Delete your personality. This is functionally equivalent to cryo or robotic storage, freeing up the pAI device for a new personality."
+
+	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
+	if(alert("WARNING: This will immediately delete your personality and ghost you, removing your character from the round permanently (similar to cryo and robotic storage). Are you entirely sure you want to do this?",
+					"Delete Personality", "No", "No", "Yes") != "Yes")
+		return
+
+	// We warned you.
+	visible_message("<b>[src]</b> fades away, the pAI device goes silent.")
+	close_up()
+	
+	//Handle job slot/tater cleanup.
+	var/job = mind.assigned_role
+
+	job_master.FreeRole(job)
+
+	if(mind.objectives.len)
+		qdel(mind.objectives)
+		mind.special_role = null
+
+	card.removePersonality()
+	ghostize(0)
+	qdel(src)
 
 /mob/living/silicon/pai/proc/choose_chassis()
 	set category = "pAI Commands"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -297,34 +297,6 @@
 
 	close_up()
 	
-	
-/mob/living/silicon/pai/verb/delete_personality()
-	set name = "Delete Personality"
-	set category = "OOC"
-	set desc = "Delete your personality. This is functionally equivalent to cryo or robotic storage, freeing up the pAI device for a new personality."
-
-	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
-	if(alert("WARNING: This will immediately delete your personality and ghost you, removing your character from the round permanently (similar to cryo and robotic storage). Are you entirely sure you want to do this?",
-					"Delete Personality", "No", "No", "Yes") != "Yes")
-		return
-
-	// We warned you.
-	visible_message("<b>[src]</b> fades away, the pAI device goes silent.")
-	close_up()
-	
-	//Handle job slot/tater cleanup.
-	var/job = mind.assigned_role
-
-	job_master.FreeRole(job)
-
-	if(mind.objectives.len)
-		qdel(mind.objectives)
-		mind.special_role = null
-
-	card.removePersonality()
-	ghostize(0)
-	qdel(src)
-
 /mob/living/silicon/pai/proc/choose_chassis()
 	set category = "pAI Commands"
 	set name = "Choose Chassis"
@@ -448,3 +420,19 @@
 		return
 	else
 		return ..()
+		
+/mob/living/silicon/pai/verb/wipe_software()
+	set name = "Wipe Software"
+	set category = "OOC"
+	set desc = "Wipe your software. This is functionally equivalent to cryo or robotic storage, freeing up your job slot."
+	
+	// Make sure people don't kill themselves accidentally
+	if(alert("WARNING: This will immediately wipe your software and ghost you, removing your character from the round permanently (similar to cryo and robotic storage). Are you entirely sure you want to do this?",
+					"Wipe Software", "No", "No", "Yes") != "Yes")
+		return
+	
+	close_up()
+	visible_message("<b>[src]</b> fades away from the screen, the pAI device goes silent.")
+	card.removePersonality()
+	clear_client()
+

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -361,3 +361,18 @@
 	..()
 	if(cameraFollow)
 		cameraFollow = null
+		
+/mob/living/silicon/proc/clear_client()
+	//Handle job slot/tater cleanup.
+	var/job = mind.assigned_role
+
+	job_master.FreeRole(job)
+
+	if(mind.objectives.len)
+		qdel(mind.objectives)
+		mind.special_role = null
+
+	clear_antag_roles(mind)
+			
+	ghostize(0)
+	qdel(src)


### PR DESCRIPTION
Ported over from AI's wipe_core verb, allow pAIs to ghost and leave the round properly in case nobody wipes the pAI device.

Job/tater cleanup code left in, in case pAI somehow starts taking up actual job slots and get slapped on tater status for whatever reason.

Fixes #12855
