### PR TITLE
refactor of admin fax handling

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1689,6 +1689,7 @@
 #include "code\modules\overmap\ships\computers\shuttle.dm"
 #include "code\modules\overmap\ships\engines\engine.dm"
 #include "code\modules\overmap\ships\engines\thermal.dm"
+#include "code\modules\paperwork\adminpaper.dm"
 #include "code\modules\paperwork\carbonpaper.dm"
 #include "code\modules\paperwork\clipboard.dm"
 #include "code\modules\paperwork\faxmachine.dm"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1374,3 +1374,94 @@ proc/admin_notice(var/message, var/rights)
 			H.paralysis = 0
 			msg = "has unparalyzed [key_name(H)]."
 		log_and_message_admins(msg)
+
+
+/datum/admins/proc/sendFax()
+	set category = "Special Verbs"
+	set name = "Send Fax"
+	set desc = "Sends a fax to this machine"
+	var/department = input("Choose a fax", "Fax") as null|anything in alldepartments
+	for(var/obj/machinery/photocopier/faxmachine/sendto in allfaxes)
+		if(sendto.department == department)
+
+			if (!istype(src,/datum/admins))
+				src = usr.client.holder
+			if (!istype(src,/datum/admins))
+				usr << "Error: you are not an admin!"
+				return
+
+			var/replyorigin = input(src.owner, "Please specify who the fax is coming from", "Origin") as text|null
+
+			var/obj/item/weapon/paper/admin/P = new /obj/item/weapon/paper/admin( null ) //hopefully the null loc won't cause trouble for us
+			faxreply = P
+
+			P.admindatum = src
+			P.origin = replyorigin
+			P.destination = sendto
+
+			P.adminbrowse()
+
+
+datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies in
+
+/datum/admins/proc/faxCallback(var/obj/item/weapon/paper/admin/P, var/obj/machinery/photocopier/faxmachine/destination)
+	var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
+
+	P.name = "[P.origin] - [customname]"
+	P.desc = "This is a paper titled '" + P.name + "'."
+
+	var/shouldStamp = 1
+	if(!P.sender) // admin initiated
+		switch(alert("Would you like the fax stamped?",, "Yes", "No"))
+			if("No")
+				shouldStamp = 0
+
+	if(shouldStamp)
+		P.stamps += "<hr><i>This paper has been stamped by the [P.origin] Quantum Relay.</i>"
+
+		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+		var/{x; y;}
+		x = rand(-2, 0)
+		y = rand(-1, 2)
+		P.offset_x += x
+		P.offset_y += y
+		stampoverlay.pixel_x = x
+		stampoverlay.pixel_y = y
+
+		if(!P.ico)
+			P.ico = new
+		P.ico += "paper_stamp-cent"
+		stampoverlay.icon_state = "paper_stamp-cent"
+
+		if(!P.stamped)
+			P.stamped = new
+		P.stamped += /obj/item/weapon/stamp/centcomm
+		P.overlays += stampoverlay
+
+	var/obj/item/rcvdcopy
+	rcvdcopy = destination.copy(P)
+	rcvdcopy.loc = null //hopefully this shouldn't cause trouble
+	adminfaxes += rcvdcopy
+
+
+
+	if(destination.recievefax(P))
+		src.owner << "\blue Message reply to transmitted successfully."
+		if(P.sender) // sent as a reply
+			log_admin("[key_name(src.owner)] replied to a fax message from [key_name(P.sender)]")
+			for(var/client/C in admins)
+				if((R_ADMIN | R_MOD) & C.holder.rights)
+					C << "<span class='log_message'><span class='prefix'>FAX LOG:</span>[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(P.sender)] (<a href='?_src_=holder;AdminFaxView=\ref[rcvdcopy]'>VIEW</a>)</span>"
+		else
+			log_admin("[key_name(src.owner)] has sent a fax message to [destination.department]")
+			for(var/client/C in admins)
+				if((R_ADMIN | R_MOD) & C.holder.rights)
+					C << "<span class='log_message'><span class='prefix'>FAX LOG:</span>[key_name_admin(src.owner)] has sent a fax message to [destination.department] (<a href='?_src_=holder;AdminFaxView=\ref[rcvdcopy]'>VIEW</a>)</span>"
+
+	else
+		src.owner << "\red Message reply failed."
+
+	spawn(100)
+		qdel(P)
+		faxreply = null
+	return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1446,7 +1446,7 @@ datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies
 
 
 	if(destination.recievefax(P))
