### PR TITLE
Lowers taste buffer duration on similar tastes

### DIFF
--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -51,7 +51,7 @@ calculate text size per text.
 					continue
 				out.Add("[size][tastes[i]]")
 	var/text_output = english_list(out, "something indescribable")
-	if(text_output != last_taste_text || last_taste_time + 500 < world.time) //We dont want to spam the same message over and over again at the person. Give it a bit of a buffer.
+	if(text_output != last_taste_text || last_taste_time + 100 < world.time) //We dont want to spam the same message over and over again at the person. Give it a bit of a buffer.
 		src << "<span class='notice'>You can taste [text_output]</span>" //no taste means there are too many tastes and not enough flavor.
 		last_taste_time = world.time
 		last_taste_text = text_output


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

It's been reduced to 1/5th the time previously. Should stop spam, but should also allow people to taste things a bit better while modifying them.
