### PR TITLE
More add antag fixes

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -190,7 +190,7 @@
 	if(!(flags & ANTAG_OVERRIDE_JOB) && (!player.current || istype(player.current, /mob/new_player)))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
 		return 0
-	if(ticker.current_state >= 2 && (isghost(player.current) || player.current.stat == DEAD || !player.current.client) && !(player in ticker.antag_pool))
+	if(ticker.current_state >= GAME_STATE_PLAYING && (isghost(player.current) || player.current.stat == DEAD || !player.current.client) && !(player in ticker.antag_pool))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they are a ghost not in the antag pool.")
 		return 0
 

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -25,8 +25,6 @@
 		M = new mob_path(get_turf(source))
 	else
 		M = new /mob/living/carbon/human(get_turf(source))
-	M.real_name = source.real_name
-	M.name = M.real_name
 	M.ckey = source.ckey
 	add_antagonist(M.mind, 1, 0, 1) // Equip them and move them to spawn.
 	return M


### PR DESCRIPTION
Fixes #12868. The candidacy check for ghosts now only runs when the game has actually started, not while the round is still in setup.

Latespawn antags like borers will no longer take the name of the player's ghost. This also means that antags like merc will start with a random species name, but that doesn't matter, since they get a rename prompt, anyway.
