### PR TITLE
Adds Aticius's request for resomi bites

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -5,6 +5,15 @@
 	sharp = 1
 	edge = 1
 
+/datum/unarmed_attack/bite/sharp/resomi
+	edge = 0
+
+/datum/unarmed_attack/bite/sharp/resomi/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
+	..()
+	var/obj/item/organ/external/affecting = target.get_organ(zone)
+
+	affecting.createwound(PIERCE, attack_damage * 2)
+
 /datum/unarmed_attack/diona
 	attack_verb = list("lashed", "bludgeoned")
 	attack_noun = list("tendril")

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -80,7 +80,7 @@
 		)
 
 	unarmed_types = list(
-		/datum/unarmed_attack/bite/sharp,
+		/datum/unarmed_attack/bite/sharp/resomi,
 		/datum/unarmed_attack/claws,
 		/datum/unarmed_attack/stomp/weak
 		)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

He wanted resomi bites to be both piercing wounds, and cause more bleeding (but not more damage).
