### PR TITLE
Rewrite english_list to be a little nicer on lists of objects, and also faster

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -11,24 +11,11 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/total = input.len
-	if (!total)
-		return "[nothing_text]"
-	else if (total == 1)
-		return "[input[1]]"
-	else if (total == 2)
-		return "[input[1]][and_text][input[2]]"
-	else
-		var/output = ""
-		var/index = 1
-		while (index < total)
-			if (index == total - 1)
-				comma_text = final_comma_text
-
-			output += "[input[index]][comma_text]"
-			index++
-
-		return "[output][and_text][input[index]]"
+	switch(input.len)
+		if(0) return nothing_text
+		if(1) return "[input[1]]"
+		if(2) return "[input[1]][and_text][input[2]]"
+		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 proc/listgetindex(var/list/list,index)


### PR DESCRIPTION
Title.

On lists of objects, the current code returns `"The one, The two, The three and the four"`. This new code returns `"the one, the two, the three and the four"`.

~~This code is very slightly slower on two-element lists (mostly due to the current code hardcoding that case)~~ This code is now faster on two-element lists (and more correct too!), but is a little faster on smaller lists, and _significantly_ faster on longer ones; it's 3x faster than the current code by an 8-element list, and rapidly heading for 4x faster by 10.
