### PR TITLE
Edge touching redo and cleanup.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -256,32 +256,30 @@
 		overmap_spacetravel(get_turf(src), src)
 		return
 
-	var/move_to_z = src.get_transit_zlevel()
-	if(move_to_z)
-		z = move_to_z
-
+	var/new_x
+	var/new_y	
+	var/new_z = src.get_transit_zlevel()
+	if(new_z)
 		if(x <= TRANSITIONEDGE)
-			x = world.maxx - TRANSITIONEDGE - 2
-			y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
+			new_x = world.maxx - TRANSITIONEDGE - 2
+			new_y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
 
 		else if (x >= (world.maxx - TRANSITIONEDGE + 1))
-			x = TRANSITIONEDGE + 1
-			y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
+			new_x = TRANSITIONEDGE + 1
+			new_y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
 
 		else if (y <= TRANSITIONEDGE)
-			y = world.maxy - TRANSITIONEDGE -2
-			x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
+			new_y = world.maxy - TRANSITIONEDGE -2
+			new_x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
 
 		else if (y >= (world.maxy - TRANSITIONEDGE + 1))
-			y = TRANSITIONEDGE + 1
-			x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
-
-		if(ticker && istype(ticker.mode, /datum/game_mode/nuclear)) //only really care if the game mode is nuclear
-			var/datum/game_mode/nuclear/G = ticker.mode
-			G.check_nuke_disks()
+			new_y = TRANSITIONEDGE + 1
+			new_x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
 
 		spawn(0)
-			if(loc) loc.Entered(src)
+			var/turf/T = locate(new_x, new_y, new_z)
+			if(T)
+				forceMove(T)
 
 //This list contains the z-level numbers which can be accessed via space travel and the percentile chances to get there.
 var/list/accessible_z_levels = list("1" = 5, "3" = 10, "4" = 15, "6" = 60)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -62,7 +62,6 @@
 /atom/movable/proc/forceMove(atom/destination, var/special_event)
 	if(loc == destination)
 		return 0
-
 	var/is_origin_turf = isturf(loc)
 	var/is_destination_turf = isturf(destination)
 	// It is a new area if:
@@ -257,7 +256,7 @@
 		return
 
 	var/new_x
-	var/new_y	
+	var/new_y
 	var/new_z = src.get_transit_zlevel()
 	if(new_z)
 		if(x <= TRANSITIONEDGE)
@@ -276,10 +275,9 @@
 			new_y = TRANSITIONEDGE + 1
 			new_x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
 
-		spawn(0)
-			var/turf/T = locate(new_x, new_y, new_z)
-			if(T)
-				forceMove(T)
+		var/turf/T = locate(new_x, new_y, new_z)
+		if(T)
+			forceMove(T)
 
 //This list contains the z-level numbers which can be accessed via space travel and the percentile chances to get there.
 var/list/accessible_z_levels = list("1" = 5, "3" = 10, "4" = 15, "6" = 60)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -19,12 +19,6 @@ var/list/nuke_disks = list()
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 	antag_tags = list(MODE_MERCENARY)
 
-//delete all nuke disks not on a station zlevel
-/datum/game_mode/nuclear/proc/check_nuke_disks()
-	for(var/obj/item/weapon/disk/nuclear/N in nuke_disks)
-		var/turf/T = get_turf(N)
-		if(isNotStationLevel(T.z)) qdel(N)
-
 //checks if L has a nuke disk on their person
 /datum/game_mode/nuclear/proc/check_mob(mob/living/L)
 	for(var/obj/item/weapon/disk/nuclear/N in nuke_disks)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -406,8 +406,22 @@ if(!N.lighthack)
 /obj/item/weapon/disk/nuclear/New()
 	..()
 	nuke_disks |= src
