### PR TITLE
Cleans up handling of mob size in reagent metabolism

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -24,7 +24,7 @@
 #define IS_TAJARA  5
 #define IS_XENOS   6
 #define IS_MACHINE 7
-#define IS_RESOMI 8
+#define IS_RESOMI  8
 
 #define CE_STABLE "stable" // Inaprovaline
 #define CE_ANTIBIOTIC "antibiotic" // Spaceacilin
@@ -35,3 +35,6 @@
 #define CE_SPEEDBOOST "gofast" // Hyperzine
 #define CE_PULSE      "xcardic" // increases or decreases heart rate
 #define CE_NOPULSE    "heartstop" // stops heartbeat
+
+//reagent flags
+#define IGNORE_MOB_SIZE 0x1

--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -38,3 +38,4 @@
 
 //reagent flags
 #define IGNORE_MOB_SIZE 0x1
+#define AFFECTS_DEAD    0x2

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -179,9 +179,6 @@ About Reagents:
 		scannable
 			If set to 1, will show up on health analyzers by name.
 
-		affects_dead
-			If set to 1, will affect dead players. Used by Adminordrazine.
-
 		glass_icon_state
 			Used by drinks. icon_state of the glass when this reagent is the master reagent.
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -30,6 +30,7 @@
 	var/affects_dead = 0
 	var/color = "#000000"
 	var/color_weight = 1
+	var/flags = 0
 
 	var/glass_icon = DRINK_ICON_DEFAULT
 	var/glass_name = "something"
@@ -54,24 +55,36 @@
 		return
 	if(!affects_dead && M.stat == DEAD)
 		return
-	if(overdose && (volume > overdose) && (location != CHEM_TOUCH))
-		overdose(M, alien)
+	if(overdose && (location != CHEM_TOUCH))
+		var/overdose_threshold = overdose * (flags & IGNORE_MOB_SIZE? 1 : MOB_MEDIUM/M.mob_size)
+		if(volume > overdose_threshold)
+			overdose(M, alien)
+
+	//determine the metabolism rate
 	var/removed = metabolism
 	if(ingest_met && (location == CHEM_INGEST))
 		removed = ingest_met
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met
 	removed = min(removed, volume)
+
+	//adjust effective amounts - removed, dose, and max_dose - for mob size
+	var/effective = removed
 	max_dose = max(volume, max_dose)
-	dose = min(dose + removed, max_dose)
-	if(removed >= (metabolism * 0.1) || removed >= 0.1) // If there's too little chemical, don't affect the mob, just remove it
+	if(!(flags & IGNORE_MOB_SIZE) && location != CHEM_TOUCH)
+		effective *= (MOB_MEDIUM/M.mob_size)
+		max_dose *= (MOB_MEDIUM/M.mob_size)
+
+	dose = min(dose + effective, max_dose)
+	if(effective >= (metabolism * 0.1) || effective >= 0.1) // If there's too little chemical, don't affect the mob, just remove it
 		switch(location)
 			if(CHEM_BLOOD)
-				affect_blood(M, alien, removed)
+				affect_blood(M, alien, effective)
 			if(CHEM_INGEST)
-				affect_ingest(M, alien, removed)
+				affect_ingest(M, alien, effective)
 			if(CHEM_TOUCH)
-				affect_touch(M, alien, removed)
+				affect_touch(M, alien, effective)
+
 	remove_self(removed)
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -27,7 +27,6 @@
 	var/max_dose = 0
 	var/overdose = 0
 	var/scannable = 0 // Shows up on health analyzers.
-	var/affects_dead = 0
 	var/color = "#000000"
 	var/color_weight = 1
 	var/flags = 0
@@ -53,7 +52,7 @@
 /datum/reagent/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/location) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
 	if(!istype(M))
 		return
-	if(!affects_dead && M.stat == DEAD)
+	if(!(flags & AFFECTS_DEAD) && M.stat == DEAD)
 		return
 	if(overdose && (location != CHEM_TOUCH))
 		var/overdose_threshold = overdose * (flags & IGNORE_MOB_SIZE? 1 : MOB_MEDIUM/M.mob_size)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -35,12 +35,9 @@
 
 /datum/reagent/blood/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 
-	var/effective_dose = dose
-	if(issmall(M)) effective_dose *= 2
-
-	if(effective_dose > 5)
+	if(dose > 5)
 		M.adjustToxLoss(removed)
