### PR TITLE
Adjusts station time helpers.

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -29,16 +29,16 @@
 
 	return wtime + (time_offset + wusage) * world.tick_lag
 
-var/roundstart_hour = 0
+var/roundstart_hour
 var/station_date = ""
 var/next_station_date_change = 1 DAY
 
-#define station_adjusted_time(time) time2text(time + station_time_in_ticks, "hh:mm")
+#define duration2stationtime(time) time2text(station_time_in_ticks + time, "hh:mm")
+#define worldtime2stationtime(time) time2text(roundstart_hour HOURS + time, "hh:mm")
 #define round_duration_in_ticks (round_start_time ? world.time - round_start_time : 0)
 #define station_time_in_ticks (roundstart_hour HOURS + round_duration_in_ticks)
 
 /proc/stationtime2text()
-	if(!roundstart_hour) roundstart_hour = pick(2,7,12,17)
 	return time2text(station_time_in_ticks, "hh:mm")
 
 /proc/stationdate2text()
@@ -53,7 +53,7 @@ var/next_station_date_change = 1 DAY
 	return station_date
 
 /proc/time_stamp()
-	return time2text(world.timeofday, "hh:mm:ss")
+	return time2text(station_time_in_ticks, "hh:mm:ss")
 
 /* Returns 1 if it is the selected month and day */
 proc/isDay(var/month, var/day)
@@ -97,3 +97,7 @@ var/round_start_time = 0
 /proc/process_schedule_interval(var/process_name)
 	var/datum/controller/process/process = processScheduler.getProcess(process_name)
 	return process.schedule_interval
+
+/hook/startup/proc/set_roundstart_hour()
+	roundstart_hour = pick(2,7,12,17)
+	return 1

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -20,15 +20,15 @@
 /obj/item/weapon/card/id/guest/examine(mob/user)
 	..(user)
 	if (world.time < expiration_time)
-		user << "<span class='notice'>This pass expires at [station_adjusted_time(expiration_time)].</span>"
+		user << "<span class='notice'>This pass expires at [worldtime2stationtime(expiration_time)].</span>"
 	else
-		user << "<span class='warning'>It expired at [station_adjusted_time(expiration_time)].</span>"
+		user << "<span class='warning'>It expired at [worldtime2stationtime(expiration_time)].</span>"
 
 /obj/item/weapon/card/id/guest/read()
 	if (world.time > expiration_time)
-		usr << "<span class='notice'>This pass expired at [station_adjusted_time(expiration_time)].</span>"
+		usr << "<span class='notice'>This pass expired at [worldtime2stationtime(expiration_time)].</span>"
 	else
-		usr << "<span class='notice'>This pass expires at [station_adjusted_time(expiration_time)].</span>"
+		usr << "<span class='notice'>This pass expires at [worldtime2stationtime(expiration_time)].</span>"
 
 	usr << "<span class='notice'>It grants access to following areas:</span>"
 	for (var/A in temp_access)
@@ -174,7 +174,7 @@
 						if (A in giver.access)
 							access_descriptors += get_access_desc(A)
 					entry += english_list(access_descriptors, and_text = ", ")
-					entry += ". Expires at [station_adjusted_time(world.time + duration MINUTES)]."
+					entry += ". Expires at [worldtime2stationtime(world.time + duration MINUTES)]."
 					internal_log.Add(entry)
 
 					var/obj/item/weapon/card/id/guest/pass = new(src.loc)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -105,7 +105,7 @@
 	data["discount_category"] = discount_item ? discount_item.category.name : ""
 	data["discount_name"] = discount_item ? discount_item.name : ""
 	data["discount_amount"] = (1-discount_amount)*100
-	data["offer_expiry"] = station_adjusted_time(next_offer_time)
+	data["offer_expiry"] = worldtime2stationtime(next_offer_time)
 
 	data += nanoui_data
 

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -86,7 +86,7 @@
 	var/scan_data = ""
 
 	if(timeofdeath)
-		scan_data += "<b>Time of death:</b> [station_adjusted_time(timeofdeath)]<br><br>"
+		scan_data += "<b>Time of death:</b> [worldtime2stationtime(timeofdeath)]<br><br>"
 
 	var/n = 1
 	for(var/wdata_idx in wdata)
@@ -133,7 +133,7 @@
 		if(damaging_weapon)
 			scan_data += "Severity: [damage_desc]<br>"
 			scan_data += "Hits by weapon: [total_hits]<br>"