-		src.owner << "\blue Message reply to transmitted successfully."
+		src.owner << "<span class='notice'>Message reply to transmitted successfully.</span>"
 		if(P.sender) // sent as a reply
 			log_admin("[key_name(src.owner)] replied to a fax message from [key_name(P.sender)]")
 			for(var/client/C in admins)
@@ -1459,7 +1459,7 @@ datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies
 					C << "<span class='log_message'><span class='prefix'>FAX LOG:</span>[key_name_admin(src.owner)] has sent a fax message to [destination.department] (<a href='?_src_=holder;AdminFaxView=\ref[rcvdcopy]'>VIEW</a>)</span>"
 
 	else
-		src.owner << "\red Message reply failed."
+		src.owner << "<span class='warning'>Message reply failed.</span>"
 
 	spawn(100)
 		qdel(P)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -92,7 +92,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/fixatmos,
 	/client/proc/list_traders,
 	/client/proc/add_trader,
-	/client/proc/remove_trader
+	/client/proc/remove_trader,
+	/datum/admins/proc/sendFax
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -302,7 +303,9 @@ var/list/admin_verbs_mod = list(
 	/client/proc/jobbans,
 	/client/proc/cmd_admin_subtle_message, // send an message to somebody as a 'voice in their head',
 	/client/proc/aooc,
-	/datum/admins/proc/paralyze_mob
+	/datum/admins/proc/paralyze_mob,
+	/datum/admins/proc/sendFax
+
 )
 
 var/list/admin_verbs_mentor = list(

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -12,7 +12,7 @@ var/list/admin_datums = list()
 	var/datum/feed_message/admincaster_feed_message = new /datum/feed_message   //These two will act as holders.
 	var/datum/feed_channel/admincaster_feed_channel = new /datum/feed_channel
 	var/admincaster_signature	//What you'll sign the newsfeeds as
-	
+
 /datum/admins/proc/marked_datum()
 	if(marked_datum_weak)
 		return marked_datum_weak.resolve()
@@ -61,21 +61,24 @@ proc/admin_proc()
 
 NOTE: It checks usr by default. Supply the "user" argument if you wish to check for a specific mob.
 */
-/proc/check_rights(rights_required, show_msg=1, var/mob/user = usr)
-	if(user && user.client)
+/proc/check_rights(rights_required, show_msg=1, var/client/C = usr)
+	if(ismob(C))
+		var/mob/M = C
+		C = M.client
+
+	if(C)
 		if(rights_required)
-			if(user.client.holder)
-				if(rights_required & user.client.holder.rights)
-					return 1
-				else
-					if(show_msg)
-						user << "<font color='red'>Error: You do not have sufficient rights to do that. You require one of the following flags:[rights2text(rights_required," ")].</font>"
-		else
-			if(user.client.holder)
+			if(rights_required & C.holder.rights)
 				return 1
 			else
 				if(show_msg)
-					user << "<font color='red'>Error: You are not an admin.</font>"
+					C << "<font color='red'>Error: You do not have sufficient rights to do that. You require one of the following flags:[rights2text(rights_required," ")].</font>"
+		else
+			if(C.holder)
+				return 1
+			else
+				if(show_msg)
+					C << "<font color='red'>Error: You are not an admin.</font>"
 	return 0
 
 //probably a bit iffy - will hopefully figure out a better solution

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1394,86 +1394,21 @@
 			H.show(src.owner)
 		return
 
-	else if(href_list["CentcommFaxReply"])
-		var/mob/sender = locate(href_list["CentcommFaxReply"])
+	else if(href_list["FaxReply"])
+		var/mob/sender = locate(href_list["FaxReply"])
 		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
-
-		//todo: sanitize
-		var/input = input(src.owner, "Please enter a message to reply to [key_name(sender)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
-		if(!input)	return
-
-		var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
-
-		// Create the reply message
-		var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( null ) //hopefully the null loc won't cause trouble for us
-		P.name = "[command_name()]- [customname]"
-		P.info = input
-		P.update_icon()
-
-		// Stamps
-		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-		stampoverlay.icon_state = "paper_stamp-cent"
-		if(!P.stamped)
-			P.stamped = new
-		P.stamped += /obj/item/weapon/stamp
-		P.overlays += stampoverlay
-		P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
-
-		if(fax.recievefax(P))
-			src.owner << "\blue Message reply to transmitted successfully."
-			log_admin("[key_name(src.owner)] replied to a fax message from [key_name(sender)]: [input]")
-			message_admins("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(sender)]", 1)
-		else
-			src.owner << "\red Message reply failed."
-
-		spawn(100)
-			qdel(P)
-		return
-
-	else if(href_list["SolGovFaxReply"])
-		//TODO
-		/*
-		var/mob/living/carbon/human/H = locate(href_list["SolGovFaxReply"])
-		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
-
-		var/input = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
-		if(!input)	return
-
-		var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
-
-		for(var/obj/machinery/photocopier/faxmachine/F in machines)
-			if(F == fax)
-				if(! (F.stat & (BROKEN|NOPOWER) ) )
-
-					// animate! it's alive!
-					flick("faxreceive", F)
-
-					// give the sprite some time to flick
-					spawn(20)
-						var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( F.loc )
-						P.name = "Sol Government- [customname]"
-						P.info = input
-						P.update_icon()
-
-						playsound(F.loc, "sound/items/polaroid1.ogg", 50, 1)
-
-						// Stamps
-						var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-						stampoverlay.icon_state = "paper_stamp-cap"
-						if(!P.stamped)
-							P.stamped = new
-						P.stamped += /obj/item/weapon/stamp
-						P.overlays += stampoverlay
-						P.stamps += "<HR><i>This paper has been stamped and encrypted by the Sol Government Quantum Relay.</i>"
-
-				src.owner << "Message reply to transmitted successfully."
-				log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [input]")
-				message_admins("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]", 1)
-				return
-		src.owner << "/red Unable to locate fax!"
-		*/
+		var/replyorigin = href_list["replyorigin"]
 
 
+		var/obj/item/weapon/paper/admin/P = new /obj/item/weapon/paper/admin( null ) //hopefully the null loc won't cause trouble for us
+		faxreply = P
+
+		P.admindatum = src
+		P.origin = replyorigin
+		P.destination = fax
+		P.sender = sender
+
+		P.adminbrowse()
 
 	else if(href_list["jumpto"])
 		if(!check_rights(R_ADMIN))	return

--- a/code/modules/paperwork/adminpaper.dm
+++ b/code/modules/paperwork/adminpaper.dm
@@ -1,0 +1,196 @@
+//Adminpaper - it's like paper, but more adminny!
+/obj/item/weapon/paper/admin
+	name = "administrative paper"
+	desc = "If you see this, something has gone horribly wrong."
+	var/datum/admins/admindatum = null
+
+	var/interactions = null
+	var/isCrayon = 0
+	var/origin = null
+	var/mob/sender = null
+	var/obj/machinery/photocopier/faxmachine/destination
+
+	var/header = null
+	var/headerOn = TRUE
+
+/obj/item/weapon/paper/admin/New()
+	..()
+	generateInteractions()
+
+
+/obj/item/weapon/paper/admin/proc/generateInteractions()
+	//clear first
+	interactions = null
+	interactions += "<HR>"
+	interactions += "<center><A href='?src=\ref[src];confirm=1'>Send fax</A> "
+	interactions += "<A href='?src=\ref[src];penmode=1'>Pen mode: [isCrayon ? "Crayon" : "Pen"]</A> "
+	interactions += "<A href='?src=\ref[src];cancel=1'>Cancel fax</A> "
+	interactions += "<BR>"
+	interactions += "<A href='?src=\ref[src];toggleheader=1'>Toggle Header</A> "
+	interactions += "<A href='?src=\ref[src];clear=1'>Clear page</A> </center>"
+
+/obj/item/weapon/paper/admin/proc/generateHeader()
+	var/originhash = md5("[origin]")
+	var/timehash = copytext(md5("[world.time]"),1,10)
+	var/text = null
+	//TODO change logo based on who you're contacting.
+	text = "<center><img src = ntlogo.png></br>"
+	text += "<b>[origin] quantum uplink signed message</b><br>"
+	text += "<font size = \"1\">Encryption key: [originhash]<br>"
+	text += "Challenge: [timehash]<br></font></center><hr>"
+
+	header = text
+
+/obj/item/weapon/paper/admin/proc/adminbrowse()
+	updateinfolinks()
+	generateHeader()
+	usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[header][info_links][stamps][interactions]</BODY></HTML>", "window=[name];can_close=0")
+
+obj/item/weapon/paper/admin/proc/updateDisplay()
+	if (headerOn)
+		usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[header][info_links][stamps][interactions]</BODY></HTML>", "window=[name];can_close=0")
+	else
+		usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info_links][stamps][interactions]</BODY></HTML>", "window=[name];can_close=0")
+
+/obj/item/weapon/paper/admin/Topic(href, href_list)
+	if(href_list["write"])
+		var/id = href_list["write"]
+		if(free_space <= 0)
+			usr << "<span class='info'>There isn't enough space left on \the [src] to write anything.</span>"
+			return
+
+		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0)
+
+		if(!t)
+			return
+
+		var last_fields_value = fields
+
+		//t = html_encode(t)
+		t = replacetext(t, "\n", "<BR>")
+		t = parsepencode(t, isCrayon) // Encode everything from pencode to html
+
+
+		if(fields > 50)//large amount of fields creates a heavy load on the server, see updateinfolinks() and addtofield()
+			usr << "<span class='warning'>Too many fields. Sorry, you can't do this.</span>"
+			fields = last_fields_value
+			return
+
+		if(id!="end")
+			addtofield(text2num(id), t) // He wants to edit a field, let him.
+		else
+			info += t // Oh, he wants to edit to the end of the file, let him.
+			updateinfolinks()
+
+		update_space(t)
+
+		updateDisplay()
+
+		update_icon()
+		return
+
+	if(href_list["confirm"])
+		switch(alert("Are you sure you want to send the fax as is?",, "Yes", "No"))
+			if("Yes")
+				if(headerOn)
+					info = header + info
+					updateinfolinks()
+				usr << browse(null, "window=[name]")
+				admindatum.faxCallback(src, destination)
+		return
+
+	if(href_list["penmode"])
+		isCrayon = !isCrayon
+		generateInteractions()
+		updateDisplay()
+		return
+
+	if(href_list["cancel"])
+		usr << browse(null, "window=[name]")
+		qdel(src)
+		return
+
+	if(href_list["clear"])
+		clearpaper()
+		updateDisplay()
+		return
+
+	if(href_list["toggleheader"])
+		headerOn = !headerOn
+		updateDisplay()
+		return
+
+
+
+
+/obj/item/weapon/paper/admin/parsepencode(var/t, var/iscrayon = 0, var/sign = 1)
+//	t = copytext(sanitize(t),1,MAX_MESSAGE_LEN)
+
+	t = replacetext(t, "\[center\]", "<center>")
+	t = replacetext(t, "\[/center\]", "</center>")
+	t = replacetext(t, "\[br\]", "<BR>")
+	t = replacetext(t, "\[b\]", "<B>")
+	t = replacetext(t, "\[/b\]", "</B>")
+	t = replacetext(t, "\[i\]", "<I>")
+	t = replacetext(t, "\[/i\]", "</I>")
+	t = replacetext(t, "\[u\]", "<U>")
+	t = replacetext(t, "\[/u\]", "</U>")
+	t = replacetext(t, "\[time\]", "[stationtime2text()]")
+	t = replacetext(t, "\[date\]", "[stationdate2text()]")
+	t = replacetext(t, "\[large\]", "<font size=\"4\">")
+	t = replacetext(t, "\[/large\]", "</font>")
+	if(!sign)
+		t = replacetext(t, "\[sign\]", "<font face=\"[signfont]\"><i>[get_signature()]</i></font>")
+	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
+
+	t = replacetext(t, "\[h1\]", "<H1>")
+	t = replacetext(t, "\[/h1\]", "</H1>")
+	t = replacetext(t, "\[h2\]", "<H2>")
+	t = replacetext(t, "\[/h2\]", "</H2>")
+	t = replacetext(t, "\[h3\]", "<H3>")
+	t = replacetext(t, "\[/h3\]", "</H3>")
+
+	if(!iscrayon)
+		t = replacetext(t, "\[*\]", "<li>")
+		t = replacetext(t, "\[hr\]", "<HR>")
+		t = replacetext(t, "\[small\]", "<font size = \"1\">")
+		t = replacetext(t, "\[/small\]", "</font>")
+		t = replacetext(t, "\[list\]", "<ul>")
+		t = replacetext(t, "\[/list\]", "</ul>")
+		t = replacetext(t, "\[table\]", "<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>")
+		t = replacetext(t, "\[/table\]", "</td></tr></table>")
+		t = replacetext(t, "\[grid\]", "<table>")
+		t = replacetext(t, "\[/grid\]", "</td></tr></table>")
+		t = replacetext(t, "\[row\]", "</td><tr>")
+		t = replacetext(t, "\[cell\]", "<td>")
+		t = replacetext(t, "\[logo\]", "<img src = ntlogo.png>")
+
+		t = "<font face=\"[deffont]\" color=\"black\">[t]</font>"
+	else // If it is a crayon, and he still tries to use these, make them empty!
+		t = replacetext(t, "\[*\]", "")
+		t = replacetext(t, "\[hr\]", "")
+		t = replacetext(t, "\[small\]", "")
+		t = replacetext(t, "\[/small\]", "")
+		t = replacetext(t, "\[list\]", "")
+		t = replacetext(t, "\[/list\]", "")
+		t = replacetext(t, "\[table\]", "")
+		t = replacetext(t, "\[/table\]", "")
+		t = replacetext(t, "\[row\]", "")
+		t = replacetext(t, "\[cell\]", "")
+		t = replacetext(t, "\[logo\]", "")
+
+		t = "<font face=\"[crayonfont]\" color=\"black\"><b>[t]</b></font>"
+
+//Count the fields
+	var/laststart = 1
+	while(1)
+		var/i = findtext(t, "<span class=\"paper_field\">", laststart)	//</span>
+		if(i==0)
+			break
+		laststart = i+1
+		fields++
+
+	return t
+
+/obj/item/weapon/paper/admin/get_signature()
+	return input(usr, "Enter the name you wish to sign the paper with (will prompt for multiple entries, in order of entry)", "Signature") as text|null

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -216,6 +216,6 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 	msg += "Receiving '[sent.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a></span>"
 
 	for(var/client/C in admins)
