### PR TITLE
Improves EMP effect on external robotic organs

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -236,6 +236,8 @@ var/list/organ_cache = list()
 
 //Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(amount, var/silent=0)
+	amount = round(amount, 0.1)
+
 	if(src.robotic >= ORGAN_ROBOT)
 		src.damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -229,11 +229,10 @@
 	return (vital || (robotic >= ORGAN_ROBOT) || brute_dam + burn_dam + additional_damage < max_damage)
 
 /obj/item/organ/external/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())
+	brute = round(brute * brute_mod, 0.1)
+	burn = round(burn * burn_mod, 0.1)
 	if((brute <= 0) && (burn <= 0))
 		return 0
-
-	brute *= brute_mod
-	burn *= burn_mod
 
 	// High brute damage or sharp objects may damage internal organs
 	if(internal_organs && (brute_dam >= max_damage || (((sharp && brute >= 5) || brute >= 10) && prob(5))))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -73,15 +73,17 @@
 	return ..()
 
 /obj/item/organ/external/emp_act(severity)
-	if(!(robotic >= ORGAN_ROBOT))
-		return
+	var/burn_damage = 0
 	switch (severity)
 		if (1)
-			take_damage(10)
+			burn_damage = 15
 		if (2)
-			take_damage(5)
+			burn_damage = 7
 		if (3)
-			take_damage(1)
+			burn_damage = 3
+	burn_damage *= robotic/burn_mod //ignore burn mod for EMP damage
+	if(burn_damage)
+		take_damage(0, burn_damage)
 
 /obj/item/organ/external/attack_self(var/mob/user)
 	if(!contents.len)


### PR DESCRIPTION
Now does burn damage instead of brute damage. I also adjusted the damage amount, based partially on the old values from [here](https://github.com/Baystation12/Baystation12/blob/e0f23aead5d9c4713cde19d1131c07c643e3f004/code/modules/organs/organ.dm#L202) and [here](https://github.com/Baystation12/Baystation12/blob/1a46db4aaf78433cc4a33df26e2e37fac6164c3e/code/modules/organs/organ.dm#L262), the existing values are pitiful, really.
