### PR TITLE
Fixes Vox Pariah bodytype

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -147,3 +147,6 @@
 			M << "<span class='danger'>A terrible stench emanates from \the [H].</span>"
 	if(prob(1) && prob(50)) //0.5% chance
 		H.vomit()
+
+/datum/species/vox/pariah/get_bodytype()
+	return "Vox"


### PR DESCRIPTION
Proc was accidentally removed in the last update. This should fix it.
