### PR TITLE
Weakened reduces resist success chance for passive grabs as well

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -348,7 +348,7 @@
 		state = GRAB_NECK
 
 /obj/item/weapon/grab/proc/handle_resist()
-	var/grab_name
+	var/grab_name = "grip"
 	var/break_strength = 1
 	var/list/break_chance_table = list(100)
 	switch(state)
@@ -360,7 +360,6 @@
 			break_chance_table = list(15, 60, 100)
 
 		if(GRAB_AGGRESSIVE)
-			grab_name = "grip"
 			//Being knocked down makes it harder to break a grab, so it is easier to cuff someone who is down without forcing them into unconsciousness.
 			if(!affecting.incapacitated(INCAPACITATION_KNOCKDOWN))
 				break_strength++

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -352,7 +352,12 @@
 	var/break_strength = 1
 	var/list/break_chance_table = list(100)
 	switch(state)
-		//if(GRAB_PASSIVE)
+		if(GRAB_PASSIVE)
+			//Being knocked down makes it harder to break a grab, so it is easier to cuff someone who is down without forcing them into unconsciousness.
+			//use same chance_table as aggressive but give +2 for not-weakened so that resomi grabs don't become auto-success for weakened either, that's lame
+			if(!affecting.incapacitated(INCAPACITATION_KNOCKDOWN))
+				break_strength += 2
+			break_chance_table = list(15, 60, 100)
 
 		if(GRAB_AGGRESSIVE)
 			grab_name = "grip"


### PR DESCRIPTION
#12777 didn't quite resolve #12608 as while being weakened makes it harder to resist aggressive grabs, that change mattered little if you can never get to aggressive since a passive grab is an automatic success.

Now resisting while being weakened and passively grabbed has the same chance of success as while weakened and aggressively grabbed.
