### PR TITLE
Fixes bluespace tomatoes

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -331,9 +331,8 @@
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(3, 1, get_turf(target))
 			s.start()
-			var/turf/picked = get_turf(pick(turfs))                      // Just in case...
 			new/obj/effect/decal/cleanable/molten_item(get_turf(target)) // Leave a pile of goo behind for dramatic effect...
-			target.forceMove(picked)                                     // And teleport them to the chosen location.
+			target.forceMove(T)                                     // And teleport them to the chosen location.
 			impact = 1
 
 	return impact


### PR DESCRIPTION
When plant products with `TRAIT_TELEPORTING` hit someone, they use `get_random_turf_in_range()` to find a random turf to teleport the victim... and then immediately discard that result, instead picking from a `turfs` list that doesn't appear to be defined in the file.

I'm not really sure what the `turfs` list is but in a recent round the tomatoes were teleporting people to other Z-levels, which is a problem, since unlike proximate teleporting you are very likely to end up in space, which makes bluespace tomatoes a bit too effective at being a silent, easy to conceal way to one-hit kill someone while simultaneously getting rid of their body.
