### PR TITLE
Additional CELLRATE-related tweaks

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -47,8 +47,8 @@
 	var/auto_return = 1	// true if auto return to home beacon after unload
 	var/auto_pickup = 1 // true if auto-pickup at beacon
 
-	var/obj/item/weapon/cell/cell
-						// the installed power cell
+	var/obj/item/weapon/cell/cell	// the installed power cell
+	var/movement_power_usage = 250	// Power usage in joules per tile
 
 	// constants for internal wiring bitflags
 	var/datum/wires/mulebot/wires = null
@@ -61,8 +61,6 @@
 	botcard = new(src)
 	botcard.access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	cell = new(src)
-	cell.charge = 2000
-	cell.maxcharge = 2000
 
 	spawn(5)	// must wait for map loading to finish
 		if(radio_controller)
@@ -556,7 +554,7 @@
 
 
 					var/moved = step_towards(src, next)	// attempt to move
-					if(cell) cell.use(1)
+					if(cell) cell.use(movement_power_usage * CELLRATE)
 					if(moved)	// successful move
 						//world << "Successful move."
 						blockcount = 0

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -6,16 +6,14 @@
 	icon_state = "flood00"
 	density = 1
 	var/on = 0
-	var/obj/item/weapon/cell/high/cell = null
+	var/obj/item/weapon/cell/cell = null
 	var/use = 200 // 200W light
 	var/unlocked = 0
 	var/open = 0
 	var/brightness_on = 8		//can't remember what the maxed out value is
 
 /obj/machinery/floodlight/New()
-	src.cell = new(src)
-	cell.maxcharge = 100
-	cell.charge = 100 // 30 minutes @ 200W (assuming no lag)
+	cell = new/obj/item/weapon/cell/crap(src)
 	..()
 
 /obj/machinery/floodlight/update_icon()

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -5,7 +5,7 @@
 	initial_icon = "phazon"
 	step_in = 1
 	dir_in = 1 //Facing North.
-	step_energy_drain = 3
+	step_energy_drain = 100
 	health = 200
 	deflect_chance = 30
 	damage_absorption = list("brute"=0.7,"fire"=0.7,"bullet"=0.7,"laser"=0.7,"energy"=0.7,"bomb"=0.7)
@@ -17,7 +17,7 @@
 	internal_damage_threshold = 25
 	force = 15
 	var/phasing = 0
-	var/phasing_energy_drain = 200
+	var/phasing_energy_drain = 5 KILOWATTS
 	max_equip = 4
 
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -377,7 +377,7 @@
 	var/max_syringes = 10
 	var/max_volume = 75 //max reagent volume
 	var/synth_speed = 5 //[num] reagent units per cycle
-	energy_drain = 10
+	energy_drain = 2 KILOWATTS // Synthetises things, so it's quite power-hungry
 	var/mode = 0 //0 - fire syringe, 1 - analyze reagents.
 	var/datum/global_iterator/mech_synth/synth
 	range = MELEE|RANGED
@@ -631,7 +631,7 @@
 	process(var/obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/S)
 		if(!S.chassis)
 			return stop()
-		var/energy_drain = S.energy_drain*10
+		var/energy_drain = S.energy_drain
 		if(!S.processed_reagents.len || S.reagents.total_volume >= S.reagents.maximum_volume || !S.chassis.has_charge(energy_drain))
 			S.occupant_message("<span class=\"alert\">Reagent processing stopped.</span>")
 			S.log_message("Reagent processing stopped.")

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -2,7 +2,7 @@
 	name = "hydraulic clamp"
 	icon_state = "mecha_clamp"
 	equip_cooldown = 15
-	energy_drain = 10
+	energy_drain = 1 KILOWATTS
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
 	required_type = /obj/mecha/working
@@ -252,7 +252,7 @@
 	icon_state = "mecha_rcd"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_BLUESPACE = 3, TECH_MAGNET = 4, TECH_POWER = 4)
 	equip_cooldown = 10
-	energy_drain = 250
+	energy_drain = 25 KILOWATTS
 	range = MELEE|RANGED
 	var/mode = 0 //0 - deconstruct, 1 - wall or floor, 2 - airlock.
 	var/disabled = 0 //malf
@@ -355,7 +355,7 @@
 	icon_state = "mecha_teleport"
 	origin_tech = list(TECH_BLUESPACE = 10)
 	equip_cooldown = 150
-	energy_drain = 1000
+	energy_drain = 200 KILOWATTS
 	range = RANGED
 
 	action(atom/target)
@@ -375,7 +375,7 @@
 	icon_state = "mecha_wholegen"
 	origin_tech = list(TECH_BLUESPACE = 3)
 	equip_cooldown = 50
