### PR TITLE
Misc. tweaks.

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -405,9 +405,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			namecounts[name] = 1
 		if (M.real_name && M.real_name != M.name)
 			name += " \[[M.real_name]\]"
-		if (M.stat == 2)
-			if(istype(M, /mob/observer/ghost/))
-				name += " \[ghost\]"
+		if (M.stat == DEAD)
+			if(isobserver(M))
+				name += " \[observer\]"
 			else
 				name += " \[dead\]"
 		creatures[name] = M

--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -10,7 +10,6 @@
 	//l_color="#0066FF"
 	layer = LIGHTING_LAYER+1
 
-	var/spawned=0 // DIR mask
 	var/next_check=0
 	var/list/avail_dirs = list(NORTH,SOUTH,EAST,WEST)
 
@@ -29,7 +28,7 @@
 
 	// No more available directions? Shut down process().
 	if(avail_dirs.len==0)
-		processing_objects.Remove(src)
+		processing_turfs.Remove(src)
 		return 1
 
 	// We're checking, reset the timer.
@@ -47,18 +46,8 @@
 		spawn(10)
 			// Nom.
 			for(var/atom/movable/A in T)
-				if(A)
-					if(istype(A,/mob/living))
-						qdel(A)
-					else if(istype(A,/mob)) // Observers, AI cameras.
-						continue
-					else
-						qdel(A)
+				Consume(A)
 			T.ChangeTurf(type)
-
-	if((spawned & (NORTH|SOUTH|EAST|WEST)) == (NORTH|SOUTH|EAST|WEST))
-		processing_turfs -= src
-		return
 
 /turf/unsimulated/wall/supermatter/attack_generic(mob/user as mob)
 	if(istype(user))
@@ -97,7 +86,6 @@
 	user.drop_from_inventory(W)
 	Consume(W)
 
-
 /turf/unsimulated/wall/supermatter/Bumped(atom/AM as mob|obj)
 	if(istype(AM, /mob/living))
 		AM.visible_message("<span class=\"warning\">\The [AM] slams into \the [src] inducing a resonance... \his body starts to glow and catch flame before flashing into ash.</span>",\
@@ -111,9 +99,9 @@
 
 	Consume(AM)
 
-
-/turf/unsimulated/wall/supermatter/proc/Consume(var/mob/living/user)
-	if(isobserver(user))
+/turf/unsimulated/wall/supermatter/proc/Consume(var/atom/A)
+	if(isobserver(A))
 		return
-
-	qdel(user)
+	if(!A.simulated)
+		return
+	qdel(A)

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -35,6 +35,12 @@ var/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 		updateallghostimages()
 	. = ..()
 
+/mob/observer/add_to_living_mob_list()
+	return
+
+/mob/observer/add_to_dead_mob_list()
+	return
+
 mob/observer/check_airflow_movable()
 	return FALSE
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Observers are no longer added to the dead/living mob lists.
Non-ghost observers are now marked as such in the follow list (as opposed to being marked as dead).
The bluespace rift no longer qdels()s non-simulated atoms (should prevent the issue of massive lighting runtimes). Cleans up the code in general.
