### PR TITLE
Refactors energy nets

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -22,7 +22,7 @@
 
 
 /obj/proc/buckle_mob(mob/living/M)
-	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || M.pinned.len || (buckle_require_restraints && !M.restrained()))
+	if(!istype(M) || (M.loc != loc) || M.buckled || M.pinned.len || (buckle_require_restraints && !M.restrained()))
 		return 0
 
 	M.buckled = src

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -41,8 +41,6 @@
 			prisonwarp += loc
 			delete_me = 1
 			return
-		if("Holding Facility")
-			holdingfacility += loc
 		if("tdome1")
 			tdome1 += loc
 		if("tdome2")

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -10,6 +10,7 @@
 	w_class = 3
 	origin_tech = "materials=1"
 	matter = list(DEFAULT_WALL_MATERIAL = 18750)
+	can_buckle = 0 //disallow manual un/buckling
 	var/deployed = 0
 
 /obj/item/weapon/beartrap/proc/can_use(mob/user)
@@ -87,11 +88,9 @@
 
 	//trap the victim in place
 	set_dir(L.dir)
-	can_buckle = 1
 	buckle_mob(L)
 	L << "<span class='danger'>The steel jaws of \the [src] bite into you, trapping you in place!</span>"
 	deployed = 0
-	can_buckle = initial(can_buckle)
 
 /obj/item/weapon/beartrap/Crossed(AM as mob|obj)
 	if(deployed && isliving(AM))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -82,10 +82,7 @@
 	var/turf/T = get_turf(M)
 	if(T)
 		var/obj/effect/energy_net/net = new net_type(T)
-		net.layer = M.layer+1
-		M.captured = 1
-		net.affecting = M
-		T.visible_message("[M] was caught in an energy net!")
+		net.capture_mob(M)
 		qdel(src)
 
 	// If we miss or hit an obstacle, we still want to delete the net.
@@ -102,75 +99,33 @@
 	opacity = 0
 	mouse_opacity = 1
 	anchored = 1
+	can_buckle = 0 //no manual buckling or unbuckling
 
 	var/health = 25
-	var/mob/living/affecting = null //Who it is currently affecting, if anyone.
-	var/mob/living/master = null    //Who shot web. Will let this person know if the net was successful.
 	var/countdown = -1
 
 /obj/effect/energy_net/teleport
 	countdown = 60
 
-/obj/effect/energy_net/New()
-	..()
-	processing_objects |= src
+/obj/effect/energy_net/proc/capture_mob(mob/living/M)
+	if(M.buckled)
+		M.buckled.unbuckle_mob()
+	buckle_mob(M)
 
-/obj/effect/energy_net/Destroy()
-
-	if(affecting)
-		var/mob/living/carbon/M = affecting
-		M.anchored = initial(affecting.anchored)
-		M.captured = 0
+/obj/effect/energy_net/post_buckle_mob(mob/living/M)
+	if(buckled_mob)
+		layer = M.layer+1
+		visible_message("\The [M] was caught in an energy net!")
+	else
 		M << "You are free of the net!"
-
-	processing_objects -= src
-	..()
+		layer = initial(layer)
+		qdel(src)
 
 /obj/effect/energy_net/proc/healthcheck()
-
 	if(health <=0)
 		density = 0
 		src.visible_message("The energy net is torn apart!")
-		qdel(src)
-	return
-
-/obj/effect/energy_net/process()
-
-	if(isnull(affecting) || affecting.loc != loc)
-		qdel(src)
-		return
-
-	// Countdown begin set to -1 will stop the teleporter from firing.
-	// Clientless mobs can be netted but they will not teleport or decrement the timer.
-	var/mob/living/M = affecting
-	if(countdown == -1 || (istype(M) && !M.client))
-		return
-
-	if(countdown > 0)
-		countdown--
-		return
-
-	// TODO: consider removing or altering this; energy nets are useful on their own
-	// merits and the teleportation was never properly implemented; it's halfassed.
-	density = 0
-	invisibility = 101 //Make the net invisible so all the animations can play out.
-	health = INFINITY  //Make the net invincible so that an explosion/something else won't kill it during anims.
-
-	playsound(affecting.loc, 'sound/effects/sparks4.ogg', 50, 1)
-	anim(affecting.loc,affecting,'icons/mob/mob.dmi',,"phaseout",,affecting.dir)
-
-	affecting.visible_message("[affecting] vanishes in a flare of light!")
-
-	if(holdingfacility.len)
-		affecting.loc = pick(holdingfacility)
-
-	affecting << "You appear in a strange place!"
-
-	playsound(affecting.loc, 'sound/effects/phasein.ogg', 25, 1)
-	playsound(affecting.loc, 'sound/effects/sparks2.ogg', 50, 1)
-	anim(affecting.loc,affecting,'icons/mob/mob.dmi',,"phasein",,affecting.dir)
-
-	qdel(src)
+		unbuckle_mob()
 
 /obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()

--- a/code/global.dm
+++ b/code/global.dm
@@ -64,7 +64,6 @@ var/list/latejoin_cryo    = list()
 var/list/latejoin_cyborg  = list()
 
 var/list/prisonwarp         = list() // Prisoners go to these
-var/list/holdingfacility    = list() // Captured people go here
 var/list/xeno_spawn         = list() // Aliens spawn at at these.
 var/list/tdome1             = list()
 var/list/tdome2             = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -755,10 +755,6 @@
 				if(buckled.buckle_movable)
 					anchored = 0
 					canmove = 1
-		else if(captured)
-			anchored = 1
-			canmove = 0
-			lying = 0
 		else
 			lying = incapacitated(INCAPACITATION_KNOCKDOWN)
 			canmove = !incapacitated(INCAPACITATION_DISABLED)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -124,7 +124,6 @@
 	var/voice_name = "unidentifiable voice"
 
 	var/faction = "neutral" //Used for checking whether hostile simple animals will attack you, possibly more stuff later
-	var/captured = 0 //Functionally, should give the same effect as being buckled into a chair when true. Only used by energy nets, TODO replace with buckling
 	var/blinded = null
 	var/ear_deaf = null		//Carbon
 


### PR DESCRIPTION
- Removed `captured` mob var
- Removed `holdingfacility` global var
- Energy nets now act just like buckling as the comment in `mob_defines.dm` used to say, since that's exactly what they now do.
- Removed unused "halfassed" [sic] energy net teleporting. Energy nets no longer need to process.
- Makes the `can_buckle` much more useful, it now specifies whether or not an obj may be buckled to or unbuckled from manually using regular interaction.
