### PR TITLE
Paaaaaain

### DIFF
--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -71,14 +71,10 @@
 
 /mob/living/carbon/brain/handle_chemicals_in_body()
 	chem_effects.Cut()
-	analgesic = 0
 
 	if(touching) touching.metabolize()
 	if(ingested) ingested.metabolize()
 	if(bloodstr) bloodstr.metabolize()
-
-	if(CE_PAINKILLER in chem_effects)
-		analgesic = chem_effects[CE_PAINKILLER]
 
 	confused = max(0, confused - 1)
 	// decrement dizziness counter, clamped to 0

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -6,9 +6,6 @@
 	var/list/antibodies = list()
 
 	var/life_tick = 0      // The amount of life ticks that have processed on this mob.
-	var/analgesic = 0 // when this is set, the mob isn't affected by shock or pain
-					  // life should decrease this by 1 every tick
-	// total amount of wounds on mob, used to spread out healing and the like over all wounds
 	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
 	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
 	//Surgery info

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1038,7 +1038,7 @@
 			"<span class='warning'>A spike of pain jolts your [organ.name] as you bump [O] inside.</span>", \
 			"<span class='warning'>Your movement jostles [O] in your [organ.name] painfully.</span>", \
 			"<span class='warning'>Your movement jostles [O] in your [organ.name] painfully.</span>")
-		src << msg
+		custom_pain(msg,40)
 
 	organ.take_damage(rand(1,3), 0, 0)
 	if(!(organ.robotic >= ORGAN_ROBOT) && (should_have_organ(BP_HEART))) //There is no blood in protheses.

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -55,7 +55,7 @@
 			//Moving around with fractured ribs won't do you any good
 				if (E.is_broken() && E.internal_organs && E.internal_organs.len && prob(15))
 					var/obj/item/organ/I = pick(E.internal_organs)
-					custom_pain("You feel broken bones moving in your [E.name]!", 1)
+					custom_pain("You feel broken bones moving in your [E.name]!", 50)
 					I.take_damage(rand(3,5))
 
 				//Moving makes open wounds get infected much faster

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -204,7 +204,7 @@
 		var/rn = rand(0, 200)
 		if(getBrainLoss() >= 5)
 			if(0 <= rn && rn <= 3)
-				custom_pain("Your head feels numb and painful.")
+				custom_pain("Your head feels numb and painful.",10)
 		if(getBrainLoss() >= 15)
 			if(4 <= rn && rn <= 6) if(eye_blurry <= 0)
 				src << "<span class='warning'>It becomes hard to see for some reason.</span>"
@@ -560,16 +560,12 @@
 
 	if(reagents)
 		chem_effects.Cut()
-		analgesic = 0
 
 		if(!isSynthetic())
 
 			if(touching) touching.metabolize()
 			if(ingested) ingested.metabolize()
 			if(bloodstr) bloodstr.metabolize()
-
-			if(CE_PAINKILLER in chem_effects)
-				analgesic = chem_effects[CE_PAINKILLER]
 
 			var/total_phoronloss = 0
 			for(var/obj/item/I in src)
@@ -796,7 +792,7 @@
 			clear_fullscreen("brute")
 
 		if(healths)
-			if (analgesic > 100)
+			if (chem_effects[CE_PAINKILLER] > 100)
 				healths.icon_state = "health_numb"
 			else
 				switch(hal_screwyhud)
@@ -960,8 +956,10 @@
 		shock_stage = max(shock_stage-1, 0)
 		return
 
+	if(stat) return 0
+
 	if(shock_stage == 10)
-		src << "<span class='danger'>[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!</span>"
+		custom_pain("[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!", 40)
 
 	if(shock_stage >= 30)
 		if(shock_stage == 30) emote("me",1,"is having trouble keeping their eyes open.")

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -67,14 +67,10 @@
 
 /mob/living/carbon/slime/handle_chemicals_in_body()
 	chem_effects.Cut()
-	analgesic = 0
 
 	if(touching) touching.metabolize()
 	if(ingested) ingested.metabolize()
 	if(bloodstr) bloodstr.metabolize()
