### PR TITLE
Makes the multikeying warning a little less invasive

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -33,7 +33,7 @@
 	var/received_irc_pm = -99999
 	var/irc_admin			//IRC admin that spoke with them last.
 	var/mute_irc = 0
-
+	var/warned_about_multikeying = 0	// Prevents people from being spammed about multikeying every time their mob changes.
 
 		////////////////////////////////////
 		//things that require the database//
@@ -44,4 +44,4 @@
 
 	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
 	var/global/obj/screen/click_catcher/void
-	
+

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -5,6 +5,7 @@
 	computer_id	= client.computer_id
 	log_access("Login: [key_name(src)] from [lastKnownIP ? lastKnownIP : "localhost"]-[computer_id] || BYOND v[client.byond_version]")
 	if(config.log_access)
+		var/is_multikeying = 0
 		for(var/mob/M in player_list)
 			if(M == src)	continue
 			if( M.key && (M.key != key) )
@@ -14,7 +15,7 @@
 				if( (client.connection != "web") && (M.computer_id == client.computer_id) )
 					if(matches)	matches += " and "
 					matches += "ID ([client.computer_id])"
-					spawn() alert("You have logged in already with another key this round, please log out of this one NOW or risk being banned!")
+					is_multikeying = 1
 				if(matches)
 					if(M.client)
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as <A href='?src=\ref[usr];priv_msg=\ref[M]'>[key_name_admin(M)]</A>.</font>", 1)
@@ -22,6 +23,11 @@
 					else
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>", 1)
 						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
+		if(is_multikeying && !client.warned_about_multikeying)
+			client.warned_about_multikeying = 1
+			spawn(1 SECOND)
+				src << "<b>WARNING:</b> It would seem that you are sharing connection or computer with another player. If you haven't done so already, please contact the staff via the Adminhelp verb to resolve this situation. Failure to do so may result in administrative action. You have been warned."
+
 
 /mob/Login()
 


### PR DESCRIPTION
- Because stacked popup windows every time your mob changes are very fun when doing localhost testing with multiple accounts.
- The multikeying warning now displays only once to the offending player. It is printed into the main chat window, instead of using a popup. Furthermore, the message is changed to be a bit more civil, so instead of "Hurr Hurr we'll ban you if you don't disconnect immediately" it's more in the tones of "Contact staff to talk about this stuff if you haven't done that yet, please"