-	energy_drain = 300
+	energy_drain = 50 KILOWATTS
 	range = RANGED
 
 
@@ -425,7 +425,7 @@
 	icon_state = "mecha_teleport"
 	origin_tech = list(TECH_BLUESPACE = 2, TECH_MAGNET = 3)
 	equip_cooldown = 10
-	energy_drain = 100
+	energy_drain = 10 KILOWATTS
 	range = MELEE|RANGED
 	var/atom/movable/locked
 	var/mode = 1 //1 - gravsling 2 - gravpush
@@ -500,7 +500,7 @@
 	desc = "Powered armor-enhancing mech equipment."
 	icon_state = "mecha_abooster_proj"
 	equip_cooldown = 10
-	energy_drain = 50
+	energy_drain = 5 KILOWATTS
 	range = 0
 	var/deflect_coeff = 1
 	var/damage_coeff = 1
@@ -590,7 +590,7 @@
 	icon_state = "repair_droid"
 	origin_tech = list(TECH_MAGNET = 3, TECH_DATA = 3)
 	equip_cooldown = 20
-	energy_drain = 100
+	energy_drain = 10 KILOWATTS
 	range = 0
 	var/health_boost = 2
 	var/datum/global_iterator/pr_repair_droid
@@ -777,7 +777,7 @@
 	var/max_fuel = 150000
 	var/fuel_per_cycle_idle = 100
 	var/fuel_per_cycle_active = 500
-	var/power_per_cycle = 20
+	var/power_per_cycle = 1 KILOWATTS
 
 	New()
 		..()
@@ -908,7 +908,7 @@
 	max_fuel = 50000
 	fuel_per_cycle_idle = 10
 	fuel_per_cycle_active = 30
-	power_per_cycle = 50
+	power_per_cycle = 5 KILOWATTS
 	var/rad_per_cycle = 0.3
 
 	init()
@@ -997,7 +997,7 @@
 	desc = "A mountable passenger compartment for exo-suits. Rather cramped."
 	icon_state = "mecha_abooster_ccw"
 	origin_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 1)
-	energy_drain = 10
+	energy_drain = 1 KILOWATTS
 	range = MELEE
 	equip_cooldown = 20
 	var/mob/living/carbon/occupant = null

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -66,7 +66,7 @@
 	equip_cooldown = 8
 	name = "\improper CH-PS \"Immolator\" laser"
 	icon_state = "mecha_laser"
-	energy_drain = 30
+	energy_drain = 3 KILOWATTS
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
 
@@ -75,7 +75,7 @@
 	name = "jury-rigged welder-laser"
 	desc = "While not regulation, this inefficient weapon can be attached to working exo-suits in desperate, or malicious, times."
 	icon_state = "mecha_laser"
-	energy_drain = 80
+	energy_drain = 10 KILOWATTS // Inefficient
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
 	required_type = list(/obj/mecha/combat, /obj/mecha/working)
@@ -84,7 +84,7 @@
 	equip_cooldown = 15
 	name = "\improper CH-LC \"Solaris\" laser cannon"
 	icon_state = "mecha_laser"
-	energy_drain = 60
+	energy_drain = 6 KILOWATTS
 	projectile = /obj/item/projectile/beam/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
@@ -92,7 +92,7 @@
 	equip_cooldown = 40
 	name = "mkIV ion heavy cannon"
 	icon_state = "mecha_ion"
-	energy_drain = 120
+	energy_drain = 25 KILOWATTS
 	projectile = /obj/item/projectile/ion
 	fire_sound = 'sound/weapons/Laser.ogg'
 
@@ -100,7 +100,7 @@
 	equip_cooldown = 30
 	name = "eZ-13 mk2 heavy pulse rifle"
 	icon_state = "mecha_pulse"
-	energy_drain = 120
+	energy_drain = 15 KILOWATTS
 	origin_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 6, TECH_POWER = 4)
 	projectile = /obj/item/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
@@ -120,7 +120,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
 	name = "\improper PBT \"Pacifier\" mounted taser"
 	icon_state = "mecha_taser"
-	energy_drain = 20
+	energy_drain = 2 KILOWATTS
 	equip_cooldown = 8
 	projectile = /obj/item/projectile/beam/stun
 	fire_sound = 'sound/weapons/Taser.ogg'
@@ -206,7 +206,7 @@
 	projectiles = 40
 	projectiles_per_shot = 4
 	deviation = 0.7
-	projectile_energy_cost = 25
+	projectile_energy_cost = 50 KILOWATTS
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"
@@ -217,7 +217,7 @@
 	projectiles = 300
 	projectiles_per_shot = 3
 	deviation = 0.3
