### PR TITLE
Lists installed hardsuit modules when examining

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -96,8 +96,15 @@
 			usr << "\icon[piece] \The [piece] [piece.gender == PLURAL ? "are" : "is"] deployed."
 
 	if(src.loc == usr)
+		usr << "The access panel is [locked? "locked" : "unlocked"]."
 		usr << "The maintenance panel is [open ? "open" : "closed"]."
 		usr << "Hardsuit systems are [offline ? "<font color='red'>offline</font>" : "<font color='green'>online</font>"]."
+
+		if(open && installed_modules.len)
+			usr << "It's equipped with:"
+			for(var/obj/item/rig_module/E in installed_modules)
+				usr << "[E]"
+
 
 /obj/item/weapon/rig/New()
 	..()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -100,11 +100,8 @@
 		usr << "The maintenance panel is [open ? "open" : "closed"]."
 		usr << "Hardsuit systems are [offline ? "<font color='red'>offline</font>" : "<font color='green'>online</font>"]."
 
-		if(open && installed_modules.len)
-			usr << "It's equipped with:"
-			for(var/obj/item/rig_module/E in installed_modules)
-				usr << "[E]"
-
+		if(open)
+			usr << "It's equipped with [english_list(installed_modules)]."
 
 /obj/item/weapon/rig/New()
 	..()

--- a/html/changelogs/Kasuobes-ShowMeTheModules.yml
+++ b/html/changelogs/Kasuobes-ShowMeTheModules.yml
@@ -1,0 +1,6 @@
+author: Haswell
+
+delete-after: True
+
+changes: 
+  - rscadd: "Modules installed within a hardsuit will now be listed when examining the hardsuit control module while being held or worn, if the maintenance panel is open."


### PR DESCRIPTION
Similar to how examining mechs will list all the installed equipment, RIGs will now list all installed modules if the panel is open, while the RIG is being held or worn.

Primarily a QOL improvement for ERT so players won't have to wear the RIG, activate it, check the interface for the list of modules, then deactivate and remove the RIG to install extra modules (or shoving in modules randomly only to realize you can't install two laser cannons). 

Also benefits merc players so they won't buy duplicate modules with their telecrystals and beg for refunds in ahelp.
