### PR TITLE
Organ replacement surgery fix

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -84,6 +84,8 @@
 
 /obj/item/organ/brain/replaced(var/mob/living/target)
 
+	if(!..()) return 0
+
 	if(target.key)
 		target.ghostize()
 
@@ -92,7 +94,8 @@
 			brainmob.mind.transfer_to(target)
 		else
 			target.key = brainmob.key
-	..()
+
+	return 1
 
 /obj/item/organ/brain/slime
 	name = "slime core"

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -58,7 +58,7 @@
 		src.has_power = 1
 	else
 		if (src.has_power)
-			src << "\red You are now running on emergency backup power."
+			src << "<span class='warning'>You are now running on emergency backup power.</span>"
 		src.has_power = 0
 		if(lights_on) // Light is on but there is no power!
 			lights_on = 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -319,9 +319,11 @@ var/list/organ_cache = list()
 
 /obj/item/organ/proc/replaced(var/mob/living/carbon/human/target,var/obj/item/organ/external/affected)
 
-	if(!istype(target)) return
+	if(!istype(target))
+		return 0
 
-	if(status & ORGAN_CUT_AWAY) return //organs don't work very well in the body when they aren't properly attached
+	if(status & ORGAN_CUT_AWAY)
+		return 0 //organs don't work very well in the body when they aren't properly attached
 
 	var/datum/reagent/blood/transplant_blood = locate(/datum/reagent/blood) in reagents.reagent_list
 	transplant_data = list()
@@ -340,8 +342,11 @@ var/list/organ_cache = list()
 	target.internal_organs |= src
 	affected.internal_organs |= src
 	target.internal_organs_by_name[organ_tag] = src
+	return 1
 
 /obj/item/organ/eyes/replaced(var/mob/living/carbon/human/target)
+
+	if(!..()) return 0
 
 	// Apply our eye colour to the target.
 	if(istype(target) && eye_colour)
@@ -349,7 +354,8 @@ var/list/organ_cache = list()
 		target.g_eyes = eye_colour[2]
 		target.b_eyes = eye_colour[3]
 		target.update_eyes()
-	..()
+
+	return 1
 
 /obj/item/organ/proc/bitten(mob/user)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -280,8 +280,12 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/cut_away(var/mob/living/user)
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	if(istype(parent)) //TODO ensure that we don't have to check this.
-		removed(user, drop_organ=0)
+		removed(user, 0)
 		parent.implants += src
+
+//TODO move cut_away() to the internal organ subtype and get rid of this
+/obj/item/organ/external/cut_away(var/mob/living/user)
+	removed(user)
 
 /obj/item/organ/proc/removed(var/mob/living/user, var/drop_organ=1)
 

--- a/code/modules/organs/organ_stack.dm
+++ b/code/modules/organs/organ_stack.dm
@@ -44,7 +44,8 @@
 	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))
 
 /obj/item/organ/stack/replaced()
-	..()
+	if(!..()) return 0
+
 	if(owner && !backup_inviable())
 		var/current_owner = owner
 		var/response = input(find_dead_player(ownerckey, 1), "Your neural backup has been placed into a new body. Do you wish to return to life?", "Resleeving") as anything in list("Yes", "No")
@@ -52,6 +53,8 @@
 			overwrite()
 	sleep(-1)
 	do_backup()
+
+	return 1
 
 /obj/item/organ/stack/removed()
 	do_backup()

--- a/code/modules/organs/subtypes/xenos.dm
+++ b/code/modules/organs/subtypes/xenos.dm
@@ -60,10 +60,13 @@
 	..(user)
 
 /obj/item/organ/xenos/hivenode/replaced(var/mob/living/carbon/human/target,var/obj/item/organ/external/affected)
