### PR TITLE
Objects in containers,hands,pockets,etc. can now hear again.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -109,6 +109,10 @@
 
 #define COMPANY_ALIGNMENTS		list(COMPANY_LOYAL,COMPANY_SUPPORTATIVE,COMPANY_NEUTRAL,COMPANY_SKEPTICAL,COMPANY_OPPOSED)
 
+// Defines the argument used for get_mobs_and_objs_in_view_fast
+#define GHOSTS_ALL_HEAR 1
+#define ONLY_GHOSTS_IN_VIEW 0
+
 
 // Defines mob sizes, used by lockers and to determine what is considered a small sized mob, etc.
 #define MOB_LARGE  		40

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -245,10 +245,11 @@
 					. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
 	return .
 
-/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/checkghosts = 1)
+/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/checkghosts = GHOSTS_ALL_HEAR)
 
 	var/list/mobs = list()
 	var/list/objs = list()
+	var/list/combined = list()
 
 	var/list/hear = dview(range,T,INVISIBILITY_MAXIMUM)
 	var/list/hearturfs = list()
@@ -263,13 +264,22 @@
 
 
 	for(var/mob/M in player_list)
-		if(checkghosts && M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
+		if(checkghosts == GHOSTS_ALL_HEAR && M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
 			mobs |= M
 			continue
 		if(M.loc && M.locs[1] in hearturfs)
 			mobs |= M
 
-	return list("mobs" = mobs, "objs" = objs)
+	
+
+	for(var/obj/O in listening_objects)
+		if(O && O.loc && O.locs[1] in hearturfs)
+			objs |= O
+
+
+	combined = mobs + objs
+
+	return list("mobs" = mobs, "objs" = objs, "combined" = combined)
 
 
 

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -245,11 +245,7 @@
 					. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
 	return .
 
-/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/checkghosts = GHOSTS_ALL_HEAR)
-
-	var/list/mobs = list()
-	var/list/objs = list()
-	var/list/combined = list()
+/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/list/mobs, var/list/objs, var/checkghosts = GHOSTS_ALL_HEAR)
 
 	var/list/hear = dview(range,T,INVISIBILITY_MAXIMUM)
 	var/list/hearturfs = list()
@@ -277,9 +273,6 @@
 			objs |= O
 
 
-	combined = mobs + objs
-
-	return list("mobs" = mobs, "objs" = objs, "combined" = combined)
 
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -467,16 +467,16 @@ its easier to just keep the beam vertical.
 	var/list/objs = list()
 	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
-	for(var/I in mobs + objs)
-		if(isobj(I))
-			var/obj/O = I
-			O.show_message(message,1,blind_message,2)
-		if(ismob(I))
-			var/mob/M = I
-			if(M.see_invisible >= invisibility)
-				M.show_message(message,1,blind_message,2)
-			else if(blind_message)
-				M.show_message(blind_message, 2)
+	for(var/o in objs)
+		var/obj/O = o
+		O.show_message(message,1,blind_message,2)
+
+	for(var/m in mobs)
+		var/mob/M = m
+		if(M.see_invisible >= invisibility)
+			M.show_message(message,1,blind_message,2)
+		else if(blind_message)
+			M.show_message(blind_message, 2)
 
 // Show a message to all mobs and objects in earshot of this atom
 // Use for objects performing audible actions
@@ -493,13 +493,12 @@ its easier to just keep the beam vertical.
 	var/list/objs = list()
 	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
-	for(var/I in mobs + objs)
-		if(isobj(I))
-			var/obj/O = I
-			O.show_message(message,2,deaf_message,1)
-		if(ismob(I))
-			var/mob/M = I
-			M.show_message(message,2,deaf_message,1)
+	for(var/m in mobs)
+		var/mob/M = m
+		M.show_message(message,2,deaf_message,1)
+	for(var/o in objs)
+		var/mob/O = o
+		O.show_message(message,2,deaf_message,1)
 
 /atom/movable/proc/dropInto(var/atom/destination)
 	while(istype(destination))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -481,17 +481,14 @@ its easier to just keep the beam vertical.
 	var/range = world.view
 	if(hearing_distance)
 		range = hearing_distance