-
-	if(CE_PAINKILLER in chem_effects)
-		analgesic = chem_effects[CE_PAINKILLER]
 
 	src.updatehealth()
 

--- a/code/modules/mob/living/carbon/metroid/powers.dm
+++ b/code/modules/mob/living/carbon/metroid/powers.dm
@@ -70,7 +70,7 @@
 				var/painMes = pick("You can feel your body becoming weak!", "You feel like you're about to die!", "You feel every part of your body screaming in agony!", "A low, rolling pain passes through your body!", "Your body feels as if it's falling apart!", "You feel extremely weak!", "A sharp, deep pain bathes every inch of your body!")
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
-					H.custom_pain(painMes)
+					H.custom_pain(painMes,100)
 				else if (istype(M, /mob/living/carbon))
 					var/mob/living/carbon/C = M
 					if (C.can_feel_pain())

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -14,25 +14,26 @@
 	1.2	* src.getBruteLoss() + 		\
 	1.7	* src.getCloneLoss() + 		\
 	2	* src.halloss + 			\
-	-1	* src.analgesic
+	-1	* src.chem_effects[CE_PAINKILLER]
 
 	if(src.slurring)
 		src.traumatic_shock -= 20
 
-	// broken or ripped off organs will add quite a bit of pain
-	if(istype(src,/mob/living/carbon/human))
-		var/mob/living/carbon/human/M = src
-		for(var/obj/item/organ/external/organ in M.organs)
-			if(organ.is_broken() || organ.open)
-				src.traumatic_shock += 30
-			else if(organ.is_dislocated())
-				src.traumatic_shock += 15
-
-	if(src.traumatic_shock < 0)
-		src.traumatic_shock = 0
+	traumatic_shock = max(0,traumatic_shock)
 
 	return src.traumatic_shock
 
+/mob/living/carbon/human/updateshock()
+	if (!can_feel_pain())
+		src.traumatic_shock = 0
+		return 0
+	traumatic_shock = ..()
+	for(var/obj/item/organ/external/organ in organs)
+		if(organ.is_broken() || organ.open)
+			src.traumatic_shock += 30
+		else if(organ.is_dislocated())
+			src.traumatic_shock += 15
+	return src.traumatic_shock
 
 /mob/living/carbon/proc/handle_shock()
 	updateshock()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -695,7 +695,7 @@
 		if(client.holder)
 			stat("CPU:","[world.cpu]")
 			stat("Instances:","[world.contents.len]")
-			
+
 	if(client.holder && statpanel("Processes"))
 		if(processScheduler)
 			processScheduler.statProcesses()
@@ -970,7 +970,7 @@ mob/proc/yank_out_object()
 		if(prob(selection.w_class * 5)) //I'M SO ANEMIC I COULD JUST -DIE-.
 			var/datum/wound/internal_bleeding/I = new (min(selection.w_class * 5, 15))
 			affected.wounds += I
-			H.custom_pain("Something tears wetly in your [affected] as [selection] is pulled free!", 1)
+			H.custom_pain("Something tears wetly in your [affected] as [selection] is pulled free!", 50)
 
 		if (ishuman(U))
 			var/mob/living/carbon/human/human_user = U

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -20,7 +20,7 @@
 		user << "<span class='notice'>You must stand still to feel [E] for fractures.</span>"
 	else if(E.status & ORGAN_BROKEN)
 		user << "<span class='warning'>The [E.encased ? E.encased : "bone in the [E.name]"] moves slightly when you poke it!</span>"
-		H.custom_pain("Your [E.name] hurts where it's poked.")
+		H.custom_pain("Your [E.name] hurts where it's poked.",40)
 	else
 		user << "<span class='notice'>The [E.encased ? E.encased : "bones in the [E.name]"] seem to be fine.</span>"
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -24,11 +24,11 @@
 /obj/item/organ/internal/lungs/set_dna(var/datum/dna/new_dna)
 	..()
 	sync_breath_types()
-	
+
 /obj/item/organ/internal/lungs/replaced()
 	..()
 	sync_breath_types()
-	
+
 /**
  *  Set these lungs' breath types based on the lungs' species
  */
