### PR TITLE
Overhauls whitelist handling, fixes #13089

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -297,8 +297,8 @@ var/global/datum/controller/gameticker/ticker
 				else if(!player.mind.assigned_role)
 					continue
 				else
-					player.create_character()
-					qdel(player)
+					if(player.create_character())
+						qdel(player)
 
 
 	proc/collect_minds()

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -342,7 +342,7 @@ var/global/datum/controller/occupations/job_master
 						else
 							permitted = 1
 
-						if(G.whitelisted && (G.whitelisted != H.species.name || !is_alien_whitelisted(H, G.whitelisted)))
+						if(G.whitelisted && (G.whitelisted != H.species.name || !is_species_whitelisted(H, G.whitelisted)))
 							permitted = 0
 
 						if(!permitted)

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -56,29 +56,41 @@ var/list/whitelist = list()
 		return 0
 	if(!config.usealienwhitelist)
 		return 1
-	if(istype(species,/datum/species) || istype(species,/datum/language))
-		species = "[species]";
-	if(species == "human" || species == "Human")
-		return 1
 	if(check_rights(R_ADMIN, 0, M))
 		return 1
+
+	if(istype(species,/datum/language))
+		var/datum/language/L = species
+		if(!(L.flags & (WHITELISTED|RESTRICTED)))
+			return 1
+		return whitelist_lookup(L.name, M.ckey)
+
+	if(istype(species,/datum/species))
+		var/datum/species/S = species
+		if(!(S.spawn_flags & (IS_WHITELISTED|IS_RESTRICTED)))
+			return 1
+		return whitelist_lookup(S.get_bodytype(), M.ckey)
+
+	return 0
+
+/proc/whitelist_lookup(var/item, var/ckey)
 	if(!alien_whitelist)
 		return 0
+
 	if(config.usealienwhitelistSQL)
-		var race = lowertext(species)
-		if(!(M.ckey in alien_whitelist))
+		//SQL Whitelist
+		if(!(ckey in alien_whitelist))
 			return 0;
-		var/list/whitelisted = alien_whitelist[M.ckey]
-		if(race in whitelisted)
+		var/list/whitelisted = alien_whitelist[ckey]
+		if(lowertext(item) in whitelisted)
 			return 1
-		return 0
 	else
-		if(M && species)
-			for (var/s in alien_whitelist)
-				if(findtext(s,"[M.ckey] - [species]"))
-					return 1
-				if(findtext(s,"[M.ckey] - All"))
-					return 1
+		//Config File Whitelist
+		for(var/s in alien_whitelist)
+			if(findtext(s,"[ckey] - [item]"))
+				return 1
+			if(findtext(s,"[ckey] - All"))
+				return 1
 	return 0
 
 #undef WHITELISTFILE

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -49,6 +49,9 @@ var/list/whitelist = list()
 				alien_whitelist[row["ckey"]] = list(row["race"])
 	return 1
 
+/proc/is_species_whitelisted(mob/M, var/species_name)
+	var/datum/species/S = all_species[species_name]
+	return is_alien_whitelisted(M, S)
 
 //todo: admin aliens
 /proc/is_alien_whitelisted(mob/M, var/species)

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -42,7 +42,7 @@
 			var/list/available_languages = S.secondary_langs.Copy()
 			for(var/L in all_languages)
 				var/datum/language/lang = all_languages[L]
-				if(!(lang.flags & RESTRICTED) && (!config.usealienwhitelist || is_alien_whitelisted(user, L) || !(lang.flags & WHITELISTED)))
+				if(!(lang.flags & RESTRICTED) && is_alien_whitelisted(user, lang))
 					available_languages |= L
 
 			// make sure we don't let them waste slots on the default languages

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -499,7 +499,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	if(config.usealienwhitelist) //If we're using the whitelist, make sure to check it!
 		if(!(current_species.spawn_flags & CAN_JOIN))
 			restricted = 2
