### PR TITLE
Makes atmos tech an engineer alt title

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -30,15 +30,16 @@
 	department = "Engineering"
 	department_flag = ENG
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 8
+	spawn_positions = 7
 	supervisors = "the chief engineer"
 	selection_color = "#5b4d20"
 	economic_modifier = 5
 	minimal_player_age = 7
-	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
-	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
+	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_emergency_storage)
+	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_emergency_storage)
+	alt_titles = list("Maintenance Technician","Engine Technician","Electrician",
+		"Atmospheric Technician" = /decl/hierarchy/outfit/job/engineering/atmos)
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
 
 /datum/job/atmos
@@ -46,12 +47,12 @@
 	department = "Engineering"
 	department_flag = ENG
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the chief engineer"
 	selection_color = "#5b4d20"
 	economic_modifier = 5
 	minimal_player_age = 7
-	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_external_airlocks)
-	minimal_access = list(access_eva, access_engine, access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks)
+	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_emergency_storage)
+	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_emergency_storage)
 	outfit_type = /decl/hierarchy/outfit/job/engineering/atmos

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -75,6 +75,9 @@
 		. += "<tr bgcolor='[job.selection_color]'><td width='60%' align='right'>"
 		var/rank = job.title
 		lastJob = job
+		if(job.total_positions == 0 && job.spawn_positions == 0)
+			. += "<del>[rank]</del></td><td><b> \[UNAVAILABLE]</b></td></tr>"
+			continue
 		if(jobban_isbanned(user, rank))
 			. += "<del>[rank]</del></td><td><b> \[BANNED]</b></td></tr>"
 			continue

--- a/html/changelogs/Kasuobes-JustLetAtmosTechsHaveFunAlready.yml
+++ b/html/changelogs/Kasuobes-JustLetAtmosTechsHaveFunAlready.yml
@@ -1,0 +1,9 @@
+author: Haswell
+
+delete-after: True
+
+changes: 
+  - rscdel: "Atmospheric technician is now unavailable for general play."
+  - rscadd: "Alt title 'Atmospheric Technician' is now added to engineers."
+  - tweak: "Engineers now have all the accesses atmospheric technicians previously held."
+  - tweak: "Tweaked job selection screen to properly indicate which jobs aren't available to play as."


### PR DESCRIPTION
Sets atmos tech as an engineer alt title, adjusted accesses and job positions. Also implemented check in occupation selection screen for unavailable jobs.

Poll for changes: https://baystation12.net/forums/threads/discussion-making-atmos-tech-an-engineer-alt-title-again.2538/
