### PR TITLE
Xenos tweaks.

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -6,7 +6,7 @@
 #define NO_SLIP           0x10   // Cannot fall over.
 #define NO_POISON         0x20   // Cannot not suffer toxloss.
 #define IS_PLANT          0x40   // Is a treeperson.
-#define NO_MINOR_CUT      0x80   // Can step on broken glass with no ill-effects. Either thick skin (diona/vox), cut resistant (slimes) or incorporeal (shadows)
+#define NO_EMBED          0x80   // Can step on broken glass with no ill-effects and cannot have shrapnel embedded in it.
 // unused: 0x8000 - higher than this will overflow
 
 // Species spawn flags

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -58,20 +58,20 @@
 	..()
 	if(isliving(AM))
 		var/mob/M = AM
-		
+
 		if(M.buckled) //wheelchairs, office chairs, rollerbeds
 			return
-		
+
 		playsound(src.loc, 'sound/effects/glass_step.ogg', 50, 1) // not sure how to handle metal shards with sounds
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 
-			if(H.species.siemens_coefficient<0.5) //Thick skin.
+			if(H.species.siemens_coefficient<0.5 || (H.species.flags & NO_EMBED)) //Thick skin.
 				return
 
 			if( H.shoes || ( H.wear_suit && (H.wear_suit.body_parts_covered & FEET) ) )
 				return
-			
+
 			M << "<span class='danger'>You step on \the [src]!</span>"
 
 			var/list/check = list("l_foot", "r_foot")

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -85,17 +85,17 @@
 		var/can_grab = 1
 		if(istype(victim, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = victim
-			if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))
+			if((istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP)) || (H.species.flags & NO_SLIP))
 				can_grab = 0
 		if(can_grab)
 			src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")
 			victim.forceMove(src.loc)
-
-	//entangling people
-	if(victim.loc == src.loc)
-		buckle_mob(victim)
-		victim.set_dir(pick(cardinal))
-		victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
+			sleep(1)
+			//entangling people
+			if(victim.loc == src.loc)
+				buckle_mob(victim)
+				victim.set_dir(pick(cardinal))
+				victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
 
 /obj/effect/plant/buckle_mob()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -25,7 +25,7 @@ meteor_act
 			return 100
 
 	//Shrapnel
-	if(P.can_embed())
+	if(!(species.flags & NO_EMBED) && P.can_embed())
 		var/armor = getarmor_organ(organ, "bullet")
 		if(prob(20 + max(P.damage - armor, -10)))
 			var/obj/item/weapon/material/shard/shrapnel/SP = new()
@@ -113,7 +113,7 @@ meteor_act
 		if(gear && istype(gear ,/obj/item/clothing))
 			var/obj/item/clothing/C = gear
 			if(istype(C) && C.body_parts_covered & def_zone.body_part)
-				protection = add_armor(protection, C.armor[type]) 
+				protection = add_armor(protection, C.armor[type])
 	return protection
 
 /mob/living/carbon/human/proc/check_head_coverage()
@@ -188,7 +188,7 @@ meteor_act
 		if(!..(I, user, effective_force, blocked, hit_zone))
 			return 0
 
-		//set the dislocate mult less than the effective force mult so that 
+		//set the dislocate mult less than the effective force mult so that
 		//dislocating limbs on disarm is a bit easier than breaking limbs on harm
 		attack_joint(affecting, I, effective_force, 0.5, blocked) //...but can dislocate joints
 	else if(!..())
@@ -215,7 +215,7 @@ meteor_act
 	return 1
 
 /mob/living/carbon/human/proc/attack_bloody(obj/item/W, mob/living/attacker, var/effective_force, var/hit_zone)
-	if(W.damtype != BRUTE) 
+	if(W.damtype != BRUTE)
 		return
 
 	//make non-sharp low-force weapons less likely to be bloodied

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -18,7 +18,7 @@
 	remains_type = /obj/effect/decal/cleanable/ash
 	death_message = "dissolves into ash..."
 
-	flags = NO_BLOOD | NO_SCAN | NO_SLIP | NO_POISON | NO_MINOR_CUT
+	flags = NO_BLOOD | NO_SCAN | NO_SLIP | NO_POISON | NO_EMBED
 	spawn_flags = IS_RESTRICTED
 
 	genders = list(NEUTER)

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -36,7 +36,7 @@
 	poison_type = "oxygen"
 	siemens_coefficient = 0.2
 
-	flags = NO_SCAN | NO_MINOR_CUT
+	flags = NO_SCAN
 	spawn_flags = IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -7,7 +7,7 @@
 
 	language = "Sol Common" //todo?
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch)
-	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON | NO_MINOR_CUT
+	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 0
 

