### PR TITLE
convert admin log now shows faction

### DIFF
--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -30,8 +30,8 @@
 		return
 
 	src << "<span class='danger'>You are attempting to convert \the [player.current]...</span>"
-	log_admin("[src]([src.ckey]) attempted to convert [player.current].")
-	message_admins("<span class='danger'>[src]([src.ckey]) attempted to convert [player.current].</span>")
+	log_admin("[src]([src.ckey]) attempted to convert [player.current] to the [faction.faction_descriptor].")
+	message_admins("<span class='danger'>[src]([src.ckey]) attempted to convert [player.current] to the [faction.faction_descriptor].</span>")
 
 	player.rev_cooldown = world.time+100
 	var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Title. Now that both loyalists and revolutionaries convert people it needs something to help admins parse the logs better.