-		else if((current_species.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(preference_mob(),current_species))
+		else if(!is_alien_whitelisted(preference_mob(), current_species))
 			restricted = 1
 
 	if(restricted)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -46,7 +46,7 @@ var/list/gear_datums = list()
 	var/mob/preference_mob = preference_mob()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
-		if(G.whitelisted && preference_mob && !is_alien_whitelisted(preference_mob, G.whitelisted))
+		if(G.whitelisted && preference_mob && !is_species_whitelisted(preference_mob, G.whitelisted))
 			continue
 		if(max_cost && G.cost > max_cost)
 			continue

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/diona/confirm_evolution()
 
-	if(!is_alien_whitelisted(src, "Diona") && config.usealienwhitelist)
+	if(!is_species_whitelisted(src, "Diona"))
 		src << alert("You are currently not whitelisted to play as a full diona.")
 		return null
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -142,15 +142,15 @@
 	for(var/current_species_name in all_species)
 		var/datum/species/current_species = all_species[current_species_name]
 
-		if(check_whitelist && config.usealienwhitelist && !check_rights(R_ADMIN, 0, src)) //If we're using the whitelist, make sure to check it!
-			if(!(current_species.spawn_flags & CAN_JOIN))
+		if(check_whitelist) //If we're using the whitelist, make sure to check it!
+			if((current_species.spawn_flags & IS_RESTRICTED) && !check_rights(R_ADMIN, 0, src))
 				continue
-			if(whitelist.len && !(current_species_name in whitelist))
+			if(!is_alien_whitelisted(src, current_species))
 				continue
-			if(blacklist.len && (current_species_name in blacklist))
-				continue
-			if((current_species.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, current_species_name))
-				continue
+		if(whitelist.len && !(current_species_name in whitelist))
+			continue
+		if(blacklist.len && (current_species_name in blacklist))
+			continue
 
 		valid_species += current_species_name
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -63,7 +63,7 @@
 			if(eta_status)
 				stat(null, eta_status)
 
-		if (internal)
+		if (istype(internal))
 			if (!internal.air_contents)
 				qdel(internal)
 			else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -189,4 +189,5 @@
 		var/list/returns[2]
 		returns[1] = sound(pick(species.speech_sounds))
 		returns[2] = 50
+		return returns
 	return ..()

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -35,7 +35,7 @@
 	siemens_coefficient = 0.2
 
 	flags = NO_SCAN | NO_MINOR_CUT
-	spawn_flags = CAN_JOIN | IS_WHITELISTED
+	spawn_flags = IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR
 
 	blood_color = "#2299FC"
@@ -90,12 +90,10 @@
 	H.internals.icon_state = "internal1"
 
 
-/datum/species/vox/get_station_variant()
-	return "Vox Pariah"
 
-// Joining as a station vox will give you this template, hence IS_RESTRICTED flag.
 /datum/species/vox/pariah
 	name = "Vox Pariah"
+	//blurb = "TODO Vox Pariah specific blurb."
 	rarity_value = 0.1
 	speech_chance = 60        // No volume control.
 	siemens_coefficient = 0.5 // Ragged scaleless patches.
@@ -117,8 +115,12 @@
 		"brain" =    /obj/item/organ/pariah_brain,
 		"eyes" =     /obj/item/organ/eyes
 		)
-	flags = IS_RESTRICTED | NO_SCAN
-	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
+	spawn_flags = IS_WHITELISTED | CAN_JOIN
+	flags = NO_SCAN
+	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR //so pariah can change their hair colour but regular vox can't?
+
+/datum/species/vox/pariah/get_bodytype()
+	return "Vox"
 
 // No combat skills for you.
 /datum/species/vox/pariah/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
@@ -148,6 +150,3 @@
 			M << "<span class='danger'>A terrible stench emanates from \the [H].</span>"
 	if(prob(1) && prob(50)) //0.5% chance
 		H.vomit()
-
-/datum/species/vox/pariah/get_bodytype()
-	return "Vox"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -181,8 +181,6 @@
 	for(var/u_type in unarmed_types)
 		unarmed_attacks += new u_type()
 
