### PR TITLE
Emitter-related tweaks and changes

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -56,6 +56,9 @@
 
 	var/proj_damage = Proj.get_structure_damage()
 
+	if(reinf_material)
+		proj_damage /= reinf_material.projectile_armor
+
 	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
 	var/damage = min(proj_damage, 100)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -57,7 +57,10 @@
 	var/proj_damage = Proj.get_structure_damage()
 
 	if(reinf_material)
-		proj_damage /= reinf_material.projectile_armor
+		if(Proj.damage_type == BURN)
+			proj_damage /= reinf_material.burn_armor
+		else if(Proj.damage_type == BRUTE)
+			proj_damage /= reinf_material.brute_armor
 
 	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
 	var/damage = min(proj_damage, 100)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -90,7 +90,8 @@ var/list/name_to_material
 	var/radioactivity            // Radiation var. Used in wall and object processing to irradiate surroundings.
 	var/ignition_point           // K, point at which the material catches on fire.
 	var/melting_point = 1800     // K, walls will take damage if they're next to a fire hotter than this
-	var/projectile_armor = 2	 // When a wall is reinforced by this material, projectile damage to the wall is divided by this. Applies to all projectile damage types!
+	var/brute_armor = 2	 		 // Brute damage to a wall is divided by this value if the wall is reinforced by this material.
+	var/burn_armor				 // Same as above, but for Burn damage type. If blank brute_armor's value is used.
 	var/integrity = 150          // General-use HP value for products.
 	var/opacity = 1              // Is the material transparent? 0.5< makes transparent walls/doors.
 	var/explosion_resistance = 5 // Only used by walls currently.
@@ -158,6 +159,8 @@ var/list/name_to_material
 		adjective_name = display_name
 	if(!shard_icon)
 		shard_icon = shard_type
+	if(!burn_armor)
+		burn_armor = brute_armor
 
 // This is a placeholder for proper integration of windows/windoors into the system.
 /material/proc/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
@@ -245,7 +248,8 @@ var/list/name_to_material
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 100
-	projectile_armor = 10
+	brute_armor = 10
+	burn_armor = 50		// Diamond walls are immune to fire, therefore it makes sense for them to be almost undamageable by burn damage type.
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	conductive = 0
 
@@ -313,7 +317,7 @@ var/list/name_to_material
 	shard_type = SHARD_STONE_PIECE
 	weight = 22
 	hardness = 55
-	projectile_armor = 3
+	brute_armor = 3
 	door_icon_base = "stone"
 	sheet_singular_name = "brick"
 	sheet_plural_name = "bricks"
@@ -324,7 +328,7 @@ var/list/name_to_material
 	icon_colour = "#AAAAAA"
 	weight = 26
 	hardness = 100
-	projectile_armor = 3
+	brute_armor = 3
 	integrity = 201 //hack to stop kitchen benches being flippable, todo: refactor into weight system
 	stack_type = /obj/item/stack/material/marble
 
@@ -332,7 +336,7 @@ var/list/name_to_material
 	name = DEFAULT_WALL_MATERIAL
 	stack_type = /obj/item/stack/material/steel
 	integrity = 150
-	projectile_armor = 5
+	brute_armor = 5
 	icon_base = "solid"
 	icon_reinf = "reinf_over"
 	icon_colour = "#666666"
@@ -370,7 +374,8 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = "#777777"
 	explosion_resistance = 25
-	projectile_armor = 10
+	brute_armor = 6
+	burn_armor = 10
 	hardness = 80
 	weight = 23
 	stack_origin_tech = list(TECH_MATERIAL = 2)
@@ -379,7 +384,8 @@ var/list/name_to_material
 
 /material/plasteel/titanium
 	name = "titanium"
-	projectile_armor = 13
+	brute_armor = 10
+	burn_armor = 8
 	integrity = 200
 	melting_point = 3000
 	stack_type = null
@@ -400,7 +406,8 @@ var/list/name_to_material
 	hardness = 50
 	melting_point = T0C + 100
 	weight = 14
