### PR TITLE
Fixes #11881

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -39,7 +39,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /mob/living/attackby(obj/item/I, mob/user)
 	if(!ismob(user))
 		return 0
-	if(can_operate(src) && do_surgery(src,user,I)) //Surgery
+	if(can_operate(src) && I.do_surgery(src,user)) //Surgery
 		return 1
 	return I.attack(src, user, user.zone_sel.selecting)
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -24,8 +24,16 @@ REAGENT SCANNER
 	origin_tech = list(TECH_MAGNET = 1, TECH_BIO = 1)
 	var/mode = 1;
 
+/obj/item/device/healthanalyzer/do_surgery(mob/living/M, mob/living/user)
+	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
+		return ..()
+	scan_mob(M, user) //default surgery behaviour is just to scan as usual
+	return 1
 
-/obj/item/device/healthanalyzer/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/device/healthanalyzer/attack(mob/living/M, mob/living/user)
+	scan_mob(M, user)
+
+/obj/item/device/healthanalyzer/proc/scan_mob(mob/living/M, mob/living/user)
 	if ((CLUMSY in user.mutations) && prob(50))
 		user << text("<span class='warning'>You try to analyze the floor's vitals!</span>")
 		for(var/mob/O in viewers(M, null))
@@ -168,8 +176,6 @@ REAGENT SCANNER
 			else
 				user.show_message("<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span>")
 		user.show_message("<span class='notice'>Subject's pulse: <font color='[H.pulse() == PULSE_THREADY || H.pulse() == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span>")
-	src.add_fingerprint(user)
-	return
 
 /obj/item/device/healthanalyzer/verb/toggle_mode()
 	set name = "Switch Verbosity"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -66,50 +66,47 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
-		if(affecting.open == 0)
-			if(affecting.is_bandaged())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>"
-				return 1
-			else
-				user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
-						             "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
-				var/used = 0
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
-						continue
-					if(W.bandaged)
-						continue
-					if(used == amount)
-						break
-					if(!do_mob(user, M, W.damage/5))
-						user << "<span class='notice'>You must stand still to bandage wounds.</span>"
-						break
+		if(affecting.open)
+			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			return
 
