### PR TITLE
Vine fixes

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -89,10 +89,6 @@
 		if(M.lying)
 			return ..()
 
-		// Ugly hack :( Should never have multiple plants in the same tile.
-		var/obj/effect/plant/plant = locate() in contents
-		if(plant) plant.trodden_on(M)
-
 		// Dirt overlays.
 		update_dirt()
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -321,8 +321,9 @@
 		if(!reagents || reagents.total_volume <= 0)
 			return
 		reagents.remove_any(rand(1,3)) //Todo, make it actually remove the reagents the seed uses.
-		seed.do_thorns(H,src)
-		seed.do_sting(H,src,pick("r_hand","l_hand"))
+		var/affected = pick("r_hand","l_hand")
+		seed.do_thorns(H,src,affected)
+		seed.do_sting(H,src,affected)
 
 // Predefined types for placing on the map.
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -114,9 +114,12 @@
 
 
 	if(!target_limb) target_limb = pick("l_foot","r_foot","l_leg","r_leg","l_hand","r_hand","l_arm", "r_arm","head","chest","groin")
+	var/blocked = target.run_armor_check(target_limb, "melee")
+	if(blocked >= 100)
+		return
+
 	var/obj/item/organ/external/affecting = target.get_organ(target_limb)
 	var/damage = 0
-
 	if(get_trait(TRAIT_CARNIVOROUS))
 		if(get_trait(TRAIT_CARNIVOROUS) == 2)
 			if(affecting)
@@ -133,13 +136,7 @@
 	else
 		return
 
-	if(affecting)
-		affecting.take_damage(damage, 0)
-		affecting.add_autopsy_data("Thorns",damage)
-	else
-		target.adjustBruteLoss(damage)
-	target.UpdateDamageIcon()
-	target.updatehealth()
+	target.apply_damage(damage, BRUTE, target_limb, blocked, "Thorns", sharp=1, edge=0)
 
 // Adds reagents to a target.
 /datum/seed/proc/do_sting(var/mob/living/carbon/human/target, var/obj/item/fruit)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -9,6 +9,7 @@
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.
 			seed.set_trait(TRAIT_POTENCY,rand(potency_min, potency_max)) // 70-100 potency will help guarantee a wide spread and powerful effects.
 			seed.set_trait(TRAIT_MATURATION,rand(maturation_min, maturation_max))
+			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
 			var/obj/effect/plant/vine = new(T,seed)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -82,7 +82,7 @@
 		parent = newparent
 
 	if(!plant_controller)
-		sleep(250) // ugly hack, should mean roundstart plants are fine.
+		sleep(250) // ugly hack, should mean roundstart plants are fine. TODO initialize perhaps?
 	if(!plant_controller)
 		world << "<span class='danger'>Plant controller does not exist and [src] requires it. Aborting.</span>"
 		qdel(src)
@@ -93,6 +93,12 @@
 	seed = newseed
 	if(!seed)
 		qdel(src)
+		return
+	var/obj/effect/plant/other = locate() in loc
+	if(other)
+		if(other.seed != src.seed) 
+			other.vine_overrun(src.seed, newparent) //vine fight
+		qdel(src) //no more having dozens of vines on a single turf please
 		return
 
 	name = seed.display_name
@@ -254,6 +260,32 @@
 		if(W.force)
 			health -= W.force
 	check_health()
+
+//handles being overrun by vines - note that attacker_parent may be null in some cases
+/obj/effect/plant/proc/vine_overrun(datum/seed/attacker_seed, obj/effect/plant/attacker_parent)
+	var/aggression = 0
+	aggression += (attacker_seed.get_trait(TRAIT_CARNIVOROUS) - seed.get_trait(TRAIT_CARNIVOROUS))
+	aggression += (attacker_seed.get_trait(TRAIT_SPREAD) - seed.get_trait(TRAIT_SPREAD))
+	
+	var/resiliance
+	if(is_mature())
+		resiliance = 0
+		switch(seed.get_trait(TRAIT_ENDURANCE))
+			if(30 to 70)
+				resiliance = 1
+			if(70 to 95)
+				resiliance = 2
+			if(95 to INFINITY)
+				resiliance = 3
+	else
+		resiliance = -2
+		if(seed.get_trait(TRAIT_ENDURANCE) >= 50)
+			resiliance = -1
+	aggression -= resiliance
+
+	if(aggression > 0)
+		health -= aggression*5
+		check_health()
 
 /obj/effect/plant/ex_act(severity)
 	switch(severity)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -92,11 +92,12 @@
 				var/turf/target_turf = pick(neighbors)
 				var/obj/effect/plant/child = new(get_turf(src),seed,parent)
 				spawn(1) // This should do a little bit of animation.
-					child.loc = target_turf
+					child.forceMove(target_turf)
 					child.update_icon()
 				// Update neighboring squares.
 				for(var/obj/effect/plant/neighbor in range(1,target_turf))
