### PR TITLE
The vermin infestation event can now affect any valid station area.

### DIFF
--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -461,7 +461,7 @@
 // - Has between 17% and 30% oxygen
 // - Has temperature between -10C and 50C
 // - Has no or only minimal phoron or N2O
-/proc/is_safe_atmosphere(datum/gas_mixture/atmosphere, var/returntext = 0)
+/proc/get_atmosphere_issues(datum/gas_mixture/atmosphere, var/returntext = 0)
     var/list/status = list()
     if(!atmosphere)
         status.Add("No atmosphere present.")

--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -1,21 +1,65 @@
-//Takes: Area type as text string or as typepath OR an instance of the area.
-//Returns: A list of all turfs in areas of that type in the world.
-/proc/get_area_turfs(var/areatype, var/list/predicates)
-	if(!areatype) return null
-	if(istext(areatype)) areatype = text2path(areatype)
-	if(isarea(areatype))
-		var/area/areatemp = areatype
-		areatype = areatemp.type
+/*
+	List generation helpers
+*/
+/proc/get_filtered_areas(var/list/predicates)
+	. = list()
+	if(!predicates || !predicates.len)
+		return
+	for(var/area/A)
+		if(!A.z)
+			continue
+		if(all_predicates_true(list(A), predicates))
+			. += A
 
-	var/list/turfs = new/list()
-	for(var/areapath in typesof(areatype))
-		var/area/A = locate(areapath)
-		for(var/turf/T in A.contents)
+/proc/get_area_turfs(var/area/A, var/list/predicates)
+	. = new/list()
+	A = istype(A) ? A : locate(A)
+	if(!A)
+		return
+	for(var/turf/T in A.contents)
+		if(!predicates || all_predicates_true(list(T), predicates))
+			. += T
+
+/proc/get_subarea_turfs(var/area/A, var/list/predicates)
+	. = new/list()
+	A = istype(A) ? A.type : A
+	if(!A)
+		return
+	for(var/sub_area_type in typesof(A))
+		var/area/sub_area = locate(sub_area_type)
+		for(var/turf/T in sub_area.contents)
 			if(!predicates || all_predicates_true(list(T), predicates))
-				turfs += T
-	return turfs
+				. += T
+
+/*
+	Pick helpers
+*/
+/proc/pick_subarea_turf(var/areatype, var/list/predicates)
+	var/list/turfs = get_subarea_turfs(areatype, predicates)
+	if(turfs && turfs.len)
+		return pick(turfs)
 
 /proc/pick_area_turf(var/areatype, var/list/predicates)
 	var/list/turfs = get_area_turfs(areatype, predicates)
 	if(turfs && turfs.len)
 		return pick(turfs)
+
+/proc/pick_area(var/list/predicates)
+	var/list/areas = get_filtered_areas(predicates)
+	if(areas && areas.len)
+		. = pick(areas)
+
+/proc/pick_area_and_turf(var/list/area_predicates, var/list/turf_predicates)
+	var/area/A = pick_area(area_predicates)
+	if(!A)
+		return
+	return pick_area_turf(A, turf_predicates)
+
+/*
+	Predicate Helpers
+*/
+/proc/is_station_area(var/area/A)
+	. = isStationLevel(A.z)
+
+/proc/is_not_space(var/area/A)
+	. = !istype(A,/area/space)

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -33,15 +33,6 @@
 		available_turfs = start_turfs
 	return pick(available_turfs)
 
-/proc/turf_contains_dense_objects(var/turf/T)
-	return T.contains_dense_objects()
-
-/proc/not_turf_contains_dense_objects(var/turf/T)
-	return !turf_contains_dense_objects(T)
-
-/proc/is_station_turf(var/turf/T)
-	return T && isStationLevel(T.z)
-
 /proc/get_random_turf_in_range(var/atom/origin, var/outer_range, var/inner_range)
 	origin = get_turf(origin)
 	if(!origin)
@@ -52,3 +43,27 @@
 			turfs += T
 	if(turfs.len)
 		return pick(turfs)
+
+/*
+	Predicate helpers
+*/
+
+/proc/turf_contains_dense_objects(var/turf/T)
+	return T.contains_dense_objects()
+
+/proc/not_turf_contains_dense_objects(var/turf/T)
+	return !turf_contains_dense_objects(T)
+
+/proc/is_station_turf(var/turf/T)
+	return T && isStationLevel(T.z)
+
+/proc/IsTurfAtmosUnsafe(var/turf/T)
+	if(istype(T, /turf/space)) // Space tiles
+		return "Spawn location is open to space."
+	var/datum/gas_mixture/air = T.return_air()
+	if(!air)
+		return "Spawn location lacks atmosphere."
+	return get_atmosphere_issues(air, 1)
+
+/proc/IsTurfAtmosSafe(var/turf/T)
+	return !IsTurfAtmosUnsafe(T)

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -390,7 +390,7 @@
 		var/area/thearea = pick(theareas)
 		var/list/L = list()
 		var/turf/pos = get_turf(src)
