### PR TITLE
Emote and visible message cleanup

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -109,11 +109,6 @@
 
 #define COMPANY_ALIGNMENTS		list(COMPANY_LOYAL,COMPANY_SUPPORTATIVE,COMPANY_NEUTRAL,COMPANY_SKEPTICAL,COMPANY_OPPOSED)
 
-// Defines the argument used for get_mobs_and_objs_in_view_fast
-#define GHOSTS_ALL_HEAR 1
-#define ONLY_GHOSTS_IN_VIEW 0
-
-
 // Defines mob sizes, used by lockers and to determine what is considered a small sized mob, etc.
 #define MOB_LARGE  		40
 #define MOB_MEDIUM 		20

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -170,3 +170,7 @@
 #define TASTE_NORMAL 1 //anything below 15%
 #define TASTE_DULL 0.5 //anything below 30%
 #define TASTE_NUMB 0.1 //anything below 150%
+
+//Used by show_message() and emotes
+#define VISIBLE_MESSAGE 1
+#define AUDIBLE_MESSAGE 2

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -245,7 +245,7 @@
 					. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
 	return .
 
-/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/list/mobs, var/list/objs, var/checkghosts = GHOSTS_ALL_HEAR)
+/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/list/mobs, var/list/objs, var/checkghosts = null)
 
 	var/list/hear = dview(range,T,INVISIBILITY_MAXIMUM)
 	var/list/hearturfs = list()
@@ -253,23 +253,19 @@
 	for(var/atom/movable/AM in hear)
 		if(ismob(AM))
 			mobs += AM
-			hearturfs += AM.locs[1]
+			hearturfs += get_turf(AM)
 		else if(isobj(AM))
 			objs += AM 
-			hearturfs += AM.locs[1]
-
+			hearturfs += get_turf(AM)
 
 	for(var/mob/M in player_list)
-		if(checkghosts == GHOSTS_ALL_HEAR && M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_ears))
+		if(checkghosts && M.stat == DEAD && M.is_preference_enabled(checkghosts))
 			mobs |= M
-			continue
-		if(M.loc && M.locs[1] in hearturfs)
+		else if(get_turf(M) in hearturfs)
 			mobs |= M
-
-	
 
 	for(var/obj/O in listening_objects)
-		if(O && O.loc && O.locs[1] in hearturfs)
+		if(get_turf(O) in hearturfs)
 			objs |= O
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -454,41 +454,38 @@ its easier to just keep the beam vertical.
 	else
 		return 0
 
+
 // Show a message to all mobs and objects in sight of this atom
 // Use for objects performing visible actions
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
-/atom/proc/visible_message(var/message, var/blind_message, var/range = world.view)
+/atom/proc/visible_message(var/message, var/blind_message, var/range = world.view, var/checkghosts = null)
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, checkghosts)
 
 	for(var/o in objs)
 		var/obj/O = o