-		if((R_ADMIN | R_MOD) & C.holder.rights)
+		if(check_rights((R_ADMIN|R_MOD),0,C))
 			C << msg
 			C << 'sound/machines/dotprinter.ogg'

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -211,9 +211,9 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 
 
 /obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/obj/item/sent, var/reply_type, font_colour="#006100")
-	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[get_options_bar(sender, 2,1,1)]"
+	var/msg = "<span class='notice'><b><font color='[font_colour]'>[faxname]: </font>[get_options_bar(sender, 2,1,1)]"
 	msg += "(<a href='?_src_=holder;FaxReply=\ref[sender];originfax=\ref[src];replyorigin=[reply_type]'>REPLY</a>)</b>: "
-	msg += "Receiving '[sent.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
+	msg += "Receiving '[sent.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a></span>"
 
 	for(var/client/C in admins)
 		if((R_ADMIN | R_MOD) & C.holder.rights)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -1,5 +1,5 @@
 var/list/obj/machinery/photocopier/faxmachine/allfaxes = list()
-var/list/admin_departments = list("[boss_name]", "Sol Government", "Supply")
+var/list/admin_departments = list("[boss_name]", "Colonial Marshal Service", "[boss_short] Supply")
 var/list/alldepartments = list()
 
 var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
@@ -157,7 +157,7 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 		return 0	//You can't send faxes to "Unknown"
 
 	flick("faxreceive", src)
