### PR TITLE
Fixes ghosts sometimes not spawning properly when selected by add-antag.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -104,7 +104,7 @@
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
-		if(ghosts_only && !(!player.current || isghost(player.current) || player.current.stat == DEAD || !player.current.client))
+		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
 		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")
@@ -190,7 +190,7 @@
 	if(!(flags & ANTAG_OVERRIDE_JOB) && (!player.current || istype(player.current, /mob/new_player)))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
 		return 0
-	if(ticker.current_state >= GAME_STATE_PLAYING && (isghost(player.current) || player.current.stat == DEAD || !player.current.client) && !(player in ticker.antag_pool))
+	if(ticker.current_state >= GAME_STATE_PLAYING && (isghostmind(player) || isnewplayer(player.current)) && !(player in ticker.antag_pool))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they are a ghost not in the antag pool.")
 		return 0
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -104,7 +104,7 @@
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
-		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current))
+		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
 		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -8,7 +8,7 @@
 		player.assigned_role = role_text
 	player.special_role = role_text
 
-	if(isghost(player.current))
+	if(isghostmind(player))
 		create_default(player.current)
 	else
 		create_antagonist(player, move_to_spawn, do_not_announce, preserve_appearance)

--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -50,7 +50,7 @@ var/datum/antagonist/actor/actor
 	if(choice != "Yes")
 		return
 
-	if(isghost(usr) || isnewplayer(usr))
+	if(isghostmind(usr.mob.mind) || isnewplayer(usr.mob))
 		if(actor.current_antagonists.len >= actor.hard_cap)
 			usr << "No more actors may spawn at the current time."
 			return

--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -50,7 +50,7 @@ var/datum/antagonist/actor/actor
 	if(choice != "Yes")
 		return
 
-	if(isghostmind(usr.mob.mind) || isnewplayer(usr.mob))
+	if(isghostmind(usr.mind) || isnewplayer(usr))
 		if(actor.current_antagonists.len >= actor.hard_cap)
 			usr << "No more actors may spawn at the current time."
 			return

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -496,7 +496,7 @@ var/global/datum/controller/gameticker/ticker
 			antag.update_current_antag_max()
 			antag.build_candidate_list(needs_ghost)
 			for(var/datum/mind/candidate in antag.candidates)
-				if(isghost(candidate.current))
+				if(isghostmind(candidate))
 					antag.candidates -= candidate
 					log_debug("[candidate.key] is a ghost and can not be selected.")
 		if(length(antag.candidates) >= antag.initial_spawn_req)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1088,3 +1088,20 @@ mob/proc/yank_out_object()
 	src.in_throw_mode = 1
 	if(src.throw_icon)
 		src.throw_icon.icon_state = "act_throw_on"
+
+/mob/verb/toggle_antag_pool()
+	set name = "Toggle Add-Antag Candidacy"
+	set desc = "Toggles whether or not you will be considered a candidate by an add-antag vote."
+	set category = "OOC"
+	if(isghostmind(src.mind) || isnewplayer(src))
+		if(ticker && ticker.looking_for_antags)
+			if(src.mind in ticker.antag_pool)
+				ticker.antag_pool -= src.mind
+				usr << "You have left the antag pool."
+			else
+				ticker.antag_pool += src.mind
+				usr << "You have joined the antag pool. Make sure you have the needed role set to high!"
+		else
+			usr << "The game is not currently looking for antags."
+	else
+		usr << "You must be observing or in the lobby to join the antag pool."

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -707,16 +707,5 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	. = "<a href='byond://?src=\ref[ghost];track=\ref[target]'>follow</a>"
 	. += target.extra_ghost_link(ghost)
 
-/mob/observer/ghost/verb/toggle_antag_pool()
-	set name = "Toggle Add-Antag Candidacy"
-	set desc = "Toggles whether or not you will be considered a candidate by an add-antag vote."
-	set category = "Ghost"
-	if(ticker.looking_for_antags)
-		if(src.mind in ticker.antag_pool)
-			ticker.antag_pool -= src.mind
-			usr << "You have left the antag pool."
-		else
-			ticker.antag_pool += src.mind
-			usr << "You have joined the antag pool. Make sure you have the needed role set to high!"
-	else
-		usr << "The game is not currently looking for antags."
+/proc/isghostmind(var/datum/mind/player)
+	return player && !player.current || istype(player.current, /mob/observer/ghost) || player.current.stat == DEAD || !player.current.client && !isnewplayer(player.current)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -708,4 +708,4 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	. += target.extra_ghost_link(ghost)
 
 /proc/isghostmind(var/datum/mind/player)
-	return player && !player.current || istype(player.current, /mob/observer/ghost) || player.current.stat == DEAD || !player.current.client && !isnewplayer(player.current)
+	return player && (!player.current || isghost(player.current) || player.current.stat == DEAD || !player.current.client) && !isnewplayer(player.current)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -708,4 +708,4 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	. += target.extra_ghost_link(ghost)
 
 /proc/isghostmind(var/datum/mind/player)
-	return player && (!player.current || isghost(player.current) || player.current.stat == DEAD || !player.current.client) && !isnewplayer(player.current)
+	return player && !isnewplayer(player.current) && (!player.current || isghost(player.current) || (isliving(player.current) && player.current.stat == DEAD) || !player.current.client)


### PR DESCRIPTION
Fixes ghosts sometimes not spawning properly when selected by add-antag by adding the more robust checks to `antagonist_add`. Should be the last oversight in regards to latespawning off station antags.
Moves the more robust ghost checks to its own proc.
Allows new players to join the antag pool as well as ghosts.
~~Fixes an oversight that would probably allow living mobs to join as actors.~~
