### PR TITLE
Ensures that attached voidsuit tanks are dropped from inventory when suit is dropped

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -133,7 +133,11 @@
 
 	if(tank)
 		tank.canremove = 1
-		tank.forceMove(src)
+		H = tank.loc
+		if(istype(H))
+			if(tank && H.s_store == tank)
+				H.drop_from_inventory(tank)
+				tank.forceMove(src)
 
 /obj/item/clothing/suit/space/void/verb/toggle_helmet()
 


### PR DESCRIPTION
I'm not sure if it was causing a problem, but in either case this PR makes the handling of voidsuit tanks consistent with the other attached items.
