### PR TITLE
Makes organ w_class scale with mob_size

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -232,6 +232,7 @@
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
+	H.mob_size = mob_size
 	for(var/obj/item/organ/organ in H.contents)
 		if((organ in H.organs) || (organ in H.internal_organs))
 			qdel(organ)
@@ -290,7 +291,6 @@
 	H.mob_swap_flags = swap_flags
 	H.mob_push_flags = push_flags
 	H.pass_flags = pass_flags
-	H.mob_size = mob_size
 
 /datum/species/proc/handle_death(var/mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).
 	return

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -379,7 +379,7 @@
 
 //returns the number of size categories between affecting and assailant, rounded. Positive means A is larger than B
 /obj/item/weapon/grab/proc/size_difference(mob/A, mob/B)
-	return round(log(2, A.mob_size/B.mob_size), 1)
+	return mob_size_difference(A.mob_size, B.mob_size)
 
 /obj/item/weapon/grab
 	var/destroying = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -11,6 +11,10 @@
 		return L.mob_size <= MOB_SMALL
 	return 0
 
+//returns the number of size categories between two mob_sizes, rounded. Positive means A is larger than B
+/proc/mob_size_difference(var/mob_size_A, var/mob_size_B)
+	return round(log(2, mob_size_A/mob_size_B), 1)
+
 /mob/proc/can_wield_item(obj/item/W)
 	if(W.w_class >= LARGE_ITEM && issmall(src))
 		return FALSE //M is too small to wield this

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -55,6 +55,7 @@ var/list/organ_cache = list()
 		max_damage = min_broken_damage * 2
 	if(istype(holder))
 		src.owner = holder
+		src.w_class = max(src.w_class + mob_size_difference(holder.mob_size, MOB_MEDIUM), 1) //smaller mobs have smaller organs.
 		species = all_species["Human"]
 		if(holder.dna)
 			dna = holder.dna.Clone()

--- a/code/modules/organs/subtypes/diona.dm
+++ b/code/modules/organs/subtypes/diona.dm
@@ -132,6 +132,7 @@
 	body_part = HEAD
 	parent_organ = "chest"
 	var/can_intake_reagents = 0 // Because it doesn't inherit regular head stuff because it's a subtype of diona for some inexplicable reason.
+	slot_flags = SLOT_BELT
 
 /obj/item/organ/external/diona/head/removed()
 	if(owner)

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -2,6 +2,8 @@
 			   ORGAN DEFINES
 ****************************************************/
 
+//Make sure that w_class is set as if the parent mob was medium sized! This is because w_class is adjusted automatically for mob_size in New()
+
 /obj/item/organ/external/chest
 	name = "upper body"
 	limb_name = "chest"

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -138,6 +138,7 @@
 	limb_name = "head"
 	icon_name = "head"
 	name = "head"
+	slot_flags = SLOT_BELT
 	max_damage = 75
 	min_broken_damage = 35
 	w_class = 3


### PR DESCRIPTION
Makes smaller mobs have smaller organs and larger mobs have larger organs. The main impact of this change is on the weapon w_class threshold for a weapon to be edge_eligible when determining if droplimb() will get called when external organs take damage, however I suppose it also affects storage of organs.