-	projectile_armor = 1
+	brute_armor = 1
+	burn_armor = 2
 	door_icon_base = "stone"
 	destruction_desc = "shatters"
 	window_options = list("One Direction" = 1, "Full Window" = 4)
@@ -495,7 +502,8 @@ var/list/name_to_material
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	weight = 17
-	projectile_armor = 2
+	brute_armor = 2
+	burn_armor = 3
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	composite_material = list(DEFAULT_WALL_MATERIAL = 1875,"glass" = 3750)
 	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 5)
@@ -509,7 +517,8 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/glass/phoronglass
 	flags = MATERIAL_BRITTLE
 	integrity = 70
-	projectile_armor = 2
+	brute_armor = 2
+	burn_armor = 5
 	melting_point = T0C + 2000
 	icon_colour = "#FC2BC5"
 	stack_origin_tech = list(TECH_MATERIAL = 4)
@@ -519,7 +528,8 @@ var/list/name_to_material
 
 /material/glass/phoron/reinforced
 	name = "rphglass"
-	projectile_armor = 3
+	brute_armor = 3
+	burn_armor = 10
 	melting_point = T0C + 4000
 	display_name = "reinforced borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronrglass
@@ -620,7 +630,7 @@ var/list/name_to_material
 	shard_type = SHARD_SPLINTER
 	shard_can_repair = 0 // you can't weld splinters back into planks
 	hardness = 15
-	projectile_armor = 1
+	brute_armor = 1
 	weight = 18
 	melting_point = T0C+300 //okay, not melting in this case, but hot enough to destroy wood
 	ignition_point = T0C+288
@@ -648,7 +658,7 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = "#AAAAAA"
 	hardness = 1
-	projectile_armor = 1
+	brute_armor = 1
 	weight = 1
 	ignition_point = T0C+232 //"the temperature at which book-paper catches fire, and burns." close enough
 	melting_point = T0C+232 //temperature at which cardboard walls would be destroyed
@@ -664,7 +674,7 @@ var/list/name_to_material
 	ignition_point = T0C+232
 	melting_point = T0C+300
 	flags = MATERIAL_PADDING
-	projectile_armor = 1
+	brute_armor = 1
 	conductive = 0
 
 /material/cult

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -90,6 +90,7 @@ var/list/name_to_material
 	var/radioactivity            // Radiation var. Used in wall and object processing to irradiate surroundings.
 	var/ignition_point           // K, point at which the material catches on fire.
 	var/melting_point = 1800     // K, walls will take damage if they're next to a fire hotter than this
+	var/projectile_armor = 2	 // When a wall is reinforced by this material, projectile damage to the wall is divided by this. Applies to all projectile damage types!
 	var/integrity = 150          // General-use HP value for products.
 	var/opacity = 1              // Is the material transparent? 0.5< makes transparent walls/doors.
 	var/explosion_resistance = 5 // Only used by walls currently.
@@ -244,6 +245,7 @@ var/list/name_to_material
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 100
+	projectile_armor = 10
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	conductive = 0
 
@@ -311,6 +313,7 @@ var/list/name_to_material
 	shard_type = SHARD_STONE_PIECE
 	weight = 22
 	hardness = 55
+	projectile_armor = 3
 	door_icon_base = "stone"
 	sheet_singular_name = "brick"
 	sheet_plural_name = "bricks"
@@ -321,6 +324,7 @@ var/list/name_to_material
 	icon_colour = "#AAAAAA"
 	weight = 26
 	hardness = 100
+	projectile_armor = 3
 	integrity = 201 //hack to stop kitchen benches being flippable, todo: refactor into weight system
 	stack_type = /obj/item/stack/material/marble
 
@@ -328,6 +332,7 @@ var/list/name_to_material
 	name = DEFAULT_WALL_MATERIAL
 	stack_type = /obj/item/stack/material/steel
 	integrity = 150
+	projectile_armor = 5
 	icon_base = "solid"
 	icon_reinf = "reinf_over"
 	icon_colour = "#666666"