-		O.show_message(message,1,blind_message,2)
+		O.show_message(message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 
 	for(var/m in mobs)
 		var/mob/M = m
 		if(M.see_invisible >= invisibility)
-			M.show_message(message,1,blind_message,2)
+			M.show_message(message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 		else if(blind_message)
-			M.show_message(blind_message, 2)
+			M.show_message(blind_message, AUDIBLE_MESSAGE)
 
 // Show a message to all mobs and objects in earshot of this atom
 // Use for objects performing audible actions
 // message is the message output to anyone who can hear.
 // deaf_message (optional) is what deaf people will see.
 // hearing_distance (optional) is the range, how many tiles away the message can be heard.
-/atom/proc/audible_message(var/message, var/deaf_message, var/hearing_distance)
-
-	var/range = world.view
-	if(hearing_distance)
-		range = hearing_distance
+/atom/proc/audible_message(var/message, var/deaf_message, var/hearing_distance = world.view, var/checkghosts = null)
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+	get_mobs_and_objs_in_view_fast(T, hearing_distance, mobs, objs, checkghosts)
 
 	for(var/m in mobs)
 		var/mob/M = m

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -33,12 +33,12 @@ obj/item/device/hailer/attack_self(mob/living/carbon/user as mob)
 
 	if(isnull(insults))
 		playsound(get_turf(src), 'sound/voice/halt.ogg', 100, 1, vary = 0)
-		user.audible_message("<span class='warning'>[user]'s [name] rasps, \"[use_message]\"</span>", "<span class='warning'>\The [user] holds up \the [name].</span>")
+		user.audible_message("<span class='warning'>[user]'s [name] rasps, \"[use_message]\"</span>", null, "<span class='warning'>\The [user] holds up \the [name].</span>")
 	else
 		if(insults > 0)
 			playsound(get_turf(src), 'sound/voice/binsult.ogg', 100, 1, vary = 0)
 			// Yes, it used to show the transcription of the sound clip. That was a) inaccurate b) immature as shit.
-			user.audible_message("<span class='warning'>[user]'s [name] gurgles something indecipherable and deeply offensive.</span>", "<span class='warning'>\The [user] holds up \the [name].</span>")
+			user.audible_message("<span class='warning'>[user]'s [name] gurgles something indecipherable and deeply offensive.</span>", null, "<span class='warning'>\The [user] holds up \the [name].</span>")
 			insults--
 		else
 			user << "<span class='danger'>*BZZZZZZZZT*</span>"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,13 +1,13 @@
 // All mobs should have custom emote, really..
-//m_type == 1 --> visual.
-//m_type == 2 --> audible
-/mob/proc/custom_emote(var/m_type=1,var/message = null)
+//m_type == VISIBLE_MESSAGE --> visual.
+//m_type == AUDIBLE_MESSAGE --> audible
+/mob/proc/custom_emote(var/m_type=VISIBLE_MESSAGE,var/message = null)
 	if(usr && stat || !use_me && usr == src)
 		src << "You are unable to emote."
 		return
 
 	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
-	if(m_type == 2 && muzzled) return
+	if(m_type == AUDIBLE_MESSAGE && muzzled) return
 
 	var/input
 	if(!message)
@@ -26,39 +26,11 @@
  //Hearing gasp and such every five seconds is not good emotes were not global for a reason.
  // Maybe some people are okay with that.
 
-		for(var/mob/M in player_list)
-			if (!M.client)
-				continue //skip monkeys and leavers
-			if (istype(M, /mob/new_player))
-				continue
-			if(findtext(message," snores.")) //Because we have so many sleeping people.
-				break
-			if(M.stat == DEAD && M.is_preference_enabled(/datum/client_preference/ghost_sight) && !(M in viewers(src,null)))
-				M.show_message(message, m_type)
-
-		if (m_type & 1)
-			var/list/see = get_mobs_or_objects_in_view(world.view,src) | viewers(get_turf(src), null)
-			for(var/I in see)
-				if(isobj(I))
-					spawn(0)
-						if(I) //It's possible that it could be deleted in the meantime.
-							var/obj/O = I
-							O.see_emote(src, message, 1)
-				else if(ismob(I))
-					var/mob/M = I
-					M.show_message(message, 1)
-
-		else if (m_type & 2)
-			var/list/hear = get_mobs_or_objects_in_view(world.view,src)
-			for(var/I in hear)
-				if(isobj(I))
-					spawn(0)
-						if(I) //It's possible that it could be deleted in the meantime.
-							var/obj/O = I
-							O.see_emote(src, message, 2)
-				else if(ismob(I))
-					var/mob/M = I
-					M.show_message(message, 2)
+		switch(m_type)
+			if(VISIBLE_MESSAGE)
+				visible_message(message, checkghosts = /datum/client_preference/ghost_sight)
+			if(AUDIBLE_MESSAGE)
+				audible_message(message, checkghosts = /datum/client_preference/ghost_sight)
 
 /mob/proc/emote_dead(var/message)
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -59,11 +59,11 @@
 		if(is_preference_enabled(/datum/client_preference/ghost_ears) && (speaker in view(src)))
 			message = "<b>[message]</b>"
 
-	if(sdisabilities & DEAF || ear_deaf)
+	if(is_deaf())
 		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
 			if(speaker == src)
 				src << "<span class='warning'>You cannot hear yourself speak!</span>"
-			else
+			else if(!is_blind())
 				src << "<span class='name'>[speaker_name]</span>[alt_name] talks but you cannot hear \him."
 	else
 		if(language)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -10,7 +10,7 @@
 		act = copytext(act,1,length(act))
 
 	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
-	//var/m_type = 1
+	//var/m_type = VISIBLE_MESSAGE
 
 	for (var/obj/item/weapon/implant/I in src)
 		if (I.implanted)
@@ -22,13 +22,13 @@
 		if ("airguitar")
 			if (!src.restrained())
 				message = "is strumming the air and headbanging like a safari chimp."
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 
 		if ("beep")
 			if (src.isSynthetic())
 				message = "beeps."
 				playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 			else
 				return
 
@@ -36,7 +36,7 @@
 			if (src.isSynthetic())
 				message = "pings."
 				playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 			else
 				return
 
@@ -44,7 +44,7 @@
 			if (src.isSynthetic())
 				message = "buzzes."
 				playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 			else
 				return
 
@@ -52,7 +52,7 @@
 			if (src.isSynthetic())
 				message = "<B>[src]</B> emits an affirmative blip."
 				playsound(src.loc, 'sound/machines/synth_yes.ogg', 50, 0)
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 			else
 				return
 
@@ -60,17 +60,17 @@
 			if (src.isSynthetic())
 				message = "<B>[src]</B> emits a negative blip."
 				playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 			else
 				return
 
 		if ("blink")
 			message = "blinks."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("blink_r")
 			message = "blinks rapidly."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("bow")
 			if (!src.buckled)
@@ -87,7 +87,7 @@
 					message = "bows to [param]."
 				else
 					message = "bows."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("custom")
 			var/input = sanitize(input("Choose an emote to display.") as text|null)
@@ -95,9 +95,9 @@
 				return
 			var/input2 = input("Is this a visible or hearable emote?") in list("Visible","Hearable")
 			if (input2 == "Visible")
-				m_type = 1
+				m_type = VISIBLE_MESSAGE
 			else if (input2 == "Hearable")
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				alert("Unable to use this emote, must be either hearable or visible.")
 				return
@@ -133,15 +133,15 @@
 					message = "salutes to [param]."
 				else
 					message = "salutes."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("choke")
 			if (!muzzled)
 				message = "chokes!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a strong noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if("vomit")
 			vomit()
@@ -150,91 +150,91 @@
 		if ("clap")
 			if (!src.restrained())
 				message = "claps."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 		if ("flap")
 			if (!src.restrained())
 				message = "flaps [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] wings."
-				m_type = 2
+				m_type = VISIBLE_MESSAGE
 
 		if ("aflap")
 			if (!src.restrained())
 				message = "flaps [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] wings ANGRILY!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("drool")
 			message = "drools."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("eyebrow")
 			message = "raises an eyebrow."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("chuckle")
 			if (!muzzled)
 				message = "chuckles."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("twitch")
 			message = "twitches violently."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("twitch_s")
 			message = "twitches."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("faint")
 			message = "faints."
 			if(src.sleeping)
 				return //Can't faint while asleep
 			src.sleeping += 10 //Short-short nap
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("cough")
 			if (!muzzled)
 				message = "coughs!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a strong noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("frown")
 			message = "frowns."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("nod")
 			message = "nods."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("blush")
 			message = "blushes."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("wave")
 			message = "waves."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("gasp")
 			if (!muzzled)
 				message = "gasps!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a weak noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("deathgasp")
 			message = "[species.death_message]"
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("giggle")
 			if (!muzzled)
 				message = "giggles."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("glare")
 			var/M = null
@@ -281,35 +281,35 @@
 				message = "looks at [param]."
 			else
 				message = "looks."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("grin")
 			message = "grins."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("cry")
 			if (!muzzled)
 				message = "cries."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a weak noise. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"] [get_visible_gender() == NEUTER ? "frown" : "frowns"]."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("sigh")
 			if (!muzzled)
 				message = "sighs."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a weak noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("laugh")
 			if (!muzzled)
 				message = "laughs."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("mumble")
 			message = "mumbles!"
@@ -318,22 +318,22 @@
 		if ("grumble")
 			if (!muzzled)
 				message = "grumbles!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("groan")
 			if (!muzzled)
 				message = "groans!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a loud noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("moan")
 			message = "moans!"
-			m_type = 2
+			m_type = AUDIBLE_MESSAGE
 
 		if ("johnny")
 			var/M
@@ -342,8 +342,9 @@
 			if (!M)
 				param = null
 			else
-				message = "says, \"[M], please. He had a family.\" [src.name] takes a drag from a cigarette and blows his name out in smoke."
-				m_type = 2
+				message = "says, \"[M], please. He had a family.\" \The [src] takes a drag from a cigarette and blows his name out in smoke."
+				m_type = AUDIBLE_MESSAGE
+
 
 		if ("point")
 			if (!src.restrained())
@@ -362,20 +363,20 @@
 				if (M)
 					message = "points to [M]."
 				else
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("raise")
 			if (!src.restrained())
 				message = "raises a hand."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if("shake")
 			message = "shakes [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] head."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("shrug")
 			message = "shrugs."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("signal")
 			if (!src.restrained())
@@ -385,68 +386,67 @@
 						message = "raises [t1] finger\s."
 					else if (t1 <= 10 && (!src.r_hand && !src.l_hand))
 						message = "raises [t1] finger\s."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("smile")
 			message = "smiles."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("shiver")
 			message = "shivers."
-			m_type = 2
 
 		if ("pale")
 			message = "goes pale for a second."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("tremble")
 			message = "trembles in fear!"
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("sneeze")
 			if (!muzzled)
 				message = "sneezes."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a strange noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("sniff")
 			message = "sniffs."
-			m_type = 2
+			m_type = AUDIBLE_MESSAGE
 
 		if ("snore")
 			if (!muzzled)
 				message = "snores."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("whimper")
 			if (!muzzled)
 				message = "whimpers."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a weak noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("wink")
 			message = "winks."
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 
 		if ("yawn")
 			if (!muzzled)
 				message = "yawns."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if ("collapse")
 			Paralyse(2)
 			message = "collapses!"
-			m_type = 2
+			m_type = AUDIBLE_MESSAGE
 
 		if("hug")
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 			if (!src.restrained())
 				var/M = null
 				if (param)
@@ -463,7 +463,7 @@
 					message = "hugs [get_visible_gender() == MALE ? "himself" : get_visible_gender() == FEMALE ? "herself" : "themselves"]."
 
 		if ("handshake")
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 			if (!src.restrained() && !src.r_hand)
 				var/mob/M = null
 				if (param)
@@ -481,7 +481,7 @@
 						message = "holds out [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] hand to [M]."
 
 		if("dap")
-			m_type = 1
+			m_type = VISIBLE_MESSAGE
 			if (!src.restrained())
 				var/M = null
 				if (param)
@@ -497,10 +497,10 @@
 		if ("scream")
 			if (!muzzled)
 				message = "screams!"
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 			else
 				message = "makes a very loud noise."
-				m_type = 2
+				m_type = AUDIBLE_MESSAGE
 
 		if("swish")
 			src.animate_tail_once()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -241,7 +241,7 @@ proc/get_radio_key_from_channel(var/channel)
 			italics = 1
 			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
-		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj)
+		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj, /datum/client_preference/ghost_ears)
 
 
 	var/speech_bubble_test = say_test(message)


