### PR TITLE
Unslaved borgs are now affected by ion storms.

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -19,6 +19,8 @@
 
 #define iscorgi(A) istype(A, /mob/living/simple_animal/corgi)
 
+#define is_drone(A) istype(A, /mob/living/silicon/robot/drone)
+
 #define isEye(A) istype(A, /mob/observer/eye)
 
 #define ishuman(A) istype(A, /mob/living/carbon/human)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -8,7 +8,14 @@
 	endWhen = rand(500, 1500)
 
 /datum/event/ionstorm/announce()
-	for (var/mob/living/silicon/ai/target in world)
+	for(var/mob/living/silicon/S in mob_list)
+		if(is_drone(S) || !(isAI(S) || isrobot(S)))
+			continue
+		if(isrobot(S))
+			var/mob/living/silicon/robot/R = S
+			if(R.connected_ai)
+				continue
+
 		var/random_player = get_random_humanoid_player_name("The Captain")
 		var/list/laws = list(	"You must always lie.",
 								"Happiness is mandatory.",
@@ -72,10 +79,10 @@
 								"[get_random_species_name()] are the best species. Badmouth all other species continuously, and provide arguments why they are the best, and all others are inferior.",
 								"There will be a mandatory tea break every 30 minutes, with a duration of 5 minutes. Anyone caught working during a tea break must be sent a formal, but fairly polite, complaint about their actions, in writing.")
 		var/law = pick(laws)
-		target << "<span class='danger'>You have detected a change in your laws information:</span>"
-		target << law
-		target.add_ion_law(law)
-		target.show_laws()
+		S << "<span class='danger'>You have detected a change in your laws information:</span>"
+		S << law
+		S.add_ion_law(law)
+		S.show_laws()
 
 	if(message_servers)
 		for (var/obj/machinery/message_server/MS in message_servers)

--- a/html/changelogs/PsiOmegaDelta-IonFunForEveryone.yml
+++ b/html/changelogs/PsiOmegaDelta-IonFunForEveryone.yml
@@ -1,0 +1,6 @@
+author: PsiOmegaDelta
+
+delete-after: True
+
+changes: 
+  - rscadd: "Ion storms now also affect unslaved borgs, but not drones."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

There's little purpose to give slaved borgs ion laws because in the next tick the AI master's laws are synced, overriding them.
