### PR TITLE
Allow disabling unit test output coloring

### DIFF
--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -95,6 +95,15 @@ proc/load_unit_test_changes()
 
 
 proc/initialize_unit_tests()
+	#ifndef UNIT_TEST_COLOURED
+	if(world.system_type != UNIX) // Not a Unix/Linux/etc system, we probably don't want to print color escapes (unless UNIT_TEST_COLOURED was defined to force escapes)
+		ascii_esc = ""
+		ascii_red = ""
+		ascii_green = ""
+		ascii_yellow = ""
+		ascii_reset = ""
+	#endif
+
 	log_unit_test("Initializing Unit Testing")
 
 	//

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -33,11 +33,20 @@ var/currently_running_tests = 0
 
 // For console out put in Linux/Bash makes the output green or red.
 // Should probably only be used for unit tests/Travis since some special folks use winders to host servers.
+// if you want plain output, use dm.sh -DUNIT_TEST -DUNIT_TEST_PLAIN baystation12.dme
+#ifdef UNIT_TEST_PLAIN
+var/ascii_esc = ""
+var/ascii_red = ""
+var/ascii_green = ""
+var/ascii_yellow = ""
+var/ascii_reset = ""
+#else
 var/ascii_esc = ascii2text(27)
 var/ascii_red = "[ascii_esc]\[31m"
 var/ascii_green = "[ascii_esc]\[32m"
 var/ascii_yellow = "[ascii_esc]\[33m"
 var/ascii_reset = "[ascii_esc]\[0m"
+#endif
 
 
 // We list these here so we can remove them from the for loop running this.


### PR DESCRIPTION
[Left: `dm.sh -DUNIT_TEST baystation12.dme`; Right: `dm.sh -DUNIT_TEST -DUNIT_TEST_PLAIN baystation12.dme`](http://nyx.gn32.uk/i/2016-05-26_17-45-24.png)
