### PR TITLE
[WIP] Adds PDA multicasting, allows faked PDA message replies to be rerouted

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -420,6 +420,7 @@
 #include "code\game\machinery\nuclear_bomb.dm"
 #include "code\game\machinery\OpTable.dm"
 #include "code\game\machinery\oxygen_pump.dm"
+#include "code\game\machinery\pda_multicaster.dm"
 #include "code\game\machinery\portable_turret.dm"
 #include "code\game\machinery\recharger.dm"
 #include "code\game\machinery\rechargestation.dm"

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -454,7 +454,7 @@
 						//Sender isn't faking as someone who exists
 						if(isnull(PDARec))
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[customsender]","[custommessage]")
-							customrecepient.new_message(customsender, customsender, customjob, custommessage)
+							customrecepient.new_message(customsender, customsender, customjob, custommessage, null) //TODO allow setting a custom reply-to
 						//Sender is faking as someone who exists
 						else
 
@@ -464,7 +464,7 @@
 							if(!customrecepient.conversations.Find("\ref[PDARec]"))
 								customrecepient.conversations.Add("\ref[PDARec]")
 
-							customrecepient.new_message(PDARec, custommessage)
+							customrecepient.new_message_from_pda(PDARec, custommessage)
 						//Finally..
 						ResetMessage()
 

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -26,6 +26,7 @@
 	// Custom Message Properties
 	var/customsender = "System Administrator"
 	var/obj/item/device/pda/customrecepient = null
+	var/obj/item/device/pda/customreply_to = null
 	var/customjob		= "Admin"
 	var/custommessage 	= "This is a test, please ignore."
 
@@ -202,6 +203,7 @@
 					<tr><td width='20%'><A href='?src=\ref[src];select=Sender'>Sender</a></td>
 					<td width='20%'><A href='?src=\ref[src];select=RecJob'>Sender's Job</a></td>
 					<td width='20%'><A href='?src=\ref[src];select=Recepient'>Recipient</a></td>
+					<td width='20%'><A href='?src=\ref[src];select=ReplyTo'>Reply-To</a></td>
 					<td width='300px' word-wrap: break-word><A href='?src=\ref[src];select=Message'>Message</a></td></tr>"}
 				//Sender  - Sender's Job  - Recepient - Message
 				//Al Green- Your Dad	  - Your Mom  - WHAT UP!?
@@ -278,6 +280,7 @@
 /obj/machinery/computer/message_monitor/proc/ResetMessage()
 	customsender 	= "System Administrator"
 	customrecepient = null
+	customreply_to	= null
 	custommessage 	= "This is a test, please ignore."
 	customjob 		= "Admin"
 
@@ -423,6 +426,17 @@
 						else
 							customrecepient = null
 
+					//Select Reply-To
+					if("ReplyTo")
+						//Get out list of viable PDAs
+						var/list/obj/item/device/pda/sendPDAs = list()
+						for(var/obj/item/device/pda/P in PDAs)
+							sendPDAs += P
+						if(PDAs && PDAs.len > 0)
+							customreply_to = input(usr, "Select a PDA from the list.") as null|anything in sortAtom(sendPDAs)
+						else
+							customreply_to = null
+
 					//Enter custom job
 					if("RecJob")
 						customjob	 	= sanitize(input(usr, "Please enter the sender's job.") as text|null)
@@ -454,17 +468,18 @@
 						//Sender isn't faking as someone who exists
 						if(isnull(PDARec))
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[customsender]","[custommessage]")
-							customrecepient.new_message(customsender, customsender, customjob, custommessage, null) //TODO allow setting a custom reply-to
+							customrecepient.new_message(customsender, customsender, customjob, custommessage, customreply_to)
+							//no way to create a PDA conversation for this unfortunately, not without a major rewrite
 						//Sender is faking as someone who exists
 						else
 
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[PDARec.owner]","[custommessage]")
-							customrecepient.tnote.Add(list(list("sent" = 0, "owner" = "[PDARec.owner]", "job" = "[customjob]", "message" = "[custommessage]", "target" ="\ref[PDARec]")))
+							customrecepient.tnote.Add(list(list("sent" = 0, "owner" = "[PDARec.owner]", "job" = "[PDARec.ownjob]", "message" = "[custommessage]", "target" ="\ref[PDARec]")))
 
