### PR TITLE
Replaces Resomi super "hearing"

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -83,3 +83,10 @@
 
 /proc/IsTurfAtmosSafe(var/turf/T)
 	return !IsTurfAtmosUnsafe(T)
+
+/proc/is_below_sound_pressure(var/turf/T)
+	var/datum/gas_mixture/environment = T ? T.return_air() : null
+	var/pressure =  environment ? environment.return_pressure() : 0
+	if(pressure < SOUND_MINIMUM_PRESSURE)
+		return TRUE
+	return FALSE

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -74,14 +74,14 @@
 // Turns a direction into text
 /proc/dir2text(direction)
 	switch (direction)
-		if (1.0)  return "north"
-		if (2.0)  return "south"
-		if (4.0)  return "east"
-		if (8.0)  return "west"
-		if (5.0)  return "northeast"
-		if (6.0)  return "southeast"
-		if (9.0)  return "northwest"
-		if (10.0) return "southwest"
+		if (NORTH)     return "north"
+		if (SOUTH)     return "south"
+		if (EAST)      return "east"
+		if (WEST)      return "west"
+		if (NORTHEAST) return "northeast"
+		if (SOUTHEAST) return "southeast"
+		if (NORTHWEST) return "northwest"
+		if (SOUTHWEST) return "southwest"
 
 // Turns text into proper directions
 /proc/text2dir(direction)

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -84,9 +84,3 @@
 		/datum/unarmed_attack/claws,
 		/datum/unarmed_attack/stomp/weak
 		)
-
-/datum/species/resomi/get_vision_flags(var/mob/living/carbon/human/H)
-	if(!(H.sdisabilities & DEAF) && !H.ear_deaf)
-		return SEE_SELF|SEE_MOBS
-	else
-		return SEE_SELF

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -84,3 +84,5 @@
 		/datum/unarmed_attack/claws,
 		/datum/unarmed_attack/stomp/weak
 		)
+
+	inherent_verbs = list(/mob/living/carbon/human/proc/sonar_ping)


### PR DESCRIPTION
The general idea of Resomi having sensitive hearing, able to pick up ques other species can only dream about is fine, but it needs to be handled in some other way.
Giving them the ability to see the names, equipment, and being able to examine mobs through solid matter is a step beyond mere hearing.