-	var/list/hear = get_mobs_or_objects_in_view(range,src)
+	var/turf/T = get_turf(src)
+	var/list/results = get_mobs_and_objs_in_view_fast(T,range, ONLY_GHOSTS_IN_VIEW)
 
-	for(var/I in hear)
-		if(isobj(I))
-			spawn(0)
-				if(I) //It's possible that it could be deleted in the meantime.
-					var/obj/O = I
-					O.show_message( message, 2, deaf_message, 1)
-		else if(ismob(I))
-			var/mob/M = I
-			M.show_message( message, 2, deaf_message, 1)
+	for(var/mob/M in results["mobs"])
+		M.show_message( message, 2, deaf_message, 1)
+
+	for(var/obj/O in results["objs"])
+		O.show_message(message,2,deaf_message,1)
 
 /atom/movable/proc/dropInto(var/atom/destination)
 	while(istype(destination))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -462,14 +462,21 @@ its easier to just keep the beam vertical.
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /atom/proc/visible_message(var/message, var/blind_message, var/range = world.view)
-	var/list/witness = get_mobs_and_objs_in_view_fast(src, range, 0)
-	for(var/mob/M in witness["mobs"])
-		if(M.see_invisible >= invisibility) // Cannot view the invisible
-			M.show_message(message, 1, blind_message, 2)
-		else if (blind_message)
-			M.show_message(blind_message, 2)
-	for(var/obj/O in witness["objs"])
-		O.show_message( message, 1, blind_message, 2)
+	var/turf/T = get_turf(src)
+	var/list/mobs = list()
+	var/list/objs = list()
+	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+
+	for(var/I in mobs + objs)
+		if(isobj(I))
+			var/obj/O = I
+			O.show_message(message,1,blind_message,2)
+		if(ismob(I))
+			var/mob/M = I
+			if(M.see_invisible >= invisibility)
+				M.show_message(message,1,blind_message,2)
+			else if(blind_message)
+				M.show_message(blind_message, 2)
 
 // Show a message to all mobs and objects in earshot of this atom
 // Use for objects performing audible actions
@@ -482,13 +489,17 @@ its easier to just keep the beam vertical.
 	if(hearing_distance)
 		range = hearing_distance
 	var/turf/T = get_turf(src)
-	var/list/results = get_mobs_and_objs_in_view_fast(T,range, ONLY_GHOSTS_IN_VIEW)
+	var/list/mobs = list()
+	var/list/objs = list()
+	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
-	for(var/mob/M in results["mobs"])
-		M.show_message( message, 2, deaf_message, 1)
-
-	for(var/obj/O in results["objs"])
-		O.show_message(message,2,deaf_message,1)
+	for(var/I in mobs + objs)
+		if(isobj(I))
+			var/obj/O = I
+			O.show_message(message,2,deaf_message,1)
+		if(ismob(I))
+			var/mob/M = I
+			M.show_message(message,2,deaf_message,1)
 
 /atom/movable/proc/dropInto(var/atom/destination)
 	while(istype(destination))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -63,9 +63,11 @@ var/global/list/default_medbay_channels = list(
 	..()
 	wires = new(src)
 	internal_channels = default_internal_channels.Copy()
+	listening_objects += src
 
 /obj/item/device/radio/Destroy()
 	qdel(wires)
+	listening_objects -= src
 	wires = null
 	if(radio_controller)
 		radio_controller.remove_object(src, frequency)

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -26,8 +26,8 @@
 	listening_objects += src
 
 /obj/item/device/spy_bug/Destroy()
-	..()
 	listening_objects -= src
+	return ..()
 
 /obj/item/device/spy_bug/examine(mob/user)
 	. = ..(user, 0)
@@ -70,8 +70,8 @@
 	listening_objects += src
 
 /obj/item/device/spy_monitor/Destroy()
-	..()
 	listening_objects -= src
+	return ..()
 
 /obj/item/device/spy_monitor/examine(mob/user)
 	. = ..(user, 1)

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -23,6 +23,11 @@
 	..()
 	radio = new(src)
 	camera = new(src)
+	listening_objects += src
+
+/obj/item/device/spy_bug/Destroy()
+	..()
+	listening_objects -= src
 
 /obj/item/device/spy_bug/examine(mob/user)
 	. = ..(user, 0)
@@ -62,6 +67,11 @@
 
 /obj/item/device/spy_monitor/New()
 	radio = new(src)
+	listening_objects += src
+
+/obj/item/device/spy_monitor/Destroy()
+	..()
+	listening_objects -= src
 
 /obj/item/device/spy_monitor/examine(mob/user)
 	. = ..(user, 1)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -20,6 +20,14 @@
 	throw_speed = 4
 	throw_range = 20
 
+/obj/item/device/taperecorder/New()
+	..()
+	listening_objects += src
+
+/obj/item/device/taperecorder/Del()
+	..()
+	listening_objects -= src
+
 /obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, var/verb="says", datum/language/speaking=null)
 	if(recording)
 		timestamp += timerecorded

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -24,7 +24,7 @@
 	..()
 	listening_objects += src
 
