### PR TITLE
Fixes #12965

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -53,9 +53,10 @@
 			if(COMPANY_OPPOSED)		loyalty = 0.70
 
 	//give them an account in the station database
-	var/species_modifier = (H.species ? economic_species_modifier[H.species.type] : 2)
-	if(!species_modifier)
-		species_modifier = economic_species_modifier[/datum/species/human]
+	if(!(H.species && (H.species.type in economic_species_modifier)))
+		return //some bizarre species like shadow, slime, or monkey? You don't get an account.
+
+	var/species_modifier = economic_species_modifier[H.species.type]
 
 	var/money_amount = (rand(5,50) + rand(5, 50)) * loyalty * economic_modifier * species_modifier
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null)

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -46,15 +46,19 @@
 
 #define GEAR_EVA 15
 
-
+//Note that you have to specify each subspecies individually. Shouldn't be a big deal.
 /var/list/economic_species_modifier = list(
-												/datum/species/human	= 10,
-												/datum/species/skrell	= 12,
-												/datum/species/tajaran	= 7,
-												/datum/species/unathi	= 7,
-												/datum/species/diona	= 5,
-												/datum/species/resomi	= 5,
-												/datum/species/vox		= 1
+												/datum/species/human             = 10,
+												/datum/species/human/gravworlder = 10,
+												/datum/species/human/spacer      = 10,
+												/datum/species/human/vatgrown    = 5, //if it weren't for the fact that they were humans I would have given them less,
+												/datum/species/skrell            = 12,
+												/datum/species/tajaran           = 7,
+												/datum/species/unathi            = 7,
+												/datum/species/machine           = 7,
+												/datum/species/diona             = 5,
+												/datum/species/resomi            = 5,
+												/datum/species/vox/pariah        = 1
 											)
 
 //---- The following corporations are friendly with NanoTrasen and loosely enable trade and travel:


### PR DESCRIPTION
Updated `economic_species_modifier`. Species that don't have an entry in `economic_species_modifier` don't get accounts.
