### PR TITLE
Fixes #13387 - can't gag/blind people with tape

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -23,7 +23,7 @@
 				return
 			user.visible_message("<span class='danger'>\The [user] begins taping over \the [H]'s eyes!</span>")
 
-			if(!do_after(user, 30, process=0))
+			if(!do_mob(user, H, 30))
 				return
 
 			// Repeat failure checks.
@@ -48,7 +48,7 @@
 				return
 			user.visible_message("<span class='danger'>\The [user] begins taping up \the [H]'s mouth!</span>")
 
-			if(!do_after(user, 30, process=0))
+			if(!do_mob(user, H, 30))
 				return
 
 			// Repeat failure checks.


### PR DESCRIPTION
Blinding and muzzling people with tape now works
Fixes #13387 
