### PR TITLE
Fix initialisation order of global_init and other global vars

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2033,4 +2033,5 @@
 #include "maps\exodus\exodus_define.dm"
 #include "maps\torch\torch_define.dm"
 #include "maps\~mapsystem\maps.dm"
+#include "~code\global_init.dm"
 // END_INCLUDE

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,34 +1,4 @@
 
-/*
-	The initialization of the game happens roughly like this:
-
-	1. All global variables are initialized (including the global_init instance).
-	2. The map is initialized, and map objects are created.
-	3. world/New() runs, creating the process scheduler (and the old master controller) and spawning their setup.
-	4. processScheduler/setup() runs, creating all the processes. game_controller/setup() runs, calling initialize() on all movable atoms in the world.
-	5. The gameticker is created.
-
-*/
-var/global/datum/global_init/init = new ()
-
-/*
-	Pre-map initialization stuff should go here.
-*/
-/datum/global_init/New()
-	generate_gameid()
-
-	makeDatumRefLists()
-	populateGlobalLists()
-	load_configuration()
-
-	initialize_chemical_reagents()
-	initialize_chemical_reactions()
-
-	qdel(src) //we're done
-
-/datum/global_init/Destroy()
-	return 1
-
 /var/game_id = null
 /proc/generate_gameid()
 	if(game_id != null)

--- a/~code/global_init.dm
+++ b/~code/global_init.dm
@@ -1,0 +1,29 @@
+/*
+	The initialization of the game happens roughly like this:
+
+	1. All global variables are initialized (including the global_init instance$
+	2. The map is initialized, and map objects are created.
+	3. world/New() runs, creating the process scheduler (and the old master con$
+	4. processScheduler/setup() runs, creating all the processes. game_controll$
+	5. The gameticker is created.
+*/
+
+var/global/datum/global_init/init = new ()
+
+/*
+    Pre-map initialization stuff should go here.
+*/
+/datum/global_init/New()
+	generate_gameid()
+
+	makeDatumRefLists()
+	populateGlobalLists()
+	load_configuration()
+
+	initialize_chemical_reagents()
+	initialize_chemical_reactions()
+
+	qdel(src) //we're done
+
+/datum/global_init/Destroy()
+	return 1


### PR DESCRIPTION
Moves the `var/datum/global_init/init = new ()` declaration to dead last. Should fix/work around/etc whatever http://www.byond.com/forum/?post=2024969 really is by ensuring (maybe, see the link) that `init` is the last thing initialised.

At the very least, putting procs before _this_ one won't break everything.
