### PR TITLE
Adds bluespace jump evac

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -139,6 +139,7 @@
 #include "code\controllers\verbs.dm"
 #include "code\controllers\voting.dm"
 #include "code\controllers\evacuation\evacuation.dm"
+#include "code\controllers\evacuation\evacuation_bluespace.dm"
 #include "code\controllers\evacuation\evacuation_eta.dm"
 #include "code\controllers\evacuation\evacuation_helpers.dm"
 #include "code\controllers\evacuation\evacuation_pods.dm"

--- a/code/controllers/evacuation/evacuation_bluespace.dm
+++ b/code/controllers/evacuation/evacuation_bluespace.dm
@@ -1,0 +1,35 @@
+/datum/evacuation_controller/bluespace
+	name = "bluespace jump controller"
+	evac_prep_delay = 10 MINUTES
+	evac_launch_delay =  2 MINUTES
+	evac_transit_delay = 3 MINUTES
+	var/list/saved = list()
+
+/datum/evacuation_controller/bluespace/launch_evacuation()
+	if(!..())
+		return 0
+	world.maxz++	//create a place for stragglers
+	using_map.sealed_levels |= world.maxz
+	for(var/mob/living/M in mob_list)
+		if(M.z in using_map.station_levels)
+			var/area/A = get_area(M)
+			if(istype(A,/area/space)) //straggler
+				var/turf/T = locate(M.x,M.y,world.maxz)
+				if(T)
+					M.forceMove(T)
+			else
+				if(M.client)
+					M.client.color = "#5050FF"
+				M.incorporeal_move = 1
+				saved |= M
+
+/datum/evacuation_controller/bluespace/finish_evacuation()
+	..()
+	for(var/mob/living/M in saved)
+		if(M.client)
+			M.client.color = null
+		M.incorporeal_move = 0
+		var/turf/T = get_turf(M)
+		if(T.density)
+			M << "<span class='danger'>[T] suddenly appears inside you!</span>"
+			M.gib()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

When it's time to go, everyone who are in space, stay in space, on their brand new empty zlevel.
Rest get blue tint visual, and can run through the walls!
But if they are still in a wall when it's time to go corporeal again, bad things happen.
