### PR TITLE
Fixes lungs not rupturing in space

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -347,6 +347,7 @@
 	put_mob(usr)
 	return
 
+//This proc literally only exists for cryo cells.
 /atom/proc/return_air_for_internal_lifeform()
 	return return_air()
 

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -25,7 +25,10 @@
 		if(!breath)
 			breath = get_breath_from_environment() //No breath from internals so let's try to get air from our location
 		if(!breath)
-			breath = new //still nothing? must be vacuum
+			var/static/datum/gas_mixture/vacuum //avoid having to create a new gas mixture for each breath in space
+			if(!vacuum) vacuum = new
+
+			breath = vacuum //still nothing? must be vacuum
 
 	handle_breath(breath)
 	handle_post_breath(breath)

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -24,6 +24,8 @@
 		breath = get_breath_from_internal() //First, check for air from internals
 		if(!breath)
 			breath = get_breath_from_environment() //No breath from internals so let's try to get air from our location
+		if(!breath)
+			breath = new //still nothing? must be vacuum
 
 	handle_breath(breath)
 	handle_post_breath(breath)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -942,10 +942,8 @@
 
 /mob/living/carbon/human/proc/rupture_lung()
 	var/obj/item/organ/lungs/L = internal_organs_by_name["lungs"]
-
-	if(L && !L.is_bruised())
-		src.custom_pain("You feel a stabbing pain in your chest!", 1)
-		L.bruise()
+	if(L)
+		L.rupture()
 
 /*
 /mob/living/carbon/human/verb/simulate()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -329,9 +329,13 @@
 	if(status_flags & GODMODE)
 		return
 
-	//check if we actually need to process breath
-	if(!breath || (breath.total_moles == 0))
+	var/obj/item/organ/lungs/L = internal_organs_by_name["lungs"]
+	if(!L && species.has_organ["lungs"])
 		failed_last_breath = 1
+	else
+		failed_last_breath = L.handle_breath(breath) //if breath is null or vacuum, the lungs will handle it for us
+
+	if(failed_last_breath)
 		if(prob(20))
 			emote("gasp")
 		if(health > config.health_threshold_crit)
@@ -341,11 +345,6 @@
 
 		oxygen_alert = max(oxygen_alert, 1)
 		return 0
-	var/obj/item/organ/lungs/L = internal_organs_by_name["lungs"]
-	if(L && L.handle_breath(breath))
-		failed_last_breath = 0
-	else
-		failed_last_breath = 1
 	return 1
 
 /mob/living/carbon/human/handle_environment(datum/gas_mixture/environment)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -99,28 +99,3 @@
 			owner.nutrition -= 10
 		else if(owner.nutrition >= 200)
 			owner.nutrition -= 3
-
-/obj/item/organ/lungs
-	name = "lungs"
-	icon_state = "lungs"
-	gender = PLURAL
-	organ_tag = "lungs"
-	parent_organ = "chest"
-
-/obj/item/organ/lungs/process()
-	..()
-
-	if(!owner)
-		return
-
-	if (germ_level > INFECTION_LEVEL_ONE)
-		if(prob(5))
-			owner.emote("cough")		//respitory tract infection
-
-	if(is_bruised())
-		if(prob(2))
-			spawn owner.emote("me", 1, "coughs up blood!")
-			owner.drip(10)
-		if(prob(4))
-			spawn owner.emote("me", 1, "gasps for air!")
-			owner.losebreath += 15

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -41,17 +41,23 @@
 			spawn owner.emote("me", 1, "gasps for air!")
 			owner.losebreath += 15
 
+/obj/item/organ/lungs/proc/rupture()
+	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+	if(istype(parent))
+		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 1)
+	bruise()
 
 /obj/item/organ/lungs/proc/handle_breath(datum/gas_mixture/breath)
 	if(!owner)
-		return 0
+		return 1
 	if(!breath)
-		return 0
+		return 1
 	//exposure to extreme pressures can rupture lungs
 	if(breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-		if(is_bruised() && prob(5))
-			owner.custom_pain("You feel a stabbing pain in your chest!", 1)
-			bruise()
+		if(!is_bruised() && prob(5)) //only rupture if NOT already ruptured
+			rupture()
+	if(breath.total_moles == 0)
+		return 1
 
 	var/safe_pressure_min = min_breath_pressure // Minimum safe partial pressure of breathable gas in kPa
 	// Lung damage increases the minimum safe pressure.
@@ -149,7 +155,7 @@
 	handle_temperature_effects(breath)
 
 	breath.update_values()
-	return !failed_breath
+	return failed_breath
 
 /obj/item/organ/lungs/proc/handle_temperature_effects(datum/gas_mixture/breath)
 	// Hot air hurts :(

--- a/html/changelogs/HarpyEagle-lung-rupture.yml
+++ b/html/changelogs/HarpyEagle-lung-rupture.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed lungs not rupturing in space."


### PR DESCRIPTION
Fixes #12946 
- Fixes lungs being bruised by vacuum only if they were already bruised.
- Breath is now null only if we did not breathe. If we breathed vacuum, a gas mix with zero moles is used instead
- Removes duplicate lung definition from heart.dm
