### PR TITLE
Straight-up removes debug verbs.

### DIFF
--- a/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
+++ b/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
@@ -97,8 +97,3 @@
 	flick("intro_nuke",cinematic)
 	sleep(30)
 
-/client/verb/test_nuclear_explosion()
-	SetUniversalState(/datum/universal_state/nuclear_explosion, args=list(usr))
-
-/client/verb/test_nuclear_explosion_malf()
-	SetUniversalState(/datum/universal_state/nuclear_explosion/malf, args=list(usr))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

The debug verbs test_nuclear_explosion() and test_nuclear_explosion_malf() have been permanently removed.
