### PR TITLE
Fixes #12879

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -27,7 +27,7 @@
 	icon_state = "capjacket"
 	item_state = "capjacket"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags_inv = HIDEJUMPSUIT
+	flags_inv = 0
 
 //Chaplain
 /obj/item/clothing/suit/chaplain_hoodie

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -70,7 +70,6 @@
 	permeability_coefficient = 0.01
 	armor = list(melee = 30, bullet = 20, laser = 20,energy = 20, bomb = 20, bio = 20, rad = 20)
 	allowed = list(/obj/item/weapon/teleportation_scroll)
-	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.8
 	wizard_garb = 1
 


### PR DESCRIPTION
Fixes #12879 
- Removed `HIDEJUMPSUIT` from wizard's jacket (`/obj/item/clothing/suit/wizrobe`) and captain's formal jacket (`/obj/item/clothing/suit/captunic/capjacket` - due to hierachy, flags_inv changed to `0`).
