### PR TITLE
Fixes non-spreading xeno plants.

### DIFF
--- a/code/game/objects/structures/alien/node.dm
+++ b/code/game/objects/structures/alien/node.dm
@@ -16,4 +16,4 @@
 /obj/structure/alien/node/process()
 	if(locate(/obj/effect/plant) in loc)
 		return
-	new /obj/effect/plant(get_turf(src), plant_controller.seeds["xenomorph"])
+	new/obj/effect/plant(get_turf(src), plant_controller.seeds["xenomorph"], start_matured = 1)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -12,7 +12,7 @@
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
-			var/obj/effect/plant/vine = new(T,seed, start_matured = 1)
+			new /obj/effect/plant(T,seed, start_matured = 1)
 
 			log_and_message_admins("Spacevines spawned in \the [get_area(T)]", location = T)
 			return

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -12,10 +12,7 @@
 			seed.display_name = "strange plants" //more thematic for the vine infestation event
 
 			//make vine zero start off fully matured
-			var/obj/effect/plant/vine = new(T,seed)
-			vine.health = vine.max_health
-			vine.mature_time = 0
-			vine.process()
+			var/obj/effect/plant/vine = new(T,seed, start_matured = 1)
 
 			log_and_message_admins("Spacevines spawned in \the [get_area(T)]", location = T)
 			return
@@ -73,7 +70,7 @@
 /obj/effect/plant/single
 	spread_chance = 0
 
-/obj/effect/plant/New(var/newloc, var/datum/seed/newseed, var/obj/effect/plant/newparent)
+/obj/effect/plant/New(var/newloc, var/datum/seed/newseed, var/obj/effect/plant/newparent, var/start_matured = 0)
 	..()
 
 	if(!newparent)
@@ -120,6 +117,10 @@
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
 	spread_distance = ((growth_type>0) ? round(spread_chance*0.6) : round(spread_chance*0.3))
 	update_icon()
+	if(start_matured)
+		mature_time = 0
+		health = max_health
+		process()
 
 // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
 /obj/effect/plant/proc/finish_spreading()
@@ -261,7 +262,7 @@
 	var/aggression = 0
 	aggression += (attacker_seed.get_trait(TRAIT_CARNIVOROUS) - seed.get_trait(TRAIT_CARNIVOROUS))
 	aggression += (attacker_seed.get_trait(TRAIT_SPREAD) - seed.get_trait(TRAIT_SPREAD))
-	
+
 	var/resiliance
 	if(is_mature())
 		resiliance = 0

--- a/code/modules/spells/targeted/entangle.dm
+++ b/code/modules/spells/targeted/entangle.dm
@@ -32,11 +32,8 @@
 /spell/targeted/entangle/cast(var/list/targets)
 	for(var/mob/M in targets)
 		var/turf/T = get_turf(M)
-		var/obj/effect/plant/single/P = new(T,seed)
+		var/obj/effect/plant/single/P = new(T,seed, start_matured =1)
 		P.can_buckle = 1
-		P.health = P.max_health
-		P.mature_time = 0
-		P.process()
 
 		P.buckle_mob(M)
 		M.set_dir(pick(cardinal))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Adds a start_matured variable to /obj/effect/plant New proc that is used in vine infestations and xeno-nodes (and the entangled spell)
