### PR TITLE
Added whole map capture tool

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -138,7 +138,7 @@ var/list/admin_verbs_spawn = list(
 	/client/proc/spawn_chemdisp_cartridge
 	)
 var/list/admin_verbs_server = list(
-	/datum/admins/proc/capture_map,
+	/datum/admins/proc/capture_map_part,
 	/client/proc/Set_Holiday,
 	/client/proc/ToRban,
 	/datum/admins/proc/startnow,
@@ -196,7 +196,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/dsay,
 	/datum/admins/proc/run_unit_test,
 	/turf/proc/view_chunk,
-	/turf/proc/update_chunk
+	/turf/proc/update_chunk,
+	/datum/admins/proc/capture_map
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/admin/map_capture.dm
+++ b/code/modules/admin/map_capture.dm
@@ -1,4 +1,4 @@
-/datum/admins/proc/capture_map(tx as null|num, ty as null|num, tz as null|num, range as null|num)
+/datum/admins/proc/capture_map_part(tx as null|num, ty as null|num, tz as null|num, range as null|num)
 	set category = "Server"
 	set name = "Capture Map Part"
 	set desc = "Usage: Capture-Map-Part target_x_cord target_y_cord target_z_cord range (captures part of a map originating from bottom left corner)"
@@ -24,3 +24,47 @@
 		usr << browse_rsc(cap, file_name)
 	else
 		usr << "Target coordinates are incorrect."
+
+/datum/admins/proc/capture_map_capture_next(currentz, currentx, currenty)
+	if(locate(currentx, currenty, currentz))
+		var/cap = generate_image(currentx ,currenty ,currentz ,32, CAPTURE_MODE_PARTIAL, null, 1, 1)
+		var/file_name = "map_capture_x[currentx]_y[currenty]_z[currentz]_r32.png"
+		usr << "Saved capture in cache as [file_name]."
+		usr << browse_rsc(cap, file_name)
+		currentx = currentx + 32
+		.(currentz, currentx, currenty)
+	else
+		currenty = currenty + 32
+		currentx = 1
+		if(locate(currentx, currenty, currentz))
+			var/cap = generate_image(currentx ,currenty ,currentz ,32, CAPTURE_MODE_PARTIAL, null, 1, 1)
+			var/file_name = "map_capture_x[currentx]_y[currenty]_z[currentz]_r32.png"
+			usr << "Saved capture in cache as [file_name]."
+			usr << browse_rsc(cap, file_name)
+			currentx = currentx + 32
+			.(currentz, currentx, currenty)
+		else
+			usr << "End of map, capture is done."
+
+/datum/admins/proc/capture_map(tz as null|num)
+	set category = "Server"
+	set name = "Capture Map"
+	set desc = "Usage: Capture-Map target_z_cord (captures map)"
+
+	if(!check_rights(R_ADMIN|R_DEBUG|R_SERVER))
+		usr << "You are not allowed to use this command"
+		return
+
+	if(isnull(tz))
+		usr << "Map Part, map using camara like rendering."
+		usr << "Usage: Capture-Map target_z_cord"
+		usr << "Target Z coordinates define z level to capture."
+		return
+
+	if(!locate(1, 1, tz))
+		usr << "Target z-level is incorrect."
+		return
+
+	switch(alert("Are you sure? (This will cause masive lag!!!)", "Map Capture", "Yes", "No"))
+		if("Yes")
+			capture_map_capture_next(tz, 1, 1)

--- a/html/changelogs/Karolis2011 - mapcapture.yml
+++ b/html/changelogs/Karolis2011 - mapcapture.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Karolis2011
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added whole map capture tool, only accessable by admins."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

It allows easy map capturing, just enter desired z level to capture and continue to click links in chat to capture map. 
This tool shouldn't be used in game, unless you want lag. 

EDIT: Tool usage process got updated, it now captures whole map immediately, after prompting. This new capture procedure wasn't tested by me.
