### PR TITLE
Make robotic organs attachable with fixovein

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -327,12 +327,13 @@
 		target.op_stage.current_organ = null
 
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		if(!affected)
+		if(!affected || affected.robotic >= ORGAN_ROBOT)
+			// robotic attachment handled via screwdriver
 			return 0
 
 		var/list/attachable_organs = list()
 		for(var/obj/item/organ/I in affected.implants)
-			if(I && (I.status & ORGAN_CUT_AWAY) && !(I.robotic >= ORGAN_ROBOT) && I.parent_organ == target_zone)
+			if(I && (I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
 				attachable_organs |= I
 
 		var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in attachable_organs

--- a/html/changelogs/Daranz-fixovein.yml
+++ b/html/changelogs/Daranz-fixovein.yml
@@ -1,0 +1,6 @@
+author: Daranz
+
+delete-after: True
+
+changes: 
+  - bugfix: "FixOVeins can now be used for attaching robotic organs (such as neural laces) in organic patients. Follow the same procedure as with normal organ transplant."


### PR DESCRIPTION
Robotic organs in fleshy parts can now be attached with fixovein. This, notably, makes neural laces inside heads attachable with fixoveins. 

The other, existing, surgery path for attaching organs is with the screwdriver, for attaching robotic organs to robotic body parts.
