### PR TITLE
Grenade launcher and dartgun fixes

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -74,7 +74,7 @@ var/datum/antagonist/raider/raiders
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/gun/energy/crossbow/largecrossbow,
 		/obj/item/weapon/gun/launcher/crossbow,
-		/obj/item/weapon/gun/launcher/grenade,
+		/obj/item/weapon/gun/launcher/grenade/loaded,
 		/obj/item/weapon/gun/launcher/pneumatic,
 		/obj/item/weapon/gun/projectile/automatic/mini_uzi,
 		/obj/item/weapon/gun/projectile/automatic/c20r,
@@ -283,17 +283,6 @@ var/datum/antagonist/raider/raiders
 				new bullet_thrower.ammo_type(ammobox)
 			player.put_in_any_hand_if_possible(ammobox)
 		return
-	if(istype(gun, /obj/item/weapon/gun/launcher/grenade))
-		var/list/grenades = list(
-			/obj/item/weapon/grenade/empgrenade,
-			/obj/item/weapon/grenade/smokebomb,
-			/obj/item/weapon/grenade/flashbang
-			)
-		var/obj/item/weapon/storage/box/ammobox = new(get_turf(player.loc))
-		for(var/i in 1 to 7)
-			var/grenade_type = pick(grenades)
-			new grenade_type(ammobox)
-		player.put_in_any_hand_if_possible(ammobox)
 
 /datum/antagonist/raider/proc/equip_vox(var/mob/living/carbon/human/player)
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -25,7 +25,26 @@
 	. = BB
 	BB = null
 	set_dir(pick(cardinal)) //spin spent casings
+
+	// Aurora forensics port, gunpowder residue.
+	if(leaves_residue)
+		leave_residue()
+
 	update_icon()
+
+/obj/item/ammo_casing/proc/leave_residue()
+	var/mob/living/carbon/human/H
+	if(ishuman(loc))
+		H = loc //in a human, somehow
+	else if(loc && ishuman(loc.loc))
+		H = loc.loc //more likely, we're in a gun being held by a human
+
+	if(H)
+		if(H.gloves && (H.l_hand == loc || H.r_hand == loc))
+			var/obj/item/clothing/G = H.gloves
+			G.gunshot_residue = caliber
+		else
+			H.gunshot_residue = caliber
 
 /obj/item/ammo_casing/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/screwdriver))

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -114,6 +114,7 @@
 	icon_state = "stunshell"
 	spent_icon = "stunshell-spent"
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
+	leaves_residue = 0
 	matter = list(DEFAULT_WALL_MATERIAL = 360, "glass" = 720)
 
 /obj/item/ammo_casing/shotgun/stunshell/emp_act(severity)

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -50,7 +50,7 @@
 	if(grenades.len >= max_grenades)
 		user << "<span class='warning'>\The [src] is full.</span>"
 		return
-	G.forceMove(src)
+	user.drop_from_inventory(G, src)
 	grenades.Insert(1, G) //add to the head of the list, so that it is loaded on the next pump
 	user.visible_message("\The [user] inserts \a [G] into \the [src].", "<span class='notice'>You insert \a [G] into \the [src].</span>")
 
@@ -127,8 +127,7 @@
 	if(chambered)
 		user << "<span class='warning'>\The [src] is already loaded.</span>"
 		return
-	user.remove_from_mob(G)
-	G.forceMove(src)
+	user.drop_from_inventory(G, src)
 	chambered = G
 	user.visible_message("\The [user] load \a [G] into \the [src].", "<span class='notice'>You load \a [G] into \the [src].</span>")
 

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -103,8 +103,10 @@
 		/obj/item/weapon/grenade/frag/shell = 1,
 		)
 
+	var/grenade_type = pickweight(grenade_types)
+	chambered = new grenade_type(src)
 	for(var/i in 1 to max_grenades)
-		var/grenade_type = pickweight(grenade_types)
+		grenade_type = pickweight(grenade_types)
 		grenades += new grenade_type(src)
 
 //Underslung grenade launcher to be used with the Z8

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -68,16 +68,6 @@
 /obj/item/weapon/gun/projectile/proc/process_chambered()
 	if (!chambered) return
 
