### PR TITLE
Changes to obj/item/stack storage cost and stack management.

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -4,13 +4,13 @@
 	singular_name = "metal rod"
 	icon_state = "rods"
 	flags = CONDUCT
-	w_class = 3.0
+	w_class = 4
 	force = 9.0
 	throwforce = 15.0
 	throw_speed = 5
 	throw_range = 20
 	matter = list(DEFAULT_WALL_MATERIAL = 1875)
-	max_amount = 60
+	max_amount = 100
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	lock_picking_level = 3
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -303,14 +303,16 @@
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
-		var/obj/item/stack/F = src.split(1)
-		if (F)
-			user.put_in_hands(F)
-			src.add_fingerprint(user)
-			F.add_fingerprint(user)
-			spawn(0)
-				if (src && usr.machine==src)
-					src.interact(usr)
+		var/N = input("How many stacks of [src] would you like to split off?", "Split stacks", 1) as num|null
+		if(N)
+			var/obj/item/stack/F = src.split(N)
+			if (F)
+				user.put_in_hands(F)
+				src.add_fingerprint(user)
+				F.add_fingerprint(user)
+				spawn(0)
+					if (src && usr.machine==src)
+						src.interact(usr)
 	else
 		..()
 	return
@@ -318,10 +320,7 @@
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
-		if (user.get_inactive_hand()==src)
-			src.transfer_to(S, 1)
-		else
-			src.transfer_to(S)
+		src.transfer_to(S)
 
 		spawn(0) //give the stacks a chance to delete themselves if necessary
 			if (S && usr.machine==S)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -296,6 +296,11 @@
 		if(!amount)
 			break
 
+/obj/item/stack/get_storage_cost()	//Scales storage cost to stack size
+	. = ..()
+	if (amount < max_amount)
+		. = ceil(. * amount / max_amount)
+
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
 		var/obj/item/stack/F = src.split(1)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -13,7 +13,7 @@
 	desc = "A non-descript floor tile."
 	randpixel = 7
 	w_class = 3
-	max_amount = 60
+	max_amount = 100
 
 /*
  * Grass

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -2,10 +2,10 @@
 /obj/item/stack/material
 	force = 5.0
 	throwforce = 5
-	w_class = 3.0
+	w_class = 4
 	throw_speed = 3
 	throw_range = 3
-	max_amount = 50
+	max_amount = 60
 	randpixel = 3
 
 	var/default_type = DEFAULT_WALL_MATERIAL

--- a/html/changelogs/Techhead-stack-attack.yml
+++ b/html/changelogs/Techhead-stack-attack.yml
@@ -1,0 +1,8 @@
+author: Techhead
+
+delete-after: True
+
+changes: 
+  - rscadd: "Stack items now take up storage space proportional to the size of the stack."
+  - tweak: "Materials, rods, and tiles have had their weight class and max stack size adjusted."
+  - rscadd: "Stacks now let you split them in any amount instead of one at a time."


### PR DESCRIPTION
Storage costs for `obj/item/stack` now scale linearly with stack size. (Rounded up)

Certain subtypes (namely, `../material`, `../rods`, and `../tiles`) have had `w_class` and `max_amount` adjusted to compensate. Before anyone asks, yes, this is a nerf to maximum sheet capacity. However, carrying around a smattering of small stacks will no longer fill your backpack.

Additionally, clicking a stack no longer transfers one sheet at a time, but instead opens an input box asking how many sheets to transfer. No more clicking 25 times simply to split a 50-stack in half. Clicking one stack with another simply combines the stacks.