-/obj/item/device/taperecorder/Del()
+/obj/item/device/taperecorder/Destroy()
 	..()
 	listening_objects -= src
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -25,8 +25,8 @@
 	listening_objects += src
 
 /obj/item/device/taperecorder/Destroy()
-	..()
 	listening_objects -= src
+	return ..()
 
 /obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, var/verb="says", datum/language/speaking=null)
 	if(recording)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -50,7 +50,7 @@
 	Destroy()
 		if(part)
 			part.implants.Remove(src)
-		..()
+		return ..()
 
 /obj/item/weapon/implant/tracking
 	name = "tracking implant"
@@ -258,8 +258,8 @@ Implant Specifics:<BR>"}
 	listening_objects += src
 
 /obj/item/weapon/implant/explosive/Destroy()
-	..()
 	listening_objects -= src
+	return ..()
 
 
 /obj/item/weapon/implant/chem

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -162,7 +162,6 @@ Implant Specifics:<BR>"}
 		if (malfunction == MALFUNCTION_PERMANENT)
 			return
 
-		listening_objects -= src
 
 		var/need_gib = null
 		if(istype(imp_in, /mob/))
@@ -212,7 +211,6 @@ Implant Specifics:<BR>"}
 		phrase = replace_characters(phrase, replacechars)
 		usr.mind.store_memory("Explosive implant in [source] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate.", 0, 0)
 		usr << "The implanted explosive implant in [source] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate."
-		listening_objects += src // Adds item to list of objects that need to be able to hear chat inside other objects.
 		return 1
 
 	emp_act(severity)
@@ -254,6 +252,15 @@ Implant Specifics:<BR>"}
 						part.droplimb(0,DROPLIMB_BLUNT)
 				explosion(get_turf(imp_in), -1, -1, 2, 3)
 				qdel(src)
+
+/obj/item/weapon/implant/explosive/New()
+	..()
+	listening_objects += src
+
+/obj/item/weapon/implant/explosive/Destroy()
+	..()
+	listening_objects -= src
+
 
 /obj/item/weapon/implant/chem
 	name = "chemical implant"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -162,6 +162,8 @@ Implant Specifics:<BR>"}
 		if (malfunction == MALFUNCTION_PERMANENT)
 			return
 
+		listening_objects -= src
+
 		var/need_gib = null
 		if(istype(imp_in, /mob/))
 			var/mob/T = imp_in
@@ -210,6 +212,7 @@ Implant Specifics:<BR>"}
 		phrase = replace_characters(phrase, replacechars)
 		usr.mind.store_memory("Explosive implant in [source] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate.", 0, 0)
 		usr << "The implanted explosive implant in [source] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate."
+		listening_objects += src // Adds item to list of objects that need to be able to hear chat inside other objects.
 		return 1
 
 	emp_act(severity)

--- a/code/global.dm
+++ b/code/global.dm
@@ -14,6 +14,8 @@ var/global/list/med_hud_users            = list() // List of all entities using 
 var/global/list/sec_hud_users            = list() // List of all entities using a security HUD.
 var/global/list/hud_icon_reference       = list()
 
+var/global/list/listening_objects         = list() // List of objects that need to be able to hear, used to avoid recursive searching through contents.
+
 
 var/global/list/global_mutations  = list() // List of hidden mutation things.
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -216,8 +216,8 @@
 	listening_objects += src
 
 /obj/item/device/assembly_holder/Destroy()
-	..()
 	listening_objects -= src