-/datum/species/proc/get_station_variant()
-	return name
 
 /datum/species/proc/get_bodytype()
 	return name

--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -1,6 +1,6 @@
 /datum/species/human/gravworlder
-	name = "grav-adapted Human"
-	name_plural = "grav-adapted Humans"
+	name = "Grav-Adapted Human"
+	name_plural = "Grav-Adapted Humans"
 	blurb = "Heavier and stronger than a baseline human, gravity-adapted people have \
 	thick radiation-resistant skin with a high lead content, denser bones, and recessed \
 	eyes beneath a prominent brow in order to shield them from the glare of a dangerously \
@@ -15,8 +15,8 @@
 	slowdown =      1
 
 /datum/species/human/spacer
-	name = "space-adapted Human"
-	name_plural = "space-adapted Humans"
+	name = "Space-Adapted Human"
+	name_plural = "Space-Adapted Humans"
 	blurb = "Lithe and frail, these sickly folk were engineered for work in environments that \
 	lack both light and atmosphere. As such, they're quite resistant to asphyxiation as well as \
 	toxins, but they suffer from weakened bone structure and a marked vulnerability to bright lights."
@@ -29,8 +29,8 @@
 	burn_mod =  1.1
 
 /datum/species/human/vatgrown
-	name = "vat-grown Human"
-	name_plural = "vat-grown Humans"
+	name = "Vat-Grown Human"
+	name_plural = "Vat-Grown Humans"
 	blurb = "With cloning on the forefront of human scientific advancement, cheap mass production \
 	of bodies is a very real and rather ethically grey industry. Vat-grown humans tend to be paler than \
 	baseline, with no appendix and fewer inherited genetic disabilities, but a weakened metabolism."

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -147,20 +147,9 @@
 	if(href_list["late_join"])
 
 		if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
-			usr << "\red The round is either not ready, or has already finished..."
+			usr << "<span class='warning'>The round is either not ready, or has already finished...</span>"
 			return
-
-		if(!check_rights(R_ADMIN, 0))
-			var/datum/species/S = all_species[client.prefs.species]
-			if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-				src << alert("You are currently not whitelisted to play [client.prefs.species].")
-				return 0
-
-			if(!(S.spawn_flags & CAN_JOIN))
-				src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
-				return 0
-
-		LateChoices()
+		LateChoices() //show the latejoin job selection menu
 
 	if(href_list["manifest"])
 		ViewManifest()
@@ -175,12 +164,7 @@
 			return
 
 		var/datum/species/S = all_species[client.prefs.species]
-		if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-			src << alert("You are currently not whitelisted to play [client.prefs.species].")
-			return 0
-
-		if(!(S.spawn_flags & CAN_JOIN))
-			src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
+		if(!check_species_allowed(S))
 			return 0
 
 		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
@@ -331,12 +315,12 @@
 			src << alert("[rank] is not available. Please try another.")
 			return 0
 
-	spawning = 1
-	close_spawn_windows()
-
 	job_master.AssignRole(src, rank, 1)
 
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
+	if(!character)
+		return 0
+
 	character = job_master.EquipRank(character, rank, 1)					//equips the human
 	UpdateFactionList(character)
 	equip_custom_items(character)
@@ -426,16 +410,15 @@
 
 	var/mob/living/carbon/human/new_character
 
-	var/use_species_name
 	var/datum/species/chosen_species
 	if(client.prefs.species)
 		chosen_species = all_species[client.prefs.species]
-		use_species_name = chosen_species.get_station_variant() //Only used by pariahs atm.
 
-	if(chosen_species && use_species_name)
-		// Have to recheck admin due to no usr at roundstart. Latejoins are fine though.
-		if(is_species_whitelisted(chosen_species) || has_admin_rights())
-			new_character = new(loc, use_species_name)
+	if(chosen_species)
+		if(!check_species_allowed(chosen_species))
+			spawning = 0 //abort
+			return null
+		new_character = new(loc, chosen_species.name)
 
 	if(!new_character)
 		new_character = new(loc)
