### PR TITLE
Robolimbs can have skintones too now

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -240,7 +240,6 @@ var/global/list/damage_icon_parts = list()
 
 //BASE MOB SPRITE
 /mob/living/carbon/human/proc/update_body(var/update_icons=1)
-
 	var/husk_color_mod = rgb(96,88,80)
 	var/hulk_color_mod = rgb(48,224,40)
 
@@ -276,22 +275,23 @@ var/global/list/damage_icon_parts = list()
 		var/obj/item/organ/external/part = organs_by_name[organ_tag]
 		if(isnull(part) || part.is_stump())
 			icon_key += "0"
-		else if(part.robotic >= ORGAN_ROBOT)
-			icon_key += "2[part.model ? "-[part.model]": ""]"
-		else if(part.status & ORGAN_DEAD)
-			icon_key += "3"
-		else
-			icon_key += "1"
+			continue
 		if(part)
 			icon_key += "[part.species.race_key]"
 			icon_key += "[part.dna.GetUIState(DNA_UI_GENDER)]"
-			icon_key += "[part.dna.GetUIValue(DNA_UI_SKIN_TONE)]"
+			icon_key += "[part.s_tone]"
 			if(part.s_col && part.s_col.len >= 3)
 				icon_key += "[rgb(part.s_col[1],part.s_col[2],part.s_col[3])]"
 			if(part.body_hair && part.h_col && part.h_col.len >= 3)
 				icon_key += "[rgb(part.h_col[1],part.h_col[2],part.h_col[3])]"
 			else
 				icon_key += "#000000"
+		if(part.robotic >= ORGAN_ROBOT)
+			icon_key += "2[part.model ? "-[part.model]": ""]"
+		else if(part.status & ORGAN_DEAD)
+			icon_key += "3"
+		else
+			icon_key += "1"
 
 	icon_key = "[icon_key][husk ? 1 : 0][fat ? 1 : 0][hulk ? 1 : 0][skeleton ? 1 : 0]"
 

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -17,7 +17,9 @@ var/list/limb_icon_cache = list()
 	s_col = null
 	h_col = null
 	if(robotic >= ORGAN_ROBOT)
-		return
+		var/datum/robolimb/franchise = all_robolimbs[model]
+		if(!(franchise && franchise.skintone))
+			return
 	if(species && human.species && species.name != human.species.name)
 		return
 	if(!isnull(human.s_tone) && (human.species.appearance_flags & HAS_SKIN_TONE))
@@ -31,7 +33,9 @@ var/list/limb_icon_cache = list()
 	s_col = null
 	h_col = null
 	if(robotic >= ORGAN_ROBOT)
-		return
+		var/datum/robolimb/franchise = all_robolimbs[model]
+		if(!(franchise && franchise.skintone))
+			return
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && (species.appearance_flags & HAS_SKIN_TONE))
 		s_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
 	if(species.appearance_flags & HAS_SKIN_COLOR)
@@ -99,7 +103,6 @@ var/list/limb_icon_cache = list()
 
 	if(model)
 		icon_cache_key += "_model_[model]"
-
 	dir = EAST
 	icon = mob_icon
 

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -19,6 +19,7 @@ var/datum/robolimb/basic_robolimb
 	var/can_eat
 	var/use_eye_icon = "eyes_s"
 	var/can_feel_pain
+	var/skintone
 	var/list/species_cannot_use = list("Resomi")
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
@@ -124,3 +125,5 @@ var/datum/robolimb/basic_robolimb
 	company = "Vey-Med"
 	desc = "This high quality limb is nearly indistinguishable from an organic one."
 	icon = 'icons/mob/human_races/cyberlimbs/veymed/veymed_main.dmi'
+	can_eat = 1
+	skintone = 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

It's a property of the model, currently only Vey-Med does it.
Zeng-hu are sorta human-looking too, but their description makes them look cheaper and probably missing this option.
Also lets Vey Med cyborgs nom foodsies, since it was weird that the most human-looking body couldn't.
