### PR TITLE
Cleans up click catcher creation.

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -173,15 +173,13 @@
 
 /atom/log_info_line()
 	var/turf/t = get_turf(src)
-	if(istype(t))
-		return "([t]) ([t.x],[t.y],[t.z]) ([t.type])"
-	else if(loc)
-		return "([loc]) (0,0,0) ([loc.type])"
-	else
-		return "(NULL) (0,0,0) (NULL)"
+	return "[src] ([t ? t : "NULL"]) ([t ? t.x : 0],[t ? t.y : 0],[t ? t.z : 0]) ([t ? t.type : "NULL"])"
 
 /mob/log_info_line()
 	return "[..()] ([ckey])"
+
+/turf/log_info_line()
+	return "[src] ([loc]) ([x],[y],[z]) ([loc.type])"
 
 /proc/log_info_line(var/datum/d)
 	if(!istype(d))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -330,7 +330,7 @@
 	mouse_opacity = 2
 	screen_loc = "CENTER-7,CENTER-7"
 
-/obj/screen/click_catcher/proc/MakeGreed()
+/proc/create_click_catcher()
 	. = list()
 	for(var/i = 0, i<15, i++)
 		for(var/j = 0, j<15, j++)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -361,7 +361,9 @@ datum/hud/New(mob/owner)
 	update_action_buttons()
 
 /mob/proc/add_click_catcher()
-	client.screen += client.void
+	if(!client.void)
+		client.void = create_click_catcher()
+	client.screen |= client.void
 
 /mob/new_player/add_click_catcher()
 	return

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -163,12 +163,6 @@
 
 	send_resources()
 
-	if(!void)
-		void = new()
-		void = void.MakeGreed()
-
-	screen += void
-
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates.
 		src << "<span class='info'>You have unread updates in the changelog.</span>"
 		winset(src, "rpane.changelog", "background-color=#eaeaea;font-style=bold")

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -56,7 +56,7 @@ var/total_runtimes_skipped = 0
 			srcinfo += "  src.loc: [locinfo]"
 	if(istype(usr))
 		usrinfo = list("  usr: [log_info_line(usr)]")
-		locinfo = log_info_line(usr)
+		locinfo = log_info_line(usr.loc)
 		if(locinfo)
 			usrinfo += "  usr.loc: [locinfo]"
 	// The proceeding mess will almost definitely break if error messages are ever changed


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Should no longer runtime on mob join.
Also corrects some runtime display issues noted while testing. Mobs were not named, and turfs reported themselves as the loc instead of the area.
