### PR TITLE
Allows burn damage to cause fluid loss

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -1,8 +1,10 @@
 //Common breathing procs
 
+#define MOB_BREATH_DELAY 2
+
 //Start of a breath chain, calls breathe()
 /mob/living/carbon/handle_breathing()
-	if(life_tick%2==0 || failed_last_breath || (health < config.health_threshold_crit)) 	//First, resolve location and get a breath
+	if((life_tick % MOB_BREATH_DELAY) == 0 || failed_last_breath || (health < config.health_threshold_crit)) 	//First, resolve location and get a breath
 		breathe()
 
 /mob/living/carbon/proc/breathe()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -2,7 +2,14 @@
 
 //NOTE: Breathing happens once per FOUR TICKS, unless the last breath fails. In which case it happens once per ONE TICK! So oxyloss healing is done once per 4 ticks while oxyloss damage is applied once per tick!
 #define HUMAN_MAX_OXYLOSS 1 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
-#define HUMAN_CRIT_MAX_OXYLOSS ( (process_schedule_interval("mob")/(1 SECOND)) / 6) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 50HP to get through, so (1/6)*last_tick_duration per second. Breaths however only happen every 4 ticks. last_tick_duration = ~2.0 on average
+
+#define HUMAN_CRIT_TIME_CUSHION (10 MINUTES) //approximate time limit to stabilize someone in crit
+#define HUMAN_CRIT_HEALTH_CUSHION (config.health_threshold_crit - config.health_threshold_dead)
+
+//The amount of damage you'll get when in critical condition. We want this to be a HUMAN_CRIT_TIME_CUSHION long deal.
+//There are HUMAN_CRIT_HEALTH_CUSHION hp to get through, so (HUMAN_CRIT_HEALTH_CUSHION/HUMAN_CRIT_TIME_CUSHION) per tick.
+//Breaths however only happen once every MOB_BREATH_DELAY life ticks. The delay between life ticks is set by the mob process.
+#define HUMAN_CRIT_MAX_OXYLOSS ( MOB_BREATH_DELAY * process_schedule_interval("mob") * (HUMAN_CRIT_HEALTH_CUSHION/HUMAN_CRIT_TIME_CUSHION) )
 
 #define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 4 //Amount of damage applied when your body temperature passes the 400K point

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -70,16 +70,16 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 	drip(blood_max)
 
 //Makes a blood drop, leaking amt units of blood from the mob
-/mob/living/carbon/human/proc/drip(var/amt as num)
+/mob/living/carbon/human/proc/drip(var/amt)
+	if(remove_blood(amt))
+		blood_splatter(src,src)
 
+/mob/living/carbon/human/proc/remove_blood(var/amt)
 	if(species && species.flags & NO_BLOOD) //TODO: Make drips come from the reagents instead.
-		return
-
+		return 0
 	if(!amt)
-		return
-
-	vessel.remove_reagent("blood", amt * (src.mob_size/MOB_MEDIUM))
-	blood_splatter(src,src)
+		return 0
+	return vessel.remove_reagent("blood", amt * (src.mob_size/MOB_MEDIUM))
 
 /****************************************************
 				BLOOD TRANSFERS

--- a/html/changelogs/HarpyEagle-burns.yml
+++ b/html/changelogs/HarpyEagle-burns.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - rscadd: "Severe enough burn damage now causes one-time blood loss due to blistering and body fluid cook-off."


### PR DESCRIPTION
Taking burn damage that is severe enough will now cause some fluid loss. The purpose of this PR is to add another small detail to the medical system, and give burn damage a secondary effect comparable to what brute damage does.

The fluid loss is calibrated so that taking 200 burn damage (or whatever is lethal for your species) will bring you to 40% blood volume, assuming that all of the burn damage is severe enough.

Also adjusts human crit oxyloss definitions to be less hardcoded. Raised the "official" buffer from 5 minutes to 10 minutes, however the calculation didn't take into account the mob breath delay which was 2 so technically nothing changed.
