### PR TITLE
More wiz balance

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/armalis.dm
+++ b/code/modules/mob/living/simple_animal/hostile/armalis.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/armalis
+/mob/living/simple_animal/hostile/armalis
 	name = "Vox Armalis"
 	desc = "In truth, this scares you."
 
@@ -28,8 +28,10 @@
 
 	a_intent = I_HURT
 
+	pixel_x = -5
 
-/mob/living/simple_animal/armalis/armored
+
+/mob/living/simple_animal/hostile/armalis/armored
 	icon_state = "armalis_armored"
 	icon_living = "armalis_armored"
 	icon_dead = "armalis_armored_dead"

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -133,7 +133,7 @@
 	smoke_amt = 5
 	smoke_spread = 1
 
-	possible_transformations = list(/mob/living/simple_animal/armalis)
+	possible_transformations = list(/mob/living/simple_animal/hostile/armalis)
 
 	hud_state = "wiz_vox"
 

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -61,14 +61,18 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 /obj/item/weapon/spellbook/proc/make_sacrifice(obj/item/I as obj, mob/user as mob, var/reagent)
 	if(has_sacrificed)
 		return
-	src.visible_message("<b>\The [src]</b> glows briefly, absorbing \the [I].")
-	user << "<span class='notice'>Your sacrifice was accepted!</span>"
 	if(reagent)
 		var/datum/reagents/R = I.reagents
 		R.remove_reagent(reagent,5)
 	else
+		if(istype(I,/obj/item/stack))
+			var/obj/item/stack/S = I
+			if(S.amount < S.max_amount)
+				usr << "<span class='warning'>You must sacrifice [S.max_amount] stacks of [S]!</span>"
+				return
 		user.remove_from_mob(I)
 		qdel(I)
+	user << "<span class='notice'>Your sacrifice was accepted!</span>"
 	has_sacrificed = 1
 	investing_time = max(investing_time - 6000,1) //subtract 10 minutes. Make sure it doesn't act funky at the beginning of the game.
 
@@ -136,7 +140,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 			dat += "<br><i>[desc]</i><br>"
 		dat += "<center><A href='byond://?src=\ref[src];reset=1'>Re-memorize your spellbook.</a></center>"
 		if(spellbook.book_flags & INVESTABLE)
-			dat += "<center><A href='byond://?src=\ref[src];invest=1'>Invest a Spell Slot</a><br><i>Investing a spellpoint will return two spellpoints back in 30 minutes.<br>Some say a sacrifice could even shorten the time...</i>"
+			dat += "<center><A href='byond://?src=\ref[src];invest=1'>Invest a Spell Slot</a><br><i>Investing a spellpoint will return two spellpoints back in 30 minutes.<br>Some say a sacrifice could even shorten the time...</i></center>"
 		if(!(spellbook.book_flags & NOREVERT))
 			dat += "<center><A href='byond://?src=\ref[src];book=1'>Choose different spellbook.</a></center>"
 		dat += "<center><A href='byond://?src=\ref[src];lock=1'>[spellbook.book_flags & LOCKED ? "Unlock" : "Lock"] the spellbook.</a></center>"

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -218,8 +218,10 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 		var/area/wizard_station/A = locate()
 		if(usr in A.contents)
 			uses = spellbook.max_uses
+			investing_time = 0
+			has_sacrificed = 0
 			H.spellremove()
