### PR TITLE
Adjusts client preference status panel

### DIFF
--- a/code/modules/client/preferences_toggle.dm
+++ b/code/modules/client/preferences_toggle.dm
@@ -12,6 +12,7 @@ var/list/client_preference_stats_
 	for(var/client_pref_description in client_preference_stats_)
 		var/stat_client_preference/scp = client_preference_stats_[client_pref_description]
 		if(scp.client_preference.may_toggle(user))
+			scp.update_name(user)
 			.[client_pref_description] = scp
 
 /client/verb/toggle_preference_verb(var/client_pref_name in client_preference_stats_for_usr())
@@ -26,8 +27,6 @@ var/list/client_preference_stats_
 
 /client/Stat()
 	. = ..()
-	if(!.)
-		return
 	if(!mob || !statpanel("Preferences"))
 		return
 	var/list/preferences = client_preference_stats_for_usr(mob)
@@ -56,4 +55,6 @@ var/list/client_preference_stats_
 		return
 	usr.client.prefs.save_preferences()
 	to_chat(usr, "[client_preference.description]: [usr.is_preference_enabled(client_preference) ? client_preference.enabled_description : client_preference.disabled_description]")
-	name = "[usr.is_preference_enabled(client_preference) ? client_preference.enabled_description : client_preference.disabled_description]"
+
+/stat_client_preference/proc/update_name(var/mob/user)
+	name = "[user.is_preference_enabled(client_preference) ? client_preference.enabled_description : client_preference.disabled_description]"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -683,35 +683,36 @@
 /mob/Stat()
 	..()
 	. = (is_client_active(10 MINUTES))
+	if(!.)
+		return
 
-	if(.)
-		if(statpanel("Status") && ticker && ticker.current_state != GAME_STATE_PREGAME)
-			stat("Station Time", stationtime2text())
-			stat("Round Duration", roundduration2text())
+	if(statpanel("Status") && ticker && ticker.current_state != GAME_STATE_PREGAME)
+		stat("Station Time", stationtime2text())
+		stat("Round Duration", roundduration2text())
 
-		if(client.holder)
-			if(statpanel("Status"))
-				stat("Location:", "([x], [y], [z]) [loc]")
-				stat("CPU:","[world.cpu]")
-				stat("Instances:","[world.contents.len]")
-			if(statpanel("Processes"))
-				if(processScheduler)
-					processScheduler.statProcesses()
+	if(client.holder)
+		if(statpanel("Status"))
+			stat("Location:", "([x], [y], [z]) [loc]")
+			stat("CPU:","[world.cpu]")
+			stat("Instances:","[world.contents.len]")
+		if(statpanel("Processes"))
+			if(processScheduler)
+				processScheduler.statProcesses()
 
-		if(listed_turf && client)
-			if(!TurfAdjacent(listed_turf))
-				listed_turf = null
-			else
-				if(statpanel("Turf"))
-					stat(listed_turf)
-					for(var/atom/A in listed_turf)
-						if(!A.mouse_opacity)
-							continue
-						if(A.invisibility > see_invisible)
-							continue
-						if(is_type_in_list(A, shouldnt_see))
-							continue
-						stat(A)
+	if(listed_turf && client)
+		if(!TurfAdjacent(listed_turf))
+			listed_turf = null
+		else
+			if(statpanel("Turf"))
+				stat(listed_turf)
+				for(var/atom/A in listed_turf)
+					if(!A.mouse_opacity)
+						continue
+					if(A.invisibility > see_invisible)
+						continue
+					if(is_type_in_list(A, shouldnt_see))
+						continue
+					stat(A)
 
 
 // facing verbs


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Client preferences are now refreshed before they are displayed. Fixes #14171.
/mob/Stat() returns a value but /client/Stat() does not*. Value no longer checked.
Reduces indentation.

\* At least, ref doesn't specify anything. Going by other built-in method calls it likely always returns 1 unless it somehow fails catastrophically.