-	projectile_energy_cost = 20
+	projectile_energy_cost = 40 KILOWATTS
 	fire_cooldown = 2
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
@@ -235,7 +235,7 @@
 	auto_rearm = 1
 	fire_cooldown = 20
 	projectiles_per_shot = 1
-	projectile_energy_cost = 20
+	projectile_energy_cost = 40 KILOWATTS
 	missile_speed = 1
 	missile_range = 15
 	required_type = /obj/mecha  //Why restrict it to just mining or combat mechs?
@@ -251,7 +251,7 @@
 	projectile = /obj/item/missile
 	fire_sound = 'sound/effects/bang.ogg'
 	projectiles = 8
-	projectile_energy_cost = 1000
+	projectile_energy_cost = 200 KILOWATTS
 	equip_cooldown = 60
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/explosive/Fire(atom/movable/AM, atom/target)
@@ -280,7 +280,7 @@
 	fire_sound = 'sound/effects/bang.ogg'
 	projectiles = 6
 	missile_speed = 1.5
-	projectile_energy_cost = 800
+	projectile_energy_cost = 200 KILOWATTS
 	equip_cooldown = 60
 	var/det_time = 20
 

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -7,11 +7,11 @@
 	layer = TURF_LAYER + 0.1
 	anchored = 1
 	idle_power_usage = 200	// Some electronics, passive drain.
-	active_power_usage = 120 KILOWATTS // When charging
+	active_power_usage = 60 KILOWATTS // When charging
 	use_power = 1
 
 	var/obj/mecha/charging = null
-	var/base_charge_rate = 120 KILOWATTS		// Comparable to hardsuit powersink or cyborg charger
+	var/base_charge_rate = 60 KILOWATTS
 	var/repair_power_usage = 10 KILOWATTS		// Per 1 HP of health.
 	var/repair = 0
 
@@ -65,9 +65,13 @@
 	if(!charging)
 		use_power = 1
 		return
-
 	if(charging.loc != loc)
 		stop_charging()
+		return
+
+	if(stat & (BROKEN|NOPOWER))
+		stop_charging()
+		charging.occupant_message("<span class='warning'>Internal System Error - Charging aborted.</span>")
 		return
 
 	// Cell could have been removed.
@@ -83,14 +87,13 @@
 		if(fully_repaired())
 			charging.occupant_message("<span class='notice'>Fully repaired.</span>")
 
-	if(!charging.cell.fully_charged())
-		charging.cell.give(remaining_energy)
+	if(!charging.cell.fully_charged() && remaining_energy)
+		charging.give_power(remaining_energy)
 		if(charging.cell.fully_charged())
 			charging.occupant_message("<span class='notice'>Fully charged.</span>")
 
 	if((!repair || fully_repaired()) && charging.cell.fully_charged())
 		stop_charging()
-	return
 
 // An ugly proc, but apparently mechs don't have maxhealth var of any kind.
 /obj/machinery/mech_recharger/proc/fully_repaired()

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -6,9 +6,13 @@
 	density = 0
 	layer = TURF_LAYER + 0.1
 	anchored = 1
+	idle_power_usage = 200	// Some electronics, passive drain.
+	active_power_usage = 120 KILOWATTS // When charging
+	use_power = 1
 
 	var/obj/mecha/charging = null
-	var/charge = 45
+	var/base_charge_rate = 120 KILOWATTS		// Comparable to hardsuit powersink or cyborg charger
+	var/repair_power_usage = 10 KILOWATTS		// Per 1 HP of health.
 	var/repair = 0
 
 /obj/machinery/mech_recharger/New()
@@ -36,43 +40,61 @@
 
 /obj/machinery/mech_recharger/RefreshParts()
 	..()
-	charge = 0
+	// Calculates an average rating of components that affect charging rate.
+	var/chargerate_multiplier = 0
+	var/chargerate_divisor = 0
 	repair = -5
 	for(var/obj/item/weapon/stock_parts/P in component_parts)
 		if(istype(P, /obj/item/weapon/stock_parts/capacitor))
-			charge += P.rating * 20
+			chargerate_multiplier += P.rating
+			chargerate_divisor++
 		if(istype(P, /obj/item/weapon/stock_parts/scanning_module))
-			charge += P.rating * 5
+			chargerate_multiplier += P.rating
+			chargerate_divisor++
 			repair += P.rating
 		if(istype(P, /obj/item/weapon/stock_parts/manipulator))
 			repair += P.rating * 2
