### PR TITLE
Tweaks shield generator values

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -1,5 +1,9 @@
 var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called manually after an event.
 
+#define KILOWATTS *1000
+#define MEGAWATTS *1000000
+#define GIGAWATTS *1000000000
+
 #define CELLRATE 0.002 // Multiplier for watts per tick <> cell storage (e.g., 0.02 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)
                        // It's a conversion constant. power_used*CELLRATE = charge_provided, or charge_used/CELLRATE = power_provided
 #define SMESRATE 0.05  // Same for SMESes. A different number for some reason.

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -12,11 +12,11 @@
 	var/stored_charge = 0	//not to be confused with power cell charge, this is in Joules
 	var/last_stored_charge = 0
 	var/time_since_fail = 100
-	var/max_charge = 8e6	//8 MJ
-	var/max_charge_rate = 400000	//400 kW
+	var/max_charge = 2 GIGAWATTS 		// 2 GJ
+	var/max_charge_rate = 4 MEGAWATTS	// 4 MW input max.
 	var/locked = 0
 	use_power = 0 //doesn't use APC power
-	var/charge_rate = 100000	//100 kW
+	var/charge_rate = 100 KILOWATTS
 	var/obj/machinery/shield_gen/owned_gen
 
 /obj/machinery/shield_capacitor/New()
@@ -82,16 +82,16 @@
 	else
 		t += "This capacitor is: [active ? "<font color=green>Online</font>" : "<font color=red>Offline</font>" ] <a href='?src=\ref[src];toggle=1'>[active ? "\[Deactivate\]" : "\[Activate\]"]</a><br>"
 		t += "Capacitor Status: [time_since_fail > 2 ? "<font color=green>OK.</font>" : "<font color=red>Discharging!</font>"]<br>"
-		t += "Stored Energy: [round(stored_charge/1000, 0.1)] kJ ([100 * round(stored_charge/max_charge, 0.1)]%)<br>"
+		t += "Stored Energy: [round(stored_charge/1000000, 0.01)]/[round(max_charge/1000000, 0.01)] MJ ([100 * round(stored_charge/max_charge, 0.01)]%)<br>"
 		t += "Charge Rate: \
-		<a href='?src=\ref[src];charge_rate=-100000'>\[----\]</a> \
-		<a href='?src=\ref[src];charge_rate=-10000'>\[---\]</a> \
-		<a href='?src=\ref[src];charge_rate=-1000'>\[--\]</a> \
-		<a href='?src=\ref[src];charge_rate=-100'>\[-\]</a>[charge_rate] W \
-		<a href='?src=\ref[src];charge_rate=100'>\[+\]</a> \
-		<a href='?src=\ref[src];charge_rate=1000'>\[++\]</a> \
-		<a href='?src=\ref[src];charge_rate=10000'>\[+++\]</a> \
-		<a href='?src=\ref[src];charge_rate=100000'>\[+++\]</a><br>"
+		<a href='?src=\ref[src];charge_rate=-1000000'>\[----\]</a> \
+		<a href='?src=\ref[src];charge_rate=-100000'>\[---\]</a> \
+		<a href='?src=\ref[src];charge_rate=-10000'>\[--\]</a> \
+		<a href='?src=\ref[src];charge_rate=-1000'>\[-\]</a>[charge_rate/1000] kW \
+		<a href='?src=\ref[src];charge_rate=1000'>\[+\]</a> \
+		<a href='?src=\ref[src];charge_rate=10000'>\[++\]</a> \
+		<a href='?src=\ref[src];charge_rate=100000'>\[+++\]</a> \
+		<a href='?src=\ref[src];charge_rate=1000000'>\[+++\]</a><br>"
 	t += "<hr>"
 	t += "<A href='?src=\ref[src]'>Refresh</A> "
 	t += "<A href='?src=\ref[src];close=1'>Close</A><BR>"

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -12,22 +12,22 @@
 	icon_state = "generator0"
 	var/active = 0
 	var/field_radius = 3
-	var/max_field_radius = 100
+	var/max_field_radius = 255
 	var/list/field
 	density = 1
 	var/locked = 0
 	var/average_field_strength = 0
 	var/strengthen_rate = 0.2
 	var/max_strengthen_rate = 0.5	//the maximum rate that the generator can increase the average field strength
