### PR TITLE
Changes vox GLUT_SMALLER to GLUT_TINY

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -29,7 +29,7 @@
 	cold_level_3 = 0
 
 	eyes = "vox_eyes_s"
-	gluttonous = GLUT_SMALLER
+	gluttonous = GLUT_TINY
 
 	breath_type = "nitrogen"
 	poison_type = "oxygen"

--- a/html/changelogs/Cirra-vox-glut.yml
+++ b/html/changelogs/Cirra-vox-glut.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cirra
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Vox can no longer devour Resomi or other small-sized mobs, and instead can devour the same mobs as Unathi or Tajarans"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimisations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

**Agreed on by the vox's species maintainer @Kearel, but this is not to be merged until a PR for a replacement special feature for Vox is ready.**

EDIT: #13738 is the aforementioned special feature, this may be merged.

**This may be slightly controversial, but it _was_ requested by the Resomi species maintainer (Aticius) and agreed on by the Vox species maintainer.** 

The functional impact of this is that vox can no longer devour Resomi or Monkeys, which was silly anyway seeing as Vox and Resomi are about the same size (Resomi are actually slightly larger than Vox according to the Resomi maintainer Aticius). 

Vox should still be able to devour mice and other TINY mobs. 

_As a note, the GLUT_SMALLER flag won't be used for anything once this is merged. I may leave it in for downstream's sake (in case they want to use it, since it's actual functionality is intact), but will remove GLUT_SMALLER's functionality if requested._ 
