### PR TITLE
Rev/loyalist conversion now only lists able mobs.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -249,3 +249,10 @@ Proc for attack log creation, because really why not
 
 	if (progbar)
 		qdel(progbar)
+
+/proc/able_mobs_in_oview(var/origin)
+	var/list/mobs = list()
+	for(var/mob/living/M in oview(origin)) // Only living mobs are considered able.
+		if(!M.is_physically_disabled())
+			mobs += M
+	return mobs

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -1,7 +1,7 @@
-/mob/living/proc/convert_to_rev(mob/M as mob in oview(src))
+/mob/living/proc/convert_to_rev(mob/M as mob in able_mobs_in_oview(src))
 	set name = "Convert Bourgeoise"
 	set category = "Abilities"
-	if(!M.mind)
+	if(!M.mind || !M.client)
 		return
 	convert_to_faction(M.mind, revs)
 
@@ -42,9 +42,9 @@
 		player << "<span class='danger'>You reject this traitorous cause!</span>"
 	src << "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>"
 
-/mob/living/proc/convert_to_loyalist(mob/M as mob in oview(src))
+/mob/living/proc/convert_to_loyalist(mob/M as mob in able_mobs_in_oview(src))
 	set name = "Convert Recidivist"
 	set category = "Abilities"
-	if(!M.mind)
+	if(!M.mind || !M.client)
 		return
 	convert_to_faction(M.mind, loyalists)


### PR DESCRIPTION
Able mobs are all living mobs which are not currently disabled.
Fixes #12895.
