### PR TITLE
Only adds /mob/living to the living/dead mob lists.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -261,6 +261,8 @@ Proc for attack log creation, because really why not
 
 // Returns true if the mob was in neither the dead or living list
 /mob/proc/add_to_living_mob_list()
+	return FALSE
+/mob/living/add_to_living_mob_list()
 	if((src in living_mob_list_) || (src in dead_mob_list_))
 		return FALSE
 	living_mob_list_ += src
@@ -272,6 +274,8 @@ Proc for attack log creation, because really why not
 
 // Returns true if the mob was in neither the dead or living list
 /mob/proc/add_to_dead_mob_list()
+	return FALSE
+/mob/living/add_to_dead_mob_list()
 	if((src in living_mob_list_) || (src in dead_mob_list_))
 		return FALSE
 	dead_mob_list_ += src

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1179,12 +1179,6 @@ var/mob/dview/dview_mob = new
 	// We don't want to be in any mob lists; we're a dummy not a mob.
 	mob_list -= src
 
-/mob/dview/add_to_living_mob_list()
-	return
-
-/mob/dview/add_to_dead_mob_list()
-	return
-
 // call to generate a stack trace and print to runtime logs
 /proc/crash_with(msg)
 	CRASH(msg)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -9,10 +9,10 @@
 	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/add_to_living_mob_list()
-	return
+	return FALSE
 
 /mob/living/carbon/human/dummy/mannequin/add_to_dead_mob_list()
-	return
+	return FALSE
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(new_name)
 	..("[new_name] (mannequin)", FALSE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,3 +1,10 @@
+/mob/living/New()
+	..()
+	if(stat == DEAD)
+		add_to_dead_mob_list()
+	else
+		add_to_living_mob_list()
+
 //mob verbs are faster than object verbs. See mob/verb/examine.
 /mob/living/verb/pulled(atom/movable/AM as mob|obj in oview(1))
 	set name = "Pull"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -41,10 +41,6 @@
 
 /mob/New()
 	mob_list += src
-	if(stat == DEAD)
-		add_to_dead_mob_list()
-	else
-		add_to_living_mob_list()
 	..()
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -35,12 +35,6 @@ var/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 		updateallghostimages()
 	. = ..()
 
-/mob/observer/add_to_living_mob_list()
-	return
-
-/mob/observer/add_to_dead_mob_list()
-	return
-
 mob/observer/check_airflow_movable()
 	return FALSE
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Which makes mannequins the only exception which has to override the relevant procs.
