### PR TITLE
Fixes the event manager keeping references it should not.

### DIFF
--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -22,6 +22,11 @@ var/list/event_listen_count = list()
 		event_sources_count[event_source] -= 1
 		event_listen_count[listener] -= 1
 
+		if(event_sources_count[event_source] <= 0)
+			event_sources_count -= event_source
+		if(event_listen_count[listener] <= 0)
+			event_listen_count -= listener
+
 /decl/observ/register_global(var/datum/listener, var/proc_call)
 	. = ..()
 	if(.)
@@ -31,6 +36,8 @@ var/list/event_listen_count = list()
 	. = ..()
 	if(.)
 		global_listen_count[listener] -= 1
+		if(global_listen_count[listener] <= 0)
+			global_listen_count -= listener
 
 /proc/cleanup_global_listener(listener, listen_count)
 	global_listen_count -= listener

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -6,6 +6,10 @@
 	async = 0
 	var/list/received_moves
 
+	var/list/stored_global_listen_count
+	var/list/stored_event_sources_count
+	var/list/stored_event_listen_count
+
 /datum/unit_test/observation/start_test()
 	if(!received_moves)
 		received_moves = list()
@@ -13,6 +17,10 @@
 
 	for(var/global_listener in moved_event.global_listeners)
 		moved_event.unregister_global(global_listener)
+
+	stored_global_listen_count = global_listen_count.Copy()
+	stored_event_sources_count = event_sources_count.Copy()
+	stored_event_listen_count = event_listen_count.Copy()
 
 	sanity_check_events("Pre-Test")
 	. = conduct_test()
@@ -42,6 +50,13 @@
 								for(var/proc_call in proc_calls)
 									if(isnull(proc_call))
 										fail("[phase]: [event] - [listener]- The proc call list contains a null entry.")
+
+	for(var/entry in (global_listen_count - stored_global_listen_count))
+		fail("[phase]: global_listen_count - Contained [entry].")
+	for(var/entry in (event_sources_count - stored_event_sources_count))
+		fail("[phase]: event_sources_count - Contained [entry].")
+	for(var/entry in (event_listen_count - stored_event_listen_count))
+		fail("[phase]: event_listen_count - Contained [entry].")
 
 /datum/unit_test/observation/proc/conduct_test()
 	return 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Objects involved in events should GC much better again.
