### PR TITLE
Adjusts backpack storage capacities

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -183,5 +183,5 @@
 // Storage
 #define base_storage_cost(w_class) (2**(w_class-1)) //1,2,4,8,16,...
 
-#define DEFAULT_BACKPACK_STORAGE 28
+#define DEFAULT_BACKPACK_STORAGE 22
 #define DEFAULT_BOX_STORAGE 14

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -107,7 +107,7 @@
 	name = "spear"
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
 	force = 10
-	w_class = 4.0
+	w_class = 5 //too long even for a dufflebag
 	slot_flags = SLOT_BACK
 	force_wielded = 0.75           // 22 when wielded with hardness 15 (glass)
 	unwielded_force_divisor = 0.65 // 14 when unwielded based on above

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -60,7 +60,7 @@
 	//active_force = 150 //holy...
 	active_force = 60
 	active_throwforce = 35
-	active_w_class = 5
+	active_w_class = 6
 	//force = 40
 	//throwforce = 25
 	force = 20
@@ -94,7 +94,7 @@
 	icon_state = "sword0"
 	active_force = 30
 	active_throwforce = 20
-	active_w_class = 4
+	active_w_class = 5
 	force = 3
 	throwforce = 5
 	throw_speed = 1

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -59,7 +59,7 @@
 	throwforce = 5.0
 	throw_speed = 1
 	throw_range = 4
-	w_class = 4.0
+	w_class = 5
 	origin_tech = list(TECH_MATERIAL = 2)
 	matter = list("glass" = 7500, DEFAULT_WALL_MATERIAL = 1000)
 	attack_verb = list("shoved", "bashed")
@@ -131,7 +131,7 @@
 	if (active)
 		force = 10
 		update_icon()
-		w_class = 4
+		w_class = 5
 		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 		user << "<span class='notice'>\The [src] is now active.</span>"
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -22,7 +22,7 @@
 		)
 	w_class = 4
 	slot_flags = SLOT_BACK
-	max_w_class = 4
+	max_w_class = 3
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -51,7 +51,6 @@
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	origin_tech = list(TECH_BLUESPACE = 4)
 	icon_state = "holdingpack"
-	max_w_class = 3
 	max_storage_space = 56
 
 	New()
@@ -151,8 +150,10 @@
 	icon_state = "duffle"
 	item_state_slots = null
 	w_class = 5
+	max_w_class = 4
 	slowdown_general = 1
-	max_storage_space = DEFAULT_BACKPACK_STORAGE + 10
+	//reduced somewhat to account for the fact that you can put backpacks in them, now fits 3 backpacks instead of 4
+	max_storage_space = DEFAULT_BACKPACK_STORAGE + 6
 
 /obj/item/weapon/storage/backpack/dufflebag/New()
 	..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -75,7 +75,7 @@
 	desc = "Space Santa uses this to deliver toys to all the nice children in space for Christmas! Wow, it's pretty big!"
 	icon_state = "giftbag0"
 	item_state = "giftbag"
-	w_class = 4.0
+	w_class = 5
 	max_w_class = 3
 	max_storage_space = 400 // can store a ton of shit!
 	item_state_slots = null

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -91,7 +91,7 @@
 	icon_state = "plantbag"
 	max_storage_space = 100
 	max_w_class = 3
-	w_class = 2
+	w_class = 3
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/grown,/obj/item/seeds,/obj/item/weapon/grown)
 
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -302,7 +302,7 @@
 				T.visible_message("<span class='danger'>\The [src] turns on.</span>")
 			src.force = 15
 			src.damtype = "fire"
-			src.w_class = 4
+			src.w_class = 5 //need a better way to indicate that something should not be stored ever.
 			welding = 1
 			update_icon()
 			processing_objects |= src

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -92,7 +92,7 @@ obj/item/weapon/gun/energy/retro
 	max_shots = 4
 	fire_delay = 35
 	force = 10
-	w_class = 4
+	w_class = 5
 	accuracy = -3 //shooting at the hip
 	scoped_accuracy = 0
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -3,7 +3,7 @@
 	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 14.5mm shells."
 	icon_state = "heavysniper"
 	item_state = "l6closednomag" //placeholder
-	w_class = 4
+	w_class = 5
 	force = 10
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 2, TECH_ILLEGAL = 8)


### PR DESCRIPTION
Yeah, I'm aware this is probably still controversial.

Returns backpack storage capacity to 22. Backpacks can now only store up to w_class 3 items, like it used to be in the past.

Dufflebags can still hold w_class 4 items though. Adjusted their storage capacity bonus to reflect this and also so that they can hold 3 backpacks, not 4. Three backpacks in a dufflebag should be plenty.
