### PR TITLE
Kablowie

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -1,23 +1,22 @@
 //TODO: Flash range does nothing currently
 
-proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = UP|DOWN)
+proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = UP|DOWN, shaped)
 	src = null	//so we don't abort once src is deleted
 	spawn(0)
-		if(config.use_recursive_explosions)
-			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
-			explosion_rec(epicenter, power)
-			return
-
 		var/start = world.timeofday
 		epicenter = get_turf(epicenter)
 		if(!epicenter) return
 
 		// Handles recursive propagation of explosions.
-		if(devastation_range > 2 || heavy_impact_range > 2)
-			if(HasAbove(epicenter.z) && z_transfer & UP)
-				explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP)
-			if(HasBelow(epicenter.z) && z_transfer & DOWN)
-				explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN)
+		if(z_transfer)
+			var/adj_dev   = max(0, devastation_range - 2 - (shaped ? 2 : 0))
+			var/adj_heavy = max(0, heavy_impact_range - 2 - (shaped ? 2 : 0))
+			var/adj_light = max(0, light_impact_range - 2 - (shaped ? 2 : 0))
+			if(adj_dev > 0 || adj_heavy > 0)
+				if(HasAbove(epicenter.z) && z_transfer & UP)
+					explosion(GetAbove(epicenter), adj_dev, adj_heavy, adj_light, max(0, flash_range - 2), 0, UP, shaped)
+				if(HasBelow(epicenter.z) && z_transfer & DOWN)
+					explosion(GetBelow(epicenter), adj_dev, adj_heavy, adj_light, max(0, flash_range - 2), 0, DOWN, shaped)
 
 		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
 
@@ -30,34 +29,22 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		far_dist += devastation_range * 20
 		var/frequency = get_rand_frequency()
 		for(var/mob/M in player_list)
-			// Double check for client
-			if(M && M.client)
+			if(M.z == epicenter.z)
 				var/turf/M_turf = get_turf(M)
-				if(M_turf && M_turf.z == epicenter.z)
-					var/dist = get_dist(M_turf, epicenter)
-					// If inside the blast radius + world.view - 2
-					if(dist <= round(max_range + world.view - 2, 1))
-						M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
+				var/dist = get_dist(M_turf, epicenter)
+				// If inside the blast radius + world.view - 2
+				if(dist <= round(max_range + world.view - 2, 1))
+					M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
+				else if(dist <= far_dist)
+					var/far_volume = Clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
+					far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
+					M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
 
-						//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
-
-					else if(dist <= far_dist)
-						var/far_volume = Clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
-						far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
-						M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
-
-		var/close = range(world.view+round(devastation_range,1), epicenter)
-		// to all distanced mobs play a different sound
-		for(var/mob/M in world) if(M.z == epicenter.z) if(!(M in close))
-			// check if the mob can hear
-			if(M.ear_deaf <= 0 || !M.ear_deaf) if(!istype(M.loc,/turf/space))
-				M << 'sound/effects/explosionfar.ogg'
 		if(adminlog)
 			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
 			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
 
 		var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range
-		var/powernet_rebuild_was_deferred_already = defer_powernet_rebuild
 		// Large enough explosion. For performance reasons, powernets will be rebuilt manually
 		if(!defer_powernet_rebuild && (approximate_intensity > 25))
 			defer_powernet_rebuild = 1
@@ -70,36 +57,30 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		var/x0 = epicenter.x
 		var/y0 = epicenter.y
 		var/z0 = epicenter.z
+		if(config.use_recursive_explosions)
+			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
+			explosion_rec(epicenter, power, shaped)
+		else
+			for(var/turf/T in trange(max_range, epicenter))
+				var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
 
-		for(var/turf/T in trange(max_range, epicenter))
-			var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
+				if(dist < devastation_range)		dist = 1
+				else if(dist < heavy_impact_range)	dist = 2
+				else if(dist < light_impact_range)	dist = 3
+				else								continue
 
