### PR TITLE
Fixes jobbans displaying 6 times. Also probably #13526

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -23,7 +23,7 @@ datum/controller/game_controller/New()
 
 	if(!job_master)
 		job_master = new /datum/controller/occupations()
-		job_master.SetupOccupations()
+		job_master.SetupOccupations(setup_titles=1)
 		job_master.LoadJobs("config/jobs.txt")
 		admin_notice("<span class='danger'>Job setup complete</span>", R_DEBUG)
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -13,7 +13,7 @@ var/global/datum/controller/occupations/job_master
 	var/list/job_debug = list()
 
 
-	proc/SetupOccupations(var/faction = "Station")
+	proc/SetupOccupations(var/faction = "Station", var/setup_titles = 0)
 		occupations = list()
 		var/list/all_jobs = list(/datum/job/assistant) | using_map.allowed_jobs
 		if(!all_jobs.len)
@@ -24,6 +24,7 @@ var/global/datum/controller/occupations/job_master
 			if(!job)	continue
 			if(job.faction != faction)	continue
 			occupations += job
+			if(!setup_titles) continue
 			if(job.department_flag & COM)
 				command_positions |= job.title
 			if(job.department_flag & SEC)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -25,21 +25,21 @@ var/global/datum/controller/occupations/job_master
 			if(job.faction != faction)	continue
 			occupations += job
 			if(job.department_flag & COM)
-				command_positions += job.title
+				command_positions |= job.title
 			if(job.department_flag & SEC)
-				security_positions += job.title
+				security_positions |= job.title
 			if(job.department_flag & ENG)
 				engineering_positions += job.title
 			if(job.department_flag & MED)
-				medical_positions += job.title
+				medical_positions |= job.title
 			if(job.department_flag & SCI)
-				science_positions += job.title
+				science_positions |= job.title
 			if(job.department_flag & CRG)
-				cargo_positions += job.title
+				cargo_positions |= job.title
 			if(job.department_flag & CIV)
-				civilian_positions += job.title
+				civilian_positions |= job.title
 			if(job.department_flag & MSC)
-				nonhuman_positions += job.title
+				nonhuman_positions |= job.title
 
 
 		return 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

I don't know why it was running through each job six times, but I believe the problem was that titles were being added 6 times each.
