### PR TITLE
Partial fix of #11902

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -127,6 +127,7 @@
 
 /atom/movable/proc/throw_at(atom/target, range, speed, thrower)
 	if(!target || !src)	return 0
+	if(!target.z != src.z) return 0
 	//use a modified version of Bresenham's algorithm to get from the atom's current position to that of the target
 
 	src.throwing = 1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -160,6 +160,7 @@
 
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, clickparams, pointblank=0, reflex=0)
 	if(!user || !target) return
+	if(target.z != user.z) return
 
 	add_fingerprint(user)
 

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -6,7 +6,7 @@
 	set desc = "Begin or stop aiming."
 	set category = "IC"
 
-	if(isliving(src))
+	if(isliving(src)) //Needs to be a mob verb to prevent error messages when using hotkeys
 		var/mob/living/M = src
 		if(!M.aiming)
 			M.aiming = new(src)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -19,7 +19,7 @@
 		return
 	if(!owner.canClick())
 		return
-	owner.setClickCooldown(5) // Spam prevention, essentially.
+	owner.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
 	if(owner.a_intent == I_HELP)
 		owner << "<span class='warning'>You refrain from firing \the [aiming_with] as your intent is set to help.</span>"
 		return


### PR DESCRIPTION
Fixes item (2) by preventing firing/throwing of objects across z-levels
Item (1) may be resolved since aiming now uses the event system, #11902 probably should be labelled for review if this is merged.
I don't really care to fix (3), it's too minor to be worth checking whether someone attacked a storage item with their held item. 
