### PR TITLE
Fixes power alarm in Abandoned Ship

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -39,9 +39,6 @@
 		icon_state = initial(icon_state)
 		handleInactive()
 
-/obj/machinery/power/powered()
-	return 1 //doesn't require an external power source
-
 /obj/machinery/power/port_gen/attack_hand(mob/user as mob)
 	if(..())
 		return

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -25,6 +25,12 @@
 // General procedures
 //////////////////////////////
 
+
+/obj/machinery/power/powered()
+	if(use_power)
+		return ..()
+	return 1 //doesn't require an external power source
+
 // common helper procs for all power machines
 /obj/machinery/power/drain_power(var/drain_check, var/surge, var/amount = 0)
 	if(drain_check)
@@ -60,7 +66,7 @@
 /obj/machinery/power/proc/disconnect_terminal() // machines without a terminal will just return, no harm no fowl.
 	return
 
-// returns true if the area has power on given channel (or doesn't require power), defaults to power_channel. 
+// returns true if the area has power on given channel (or doesn't require power), defaults to power_channel.
 // May also optionally specify an area, otherwise defaults to src.loc.loc
 /obj/machinery/proc/powered(var/chan = -1, var/area/check_area = null)
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -525,14 +525,11 @@ var/list/solars_list = list()
 /obj/machinery/power/solar_control/autostart
 	track = 2 // Auto tracking mode
 
-/obj/machinery/power/solar_control/autostart/New()
-	..()
-	spawn(150) // Wait 15 seconds to ensure everything was set up properly (such as, powernets, solar panels, etc.
-		src.search_for_connected()
-		if(connected_tracker && track == 2)
-			connected_tracker.set_angle(sun.angle)
-		src.set_panels(cdir)
-
+/obj/machinery/power/solar_control/autostart/initialize()
+	search_for_connected()
+	if(connected_tracker && track == 2)
+		connected_tracker.set_angle(sun.angle)
+		set_panels(cdir)
 //
 // MISC
 //


### PR DESCRIPTION
- Solar control consoles now respects status of APC's power channels. If the APC is turned off, the console will shut down.
- Also a minor change in subtype that automatically starts (used on telecomms for example). It now uses initialize() instead of a spawn(150) in New(). A bit cleaner implementation.