+	
+/obj/item/weapon/disk/nuclear/initialize()
+	..()
+	// Can never be quite sure that a game mode has been properly initiated or not at this point, so always register
+	moved_event.register(src, src, /obj/item/weapon/disk/nuclear/proc/check_z_level)
+	
+/obj/item/weapon/disk/nuclear/proc/check_z_level()
+	if(!(ticker && istype(ticker.mode, /datum/game_mode/nuclear)))
+		moved_event.unregister(src, src, /obj/item/weapon/disk/nuclear/proc/check_z_level) // However, when we are certain unregister if necessary
+		return
+	var/turf/T = get_turf(src)
+	if(!T || isNotStationLevel(T.z))
+		qdel(src)
 
 /obj/item/weapon/disk/nuclear/Destroy()
+	moved_event.unregister(src, src, /obj/item/weapon/disk/nuclear/proc/check_z_level)
 	nuke_disks -= src
 	if(!nuke_disks.len)
 		var/turf/T = pick_area_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -431,6 +431,3 @@ if(!N.lighthack)
 		else
 			log_and_message_admins("[src], the last authentication disk, has been destroyed. Failed to respawn disc!")
 	return ..()
-
-/obj/item/weapon/disk/nuclear/touch_map_edge()
-	qdel(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -808,26 +808,6 @@ default behaviour is:
 		return
 	. = ..()
 
-/mob/living/touch_map_edge()
-
-	//check for nuke disks
-	if(client && stat != DEAD) //if they are clientless and dead don't bother, the parent will treat them as any other container
-		if(ticker && istype(ticker.mode, /datum/game_mode/nuclear)) //only really care if the game mode is nuclear
-			var/datum/game_mode/nuclear/G = ticker.mode
-			if(G.check_mob(src))
-				if(x <= TRANSITIONEDGE)
-					inertia_dir = 4
-				else if(x >= world.maxx -TRANSITIONEDGE)
-					inertia_dir = 8
-				else if(y <= TRANSITIONEDGE)
-					inertia_dir = 1
-				else if(y >= world.maxy -TRANSITIONEDGE)
-					inertia_dir = 2
-				src << "<span class='warning'>Something you are carrying is preventing you from leaving.</span>"
-				return
-
-	..()
-
 //damage/heal the mob ears and adjust the deaf amount
 /mob/living/adjustEarDamage(var/damage, var/deaf)
 	ear_damage = max(0, ear_damage + damage)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -522,3 +522,6 @@
 
 mob/new_player/MayRespawn()
 	return 1
+
+/mob/new_player/touch_map_edge()
+	return

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -52,4 +52,24 @@ mob/observer/check_airflow_movable()
 		O.updateghostimages()
 
 /mob/observer/touch_map_edge()
-	return
+	if(z in using_map.sealed_levels)
+		return
+
+	var/new_x = x
+	var/new_y = y
+
+	if(x <= TRANSITIONEDGE)
+		new_x = TRANSITIONEDGE + 1
+	else if (x >= (world.maxx - TRANSITIONEDGE + 1))
+		new_x = world.maxx - TRANSITIONEDGE
+	else if (y <= TRANSITIONEDGE)
+		new_y = TRANSITIONEDGE + 1
+	else if (y >= (world.maxy - TRANSITIONEDGE + 1))
+		new_y = world.maxy - TRANSITIONEDGE
+
+	var/turf/T = locate(new_x, new_y, z)
+	if(T)
+		forceMove(T)
+		inertia_dir = 0
+		throwing = 0
+		src << "<span class='notice'>You cannot move further in this direction.</span>"

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -50,3 +50,6 @@ mob/observer/check_airflow_movable()
 /proc/updateallghostimages()
 	for (var/mob/observer/ghost/O in player_list)
 		O.updateghostimages()
+
+/mob/observer/touch_map_edge()
+	return


### PR DESCRIPTION
Observers are no longer affected by the edge of space, nor do they become unable to move if thrown at the edge.
Neither are nuclear discs as such. Instead they listen to their own movement and handle Z-level shifts as appropriate.

Removes some unnecessary touch_map_edge() procs now that nuclear discs handle themselves.