-	if(effective_dose > 15)
+	if(dose > 15)
 		M.adjustToxLoss(removed)
 	if(data && data["virus2"])
 		var/list/vlist = data["virus2"]
@@ -163,7 +160,6 @@
 	return
 
 /datum/reagent/fuel/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(issmall(M)) removed *= 2
 	M.adjustToxLoss(2 * removed)
 
 /datum/reagent/fuel/touch_mob(var/mob/living/L, var/amount)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -113,12 +113,10 @@
 		L.adjust_fire_stacks(amount / 15)
 
 /datum/reagent/ethanol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(issmall(M)) removed *= 2
 	M.adjustToxLoss(removed * 2 * toxicity)
 	return
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(issmall(M)) removed *= 2
 	M.nutrition += nutriment_factor * removed
 	var/strength_mod = 1
 	if(alien == IS_SKRELL)
@@ -262,7 +260,6 @@
 	color = "#C7C7C7"
 
 /datum/reagent/radium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(issmall(M)) removed *= 2
 	M.apply_effect(10 * removed, IRRADIATE, blocked = 0) // Radium may increase your chances to cure a disease
 	if(M.virus2.len)
 		for(var/ID in M.virus2)
@@ -299,7 +296,6 @@
 	var/meltdose = 10 // How much is needed to melt
 
 /datum/reagent/acid/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(issmall(M)) removed *= 2
 	M.take_organ_damage(0, removed * power * 2)
 
 /datum/reagent/acid/affect_touch(var/mob/living/carbon/M, var/alien, var/removed) // This is the most interesting
@@ -414,17 +410,13 @@
 /datum/reagent/sugar/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.nutrition += removed * 3
 
-	var/effective_dose = dose
-	if(issmall(M))
-		effective_dose *= 2
-
 	if(alien == IS_UNATHI)
-		if(effective_dose < 2)
-			if(effective_dose == metabolism * 2 || prob(5))
+		if(dose < 2)
+			if(dose == metabolism * 2 || prob(5))
 				M.emote("yawn")
-		else if(effective_dose < 5)
+		else if(dose < 5)
 			M.eye_blurry = max(M.eye_blurry, 10)
-		else if(effective_dose < 20)
+		else if(dose < 20)
 			if(prob(50))
 				M.Weaken(2)
 			M.drowsyness = max(M.drowsyness, 20)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -40,7 +40,6 @@
 /datum/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	M.heal_organ_damage(0.5 * removed, 0) //what
 
-	if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
 	adjust_nutrition(M, alien, removed)
 	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 
@@ -99,17 +98,13 @@
 /datum/reagent/honey/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 
-	var/effective_dose = dose
-	if(issmall(M))
-		effective_dose *= 2
-
 	if(alien == IS_UNATHI)
-		if(effective_dose < 2)
-			if(effective_dose == metabolism * 2 || prob(5))
+		if(dose < 2)
+			if(dose == metabolism * 2 || prob(5))
 				M.emote("yawn")
-		else if(effective_dose < 5)
+		else if(dose < 5)
 			M.eye_blurry = max(M.eye_blurry, 10)
-		else if(effective_dose < 20)
+		else if(dose < 20)
 			if(prob(50))
 				M.Weaken(2)
 			M.drowsyness = max(M.drowsyness, 20)
@@ -437,9 +432,6 @@
 	..()
 
 	var/effective_dose = dose/2
-	if(issmall(M))
-		effective_dose *= 2
-
 	if(alien == IS_UNATHI)
 		if(effective_dose < 2)
 			if(effective_dose == metabolism * 2 || prob(5))
@@ -864,9 +856,6 @@
 	..()
 
 	var/effective_dose = dose/2
-	if(issmall(M))
-		effective_dose *= 2
-
 	if(alien == IS_UNATHI)
 		if(effective_dose < 2)
 			if(effective_dose == metabolism * 2 || prob(5))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -10,6 +10,7 @@
 	overdose = REAGENTS_OVERDOSE * 2
 	metabolism = REM * 0.5
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -27,6 +28,7 @@
 	color = "#BF0000"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -41,6 +43,7 @@
 	color = "#FFA800"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/kelotane/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -56,6 +59,7 @@
 	color = "#FF8000"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/dermaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -69,6 +73,7 @@
 	reagent_state = LIQUID
 	color = "#00A000"
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/dylovene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -85,6 +90,7 @@
 	color = "#0080FF"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
