### PR TITLE
Expands food replicator construction code

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1229,6 +1229,7 @@
 #include "code\modules\examine\descriptions\armor.dm"
 #include "code\modules\examine\descriptions\atmospherics.dm"
 #include "code\modules\examine\descriptions\engineering.dm"
+#include "code\modules\examine\descriptions\machinery.dm"
 #include "code\modules\examine\descriptions\medical.dm"
 #include "code\modules\examine\descriptions\mobs.dm"
 #include "code\modules\examine\descriptions\paperwork.dm"

--- a/code/modules/examine/descriptions/machinery.dm
+++ b/code/modules/examine/descriptions/machinery.dm
@@ -1,0 +1,3 @@
+/obj/machinery/food_replicator
+	description_info = "The food replicator is operated through voice commands. To inquire available dishes on the menu, say 'menu'. To dispense a dish, say the name of the dish listed in its menu. \
+	Dishes can only be produced as long as the replicator has biomass. To check on the biomass level of the replicator, say 'status'. Various food items or plants may be inserted to refill biomass."

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -48,6 +48,25 @@
 			for(var/datum/reagent/nutriment/N in G.reagents.reagent_list)
 				biomass = Clamp(biomass + round(N.volume*deconstruct_eff),1,biomass_max)
 			qdel(G)
+
+	if (istype(O, /obj/item/weapon/wrench))
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+		if(anchored)
+			user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
+		else
+			user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
+
+		if(do_after(user, 20, src))
+			if(!src) return
+			user << "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>"
+			anchored = !anchored
+		return
+	else if(default_deconstruction_screwdriver(user, O))
+		return
+	else if(default_deconstruction_crowbar(user, O))
+		return
+	else if(default_part_replacement(user, O))
+		return
 	else
 		..()
 
@@ -145,3 +164,8 @@
 				queued_dishes -= queued_dishes[1]
 				start_making = 1
 	..()
+
+/obj/machinery/food_replicator/examine(mob/user)
+	..(user)
+	if(panel_open)
+		user << "The maintenance hatch is open."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Food replicators can now be unanchored with a wrench, have its panel opened with a screwdriver, upgraded with a RPED and deconstructed with a crowbar, just like other machinery. Unanchoring function implemented to bring it in line with vending machines.

Fixes #13694
