### PR TITLE
Remove nonfunctional malf check

### DIFF
--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -17,10 +17,6 @@ var/global/list/empty_playable_ai_cores = list()
 	set category = "OOC"
 	set desc = "Wipe your core. This is functionally equivalent to cryo or robotic storage, freeing up your job slot."
 
-	if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
-		usr << "<span class='danger'>You cannot use this verb in malfunction. If you need to leave, please adminhelp.</span>"
-		return
-
 	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
 	if(alert("WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo and robotic storage). Are you entirely sure you want to do this?",
 					"Wipe Core", "No", "No", "Yes") != "Yes")

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -22,6 +22,9 @@ var/global/list/empty_playable_ai_cores = list()
 					"Wipe Core", "No", "No", "Yes") != "Yes")
 		return
 
+	if(is_special_character(src))
+		log_and_message_admins("removed themselves from the round via Wipe Core")
+
 	// We warned you.
 	empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(loc)
 	global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")


### PR DESCRIPTION
Msay discussion said remove the check rather than fix it;

it's checking for `"AI malfunction"`, the mode name is "sanitised" to `"Ai malfunction"`.