@@ -103,6 +109,7 @@
 	color = "#0040FF"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/dexalinp/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
@@ -120,6 +127,7 @@
 	reagent_state = LIQUID
 	color = "#8040FF"
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -136,6 +144,7 @@
 	color = "#8080FF"
 	metabolism = REM * 0.5
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/cryoxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
@@ -154,6 +163,7 @@
 	color = "#80BFFF"
 	metabolism = REM * 0.5
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/clonexadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
@@ -175,6 +185,7 @@
 	overdose = 60
 	scannable = 1
 	metabolism = 0.02
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/paracetamol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 50)
@@ -193,6 +204,7 @@
 	overdose = 30
 	scannable = 1
 	metabolism = 0.02
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/tramadol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 80)
@@ -210,6 +222,7 @@
 	color = "#800080"
 	overdose = 20
 	metabolism = 0.02
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/oxycodone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 200)
@@ -254,6 +267,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
@@ -270,6 +284,8 @@
 	color = "#C8A5DC"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
+
 
 /datum/reagent/imidazoline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.eye_blurry = max(M.eye_blurry - 5, 0)
@@ -290,6 +306,7 @@
 	color = "#561EC3"
 	overdose = 10
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/peridaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
@@ -368,6 +385,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/hyronalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.radiation = max(M.radiation - 30 * removed, 0)
@@ -381,6 +399,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/arithrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.radiation = max(M.radiation - 70 * removed, 0)
@@ -544,6 +563,7 @@
 	color = "#669900"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/rezadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustCloneLoss(-20 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -113,7 +113,7 @@
 	taste_description = "100% abuse"
 	reagent_state = LIQUID
 	color = "#C8A5DC"
-	affects_dead = 1 //This can even heal dead people.
+	flags = AFFECTS_DEAD //This can even heal dead people.
 
 	glass_name = "liquid gold"
 	glass_desc = "It's magic. We don't have to explain it."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -13,7 +13,6 @@
 
 /datum/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(strength && alien != IS_DIONA)
-		if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
 		M.adjustToxLoss(strength * removed)
 
 /datum/reagent/toxin/plasticide
@@ -296,16 +295,12 @@
 	if(alien == IS_DIONA)
 		return
 
-	var/effective_dose = dose
-	if(issmall(M))
-		effective_dose *= 2
-
-	if(effective_dose < 1)
-		if(effective_dose == metabolism * 2 || prob(5))
+	if(dose < 1)
+		if(dose == metabolism * 2 || prob(5))
 			M.emote("yawn")
-	else if(effective_dose < 1.5)
+	else if(dose < 1.5)
 		M.eye_blurry = max(M.eye_blurry, 10)
-	else if(effective_dose < 5)
+	else if(dose < 5)
 		if(prob(50))
 			M.Weaken(2)
 		M.drowsyness = max(M.drowsyness, 20)
@@ -328,20 +323,16 @@
 	if(alien == IS_DIONA)
 		return
 
-	var/effective_dose = dose
-	if(issmall(M))
-		effective_dose *= 2
-
-	if(effective_dose == metabolism)
+	if(dose == metabolism)
 		M.confused += 2
 		M.drowsyness += 2
-	else if(effective_dose < 2)
+	else if(dose < 2)
 		M.Weaken(30)
 		M.eye_blurry = max(M.eye_blurry, 10)
 	else
 		M.sleeping = max(M.sleeping, 30)
 
-	if(effective_dose > 1)
+	if(dose > 1)
 		M.adjustToxLoss(removed)
 
 /datum/reagent/chloralhydrate/beer2 //disguised as normal beer for use by emagged brobots
@@ -459,14 +450,12 @@
 		return
 	M.druggy = max(M.druggy, 30)
 
-	var/effective_dose = dose
-	if(issmall(M)) effective_dose *= 2
-	if(effective_dose < 1)
+	if(dose < 1)
 		M.apply_effect(3, STUTTER)
 		M.make_dizzy(5)
 		if(prob(5))
 			M.emote(pick("twitch", "giggle"))
-	else if(effective_dose < 2)
+	else if(dose < 2)
 		M.apply_effect(3, STUTTER)
 		M.make_jittery(5)
 		M.make_dizzy(5)


### PR DESCRIPTION
I'm not sure who thought it was a great idea to copy the same check into dozens of reagent definitions, but this cleans that up.

Mob size is handled by default, and a bitflag is used to indicate reagents that should not scale - currently most medicines.
