### PR TITLE
Fixes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -65,6 +65,7 @@
 			bound_height = width * world.icon_size
 
 	health = maxhealth
+	update_icon()
 
 	update_nearby_tiles(need_rebuild=1)
 	return

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -13,10 +13,21 @@
 /obj/item/weapon/storage/fancy
 	item_state = "syringe_kit" //placeholder, many of these don't have inhands
 	var/obj/item/key_type //path of the key item that this "fancy" container is meant to store
+	var/opened = 0 //if an item has been removed from this container
+
+/obj/item/weapon/storage/fancy/remove_from_storage()
+	. = ..()
+	if(!opened && .)
+		opened = 1
+		update_icon()
+
 
 /obj/item/weapon/storage/fancy/update_icon()
-	var/key_count = count_by_type(contents, key_type)
-	src.icon_state = "[initial(icon_state)][key_count]"
+	if(!opened)
+		src.icon_state = initial(icon_state)
+	else
+		var/key_count = count_by_type(contents, key_type)
+		src.icon_state = "[initial(icon_state)][key_count]"
 
 /obj/item/weapon/storage/fancy/examine(mob/user)
 	if(!..(user, 1))

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -18,6 +18,7 @@
 	update_nearby_tiles()
 
 /obj/effect/energy_field/Destroy()
+	density = 0
 	update_nearby_tiles()
 	..()
 

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -42,7 +42,7 @@
 /obj/machinery/shield_gen/Destroy()
 	for(var/obj/effect/energy_field/D in field)
 		field.Remove(D)
-		D.loc = null
+		qdel(D)
 	..()
 	
 /obj/machinery/shield_gen/emag_act(var/remaining_charges, var/mob/user)
@@ -222,7 +222,7 @@
 	else
 		for(var/obj/effect/energy_field/D in field)
 			field.Remove(D)
-			D.loc = null
+			qdel(D)
 
 		for(var/mob/M in view(5,src))
 			M << "\icon[src] You hear heavy droning fade out."

--- a/code/modules/shieldgen/shield_gen_external.dm
+++ b/code/modules/shieldgen/shield_gen_external.dm
@@ -4,9 +4,6 @@
 /obj/machinery/shield_gen/external
 	name = "hull shield generator"
 
-/obj/machinery/shield_gen/external/New()
-	..()
-
 //NOT MULTIZ COMPATIBLE
 //Search for space turfs within range that are adjacent to a simulated turf.
 /obj/machinery/shield_gen/external/get_shielded_turfs()


### PR DESCRIPTION
- Fixes doors sparking as if damaged when spawned or created by RCD
- Fixes #13088 
- Fixes #13016
