### PR TITLE
Disposal Diversion Junctions

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -181,6 +181,8 @@ Nah
 <A href='?src=\ref[src];dmake=10'>Sorting (Untagged)</A><BR>
 <A href='?src=\ref[src];dmake=11'>Tagger</A><BR>
 <A href='?src=\ref[src];dmake=12'>Tagger (Partial)</A><BR>
+<A href='?src=\ref[src];dmake=13'>Diversion</A><BR>
+<A href='?src=\ref[src];dmake=14'>Diversion Switch</A><BR>
 "}
 ///// Z-Level stuff
 
@@ -201,48 +203,53 @@ Nah
 			return
 		if(!wait)
 			var/p_type = text2num(href_list["dmake"])
-			var/obj/structure/disposalconstruct/C = new (src.loc)
-			switch(p_type)
-				if(0)
-					C.ptype = 0
-				if(1)
-					C.ptype = 1
-				if(2)
-					C.ptype = 2
-				if(3)
-					C.ptype = 4
-				if(4)
-					C.ptype = 5
-				if(5)
-					C.ptype = 6
-					C.density = 1
-				if(6)
-					C.ptype = 7
-					C.density = 1
-				if(7)
-					C.ptype = 8
-					C.density = 1
-				if(8)
-					C.ptype = 9
-					C.subtype = 0
-				if(9)
-					C.ptype = 9
-					C.subtype = 1
-				if(10)
-					C.ptype = 9
-					C.subtype = 2
-				if(11)
-					C.ptype = 13
-				if(12)
-					C.ptype = 14
+			if(p_type == 15)
+				new /obj/machinery/disposal_switch (get_turf(src))
+			else
+				var/obj/structure/disposalconstruct/C = new (src.loc)
+				switch(p_type)
+					if(0)
+						C.ptype = 0
+					if(1)
+						C.ptype = 1
+					if(2)
+						C.ptype = 2
+					if(3)
+						C.ptype = 4
+					if(4)
+						C.ptype = 5
+					if(5)
+						C.ptype = 6
+						C.density = 1
+					if(6)
+						C.ptype = 7
+						C.density = 1
+					if(7)
+						C.ptype = 8
+						C.density = 1
+					if(8)
+						C.ptype = 9
+						C.subtype = 0
+					if(9)
+						C.ptype = 9
+						C.subtype = 1
+					if(10)
+						C.ptype = 9
+						C.subtype = 2
+					if(11)
+						C.ptype = 13
+					if(12)
+						C.ptype = 14
+					if(13)
+						C.ptype = 15
 ///// Z-Level stuff
-				if(21)
-					C.ptype = 11
-				if(22)
-					C.ptype = 12
+					if(21)
+						C.ptype = 11
+					if(22)
+						C.ptype = 12
 ///// Z-Level stuff
-			C.add_fingerprint(usr)
-			C.update()
+				C.add_fingerprint(usr)
+				C.update()
 			wait = 1
 			spawn(15)
 				wait = 0

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -79,10 +79,12 @@
 			if(14)
 				base_state = "pipe-tagger-partial"
 				dpdir = dir | flip
-
+			if(15)
+				base_state = "pipe-j1s"
+				dpdir = dir | flip
 
 ///// Z-Level stuff
-		if(!(ptype in list(6, 7, 8, 11, 12, 13, 14)))
+		if(!(ptype in list(6, 7, 8, 11, 12, 13, 14, 15)))
 ///// Z-Level stuff
 			icon_state = "con[base_state]"
 		else
@@ -182,6 +184,8 @@
 				return /obj/structure/disposalpipe/tagger
 			if(14)
 				return /obj/structure/disposalpipe/tagger/partial
+			if(15)
+				return /obj/structure/disposalpipe/diversion_junction
 		return
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1190,10 +1190,17 @@
 	if(!id_tag)
 		id_tag = newid
 
-	spawn(2)
-		for(var/obj/structure/disposalpipe/diversion_junction/D in world)
-			if(D.id_tag == src.id_tag)
-				junctions += D
+/obj/machinery/disposal_switch/initialize()
+	for(var/obj/structure/disposalpipe/diversion_junction/D in world)
+		if(D.id_tag && !D.linked && D.id_tag == src.id_tag)
+			junctions += D
+			D.linked = src
+
+	..()
+
+/obj/machinery/disposal_switch/Destroy()
+	junctions.Cut()
+	return ..()
 
 /obj/machinery/disposal_switch/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/crowbar))