-					if (W.current_stage <= W.max_bleeding_stage)
-						user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
-						                              "<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )
-						//H.add_side_effect("Itch")
-					else if (W.damage_type == BRUISE)
-						user.visible_message("<span class='notice'>\The [user] places a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
-						                              "<span class='notice'>You place a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					else
-						user.visible_message("<span class='notice'>\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>", \
-						                              "<span class='notice'>You place a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					W.bandage()
-					used++
-				affecting.update_damages()
-				if(used == amount)
-					if(affecting.is_bandaged())
-						user << "<span class='warning'>\The [src] is used up.</span>"
-					else
-						user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
-				use(used)
+		if(affecting.is_bandaged())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>"
+			return 1
 		else
-			if (can_operate(H))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
-					return
-			else
-				user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+					             "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
+			var/used = 0
+			for (var/datum/wound/W in affecting.wounds)
+				if (W.internal)
+					continue
+				if(W.bandaged)
+					continue
+				if(used == amount)
+					break
+				if(!do_mob(user, M, W.damage/5))
+					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					break
+
+				if (W.current_stage <= W.max_bleeding_stage)
+					user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
+					                              "<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )
+					//H.add_side_effect("Itch")
+				else if (W.damage_type == BRUISE)
+					user.visible_message("<span class='notice'>\The [user] places a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					                              "<span class='notice'>You place a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				else
+					user.visible_message("<span class='notice'>\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					                              "<span class='notice'>You place a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				W.bandage()
+				used++
+			affecting.update_damages()
+			if(used == amount)
+				if(affecting.is_bandaged())
+					user << "<span class='warning'>\The [src] is used up.</span>"
+				else
+					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+			use(used)
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
@@ -129,26 +126,23 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
-		if(affecting.open == 0)
-			if(affecting.is_salved())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>"
-				return 1
-			else
-				user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
-						             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
-				if(!do_mob(user, M, 10))
-					user << "<span class='notice'>You must stand still to salve wounds.</span>"
-					return 1
-				user.visible_message("<span class='notice'>[user] salved wounds on [M]'s [affecting.name].</span>", \
-				                         "<span class='notice'>You salved wounds on [M]'s [affecting.name].</span>" )
-				use(1)
-				affecting.salve()
+		if(affecting.open)
+			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			return
+
+		if(affecting.is_salved())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>"
+			return 1
 		else
-			if (can_operate(H))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
-					return
-			else
-				user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
+					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
+			if(!do_mob(user, M, 10))
+				user << "<span class='notice'>You must stand still to salve wounds.</span>"
+				return 1
+			user.visible_message("<span class='notice'>[user] salved wounds on [M]'s [affecting.name].</span>", \
+			                         "<span class='notice'>You salved wounds on [M]'s [affecting.name].</span>" )
+			use(1)
+			affecting.salve()
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -167,50 +161,47 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
-		if(affecting.open == 0)
-			if(affecting.is_bandaged() && affecting.is_disinfected())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
-				return 1
-			else
-				user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
-						             "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
-				var/used = 0
-				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
-						continue
-					if (W.bandaged && W.disinfected)
-						continue
-					if(used == amount)
-						break
-					if(!do_mob(user, M, W.damage/5))
-						user << "<span class='notice'>You must stand still to bandage wounds.</span>"
-						break
-					if (W.current_stage <= W.max_bleeding_stage)
-						user.visible_message("<span class='notice'>\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue.</span>", \
-						                     "<span class='notice'>You clean and seal \a [W.desc] on [M]'s [affecting.name].</span>" )
-					else if (W.damage_type == BRUISE)
-						user.visible_message("<span class='notice'>\The [user] places a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
-						                              "<span class='notice'>You place a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					else
-						user.visible_message("<span class='notice'>\The [user] smears some bioglue over \a [W.desc] on [M]'s [affecting.name].</span>", \
-						                              "<span class='notice'>You smear some bioglue over \a [W.desc] on [M]'s [affecting.name].</span>" )
-					W.bandage()
-					W.disinfect()
-					W.heal_damage(heal_brute)
-					used++
-				affecting.update_damages()
-				if(used == amount)
-					if(affecting.is_bandaged())
-						user << "<span class='warning'>\The [src] is used up.</span>"
-					else
-						user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
-				use(used)
+		if(affecting.open)
+			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			return
+
+		if(affecting.is_bandaged() && affecting.is_disinfected())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been treated.</span>"
+			return 1
 		else
-			if (can_operate(H))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
-					return
-			else
-				user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+					             "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
+			var/used = 0
+			for (var/datum/wound/W in affecting.wounds)
+				if (W.internal)
+					continue
+				if (W.bandaged && W.disinfected)
+					continue
+				if(used == amount)
+					break
+				if(!do_mob(user, M, W.damage/5))
+					user << "<span class='notice'>You must stand still to bandage wounds.</span>"
+					break
+				if (W.current_stage <= W.max_bleeding_stage)
+					user.visible_message("<span class='notice'>\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue.</span>", \
+					                     "<span class='notice'>You clean and seal \a [W.desc] on [M]'s [affecting.name].</span>" )
+				else if (W.damage_type == BRUISE)
+					user.visible_message("<span class='notice'>\The [user] places a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					                              "<span class='notice'>You place a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				else
+					user.visible_message("<span class='notice'>\The [user] smears some bioglue over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					                              "<span class='notice'>You smear some bioglue over \a [W.desc] on [M]'s [affecting.name].</span>" )
+				W.bandage()
+				W.disinfect()
+				W.heal_damage(heal_brute)
+				used++
+			affecting.update_damages()
+			if(used == amount)
+				if(affecting.is_bandaged())
+					user << "<span class='warning'>\The [src] is used up.</span>"
+				else
+					user << "<span class='warning'>\The [src] is used up, but there are more wounds to treat on \the [affecting.name].</span>"
+			use(used)
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -230,27 +221,23 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
-		if(affecting.open == 0)
-			if(affecting.is_salved())
-				user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>"
-				return 1
-			else
-				user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
-						             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
-				if(!do_mob(user, M, 10))
-					user << "<span class='notice'>You must stand still to salve wounds.</span>"
-					return 1
-				user.visible_message( 	"<span class='notice'>[user] covers wounds on [M]'s [affecting.name] with regenerative membrane.</span>", \
-										"<span class='notice'>You cover wounds on [M]'s [affecting.name] with regenerative membrane.</span>" )
-				affecting.heal_damage(0,heal_burn)
-				use(1)
-				affecting.salve()
+		if(affecting.open)
+			user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+
+		if(affecting.is_salved())
+			user << "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>"
+			return 1
 		else
-			if (can_operate(H))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
-					return
-			else
-				user << "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>"
+			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
+					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
+			if(!do_mob(user, M, 10))
+				user << "<span class='notice'>You must stand still to salve wounds.</span>"
+				return 1
+			user.visible_message( 	"<span class='notice'>[user] covers wounds on [M]'s [affecting.name] with regenerative membrane.</span>", \
+									"<span class='notice'>You cover wounds on [M]'s [affecting.name] with regenerative membrane.</span>" )
+			affecting.heal_damage(0,heal_burn)
+			use(1)
+			affecting.salve()
 
 /obj/item/stack/medical/splint
 	name = "medical splints"

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -19,7 +19,7 @@
 			R.adjustFireLoss(-15)
 			R.updatehealth()
 			use(1)
-			user.visible_message("<span class='notice'>\The [user] applied some [src] at [R]'s damaged areas.</span>",\
+			user.visible_message("<span class='notice'>\The [user] applied some [src] on [R]'s damaged areas.</span>",\
 				"<span class='notice'>You apply some [src] at [R]'s damaged areas.</span>")
 		else
 			user << "<span class='notice'>All [R]'s systems are nominal.</span>"
@@ -28,20 +28,14 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 
-		if(S.open == 1)
+		if(S.open >= 2)
 			if (S && (S.robotic >= ORGAN_ROBOT))
-				if(S.get_damage())
+				if(!S.get_damage())
+					user << "<span class='notice'>Nothing to fix here.</span>"
+				else if(can_use(1))
 					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 					S.heal_damage(15, 15, robo_repair = 1)
 					H.updatehealth()
 					use(1)
-					user.visible_message("<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the"][S.name] with \the [src].</span>",\
-					"<span class='notice'>You apply some nanite paste at [user == M ? "your" : "[M]'s"] [S.name].</span>")
-				else
-					user << "<span class='notice'>Nothing to fix here.</span>"
-		else
-			if (can_operate(H))
-				if (do_surgery(H,user,src))
-					return
-			else
-				user << "<span class='notice'>Nothing to fix in here.</span>"
+					user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\
+					"<span class='notice'>You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].</span>")

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -163,19 +163,16 @@
 		// place the item in the usr's hand if possible
 		usr.put_in_hands(P)
 
-/obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/autopsy_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
 	if(!istype(M))
-		return
-
-	if(!can_operate(M))
-		return
+		return 0
 
 	if(target_name != M.name)
 		target_name = M.name
 		src.wdata = list()
 		src.chemtraces = list()
 		src.timeofdeath = null
-		user << "<span class='notice'>A new patient has been registered.. Purging data for previous patient.</span>"
+		user << "<span class='notice'>A new patient has been registered. Purging data for previous patient.</span>"
 
 	src.timeofdeath = M.timeofdeath
 
@@ -184,10 +181,9 @@
 		usr << "<span class='warning'>You can't scan this body part.</span>"
 		return
 	if(!S.open)
-		usr << "<span class='warning'>You have to cut the limb open first!</span>"
+		usr << "<span class='warning'>You have to cut [S] open first!</span>"
 		return
-	for(var/mob/O in viewers(M))
-		O.show_message("<span class='notice'>\The [user] scans the wounds on [M.name]'s [S.name] with \the [src]</span>", 1)
+	M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
 
 	src.add_data(S)
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -12,8 +12,14 @@
 	slot_flags = SLOT_EARS
 	volume = 5
 
-	afterattack(var/obj/target, var/mob/user, var/flag)
-		if(!target.reagents || !flag) return
+	do_surgery(mob/living/carbon/M, mob/living/user)
+		if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
+			return ..()
+		afterattack(M, user, 1)
+		return 1
+
+	afterattack(var/obj/target, var/mob/user, var/proximity)
+		if(!target.reagents || !proximity) return
 
 		if(reagents.total_volume)
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -68,9 +68,15 @@
 			flags |= OPENCONTAINER
 		update_icon()
 
-	afterattack(var/obj/target, var/mob/user, var/flag)
+	do_surgery(mob/living/carbon/M, mob/living/user)
+		if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
+			return ..()
+		afterattack(M, user, 1)
+		return 1
 
-		if(!is_open_container() || !flag)
+	afterattack(var/obj/target, var/mob/user, var/proximity)
+
+		if(!is_open_container() || !proximity)
 			return
 
 		for(var/type in can_be_placed_into)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -20,6 +20,12 @@
 //	reagents.add_reagent("tricordrazine", 30)
 //	return
 
+/obj/item/weapon/reagent_containers/hypospray/do_surgery(mob/living/carbon/M, mob/living/user)
+	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
+		return ..()
+	attack(M, user)
+	return 1
+
 /obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
 	if(!reagents.total_volume)
 		user << "<span class='warning'>[src] is empty.</span>"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -53,6 +53,14 @@
 	attackby(obj/item/I as obj, mob/user as mob)
 		return
 
+	do_surgery(mob/living/carbon/M, mob/living/user)
+		if(user.a_intent == I_HURT)
+			return 0
+		if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
+			return ..()
+		afterattack(M, user, 1)
+		return 1
+
 	afterattack(obj/target, mob/user, proximity)
 		if(!proximity || !target.reagents)
 			return

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -167,14 +167,16 @@
 			var/obj/item/stack/cable_coil/C = tool
 			var/obj/item/organ/external/affected = target.get_organ(target_zone)
 			var/limb_can_operate = (affected && affected.open == 2 && affected.burn_dam > 0 && target_zone != "mouth")
-			if(limb_can_operate)
-				if(istype(C))
-					if(!C.get_amount() >= 3)
-						user << "<span class='danger'>You need three or more cable pieces to repair this damage.</span>"
-						return SURGERY_FAILURE
-					C.use(3)
-				return 1
-			return 0
+
+			if(!limb_can_operate)
+				return 0
+
+			if(istype(C))
+				if(!C.can_use(10))
+					user << "<span class='danger'>You need ten or more cable pieces to repair this damage.</span>" //usage amount made more consistent with regular cable repair
+					return SURGERY_FAILURE
+				C.use(10)
+			return 1
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -68,7 +68,7 @@
 	proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		return null
 
-proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/human/user)
+/proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/human/user)
 	if(!istype(user) || !istype(E)) return
 
 	var/germ_level = user.germ_level
@@ -77,7 +77,7 @@ proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/
 
 	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
-proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
+/obj/item/proc/do_surgery(mob/living/carbon/M, mob/living/user)
 	if(!istype(M))
 		return 0
 	if (user.a_intent == I_HURT)	//check for Hippocratic Oath
@@ -88,18 +88,18 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 		return 1
 	for(var/datum/surgery_step/S in surgery_steps)
 		//check if tool is right or close enough and if this step is possible
-		if(S.tool_quality(tool))
-			var/step_is_valid = S.can_use(user, M, zone, tool)
+		if(S.tool_quality(src))
+			var/step_is_valid = S.can_use(user, M, zone, src)
 			if(step_is_valid && S.is_valid_target(M))
 				if(step_is_valid == SURGERY_FAILURE) // This is a failure that already has a message for failing.
 					return 1
 				M.op_stage.in_progress += zone
-				S.begin_step(user, M, zone, tool)		//start on it
+				S.begin_step(user, M, zone, src)		//start on it
 				//We had proper tools! (or RNG smiled.) and user did not move or change hands.
-				if(prob(S.tool_quality(tool)) &&  do_mob(user, M, rand(S.min_duration, S.max_duration)))
-					S.end_step(user, M, zone, tool)		//finish successfully
-				else if ((tool in user.contents) && user.Adjacent(M))			//or
-					S.fail_step(user, M, zone, tool)		//malpractice~
+				if(prob(S.tool_quality(src)) &&  do_mob(user, M, rand(S.min_duration, S.max_duration)))
+					S.end_step(user, M, zone, src)		//finish successfully
+				else if ((src in user.contents) && user.Adjacent(M))			//or
+					S.fail_step(user, M, zone, src)		//malpractice~
 				else // This failing silently was a pain.
 					user << "<span class='warning'>You must remain close to your patient to conduct surgery.</span>"
 				M.op_stage.in_progress -= zone 									// Clear the in-progress flag.
@@ -109,11 +109,11 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 				return	1	  												//don't want to do weapony things after surgery
 
 	if (user.a_intent == I_HELP)
-		user << "<span class='warning'>You can't see any useful way to use [tool] on [M].</span>"
+		user << "<span class='warning'>You can't see any useful way to use [src] on [M].</span>"
 		return 1
 	return 0
 
-proc/sort_surgeries()
+/proc/sort_surgeries()
 	var/gap = surgery_steps.len
 	var/swapped = 1
 	while (gap > 1 || swapped)


### PR DESCRIPTION
Makes `do_surgery()` an item proc, adds surgery behaviour for health analyzers, autopsy scanners, syringes, hyposprays, droppers, and bottles.

Also refactors medical stack `attack()` since surgery stuff is checked before `attacked()` even gets called now so no need for those checks anymore.
