### PR TITLE
Improves robot lockdown

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -75,6 +75,9 @@ var/datum/antagonist/traitor/traitors
 /datum/antagonist/traitor/equip(var/mob/living/carbon/human/traitor_mob)
 	if(istype(traitor_mob, /mob/living/silicon)) // this needs to be here because ..() returns false if the mob isn't human
 		add_law_zero(traitor_mob)
+		if(istype(traitor_mob, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/R = traitor_mob
+			R.SetLockdown(0)
 		return 1
 
 	if(!..())

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -91,15 +91,13 @@
 		if(!target || !istype(target))
 			return
 
-		message_admins("<span class='notice'>[key_name_admin(usr)] [target.canmove ? "locked down" : "released"] [target.name]!</span>")
-		log_game("[key_name(usr)] [target.canmove ? "locked down" : "released"] [target.name]!")
-		target.canmove = !target.canmove
-		if (target.lockcharge)
-			target.lockcharge = !target.lockcharge
-			target << "Your lockdown has been lifted!"
-		else
-			target.lockcharge = !target.lockcharge
-			target << "You have been locked down!"
+		if(target.SetLockdown(!target.lockcharge))
+			message_admins("<span class='notice'>[key_name_admin(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!</span>")
+			log_game("[key_name(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!")
+			if(target.lockcharge)
+				target << "<span class='danger'>You have been locked down!</span>"
+			else
+				target << "<span class='notice'>Your lockdown has been lifted!</span>"
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -77,11 +77,11 @@
 			return
 
 		if(isAI(user) && (target.connected_ai != user))
-			user << "Access Denied. This robot is not linked to you."
+			user << "<span class='warning'>Access Denied. This robot is not linked to you.</span>"
 			return
 
 		if(isrobot(user))
-			user << "Access Denied."
+			user << "<span class='warning'>Access Denied.</span>"
 			return
 
 		var/choice = input("Really [target.lockcharge ? "unlock" : "lockdown"] [target.name] ?") in list ("Yes", "No")
@@ -98,6 +98,8 @@
 				target << "<span class='danger'>You have been locked down!</span>"
 			else
 				target << "<span class='notice'>Your lockdown has been lifted!</span>"
+		else
+			user << "<span class='warning'>ERROR: Lockdown attempt failed.</span>"
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -83,7 +83,7 @@
 	var/weapon_lock = 0
 	var/weaponlock_time = 120
 	var/lawupdate = 1 //Cyborgs will sync their laws with their AI by default
-	var/lockcharge //Used when locking down a borg to preserve cell charge
+	var/lockcharge //If a robot is locked down
 	var/speed = 0 //Cause sec borgs gotta go fast //No they dont!
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
@@ -931,8 +931,12 @@
 	// They stay locked down if their wire is cut.
 	if(wires.LockedCut())
 		state = 1
-	lockcharge = state
-	update_canmove()
+
+	if(lockcharge != state)
+		lockcharge = state
+		update_canmove()
+		return 1
+	return 0
 
 /mob/living/silicon/robot/mode()
 	set name = "Activate Held Object"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -931,6 +931,8 @@
 	// They stay locked down if their wire is cut.
 	if(wires.LockedCut())
 		state = 1
+	else if(has_zeroth_law())
+		state = 0
 
 	if(lockcharge != state)
 		lockcharge = state
@@ -1073,6 +1075,7 @@
 				var/time = time2text(world.realtime,"hh:mm:ss")
 				lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
 				set_zeroth_law("Only [user.real_name] and people \he designates as being such are operatives.")
+				SetLockdown(0)
 				. = 1
 				spawn()
 					src << "<span class='danger'>ALERT: Foreign software detected.</span>"

--- a/html/changelogs/HarpyEagle-robot-lockdown.yml
+++ b/html/changelogs/HarpyEagle-robot-lockdown.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes: 
+  - rscadd: "Emagged and traitor synths can no longer be locked down, except by physically cutting the lockdown wire (merely pulsing will not work)."


### PR DESCRIPTION
- Updated lockdown toggling in the robot console, now uses proc and only messages if an actual change occurred.
- Makes traitor and emagged robots immune to lockdown, except when the lockdown wire is physically cut. Checking `has_zeroth_law()` might be kind of questionable, but it's the same thing that controls if a borg gets messages about AI tracking, so eh.
