### PR TITLE
Fixes #14095 and other minor PDA gubbins

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1129,7 +1129,11 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(issilicon(usr))
 		return
 
-	if (can_use(usr) && !isnull(cartridge))
+	if(isnull(cartridge))
+		usr << "<span class='notice'>\The [src] does not have a cartridge in it.</span>"
+		return
+
+	if (can_use(usr))
 		var/turf/T = get_turf(src)
 		cartridge.loc = T
 		if (ismob(loc))
@@ -1141,8 +1145,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		scanmode = 0
 		if (cartridge.radio)
 			cartridge.radio.hostpda = null
-		cartridge = null
 		usr << "<span class='notice'>You remove \the [cartridge] from the [name].</span>"
+		cartridge = null
 	else
 		usr << "<span class='notice'>You cannot do this while restrained.</span>"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1093,7 +1093,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if(id)
 			remove_id()
 		else
-			usr << "<span class='notice'>This PDA does not have an ID in it.</span>"
+			usr << "<span class='notice'>\The [src] does not have an ID in it.</span>"
 	else
 		usr << "<span class='notice'>You cannot do this while restrained.</span>"
 
@@ -1117,7 +1117,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					return
 			O.loc = get_turf(src)
 		else
-			usr << "<span class='notice'>This PDA does not have a pen in it.</span>"
+			usr << "<span class='notice'>\The [src] does not have a pen in it.</span>"
 	else
 		usr << "<span class='notice'>You cannot do this while restrained.</span>"
 


### PR DESCRIPTION
PDAs will no longer think you're restrained if you try to eject a non-existent cartridge, although they may of course think less of you as a person.

Cartridge name will be properly reported on ejection.

Tweaked a couple of instances of 'This PDA' to be consistent with everywhere else.
