### PR TITLE
Organs are now removed when detached, and replaced when re-attached

### DIFF
--- a/code/game/machinery/resleever.dm
+++ b/code/game/machinery/resleever.dm
@@ -145,6 +145,7 @@ obj/machinery/resleever/process()
 /obj/machinery/resleever/proc/sleeve()
 	if(lace && occupant)
 		var/obj/item/organ/I = occupant.organs_by_name["head"]
+		lace.status &= ~ORGAN_CUT_AWAY //properly attach the lace
 		lace.replaced(occupant, I)
 		lace = null
 		lace_name = null

--- a/code/game/machinery/resleever.dm
+++ b/code/game/machinery/resleever.dm
@@ -144,11 +144,12 @@ obj/machinery/resleever/process()
 
 /obj/machinery/resleever/proc/sleeve()
 	if(lace && occupant)
-		var/obj/item/organ/I = occupant.organs_by_name["head"]
-		lace.status &= ~ORGAN_CUT_AWAY //properly attach the lace
-		lace.replaced(occupant, I)
-		lace = null
-		lace_name = null
+		var/obj/item/organ/O = occupant.get_organ(lace.parent_organ)
+		if(istype(O))
+			lace.status &= ~ORGAN_CUT_AWAY //ensure the lace is properly attached
+			lace.replaced(occupant, O)
+			lace = null
+			lace_name = null
 	else
 		return
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -275,7 +275,15 @@ var/list/organ_cache = list()
 		if (3)
 			take_damage(1)
 
-/obj/item/organ/proc/removed(var/mob/living/user)
+//disconnected the organ from it's owner but does not remove it, instead it becomes an implant that can be removed with implant surgery
+//TODO move this to organ/internal once the FPB port comes through
+/obj/item/organ/proc/cut_away(var/mob/living/user)
+	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+	if(istype(parent)) //TODO ensure that we don't have to check this.
+		removed(user, drop_organ=0)
+		parent.implants += src
+
+/obj/item/organ/proc/removed(var/mob/living/user, var/drop_organ=1)
 
 	if(!istype(owner))
 		return
@@ -286,14 +294,19 @@ var/list/organ_cache = list()
 	owner.internal_organs -= src
 
 	var/obj/item/organ/external/affected = owner.get_organ(parent_organ)
-	if(affected) affected.internal_organs -= src
+	if(affected) 
+		affected.internal_organs -= src
+		status |= ORGAN_CUT_AWAY
 
-	loc = get_turf(owner)
+	if(drop_organ)
+		dropInto(owner.loc)
+
 	processing_objects |= src
 	rejecting = null
-	var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list
-	if(!organ_blood || !organ_blood.data["blood_DNA"])
-		owner.vessel.trans_to(src, 5, 1, 1)
+	if(robotic < ORGAN_ROBOT)
+		var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list //TODO fix this and all other occurences of locate(/datum/reagent/blood) horror
+		if(!organ_blood || !organ_blood.data["blood_DNA"])
+			owner.vessel.trans_to(src, 5, 1, 1)
 
 	if(owner && vital)
 		if(user)
@@ -308,6 +321,8 @@ var/list/organ_cache = list()
 
 	if(!istype(target)) return
 
+	if(status & ORGAN_CUT_AWAY) return //organs don't work very well in the body when they aren't properly attached
+
 	var/datum/reagent/blood/transplant_blood = locate(/datum/reagent/blood) in reagents.reagent_list
 	transplant_data = list()
 	if(!transplant_blood)
@@ -320,7 +335,7 @@ var/list/organ_cache = list()
 		transplant_data["blood_DNA"] =  transplant_blood.data["blood_DNA"]
 
 	owner = target
-	loc = owner
+	forceMove(owner) //just in case
 	processing_objects -= src
 	target.internal_organs |= src
 	affected.internal_organs |= src

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -185,10 +185,10 @@
 				my_atom.on_reagent_change()
 			return 0
 
-/datum/reagents/proc/has_reagent(var/id, var/amount = 0)
+/datum/reagents/proc/has_reagent(var/id, var/amount = null)
 	for(var/datum/reagent/current in reagent_list)
 		if(current.id == id)
-			if(current.volume >= amount)
+			if((isnull(amount) && current.volume > 0) || current.volume >= amount)
 				return 1
 			else
 				return 0

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -182,6 +182,8 @@
 					find_prob +=60
 				else
 					find_prob +=40
+			else if(istype(obj, /obj/item/organ))
+				find_prob += 100
 			else
 				find_prob +=50
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -158,63 +158,6 @@
 		"<span class='warning'>Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(CUT, rand(30,50), 1)
 
