### PR TITLE
Tweaks maintenance drone laws and blurb

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -93,9 +93,9 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve the station to the best of your abilities.")
-	add_inherent_law("Cause no harm to the station or anything on it.")
-	add_inherent_law("Interact with no being that is not a fellow maintenance drone.")
+	add_inherent_law("Preserve, repair and improve your assigned platform to the best of your abilities.")
+	add_inherent_law("Cause no harm to your assigned platform or anything on it.")
+	add_inherent_law("Interfere with no sentient being that is not a fellow maintenance drone.")
 	..()
 
 /datum/ai_laws/construction_drone
@@ -103,8 +103,8 @@
 	law_header = "Construction Protocols"
 
 /datum/ai_laws/construction_drone/New()
-	add_inherent_law("Repair, refit and upgrade your assigned vessel.")
-	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
+	add_inherent_law("Repair, refit and upgrade your assigned platform.")
+	add_inherent_law("Prevent unplanned damage to your assigned platform wherever possible.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -93,8 +93,8 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve your assigned platform to the best of your abilities.")
-	add_inherent_law("Cause no harm to your assigned platform or anything on it.")
+	add_inherent_law("Preserve, repair and improve your assigned vessel to the best of your abilities.")
+	add_inherent_law("Cause no harm to your assigned vessel or anything on it.")
 	add_inherent_law("Interfere with no sentient being that is not a fellow maintenance drone.")
 	..()
 
@@ -103,8 +103,8 @@
 	law_header = "Construction Protocols"
 
 /datum/ai_laws/construction_drone/New()
-	add_inherent_law("Repair, refit and upgrade your assigned platform.")
-	add_inherent_law("Prevent unplanned damage to your assigned platform wherever possible.")
+	add_inherent_law("Repair, refit and upgrade your assigned vessel.")
+	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/

--- a/code/modules/examine/descriptions/mobs.dm
+++ b/code/modules/examine/descriptions/mobs.dm
@@ -1,8 +1,9 @@
 /mob/living/silicon/robot/drone
-	description_info = "Drones are player-controlled synthetics which are lawed to maintain the station and not \
-	interact with anyone else, except for other drones.  They hold a wide array of tools to build, repair, maintain, and clean. \
-	They fuction similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
-	such as fire, radiation, vacuum, and more.  Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \
-	An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access, and an active drone can be shut down in the same manner."
+	description_info = "Drones are player-controlled synthetics which are lawed to maintain their assigned platform and not \
+	interfere with anyone else, except for other drones. They hold a wide array of tools to build, repair, maintain, and clean. \
+	They function similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
+	such as fire, radiation, vacuum, and more. Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \
+	An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access, and an active drone can be shut down in the same manner. \
+	Maintenance drone presence can be requested to specific areas from any maintenance drone control console."
 
 	description_antag = "An Electromagnetic Sequencer can be used to subvert the drone to your cause."

--- a/code/modules/examine/descriptions/mobs.dm
+++ b/code/modules/examine/descriptions/mobs.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/drone
-	description_info = "Drones are player-controlled synthetics which are lawed to maintain their assigned platform and not \
+	description_info = "Drones are player-controlled synthetics which are lawed to maintain their assigned vessel and not \
 	interfere with anyone else, except for other drones. They hold a wide array of tools to build, repair, maintain, and clean. \
 	They function similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
 	such as fire, radiation, vacuum, and more. Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -323,9 +323,9 @@ var/list/mob_hat_cache = list()
 	welcome_drone()
 
 /mob/living/silicon/robot/drone/proc/welcome_drone()
-	src << "<b>You are a maintenance drone, a tiny-brained robotic repair machine</b>."
-	src << "You have no individual will, no personality, and no drives or urges other than your laws."
-	src << "Remember,  you are <b>lawed against interference with the crew</b>. Also remember, <b>you DO NOT take orders from the AI.</b>"
+	src << "<b>You are a maintenance drone, a tiny-brained robotic repair machine</b>. You have no individual will, no personality, and no drives or urges other than your laws."
+	src << "Remember, you are <b>lawed against interference with the crew</b>, you should leave the area if your actions are interfering, or that the crew does not want your presence."
+	src << "You are <b>not required to follow orders from anyone; not the AI, not humans, and not other synthetics.</b>. However, you should respond to presence requests issued from drone controls consoles."
 	src << "Use <b>say ;Hello</b> to talk to other drones and <b>say Hello</b> to speak silently to your nearby fellows."
 
 /mob/living/silicon/robot/drone/add_robot_verbs()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Changes made as discussed in staff meeting
https://baystation12.net/forums/threads/roll-call-staff-meeting-09-july-2016-2000-gmt-utc.2178/page-2#post-33524
- "Non-interaction" bits replaced with "non-interference", laws updated to allow removing blob or fungi (which people already do all the time).
- Expanded blurb to emphasize on non-interference, following orders is not mandatory but drones should bugger off if their presence is interfering.
- Included notes on drone control consoles being able to send presence requests.
- Reword station/vessel to "assigned platform", allowing better usability across maps (pretty sure Torch isn't a space station).
