### PR TITLE
Uplink and antag item tweaks.

### DIFF
--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -18,16 +18,16 @@
 **************/
 /datum/uplink_item/item/badassery/random_one
 	name = "Random Item"
-	desc = "Buys you one random item."
+	desc = "Buys you a random item for at least 1TC. Careful: No upper price cap!"
+	item_cost = 1
 
 /datum/uplink_item/item/badassery/random_one/buy(var/obj/item/device/uplink/U, var/mob/user)
 	var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/default)
 	var/datum/uplink_item/item = uplink_selection.get_random_item(U.uses, U)
-	return item.buy(U, user)
+	return item && item.buy(U, user)
 
 /datum/uplink_item/item/badassery/random_one/can_buy(obj/item/device/uplink/U)
-	var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/default)
-	return uplink_selection.get_random_item(U.uses, U) != null
+	return U.uses
 
 /datum/uplink_item/item/badassery/random_many
 	name = "Random Items"
@@ -66,7 +66,7 @@
 
 /datum/uplink_item/item/badassery/surplus/get_goods(var/obj/item/device/uplink/U, var/loc)
 	var/obj/structure/largecrate/C = new(loc)
-	var/random_items = get_random_uplink_items(null, item_worth, C)
+	var/random_items = get_random_uplink_items(U, item_worth, C)
 	for(var/datum/uplink_item/I in random_items)
 		I.purchase_log(U)
 		I.get_goods(U, C)

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -59,7 +59,7 @@
 
 	if(hack_result && in_hack_mode)
 		user << "<span class='notice'>Your hacking attempt was succesful!</span>"
-		playsound(src.loc, 'sound/piano/A#6.ogg', 75)
+		user.playsound_local(get_turf(src), 'sound/piano/A#6.ogg', 50)
 		known_targets.Insert(1, target)	// Insert the newly hacked target first,
 		destroyed_event.register(target, src, /obj/item/device/multitool/hacktool/proc/on_target_destroy)
 	else

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -59,17 +59,31 @@
 		next_offer_time = world.time + offer_time
 		discount_amount = pick(90;0.9, 80;0.8, 70;0.7, 60;0.6, 50;0.5, 40;0.4, 30;0.3, 20;0.2, 10;0.1)
 
+		var/datum/uplink_item/new_discount_item
 		do
 			var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/blacklist)
-			discount_item = uplink_selection.get_random_item(INFINITY, src)
+			new_discount_item = uplink_selection.get_random_item(INFINITY, src)
 		// Ensures we only only get items for which we get an actual discount and that this particular uplink can actually view (can buy would risk near-infinite loops).
-		while(discount_item && (discount_item.cost(uses) == discount_item.cost(uses) * discount_amount) || !discount_item.can_view(src))
+		while(is_improper_item(new_discount_item, discount_amount))
+		if(!new_discount_item)
+			return
 
-		if(!discount_item)
-			discount_amount = 0
-
+		discount_item = new_discount_item
 		update_nano_data()
 		nanomanager.update_uis(src)
+
+/obj/item/device/uplink/proc/is_improper_item(var/datum/uplink_item/new_discount_item, discount_amount)
+	if(!new_discount_item)
+		return FALSE
+
+	var/discount_price = round(new_discount_item.cost(uses) * discount_amount)
+	if(!discount_price || new_discount_item.cost(uses) == discount_price)
+		return TRUE
+
+	if(!new_discount_item.can_view(src))
+		return TRUE
+
+	return FALSE
 
 /obj/item/device/uplink/proc/get_item_cost(var/item_type, var/item_cost)
 	return item_type == discount_item ? max(1, round(item_cost*discount_amount)) : item_cost

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -32,6 +32,7 @@
 		if(U && !I.can_buy(U))
 			continue
 		return I
+	return uplink.items_assoc[/datum/uplink_item/item/stealthy_weapons/soap]
 
 var/list/uplink_random_selections_
 /proc/get_uplink_random_selection_by_type(var/uplist_selection_type)
@@ -119,6 +120,20 @@ var/list/uplink_random_selections_
 			continue
 		var/new_thing = new/datum/uplink_random_item(uplink_item_type)
 		items += new_thing
+
+/datum/uplink_random_selection/blacklist/get_random_item(var/telecrystals, obj/item/device/uplink/U, var/list/bought_items)
+	var/const/attempts = 50
+	for(var/i = 0; i < attempts; i++)
+		var/datum/uplink_random_item/RI = pick(items)
+		if(!prob(RI.keep_probability))
+			continue
+		var/datum/uplink_item/I = uplink.items_assoc[RI.uplink_item]
+		if(I.cost(telecrystals, U) > telecrystals)
+			continue
+		if(bought_items && (I in bought_items) && !prob(RI.reselect_probability))
+			continue
+		return I
+	return uplink.items_assoc[/datum/uplink_item/item/stealthy_weapons/soap]
 
 #ifdef DEBUG
 /proc/debug_uplink_purchage_log()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

The door hacker now only pings the user.
Cleaned up the discount code.
The blacklist-variant of the random uplink item generator no longer checks if the uplink can afford it.
All random uplink item variants now fallback to offer soap if everything else failed.
