### PR TITLE
Uplink Discounts

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -14,7 +14,7 @@ var/roundstart_hour = 0
 var/station_date = ""
 var/next_station_date_change = 1 DAY
 
-#define round_adjusted_time(time) time2text(time + round_duration_in_ticks, "hh:mm")
+#define station_adjusted_time(time) time2text(time + station_time_in_ticks, "hh:mm")
 #define round_duration_in_ticks (round_start_time ? world.time - round_start_time : 0)
 #define station_time_in_ticks (roundstart_hour HOURS + round_duration_in_ticks)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -401,7 +401,7 @@
 				memory = null//Remove any memory they may have had.
 			if("crystals")
 				if (usr.client.holder.rights & R_FUN)
-					var/obj/item/device/uplink/hidden/suplink = find_syndicate_uplink()
+					var/obj/item/device/uplink/suplink = find_syndicate_uplink()
 					var/crystals
 					if (suplink)
 						crystals = suplink.uses
@@ -426,7 +426,7 @@
 	return null
 
 /datum/mind/proc/take_uplink()
-	var/obj/item/device/uplink/hidden/H = find_syndicate_uplink()
+	var/obj/item/device/uplink/H = find_syndicate_uplink()
 	if(H)
 		qdel(H)
 

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -21,6 +21,7 @@ var/datum/uplink/uplink = new()
 		for(var/datum/uplink_category/category in categories)
 			if(item.category == category.type)
 				category.items += item
+				item.category = category
 
 	for(var/datum/uplink_category/category in categories)
 		category.items = dd_sortedObjectList(category.items)
@@ -89,13 +90,13 @@ var/datum/uplink/uplink = new()
 	return 0
 
 /datum/uplink_item/proc/cost(var/telecrystals, obj/item/device/uplink/U)
-	return U ?  U.get_item_cost(src, item_cost) : item_cost
-
+	. = item_cost
 	if(U && U.uplink_owner)
 		for(var/antag_role in antag_costs)
 			var/datum/antagonist/antag = all_antag_types[antag_role]
 			if(antag.is_antagonist(U.uplink_owner))
-				. = min(antag_costs[antag_role], . )
+				. = min(antag_costs[antag_role], .)
+	return U ?  U.get_item_cost(src, .) : .
 
 /datum/uplink_item/proc/description()
 	return desc

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -89,7 +89,7 @@ var/datum/uplink/uplink = new()
 	return 0
 
 /datum/uplink_item/proc/cost(var/telecrystals, obj/item/device/uplink/U)
-	. = item_cost
+	return U ?  U.get_item_cost(src, item_cost) : item_cost
 
 	if(U && U.uplink_owner)
 		for(var/antag_role in antag_costs)

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -146,7 +146,7 @@ var/datum/antagonist/traitor/traitors
 			if ((freq % 2) == 0)
 				freq += 1
 		freq = freqlist[rand(1, freqlist.len)]
-		var/obj/item/device/uplink/hidden/T = new(R, traitor_mob.mind)
+		var/obj/item/device/uplink/T = new(R, traitor_mob.mind)
 		target_radio.hidden_uplink = T
 		target_radio.traitor_frequency = freq
 		traitor_mob << "A portable object teleportation relay has been installed in your [R.name] [loc]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features."
@@ -155,7 +155,7 @@ var/datum/antagonist/traitor/traitors
 	else if (istype(R, /obj/item/device/pda))
 		// generate a passcode if the uplink is hidden in a PDA
 		var/pda_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
-		var/obj/item/device/uplink/hidden/T = new(R, traitor_mob.mind)
+		var/obj/item/device/uplink/T = new(R, traitor_mob.mind)
 		R.hidden_uplink = T
 		var/obj/item/device/pda/P = R
 		P.lock_code = pda_pass

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -20,15 +20,15 @@
 /obj/item/weapon/card/id/guest/examine(mob/user)
 	..(user)
 	if (world.time < expiration_time)
-		user << "<span class='notice'>This pass expires at [round_adjusted_time(expiration_time)].</span>"
+		user << "<span class='notice'>This pass expires at [station_adjusted_time(expiration_time)].</span>"
 	else
-		user << "<span class='warning'>It expired at [round_adjusted_time(expiration_time)].</span>"
+		user << "<span class='warning'>It expired at [station_adjusted_time(expiration_time)].</span>"
 
 /obj/item/weapon/card/id/guest/read()
 	if (world.time > expiration_time)
-		usr << "<span class='notice'>This pass expired at [round_adjusted_time(expiration_time)].</span>"
+		usr << "<span class='notice'>This pass expired at [station_adjusted_time(expiration_time)].</span>"
 	else