+	return ..()
 	
 
 /obj/item/device/assembly_holder/hear_talk(mob/living/M as mob, msg, verb, datum/language/speaking)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -211,6 +211,15 @@
 		return 1
 
 
+/obj/item/device/assembly_holder/New()
+	..()
+	listening_objects += src
+
+/obj/item/device/assembly_holder/Destroy()
+	..()
+	listening_objects -= src
+	
+
 /obj/item/device/assembly_holder/hear_talk(mob/living/M as mob, msg, verb, datum/language/speaking)
 	if(a_right)
 		a_right.hear_talk(M,msg,verb,speaking)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -12,8 +12,8 @@
 	listening_objects += src
 
 /obj/item/device/assembly/voice/Destroy()
-	..()
 	listening_objects -= src
+	return ..()
 
 /obj/item/device/assembly/voice/hear_talk(mob/living/M as mob, msg)
 	if(listening)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -7,6 +7,14 @@
 	var/listening = 0
 	var/recorded	//the activation message
 
+/obj/item/device/assembly/voice/New()
+	..()
+	listening_objects += src
+
+/obj/item/device/assembly/voice/Destroy()
+	..()
+	listening_objects -= src
+
 /obj/item/device/assembly/voice/hear_talk(mob/living/M as mob, msg)
 	if(listening)
 		recorded = msg

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -217,6 +217,8 @@ proc/get_radio_key_from_channel(var/channel)
 			if (speech_sound)
 				sound_vol *= 0.5
 
+	var/list/listening = list()
+	var/list/listening_obj = list()
 	var/turf/T = get_turf(src)
 
 	//handle nonverbal and sign languages here
@@ -227,9 +229,6 @@ proc/get_radio_key_from_channel(var/channel)
 
 		if (speaking.flags & SIGNLANG)
 			return say_signlang(message, pick(speaking.signlang_verb), speaking)
-
-	var/list/listening = list()
-	var/list/listening_obj = list()
 
 	if(T)
 		//make sure the air can transmit speech - speaker's side
@@ -242,9 +241,7 @@ proc/get_radio_key_from_channel(var/channel)
 			italics = 1
 			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
-		var/list/results = get_mobs_and_objs_in_view_fast(T, message_range)
-		listening = results["mobs"]
-		listening_obj = results["objs"]
+		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj)
 
 
 	var/speech_bubble_test = say_test(message)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -120,10 +120,13 @@
 
 	var/turf/T = get_turf(src)
 
-	var/list/results = get_mobs_or_objects_in_view(T,range, ONLY_GHOSTS_IN_VIEW)
+	var/list/mobs = list()
+	var/list/objs = list()
+	get_mobs_and_objs_in_view_fast(T, range, mobs, objs)
 
 
-	for(var/mob/M in results["mobs"])
+	for(var/m in mobs)
+		var/mob/M = m
 		if(self_message && M==src)
 			M.show_message(self_message,2,deaf_message,1)
 			continue
@@ -131,7 +134,8 @@
 		M.show_message(message,2,deaf_message,1)
 
 
