### PR TITLE
More flexible reagent dispenser initialization.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2138,6 +2138,7 @@
 #include "code\unit_tests\mob_tests.dm"
 #include "code\unit_tests\movement_tests.dm"
 #include "code\unit_tests\observation_tests.dm"
+#include "code\unit_tests\reagent_tests.dm"
 #include "code\unit_tests\shuttle_tests.dm"
 #include "code\unit_tests\test_obj.dm"
 #include "code\unit_tests\unique_tests.dm"

--- a/code/unit_tests/reagent_tests.dm
+++ b/code/unit_tests/reagent_tests.dm
@@ -1,0 +1,31 @@
+/datum/unit_test/reagent_dispensers_shall_have_valid_initial_reagents
+	name = "REAGENT: Dispensers shall have valid initial reagents"
+
+/datum/unit_test/reagent_dispensers_shall_have_valid_initial_reagents/start_test()
+	var/list/bad_reagents = list()
+
+	for(var/dispenser_type in typesof(/obj/structure/reagent_dispensers))
+		var/obj/structure/reagent_dispensers/rd = dispenser_type
+		var/list/reagent_list = json_decode(initial(rd.initial_reagents))
+		var/total_ratio = 0
+		for(var/reagent in reagent_list)
+			if(!(reagent in chemical_reagents_list))
+				bad_reagents |= dispenser_type
+				log_bad("[dispenser_type]: The reagent '[reagent]' is invalid.")
+
+			var/reagent_ratio = reagent_list[reagent]
+			total_ratio += reagent_ratio
+			if(reagent_ratio <= 0 || reagent_ratio > 1)
+				bad_reagents |= dispenser_type
+				log_bad("[dispenser_type]: Reagent ratio was [reagent_ratio], expected a number 0 < x <= 1.")
+
+		if(total_ratio < 0 || total_ratio > 1) // A dispenser may of course be empty
+			bad_reagents |= dispenser_type
+			log_bad("[dispenser_type]: Total reagent ratio was [total_ratio], expected a number 0 <= x <= 1.")
+
+	if(bad_reagents.len)
+		fail("Following reagent dispenser types have an invalid initial reagent setup: [english_list(bad_reagents)]")
+	else
+		pass("All reagent dispenser types have an expected initial reagents setup.")
+
+	return 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

As per suggestions in #14116.
Possible to add a helper `#define jsonstring(x) "\"[x]\""` to avoid having to do `"{\"water\":5}"` and instead write `"{[jsonstring("water")]:5}"` but it doesn't feel that much more convenient (not to mention the nested [[]]). On the other than I suppose it is more clear.
