### PR TITLE
Changes conditions for lung popping

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -56,10 +56,15 @@
 		return 1
 	if(!breath)
 		return 1
+
+	var/breath_pressure = breath.total_moles*R_IDEAL_GAS_EQUATION*breath.temperature/BREATH_VOLUME
 	//exposure to extreme pressures can rupture lungs
-	if(breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-		if(!is_bruised() && prob(5)) //only rupture if NOT already ruptured
-			rupture()
+	if(breath_pressure < species.hazard_low_pressure || breath_pressure > species.hazard_high_pressure)
+		var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
+		var/env_pressure = environment.return_pressure()
+		if(env_pressure < species.hazard_low_pressure || env_pressure > species.hazard_high_pressure)
+			if(!is_bruised() && prob(5)) //only rupture if NOT already ruptured
+				rupture()
 	if(breath.total_moles == 0)
 		return 1
 
@@ -70,7 +75,6 @@
 	else if(is_bruised())
 		safe_pressure_min *= 1.25
 
-	var/breath_pressure = (breath.total_moles*R_IDEAL_GAS_EQUATION*breath.temperature)/BREATH_VOLUME
 
 	var/failed_inhale = 0
 	var/failed_exhale = 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Now requiers not only breath pressure to be bad, but outside one too. Prevents setting your internals too low in pressurized area popping your lungs.
Thresholds are more or less same, 1/5th of normal pressure to 5x normal pressure, no species seem to change these so far so everyone's same.
