### PR TITLE
Bubble, hull, and emergency shields no longer prevent doors from closing

### DIFF
--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -16,6 +16,12 @@
 /obj/machinery/mech_sensor/blocks_airlock()
 	return 0
 
+/obj/effect/energy_field/blocks_airlock()
+	return 0
+
+/obj/machinery/shield/blocks_airlock()
+	return 0
+
 /mob/living/blocks_airlock()
 	return 1
 


### PR DESCRIPTION
Bubble, hull, and emergency shields no longer prevent doors from closing.
