### PR TITLE
Adjacency/Topic Z awareness.

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -29,6 +29,8 @@
 	var/turf/T0 = get_turf(neighbor)
 	if(T0 == src)
 		return 1
+	if(!T0 || T0.z != z)
+		return 0
 	if(get_dist(src,T0) > 1)
 		return 0
 

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -63,12 +63,14 @@
 	return user.shared_living_nano_distance(src_object)
 
 /mob/living/proc/shared_living_nano_distance(var/atom/movable/src_object)
-	if (!(src_object in view(4, src))) 	// If the src object is not in visable, disable updates
+	if (!(src_object in view(4, src))) 	// If the src object is not visable, disable updates
 		return STATUS_CLOSE
 
 	var/dist = get_dist(src_object, src)
-	if (dist <= 1)
-		return STATUS_INTERACTIVE	// interactive (green visibility)
+	if (dist <= 1) // interactive (green visibility)
+		// Checking adjacency even when distance is 0 because get_dist() doesn't include Z-level differences and
+		// the client might have its eye shifted up/down thus putting src_object in view.
+		return Adjacent(src_object) ? STATUS_INTERACTIVE : STATUS_UPDATE
 	else if (dist <= 2)
 		return STATUS_UPDATE 		// update only (orange visibility)
 	else if (dist <= 4)


### PR DESCRIPTION
Makes Adjacent() Z-level aware in that separate Z-levels are considered too far away to be adjacent.

Makes Topic/NanoUI/tgui utilize Adjacent when within 1 distance from objects. No longer can you move behind window panes or otherwise and still be able to interact.

Fixes #14260 in the least performance intensive way.
