### PR TITLE
Prevents add-antag vote from being used multiple times in a round

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -27,7 +27,7 @@ datum/controller/vote
 		if(mode)
 			// No more change mode votes after the game has started.
 			// 3 is GAME_STATE_PLAYING, but that #define is undefined for some reason
-			if(mode == "gamemode" && ticker.current_state >= 2)
+			if(mode == "gamemode" && ticker.current_state >= GAME_STATE_SETTING_UP)
 				world << "<b>Voting aborted due to game start.</b>"
 				src.reset()
 				return
@@ -222,23 +222,23 @@ datum/controller/vote
 								.[i] = pick(choices)
 								world << "The random antag in [i]\th place is [.[i]]."
 						var/antag_type = antag_names_to_ids[.[1]]
-						if(ticker.current_state >= 2)
+						if(ticker.current_state < GAME_STATE_SETTING_UP)
+							additional_antag_types |= antag_type
+						else
 							spawn(0) // break off so we don't hang the vote process
 								var/list/antag_choices = list(all_antag_types[antag_type], all_antag_types[antag_names_to_ids[.[2]]], all_antag_types[antag_names_to_ids[.[3]]])
-								if(!ticker.attempt_late_antag_spawn(antag_choices))
-									world << "<b>No antags were added.</b>"
-									if(auto_add_antag)
-										auto_add_antag = 0
-										spawn(10)
-											autotransfer()
-								else
+								if(ticker.attempt_late_antag_spawn(antag_choices))
 									antag_add_finished = 1
 									if(auto_add_antag)
 										auto_add_antag = 0
 										// the buffer will already have an hour added to it, so we'll give it one more
 										transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
-						else
-							additional_antag_types |= antag_type
+								else
+									world << "<b>No antags were added.</b>"
+									if(auto_add_antag)
+										auto_add_antag = 0
+										spawn(10)
+											autotransfer()
 				if("map")
 					var/datum/map/M = all_maps[.[1]]
 					fdel("use_map")
@@ -299,7 +299,7 @@ datum/controller/vote
 				if("restart")
 					choices.Add("Restart Round","Continue Playing")
 				if("gamemode")
-					if(ticker.current_state >= 2)
+					if(ticker.current_state >= GAME_STATE_SETTING_UP)
 						return 0
 					choices.Add(config.votable_modes)
 					for (var/F in choices)
@@ -319,7 +319,7 @@ datum/controller/vote
 						if (get_security_level() == "red" || get_security_level() == "delta")
 							initiator_key << "The current alert status is too high to call for a crew transfer!"
 							return 0
-						if(ticker.current_state <= 2)
+						if(ticker.current_state <= GAME_STATE_SETTING_UP)
 							return 0
 							initiator_key << "The crew transfer button has been disabled!"
 						question = "End the shift?"

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -227,15 +227,16 @@ datum/controller/vote
 								var/list/antag_choices = list(all_antag_types[antag_type], all_antag_types[antag_names_to_ids[.[2]]], all_antag_types[antag_names_to_ids[.[3]]])
 								if(!ticker.attempt_late_antag_spawn(antag_choices))
 									world << "<b>No antags were added.</b>"
-									antag_add_finished = 1
 									if(auto_add_antag)
 										auto_add_antag = 0
 										spawn(10)
-											autotransfer();
-								else if(auto_add_antag)
-									auto_add_antag = 0
-									// the buffer will already have an hour added to it, so we'll give it one more
-									transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
+											autotransfer()
+								else
+									antag_add_finished = 1
+									if(auto_add_antag)
+										auto_add_antag = 0
+										// the buffer will already have an hour added to it, so we'll give it one more
+										transfer_controller.timerbuffer = transfer_controller.timerbuffer + config.vote_autotransfer_interval
 						else
 							additional_antag_types |= antag_type
 				if("map")


### PR DESCRIPTION
Prevents add-antag votes from being called after successfully adding antags. Instead, further votes are only allowed if the previous attempt failed.