+	if(chargerate_multiplier)
+		active_power_usage = base_charge_rate * (chargerate_multiplier / chargerate_divisor)
+	else
+		active_power_usage = base_charge_rate
+
 
 /obj/machinery/mech_recharger/process()
 	..()
 	if(!charging)
+		use_power = 1
 		return
-	if(charging.loc != loc) // Could be qdel or teleport or something
+
+	if(charging.loc != loc)
 		stop_charging()
 		return
-	var/done = 1
-	if(charging.cell)
-		var/t = min(charge, charging.cell.maxcharge - charging.cell.charge)
-		if(t > 0)
-			charging.give_power(t)
-			use_power(t * 150)
-			done = 0
-		else
-			charging.occupant_message("<span class='notice'>Fully charged.</span>")
-	if(repair && charging.health < initial(charging.health))
+
+	// Cell could have been removed.
+	if(!charging.cell)
+		stop_charging()
+		return
+
+	var/remaining_energy = active_power_usage
+
+	if(repair && !fully_repaired())
 		charging.health = min(charging.health + repair, initial(charging.health))
-		if(charging.health == initial(charging.health))
+		remaining_energy -= repair * repair_power_usage
+		if(fully_repaired())
 			charging.occupant_message("<span class='notice'>Fully repaired.</span>")
 
-		else
-			done = 0
-	if(done)
+	if(!charging.cell.fully_charged())
+		charging.cell.give(remaining_energy)
+		if(charging.cell.fully_charged())
+			charging.occupant_message("<span class='notice'>Fully charged.</span>")
+
+	if((!repair || fully_repaired()) && charging.cell.fully_charged())
 		stop_charging()
 	return
+
+// An ugly proc, but apparently mechs don't have maxhealth var of any kind.
+/obj/machinery/mech_recharger/proc/fully_repaired()
+	return charging && (charging.health == initial(charging.health))
 
 /obj/machinery/mech_recharger/attackby(var/obj/item/I, var/mob/user)
 	if(default_deconstruction_screwdriver(user, I))
@@ -85,15 +107,13 @@
 /obj/machinery/mech_recharger/proc/start_charging(var/obj/mecha/M)
 	if(stat & (NOPOWER | BROKEN))
 		M.occupant_message("<span class='warning'>Power port not responding. Terminating.</span>")
-
 		return
+
 	if(M.cell)
 		M.occupant_message("<span class='notice'>Now charging...</span>")
 		charging = M
-	return
+		use_power = 2
 
 /obj/machinery/mech_recharger/proc/stop_charging()
-	if(!charging)
-
-		return
+	use_power = 1
 	charging = null

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1683,7 +1683,7 @@
 /obj/mecha/proc/get_charge()
 	if(!src.cell)
 		return
-	return max(0, src.cell.charge)
+	return max(0, src.cell.charge / CELLRATE)
 
 /obj/mecha/proc/use_power(amount)
 	if(get_charge())

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -24,7 +24,7 @@
 	var/list/dropped_items = list()
 	var/step_in = 10 //make a step in step_in/10 sec.
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
-	var/step_energy_drain = 10
+	var/step_energy_drain = 200		// Energy usage per step in joules.
 	var/health = 300 //health is health
 	var/deflect_chance = 10 //chance to deflect incoming projectiles, hits, or lesser the effect of ex_act.
 	var/r_deflect_coeff = 1
@@ -1687,13 +1687,13 @@
 
 /obj/mecha/proc/use_power(amount)
 	if(get_charge())
-		cell.use(amount)
+		cell.use(amount * CELLRATE)
 		return 1
 	return 0
 
 /obj/mecha/proc/give_power(amount)
 	if(!isnull(get_charge()))
-		cell.give(amount)
+		cell.give(amount * CELLRATE)
 		return 1
 	return 0
 
@@ -1817,8 +1817,7 @@
 		if(mecha.hasInternalDamage(MECHA_INT_SHORT_CIRCUIT))
 			if(mecha.get_charge())
 				mecha.spark_system.start()
-				mecha.cell.charge -= min(20,mecha.cell.charge)
-				mecha.cell.maxcharge -= min(20,mecha.cell.maxcharge)
+				mecha.use_power(rand(1 KILOWATTS, 5 KILOWATTS))
 		return
 
 

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -9,7 +9,6 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus
 	internal_damage_threshold = 35
 	deflect_chance = 15
-	step_energy_drain = 6
 	var/obj/item/clothing/glasses/hud/health/mech/hud
 
 	New()

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -5,7 +5,7 @@
 	initial_icon = "engineering_pod"
 	internal_damage_threshold = 80
 	step_in = 4
