### PR TITLE
(mainly) Supermatter damage tweaks

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -27,6 +27,7 @@
 #define    MAX_HIGH_PRESSURE_DAMAGE 4 // This used to be 20... I got this much random rage for some retarded decision by polymorph?! Polymorph now lies in a pool of blood with a katana jammed in his spleen. ~Errorage --PS: The katana did less than 20 damage to him :(
 #define         LOW_PRESSURE_DAMAGE 2 // The amount of damage someone takes when in a low pressure area. (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
 
+#define MINIMUM_PRESSURE_DIFFERENCE_TO_SUSPEND 2										// Minimum pressure difference between zones to suspend
 #define MINIMUM_AIR_RATIO_TO_SUSPEND 0.05 // Minimum ratio of air that must move to/from a tile to suspend group processing
 #define MINIMUM_AIR_TO_SUSPEND       (MOLES_CELLSTANDARD * MINIMUM_AIR_RATIO_TO_SUSPEND) // Minimum amount of air that has to move before a group processing can be suspended
 #define MINIMUM_MOLES_DELTA_TO_MOVE  (MOLES_CELLSTANDARD * MINIMUM_AIR_RATIO_TO_SUSPEND) // Either this must be active

--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -27,7 +27,7 @@
 #define    MAX_HIGH_PRESSURE_DAMAGE 4 // This used to be 20... I got this much random rage for some retarded decision by polymorph?! Polymorph now lies in a pool of blood with a katana jammed in his spleen. ~Errorage --PS: The katana did less than 20 damage to him :(
 #define         LOW_PRESSURE_DAMAGE 2 // The amount of damage someone takes when in a low pressure area. (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
 
-#define MINIMUM_PRESSURE_DIFFERENCE_TO_SUSPEND 2										// Minimum pressure difference between zones to suspend
+#define MINIMUM_PRESSURE_DIFFERENCE_TO_SUSPEND (MINIMUM_AIR_TO_SUSPEND*R_IDEAL_GAS_EQUATION*T20C)/CELL_VOLUME			// Minimum pressure difference between zones to suspend
 #define MINIMUM_AIR_RATIO_TO_SUSPEND 0.05 // Minimum ratio of air that must move to/from a tile to suspend group processing
 #define MINIMUM_AIR_TO_SUSPEND       (MOLES_CELLSTANDARD * MINIMUM_AIR_RATIO_TO_SUSPEND) // Minimum amount of air that has to move before a group processing can be suspended
 #define MINIMUM_MOLES_DELTA_TO_MOVE  (MOLES_CELLSTANDARD * MINIMUM_AIR_RATIO_TO_SUSPEND) // Either this must be active

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -212,7 +212,8 @@
 	else
 		damage_archived = damage
 
-		damage = max( damage + min( ( (removed.temperature - CRITICAL_TEMPERATURE) / 150 ), damage_inc_limit ) , 0 )
+		damage = max(0, damage + between(-DAMAGE_RATE_LIMIT, (removed.temperature - CRITICAL_TEMPERATURE) / 150, damage_inc_limit))
+
 		//Ok, 100% oxygen atmosphere = best reaction
 		//Maxes out at 100% oxygen pressure
 		oxygen = max(min((removed.gas["oxygen"] - (removed.gas["nitrogen"] * NITROGEN_RETARDATION_FACTOR)) / removed.total_moles, 1), 0)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -290,6 +290,9 @@
 			return 0
 		marked[g] = 1
 
+	if(abs(return_pressure() - sample.return_pressure()) > MINIMUM_PRESSURE_DIFFERENCE_TO_SUSPEND)
+		return 0
+
 	for(var/g in sample.gas)
 		if(!marked[g])
 			if((abs(gas[g] - sample.gas[g]) > MINIMUM_AIR_TO_SUSPEND) && \


### PR DESCRIPTION
- Among other checks, ZAS now verifies pressure difference when determining whether edge should be suspended or not.
- Reason for this is that at extreme temperatures (thousands of degrees) even few moles of gas can actually make up few hundred kilopascals.
- This could be observed with Supermatter delamination, when the walls to space melted. Despite pressure inside core being ~300kPa at some situations, the gas didn't leak until certain very large value was exceeded. This value grows with temperature (hot gas expands as we all know).
- To use previous example (SM delamination), it now behaves as one would expect it to, with a nice added benefit (i believe). The temperature seems to stabilize around ~10k K when the core is leaking into space (without fresh coolant being injected). Core pressure stabilizes at around ~10-20kPa. This results in constant deterioration of integrity, in comparison to very rapid jumps that are common now. Right now, if the core is in full vacuum for a tick or two, integrity drops by few % per tick. On the other hand, when some gas enters the chamber (core produces gas on it's own, remember) the core gets briefly cooled, restoring bunch of integrity.
- Furthermore, the rate at which Supermatter restores itself is now capped to the same variable that contols how quickly it takes damage. It's still faster to damage the core if the power is very high though. The core regenerates at ~0.6% integrity per second (approximately) in ideal conditions (read: temperature not on edge of meltdown). This was done to prevent supermatter from being stabilized within few seconds due to being in extremely cold environment only briefly.
- This does not have any major effects on normal operation. Amount of emitter shots, differences between coolants, everything remains as it used to be. The only tweaks are to delamination-related stuff.