-	// Aurora forensics port, gunpowder residue.
-	if(chambered.leaves_residue)
-		var/mob/living/carbon/human/H = loc
-		if(istype(H))
-			if(!H.gloves)
-				H.gunshot_residue = chambered.caliber
-			else
-				var/obj/item/clothing/G = H.gloves
-				G.gunshot_residue = chambered.caliber
-
 	switch(handle_casings)
 		if(EJECT_CASINGS) //eject casing onto ground.
 			chambered.loc = get_turf(src)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -56,7 +56,7 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/chemdart
 	auto_eject = 0
-	handle_casings = HOLD_CASING //delete casings instead of dropping them
+	handle_casings = HOLD_CASINGS //delete casings instead of dropping them
 
 	var/list/beakers = list() //All containers inside the gun.
 	var/list/mixing = list() //Containers being used for mixing.
@@ -99,12 +99,9 @@
 	return null
 
 /obj/item/weapon/gun/projectile/dartgun/process_chambered()
-	chambered = null //darts qdel themselves when expended, so we just need to null this so it can qdel
+	chambered = null //darts qdel themselves when expended, just need to null this so that they can qdel properly
 
 /obj/item/weapon/gun/projectile/dartgun/examine(mob/user)
-	//update_icon()
-	//if (!..(user, 2))
-	//	return
 	..()
 	if (beakers.len)
 		user << "\blue [src] contains:"
@@ -115,20 +112,26 @@
 
 /obj/item/weapon/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))
-		if(!istype(I, container_type))
-			user << "\blue [I] doesn't seem to fit into [src]."
-			return
-		if(beakers.len >= max_beakers)
-			user << "\blue [src] already has [max_beakers] beakers in it - another one isn't going to fit!"
-			return
-		var/obj/item/weapon/reagent_containers/glass/beaker/B = I
-		user.drop_item()
-		B.loc = src
-		beakers += B
-		user << "\blue You slot [B] into [src]."
-		src.updateUsrDialog()
+		add_beaker(I, user)
 		return 1
 	..()
+
+/obj/item/weapon/gun/projectile/dartgun/proc/add_beaker(var/obj/item/weapon/reagent_containers/glass/B, mob/user)
+	if(!istype(B, container_type))
+		user << "<span class='warning'>[B] doesn't seem to fit into [src].</span>"
+		return
+	if(beakers.len >= max_beakers)
+		user << "<span class='warning'>[src] already has [max_beakers] beakers in it - another one isn't going to fit!</span>"
+		return
+	user.drop_from_inventory(B, src)
+	beakers |= B
+	user.visible_message("\The [user] inserts \a [B] into [src].", "<span class='notice'>You slot [B] into [src].</span>")
+
+/obj/item/weapon/gun/projectile/dartgun/proc/remove_beaker(var/obj/item/weapon/reagent_containers/glass/B, mob/user)
+	mixing -= B
+	beakers -= B
+	user.put_in_hands(B)
+	user.visible_message("\The [user] removes \a [B] from [src].", "<span class='notice'>You remove [B] from [src].</span>")
 
 //fills the given dart with reagents
 /obj/item/weapon/gun/projectile/dartgun/proc/fill_dart(var/obj/item/projectile/bullet/chemdart/dart)
@@ -138,72 +141,66 @@
 			B.reagents.trans_to_obj(dart, mix_amount)
 
 /obj/item/weapon/gun/projectile/dartgun/attack_self(mob/user)
-	user.set_machine(src)
-	var/dat = "<b>[src] mixing control:</b><br><br>"
+	Interact(user)
 
-	if (beakers.len)
-		var/i = 1
-		for(var/obj/item/weapon/reagent_containers/glass/beaker/B in beakers)
+/obj/item/weapon/gun/projectile/dartgun/proc/Interact(mob/user)
+	user.set_machine(src)
+	var/list/dat = list("<b>[src] mixing control:</b><br><br>")
+
+	if (!beakers.len)
+		dat += "There are no beakers inserted!<br><br>"
+	else
+		for(var/i in 1 to beakers.len)
+			var/obj/item/weapon/reagent_containers/glass/beaker/B = beakers[i]
+			if(!istype(B)) continue
+
 			dat += "Beaker [i] contains: "
 			if(B.reagents && B.reagents.reagent_list.len)
 				for(var/datum/reagent/R in B.reagents.reagent_list)
 					dat += "<br>    [R.volume] units of [R.name], "
-				if (check_beaker_mixing(B))
-					dat += text("<A href='?src=\ref[src];stop_mix=[i]'><font color='green'>Mixing</font></A> ")
+				if(B in mixing)
+					dat += "<A href='?src=\ref[src];stop_mix=[i]'><font color='green'>Mixing</font></A> "
 				else