@@ -365,6 +370,7 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = "#777777"
 	explosion_resistance = 25
+	projectile_armor = 10
 	hardness = 80
 	weight = 23
 	stack_origin_tech = list(TECH_MATERIAL = 2)
@@ -373,6 +379,9 @@ var/list/name_to_material
 
 /material/plasteel/titanium
 	name = "titanium"
+	projectile_armor = 13
+	integrity = 200
+	melting_point = 3000
 	stack_type = null
 	icon_base = "metal"
 	door_icon_base = "metal"
@@ -389,7 +398,9 @@ var/list/name_to_material
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 50
+	melting_point = T0C + 100
 	weight = 14
+	projectile_armor = 1
 	door_icon_base = "stone"
 	destruction_desc = "shatters"
 	window_options = list("One Direction" = 1, "Full Window" = 4)
@@ -480,9 +491,11 @@ var/list/name_to_material
 	icon_colour = "#00E1FF"
 	opacity = 0.3
 	integrity = 100
+	melting_point = T0C + 750
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	weight = 17
+	projectile_armor = 2
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	composite_material = list(DEFAULT_WALL_MATERIAL = 1875,"glass" = 3750)
 	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 5)
@@ -496,6 +509,8 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/glass/phoronglass
 	flags = MATERIAL_BRITTLE
 	integrity = 70
+	projectile_armor = 2
+	melting_point = T0C + 2000
 	icon_colour = "#FC2BC5"
 	stack_origin_tech = list(TECH_MATERIAL = 4)
 	created_window = /obj/structure/window/phoronbasic
@@ -504,6 +519,8 @@ var/list/name_to_material
 
 /material/glass/phoron/reinforced
 	name = "rphglass"
+	projectile_armor = 3
+	melting_point = T0C + 4000
 	display_name = "reinforced borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronrglass
 	stack_origin_tech = list(TECH_MATERIAL = 5)
@@ -603,6 +620,7 @@ var/list/name_to_material
 	shard_type = SHARD_SPLINTER
 	shard_can_repair = 0 // you can't weld splinters back into planks
 	hardness = 15
+	projectile_armor = 1
 	weight = 18
 	melting_point = T0C+300 //okay, not melting in this case, but hot enough to destroy wood
 	ignition_point = T0C+288
@@ -630,6 +648,7 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = "#AAAAAA"
 	hardness = 1
+	projectile_armor = 1
 	weight = 1
 	ignition_point = T0C+232 //"the temperature at which book-paper catches fire, and burns." close enough
 	melting_point = T0C+232 //temperature at which cardboard walls would be destroyed
@@ -645,6 +664,7 @@ var/list/name_to_material
 	ignition_point = T0C+232
 	melting_point = T0C+300
 	flags = MATERIAL_PADDING
+	projectile_armor = 1
 	conductive = 0
 
 /material/cult

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -11,8 +11,9 @@
 	var/id = null
 
 	use_power = 0	//uses powernet power, not APC power
-	active_power_usage = 30000	//30 kW laser. I guess that means 30 kJ per shot.
+	active_power_usage = 100 KILOWATTS
 
+	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.
 	var/active = 0
 	var/powered = 0
 	var/fire_delay = 100
@@ -26,7 +27,7 @@
 
 	var/_wifi_id
 	var/datum/wifi/receiver/button/emitter/wifi_receiver
-	
+
 /obj/machinery/power/emitter/anchored
 	anchored = 1
 	state = 2
@@ -95,12 +96,7 @@
 		return 1
 
 
-/obj/machinery/power/emitter/emp_act(var/severity)//Emitters are hardened but still might have issues
-//	add_load(1000)
-/*	if((severity == 1)&&prob(1)&&prob(1))
-		if(src.active)
-			src.active = 0
-			src.use_power = 1	*/
+/obj/machinery/power/emitter/emp_act(var/severity)
 	return 1
 
 /obj/machinery/power/emitter/process()
@@ -135,7 +131,7 @@
 
 		//need to calculate the power per shot as the emitter doesn't fire continuously.
 		var/burst_time = (min_burst_delay + max_burst_delay)/2 + 2*(burst_shots-1)
