### PR TITLE
Id and access tweaks.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -10,16 +10,13 @@
 		return 1
 	if(!istype(M))
 		return 0
+	return check_access_list(M.GetAccess())
 
-	var/id = M.GetIdCard()
-	if(id)
-		return check_access(id)
-	return 0
+/atom/movable/proc/GetAccess()
+	var/obj/item/weapon/card/id/id = GetIdCard()
+	return id ? id.GetAccess() : list()
 
-/obj/item/proc/GetAccess()
-	return list()
-
-/obj/proc/GetID()
+/atom/movable/proc/GetIdCard()
 	return null
 
 /obj/proc/check_access(obj/item/I)
@@ -28,7 +25,6 @@
 /obj/proc/check_access_list(var/list/L)
 	if(!req_access)		req_access = list()
 	if(!req_one_access)	req_one_access = list()
-	if(!L)	return 0
 	if(!istype(L, /list))	return 0
 	return has_access(req_access, req_one_access, L)
 
@@ -193,11 +189,9 @@
 		"Emergency Response Team",
 		"Emergency Response Team Leader")
 
-/mob/proc/GetIdCard()
-	return null
-
 /mob/observer/ghost
 	var/static/obj/item/weapon/card/id/all_access/ghost_all_access
+
 /mob/observer/ghost/GetIdCard()
 	if(!is_admin(src))
 		return
@@ -209,29 +203,37 @@
 /mob/living/bot/GetIdCard()
 	return botcard
 
+#define HUMAN_ID_CARDS list(get_active_hand(), wear_id, get_inactive_hand())
 /mob/living/carbon/human/GetIdCard()
-	var/obj/item/I = get_active_hand()
-	if(I)
-		var/id = I.GetID()
+	for(var/item_slot in HUMAN_ID_CARDS)
+		var/obj/item/I = item_slot
+		var/obj/item/weapon/card/id = I ? I.GetIdCard() : null
 		if(id)
 			return id
-	if(wear_id)
-		return wear_id.GetID()
+
+/mob/living/carbon/human/GetAccess()
+	. = list()
+	for(var/item_slot in HUMAN_ID_CARDS)
+		var/obj/item/I = item_slot
+		var/obj/item/weapon/card/id = I ? I.GetIdCard() : null
+		if(id)
+			. |= id.GetAccess()
+#undef HUMAN_ID_CARDS
 
 /mob/living/silicon/GetIdCard()
 	return idcard
 
-proc/FindNameFromID(var/mob/M, var/missing_id_name = "Unknown")
+/proc/FindNameFromID(var/mob/M, var/missing_id_name = "Unknown")
 	var/obj/item/weapon/card/id/C = M.GetIdCard()
 	if(C)
 		return C.registered_name
 	return missing_id_name
 
-proc/get_all_job_icons() //For all existing HUD icons
+/proc/get_all_job_icons() //For all existing HUD icons
 	return joblist + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation
-	var/obj/item/weapon/card/id/I = GetID()
+	var/obj/item/weapon/card/id/I = GetIdCard()
 
 	if(I)
 		var/job_icons = get_all_job_icons()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -219,8 +219,10 @@
 			return
 		if(default_part_replacement(user, W))
 			return
-	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if(!check_access(W))
+			
+	var/id = W.GetIdCard()
+	if(id)
+		if(!check_access(id))
 			user << "<span class='warning'>Access Denied.</span>"
 			return
 		if((!locked) || (isnull(occupant)))

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -81,16 +81,14 @@
 				last_configurator = usr.name
 				return TRUE
 			else
