### PR TITLE
Balances leap. Pariah changes, adds missing flag.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -75,7 +75,7 @@
 		src << "<span class='warning'>You cannot leap in your current state.</span>"
 		return
 
-	last_special = world.time + 17.5 SECONDS
+	last_special = world.time + (17.5 SECONDS)
 	status_flags |= LEAPING
 
 	src.visible_message("<span class='danger'>\The [src] leaps at [T]!</span>")

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -71,11 +71,11 @@
 	if(last_special > world.time)
 		return
 
-	if(incapacitated(INCAPACITATION_DISABLED) || buckled || pinned.len)
+	if(incapacitated(INCAPACITATION_DISABLED) || buckled || pinned.len || stance_damage >= 4 || src.legcuffed)
 		src << "<span class='warning'>You cannot leap in your current state.</span>"
 		return
 
-	last_special = world.time + 75
+	last_special = world.time + 17.5 SECONDS
 	status_flags |= LEAPING
 
 	src.visible_message("<span class='danger'>\The [src] leaps at [T]!</span>")
@@ -93,7 +93,7 @@
 	T.Weaken(3)
 
 	// Pariahs are not good at leaping. This is snowflakey, pls fix.
-	if(species.name == "Vox Pariah")
+	if(species.name == "Vox Pariah" || src.handcuffed || stance_damage >= 2)
 		src.Weaken(5)
 		return
 

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -37,7 +37,7 @@
 
 	flags = NO_SCAN | NO_MINOR_CUT
 	spawn_flags = IS_WHITELISTED
-	appearance_flags = HAS_EYE_COLOR
+	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"
@@ -92,12 +92,18 @@
 
 /datum/species/vox/pariah
 	name = "Vox Pariah"
-	//blurb = "TODO Vox Pariah specific blurb."
+	blurb = "Sickly biproducts of Vox society, these creatures are vilified by their own kind \
+	and taken advantage of by enterprising companies for cheap, disposable labor. \
+	They aren't very smart, smell worse than a vox, and vomit constantly, \
+	earning them the true title of 'shitbird'."
 	rarity_value = 0.1
 	speech_chance = 60        // No volume control.
 	siemens_coefficient = 0.5 // Ragged scaleless patches.
 
-	total_health = 65
+	oxy_mod = 1.4
+	brute_mod = 1.3
+	burn_mod = 1.4
+	toxins_mod = 1.3
 
 	cold_level_1 = 130
 	cold_level_2 = 100
@@ -116,7 +122,7 @@
 		)
 	spawn_flags = IS_WHITELISTED | CAN_JOIN
 	flags = NO_SCAN
-	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR //so pariah can change their hair colour but regular vox can't?
+	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 /datum/species/vox/pariah/get_bodytype()
 	return "Vox"

--- a/html/changelogs/TheWelp - leapNShit.yml
+++ b/html/changelogs/TheWelp - leapNShit.yml
@@ -1,0 +1,6 @@
+author: TheWelp
+delete-after: True
+changes: 
+  - tweak: "Rebalances leap to respect handcuffs, ability to walk, etc."
+  - tweak: "Pariahs HP deficit has been removed (65->100), instead they are now more vulnerable to all types of damage."
+  - rscadd: "Adds missing hair color flag for regular Vox. Now you can have colorful dyed Vox hair! Within reason."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Leap now has a cooldown of 17.5 seconds compared to the previous 7.5 seconds. Also respects stuff like disability to walk, grab.

Pariah's health has been reverted back to 100, but their damage mods have been increased. Not the SAME percent of damage taken, but should make them blow off limbs, bleed, etc. Also adds the Pariah blurb.

Adds a missing hair flag on regular Vox.
