### PR TITLE
Adds slight transparency to certain floor decals

### DIFF
--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -13,7 +13,7 @@
 		"hazard stripes" =    list("path" = /obj/effect/floor_decal/industrial/warning),
 		"corner, hazard" =    list("path" = /obj/effect/floor_decal/industrial/warning/corner),
 		"hatched marking" =   list("path" = /obj/effect/floor_decal/industrial/hatch, "coloured" = 1),
-		"dotted outline" =    list("path" = /obj/effect/floor_decal/industrial/outline, "coloured" = 1),
+		"dashed outline" =    list("path" = /obj/effect/floor_decal/industrial/outline, "coloured" = 1),
 		"loading sign" =      list("path" = /obj/effect/floor_decal/industrial/loading),
 		"mosaic, large" =     list("path" = /obj/effect/floor_decal/chapel),
 		"1" =                 list("path" = /obj/effect/floor_decal/sign),

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -44,6 +44,7 @@ var/list/floor_decals = list()
 
 /obj/effect/floor_decal/corner
 	icon_state = "corner_white"
+	alpha = 229
 
 /obj/effect/floor_decal/corner/black
 	name = "black corner"
@@ -246,6 +247,7 @@ var/list/floor_decals = list()
 /obj/effect/floor_decal/industrial/hatch
 	name = "hatched marking"
 	icon_state = "delivery"
+	alpha = 229
 
 /obj/effect/floor_decal/industrial/hatch/yellow
 	color = "#CFCF55"
@@ -253,6 +255,7 @@ var/list/floor_decals = list()
 /obj/effect/floor_decal/industrial/outline
 	name = "white outline"
 	icon_state = "outline"
+	alpha = 229
 
 /obj/effect/floor_decal/industrial/outline/blue
 	name = "blue outline"
@@ -269,6 +272,7 @@ var/list/floor_decals = list()
 /obj/effect/floor_decal/industrial/loading
 	name = "loading area"
 	icon_state = "loadingarea"
+	alpha = 229
 
 /obj/effect/floor_decal/plaque
 	name = "plaque"


### PR DESCRIPTION
Floor decals representing painted markings now have a slight transparency. This makes them look nicer as they blend a little bit with the floor texture, instead of being a solid block of colour.

Also corrects the floor painter menu.