@@ -59,7 +59,7 @@
 /obj/item/organ/internal/lungs/proc/rupture()
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	if(istype(parent))
-		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 1)
+		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50)
 	bruise()
 
 /obj/item/organ/internal/lungs/proc/handle_breath(datum/gas_mixture/breath)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -248,7 +248,7 @@ var/list/organ_cache = list()
 		if(owner && parent_organ && amount > 0)
 			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 			if(parent && !silent)
-				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
+				owner.custom_pain("Something inside your [parent.name] hurts a lot.", amount)
 
 /obj/item/organ/proc/bruise()
 	damage = max(damage, min_bruised_damage)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -499,7 +499,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(damage > 15 && type != BURN && local_damage > 30 && prob(damage) && (robotic < ORGAN_ROBOT))
 		var/datum/wound/internal_bleeding/I = new (min(damage - 15, 15))
 		wounds += I
-		owner.custom_pain("You feel something rip in your [name]!", 1)
+		owner.custom_pain("You feel something rip in your [name]!", 50)
 
 	//Burn damage can cause fluid loss due to blistering and cook-off
 	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT))
@@ -716,7 +716,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 			owner.vessel.remove_reagent("blood", wound_update_accuracy * W.damage/40) //line should possibly be moved to handle_blood, so all the bleeding stuff is in one place.
 			if(prob(1 * wound_update_accuracy))
-				owner.custom_pain("You feel a stabbing pain in your [name]!",1)
+				owner.custom_pain("You feel a stabbing pain in your [name]!",50)
 
 		// slow healing
 		var/heal_amt = 0

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -203,12 +203,14 @@
 	if(inflamed && owner)
 		inflamed++
 		if(prob(5))
-			owner << "<span class='warning'>You feel a stinging pain in your abdomen!</span>"
-			owner.emote("me",1,"winces slightly.")
+			if(owner.can_feel_pain())
+				owner.custom_pain("You feel a stinging pain in your abdomen!")
+				owner.emote("me",1,"winces slightly.")
 		if(inflamed > 200)
 			if(prob(3))
 				take_damage(0.1)
-				owner.emote("me",1,"winces painfully.")
+				if(owner.can_feel_pain())
+					owner.emote("me",1,"winces painfully.")
 				owner.adjustToxLoss(1)
 		if(inflamed > 400)
 			if(prob(1))
@@ -220,8 +222,9 @@
 					owner.Weaken(10)
 		if(inflamed > 600)
 			if(prob(1))
-				owner << "<span class='danger'>Your abdomen is a world of pain!</span>"
-				owner.Weaken(10)
+				if(owner.can_feel_pain())
+					owner.custom_pain("You feel a stinging pain in your abdomen!")
+					owner.Weaken(10)
 
 				var/obj/item/organ/external/E = owner.get_organ(parent_organ)
 				var/datum/wound/W = new /datum/wound/internal_bleeding(20)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -8,11 +8,9 @@ mob/var/next_pain_time = 0
 // partname is the name of a body part
 // amount is a num from 1 to 100
 mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0)
-	if(stat >= 1)
-		return
 	if(!can_feel_pain())
 		return
-	if(analgesic > 40)
+	if(chem_effects[CE_PAINKILLER] > amount)
 		return
 	if(world.time < next_pain_time && !force)
 		return
@@ -20,64 +18,56 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 		if(src:paralysis)
 			src:paralysis = max(0, src:paralysis-round(amount/10))
 	if(amount > 50 && prob(amount / 5))
-		src:drop_item()
+		drop_item()
 	var/msg
 	if(burning)
 		switch(amount)
 			if(1 to 10)
-				msg = "<span class='danger'>Your [partname] burns.</span>"
+				msg = "Your [partname] burns."
 			if(11 to 90)
 				flash_weak_pain()
-				msg = "<span class='danger'><font size=2>Your [partname] burns badly!</font></span>"
+				msg = "<font size=2>Your [partname] burns badly!</font>"
 			if(91 to 10000)
 				flash_pain()
