### PR TITLE
Set IAA minimum age

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -245,6 +245,7 @@
 	economic_modifier = 7
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
+	minimal_player_age = 10
 
 
 	equip(var/mob/living/carbon/human/H)


### PR DESCRIPTION
Minimum player age for IAA is now 10 due to having access_head, making it consistent with other head positions as discussed in msay with Raptor and other staff.
