### PR TITLE
[READY] Giant Spider balance adjustments and fixes (updated)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -27,7 +27,7 @@
 	melee_damage_upper = 20
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
-	var/poison_per_bite = 4
+	var/poison_per_bite = 3
 	var/poison_extra_chance = 5
 	var/poison_type = "venom"
 	faction = "spiders"
@@ -46,7 +46,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 4
+	poison_per_bite = 3
 	poison_extra_chance = 10
 	var/atom/cocoon_target
 	poison_type = "stoxin"
@@ -62,7 +62,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 8
+	poison_per_bite = 6
 	poison_extra_chance = 0
 	move_to_delay = 4
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -27,7 +27,7 @@
 	melee_damage_upper = 20
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
-	var/poison_per_bite = 5
+	var/poison_per_bite = 4
 	var/poison_extra_chance = 5
 	var/poison_type = "toxin"
 	faction = "spiders"
@@ -46,7 +46,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 10
+	poison_per_bite = 8
 	poison_extra_chance = 10
 	var/atom/cocoon_target
 	poison_type = "stoxin"
@@ -62,7 +62,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 15
+	poison_per_bite = 12
 	poison_extra_chance = 0
 	move_to_delay = 4
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -27,8 +27,9 @@
 	melee_damage_upper = 20
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
-	var/poison_per_bite = 5
-	var/poison_type = "toxin"
+	var/poison_per_bite = 4
+	var/poison_extra_chance = 5
+	var/poison_type = "venom"
 	faction = "spiders"
 	var/busy = 0
 	pass_flags = PASSTABLE
@@ -45,7 +46,8 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 10
+	poison_per_bite = 4
+	poison_extra_chance = 10
 	var/atom/cocoon_target
 	poison_type = "stoxin"
 	var/fed = 0
@@ -60,7 +62,8 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 5
+	poison_per_bite = 8
+	poison_extra_chance = 0
 	move_to_delay = 4
 
 /mob/living/simple_animal/hostile/giant_spider/New(var/location, var/atom/parent)
@@ -68,20 +71,20 @@
 	..()
 
 /mob/living/simple_animal/hostile/giant_spider/AttackingTarget()
-	var/target = ..()
-	if(isliving(target))
-		var/mob/living/L = target
+	. = ..()
+	if(isliving(.))
+		var/mob/living/L = .
 		if(L.reagents)
-			L.reagents.add_reagent("toxin", poison_per_bite)
-			if(prob(poison_per_bite))
-				L << "\red You feel a tiny prick."
+			L.reagents.add_reagent("venom", poison_per_bite)
+			if(prob(poison_extra_chance))
+				L << "<span class='warning'>You feel a tiny prick.</span>"
 				L.reagents.add_reagent(poison_type, 5)
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/AttackingTarget()
-	var/target = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(prob(poison_per_bite))
+	. = ..()
+	if(ishuman(.))
+		var/mob/living/carbon/human/H = .
+		if(prob(poison_extra_chance))
 			var/obj/item/organ/external/O = pick(H.organs)
 			if(!(O.robotic >= ORGAN_ROBOT))
 				var/eggs = PoolOrNew(/obj/effect/spider/eggcluster/, list(O, src))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -27,9 +27,9 @@
 	melee_damage_upper = 20
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
-	var/poison_per_bite = 3
+	var/poison_per_bite = 5
 	var/poison_extra_chance = 5
-	var/poison_type = "venom"
+	var/poison_type = "toxin"
 	faction = "spiders"
 	var/busy = 0
 	pass_flags = PASSTABLE
@@ -46,7 +46,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 3
+	poison_per_bite = 10
 	poison_extra_chance = 10
 	var/atom/cocoon_target
 	poison_type = "stoxin"
@@ -62,7 +62,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 6
+	poison_per_bite = 15
 	poison_extra_chance = 0
 	move_to_delay = 4
 
@@ -75,7 +75,7 @@
 	if(isliving(.))
 		var/mob/living/L = .
 		if(L.reagents)
-			L.reagents.add_reagent("venom", poison_per_bite)
+			L.reagents.add_reagent("toxin", poison_per_bite)
 			if(prob(poison_extra_chance))
 				L << "<span class='warning'>You feel a tiny prick.</span>"
 				L.reagents.add_reagent(poison_type, 5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -24,19 +24,6 @@
 	color = "#CF3600"
 	strength = 5
 
-/datum/reagent/toxin/venom
-	name = "Venom"
-	id = "venom"
-	//If anyone has suggestions for a description, let me know.
-	reagent_state = LIQUID
-	color = "#CBCBB3"
-	strength = 8
-
-/datum/reagent/toxin/venom/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-	if(prob(5))
-		M << "<span class='danger'>You feel a searing pain in your veins!</span>"
-
 /datum/reagent/toxin/amatoxin
 	name = "Amatoxin"
 	id = "amatoxin"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -24,6 +24,19 @@
 	color = "#CF3600"
 	strength = 5
 
+/datum/reagent/toxin/venom
+	name = "Venom"
+	id = "venom"
+	//If anyone has suggestions for a description, let me know.
+	reagent_state = LIQUID
+	color = "#CBCBB3"
+	strength = 8
+
+/datum/reagent/toxin/venom/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(prob(5))
+		M << "<span class='danger'>You feel a searing pain in your veins!</span>"
+
 /datum/reagent/toxin/amatoxin
 	name = "Amatoxin"
 	id = "amatoxin"

--- a/html/changelogs/Cirra-venom.yml
+++ b/html/changelogs/Cirra-venom.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cirra
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Giant Spiders have been given new, stronger venom."
+  - tweak: "Nurse spiders now inject less venom, while hunter spiders inject more."
+  - bugfix: "Nurse spiders should now correctly have a chance to implant eggs on attack."

--- a/html/changelogs/Cirra-venom.yml
+++ b/html/changelogs/Cirra-venom.yml
@@ -33,6 +33,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Giant Spiders have been given new, stronger venom."
-  - tweak: "Nurse spiders now inject less venom, while hunter spiders inject more."
+  - tweak: "Slightly decreased how much toxin nurse and guard spiders inject, while increasing it for hunters."
   - bugfix: "Nurse spiders should now correctly have a chance to implant eggs on attack."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
- Increases the amount of toxin injected by hunters, in line with their intended purpose according to the code. Removed their chance to inject extra toxin though.
- Decreased the amount of toxin injected by guards and nurses.
- Fixed nurse spiders being unable to implant eggs into people.
- Moves the chance to inject extra stuff over into a new var.

This will be squashed upon request.
