### PR TITLE
Increases dangers from SM delamination

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -240,7 +240,7 @@
 		if(gene.is_active(src))
 			gene.OnMobLife(src)
 
-	radiation = Clamp(radiation,0,100)
+	radiation = Clamp(radiation,0,500)
 
 	if (radiation)
 
@@ -288,6 +288,9 @@
 					src << "<span class='warning'>You feel strange!</span>"
 					adjustCloneLoss(5 * RADIATION_SPEED_COEFFICIENT)
 					emote("gasp")
+		if(radiation > 150)
+			damage = 8
+			radiation -= 1 * RADIATION_SPEED_COEFFICIENT
 
 		if(damage)
 			damage *= isSynthetic() ? 0.5 : species.radiation_mod

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -84,12 +84,7 @@ var/list/solars_list = list()
 	if (src.health <= 0)
 		if(!(stat & BROKEN))
 			broken()
-		else
-			new /obj/item/weapon/material/shard(src.loc)
-			new /obj/item/weapon/material/shard(src.loc)
-			qdel(src)
-			return
-	return
+
 
 
 /obj/machinery/power/solar/update_icon()
@@ -138,9 +133,13 @@ var/list/solars_list = list()
 
 /obj/machinery/power/solar/proc/broken()
 	stat |= BROKEN
+	health = 0
+	new /obj/item/weapon/material/shard(src.loc)
+	new /obj/item/weapon/material/shard(src.loc)
+	var/obj/item/solar_assembly/S = locate() in src
+	S.glass_type = null
 	unset_control()
 	update_icon()
-	return
 
 
 /obj/machinery/power/solar/ex_act(severity)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -20,13 +20,26 @@
 #define DECAY_FACTOR 700			//Affects how fast the supermatter power decays
 #define CRITICAL_TEMPERATURE 5000	//K
 #define CHARGING_FACTOR 0.05
-#define DAMAGE_RATE_LIMIT 3			//damage rate cap at power = 300, scales linearly with power
+#define DAMAGE_RATE_LIMIT 4.5		//damage rate cap at power = 300, scales linearly with power
 
 
-//These would be what you would get at point blank, decreases with distance
-#define DETONATION_RADS 200
-#define DETONATION_HALLUCINATION 600
+// Base variants are applied to everyone on the same Z level
+// Range variants are applied on per-range basis: numbers here are on point blank, it scales with the map size (assumes square shaped Z levels)
+#define DETONATION_RADS_RANGE 200
+#define DETONATION_RADS_BASE 200
+#define DETONATION_HALLUCINATION_BASE 300
+#define DETONATION_HALLUCINATION_RANGE 300
 
+#define DETONATION_MOB_CONCUSSION 20		// Value that will be used for Weaken() for mobs.
+
+// Base amount of ticks for which a specific type of machine will be offline for. +- 20% added by RNG.
+// This does pretty much the same thing as an electrical storm, it just affects the whole Z level instantly.
+#define DETONATION_APC_OVERLOAD_PROB 10		// prob() of overloading an APC's lights.
+#define DETONATION_SHUTDOWN_APC 120			// Regular APC.
+#define DETONATION_SHUTDOWN_CRITAPC 10		// Critical APC. AI core and such. Considerably shorter as we don't want to kill the AI with a single blast. Still a nuisance.
+#define DETONATION_SHUTDOWN_SMES 60			// SMES
+#define DETONATION_SHUTDOWN_RNG_FACTOR 20	// RNG factor. Above shutdown times can be +- X%, where this setting is the percent. Do not set to 100 or more.
+#define DETONATION_SOLAR_BREAK_CHANCE 60	// prob() of breaking solar arrays (this is per-panel, and only affects the Z level SM is on)
 
 #define WARNING_DELAY 20			//seconds between warnings.
 
@@ -96,23 +109,67 @@
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
-	log_and_message_admins("Supermatter exploded at [x] [y] [z]")
+	if(exploded)
+		return
+
+	log_and_message_admins("Supermatter delaminating at [x] [y] [z]")
 	anchored = 1
 	grav_pulling = 1
 	exploded = 1
+	sleep(pull_time)
+	var/turf/TS = get_turf(src)		// The turf supermatter is on. SM being in a locker, mecha, or other container shouldn't block it's effects that way.
+
+	// Effect 1: Radiation, weakening and hallucinations to all mobs on Z level
 	for(var/mob/living/mob in living_mob_list_)
-		var/turf/T = get_turf(mob)
-		if(T && (loc.z == T.z))
-			if(istype(mob, /mob/living/carbon/human))
-				//Hilariously enough, running into a closet should make you get hit the hardest.
-				var/mob/living/carbon/human/H = mob
-				H.hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1)) ) )
-			var/rads = DETONATION_RADS * sqrt( 1 / (get_dist(mob, src) + 1) )
+		var/turf/TM = get_turf(mob)
+
+		if(TS && TM && (TS.z == TM.z))
+			var/range_multiplier = between(0, get_dist(mob, src) / world.maxx, 1)
+			var/rads = DETONATION_RADS_BASE + (range_multiplier * DETONATION_RADS_RANGE)
+			var/hallucinations = DETONATION_HALLUCINATION_BASE + (range_multiplier * DETONATION_HALLUCINATION_RANGE)
 			mob.apply_effect(rads, IRRADIATE)
