### PR TITLE
Fixes #12839

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -90,7 +90,7 @@
 	icon = 'icons/obj/device.dmi'
 
 //Checks if the item is being held by a mob, and if so, updates the held icons
-/obj/item/proc/update_held_icon()
+/obj/item/proc/update_twohanding()
 	if(ismob(src.loc))
 		var/mob/M = src.loc
 		if(M.l_hand == src)
@@ -273,9 +273,9 @@
 	if(!istype(M))
 		return
 	if(M.l_hand)
-		M.l_hand.update_held_icon()
+		M.l_hand.update_twohanding()
 	if(M.r_hand)
-		M.r_hand.update_held_icon()
+		M.r_hand.update_twohanding()
 
 //Defines which slots correspond to which slot flags
 var/list/global/slot_flags_enumeration = list(

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -27,13 +27,12 @@
 	var/base_name
 	var/unwielded_force_divisor = 0.25
 
-/obj/item/weapon/material/twohanded/update_held_icon()
+/obj/item/weapon/material/twohanded/update_twohanding()
 	var/mob/living/M = loc
 	if(istype(M) && !issmall(M) && is_held_twohanded(M))
 		wielded = 1
 		force = force_wielded
 		name = "[base_name] (wielded)"
-		update_icon()
 	else
 		wielded = 0
 		force = force_unwielded

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -165,13 +165,13 @@ This saves us from having to call add_fingerprint() any time something is put in
 	else if (W == r_hand)
 		r_hand = null
 		if(l_hand)
-			l_hand.update_held_icon()
+			l_hand.update_twohanding()
 			update_inv_l_hand()
 		update_inv_r_hand()
 	else if (W == l_hand)
 		l_hand = null
 		if(r_hand)
-			r_hand.update_held_icon()
+			r_hand.update_twohanding()
 			update_inv_l_hand()
 		update_inv_l_hand()
 	else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -88,19 +88,26 @@
 	if(isnull(scoped_accuracy))
 		scoped_accuracy = accuracy
 
-/obj/item/weapon/gun/update_held_icon()
+/obj/item/weapon/gun/update_twohanding()
 	if(requires_two_hands)
 		var/mob/living/M = loc
 		if(istype(M))
 			if(src.is_held_twohanded(M))
 				name = "[initial(name)] (wielded)"
-				if(wielded_item_state)
-					item_state = wielded_item_state
 			else
 				name = initial(name)
 				item_state = initial(item_state)
-				update_icon(ignore_inhands=1) // In case item_state is set somewhere else.
+		update_icon() // In case item_state is set somewhere else.
 	..()
+
+/obj/item/weapon/gun/update_icon()
+	if(wielded_item_state)
+		var/mob/living/M = loc
+		if(istype(M))
+			if(src.is_held_twohanded())
+				item_state = wielded_item_state
+			else
+				item_state = initial(item_state)
 
 //Checks whether a given mob can use the gun
 //Any checks that shouldn't result in handle_click_empty() being called if they fail should go here.

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -87,7 +87,8 @@
 	user << "Has [shots_remaining] shot\s remaining."
 	return
 
-/obj/item/weapon/gun/energy/update_icon(var/ignore_inhands)
+/obj/item/weapon/gun/energy/update_icon()
+	..()
 	if(charge_meter)
 		var/ratio = power_supply.charge / power_supply.maxcharge
 
@@ -101,4 +102,4 @@
 			icon_state = "[modifystate][ratio]"
 		else
 			icon_state = "[initial(icon_state)][ratio]"
-	if(!ignore_inhands) update_held_icon()
+

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -89,10 +89,9 @@
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=6,    requires_two_hands=6, burst_accuracy=list(0,-1,-2,-3,-3), dispersion=list(0.6, 1.0, 1.2, 1.2, 1.5)),
 		)
 
-/obj/item/weapon/gun/projectile/automatic/sts35/update_icon(var/ignore_inhands)
+/obj/item/weapon/gun/projectile/automatic/sts35/update_icon()
 	..()
 	icon_state = (ammo_magazine)? "arifle" : "arifle-empty"
-	if(!ignore_inhands) update_held_icon()
 
 /obj/item/weapon/gun/projectile/automatic/wt550
 	name = "machine pistol"


### PR DESCRIPTION
Fixes #12839 

`update_held_icon()` is no longer responsible for updating item_state, renamed to `update_twohanding()`.

Updating item state for twohanded items should be done in `update_icon()`, to avoid infinite recursion and the need for optional arguments to prevent the same.

Future guns that use wielded_state will need to ensure that it is updated if they also override `update_icon`. Currently no guns do that though.
