### PR TITLE
Tweaks stealth mode and staffwho feedback.

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -137,10 +137,7 @@
 		if(include_link && C)
 			. += "<a href='?priv_msg=\ref[C]'>"
 
-		if(C && C.holder && C.holder.fakekey && !include_name)
-			. += "Administrator"
-		else
-			. += key
+		. += key
 
 		if(include_link)
 			if(C)	. += "</a>"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -66,8 +66,6 @@ var/list/gamemode_cache = list()
 	var/guest_jobban = 1
 	var/usewhitelist = 0
 	var/kick_inactive = 0				//force disconnect for inactive players after this many minutes, if non-0
-	var/show_mods = 0
-	var/show_mentors = 0
 	var/mods_can_tempban = 0
 	var/mods_can_job_tempban = 0
 	var/mod_tempban_max = 1440
@@ -515,12 +513,6 @@ var/list/gamemode_cache = list()
 
 				if("kick_inactive")
 					config.kick_inactive = text2num(value)
-
-				if("show_mods")
-					config.show_mods = 1
-
-				if("show_mentors")
-					config.show_mentors = 1
 
 				if("mods_can_tempban")
 					config.mods_can_tempban = 1

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -5,36 +5,35 @@
 
 	if(!mob)	return
 	if(IsGuestKey(key))
-		src << "Guests may not use OOC."
+		to_chat(src, "Guests may not use OOC.")
 		return
 
 	msg = sanitize(msg)
 	if(!msg)	return
 
 	if(!is_preference_enabled(/datum/client_preference/show_ooc))
-		src << "<span class='warning'>You have OOC muted.</span>"
+		to_chat(src, "<span class='warning'>You have OOC muted.</span>")
 		return
 
 	if(!holder)
 		if(!config.ooc_allowed)
-			src << "<span class='danger'>OOC is globally muted.</span>"
+			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return
 		if(!config.dooc_allowed && (mob.stat == DEAD))
