### PR TITLE
Drones are no longer eligible for antagonist roles

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -10,10 +10,9 @@
 #define CANPUSH     0x8
 #define LEAPING     0x10
 #define PASSEMOTES  0x32    // Mob has a cortical borer or holders inside of it that need to see emotes.
-#define NO_ANTAG    0x0800  // Players are restricted from gaining antag roles when occupying this mob
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.
-#define DISFIGURED  0x4000  // Set but never checked. Remove this sometime and replace occurences with the appropriate organ code
+#define NO_ANTAG    0x4000  // Players are restricted from gaining antag roles when occupying this mob
 #define XENO_HOST   0x8000  // Tracks whether we're gonna be a baby alien's mummy.
 
 // Grab levels.

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -10,6 +10,7 @@
 #define CANPUSH     0x8
 #define LEAPING     0x10
 #define PASSEMOTES  0x32    // Mob has a cortical borer or holders inside of it that need to see emotes.
+#define NO_ANTAG    0x0800  // Players are restricted from gaining antag roles when occupying this mob
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.
 #define DISFIGURED  0x4000  // Set but never checked. Remove this sometime and replace occurences with the appropriate organ code

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -6,7 +6,7 @@
 			return 0
 		if(config.protect_roles_from_antagonist && (player.assigned_role in protected_jobs))
 			return 0
-		if(istype(player.current, /mob/living/silicon/robot/drone))
+		if(player.current && (player.current.status_flags & NO_ANTAG))
 			return 0
 	return 1
 

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -6,6 +6,8 @@
 			return 0
 		if(config.protect_roles_from_antagonist && (player.assigned_role in protected_jobs))
 			return 0
+		if(istype(player.current, /mob/living/silicon/robot/drone))
+			return 0
 	return 1
 
 /datum/antagonist/proc/antags_are_dead()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -81,7 +81,8 @@
 	update_hair(0)
 
 	mutations.Add(HUSK)
-	status_flags |= DISFIGURED	//makes them unknown without fucking up other stuff like admintools
+	for(var/obj/item/organ/external/E in organs)
+		E.disfigured = 1
 	update_body(1)
 	return
 
@@ -100,6 +101,7 @@
 	update_hair(0)
 
 	mutations.Add(SKELETON)
-	status_flags |= DISFIGURED
+	for(var/obj/item/organ/external/E in organs)
+		E.disfigured = 1
 	update_body(1)
 	return

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -78,6 +78,7 @@
 	var/current_pda_messaging = null
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
+	status_flags |= NO_ANTAG
 	src.loc = paicard
 	card = paicard
 	sradio = new(src)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -84,6 +84,7 @@
 	new_drone.master_fabricator = src
 
 	drone_progress = 0
+	return new_drone
 
 /mob/observer/ghost/verb/join_as_drone()
 	set category = "Ghost"
@@ -126,6 +127,8 @@
 		fabricator = all_fabricators[choice]
 
 	if(user && fabricator && !((fabricator.stat & NOPOWER) || !fabricator.produce_drones || fabricator.drone_progress < 100))
-		fabricator.create_drone(user.client)
+		var/mob/drone = fabricator.create_drone(user.client)
+		if(drone)
+			drone.status_flags |= NO_ANTAG
 		return 1
 	return

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -462,6 +462,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			host.universal_understand = 0
 		announce_ghost_joinleave(src, 0, "They are now a mouse.")
 		host.ckey = src.ckey
+		host.status_flags |= NO_ANTAG
 		host << "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>"
 
 /mob/observer/ghost/verb/view_manfiest()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -354,7 +354,7 @@
 				if(prob(100 * removed / meltdose)) // Applies disfigurement
 					if (!(H.species && (H.species.flags & NO_PAIN)))
 						H.emote("scream")
-					H.status_flags |= DISFIGURED
+					affecting.disfigured = 1
 		else
 			M.take_organ_damage(0, removed * power * 0.1) // Balance. The damage is instant, so it's weaker. 10 units -> 5 damage, double for pacid. 120 units beaker could deal 60, but a) it's burn, which is not as dangerous, b) it's a one-use weapon, c) missing with it will splash it over the ground and d) clothes give some protection, so not everything will hit
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -341,22 +341,19 @@
 		if(removed <= 0)
 			return
 
-	if(volume < meltdose) // Not enough to melt anything
-		M.take_organ_damage(0, removed * power * 0.2) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.
+	if(M.unacidable)
 		return
-	if(!M.unacidable && removed > 0)
-		if(istype(M, /mob/living/carbon/human) && volume >= meltdose)
+
+	if(volume < meltdose) // Not enough to melt anything
+		M.take_organ_damage(0, removed * power * 0.1) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.
+	else
+		M.take_organ_damage(0, removed * power * 0.2)
+		if(removed && ishuman(M) && prob(100 * removed / meltdose)) // Applies disfigurement
 			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/external/affecting = H.get_organ("head")
-			if(affecting)
-				if(affecting.take_damage(0, removed * power * 0.1))
-					H.UpdateDamageIcon()
-				if(prob(100 * removed / meltdose)) // Applies disfigurement
-					if (!(H.species && (H.species.flags & NO_PAIN)))
-						H.emote("scream")
-					affecting.disfigured = 1
-		else
-			M.take_organ_damage(0, removed * power * 0.1) // Balance. The damage is instant, so it's weaker. 10 units -> 5 damage, double for pacid. 120 units beaker could deal 60, but a) it's burn, which is not as dangerous, b) it's a one-use weapon, c) missing with it will splash it over the ground and d) clothes give some protection, so not everything will hit
+			if(!(H.species && (H.species.flags & NO_PAIN))) //TODO proc for whether someone can feel pain
+				H.emote("scream")
+			for(var/obj/item/organ/external/affecting in H.organs)
+				affecting.disfigured = 1
 
 /datum/reagent/acid/touch_obj(var/obj/O)
 	if(O.unacidable)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -570,8 +570,10 @@
 	M.adjustOxyLoss(-2 * removed)
 	M.heal_organ_damage(20 * removed, 20 * removed)
 	M.adjustToxLoss(-20 * removed)
-	if(dose > 3)
-		M.status_flags &= ~DISFIGURED
+	if(dose > 3 && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for(var/obj/item/organ/external/E in H.organs)
+			E.disfigured = 1 //currently only matters for the head, but might as well disfigure them all.
 	if(dose > 10)
 		M.make_dizzy(5)
 		M.make_jittery(5)


### PR DESCRIPTION
Drones can no longer become antagonists, except if given through means that ignore roles.
