### PR TITLE
Buffs fire extinguisher and watertank capacities

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -16,7 +16,7 @@
 
 	var/spray_particles = 3
 	var/spray_amount = 120	//units of liquid per spray - 120 -> same as splashing them with a bucket per spray
-	var/max_water = 500
+	var/max_water = 2000
 	var/last_use = 1.0
 	var/safety = 1
 	var/sprite_name = "fire_extinguisher"
@@ -31,7 +31,7 @@
 	w_class = 2.0
 	force = 3.0
 	spray_amount = 80
-	max_water = 200
+	max_water = 1000
 	sprite_name = "miniFE"
 
 /obj/item/weapon/extinguisher/New()
@@ -74,7 +74,7 @@
 
 	if( istype(target, /obj/structure/reagent_dispensers/watertank) && flag)
 		var/obj/o = target
-		var/amount = o.reagents.trans_to_obj(src, 50)
+		var/amount = o.reagents.trans_to_obj(src, 500)
 		user << "<span class='notice'>You fill [src] with [amount] units of the contents of [target].</span>"
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		return

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -8,6 +8,7 @@
 	density = 1
 	anchored = 0
 
+	var/initial_capacity = 1000
 	var/amount_per_transfer_from_this = 10
 	var/possible_transfer_amounts = "10;25;50;100"
 
@@ -15,7 +16,7 @@
 		return
 
 	New()
-		var/datum/reagents/R = new/datum/reagents(1000)
+		var/datum/reagents/R = new/datum/reagents(initial_capacity)
 		reagents = R
 		R.my_atom = src
 		if (!possible_transfer_amounts)
@@ -71,9 +72,12 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
 	amount_per_transfer_from_this = 10
-	New()
-		..()
-		reagents.add_reagent("water",1000)
+	possible_transfer_amounts = "10;25;50;100"
+	initial_capacity = 50000
+
+/obj/structure/reagent_dispensers/watertank/New()
+	..()
+	reagents.add_reagent("water", initial_capacity)
 
 /obj/structure/reagent_dispensers/fueltank
 	name = "fueltank"
@@ -85,7 +89,7 @@
 	var/obj/item/device/assembly_holder/rig = null
 	New()
 		..()
-		reagents.add_reagent("fuel",1000)
+		reagents.add_reagent("fuel", initial_capacity)
 
 /obj/structure/reagent_dispensers/fueltank/examine(mob/user)
 	if(!..(user, 2))
@@ -190,7 +194,7 @@
 	amount_per_transfer_from_this = 45
 	New()
 		..()
-		reagents.add_reagent("condensedcapsaicin",1000)
+		reagents.add_reagent("condensedcapsaicin", initial_capacity)
 
 
 /obj/structure/reagent_dispensers/water_cooler
@@ -201,9 +205,10 @@
 	icon_state = "water_cooler"
 	possible_transfer_amounts = null
 	anchored = 1
+	initial_capacity = 500
 	New()
 		..()
-		reagents.add_reagent("water",500)
+		reagents.add_reagent("water", initial_capacity)
 
 /obj/structure/reagent_dispensers/water_cooler/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W,/obj/item/weapon/wrench))
@@ -229,7 +234,7 @@
 	amount_per_transfer_from_this = 10
 	New()
 		..()
-		reagents.add_reagent("beer",1000)
+		reagents.add_reagent("beer", initial_capacity)
 
 /obj/structure/reagent_dispensers/virusfood
 	name = "Virus Food Dispenser"
@@ -241,7 +246,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("virusfood", 1000)
+		reagents.add_reagent("virusfood", initial_capacity)
 
 /obj/structure/reagent_dispensers/acid
 	name = "Sulphuric Acid Dispenser"
@@ -253,4 +258,4 @@
 
 	New()
 		..()
-		reagents.add_reagent("sacid", 1000)
+		reagents.add_reagent("sacid", initial_capacity)

--- a/html/changelogs/atlantiscze-waterbuff.yml
+++ b/html/changelogs/atlantiscze-waterbuff.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Vastly increases amount of water held in fire extinguishers and water tanks."


### PR DESCRIPTION
- Water tanks now have 50 000u of water in them. Fire extinguishers have 2000u. This is roughly fifteen sprays. The amount of water per spray has not changed.
- These values use a rough assumption that 1u = 1ml. Therefore the watertanks are 50l barrels, and fire extinguishers are 2l containers.
- Fixes #14096
