### PR TITLE
Minor malf additions

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -113,7 +113,7 @@
 	if(user.research.stored_cpu < check_price)
 		user << "You do not have enough CPU power stored. Please wait a moment."
 		return 0
-	if(user.hacking && !override)
+	if(user.hacking && !user.system_override && !override)
 		user << "Your system is busy processing another task. Please wait until completion."
 		return 0
 	if(user.APU_power && !override)
@@ -169,6 +169,8 @@
 /proc/get_unhacked_apcs(var/mob/living/silicon/ai/user)
 	var/list/H = list()
 	for(var/obj/machinery/power/apc/A in machines)
+		if(!(A.z in using_map.station_levels))
+			continue
 		if(A.hacker && A.hacker == user)
 			continue
 		H.Add(A)

--- a/html/changelogs/Kelenius-MalfQoL.yml
+++ b/html/changelogs/Kelenius-MalfQoL.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Malfunctioning AI's hackable APC list now only includes station APCs."
+  - tweak: "Malfunctioning AI can now use its abilities while doing the system override."


### PR DESCRIPTION
Malfunctioning AI's hackable APC list now only includes station APCs.
Malfunctioning AI can now use its abilities while doing the system override.
