### PR TITLE
Replaces the ticker nuke cinematic with universal_state datum

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -329,6 +329,7 @@
 #include "code\game\gamemodes\cult\cultify\obj.dm"
 #include "code\game\gamemodes\cult\cultify\turf.dm"
 #include "code\game\gamemodes\endgame\endgame.dm"
+#include "code\game\gamemodes\endgame\nuclear_explosion\nuclear_explosion.dm"
 #include "code\game\gamemodes\endgame\supermatter_cascade\blob.dm"
 #include "code\game\gamemodes\endgame\supermatter_cascade\portal.dm"
 #include "code\game\gamemodes\endgame\supermatter_cascade\universe.dm"

--- a/code/game/gamemodes/endgame/endgame.dm
+++ b/code/game/gamemodes/endgame/endgame.dm
@@ -63,9 +63,9 @@
 /datum/universal_state/proc/OverlayAndAmbientSet()
 	return
 
-/proc/SetUniversalState(var/newstate,var/on_exit=1, var/on_enter=1)
+/proc/SetUniversalState(var/newstate,var/on_exit=1, var/on_enter=1, list/args=list())
 	if(on_exit)
 		universe.OnExit()
-	universe = new newstate
+	universe = new newstate(arglist(args))
 	if(on_enter)
 		universe.OnEnter()

