### PR TITLE
Fix multi-powersupply AI bug

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -164,8 +164,7 @@ var/list/ai_verbs_default = list(
 
 			on_mob_init()
 
-	spawn(5)
-		new /obj/machinery/ai_powersupply(src)
+	create_powersupply()
 
 	hud_list[HEALTH_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
 	hud_list[STATUS_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -141,9 +141,3 @@
 				stat("SYSTEM OVERRIDE INITIATED")
 			else if(system_override == 2)
 				stat("SYSTEM OVERRIDE COMPLETED")
-
-// Cleaner proc for creating powersupply for an AI.
-/mob/living/silicon/ai/proc/create_powersupply()
-	if(psupply)
-		qdel(psupply)
-	psupply = new/obj/machinery/ai_powersupply(src)

--- a/code/modules/mob/living/silicon/ai/power.dm
+++ b/code/modules/mob/living/silicon/ai/power.dm
@@ -175,6 +175,10 @@
 		return
 
 
+/mob/living/silicon/ai/proc/create_powersupply()
+	if(psupply)
+		qdel(psupply)
+	psupply = new/obj/machinery/ai_powersupply(src)
 
 
 /*


### PR DESCRIPTION
- Fixes a bug where AI could have multiple powersupply objects at once, which effectively doubled (or tripled) it's power usage in specific situations. This occured during the Malfunction gamemode.
