### PR TITLE
Added a 'reset slot' button to chargen.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1,4 +1,4 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
+#define SAVE_RESET -1
 
 var/list/preferences_datums = list()
 
@@ -194,6 +194,7 @@ datum/preferences
 		dat += "Slot - "
 		dat += "<a href='?src=\ref[src];load=1'>Load slot</a> - "
 		dat += "<a href='?src=\ref[src];save=1'>Save slot</a> - "
+		dat += "<a href='?src=\ref[src];resetslot=1'>Reset slot</a> - "
 		dat += "<a href='?src=\ref[src];reload=1'>Reload slot</a>"
 
 	else
@@ -242,6 +243,9 @@ datum/preferences
 		load_character(text2num(href_list["changeslot"]))
 		sanitize_preferences()
 		close_load_dialog(usr)
+	else if(href_list["resetslot"])
+		load_character(SAVE_RESET)
+		sanitize_preferences()
 	else
 		return 0
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -36,14 +36,24 @@
 	if(!S)					return 0
 	S.cd = "/"
 	if(!slot)	slot = default_slot
-	slot = sanitize_integer(slot, 1, config.character_slots, initial(default_slot))
-	if(slot != default_slot)
-		default_slot = slot
-		S["default_slot"] << slot
-	S.cd = "/character[slot]"
 
-	player_setup.load_character(S)
+	if(slot != SAVE_RESET) // SAVE_RESET will reset the slot as though it does not exist, but keep the current slot for saving purposes.
+		slot = sanitize_integer(slot, 1, config.character_slots, initial(default_slot))
+		if(slot != default_slot)
+			default_slot = slot
+			S["default_slot"] << slot
+	else
+		S["default_slot"] << default_slot
+
+	if(slot != SAVE_RESET)
+		S.cd = "/character[slot]"
+		player_setup.load_character(S)
+	else
+		player_setup.load_character(S)
+		S.cd = "/character[default_slot]"
+
 	loaded_character = S
+
 	return 1
 
 /datum/preferences/proc/save_character()

--- a/html/changelogs/zuhayr-saves.yml
+++ b/html/changelogs/zuhayr-saves.yml
@@ -1,0 +1,4 @@
+author: Zuhayr
+delete-after: True
+changes: 
+  - rscadd: "Added a reset slot button to chargen."


### PR DESCRIPTION
SparklySheep's commission. Reset button resets the slot as though the player attempted to load a non-existent slot. Tested locally, works fine.
