### PR TITLE
Removes randomly vomitting as pariah

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -154,5 +154,3 @@
 				if(target.species.flags & NO_BREATHE) //dont breathe so why do they smell it.
 					continue
 			M << "<span class='danger'>A terrible stench emanates from \the [H].</span>"
-	if(prob(1) && prob(50)) //0.5% chance
-		H.vomit()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Due to the new vomit emote, this PR removes pariah randomly vomitting.

This doesn't mean that Pariah don't vomit, it just means that they can voluntarily be gross in their own time now.