-			usr << "<span class='danger'>OOC for dead mobs has been turned off.</span>"
+			to_chat(src, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
 			return
 		if(prefs.muted & MUTE_OOC)
-			src << "<span class='danger'>You cannot use OOC (muted).</span>"
+			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
 		if(findtext(msg, "byond://"))
-			src << "<B>Advertising other servers is not allowed.</B>"
-			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
-			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
+			to_chat(src, "<B>Advertising other servers is not allowed.</B>")
+			log_and_message_admins("has attempted to advertise in OOC: [msg]")
 			return
 
 	log_ooc("[mob.name]/[key] : [msg]")
 
 	var/ooc_style = "everyone"
-	if(holder && !holder.fakekey)
+	if(holder && !is_stealthed())
 		ooc_style = "elevated"
 		if(holder.rights & R_MOD)
 			ooc_style = "moderator"
@@ -47,17 +46,10 @@
 		if(target.is_preference_enabled(/datum/client_preference/show_ooc))
 			if(target.is_key_ignored(key)) // If we're ignored by this person, then do nothing.
 				continue
-			var/display_name = src.key
-			if(holder)
-				if(holder.fakekey)
-					if(target.holder)
-						display_name = "[holder.fakekey]/([src.key])"
-					else
-						display_name = holder.fakekey
-			if(holder && !holder.fakekey && (holder.rights & R_ADMIN) && config.allow_admin_ooccolor && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
-				target << "<font color='[src.prefs.ooccolor]'><span class='ooc'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+			if(!is_stealthed() && config.allow_admin_ooccolor && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
+				to_chat(target, "<font color='[src.prefs.ooccolor]'><span class='ooc'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[key]:</EM> <span class='message'>[msg]</span></span></font>")
 			else
-				target << "<span class='ooc'><span class='[ooc_style]'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></span>"
+				to_chat(target, "<span class='ooc'><span class='[ooc_style]'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[key]:</EM> <span class='message'>[msg]</span></span></span>")
 
 /client/verb/looc(msg as text)
 	set name = "LOOC"
@@ -100,8 +92,6 @@
 	var/mob/source = mob.get_looc_source()
 
 	var/display_name = key
-	if(holder && holder.fakekey)
-		display_name = holder.fakekey
 	if(mob.stat != DEAD)
 		display_name = mob.name
 
@@ -155,14 +145,14 @@
 				prefix = "(Eye) "
 			else
 				prefix = "(Core) "
-		t << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", t) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+		to_chat(t, "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", t) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>")
 
 	for(var/client/adm in admins)	//Now send to all admins that weren't in range.
 		if(!(adm in listening) && adm.is_preference_enabled(/datum/client_preference/show_looc) && adm.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
 			var/admin_stuff = "/([key])([admin_jump_link(mob, adm.holder)])"
 			var/prefix = "(R)"
 
-			adm << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", adm) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+			to_chat(adm, "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", adm) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>")
 
 /mob/proc/get_looc_source()
 	return src

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -7,11 +7,9 @@
 
 	var/list/Lines = list()
 
-	if(holder && (R_ADMIN & holder.rights || R_MOD & holder.rights))
+	if(check_rights(R_INVESTIGATE, 0))
 		for(var/client/C in clients)
 			var/entry = "\t[C.key]"
-			if(C.holder && C.holder.fakekey)
-				entry += " <i>(as [C.holder.fakekey])</i>"
 			entry += " - Playing as [C.mob.real_name]"
 			switch(C.mob.stat)
 				if(UNCONSCIOUS)
@@ -47,101 +45,42 @@
 			Lines += entry
 	else
 		for(var/client/C in clients)
-			if(C.holder && C.holder.fakekey)
-				Lines += C.holder.fakekey
-			else
-				Lines += C.key
+			Lines += C.key
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"
 
 	msg += "<b>Total Players: [length(Lines)]</b>"
-	src << msg
+	to_chat(src, msg)
 
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"
 
-	var/msg = ""
-	var/modmsg = ""
-	var/mentmsg = ""
-	var/num_mods_online = 0
-	var/num_admins_online = 0
-	var/num_mentors_online = 0
-	if(holder)
-		for(var/client/C in admins)
-			if(R_ADMIN & C.holder.rights || (!R_MOD & C.holder.rights && !R_MENTOR & C.holder.rights))	//Used to determine who shows up in admin rows
+	var/msg = list()
+	var/active_staff = 0
+	var/total_staff = 0
+	var/can_investigate = check_rights(R_INVESTIGATE, 0)
 
-				if(C.holder.fakekey && (!R_ADMIN & holder.rights && !R_MOD & holder.rights))		//Mentors can't see stealthmins
-					continue
-
-				msg += "\t[C] is a [C.holder.rank]"
-
-				if(C.holder.fakekey)
-					msg += " <i>(as [C.holder.fakekey])</i>"
-
-				if(isobserver(C.mob))
-					msg += " - Observing"
-				else if(istype(C.mob,/mob/new_player))
-					msg += " - Lobby"
-				else
-					msg += " - Playing"
-
-				if(C.is_afk())
-					msg += " (AFK - [C.inactivity2text()])"
-				msg += "\n"
-
-				num_admins_online++
-			else if(R_MOD & C.holder.rights)				//Who shows up in mod/mentor rows.
-				modmsg += "\t[C] is a [C.holder.rank]"
-
-				if(isobserver(C.mob))
-					modmsg += " - Observing"
-				else if(istype(C.mob,/mob/new_player))
-					modmsg += " - Lobby"
-				else
-					modmsg += " - Playing"
-
-				if(C.is_afk())
-					modmsg += " (AFK - [C.inactivity2text()])"
-				modmsg += "\n"
-				num_mods_online++
-
-			else if(R_MENTOR & C.holder.rights)
-				mentmsg += "\t[C] is a [C.holder.rank]"
-				if(isobserver(C.mob))
-					mentmsg += " - Observing"
-				else if(istype(C.mob,/mob/new_player))
-					mentmsg += " - Lobby"
-				else
-					mentmsg += " - Playing"
-
-				if(C.is_afk())
-					mentmsg += " (AFK - [C.inactivity2text()])"
-				mentmsg += "\n"
-				num_mentors_online++
-
-	else
-		for(var/client/C in admins)
-			if(R_ADMIN & C.holder.rights || (!R_MOD & C.holder.rights && !R_MENTOR & C.holder.rights))
-				if(!C.holder.fakekey)
-					msg += "\t[C] is a [C.holder.rank]\n"
-					num_admins_online++
-			else if (R_MOD & C.holder.rights)
-				modmsg += "\t[C] is a [C.holder.rank]\n"
-				num_mods_online++
-			else if (R_MENTOR & C.holder.rights)
-				mentmsg += "\t[C] is a [C.holder.rank]\n"
-				num_mentors_online++
+	for(var/client/C in admins)
+		if(C.is_stealthed())
+			continue
+		total_staff++
+		msg += "\t[C] is \a [C.holder.rank]"
+		if(C.is_afk())
+			msg += can_investigate ? " (AFK - [C.inactivity2text()])" : "(AFK)"
+		else
+			active_staff++
+		if(can_investigate)
+			if(isghost(C.mob))
+				msg += " - Observing"
+			else if(istype(C.mob,/mob/new_player))
+				msg += " - Lobby"
+			else
+				msg += " - Playing"
+		msg += "\n"
 
 	if(config.admin_irc)
-		src << "<span class='info'>Adminhelps are also sent to IRC. If no admins are available in game try anyway and an admin on IRC may see it and respond.</span>"
-	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg
-
-	if(config.show_mods)
-		msg += "\n<b> Current Moderators ([num_mods_online]):</b>\n" + modmsg
-
-	if(config.show_mentors)
-		msg += "\n<b> Current Mentors ([num_mentors_online]):</b>\n" + mentmsg
-
-	src << msg
+		to_chat(src, "<span class='info'>Adminhelps are also sent to IRC. If no admins are available in game try anyway and an admin on IRC may see it and respond.</span>")
+	to_chat(src, "<b>Current Staff ([active_staff]/[total_staff]):</b>")
+	to_chat(src, jointext(msg,null))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -644,10 +644,10 @@ var/global/floorIsLava = 0
 	if(confirm == "Cancel")
 		return
 	if(confirm == "Yes")
-		world << "<span class='danger'>Restarting world!</span> <span class='notice'>Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key]!</span>"
+		world << "<span class='danger'>Restarting world!</span> <span class='notice'>Initiated by [usr.key]!</span>"
 		log_admin("[key_name(usr)] initiated a reboot.")
 
-		feedback_set_details("end_error","admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]")
+		feedback_set_details("end_error","admin reboot - by [usr.key]")
 		feedback_add_details("admin_verb","R") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 		if(blackbox)
@@ -667,7 +667,7 @@ var/global/floorIsLava = 0
 	message = sanitize(message, 500, extra = 0)
 	if(message)
 		message = replacetext(message, "\n", "<br>") // required since we're putting it in a <p> tag
-		world << "<span class=notice><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b><p style='text-indent: 50px'>[message]</p></span>"
+		world << "<span class=notice><b>[usr.key] Announces:</b><p style='text-indent: 50px'>[message]</p></span>"
 		log_admin("Announce: [key_name(usr)] : [message]")
 	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -905,10 +905,10 @@ var/global/floorIsLava = 0
 	if(!usr.client.holder)	return
 	if( alert("Reboot server?",,"Yes","No") == "No")
 		return
-	world << "\red <b>Rebooting world!</b> \blue Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key]!"
+	world << "<span class='danger'>Rebooting world!</span> <span class='notice'>Initiated by [usr.key]!</span>"
 	log_admin("[key_name(usr)] initiated an immediate reboot.")
 
-	feedback_set_details("end_error","immediate admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]")
+	feedback_set_details("end_error","immediate admin reboot - by [usr.key]")
 	feedback_add_details("admin_verb","IR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	if(blackbox)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -53,7 +53,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/manage_silicon_laws,	// Allows viewing and editing silicon laws. ,
 	/client/proc/check_antagonists,
 	/client/proc/admin_memo,			//admin memo system. show/delete/write. +SERVER needed to delete admin memos of others,
-	/client/proc/dsay,					//talk in deadchat using our ckey/fakekey,
+	/client/proc/dsay,					//talk in deadchat using our ckey
 //	/client/proc/toggle_hear_deadcast,	//toggles whether we hear deadchat,
 	/client/proc/investigate_show,		//various admintools for investigation. Such as a singulo grief-log,
 	/datum/admins/proc/toggleooc,		//toggles ooc on/off for everyone,
@@ -518,26 +518,6 @@ var/list/admin_verbs_mentor = list(
 
 	feedback_add_details("admin_verb","OC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
-
-/client/proc/stealth()
-	set category = "Admin"
-	set name = "Stealth Mode"
-	if(holder)
-		if(holder.fakekey)
-			holder.fakekey = null
-			if(istype(src.mob, /mob/new_player))
-				mob.name = key
-		else
-			var/new_key = ckeyEx(input("Enter your desired display name.", "Fake Key", key) as text|null)
-			if(!new_key)	return
-			if(length(new_key) >= 26)
-				new_key = copytext(new_key, 1, 26)
-			holder.fakekey = new_key
-			if(istype(mob, /mob/new_player))
-				mob.name = new_key
-		log_admin("[key_name(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")
-		message_admins("[key_name_admin(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]", 1)
-	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 #define MAX_WARNS 3
 #define AUTOBANTIME 10

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -1,10 +1,14 @@
+#define STEALTH_OFF 0
+#define STEALTH_MANUAL 1
+#define STEALTH_AUTO 2
+
 var/list/admin_datums = list()
 
 /datum/admins
-	var/rank			= "Temporary Admin"
-	var/client/owner	= null
-	var/rights = 0
-	var/fakekey			= null
+	var/rank         = "Temporary Admin"
+	var/client/owner = null
+	var/rights       = 0
+	var/stealthy_    = STEALTH_OFF
 
 	var/datum/weakref/marked_datum_weak
 
@@ -69,7 +73,7 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 		return FALSE
 	if(!C.holder)
 		if(show_msg)
-			C << "<span class='warning'>Error: You are not an admin.</span>"
+			to_chat(C, "<span class='warning'>Error: You are not an admin.</span>")
 		return FALSE
 
 	if(rights_required)
@@ -77,7 +81,7 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 			return TRUE
 		else
 			if(show_msg)
-				C << "<span class='warning'>Error: You do not have sufficient rights to do that. You require one of the following flags:[rights2text(rights_required," ")].</span>"
+				to_chat(C, "<span class='warning'>Error: You do not have sufficient rights to do that. You require one of the following flags:[rights2text(rights_required," ")].</span>")
 			return FALSE
 	else
 		return TRUE
@@ -91,13 +95,54 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 			if(usr.client.holder.rights != other.holder.rights)
 				if( (usr.client.holder.rights & other.holder.rights) == other.holder.rights )
 					return 1	//we have all the rights they have and more
-		usr << "<font color='red'>Error: Cannot proceed. They have more or equal rights to us.</font>"
+		to_chat(usr, "<font color='red'>Error: Cannot proceed. They have more or equal rights to us.</font>")
 	return 0
-
-
 
 /client/proc/deadmin()
 	if(holder)
 		holder.disassociate()
 		//qdel(holder)
 	return 1
+
+/client/Stat()
+	. = ..()
+	var/stealth_status = is_stealthed()
+	if(statpanel("Status") && stealth_status)
+		stat("Stealth", "Engaged [holder.stealthy_ == STEALTH_AUTO ? "(Auto)" : "(Manual)"]")
+
+/client/proc/is_stealthed()
+	if(!holder)
+		return FALSE
+
+	// If someone has been AFK since round-start or longer, stealth them
+	// BYOND keeps track of inactivity between rounds as long as it's not a full stop/start.
+	if(holder.stealthy_ == STEALTH_OFF && inactivity >= world.time)
+		holder.stealthy_ = STEALTH_AUTO
+	else if(holder.stealthy_ == STEALTH_AUTO && inactivity < world.time)
+		// And if someone has been set to auto-stealth and returns, unstealth them
+		holder.stealthy_ = STEALTH_OFF
+	return holder.stealthy_
+
+/mob/proc/is_stealthed()
+	return client && client.is_stealthed()
+
+/client/proc/stealth()
+	set category = "Admin"
+	set name = "Stealth Mode"
+
+	if(!holder)
+		to_chat(src, "<span class='warning'>Error: You are not an admin.</span>")
+		return
+
+	holder.stealthy_ = holder.stealthy_ == STEALTH_OFF ? STEALTH_MANUAL : STEALTH_OFF
+	if(holder.stealthy_)
+		to_chat(src, "<span class='notice'>You are now stealthed.</span>")
+	else
+		to_chat(src, "<span class='notice'>You are no longer stealthed.</span>")
+
+	log_and_message_admins("has turned stealth mode [holder.stealthy_ ? "ON" : "OFF"]")
+	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!´
+
+#undef STEALTH_OFF
+#undef STEALTH_MANUAL
+#undef STEALTH_AUTO

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -63,10 +63,7 @@
 		//mod PMs are maroon
 		//PMs sent from admins and mods display their rank
 		if(holder)
-			if(!C.holder && holder && holder.fakekey)
-				recieve_pm_type = "Admin"
-			else
-				recieve_pm_type = holder.rank
+			recieve_pm_type = holder.rank
 
 	else if(!C.holder)
 		src << "<span class='warning'>Error: Admin-PM: Non-admin to non-admin PM communication is forbidden.</span>"
@@ -136,7 +133,7 @@
 	admin_pm_repository.store_pm(src, sender, msg)
 
 	src << "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "", src) + " to <span class='name'>IRC-[sender]</span>: <span class='message'>[msg]</span></span></span>"
-	
+
 	for(var/client/X in admins)
 		if(X == src)
 			continue

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -13,9 +13,6 @@
 	msg = sanitize(msg)
 	if(!msg)	return
 	var/display_name = src.key
-	if(holder)
-		if(holder.fakekey)
-			display_name = usr.client.holder.fakekey
 	var/player_display = holder ? "[display_name]([usr.client.holder.rank])" : display_name
 	for(var/mob/M in mob_list)
 		if(check_rights(R_ADMIN|R_MOD, 0, M)) // What staff see

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -24,6 +24,6 @@
 	if (!msg)
 		return
 
-	say_dead_direct("<span class='name'>[stafftype]([src.holder.fakekey ? src.holder.fakekey : src.key])</span> says, <span class='message'>\"[msg]\"</span>")
+	say_dead_direct("<span class='name'>[stafftype]([src.key])</span> says, <span class='message'>\"[msg]\"</span>")
 
 	feedback_add_details("admin_verb","D") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -421,7 +421,7 @@ proc/is_blind(A)
 	var/keyname
 	if(subject && subject.client)
 		var/client/C = subject.client
-		keyname = (C.holder && C.holder.fakekey) ? C.holder.fakekey : C.key
+		keyname = C.key
 		if(C.mob) //Most of the time this is the dead/observer mob; we can totally use him if there is no better name
 			var/mindname
 			var/realname = C.mob.real_name
@@ -489,7 +489,7 @@ proc/is_blind(A)
 				else
 					name = M.real_name
 		if(!name)
-			name = (C.holder && C.holder.fakekey) ? C.holder.fakekey : C.key
+			name = C.key
 		if(joined_ghosts)
 			say_dead_direct("The ghost of <span class='name'>[name]</span> now [pick("skulks","lurks","prowls","creeps","stalks")] among the dead. [message]")
 		else

--- a/code/world.dm
+++ b/code/world.dm
@@ -191,7 +191,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 			for(var/client/C in clients)
 				if(C.holder)
-					if(C.holder.fakekey)
+					if(C.is_stealthed())
 						continue
 					admins[C.key] = C.holder.rank
 				players += C.key
@@ -206,7 +206,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 			for(var/client/C in clients)
 				if(C.holder)
-					if(C.holder.fakekey)
+					if(C.is_stealthed())
 						continue	//so stealthmins aren't revealed by the hub
 					admins++
 				s["player[n]"] = C.key

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -80,12 +80,6 @@ LOG_PDA
 ## disconnect players who did nothing during the set amount of minutes
 # KICK_INACTIVE 10
 
-##Show mods on staffwho
-SHOW_MODS
-
-##Show mentors on staffwho
-SHOW_MENTORS
-
 ## Chooses whether mods have the ability to tempban or not
 MODS_CAN_TEMPBAN
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Stealth mode now only hides staff from being listed and any outward communication now shows the original ckey at all times.
If a stealthed staff member use OOC/LOOC they'll appear as normal players, similar to if deadmined.
staffwho now lists afk staff members as such and now lists all ranks at all times.