-					dat += text("<A href='?src=\ref[src];mix=[i]'><font color='red'>Not mixing</font></A> ")
+					dat += "<A href='?src=\ref[src];mix=[i]'><font color='red'>Not mixing</font></A> "
 			else
 				dat += "nothing."
 			dat += " \[<A href='?src=\ref[src];eject=[i]'>Eject</A>\]<br>"
-			i++
-	else
-		dat += "There are no beakers inserted!<br><br>"
 
 	if(ammo_magazine)
 		if(ammo_magazine.stored_ammo && ammo_magazine.stored_ammo.len)
 			dat += "The dart cartridge has [ammo_magazine.stored_ammo.len] shots remaining."
 		else
 			dat += "<font color='red'>The dart cartridge is empty!</font>"
-		dat += " \[<A href='?src=\ref[src];eject_cart=1'>Eject</A>\]"
+		dat += " \[<A href='?src=\ref[src];eject_cart=1'>Eject</A>\]<br>"
 
-	user << browse(dat, "window=dartgun")
-	onclose(user, "dartgun", src)
+	dat += "<br>\[<A href='?src=\ref[src];refresh=1'>Refresh</A>\]"
 
-/obj/item/weapon/gun/projectile/dartgun/proc/check_beaker_mixing(var/obj/item/B)
-	if(!mixing || !beakers)
-		return 0
-	for(var/obj/item/M in mixing)
-		if(M == B)
-			return 1
-	return 0
+	var/datum/browser/popup = new(user, "dartgun", "[src] mixing control")
+	popup.set_content(jointext(dat,null))
+	popup.open()
 
 /obj/item/weapon/gun/projectile/dartgun/Topic(href, href_list)
 	if(..()) return 1
+
+	if(!Adjacent(usr) || usr.incapacitated())
+		return
+
 	src.add_fingerprint(usr)
+
 	if(href_list["stop_mix"])
 		var/index = text2num(href_list["stop_mix"])
-		if(index <= beakers.len)
-			for(var/obj/item/M in mixing)
-				if(M == beakers[index])
-					mixing -= M
-					break
+		mixing -= beakers[index]
 	else if (href_list["mix"])
 		var/index = text2num(href_list["mix"])
-		if(index <= beakers.len)
-			mixing |= beakers[index]
+		mixing |= beakers[index]
 	else if (href_list["eject"])
 		var/index = text2num(href_list["eject"])
-		if(index <= beakers.len)
-			if(beakers[index])
-				var/obj/item/weapon/reagent_containers/glass/beaker/B = beakers[index]
-				usr << "You remove [B] from [src]."
-				mixing -= B
-				beakers -= B
-				B.loc = get_turf(src)
+		if(beakers[index])
+			remove_beaker(beakers[index], usr)
 	else if (href_list["eject_cart"])
 		unload_ammo(usr)
-	src.updateUsrDialog()
-	return
+
+	Interact(usr)
 
 /obj/item/weapon/gun/projectile/dartgun/vox
 	name = "alien dart gun"

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -6,6 +6,7 @@
 	embed = 1 //the dart is shot fast enough to pierce space suits, so I guess splintering inside the target can be a thing. Should be rare due to low damage.
 	var/reagent_amount = 15
 	kill_count = 15 //shorter range
+	unacidable = 1
 
 	muzzle_type = null
 


### PR DESCRIPTION
- Fixes grenade launcher loading being broken, it did not unequip the grenade before forceMove()ing it meaning that it remained in the player's screen obj list.
- The loaded grenade launcher now also gets a grenade in the chamber, so that it spawns with a full complement of grenades.
- Replaces the grenade launcher in the raider equipment list with the pre-loaded subtype, removing a typecheck and allowing raiders to potentially spawn with some of the newer grenade types.
- Dartgun darts now qdel properly, EJECT_CASINGS would forceMove() the "spent" darts onto the ground, preventing them qdeling. This would cause the darts to momentarily appear on the ground until they got hard-deleted.
- Fixes dartgun darts being acidable, a problem when the dartgun is loaded with polyacid.
- Rewrites the dartgun UI, now uses a browser datum.
- Fixes residue potentially being added even if the gun did not successfully fire. Residue is now done by the casing when it is expended. Stunshells and darts no longer leave residue.