-							if(!customrecepient.conversations.Find("\ref[PDARec]"))
-								customrecepient.conversations.Add("\ref[PDARec]")
+							//reroute replies to the PDA of our choosing until the next time the PDA we are impersonating sends a message to this recipient
+							customrecepient.conversations["\ref[PDARec]"] = "\ref[customreply_to]"
 
-							customrecepient.new_message_from_pda(PDARec, custommessage)
+							customrecepient.new_message(PDARec, PDARec.owner, PDARec.ownjob, custommessage, customreply_to) //you can send a message pretending to be someone else, 
 						//Finally..
 						ResetMessage()
 

--- a/code/game/machinery/pda_multicaster.dm
+++ b/code/game/machinery/pda_multicaster.dm
@@ -1,0 +1,101 @@
+/obj/machinery/pda_multicaster
+	name = "\improper PDA multicaster"
+	desc = "This machine mirrors messages sent to it to specific departments."
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "controller"
+	density = 1
+	anchored = 1
+	circuit = /obj/item/weapon/circuitboard/telecomms/pda_multicaster
+	use_power = 1
+	idle_power_usage = 750
+	var/on = 1		// If we're currently active,
+	var/toggle = 1	// If we /should/ be active or not,
+	var/list/internal_PDAs = list() // Assoc list of PDAs inside of this, with the department name being the index,
+
+/obj/machinery/pda_multicaster/New()
+	..()
+	internal_PDAs = list("command" = new /obj/item/device/pda/multicaster/command(src),
+		"security" = new /obj/item/device/pda/multicaster/security(src),
+		"engineering" = new /obj/item/device/pda/multicaster/engineering(src),
+		"medical" = new /obj/item/device/pda/multicaster/medical(src),
+		"research" = new /obj/item/device/pda/multicaster/research(src),
+		"cargo" = new /obj/item/device/pda/multicaster/cargo(src),
+		"civilian" = new /obj/item/device/pda/multicaster/civilian(src))
+
+/obj/machinery/pda_multicaster/prebuilt/New()
+	..()
+
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/telecomms/pda_multicaster(src)
+	component_parts += new /obj/item/weapon/stock_parts/subspace/ansible(src)
+	component_parts += new /obj/item/weapon/stock_parts/subspace/filter(src)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(src)
+	component_parts += new /obj/item/weapon/stock_parts/subspace/treatment(src)
+	component_parts += new /obj/item/stack/cable_coil(src, 2)
+	RefreshParts()
+
+/obj/machinery/pda_multicaster/Destroy()
+	for(var/atom/movable/AM in contents)
+		qdel(AM)
+	..()
+
+/obj/machinery/pda_multicaster/update_icon()
+	if(on)
+		icon_state = initial(icon_state)
+	else
+		icon_state = "[initial(icon_state)]-p"
+
+/obj/machinery/pda_multicaster/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/screwdriver))
+		default_deconstruction_screwdriver(user, I)
+	else if(istype(I, /obj/item/weapon/crowbar))
+		default_deconstruction_crowbar(user, I)
+	else
+		..()
+
+/obj/machinery/pda_multicaster/attack_ai(mob/user)
+	attack_hand(user)
+
+/obj/machinery/pda_multicaster/attack_hand(mob/user)
+	toggle_power(user)
+
+/obj/machinery/pda_multicaster/proc/toggle_power(mob/user)
+	toggle = !toggle
+	visible_message("\the [user] turns \the [src] [toggle ? "on" : "off"].")
+	update_power()
+	if(!toggle)
+		var/msg = "[usr.client.key] ([usr]) has turned [src] off, at [x],[y],[z]."
+		message_admins(msg)
+		log_game(msg)
+
+/obj/machinery/pda_multicaster/proc/update_PDAs(var/turn_off)
+	for(var/obj/item/device/pda/pda in contents)
+		pda.toff = turn_off
+
+/obj/machinery/pda_multicaster/proc/update_power()
+	if(toggle)
+		if(stat & (BROKEN|NOPOWER|EMPED))
+			on = 0
+			update_PDAs(1) // 1 being to turn off.
+			idle_power_usage = 0
+		else
+			on = 1
+			update_PDAs(0)
+			idle_power_usage = 750
+	else
+		on = 0
+		update_PDAs(1)
+		idle_power_usage = 0
+	update_icon()
+
+/obj/machinery/pda_multicaster/process()
+	update_power()
+
+/obj/machinery/pda_multicaster/emp_act(severity)
+	if(!(stat & EMPED))
+		stat |= EMPED
+		var/duration = (300 * 10)/severity
+		spawn(rand(duration - 20, duration + 20))
+			stat &= ~EMPED
+	update_icon()
+	..()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -44,7 +44,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/detonate = 1 // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/active_conversation = null // New variable that allows us to only view a single conversation.
-	var/list/conversations = list()    // For keeping up with who we have PDA messsages from.
+	var/list/conversations = list()    // For keeping up with who we have PDA messsages from. Assoc list: \ref[conversation PDA] => \ref[reply-to PDA]
 	var/new_message = 0			//To remove hackish overlay check
 	var/new_news = 0
 
