### PR TITLE
Fix airlock electronics not working in borg grippers

### DIFF
--- a/code/modules/tgui/states/hands.dm
+++ b/code/modules/tgui/states/hands.dm
@@ -1,7 +1,7 @@
  /**
   * tgui state: hands_state
   *
-  * Checks that the src_object is in the user's hands.
+  * Checks that the src_object is in the user's hands, or user's active gripper.
  **/
 
 /var/global/datum/ui_state/hands_state/tg_hands_state = new()
@@ -17,4 +17,10 @@
 /mob/living/hands_can_use_topic(src_object)
 	if(src_object in get_both_hands(src))
 		return UI_INTERACTIVE
+	return UI_CLOSE
+
+/mob/living/silicon/robot/hands_can_use_topic(src_object)
+	for(var/obj/item/weapon/gripper/active_gripper in list(module_state_1, module_state_2, module_state_3))
+		if(active_gripper.contains(src_object))
+			return UI_INTERACTIVE
 	return UI_CLOSE


### PR DESCRIPTION
Tgui's `hands_state` is now satisfied by the item being in a gripper.

Resolves #13830
