### PR TITLE
Fix ghost icons looking strange

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -125,6 +125,7 @@
 			var/mob/living/carbon/human/dummy/mannequin = new()
 			client.prefs.dress_preview_mob(mannequin)
 			observer.appearance = mannequin
+			observer.appearance_flags |= KEEP_TOGETHER // replace KEEP_TOGETHER flag so the ghost looks normal-ish
 			observer.alpha = 127
 			observer.layer = initial(observer.layer)
 			observer.invisibility = initial(observer.invisibility)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -6,6 +6,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "ghost"
+	appearance_flags = KEEP_TOGETHER
 	canmove = 0
 	blinded = 0
 	anchored = 1	//  don't get pushed around


### PR DESCRIPTION
Adds KEEP_TOGETHER to observers, making their icon render as a whole _then_ have transparency applied, rather than each component rendering with its own separate transparency.

Before: 
![](http://nyx.gn32.uk/i/2016-07-04_10-56-54.png)![](http://nyx.gn32.uk/i/2016-07-04_10-58-34.png)![](http://nyx.gn32.uk/i/2016-07-04_10-59-06.png)

After:
![](http://nyx.gn32.uk/i/2016-07-04_10-56-43.png)![](http://nyx.gn32.uk/i/2016-07-04_10-58-40.png)![](http://nyx.gn32.uk/i/2016-07-04_10-58-54.png)