-			temp = "All spells have been removed. You may now memorize a new set of spells."
+			temp = "All spells and investments have been removed. You may now memorize a new set of spells."
 			feedback_add_details("wizard_spell_learned","UM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 		else
 			usr << "<span class='warning'>You must be in the wizard academy to re-memorize your spells.</span>"

--- a/code/modules/spells/spellbook/battlemage.dm
+++ b/code/modules/spells/spellbook/battlemage.dm
@@ -7,7 +7,7 @@
 	book_desc = "Mix physical with the mystical in head to head combat."
 	title = "The Art of Magical Combat"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = 4
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
 	max_uses = 5
 
 	spells = list(/spell/targeted/projectile/dumbfire/passage = 	1,

--- a/code/modules/spells/spellbook/battlemage.dm
+++ b/code/modules/spells/spellbook/battlemage.dm
@@ -29,3 +29,5 @@
 				/obj/item/weapon/contract/apprentice = 				1
 					)
 
+	sacrifice_objects = list(/obj/item/weapon/material/sword,
+							/obj/item/weapon/material/twohanded/fireaxe)

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -9,7 +9,7 @@
 	book_desc = "All about healing. Mobility and offense comes at a higher price but not impossible."
 	title = "Cleric's Tome of Healing"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = 4
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
 	max_uses = 6
 
 	spells = list(/spell/targeted/heal_target = 					1,

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -32,4 +32,4 @@
 
 	sacrifice_reagents = list("peridaxon",
 							"adminordrazine")
-	sacrifice_objects = list(/obj/item/weapon/storage/bible)
+	sacrifice_objects = list(/obj/item/seeds/mtearseed)

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -29,3 +29,7 @@
 				/obj/item/weapon/gun/energy/staff/focus = 			2,
 				/obj/item/weapon/contract/apprentice = 				1
 				)
+
+	sacrifice_reagents = list("peridaxon",
+							"adminordrazine")
+	sacrifice_objects = list(/obj/item/weapon/storage/bible)

--- a/code/modules/spells/spellbook/druid.dm
+++ b/code/modules/spells/spellbook/druid.dm
@@ -10,7 +10,7 @@
 	book_desc = "Summons, nature, and a bit o' healin."
 	title = "Druidic Guide on how to be smug about nature"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = 4
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
 	max_uses = 5
 
 	spells = list(/spell/targeted/heal_target = 					1,

--- a/code/modules/spells/spellbook/druid.dm
+++ b/code/modules/spells/spellbook/druid.dm
@@ -29,4 +29,5 @@
 				/obj/item/weapon/monster_manual = 					1,
 				/obj/item/weapon/contract/apprentice = 				1
 				)
-
+	sacrifice_objects = list(/obj/item/seeds/ambrosiavulgarisseed,
+							/obj/item/seeds/ambrosiadeusseed)

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -10,8 +10,7 @@
 	book_desc = "Movement and teleportation. Run from your problems!"
 	title = "Manual of Spatial Transportation"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-
-	book_flags = 4
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
 	max_uses = 10
 
 	spells = list(/spell/targeted/ethereal_jaunt = 				1,

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -31,3 +31,6 @@
 				/obj/item/weapon/magic_rock = 					1,
 				/obj/item/weapon/contract/apprentice = 			1
 				)
+
+	sacrifice_reagents = list("hyperzine")
+	sacrifice_objects = list(/obj/item/stack/telecrystal)

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -36,3 +36,6 @@
 							/obj/item/weapon/magic_rock = 						1,
 							/obj/item/weapon/contract/apprentice = 				1
 							)
+
+	sacrifice_objects = list(/obj/item/stack/material/gold,
+							/obj/item/stack/material/silver)

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -9,7 +9,7 @@
 	title = "Book of Spells and Artefacts"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_desc = "A general wizard's spellbook. All its spells are easy to use but hard to master."