-				msg = "<span class='danger'><font size=3>OH GOD! Your [partname] is on fire!</font></span>"
+				msg = "<font size=3>OH GOD! Your [partname] is on fire!</font>"
 	else
 		switch(amount)
 			if(1 to 10)
-				msg = "<b>Your [partname] hurts.</b>"
+				msg = "Your [partname] hurts."
 			if(11 to 90)
 				flash_weak_pain()
-				msg = "<b><font size=2>Your [partname] hurts badly.</font></b>"
+				msg = "<font size=2>Your [partname] hurts badly.</font>"
 			if(91 to 10000)
 				flash_pain()
-				msg = "<b><font size=3>OH GOD! Your [partname] is hurting terribly!</font></b>"
-	if(msg && (msg != last_pain_message || prob(10)))
-		last_pain_message = msg
-		src << msg
-	next_pain_time = world.time + (100 - amount)
-
+				msg = "<font size=3>OH GOD! Your [partname] is hurting terribly!</font>"
+	custom_pain(msg, amount, force || prob(10))
 
 // message is the custom message to be displayed
-// flash_strength is 0 for weak pain flash, 1 for strong pain flash
-mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
-	if(stat >= 1)
+// power decides how much painkillers will stop the message
+// force means it ignores anti-psam timer
+mob/living/carbon/proc/custom_pain(message, power, force)
+	if(stat)
+		return 0
+	if(!message)
 		return
 	if(!can_feel_pain())
 		return
-	if(reagents.has_reagent("tramadol"))
+	if(chem_effects[CE_PAINKILLER] > power)
 		return
-	if(reagents.has_reagent("oxycodone"))
-		return
-	if(analgesic)
-		return
-	var/msg = "<span class='danger'>[message]</span>"
-	if(flash_strength >= 1)
-		msg = "<span class='danger'><font size=3>[message]</font></span>"
+	message = "<span class='danger'>[message]</span>"
+	if(power >= 50)
+		message = "<font size=3>[message]</font>"
 
 	// Anti message spam checks
-	if(msg && ((msg != last_pain_message) || (world.time >= next_pain_time)))
-		last_pain_message = msg
-		src << msg
-	next_pain_time = world.time + 100
+	if(force || (message != last_pain_message) || (world.time >= next_pain_time))
+		last_pain_message = message
+		src << message
+	next_pain_time = world.time + (100-power)
 
 mob/living/carbon/human/proc/handle_pain()
-	// not when sleeping
-
-	if(!can_feel_pain()) return
-
-	if(stat >= 2) return
-	if(analgesic > 70)
+	if(stat)
+		return
+	if(!can_feel_pain())
 		return
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
@@ -97,26 +87,13 @@ mob/living/carbon/human/proc/handle_pain()
 		if((I.status & ORGAN_DEAD) || I.robotic >= ORGAN_ROBOT) continue
 		if(I.damage > 2) if(prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
-			src.custom_pain("You feel a sharp pain in your [parent.name]", 1)
+			src.custom_pain("You feel a sharp pain in your [parent.name]", 50)
 
-	var/toxDamageMessage = null
-	var/toxMessageProb = 1
-	switch(getToxLoss())
-		if(1 to 5)
-			toxMessageProb = 1
-			toxDamageMessage = "Your body stings slightly."
-		if(6 to 10)
-			toxMessageProb = 2
-			toxDamageMessage = "Your whole body hurts a little."
-		if(11 to 15)
-			toxMessageProb = 2
-			toxDamageMessage = "Your whole body hurts."
-		if(15 to 25)
-			toxMessageProb = 3
-			toxDamageMessage = "Your whole body hurts badly."
-		if(26 to INFINITY)
-			toxMessageProb = 5
-			toxDamageMessage = "Your body aches all over, it's driving you mad."
-
-	if(toxDamageMessage && prob(toxMessageProb))
-		src.custom_pain(toxDamageMessage, getToxLoss() >= 15)
+	if(prob(2))
+		switch(getToxLoss())
+			if(1 to 10)
+				custom_pain("Your body stings slightly.", getToxLoss())
+			if(11 to 60)
+				custom_pain("Your whole body hurts badly.", getToxLoss())
+			if(61 to INFINITY)
+				custom_pain("Your body aches all over, it's driving you mad.", getToxLoss())

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -207,7 +207,7 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/tramadol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 70)
+	M.add_chemical_effect(CE_PAINKILLER, 80)
 
 /datum/reagent/tramadol/overdose(var/mob/living/carbon/M, var/alien)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -15,7 +15,7 @@
 /datum/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE)
