### PR TITLE
Wall shield range is now controlled by a var

### DIFF
--- a/code/modules/shieldgen/sheldwallgen.dm
+++ b/code/modules/shieldgen/sheldwallgen.dm
@@ -17,6 +17,7 @@
 		var/locked = 1
 		var/destroyed = 0
 		var/directwired = 1
+		var/max_range = 8
 //		var/maxshieldload = 200
 		var/obj/structure/cable/attached		// the attached cable
 		var/storedpower = 0
@@ -131,7 +132,7 @@
 	else if(NSEW == 8)
 		oNSEW = 4
 
-	for(var/dist = 0, dist <= 9, dist += 1) // checks out to 8 tiles away for another generator
+	for(var/dist = 0, dist <= (max_range + 1), dist += 1) // checks out to max_range + 1 tiles away for another generator
 		T = get_step(T2, NSEW)
 		T2 = T
 		steps += 1
@@ -194,7 +195,7 @@
 	var/turf/T = src.loc
 	var/turf/T2 = src.loc
 
-	for(var/dist = 0, dist <= 9, dist += 1) // checks out to 8 tiles away for fields
+	for(var/dist = 0, dist <= (max_range + 1), dist += 1) // checks out to max range + 1 tiles away for fields
 		T = get_step(T2, NSEW)
 		T2 = T
 		if(locate(/obj/machinery/shieldwall) in T)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

This is to allow the shield in front of the Torch's bridge to work. If you want a shield to have a longer range, you can manually set its range while mapping.

At Raptor's request.
