### PR TITLE
Partial fix for #14251

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -264,7 +264,7 @@ mob/living/silicon/robot/tracking_initiated()
 
 mob/living/proc/tracking_cancelled()
 
-mob/living/silicon/robot/tracking_initiated()
+mob/living/silicon/robot/tracking_cancelled()
 	tracking_entities--
 	if(!tracking_entities && has_zeroth_law())
 		src << "<span class='notice'>Internal camera is no longer being accessed.</span>"

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -25,8 +25,8 @@
 
 // ===== ENGINEERING CONSOLE =====
 /obj/machinery/modular_computer/console/preset/engineering
-	 console_department = "Engineering"
-	 desc = "A stationary computer. This one comes preloaded with engineering programs."
+	console_department = "Engineering"
+	desc = "A stationary computer. This one comes preloaded with engineering programs."
 
 /obj/machinery/modular_computer/console/preset/engineering/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/power_monitor())
@@ -38,8 +38,8 @@
 
 // ===== MEDICAL CONSOLE =====
 /obj/machinery/modular_computer/console/preset/medical
-	 console_department = "Medical"
-	 desc = "A stationary computer. This one comes preloaded with medical programs."
+	console_department = "Medical"
+	desc = "A stationary computer. This one comes preloaded with medical programs."
 
 /obj/machinery/modular_computer/console/preset/medical/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/suit_sensors())
@@ -48,9 +48,9 @@
 
 // ===== RESEARCH CONSOLE =====
 /obj/machinery/modular_computer/console/preset/research
-	 console_department = "Research"
-	 desc = "A stationary computer. This one comes preloaded with research programs."
-	 _has_aislot = 1
+	console_department = "Research"
+	desc = "A stationary computer. This one comes preloaded with research programs."
+	_has_aislot = 1
 
 /obj/machinery/modular_computer/console/preset/research/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/ntnetmonitor())
@@ -62,10 +62,10 @@
 
 // ===== COMMAND CONSOLE =====
 /obj/machinery/modular_computer/console/preset/command
-	 console_department = "Command"
-	 desc = "A stationary computer. This one comes preloaded with command programs."
-	 _has_id_slot = 1
-	 _has_printer = 1
+	console_department = "Command"
+	desc = "A stationary computer. This one comes preloaded with command programs."
+	_has_id_slot = 1
+	_has_printer = 1
 
 /obj/machinery/modular_computer/console/preset/command/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/chatclient())
@@ -74,13 +74,13 @@
 	cpu.hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 
 /obj/machinery/modular_computer/console/preset/command/main
-	 console_department = "Command"
-	 desc = "A stationary computer. This one comes preloaded with essential command programs."
+	console_department = "Command"
+	desc = "A stationary computer. This one comes preloaded with essential command programs."
 
 // ===== SECURITY CONSOLE =====
 /obj/machinery/modular_computer/console/preset/security
-	 console_department = "Security"
-	 desc = "A stationary computer. This one comes preloaded with security programs."
+	console_department = "Security"
+	desc = "A stationary computer. This one comes preloaded with security programs."
 
 /obj/machinery/modular_computer/console/preset/security/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
@@ -88,8 +88,8 @@
 
 // ===== CIVILIAN CONSOLE =====
 /obj/machinery/modular_computer/console/preset/civilian
-	 console_department = "Civilian"
-	 desc = "A stationary computer. This one comes preloaded with generic programs."
+	console_department = "Civilian"
+	desc = "A stationary computer. This one comes preloaded with generic programs."
 
 /obj/machinery/modular_computer/console/preset/civilian/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/chatclient())
@@ -99,23 +99,29 @@
 
 // ===== ERT CONSOLE =====
 /obj/machinery/modular_computer/console/preset/ert
-	 console_department = "Crescent"
-	 desc = "A stationary computer. This one comes preloaded with various programs used by Nanotrasen response teams."
+	console_department = "Crescent"
+	desc = "A stationary computer. This one comes preloaded with various programs used by Nanotrasen response teams."
+	_has_printer = 1
+	_has_id_slot = 1
+	_has_aislot = 1
 
 /obj/machinery/modular_computer/console/preset/ert/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/nttransfer())
 	cpu.hard_drive.store_file(new/datum/computer_file/program/camera_monitor/ert())
 	cpu.hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
 	cpu.hard_drive.store_file(new/datum/computer_file/program/comm())
+	cpu.hard_drive.store_file(new/datum/computer_file/program/aidiag())
 
 // ===== MERCENARY CONSOLE =====
 /obj/machinery/modular_computer/console/preset/mercenary
-	 console_department = "Unset"
-	 desc = "A stationary computer. This one comes preloaded with various programs used by shady organizations."
-	 _has_printer = 1
-	 _has_id_slot = 1
-	 emagged = 1		// Allows download of other antag programs for free.
+	console_department = "Unset"
+	desc = "A stationary computer. This one comes preloaded with various programs used by shady organizations."
+	_has_printer = 1
+	_has_id_slot = 1
+	_has_aislot = 1
+	emagged = 1		// Allows download of other antag programs for free.
 
-/obj/machinery/modular_computer/console/preset/ert/install_programs()
+/obj/machinery/modular_computer/console/preset/mercenary/install_programs()
 	cpu.hard_drive.store_file(new/datum/computer_file/program/camera_monitor/hacked())
 	cpu.hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
+	cpu.hard_drive.store_file(new/datum/computer_file/program/aidiag())

--- a/code/modules/modular_computers/file_system/programs/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/camera.dm
@@ -92,9 +92,6 @@
 		return 1
 
 	else if(href_list["switch_network"])
-		if(!(href_list["switch_network"] in using_map.station_networks))
-			return
-
 		// Either security access, or access to the specific camera network's department is required in order to access the network.
 		if(can_access_network(usr, get_camera_access(href_list["switch_network"])))
 			current_network = href_list["switch_network"]

--- a/code/modules/modular_computers/file_system/programs/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/camera.dm
@@ -167,7 +167,7 @@
 	available_to_ai = FALSE
 
 // The ERT variant has access to ERT and crescent cams, but still checks for accesses. ERT members should be able to use it.
-/datum/nano_module/camera_monitor/hacked/modify_networks_list(var/list/networks)
+/datum/nano_module/camera_monitor/ert/modify_networks_list(var/list/networks)
 	..()
 	networks.Add(list(list("tag" = NETWORK_ERT, "has_access" = 1)))
 	networks.Add(list(list("tag" = NETWORK_CRESCENT, "has_access" = 1)))


### PR DESCRIPTION
Partially fixes the problem with mercenary console
- Console now has pre-installed programs as expected. The hacked camera program can now correctly access all networks it should be able to access (including the off-station networks which were problematic so far)

One problem remains (as i have said in comments of #14251) - Apparently, helmet cameras are not in the camera repository, and therefore the program simply can't see them. 
