### PR TITLE
SQL error executing initial schema while line lacks a space

### DIFF
--- a/sql/migrate/V003__Update_Antag_Bans.sql
+++ b/sql/migrate/V003__Update_Antag_Bans.sql
@@ -4,7 +4,7 @@ UPDATE erro_ban SET job="Xenomorph" WHERE job="xeno";
 -- UPDATE erro_ban SET job="actor" WHERE job="actor"; -- Same
 UPDATE erro_ban SET job="ert" WHERE job="Emergency Response Team";
 UPDATE erro_ban SET job="mercenary" WHERE job="operative";
---UPDATE erro_ban SET job="raider" WHERE job="raider"; -- Same
+-- UPDATE erro_ban SET job="raider" WHERE job="raider"; -- Same
 -- UPDATE erro_ban SET job="wizard" WHERE job="wizard"; -- Same
 -- UPDATE erro_ban SET job="changeling" WHERE job="changeling"; -- Same
 -- UPDATE erro_ban SET job="cultist" WHERE job="cultist"; -- Same


### PR DESCRIPTION
Without that space, the following error is produced:

`Error Code: 1064. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '--UPDATE erro_ban SET job="raider" WHERE job="raider"' at line 1`

Formatting error?