-					neighbor.neighbors -= target_turf
+					if(seed == neighbor.seed) //neighbors of different seeds will continue to try to overrun each other
+						neighbor.neighbors -= target_turf
 
 	// We shouldn't have spawned if the controller doesn't exist.
 	check_health()

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -71,9 +71,14 @@
 
 	if(sampled)
 		//Should be between 2-7 for given the default range of values for TRAIT_PRODUCTION
-		var/chance = max(1, round(30/seed.get_trait(TRAIT_PRODUCTION)))
+		var/chance = max(1, round(15/seed.get_trait(TRAIT_PRODUCTION)))
 		if(prob(chance))
 			sampled = 0
+
+	if(is_mature() && !buckled_mob)
+		for(var/mob/living/carbon/human/M in range(1))
+			if(!M.buckled && !M.anchored && (issmall(M) || M.lying || prob(round(seed.get_trait(TRAIT_POTENCY)/6))))
+				entangle(M)
 
 	if(is_mature() && neighbors.len && prob(spread_chance))
 		//spread to 1-3 adjacent turfs depending on yield trait.

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -20,6 +20,10 @@
 	if(istype(user))
 		manual_unbuckle(user)
 
+/obj/effect/plant/Crossed(atom/movable/O)
+	if(isliving(O))
+		trodden_on(O)
+
 /obj/effect/plant/proc/trodden_on(var/mob/living/victim)
 	if(!is_mature())
 		return

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -24,6 +24,8 @@
 	if(!is_mature())
 		return
 	var/mob/living/carbon/human/H = victim
+	if(prob(round(seed.get_trait(TRAIT_POTENCY)/4)))
+		entangle(victim)
 	if(istype(H) && H.shoes)
 		return
 	seed.do_thorns(victim,src)
@@ -40,24 +42,27 @@
 
 /obj/effect/plant/proc/manual_unbuckle(mob/user as mob)
 	if(buckled_mob)
-		if(prob(seed ? min(max(0,100 - seed.get_trait(TRAIT_POTENCY)/2),100) : 50))
-			if(buckled_mob.buckled == src)
-				if(buckled_mob != user)
-					buckled_mob.visible_message(\
-						"<span class='notice'>[user.name] frees [buckled_mob.name] from \the [src].</span>",\
-						"<span class='notice'>[user.name] frees you from \the [src].</span>",\
-						"<span class='warning'>You hear shredding and ripping.</span>")
-				else
-					buckled_mob.visible_message(\
-						"<span class='notice'>[buckled_mob.name] struggles free of \the [src].</span>",\
-						"<span class='notice'>You untangle \the [src] from around yourself.</span>",\
-						"<span class='warning'>You hear shredding and ripping.</span>")
+		var/fail_chance = 50
+		if(seed)
+			fail_chance = seed.get_trait(TRAIT_POTENCY) * (user == buckled_mob ? 5 : 2)
+		if(prob(100 - fail_chance))
+			if(buckled_mob != user)
+				buckled_mob.visible_message(\
+					"<span class='notice'>\The [user] frees \the [buckled_mob] from \the [src].</span>",\
+					"<span class='notice'>\The [user] frees you from \the [src].</span>",\
+					"<span class='warning'>You hear shredding and ripping.</span>")
+			else
+				buckled_mob.visible_message(\
+					"<span class='notice'>\The [buckled_mob] struggles free of \the [src].</span>",\
+					"<span class='notice'>You untangle \the [src] from around yourself.</span>",\
+					"<span class='warning'>You hear shredding and ripping.</span>")
 			unbuckle()
 		else
-			var/text = pick("rip","tear","pull")
+			health -= rand(1,5)
+			var/text = pick("rip","tear","pull", "bite", "tug")
 			user.visible_message(\
-				"<span class='notice'>[user.name] [text]s at \the [src].</span>",\
-				"<span class='notice'>You [text] at \the [src].</span>",\
+				"<span class='warning'>\The [user] [text]s at \the [src].</span>",\
+				"<span class='warning'>You [text] at \the [src].</span>",\
 				"<span class='warning'>You hear shredding and ripping.</span>")
 	return
 
@@ -78,7 +83,7 @@
 				can_grab = 0
 		if(can_grab)
 			src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")
-			victim.loc = src.loc
+			victim.forceMove(src.loc)
 
 	//entangling people
 	if(victim.loc == src.loc)


### PR DESCRIPTION
Prevents vines (or just spreadable plants in general) from stacking up on a single turf. It's really not clear why it still happens despite the attempts to prevent creating new vines on turfs that already have vines, so this PR embraces it. If a vine is created on a turf that already has a vine, it deletes itself, and if the vines are of two different seed types, the existing vine may take damage, allowing for vine wars.

Also grabs Inforsaken's vine fixes from #12572, allowing vines to entangle once again.

Also, vines created by the vine event now again have "strange plants" as their display name, I felt it was much more thematic than the generated ones. Seed packets collected from these vines still use a generated name however.
