### PR TITLE
Fixes #13000

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -3,6 +3,7 @@
 	desc = "Should anything ever go wrong..."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "red_phone"
+	randpixel = 0
 	flags = CONDUCT
 	force = 3.0
 	throwforce = 2.0

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -16,6 +16,7 @@
 /obj/item/mecha_parts/chassis
 	name="Mecha Chassis"
 	icon_state = "backbone"
+	randpixel = 0
 	var/datum/construction/construct
 	flags = CONDUCT
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -196,7 +196,7 @@
 	if(user.put_in_active_hand(src))
 		if(randpixel)
 			pixel_x = rand(-randpixel, randpixel)
-			pixel_y = rand(-randpixel, 0) //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character's feet
+			pixel_y = rand(-randpixel, 0) - randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character's feet
 		else if(randpixel == 0)
 			pixel_x = 0
 			pixel_y = 0

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -2,6 +2,7 @@
 	name = "station intercom (General)"
 	desc = "Talk through this."
 	icon_state = "intercom"
+	randpixel = 0
 	anchored = 1
 	w_class = 4.0
 	canhear_range = 2

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -746,6 +746,7 @@ var/global/list/default_medbay_channels = list(
 	broadcasting = 0
 	icon = 'icons/obj/items.dmi'
 	icon_state = "red_phone"
+	randpixel = 0
 	listening = 1
 	name = "phone"
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -16,6 +16,7 @@ var/list/tape_roll_applications = list()
 	name = "tape"
 	icon = 'icons/policetape.dmi'
 	icon_state = "tape"
+	randpixel = 0
 	anchored = 1
 	var/lifted = 0
 	var/crumpled = 0

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -10,6 +10,7 @@ LINEN BINS
 	icon = 'icons/obj/items.dmi'
 	icon_state = "sheet"
 	item_state = "bedsheet"
+	randpixel = 0
 	slot_flags = SLOT_BACK
 	layer = 4.0
 	throwforce = 1

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -6,6 +6,7 @@ var/global/list/stool_cache = list() //haha stool
 	desc = "Apply butt."
 	icon = 'icons/obj/furniture.dmi'
 	icon_state = "stool_preview" //set for the map
+	randpixel = 0
 	force = 10
 	throwforce = 10
 	w_class = 5

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_bin1"
 	item_state = "sheet-metal"
+	randpixel = 0
 	throwforce = 1
 	w_class = 3
 	throw_speed = 3


### PR DESCRIPTION
Sets randpixel = 0 for:
- mech chassis
- intercoms
- red telephones
- tape
- bedsheets
- stools
- paper bins

Also tweaks the pixel_y randomization for item pickup.
