### PR TITLE
Few spell changes

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -21,9 +21,9 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
 	//if(user != M)
-	if(user.spell_list.len)
-		user.silence_spells(300) //30 seconds
-		user << "<span class='danger'>You've been silenced!</span>"
+	if(M.spell_list.len)
+		M.silence_spells(300) //30 seconds
+		M << "<span class='danger'>You've been silenced!</span>"
 		return
 
 	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")

--- a/code/modules/spells/targeted/projectile/magic_missile.dm
+++ b/code/modules/spells/targeted/projectile/magic_missile.dm
@@ -23,6 +23,7 @@
 	amt_stunned = 3
 
 	amt_dam_fire = 10
+	cast_prox_range = 0
 
 /spell/targeted/projectile/magic_missile/prox_cast(var/list/targets, atom/spell_holder)
 	spell_holder.visible_message("<span class='danger'>\The [spell_holder] pops with a flash!</span>")

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -25,6 +25,8 @@
 		if(M.stat == DEAD)
 			user << "[name] can only transform living targets."
 			continue
+		if(M.buckled)
+			M.buckled.unbuckle_mob()
 		var/new_mob = pick(possible_transformations)
 
 		var/mob/living/trans = new new_mob(get_turf(M))


### PR DESCRIPTION
Magic missile hits everyone in the area. 

Each magic missile has a prox range of 1, meaning every tile around themagic missile when it pops, gets hit.

This means that in a clumped up area _magic missile will hit people multiple times per cast_, which can ruin the balance.

Also made shapeshifting unbuckle you so you aren't stuck if you move.

Nullrod is no longer bugged to silence the user, instead the defender.
