### PR TITLE
Fixes Circuit Imprinter Manipulator logic

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -163,7 +163,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 
 /obj/machinery/r_n_d/circuit_imprinter/proc/canBuild(var/datum/design/D)
 	for(var/M in D.materials)
-		if(materials[M] < D.materials[M])
+		if(materials[M] <= D.materials[M] * mat_efficiency)
 			return 0
 	for(var/C in D.chemicals)
 		if(!reagents.has_reagent(C, D.chemicals[C]))


### PR DESCRIPTION
Currently, upgrading the Circuit Imprinter's Manipulator will reduce resource costs, but the machine will not take into account the lower costs when initiating a construction order, requiring the original required amount of materials in order to begin processing. In addition, having exactly the correct number of materials will still fail to initiate construction due to using a < vs a <= operator.

This fixes both issues, and checks for the correct amount of materials in the hopper before initiating construction.