-				var/obj/item/I = usr.get_active_hand()
-				if (istype(I, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = I
-					I = pda.id
+				var/obj/item/weapon/card/id/I = usr.get_active_hand()
+				I = I ? I.GetIdCard() : null
 				if(!istype(I, /obj/item/weapon/card/id))
 					usr << "<span class='warning'>[\src] flashes a yellow LED near the ID scanner. Did you remember to scan your ID or PDA?</span>"
 					return TRUE
-				if (I && src.check_access(I))
+				if (check_access(I))
 					locked = 0
-					last_configurator = I:registered_name
+					last_configurator = I.registered_name
 				else
 					usr << "<span class='warning'>[\src] flashes a red LED near the ID scanner, indicating your access has been denied.</span>"
 					return TRUE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -148,7 +148,7 @@
 
 /obj/machinery/vending/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
-	var/obj/item/weapon/card/id/I = W.GetID()
+	var/obj/item/weapon/card/id/I = W.GetIdCard()
 
 	if (currently_vending && vendor_account && !vendor_account.suspended)
 		var/paid = 0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -344,7 +344,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		return ..()
 
-/obj/item/device/pda/GetID()
+/obj/item/device/pda/GetIdCard()
 	return id
 
 /obj/item/device/pda/MouseDrop(obj/over_object as obj, src_location, over_location)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -200,7 +200,7 @@ var/const/NO_EMAG_ACT = -50
 /obj/item/weapon/card/id/GetAccess()
 	return access
 
-/obj/item/weapon/card/id/GetID()
+/obj/item/weapon/card/id/GetIdCard()
 	return src
 
 /obj/item/weapon/card/id/verb/read()

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -75,11 +75,11 @@
 		tiny_image.appearance_flags = RESET_COLOR
 		overlays += tiny_image
 
-/obj/item/weapon/storage/wallet/GetID()
+/obj/item/weapon/storage/wallet/GetIdCard()
 	return front_id
 
 /obj/item/weapon/storage/wallet/GetAccess()
-	var/obj/item/I = GetID()
+	var/obj/item/I = GetIdCard()
 	if(I)
 		return I.GetAccess()
 	else

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -33,7 +33,7 @@
 	if(cult)
 		return ..()
 
-	var/obj/item/weapon/card/id/card = I.GetID()
+	var/obj/item/weapon/card/id/card = I.GetIdCard()
 	if(istype(card))
 		if(access_bar in card.GetAccess())
 			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states(0)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -66,8 +66,8 @@
 			src.MouseDrop_T(W:affecting, user)      //act like they were dragged onto the closet
 		user.drop_item()
 		if (W) W.forceMove(src.loc)
-	else if(W.GetID())
-		var/obj/item/weapon/card/id/I = W.GetID()
+	else if(W.GetIdCard())
+		var/obj/item/weapon/card/id/I = W.GetIdCard()
 
 		if(src.broken)
 			user << "<span class='warning'>It appears to be broken.</span>"

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -11,7 +11,7 @@
 		return chest.attackby(W,user)
 
 	// Lock or unlock the access panel.
-	if(W.GetID())
+	if(W.GetIdCard())
 		if(subverted)
 			locked = 0
 			user << "<span class='danger'>It looks like the locking system has been shorted out.</span>"

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -112,7 +112,7 @@
 
 /obj/item/device/eftpos/attackby(obj/item/O as obj, user as mob)
 
-	var/obj/item/weapon/card/id/I = O.GetID()
+	var/obj/item/weapon/card/id/I = O.GetIdCard()
 
 	if(I)
 		if(linked_account)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -62,7 +62,7 @@ var/list/holder_mob_icon_cache = list()
 		return loc.loc
 	return ..()
 
-/obj/item/weapon/holder/GetID()
+/obj/item/weapon/holder/GetIdCard()
 	for(var/mob/M in contents)
 		var/obj/item/I = M.GetIdCard()
 		if(I)
@@ -70,7 +70,7 @@ var/list/holder_mob_icon_cache = list()
 	return null
 
 /obj/item/weapon/holder/GetAccess()
-	var/obj/item/I = GetID()
+	var/obj/item/I = GetIdCard()
 	return I ? I.GetAccess() : ..()
 
 /obj/item/weapon/holder/attack_self()

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -53,7 +53,7 @@
 	explode()
 
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
-	if(O.GetID())
+	if(O.GetIdCard())
 		if(access_scanner.allowed(user) && !open && !emagged)
 			locked = !locked
 			user << "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -292,7 +292,7 @@
 		var/criminal = "None"
 
 		if(wear_id)
-			var/obj/item/weapon/card/id/I = wear_id.GetID()
+			var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
 			if(I)
 				perpname = I.registered_name
 			else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -317,7 +317,7 @@
 		var/obj/item/device/pda/P = wear_id
 		return P.owner
 	if(wear_id)
-		var/obj/item/weapon/card/id/I = wear_id.GetID()
+		var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
 		if(I)
 			return I.registered_name
 	return
@@ -325,7 +325,7 @@
 //gets ID card object from special clothes slot or null.
 /mob/living/carbon/human/proc/get_idcard()
 	if(wear_id)
-		return wear_id.GetID()
+		return wear_id.GetIdCard()
 
 //Removed the horrible safety parameter. It was only being used by ninja code anyways.
 //Now checks siemens_coefficient of the affected area by default
@@ -361,7 +361,7 @@
 			var/modified = 0
 			var/perpname = "wot"
 			if(wear_id)
-				var/obj/item/weapon/card/id/I = wear_id.GetID()
+				var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
 				if(I)
 					perpname = I.registered_name
 				else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1059,7 +1059,7 @@
 	if (BITTEST(hud_updateflag, ID_HUD))
 		var/image/holder = hud_list[ID_HUD]
 		if(wear_id)
-			var/obj/item/weapon/card/id/I = wear_id.GetID()
+			var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
 			if(I)
 				holder.icon_state = "hud[ckey(I.GetJobName())]"
 			else
@@ -1075,7 +1075,7 @@
 		holder.icon_state = "hudblank"
 		var/perpname = name
 		if(wear_id)
-			var/obj/item/weapon/card/id/I = wear_id.GetID()
+			var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
 			if(I)
 				perpname = I.registered_name
 

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -242,7 +242,7 @@
 
 
 obj/machinery/lapvend/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	var/obj/item/weapon/card/id/I = W.GetID()
+	var/obj/item/weapon/card/id/I = W.GetIdCard()
 	// Awaiting payment state
 	if(state == 2)
 		if(process_payment(I,W))

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -134,7 +134,7 @@
 	var/auth_name
 	var/dna_hash
 
-	var/obj/item/weapon/card/id/ID = ident.GetID()
+	var/obj/item/weapon/card/id/ID = ident.GetIdCard()
 
 	if(!ID)
 		return

--- a/html/changelogs/PsiOmegaDelta-access.yml
+++ b/html/changelogs/PsiOmegaDelta-access.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - rscadd: "Equipment that doesn't check a specific id card for access now checks the collective access of all id cards in both hands and the id slot. Among other things such equipment includes doors."


### PR DESCRIPTION
Combines GetID/GetIdCard and moves the proc up to atom/movable.
Moves GetAccess() up to atom/movable.

GetIdCard returns the most specific id card. For humans the order is active hand, id slot, inactive hand.
GetAccess returns all relevant accesses. For humans this is the collective access of all the slots above.

Less juggling is now needed when general access is checked, which includes doors and turrets for example. However, security records are still checked against the most specific id card, thus some care will still be needed around security units.
