### PR TITLE
Organ fixes and tweaks

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -51,6 +51,14 @@
 		if(part)
 			part.implants.Remove(src)
 		return ..()
+	
+/**
+ *  Let the implant know it's no longer implanted
+ */ 
+/obj/item/weapon/implant/proc/removed()
+	imp_in = null
+	implanted = 0
+	
 
 /obj/item/weapon/implant/tracking
 	name = "tracking implant"
@@ -464,6 +472,10 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		mobname = source.real_name
 		processing_objects.Add(src)
 		return 1
+		
+/obj/item/weapon/implant/death_alarm/removed()
+	..()
+	processing_objects.Remove(src)
 
 /obj/item/weapon/implant/compressed
 	name = "compressed matter implant"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -286,7 +286,14 @@ var/list/organ_cache = list()
 /obj/item/organ/external/cut_away(var/mob/living/user)
 	removed(user)
 
-/obj/item/organ/proc/removed(var/mob/living/user, var/drop_organ=1)
+/**
+ *  Remove an organ
+ * 
+ *  drop_organ - if true, organ will be dropped at the loc of its former owner
+ *  detach - if true, organ will be detached from parent. Keep false for organs 
+ *           removed together with parent, as with an amputation.
+ */
+/obj/item/organ/proc/removed(var/mob/living/user, var/drop_organ=1, var/detach=1)
 
 	if(!istype(owner))
 		return
@@ -296,10 +303,11 @@ var/list/organ_cache = list()
 	owner.internal_organs_by_name -= null
 	owner.internal_organs -= src
 
-	var/obj/item/organ/external/affected = owner.get_organ(parent_organ)
-	if(affected) 
-		affected.internal_organs -= src
-		status |= ORGAN_CUT_AWAY
+	if(detach)
+		var/obj/item/organ/external/affected = owner.get_organ(parent_organ)
+		if(affected) 
+			affected.internal_organs -= src
+			status |= ORGAN_CUT_AWAY
 
 	if(drop_organ)
 		dropInto(owner.loc)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1173,6 +1173,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/obj/item/I = implant
 		if(istype(I) && I.w_class < NORMAL_ITEM)
 			implant.forceMove(src)
+			
+			// let actual implants still inside know they're no longer implanted
+			if(istype(I, /obj/item/weapon/implant))
+				var/obj/item/weapon/implant/imp_device = I
+				imp_device.removed()
 		else
 			implants.Remove(implant)
 			implant.forceMove(get_turf(src))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -254,6 +254,13 @@
 		for(var/obj/implant in implants)
 			implant.forceMove(owner)
 			
+			if(istype(implant, /obj/item/weapon/implant))
+				var/obj/item/weapon/implant/imp_device = implant
+				
+				// we can't use implanted() here since it's often interactive
+				imp_device.imp_in = owner
+				imp_device.implanted = 1
+			
 		for(var/obj/item/organ/external/organ in children)
 			organ.replaced(owner)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -141,22 +141,31 @@
 	return
 
 /obj/item/organ/external/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	switch(stage)
+	switch(open)
 		if(0)
 			if(istype(W,/obj/item/weapon/scalpel))
 				user.visible_message("<span class='danger'><b>[user]</b> cuts [src] open with [W]!</span>")
-				stage++
+				open++
 				return
 		if(1)
 			if(istype(W,/obj/item/weapon/retractor))
 				user.visible_message("<span class='danger'><b>[user]</b> cracks [src] open like an egg with [W]!</span>")
-				stage++
+				open++
 				return
 		if(2)
 			if(istype(W,/obj/item/weapon/hemostat))
-				if(contents.len)
-					var/obj/item/removing = pick(contents)
-					removing.loc = get_turf(user.loc)
+				var/list/organs = get_contents_recursive()
+				if(organs.len)
+					var/obj/item/removing = pick(organs)
+					var/obj/item/organ/external/current_child = removing.loc
+					
+					current_child.implants.Remove(removing)
+					current_child.internal_organs.Remove(removing)
+					
+					status |= ORGAN_CUT_AWAY
+
+					removing.forceMove(get_turf(user))
+					
 					if(!(user.l_hand && user.r_hand))
 						user.put_in_hands(removing)
 					user.visible_message("<span class='danger'><b>[user]</b> extracts [removing] from [src] with [W]!</span>")
@@ -164,6 +173,21 @@
 					user.visible_message("<span class='danger'><b>[user]</b> fishes around fruitlessly in [src] with [W].</span>")
 				return
 	..()
