### PR TITLE
Drones should now be Z-level aware.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -82,7 +82,6 @@
 	if(player.mob && player.mob.mind) player.mob.mind.reset()
 	var/mob/living/silicon/robot/drone/new_drone = PoolOrNew(drone_type, get_turf(src))
 	new_drone.transfer_personality(player)
-	new_drone.master_fabricator = src
 
 	drone_progress = 0
 	return new_drone


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

This allows drones to move between connected Z-levels, or otherwise explode as before.
Matters more for a map like Torch than Exodus.
