### PR TITLE
Adds admin_cryo() proc to easily cryo players

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -13,6 +13,8 @@
 
 #define isairlock(A) istype(A, /obj/machinery/door/airlock)
 
+#define isbot(A) istype(A, /mob/living/bot)
+
 #define isbrain(A) istype(A, /mob/living/carbon/brain)
 
 #define iscarbon(A) istype(A, /mob/living/carbon)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -89,6 +89,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/view_chemical_reaction_logs,
 	/client/proc/makePAI,
 	/datum/admins/proc/paralyze_mob,
+	/datum/admins/proc/admin_cryo,
 	/client/proc/fixatmos,
 	/client/proc/list_traders,
 	/client/proc/add_trader,

--- a/html/changelogs/Kasuobes-admincryo.yml
+++ b/html/changelogs/Kasuobes-admincryo.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Haswell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added admin_cryo() as an admin proc for quickly disposing inactive characters. Note this does not replace the delete proc, but rather allow characters lying around in the hallway to be removed similarly to going into cryo without having to drop the mob into cryo manually. This works for all mobs, but please do not use it on pAIs and AIs as they have their own processes for ghosting."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Added admin_cryo() as an admin proc for quickly disposing inactive
characters. Note this does not replace the delete proc, but rather allow
characters lying around in the hallway to be removed similarly to going
into cryo without having to drop the mob into cryo manually. This works
for all mobs, but please do not use it on pAIs and AIs as they have their
own processes for ghosting.
