### PR TITLE
Adds 'up' and 'down' as options in Test ZAS Connection for multiZAS

### DIFF
--- a/code/ZAS/Diagnostic.dm
+++ b/code/ZAS/Diagnostic.dm
@@ -39,6 +39,10 @@ client/proc/Test_ZAS_Connection(var/turf/simulated/T as turf)
 	"South" = SOUTH,\
 	"East" = EAST,\
 	"West" = WEST,\
+	#ifdef ZLEVELS
+	"Up" = UP,\
+	"Down" = DOWN,\
+	#endif
 	"N/A" = null)
 	var/direction = input("What direction do you wish to test?","Set direction") as null|anything in direction_list
 	if(!direction)


### PR DESCRIPTION
They'll only appear if ZLEVELS is defined.
