### PR TITLE
Adds ability to devour items.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -124,7 +124,12 @@
 // Gluttony levels.
 #define GLUT_TINY 1       // Eat anything tiny and smaller
 #define GLUT_SMALLER 2    // Eat anything smaller than we are
-#define GLUT_ANYTHING 3   // Eat anything, ever
+#define GLUT_ANYTHING 4   // Eat anything, ever
+
+#define GLUT_ITEM_TINY 8         // Eat items with a w_class of small or smaller
+#define GLUT_ITEM_NORMAL 16      // Eat items with a w_class of normal or smaller
+#define GLUT_ITEM_ANYTHING 32    // Eat any item
+#define GLUT_PROJECTILE_VOMIT 64 // When vomitting, does it fly out?
 
 // Devour speeds, returned by can_devour()
 #define DEVOUR_SLOW 1

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -15,7 +15,7 @@ mob/attacked_with_item() should then do mob-type specific stuff (like determinin
 
 Item Hit Effects:
 
-item/apply_hit_effect() can be overriden to do whatever you want. However "standard" physical damage based weapons should make use of the target mob's hit_with_weapon() proc to 
+item/apply_hit_effect() can be overriden to do whatever you want. However "standard" physical damage based weapons should make use of the target mob's hit_with_weapon() proc to
 avoid code duplication. This includes items that may sometimes act as a standard weapon in addition to having other effects (e.g. stunbatons on harm intent).
 */
 
@@ -42,6 +42,16 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(can_operate(src) && I.do_surgery(src,user)) //Surgery
 		return 1
 	return I.attack(src, user, user.zone_sel.selecting)
+
+/mob/living/carbon/human/attackby(obj/item/I, mob/user)
+	if(user == src && src.a_intent == I_DISARM && src.zone_sel.selecting == "mouth")
+		var/obj/item/blocked = src.check_mouth_coverage()
+		if(blocked)
+			user << "<span class='warning'>\The [blocked] is in the way!</span>"
+			return 1
+		else if(devour(I))
+			return 1
+	return ..()
 
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.
@@ -78,7 +88,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	if(hitsound)
 		playsound(loc, hitsound, 50, 1, -1)
-	
+
 	var/power = force
 	if(HULK in user.mutations)
 		power *= 2

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -44,7 +44,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return I.attack(src, user, user.zone_sel.selecting)
 
 /mob/living/carbon/human/attackby(obj/item/I, mob/user)
-	if(user == src && src.a_intent == I_DISARM && src.zone_sel.selecting == "mouth")
+	if(user == src && src.a_intent == I_DISARM && src.zone_sel.selecting == "mouth" && I.abstract == 0 && I.anchored == 0) //We check abstract/anchored so we don't get bad objects like ninja blade/grabs
 		var/obj/item/blocked = src.check_mouth_coverage()
 		if(blocked)
 			user << "<span class='warning'>\The [blocked] is in the way!</span>"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -44,7 +44,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return I.attack(src, user, user.zone_sel.selecting)
 
 /mob/living/carbon/human/attackby(obj/item/I, mob/user)
-	if(user == src && src.a_intent == I_DISARM && src.zone_sel.selecting == "mouth" && I.abstract == 0 && I.anchored == 0) //We check abstract/anchored so we don't get bad objects like ninja blade/grabs
+	if(user == src && src.a_intent == I_DISARM && src.zone_sel.selecting == "mouth")
 		var/obj/item/blocked = src.check_mouth_coverage()
 		if(blocked)
 			user << "<span class='warning'>\The [blocked] is in the way!</span>"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -458,3 +458,12 @@
 		return DEVOUR_FAST
 
 	return FALSE
+
+/mob/living/carbon/onDropInto(var/atom/movable/AM)
+	if(AM.loc in stomach_contents)
+		if(can_devour(AM))
+			stomach_contents += AM
+			return null
+		src.visible_message("<span class='warning'>\The [src] regurgitates \the [AM]!</span>")
+		return loc
+	return ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -453,7 +453,7 @@
 /**
  *  Return FALSE if victim can't be devoured, DEVOUR_FAST if they can be devoured quickly, DEVOUR_SLOW for slow devour
  */
-/mob/living/carbon/proc/can_devour(mob/victim)
+/mob/living/carbon/proc/can_devour(atom/movable/victim)
 	if((FAT in mutations) && issmall(victim))
 		return DEVOUR_FAST
 

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -62,25 +62,31 @@
 	else
 		src << "You do not have enough chemicals stored to reproduce."
 		return
-		
+
 /**
  *  Attempt to devour victim
  *
  *  Returns TRUE on success, FALSE on failure
  */
-/mob/living/carbon/proc/devour(mob/victim)
+/mob/living/carbon/proc/devour(atom/movable/victim)
 	var/can_eat = can_devour(victim)
 	if(!can_eat)
 		return FALSE
-	
-	src.visible_message("<span class='danger'>\The [src] is attempting to devour \the [victim]!</span>")
+	var/eat_speed = 100
 	if(can_eat == DEVOUR_FAST)
-		if(!do_mob(src, victim, 30)) return FALSE
-	else
-		if(!do_mob(src, victim, 100)) return FALSE
+		eat_speed = 30
+	src.visible_message("<span class='danger'>\The [src] is attempting to devour \the [victim]!</span>")
+	var/mob/target = victim
+	if(isobj(victim))
+		target = src
+	if(!do_mob(src,target,eat_speed))
+		return FALSE
 	src.visible_message("<span class='danger'>\The [src] devours \the [victim]!</span>")
-	admin_attack_log(src, victim, "Devoured.", "Was devoured by.", "devoured")
+	if(ismob(victim))
+		admin_attack_log(src, victim, "Devoured.", "Was devoured by.", "devoured")
+	else
+		src.drop_from_inventory(victim)
 	victim.forceMove(src)
 	src.stomach_contents.Add(victim)
-	
+
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1483,7 +1483,7 @@
 		if(ismob(a))
 			var/mob/M = a
 			total += M.mob_size
-		else
+		else if(isobj(a))
 			var/obj/item/I = a
 			total += I.get_storage_cost()
 	if(total > src.species.stomach_capacity)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1479,20 +1479,14 @@
 	if(!src.species.gluttonous)
 		return FALSE
 	var/total = 0
-	for(var/a in stomach_contents)
+	for(var/a in stomach_contents + victim)
 		if(ismob(a))
 			var/mob/M = a
 			total += M.mob_size
 		else
 			var/obj/item/I = a
 			total += I.w_class
-	if(isobj(victim,/obj/item))
-		var/obj/item/I = victim
-		total += I.w_class
-	else
-		var/mob/M = victim
-		total += M.mob_size
-	if(total >= src.species.stomach_capacity)
+	if(total > src.species.stomach_capacity)
 		return FALSE
 
 	if(iscarbon(victim) || isanimal(victim))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1485,7 +1485,7 @@
 			total += M.mob_size
 		else
 			var/obj/item/I = a
-			total += I.w_class
+			total += I.get_storage_cost()
 	if(total > src.species.stomach_capacity)
 		return FALSE
 
@@ -1499,11 +1499,12 @@
 			return DEVOUR_FAST
 	else if(istype(victim, /obj/item) && !istype(victim, /obj/item/weapon/holder)) //Don't eat holders. They are special.
 		var/obj/item/I = victim
-		if((src.species.gluttonous & GLUT_ITEM_TINY) && I.w_class < 3)
-			return DEVOUR_SLOW
-		else if((src.species.gluttonous & GLUT_ITEM_NORMAL) && I.w_class <= 3)
-			return DEVOUR_SLOW
-		else if(src.species.gluttonous & GLUT_ITEM_ANYTHING)
-			return DEVOUR_FAST
-
+		var/cost = I.get_storage_cost()
+		if(cost != DO_NOT_STORE)
+			if((src.species.gluttonous & GLUT_ITEM_TINY) && cost < 4)
+				return DEVOUR_SLOW
+			else if((src.species.gluttonous & GLUT_ITEM_NORMAL) && cost <= 4)
+				return DEVOUR_SLOW
+			else if(src.species.gluttonous & GLUT_ITEM_ANYTHING)
+				return DEVOUR_FAST
 	return ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1478,6 +1478,17 @@
 /mob/living/carbon/human/can_devour(atom/movable/victim)
 	if(!src.species.gluttonous)
 		return FALSE
+	var/total = 0
+	for(var/a in stomach_contents)
+		if(ismob(a))
+			var/mob/M = a
+			total += M.mob_size
+		else
+			var/obj/item/I = a
+			total += I.w_class
+	if(total > src.species.stomach_capacity)
+		return FALSE
+
 	if(iscarbon(victim) || isanimal(victim))
 		var/mob/living/L = victim
 		if((src.species.gluttonous & GLUT_TINY) && (L.mob_size <= MOB_TINY) && !ishuman(victim)) // Anything MOB_TINY or smaller

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1486,7 +1486,13 @@
 		else
 			var/obj/item/I = a
 			total += I.w_class
-	if(total > src.species.stomach_capacity)
+	if(isobj(victim,/obj/item))
+		var/obj/item/I = victim
+		total += I.w_class
+	else
+		var/mob/M = victim
+		total += M.mob_size
+	if(total >= src.species.stomach_capacity)
 		return FALSE
 
 	if(iscarbon(victim) || isanimal(victim))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -6,8 +6,8 @@
 
 	if (istype(loc, /turf/space)) return -1 // It's hard to be slowed down in space by... anything
 
-	if(embedded_flag)
-		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.
+	if(embedded_flag || (stomach_contents && stomach_contents.len))
+		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
 
 	if(CE_SPEEDBOOST in chem_effects)
 		return -1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -906,7 +906,7 @@
 /mob/living/carbon/human/handle_stomach()
 	spawn(0)
 		for(var/a in stomach_contents)
-			if(!a in contents)
+			if(!(a in contents) || isnull(a))
 				stomach_contents.Remove(a)
 				continue
 			if(iscarbon(a)|| isanimal(a))
@@ -922,10 +922,10 @@
 					nutrition += 10
 			else if(istype(a,/obj/item))
 				var/obj/item/I = a
-				if(air_master.current_cycle%6==1 && (I.sharp || I.edge))
+				if((I.sharp || I.edge) && prob(1))
 					var/obj/item/organ/external/organ = src.get_organ("chest")
-					if (istype(organ) && organ.take_damage(rand(1,round(I.force*1.5)), 0))
-						src.UpdateDamageIcon()
+					var/datum/wound/internal_bleeding/wound = new(max(min(I.w_class * 5, 15), min(I.force, 30)))
+					organ.wounds += wound
 
 /mob/living/carbon/human/proc/handle_changeling()
 	if(mind && mind.changeling)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -922,10 +922,17 @@
 					nutrition += 10
 			else if(istype(a,/obj/item))
 				var/obj/item/I = a
-				if((I.sharp || I.edge) && prob(1))
+				if((I.sharp || I.edge))
 					var/obj/item/organ/external/organ = src.get_organ("chest")
-					var/datum/wound/internal_bleeding/wound = new(max(min(I.w_class * 5, 15), min(I.force, 30)))
-					organ.wounds += wound
+					if(!organ)
+						continue
+					if(prob(1))
+						var/datum/wound/internal_bleeding/wound = new(max(min(I.w_class * 5, 15), min(I.force, 30)))
+						organ.wounds += wound
+					else if(prob(1))
+						stomach_contents.Remove(I)
+						src << "<span class='danger'>You feel something rip painfully out of your stomach!</span>"
+						organ.embed(I)
 
 /mob/living/carbon/human/proc/handle_changeling()
 	if(mind && mind.changeling)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -920,19 +920,6 @@
 					if(!(M.status_flags & GODMODE))
 						M.adjustBruteLoss(5)
 					nutrition += 10
-			else if(istype(a,/obj/item))
-				var/obj/item/I = a
-				if((I.sharp || I.edge))
-					var/obj/item/organ/external/organ = src.get_organ("groin")
-					if(!organ)
-						continue
-					if(prob(1))
-						var/datum/wound/internal_bleeding/wound = new(max(min(I.w_class * 5, 15), min(I.force, 30)))
-						organ.wounds += wound
-					else if(prob(1))
-						stomach_contents.Remove(I)
-						src << "<span class='danger'>You feel something rip painfully out of your stomach!</span>"
-						organ.embed(I)
 
 /mob/living/carbon/human/proc/handle_changeling()
 	if(mind && mind.changeling)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -923,7 +923,7 @@
 			else if(istype(a,/obj/item))
 				var/obj/item/I = a
 				if((I.sharp || I.edge))
-					var/obj/item/organ/external/organ = src.get_organ("chest")
+					var/obj/item/organ/external/organ = src.get_organ("groin")
 					if(!organ)
 						continue
 					if(prob(1))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -905,11 +905,12 @@
 
 /mob/living/carbon/human/handle_stomach()
 	spawn(0)
-		for(var/mob/living/M in stomach_contents)
-			if(M.loc != src)
-				stomach_contents.Remove(M)
+		for(var/a in stomach_contents)
+			if(!a in contents)
+				stomach_contents.Remove(a)
 				continue
-			if(iscarbon(M)|| isanimal(M))
+			if(iscarbon(a)|| isanimal(a))
+				var/mob/living/M = a
 				if(M.stat == DEAD)
 					M.death(1)
 					stomach_contents.Remove(M)
@@ -919,6 +920,12 @@
 					if(!(M.status_flags & GODMODE))
 						M.adjustBruteLoss(5)
 					nutrition += 10
+			else if(istype(a,/obj/item))
+				var/obj/item/I = a
+				if(air_master.current_cycle%6==1 && (I.sharp || I.edge))
+					var/obj/item/organ/external/organ = src.get_organ("chest")
+					if (istype(organ) && organ.take_damage(rand(1,round(I.force*1.5)), 0))
+						src.UpdateDamageIcon()
 
 /mob/living/carbon/human/proc/handle_changeling()
 	if(mind && mind.changeling)

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -29,7 +29,8 @@
 	cold_level_3 = 0
 
 	eyes = "vox_eyes_s"
-	gluttonous = GLUT_ITEM_NORMAL
+	gluttonous = GLUT_TINY|GLUT_ITEM_NORMAL
+	stomach_capacity = 12
 
 	breath_type = "nitrogen"
 	poison_type = "oxygen"

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -29,7 +29,7 @@
 	cold_level_3 = 0
 
 	eyes = "vox_eyes_s"
-	gluttonous = GLUT_SMALLER
+	gluttonous = GLUT_ITEM_NORMAL
 
 	breath_type = "nitrogen"
 	poison_type = "oxygen"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -130,6 +130,7 @@
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
 	var/holder_type               // In-hand wrapper object, if any.
 	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING, GLUT_ITEM_TINY, GLUT_ITEM_NORMAL, GLUT_ITEM_ANYTHING, GLUT_PROJECTILE_VOMIT
+	var/stomach_capacity = 5      // How much stuff they can stick in their stomach
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	                              // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -129,7 +129,7 @@
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
 	var/holder_type               // In-hand wrapper object, if any.
-	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
+	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING, GLUT_ITEM_TINY, GLUT_ITEM_NORMAL, GLUT_ITEM_ANYTHING, GLUT_PROJECTILE_VOMIT
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	                              // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -13,6 +13,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = GLUT_ANYTHING
+	stomach_capacity = 40
 
 	eyes = "blank_eyes"
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -13,7 +13,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = GLUT_ANYTHING
-	stomach_capacity = 20
+	stomach_capacity = MOB_MEDIUM
 
 	eyes = "blank_eyes"
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -13,7 +13,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = GLUT_ANYTHING
-	stomach_capacity = 40
+	stomach_capacity = 20
 
 	eyes = "blank_eyes"
 

--- a/html/changelogs/TheWelp-itemSwallowing.yml
+++ b/html/changelogs/TheWelp-itemSwallowing.yml
@@ -1,0 +1,8 @@
+author: TheWelp
+
+delete-after: True
+
+changes: 
+  - rscadd: "Certain races can now swallow objects whole by using the disarm intent and aiming at their mouth."
+  - rscadd: "Vomitting now shoves out all the things in your stomach."
+  - rscadd: "Adds support for projectile vomitting being an ability of a species."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Changes gluttony to being a bit operator.
Adds the following states:
GLUT_ITEM_TINY - swallow anything with a w_class of 2 or under
GLUT_ITEM_NORMAL - swallow anything with a w_class of 3 or under
GLUT_ITEM_ANYTHING - swallow anything
GLUT_PROJECTILE_VOMIT - when vomitting, the objects get thrown in whatever direction you are facing.

Also makes vomiting purge everything from your stomach (but /only/ when you vomit. Dry heaving does nothing).

Sharp/edged objects also deal damage to the person while they are in their stomach. About every 6~8ish seconds, from 1 to 1.5 times their force.

Swallowing something can only be done by Vox currently. The way it is done is by using disarm intent, aiming at your mouth, and 'eating' it.