@@ -1201,7 +1208,8 @@
 		transfer_fingerprints_to(C)
 		user.visible_message("<span class='notice'>\The [user] deattaches \the [src]</span>")
 		qdel(src)
-	..()
+	else
+		..()
 
 /obj/machinery/disposal_switch/attack_hand(mob/user)
 	if(!allowed(user))
@@ -1229,13 +1237,7 @@
 	..(loc)
 	if(id) id_tag = id
 	else
-		var/num = 0
-		for(var/obj/item/disposal_switch_construct/S in world)
-			num++
-		for(var/obj/item/disposal_switch_construct/C in world)
-			num++
-			if(C == src) break
-		id_tag = "ds[num]"
+		id_tag = "ds[sequential_id(/obj/item/disposal_switch_construct)]"
 
 /obj/item/disposal_switch_construct/afterattack(atom/A, mob/user, proximity)
 	if(!proximity || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated() || !id_tag)
@@ -1262,11 +1264,12 @@
 	var/inactive_dir = 0
 	var/sortdir = 0
 	var/id_tag
+	var/obj/machinery/disposal_switch/linked
 
 /obj/structure/disposalpipe/diversion_junction/proc/updatedesc()
 	desc = initial(desc)
 	if(sortType)
-		desc += "\nIt's currently [active ? "" : "un"] active!"
+		desc += "\nIt's currently [active ? "" : "un"]active!"
 
 /obj/structure/disposalpipe/diversion_junction/proc/updatedir()
 	inactive_dir = dir
@@ -1279,15 +1282,21 @@
 	dpdir = sortdir | inactive_dir | active_dir
 
 /obj/structure/disposalpipe/diversion_junction/New()
-	. = ..()
+	..()
 
 	updatedir()
 	updatedesc()
 	update()
 
+/obj/structure/disposalpipe/diversion_junction/Destroy()
+	if(linked)
+		linked.junctions.Remove(src)
+	linked = null
+	return ..()
+
 /obj/structure/disposalpipe/diversion_junction/attackby(var/obj/item/I, var/mob/user)
 	if(..())
-		return
+		return 1
 
 	if(istype(I, /obj/item/disposal_switch_construct))
 		var/obj/item/disposal_switch_construct/C = I
@@ -1296,19 +1305,14 @@
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 100, 1)
 			user.visible_message("<span class='notice'>\The [user] changes \the [src]'s tag.</span>")
 
-	// next direction to move
-	// if coming in from negdir, then next is primary dir or sortdir
-	// if coming in from posdir, then flip around and go back to posdir
-	// if coming in from sortdir, go to posdir
 
 /obj/structure/disposalpipe/diversion_junction/nextdir(var/fromdir, var/sortTag)
-	if(fromdir != sortdir)	// probably came from the negdir
+	if(fromdir != sortdir)
 		if(active)
 			return sortdir
 		else
 			return inactive_dir
-	else				// came from sortdir
-							// so go with the flow to positive direction
+	else
 		return inactive_dir
 
 /obj/structure/disposalpipe/diversion_junction/transfer(var/obj/structure/disposalholder/H)
@@ -1318,13 +1322,12 @@
 	var/obj/structure/disposalpipe/P = H.findpipe(T)
 
 	if(P)
-		// find other holder in next loc, if inactive merge it with current
 		var/obj/structure/disposalholder/H2 = locate() in P
 		if(H2 && !H2.active)
 			H.merge(H2)
 
 		H.forceMove(P)
-	else			// if wasn't a pipe, then set loc to turf
+	else
 		H.forceMove(T)
 		return null
 


### PR DESCRIPTION
- Adds in disposal diversion junctions. These can be linked to a disposal_switch that can be used to toggle the active state of the diversion junction. If the diversion junction is active, it will sort things out of the main line just like a normal sorting junction. If it is inactive, objects passing through will continue through like normal. 

(Just a lazy copy-paste of sorting junction & conveyor switch with a minor clean-ups like the random id assignment & relative pathing.
