### PR TITLE
Chessboard tweaks

### DIFF
--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -67,39 +67,39 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 		user.unset_machine()
 		return
 
-	var/dat = "<HTML>"
-	dat += "<table border='0'>"
+	var/dat = {"
+	<html><head><style type='text/css'>
+	td,td a{height:50px;width:50px}table{border-spacing:0;border:none;border-collapse:collapse}td{text-align:center;padding:0;background-repeat:no-repeat;background-position:center center}td.light{background-color:#6cf}td.dark{background-color:#544b50}td.selected{background-color:#c8dbc3}td a{display:table-cell;text-decoration:none;position:relative;line-height:50px;height:50px;width:50 px;vertical-align:middle}
+	</style></head><body><table>
+	"}
 	var i, stagger
 	stagger = 0 //so we can have the checkerboard effect
 	for(i=0, i<64, i++)
 		if(i%8 == 0)
 			dat += "<tr>"
 			stagger = !stagger
-		dat += "<td align='center' height='50' width='50' bgcolor="
 		if(selected == i)
-			dat += "'#FF8566'>"
+			dat += "<td class='selected'"
 		else if((i + stagger)%2 == 0)
-			dat += "'#66CCFF'>"
+			dat += "<td class='dark'"
 		else
-			dat += "'#252536'>"
-		if(!isobserver(user))
-			dat += "<A href='?src=\ref[src];select=[i];person=\ref[user]' style='display:block;text-decoration:none;'>"
+			dat += "<td class='light'"
+			
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
 			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
-			dat += "<image src='[I.icon_state].png' style='border-style: none'>"
+			dat += " style='background-image:url([I.icon_state].png)'>"
 		else
-			dat += "&nbsp;"
-
+			dat+= ">"
 		if(!isobserver(user))
-			dat += "</A>"
+			dat += "<a href='?src=\ref[src];select=[i];person=\ref[user]'></a>"
 		dat += "</td>"
 
-	dat += "</table><br>"
+	dat += "</table>"
 
 	if(selected >= 0 && !isobserver(user))
 		dat += "<br><A href='?src=\ref[src];remove=0'>Remove Selected Piece</A>"
-	user << browse(dat,"window=boardgame;size=500x500")
+	user << browse(dat,"window=boardgame;size=430x500") // 50px * 8 squares + 30 margin
 	onclose(usr, "boardgame")
 
 /obj/item/weapon/board/Topic(href, href_list)

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -183,25 +183,25 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 
 //Chess
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/pawn
+/obj/item/weapon/reagent_containers/food/snacks/checker/pawn
 	name = "pawn"
 	desc = "How many pawns will die in your war?"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/pawn/red
+/obj/item/weapon/reagent_containers/food/snacks/checker/pawn/red
 	piece_color ="red"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/knight
+/obj/item/weapon/reagent_containers/food/snacks/checker/knight
 	name = "knight"
 	desc = "The piece chess deserves, and needs to actually play."
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/knight/red
+/obj/item/weapon/reagent_containers/food/snacks/checker/knight/red
 	piece_color ="red"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/bishop
+/obj/item/weapon/reagent_containers/food/snacks/checker/bishop
 	name = "bishop"
 	desc = "What corruption occured, urging holy men to fight?"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/bishop/red
+/obj/item/weapon/reagent_containers/food/snacks/checker/bishop/red
 	piece_color ="red"
 
 /obj/item/weapon/reagent_containers/food/snacks/checker/rook
@@ -211,16 +211,16 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 /obj/item/weapon/reagent_containers/food/snacks/checker/rook/red
 	piece_color ="red"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/queen
+/obj/item/weapon/reagent_containers/food/snacks/checker/queen
 	name = "queen"
 	desc = "A queen of battle and pain. She dances across the battlefield."
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/queen/red
+/obj/item/weapon/reagent_containers/food/snacks/checker/queen/red
 	piece_color ="red"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/king
+/obj/item/weapon/reagent_containers/food/snacks/checker/king
 	name = "king"
 	desc = "Why does a chess game end when the king dies?"
 
-/obj/item/weapon.reagent_containers/food/snacks/checker/king/red
+/obj/item/weapon/reagent_containers/food/snacks/checker/king/red
 	piece_color ="red"

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -67,11 +67,11 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 		user.unset_machine()
 		return
 
-	var/dat = {"
+	var/list/dat = list({"
 	<html><head><style type='text/css'>
 	td,td a{height:50px;width:50px}table{border-spacing:0;border:none;border-collapse:collapse}td{text-align:center;padding:0;background-repeat:no-repeat;background-position:center center}td.light{background-color:#6cf}td.dark{background-color:#544b50}td.selected{background-color:#c8dbc3}td a{display:table-cell;text-decoration:none;position:relative;line-height:50px;height:50px;width:50 px;vertical-align:middle}
 	</style></head><body><table>
-	"}
+	"})
 	var i, stagger
 	stagger = 0 //so we can have the checkerboard effect
 	for(i=0, i<64, i++)
@@ -99,7 +99,7 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 
 	if(selected >= 0 && !isobserver(user))
 		dat += "<br><A href='?src=\ref[src];remove=0'>Remove Selected Piece</A>"
-	user << browse(dat,"window=boardgame;size=430x500") // 50px * 8 squares + 30 margin
+	user << browse(jointext(dat, null),"window=boardgame;size=430x500") // 50px * 8 squares + 30 margin
 	onclose(usr, "boardgame")
 
 /obj/item/weapon/board/Topic(href, href_list)


### PR DESCRIPTION
- The lower right square in the checker/chess board is now light. This allows playing in the up/down direction, and is usually how chess and checkers boards are rendered in illustrations. (Resolves #13063)
- The board now has no margins between the squares. The dark squares are now also slightly lighter, to allow for better contrast with black pieces. 
- Whole squares are now anchors. This translates to being able to click anywhere in the square, instead of just the middle (or wherever the browser decided to put the link).
- Some dots in paths were switched with slashes. This has no practical effect, but makes things consistent with the usual style. 

This should look right in at least IE8, as well as relatively modern Firefox and Chromium.
![chess](https://cloud.githubusercontent.com/assets/156239/15547637/f0a9bab0-22a4-11e6-8d20-761d83b5924d.png)
