### PR TITLE
get_turf() performance optimization

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1024,10 +1024,9 @@ proc/get_mob_with_client_list()
 
 //gets the turf the atom is located in (or itself, if it is a turf).
 //returns null if the atom is not in a turf.
-/proc/get_turf(atom/A)
-	if(!istype(A)) return
-	for(A, A && !isturf(A), A=A.loc);
-	return A
+/proc/get_turf(atom/movable/A)
+	if(isturf(A)) return A
+	if(A.locs.len) return A.locs[1]
 
 /proc/get(atom/loc, type)
 	while(loc)


### PR DESCRIPTION
`get_turf()` now checks `isturf()` then looks at `locs[1]` instead of looping.
