### PR TITLE
Fixes ear_deaf ticking down twice each life tick

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -146,7 +146,7 @@
 	else
 		return ONE_ATMOSPHERE + pressure_difference
 
-/mob/living/carbon/human/handle_disabilities()
+/mob/living/carbon/human/handle_impaired_vision()
 	..()
 	//Vision
 	var/obj/item/organ/vision
@@ -166,6 +166,9 @@
 		if(!(sdisabilities & BLIND))
 			if(equipment_tint_total >= TINT_BLIND)	// Covered eyes, heal faster
 				eye_blurry = max(eye_blurry-2, 0)
+
+/mob/living/carbon/human/handle_disabilities()
+	..()
 
 	if (disabilities & EPILEPSY)
 		if ((prob(1) && paralysis < 1))
@@ -696,17 +699,6 @@
 		if(embedded_flag && !(life_tick % 10))
 			if(!embedded_needs_process())
 				embedded_flag = 0
-
-		//Ears
-		if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(istype(l_ear, /obj/item/clothing/ears/earmuffs) || istype(r_ear, /obj/item/clothing/ears/earmuffs))	//resting your ears with earmuffs heals ear damage faster
-			ear_damage = max(ear_damage-0.15, 0)
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
 
 		//Resting
 		if(resting)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -144,6 +144,10 @@
 	return paralysis
 
 /mob/living/proc/handle_disabilities()
+	handle_impaired_vision()
+	handle_impaired_hearing()
+
+/mob/living/proc/handle_impaired_vision()
 	//Eyes
 	if(sdisabilities & BLIND || stat)	//blindness from disability or unconsciousness doesn't get better on its own
 		eye_blind = max(eye_blind, 1)
@@ -152,13 +156,15 @@
 	else if(eye_blurry)			//blurry eyes heal slowly
 		eye_blurry = max(eye_blurry-1, 0)
 
+/mob/living/proc/handle_impaired_hearing()
 	//Ears
-	if(sdisabilities & DEAF)		//disabled-deaf, doesn't get better on its own
+	if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
 		setEarDamage(-1, max(ear_deaf, 1))
-	else
-		// deafness heals slowly over time, unless ear_damage is over 100
-		if(ear_damage < 100)
-			adjustEarDamage(-0.05,-1)
+	else if(ear_damage < 25)
+		adjustEarDamage(-0.05, 0)	// having ear damage impairs the recovery of ear_deaf
+	else if(ear_damage < 100)
+		adjustEarDamage(-0.05, -1)	// deafness recovers slowly over time, unless ear_damage is over 100. TODO meds that heal ear_damage
+
 
 //this handles hud updates. Calls update_vision() and handle_hud_icons()
 /mob/living/proc/handle_regular_hud_updates()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -814,10 +814,10 @@ default behaviour is:
 	ear_deaf = max(0, ear_deaf + deaf)
 
 //pass a negative argument to skip one of the variable
-/mob/living/setEarDamage(var/damage, var/deaf)
-	if(damage >= 0)
+/mob/living/setEarDamage(var/damage = null, var/deaf = null)
+	if(!isnull(damage))
 		ear_damage = damage
-	if(deaf >= 0)
+	if(!isnull(deaf))
 		ear_deaf = deaf
 
 /mob/proc/can_be_possessed_by(var/mob/observer/ghost/possessor)


### PR DESCRIPTION
Was being decremented in `living/handle_disabilities()`, and then again in `human/handle_disabilities()`.

Vision and hearing seemed important enough to deserve their own procs for other mob types to override.