@@ -445,8 +428,8 @@
 	for(var/lang in client.prefs.alternate_languages)
 		var/datum/language/chosen_language = all_languages[lang]
 		if(chosen_language)
-			if(!config.usealienwhitelist || !(chosen_language.flags & WHITELISTED) || is_alien_whitelisted(src, lang) || has_admin_rights() \
-				|| (new_character.species && (chosen_language.name in new_character.species.secondary_langs)))
+			var/is_species_lang = (chosen_language.name in new_character.species.secondary_langs)
+			if(is_species_lang || ((!(chosen_language.flags & RESTRICTED) || has_admin_rights()) && is_alien_whitelisted(src, chosen_language)))
 				new_character.add_language(lang)
 
 	if(ticker.random_players)
@@ -501,22 +484,26 @@
 /mob/new_player/proc/has_admin_rights()
 	return check_rights(R_ADMIN, 0, src)
 
-/mob/new_player/proc/is_species_whitelisted(datum/species/S)
-	if(!S) return 1
-	return is_alien_whitelisted(src, S.name) || !config.usealienwhitelist || !(S.spawn_flags & IS_WHITELISTED)
+/mob/new_player/proc/check_species_allowed(datum/species/S, var/show_alert=1)
+	if(!(S.spawn_flags & CAN_JOIN) && !has_admin_rights())
+		if(show_alert)
+			src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
+		return 0
+	if(!is_alien_whitelisted(src, S))
+		if(show_alert)
+			src << alert("You are currently not whitelisted to play [client.prefs.species].")
+		return 0
+	return 1
 
 /mob/new_player/get_species()
 	var/datum/species/chosen_species
 	if(client.prefs.species)
 		chosen_species = all_species[client.prefs.species]
 
-	if(!chosen_species)
+	if(!chosen_species || !check_species_allowed(chosen_species, 0))
 		return "Human"
 
-	if(is_species_whitelisted(chosen_species) || has_admin_rights())
-		return chosen_species.name
-
-	return "Human"
+	return chosen_species.name
 
 /mob/new_player/get_gender()
 	if(!client || !client.prefs) ..()


### PR DESCRIPTION
Overhauls is_alien_whitelisted() in order to reduce the need for repeated checks everywhere and fix #13089 by making whitelist handling during character creation a little less convoluted.

A very odd thing about the way the species flags were set up was that regular Vox were flagged with CAN_JOIN while Pariah where flagged as being restricted, despite the fact that CAN_JOIN appears to imply that the species is meant to be a station species as per [the text](https://github.com/Baystation12/Baystation12/blob/dev/code/modules/client/preference_setup/general/03_body.dm#L471) in the species selection UI. This was probably an artefact of Pariah pre-dating subspecies.

Instead, both Vox and Pariah are now both unrestricted whitelisted species, while only Pariah have CAN_JOIN, directly reflecting the intended usage of these species. This is meant to fix #13089 in combination with an overhaul of how the species spawn_flags are handled:
- Being whitelisted for a species now implies being whitelisted for all of its subspecies. Everyone who is whitelisted for Vox is now automatically whitelisted for Pariah.
- CAN_JOIN is required to round-start-spawn or late-spawn as a species without admin rights, irrespective of whitelist. It does not affect anything else such as appearance changers.
- (Unrelated) If a language or species is not restricted and not whitelisted, then everyone is considered whitelisted for it - avoids repeating the same flag checks everywhere.

As a result, players will be able to view both Vox and Vox Pariah in species selection, players whitelisted for Vox will be able to select both, and only Vox Pariah characters will be allowed to join unless you have admin rights. 

As a side effect this means that all players who have Vox characters that were actually meant to be Vox Pariah characters will have to change their (sub)species to Vox Pariah. A further side effect of this is that mercs or any other antag that get to change their species after spawning may choose Vox as their species if they are whitelisted for it.

Also fixes species speech sounds never playing since I noticed it was broken.

_Disclaimer: I tested this as Host. Still need to test properly._
