### PR TITLE
Cleaner implementation of #14222

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -167,14 +167,22 @@
 
 // Proc: get_unhacked_apcs()
 // Parameters: None
-// Description: Returns a list of all unhacked APCs
+// Description: Returns a list of all unhacked APCs. APCs on station Zs are on top of the list.
 /proc/get_unhacked_apcs(var/mob/living/silicon/ai/user)
-	var/list/H = list()
+	var/list/station_apcs = list()
+	var/list/offstation_apcs = list()
+
 	for(var/obj/machinery/power/apc/A in machines)
 		if(A.hacker && A.hacker == user)
 			continue
-		H.Add(A)
-	return H
+		if(A.z in using_map.station_levels)
+			station_apcs.Add(A)
+		else
+			offstation_apcs.Add(A)
+
+	// Append off-station APCs to the end of station APCs list and return it.
+	station_apcs.Add(offstation_apcs)
+	return station_apcs
 
 
 // Helper procs which return lists of relevant mobs.

--- a/html/changelogs/atlantiscze-BEH.yml
+++ b/html/changelogs/atlantiscze-BEH.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Malfunctioning AI ability Basic Encryption Hack now lists station APCs first. Off-station APCs (that do not contribute to CPU generation) are appended to the bottom of the list."


### PR DESCRIPTION
- Fixes the same problem as PR #14222 , without introducing extra special verbs and stuff.
- The list when using Basic Encryption Hack as a verb (instead of right-click) now shows station APCs first. Off-Station APCs (those which don't contribute to CPU) are appended to the bottom of the list.
