### PR TITLE
Tweak minimum ages as discussed with Raptor

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -24,7 +24,7 @@
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
-	minimal_player_age = 7
+	minimal_player_age = 10
 
 
 	equip(var/mob/living/carbon/human/H)
@@ -59,6 +59,7 @@
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
 	economic_modifier = 5
+	minimal_player_age = 3
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
 	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
@@ -96,6 +97,7 @@
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
 	economic_modifier = 5
+	minimal_player_age = 3
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_external_airlocks)
 	minimal_access = list(access_eva, access_engine, access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks)
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -20,7 +20,7 @@
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
-	minimal_player_age = 14
+	minimal_player_age = 10
 	ideal_character_age = 50
 
 	equip(var/mob/living/carbon/human/H)
@@ -54,7 +54,7 @@
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher")
 
-	minimal_player_age = 14
+	minimal_player_age = 7
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -84,7 +84,7 @@
 	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
 	alt_titles = list("Xenobotanist")
 
-	minimal_player_age = 14
+	minimal_player_age = 7
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H) return 0
@@ -114,7 +114,7 @@
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 
-	minimal_player_age = 7
+	minimal_player_age = 3
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -136,7 +136,7 @@
 	economic_modifier = 4
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks)
-	minimal_player_age = 3
+	minimal_player_age = 5
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_l_ear)


### PR DESCRIPTION
Current locked jobs:
1 day: Cyborg
3 days: Detective, Officer
5 days: Warden
7 days: CE, Roboticist, AI
10 days: CMO, HoP
14 days: Captain, HoS, RD, Scientist, Xenobio

Locked jobs as of this PR (changes in **bold**):
1 day: Cyborg
3 days: Detective, **Roboticist**, **Engineer**, **Atmos**
5 days: Warden, **Officer**
7 days: **Scientist**, **Xenobio**, AI
10 days: CMO, HoP, **CE**, **RD**
14 days: Captain, HoS

Changes:
Engineer, Atmos 0 -> 3
Officer 3 -> 5
CE 7 -> 10
Roboticist 7 -> 3
RD 14 -> 10
Scientist, Xenobio 14 -> 7
