### PR TITLE
Secbot Refactoring

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -23,6 +23,11 @@
 	update_icon()
 	return
 
+/obj/item/weapon/melee/baton/Destroy()
+	qdel(bcell)
+	bcell = null
+	return ..()
+
 /obj/item/weapon/melee/baton/loaded/New() //this one starts with a cell pre-installed.
 	..()
 	bcell = new/obj/item/weapon/cell/high(src)
@@ -48,7 +53,7 @@
 		icon_state = "[initial(name)]"
 
 	if(icon_state == "[initial(name)]_active")
-		set_light(1.5, 1, "#FF6A00")
+		set_light(1.5, 2, "#FF6A00")
 	else
 		set_light(0)
 
@@ -85,18 +90,22 @@
 	return
 
 /obj/item/weapon/melee/baton/attack_self(mob/user)
+	set_status(!status, user)
+	add_fingerprint(user)
+
+/obj/item/weapon/melee/baton/proc/set_status(var/newstatus, mob/user)
 	if(bcell && bcell.charge > hitcost)
-		status = !status
-		user << "<span class='notice'>[src] is now [status ? "on" : "off"].</span>"
-		playsound(loc, "sparks", 75, 1, -1)
-		update_icon()
+		if(status != newstatus)
+			status = newstatus
+			user << "<span class='notice'>[src] is now [status ? "on" : "off"].</span>"
+			playsound(loc, "sparks", 75, 1, -1)
+			update_icon()
 	else
 		status = 0
 		if(!bcell)
 			user << "<span class='warning'>[src] does not have a power source!</span>"
 		else
 			user << "<span class='warning'>[src] is out of charge.</span>"
-	add_fingerprint(user)
 
 /obj/item/weapon/melee/baton/attack(mob/M, mob/user)
 	if(status && (CLUMSY in user.mutations) && prob(50))

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -3,11 +3,12 @@
 	desc = "A security robot.  He looks less than thrilled."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "ed2090"
+	attack_state = "ed209-c"
 	density = 1
 	health = 100
 	maxHealth = 100
 
-	bot_version = "2.5"
+	bot_version = 2.6
 	is_ranged = 1
 	preparing_arrest_sounds = new()
 
@@ -18,12 +19,6 @@
 
 	var/shot_delay = 4
 	var/last_shot = 0
-
-/mob/living/bot/secbot/ed209/update_icons()
-	if(on && is_attacking)
-		icon_state = "ed209-c"
-	else
-		icon_state = "ed209[on]"
 
 /mob/living/bot/secbot/ed209/explode()
 	visible_message("<span class='warning'>[src] blows apart!</span>")

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -160,9 +160,10 @@
 	moved_event.register(target, src, /mob/living/bot/secbot/proc/target_moved)
 
 /mob/living/bot/secbot/proc/target_moved(atom/movable/moving_instance, atom/old_loc, atom/new_loc)
-	mode = SECBOT_ARREST // I'm done playing nice
-	awaiting_surrender = INFINITY
-	moved_event.unregister(moving_instance, src)
+	if(get_dist(get_turf(src), get_turf(target)) >= 3)
+		mode = SECBOT_ARREST // I'm done playing nice
+		awaiting_surrender = INFINITY
+		moved_event.unregister(moving_instance, src)
 
 /mob/living/bot/secbot/proc/react_to_attack(mob/attacker)
 	if(!target)

--- a/html/changelogs/HarpyEagle-secbot.yml
+++ b/html/changelogs/HarpyEagle-secbot.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - bugfix: "Beepsky and other securitrons now react quicker when attacked or their perp tries to run, and move at closer to a running pace. Beepsky should no longer be so easy to outrun."


### PR DESCRIPTION
- Partial rewrite of Beepsky state machine, less duplicated code. Now switches to arresting immediately when Adjacent() instead of waiting two life ticks. Now proceeds from SECBOT_HUNT -> SECBOT_ARREST instead of jumping back and forth depending on if the target is Adjacent(), easier to manage state.
- Now reads ID name for broadcast to SecHUDs instead of magically knowing the name of the suspect
- Now broadcasts detection instead of spamming each tick we are arresting someone
- Secbots again use walk_to() in order to simplify chasing targets
- Emagged secbots now check incapacitated()
- Secbots now play speech sounds again
- Uses internal stun baton and handcuffs instead of copypasta
- Uses flick() instead of bizarre update_icon() + spawn() combination
- Removes arrest_type because it was dumb and meant that the secbot would continue to baton forever
- Probably other improvements