-	..(target, affected)
+	if(!..()) return 0
+
 	if(owner && ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.add_language("Hivemind")
 		if(H.mind && H.species.get_bodytype() != "Xenomorph")
 			H << "<span class='alium'>You feel a sense of pressure as a vast intelligence meshes with your thoughts...</span>"
 			xenomorphs.add_antagonist_mind(H.mind,1, xenomorphs.faction_role_text, xenomorphs.faction_welcome)
+
+	return 1

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -182,8 +182,6 @@
 					find_prob +=60
 				else
 					find_prob +=40
-			else if(istype(obj, /obj/item/organ))
-				find_prob += 100
 			else
 				find_prob +=50
 
@@ -202,7 +200,7 @@
 					worm.detatch()
 					worm.leave_host()
 				else
-					obj.loc = get_turf(target)
+					obj.dropInto(target.loc)
 					obj.add_blood(target)
 					obj.update_icon()
 					if(istype(obj,/obj/item/weapon/implant))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -141,7 +141,7 @@
 
 		user.visible_message("[user] starts to separate [target]'s [target.op_stage.current_organ] with \the [tool].", \
 		"You start to separate [target]'s [target.op_stage.current_organ] with \the [tool]." )
-		target.custom_pain("The pain in your [affected.name] is living hell!",1)
+		target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",1)
 		..()
 
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -158,7 +158,6 @@
 		"<span class='warning'>Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(CUT, rand(30,50), 1)
 
-/*
 /datum/surgery_step/internal/remove_organ
 
 	allowed_tools = list(
@@ -177,11 +176,14 @@
 
 		target.op_stage.current_organ = null
 
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(!affected)
+			return 0
+
 		var/list/removable_organs = list()
-		for(var/organ in target.internal_organs_by_name)
-			var/obj/item/organ/I = target.internal_organs_by_name[organ]
-			if((I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
-				removable_organs |= organ
+		for(var/obj/item/organ/I in affected.implants)
+			if(I.status & ORGAN_CUT_AWAY)
+				removable_organs |= I
 
 		var/organ_to_remove = input(user, "Which organ do you want to remove?") as null|anything in removable_organs
 		if(!organ_to_remove)
@@ -193,7 +195,7 @@
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		user.visible_message("[user] starts removing [target]'s [target.op_stage.current_organ] with \the [tool].", \
 		"You start removing [target]'s [target.op_stage.current_organ] with \the [tool].")
-		target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",1)
+		target.custom_pain("The pain in your [affected.name] is living hell!",1)
 		..()
 
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -201,10 +203,11 @@
 		"<span class='notice'>You have removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>")
 
 		// Extract the organ!
-		if(target.op_stage.current_organ)
-			var/obj/item/organ/O = target.internal_organs_by_name[target.op_stage.current_organ]
-			if(O && istype(O))
-				O.removed(user)
+		var/obj/item/organ/O = target.op_stage.current_organ
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(istype(O) && istype(affected))
+			affected.implants -= O
+			O.dropInto(target.loc)
 			target.op_stage.current_organ = null
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 
@@ -213,7 +216,6 @@
 		user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
 		"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(BRUISE, 20)
-*/
 
 /datum/surgery_step/internal/replace_organ
 	allowed_tools = list(
@@ -330,12 +332,12 @@
 		if(!affected)
 			return 0
 
-		var/list/removable_organs = list()
+		var/list/attachable_organs = list()
 		for(var/obj/item/organ/I in affected.implants)
 			if(I && (I.status & ORGAN_CUT_AWAY) && !(I.robotic >= ORGAN_ROBOT) && I.parent_organ == target_zone)
-				removable_organs |= I
+				attachable_organs |= I
 
-		var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs
+		var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in attachable_organs
 		if(!organ_to_replace)
 			return 0
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -136,9 +136,6 @@
 		return ..() && organ_to_remove
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-
 		user.visible_message("[user] starts to separate [target]'s [target.op_stage.current_organ] with \the [tool].", \
 		"You start to separate [target]'s [target.op_stage.current_organ] with \the [tool]." )
 		target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",1)
@@ -193,6 +190,7 @@
 		return ..()
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("[user] starts removing [target]'s [target.op_stage.current_organ] with \the [tool].", \
 		"You start removing [target]'s [target.op_stage.current_organ] with \the [tool].")
 		target.custom_pain("The pain in your [affected.name] is living hell!",1)
@@ -357,6 +355,7 @@
 		var/obj/item/organ/I = target.op_stage.current_organ
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(istype(I) && I.parent_organ == target_zone && affected && (I in affected.implants))
+			I.status &= ~ORGAN_CUT_AWAY //apply fixovein
 			affected.implants -= I
 			I.replaced(target, affected)
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -127,7 +127,7 @@
 			if(I && !(I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
 				attached_organs |= organ
 
-		var/organ_to_remove = input(user, "Which organ do you want to prepare for removal?") as null|anything in attached_organs
+		var/organ_to_remove = input(user, "Which organ do you want to separate?") as null|anything in attached_organs
 		if(!organ_to_remove)
 			return 0
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -158,6 +158,63 @@
 		"<span class='warning'>Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(CUT, rand(30,50), 1)
 
+/*
+/datum/surgery_step/internal/remove_organ
+
+	allowed_tools = list(
+	/obj/item/weapon/hemostat = 100,	\
+	/obj/item/weapon/wirecutters = 75,	\
+	/obj/item/weapon/material/kitchen/utensil/fork = 20
+	)
+
+	min_duration = 60
+	max_duration = 80
+
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+
+		if (!..())
+			return 0
+
+		target.op_stage.current_organ = null
+
+		var/list/removable_organs = list()
+		for(var/organ in target.internal_organs_by_name)
+			var/obj/item/organ/I = target.internal_organs_by_name[organ]
+			if((I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
+				removable_organs |= organ
+
+		var/organ_to_remove = input(user, "Which organ do you want to remove?") as null|anything in removable_organs
+		if(!organ_to_remove)
+			return 0
+
+		target.op_stage.current_organ = organ_to_remove
+		return ..()
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("[user] starts removing [target]'s [target.op_stage.current_organ] with \the [tool].", \
+		"You start removing [target]'s [target.op_stage.current_organ] with \the [tool].")
+		target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",1)
+		..()
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("<span class='notice'>[user] has removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>", \
+		"<span class='notice'>You have removed [target]'s [target.op_stage.current_organ] with \the [tool].</span>")
+
+		// Extract the organ!
+		if(target.op_stage.current_organ)
+			var/obj/item/organ/O = target.internal_organs_by_name[target.op_stage.current_organ]
+			if(O && istype(O))
+				O.removed(user)
+			target.op_stage.current_organ = null
+			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
+		"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
+		affected.createwound(BRUISE, 20)
+*/
+
 /datum/surgery_step/internal/replace_organ
 	allowed_tools = list(
 	/obj/item/organ = 100


### PR DESCRIPTION
Forgot to clear the `CUT_AWAY` flag when applying fixovein, preventing the internal organ from being properly replaced.

Ensures that `replaced()` overrides that call the parent also pass the parent's checks before doing stuff.

Brought back the `remove_organ` surgery. While it's not necessary to have, it was nice having surgery messages specifically for organ removal. The `remove_organ` surgery step now just removes implanted organs that are already cut away.
