### PR TITLE
Makes ninja cloaking use alpha instead of invisibility

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -38,7 +38,7 @@
 	var/mob/living/carbon/human/H = holder.wearer
 
 	H << "<font color='blue'><b>You are now invisible to normal detection.</b></font>"
-	H.invisibility = INVISIBILITY_LEVEL_TWO
+	H.alpha = 0
 
 	anim(get_turf(H), H, 'icons/effects/effects.dmi', "electricity",null,20,null)
 
@@ -52,7 +52,7 @@
 	var/mob/living/carbon/human/H = holder.wearer
 
 	H << "<span class='danger'>You are now visible.</span>"
-	H.invisibility = 0
+	H.alpha = initial(H.alpha)
 
 	anim(get_turf(H), H,'icons/mob/mob.dmi',,"uncloak",,H.dir)
 	anim(get_turf(H), H, 'icons/effects/effects.dmi', "electricity",null,20,null)

--- a/html/changelogs/HarpyEagle-ninja-cloak.yml
+++ b/html/changelogs/HarpyEagle-ninja-cloak.yml
@@ -1,0 +1,7 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - rscadd: "Held items are now visible while using the rigsuit cloaking module."
+


### PR DESCRIPTION
Combined with https://github.com/Baystation12/Baystation12/pull/13307/commits/3e97ed81656c604b07e47539185e6c67daef1330, this makes held items visible when cloaked.

Potential Issues:
- Beepsky/turrets/hostile mobs being able to see cloaked people