@@ -356,8 +356,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		P.tnote.Add(list(list("sent" = 0, "owner" = "[owner]", "job" = "[ownjob]", "message" = "[t]", "target" = "\ref[src]")))
 
-		if(!P.conversations.Find("\ref[src]"))
-			P.conversations.Add("\ref[src]")
+		P.conversations["\ref[src]"] = "\ref[src]"
 
 		P.new_message(src, "[original_sender] \[Relayed\]", original_job, t, null)
 
@@ -531,7 +530,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		var/count = 0
 		for (var/obj/item/device/pda/P in PDAs)
 			if (!P.owner||P.toff||P == src||P.hidden)       continue
-			if(conversations.Find("\ref[P]"))
+			if("\ref[P]" in conversations)
 				convopdas.Add(list(list("Name" = "[P]", "Reference" = "\ref[P]", "Detonate" = "[P.detonate]", "inconvo" = "1")))
 			else
 				pdas.Add(list(list("Name" = "[P]", "Reference" = "\ref[P]", "Detonate" = "[P.detonate]", "inconvo" = "0")))
@@ -823,7 +822,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				return 0
 		if("Message")
 
-			var/obj/item/device/pda/P = locate(href_list["target"])
+			var/obj/item/device/pda/P = locate(conversations[href_list["target"]])
 			var/tap = istype(U, /mob/living/carbon)
 			src.create_message(U, P, tap)
 			if(mode == 2)
@@ -833,10 +832,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if("Select Conversation")
 			var/P = href_list["convo"]
-			for(var/n in conversations)
-				if(P == n)
-					active_conversation=P
-					mode=21
+			if(P in conversations)
+				active_conversation=P
+				mode=21
 		if("Select Feed")
 			var/n = href_list["name"]
 			for(var/f in feeds)
@@ -1091,10 +1089,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					continue
 				M.show_message("<span class='game say'>PDA Message - <span class='name'>[owner]</span> -> <span class='name'>[P.owner]</span>: <span class='message'>[t]</span></span>")
 
