### PR TITLE
Character preview tweaks.

### DIFF
--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -82,7 +82,7 @@
 		var/new_backbag = input(user, "Choose your character's style of bag:", "Character Preference", backbaglist[pref.backbag]) as null|anything in backbaglist
 		if(!isnull(new_backbag) && CanUseTopic(user))
 			pref.backbag = backbaglist.Find(new_backbag)
-			return TOPIC_REFRESH
+			return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["change_underwear"])
 		var/datum/category_group/underwear/UWC = global_underwear.categories_by_name[href_list["change_underwear"]]
 		if(!UWC)
@@ -90,7 +90,7 @@
 		var/datum/category_item/underwear/selected_underwear = input(user, "Choose underwear:", "Character Preference", pref.all_underwear[UWC.name]) as null|anything in UWC.items
 		if(selected_underwear && CanUseTopic(user))
 			pref.all_underwear[UWC.name] = selected_underwear.name
-		return TOPIC_REFRESH
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["underwear"] && href_list["tweak"])
 		var/underwear = href_list["underwear"]
 		if(!(underwear in pref.all_underwear))
@@ -101,6 +101,6 @@
 		var/new_metadata = gt.get_metadata(usr, get_metadata(underwear, gt))
 		if(new_metadata)
 			set_metadata(underwear, gt, new_metadata)
-			return TOPIC_REFRESH
+			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	return ..()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -163,7 +163,7 @@ var/list/gear_datums = list()
 				if(istype(G)) total_cost += G.cost
 			if((total_cost+TG.cost) <= MAX_GEAR_COST)
 				pref.gear += TG.display_name
-		return TOPIC_REFRESH
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["gear"] && href_list["tweak"])
 		var/datum/gear/gear = gear_datums[href_list["gear"]]
 		var/datum/gear_tweak/tweak = locate(href_list["tweak"])
@@ -173,13 +173,13 @@ var/list/gear_datums = list()
 		if(!metadata || !CanUseTopic(user))
 			return TOPIC_NOACTION
 		set_tweak_metadata(gear, tweak, metadata)
-		return TOPIC_REFRESH
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["select_category"])
 		current_tab = href_list["select_category"]
 		return TOPIC_REFRESH
 	else if(href_list["clear_loadout"])
 		pref.gear.Cut()
-		return TOPIC_REFRESH
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 	return ..()
 
 /datum/gear

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -233,7 +233,7 @@
 
 	. = OnTopic(href, href_list, usr)
 	if(. & TOPIC_UPDATE_PREVIEW)
-		pref_mob.client.prefs.update_preview_icon()
+		pref_mob.client.prefs.preview_icon = null
 	if(. & TOPIC_REFRESH)
 		pref_mob.client.prefs.ShowChoices(usr)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -240,11 +240,16 @@ var/list/slot_equipment_priority = list( \
 		if(slot_wear_mask) return wear_mask
 	return null
 
-//Outdated but still in use apparently. This should at least be a human proc.
-/mob/proc/get_equipped_items()
-	return list()
+/mob/proc/get_equipped_items(var/include_carried = 0)
+	. = list()
+	if(slot_back) . += back
+	if(slot_wear_mask) . += wear_mask
 
-/mob/proc/delete_inventory()
-	for(var/entry in get_equipped_items())
+	if(include_carried)
+		if(slot_l_hand) . += l_hand
+		if(slot_r_hand) . += r_hand
+
+/mob/proc/delete_inventory(var/include_carried = FALSE)
+	for(var/entry in get_equipped_items(include_carried))
 		drop_from_inventory(entry)
 		qdel(entry)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -361,28 +361,21 @@ This saves us from having to call add_fingerprint() any time something is put in
 	return ..()
 
 /mob/living/carbon/human/get_equipped_items(var/include_carried = 0)
-	var/list/items = new/list()
-
-	if(back) items += back
-	if(belt) items += belt
-	if(l_ear) items += l_ear
-	if(r_ear) items += r_ear
-	if(glasses) items += glasses
-	if(gloves) items += gloves
-	if(head) items += head
-	if(shoes) items += shoes
-	if(wear_id) items += wear_id
-	if(wear_mask) items += wear_mask
-	if(wear_suit) items += wear_suit
-	if(w_uniform) items += w_uniform
+	. = ..()
+	if(belt) . += belt
+	if(l_ear) . += l_ear
+	if(r_ear) . += r_ear
+	if(glasses) . += glasses
+	if(gloves) . += gloves
+	if(head) . += head
+	if(shoes) . += shoes
+	if(wear_id) . += wear_id
+	if(wear_suit) . += wear_suit
+	if(w_uniform) . += w_uniform
 
 	if(include_carried)
-		if(slot_l_hand)     items += l_hand
-		if(slot_r_hand)     items += r_hand
-		if(slot_l_store)    items += l_store
-		if(slot_r_store)    items += r_store
-		if(slot_legcuffed)  items += legcuffed
-		if(slot_handcuffed) items += handcuffed
-		if(slot_s_store)    items += s_store
-
-	return items
+		if(slot_l_store)    . += l_store
+		if(slot_r_store)    . += r_store
+		if(slot_legcuffed)  . += legcuffed
+		if(slot_handcuffed) . += handcuffed
+		if(slot_s_store)    . += s_store

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -215,11 +215,33 @@ datum/preferences
 	if(previewJob)
 		mannequin.job = previewJob.title
 		previewJob.equip_preview(mannequin, player_alt_titles[previewJob.title])
-		sleep(1)
+		var/list/equipped_slots = list() //If more than one item takes the same slot only spawn the first
+		for(var/thing in gear)
+			var/datum/gear/G = gear_datums[thing]
+			if(G)
+				var/permitted = 0
+				if(G.allowed_roles)
+					for(var/job_name in G.allowed_roles)
+						if(previewJob.title == job_name)
+							permitted = 1
+				else
+					permitted = 1
+
+				if(G.whitelisted && (G.whitelisted != mannequin.species.name))
+					permitted = 0
+
+				if(!permitted)
+					continue
+
+				if(G.slot && !(G.slot in equipped_slots))
+					equipped_slots += G.slot
+					var/metadata = gear[G.display_name]
+					mannequin.equip_to_slot_or_del(G.spawn_item(mannequin, metadata), G.slot)
+		mannequin.update_icons()
 
 /datum/preferences/proc/update_preview_icon()
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
-	mannequin.delete_inventory()
+	mannequin.delete_inventory(TRUE)
 	dress_preview_mob(mannequin)
 
 	preview_icon = icon('icons/effects/effects.dmi', "nothing")


### PR DESCRIPTION
The preview image now only actively refresh while viewing the general tab. Saves quite a few cycles.
More types of preference changes now cause a preview refresh.
delete_inventory() can now delete held items as well. Fixes #13083.
equip_to_slot_or_del() doesn't actually refresh the mob icon. As a result, now explicitly updates it instead of sleeping and hoping it becomes refreshed.
Loadout items that are equipped to slots are now also included in the preview.
