### PR TITLE
Emergency shuttle limitations.

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -119,9 +119,26 @@ proc/trigger_armed_response_team(var/force = 0)
 		return
 
 	command_announcement.Announce("It would appear that an emergency response team was requested for [station_name()]. We will prepare and send one as soon as possible.", "[boss_name]")
+	emergency_shuttle.add_can_call_predicate(new/datum/emergency_shuttle_predicate/ert())
 
 	can_call_ert = 0 // Only one call per round, gentleman.
 	send_emergency_team = 1
 
 	sleep(600 * 5)
 	send_emergency_team = 0 // Can no longer join the ERT.
+
+/datum/emergency_shuttle_predicate/ert
+	var/prevent_until
+
+/datum/emergency_shuttle_predicate/ert/New()
+	..()
+	prevent_until = world.time + 30 MINUTES
+
+/datum/emergency_shuttle_predicate/ert/is_valid()
+	return world.time < prevent_until
+
+/datum/emergency_shuttle_predicate/ert/can_call(var/user)
+	if(world.time >= prevent_until)
+		return TRUE
+	user << "<span class='warning'>An emergency response team has been dispatched. Emergency shuttle requests will be denied until [station_adjusted_time(prevent_until - world.time)].</span>"
+	return FALSE

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -771,9 +771,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	choice = input("Is this an emergency evacuation or a crew transfer?") in list("Emergency", "Crew Transfer")
 	if (choice == "Emergency")
-		emergency_shuttle.call_evac()
+		emergency_shuttle.call_evac(usr, TRUE)
 	else
-		emergency_shuttle.call_transfer()
+		emergency_shuttle.call_transfer(usr, TRUE)
 
 
 	feedback_add_details("admin_verb","CSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -366,12 +366,9 @@ var/last_message_id = 0
 		user << "Under directive 7-10, [station_name()] is quarantined until further notice."
 		return
 
-	emergency_shuttle.call_evac()
-	log_game("[key_name(user)] has called the shuttle.")
-	message_admins("[key_name_admin(user)] has called the shuttle.", 1)
-
-
-	return
+	if(!emergency_shuttle.call_evac(user))
+		return
+	log_and_message_admins("has called the shuttle.")
 
 /proc/init_shift_change(var/mob/user, var/force = 0)
 	if ((!( ticker ) || !emergency_shuttle.location()))

--- a/html/changelogs/PsiOmegaDelta-YouCanPickOneAndOnlyOne.yml
+++ b/html/changelogs/PsiOmegaDelta-YouCanPickOneAndOnlyOne.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: PsiOmegaDelta
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Once an emergency response team has been successfully dispatched, as opposed to simply requested, the emergency shuttle cannot be called for 30 minutes."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Once an ERT has been dispatched emergency shuttles cannot be called for 30 minutes.
Admins can still manually send emergency shuttles as usual.