-		M.add_chemical_effect(CE_PAINKILLER, 25)
+		M.add_chemical_effect(CE_PAINKILLER, 10)
 	M.add_chemical_effect(CE_PULSE, 1)
 
 /datum/reagent/bicaridine
@@ -188,7 +188,7 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/paracetamol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 50)
+	M.add_chemical_effect(CE_PAINKILLER, 25)
 
 /datum/reagent/paracetamol/overdose(var/mob/living/carbon/M, var/alien)
 	..()
@@ -207,7 +207,7 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/tramadol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 80)
+	M.add_chemical_effect(CE_PAINKILLER, 70)
 
 /datum/reagent/tramadol/overdose(var/mob/living/carbon/M, var/alien)
 	..()
@@ -255,7 +255,7 @@
 	holder.remove_reagent("mindbreaker", 5)
 	M.hallucination = max(0, M.hallucination - 10)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
-	M.add_chemical_effect(CE_PAINKILLER, 40)
+	M.add_chemical_effect(CE_PAINKILLER, 20)
 
 /datum/reagent/alkysine
 	name = "Alkysine"

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -32,7 +32,7 @@
 	if (affected.stage == 0)
 		user.visible_message("[user] starts applying medication to the damaged bones in [target]'s [affected.name] with \the [tool]." , \
 		"You start applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",1)
+	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",50)
 	..()
 
 /datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -69,7 +69,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to set the bone in [target]'s [affected.name] in place with \the [tool]." , \
 		"You are beginning to set the bone in [target]'s [affected.name] in place with \the [tool].")
-	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",1)
+	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",50)
 	..()
 
 /datum/surgery_step/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -44,7 +44,7 @@
 
 	user.visible_message("[user] begins to cut through [target]'s [affected.encased] with \the [tool].", \
 	"You begin to cut through [target]'s [affected.encased] with \the [tool].")
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!",60)
 	..()
 
 /datum/surgery_step/open_encased/saw/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -96,7 +96,7 @@
 	var/msg = "[user] starts to force open the [affected.encased] in [target]'s [affected.name] with \the [tool]."
 	var/self_msg = "You start to force open the [affected.encased] in [target]'s [affected.name] with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!",40)
 	..()
 
 /datum/surgery_step/open_encased/retract/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -156,7 +156,7 @@
 	var/msg = "[user] starts bending [target]'s [affected.encased] back into place with \the [tool]."
 	var/self_msg = "You start bending [target]'s [affected.encased] back into place with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!",100)
 	..()
 
 /datum/surgery_step/open_encased/close/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -218,7 +218,7 @@
 	var/msg = "[user] starts applying \the [tool] to [target]'s [affected.encased]."
 	var/self_msg = "You start applying \the [tool] to [target]'s [affected.encased]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!",100)
 	..()
 
 /datum/surgery_step/open_encased/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -50,7 +50,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts the bloodless incision on [target]'s [affected.name] with \the [tool].", \
 	"You start the bloodless incision on [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("You feel a horrible, searing pain in your [affected.name]!",1)
+	target.custom_pain("You feel a horrible, searing pain in your [affected.name]!",50)
 	..()
 
 /datum/surgery_step/generic/cut_with_laser/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -92,7 +92,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to construct a prepared incision on and within [target]'s [affected.name] with \the [tool].", \
 	"You start to construct a prepared incision on and within [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("You feel a horrible, searing pain in your [affected.name] as it is pushed apart!",1)
+	target.custom_pain("You feel a horrible, searing pain in your [affected.name] as it is pushed apart!",50)
 	..()
 
 /datum/surgery_step/generic/incision_manager/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -137,7 +137,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts the incision on [target]'s [affected.name] with \the [tool].", \
 	"You start the incision on [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!",1)
