### PR TITLE
Removes end_on_antag_death flag from most gamemodes

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,6 +13,6 @@
 	config_tag = "changeling"
 	required_players = 2
 	required_enemies = 1
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_scaling_coeff = 10
 	antag_tags = list(MODE_CHANGELING)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -5,5 +5,5 @@
 	config_tag = "cult"
 	required_players = 5
 	required_enemies = 3
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/mixed/bughunt.dm
+++ b/code/game/gamemodes/mixed/bughunt.dm
@@ -5,7 +5,7 @@
 	config_tag = "bughunt"
 	required_players = 15
 	required_enemies = 1
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_XENOMORPH, MODE_DEATHSQUAD)
 	require_all_templates = 1
 	votable = 0

--- a/code/game/gamemodes/mixed/conflux.dm
+++ b/code/game/gamemodes/mixed/conflux.dm
@@ -5,7 +5,7 @@
 	config_tag = "conflux"
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_WIZARD, MODE_CULTIST)
 	require_all_templates = 1
 	votable = 0

--- a/code/game/gamemodes/mixed/infestation.dm
+++ b/code/game/gamemodes/mixed/infestation.dm
@@ -5,7 +5,7 @@
 	config_tag = "infestation"
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_BORER, MODE_XENOMORPH, MODE_CHANGELING)
 	require_all_templates = 1
 	votable = 0

--- a/code/game/gamemodes/mixed/paranoia.dm
+++ b/code/game/gamemodes/mixed/paranoia.dm
@@ -5,7 +5,7 @@
 	config_tag = "paranoia"
 	required_players = 2
 	required_enemies = 1
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_MALFUNCTION, MODE_RENEGADE, MODE_CHANGELING)
 	require_all_templates = 1
 	votable = 0

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -5,6 +5,6 @@
 	config_tag = "traitorling"
 	required_players = 10
 	required_enemies = 5
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/uprising.dm
+++ b/code/game/gamemodes/mixed/uprising.dm
@@ -5,7 +5,7 @@
 	config_tag = "uprising"
 	required_players = 15
 	required_enemies = 3
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_CULTIST)
 	require_all_templates = 1
 	votable = 0

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -11,5 +11,5 @@
 	config_tag = "ninja"
 	required_players = 1
 	required_enemies = 1
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_NINJA)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -5,5 +5,5 @@
 	config_tag = "wizard"
 	required_players = 1
 	required_enemies = 1
-	end_on_antag_death = 1
+	end_on_antag_death = 0
 	antag_tags = list(MODE_WIZARD)


### PR DESCRIPTION
- Fixes #13732 (as wizard no longer has the flag)
- Leaves the flag enabled only for Mercenary and Heist. It sounds reasonable to have it there. For other modes it is just silly, as RP can very easily continue after the antags have died - the antag may have subverted the AI, another crew member, or something similar.
- There is also obvious metagaming problem, where people will OOCly know the antag is dead when server calls for transfer vote on nonstandard time.
