### PR TITLE
Adjusts the siemens coefficient of voidsuits and light hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -6,6 +6,7 @@
 	suit_type = "light suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/cell)
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	siemens_coefficient = 0.4
 	emp_protection = 10
 	online_slowdown = 0
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL
@@ -58,14 +59,13 @@
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
 /obj/item/clothing/head/lightrig/hacker
 	name = "HUD"
-	siemens_coefficient = 0.4
 	flags = 0
 
 /obj/item/clothing/suit/lightrig/hacker
-	siemens_coefficient = 0.4
+	siemens_coefficient = 0.2
 
 /obj/item/clothing/shoes/lightrig/hacker
-	siemens_coefficient = 0.4
+	siemens_coefficient = 0.2
 	flags = NOSLIP //All the other rigs have magboots anyways, hopefully gives the hacker suit something more going for it.
 
 /obj/item/clothing/gloves/lightrig/hacker
@@ -77,6 +77,7 @@
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."
 	icon_state = "ninja_rig"
 	armor = list(melee = 50, bullet = 15, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 30)
+	siemens_coefficient = 0.2 //heavy hardsuit level shock protection
 	emp_protection = 40 //change this to 30 if too high.
 	online_slowdown = 0
 	aimove_power_usage = 50

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -5,7 +5,7 @@
 	item_state = "syndicate"
 	desc = "A crimson helmet sporting clean lines and durable plating. Engineered to look menacing."
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
@@ -15,7 +15,7 @@
 	w_class = 3
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency)
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/syndicate/New()
 	..()

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -5,7 +5,7 @@
 	icon_state = "rig0-syndie"
 	item_state = "syndie_helm"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 60)
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.3
 	species_restricted = list("Human")
 	camera_networks = list(NETWORK_MERCENARY)
 	light_overlay = "helmet_light_green" //todo: species-specific light overlays
@@ -18,7 +18,7 @@
 	w_class = 4 //normally voidsuits are bulky but the merc voidsuit is 'advanced' or something
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 60)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.3
 	species_restricted = list("Human", "Skrell")
 
 /obj/item/clothing/suit/space/void/merc/New()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -7,7 +7,7 @@
 	heat_protection = HEAD
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 20)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.7
+	siemens_coefficient = 0.4
 
 	//Species-specific stuff.
 	species_restricted = list("Human")
@@ -36,7 +36,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.7
+	siemens_coefficient = 0.4
 
 	species_restricted = list("Human", "Skrell")
 	sprite_sheets_refit = list(

--- a/html/changelogs/HarpyEagle-voidsuit-siemens.yml
+++ b/html/changelogs/HarpyEagle-voidsuit-siemens.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - tweak: "Voidsuits and cyber suits are now more shock resistant, now roughly between hardsuits and thick clothing."


### PR DESCRIPTION
Voidsuits are meant to be somewhat resistant to shocks and tasers, however their 0.7 siemens coefficient is still rather paltry.

Given that hardsuits are at 0.2 and several examples of thick clothing are at 0.7, I've given them a value of 0.4, roughly in between.

Keeping with current patterns:
- mercenary voidsuits were given a improved value of 0.3, and mercenary softsuits match the voidsuit values.
- light rigsuits have a siemens coefficient that matches that of voidsuits, except for the ninja rig which has values that match heavy rigs.
