### PR TITLE
Fixes #12896, spiderling puddles can no longer be pulled

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -239,6 +239,7 @@
 	desc = "Green squishy mess."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "greenshatter"
+	anchored = 1
 
 /obj/effect/spider/cocoon
 	name = "cocoon"

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -150,7 +150,7 @@
 
 		//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
 		W.pixel_x = Clamp(text2num(click_data["icon-x"]) - center_x, -(world.icon_size/2), world.icon_size/2)
-		W.pixel_z = Clamp(text2num(click_data["icon-y"]) - center_y, -(world.icon_size/2), world.icon_size/2)
+		W.pixel_y = Clamp(text2num(click_data["icon-y"]) - center_y, -(world.icon_size/2), world.icon_size/2)
 	return
 
 /obj/structure/table/attack_tk() // no telehulk sorry


### PR DESCRIPTION
Fixes #12896 

Also, spiderling puddles can no longer be pulled. Maybe there was a sprite change or something, but now that spiderling remains look like a pool of liquid it really doesn't make sense to pull them. Also, many other (if not all) cleanables are anchored anyways (it might be worth it to just set anchor for the parent type).
