### PR TITLE
Tweaks the Add Antagonist behavior.

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -36,3 +36,7 @@
 #define R_HOST          0x8000 //higher than this will overflow
 
 #define R_MAXPERMISSION 0x8000 // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+
+#define ADDANTAG_PLAYER 1	// Any player may call the add antagonist vote.
+#define ADDANTAG_ADMIN 2	// Any player with admin privilegies may call the add antagonist vote.
+#define ADDANTAG_AUTO 4		// The add antagonist vote is available as an alternative for transfer vote.

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,3 +4,4 @@
 	required_players = 0
 	round_description = "Just have fun and role-play!"
 	extended_round_description = "There are no antagonists during extended, unless an admin decides to be cheeky. Just play your character, mess around with your job, and have fun."
+	addantag_allowed = ADDANTAG_ADMIN // No add antag vote allowed on extended, except when manually called by admins.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -27,6 +27,7 @@ var/global/list/additional_antag_types = list()
 	var/round_autoantag = 0                  // Will this round attempt to periodically spawn more antagonists?
 	var/antag_scaling_coeff = 5              // Coefficient for scaling max antagonists to player count.
 	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
+	var/addantag_allowed = ADDANTAG_ADMIN | ADDANTAG_AUTO
 
 	var/station_was_nuked = 0                // See nuclearbomb.dm and malfunction.dm.
 	var/explosion_in_progress = 0            // Sit back and relax

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -502,6 +502,7 @@ var/global/datum/controller/gameticker/ticker
 		if(length(antag.candidates) >= antag.initial_spawn_req)
 			antag.attempt_spawn()
 			antag.finalize_spawn()
+			additional_antag_types.Add(antag.id)
 			return 1
 		else
 			if(antag.initial_spawn_req > 1)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -73,6 +73,8 @@
 
 	if(statpanel("Lobby") && ticker)
 		stat("Game Mode:", PUBLIC_GAME_MODE)
+		var/extra_antags = list2params(additional_antag_types)
+		stat("Added Antagonists:", extra_antags ? extra_antags : "None")
 
 		if(ticker.current_state == GAME_STATE_PREGAME)
 			stat("Time To Start:", "[ticker.pregame_timeleft][round_progressing ? "" : " (DELAYED)"]")

--- a/html/changelogs/atlantiscze-addantag.yml
+++ b/html/changelogs/atlantiscze-addantag.yml
@@ -1,0 +1,8 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Add Antagonist vote can no longer be freely called by players. It can still be called by admins, or as an alternative to crew transfer."
+  - tweak: "Add Antagonist is no longer an alternative to crew transfer during Extended gamemode. The intention is to keep that gamemode antagonist-free, as it was originally intended."
+  - rscadd: "Players in the lobby will now see which antagonist types were added to the game. This is displayed below the gamemode's name in the Lobby tab."


### PR DESCRIPTION
- Each game mode can now have combination of three groups defined, to control who can call add antagonist votes: PLAYERS, ADMINS, AUTO.
- PLAYERS allow any player to trigger the vote. Currently, this option is not enabled for any game mode, but support for it exists for future changes.
- ADMINS allows anyone with R_ADMIN permission to trigger the vote. Furthermore, this allows admins to call the vote even when previous vote ended with "None" as result. Currently this option is enabled for all game modes by default.
- AUTO controls whether the add antagonist option will be available as alternative to crew transfer. Currently, this option has been disabled for Extended, other modes have it enabled.

Other related changes:
- Add antagonist vote can only be called once the round is started. This fixes a bug where calling an add antagonist vote shortly before game mode vote would result in game mode vote never being called. This is global, nobody, even admins, can call a vote before the round begins, as it's also required for technical reasons (we need to know for sure what the game mode is, in order to check whether that game mode allows add antag vote to be called).
- Antagonist types added by add antag votes are now displayed along with the game mode in the Lobby tab. This ensures late joining players are informed of what was voted in the past, without having to ask.
- As of now, all game modes allow add antagonist vote calling by admins. All game modes except extended allow add antagonist vote calling as the alternative to crew transfer, and no game modes allow players to call the vote on their own. An admin has to do that. This can be easily changed by tweaking the addantag_allowed var of each game mode. Relevant discussion topic in the public staff forum: https://baystation12.net/forums/threads/discussion-vote-add-antag-votes.2284/   - As of this commit, 50% are for admin-only add antag votes, 25% for admin-only during extended, and 25% for free-for-all.
