### PR TITLE
Area ambience changes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -255,25 +255,39 @@ var/list/mob/living/forced_ambiance_list = new
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
 	if(!(L && L.is_preference_enabled(/datum/client_preference/play_ambiance)))	return
 
+
 	// If we previously were in an area with force-played ambiance, stop it.
 	if(L in forced_ambiance_list)
 		L << sound(null, channel = 1)
 		forced_ambiance_list -= L
 
-	if(!L.client.ambience_playing)
-		L.client.ambience_playing = 1
-		L << sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 35, channel = 2)
+	var/turf/T = get_turf(L)
+	var/hum = 0
+	if(!L.ear_deaf)
+		for(var/obj/machinery/atmospherics/unary/vent_pump/vent in src)
+			if(vent.can_pump())
+				hum = 1
+				break
+
+	if(hum)
+		if(!L.client.ambience_playing)
+			L.client.ambience_playing = 1
+			L.playsound_local(T,sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 25, channel = 2))
+	else
+		if(L.client.ambience_playing)
+			L.client.ambience_playing = 0
+			L << sound(null, channel = 2)
 
 	if(forced_ambience)
 		if(forced_ambience.len)
 			forced_ambiance_list |= L
-			L << sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = 1)
+			L.playsound_local(T,sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = 1))
 		else
 			L << sound(null, channel = 1)
 	else if(src.ambience.len && prob(35))
 		if((world.time >= L.client.played + 600))
 			var/sound = pick(ambience)
-			L << sound(sound, repeat = 0, wait = 0, volume = 25, channel = 1)
+			L.playsound_local(T, sound(sound, repeat = 0, wait = 0, volume = 25, channel = 1))
 			L.client.played = world.time
 
 /area/proc/gravitychange(var/gravitystate = 0, var/area/A)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -74,18 +74,19 @@ var/const/FALLOFF_SOUNDS = 0.5
 
 /mob/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global)
 	if(!src.client || ear_deaf > 0)	return
-	soundin = get_sfx(soundin)
-
-	var/sound/S = sound(soundin)
-	S.wait = 0 //No queue
-	S.channel = 0 //Any channel
-	S.volume = vol
-	S.environment = -1
-	if (vary)
-		if(frequency)
-			S.frequency = frequency
-		else
-			S.frequency = get_rand_frequency()
+	var/sound/S = soundin
+	if(!istype(S))
+		soundin = get_sfx(soundin)
+		S = sound(soundin)
+		S.wait = 0 //No queue
+		S.channel = 0 //Any channel
+		S.volume = vol
+		S.environment = -1
+		if (vary)
+			if(frequency)
+				S.frequency = frequency
+			else
+				S.frequency = get_rand_frequency()
 
 	//sound volume falloff with pressure
 	var/pressure_factor = 1.0

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -42,9 +42,7 @@
 			pulse = Clamp(pulse + owner.chem_effects[CE_PULSE], PULSE_SLOW, PULSE_2FAST)
 
 /obj/item/organ/internal/heart/proc/handle_heartbeat()
-	var/turf/T = get_turf(owner)
-	var/datum/gas_mixture/environment = T.return_air()
-	if(pulse >= PULSE_2FAST || owner.shock_stage >= 10 || environment.return_pressure() < SOUND_MINIMUM_PRESSURE)
+	if(pulse >= PULSE_2FAST || owner.shock_stage >= 10 || is_below_sound_pressure(get_turf(owner)))
 		//PULSE_THREADY - maximum value for pulse, currently it 5.
 		//High pulse value corresponds to a fast rate of heartbeat.
 		//Divided by 2, otherwise it is too slow.

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -42,7 +42,9 @@
 			pulse = Clamp(pulse + owner.chem_effects[CE_PULSE], PULSE_SLOW, PULSE_2FAST)
 
 /obj/item/organ/internal/heart/proc/handle_heartbeat()
-	if(pulse >= PULSE_2FAST || owner.shock_stage >= 10 || istype(get_turf(owner), /turf/space))
+	var/turf/T = get_turf(owner)
+	var/datum/gas_mixture/environment = T.return_air()
+	if(pulse >= PULSE_2FAST || owner.shock_stage >= 10 || environment.return_pressure() < SOUND_MINIMUM_PRESSURE)
 		//PULSE_THREADY - maximum value for pulse, currently it 5.
 		//High pulse value corresponds to a fast rate of heartbeat.
 		//Divided by 2, otherwise it is too slow.


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Now using playsound_local instead of direct <<. to user. That way deafness/area sound environment/air pressure are respected.
The omnipresent HUMMMMM now requiers a working vent in the area to appear. Space is finally quiet. Or powered-down station.
Also makes that hum a bit quieter, to the level of other ambient sounds (35 -> 25).
