### PR TITLE
Using a telecrystal now randomly teleports the user.

### DIFF
--- a/code/_helpers/datum_pool.dm
+++ b/code/_helpers/datum_pool.dm
@@ -45,7 +45,6 @@ var/global/list/GlobalPool = list()
 
 	var/datum/D = pick_n_take(GlobalPool[get_type])
 	if(D)
-		D.ResetVars()
 		D.Prepare(second_arg)
 		return D
 	return 0

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -41,3 +41,14 @@
 
 /proc/is_station_turf(var/turf/T)
 	return T && isStationLevel(T.z)
+
+/proc/get_random_turf_in_range(var/atom/origin, var/outer_range, var/inner_range)
+	origin = get_turf(origin)
+	if(!origin)
+		return
+	var/list/turfs = list()
+	for(var/turf/T in orange(origin, outer_range))
+		if(get_dist(origin, T) >= inner_range)
+			turfs += T
+	if(turfs.len)
+		return pick(turfs)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -234,6 +234,10 @@
 		src.verbs -= x
 	..()
 
+/atom/movable/overlay/Destroy()
+	master = null
+	. = ..()
+
 /atom/movable/overlay/attackby(a, b)
 	if (src.master)
 		return src.master.attackby(a, b)

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -20,3 +20,12 @@
 			nanomanager.update_uis(I.hidden_uplink)
 			use(amount)
 			user << "<span class='notice'>You slot \the [src] into \the [I] and charge its internal uplink.</span>"
+
+/obj/item/stack/telecrystal/attack_self(var/mob/user)
+	if(use(1))
+		user.visible_message("<span class='warning'>\The [user] crushes a crystal!</span>", "<span class='warning'>You crush \a [src]!</span>", "You hear the sound of a crystal breaking just before a sudden crack of electricity.")
+		var/turf/T = get_random_turf_in_range(user, 7, 3)
+		if(T)
+			user.phase_out(T, get_turf(user))
+			user.forceMove(T)
+			user.phase_in(T, get_turf(user))

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -1,4 +1,4 @@
-/proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,flick_anim as text,sleeptime = 0,direction as num)
+/proc/anim(turf/location, var/atom/target, a_icon, a_icon_state, flick_anim, sleeptime = 0, direction as num)
 //This proc throws up either an icon or an animation for a specified amount of time.
 //The variables should be apparent enough.
 	if(!location && target)
@@ -9,7 +9,7 @@
 	if(direction)
 		animation.set_dir(direction)
 	animation.icon = a_icon
-	animation.layer = target:layer+1
+	animation.layer = target.layer + 0.1
 	if(a_icon_state)
 		animation.icon_state = a_icon_state
 	else

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -78,22 +78,15 @@
 	interface_desc = "An advanced teleportation system. It is capable of pinpoint precision or random leaps forward."
 
 /obj/item/rig_module/teleporter/proc/phase_in(var/mob/M,var/turf/T)
-
 	if(!M || !T)
 		return
-
 	holder.spark_system.start()
-	playsound(T, 'sound/effects/phasein.ogg', 25, 1)
-	playsound(T, 'sound/effects/sparks2.ogg', 50, 1)
-	anim(T,M,'icons/mob/mob.dmi',,"phasein",,M.dir)
+	M.phase_in(T)
 
 /obj/item/rig_module/teleporter/proc/phase_out(var/mob/M,var/turf/T)
-
 	if(!M || !T)
 		return
-
-	playsound(T, "sparks", 50, 1)
-	anim(T,M,'icons/mob/mob.dmi',,"phaseout",,M.dir)
+	M.phase_out(T)
 
 /obj/item/rig_module/teleporter/engage(var/atom/target, var/notify_ai)
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -329,21 +329,14 @@
 		var/outer_teleport_radius = get_trait(TRAIT_POTENCY)/5
 		var/inner_teleport_radius = get_trait(TRAIT_POTENCY)/15
 
-		var/list/turfs = list()
-		if(inner_teleport_radius > 0)
-			for(var/turf/T in orange(target,outer_teleport_radius))
-				if(get_dist(target,T) >= inner_teleport_radius)
-					turfs |= T
-
-		if(turfs.len)
-			// Moves the mob, causes sparks.
+		var/turf/T = get_random_turf_in_range(target, outer_teleport_radius, inner_teleport_radius)
+		if(T)
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(3, 1, get_turf(target))
 			s.start()
 			var/turf/picked = get_turf(pick(turfs))                      // Just in case...
 			new/obj/effect/decal/cleanable/molten_item(get_turf(target)) // Leave a pile of goo behind for dramatic effect...
-			target.loc = picked                                          // And teleport them to the chosen location.
-
+			target.forceMove(picked)                                     // And teleport them to the chosen location.
 			impact = 1
 
 	return impact

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -209,3 +209,17 @@ note dizziness decrements automatically in the mob's Life() proc.
 			set_dir(D)
 			spintime -= speed
 	return
+
+/mob/proc/phase_in(var/turf/T)
+	if(!T)
+		return
+
+	playsound(T, 'sound/effects/phasein.ogg', 25, 1)
+	playsound(T, 'sound/effects/sparks2.ogg', 50, 1)
+	anim(T,src,'icons/mob/mob.dmi',,"phasein",,dir)
+
+/mob/proc/phase_out(var/turf/T)
+	if(!T)
+		return
+	playsound(T, "sparks", 50, 1)
+	anim(T,src,'icons/mob/mob.dmi',,"phaseout",,dir)

--- a/html/changelogs/PsiOmegaDelta-Telecrystal.yml
+++ b/html/changelogs/PsiOmegaDelta-Telecrystal.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - rscadd: "Crushing an uplink telecrystal now teleports you to a random semi-near location."


### PR DESCRIPTION
Along with various misc. tweaks.
- Pooled objects are now only var reset once, rather than twice.
- Phase in/phase out is now a mob helper proc.
- Grabbing a random turf within a given range span broken out from seeds as a shared proc.
