### PR TITLE
Adjusts toxin metabolism rate

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -8,7 +8,7 @@
 	taste_mult = 1.2
 	reagent_state = LIQUID
 	color = "#CF3600"
-	metabolism = REM * 0.05 // 0.01 by default. They last a while and slowly kill you.
+	metabolism = REM * 0.25 // 0.05 by default. They last a while and slowly kill you.
 	var/strength = 4 // How much damage it deals per unit
 
 /datum/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
Based on https://github.com/PolarisSS13/Polaris/pull/2110

The current metabolism rate of toxins is extremely slow. While it takes 37.5 units to put a human into crit, it takes over 2 hours to do so. This reduces that time to 25 minutes.

@Kearel this should also impact oxygen poisoning for vox.
