### PR TITLE
Fixes on-back icon states

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -23,6 +23,10 @@
 	charge_costs = list(500)
 	stacktype = /obj/item/stack/rods
 
+/obj/item/stack/rods/New()
+	..()
+	update_icon()
+
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
 	..()
 	if (istype(W, /obj/item/weapon/weldingtool))
@@ -78,3 +82,19 @@
 		F.add_fingerprint(usr)
 		use(2)
 	return
+
+/obj/item/stack/rods/update_icon()
+	if(amount == 1)
+		icon = 'icons/obj/weapons.dmi'
+		icon_state = "metal-rod"
+	else
+		icon = initial(icon)
+		icon_state = initial(icon_state)
+
+/obj/item/stack/rods/use()
+	. = ..()
+	update_icon()
+
+/obj/item/stack/rods/add()
+	. = ..()
+	update_icon()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -66,7 +66,8 @@
 
 /obj/item/weapon/material/twohanded/update_icon()
 	icon_state = "[base_icon][wielded]"
-	item_state = icon_state
+	item_state_slots[slot_l_hand_str] = icon_state
+	item_state_slots[slot_r_hand_str] = icon_state
 
 /*
  * Fireaxe

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -96,7 +96,6 @@
 				name = "[initial(name)] (wielded)"
 			else
 				name = initial(name)
-				item_state = initial(item_state)
 		update_icon() // In case item_state is set somewhere else.
 	..()
 
@@ -105,9 +104,11 @@
 		var/mob/living/M = loc
 		if(istype(M))
 			if(M.can_wield_item(src) && src.is_held_twohanded(M))
-				item_state = wielded_item_state
+				item_state_slots[slot_l_hand_str] = wielded_item_state
+				item_state_slots[slot_r_hand_str] = wielded_item_state
 			else
-				item_state = initial(item_state)
+				item_state_slots[slot_l_hand_str] = initial(item_state)
+				item_state_slots[slot_r_hand_str] = initial(item_state)
 
 //Checks whether a given mob can use the gun
 //Any checks that shouldn't result in handle_click_empty() being called if they fail should go here.

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -97,6 +97,10 @@ obj/item/weapon/gun/energy/retro
 	accuracy = -3 //shooting at the hip
 	scoped_accuracy = 0
 
+/obj/item/weapon/gun/energy/sniperrifle/update_icon()
+	..()
+	item_state_slots[slot_back_str] = icon_state //so that the on-back overlay uses the different charged states
+
 /obj/item/weapon/gun/energy/sniperrifle/verb/scope()
 	set category = "Object"
 	set name = "Use Scope"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -19,9 +19,11 @@
 /obj/item/weapon/gun/energy/ionrifle/update_icon()
 	..()
 	if(power_supply.charge < charge_cost)
-		item_state = "ionrifle-empty"
+		item_state_slots[slot_l_hand_str] = "ionrifle-empty"
+		item_state_slots[slot_r_hand_str] = "ionrifle-empty"
 	else
-		item_state = initial(item_state)
+		item_state_slots[slot_l_hand_str] = initial(item_state)
+		item_state_slots[slot_r_hand_str] = initial(item_state)
 
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"


### PR DESCRIPTION
Fixes #13409 
Fixes some other on-back states (empty ion rifle and LWAP)
Adds singular icon state for metal rods.
