### PR TITLE
Let boots carry knives

### DIFF
--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -4,6 +4,7 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
 	item_flags = NOSLIP
+	can_hold_knife = 1
 	species_restricted = null
 
 /obj/item/clothing/shoes/galoshes/New()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -3,6 +3,7 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
+	can_hold_knife = 1
 	species_restricted = null
 	force = 3
 	overshoes = 1

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -22,6 +22,7 @@
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	item_flags = NOSLIP
 	siemens_coefficient = 0.6
+	can_hold_knife = 1
 
 /obj/item/clothing/shoes/combat //Basically SWAT shoes combined with galoshes.
 	name = "combat boots"
@@ -31,6 +32,7 @@
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	item_flags = NOSLIP
 	siemens_coefficient = 0.6
+	can_hold_knife = 1
 
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE


### PR DESCRIPTION
They are boots, their sprites are boots, boot knives are for boots. Changelog not required because for the longest time they could carry knives due to #13461, this PR simply allow boots to keep on carrying knives.

Affected boots: combat boots, swat boots, magboots and galoshes.