-/*
-/datum/surgery_step/internal/remove_organ
-
-	allowed_tools = list(
-	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/weapon/wirecutters = 75,	\
-	/obj/item/weapon/material/kitchen/utensil/fork = 20
-	)
-
-	min_duration = 60
-	max_duration = 80
-
-	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-
-		if (!..())
-			return 0
-
-		target.op_stage.current_organ = null
-
-		var/list/removable_organs = list()
-		for(var/organ in target.internal_organs_by_name)
-			var/obj/item/organ/I = target.internal_organs_by_name[organ]
-			if((I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
-				removable_organs |= organ
-
-		var/organ_to_remove = input(user, "Which organ do you want to remove?") as null|anything in removable_organs
-		if(!organ_to_remove)
-			return 0
-
-		target.op_stage.current_organ = organ_to_remove
-		return ..()
-
-	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		user.visible_message("[user] starts removing [target]'s [target.op_stage.current_organ] with \the [tool].", \
-		"You start removing [target]'s [target.op_stage.current_organ] with \the [tool].")
-		target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",1)
-		..()
-
-	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		user.visible_message("<span class='notice'>[user] has removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>", \
-		"<span class='notice'>You have removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>")
-
-		// Extract the organ!
-		if(target.op_stage.current_organ)
-			var/obj/item/organ/O = target.internal_organs_by_name[target.op_stage.current_organ]
-			if(O && istype(O))
-				O.removed(user)
-			target.op_stage.current_organ = null
-			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
-
-	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
-		"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
-		affected.createwound(BRUISE, 20)
-*/
-
 /datum/surgery_step/internal/replace_organ
 	allowed_tools = list(
 	/obj/item/organ = 100

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -150,7 +150,7 @@
 
 		var/obj/item/organ/I = target.internal_organs_by_name[target.op_stage.current_organ]
 		if(I && istype(I))
-			I.status |= ORGAN_CUT_AWAY
+			I.cut_away(user)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -158,6 +158,7 @@
 		"<span class='warning'>Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(CUT, rand(30,50), 1)
 
+/*
 /datum/surgery_step/internal/remove_organ
 
 	allowed_tools = list(
@@ -212,6 +213,7 @@
 		user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
 		"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(BRUISE, 20)
+*/
 
 /datum/surgery_step/internal/replace_organ
 	allowed_tools = list(
@@ -237,7 +239,7 @@
 			return SURGERY_FAILURE
 
 		if(!target.species)
-			user << "<span class='danger'>You have no idea what species this person is. Report this on the bug tracker.</span>"
+			CRASH("Target ([target]) of surgery [src.type] has no species!")
 			return SURGERY_FAILURE
 
 		var/o_is = (O.gender == PLURAL) ? "are" : "is"
@@ -297,7 +299,8 @@
 		var/obj/item/organ/O = tool
 		if(istype(O))
 			user.remove_from_mob(O)
-			O.replaced(target,affected)
+			O.forceMove(target)
+			affected.implants |= O //move the organ into the patient. The organ is properly reattached in the next step
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -323,11 +326,14 @@
 
 		target.op_stage.current_organ = null
 
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(!affected)
+			return 0
+
 		var/list/removable_organs = list()
-		for(var/organ in target.internal_organs_by_name)
-			var/obj/item/organ/I = target.internal_organs_by_name[organ]
+		for(var/obj/item/organ/I in affected.implants)
 			if(I && (I.status & ORGAN_CUT_AWAY) && !(I.robotic >= ORGAN_ROBOT) && I.parent_organ == target_zone)
-				removable_organs |= organ
+				removable_organs |= I
 
 		var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs
 		if(!organ_to_replace)
@@ -346,9 +352,11 @@
 		user.visible_message("<span class='notice'>[user] has reattached [target]'s [target.op_stage.current_organ] with \the [tool].</span>" , \
 		"<span class='notice'>You have reattached [target]'s [target.op_stage.current_organ] with \the [tool].</span>")
 
-		var/obj/item/organ/I = target.internal_organs_by_name[target.op_stage.current_organ]
-		if(I && istype(I))
-			I.status &= ~ORGAN_CUT_AWAY
+		var/obj/item/organ/I = target.op_stage.current_organ
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(istype(I) && I.parent_organ == target_zone && affected && (I in affected.implants))
+			affected.implants -= I
+			I.replaced(target, affected)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
Fixes an inconsistency in organ removal and replacement surgery that allowed #13565 to occur, which was that organs can be placed in a human and function while also being simultaneously cut away.

Now, cutting away an organ causes the organ to be `removed()`, while an organ is only `replaced()` once it is no longer cut away.

To reflect this, the organ removal and replacement surgery was modified as follows:

Cutting away an organ with a scalpel now causes it to be `removed()`, however the organ remains inside the patient (it becomes an implant, and is now removed like any other implant). The hemostat `remove_organ` surgery step has been removed.

Placing an organ inside an open body part now just implants the organ. Reattaching an implanted organ using fixovein causes it to be `replaced()`.
