### PR TITLE
Transplantation and organ tweaks

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -183,6 +183,10 @@
 		
 		O.set_dna(C.dna)
 		
+		if(O.species)
+			// This is a very hacky way of doing of what organ/New() does if it has an owner
+			O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)
+		
 		O.transplant_data["species"] =    C.species.name
 		O.transplant_data["blood_type"] = loaded_dna["blood_type"]
 		O.transplant_data["blood_DNA"] =  loaded_dna["blood_DNA"]

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -180,6 +180,9 @@
 	if(loaded_dna)
 		O.transplant_data = list()
 		var/mob/living/carbon/C = loaded_dna["donor"]
+		
+		O.set_dna(C.dna)
+		
 		O.transplant_data["species"] =    C.species.name
 		O.transplant_data["blood_type"] = loaded_dna["blood_type"]
 		O.transplant_data["blood_DNA"] =  loaded_dna["blood_DNA"]

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -178,7 +178,6 @@
 /obj/machinery/organ_printer/flesh/print_organ(var/choice)
 	var/obj/item/organ/O = ..()
 	if(loaded_dna)
-		O.transplant_data = list()
 		var/mob/living/carbon/C = loaded_dna["donor"]
 		
 		O.set_dna(C.dna)
@@ -187,9 +186,6 @@
 			// This is a very hacky way of doing of what organ/New() does if it has an owner
 			O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)
 		
-		O.transplant_data["species"] =    C.species.name
-		O.transplant_data["blood_type"] = loaded_dna["blood_type"]
-		O.transplant_data["blood_DNA"] =  loaded_dna["blood_DNA"]
 		visible_message("<span class='info'>\The [src] churns for a moment, injects its stored DNA into the biomass, then spits out \a [O].</span>")
 	else
 		visible_message("<span class='info'>\The [src] churns for a moment, then spits out \a [O].</span>")

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -22,6 +22,16 @@
 
 /obj/item/organ/internal/lungs/set_dna(var/datum/dna/new_dna)
 	..()
+	sync_breath_types()
+	
+/obj/item/organ/internal/lungs/replaced()
+	..()
+	sync_breath_types()
+	
+/**
+ *  Set these lungs' breath types based on the lungs' species
+ */
+/obj/item/organ/internal/lungs/proc/sync_breath_types()
 	min_breath_pressure = species.breath_pressure
 	breath_type = species.breath_type ? species.breath_type : "oxygen"
 	poison_type = species.poison_type ? species.poison_type : "phoron"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -17,7 +17,6 @@ var/list/organ_cache = list()
 
 	// Reference data.
 	var/mob/living/carbon/human/owner // Current mob owning the organ.
-	var/list/transplant_data          // Transplant match data.
 	var/list/autopsy_data = list()    // Trauma data for forensics.
 	var/list/trace_chemicals = list() // Traces of chemicals in the organ.
 	var/datum/dna/dna                 // Original DNA.
@@ -32,7 +31,6 @@ var/list/organ_cache = list()
 /obj/item/organ/Destroy()
 
 	if(owner)           owner = null
-	if(transplant_data) transplant_data.Cut()
 	if(autopsy_data)    autopsy_data.Cut()
 	if(trace_chemicals) trace_chemicals.Cut()
 	dna = null
@@ -329,17 +327,6 @@ var/list/organ_cache = list()
 
 	if(status & ORGAN_CUT_AWAY)
 		return 0 //organs don't work very well in the body when they aren't properly attached
-
-	var/datum/reagent/blood/transplant_blood = locate(/datum/reagent/blood) in reagents.reagent_list
-	transplant_data = list()
-	if(!transplant_blood)
-		transplant_data["species"] =    target.species.name
-		transplant_data["blood_type"] = target.dna.b_type
-		transplant_data["blood_DNA"] =  target.dna.unique_enzymes
-	else
-		transplant_data["species"] =    transplant_blood.data["species"]
-		transplant_data["blood_type"] = transplant_blood.data["blood_type"]
-		transplant_data["blood_DNA"] =  transplant_blood.data["blood_DNA"]
 		
 	// robotic organs emulate behavior of the equivalent flesh organ of the species
 	if(robotic >= ORGAN_ROBOT || !species)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -340,7 +340,11 @@ var/list/organ_cache = list()
 		transplant_data["species"] =    transplant_blood.data["species"]
 		transplant_data["blood_type"] = transplant_blood.data["blood_type"]
 		transplant_data["blood_DNA"] =  transplant_blood.data["blood_DNA"]
-
+		
+	// robotic organs emulate behavior of the equivalent flesh organ of the species
+	if(robotic >= ORGAN_ROBOT || !species)
+		species = target.species
+		
 	owner = target
 	forceMove(owner) //just in case
 	processing_objects -= src


### PR DESCRIPTION
Bioprinters now set the `dna` and `species` of the printed organ. This matters for rejection checks, although as of right now organs printed without supplying any samples will never get rejected anyway. 

Robotic organs will now adopt the species of the host on transplantation. This matters for lungs and hearts, which check for their own `species` (instead of `owner`'s) in their `process()`s, and thus generate errors if their species is null. I figured it'd make sense for robo-organs to just emulate regular organs, so if you give a Vox robolungs it'll get the Vox breath types. 

Generic (un-DNA'd) organs from the organ printer will now take the species of the host on first transplantation. This is weird, but they _need_ a species.

Lungs additionally have some local variables storing the breath types. These are now updated from the lungs' species on transplantation. Previously, they were only updated when a mob spawned, so printed lungs didn't have breath types set. 

On another note, organs seem to hold a `transplant_data` list which is used exactly nowhere. I left it in place, but it seems like a leftover from something.
