### PR TITLE
Fixes closets saving people from penetrating bullets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -192,11 +192,16 @@
 
 /obj/structure/closet/bullet_act(var/obj/item/projectile/Proj)
 	var/proj_damage = Proj.get_structure_damage()
-	if(!proj_damage)
-		return
+	if(proj_damage)
+		..()
+		damage(proj_damage)
 
-	..()
-	damage(proj_damage)
+	if(Proj.penetrating)
+		var/distance = get_dist(Proj.starting, get_turf(loc))
+		for(var/mob/living/L in contents)
+			Proj.attack_mob(L, distance)
+			if(!(--Proj.penetrating))
+				break
 
 	return
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -22,7 +22,10 @@
 		mob_passthrough_check = 1
 	else
 		mob_passthrough_check = 0
-	return ..()
+	. = ..()
+
+	if(. == 1 && iscarbon(target_mob))
+		damage *= 0.7 //squishy mobs absorb KE
 
 /obj/item/projectile/bullet/can_embed()
 	//prevent embedding if the projectile is passing through the mob
@@ -39,8 +42,6 @@
 	if(ismob(A))
 		if(!mob_passthrough_check)
 			return 0
-		if(iscarbon(A))
-			damage *= 0.7 //squishy mobs absorb KE
 		return 1
 
 	var/chance = damage


### PR DESCRIPTION
Bullets penetrating into a closet will hit living mobs inside.

Also ensures that bullet damage is attenuated even if check_penetrate() isn't called. check_penetrate() now just checks, no side effects other than a message.
