### PR TITLE
Rework hivebot tele. Makes mimics die properly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -45,8 +45,7 @@
 
 
 /mob/living/simple_animal/hostile/hivebot/death()
-	..()
-	visible_message("<b>[src]</b> blows apart!")
+	..(null, "blows apart!")
 	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
@@ -54,7 +53,7 @@
 	qdel(src)
 	return
 
-/mob/living/simple_animal/hostile/hivebot/tele//this still needs work
+/mob/living/simple_animal/hostile/hivebot/tele
 	name = "Beacon"
 	desc = "Some odd beacon thing"
 	icon = 'icons/mob/hivebot.dmi'
@@ -65,43 +64,45 @@
 	status_flags = 0
 	anchored = 1
 	stop_automated_movement = 1
-	var/bot_type = "norm"
+	var/bot_type = /mob/living/simple_animal/hostile/hivebot
 	var/bot_amt = 10
-	var/spawn_delay = 600
-	var/turn_on = 0
-	var/auto_spawn = 1
-	proc
+	var/spawn_delay = 100
+	var/spawn_time = 0
+
+/mob/living/simple_animal/hostile/hivebot/tele/New()
+	..()
+	var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
+	smoke.set_up(5, 0, src.loc)
+	smoke.start()
+	visible_message("\red <B>The [src] warps in!</B>")
+	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
+
+/mob/living/simple_animal/hostile/hivebot/tele/proc/warpbots()
+	while(bot_amt > 0 && bot_type)
+		bot_amt--
+		var/mob/M = new bot_type(get_turf(src))
+		M.faction = faction
+	playsound(src.loc, 'sound/effects/teleport.ogg', 50, 1)
+	qdel(src)
+	return
+
+/mob/living/simple_animal/hostile/hivebot/tele/FindTarget()
+	if(..() && !spawn_time)
+		spawn_time = world.time + spawn_delay
+		visible_message("<span class='danger'>\The [src] turns on!</span>")
+		icon_state = "def_radar"
+	return null
+
+/mob/living/simple_animal/hostile/hivebot/tele/Life()
+	. = ..()
+	if(. && spawn_time && spawn_time <= world.time)
 		warpbots()
 
+/mob/living/simple_animal/hostile/hivebot/tele/strong
+	bot_type = /mob/living/simple_animal/hostile/hivebot/strong
 
-	New()
-		..()
-		var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
-		smoke.set_up(5, 0, src.loc)
-		smoke.start()
-		visible_message("\red <B>The [src] warps in!</B>")
-		playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
+/mob/living/simple_animal/hostile/hivebot/tele/range
+	bot_type = /mob/living/simple_animal/hostile/hivebot/range
 
-	warpbots()
-		icon_state = "def_radar"
-		visible_message("\red The [src] turns on!")
-		while(bot_amt > 0)
-			bot_amt--
-			switch(bot_type)
-				if("norm")
-					new /mob/living/simple_animal/hostile/hivebot(get_turf(src))
-				if("range")
-					new /mob/living/simple_animal/hostile/hivebot/range(get_turf(src))
-				if("rapid")
-					new /mob/living/simple_animal/hostile/hivebot/rapid(get_turf(src))
-		spawn(100)
-			qdel(src)
-		return
-
-
-	Life()
-		..()
-		if(stat == 0)
-			if(prob(2))//Might be a bit low, will mess with it likely
-				warpbots()
-
+/mob/living/simple_animal/hostile/hivebot/tele/rapid
+	bot_type = /mob/living/simple_animal/hostile/hivebot/rapid

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -94,28 +94,26 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	if(!copy_of)
 		return
 	var/atom/movable/C = copy_of.resolve()
-	if(!C)
-		return
-	C.forceMove(src.loc)
+	..(null, "dies!")
+	if(C)
+		C.forceMove(src.loc)
 
-	if(istype(C,/obj/structure/closet))
+		if(istype(C,/obj/structure/closet))
+			for(var/atom/movable/M in src)
+				M.forceMove(C)
+
+		if(istype(C,/obj/item/weapon/storage))
+			var/obj/item/weapon/storage/S = C
+			for(var/atom/movable/M in src)
+				if(S.can_be_inserted(M,1))
+					S.handle_item_insertion(M)
+				else
+					M.forceMove(src.loc)
+
 		for(var/atom/movable/M in src)
-			M.forceMove(C)
-		return
+			M.loc = get_turf(src)
+		qdel(src)
 
-	if(istype(C,/obj/item/weapon/storage))
-		var/obj/item/weapon/storage/S = C
-		for(var/atom/movable/M in src)
-			if(S.can_be_inserted(M,1))
-				S.handle_item_insertion(M)
-			else
-				M.forceMove(src.loc)
-		return
-
-	for(var/atom/movable/M in src)
-		M.loc = get_turf(src)
-	..()
-	qdel(src)
 
 /mob/living/simple_animal/hostile/mimic/DestroySurroundings()
 	if(destroy_objects)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -111,7 +111,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 					M.forceMove(src.loc)
 
 		for(var/atom/movable/M in src)
-			M.loc = get_turf(src)
+			M.forceMove(get_turf(src))
 		qdel(src)
 
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Mimics now don't /ever/ leave a corpse unless they aren't copies of
something.

Hivebot tele no longer uses spawn. Now only starts warping when it sees
somebody nearby.
