### PR TITLE
Added Resomi organ variants and a metabolism modifier var

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -43,9 +43,6 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "chitin"
 
-/obj/item/organ/internal/brain/resomi
-	w_class = 1.0
-
 /obj/item/organ/internal/brain/robotize()
 	. = ..()
 	icon_state = "brain-prosthetic"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -43,6 +43,9 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "chitin"
 
+/obj/item/organ/internal/brain/resomi
+	w_class = 1.0
+
 /obj/item/organ/internal/brain/robotize()
 	. = ..()
 	icon_state = "brain-prosthetic"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -476,3 +476,6 @@
 	if(isSynthetic())
 		return 0
 	return !(species.flags & NO_PAIN)
+
+/mob/living/carbon/proc/get_adjusted_metabolism(metabolism)
+	return metabolism

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1486,3 +1486,6 @@
 			return 0
 		return check_organ.can_feel_pain()
 	return !(species.flags & NO_PAIN)
+
+/mob/living/carbon/human/get_adjusted_metabolism(metabolism)
+	return ..() * (species ? species.metabolism_mod : 1)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -61,6 +61,7 @@
 	var/toxins_mod =    1                    // Toxloss modifier
 	var/radiation_mod = 1                    // Radiation modifier
 	var/flash_mod =     1                    // Stun from blindness modifier.
+	var/metabolism_mod = 1
 	var/vision_flags = SEE_SELF              // Same flags as glasses.
 
 	// Death vars.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -61,7 +61,7 @@
 	var/toxins_mod =    1                    // Toxloss modifier
 	var/radiation_mod = 1                    // Radiation modifier
 	var/flash_mod =     1                    // Stun from blindness modifier.
-	var/metabolism_mod = 1
+	var/metabolism_mod = 1					 // Reagent metabolism modifier
 	var/vision_flags = SEE_SELF              // Same flags as glasses.
 
 	// Death vars.

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -72,12 +72,12 @@
 		)
 
 	has_organ = list(
-		BP_HEART =    /obj/item/organ/internal/heart,
-		BP_LUNGS =    /obj/item/organ/internal/lungs,
-		BP_LIVER =    /obj/item/organ/internal/liver,
-		BP_KIDNEYS =  /obj/item/organ/internal/kidneys,
-		BP_BRAIN =    /obj/item/organ/internal/brain,
-		BP_EYES =     /obj/item/organ/internal/eyes
+		BP_HEART =    /obj/item/organ/internal/heart/resomi,
+		BP_LUNGS =    /obj/item/organ/internal/lungs/resomi,
+		BP_LIVER =    /obj/item/organ/internal/liver/resomi,
+		BP_KIDNEYS =  /obj/item/organ/internal/kidneys/resomi,
+		BP_BRAIN =    /obj/item/organ/internal/brain/resomi,
+		BP_EYES =     /obj/item/organ/internal/eyes/resomi
 		)
 
 	unarmed_types = list(

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -30,6 +30,7 @@
 	total_health = 50
 	brute_mod = 1.35
 	burn_mod =  1.35
+	metabolism_mod = 2.0
 	mob_size = MOB_SMALL
 	holder_type = /obj/item/weapon/holder/human
 	short_sighted = 1

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -72,12 +72,12 @@
 		)
 
 	has_organ = list(
-		BP_HEART =    /obj/item/organ/internal/heart/resomi,
-		BP_LUNGS =    /obj/item/organ/internal/lungs/resomi,
+		BP_HEART =    /obj/item/organ/internal/heart,
+		BP_LUNGS =    /obj/item/organ/internal/lungs,
 		BP_LIVER =    /obj/item/organ/internal/liver/resomi,
 		BP_KIDNEYS =  /obj/item/organ/internal/kidneys/resomi,
-		BP_BRAIN =    /obj/item/organ/internal/brain/resomi,
-		BP_EYES =     /obj/item/organ/internal/eyes/resomi
+		BP_BRAIN =    /obj/item/organ/internal/brain,
+		BP_EYES =     /obj/item/organ/internal/eyes
 		)
 
 	unarmed_types = list(

--- a/code/modules/organs/subtypes/resomi.dm
+++ b/code/modules/organs/subtypes/resomi.dm
@@ -8,3 +8,15 @@
 	body_hair = "feathers"
 /obj/item/organ/external/head/resomi
 	eye_icon = "eyes_resomi"
+/obj/item/organ/internal/heart/resomi
+	w_class = 2.0
+/obj/item/organ/internal/lungs/resomi
+	w_class = 2.0
+/obj/item/organ/internal/kidneys/resomi
+	w_class = 2.0
+	parent_organ = BP_CHEST
+/obj/item/organ/internal/liver/resomi
+	w_class = 2.0
+	parent_organ = BP_CHEST
+/obj/item/organ/internal/eyes/resomi
+	w_class = 2.0

--- a/code/modules/organs/subtypes/resomi.dm
+++ b/code/modules/organs/subtypes/resomi.dm
@@ -8,15 +8,7 @@
 	body_hair = "feathers"
 /obj/item/organ/external/head/resomi
 	eye_icon = "eyes_resomi"
-/obj/item/organ/internal/heart/resomi
-	w_class = 2.0
-/obj/item/organ/internal/lungs/resomi
-	w_class = 2.0
 /obj/item/organ/internal/kidneys/resomi
-	w_class = 2.0
 	parent_organ = BP_CHEST
 /obj/item/organ/internal/liver/resomi
-	w_class = 2.0
 	parent_organ = BP_CHEST
-/obj/item/organ/internal/eyes/resomi
-	w_class = 2.0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -65,7 +65,11 @@
 		removed = ingest_met
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met
+	var/mob/living/carbon/human/H = M
+	if(istype(H))
+		removed *= H.species.metabolism_mod
 	removed = min(removed, volume)
+
 
 	//adjust effective amounts - removed, dose, and max_dose - for mob size
 	var/effective = removed

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -65,10 +65,7 @@
 		removed = ingest_met
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met
-	var/mob/living/carbon/human/H = M
-	if(istype(H))
-		removed *= H.species.metabolism_mod
-	removed = min(removed, volume)
+	removed = M.get_adjusted_metabolism(removed)
 
 
 	//adjust effective amounts - removed, dose, and max_dose - for mob size

--- a/html/changelogs/Cirra-Aticius.yml
+++ b/html/changelogs/Cirra-Aticius.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cirra
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Resomi now process reagents twice as fast."
+  - tweak: "Moved all Resomi organs to the chest, apart from the brain and eyes."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

This is by request of @Aticius . 
- Added a metabolism modifier, which affects how much reagent is processed per tick. For resomi, this is 2.0, and it is 1.0 by default
- Added resomi variants of the liver and kidneys, and moved them to the chest.

Testing status: **Successful**
