### PR TITLE
Removes rack item placement, fixes mech traps, dropping items now sets pixel_z

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -133,6 +133,7 @@
 	src.throwing = 1
 	src.thrower = thrower
 	src.throw_source = get_turf(src)	//store the origin turf
+	src.pixel_z = 0
 	if(usr)
 		if(HULK in usr.mutations)
 			src.throwing = 2 // really strong throw!

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -198,7 +198,8 @@
 	if(user.put_in_active_hand(src))
 		if(randpixel)
 			pixel_x = rand(-randpixel, randpixel)
-			pixel_y = rand(-randpixel, 0) - randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character's feet
+			pixel_y = rand(-randpixel/2, randpixel/2)
+			pixel_z = 0
 		else if(randpixel == 0)
 			pixel_x = 0
 			pixel_y = 0
@@ -254,7 +255,8 @@
 
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user as mob)
-	..()
+	if(randpixel)
+		pixel_z = randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character
 	if(zoom) zoom() //binoculars, scope, etc
 
 // called just as an item is picked up (loc is not yet changed)

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -131,5 +131,6 @@
 
 /obj/item/device/t_scanner/dropped(mob/user)
 	set_user_client(null)
+	..()
 
 #undef OVERLAY_CACHE_LEN

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -205,6 +205,7 @@
 	spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/dropped()
+	..()
 	spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/process()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -36,13 +36,6 @@
 	..(user, slot)
 
 /*
-/obj/item/weapon/storage/backpack/dropped(mob/user as mob)
-	if (loc == user && src.use_sound)
-		playsound(src.loc, src.use_sound, 50, 1, -5)
-	..(user)
-*/
-
-/*
  * Backpack Types
  */
 

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -82,6 +82,7 @@
 	use_to_pickup = 0
 
 /obj/item/weapon/storage/laundry_basket/offhand/dropped(mob/user as mob)
+	..()
 	user.drop_from_inventory(linked)
 	return
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -433,9 +433,6 @@
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)
 
-/obj/item/weapon/storage/dropped(mob/user as mob)
-	return
-
 /obj/item/weapon/storage/attack_hand(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -5,6 +5,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "beartrap0"
+	randpixel = 0
 	desc = "A mechanically activated leg trap. Low-tech, but reliable. Looks like it could really hurt if you set it off."
 	throwforce = 0
 	w_class = 3

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -176,6 +176,7 @@
 			overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = 30 + I.layer, "pixel_x" = I.pixel_x, "pixel_y" = I.pixel_y)
 
 /obj/item/weapon/tray/dropped(mob/user)
+	..()
 	spawn(1) //why sleep 1? Because forceMove first drops us on the ground.
 		if(!isturf(loc)) //to handle hand switching
 			return

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -67,6 +67,7 @@
 	var/net_type = /obj/effect/energy_net
 
 /obj/item/weapon/energy_net/dropped()
+	..()
 	spawn(10)
 		if(src) qdel(src)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -237,6 +237,7 @@
 		usr.drop_item()
 		if(W)
 			W.forceMove(src.loc)
+			W.pixel_z = 0
 	else if(istype(W, /obj/item/weapon/packageWrap))
 		return
 	else if(istype(W, /obj/item/weapon/weldingtool))

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -300,6 +300,7 @@
 		i++
 
 /obj/item/weapon/hand/dropped(mob/user as mob)
+	..()
 	if(locate(/obj/structure/table, loc))
 		src.update_icon(user.dir)
 	else

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -329,6 +329,7 @@
 			qdel(src)
 
 /obj/item/weapon/grab/dropped()
+	..()
 	loc = null
 	if(!destroying)
 		qdel(src)

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -54,6 +54,7 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	usr.drop_from_inventory(src)
 
 /obj/item/magic_hand/dropped() //gets deleted on drop
+	..()
 	loc = null
 	qdel(src)
 

--- a/code/modules/spells/targeted/projectile/stuncuff.dm
+++ b/code/modules/spells/targeted/projectile/stuncuff.dm
@@ -40,6 +40,7 @@
 	breakouttime = 300 //30 seconds
 
 /obj/item/weapon/handcuffs/wizard/dropped(var/mob/user)
+	..()
 	qdel(src)
 
 /obj/item/projectile/spell_projectile/stuncuff

--- a/code/modules/tables/rack.dm
+++ b/code/modules/tables/rack.dm
@@ -12,12 +12,6 @@
 	verbs -= /obj/structure/table/verb/do_flip
 	verbs -= /obj/structure/table/proc/do_put
 
-/obj/structure/table/rack/initialize()
-	..()
-	//arrange everything on our turf, similar to how closets store everything on theirs
-	for(var/obj/item/I in src.loc)
-		place_item(I, null) //inefficient, but saves us some copypasta
-
 /obj/structure/table/rack/update_connections()
 	return
 
@@ -30,49 +24,3 @@
 /obj/structure/table/rack/holorack/dismantle(obj/item/weapon/wrench/W, mob/user)
 	user << "<span class='warning'>You cannot dismantle \the [src].</span>"
 	return
-
-/obj/structure/table/rack/place_item(obj/item/I, var/click_params)
-	var/index = 1
-	for(var/obj/item/J in src.loc)
-		if(J.anchored)
-			continue
-		if(I == J)
-			arrange_item(I, index)
-			break
-		index++
-
-
-//spent waaay too much time tweaking these
-#define START_X -4
-#define START_Y 8
-#define NUM_ROWS 3
-#define NUM_COLS 2
-#define ROW_SPACING 4
-#define COL_SPACING 5
-#define COL_OFFSET 3
-
-//Sets the pixel_x/y values of an item to place it neatly on the rack
-/obj/structure/table/rack/proc/arrange_item(obj/item/I, var/index)
-	//respect center_of_mass
-	var/center_x = 0
-	var/center_y = 0
-	if(istype(I, /obj/item/weapon/reagent_containers/food))
-		var/obj/item/weapon/reagent_containers/food/F = I
-		if(F.center_of_mass.len)
-			center_x = F.center_of_mass["x"] - 16
-			center_y = F.center_of_mass["y"] - 16
-
-
-	var/col = (index-1) % NUM_COLS //0-indexed
-	var/row = round((index-1)/NUM_COLS) % NUM_ROWS //I just love how round() actually floors the value. Makes things so clear. Also 0-indexed
-
-	I.pixel_x = START_X + ROW_SPACING*row + COL_OFFSET - COL_SPACING*col - center_x
-	I.pixel_y = START_Y - ROW_SPACING*row - round(ROW_SPACING/NUM_COLS)*col - center_y
-
-#undef START_X
-#undef START_Y
-#undef NUM_ROWS
-#undef NUM_COLS
-#undef ROW_SPACING
-#undef COL_SPACING
-#undef COL_OFFSET


### PR DESCRIPTION
- Fixes mechanical traps randomizing their pixel_[xy]
- Removes rack item placement, after having some time to evaluate it, it looks ugly and I'm not satisfied with it. I think it's probably better to just leave it to mappers to set the initial pixel shift, and have the racks act like tables - which is what they do now as of this PR.
- Instead of randomizing and shifting pixel_y, randomization is applied to pixel_y while pixel_z is shifted upon dropping an item. pixel_z is then reset upon picking the item back up. Fixes dropped items looking strange when client dir is rotated.