-			if(dist < devastation_range)		dist = 1
-			else if(dist < heavy_impact_range)	dist = 2
-			else if(dist < light_impact_range)	dist = 3
-			else								continue
-
-			T.ex_act(dist)
-			if(T)
+				T.ex_act(dist)
+				if(!T)
+					T = locate(x0,y0,z0)
 				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 					var/atom/movable/AM = atom_movable
 					if(AM && AM.simulated)	AM.ex_act(dist)
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
-		if(Debug2)	world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
-
-		//Machines which report explosions.
-		for(var/i,i<=doppler_arrays.len,i++)
-			var/obj/machinery/doppler_array/Array = doppler_arrays[i]
-			if(Array)
-				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took)
+		if(Debug2) world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
 
 		sleep(8)
-
-		if(!powernet_rebuild_was_deferred_already && defer_powernet_rebuild)
-			makepowernets()
-			defer_powernet_rebuild = 0
 
 	return 1
 

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -1,10 +1,4 @@
-/client/proc/kaboom()
-	var/power = input(src, "power?", "power?") as num
-	var/turf/T = get_turf(src.mob)
-	explosion_rec(T, power)
 
-/obj
-	var/explosion_resistance
 
 
 
@@ -13,8 +7,7 @@ var/list/explosion_turfs = list()
 var/explosion_in_progress = 0
 
 
-proc/explosion_rec(turf/epicenter, power)
-
+proc/explosion_rec(turf/epicenter, power, shaped)
 	var/loopbreak = 0
 	while(explosion_in_progress)
 		if(loopbreak >= 15) return
@@ -25,12 +18,6 @@ proc/explosion_rec(turf/epicenter, power)
 	epicenter = get_turf(epicenter)
 	if(!epicenter) return
 
-	message_admins("Explosion with size ([power]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z])")
-	log_game("Explosion with size ([power]) in area [epicenter.loc.name] ")
-
-	playsound(epicenter, 'sound/effects/explosionfar.ogg', 100, 1, round(power*2,1) )
-	playsound(epicenter, "explosion", 100, 1, round(power,1) )
-
 	explosion_in_progress = 1
 	explosion_turfs = list()
 
@@ -39,10 +26,20 @@ proc/explosion_rec(turf/epicenter, power)
 	//This steap handles the gathering of turfs which will be ex_act() -ed in the next step. It also ensures each turf gets the maximum possible amount of power dealt to it.
 	for(var/direction in cardinal)
 		var/turf/T = get_step(epicenter, direction)
-		T.explosion_spread(power - epicenter.explosion_resistance, direction)
+		var/adj_power = power - epicenter.explosion_resistance
+		if(shaped)
+			if (shaped == direction)
+				adj_power *= 3
+			else if (shaped == reverse_direction(direction))
+				adj_power *= 0.10
+			else
+				adj_power *= 0.45
+
+		T.explosion_spread(adj_power, direction)
 
 	//This step applies the ex_act effects for the explosion, as planned in the previous step.
-	for(var/turf/T in explosion_turfs)
+	for(var/spot in explosion_turfs)
+		var/turf/T = spot
 		if(explosion_turfs[T] <= 0) continue
 		if(!T) continue
 
@@ -56,13 +53,54 @@ proc/explosion_rec(turf/epicenter, power)
 		T.ex_act(severity)
 		if(!T)
 			T = locate(x,y,z)
-		for(var/atom/A in T)
-			A.ex_act(severity)
+		for(var/atom_movable in T.contents)
+			var/atom/movable/AM = atom_movable
+			if(AM && AM.simulated)	AM.ex_act(severity)
 
+	explosion_turfs.Cut()
 	explosion_in_progress = 0
 