-		for(var/turf/T in get_area_turfs(thearea.type))
+		for(var/turf/T in get_area_turfs(thearea))
 			if(!T.density && pos.z == T.z)
 				var/clear = 1
 				for(var/obj/O in T)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -58,7 +58,7 @@
 	smoke.attach(user)
 	smoke.start()
 	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea.type))
+	for(var/turf/T in get_area_turfs(thearea))
 		if(!T.density)
 			var/clear = 1
 			for(var/obj/O in T)

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -46,7 +46,7 @@
 			command_announcement.Announce("Bluespace artillery fire detected. Brace for impact.")
 			message_admins("[key_name_admin(usr)] has launched an artillery strike.", 1)
 			var/list/L = list()
-			for(var/turf/T in get_area_turfs(thearea.type))
+			for(var/turf/T in get_area_turfs(thearea))
 				L+=T
 			var/loc = pick(L)
 			explosion(loc,2,5,11)
@@ -60,7 +60,7 @@
 	spawn(30)
 	var/list/L = list()
 
-	for(var/turf/T in get_area_turfs(thearea.type))
+	for(var/turf/T in get_area_turfs(thearea))
 		L+=T
 	var/loc = pick(L)
 	explosion(loc,2,5,11)*/

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -7,13 +7,13 @@
 	level_seven_announcement()
 
 /datum/event/blob/start()
-	var/turf/T = pick_area_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+	var/turf/T = pick_subarea_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 	if(!T)
 		log_and_message_admins("Blob failed to find a viable turf.")
 		kill()
 		return
 
-	log_and_message_admins("Blob spawned at \the [get_area(T)]", location = T)
+	log_and_message_admins("Blob spawned in \the [get_area(T)]", location = T)
 	Blob = new /obj/effect/blob/core(T)
 	for(var/i = 1; i < rand(3, 4), i++)
 		Blob.process()

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -3,7 +3,7 @@
 
 /proc/spacevine_infestation(var/potency_min=70, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
-		var/turf/T = pick_area_turf(/area/hallway, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+		var/turf/T = pick_subarea_turf(/area/hallway, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 		if(T)
 			var/datum/seed/seed = plant_controller.create_random_seed(1)
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
@@ -16,7 +16,7 @@
 			vine.mature_time = 0
 			vine.process()
 
-			log_and_message_admins("Spacevines spawned at \the [get_area(T)]", location = T)
+			log_and_message_admins("Spacevines spawned in \the [get_area(T)]", location = T)
 			return
 		log_and_message_admins("<span class='notice'>Event: Spacevines failed to find a viable turf.</span>")
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -273,14 +273,6 @@
 	if(!job.player_old_enough(src.client))	return 0
 	return 1
 
-/mob/new_player/proc/IsSpawnSafe(var/turf/T)
-	if(istype(T, /turf/space)) // Space tiles
-		return "Spawn location is open to space."
-	var/datum/gas_mixture/air = T.return_air()
-	if(!air)
-		return "Spawn location lacks atmosphere."
-	return is_safe_atmosphere(air, 1)
-
 /mob/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
 	if(src != usr)
 		return 0
@@ -295,7 +287,7 @@
 		return 0
 
 	var/turf/T = job_master.LateSpawn(client, rank, 1)
-	var/airstatus = IsSpawnSafe(T)
+	var/airstatus = IsTurfAtmosUnsafe(T)
 	if(airstatus)
 		var/reply = alert(usr, "Warning. Your selected spawn location seems to have unfavorable atmospheric conditions. \
 		You may die shortly after spawning. It is possible to select different spawn point via character preferences. \

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -288,13 +288,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/holyblock = 0
 
 	if(usr.invisibility <= SEE_INVISIBLE_LIVING || (usr.mind in cult.current_antagonists))
-		for(var/turf/T in get_area_turfs(thearea.type))
+		for(var/turf/T in get_area_turfs(thearea))
 			if(!T.holy)
 				L+=T
 			else
 				holyblock = 1
 	else
-		for(var/turf/T in get_area_turfs(thearea.type))
+		for(var/turf/T in get_area_turfs(thearea))
 			L+=T
 
 	if(!L || !L.len)

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -39,7 +39,7 @@
 		if(istype(thearea, /list))
 			thearea = thearea[1]
 	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea.type))
+	for(var/turf/T in get_area_turfs(thearea))
 		if(!T.density)
 			var/clear = 1
 			for(var/obj/O in T)

--- a/html/changelogs/PsiOmegaDelta-Vermin.yml
+++ b/html/changelogs/PsiOmegaDelta-Vermin.yml
@@ -1,0 +1,6 @@
+author: PsiOmegaDelta
+
+delete-after: True
+
+changes: 
+  - tweak: "Vermin may now breed anywhere on the station but should also no longer spawn inside areas such as the atmospheric tanks."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Slightly increases the performance of random turf acquirement (there is now a separate proc for checking all area subtypes, as opposed to the specific area).
Changed many callers of the various pick/get area/turf procs to send a proper area instance directly, instead of its type.
The vermin infestation event will no longer spawn vermin in turfs with major atmospheric hazards.
The vermin infestation event now takes severity into consideration.