-	step_energy_drain = 10
+	step_energy_drain = 400
 	max_temperature = 20000
 	health = 150
 	infra_luminosity = 6

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -26,7 +26,7 @@
 	var/cover_open = 0						//is the cover open?
 	var/obj/item/weapon/cell/cell
 	var/max_cooling = 12					// in degrees per second - probably don't need to mess with heat capacity here
-	var/charge_consumption = 1 KILOWATTS	// energy usage at full power
+	var/charge_consumption = 2 KILOWATTS	// energy usage at full power
 	var/thermostat = T20C
 
 /obj/item/device/suit_cooling_unit/ui_action_click()

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -22,11 +22,11 @@
 	matter = list("steel" = 15000, "glass" = 3500)
 	origin_tech = list(TECH_MAGNET = 2, TECH_MATERIAL = 2)
 
-	var/on = 0							//is it turned on?
-	var/cover_open = 0					//is the cover open?
+	var/on = 0								//is it turned on?
+	var/cover_open = 0						//is the cover open?
 	var/obj/item/weapon/cell/cell
-	var/max_cooling = 12				// in degrees per second - probably don't need to mess with heat capacity here
-	var/charge_consumption = 3			// charge per second at max_cooling
+	var/max_cooling = 12					// in degrees per second - probably don't need to mess with heat capacity here
+	var/charge_consumption = 1 KILOWATTS	// energy usage at full power
 	var/thermostat = T20C
 
 /obj/item/device/suit_cooling_unit/ui_action_click()
@@ -55,7 +55,7 @@
 
 	H.bodytemperature -= temp_adj
 
-	cell.use(charge_usage)
+	cell.use(charge_usage * CELLRATE)
 	update_icon()
 
 	if(cell.charge <= 0)

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -22,6 +22,7 @@
 	desc = "A shoulder-mounted micro-explosive dispenser."
 	selectable = 1
 	icon_state = "grenadelauncher"
+	use_power_cost = 2 KILOWATTS	// 2kJ per shot, a mass driver that propels the grenade?
 
 	interface_name = "integrated grenade launcher"
 	interface_desc = "Discharges loaded grenades against the wearer's location."
@@ -164,8 +165,8 @@
 	usable = 0
 	selectable = 1
 	toggleable = 1
-	use_power_cost = 50
-	active_power_cost = 10
+	use_power_cost = 10 KILOWATTS
+	active_power_cost = 500
 	passive_power_cost = 0
 
 	gun_type = /obj/item/weapon/gun/energy/crossbow/ninja
@@ -213,7 +214,7 @@
 	desc = "A self-contained microfactory system for hardsuit integration."
 	selectable = 1
 	usable = 1
-	use_power_cost = 15
+	use_power_cost = 5 KILOWATTS
 	icon_state = "enet"
 
 	engage_string = "Fabricate Star"

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -324,6 +324,7 @@
 	icon_state = "ewar"
 	toggleable = 1
 	usable = 0
+	active_power_cost = 100
 
 	activate_string = "Enable Countermeasures"
 	deactivate_string = "Disable Countermeasures"
@@ -366,6 +367,7 @@
 	var/atom/interfaced_with // Currently draining power from this device.
 	var/total_power_drained = 0
 	var/drain_loc
+	var/max_draining_rate = 120 KILOWATTS // The same as unupgraded cyborg recharger.
 
 /obj/item/rig_module/power_sink/deactivate()
 
@@ -449,9 +451,8 @@
 		drain_complete(H)
 		return
 
-	// Attempts to drain up to 12.5*cell-capacity kW, determines this value from remaining cell capacity to ensure we don't drain too much.
-	// 1Ws/(12.5*CELLRATE) = 40s to charge
-	var/to_drain = max(min(12.5*holder.cell.maxcharge, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE)), 200000)
+
+	var/to_drain = max_draining_rate / CELLRATE
 	var/target_drained = interfaced_with.drain_power(0,0,to_drain)
 	if(target_drained <= 0)
 		H << "<span class = 'danger'>Your power sink flashes a red light; there is no power left in [interfaced_with].</span>"

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -451,9 +451,7 @@
 		drain_complete(H)
 		return
 
-
-	var/to_drain = max_draining_rate / CELLRATE
-	var/target_drained = interfaced_with.drain_power(0,0,to_drain)
+	var/target_drained = interfaced_with.drain_power(0,0,max_draining_rate)
 	if(target_drained <= 0)
 		H << "<span class = 'danger'>Your power sink flashes a red light; there is no power left in [interfaced_with].</span>"
 		drain_complete(H)
@@ -467,9 +465,9 @@
 /obj/item/rig_module/power_sink/proc/drain_complete(var/mob/living/M)
 
 	if(!interfaced_with)