-		scan_data += "Approximate time of wound infliction: [station_adjusted_time(age)]<br>"
+		scan_data += "Approximate time of wound infliction: [worldtime2stationtime(age)]<br>"
 		scan_data += "Affected limbs: [D.organ_names]<br>"
 		scan_data += "Possible weapons:<br>"
 		for(var/weapon_name in weapon_chances)

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -140,5 +140,5 @@ proc/trigger_armed_response_team(var/force = 0)
 /datum/emergency_shuttle_predicate/ert/can_call(var/user)
 	if(world.time >= prevent_until)
 		return TRUE
-	user << "<span class='warning'>An emergency response team has been dispatched. Emergency shuttle requests will be denied until [station_adjusted_time(prevent_until - world.time)].</span>"
+	user << "<span class='warning'>An emergency response team has been dispatched. Emergency shuttle requests will be denied until [duration2stationtime(prevent_until - world.time)].</span>"
 	return FALSE

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -5,7 +5,9 @@
 proc/log_and_message_admins(var/message as text, var/mob/user = usr, var/turf/location)
 	var/turf/T = location ? location : (user ? get_turf(user) : null)
 	if(T)
-		message = message + " (<a HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)"
+		message = message + " (<a HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP LOC</a>)"
+	if(user)
+		message = message + " (<a HREF='?_src_=holder;adminplayerobservejump=\ref[user]'>JMP MOB</a>)"
 
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")
 	message_admins(user ? "[key_name_admin(user)] [message]" : "EVENT [message]")

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -36,7 +36,7 @@
 	if(EM.add_to_queue)
 		EC.available_events += EM
 
-	log_debug("Event '[EM.name]' has completed at [station_adjusted_time(world.time)].")
+	log_debug("Event '[EM.name]' has completed at [worldtime2stationtime(world.time)].")
 
 /datum/event_manager/proc/delay_events(var/severity, var/delay)
 	var/list/datum/event_container/EC = event_containers[severity]
@@ -59,12 +59,12 @@
 		var/datum/event_meta/EM = E.event_meta
 		if(EM.name == "Nothing")
 			continue
-		var/message = "'[EM.name]' began at [station_adjusted_time(E.startedAt)] "
+		var/message = "'[EM.name]' began at [worldtime2stationtime(E.startedAt)] "
 		if(E.isRunning)
 			message += "and is still running."
 		else
 			if(E.endedAt - E.startedAt > MinutesToTicks(5)) // Only mention end time if the entire duration was more than 5 minutes
-				message += "and ended at [station_adjusted_time(E.endedAt)]."
+				message += "and ended at [worldtime2stationtime(E.endedAt)]."
 			else
 				message += "and ran to completion."
 
@@ -122,7 +122,7 @@
 			var/next_event_at = max(0, EC.next_event_time - world.time)
 			html += "<tr>"
 			html += "<td>[severity_to_string[severity]]</td>"
-			html += "<td>[station_adjusted_time(max(EC.next_event_time, world.time))]</td>"
+			html += "<td>[worldtime2stationtime(max(EC.next_event_time, world.time))]</td>"
 			html += "<td>[round(next_event_at / 600, 0.1)]</td>"
 			html += "<td>"
 			html +=   "<A align='right' href='?src=\ref[src];dec_timer=2;event=\ref[EC]'>--</A>"
@@ -170,7 +170,7 @@
 			html += "<tr>"
 			html += "<td>[severity_to_string[EM.severity]]</td>"
 			html += "<td>[EM.name]</td>"
-			html += "<td>[station_adjusted_time(ends_at)]</td>"
+			html += "<td>[worldtime2stationtime(ends_at)]</td>"
 			html += "<td>[ends_in]</td>"
 			html += "<td><A align='right' href='?src=\ref[src];stop=\ref[E]'>Stop</A></td>"
 			html += "</tr>"

--- a/code/world.dm
+++ b/code/world.dm
@@ -205,14 +205,14 @@ var/world_topic_spam_protect_time = world.timeofday
 		L["gameid"] = game_id
 		L["dm_version"] = DM_VERSION // DreamMaker version compiled in
 		L["dd_version"] = world.byond_version // DreamDaemon version running on
-		
+
 		if(revdata.revision)
 			L["revision"] = revdata.revision
 			L["branch"] = revdata.branch
 			L["date"] = revdata.date
 		else
 			L["revision"] = "unknown"
-		
+
 		return list2params(L)
 
 	else if(copytext(T,1,5) == "info")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Autopsy results as well as anything using time_stamp() should now return the value as a proper station time.
The latter basically includes fingerprints, and attack logs.