-/turf
-	var/explosion_resistance
+
+//Code-wise, a safe value for power is something up to ~25 or ~30.. This does quite a bit of damage to the station.
+//direction is the direction that the spread took to come to this tile. So it is pointing in the main blast direction - meaning where this tile should spread most of it's force.
+/turf/proc/explosion_spread(power, direction)
+	if(power <= 0)
+		return
+
+	if(explosion_turfs[src] >= power)
+		return //The turf already sustained and spread a power greated than what we are dealing with. No point spreading again.
+	explosion_turfs[src] = power
+
+/*	sleep(2)
+	var/obj/effect/debugging/M = locate() in src
+	if (!M)
+		M = new(src, power, direction)
+	M.maptext = "[power]"
+	if(power > 10)
+		M.color = "#CCCC00"
+	if(power > 20)
+		M.color = "#FFCC00"
+*/
+	var/spread_power = power - src.explosion_resistance //This is the amount of power that will be spread to the tile in the direction of the blast
+	for(var/obj/O in src)
+		if(O.explosion_resistance)
+			spread_power -= O.explosion_resistance
+
+	var/turf/T = get_step(src, direction)
+	if(T)
+		T.explosion_spread(spread_power, direction)
+	T = get_step(src, turn(direction,90))
+	if(T)
+		T.explosion_spread(spread_power, turn(direction,90))
+	T = get_step(src, turn(direction,-90))
+	if(T)
+		T.explosion_spread(spread_power, turn(direction,90))
+
+/turf/unsimulated/explosion_spread(power)
+	return //So it doesn't get to the parent proc, which simulates explosions
+
+/obj/var/explosion_resistance
+/turf/var/explosion_resistance
 
 /turf/space
 	explosion_resistance = 3
@@ -78,33 +116,3 @@ proc/explosion_rec(turf/epicenter, power)
 
 /turf/simulated/wall
 	explosion_resistance = 10
-
-//Code-wise, a safe value for power is something up to ~25 or ~30.. This does quite a bit of damage to the station.
-//direction is the direction that the spread took to come to this tile. So it is pointing in the main blast direction - meaning where this tile should spread most of it's force.
-/turf/proc/explosion_spread(power, direction)
-	if(power <= 0)
-		return
-
-	/*
-	sleep(2)
-	new/obj/effect/debugging/marker(src)
-	*/
-
-	if(explosion_turfs[src] >= power)
-		return //The turf already sustained and spread a power greated than what we are dealing with. No point spreading again.
-	explosion_turfs[src] = power
-
-	var/spread_power = power - src.explosion_resistance //This is the amount of power that will be spread to the tile in the direction of the blast
-	for(var/obj/O in src)
-		if(O.explosion_resistance)
-			spread_power -= O.explosion_resistance
-
-	var/turf/T = get_step(src, direction)
-	T.explosion_spread(spread_power, direction)
-	T = get_step(src, turn(direction,90))
-	T.explosion_spread(spread_power, turn(direction,90))
-	T = get_step(src, turn(direction,-90))
-	T.explosion_spread(spread_power, turn(direction,90))
-
-/turf/unsimulated/explosion_spread(power)
-	return //So it doesn't get to the parent proc, which simulates explosions

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -139,7 +139,6 @@ var/list/debug_verbs = list (
         ,/client/proc/startSinglo
         ,/client/proc/ticklag
         ,/client/proc/cmd_admin_grantfullaccess
-        ,/client/proc/kaboom
         ,/client/proc/cmd_admin_areatest
         ,/client/proc/cmd_admin_rejuvenate
         ,/datum/admins/proc/show_traitor_panel

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -560,13 +560,17 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(light == null) return
 	var/flash = input("Range of flash. -1 to none", text("Input"))  as num|null
 	if(flash == null) return
-
+	var/shaped = 0
+	if(config.use_recursive_explosions)
+		if(alert(src, "Shaped explosion?", "Shape", "Yes", "No") == "Yes")
+			shaped = input("Shaped where to?", "Input")  as anything in list("NORTH","SOUTH","EAST","WEST")
+			shaped = text2dir(shaped)
 	if ((devastation != -1) || (heavy != -1) || (light != -1) || (flash != -1))
 		if ((devastation > 20) || (heavy > 20) || (light > 20))
 			if (alert(src, "Are you sure you want to do this? It will laaag.", "Confirmation", "Yes", "No") == "No")
 				return
 
-		explosion(O, devastation, heavy, light, flash)
+		explosion(O, devastation, heavy, light, flash, shaped=shaped)
 		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flash]) at ([O.x],[O.y],[O.z])")
 		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flash]) at ([O.x],[O.y],[O.z])", 1)
 		feedback_add_details("admin_verb","EXPL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
-Cleaned up main explosion proc, now it picks normal/recursive explosion method in the end, so recursion explosions get proper sounds/logging.
-Recursion explosives can now be 'shaped' which causes bulk of their power to spread into one direction.
-Updates admin explosion verb to let you shape booms if recursive explosions are used
