### PR TITLE
PDA Server now reboots itself after power outage

### DIFF
--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -90,7 +90,6 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	return newKey
 
 /obj/machinery/message_server/process()
-	..()
 	if(active && (stat & (BROKEN|NOPOWER)))
 		active = 0
 		power_failure = 10
@@ -99,8 +98,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	else if(stat & (BROKEN|NOPOWER))
 		return
 	else if(power_failure > 0)
-		power_failure--
-		if(!power_failure)
+		if(!(--power_failure))
 			active = 1
 			update_icon()
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -60,6 +60,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	var/list/datum/data_pda_msg/pda_msgs = list()
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/active = 1
+	var/power_failure = 0 // Reboot timer after power outage
 	var/decryptkey = "password"
 
 	//Spam filtering stuff
@@ -89,13 +90,19 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	return newKey
 
 /obj/machinery/message_server/process()
-	//if(decryptkey == "password")
-	//	decryptkey = generateKey()
+	..()
 	if(active && (stat & (BROKEN|NOPOWER)))
 		active = 0
+		power_failure = 10
+		update_icon()
 		return
-	update_icon()
-	return
+	else if(stat & (BROKEN|NOPOWER))
+		return
+	else if(power_failure > 0)
+		power_failure--
+		if(!power_failure)
+			active = 1
+			update_icon()
 
 /obj/machinery/message_server/proc/send_pda_message(var/recipient = "",var/sender = "",var/message = "")
 	var/result
@@ -116,7 +123,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	for (var/obj/machinery/requests_console/Console in allConsoles)
 		if (ckey(Console.department) == ckey(recipient))
 			if(Console.inoperable())
-				Console.message_log += "<B>Message lost due to console failure.</B><BR>Please contact [station_name()] system adminsitrator or AI for technical assistance.<BR>"
+				Console.message_log += "<B>Message lost due to console failure.</B><BR>Please contact [station_name()] system administrator or AI for technical assistance.<BR>"
 				continue
 			if(Console.newmessagepriority < priority)
 				Console.newmessagepriority = priority
@@ -139,6 +146,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 //	user << "\blue There seem to be some parts missing from this server. They should arrive on the station in a few days, give or take a few CentCom delays."
 	user << "You toggle PDA message passing from [active ? "On" : "Off"] to [active ? "Off" : "On"]"
 	active = !active
+	power_failure = 0
 	update_icon()
 
 	return

--- a/html/changelogs/atlantiscze-reboot.yml
+++ b/html/changelogs/atlantiscze-reboot.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "The PDA messaging server now reboots automatically after a power outage. This reboot takes about twenty seconds."


### PR DESCRIPTION
- The PDA server now reboots itself automatically few seconds after power is restored, unless the server was turned off manually.

Forum thread that requests this: https://baystation12.net/forums/threads/suggestion-make-the-pda-server-reboot-itself.2019/
