### PR TITLE
Hand-tele and admin jump tweaks.

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -39,7 +39,10 @@
 		return
 	var/list/turfs = list()
 	for(var/turf/T in orange(origin, outer_range))
-		if(get_dist(origin, T) >= inner_range)
+		if(!(T.z in using_map.sealed_levels)) // Picking a turf outside the map edge isn't recommended
+			if(T.x >= world.maxx-TRANSITIONEDGE || T.x <= TRANSITIONEDGE)	continue
+			if(T.y >= world.maxy-TRANSITIONEDGE || T.y <= TRANSITIONEDGE)	continue
+		if(!inner_range || get_dist(origin, T) >= inner_range)
 			turfs += T
 	if(turfs.len)
 		return pick(turfs)

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -30,5 +30,5 @@ var/list/obj/effect/bump_teleporter/BUMP_TELEPORTERS = list()
 
 	for(var/obj/effect/bump_teleporter/BT in BUMP_TELEPORTERS)
 		if(BT.id == src.id_target)
-			usr.loc = BT.loc	//Teleport to location with correct id.
+			usr.forceMove(BT.loc)	//Teleport to location with correct id.
 			return

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -134,41 +134,54 @@ Frequency:
 	throw_range = 5
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
 	matter = list(DEFAULT_WALL_MATERIAL = 10000)
+	var/max_portals = 3
+	var/list/spawned_portals
+
+/obj/item/weapon/hand_tele/New()
+	spawned_portals = list()
+	..()
+
+/obj/item/weapon/hand_tele/Destroy()
+	for(var/portal in spawned_portals)
+		portal_destroyed(portal)
+	. = ..()
 
 /obj/item/weapon/hand_tele/attack_self(mob/user as mob)
 	var/turf/current_location = get_turf(user)//What turf is the user on?
-	if(!current_location||current_location.z==2||current_location.z>=7)//If turf was not found or they're on z level 2 or >7 which does not currently exist.
+	if(!current_location || !isPlayerLevel(current_location.z))//If turf was not found or they're on z level outside the what's normally accesible
 		user << "<span class='notice'>\The [src] is malfunctioning.</span>"
 		return
-	var/list/L = list(  )
-	for(var/obj/machinery/teleport/hub/R in world)
-		var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(R.x - 2, R.y, R.z))
-		if (istype(com, /obj/machinery/computer/teleporter) && com.locked && !com.one_time_use)
+	if(spawned_portals.len >= max_portals)
+		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
+		return
+
+	var/list/L = list()
+	for(var/obj/machinery/teleport/hub/R in machines)
+		var/obj/machinery/computer/teleporter/com = R.com
+		if (istype(com, /obj/machinery/computer/teleporter) && com.locked && !com.one_time_use && com.operable())
 			if(R.icon_state == "tele1")
 				L["[com.id] (Active)"] = com.locked
 			else
 				L["[com.id] (Inactive)"] = com.locked
-	var/list/turfs = list(	)
-	for(var/turf/T in orange(10))
-		if(T.x>world.maxx-8 || T.x<8)	continue	//putting them at the edge is dumb
-		if(T.y>world.maxy-8 || T.y<8)	continue
-		turfs += T
-	if(turfs.len)
-		L["None (Dangerous)"] = pick(turfs)
-	var/t1 = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") in L
-	if ((user.get_active_hand() != src || user.stat || user.restrained()))
+	var/random_turf = get_random_turf_in_range(src, 10)
+	if(random_turf)
+		L["None (Dangerous)"] = random_turf
+	var/t1 = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") as null|anything in L
+	if (!t1 || user.get_active_hand() != src || user.incapacitated())
 		return
-	var/count = 0	//num of portals from this teleport in world
-	for(var/obj/effect/portal/PO in world)
-		if(PO.creator == src)	count++
-	if(count >= 3)
-		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
-		return
+
 	var/T = L[t1]
 	for(var/mob/O in hearers(user, null))
 		O.show_message("<span class='notice'>Locked In.</span>", 2)
-	var/obj/effect/portal/P = new /obj/effect/portal( get_turf(src) )
-	P.target = T
-	P.creator = src
-	src.add_fingerprint(user)
-	return
+	create_portal(T)
+	add_fingerprint(user)
+
+/obj/item/weapon/hand_tele/proc/create_portal(var/location)
+	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(src))
+	P.target = location
+	destroyed_event.register(P, src, /obj/item/weapon/hand_tele/proc/portal_destroyed)
+	spawned_portals += P
+
+/obj/item/weapon/hand_tele/proc/portal_destroyed(var/portal)
+	spawned_portals -= portal
+	destroyed_event.unregister(portal, src, /obj/item/weapon/hand_tele/proc/portal_destroyed)

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -1,8 +1,9 @@
-/mob/proc/on_mob_jump()
-	return
+/mob/proc/jumpTo(var/location)
+	forceMove(location)
 
-/mob/observer/ghost/on_mob_jump()
+/mob/observer/ghost/jumpTo()
 	stop_following()
+	..()
 
 /client/proc/Jump(var/area/A in return_sorted_areas())
 	set name = "Jump to Area"
@@ -12,11 +13,8 @@
 		return
 
 	if(config.allow_admin_jump)