-	book_flags = 4
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
 	max_uses = 5
 
 	spells = list(/spell/targeted/projectile/magic_missile = 			1,

--- a/code/modules/spells/spellbook/student.dm
+++ b/code/modules/spells/spellbook/student.dm
@@ -10,8 +10,7 @@
 	book_desc = "This spellbook is dedicated to teaching neophytes in the ways of magic."
 	title = "Book of Spells and Education"
 	title_desc = "Hello. Congratulations on becoming a wizard. You may be asking yourself: What? A wizard? Already? Of course! Anybody can become a wizard! Learning to be a good one is the hard part.<br>Without further adue, let us begin by learning the three concepts of wizardry, 'Spell slots', 'Spells', and 'Artifacts'.<br>Firstly lets try to understand the 'spell slot'. A spell slot is the measurable amount of spells and artifacts one tome can give. Most spells will only take up a singular spell slot, however more powerful spells/artifacts can take up more.<br>Spells are spells. They can have requirements, such as wizard garb, and most can be upgraded by purchasing additional spell slots for them. Most upgrades fall into two categories, 'Speed' and 'Power'. Speed upgrades decrease the time you have to spend recharging your spell. Power increases the potency of your spells. Spells are also special in that they can be refunded while inside the Wizard Acadamy, so if you want to test a spell out before moving out into the field, feel free to do that in the comfort of our home.<br>Artifacts, or 'Artefacts' as we call them, are powerful wizard tools or items made specially for wizards everywhere. Extremely potent, they cannot be refunded like spells, and some of them can be used by non-wizards, so be careful!<br>Knowing these three concepts puts you in a league above most wizards, however knowledge of spells is just as important so we've included a list of spells below made specifically for the beginning wizard. Take all of them, or mix and match, remember being creative is half of being a wizard!"
-
-	book_flags = 4
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
 	max_uses = 5
 
 	spells = list(/spell/aoe_turf/knock = 						1,

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -66,7 +66,7 @@
 				if(share_damage)
 					var/damage = M.maxHealth - round(M.maxHealth*(trans.health/trans.maxHealth))
 					for(var/i in 1 to ceil(damage/10))
-						M.adjustBruteLoss(round(damage/10)) //Spreads the damage out, rather than putting it on one limb only.
+						M.adjustBruteLoss(10) //Spreads the damage out, rather than putting it on one limb only.
 				if(trans.mind)
 					trans.mind.transfer_to(M)
 				else

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -64,7 +64,9 @@
 					qdel(M)
 					return
 				if(share_damage)
-					M.adjustBruteLoss(M.maxHealth - round(M.maxHealth*(trans.health/trans.maxHealth))) //basically I want the % hp to be the same afterwards
+					var/damage = M.maxHealth - round(M.maxHealth*(trans.health/trans.maxHealth))
+					for(var/i in 1 to ceil(damage/10))
+						M.adjustBruteLoss(round(damage/10)) //Spreads the damage out, rather than putting it on one limb only.
 				if(trans.mind)
 					trans.mind.transfer_to(M)
 				else
@@ -79,7 +81,7 @@
 	feedback = "BP"
 	possible_transformations = list(/mob/living/simple_animal/lizard,/mob/living/simple_animal/mouse,/mob/living/simple_animal/corgi)
 
-
+	share_damage = 0
 	invocation = "Yo'balada!"
 	invocation_type = SpI_SHOUT
 	spell_flags = NEEDSCLOTHES | SELECTABLE
@@ -88,6 +90,8 @@
 	cooldown_min = 300 //30 seconds
 
 	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 2, Sp_POWER = 2)
+
+	newVars = list("health" = 50, "maxHealth" = 50)
 
 	hud_state = "wiz_poly"
 
@@ -101,11 +105,13 @@
 	return "Your target will now stay in their polymorphed form for [duration/10] seconds."
 
 /spell/targeted/shapeshift/avian
-	name = "Avian Form"
+	name = "Polymorph"
 	desc = "This spell transforms the wizard into the common parrot."
 	feedback = "AV"
 	possible_transformations = list(/mob/living/simple_animal/parrot)
 
+	drop_items = 0
+	share_damage = 0
 	invocation = "Poli'crakata!"
 	invocation_type = SpI_SHOUT
 	spell_flags = INCLUDEUSER
@@ -130,6 +136,8 @@
 	charge_max = 1200
 	cooldown_min = 600
 
+	drop_items = 0
+	share_damage = 0
 	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 2, Sp_POWER = 2)
 
 	newVars = list("name" = "corrupted soul")

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -87,7 +87,7 @@
 	spell_flags = NEEDSCLOTHES | SELECTABLE
 	range = 3
 	duration = 150 //15 seconds.
-	cooldown_min = 300 //30 seconds
+	cooldown_min = 200 //20 seconds
 
 	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 2, Sp_POWER = 2)
 

--- a/html/changelogs/TheWelp-magicBalance.yml
+++ b/html/changelogs/TheWelp-magicBalance.yml
@@ -1,0 +1,10 @@
+author: TheWelp
+delete-after: True
+changes: 
+  - rscadd: "Added a system to invest spell slots to get more back. You can invest one spellslot at a time and you will recieve two back. Sacrificing specific items/reagents onto the spellbook will shorten the time by ten minutes. Can be done once per investment."
+  - tweak: "Shapeshifting damage share now spreads out the damage to roughly ten damage chunks. Makes it less of a limb-gibber."
+  - tweak: "Baleful Polymorph buffs the shapeshiftee's health pool to fifty, so no longer can you get insta-killed."
+  - tweak: "Avian Form has been renamed to Polymorph (get it?)"
+  - tweak: "Polymorph no longer strips you when you transform."
+  - tweak: "Polymorph and Baleful Polymorph no longer share damage."
+  - tweak: "Armalis icons are properly centered, for real this time."


### PR DESCRIPTION
Some more wiz balancing:

:rscadd: Added a system to invest spell slots to get more back. You can invest one spellslot at a time and you will recieve two back. Sacrificing specific items/reagents onto the spellbook will shorten the time by ten minutes. Can be done once per investment.
:tweak: Shapeshifting damage share now spreads out the damage to roughly ten damage chunks. Makes it less of a limb-gibber.
:tweak: Baleful Polymorph buffs the shapeshiftee's health pool to fifty, so no longer can you get insta-killed by getting morphed and wacked.
:tweak: Avian Form has been renamed to Polymorph (get it?)
:tweak: Polymorph no longer strips you when you transform.
:tweak: Polymorph and Baleful Polymorph no longer share damage.
:tweak: Armalis icons are properly centered, for real this time.
