### PR TITLE
Makes no heart or low blood effects consistent

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -20,7 +20,7 @@
 		//Chemicals in the body
 		handle_chemicals_in_body()
 
-		//Blood
+		//Blood - do this after chemicals so that dexplus doesn't keep people awake with no heart
 		handle_blood()
 
 		//Random events (vomiting etc)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -44,7 +44,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 
 	var/obj/item/organ/heart/H = internal_organs_by_name["heart"]
 	if(!H)	//not having a heart is bad for health
-		setOxyLoss(max(getOxyLoss(),60))
+		setOxyLoss(max(getOxyLoss(), maxHealth))
 		adjustOxyLoss(10)
 
 	//Bleeding out

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -47,7 +47,7 @@
 /obj/item/organ/heart/proc/handle_blood()
 	if(!owner)
 		return
-	if(owner.stat == DEAD && owner.bodytemperature >= 170)	//Dead or cryosleep people do not pump the blood.
+	if(owner.stat == DEAD || owner.bodytemperature < 170)	//Dead or cryosleep people do not pump the blood.
 		return
 
 	var/blood_volume_raw = owner.vessel.get_reagent_amount("blood")

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -84,7 +84,8 @@
 			if(prob(15))
 				owner << "<span class='warning'>You feel extremely [pick("dizzy","woosey","faint")]</span>"
 		else if(blood_volume < BLOOD_VOLUME_SURVIVE)
-			owner.death()
+			owner.setOxyLoss(max(owner.getOxyLoss(), owner.maxHealth))
+			owner.adjustOxyLoss(10)
 
 	//Blood regeneration if there is some space
 	if(blood_volume_raw < species.blood_volume)


### PR DESCRIPTION
Makes it so that these two conditions apply the same effect instead of having too low blood levels being more deadly than no heart at all. Having no heart is also now a little more dangerous.

Also fixes a check to match the description provided in a comment.
