### PR TITLE
Fixes #13449, various other vine issues

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -120,23 +120,23 @@
 
 	var/obj/item/organ/external/affecting = target.get_organ(target_limb)
 	var/damage = 0
-	if(get_trait(TRAIT_CARNIVOROUS))
-		if(get_trait(TRAIT_CARNIVOROUS) == 2)
-			if(affecting)
-				target << "<span class='danger'>\The [fruit]'s thorns pierce your [affecting.name] greedily!</span>"
-			else
-				target << "<span class='danger'>\The [fruit]'s thorns pierce your flesh greedily!</span>"
-			damage = get_trait(TRAIT_POTENCY)/2
+	var/has_edge = 0
+	if(get_trait(TRAIT_CARNIVOROUS) >= 2)
+		if(affecting)
+			target << "<span class='danger'>\The [fruit]'s thorns pierce your [affecting.name] greedily!</span>"
 		else
-			if(affecting)
-				target << "<span class='danger'>\The [fruit]'s thorns dig deeply into your [affecting.name]!</span>"
-			else
-				target << "<span class='danger'>\The [fruit]'s thorns dig deeply into your flesh!</span>"
-			damage = get_trait(TRAIT_POTENCY)/5
+			target << "<span class='danger'>\The [fruit]'s thorns pierce your flesh greedily!</span>"
+		damage = max(5, round(15*get_trait(TRAIT_POTENCY)/100, 1))
+		has_edge = prob(get_trait(TRAIT_POTENCY)/2)
 	else
-		return
+		if(affecting)
+			target << "<span class='danger'>\The [fruit]'s thorns dig deeply into your [affecting.name]!</span>"
+		else
+			target << "<span class='danger'>\The [fruit]'s thorns dig deeply into your flesh!</span>"
+		damage = max(1, round(5*get_trait(TRAIT_POTENCY)/100, 1))
+		has_edge = prob(get_trait(TRAIT_POTENCY)/5)
 
-	target.apply_damage(damage, BRUTE, target_limb, blocked, "Thorns", sharp=1, edge=0)
+	target.apply_damage(damage, BRUTE, target_limb, blocked, "Thorns", sharp=1, edge=has_edge)
 
 // Adds reagents to a target.
 /datum/seed/proc/do_sting(var/mob/living/carbon/human/target, var/obj/item/fruit)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,9 +1,12 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
