### PR TITLE
Tiny typepath fix

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -964,13 +964,14 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic/small
 	sort_string = "VBAAY"
 
-// Tesla Link
-/datum/design/item/modularcomponent/teslalink
+// Intellicard Slot
+/datum/design/item/modularcomponent/aislot
 	name = "intellicard slot"
 	id = "aislot"
 	req_tech = list(TECH_POWER = 2, TECH_DATA = 3)
 	build_type = IMPRINTER
 	materials = list(DEFAULT_WALL_MATERIAL = 2000)
+	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/ai_slot
 	sort_string = "VBAAZ"
 /*


### PR DESCRIPTION
- Fixed a minor thing i've missed in my previous PR. The AI slot hardware should no longer collide with tesla link in terms of research datums.
- Also adds standard 20u sacid cost, given it's made in the imprinter.
