### PR TITLE
Prevents many dense /objs from blocking penetrating bullets

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -43,7 +43,7 @@
 			damage *= 0.7 //squishy mobs absorb KE
 		return 1
 
-	var/chance = 0
+	var/chance = damage
 	if(istype(A, /turf/simulated/wall))
 		var/turf/simulated/wall/W = A
 		chance = round(damage/W.material.integrity*180)
@@ -53,8 +53,6 @@
 		if(D.glass) chance *= 2
 	else if(istype(A, /obj/structure/girder))
 		chance = 100
-	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		chance = damage
 
 	if(prob(chance))
 		if(A.opacity)


### PR DESCRIPTION
Adjust the default penetration chance for penetrating bullets. I think this is a more sensible default as there are many dense /objs that really should be penetrable.

I'm considering giving the default chance a bit of a boost too, just so that PTRs don't have a 20% chance of being stopped by filling cabinets and stuff like that. Main thing stopping me is that I don't want to boost assault rifles too much.
