### PR TITLE
Adds synths to PDA manifest

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -58,7 +58,8 @@
 We can't just insert in HTML into the nanoUI so we need the raw data to play with.
 Instead of creating this list over and over when someone leaves their PDA open to the page
 we'll only update it when it changes.  The PDA_Manifest global list is zeroed out upon any change
-using /datum/datacore/proc/manifest_inject( ), or manifest_insert( )
+using /datum/datacore/proc/manifest_inject( ), or manifest_insert( ). Synth despawns and 
+name updates also zero the list; although they are not in data_core, synths are on manifest.
 */
 
 var/global/list/PDA_Manifest = list()
@@ -126,12 +127,20 @@ var/global/list/PDA_Manifest = list()
 			if(depthead && civ.len != 1)
 				civ.Swap(1,civ.len)
 
-		if(real_rank in nonhuman_positions)
-			bot[++bot.len] = list("name" = name, "rank" = rank, "active" = isactive)
-			department = 1
-
 		if(!department && !(name in heads))
 			misc[++misc.len] = list("name" = name, "rank" = rank, "active" = isactive)
+
+
+	// Silicons do not have records. See also /datum/datacore/proc/get_manifest 
+	for(var/mob/living/silicon/ai/ai in mob_list)
+		bot[++bot.len] = list("name" = ai.name, "rank" = "Artificial Intelligence", "active" = null)
+
+	for(var/mob/living/silicon/robot/robot in mob_list)
+		// No combat/syndicate cyborgs, no drones.
+		if(robot.module && robot.module.hide_on_manifest)
+			continue
+
+		bot[++bot.len] = list("name" = robot.name, "rank" = "[robot.modtype] [robot.braintype]", "active" = null)
 
 
 	PDA_Manifest = list(\

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -265,6 +265,8 @@ var/list/ai_verbs_default = list(
 		aiPDA.ownjob = "AI"
 		aiPDA.owner = pickedName
 		aiPDA.name = pickedName + " (" + aiPDA.ownjob + ")"
+		
+	data_core.ResetPDAManifest()
 
 /*
 	The AI Power supply is a dummy object used for powering the AI since only machinery should be using power.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -300,6 +300,10 @@
 
 	// if we've changed our name, we also need to update the display name for our PDA
 	setup_PDA()
+	
+	// Synths aren't in data_core, but are on manifest. Invalidate old one so the
+	// synth shows up.
+	data_core.ResetPDAManifest() 
 
 	//We also need to update name of internal camera.
 	if (camera)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -368,7 +368,8 @@
 	var/job = mind.assigned_role
 
 	job_master.FreeRole(job)
-
+	data_core.ResetPDAManifest()
+	
 	if(mind.objectives.len)
 		qdel(mind.objectives)
 		mind.special_role = null

--- a/code/world.dm
+++ b/code/world.dm
@@ -182,34 +182,16 @@ var/world_topic_spam_protect_time = world.timeofday
 		return list2params(s)
 
 	else if(T == "manifest")
+		data_core.get_manifest_list()
 		var/list/positions = list()
-		var/list/set_names = list(
-				"heads" = command_positions,
-				"sec" = security_positions,
-				"eng" = engineering_positions,
-				"med" = medical_positions,
-				"sci" = science_positions,
-				"car" = cargo_positions,
-				"civ" = civilian_positions,
-				"bot" = nonhuman_positions
-			)
 
-		for(var/datum/data/record/t in data_core.general)
-			var/name = t.fields["name"]
-			var/rank = t.fields["rank"]
-			var/real_rank = make_list_rank(t.fields["real_rank"])
-
-			var/department = 0
-			for(var/k in set_names)
-				if(real_rank in set_names[k])
-					if(!positions[k])
-						positions[k] = list()
-					positions[k][name] = rank
-					department = 1
-			if(!department)
-				if(!positions["misc"])
-					positions["misc"] = list()
-				positions["misc"][name] = rank
+		// We rebuild the list in the format external tools expect
+		for(var/dept in PDA_Manifest)
+			var/list/dept_list = PDA_Manifest[dept]
+			if(dept_list.len > 0)
+				positions[dept] = list()
+				for(var/list/person in dept_list)
+					positions[dept][person["name"]] = person["rank"]
 
 		for(var/k in positions)
 			positions[k] = list2params(positions[k]) // converts positions["heads"] = list("Bob"="Captain", "Bill"="CMO") into positions["heads"] = "Bob=Captain&Bill=CMO"

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -633,6 +633,11 @@ th.misc {
     font-weight: bold;
     color: #ffffff;
 }
+th.bot {
+    background: #414249;
+    font-weight: bold;
+    color: #ffffff;
+}
 
 /* Damage colors for crew monitoring computer */
 

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -373,6 +373,12 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <tr><td><span class="average">{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
                     {{/for}}
                 {{/if}}
+                {{if data.manifest.bot.length}}
+                    <tr><th colspan="3" class="bot">Synthetic</th></tr>
+                    {{for data.manifest["bot"]}}
+                        <tr><td><span class="average">{{:value.name}}</span></td><td colspan="2"><span class="average">{{:value.rank}}</span></td></tr>
+                    {{/for}}
+                {{/if}}
             </tbody></table></center>
         </div>
 


### PR DESCRIPTION
Synths were already on non-PDA manifests, and now they are on PDA ones as well. 

This also changes the world.dm's `Topic`'s `manifest` to use the PDA manifest as well. This means `manifest` queries to the server will include synths, and reflect the IC manifest. Bot32's `!manifest` works here seamlessly.
