### PR TITLE
Clean up of dropped() calls, ensures (wielded) is reset when an item is dropped, small mobs can't wield

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -163,9 +163,7 @@
 				if(istype(W, /obj/item/weapon/implant))
 					qdel(W)
 					continue
-				W.layer = initial(W.layer)
-				W.loc = M.loc
-				W.dropped(M)
+				M.drop_from_inventory(W)
 
 		var/mob/living/new_mob = new /mob/living/simple_animal/corgi(A.loc)
 		new_mob.a_intent = I_HURT

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -257,7 +257,15 @@
 /obj/item/proc/dropped(mob/user as mob)
 	if(randpixel)
 		pixel_z = randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character
-	if(zoom) zoom() //binoculars, scope, etc
+	if(zoom)
+		zoom() //binoculars, scope, etc
+
+	update_twohanding()
+	if(user)
+		if(user.l_hand)
+			user.l_hand.update_twohanding()
+		if(user.r_hand)
+			user.r_hand.update_twohanding()
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -106,9 +106,6 @@
 			M.update_inv_r_hand()
 
 /obj/item/proc/is_held_twohanded(mob/living/M)
-	if(w_class >= LARGE_ITEM && issmall(M))
-		return FALSE //M is too small to wield this
-
 	var/check_hand
 	if(M.l_hand == src && !M.r_hand) 
 		check_hand = "r_hand" //item in left hand, check right hand

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -106,6 +106,9 @@
 			M.update_inv_r_hand()
 
 /obj/item/proc/is_held_twohanded(mob/living/M)
+	if(w_class >= LARGE_ITEM && issmall(M))
+		return FALSE //M is too small to wield this
+
 	var/check_hand
 	if(M.l_hand == src && !M.r_hand) 
 		check_hand = "r_hand" //item in left hand, check right hand

--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -58,8 +58,6 @@
 	wax--
 	if(!wax)
 		new/obj/item/trash/candle(src.loc)
-		if(istype(src.loc, /mob))
-			src.dropped(loc)
 		qdel(src)
 	update_icon()
 	if(istype(loc, /turf)) //start a fire if possible

--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -14,44 +14,25 @@
 		..()
 		return
 
-
 	trigger(emote, mob/living/carbon/source as mob)
 		if (src.uses < 1)	return 0
 		if (emote == src.activation_emote)
-			src.uses--
-			source << "You feel a faint click."
-			if (source.handcuffed)
-				var/obj/item/weapon/W = source.handcuffed
-				source.handcuffed = null
-				if(source.buckled && source.buckled.buckle_require_restraints)
-					source.buckled.unbuckle_mob()
-				source.update_inv_handcuffed()
-				if (source.client)
-					source.client.screen -= W
-				if (W)
-					W.loc = source.loc
-					dropped(source)
-					if (W)
-						W.layer = initial(W.layer)
-			if (source.legcuffed)
-				var/obj/item/weapon/W = source.legcuffed
-				source.legcuffed = null
-				source.update_inv_legcuffed()
-				if (source.client)
-					source.client.screen -= W
-				if (W)
-					W.loc = source.loc
-					dropped(source)
-					if (W)
-						W.layer = initial(W.layer)
-		return
+			if(remove_cuffs_and_unbuckle(source))
+				src.uses--
+				source << "You feel a faint click."
 
