### PR TITLE
Reimplements emergency lighting, fixes #13492

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -102,6 +102,9 @@ var/list/ghostteleportlocs = list()
 	power_environ = 0
 	ambience = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/main.ogg','sound/music/traitor.ogg')
 
+/area/space/updateicon()
+	return
+
 area/space/atmosalert()
 	return
 
@@ -117,7 +120,7 @@ area/space/atmosalert()
 /area/space/partyalert()
 	return
 
-/area/turret_protected/
+/area/turret_protected
 
 /area/arrival
 	requires_power = 0

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -149,7 +149,7 @@
 	return
 
 /area/proc/updateicon()
-	if ((fire || eject || party) && (!requires_power||power_environ) && !istype(src, /area/space))//If it doesn't require power, can still activate this proc.
+	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.
 		if(fire && !eject && !party)
 			icon_state = "blue"
 		/*else if(atmosalm && !fire && !eject && !party)
@@ -163,7 +163,6 @@
 	else
 	//	new lighting behaviour with obj lights
 		icon_state = null
-
 
 /*
 #define EQUIP 1
@@ -220,6 +219,16 @@
 			used_light += amount
 		if(ENVIRON)
 			used_environ += amount
+
+/area/proc/set_lightswitch(var/new_switch)
+	if(lightswitch != new_switch)
+		lightswitch = new_switch
+		updateicon()
+		power_change()
+
+/area/proc/set_emergency_lighting(var/enable)
+	for(var/obj/machinery/light/M in src)
+		M.set_emergency_lighting(enable)
 
 
 var/list/mob/living/forced_ambiance_list = new

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -47,11 +47,7 @@
 /obj/machinery/light_switch/proc/set_state(var/newstate)
 	if(on != newstate)
 		on = newstate
-
-		connected_area.lightswitch = on
-		connected_area.updateicon()
-		connected_area.power_change()
-
+		connected_area.set_lightswitch(on)
 		update_icon()
 
 /obj/machinery/light_switch/proc/sync_state()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -39,6 +39,9 @@
 #define POWERCHAN_ON       2
 #define POWERCHAN_ON_AUTO  3
 
+//thresholds for channels going off automatically. ENVIRON channel stays on as long as possible, and doesn't have a threshold
+#define AUTO_THRESHOLD_LIGHTING  50
+#define AUTO_THRESHOLD_EQUIPMENT 25
 
 //NOTE: STUFF STOLEN FROM AIRLOCK.DM thx
 
@@ -1121,21 +1124,21 @@
 	else if(longtermpower > -10)
 		longtermpower -= 2
 
-	if((cell.percent() > 30) || longtermpower > 0)              // Put most likely at the top so we don't check it last, effeciency 101
+	if((cell.percent() > AUTO_THRESHOLD_LIGHTING) || longtermpower > 0)              // Put most likely at the top so we don't check it last, effeciency 101
 		if(autoflag != 3)
 			equipment = autoset(equipment, 1)
 			lighting = autoset(lighting, 1)
 			environ = autoset(environ, 1)
 			autoflag = 3
 			power_alarm.clearAlarm(loc, src)
-	else if((cell.percent() <= 30) && (cell.percent() > 20) && longtermpower < 0)                       // <30%, turn off equipment
+	else if((cell.percent() <= AUTO_THRESHOLD_LIGHTING) && (cell.percent() > AUTO_THRESHOLD_EQUIPMENT) && longtermpower < 0)                       // <50%, turn off lighting
 		if(autoflag != 2)
-			equipment = autoset(equipment, 2)
-			lighting = autoset(lighting, 1)
+			equipment = autoset(equipment, 1)
+			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
 			power_alarm.triggerAlarm(loc, src)
 			autoflag = 2
-	else if(cell.percent() <= 20)        // <20%, turn off lighting & equipment
+	else if(cell.percent() <= AUTO_THRESHOLD_EQUIPMENT)        // <25%, turn off lighting & equipment
 		if((autoflag > 1 && longtermpower < 0) || (autoflag > 1 && longtermpower >= 0))
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 2)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1128,14 +1128,14 @@
 			environ = autoset(environ, 1)
 			autoflag = 3
 			power_alarm.clearAlarm(loc, src)
-	else if((cell.percent() <= 30) && (cell.percent() > 15) && longtermpower < 0)                       // <30%, turn off equipment
+	else if((cell.percent() <= 30) && (cell.percent() > 20) && longtermpower < 0)                       // <30%, turn off equipment
 		if(autoflag != 2)
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 1)
 			environ = autoset(environ, 1)
 			power_alarm.triggerAlarm(loc, src)
 			autoflag = 2
-	else if(cell.percent() <= 15)        // <15%, turn off lighting & equipment
+	else if(cell.percent() <= 20)        // <20%, turn off lighting & equipment
 		if((autoflag > 1 && longtermpower < 0) || (autoflag > 1 && longtermpower >= 0))
 			equipment = autoset(equipment, 2)
 			lighting = autoset(lighting, 2)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -824,18 +824,20 @@
 
 /obj/machinery/power/apc/proc/update()
 	if(operating && !shorted && !failure_timer)
-		area.power_light = (lighting >= POWERCHAN_ON)
+		
+		//prevent unnecessary updates to emergency lighting
+		var/new_power_light = (lighting >= POWERCHAN_ON)
+		if(area.power_light != new_power_light)
+			area.power_light = new_power_light
+			area.set_emergency_lighting(lighting == POWERCHAN_OFF_AUTO) //if lights go auto-off, emergency lights go on
+
 		area.power_equip = (equipment >= POWERCHAN_ON)
 		area.power_environ = (environ >= POWERCHAN_ON)
-//		if (area.name == "AI Chamber")
-//			spawn(10)
-//				world << " [area.name] [area.power_equip]"
 	else
 		area.power_light = 0
 		area.power_equip = 0
 		area.power_environ = 0
-//		if (area.name == "AI Chamber")
-//			world << "[area.power_equip]"
+
 	area.power_change()
 
 /obj/machinery/power/apc/proc/isWireCut(var/wireIndex)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -175,12 +175,12 @@
 	light_type = /obj/item/weapon/light/bulb
 
 /obj/machinery/light/small/emergency
-	brightness_range = 6
-	brightness_power = 2
+	brightness_range = 4
+	brightness_power = 1
 	brightness_color = "#da0205"
 
 /obj/machinery/light/small/red
-	brightness_range = 5
+	brightness_range = 4
 	brightness_power = 1
 	brightness_color = "#da0205"
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -252,35 +252,36 @@
 
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(var/trigger = 1)
-
 	update_icon()
 	if(on)
-		if(light_range != brightness_range || light_power != brightness_power || light_color != brightness_color)
-			switchcount++
-			if(rigged)
-				if(status == LIGHT_OK && trigger)
+		use_power = 2
 
-					log_admin("LOG: Rigged light explosion, last touched by [fingerprintslast]")
-					message_admins("LOG: Rigged light explosion, last touched by [fingerprintslast]")
+		var/changed = 0
+		if(current_mode && (current_mode in lighting_modes))
+			changed = set_light(arglist(lighting_modes[current_mode]))
+		else
+			changed = set_light(brightness_range, brightness_power, brightness_color)
 
-					explode()
-			else if( prob( min(60, switchcount*switchcount*0.01) ) )
-				if(status == LIGHT_OK && trigger)
-					status = LIGHT_BURNED
-					icon_state = "[base_state]-burned"
-					on = 0
-					set_light(0)
-			else
-				use_power = 2
-				if(current_mode && (current_mode in lighting_modes))
-					set_light(arglist(lighting_modes[current_mode]))
-				else
-					set_light(brightness_range, brightness_power, brightness_color)
+		if(trigger && changed)
+			switch_check()
 	else
-		use_power = 1
+		use_power = 0
 		set_light(0)
 
-	active_power_usage = ((light_range + light_power) * 10)
+	active_power_usage = ((light_range * light_power) * 5)
+
+/obj/machinery/light/proc/switch_check()
+	if(status != LIGHT_OK)
+		return //already busted
+
+	switchcount++
+	if(rigged)
+		log_admin("LOG: Rigged light explosion, last touched by [fingerprintslast]")
+		message_admins("LOG: Rigged light explosion, last touched by [fingerprintslast]")
+
+		explode()
+	else if( prob( min(60, switchcount*switchcount*0.01) ) )
+		burn_out()
 
 /obj/machinery/light/attack_generic(var/mob/user, var/damage)
 	if(!damage)
@@ -299,6 +300,16 @@
 	if(current_mode != new_mode)
 		current_mode = new_mode
 		update(0)
+
+/obj/machinery/light/proc/set_emergency_lighting(var/enable)
+	if(enable)
+		if("emergency_lighting" in lighting_modes)
+			set_mode("emergency_lighting")
+			power_channel = ENVIRON
+	else
+		if(current_mode == "emergency_lighting")
+			set_mode(null)
+			power_channel = initial(power_channel)
 
 // attempt to set the light's on/off status
 // will not switch on if broken/burned/empty
@@ -423,7 +434,7 @@
 // true if area has power and lightswitch is on
 /obj/machinery/light/powered()
 	var/area/A = get_area(src)
-	return A && A.lightswitch && (!A.requires_power || A.power_light)
+	return A && A.lightswitch && ..(power_channel)
 
 /obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
 	if(flickering) return
@@ -607,6 +618,11 @@
 		explosion(T, 0, 0, 2, 2)
 		sleep(1)
 		qdel(src)
+
+obj/machinery/light/proc/burn_out()
+	status = LIGHT_BURNED
+	update_icon()
+	set_light(0)
 
 // the light item
 // can be tube or bulb subtypes


### PR DESCRIPTION
Integrates emergency lighting into APC/area lighting control instead of being tacked onto the light fixtures themselves. This has the advantage of control flowing from APCs->areas->lights instead of every single light having to go back and grab their area's APC after a power change which was mildly spaghetti. Every single individual light in an area having to call get_area() and then get_apc() when they all have the same APC by virtue of being in the same area was probably a bit inefficient as well.

Emergency lighting now kicks in whenever the APC's lighting power channel goes to auto-off. I added defines so we don't have to deal with magic numbers anymore. When this happens, any lights that have an "emergency_lighting" light mode switch themselves to the ENVIRON channel.

Thus, emergency lights still continue to use power, but remain on until the ENVIRON channel shuts off. I've adjusted light power usage to scale much more dramatically with light power and light range (and to be much more sensible overall). The result is that while emergency lights still use power, they use far less power (2.85 times less) while in emergency_lighting mode.

Fixes #13492