-		if(M) M << "<font color='blue'><b>Total power drained:</b> [round(total_power_drained*CELLRATE)] cell units.</font>"
+		if(M) M << "<font color='blue'><b>Total power drained:</b> [round(total_power_drained*CELLRATE)] Wh.</font>"
 	else
-		if(M) M << "<font color='blue'><b>Total power drained from [interfaced_with]:</b> [round(total_power_drained*CELLRATE)] cell units.</font>"
+		if(M) M << "<font color='blue'><b>Total power drained from [interfaced_with]:</b> [round(total_power_drained*CELLRATE)] Wh.</font>"
 		interfaced_with.drain_power(0,1,0) // Damage the victim.
 
 	drain_loc = null

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -32,6 +32,7 @@
 	var/active                          // Basic module status
 	var/disruptable                     // Will deactivate if some other powers are used.
 
+	// Now in joules/watts!
 	var/use_power_cost = 0              // Power used when single-use ability called.
 	var/active_power_cost = 0           // Power used when turned on.
 	var/passive_power_cost = 0          // Power used when turned off.

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -16,8 +16,8 @@
 	disruptable = 1
 	disruptive = 0
 
-	use_power_cost = 50
-	active_power_cost = 10
+	use_power_cost = 5 KILOWATTS
+	active_power_cost = 500
 	passive_power_cost = 0
 	module_cooldown = 30
 
@@ -67,11 +67,11 @@
 	name = "teleportation module"
 	desc = "A complex, sleek-looking, hardsuit-integrated teleportation module."
 	icon_state = "teleporter"
-	use_power_cost = 200
+	use_power_cost = 25 KILOWATTS
 	redundant = 1
 	usable = 1
 	selectable = 1
-
+	module_cooldown = 60
 	engage_string = "Emergency Leap"
 
 	interface_name = "VOID-shift phase projector"
@@ -148,7 +148,7 @@
 	engage_string = "Fabricate Net"
 
 	fabrication_type = /obj/item/weapon/energy_net
-	use_power_cost = 70
+	use_power_cost = 20 KILOWATTS
 
 /obj/item/rig_module/fabricator/energy_net/engage(atom/target)
 

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -36,7 +36,7 @@
 	interface_desc = "A self-sustaining plasma arc capable of cutting through walls."
 	suit_overlay_active = "plasmacutter"
 	suit_overlay_inactive = "plasmacutter"
-	use_power_cost = 0.5
+	use_power_cost = 50
 
 	device_type = /obj/item/weapon/pickaxe/plasmacutter
 
@@ -46,6 +46,7 @@
 	icon_state = "scanner"
 	interface_name = "health scanner"
 	interface_desc = "Shows an informative health readout when used on a subject."
+	use_power_cost = 200
 
 	device_type = /obj/item/device/healthanalyzer
 
@@ -57,7 +58,7 @@
 	interface_desc = "A diamond-tipped industrial drill."
 	suit_overlay_active = "mounted-drill"
 	suit_overlay_inactive = "mounted-drill"
-	use_power_cost = 0.1
+	use_power_cost = 75
 
 	device_type = /obj/item/weapon/pickaxe/diamonddrill
 
@@ -68,6 +69,7 @@
 	interface_name = "Alden-Saraspova counter"
 	interface_desc = "An exotic particle detector commonly used by xenoarchaeologists."
 	engage_string = "Begin Scan"
+	use_power_cost = 200
 	usable = 1
 	selectable = 0
 	device_type = /obj/item/device/ano_scanner
@@ -81,6 +83,7 @@
 	engage_string = "Begin Scan"
 	usable = 1
 	selectable = 0
+	use_power_cost = 200
 	device_type = /obj/item/weapon/mining_scanner
 
 /obj/item/rig_module/device/rcd
@@ -91,6 +94,7 @@
 	interface_desc = "A device for building or removing walls. Cell-powered."
 	usable = 1
 	engage_string = "Configure RCD"
+	use_power_cost = 100 KILOWATTS // Matter fabrication is a very energy-demanding process.
 
 	device_type = /obj/item/weapon/rcd/mounted
 
@@ -125,6 +129,7 @@
 	selectable = 0
 	toggleable = 0
 	disruptive = 0
+	use_power_cost = 500
 
 	engage_string = "Inject"
 
@@ -270,6 +275,7 @@
 	selectable = 0
 	toggleable = 0
 	disruptive = 0
+	active_power_cost = 100
 
 	engage_string = "Configure Synthesiser"
 
@@ -323,6 +329,7 @@
 	toggleable = 1
 	selectable = 0
 	disruptive = 0
+	active_power_cost = 50
 
 	suit_overlay_active = "maneuvering_active"
 	suit_overlay_inactive = null //"maneuvering_inactive"