-	spawn(pull_time)
-		explosion(get_turf(src), explosion_power, explosion_power * 1.25, explosion_power * 1.5, explosion_power * 1.75, 1)
+			if(istype(mob, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = mob
+				H.hallucination += hallucinations
+			mob.Weaken(DETONATION_MOB_CONCUSSION)
+			mob << "<span class='danger'>An invisible force slams you against the ground!</span>"
+
+	// Effect 2: Z-level wide electrical pulse
+	for(var/obj/machinery/power/apc/A in machines)
+		if(A.z != TS.z)
+			continue
+
+		// Overloads lights
+		if(prob(DETONATION_APC_OVERLOAD_PROB))
+			A.overload_lighting()
+		// Causes the APCs to go into system failure mode.
+		var/random_change = rand(100 - DETONATION_SHUTDOWN_RNG_FACTOR, 100 + DETONATION_SHUTDOWN_RNG_FACTOR) / 100
+		if(A.is_critical)
+			A.energy_fail(round(DETONATION_SHUTDOWN_CRITAPC * random_change))
+		else
+			A.energy_fail(round(DETONATION_SHUTDOWN_APC * random_change))
+
+	for(var/obj/machinery/power/smes/buildable/S in machines)
+		if(S.z != TS.z)
+			continue
+		// Causes SMESes to shut down for a bit
+		var/random_change = rand(100 - DETONATION_SHUTDOWN_RNG_FACTOR, 100 + DETONATION_SHUTDOWN_RNG_FACTOR) / 100
+		S.energy_fail(round(DETONATION_SHUTDOWN_SMES * random_change))
+
+	// Effect 3: Break solar arrays
+
+	for(var/obj/machinery/power/solar/S in machines)
+		if(S.z != TS.z)
+			continue
+		if(prob(DETONATION_SOLAR_BREAK_CHANCE))
+			S.broken()
+
+
+
+	// Effect 4: Medium scale explosion
+	spawn(0)
+		explosion(TS, explosion_power/2, explosion_power, explosion_power * 2, explosion_power * 4, 1)
 		qdel(src)
-		return
 
 //Changes color and luminosity of the light to these values if they were not already set
 /obj/machinery/power/supermatter/proc/shift_light(var/lum, var/clr)
@@ -153,19 +210,6 @@
 			radio.autosay(alert_msg, "Supermatter Monitor")
 			public_alert = 0
 
-
-/obj/machinery/power/supermatter/get_transit_zlevel()
-	//don't send it back to the station -- most of the time
-	if(prob(99))
-		var/list/candidates = accessible_z_levels.Copy()
-		for(var/zlevel in using_map.station_levels)
-			candidates.Remove("[zlevel]")
-		candidates.Remove("[src.z]")
-
-		if(candidates.len)
-			return text2num(pickweight(candidates))
-
-	return ..()
 
 /obj/machinery/power/supermatter/process()
 
@@ -232,9 +276,6 @@
 
 		temp_factor = ( (equilibrium_power/DECAY_FACTOR)**3 )/800
 		power = max( (removed.temperature * temp_factor) * oxygen + power, 0)
-
-		//We've generated power, now let's transfer it to the collectors for storing/usage
-		//transfer_energy()
 
 		var/device_energy = power * REACTION_POWER_MODIFIER
 
@@ -326,16 +367,6 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-
-/*
-/obj/machinery/power/supermatter/proc/transfer_energy()
-	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
-		var/distance = get_dist(R, src)
-		if(distance <= 15)
-			//for collectors using standard phoron tanks at 1013 kPa, the actual power generated will be this power*POWER_FACTOR*20*29 = power*POWER_FACTOR*580
-			R.receive_pulse(power * POWER_FACTOR * (min(3/distance, 1))**2)
-	return
-*/
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -1,4 +1,3 @@
-
 #define NITROGEN_RETARDATION_FACTOR 0.15	//Higher == N2 slows reaction more
 #define THERMAL_RELEASE_MODIFIER 10000		//Higher == more heat released during reaction
 #define PHORON_RELEASE_MODIFIER 1500		//Higher == less phoron released by reaction
@@ -30,7 +29,7 @@
 #define DETONATION_HALLUCINATION_BASE 300
 #define DETONATION_HALLUCINATION_RANGE 300
 
-#define DETONATION_MOB_CONCUSSION 20		// Value that will be used for Weaken() for mobs.
+#define DETONATION_MOB_CONCUSSION 4			// Value that will be used for Weaken() for mobs.
 
 // Base amount of ticks for which a specific type of machine will be offline for. +- 20% added by RNG.
 // This does pretty much the same thing as an electrical storm, it just affects the whole Z level instantly.
@@ -109,6 +108,8 @@
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
+	set waitfor = 0
+
 	if(exploded)
 		return
 
@@ -127,12 +128,12 @@
 			var/range_multiplier = between(0, get_dist(mob, src) / world.maxx, 1)
 			var/rads = DETONATION_RADS_BASE + (range_multiplier * DETONATION_RADS_RANGE)
 			var/hallucinations = DETONATION_HALLUCINATION_BASE + (range_multiplier * DETONATION_HALLUCINATION_RANGE)
-			mob.apply_effect(rads, IRRADIATE)
+			mob.apply_effect(rads, IRRADIATE, mob.getarmor(null, "rad"))
 			if(istype(mob, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = mob
 				H.hallucination += hallucinations
 			mob.Weaken(DETONATION_MOB_CONCUSSION)
-			mob << "<span class='danger'>An invisible force slams you against the ground!</span>"
+			to_chat(mob, "<span class='danger'>An invisible force slams you against the ground!</span>")
 
 	// Effect 2: Z-level wide electrical pulse
 	for(var/obj/machinery/power/apc/A in machines)
@@ -439,3 +440,27 @@
 
 /obj/machinery/power/supermatter/shard/announce_warning() //Shards don't get announcements
 	return
+
+
+#undef NITROGEN_RETARDATION_FACTOR
+#undef THERMAL_RELEASE_MODIFIER
+#undef PHORON_RELEASE_MODIFIER
+#undef OXYGEN_RELEASE_MODIFIER
+#undef REACTION_POWER_MODIFIER
+#undef POWER_FACTOR
+#undef DECAY_FACTOR
+#undef CRITICAL_TEMPERATURE
+#undef CHARGING_FACTOR
+#undef DAMAGE_RATE_LIMIT
+#undef DETONATION_RADS_RANGE
+#undef DETONATION_RADS_BASE
+#undef DETONATION_HALLUCINATION_BASE
+#undef DETONATION_HALLUCINATION_RANGE
+#undef DETONATION_MOB_CONCUSSION
+#undef DETONATION_APC_OVERLOAD_PROB
+#undef DETONATION_SHUTDOWN_APC
+#undef DETONATION_SHUTDOWN_CRITAPC
+#undef DETONATION_SHUTDOWN_SMES
+#undef DETONATION_SHUTDOWN_RNG_FACTOR
+#undef DETONATION_SOLAR_BREAK_CHANCE
+#undef WARNING_DELAY


### PR DESCRIPTION
A feedback thread will be open on the forums and linked to in this PR. Please keep all code-unrelated feedback to that thread.

EDIT: Thread located at: https://baystation12.net/forums/threads/feedback-supermatter-delamination-changes.2655/

Almost everything is in the form of defines, so it can be further tweaked easily.

DNM at least until 18.9.2016 - allowing time for feedback on the forums.
- Radiation in general is more dangerous, and has a third "stage" in which it deals 0.8 Tox damage per tick. This stage is only reached by long exposure or delamination. Radiation can also build up to 5 times larger number than it used to, making larger exposures actually highly dangerous and lethal without medical aid.
- Supermatter stabilization/destabilization is now faster, by roughly 50% (the core takes/loses damage faster). This is still (that was unchanged) influenced with the energy level. More emitter shots = faster destabilization.
- Ejected supermatter no longer has a special treatment for ejection that makes it miss the station in 99.9% of cases. That should make ejection a bit riskier. After all, it's a last resort thing, and should be expected to have it's risks.
- Delamination radiation and hallucinations are now 50% range based (linear scaling) and 50% Z level based. In other words, if you are on the same Z level you will always take at least half of the radiation and hallucinations.
- Delamination now weakens mobs for 20 ticks on explosion.
- Delamination now releases an electrical pulse. All APCs and SMESes on the same Z level will be affected and shut down, as if a grid check occured. This also affects critical APCs, but only for a fraction of the time. There is also a small (20%) RNG involved that adjusts the duration. Tested and shouldn't be lethal to AIs, assuming they don't panic and manage their power or manually reboot their SMES. In general, this is a combination of grid check and an electrical storm, even with the blown lights.
- Delamination now breaks majority of solar panels. It doesn't make the array nonfunctional completely - it only has a certain probability (60% for now) to break every individual solar panel on the same Z level. That should make it more threatening to station's power generation. These solars can be repaired relatively easily, but it requires some intervention from the engineers.
- Delamination explosion tweaked a bit. In general, it's strength is more or less the same, however it should have slightly lower devastation range, while having quite considerably larger light damage range (which carries a risk of damaging adjacent rooms slightly, it shouldn't breach those in 99% of cases however)
- Removes some outdated and commented out code relevant to radiation collectors.
