### PR TITLE
Limits the amount of fire_stacks that can be gained from being in a fire tile, fixes fire extingushers being garbage at putting out mob fires

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -98,10 +98,6 @@
 				propel_object(user.buckled, user, turn(direction,180))
 
 		var/turf/T = get_turf(target)
-		var/turf/T1 = get_step(T,turn(direction, 90))
-		var/turf/T2 = get_step(T,turn(direction, -90))
-
-		var/list/the_targets = list(T,T1,T2)
 
 		var/per_particle = min(spray_amount, reagents.total_volume)/spray_particles
 		for(var/a = 1 to spray_particles)
@@ -109,15 +105,10 @@
 				if(!src || !reagents.total_volume) return
 
 				var/obj/effect/effect/water/W = PoolOrNew(/obj/effect/effect/water, get_turf(src))
-				var/turf/my_target
-				if(a <= the_targets.len)
-					my_target = the_targets[a]
-				else
-					my_target = pick(the_targets)
 				W.create_reagents(per_particle)
 				reagents.trans_to_obj(W, per_particle)
 				W.set_color()
-				W.set_up(my_target)
+				W.set_up(T)
 
 		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
 			user.inertia_dir = get_dir(target, user)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -264,7 +264,7 @@
 	return
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
-    fire_stacks = Clamp(fire_stacks + add_fire_stacks, FIRE_MIN_STACKS, FIRE_MAX_STACKS)
+	fire_stacks = Clamp(fire_stacks + add_fire_stacks, FIRE_MIN_STACKS, FIRE_MAX_STACKS)
 
 /mob/living/proc/handle_fire()
 	if(fire_stacks < 0)
@@ -284,8 +284,11 @@
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
 
-/mob/living/fire_act()
-	adjust_fire_stacks(2)
+/mob/living/fire_act(datum/gas_mixture/air, temperature, volume)
+	//once our fire_burn_temperature has reached the temperature of the fire that's giving fire_stacks, stop adding them.
+	//allow fire_stacks to go up to 4 for fires cooler than 700 K, since are being immersed in flame after all.
+	if(fire_stacks <= 4 || fire_burn_temperature() < temperature))
+		adjust_fire_stacks(2)
 	IgniteMob()
 
 /mob/living/proc/get_cold_protection()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -287,7 +287,7 @@
 /mob/living/fire_act(datum/gas_mixture/air, temperature, volume)
 	//once our fire_burn_temperature has reached the temperature of the fire that's giving fire_stacks, stop adding them.
 	//allow fire_stacks to go up to 4 for fires cooler than 700 K, since are being immersed in flame after all.
-	if(fire_stacks <= 4 || fire_burn_temperature() < temperature))
+	if(fire_stacks <= 4 || fire_burn_temperature() < temperature)
 		adjust_fire_stacks(2)
 	IgniteMob()
 


### PR DESCRIPTION
Currently, if you stand in a fire tile your fire_stacks will keep going up unconditionally until you hit `FIRE_MAX_STACKS`. This results in the curious behaviour where no matter how good the heat_protection is on your voidsuit, your `fire_stacks` will reach a point where the `fire_burn_temperature` is too high and you will start taking burn damage, even if the fire itself isn't hot enough to burn through your suit. This fixes that.

As well, fire extinguishers are no longer terrible at putting out mob fires, and even at `FIRE_MAX_STACKS` it no longer takes multiple extinguishers to put someone out. I managed to achieve this without increasing the capacity of the extinguishers or buffing the ability of water to put out mob fires. 

Turns out the main reason for the ineffectiveness of extinguisher for putting out mob fires is that they spray water in a wide cone. Thus, attempts to put someone out usually result with most of the water ending up splashing the floor instead. This PR changes extinguishers to spray in a jet instead.
