### PR TITLE
Change ore datum name fields to iron and coal.

### DIFF
--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -38,7 +38,7 @@ var/global/list/ore_data = list()
 	xarch_source_mineral = "potassium"
 
 /ore/hematite
-	name = "hematite"
+	name = "iron"
 	display_name = "hematite"
 	smelts_to = "iron"
 	alloy = 1
@@ -48,7 +48,7 @@ var/global/list/ore_data = list()
 	scan_icon = "mineral_common"
 
 /ore/coal
-	name = "carbon"
+	name = "coal"
 	display_name = "raw carbon"
 	smelts_to = "plastic"
 	alloy = 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

To match icon names and /turf/simulated/mineral/random . Fixes #14165 (missing iron and coal deposits)
