### PR TITLE
Fix loading crates on trolleys

### DIFF
--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -270,7 +270,7 @@
 
 	// if a create/closet, close before loading
 	var/obj/structure/closet/crate = C
-	if(istype(crate) && !crate.close())
+	if(istype(crate) && crate.opened && !crate.close())
 		return 0
 
 	C.forceMove(loc)


### PR DESCRIPTION
Crates now properly load if already closed, and close before loading if open. Previously, they were trying to close if already closed, failing, and failing to load. 

Resolves #13752
