### PR TITLE
Ghosts can only rotate chairs if the veil is thin enough

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -77,19 +77,18 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(config.ghost_interaction)
-		src.set_dir(turn(src.dir, 90))
+	if(!usr || !Adjacent(usr))
 		return
-	else
-		if(istype(usr,/mob/living/simple_animal/mouse))
-			return
-		if(!usr || !isturf(usr.loc))
-			return
-		if(usr.stat || usr.restrained())
-			return
 
-		src.set_dir(turn(src.dir, 90))
+	if(usr.stat == DEAD)
+		if(!round_is_spooky())
+			src << "<span class='warning'>The veil is not thin enough for you to do that.</span>"
+			return
+	else if(usr.incapacitated())
 		return
+
+	src.set_dir(turn(src.dir, 90))
+	return
 
 // Leaving this in for the sake of compilation.
 /obj/structure/bed/chair/comfy


### PR DESCRIPTION
Generally unfun for everyone except the ghost doing it, it doesn't have a place except during cult rounds, where it will be possible anyways.
