### PR TITLE
Allows emitter to be ID locked while on or off

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -213,12 +213,8 @@
 			user << "<span class='warning'>The lock seems to be broken.</span>"
 			return
 		if(src.allowed(user))
-			if(active)
-				src.locked = !src.locked
-				user << "The controls are now [src.locked ? "locked." : "unlocked."]"
-			else
-				src.locked = 0 //just in case it somehow gets locked
-				user << "<span class='warning'>The controls can only be locked when [src] is online.</span>"
+			src.locked = !src.locked
+			user << "The controls are now [src.locked ? "locked." : "unlocked."]"
 		else
 			user << "<span class='warning'>Access denied.</span>"
 		return

--- a/html/changelogs/Kasuobes-patch-1.yml
+++ b/html/changelogs/Kasuobes-patch-1.yml
@@ -1,0 +1,6 @@
+author: Haswell
+
+delete-after: True
+
+changes:
+  - tweak: "Emitters can now be locked using IDs with engine room access while it's on or off."


### PR DESCRIPTION
With the singulo engine gone and the emitter used for the SM engine, it makes no sense for the emitter to only become lockable while it's on.

Emitters can now be locked at both on and off states with any ID with access_engine_equip (engine room access).
