### PR TITLE
Adds missing state arguments in the camera monitor UI.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/camera.dm
@@ -36,7 +36,7 @@
 	var/obj/machinery/camera/current_camera = null
 	var/current_network = null
 
-/datum/nano_module/camera_monitor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
+/datum/nano_module/camera_monitor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = default_state)
 	var/list/data = host.initial_data()
 
 	data["current_camera"] = current_camera ? current_camera.nano_structure() : null
@@ -58,7 +58,7 @@
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "sec_camera.tmpl", "Camera Monitoring", 900, 800)
+		ui = new(user, src, ui_key, "sec_camera.tmpl", "Camera Monitoring", 900, 800, state = state)
 		// ui.auto_update_layout = 1 // Disabled as with suit sensors monitor - breaks the UI map. Re-enable once it's fixed somehow.
 
 		ui.add_template("mapContent", "sec_camera_map_content.tmpl")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

```
Runtime in ,: bad arg name 'state'
   proc name: ui interact (/datum/nano_module/camera_monitor/ui_interact)
   usr: XXX (the processing strata) (113,128,1) (/turf/simulated/floor/bluegrid) (YYY)
   usr.loc: The processing strata (the AI Chamber) (113,128,1) (/area/turret_protected/ai)
   src: Camera Monitoring program (/datum/nano_module/camera_monitor)
   call stack:
   Camera Monitoring program (/datum/nano_module/camera_monitor): ui interact(XXX (/mob/living/silicon/ai), null, null, null)
   Camera Monitoring program (/stat_silicon_subsystem): Click("Subsystems", "infowindow.info", "left=1")
   YYY (/client): Click(Camera Monitoring program (/stat_silicon_subsystem), "Subsystems", "infowindow.info", "left=1")
```
