### PR TITLE
Move borg vision modes checks to handle_vision()

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -150,38 +150,6 @@
 	return 1
 
 /mob/living/silicon/robot/handle_regular_hud_updates()
-
-	if (src.stat == 2 || (XRAY in mutations) || (src.sight_mode & BORGXRAY))
-		src.sight |= SEE_TURFS
-		src.sight |= SEE_MOBS
-		src.sight |= SEE_OBJS
-		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_MINIMUM
-	else if ((src.sight_mode & BORGMESON) && (src.sight_mode & BORGTHERM))
-		src.sight |= SEE_TURFS
-		src.sight |= SEE_MOBS
-		src.see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_MINIMUM
-	else if (src.sight_mode & BORGMESON)
-		src.sight |= SEE_TURFS
-		src.see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_MINIMUM
-	else if (src.sight_mode & BORGMATERIAL)
-		src.sight |= SEE_OBJS
-		src.see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_MINIMUM
-	else if (src.sight_mode & BORGTHERM)
-		src.sight |= SEE_MOBS
-		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	else if (src.stat != 2)
-		src.sight &= ~SEE_MOBS
-		src.sight &= ~SEE_TURFS
-		src.sight &= ~SEE_OBJS
-		src.see_in_dark = 8 			 // see_in_dark means you can FAINTLY see in the dark, humans have a range of 3 or so, tajaran have it at 8
-		src.see_invisible = SEE_INVISIBLE_LIVING // This is normal vision (25), setting it lower for normal vision means you don't "see" things like darkness since darkness
-							 // has a "invisible" value of 15
-
 	..()
 
 	var/obj/item/borg/sight/hud/hud = (locate(/obj/item/borg/sight/hud) in src)
@@ -303,6 +271,40 @@
 				reset_view(null)
 
 	return 1
+
+/mob/living/silicon/robot/handle_vision()
+	..()
+	
+	if (src.stat == 2 || (XRAY in mutations) || (src.sight_mode & BORGXRAY))
+		src.sight |= SEE_TURFS
+		src.sight |= SEE_MOBS
+		src.sight |= SEE_OBJS
+		src.see_in_dark = 8
+		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+	else if ((src.sight_mode & BORGMESON) && (src.sight_mode & BORGTHERM))
+		src.sight |= SEE_TURFS
+		src.sight |= SEE_MOBS
+		src.see_in_dark = 8
+		src.see_invisible = SEE_INVISIBLE_NOLIGHTING
+	else if (src.sight_mode & BORGMESON)
+		src.sight |= SEE_TURFS
+		src.see_in_dark = 8
+		src.see_invisible = SEE_INVISIBLE_NOLIGHTING
+	else if (src.sight_mode & BORGMATERIAL)
+		src.sight |= SEE_OBJS
+		src.see_in_dark = 8
+	else if (src.sight_mode & BORGTHERM)
+		src.sight |= SEE_MOBS
+		src.see_in_dark = 8
+		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+	else if (src.stat != 2)
+		src.sight &= ~SEE_MOBS
+		src.sight &= ~SEE_TURFS
+		src.sight &= ~SEE_OBJS
+		src.see_in_dark = 8 			 // see_in_dark means you can FAINTLY see in the dark, humans have a range of 3 or so, tajaran have it at 8
+		src.see_invisible = SEE_INVISIBLE_LIVING // This is normal vision (25), setting it lower for normal vision means you don't "see" things like darkness since darkness
+							 // has a "invisible" value of 15
+	
 
 /mob/living/silicon/robot/proc/update_items()
 	if (src.client)


### PR DESCRIPTION
`/mob/living/silicon/robot/handle_regular_hud_updates()` set the vision flags and then called super, which called `/mob/living/proc/handle_vision()` which called `update_sight()` which dutifully reset the just-set flags.

This moves the flag setting code to `handle_vision()`. This is how `carbon/human` sets its vision flags, so hopefully this should result in fewer surprises. 

I've also altered `see_invisible` values to match those of the corresponding glasses items. I don't think there was anything that actually used values between `SEE_INVISIBLE_MINIMUM` and `SEE_INVISIBLE_NOLIGHTING`, so this has no effect right now, but consistency seemed desirable.

Resolves #12891