--- a/code/modules/mob/living/carbon/human/species/station/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/slime.dm
@@ -8,7 +8,7 @@
 
 	language = null //todo?
 	unarmed_types = list(/datum/unarmed_attack/slime_glomp)
-	flags = NO_SCAN | NO_SLIP | NO_BREATHE | NO_MINOR_CUT
+	flags = NO_SCAN | NO_SLIP | NO_BREATHE | NO_EMBED
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 3 //conductive
 	darksight = 3

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -238,7 +238,7 @@
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 
-	flags = NO_BREATHE | NO_SCAN | IS_PLANT | NO_BLOOD | NO_PAIN | NO_SLIP | NO_MINOR_CUT
+	flags = NO_BREATHE | NO_SCAN | IS_PLANT | NO_BLOOD | NO_PAIN | NO_SLIP
 	appearance_flags = 0
 	spawn_flags = CAN_JOIN | IS_WHITELISTED
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -27,7 +27,7 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	flags =  NO_BREATHE | NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT
+	flags =  NO_BREATHE | NO_SCAN | NO_PAIN | NO_SLIP | NO_POISON | NO_EMBED
 	spawn_flags = IS_RESTRICTED
 
 	reagent_tag = IS_XENOS
@@ -55,13 +55,27 @@
 		"nutrient channel" = /obj/item/organ/diona/nutrients
 		)
 
+	has_limbs = list(
+		"chest" =  list("path" = /obj/item/organ/external/chest/unbreakable),
+		"groin" =  list("path" = /obj/item/organ/external/groin/unbreakable),
+		"head" =   list("path" = /obj/item/organ/external/head/unbreakable),
+		"l_arm" =  list("path" = /obj/item/organ/external/arm/unbreakable),
+		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/unbreakable),
+		"l_leg" =  list("path" = /obj/item/organ/external/leg/unbreakable),
+		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/unbreakable),
+		"l_hand" = list("path" = /obj/item/organ/external/hand/unbreakable),
+		"r_hand" = list("path" = /obj/item/organ/external/hand/right/unbreakable),
+		"l_foot" = list("path" = /obj/item/organ/external/foot/unbreakable),
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right/unbreakable)
+		)
+
 	bump_flag = ALIEN
 	swap_flags = ~HEAVY
 	push_flags = (~HEAVY) ^ ROBOT
 
 	var/alien_number = 0
 	var/caste_name = "creature" // Used to update alien name.
-	var/weeds_heal_rate = 1     // Health regen on weeds.
+	var/weeds_heal_rate = 3     // Health regen on weeds.
 	var/weeds_plasma_rate = 5   // Plasma regen on weeds.
 
 	genders = list(NEUTER)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -446,7 +446,7 @@ This function completely restores a damaged organ to perfect condition.
 /obj/item/organ/external/proc/createwound(var/type = CUT, var/damage)
 	if(damage == 0) return
 
-	//moved these before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return) 
+	//moved these before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 
 	//Brute damage can possibly trigger an internal wound, too.
 	var/local_damage = brute_dam + burn_dam + damage
@@ -1053,6 +1053,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /obj/item/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0, var/supplied_message)
 	if(!owner || loc != owner)
+		return
+	if(species.flags & NO_EMBED)
 		return
 	if(!silent)
 		if(supplied_message)

--- a/code/modules/organs/subtypes/unbreakable.dm
+++ b/code/modules/organs/subtypes/unbreakable.dm
@@ -1,4 +1,4 @@
-// Slime limbs.
+// Slime/xeno limbs.
 /obj/item/organ/external/chest/unbreakable
 	cannot_break = 1
 	dislocated = -1

--- a/html/changelogs/Zuhayr-xenos.yml
+++ b/html/changelogs/Zuhayr-xenos.yml
@@ -1,0 +1,5 @@
+author: Zuhayr
+delete-after: True
+changes: 
+  - rscadd: "Prevented xenomorphs from taking shrapnel or breaking limbs. Buffed non-queen xeno weed health regen. Remember to rest to not take a heal penalty."
+  - rscadd: "Prevented weeds from entangling species with the NO_SLIP flag."


### PR DESCRIPTION
- Repurposed the unused NO_MINOR_CUT flag for preventing embedding.
- Tripled non-queen xenos health regen. Gentle reminder that if you aren't resting on weeds you won't heal as much.
- Prevented weeds from entangling species with NO_SLIP (vox, slimes, xenos, dionaea). Entangling xenoweeds was not intended in the first place.
- Gave xenomorphs unbreakable limbs.

I haven't touched #12587 because of the discussion involved.

Seems to work fine locally.
