### PR TITLE
Fixes #12893 and partial syringe cleanup

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -17,6 +17,10 @@
 	icon_state = "armor"
 	item_state = "armor"
 	blood_overlay_type = "armor"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	cold_protection = UPPER_TORSO|LOWER_TORSO
+	heat_protection = UPPER_TORSO|LOWER_TORSO
+
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/vest/security

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1212,14 +1212,11 @@
 		W.message = message
 		W.add_fingerprint(src)
 
-/mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone)
-	if(!target_zone)
-		if(!user)
-			target_zone = ran_zone()
-		else
-			target_zone = user.zone_sel.selecting
-
+#define CAN_INJECT 1
+#define INJECTION_PORT 2
+/mob/living/carbon/human/can_inject(var/mob/user, var/target_zone)
 	var/obj/item/organ/external/affecting = get_organ(target_zone)
+
 	if(!affecting)
 		user << "<span class='warning'>They are missing that limb.</span>"
 		return 0
@@ -1228,12 +1225,15 @@
 		user << "<span class='warning'>That limb is robotic.</span>"
 		return 0
 
+	. = CAN_INJECT
 	for(var/obj/item/clothing/C in list(head, wear_mask, wear_suit, w_uniform, gloves, shoes))
 		if(C && (C.body_parts_covered & affecting.body_part) && (C.item_flags & THICKMATERIAL))
-			user << "<span class='warning'>There is no exposed flesh or thin material on \his [affecting.name] to inject into.</span>"
-			return 0
+			if(istype(C, /obj/item/clothing/suit/space))
+				. = INJECTION_PORT //it was going to block us, but it's a space suit so it doesn't because it has some kind of port
+			else
+				user << "<span class='warning'>There is no exposed flesh or thin material on [src]'s [affecting.name] to inject into.</span>"
+				return 0
 
-	return 1
 
 /mob/living/carbon/human/print_flavor_text(var/shrink = 1)
 	var/list/equipment = list(src.head,src.wear_mask,src.glasses,src.w_uniform,src.wear_suit,src.gloves,src.shoes)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1213,34 +1213,27 @@
 		W.add_fingerprint(src)
 
 /mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone)
-	. = 1
-
 	if(!target_zone)
 		if(!user)
-			target_zone = pick("chest","chest","chest","left leg","right leg","left arm", "right arm", "head")
+			target_zone = ran_zone()
 		else
 			target_zone = user.zone_sel.selecting
 
 	var/obj/item/organ/external/affecting = get_organ(target_zone)
-	var/fail_msg
 	if(!affecting)
-		. = 0
-		fail_msg = "They are missing that limb."
-	else if (affecting.status & ORGAN_ROBOT)
-		. = 0
-		fail_msg = "That limb is robotic."
-	else
-		switch(target_zone)
-			if("head")
-				if(head && head.item_flags & THICKMATERIAL)
-					. = 0
-			else
-				if(wear_suit && wear_suit.item_flags & THICKMATERIAL)
-					. = 0
-	if(!. && error_msg && user)
-		if(!fail_msg)
-			fail_msg = "There is no exposed flesh or thin material [target_zone == "head" ? "on their head" : "on their body"] to inject into."
-		user << "<span class='alert'>[fail_msg]</span>"
+		user << "<span class='warning'>They are missing that limb.</span>"
+		return 0
+
+	if(affecting.status & ORGAN_ROBOT)
+		user << "<span class='warning'>That limb is robotic.</span>"
+		return 0
+
+	for(var/obj/item/clothing/C in list(head, wear_mask, wear_suit, w_uniform, gloves, shoes))
+		if(C && (C.body_parts_covered & affecting.body_part) && (C.item_flags & THICKMATERIAL))
+			user << "<span class='warning'>There is no exposed flesh or thin material on \his [affecting.name] to inject into.</span>"
+			return 0
+
+	return 1
 
 /mob/living/carbon/human/print_flavor_text(var/shrink = 1)
 	var/list/equipment = list(src.head,src.wear_mask,src.glasses,src.w_uniform,src.wear_suit,src.gloves,src.shoes)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -360,7 +360,7 @@ default behaviour is:
 	return 0
 
 
-/mob/living/proc/can_inject()
+/mob/living/proc/can_inject(var/mob/user, var/target_zone)
 	return 1
 
 /mob/living/proc/get_organ_target()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -179,9 +179,8 @@
 	onclose(src, "airoster")
 
 //can't inject synths
-/mob/living/silicon/can_inject(var/mob/user, var/error_msg)
-	if(error_msg)
-		user << "<span class='alert'>The armoured plating is too tough.</span>"
+/mob/living/silicon/can_inject(var/mob/user, var/target_zone)
+	user << "<span class='warning'>The armoured plating is too tough.</span>"
 	return 0
 
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -81,14 +81,14 @@
 	..()
 	create_reagents(30)
 
-/obj/item/weapon/pen/reagent/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/weapon/pen/reagent/attack(mob/living/M, mob/user, var/target_zone)
 
 	if(!istype(M))
 		return
 
 	. = ..()
 
-	if(M.can_inject(user,1))
+	if(M.can_inject(user, target_zone))
 		if(reagents.total_volume)
 			if(M.reagents)
 				var/contained_reagents = reagents.get_reagents()

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -50,7 +50,7 @@
 		if(speed >= 10 && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
-			if(L.can_inject() && syringe.reagents)
+			if(L.can_inject(null, ran_zone()) && syringe.reagents)
 				var/reagent_log = syringe.reagents.get_reagents()
 				syringe.reagents.trans_to_mob(L, 15, CHEM_BLOOD)
 				admin_inject_log(thrower, L, src, reagent_log, 15, violent=1)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -16,7 +16,7 @@
 /obj/item/projectile/bullet/chemdart/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
 	if(blocked < 100 && isliving(target))
 		var/mob/living/L = target
-		if(L.can_inject(target_zone=def_zone))
+		if(L.can_inject(null, def_zone))
 			reagents.trans_to_mob(L, reagent_amount, CHEM_BLOOD)
 
 /obj/item/ammo_casing/chemdart

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -51,7 +51,7 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/weapon/reagent_containers/borghypo/attack(var/mob/living/M, var/mob/user)
+/obj/item/weapon/reagent_containers/borghypo/attack(var/mob/living/M, var/mob/user, var/target_zone)
 	if(!istype(M))
 		return
 
@@ -61,7 +61,7 @@
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
-		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/affected = H.get_organ(target_zone)
 		if(!affected)
 			user << "<span class='danger'>\The [H] is missing that limb!</span>"
 			return
@@ -69,7 +69,7 @@
 			user << "<span class='danger'>You cannot inject a robotic limb.</span>"
 			return
 
-	if (M.can_inject(user, 1))
+	if (M.can_inject(user, target_zone))
 		user << "<span class='notice'>You inject [M] with the injector.</span>"
 		M << "<span class='notice'>You feel a tiny prick!</span>"
 


### PR DESCRIPTION
can_inject() now checks if the clothing actually covers the body part in question.

Also attempts to clean up injection and can_inject() handling.
Taking blood now follows the same rules as injecting.

`armor/vest` now explicitly only covers the torso. Doesn't change anything at the moment, but it seemed like a good idea to set the coverage specifically for the vest subtype.