-	playsound(loc, "sound/items/polaroid1.ogg", 50, 1)
+	playsound(loc, "sound/machines/dotprinter.ogg", 50, 1)
 
 	// give the sprite some time to flick
 	sleep(20)
@@ -180,11 +180,12 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 
 	use_power(200)
 
+	//recieved copies should not use toner since it's being used by admins only.
 	var/obj/item/rcvdcopy
 	if (istype(copyitem, /obj/item/weapon/paper))
-		rcvdcopy = copy(copyitem)
+		rcvdcopy = copy(copyitem, 0)
 	else if (istype(copyitem, /obj/item/weapon/photo))
-		rcvdcopy = photocopy(copyitem)
+		rcvdcopy = photocopy(copyitem, 0)
 	else if (istype(copyitem, /obj/item/weapon/paper_bundle))
 		rcvdcopy = bundlecopy(copyitem, 0)
 	else
@@ -195,14 +196,14 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 	adminfaxes += rcvdcopy
 
 	//message badmins that a fax has arrived
-	switch(destination)
-		if (boss_name)
-			message_admins(sender, "[uppertext(boss_short)] FAX", rcvdcopy, "CentcommFaxReply", "#006100")
-		if ("Sol Government")
-			message_admins(sender, "SOL GOVERNMENT FAX", rcvdcopy, "CentcommFaxReply", "#1F66A0")
-			//message_admins(sender, "SOL GOVERNMENT FAX", rcvdcopy, "SolGovFaxReply", "#1F66A0")
-		if ("Supply")
-			message_admins(sender, "[uppertext(boss_short)] SUPPLY FAX", rcvdcopy, "CentcommFaxReply", "#5F4519")
+	if (destination == boss_name)
+		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, destination, "#006100")
+	else if (destination == "Colonial Marshal Service")
+		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, destination, "#1F66A0")
+	else if (destination == "[boss_short] Supply")
+		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, destination, "#5F4519")
+	else
+		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, "UNKNOWN")
 
 	sendcooldown = 1800
 	sleep(50)
