### PR TITLE
Fixes station cinematic runtime.

### DIFF
--- a/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
+++ b/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
@@ -51,7 +51,7 @@
 /datum/universal_state/nuclear_explosion/proc/dust_mobs(var/list/affected_z_levels)
 	for(var/mob/living/L in mob_list)
 		var/turf/T = get_turf(L)
-		if(T.z in affected_z_levels)
+		if(T && (T.z in affected_z_levels))
 			//this is needed because dusting resets client screen 1.5 seconds after being called (delayed due to the dusting animation)
 			var/mob/ghost = L.ghostize(0) //So we ghostize them right beforehand instead
 			if(ghost && ghost.client)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

If a mob was in null space the loop would runtime and cease processing any additional mobs.
