### PR TITLE
replace pointless english_list call with jointext

### DIFF
--- a/code/modules/client/preference_setup/global/03_language.dm
+++ b/code/modules/client/preference_setup/global/03_language.dm
@@ -14,7 +14,7 @@
 
 /datum/category_item/player_setup_item/player_global/language/content(var/mob/user)
 	. += "<b>Language Keys</b><br>"
-	. += " [english_list(pref.language_prefixes, and_text = " ", comma_text = " ")] <a href='?src=\ref[src];change_prefix=1'>Change</a> <a href='?src=\ref[src];reset_prefix=1'>Reset</a><br>"
+	. += " [jointext(pref.language_prefixes, " ")] <a href='?src=\ref[src];change_prefix=1'>Change</a> <a href='?src=\ref[src];reset_prefix=1'>Reset</a><br>"
 
 /datum/category_item/player_setup_item/player_global/language/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["change_prefix"])


### PR DESCRIPTION
`english_list(x, and_text=y, comma_text=y) == jointext(x, y)`. No point using `english_list` where it's not needed.