### PR DESCRIPTION
#### Description
- emotes no longer use the old recursive get mobs and objs in view proc, they now defer to `visible_message()` or `audible_message()` as desired.
- `get_mobs_and_objs_in_view_fast()` now uses `get_turf()` instead of `locs[1]`. I have reason to believe that `locs[1]` is only fast if the the movable atom never changes position, otherwise DM has to rebuild the locs list which involves list creation and is slow. Unfortunately when I tested `locs[1]` a few months back I did not test changing locations. `get_turf()` is reasonably fast however, and even the old version  compared favourably with `locs[1]` for mobs directly on turfs, which is where the majority of mobs will be anyways.
- The `checkghosts` parameter is no longer an enumeration, instead it expects the preference to check for.
- How to check for whether a mob is blind or deaf is a bit unclear, there's a bunch of different vars, `blinded`, `eye_blind`, plus the disabilities bitflags, that all could indicate blindness. I've added a proc to try and make the blind and deaf checks more consistent, however I have not attempted to replace anything other than what I've touched while dealing with emotes.
- I wanted to refactor `show_message()` however I couldn't figure out a way to do it that was both clean and avoided unnecessary calls to `is_blind()` and `is_deaf()`
#### Some things it would be nice to have a discussion about for the future
- I'm worried about the inconsistency in parameters for `atom/visible_message()` and `mob/visible_message()` being a source of bugs. I'd like to change the proc signature so that `self_message` comes after the first two parameters while keeping the optional parameters last, however I do not look forwards to updating every usage of visible_message(). I suppose we could keep it the way it is, but that requires us to be aware of whether they are calling `visible_message()` on an atom or or a mob, and reminding people who mess up.
- Emotes are god-awful. I'd like to change them to be more declarative, however I don't want to give every mob their own list of what emotes they can use. Not sure what to do. Also I'd like to get rid of emote arguments, it isn't really necessary and not having to support those would make cleanup easier.