+	proc/remove_cuffs_and_unbuckle(mob/living/carbon/user)
+		if(!user.handcuffed)
+			return 0
+		. = user.unEquip(user.handcuffed)
+		if(. && user.buckled && user.buckled.buckle_require_restraints)
+			user.buckled.unbuckle_mob()
+		return
 
 	implanted(mob/living/carbon/source)
 		source.mind.store_memory("Freedom implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 		source << "The implanted freedom implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
 		return 1
-
 
 	get_data()
 		var/dat = {"

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -29,7 +29,7 @@
 
 /obj/item/weapon/material/twohanded/update_twohanding()
 	var/mob/living/M = loc
-	if(istype(M) && !issmall(M) && is_held_twohanded(M))
+	if(istype(M) && M.can_wield_item(src) && is_held_twohanded(M))
 		wielded = 1
 		force = force_wielded
 		name = "[base_name] (wielded)"

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -79,7 +79,6 @@
 	can_hold = list() // any
 	cant_hold = list(/obj/item/weapon/disk/nuclear)
 
-
 // -----------------------------
 //           Cash Bag
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -104,15 +104,10 @@
 				break
 
 		if(!inserted || !S.amount)
-			usr.remove_from_mob(S)
-			usr.update_icons()	//update our overlays
-			if (usr.client && usr.s_active != src)
-				usr.client.screen -= S
-			S.dropped(usr)
+			usr.drop_from_inventory(S, src)
 			if(!S.amount)
 				qdel(S)
-			else
-				S.loc = src
+			usr.update_icons()	//update our overlays
 
 		orient2hud(usr)
 		if(usr.s_active)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -341,19 +341,16 @@
 	if(usr)
 		usr.remove_from_mob(W)
 		usr.update_icons()	//update our overlays
-	W.loc = src
+	W.forceMove(src)
 	W.on_enter_storage(src)
 	if(usr)
-		if (usr.client && usr.s_active != src)
-			usr.client.screen -= W
-		W.dropped(usr)
 		add_fingerprint(usr)
 
 		if(!prevent_warning)
 			for(var/mob/M in viewers(usr, null))
 				if (M == usr)
 					usr << "<span class='notice'>You put \the [W] into [src].</span>"
-				else if (M in range(1)) //If someone is standing close enough, they can tell what it is...
+				else if (M in range(1)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
 				else if (W && W.w_class >= NORMAL_ITEM) //Otherwise they can only see large or normal items from a distance...
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
@@ -426,11 +423,8 @@
 				user << "<span class='warning'>The tray won't fit in [src].</span>"
 				return
 			else
-				W.loc = user.loc
-				if ((user.client && user.s_active != src))
-					user.client.screen -= W
-				W.dropped(user)
-				user << "<span class='warning'>God damnit!</span>"
+				if(user.unEquip(W))
+					user << "<span class='warning'>God damnit!</span>"
 
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -648,8 +648,6 @@
 						wearer << "<font color='blue'><b>Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.</b></font>"
 						use_obj.canremove = 1
 						holder.drop_from_inventory(use_obj)
-						use_obj.forceMove(get_turf(src))
-						use_obj.dropped(wearer)
 						use_obj.canremove = 0
 						use_obj.forceMove(src)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -132,9 +132,7 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/put_in_hands(var/obj/item/W)
 	if(!W)
 		return 0
-	W.forceMove(get_turf(src))
-	W.layer = initial(W.layer)
-	W.dropped(src)
+	drop_from_inventory(W)
 	return 0
 
 // Removes an item from inventory and places it in the target atom.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -11,6 +11,11 @@
 		return L.mob_size <= MOB_SMALL
 	return 0
 
+/mob/proc/can_wield_item(obj/item/W)
+	if(W.w_class >= LARGE_ITEM && issmall(src))
+		return FALSE //M is too small to wield this
+	return TRUE
+
 /mob/living/proc/isSynthetic()
 	return 0
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -92,7 +92,7 @@
 	if(requires_two_hands)
 		var/mob/living/M = loc
 		if(istype(M))
-			if(src.is_held_twohanded(M))
+			if(M.can_wield_item(src) && src.is_held_twohanded(M))
 				name = "[initial(name)] (wielded)"
 			else
 				name = initial(name)
@@ -104,7 +104,7 @@
 	if(wielded_item_state)
 		var/mob/living/M = loc
 		if(istype(M))
-			if(src.is_held_twohanded())
+			if(M.can_wield_item(src) && src.is_held_twohanded(M))
 				item_state = wielded_item_state
 			else
 				item_state = initial(item_state)
@@ -184,7 +184,7 @@
 	user.setMoveCooldown(shoot_time) //no moving while shooting either
 	next_fire_time = world.time + shoot_time
 
-	var/held_twohanded = src.is_held_twohanded(user)
+	var/held_twohanded = (user.can_wield_item(src) && src.is_held_twohanded(user))
 
 	//actually attempt to shoot
 	var/turf/targloc = get_turf(target) //cache this in case target gets deleted during shooting, e.g. if it was a securitron that got destroyed.
@@ -257,18 +257,29 @@
 		if(muzzle_flash)
 			set_light(muzzle_flash)
 
-	if(requires_two_hands && !src.is_held_twohanded(user))
-		switch(requires_two_hands)
-			if(1)
-				if(prob(50)) //don't need to tell them every single time
-					user << "<span class='warning'>Your aim wavers slightly.</span>"
-			if(2)
-				user << "<span class='warning'>Your aim wavers as you fire \the [src] with just one hand.</span>"
-			if(3)
-				user << "<span class='warning'>You have trouble keeping \the [src] on target with just one hand.</span>"
-			if(4 to INFINITY)
-				user << "<span class='warning'>You struggle to keep \the [src] on target with just one hand!</span>"
-
+	if(requires_two_hands)
+		if(!src.is_held_twohanded(user))
+			switch(requires_two_hands)
+				if(1)
+					if(prob(50)) //don't need to tell them every single time
+						user << "<span class='warning'>Your aim wavers slightly.</span>"
+				if(2)
+					user << "<span class='warning'>Your aim wavers as you fire \the [src] with just one hand.</span>"
+				if(3)
+					user << "<span class='warning'>You have trouble keeping \the [src] on target with just one hand.</span>"
+				if(4 to INFINITY)
+					user << "<span class='warning'>You struggle to keep \the [src] on target with just one hand!</span>"
+		else if(!user.can_wield_item(src))
+			switch(requires_two_hands)
+				if(1)
+					if(prob(50)) //don't need to tell them every single time
+						user << "<span class='warning'>Your aim wavers slightly.</span>"
+				if(2)
+					user << "<span class='warning'>Your aim wavers as you try to hold \the [src] steady.</span>"
+				if(3)
+					user << "<span class='warning'>You have trouble holding \the [src] steady.</span>"
+				if(4 to INFINITY)
+					user << "<span class='warning'>You struggle to hold \the [src] steady!</span>"
 
 	if(screen_shake)
 		spawn()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -519,9 +519,7 @@
 		if(istype(W, /obj/item/weapon/implant)) //TODO: Carn. give implants a dropped() or something
 			qdel(W)
 			continue
-		W.layer = initial(W.layer)
-		W.loc = M.loc
-		W.dropped(M)
+		M.drop_from_inventory(W)
 	var/mob/living/carbon/slime/new_mob = new /mob/living/carbon/slime(M.loc)
 	new_mob.a_intent = "hurt"
 	new_mob.universal_speak = 1

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -160,8 +160,7 @@
 				return
 
 			user << "<span class='warning'>You slip \the [W] inside \the [src].</span>"
-			user.remove_from_mob(W)
-			W.dropped(user)
+			user.drop_from_inventory(W, src)
 			add_fingerprint(user)
 			contents += W
 			return

--- a/html/changelogs/HarpyEagle-wielding.yml
+++ b/html/changelogs/HarpyEagle-wielding.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - tweak: "Small mobs such as monkeys and resomi no longer gain the benefits of holding large or bulky items in two hands."


### PR DESCRIPTION
- Cleans up inappropriate dropped() calls. In most cases this meant replacing duplicated inventory code with the appropriate inventory call.
- Makes items update weilding/twohanding when dropped()
- Prevents small mobs from wielding large items