@@ -210,8 +211,11 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 
 
 /obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/obj/item/sent, var/reply_type, font_colour="#006100")
-	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[key_name(sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) ([admin_jump_link(sender, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<a href='?_src_=holder;[reply_type]=\ref[sender];originfax=\ref[src]'>REPLY</a>)</b>: Receiving '[sent.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
+	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[get_options_bar(sender, 2,1,1)]"
+	msg += "(<a href='?_src_=holder;FaxReply=\ref[sender];originfax=\ref[src];replyorigin=[reply_type]'>REPLY</a>)</b>: "
+	msg += "Receiving '[sent.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
 
 	for(var/client/C in admins)
-		if(R_ADMIN & C.holder.rights)
+		if((R_ADMIN | R_MOD) & C.holder.rights)
 			C << msg
+			C << 'sound/machines/dotprinter.ogg'

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -146,7 +146,7 @@
 					toner = 0
 	return
 
-/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy)
+/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy, var/need_toner=1)
 	var/obj/item/weapon/paper/c = new /obj/item/weapon/paper (loc)
 	if(toner > 10)	//lots of toner, make it dark
 		c.info = "<font color = #101010>"
@@ -177,13 +177,14 @@
 		img.pixel_y = copy.offset_y[j]
 		c.overlays += img
 	c.updateinfolinks()
-	toner--
+	if(need_toner)
+		toner--
 	if(toner == 0)
 		visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
 	return c
 
 
-/obj/machinery/photocopier/proc/photocopy(var/obj/item/weapon/photo/photocopy)
+/obj/machinery/photocopier/proc/photocopy(var/obj/item/weapon/photo/photocopy, var/need_toner=1)
 	var/obj/item/weapon/photo/p = photocopy.copy()
 	p.loc = src.loc
 
@@ -197,7 +198,8 @@
 		p.img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
 		p.tiny.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
 	p.icon = I
-	toner -= 5	//photos use a lot of ink!
+	if(need_toner)
+		toner -= 5	//photos use a lot of ink!
 	if(toner < 0)
 		toner = 0
 		visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Completely replaces how admins reply to faxes so that they can use the more intuitive paperwork code system instead of raw HTML. The changes include an interaction menu on their papers that allow them to change between pen and crayon, clear and restart the paper, and toggle a header and footer that are designed to provide more legitimacy to faxes. The header defaults to on and the footer defaults to off.

![image of new paperwork system for admin faxes](http://i.imgur.com/N58q5pJ.png)

Admins also gain the ability to initiate faxes with the new send fax verb.
And mods can send and receive faxes now.