-		var/power_per_shot = active_power_usage * (burst_time/10) / burst_shots
+		var/power_per_shot = (active_power_usage * efficiency) * (burst_time/10) / burst_shots
 
 		if(prob(35))
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread

--- a/html/changelogs/atlantiscze-emitterstuff.yml
+++ b/html/changelogs/atlantiscze-emitterstuff.yml
@@ -1,0 +1,10 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Blobs are now considerably more resistant to energetic weapons, be it handheld lasers, energy guns, or even emitters. An emitter is still useful to suppress the blob a bit, but one emitter shouldn't be capable of outright killing the blob."
+  - rscadd: "Blob has a relatively small chance to grow secondary cores. These cores are considerably weaker, have lower health, but still help spread the blob a bit more."
+  - tweak: "Emitter power usage increased (30kW to 100kW). While it is still possible to run one with PACMAN, you have to keep it on overload."
+  - tweak: "Reinforced walls are now considerably more resistant against projectiles of all kinds, be it emitters, handheld weaponry, or anything else. Regular walls are unaffected. An emitter is still useful if you need to burn through one, but expect to wait - it needs over fifty pulses for a plasteel reinforced wall."
+  - tweak: "Details on the above. Reinforcement is calculated from the material that is used to reinforce the girders when building the wall. Weak materials such as wood have 0% reduction in taken damage. Most basic materials have 50% or so. Steel is decent material with 80% reduction. Plasteel is very good with 90%, and titanium is the best with approx. 92% reduction (though it has lower overall health)"


### PR DESCRIPTION
This PR is slightly inspired by the staff meeting. It keeps emitters usable, but it prevents them from being way too overpowered which is what they are now (capable of punching through r-wall within 8 pulses, or soloing a blob). Instead of reflective walls (which i still find kind of silly) i added reinforcement for materials. In other words, plasteel reinforced walls take 10x less damage from projectiles on any kind. Steel walls take 5x less damage, et cetera. It is all material datum based. Rough amount of shots required to burn through a r-wall increased from 8 to a little over 50. That means it still works, just not within ten seconds. A r-wall will hold few minutes.

The same goes for blobs. They are generally stronger, and take much less damage from lasers in general. An emitter is still useful. It keeps the blob suppressed a bit, but it shouldn't be able to solo the core. Multiple emitters should still work quite reliably against a single-core blob, but i find that acceptable.
- Emitters now use 100kW, instead of 30kW. That means it is only possible to run them with a regular PACMAN if you overload it (which has it's risks if not watched closely). Also makes it a little bit more expensive to run one off the grid as usual.
- Blobs are now considerably more resistant to emitters (and lasers in general). Emitters are still useful to keep the blob under stress. They will cause damage, and may actually help you damage the core a bit, but they shouldn't be capable of outright destroying the core. Multiple emitters shooting from all directions would be required for that, or an engineer with welder or other weapon.
- BONUS: Blobs now have a 2.5% chance to grow a secondary core instead of regular blob segment. This secondary core is weaker in terms of growth - it will only grow 4 tiles away, and is generally easier to kill, but it is still a nuisance.
- BONUS2: I recycled two blob icon states and used them for the core. The blob core sprite will now change to reflect how damaged it is.
- Materials now have a new variable that indicates how good are they as reinforcement material. This is used by walls. If a wall is reinforced with a material, any projectile damage gets divided by this reinforcement potential. Practical effect is that emitters and other handheld weaponry are much worse against r-walls now. You need over 50 shots to bring one down. This shouldn't affect regular non-reinforced walls.
- Note: Steel is a decent reinforcement material with 80% reduction. Plasteel is even better with 90% reduction. Titanium is a little bit over 92%, however it has worse overall health and heat resistance as compared to plasteel. Most common materials have values around 50%, with some weaker ones (wood) having outright 0% reduction.
- Fix: Glass materials now have melting point set. That means a borosilicate glass plated wall won't melt at room temperature.