--- a/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
+++ b/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
@@ -1,0 +1,104 @@
+/datum/universal_state/nuclear_explosion
+	name = "Nuclear Demolition Warhead"
+	var/atom/explosion_source
+	var/obj/screen/cinematic
+
+/datum/universal_state/nuclear_explosion/New(atom/nuke)
+	explosion_source = nuke
+
+	//create the cinematic screen obj
+	cinematic = new
+	cinematic.icon = 'icons/effects/station_explosion.dmi'
+	cinematic.icon_state = "station_intact"
+	cinematic.layer = CINEMA_LAYER
+	cinematic.mouse_opacity = 2
+	cinematic.screen_loc = "1,0"
+
+/datum/universal_state/nuclear_explosion/OnEnter()
+	if(ticker && ticker.mode)
+		ticker.mode.explosion_in_progress = 1
+
+	start_cinematic_intro()
+
+	var/turf/T = get_turf(explosion_source)
+	if(isStationLevel(T.z))
+		world << "<span class='danger'>The station was destoyed by the nuclear blast!</span>"
+		dust_mobs(using_map.station_levels)
+		play_cinematic_station_destroyed()
+	else
+		world << "<span class='danger'>A nuclear device was set off, but the explosion was out of reach of the station!</span>"
+		dust_mobs(list(T.z))
+		play_cinematic_station_unaffected()
+
+	sleep(100)
+
+	for(var/mob/living/L in living_mob_list)
+		if(L.client)
+			L.client.screen -= cinematic
+
+	sleep(200)
+
+	if(ticker && ticker.mode)
+		ticker.mode.station_was_nuked = 1
+		ticker.mode.explosion_in_progress = 0
+		if(!ticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
+			universe_has_ended = 1
+
+/datum/universal_state/nuclear_explosion/OnExit()
+	if(ticker && ticker.mode)
+		ticker.mode.explosion_in_progress = 0
+
+/datum/universal_state/nuclear_explosion/proc/dust_mobs(var/list/affected_z_levels)
+	for(var/mob/living/L in mob_list)
+		var/turf/T = get_turf(L)
+		if(T.z in affected_z_levels)
+			//this is needed because dusting resets client screen 1.5 seconds after being called (delayed due to the dusting animation)
+			var/mob/ghost = L.ghostize(0) //So we ghostize them right beforehand instead
+			if(ghost && ghost.client)
+				ghost.client.screen += cinematic
+			L.dust() //then dust the body
+
+/datum/universal_state/nuclear_explosion/proc/show_cinematic_to_players()
+	for(var/mob/M in player_list)
+		if(M.client)
+			M.client.screen += cinematic
+
+/datum/universal_state/nuclear_explosion/proc/start_cinematic_intro()
+	for(var/mob/M in player_list) //I guess so that people in the lobby only hear the explosion
+		M << sound('sound/machines/Alarm.ogg')
+	sleep(100)
+
+	show_cinematic_to_players()
+	flick("intro_nuke",cinematic)
+	sleep(30)
+
+/datum/universal_state/nuclear_explosion/proc/play_cinematic_station_destroyed()
+	world << sound('sound/effects/explosionfar.ogg') //makes no sense if you're not on the station but whatever
+	flick("station_explode_fade_red",cinematic)
+	cinematic.icon_state = "summary_selfdes"
+	sleep(80)
+
+/datum/universal_state/nuclear_explosion/proc/play_cinematic_station_unaffected()
+	cinematic.icon_state = "station_intact"
+	sleep(5)
+	world << sound('sound/effects/explosionfar.ogg') //makes no sense if you are on the station but whatever
+	sleep(75)
+
+
+//MALF
+/datum/universal_state/nuclear_explosion/malf/start_cinematic_intro()
+	for(var/mob/M in player_list) //I guess so that people in the lobby only hear the explosion
+		M << sound('sound/machines/Alarm.ogg')
+	sleep(28)
+
+	show_cinematic_to_players()
+	flick("intro_malf",cinematic)
+	sleep(72)
+	flick("intro_nuke",cinematic)
+	sleep(30)
+
+/client/verb/test_nuclear_explosion()
+	SetUniversalState(/datum/universal_state/nuclear_explosion, args=list(usr))
+
+/client/verb/test_nuclear_explosion_malf()
+	SetUniversalState(/datum/universal_state/nuclear_explosion/malf, args=list(usr))

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HARDWARE.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HARDWARE.dm
@@ -105,9 +105,6 @@
 			radio.autosay("Self destructing now. Have a nice day.", "Self-Destruct Control")
 		timer--
 
-	if(ticker)
-		ticker.station_explosion_cinematic(0,null)
-		if(ticker.mode)
-			ticker.mode:station_was_nuked = 1
+	SetUniversalState(/datum/universal_state/nuclear_explosion/malf, args=list(user)) //TODO: find the station nuclear device and use that
 
 

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -338,41 +338,9 @@ var/bomb_set
 	src.yes_code = 0
 	src.safety = 1
 	update_icon()
-	playsound(src,'sound/machines/Alarm.ogg',100,0,5)
-	if (ticker && ticker.mode)
-		ticker.mode.explosion_in_progress = 1
-	sleep(100)
+	
+	SetUniversalState(/datum/universal_state/nuclear_explosion, args=list(src))
 
-	var/off_station = 0
-	var/turf/bomb_location = get_turf(src)
-	if(bomb_location && (bomb_location.z in using_map.station_levels))
-		if( (bomb_location.x < (128-NUKERANGE)) || (bomb_location.x > (128+NUKERANGE)) || (bomb_location.y < (128-NUKERANGE)) || (bomb_location.y > (128+NUKERANGE)) )
-			off_station = 1
-	else
-		off_station = 2
-
-	if(ticker)
-		if(ticker.mode && ticker.mode.name == "Mercenary")
-			var/obj/machinery/computer/shuttle_control/multi/syndicate/syndie_location = locate(/obj/machinery/computer/shuttle_control/multi/syndicate)
-			if(syndie_location)
-				ticker.mode:syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
-			ticker.mode:nuke_off_station = off_station
-		ticker.station_explosion_cinematic(off_station,null)
-		if(ticker.mode)
-			ticker.mode.explosion_in_progress = 0
-			if(off_station == 1)
-				world << "<b>A nuclear device was set off, but the explosion was out of reach of the station!</b>"
-			else if(off_station == 2)
-				world << "<b>A nuclear device was set off, but the device was not on the station!</b>"
-			else
-				world << "<b>The station was destoyed by the nuclear blast!</b>"
-
-			ticker.mode.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
-															//kinda shit but I couldn't  get permission to do what I wanted to do.
-
-			if(!ticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
-				universe_has_ended = 1
-				return
 	return
 
 /obj/machinery/nuclearbomb/update_icon()


### PR DESCRIPTION
Turns out the nuke cinematic broke due to `station_explosion_cinematic()` using the name of the current game mode to decide what cinematic to play. Since it was pretty horrible, I've reimplemented the cinematic as a universal_state datum instead.
