### PR TITLE
Fixes IPC permashock.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -981,7 +981,9 @@
 /mob/living/carbon/human/handle_shock()
 	..()
 	if(status_flags & GODMODE)	return 0	//godmode
-	if(species && species.flags & NO_PAIN) return
+	if(species && species.flags & NO_PAIN) 
+		shock_stage = 0
+		return
 
 	if(health < config.health_threshold_softcrit)// health 0 makes you immediately collapse
 		shock_stage = max(shock_stage, 61)


### PR DESCRIPTION
Resets `shock_stage` to 0 for species with `NO_PAIN` instead of halting `shock_stage` processing completely.
Necessary because certain injuries (limb relocation, embedded object yanking, and damage spillover) increment `shock_stage` directly.

Fixes #13010
