### PR TITLE
Fixes #14074

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -11,7 +11,7 @@
 	var/open = 0
 	var/screwed = 1
 	var/field_type = ""
-	var/power_use = 25
+	var/power_use = 5 KILOWATTS
 	var/obj/effect/suspension_field/suspension_field
 	var/list/secured_mobs = list()
 
@@ -23,20 +23,20 @@
 	set background = 1
 
 	if (suspension_field)
-		cell.charge -= power_use
+		cell.use(power_use * CELLRATE)
 
 		var/turf/T = get_turf(suspension_field)
 		if(field_type == "carbon")
 			for(var/mob/living/carbon/M in T)
 				M.weakened = max(M.weakened, 3)
-				cell.charge -= power_use
+				cell.use(power_use * CELLRATE)
 				if(prob(5))
 					M << "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]"
 
 		if(field_type == "iron")
 			for(var/mob/living/silicon/M in T)
 				M.weakened = max(M.weakened, 3)
-				cell.charge -= power_use
+				cell.use(power_use * CELLRATE)
 				if(prob(5))
 					M << "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]"
 
@@ -48,7 +48,7 @@
 
 		for(var/mob/living/simple_animal/M in T)
 			M.weakened = max(M.weakened, 3)
-			cell.charge -= power_use
+			cell.use(power_use * CELLRATE)
 			if(prob(5))
 				M << "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]"
 

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -35,7 +35,7 @@
 
 /obj/vehicle/bike/verb/toggle()
 	set name = "Toggle Engine"
-	set category = "Vehicle"
+	set category = "Object"
 	set src in view(0)
 
 	if(usr.incapacitated()) return
@@ -50,7 +50,7 @@
 
 /obj/vehicle/bike/verb/kickstand()
 	set name = "Toggle Kickstand"
-	set category = "Vehicle"
+	set category = "Object"
 	set src in view(0)
 
 	if(usr.incapacitated()) return

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -12,6 +12,7 @@
 	buckle_pixel_shift = "x=0;y=7"
 
 	var/car_limit = 3		//how many cars an engine can pull before performance degrades
+	charge_use = 1 KILOWATTS
 	active_engines = 1
 	var/obj/item/weapon/key/cargo_train/key
 
@@ -47,7 +48,7 @@
 	turn_off()	//so engine verbs are correctly set
 
 /obj/vehicle/train/cargo/engine/Move(var/turf/destination)
-	if(on && cell.charge < charge_use)
+	if(on && cell.charge < (charge_use * CELLRATE))
 		turn_off()
 		update_stats()
 		if(load && is_train_head())
@@ -198,7 +199,7 @@
 
 /obj/vehicle/train/cargo/engine/verb/start_engine()
 	set name = "Start engine"
-	set category = "Vehicle"
+	set category = "Object"
 	set src in view(0)
 
 	if(!istype(usr, /mob/living/carbon/human))
@@ -219,7 +220,7 @@
 
 /obj/vehicle/train/cargo/engine/verb/stop_engine()
 	set name = "Stop engine"
-	set category = "Vehicle"
+	set category = "Object"
 	set src in view(0)
 
 	if(!istype(usr, /mob/living/carbon/human))
@@ -235,7 +236,7 @@
 
 /obj/vehicle/train/cargo/engine/verb/remove_key()
 	set name = "Remove key"
-	set category = "Vehicle"
+	set category = "Object"
 	set src in view(0)
 
 	if(!istype(usr, /mob/living/carbon/human))

--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -29,6 +29,7 @@
 	desc = "A battery-powered engine used to power a small vehicle."
 	icon_state = "engine_electric"
 	trail_type = /datum/effect/effect/system/trail/ion
+	cost_per_move = 200	// W
 	var/obj/item/weapon/cell/cell
 
 /obj/item/weapon/engine/electric/attackby(var/obj/item/I, var/mob/user)
@@ -54,7 +55,7 @@
 /obj/item/weapon/engine/electric/use_power()
 	if(!cell)
 		return 0
-	return cell.use(cost_per_move)
+	return cell.use(cost_per_move * CELLRATE)
 
 /obj/item/weapon/engine/electric/rev_engine(var/atom/movable/M)
 	M.audible_message("\The [M] beeps, spinning up.")

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -118,7 +118,7 @@
 /obj/vehicle/train/verb/unlatch_v()
 	set name = "Unlatch"
 	set desc = "Unhitches this train from the one in front of it."
-	set category = "Vehicle"
+	set category = "Object"
 	set src in view(1)
 
 	if(!istype(usr, /mob/living/carbon/human))

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -31,7 +31,7 @@
 	var/move_delay = 1	//set this to limit the speed of the vehicle
 
 	var/obj/item/weapon/cell/cell
-	var/charge_use = 5	//set this to adjust the amount of power the vehicle uses per move
+	var/charge_use = 200 //W
 
 	var/atom/movable/load		//all vehicles can take a load, since they should all be a least drivable
 	var/load_item_visible = 1	//set if the loaded item should be overlayed on the vehicle sprite
@@ -61,7 +61,7 @@
 		anchored = init_anc
 
 		if(on && powered)
-			cell.use(charge_use)
+			cell.use(charge_use * CELLRATE)
 
 		//Dummy loads do not have to be moved as they are just an overlay
 		//See load_object() proc in cargo_trains.dm for an example


### PR DESCRIPTION
- Vehicle subtypes should now work with CELLRATE instead of by deducting charge units directly. Cargo tug uses 1kJ per tile. With default cell this is enough to run to departures and back (from cargo) about eight to ten times.
- Verbs that used the Vehicle tab were moved to the Object tab. The reason for this is that BYOND client tends to freeze for five seconds while the UI redraws every time the tab appears or disappears. As it only appears if you are adjacent to a piece of the cargo train or other vehicle and disappears when you are further than one tile, this tends to happen quite often when you are moving near one.
- Fixes #14074
