### PR TITLE
Cargo supplies no longer use the amount var.

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -10,29 +10,25 @@
 
 /decl/hierarchy/supply_pack/engineering/metal50
 	name = "50 metal sheets"
-	contains = list(/obj/item/stack/material/steel)
-	amount = 50
+	contains = list(/obj/item/stack/material/steel/fifty)
 	cost = 10
 	containername = "\improper Metal sheets crate"
 
 /decl/hierarchy/supply_pack/engineering/glass50
 	name = "50 glass sheets"
-	contains = list(/obj/item/stack/material/glass)
-	amount = 50
+	contains = list(/obj/item/stack/material/glass/fifty)
 	cost = 10
 	containername = "\improper Glass sheets crate"
 
 /decl/hierarchy/supply_pack/engineering/wood50
 	name = "50 wooden planks"
-	contains = list(/obj/item/stack/material/wood)
-	amount = 50
+	contains = list(/obj/item/stack/material/wood/fifty)
 	cost = 10
 	containername = "\improper Wooden planks crate"
 
 /decl/hierarchy/supply_pack/engineering/plastic50
 	name = "50 plastic sheets"
-	contains = list(/obj/item/stack/material/plastic)
-	amount = 50
+	contains = list(/obj/item/stack/material/plastic/fifty)
 	cost = 10
 	containername = "\improper Plastic sheets crate"
 

--- a/code/datums/supplypacks/miscellaneous.dm
+++ b/code/datums/supplypacks/miscellaneous.dm
@@ -13,38 +13,33 @@
 
 /decl/hierarchy/supply_pack/miscellaneous/carpet
 	name = "Imported carpet"
-	contains = list(/obj/item/stack/tile/carpet)
+	contains = list(/obj/item/stack/tile/carpet/fifty)
 	cost = 15
 	containername = "\improper Imported carpet crate"
-	amount = 50
 
 /decl/hierarchy/supply_pack/miscellaneous/linoleum
 	name = "Linoleum"
-	contains = list(/obj/item/stack/tile/linoleum)
+	contains = list(/obj/item/stack/tile/linoleum/fifty)
 	cost = 15
 	containername = "\improper Linoleum crate"
-	amount = 50
 
 /decl/hierarchy/supply_pack/miscellaneous/white_tiles
 	name = "White floor tiles"
-	contains = list(/obj/item/stack/tile/floor_white)
+	contains = list(/obj/item/stack/tile/floor_white/fifty)
 	cost = 15
 	containername = "\improper White floor tile crate"
-	amount = 50
 
 /decl/hierarchy/supply_pack/miscellaneous/dark_tiles
 	name = "Dark floor tiles"
-	contains = list(/obj/item/stack/tile/floor_dark)
+	contains = list(/obj/item/stack/tile/floor_dark/fifty)
 	cost = 15
 	containername = "\improper Dark floor tile crate"
-	amount = 50
 
 /decl/hierarchy/supply_pack/miscellaneous/freezer_tiles
 	name = "Freezer floor tiles"
-	contains = list(/obj/item/stack/tile/floor_freezer)
+	contains = list(/obj/item/stack/tile/floor_freezer/fifty)
 	cost = 15
 	containername = "\improper Freezer floor tile crate"
-	amount = 50
 
 /decl/hierarchy/supply_pack/miscellaneous/costume
 	num_contained = 2
@@ -145,10 +140,9 @@
 
 /decl/hierarchy/supply_pack/miscellaneous/cardboard_sheets
 	name = "50 cardboard sheets"
-	contains = list(/obj/item/stack/material/cardboard)
+	contains = list(/obj/item/stack/material/cardboard/fifty)
 	cost = 10
 	containername = "\improper Cardboard sheets crate"
-	amount = 50
 
 /decl/hierarchy/supply_pack/miscellaneous/witch
 	name = "Witch costume"