@@ -390,6 +397,7 @@
 	interface_name = "paper dispenser"
 	interface_desc = "Dispenses warm, clean, and crisp sheets of paper."
 	engage_string = "Dispense"
+	use_power_cost = 200
 	usable = 1
 	selectable = 0
 	device_type = /obj/item/weapon/paper_bin

--- a/code/modules/clothing/spacesuits/rig/modules/vision.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/vision.dm
@@ -51,6 +51,7 @@
 	toggleable = 1
 	disruptive = 0
 	module_cooldown = 0
+	active_power_cost = 100
 
 	engage_string = "Cycle Visor Mode"
 	activate_string = "Enable Visor"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -390,7 +390,7 @@
 			malfunction()
 
 		for(var/obj/item/rig_module/module in installed_modules)
-			cell.use(module.process()*10)
+			cell.use(module.process() * CELLRATE)
 
 //offline should not change outside this proc
 /obj/item/weapon/rig/proc/update_offline()
@@ -419,7 +419,7 @@
 		fail_msg = "<span class='warning'>You are in no fit state to do that.</span>"
 	else if(!cell)
 		fail_msg = "<span class='warning'>There is no cell installed in the suit.</span>"
-	else if(cost && !cell.check_charge(cost * 10)) //TODO: Cellrate?
+	else if(cost && !cell.check_charge(cost * CELLRATE)) //TODO: Cellrate?
 		fail_msg = "<span class='warning'>Not enough stored power.</span>"
 
 	if(fail_msg)
@@ -432,7 +432,7 @@
 			if(module.active && module.disruptable)
 				module.deactivate()
 
-	cell.use(cost*10)
+	cell.use(cost * CELLRATE)
 	return 1
 
 /obj/item/weapon/rig/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/nano_state = inventory_state)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -419,7 +419,7 @@
 		fail_msg = "<span class='warning'>You are in no fit state to do that.</span>"
 	else if(!cell)
 		fail_msg = "<span class='warning'>There is no cell installed in the suit.</span>"
-	else if(cost && !cell.check_charge(cost * CELLRATE)) //TODO: Cellrate?
+	else if(cost && !cell.check_charge(cost * CELLRATE))
 		fail_msg = "<span class='warning'>Not enough stored power.</span>"
 
 	if(fail_msg)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -12,6 +12,8 @@
 	var/braces_needed = 2
 	var/list/supports = list()
 	var/supported = 0
+	var/base_power_usage = 10 KILOWATTS // Base power usage when the drill is running.
+	var/actual_power_usage = 10 KILOWATTS // Actual power usage, with upgrades in mind.
 	var/active = 0
 	var/list/resource_field = list()
 
@@ -31,7 +33,6 @@
 	//Upgrades
 	var/harvest_speed
 	var/capacity
-	var/charge_use
 	var/obj/item/weapon/cell/cell = null
 
 	//Flags
@@ -208,7 +209,7 @@
 	..()
 	harvest_speed = 0
 	capacity = 0
-	charge_use = 50
+	var/charge_multiplier = 0
 
 	for(var/obj/item/weapon/stock_parts/P in component_parts)
 		if(istype(P, /obj/item/weapon/stock_parts/micro_laser))
@@ -216,8 +217,12 @@
 		if(istype(P, /obj/item/weapon/stock_parts/matter_bin))
 			capacity = 200 * P.rating
 		if(istype(P, /obj/item/weapon/stock_parts/capacitor))
-			charge_use -= 10 * P.rating
+			charge_multiplier += P.rating
 	cell = locate(/obj/item/weapon/cell) in component_parts
+	if(charge_multiplier)
+		actual_power_usage = base_power_usage / charge_multiplier
+	else
+		actual_power_usage = base_power_usage
 
 /obj/machinery/mining/drill/proc/check_supports()
 
@@ -265,8 +270,9 @@
 
 /obj/machinery/mining/drill/proc/use_cell_power()
 	if(!cell) return 0
-	if(cell.charge >= charge_use)
-		cell.use(charge_use)
+	var/charge_to_use = actual_power_usage * CELLRATE
+	if(cell.charge >= charge_to_use)
+		cell.use(charge_to_use)
 		return 1
 	return 0
 
@@ -294,7 +300,7 @@
 
 /obj/machinery/mining/brace/New()
 	..()
-	
+
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/miningdrillbrace(src)
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -269,12 +269,7 @@
 		system_error("resources depleted")
 
 /obj/machinery/mining/drill/proc/use_cell_power()
