### PR TITLE
gear_tweak_free_color_choice is now initialized when acquired.

### DIFF
--- a/code/_helpers/_global_objects.dm
+++ b/code/_helpers/_global_objects.dm
@@ -1,1 +1,8 @@
-var/datum/gear_tweak/color/gear_tweak_free_color_choice = new()
+var/datum/gear_tweak/color/gear_tweak_free_color_choice_
+/proc/gear_tweak_free_color_choice()
+	if(!gear_tweak_free_color_choice_) gear_tweak_free_color_choice_ = new()
+	return gear_tweak_free_color_choice_
+
+//var/datum/gear_tweak/color/gear_tweak_free_color_choice_
+//#define gear_tweak_free_color_choice (gear_tweak_free_color_choice_ ? gear_tweak_free_color_choice_ : (gear_tweak_free_color_choice_ = new()))
+// Might work in 511 assuming x=y=5 gets implemented.

--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -46,7 +46,7 @@ datum/category_group/underwear/dd_SortValue()
 
 /datum/category_item/underwear/New()
 	if(has_color)
-		tweaks += gear_tweak_free_color_choice
+		tweaks += gear_tweak_free_color_choice()
 
 /datum/category_item/underwear/dd_SortValue()
 	if(always_last)

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -166,7 +166,7 @@
 
 /datum/gear/head/hijab/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks = list(gear_tweak_free_color_choice())
 
 /datum/gear/head/kippa
 	display_name = "kippa"
@@ -174,7 +174,7 @@
 
 /datum/gear/head/kippa/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks = list(gear_tweak_free_color_choice())
 
 /datum/gear/head/turban
 	display_name = "turban"
@@ -182,4 +182,4 @@
 
 /datum/gear/head/turban/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks = list(gear_tweak_free_color_choice())

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -32,10 +32,10 @@
 	path = /obj/item/clothing/ears/skrell/colored/chain
 	sort_category = "Xenowear"
 	whitelisted = "Skrell"
-	
+
 /datum/gear/ears/skrell/colored/chain/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks = list(gear_tweak_free_color_choice())
 
 //Skrell Bands
 /datum/gear/ears/skrell/bands
@@ -51,16 +51,16 @@
 		var/obj/item/clothing/ears/skrell/band/band = band_style
 		bandtypes[initial(band.name)] = band
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(bandtypes))
-	
+
 /datum/gear/ears/skrell/colored/band
 	display_name = "colored headtail bands (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/band
 	sort_category = "Xenowear"
 	whitelisted = "Skrell"
-	
+
 /datum/gear/ears/skrell/colored/band/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks = list(gear_tweak_free_color_choice())
 
 //Skrell Cloth
 /datum/gear/ears/skrell/cloth/male
@@ -112,7 +112,7 @@
 /datum/gear/uniform/resomi/med
 	display_name = "uniform, Medical (Resomi)"
 	path = /obj/item/clothing/under/resomi/medical
-	
+
 /datum/gear/uniform/resomi/science
 	display_name = "uniform, Science (Resomi)"
 	path = /obj/item/clothing/under/resomi/science


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Instead of relying on global init order. Fixes #13313.
No idea how many more subtle issues we have.
