### PR TITLE
Fixes damage descriptions lingering on robot limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -253,7 +253,7 @@
 					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]!</span>\n"
 					continue
 				else
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]. It has[temp.get_wounds_desc()]!</span>\n"
+					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]. It has [temp.get_wounds_desc()]!</span>\n"
 			else if(temp.wounds.len > 0 || temp.open)
 				if(temp.is_stump() && temp.parent_organ && organs_by_name[temp.parent_organ])
 					var/obj/item/organ/external/parent = organs_by_name[temp.parent_organ]

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1066,26 +1066,28 @@ Note that amputating the affected organ does in fact remove the infection from t
 	disfigured = 1
 
 /obj/item/organ/external/proc/get_wounds_desc()
-	. = ""
-	if(status & ORGAN_DESTROYED && !is_stump())
-		. += "tear at [amputation_point] so severe that it hangs by a scrap of flesh"
-
 	if(status & ORGAN_ROBOT)
+		var/list/descriptors = list()
 		if(brute_dam)
 			switch(brute_dam)
 				if(0 to 20)
-					. += " some dents"
+					descriptors += "some dents"
 				if(21 to INFINITY)
-					. += pick(" a lot of dents"," severe denting")
-		if(brute_dam && burn_dam)
-			. += " and"
+					descriptors += pick("a lot of dents","severe denting")
 		if(burn_dam)
 			switch(burn_dam)
 				if(0 to 20)
-					. += " some burns"
+					descriptors += "some burns"
 				if(21 to INFINITY)
-					. += pick(" a lot of burns"," severe melting")
-		return
+					descriptors += pick("a lot of burns","severe melting")
+		if(open)
+			descriptors += "an open panel"
+
+		return english_list(descriptors)
+
+	var/list/flavor_text = list()
+	if((status & ORGAN_DESTROYED) && !is_stump())
+		flavor_text += "a tear at the [amputation_point] so severe that it hangs by a scrap of flesh"
 
 	var/list/wound_descriptors = list()
 	if(open > 1)
@@ -1105,21 +1107,18 @@ Note that amputating the affected organ does in fact remove the infection from t
 		else
 			wound_descriptors[this_wound_desc] = W.amount
 
-	if(wound_descriptors.len)
-		var/list/flavor_text = list()
-		var/list/no_exclude = list("gaping wound", "big gaping wound", "massive wound", "large bruise",\
-		"huge bruise", "massive bruise", "severe burn", "large burn", "deep burn", "carbonised area") //note to self make this more robust
-		for(var/wound in wound_descriptors)
-			switch(wound_descriptors[wound])
-				if(1)
-					flavor_text += "[prob(10) && !(wound in no_exclude) ? "what might be " : ""]a [wound]"
-				if(2)
-					flavor_text += "[prob(10) && !(wound in no_exclude) ? "what might be " : ""]a pair of [wound]s"
-				if(3 to 5)
-					flavor_text += "several [wound]s"
-				if(6 to INFINITY)
-					flavor_text += "a ton of [wound]\s"
-		return english_list(flavor_text)
+	for(var/wound in wound_descriptors)
+		switch(wound_descriptors[wound])
+			if(1)
+				flavor_text += "a [wound]"
+			if(2)
+				flavor_text += "a pair of [wound]s"
+			if(3 to 5)
+				flavor_text += "several [wound]s"
+			if(6 to INFINITY)
+				flavor_text += "a ton of [wound]\s"
+
+	return english_list(flavor_text)
 
 /****************************************************
 			   ORGAN DEFINES

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -581,11 +581,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/update_wounds()
 
 	if((status & ORGAN_ROBOT)) //Robotic limbs don't heal or get worse.
+		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
+			if(W.damage <= 0)  //and they disappear right away
+				wounds -= W    //TODO: robot wounds for robot limbs
 		return
 
 	for(var/datum/wound/W in wounds)
 		// wounds can disappear after 10 minutes at the earliest
-		if(W.damage <= 0 && W.created + 10 * 10 * 60 <= world.time)
+		if(W.damage <= 0 && W.created + (10 MINUTES) <= world.time)
 			wounds -= W
 			continue
 			// let the GC handle the deletion of the wound


### PR DESCRIPTION
`update_wounds()` was returning early before they could be removed, resulting in 0-damage wounds lingering forever. Credit to https://github.com/PolarisSS13/Polaris/pull/1681 for discovering the cause.

Also improves wound description generation a little.