-		usr << "<span class='notice'>This pass expires at [round_adjusted_time(expiration_time)].</span>"
+		usr << "<span class='notice'>This pass expires at [station_adjusted_time(expiration_time)].</span>"
 
 	usr << "<span class='notice'>It grants access to following areas:</span>"
 	for (var/A in temp_access)
@@ -174,7 +174,7 @@
 						if (A in giver.access)
 							access_descriptors += get_access_desc(A)
 					entry += english_list(access_descriptors, and_text = ", ")
-					entry += ". Expires at [round_adjusted_time(world.time + duration MINUTES)]."
+					entry += ". Expires at [station_adjusted_time(world.time + duration MINUTES)]."
 					internal_log.Add(entry)
 
 					var/obj/item/weapon/card/id/guest/pass = new(src.loc)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -46,7 +46,7 @@
 	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
 	var/list/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/list/allowed = null //suit storage stuff.
-	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
+	var/obj/item/device/uplink/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 	var/zoomdevicename = null //name used for message when binoculars/scope is used
 	var/zoom = 0 //1 if item is actively being used to zoom. For scoped guns and binoculars.
 

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -31,13 +31,6 @@
 	processing_objects -= src
 	return ..()
 
-/obj/item/device/uplink/process()
-	if(world.time > next_offer_time)
-		discount_item = default_uplink_selection.get_random_item(INFINITY)
-		discount_amount = pick(90;0.9, 80;0.8, 70;0.7, 60;0.6, 50;0.5, 40;0.4, 30;0.3, 20;0.2, 10;0.1)
-		next_offer_time = world.time + offer_time
-		nanomanager.update_uis(src)
-
 /obj/item/device/uplink/get_item_cost(var/item_type, var/item_cost)
 	return (discount_item && (item_type == discount_item)) ? max(1, round(item_cost*discount_amount)) : item_cost
 
@@ -60,7 +53,6 @@
 	var/datum/uplink_category/category 	= 0		// The current category we are in
 	var/exploit_id								// Id of the current exploit record we are viewing
 
-
 // The hidden uplink MUST be inside an obj/item's contents.
 /obj/item/device/uplink/hidden/New()
 	spawn(2)
@@ -69,6 +61,14 @@
 	..()
 	nanoui_data = list()
 	update_nano_data()
+
+/obj/item/device/uplink/hidden/process()
+	if(world.time > next_offer_time)
+		discount_item = default_uplink_selection.get_random_item(INFINITY)
+		discount_amount = pick(90;0.9, 80;0.8, 70;0.7, 60;0.6, 50;0.5, 40;0.4, 30;0.3, 20;0.2, 10;0.1)
+		next_offer_time = world.time + offer_time
+		update_nano_data()
+		nanomanager.update_uis(src)
 
 // Toggles the uplink on and off. Normally this will bypass the item's normal functions and go to the uplink menu, if activated.
 /obj/item/device/uplink/hidden/proc/toggle()
@@ -152,7 +152,7 @@
 		nanoui_data["categories"] = categories
 		nanoui_data["discount_name"] = discount_item ? discount_item.name : ""
 		nanoui_data["discount_amount"] = (1-discount_amount)*100
-		nanoui_data["offer_expiry"] = worldtime2text(next_offer_time - world.time)
+		nanoui_data["offer_expiry"] = worldtime2text(next_offer_time)
 	else if(nanoui_menu == 1)
 		var/items[0]
 		for(var/datum/uplink_item/item in category.items)

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -27,7 +27,7 @@ var/datum/uplink_random_selection/default_uplink_selection = new/datum/uplink_ra
 		if(!prob(RI.keep_probability))
 			continue
 		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
-		if(I.cost(telecrystals) > telecrystals)
+		if(I.cost(telecrystals, U) > telecrystals)
 			continue
 		if(bought_items && (I in bought_items) && !prob(RI.reselect_probability))
 			continue

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -86,7 +86,7 @@
 	var/scan_data = ""
 
 	if(timeofdeath)
-		scan_data += "<b>Time of death:</b> [round_adjusted_time(timeofdeath)]<br><br>"
+		scan_data += "<b>Time of death:</b> [station_adjusted_time(timeofdeath)]<br><br>"
 
 	var/n = 1
 	for(var/wdata_idx in wdata)
@@ -133,7 +133,7 @@
 		if(damaging_weapon)
 			scan_data += "Severity: [damage_desc]<br>"
 			scan_data += "Hits by weapon: [total_hits]<br>"
-		scan_data += "Approximate time of wound infliction: [round_adjusted_time(age)]<br>"
+		scan_data += "Approximate time of wound infliction: [station_adjusted_time(age)]<br>"
 		scan_data += "Affected limbs: [D.organ_names]<br>"
 		scan_data += "Possible weapons:<br>"
 		for(var/weapon_name in weapon_chances)

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -36,7 +36,7 @@
 	if(EM.add_to_queue)
 		EC.available_events += EM
 