-		usr.on_mob_jump()
-		usr.forceMove(pick(get_area_turfs(A)))
-
-		log_admin("[key_name(usr)] jumped to [A]")
-		message_admins("[key_name_admin(usr)] jumped to [A]", 1)
+		mob.jumpTo(pick(get_area_turfs(A)))
+		log_and_message_admins("jumped to [A]")
 		feedback_add_details("admin_verb","JA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
 		alert("Admin jumping disabled")
@@ -27,10 +25,8 @@
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 		return
 	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
-		message_admins("[key_name_admin(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]", 1)
-		usr.on_mob_jump()
-		usr.forceMove(T)
+		log_and_message_admins("jumped to [T.x],[T.y],[T.z] in [T.loc]")
+		mob.jumpTo(T)
 		feedback_add_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
 		alert("Admin jumping disabled")
@@ -44,17 +40,14 @@
 		return
 
 	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [key_name(M)]")
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
-		if(src.mob)
-			var/mob/A = src.mob
+		log_and_message_admins("jumped to [key_name(M)]")
+		if(mob)
 			var/turf/T = get_turf(M)
 			if(T && isturf(T))
 				feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-				A.on_mob_jump()
-				A.forceMove(T)
+				mob.jumpTo(T)
 			else
-				A << "This mob is not located in the game world."
+				mob << "This mob is not located in the game world."
 	else
 		alert("Admin jumping disabled")
 
@@ -65,18 +58,19 @@
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 		return
 
-	if (config.allow_admin_jump)
-		if(src.mob)
-			var/mob/A = src.mob
-			A.on_mob_jump()
-			A.x = tx
-			A.y = ty
-			A.z = tz
-			feedback_add_details("admin_verb","JC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		message_admins("[key_name_admin(usr)] jumped to coordinates [tx], [ty], [tz]")
-
-	else
+	if(!config.allow_admin_jump)
 		alert("Admin jumping disabled")
+		return
+	if(!mob)
+		return
+
+	var/turf/T = locate(tx, ty, tz)
+	if(!T)
+		return
+	mob.jumpTo(T)
+
+	feedback_add_details("admin_verb","JC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	log_and_message_admins("jumped to coordinates [tx], [ty], [tz]")
 
 /client/proc/jumptokey()
 	set category = "Admin"
@@ -94,10 +88,8 @@
 			src << "No keys found."
 			return
 		var/mob/M = selection:mob
-		log_admin("[key_name(usr)] jumped to [key_name(M)]")
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
-		usr.on_mob_jump()
-		usr.forceMove(M.loc)
+		log_and_message_admins("jumped to [key_name(M)]")
+		M.jumpTo(get_turf(M))
 		feedback_add_details("admin_verb","JK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
 		alert("Admin jumping disabled")
@@ -109,10 +101,8 @@
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 		return
 	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] teleported [key_name(M)]")
-		message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
-		M.on_mob_jump()
-		M.forceMove(get_turf(usr))
+		log_and_message_admins("teleported [key_name(M)] to self.")
+		M.jumpTo(get_turf(mob))
 		feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
 		alert("Admin jumping disabled")
@@ -136,11 +126,9 @@
 
 		if(!M)
 			return
-		log_admin("[key_name(usr)] teleported [key_name(M)]")
-		message_admins("[key_name_admin(usr)] teleported [key_name(M)]", 1)
+		log_and_message_admins("teleported [key_name(M)] to self.")
 		if(M)
-			M.on_mob_jump()
-			M.forceMove(get_turf(usr))
+			M.jumpTo(get_turf(mob))
 			feedback_add_details("admin_verb","GK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
 		alert("Admin jumping disabled")
@@ -153,11 +141,8 @@
 	var/area/A = input(usr, "Pick an area.", "Pick an area") in return_sorted_areas()
 	if(A)
 		if(config.allow_admin_jump)
-			M.on_mob_jump()
-			M.forceMove(pick(get_area_turfs(A)))
+			M.jumpTo(pick(get_area_turfs(A)))
 			feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-			log_admin("[key_name(usr)] teleported [key_name(M)] to [A]")
-			message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)] to [A]", 1)
+			log_and_message_admins("teleported [key_name(M)] to [A].")
 		else
 			alert("Admin jumping disabled")

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -63,7 +63,7 @@ var/global/datum/ntnet/ntnet_global = new()
 
 	// Check all relays. If we have at least one working relay, network is up.
 	for(var/obj/machinery/ntnet_relay/R in relays)
-		if(R.is_operational())
+		if(R.operable())
 			operating = 1
 			break
 

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -20,8 +20,8 @@
 
 
 // TODO: Implement more logic here. For now it's only a placeholder.
-/obj/machinery/ntnet_relay/proc/is_operational()
-	if(stat & (BROKEN | NOPOWER | EMPED))
+/obj/machinery/ntnet_relay/operable()
+	if(!..(EMPED))
 		return 0
 	if(dos_failure)
 		return 0
@@ -30,13 +30,13 @@
 	return 1
 
 /obj/machinery/ntnet_relay/update_icon()
-	if(is_operational())
+	if(operable())
 		icon_state = "bus"
 	else
 		icon_state = "bus_off"
 
 /obj/machinery/ntnet_relay/process()
-	if(is_operational())
+	if(operable())
 		use_power = 2
 	else
 		use_power = 1

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -24,7 +24,7 @@
 			dos_speed = NTNETSPEED_ETHERNET * 10
 	if(target && executed)
 		target.dos_overload += dos_speed
-		if(!target.is_operational())
+		if(!target.operable())
 			target.dos_sources.Remove(src)
 			target = null
 			error = "Connection to destination relay lost."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Hand-teleporters now allow you to cancel out from selecting a teleport location.
Hand-teleporters no longer scan the entire world to see if the max number of portals for the unit has been reached.
Jump-To-Coordinate now properly forceMoves, same as all the other Jump-To variants.
get_random_turf_in_range should no longer put mobs outside the world edge.
