### PR TITLE
Improves unarmed attack messages, fixes #9508

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -39,8 +39,8 @@
 				if(1 to 2) user.visible_message("<span class='danger'>[user] scratched [target] across \his cheek!</span>")
 				if(3 to 4)
 					user.visible_message(pick(
-						80; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target]'s [pick(affecting.name, "neck")]!</span>"),
-						20; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [pick("[target] in the [affecting.name]", "[target] across \his [affecting.name]")]!</span>"),
+						80; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target]'s [pick("face", "neck", affecting.name)]!</span>"),
+						20; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [pick("[target] in the [affecting.name]", "[target] across \his [pick("face", "neck", affecting.name)]")]!</span>"),
 						))
 				if(5)
 					user.visible_message(pick(

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -36,20 +36,26 @@
 		if("head", "mouth", "eyes")
 			// ----- HEAD ----- //
 			switch(attack_damage)
-				if(1 to 2)
-					user.visible_message("<span class='danger'>[user] scratched [target] across \his cheek!</span>")
+				if(1 to 2) user.visible_message("<span class='danger'>[user] scratched [target] across \his cheek!</span>")
 				if(3 to 4)
-					user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target]'s [pick("head", "neck")]!</span>") //'with spread claws' sounds a little bit odd, just enough that conciseness is better here I think
+					user.visible_message(pick(
+						80; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target]'s [pick(affecting.name, "neck")]!</span>"),
+						20; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [pick("[target] in the [affecting.name]", "[target] across \his [affecting.name]")]!</span>"),
+						))
 				if(5)
 					user.visible_message(pick(
-						"<span class='danger'>[user] rakes \his [pick(attack_noun)] across [target]'s face!</span>",
-						"<span class='danger'>[user] tears \his [pick(attack_noun)] into [target]'s face!</span>",
+						"<span class='danger'>[user] rakes \his [pick(attack_noun)] across [target]'s [pick("face", "neck", affecting.name)]!</span>",
+						"<span class='danger'>[user] tears \his [pick(attack_noun)] into [target]'s [pick("face", "neck", affecting.name)]!</span>",
 						))
 		else
 			// ----- BODY ----- //
 			switch(attack_damage)
-				if(1 to 2)	user.visible_message("<span class='danger'>[user] scratched [target]'s [affecting.name]!</span>")
-				if(3 to 4)	user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [pick("", "", "the side of")] [target]'s [affecting.name]!</span>")
+				if(1 to 2)	user.visible_message("<span class='danger'>[user] [pick("scratched", "grazed")] [target]'s [affecting.name]!</span>")
+				if(3 to 4)
+					user.visible_message(pick(
+						80; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target]'s [affecting.name]!</span>"),
+						20; user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [pick("[target] in the [affecting.name]", "[target] across \his [affecting.name]")]!</span>"),
+						))
 				if(5)		user.visible_message("<span class='danger'>[user] tears \his [pick(attack_noun)] [pick("deep into", "into", "across")] [target]'s [affecting.name]!</span>")
 
 /datum/unarmed_attack/claws/strong

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -147,28 +147,23 @@ var/global/list/sparring_attack_cache = list()
 						user.visible_message("<span class='danger'>[user] slapped [target] across \his cheek!</span>")
 					if(3 to 4)
 						user.visible_message(pick(
-							40; "<span class='danger'>[user] [pick(attack_verb)] [target] in the head!</span>",
-							30; "<span class='danger'>[user] struck [target] in the head[pick("", " with a closed fist")]!</span>",
+							80; "<span class='danger'>[user] [pick(attack_verb)] [target] in the head!</span>",
+							20; "<span class='danger'>[user] struck [target] in the head[pick("", " with a closed fist")]!</span>",
 							30; "<span class='danger'>[user] threw a hook against [target]'s head!</span>"
 							))
 					if(5)
 						user.visible_message(pick(
-							30; "<span class='danger'>[user] gave [target] a resounding [pick("slap", "punch")] to the face!</span>",
-							40; "<span class='danger'>[user] smashed \his [pick(attack_noun)] into [target]'s face!</span>",
-							30; "<span class='danger'>[user] gave a strong blow against [target]'s jaw!</span>"
+							10; "<span class='danger'>[user] gave [target] a solid slap across \his face!</span>",
+							90; "<span class='danger'>[user] smashed \his [pick(attack_noun)] into [target]'s [pick("[organ]", "face", "jaw")]!</span>"
 							))
 			else
 				// ----- BODY ----- //
 				switch(attack_damage)
 					if(1 to 2)	user.visible_message("<span class='danger'>[user] threw a glancing punch at [target]'s [organ]!</span>")
 					if(1 to 4)	user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target] in \his [organ]!</span>")
