### PR TITLE
Buffs thermal engine's efficiency with reagents

### DIFF
--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -78,7 +78,7 @@
 	//fuel points are determined by differing reagents
 
 /obj/item/weapon/engine/thermal/prefill()
-	fuel_points = 1000
+	fuel_points = 5000
 
 /obj/item/weapon/engine/thermal/New()
 	..()
@@ -131,7 +131,7 @@
 		multiplier = (multiplier + new_multiplier)/2
 	if(!actually_flameable)
 		return 0
-	fuel_points += 5 * multiplier * temp_reagents_holder.reagents.total_volume
+	fuel_points += 20 * multiplier * temp_reagents_holder.reagents.total_volume
 	temp_reagents_holder.reagents.clear_reagents()
 	return use_power()
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Now, 1000 fuel points will get you roughly 200 tiles worth of movement. Not a whole lot.
5000 will give you 1000.

Similarly, buffed how many points are given from reagents by 5 times. Should give more leeway now.