-	for(var/obj/O in results["objs"])
+	for(var/o in objs)
+		var/obj/O = o
 		O.show_message(message,2,deaf_message,1)
 
 /mob/proc/findname(msg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -117,21 +117,22 @@
 	var/range = world.view
 	if(hearing_distance)
 		range = hearing_distance
-	var/list/hear = get_mobs_or_objects_in_view(range,src)
 
-	for(var/I in hear)
-		if(isobj(I))
-			spawn(0)
-				if(I) //It's possible that it could be deleted in the meantime.
-					var/obj/O = I
-					O.show_message( message, 2, deaf_message, 1)
-		else if(ismob(I))
-			var/mob/M = I
-			var/msg = message
-			if(self_message && M==src)
-				msg = self_message
-			M.show_message( msg, 2, deaf_message, 1)
+	var/turf/T = get_turf(src)
 
+	var/list/results = get_mobs_or_objects_in_view(T,range, ONLY_GHOSTS_IN_VIEW)
+
+
+	for(var/mob/M in results["mobs"])
+		if(self_message && M==src)
+			M.show_message(self_message,2,deaf_message,1)
+			continue
+
+		M.show_message(message,2,deaf_message,1)
+
+
+	for(var/obj/O in results["objs"])
+		O.show_message(message,2,deaf_message,1)
 
 /mob/proc/findname(msg)
 	for(var/mob/M in mob_list)

--- a/code/modules/research/xenoarchaeology/finds/finds_special.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_special.dm
@@ -10,6 +10,7 @@
 	processing_objects.Add(src)
 	spawning_id = pick("blood","holywater","lube","stoxin","ethanol","ice","glycerol","fuel","cleaner")
 
+
 /obj/item/weapon/reagent_containers/glass/replenishing/process()
 	reagents.add_reagent(spawning_id, 0.3)
 
@@ -23,6 +24,12 @@
 
 /obj/item/clothing/mask/gas/poltergeist/New()
 	processing_objects.Add(src)
+	listening_objects += src
+
+/obj/item/clothing/mask/gas/poltergeist/Destroy()
+	..()
+	processing_objects.Remove(src)
+	listening_objects += src
 
 /obj/item/clothing/mask/gas/poltergeist/process()
 	if(heard_talk.len && istype(src.loc, /mob/living) && prob(10))
@@ -57,6 +64,11 @@
 /obj/item/weapon/vampiric/New()
 	..()
 	processing_objects.Add(src)
+	listening_objects += src
+
+/obj/item/weapon/vampiric/Destroy()
+	..()
+	listening_objects -= src
 
 /obj/item/weapon/vampiric/process()
 	//see if we've identified anyone nearby

--- a/code/modules/research/xenoarchaeology/finds/finds_special.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_special.dm
@@ -27,9 +27,9 @@
 	listening_objects += src
 
 /obj/item/clothing/mask/gas/poltergeist/Destroy()
-	..()
 	processing_objects.Remove(src)
 	listening_objects += src
+	return ..()
 
 /obj/item/clothing/mask/gas/poltergeist/process()
 	if(heard_talk.len && istype(src.loc, /mob/living) && prob(10))
@@ -67,8 +67,9 @@
 	listening_objects += src
 
 /obj/item/weapon/vampiric/Destroy()
-	..()
+	processing_objects.Remove(src)
 	listening_objects -= src
+	return ..()
 
 /obj/item/weapon/vampiric/process()
 	//see if we've identified anyone nearby
@@ -158,6 +159,10 @@
 	processing_objects.Add(src)
 	loc_last_process = src.loc
 
+/obj/effect/decal/cleanable/blood/splatter/animated/Destroy()
+	processing_objects.Remove(src)
+	return ..()
+
 /obj/effect/decal/cleanable/blood/splatter/animated/process()
 	if(target_turf && src.loc != target_turf)
 		step_towards(src,target_turf)
@@ -187,6 +192,10 @@
 /obj/effect/shadow_wight/New()
 	processing_objects.Add(src)
 
+/obj/effect/shadow_wight/Destroy()
+	processing_objects.Remove(src)
+	return ..()
+
 /obj/effect/shadow_wight/process()
 	if(src.loc)
 		src.loc = get_turf(pick(orange(1,src)))
@@ -212,4 +221,4 @@
 		processing_objects.Remove(src)
 
 /obj/effect/shadow_wight/Bump(var/atom/obstacle)
-	obstacle << "\red You feel a chill run down your spine!"
+	obstacle << "<span class='warning'>You feel a chill run down your spine!</span>"

--- a/html/changelogs/Ccomp5950-saycodefix.yml
+++ b/html/changelogs/Ccomp5950-saycodefix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Ccomp5950
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Objects in bags and other containers (including your hands and pocket) will now hear speach again.  This impacts radios, explosive implants, and the universal recorder."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Changed visible_message to now use the faster proc.  Yay less lag.

Created a global list called listening_objects, added tape recorders,radios, and explosive implants to it.  If you think of other objects that need this speak up!

Made a loop in get_mobs_and_objects_in_view_fast_or_whatever_the_hell_it's_called() to loop through this list same as mobs (fuck recursion!)

Removed "magic numbers" from the proc for ghost listening made 2 defines..

Resolves: #13075 
Resolves: #12645
Resolves: #10224 
Much easier to review if you ignore whitespace:  https://github.com/Baystation12/Baystation12/pull/13264/files?w=1
