### PR TITLE
A smoother lobby experience during server start.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -42,26 +42,33 @@ datum/controller/game_controller/proc/setup()
 
 	transfer_controller = new
 
+#ifdef UNIT_TEST
+#define CHECK_SLEEP_MASTER // For unit tests we don't care about a smooth lobby screen experience. We care about speed.
+#else
+#define CHECK_SLEEP_MASTER if(++initialized_objects > 500) { initialized_objects=0;sleep(world.tick_lag); }
+#endif
 
 datum/controller/game_controller/proc/setup_objects()
+#ifndef UNIT_TEST
+	var/initialized_objects = 0
+#endif
 	admin_notice("<span class='danger'>Initializing objects</span>", R_DEBUG)
-	sleep(-1)
 	for(var/atom/movable/object in world)
-		if(isnull(object.gcDestroyed))
+		if(!deleted(object))
 			object.initialize()
+			CHECK_SLEEP_MASTER
 
 	admin_notice("<span class='danger'>Initializing areas</span>", R_DEBUG)
-	sleep(-1)
 	for(var/area/area in all_areas)
 		area.initialize()
+		CHECK_SLEEP_MASTER
 
 	admin_notice("<span class='danger'>Initializing pipe networks</span>", R_DEBUG)
-	sleep(-1)
 	for(var/obj/machinery/atmospherics/machine in machines)
 		machine.build_network()
+		CHECK_SLEEP_MASTER
 
 	admin_notice("<span class='danger'>Initializing atmos machinery.</span>", R_DEBUG)
-	sleep(-1)
 	for(var/obj/machinery/atmospherics/unary/U in machines)
 		if(istype(U, /obj/machinery/atmospherics/unary/vent_pump))
 			var/obj/machinery/atmospherics/unary/vent_pump/T = U
@@ -69,6 +76,7 @@ datum/controller/game_controller/proc/setup_objects()
 		else if(istype(U, /obj/machinery/atmospherics/unary/vent_scrubber))
 			var/obj/machinery/atmospherics/unary/vent_scrubber/T = U
 			T.broadcast_status()
+		CHECK_SLEEP_MASTER
 
 	// Set up antagonists.
 	populate_antag_type_list()
@@ -77,4 +85,5 @@ datum/controller/game_controller/proc/setup_objects()
 	populate_spawn_points()
 
 	admin_notice("<span class='danger'>Initializations complete.</span>", R_DEBUG)
-	sleep(-1)
+
+#undef CHECK_SLEEP_MASTER


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Server start initialization now sleeps in a much less aggressive but more efficient manner (similar to how processes sleep). As a result the lobby screen experience is much smoother and allow OOC-chatter, character setup, etc. from the get-go.
The total initialization time does increase some, and as such unit tests don't utilize this at all to complete the process as quickly as possible.

This is basically #13208 but without the attempt to re-organize when and how initialize() is called.
Shuttles and pipes (specifically those in space) now remain working as intended.
