### PR TITLE
Gamemodes with end_on_antag_death set now call a transfer shuttle

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -273,13 +273,14 @@ var/global/list/additional_antag_types = list()
 	if(emergency_shuttle.returned() || station_was_nuked)
 		return 1
 	if(end_on_antag_death && antag_templates && antag_templates.len)
+		var/has_antags = 0
 		for(var/datum/antagonist/antag in antag_templates)
 			if(!antag.antags_are_dead())
-				return 0
-		if(config.continous_rounds)
+				has_antags = 1
+				break
+		if(!has_antags)
 			emergency_shuttle.auto_recall = 0
-			return 0
-		return 1
+			return 1
 	return 0
 
 /datum/game_mode/proc/cleanup()	//This is called when the round has ended but not the game, if any cleanup would be necessary in that case.


### PR DESCRIPTION
I suppose before the antag and gamemode rewrite things were kind of inconsistent and unclear, but I believe the way `config.continous_rounds` is supposed to work is that if it is set, then it calls a transfer shuttle vote when the gamemode's end conditions have been met (otherwise it ends the round immediately).

Therefore the game mode should not be checking `config.continous_rounds`, that's done in the gameticker.

To reiterate, if `config.continous_rounds` is not set, then when the gamemode's end condition is met then the server restarts in 60 seconds, otherwise if it is set, it calls a transfer shuttle. Either way, the gamemode end condition should not be dependent on `config.continous_rounds`, it should just declare that the gamemode has ended and leave it to the game ticker to decide what to do.
