### PR TITLE
Tweaks emergency shuttle control console

### DIFF
--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -126,7 +126,7 @@
 	if (authorized.len >= req_authorizations)
 		return 0	//don't need any more
 
-	if (!emergency_shuttle.evac)
+	if (!emergency_shuttle.evac && security_level < SEC_LEVEL_RED)
 		src.visible_message("\The [src] buzzes. It does not appear to be accepting any commands.")
 		return 0
 

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -126,6 +126,10 @@
 	if (authorized.len >= req_authorizations)
 		return 0	//don't need any more
 
+	if (!emergency_shuttle.evac)
+		src.visible_message("\The [src] buzzes. It does not appear to be accepting any commands.")
+		return 0
+
 	var/list/access
 	var/auth_name
 	var/dna_hash

--- a/html/changelogs/Kasuobes - evac.yml
+++ b/html/changelogs/Kasuobes - evac.yml
@@ -3,4 +3,4 @@ author: Haswell
 delete-after: True
 
 changes: 
-  - tweak: "The autopilot on the escape shuttle can no longer be overridden during crew transfers. It can only be overridden during an evacuation."
+  - tweak: "The autopilot on the escape shuttle can no longer be overridden during crew transfers while on blue alert or lower. It can only be overridden during an evacuation, or during an alert level higher than blue."

--- a/html/changelogs/Kasuobes - evac.yml
+++ b/html/changelogs/Kasuobes - evac.yml
@@ -1,0 +1,6 @@
+author: Haswell
+
+delete-after: True
+
+changes: 
+  - tweak: "The autopilot on the escape shuttle can no longer be overridden during crew transfers. It can only be overridden during an evacuation."


### PR DESCRIPTION
The control console will no longer accept ID authorizations during crew transfers, functionality remains the same for evacuations.

The reason for this change is that there are no circumstances where overriding the autopilot during a crew transfer isn't breaking RP. If people launch the shuttle early, they get bwoinked; if they hold the shuttle, they get bwoinked. In both cases overriding the autopilot during a crew transfer is unrealistic and pointless, might as well stop the practice entirely.