+/proc/foo()
+	spacevine_infestation()
+
 /proc/spacevine_infestation(var/potency_min=70, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
-		var/turf/T = pick_subarea_turf(/area/hallway, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+		var/turf/T = pick_subarea_turf(/area/constructionsite , list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 		if(T)
 			var/datum/seed/seed = plant_controller.create_random_seed(1)
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,12 +1,9 @@
 #define DEFAULT_SEED "glowshroom"
 #define VINE_GROWTH_STAGES 5
 
-/proc/foo()
-	spacevine_infestation()
-
 /proc/spacevine_infestation(var/potency_min=70, var/potency_max=100, var/maturation_min=5, var/maturation_max=15)
 	spawn() //to stop the secrets panel hanging
-		var/turf/T = pick_subarea_turf(/area/constructionsite , list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+		var/turf/T = pick_subarea_turf(/area/hallway , list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 		if(T)
 			var/datum/seed/seed = plant_controller.create_random_seed(1)
 			seed.set_trait(TRAIT_SPREAD,2)             // So it will function properly as vines.

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -94,12 +94,6 @@
 	if(!seed)
 		qdel(src)
 		return
-	var/obj/effect/plant/other = locate() in loc
-	if(other)
-		if(other.seed != src.seed) 
-			other.vine_overrun(src.seed, newparent) //vine fight
-		qdel(src) //no more having dozens of vines on a single turf please
-		return
 
 	name = seed.display_name
 	max_health = round(seed.get_trait(TRAIT_ENDURANCE)/2)
@@ -127,14 +121,15 @@
 	spread_distance = ((growth_type>0) ? round(spread_chance*0.6) : round(spread_chance*0.3))
 	update_icon()
 
-	spawn(1) // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
-		set_dir(calc_dir())
-		update_icon()
-		plant_controller.add_plant(src)
-		// Some plants eat through plating.
-		if(islist(seed.chems) && !isnull(seed.chems["pacid"]))
-			var/turf/T = get_turf(src)
-			T.ex_act(prob(80) ? 3 : 2)
+// Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
+/obj/effect/plant/proc/finish_spreading()
+	set_dir(calc_dir())
+	update_icon()
+	plant_controller.add_plant(src)
+	// Some plants eat through plating.
+	if(islist(seed.chems) && !isnull(seed.chems["pacid"]))
+		var/turf/T = get_turf(src)
+		T.ex_act(prob(80) ? 3 : 2)
 
 /obj/effect/plant/update_icon()
 	//TODO: should really be caching this.

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -108,7 +108,7 @@
 
 	// We shouldn't have spawned if the controller doesn't exist.
 	check_health()
-	if(neighbors.len)
+	if(buckled_mob || neighbors.len)
 		plant_controller.add_plant(src)
 
 //spreading vines aren't created on their final turf. 

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -90,9 +90,10 @@
 			sampled = 0
 
 	if(is_mature() && !buckled_mob)
-		for(var/mob/living/carbon/human/M in range(1))
-			if(!M.buckled && !M.anchored && (issmall(M) || M.lying || prob(round(seed.get_trait(TRAIT_POTENCY)/6))))
-				entangle(M)
+		for(var/turf/neighbor in neighbors)
+			for(var/mob/living/M in neighbor)
+				if(seed.get_trait(TRAIT_SPREAD) >= 2 && (M.lying || prob(round(seed.get_trait(TRAIT_POTENCY)))))
+					entangle(M)
 
 	if(is_mature() && neighbors.len && prob(spread_chance))
 		//spread to 1-3 adjacent turfs depending on yield trait.
@@ -126,18 +127,21 @@
 		child.update_icon()
 
 		//see if anything is there
-		for(var/obj/effect/plant/other in child.loc)
-			if(other != child)
+		for(var/thing in child.loc)
+			if(thing != child && istype(thing, /obj/effect/plant))
+				var/obj/effect/plant/other = thing
 				if(other.seed != child.seed)
 					other.vine_overrun(child.seed, src) //vine fight
 				qdel(child)
 				return
-
-		var/obj/effect/dead_plant/dead = locate() in child.loc
-		if(dead)
-			qdel(dead)
-			qdel(child)
-			return
+			if(istype(thing, /obj/effect/dead_plant))
+				qdel(thing)
+				qdel(child)
+				return
+			if(isliving(thing) && (seed.get_trait(TRAIT_CARNIVOROUS) || (seed.get_trait(TRAIT_SPREAD) >= 2 && prob(round(seed.get_trait(TRAIT_POTENCY))))))
+				entangle(thing)
+				qdel(child)
+				return
 
 		// Update neighboring squares.
 		for(var/obj/effect/plant/neighbor in range(1, child.loc)) //can use the actual final child loc now

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -33,6 +33,9 @@
 
 		neighbors |= floor
 
+	if(neighbors.len)
+		plant_controller.add_plant(src) //if we have neighbours again, start processing
+
 	// Update all of our friends.
 	var/turf/T = get_turf(src)
 	for(var/obj/effect/plant/neighbor in range(1,src))
@@ -104,7 +107,7 @@
 
 	// We shouldn't have spawned if the controller doesn't exist.
 	check_health()
-	if(neighbors.len || health != max_health)
+	if(neighbors.len)
 		plant_controller.add_plant(src)
 
 //spreading vines aren't created on their final turf. 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -96,3 +96,7 @@
 		buckle_mob(victim)
 		victim.set_dir(pick(cardinal))
 		victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
+
+/obj/effect/plant/buckle_mob()
+	. = ..()
+	if(.) plant_controller.add_plant(src)

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -46,10 +46,10 @@
 
 /obj/effect/plant/proc/manual_unbuckle(mob/user as mob)
 	if(buckled_mob)
-		var/fail_chance = 50
+		var/chance = 20
 		if(seed)
-			fail_chance = seed.get_trait(TRAIT_POTENCY) * (user == buckled_mob ? 5 : 2)
-		if(prob(100 - fail_chance))
+			chance = round(100/(20*seed.get_trait(TRAIT_POTENCY)/100))
+		if(prob(chance))
 			if(buckled_mob != user)
 				buckled_mob.visible_message(\
 					"<span class='notice'>\The [user] frees \the [buckled_mob] from \the [src].</span>",\

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -62,12 +62,14 @@
 					"<span class='warning'>You hear shredding and ripping.</span>")
 			unbuckle()
 		else
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			health -= rand(1,5)
 			var/text = pick("rip","tear","pull", "bite", "tug")
 			user.visible_message(\
 				"<span class='warning'>\The [user] [text]s at \the [src].</span>",\
 				"<span class='warning'>You [text] at \the [src].</span>",\
 				"<span class='warning'>You hear shredding and ripping.</span>")
+			check_health()
 	return
 
 /obj/effect/plant/proc/entangle(var/mob/living/victim)
@@ -75,11 +77,11 @@
 	if(buckled_mob)
 		return
 
-	if(victim.buckled)
+	if(victim.buckled || victim.anchored)
 		return
 
 	//grabbing people
-	if(!victim.anchored && Adjacent(victim) && victim.loc != get_turf(src))
+	if(!victim.anchored && Adjacent(victim) && victim.loc != src.loc)
 		var/can_grab = 1
 		if(istype(victim, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = victim


### PR DESCRIPTION
- Fixes #13449
- Refactors plant/vine spreading
- Fixes plants no processing in various situations when they need to be (use a proper process sometime?)
- Adjusted entangle chance - plant processing has a fairly long interval so the old value isn't appropriate (that was geared at HasProximity where it would fire any time you passed near some vines)
- Fixes freeing mobs not having any click cooldown
- Fixes carnivorous damage and escape chance not making any sense given the range of potency values.

Tested and working.
