### PR TITLE
Fixes spears, adjusts a few material properties, adjusts fire axe

### DIFF
--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -71,10 +71,11 @@
 /obj/item/weapon/material/apply_hit_effect()
 	. = ..()
 	if(!unbreakable)
-		if(material.is_brittle())
-			health = 0
-		else if(!prob(material.hardness))
-			health--
+		if(!prob(material.hardness))
+			if(material.is_brittle())
+				health = 0
+			else
+				health--
 		check_health()
 
 /obj/item/weapon/material/proc/check_health(var/consumed)

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -119,3 +119,8 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	default_material = "glass"
+
+/obj/item/weapon/material/twohanded/spear/shatter(var/consumed)
+	if(!consumed)
+		new /obj/item/weapon/material/wirerod(get_turf(src)) //give back the wired rod
+	..()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -108,8 +108,10 @@
 	force = 10
 	w_class = 5
 	slot_flags = SLOT_BACK
-	force_wielded = 0.75           // 22 when wielded with hardness 15 (glass)
-	unwielded_force_divisor = 0.65 // 14 when unwielded based on above
+
+	// 12/19 with hardness 60 (steel) or 10/16 with hardness 50 (glass)
+	force_divisor = 0.33
+	unwielded_force_divisor = 0.20
 	thrown_force_divisor = 1.5 // 20 when thrown with weight 15 (glass)
 	throw_speed = 3
 	edge = 0

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -76,8 +76,10 @@
 	base_icon = "fireaxe"
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
+	
+	// 15/32 with hardness 60 (steel) and 20/42 with hardness 80 (plasteel)
+	force_divisor = 0.525
 	unwielded_force_divisor = 0.25
-	force_divisor = 0.7 // 15/42 with hardness 60 (steel) and 0.25 unwielded divisor
 	sharp = 1
 	edge = 1
 	w_class = 5

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -186,7 +186,7 @@
 	return 1
 
 /obj/structure/girder/proc/reinforce_girder()
-	cover = reinf_material.hardness
+	cover = 75
 	health = 500
 	state = 2
 	icon_state = "reinforced"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -251,8 +251,9 @@ var/list/name_to_material
 	name = "gold"
 	stack_type = /obj/item/stack/material/gold
 	icon_colour = "#EDD12F"
-	weight = 24
-	hardness = 40
+	weight = 25
+	hardness = 25
+	integrity = 100
 	stack_origin_tech = list(TECH_MATERIAL = 4)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -384,11 +384,11 @@ var/list/name_to_material
 	flags = MATERIAL_BRITTLE
 	icon_colour = "#00E1FF"
 	opacity = 0.3
-	integrity = 100
+	integrity = 50
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
-	hardness = 30
-	weight = 15
+	hardness = 50
+	weight = 14
 	door_icon_base = "stone"
 	destruction_desc = "shatters"
 	window_options = list("One Direction" = 1, "Full Window" = 4)
@@ -466,7 +466,10 @@ var/list/name_to_material
 	return 1
 
 /material/glass/proc/is_reinforced()
-	return (hardness > 35) //todo
+	return (integrity > 75) //todo
+
+/material/glass/is_brittle()
+	return ..() && !is_reinforced()
 
 /material/glass/reinforced
 	name = "rglass"
@@ -478,8 +481,7 @@ var/list/name_to_material
 	integrity = 100
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
-	hardness = 40
-	weight = 30
+	weight = 17
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	composite_material = list(DEFAULT_WALL_MATERIAL = 1875,"glass" = 3750)
 	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 5)
@@ -492,7 +494,7 @@ var/list/name_to_material
 	display_name = "borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronglass
 	flags = MATERIAL_BRITTLE
-	integrity = 100
+	integrity = 70
 	icon_colour = "#FC2BC5"
 	stack_origin_tech = list(TECH_MATERIAL = 4)
 	created_window = /obj/structure/window/phoronbasic
@@ -506,11 +508,11 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	composite_material = list() //todo
 	created_window = /obj/structure/window/phoronreinforced
-	hardness = 40
-	weight = 30
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	composite_material = list() //todo
 	rod_product = null
+	integrity = 100
+
 
 /material/plastic
 	name = "plastic"
@@ -520,7 +522,7 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = "#CCCCCC"
 	hardness = 10
-	weight = 12
+	weight = 5
 	melting_point = T0C+371 //assuming heat resistant plastic
 	stack_origin_tech = list(TECH_MATERIAL = 3)
 	conductive = 0

--- a/html/changelogs/HarpyEagle-material-weapons.yml
+++ b/html/changelogs/HarpyEagle-material-weapons.yml
@@ -1,0 +1,8 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed spear damage being set to a default value."
+  - tweak: "Adjused spear damage, fixes steel spears now do somewhat less damage than steel baseball bats, but are sharp."
+  - tweak: "Steel fire axes now do somewhat less damage when wielded, unwieled damage unaffected."


### PR DESCRIPTION
Spears had their `force_divisor` assigned to `force_wielded` by accident, which is pointless because `force_wielded` is updated when the weapon is created. 

However, simply fixing that leaves a balance problem since spears have higher force_divisors than that of fire axes, likely because previously they could only be made of glass. Now that spears can also be made of steel that is a bit of a problem.

I adjusted the divisor values by making plasteel spears deal the similar damage as plasteel bats as my guide. Consequently steel spears deal less damage than steel bats, but are sharp so it seems like a nice tradeoff. So as to not nerf glass spears too much I increased the hardness of glass. 

Played around with glass and rglass a bit too, glass has more hardness but less integrity, rglass has the same hardness as glass but has more integrity and is not brittle (it's reinforced with metal after all).

Since fire axes are a bit more common now I've reduced their force_divisor (now less of an outlier among material weapons). A steel fireaxe still does a respectable 32 damage when wielded.
