### PR TITLE
Uplink Weapon Tweaks

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -28,10 +28,10 @@
 
 /datum/uplink_item/item/ammo/a762
 	name = "7.62mm"
-	item_cost = 3
-	path = /obj/item/ammo_magazine/box/a762
+	item_cost = 2
+	path = /obj/item/ammo_magazine/c762
 
 /datum/uplink_item/item/ammo/sniperammo
 	name = "14.5mm"
-	item_cost = 4
+	item_cost = 2
 	path = /obj/item/weapon/storage/box/sniperammo

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -31,14 +31,14 @@
 
 /datum/uplink_item/item/visible_weapons/revolver
 	name = "Revolver"
-	item_cost = 11
+	item_cost = 13
 	antag_costs = list(MODE_MERCENARY = 6)
 	path = /obj/item/weapon/gun/projectile/revolver
 
 /datum/uplink_item/item/visible_weapons/grenade_launcher
 	name = "Grenade Launcher"
-	item_cost = 12
-	antag_roles = list(MODE_MERCENARY)
+	item_cost = 15
+	antag_roles = list(MODE_MERCENARY = 12)
 	path = /obj/item/weapon/gun/launcher/grenade/loaded
 
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
@@ -50,11 +50,11 @@
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
-	item_cost = 16
+	item_cost = 15
 	antag_costs = list(MODE_MERCENARY = 9)
 	path = /obj/item/weapon/gun/projectile/automatic/sts35
 
 /datum/uplink_item/item/visible_weapons/heavysniper
 	name = "Anti-materiel Rifle"
-	item_cost = 21
+	item_cost = 15
 	path = /obj/item/weapon/gun/projectile/heavysniper

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -3,11 +3,11 @@
 	//desc = "A box of .357 ammo"
 	//icon_state = "357"
 	name = "speed loader (.357)"
-	icon_state = "T38"
+	icon_state = "38"
 	caliber = "357"
 	ammo_type = /obj/item/ammo_casing/a357
 	matter = list(DEFAULT_WALL_MATERIAL = 1260)
-	max_ammo = 7
+	max_ammo = 6
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/c38

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -104,7 +104,7 @@ obj/item/weapon/gun/energy/retro
 	fire_delay = 35
 	force = 10
 	w_class = 5
-	accuracy = -3 //shooting at the hip
+	accuracy = -2 //shooting at the hip
 	scoped_accuracy = 0
 
 /obj/item/weapon/gun/energy/sniperrifle/update_icon()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -6,7 +6,7 @@
 	caliber = "357"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	handle_casings = CYCLE_CASINGS
-	max_shells = 7
+	max_shells = 6
 	ammo_type = /obj/item/ammo_casing/a357
 	var/chamber_offset = 0 //how many empty chambers in the cylinder until you hit a round
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -14,7 +14,7 @@
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/a145
 	requires_two_hands = 6
-	accuracy = -3
+	accuracy = -2
 	scoped_accuracy = 5 //increased accuracy over the LWAP because only one shot
 	var/bolt_open = 0
 


### PR DESCRIPTION
Some tweaks following the discussion here: https://baystation12.net/forums/threads/discussion-revolvers-and-ptr.2044/

Adjusted the TC costs of several "highly visible and dangerous weapons."
- Revolvers now cost 13 TC like the C-20r.
- PTR now costs 15 TC, STS-35 reduced from 16 to 15 TC to match.
- PTR ammo now costs 2 TC instead of 4 TC.
- Fixes the 7.62mm ammo spawning ammo boxes instead of mags.
- Revolvers now hold 6 rounds instead of 7 rounds.

Also:
- Non-mercenaries can now buy the grenade launcher for 15 TC.
- Scoped weapons now have a -2 penalty for firing unscoped. -3 was just a little bit too much, considering the two weapons it applies to already have other features that hinder close combat with them. Anecdotal but I can recall times where people have unloaded the LWAP at me without hitting once.
