### PR TITLE
Fixes #13654 + minor Tesla Link tweaks

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -9,7 +9,7 @@ obj/machinery/recharger
 	idle_power_usage = 4
 	active_power_usage = 15000	//15 kW
 	var/obj/item/charging = null
-	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton, /obj/item/laptop, /obj/item/weapon/cell, /obj/item/modular_computer/, /obj/item/device/suit_sensor_jammer)
+	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton, /obj/item/laptop, /obj/item/weapon/cell, /obj/item/modular_computer/, /obj/item/device/suit_sensor_jammer, /obj/item/weapon/computer_hardware/battery_module)
 	var/icon_state_charged = "recharger2"
 	var/icon_state_charging = "recharger1"
 	var/icon_state_idle = "recharger0" //also when unpowered
@@ -102,7 +102,9 @@ obj/machinery/recharger/process()
 		else if(istype(charging, /obj/item/weapon/gun/energy))
 			var/obj/item/weapon/gun/energy/E = charging
 			cell = E.power_supply
-
+		else if(istype(charging, /obj/item/weapon/computer_hardware/battery_module))
+			var/obj/item/weapon/computer_hardware/battery_module/BM = charging
+			cell = BM.battery
 		if(istype(cell, /obj/item/weapon/cell))
 			var/obj/item/weapon/cell/C = cell
 			if(!C.fully_charged())

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -103,10 +103,6 @@
 		var/obj/item/weapon/computer_hardware/tesla_link/L = H
 		L.holder = machinery_computer
 		machinery_computer.tesla_link = L
-		// Consoles don't usually have internal power source, so we can't disable tesla link in them.
-		if(istype(machinery_computer, /obj/machinery/modular_computer/console))
-			L.critical = 1
-			L.enabled = 1
 		found = 1
 	..(user, H, found)
 
@@ -114,7 +110,6 @@
 	if(machinery_computer.tesla_link == H)
 		machinery_computer.tesla_link = null
 		var/obj/item/weapon/computer_hardware/tesla_link/L = H
-		L.critical = 0		// That way we can install tesla link from console to laptop and it will be possible to turn it off via config.
 		L.holder = null
 		found = 1
 	..(user, H, found, critical)
@@ -130,3 +125,9 @@
 	if(!machinery_computer)
 		return 0
 	return machinery_computer.Adjacent(neighbor)
+
+/obj/item/modular_computer/processor/turn_on(var/mob/user)
+	// If we have a tesla link on our machinery counterpart, enable it automatically. Lets computer without a battery work.
+	if(machinery_computer && machinery_computer.tesla_link)
+		machinery_computer.tesla_link.enabled = 1
+	..()

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -30,8 +30,6 @@
 	cpu.battery_module = null
 	cpu.network_card = new/obj/item/weapon/computer_hardware/network_card/wired(src)
 	tesla_link = new/obj/item/weapon/computer_hardware/tesla_link(src)
-	tesla_link.enabled = 1
-	tesla_link.critical = 1 // Consoles don't usually come with cells, and this prevents people from disabling their only power source, as they wouldn't be able to enable it again.
 	cpu.hard_drive = new/obj/item/weapon/computer_hardware/hard_drive/super(src) // Consoles generally have better HDDs due to lower space limitations
 	var/area/A = get_area(src)
 	// Attempts to set this console's tag according to our area. Since some areas have stuff like "XX - YY" in their names we try to remove that too.

--- a/code/modules/modular_computers/hardware/tesla_link.dm
+++ b/code/modules/modular_computers/hardware/tesla_link.dm
@@ -2,7 +2,7 @@
 	name = "tesla link"
 	desc = "An advanced tesla link that wirelessly recharges connected device from nearby area power controller."
 	critical = 0
-	enabled = 0 // Starts turned off
+	enabled = 1
 	icon_state = "teslalink"
 	hardware_size = 2		// Can't be installed into tablets
 	origin_tech = list(TECH_DATA = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)


### PR DESCRIPTION
- It is now possible to place modular computer battery modules into recharger directly.
- Tesla link is no longer "conditionally critical" hardware, it's critical flag should always be false now.
- Tesla link is automatically turned on when the computer is turned on, regardless on whether the user turned it off beforehand. You can still turn it off via the configuration tool, but it will be turned on automatically after you reboot the device. This is a QOL change, as almost everyone wants the tesla link to be turned on anyway.
- Fixes #13654