-		if(!conversations.Find("\ref[P]"))
-			conversations.Add("\ref[P]")
-		if(!P.conversations.Find("\ref[src]"))
-			P.conversations.Add("\ref[src]")
+		src.conversations["\ref[P]"] = "\ref[P]"
+		P.conversations["\ref[src]"] = "\ref[src]"
 
 
 		if (prob(15)) //Give the AI a chance of intercepting the message

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -1,3 +1,48 @@
+var/list/command_cartridges = list(
+	/obj/item/weapon/cartridge/captain,
+	/obj/item/weapon/cartridge/hop,
+	/obj/item/weapon/cartridge/hos,
+	/obj/item/weapon/cartridge/ce,
+	/obj/item/weapon/cartridge/rd,
+	/obj/item/weapon/cartridge/head,
+	/obj/item/weapon/cartridge/lawyer // Internal Affaris,
+	)
+
+var/list/security_cartridges = list(
+	/obj/item/weapon/cartridge/security,
+	/obj/item/weapon/cartridge/detective,
+	/obj/item/weapon/cartridge/hos
+	)
+
+var/list/engineering_cartridges = list(
+	/obj/item/weapon/cartridge/engineering,
+	/obj/item/weapon/cartridge/atmos,
+	/obj/item/weapon/cartridge/ce
+	)
+
+var/list/medical_cartridges = list(
+	/obj/item/weapon/cartridge/medical,
+	/obj/item/weapon/cartridge/chemistry,
+	/obj/item/weapon/cartridge/cmo
+	)
+
+var/list/research_cartridges = list(
+	/obj/item/weapon/cartridge/signal/science,
+	/obj/item/weapon/cartridge/rd
+	)
+
+var/list/cargo_cartridges = list(
+	/obj/item/weapon/cartridge/quartermaster, // This also covers cargo-techs, apparently,
+	/obj/item/weapon/cartridge/miner,
+	/obj/item/weapon/cartridge/hop
+	)
+
+var/list/civilian_cartridges = list(
+	/obj/item/weapon/cartridge/janitor,
+	/obj/item/weapon/cartridge/service,
+	/obj/item/weapon/cartridge/hop
+	)
+
 /obj/item/weapon/cartridge
 	name = "generic cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -98,6 +143,10 @@
 	access_flora = 1
 */
 
+/obj/item/weapon/cartridge/service
+	name = "\improper Serv-U Pro"
+	desc = "A data cartridge designed to serve YOU!"
+
 /obj/item/weapon/cartridge/signal
 	name = "generic signaler cartridge"
 	desc = "A data cartridge with an integrated radio signaler module."
@@ -127,6 +176,11 @@
 /obj/item/weapon/cartridge/quartermaster/initialize()
 	radio = new /obj/item/radio/integrated/mule(src)
 	..()
+
+/obj/item/weapon/cartridge/miner
+	name = "\improper Drill-Jockey 4.5"
+	desc = "It's covered in some sort of sand."
+	icon_state = "cart-q"
 
 /obj/item/weapon/cartridge/head
 	name = "\improper Easy-Record DELUXE"

--- a/code/game/objects/items/weapons/circuitboards/machinery/telecomms.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/telecomms.dm
@@ -73,3 +73,14 @@
 							/obj/item/weapon/stock_parts/subspace/filter = 1,
 							/obj/item/weapon/stock_parts/subspace/crystal = 1,
 							/obj/item/weapon/stock_parts/micro_laser/high = 2)
+
+/obj/item/weapon/circuitboard/telecomms/pda_multicaster
+	name = T_BOARD("pda multicaster")
+	build_path = "/obj/machinery/pda_multicaster"
+	origin_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
+	req_components = list(
+							/obj/item/weapon/stock_parts/subspace/ansible = 1,
+							/obj/item/weapon/stock_parts/subspace/filter = 1,
+							/obj/item/weapon/stock_parts/manipulator = 1,
+							/obj/item/weapon/stock_parts/subspace/treatment = 1,
+							/obj/item/stack/cable_coil = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/telecomms.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/telecomms.dm
@@ -76,7 +76,7 @@
 
 /obj/item/weapon/circuitboard/telecomms/pda_multicaster
 	name = T_BOARD("pda multicaster")
-	build_path = "/obj/machinery/pda_multicaster"
+	build_path = /obj/machinery/pda_multicaster
 	origin_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
 	req_components = list(
 							/obj/item/weapon/stock_parts/subspace/ansible = 1,

--- a/html/changelogs/HarpyEagle-pda-multicast.yml
+++ b/html/changelogs/HarpyEagle-pda-multicast.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - rscadd: "Allows replies to fake PDA messages to be re-routed to a PDA of your choosing."


### PR DESCRIPTION
Adds PDA multicasting, port of https://github.com/PolarisSS13/Polaris/pull/1581/files. Nothing added to the map yet, just ports the machinery.

Also allows faked PDA messages to have their replies rerouted to another PDA. If you fake a message using the message monitor, you can choose a PDA to which replies will be sent. This re-routing lasts until the PDA you are impersonating sends a message to the recipient of the faked message.