--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -6,7 +6,6 @@ var/decl/hierarchy/supply_pack/cargo_supply_packs	// Non-category supply packs
 	hierarchy_type = /decl/hierarchy/supply_pack
 	var/list/contains = list()
 	var/manifest = ""
-	var/amount = null
 	var/cost = null
 	var/containertype = /obj/structure/closet/crate
 	var/containername = null

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -65,6 +65,9 @@
 	throw_speed = 5
 	throw_range = 20
 	flags = 0
+	
+/obj/item/stack/tile/carpet/fifty
+	amount = 50
 
 /obj/item/stack/tile/floor
 	name = "floor tile"
@@ -83,24 +86,35 @@
 	singular_name = "steel floor tile"
 	icon_state = "tile_steel"
 	matter = list("plasteel" = 937.5)
+	
+/obj/item/stack/tile/floor_steel/fifty
+	amount = 50
 
 /obj/item/stack/tile/floor_white
 	name = "white floor tile"
 	singular_name = "white floor tile"
 	icon_state = "tile_white"
 	matter = list("plastic" = 937.5)
+	
+/obj/item/stack/tile/floor_white/fifty
 
 /obj/item/stack/tile/floor_dark
 	name = "dark floor tile"
 	singular_name = "dark floor tile"
 	icon_state = "fr_tile"
 	matter = list("plasteel" = 937.5)
+	
+/obj/item/stack/tile/floor_dark/fifty
+	amount = 50
 
 /obj/item/stack/tile/floor_freezer
 	name = "freezer floor tile"
 	singular_name = "freezer floor tile"
 	icon_state = "tile_freezer"
 	matter = list("plastic" = 937.5)
+	
+/obj/item/stack/tile/floor_freezer/fifty
+	amount = 50
 
 /obj/item/stack/tile/floor/cyborg
 	name = "floor tile synthesizer"
@@ -122,3 +136,6 @@
 	throw_speed = 5
 	throw_range = 20
 	flags = 0
+	
+/obj/item/stack/tile/linoleum/fifty
+	amount = 50

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -118,6 +118,9 @@
 	name = "plastic"
 	icon_state = "sheet-plastic"
 	default_type = "plastic"
+	
+/obj/item/stack/material/plastic/fifty
+	amount = 50
 
 /obj/item/stack/material/gold
 	name = "gold"
@@ -158,17 +161,26 @@
 	name = DEFAULT_WALL_MATERIAL
 	icon_state = "sheet-metal"
 	default_type = DEFAULT_WALL_MATERIAL
+	
+/obj/item/stack/material/steel/fifty
+	amount = 50
 
-/obj/item/stack/material/plasteel
+/obj/item/stack/material/plasteel/fifty
 	name = "plasteel"
 	icon_state = "sheet-plasteel"
 	item_state = "sheet-metal"
 	default_type = "plasteel"
+	
+/obj/item/stack/material/plasteel/fifty
+	amount = 50
 
 /obj/item/stack/material/wood
 	name = "wooden plank"
 	icon_state = "sheet-wood"
 	default_type = "wood"
+	
+/obj/item/stack/material/wood/fifty
+	amount = 50
 
 /obj/item/stack/material/cloth
 	name = "cloth"
@@ -179,6 +191,9 @@
 	name = "cardboard"
 	icon_state = "sheet-card"
 	default_type = "cardboard"
+	
+/obj/item/stack/material/cardboard/fifty
+	amount = 50
 
 /obj/item/stack/material/leather
 	name = "leather"
@@ -190,6 +205,8 @@
 	name = "glass"
 	icon_state = "sheet-glass"
 	default_type = "glass"
+	
+/obj/item/stack/material/glass/fifty
 
 /obj/item/stack/material/glass/reinforced
 	name = "reinforced glass"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

The original method was a bit snowflaky, as the proper non-colon method is to check specifically for /obj/item/stack.
The original method would not allow having multiple stack types of various amounts.
This enforces using proper type definitions, which is handy for mapping.
Fixes #13262.
