### PR TITLE
Fix typos in modular consoles

### DIFF
--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -35,7 +35,7 @@
 
 // ===== MEDICAL CONSOLE =====
 /obj/machinery/modular_computer/console/preset/medical
-	 console_department = "Medbay"
+	 console_department = "Medical"
 	 desc = "A stationary computer. This one comes preloaded with medical programs."
 
 /obj/machinery/modular_computer/console/preset/medical/install_programs()
@@ -44,7 +44,7 @@
 
 // ===== RESEARCH CONSOLE =====
 /obj/machinery/modular_computer/console/preset/research
-	 console_department = "Medbay"
+	 console_department = "Research"
 	 desc = "A stationary computer. This one comes preloaded with research programs."
 
 /obj/machinery/modular_computer/console/preset/research/install_programs()


### PR DESCRIPTION
Research console now belongs to research department, renamed medbay to medical.
