### PR TITLE
Tweaks recharge station repair capabilities

### DIFF
--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -508,7 +508,6 @@ var/list/worths = list(
 					/obj/item/organ = 400,
 //ITEMS,
 					/obj/item/slime_extract = 200,
-					/obj/item/broken_device = 10,
 					/obj/item/robot_parts/robot_component = 250,
 					/obj/item/robot_parts = 30,
 					/obj/item/modular_computer/tablet = 1300,

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -24,20 +24,20 @@
 /datum/robot_component/proc/uninstall()
 
 /datum/robot_component/proc/destroy()
-	var/brokenstate = "broken" // Generic icon
 	if (istype(wrapped, /obj/item/robot_parts/robot_component))
 		var/obj/item/robot_parts/robot_component/comp = wrapped
-		brokenstate = comp.icon_state_broken
-	if(wrapped)
-		qdel(wrapped)
+		wrapped.icon_state = comp.icon_state_broken
 
-
-	wrapped = new/obj/item/broken_device
-	wrapped.icon_state = brokenstate // Module-specific broken icons! Yay!
-
-	// The thing itself isn't there anymore, but some fried remains are.
 	installed = -1
 	uninstall()
+
+/datum/robot_component/proc/repair()
+	if (istype(wrapped, /obj/item/robot_parts/robot_component))
+		var/obj/item/robot_parts/robot_component/comp = wrapped
+		wrapped.icon_state = comp.icon_state
+
+	installed = 1
+	install()
 
 /datum/robot_component/proc/take_damage(brute, electronics, sharp, edge)
 	if(installed != 1) return
@@ -62,8 +62,7 @@
 	if(toggled == 0)
 		powered = 0
 		return
-	if(owner.cell && owner.cell.charge >= idle_usage)
-		owner.cell_use_power(idle_usage)
+	if(owner.cell_use_power(idle_usage))
 		powered = 1
 	else
 		powered = 0
@@ -100,11 +99,16 @@
 /datum/robot_component/cell
 	name = "power cell"
 	max_damage = 50
+	var/obj/item/weapon/cell/stored_cell = null
 
 /datum/robot_component/cell/destroy()
 	..()
+	stored_cell = owner.cell
 	owner.cell = null
 
+/datum/robot_component/cell/repair()
+	owner.cell = stored_cell
+	stored_cell = null
 
 // RADIO
 // Enables radio communications
@@ -208,12 +212,6 @@
 
 // Component Objects
 // These objects are visual representation of modules
-
-/obj/item/broken_device
-	name = "broken component"
-	icon = 'icons/obj/robot_component.dmi'
-	icon_state = "broken"
-
 /obj/item/robot_parts/robot_component
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "working"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -300,10 +300,10 @@
 
 	// if we've changed our name, we also need to update the display name for our PDA
 	setup_PDA()
-	
+
 	// Synths aren't in data_core, but are on manifest. Invalidate old one so the
 	// synth shows up.
-	data_core.ResetPDAManifest() 
+	data_core.ResetPDAManifest()
 
 	//We also need to update name of internal camera.
 	if (camera)
@@ -368,10 +368,12 @@
 
 	if(!is_component_functioning("diagnosis unit"))
 		src << "\red Your self-diagnosis component isn't functioning."
+		return
 
 	var/datum/robot_component/CO = get_component("diagnosis unit")
 	if (!cell_use_power(CO.active_usage))
 		src << "\red Low Power."
+		return
 	var/dat = self_diagnosis()
 	src << browse(dat, "window=robotdiagnosis")
 
@@ -994,10 +996,6 @@
 /mob/living/silicon/robot/proc/cell_use_power(var/amount = 0)
 	// No cell inserted
 	if(!cell)
-		return 0
-
-	// Power cell is empty.
-	if(cell.charge == 0)
 		return 0
 
 	var/power_use = amount * CYBORG_POWER_USAGE_MULTIPLIER

--- a/html/changelogs/atlantiscze-RepairMe.yml
+++ b/html/changelogs/atlantiscze-RepairMe.yml
@@ -1,0 +1,7 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscadd: "Repair capability of upgraded cyborg rechargers now also works on IPCs and FBPs."
+  - tweak: "If the cyborg recharger is upgraded enough, it will be capable of rebooting (and eventually repairing) destroyed modules, for some extra power."


### PR DESCRIPTION
- Recharge station now also repairs IPCs and FBPs, if it is upgraded with better manipulators.
- Recharge station now reboots destroyed internal components of cyborgs for large one-time power spike. The recharge station has to be upgraded with ability to repair both burn and brute damage for this to work.

As a note, this doesn't allow cyborgs to repair themselves from any kind of damage. Completely destroyed cyborgs will be repaired, but not rebooted (reboot module would be required). Destruction of actuator obviously prevents you from moving to the charger so you still need external aid. Destruction of internal power cell prevents you from even entering the recharger before the cell is replaced. Other damage will be repaired, given enough time and energy.
