### PR TITLE
Modular computer batteries no longer require sulphuric acid

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -5,6 +5,7 @@
 	desc = "A low-end tablet often seen among low ranked station personnel."
 	processor_unit = new/obj/item/weapon/computer_hardware/processor_unit/small(src)
 	battery_module = new/obj/item/weapon/computer_hardware/battery_module/nano(src)
+	battery_module.charge_to_full()
 	hard_drive = new/obj/item/weapon/computer_hardware/hard_drive/micro(src)
 	network_card = new/obj/item/weapon/computer_hardware/network_card(src)
 
@@ -13,6 +14,7 @@
 	. = ..()
 	processor_unit = new/obj/item/weapon/computer_hardware/processor_unit/small(src)
 	battery_module = new/obj/item/weapon/computer_hardware/battery_module(src)
+	battery_module.charge_to_full()
 	hard_drive = new/obj/item/weapon/computer_hardware/hard_drive/small(src)
 	network_card = new/obj/item/weapon/computer_hardware/network_card(src)
 	nano_printer = new/obj/item/weapon/computer_hardware/nano_printer(src)

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -63,5 +63,9 @@
 /obj/item/weapon/computer_hardware/battery_module/New()
 	battery = new/obj/item/weapon/cell(src)
 	battery.maxcharge = battery_rating
-	battery.charge = battery_rating
+	battery.charge = 0
 	..()
+
+/obj/item/weapon/computer_hardware/battery_module/proc/charge_to_full()
+	if(battery)
+		battery.charge = battery.maxcharge

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -246,10 +246,12 @@ obj/machinery/lapvend/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(process_payment(I,W))
 			fabricate_and_recalc_price(1)
 			if((devtype == 1) && fabricated_laptop)
+				fabricated_laptop.cpu.battery_module.charge_to_full()
 				fabricated_laptop.forceMove(src.loc)
 				fabricated_laptop.close_laptop()
 				fabricated_laptop = null
 			else if((devtype == 2) && fabricated_tablet)
+				fabricated_tablet.battery_module.charge_to_full()
 				fabricated_tablet.forceMove(src.loc)
 				fabricated_tablet = null
 			ping("Enjoy your new product!")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -868,7 +868,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
 	materials = list(DEFAULT_WALL_MATERIAL = 400)
-	chemicals = list("sacid" = 10)
 	build_path = /obj/item/weapon/computer_hardware/battery_module
 	sort_string = "VBAAP"
 
@@ -878,7 +877,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(DEFAULT_WALL_MATERIAL = 800)
-	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/advanced
 	sort_string = "VBAAQ"
 
@@ -888,7 +886,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
 	build_type = PROTOLATHE
 	materials = list(DEFAULT_WALL_MATERIAL = 1600)
-	chemicals = list("sacid" = 40)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/super
 	sort_string = "VBAAR"
 
@@ -898,7 +895,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 5, TECH_ENGINEERING = 4)
 	build_type = PROTOLATHE
 	materials = list(DEFAULT_WALL_MATERIAL = 3200)
-	chemicals = list("sacid" = 80)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/ultra
 	sort_string = "VBAAS"
 
@@ -908,7 +904,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
 	materials = list(DEFAULT_WALL_MATERIAL = 200)
-	chemicals = list("sacid" = 5)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/nano
 	sort_string = "VBAAT"
 
@@ -918,7 +913,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(DEFAULT_WALL_MATERIAL = 400)
-	chemicals = list("sacid" = 10)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/micro
 	sort_string = "VBAAU"
 

--- a/html/changelogs/atlantiscze-batteries.yml
+++ b/html/changelogs/atlantiscze-batteries.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Modular computer batteries are no longer fully charged when printed by research."


### PR DESCRIPTION
- Partial revert of #13213 - as Protolathe designs should not contain liquid chemicals. Chemical requirements have been removed.
