### PR TITLE
Lock feature update

### DIFF
--- a/code/modules/locks/lock_construct.dm
+++ b/code/modules/locks/lock_construct.dm
@@ -22,7 +22,7 @@
 			user << "<span class='warning'>\The [I] already unlocks something...</span>"
 		return
 	if(istype(I,/obj/item/weapon/material/lock_construct))
-		var/obj/item/weapon/material/lock_contruct/L = I
+		var/obj/item/weapon/material/lock_construct/L = I
 		src.lock_data = L.lock_data
 		user << "<span class='notice'>You copy the lock from \the [L] to \the [src], making them identical.</span>"
 		return

--- a/code/modules/locks/lock_construct.dm
+++ b/code/modules/locks/lock_construct.dm
@@ -21,6 +21,11 @@
 		else
 			user << "<span class='warning'>\The [I] already unlocks something...</span>"
 		return
+	if(istype(I,/obj/item/weapon/material/lock_construct))
+		var/obj/item/weapon/material/lock_contruct/L = I
+		src.lock_data = L.lock_data
+		user << "<span class='notice'>You copy the lock from \the [L] to \the [src], making them identical.</span>"
+		return
 	..()
 
 /obj/item/weapon/material/lock_construct/proc/create_lock(var/atom/target, var/mob/user)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -10,6 +10,7 @@
 	w_class = 3.0
 	sharp = 1
 	edge = 0
+	lock_picking_level = 3
 
 /obj/item/weapon/arrow/proc/removed() //Helper for metal rods falling apart.
 	return


### PR DESCRIPTION
Lock constructs can be synced with one another. Letting multiple locks be unlocked by one key.

Arrows can now be used as lockpicks (since they are basically metal rods to begin with)