-	if(!cell) return 0
-	var/charge_to_use = actual_power_usage * CELLRATE
-	if(cell.charge >= charge_to_use)
-		cell.use(charge_to_use)
-		return 1
-	return 0
+	return cell && cell.checked_use(actual_power_usage * CELLRATE)
 
 /obj/machinery/mining/drill/verb/unload()
 	set name = "Unload Drill"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -139,10 +139,6 @@ var/list/mob_hat_cache = list()
 	add_language("Robot Talk", 0)
 	add_language("Drone Talk", 1)
 
-	//They are unable to be upgraded, so let's give them a bit of a better battery.
-	cell.maxcharge = 10000
-	cell.charge = 10000
-
 	// NO BRAIN.
 	mmi = null
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -134,9 +134,7 @@
 		C.wrapped = new C.external_type
 
 	if(!cell)
-		cell = new /obj/item/weapon/cell(src)
-		cell.maxcharge = 7500
-		cell.charge = 7500
+		cell = new /obj/item/weapon/cell/high(src)
 
 	..()
 
@@ -300,10 +298,10 @@
 
 	// if we've changed our name, we also need to update the display name for our PDA
 	setup_PDA()
-	
+
 	// Synths aren't in data_core, but are on manifest. Invalidate old one so the
 	// synth shows up.
-	data_core.ResetPDAManifest() 
+	data_core.ResetPDAManifest()
 
 	//We also need to update name of internal camera.
 	if (camera)

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -8,9 +8,7 @@
 
 /mob/living/silicon/robot/syndicate/New()
 	if(!cell)
-		cell = new /obj/item/weapon/cell(src)
-		cell.maxcharge = 25000
-		cell.charge = 25000
+		cell = new /obj/item/weapon/cell/super(src)
 
 	..()
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -124,12 +124,6 @@
 
 	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot( loc )
 
-	// cyborgs produced by Robotize get an automatic power cell
-	O.cell = new(O)
-	O.cell.maxcharge = 7500
-	O.cell.charge = 7500
-
-
 	O.gender = gender
 	O.invisibility = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -80,7 +80,6 @@ var/cell_uid = 1		// Unique ID of this power cell. Used to reduce bunch of uglie
 	use(amount)
 	return 1
 
-
 /obj/item/weapon/cell/proc/give(var/amount)
 	if(maxcharge < amount)	return 0
 	var/amount_used = min(maxcharge-charge,amount)
@@ -88,12 +87,10 @@ var/cell_uid = 1		// Unique ID of this power cell. Used to reduce bunch of uglie
 	update_icon()
 	return amount_used
 
-
 /obj/item/weapon/cell/examine(mob/user)
 	..()
 	user << "The label states it's capacity is [maxcharge] Wh"
 	user << "The charge meter reads [round(src.percent(), 0.1)]%"
-
 
 /obj/item/weapon/cell/emp_act(severity)
 	//remove this once emp changes on dev are merged in

--- a/html/changelogs/atlantiscze-cellrate2.yml
+++ b/html/changelogs/atlantiscze-cellrate2.yml
@@ -1,0 +1,9 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Converts few other things over to work with the recent CELLRATE change. This fixes various issues where battery life of some things (drills, etc.) was very short, while some other things had power cells with very large capacities."
+  - tweak: "Hardsuits and Mechas now use energy in joules rather than Wh (this fixes Ninja suit, among others). Various exosuit tools now have rebalanced power usage. Energy based exosuit weapons use energy on per-shot basis, ballistic weapons use single massive spike when fabricating a new magazine."
+  - tweak: "Minor power-related changes to exosuit modules. Energy cost of some offensive modules increased a bit. Added short cooldown for teleporter module to prevent spamming. Added power usage to various industrial/science modules (anomaly scanner, various drills, etc.). Increased mounted RCD power usage by a lot (matter fabrication is very power demanding process). Powersink module is limited to 120kW transfer rate, and is slower (30kW) when used on APCs with enabled interface lock. Furthermore, when draining from APC it first tries to take energy from the grid, before resorting to taking it from the cell."
+  - bugfix: "APCs drained by a ninja no longer get stuck on 0% charge, and instead recharge themselves as usual."


### PR DESCRIPTION
- Technically a bugfix, converts two things that were using charge units directly to respect CELLRATE and use energy in watts.
- Mining drills now use CELLRATE correctly. Base power usage is 10kW, with advanced capacitor 5kW, and with super capacitor 3.3kW.
- Hardsuits should now use CELLRATE correctly.
- Tweaks power usage of hardsuit modules a bit, while i was at it. Many modules have received active power usage, which means they use power when running/on use. The power usages are now in joules/watts, instead of charge units. In the event of future cellrate changes, a similar problem should not occur.

Should be ready for review