+	
+	
+/**
+ *  Get a list of contents of this organ and all the child organs
+ */
+/obj/item/organ/external/proc/get_contents_recursive()
+	var/list/all_items = list()
+	
+	all_items.Add(implants)
+	all_items.Add(internal_organs)
+	
+	for(var/obj/item/organ/external/child in children)
+		all_items.Add(child.get_contents_recursive())
+	
+	return all_items
 
 /obj/item/organ/external/proc/is_dislocated()
 	if(dislocated > 0)
@@ -219,13 +243,21 @@
 /obj/item/organ/external/replaced(var/mob/living/carbon/human/target)
 	owner = target
 	forceMove(owner)
+	
 	if(istype(owner))
 		owner.organs_by_name[organ_tag] = src
-		owner.organs |= src
-		for(var/obj/item/organ/organ in src)
-			organ.replaced(owner,src)
+		owner.organs |= src	
+		
+		for(var/obj/item/organ/organ in internal_organs)
+			organ.replaced(owner, src)
+				
+		for(var/obj/implant in implants)
+			implant.forceMove(owner)
+			
+		for(var/obj/item/organ/external/organ in children)
+			organ.replaced(owner)
 
-	if(parent_organ)
+	if(!parent && parent_organ)
 		parent = owner.organs_by_name[src.parent_organ]
 		if(parent)
 			if(!parent.children)
@@ -1140,24 +1172,26 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//large items and non-item objs fall to the floor, everything else stays
 		var/obj/item/I = implant
 		if(istype(I) && I.w_class < NORMAL_ITEM)
-			implant.loc = get_turf(victim.loc)
+			implant.forceMove(src)
 		else
-			implant.loc = src
-	implants.Cut()
+			implants.Remove(implant)
+			implant.forceMove(get_turf(src))
 
 	// Attached organs also fly off.
 	if(!ignore_children)
 		for(var/obj/item/organ/external/O in children)
 			O.removed()
 			if(O)
-				O.loc = src
-				for(var/obj/item/I in O.contents)
-					I.loc = src
+				O.forceMove(src)
+				
+				// if we didn't lose the organ we still want it as a child
+				children += O
+				O.parent = src
 
 	// Grab all the internal giblets too.
 	for(var/obj/item/organ/organ in internal_organs)
-		organ.removed()
-		organ.loc = src
+		organ.removed(user, 0, 0)  // Organ stays inside and connected
+		organ.forceMove(src)
 
 	// Remove parent references
 	parent.children -= src

--- a/code/modules/organs/organ_stump.dm
+++ b/code/modules/organs/organ_stump.dm
@@ -10,7 +10,6 @@
 		amputation_point = limb.amputation_point
 		joint = limb.joint
 		parent_organ = limb.parent_organ
-		wounds = limb.wounds
 	..(holder, internal)
 	if(istype(limb))
 		max_damage = limb.max_damage

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -216,8 +216,7 @@
 				obj.update_icon()
 				if(istype(obj,/obj/item/weapon/implant))
 					var/obj/item/weapon/implant/imp = obj
-					imp.imp_in = null
-					imp.implanted = 0
+					imp.removed()
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 		else
 			user.visible_message("<span class='notice'>[user] removes \the [tool] from [target]'s [affected.name].</span>", \

--- a/html/changelogs/daranz - organizing-organs.yml
+++ b/html/changelogs/daranz - organizing-organs.yml
@@ -1,0 +1,4 @@
+author: Daranz
+delete-after: True
+changes: 
+  - tweak: "If you crack open an amputated limb and later reattach it, you will now have to cauterize it after reattachment."


### PR DESCRIPTION
## Limb removal and reattachment
- External organs now retain their `implants` and `internal_organs`. This makes it easier to add them back to the mob after the limb is reattached, which is what happens now. This resolves #14008.
- Cracking amputated limbs open now sets `open` instead of `stage`. This means that if you crack an amputated external organ open to go fishing in it, and then reattach it, you'll have to cauterize the incision. This isn't fine grained (it doesn't keep track of ribcage sawing), but it makes more sense than `stage`.
## Implants
- Implants now remain in amputated limbs. Previously, while small items were supposed to stay in amputated limbs, it was the the small items that _didn't_. 
- Implants now register being removed when the limb they're in is cut off. Previously, death alarms worked even if you were beating the victim to death with his own leg with the death alarm in it. 
- Caveat: Implants in limbs do not consider themselves re-implanted when the limb is reattached. Handling this would require more extensive modification to the implant system, as implants handle both internal setup and interactive setup in the same proc. I left it be for now. 
## Stumps
- Stumps no longer share the wound list with the amputated limb. I suppose this was either an accidental copy-by-reference where copy-by-value was more appropriate, or someone actually wanted the wounds to be fixable on either the stump or the limb. Problem is, stumps are amputated before reattachment, and your newly reattached limb ended up with the stump's `lost_limb` wound. 
