### PR TITLE
Make bioprinter organs start with ORGAN_CUT_AWAY status

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -18,6 +18,7 @@
 	var/print_delay = 100
 	var/printing
 
+	// These should be subtypes of /obj/item/organ
 	var/list/products = list(
 		BP_HEART   = list(/obj/item/organ/internal/heart,  50),
 		BP_LUNGS   = list(/obj/item/organ/internal/lungs,  40),
@@ -99,7 +100,9 @@
 
 /obj/machinery/organ_printer/proc/print_organ(var/choice)
 	var/new_organ = products[choice][1]
-	var/obj/item/result = new new_organ(get_turf(src))
+	var/obj/item/organ/result = new new_organ(get_turf(src))
+	result.status |= ORGAN_CUT_AWAY
+	
 	return result
 // END GENERIC PRINTER
 
@@ -128,6 +131,7 @@
 /obj/machinery/organ_printer/robot/print_organ(var/choice)
 	var/obj/item/organ/O = ..()
 	O.robotize()
+	O.status |= ORGAN_CUT_AWAY  // robotize() resets status to 0
 	visible_message("<span class='info'>\The [src] churns for a moment, then spits out \a [O].</span>")
 	return O
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -288,6 +288,10 @@
 			user.remove_from_mob(O)
 			O.forceMove(target)
 			affected.implants |= O //move the organ into the patient. The organ is properly reattached in the next step
+			if(!(O.status & ORGAN_CUT_AWAY))
+				log_debug("[user] ([user.ckey]) replaced organ [O], which didn't have ORGAN_CUT_AWAY set, in [target] ([target.ckey])")
+				O.status |= ORGAN_CUT_AWAY
+			
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
This is a possible fix for #14028 (depending on followup by bug submitter), but it does make organs printed by bioprinters (including robotic bioprinter) transplantable into people. 

(edit: fixes #14028)