-	var/dissipation_rate = 0.030	//the percentage of the shield strength that needs to be replaced each second
-	var/min_dissipation = 0.01		//will dissipate by at least this rate in renwicks per field tile (otherwise field would never dissipate completely as dissipation is a percentage)
+	var/dissipation_rate = 0.001	//the percentage of the shield strength that needs to be replaced each second
+	var/min_dissipation = 0.0001	//will dissipate by at least this rate in renwicks per field tile (otherwise field would never dissipate completely as dissipation is a percentage)
 	var/powered = 0
 	var/check_powered = 1
 	var/obj/machinery/shield_capacitor/owned_capacitor
 	var/target_field_strength = 10
 	var/max_field_strength = 10
 	var/time_since_fail = 100
-	var/energy_conversion_rate = 0.0002	//how many renwicks per watt?
+	var/energy_conversion_rate = 0.00002	//how many renwicks per watt?
 	use_power = 0	//doesn't use APC power
 
 /obj/machinery/shield_gen/New()
@@ -44,7 +44,7 @@
 		field.Remove(D)
 		qdel(D)
 	..()
-	
+
 /obj/machinery/shield_gen/emag_act(var/remaining_charges, var/mob/user)
 	if(prob(75))
 		src.locked = !src.locked
@@ -117,11 +117,11 @@
 		<a href='?src=\ref[src];change_radius=5'>++</a> \
 		<a href='?src=\ref[src];change_radius=50'>+++</a><br>"
 		t += "Overall Field Strength: [round(average_field_strength, 0.01)] Renwick ([target_field_strength ? round(100 * average_field_strength / target_field_strength, 0.1) : "NA"]%)<br>"
-		t += "Upkeep Power: [round(field.len * max(average_field_strength * dissipation_rate, min_dissipation) / energy_conversion_rate)] W<br>"
+		t += "Upkeep Power: [round(field.len * max(average_field_strength * dissipation_rate, min_dissipation) / energy_conversion_rate / 1000)] kW<br>"
 		t += "Charge Rate: <a href='?src=\ref[src];strengthen_rate=-0.1'>--</a> \
 		[strengthen_rate] Renwick/s \
 		<a href='?src=\ref[src];strengthen_rate=0.1'>++</a><br>"
-		t += "Shield Generation Power: [round(field.len * min(strengthen_rate, target_field_strength - average_field_strength) / energy_conversion_rate)] W<br>"
+		t += "Shield Generation Power: [round(field.len * min(strengthen_rate, target_field_strength - average_field_strength) / energy_conversion_rate / 1000)] kW<br>"
 		t += "Maximum Field Strength: \
 		<a href='?src=\ref[src];target_field_strength=-10'>\[min\]</a> \
 		<a href='?src=\ref[src];target_field_strength=-5'>--</a> \

--- a/html/changelogs/atlantiscze-shieldtweak.yml
+++ b/html/changelogs/atlantiscze-shieldtweak.yml
@@ -1,0 +1,8 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Shield generator configuration has been tweaked. Shield generators upkeep power is reduced considerably (stationwide shield is approx. 1.1MW at full strength). Shields still use a lot of power when regenerating."
+  - tweak: "Shield capacitors now act as actual capacitors. Their power storage is 2 GJ, and maximal input 4MW, as opposed to 8MJ/400kW it was now."
+  - tweak: "Shield generator+capacitor UI now displays in kilowatts and megawatts instead of watts where applicable."


### PR DESCRIPTION
- Shield generators use generally less power now. 10 Renwick stationwide shield uses approximatley 1.1MW when idle. This combined with normal station power usage results in about 1.5MW total power usage.
- Shield capacitors now work as actual capacitors. Maximal stored charge is 2 gigajoules, meaning an idle shield can run off them for a while when fully charged. Maximal input increased to 4MW (up from 400kW) so it is actually possible to input the power needed to run the shield.
- Various shield generator/capacitor values are now in kilowatts and megawatts to prevent ugly rounding and giant numbers where possible (1e006)
- Shield generator maximal radius increased to 255. You no longer have to place the generator on bridge in order to cover whole station - it can be anywhere on the station.
- Shield generator power usage is now shifted more towards regeneration. Regenerating the field is still a very power hungry process, while upkeep is lower.

Note: This PR isn't intended as complete overhaul of shield generators. I might restore that project in the future, but for now this will do.
