### PR TITLE
Fixes lit welding tools and activated energy swords/axes being storable

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -183,5 +183,7 @@
 // Storage
 #define base_storage_cost(w_class) (2**(w_class-1)) //1,2,4,8,16,...
 
+#define DO_NOT_STORE INFINITY //A special storage "cost" that indicates an item should not be storable
+
 #define DEFAULT_BACKPACK_STORAGE 28
 #define DEFAULT_BOX_STORAGE 14

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -2,7 +2,6 @@
 	var/active = 0
 	var/active_force
 	var/active_throwforce
-	var/active_w_class
 	sharp = 0
 	edge = 0
 	armor_penetration = 50
@@ -17,7 +16,7 @@
 	throwforce = active_throwforce
 	sharp = 1
 	edge = 1
-	w_class = active_w_class
+	slot_flags |= SLOT_DENYPOCKET
 	playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 
 /obj/item/weapon/melee/energy/proc/deactivate(mob/living/user)
@@ -30,7 +29,7 @@
 	throwforce = initial(throwforce)
 	sharp = initial(sharp)
 	edge = initial(edge)
-	w_class = initial(w_class)
+	slot_flags = initial(slot_flags)
 
 /obj/item/weapon/melee/energy/attack_self(mob/living/user as mob)
 	if (active)
@@ -50,6 +49,11 @@
 	add_fingerprint(user)
 	return
 
+/obj/item/weapon/melee/energy/get_storage_cost()
+	if(active)
+		return DO_NOT_STORE
+	return ..()
+
 /*
  * Energy Axe
  */
@@ -60,7 +64,6 @@
 	//active_force = 150 //holy...
 	active_force = 60
 	active_throwforce = 35
-	active_w_class = 5
 	//force = 40
 	//throwforce = 25
 	force = 20
@@ -94,7 +97,6 @@
 	icon_state = "sword0"
 	active_force = 30
 	active_throwforce = 20
-	active_w_class = 4
 	force = 3
 	throwforce = 5
 	throw_speed = 1

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -334,6 +334,9 @@
 		return 0
 
 	var/total_storage_space = W.get_storage_cost()
+	if(total_storage_space == DO_NOT_STORE)
+		usr << "<span class='notice'>\The [W] cannot be placed in [src].</span>" //TODO replace usr
+		return 0
 	for(var/obj/item/I in contents)
 		total_storage_space += I.get_storage_cost() //Adds up the combined w_classes which will be in the storage item if the item is added to it.
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -279,6 +279,11 @@
 /obj/item/weapon/weldingtool/proc/isOn()
 	return src.welding
 
+/obj/item/weapon/weldingtool/get_storage_cost()
+	if(isOn())
+		return DO_NOT_STORE
+	return ..()
+
 /obj/item/weapon/weldingtool/update_icon()
 	..()
 	icon_state = welding ? "welder1" : "welder"
@@ -302,7 +307,7 @@
 				T.visible_message("<span class='danger'>\The [src] turns on.</span>")
 			src.force = 15
 			src.damtype = "fire"
-			src.w_class = 4
+			src.slot_flags |= SLOT_DENYPOCKET //could also make it just set you on fire, but lets disable putting lit welders in pockets for now
 			welding = 1
 			update_icon()
 			processing_objects |= src
@@ -319,7 +324,7 @@
 			T.visible_message("<span class='warning'>\The [src] turns off.</span>")
 		src.force = 3
 		src.damtype = "brute"
-		src.w_class = initial(src.w_class)
+		src.slot_flags = initial(src.slot_flags)
 		src.welding = 0
 		update_icon()
 


### PR DESCRIPTION
Whoever changed backpacks to be able to store w_class 4 items didn't update weldingtools and energy weapons. This fixes the problem for good.

Allows items to specify not being storable, updates weldingtools and energy swords.

Split from #12874 so that the discussion doesn't get confused with random fixes.