-	log_debug("Event '[EM.name]' has completed at [round_adjusted_time(world.time)].")
+	log_debug("Event '[EM.name]' has completed at [station_adjusted_time(world.time)].")
 
 /datum/event_manager/proc/delay_events(var/severity, var/delay)
 	var/list/datum/event_container/EC = event_containers[severity]
@@ -59,12 +59,12 @@
 		var/datum/event_meta/EM = E.event_meta
 		if(EM.name == "Nothing")
 			continue
-		var/message = "'[EM.name]' began at [round_adjusted_time(E.startedAt)] "
+		var/message = "'[EM.name]' began at [station_adjusted_time(E.startedAt)] "
 		if(E.isRunning)
 			message += "and is still running."
 		else
 			if(E.endedAt - E.startedAt > MinutesToTicks(5)) // Only mention end time if the entire duration was more than 5 minutes
-				message += "and ended at [round_adjusted_time(E.endedAt)]."
+				message += "and ended at [station_adjusted_time(E.endedAt)]."
 			else
 				message += "and ran to completion."
 
@@ -122,7 +122,7 @@
 			var/next_event_at = max(0, EC.next_event_time - world.time)
 			html += "<tr>"
 			html += "<td>[severity_to_string[severity]]</td>"
-			html += "<td>[round_adjusted_time(max(EC.next_event_time, world.time))]</td>"
+			html += "<td>[station_adjusted_time(max(EC.next_event_time, world.time))]</td>"
 			html += "<td>[round(next_event_at / 600, 0.1)]</td>"
 			html += "<td>"
 			html +=   "<A align='right' href='?src=\ref[src];dec_timer=2;event=\ref[EC]'>--</A>"
@@ -170,7 +170,7 @@
 			html += "<tr>"
 			html += "<td>[severity_to_string[EM.severity]]</td>"
 			html += "<td>[EM.name]</td>"
-			html += "<td>[round_adjusted_time(ends_at)]</td>"
+			html += "<td>[station_adjusted_time(ends_at)]</td>"
 			html += "<td>[ends_in]</td>"
 			html += "<td><A align='right' href='?src=\ref[src];stop=\ref[E]'>Stop</A></td>"
 			html += "</tr>"

--- a/html/changelogs/PsiOmegaDelta-PolarDiscount.yml
+++ b/html/changelogs/PsiOmegaDelta-PolarDiscount.yml
@@ -1,0 +1,6 @@
+author: Yoshax
+
+delete-after: True
+
+changes: 
+  - rscadd: "The antag uplink now offers regular discounts on randomly items."

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -29,6 +29,17 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 </div>
 
 {{if data.menu == 0}}
+	{{if data.discount_amount < 100}}
+		<div class="item">
+			<div class="itemLabel">
+				<b>Currently discounted</b>:
+			</div>
+			<div class="itemContent">
+				{{:data.discount_name}} - {{:data.discount_amount}}% off. Offer will expire at: {{:data.offer_expiry}}
+			</div>
+		</div>
+	{{/if}}
+
 	<H2>Categories:</H2>
 	{{for data.categories}}
 		<div class="item">

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -19,27 +19,29 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 </div>
 <br>
 
-<div class="item">
-	<div class="itemLabel">
-		<b>Tele-Crystals</b>:
+{{if data.menu == 0 || data.menu == 1}}
+	<div class="item">
+		<div class="itemLabel">
+			<b>Tele-Crystals</b>:
+		</div>
+		<div class="itemContent">
+			{{:data.crystals}}
+		</div>
 	</div>
-	<div class="itemContent">
-		{{:data.crystals}}
-	</div>
-</div>
 
-{{if data.menu == 0}}
 	{{if data.discount_amount < 100}}
 		<div class="item">
 			<div class="itemLabel">
 				<b>Currently discounted</b>:
 			</div>
 			<div class="itemContent">
-				{{:data.discount_name}} - {{:data.discount_amount}}% off. Offer will expire at: {{:data.offer_expiry}}
+				{{:data.discount_category}}<br>{{:data.discount_name}}<br>{{:data.discount_amount}}% off. Offer will expire at: {{:data.offer_expiry}}
 			</div>
 		</div>
 	{{/if}}
+{{/if}}
 
+{{if data.menu == 0}}
 	<H2>Categories:</H2>
 	{{for data.categories}}
 		<div class="item">


### PR DESCRIPTION
Antag uplinks now offer regular discounts on random items.

Partial port of https://github.com/PolarisSS13/Polaris/pull/1645.
Port of https://github.com/PolarisSS13/Polaris/pull/1662.

Additionally:
Hidden uplinks are now just uplinks. "Normal" uplinks could not be interacted with and were rather meaningless overall.
Traitors also only get discounts for items they are actually able to view.
Makes it easier to locate the discounted items.
Changes round adjusted time to station adjusted time.
