### PR TITLE
Visualnet fixes.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -14,7 +14,7 @@
 	if(mind && mind.current == src)
 		spellremove(src)
 	ghostize()
-	..()
+	. = ..()
 
 /mob/proc/remove_screen_obj_references()
 	flash = null

--- a/code/modules/mob/observer/freelook/ai/cameranet.dm
+++ b/code/modules/mob/observer/freelook/ai/cameranet.dm
@@ -28,18 +28,21 @@ var/datum/visualnet/camera/cameranet_
 	if(istype(c))
 		if(c in cameras)
 			return
-		var/list/open_networks = c.network - restricted_camera_networks
-		if(!open_networks.len)
-			return
-		dd_insertObjectList(cameras, c)
-		..(c, c.can_use())
+		. = ..(c, c.can_use())
+		if(.)
+			var/list/open_networks = c.network - restricted_camera_networks
+			if(!open_networks.len)
+				return
+			dd_insertObjectList(cameras, c)
 	else if(isAI(c))
 		var/mob/living/silicon/AI = c
-		..(AI, AI.stat != DEAD)
+		return ..(AI, AI.stat != DEAD)
 
 // Add a camera to a chunk.
 
 /datum/visualnet/camera/remove_source(obj/machinery/camera/c)
-	if(!cameras.Remove(c))
-		return
-	..(c, c.can_use())
+	if(istype(c) && cameras.Remove(c))
+		. = ..(c, c.can_use())
+	if(isAI(c))
+		var/mob/living/silicon/AI = c
+		return ..(AI, AI.stat != DEAD)

--- a/code/modules/mob/observer/freelook/ai/chunk.dm
+++ b/code/modules/mob/observer/freelook/ai/chunk.dm
@@ -11,13 +11,13 @@
 	. = ..()
 
 /datum/chunk/camera/add_source(var/atom/source)
-	..()
-	if(istype(source, /obj/machinery/camera))
+	. = ..()
+	if(. && istype(source, /obj/machinery/camera))
 		cameras += source
 
 /datum/chunk/camera/remove_source(var/atom/source)
-	..()
-	if(istype(source, /obj/machinery/camera))
+	. = ..()
+	if(. && istype(source, /obj/machinery/camera))
 		cameras -= source
 
 /datum/chunk/camera/acquire_visible_turfs(var/list/visible)

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -86,14 +86,18 @@
 			continue
 		add_source(A)
 
-// The visualnet checks if a source already exists or not, as appropriate, before calling add/remove_source on the chunk
 /datum/chunk/proc/add_source(var/atom/source)
+	if(source in sources)
+		return FALSE
 	sources += source
 	visibility_changed()
+	return TRUE
 
 /datum/chunk/proc/remove_source(var/atom/source)
-	sources -= source
-	visibility_changed()
+	if(sources.Remove(source))
+		visibility_changed()
+		return TRUE
+	return FALSE
 
 // The visual net is responsible for adding/removing eyes.
 /datum/chunk/proc/add_eye(mob/observer/eye/eye)

--- a/code/modules/mob/observer/freelook/visualnet.dm
+++ b/code/modules/mob/observer/freelook/visualnet.dm
@@ -104,21 +104,25 @@
 
 /datum/visualnet/proc/add_source(var/atom/source, var/update_visibility = TRUE, var/opacity_check = FALSE)
 	if(source in sources)
-		return
+		return FALSE
 	sources += source
 	moved_event.register(source, src, /datum/visualnet/proc/source_moved)
 	destroyed_event.register(source, src, /datum/visualnet/proc/remove_source)
 	for_all_chunks_in_range(source, /datum/chunk/proc/add_source, list(source))
 	if(update_visibility)
 		update_visibility(source, opacity_check)
+	return TRUE
 
 /datum/visualnet/proc/remove_source(var/atom/source, var/update_visibility = TRUE, var/opacity_check = FALSE)
-	if(sources.Remove(source))
-		moved_event.unregister(source, src)
-		destroyed_event.unregister(source, src)
-		for_all_chunks_in_range(source, /datum/chunk/proc/remove_source, list(source))
-		if(update_visibility)
-			update_visibility(source, opacity_check)
+	if(!sources.Remove(source))
+		return FALSE
+
+	moved_event.unregister(source, src, /datum/visualnet/proc/source_moved)
+	destroyed_event.unregister(source, src, /datum/visualnet/proc/remove_source)
+	for_all_chunks_in_range(source, /datum/chunk/proc/remove_source, list(source))
+	if(update_visibility)
+		update_visibility(source, opacity_check)
+	return TRUE
 
 /datum/visualnet/proc/source_moved(var/atom/movable/source, var/old_loc, var/new_loc)
 	var/turf/old_turf = get_turf(old_loc)


### PR DESCRIPTION
This corrects a lie, makes is possible to remove AIs as a camera source, and fixes #12944 (or the visualnet relevant parts anyway).
