### PR TITLE
'Start Now' now allow initializations to complete before starting the round.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -12,6 +12,7 @@ var/global/pipe_processing_killed = 0
 
 datum/controller/game_controller
 	var/list/shuttle_list	                    // For debugging and VV
+	var/init_immediately = FALSE
 
 datum/controller/game_controller/New()
 	//There can be only one master_controller. Out with the old and in with the new.
@@ -42,10 +43,14 @@ datum/controller/game_controller/proc/setup()
 
 	transfer_controller = new
 
+	admin_notice("<span class='danger'>Initializations complete.</span>", R_DEBUG)
+	if(init_immediately && ticker && ticker.current_state == GAME_STATE_PREGAME)
+		ticker.current_state = GAME_STATE_SETTING_UP
+
 #ifdef UNIT_TEST
 #define CHECK_SLEEP_MASTER // For unit tests we don't care about a smooth lobby screen experience. We care about speed.
 #else
-#define CHECK_SLEEP_MASTER if(++initialized_objects > 500) { initialized_objects=0;sleep(world.tick_lag); }
+#define CHECK_SLEEP_MASTER if(!init_immediately && ++initialized_objects > 500) { initialized_objects=0;sleep(world.tick_lag); }
 #endif
 
 datum/controller/game_controller/proc/setup_objects()
@@ -86,7 +91,5 @@ datum/controller/game_controller/proc/setup_objects()
 			var/obj/machinery/atmospherics/unary/vent_scrubber/T = U
 			T.broadcast_status()
 		CHECK_SLEEP_MASTER
-
-	admin_notice("<span class='danger'>Initializations complete.</span>", R_DEBUG)
 
 #undef CHECK_SLEEP_MASTER

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -764,14 +764,14 @@ proc/admin_notice(var/message, var/rights)
 	if(!ticker)
 		alert("Unable to start the game as it is not set up.")
 		return
-	if(ticker.current_state == GAME_STATE_PREGAME)
-		ticker.current_state = GAME_STATE_SETTING_UP
+	if(ticker.current_state == GAME_STATE_PREGAME && !master_controller.init_immediately)
 		log_admin("[usr.key] has started the game.")
 		message_admins("<font color='blue'>[usr.key] has started the game.</font>")
 		feedback_add_details("admin_verb","SN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		master_controller.init_immediately = TRUE
 		return 1
 	else
-		usr << "<font color='red'>Error: Start Now: Game has already started.</font>"
+		usr << "<span class='warning'>Error: Start Now: Game has already started.</span>"
 		return 0
 
 /datum/admins/proc/toggleenter()


### PR DESCRIPTION
That's all there is to it really. Prevents all kinds of runtime errors.
