### PR TITLE
Reverts android change

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -28,7 +28,7 @@
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#254c25"
 	minimal_player_age = 7
-	alt_titles = list("Robot", "Drone")
+	alt_titles = list("Android", "Robot")
 	account_allowed = 0
 	economic_modifier = 0
 	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -145,9 +145,9 @@
 	O.loc = loc
 	O.job = "Cyborg"
 	if(O.mind.assigned_role == "Cyborg")
-		if(O.mind.role_alt_title == "Robot")
+		if(O.mind.role_alt_title == "Android")
 			O.mmi = new /obj/item/device/mmi/digital/posibrain(O)
-		else if(O.mind.role_alt_title == "Drone")
+		else if(O.mind.role_alt_title == "Robot")
 			O.mmi = new /obj/item/device/mmi/digital/robot(O)
 		else
 			O.mmi = new /obj/item/device/mmi(O)


### PR DESCRIPTION
- Reverts (undocumented!) change that removed Android alt title for cyborgs that was smuggled into FBP port. Limits the confusion, and keeps things how they used to be before FBPs were added.

With this PR (same as before FBP merge):
- Cyborg: Brain in a MMI
- Android: A positronic brain based intelligence
- Robot: A Robotic Intelligence Circuit based intelligence, less advanced than an Android
- (for comparison) Drone: A small robot with even more limited intelligence circuitry, capable of performing only very rudimentary tasks.

Now (before this PR):
- Cyborg: Same, MMI brain
- Android: Does not exist
- Robot: Positronic brain based
- Drone: Robotic intelligence circuit based (and thrown into same box as maintenance drones)
