### PR TITLE
Fix missing surgery caps

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -47,7 +47,7 @@
 	name = OUTFIT_JOB_NAME("Nurse")
 	suit = null
 
-/decl/hierarchy/outfit/job/medical/doctor/pre_equip(mob/living/carbon/human/H)
+/decl/hierarchy/outfit/job/medical/doctor/nurse/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.gender == FEMALE)
 		if(prob(50))


### PR DESCRIPTION
doctor/pre_equip() was overriding all the alt title outfits, making every
MD look like nurses.

Fixes #13630
