### PR TITLE
add time to runtime log filenames so they sort properly

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -46,7 +46,7 @@
 		config.server_name += " #[(world.port % 1000) / 100]"
 
 	if(config && config.log_runtime)
-		var/runtime_log = file("data/logs/runtime/[date_string]-[game_id].log")
+		var/runtime_log = file("data/logs/runtime/[date_string]_[time2text(world.timeofday, "hh:mm")]_[game_id].log")
 		runtime_log << "Game [game_id] starting up at [time2text(world.timeofday, "hh:mm.ss")]"
 		log = runtime_log
 


### PR DESCRIPTION
gameid is `a-z A-Z 0-9`, the old admin panel sorts into ASCIIbetical `A-Z 0-9 a-z` as far as I can tell
