### PR TITLE
 Adds more SMES coils and circuitry to supply packs

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -31,11 +31,35 @@
 	cost = 10
 	containername = "\improper Plastic sheets crate"
 
+/decl/hierarchy/supply_pack/engineering/smes_circuit
+	name = "Superconducting Magnetic Energy Storage Unit Circuitry"
+	contains = list(/obj/item/weapon/circuitboard/smes)
+	cost = 20
+	containername = "\improper Superconducting Magnetic Energy Storage Unit Circuitry"
+
 /decl/hierarchy/supply_pack/engineering/smescoil
-	name = "Superconducting Magnetic Coil"
+	name = "Superconductive Magnetic Coil"
 	contains = list(/obj/item/weapon/smes_coil)
-	cost = 75
-	containername = "\improper Superconducting Magnetic Coil crate"
+	cost = 35
+	containername = "\improper Superconductive Magnetic Coil crate"
+
+/decl/hierarchy/supply_pack/engineering/smescoil_weak
+	name = "Basic Superconductive Magnetic Coil"
+	contains = list(/obj/item/weapon/smes_coil/weak)
+	cost = 25
+	containername = "\improper Basic Superconductive Magnetic Coil crate"
+
+/decl/hierarchy/supply_pack/engineering/smescoil_super_capacity
+	name = "Superconductive Capacitance Coil"
+	contains = list(/obj/item/weapon/smes_coil/super_capacity)
+	cost = 45
+	containername = "\improper Superconductive Capacitance Coil crate"
+
+/decl/hierarchy/supply_pack/engineering/smescoil_super_io
+	name = "Superconductive Transmission Coil"
+	contains = list(/obj/item/weapon/smes_coil/super_io)
+	cost = 45
+	containername = "\improper Superconductive Transmission Coil crate"
 
 /decl/hierarchy/supply_pack/engineering/electrical
 	name = "Electrical maintenance crate"

--- a/html/changelogs/Kasuobes-ImGonnaCoilAroundYouBby.yml
+++ b/html/changelogs/Kasuobes-ImGonnaCoilAroundYouBby.yml
@@ -1,0 +1,7 @@
+author: Haswell
+
+delete-after: True
+
+changes:
+  - rscadd: "Added more SMES coils and circuitboard to supply packs."
+  - tweak: "Adjusted price of SMES coil."


### PR DESCRIPTION
Added weak, super capacitance, super IO coils and SMES circuitry to supply packs. Revised cost of standard SMES coil 75 > 35

New prices:
- SMES circuitry: 20 points
- standard coil: 35 points
- weak coil: 25 points
- super capacitance coil: 45 points
- super IO coil: 45 points
