### PR TITLE
Mob fire related changes

### DIFF
--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -43,3 +43,4 @@
 
 	tile_overlay = "sleeping_agent"
 	overlay_limit = 1
+	flags = XGM_GAS_OXIDIZER //N2O is a powerful oxidizer

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -496,19 +496,22 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/flame/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M, /mob))
 		return
-	M.IgniteMob()
 
-	if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == "mouth" && lit)
-		var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
-		if(M == user)
-			cig.attackby(src, user)
-		else
-			if(istype(src, /obj/item/weapon/flame/lighter/zippo))
-				cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M].</span>")
+	if(lit)
+		M.IgniteMob()
+
+		if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == "mouth")
+			var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
+			if(M == user)
+				cig.attackby(src, user)
 			else
-				cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
-	else
-		..()
+				if(istype(src, /obj/item/weapon/flame/lighter/zippo))
+					cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M].</span>")
+				else
+					cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
+			return
+
+	..()
 
 /obj/item/weapon/flame/lighter/process()
 	var/turf/location = get_turf(src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -922,7 +922,7 @@
 				stomach_contents.Remove(M)
 				continue
 			if(iscarbon(M)|| isanimal(M))
-				if(M.stat == 2)
+				if(M.stat == DEAD)
 					M.death(1)
 					stomach_contents.Remove(M)
 					qdel(M)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -26,6 +26,9 @@
 		//Random events (vomiting etc)
 		handle_random_events()
 
+		//stuff in the stomach
+		handle_stomach()
+
 		. = 1
 
 	//Handle temperature/pressure differences between body and environment
@@ -34,9 +37,6 @@
 
 	//Check if we're on fire
 	handle_fire()
-
-	//stuff in the stomach
-	handle_stomach()
 
 	update_pulling()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -273,8 +273,11 @@
 		ExtinguishMob() //Fire's been put out.
 		return 1
 
+	if(HUSK in mutations)
+		fire_stacks = max(0, --fire_stacks) //I guess the fire runs out of fuel eventually
+
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
-	if(G.gas["oxygen"] < 1)
+	if(G.get_by_flag(XGM_GAS_OXIDIZER) < 1)
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire
 		return 1
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -274,7 +274,7 @@
 		return 1
 
 	if(HUSK in mutations)
-		fire_stacks = max(0, --fire_stacks) //I guess the fire runs out of fuel eventually
+		fire_stacks = max(0, fire_stacks - 0.1) //I guess the fire runs out of fuel eventually
 
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.get_by_flag(XGM_GAS_OXIDIZER) < 1)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -216,7 +216,7 @@
 
 		//Ok, 100% oxygen atmosphere = best reaction
 		//Maxes out at 100% oxygen pressure
-		oxygen = max(min((removed.gas["oxygen"] - (removed.gas["nitrogen"] * NITROGEN_RETARDATION_FACTOR)) / removed.total_moles, 1), 0)
+		oxygen = Clamp((removed.get_by_flag(XGM_GAS_OXIDIZER) - (removed.gas["nitrogen"] * NITROGEN_RETARDATION_FACTOR)) / removed.total_moles, 0, 1)
 
 		//calculate power gain for oxygen reaction
 		var/temp_factor

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -267,6 +267,12 @@
 
 	return removed
 
+//Returns the amount of gas that has the given flag, in moles
+/datum/gas_mixture/proc/get_by_flag(flag)
+	. = 0
+	for(var/g in gas)
+		if(gas_data.flags[g] & flag)
+			. += gas[g]
 
 //Copies gas and temperature from another gas_mixture.
 /datum/gas_mixture/proc/copy_from(const/datum/gas_mixture/sample)


### PR DESCRIPTION
- Fixes igniting mobs with an unlit lighter
- Mob fires eventually die out after the mob is husked
- Fires now check for oxidizer instead of just oxygen
- Makes N2O an oxidizer (because it is one, and a very effective one, sometimes used in rocket motors)
- Also, dead mobs no longer process stuff in their stomach