-					if(5)
-						user.visible_message(pick(
-							50; "<span class='danger'>[user] smashed \his [pick(attack_noun)] into [target]'s [organ]!</span>",
-							50; "<span class='danger'>[user] landed a striking [pick(attack_noun)] on [target]'s [organ]!</span>"
-							))
+					if(5)		user.visible_message("<span class='danger'>[user] smashed \his [pick(attack_noun)] into [target]'s [organ]!</span>")
 	else
-		user.visible_message("<span class='danger'>[user] [pick("punched", "threw a punch against", "struck", "slammed their [pick(attack_noun)] into")] [target]'s [organ]!</span>") //why do we have a separate set of verbs for lying targets?
+		user.visible_message("<span class='danger'>[user] [pick("punched", "threw a punch at", "struck", "slammed their [pick(attack_noun)] into")] [target]'s [organ]!</span>") //why do we have a separate set of verbs for lying targets?
 
 /datum/unarmed_attack/kick
 	attack_verb = list("kicked", "kicked", "kicked", "kneed")
@@ -248,9 +243,16 @@ var/global/list/sparring_attack_cache = list()
 
 	attack_damage = Clamp(attack_damage, 1, 5)
 
+	var/shoe_text = shoes ? copytext(shoes.name, 1, -1) : "foot"
 	switch(attack_damage)
-		if(1 to 4)	user.visible_message("<span class='danger'>[pick("[user] stomped on", "[user] slammed \his [shoes ? copytext(shoes.name, 1, -1) : "foot"] down onto")] [target]'s [organ]!</span>")
-		if(5)		user.visible_message("<span class='danger'>[pick("[user] landed a powerful stomp on", "[user] stomped down hard on", "[user] slammed \his [shoes ? copytext(shoes.name, 1, -1) : "foot"] down hard onto")] [target]'s [organ]!</span>") //Devastated lol. No. We want to say that the stomp was powerful or forceful, not that it /wrought devastation/
+		if(1 to 4)
+			user.visible_message(pick(
+				"<span class='danger'>[user] stomped on [target]'s [organ][pick("", "with their [shoe_text]")]!</span>",
+				"<span class='danger'>[user] stomped \his [shoe_text] down onto [target]'s [organ]!</span>"))
+		if(5)
+			user.visible_message(pick(
+				"<span class='danger'>[user] stomped down hard onto [target]'s [organ][pick("", "with their [shoe_text]")]!</span>",
+				"<span class='danger'>[user] slammed \his [shoe_text] down onto [target]'s [organ]!</span>"))
 
 /datum/unarmed_attack/light_strike
 	deal_halloss = 3

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -149,7 +149,7 @@ var/global/list/sparring_attack_cache = list()
 						user.visible_message(pick(
 							80; "<span class='danger'>[user] [pick(attack_verb)] [target] in the head!</span>",
 							20; "<span class='danger'>[user] struck [target] in the head[pick("", " with a closed fist")]!</span>",
-							30; "<span class='danger'>[user] threw a hook against [target]'s head!</span>"
+							50; "<span class='danger'>[user] threw a hook against [target]'s head!</span>"
 							))
 					if(5)
 						user.visible_message(pick(

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -206,7 +206,7 @@ var/global/list/sparring_attack_cache = list()
 		if(5)		user.visible_message("<span class='danger'>[user] landed a strong [pick(attack_noun)] against [target]'s [organ]!</span>")
 
 /datum/unarmed_attack/stomp
-	attack_verb = null
+	attack_verb = list("stomped on")
 	attack_noun = list("stomp")
 	attack_sound = "swing_hit"
 	damage = 0


### PR DESCRIPTION
"[user] punched [target] in the head" sounds much more natural than "[user] struck [target] in the head with a closed fist", so I adjusted the weights to make the former more common.

Similarly, it sounds really strange to "give someone a resounding punch" and so on. I've adjusted messages accordingly, and expanded some things. Some messages are still a little awkward sounding but have been kept in for variety with reduced weight. I also expanded on the clawed attack messages, and fixed #9508.
