### PR TITLE
Updates ignore lists for mapmergepy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 *.dmb
 *.lk
 *.backup
+*.before
 data/
 cfg/
 build_log.txt
@@ -13,3 +14,4 @@ use_map
 stopserver
 reboot_called
 atupdate
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - (num=`grep -E '"/obj' **/*.dm | wc -l`; echo "$num /obj text paths (expecting 13 or less)"; [ $num -le 13 ])
   - (num=`grep -E '"/turf' **/*.dm | wc -l`; echo "$num /turf text paths (expecting 8 or less)"; [ $num -le 8 ])
   - awk -f tools/indentation.awk **/*.dm
-  - md5sum -c - <<< "a7534ef155ebb32ae7249c48a87abf0d *.gitignore"
+  - md5sum -c - <<< "4bab08611ef5a6f7478d8c4f8b1aa355 *.gitignore"
   - md5sum -c - <<< "0af969f671fba6cf9696c78cd175a14a *baystation12.int"
   - md5sum -c - <<< "88490b460c26947f5ec1ab1bb9fa9f17 *html/changelogs/example.yml"
   - python tools/TagMatcher/tag-matcher.py ../..


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Added `.before`and `__pycache__` to .gitignore, general QOL improvement I guess.

`.before` is the extension for backed up map files using mapmergepy, `__pycache__` is the directory inside /mapmergepy used for caching/compiled binaries.