+	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!",40)
 	..()
 
 /datum/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -180,7 +180,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].", \
 	"You start clamping bleeders in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("The pain in your [affected.name] is maddening!",1)
+	target.custom_pain("The pain in your [affected.name] is maddening!",40)
 	..()
 
 /datum/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -226,7 +226,7 @@
 		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
 		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("It feels like the skin on your [affected.name] is on fire!",1)
+	target.custom_pain("It feels like the skin on your [affected.name] is on fire!",40)
 	..()
 
 /datum/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -278,7 +278,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to cauterize the incision on [target]'s [affected.name] with \the [tool]." , \
 	"You are beginning to cauterize the incision on [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Your [affected.name] is being burned!",1)
+	target.custom_pain("Your [affected.name] is being burned!",40)
 	..()
 
 /datum/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -321,7 +321,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to amputate [target]'s [affected.name] with \the [tool]." , \
 	"You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool].")
-	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",1)
+	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",100)
 	..()
 
 /datum/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -58,7 +58,7 @@
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 				"You start treating damage to [target]'s [I.name] with [tool_name]." )
 
-	target.custom_pain("The pain in your [affected.name] is living hell!",1)
+	target.custom_pain("The pain in your [affected.name] is living hell!",100)
 	..()
 
 /datum/surgery_step/internal/fix_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -144,7 +144,7 @@
 /datum/surgery_step/internal/detatch_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts to separate [target]'s [target.op_stage.current_organ] with \the [tool].", \
 	"You start to separate [target]'s [target.op_stage.current_organ] with \the [tool]." )
-	target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",1)
+	target.custom_pain("Someone's ripping out your [target.op_stage.current_organ]!",100)
 	..()
 
 /datum/surgery_step/internal/detatch_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -205,7 +205,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts removing [target]'s [target.op_stage.current_organ] with \the [tool].", \
 	"You start removing [target]'s [target.op_stage.current_organ] with \the [tool].")
-	target.custom_pain("The pain in your [affected.name] is living hell!",1)
+	target.custom_pain("The pain in your [affected.name] is living hell!",100)
 	..()
 
 /datum/surgery_step/internal/remove_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -295,7 +295,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts transplanting \the [tool] into [target]'s [affected.name].", \
 	"You start transplanting \the [tool] into [target]'s [affected.name].")
-	target.custom_pain("Someone's rooting around in your [affected.name]!",1)
+	target.custom_pain("Someone's rooting around in your [affected.name]!",100)
 	..()
 
 /datum/surgery_step/internal/replace_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -359,7 +359,7 @@
 /datum/surgery_step/internal/attach_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] begins reattaching [target]'s [target.op_stage.current_organ] with \the [tool].", \
 	"You start reattaching [target]'s [target.op_stage.current_organ] with \the [tool].")
-	target.custom_pain("Someone's digging needles into your [target.op_stage.current_organ]!",1)
+	target.custom_pain("Someone's digging needles into your [target.op_stage.current_organ]!",100)
 	..()
 
 /datum/surgery_step/internal/attach_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -35,7 +35,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts patching the damaged vein in [target]'s [affected.name] with \the [tool]." , \
 	"You start patching the damaged vein in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("The pain in [affected.name] is unbearable!",1)
+	target.custom_pain("The pain in [affected.name] is unbearable!",100)
 	..()
 
 /datum/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -86,7 +86,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts cutting away necrotic tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start cutting away necrotic tissue in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("The pain in [affected.name] is unbearable!",1)
+	target.custom_pain("The pain in [affected.name] is unbearable!",100)
 	..()
 
 /datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -139,7 +139,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",1)
+	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",50)
 	..()
 
 /datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Being unconscious makes you get no pain messages. Fxes #14267
Axed 'analgesic' var that was only used to take chem_effects[CE_PAINKILLER] in life()
CE_PAINKILLER effects now block pain/pain messages according to its severity rather than hardcoded values for all messages/pains.
Updated all usages of custom_pain to use power.
Shock effects are now not applied if mob is not awake. Fixes #14268 

feedback, suggestions, screams, insults?
