### PR TITLE
Maybe fixes a bad usr runtime, adjusts staffwho and OOC

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -46,7 +46,7 @@
 		if(target.is_preference_enabled(/datum/client_preference/show_ooc))
 			if(target.is_key_ignored(key)) // If we're ignored by this person, then do nothing.
 				continue
-			if(!is_stealthed() && config.allow_admin_ooccolor && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
+			if(!is_stealthed() && can_select_ooc_color(src) && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
 				to_chat(target, "<font color='[src.prefs.ooccolor]'><span class='ooc'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[key]:</EM> <span class='message'>[msg]</span></span></font>")
 			else
 				to_chat(target, "<span class='ooc'><span class='[ooc_style]'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[key]:</EM> <span class='message'>[msg]</span></span></span>")

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -57,30 +57,40 @@
 	set category = "Admin"
 	set name = "Staffwho"
 
-	var/msg = list()
+	var/list/msg = list()
 	var/active_staff = 0
 	var/total_staff = 0
 	var/can_investigate = check_rights(R_INVESTIGATE, 0)
 
 	for(var/client/C in admins)
-		if(C.is_stealthed())
+		var/line = list()
+		if(!can_investigate && C.is_stealthed())
 			continue
 		total_staff++
-		msg += "\t[C] is \a [C.holder.rank]"
+		if(check_rights(R_ADMIN,0,C))
+			line += "\t[C] is \an <b>["\improper[C.holder.rank]"]</b>"
+		else
+			line += "\t[C] is \an ["\improper[C.holder.rank]"]"
 		if(C.is_afk())
-			msg += can_investigate ? " (AFK - [C.inactivity2text()])" : "(AFK)"
+			line += can_investigate ? " (AFK - [C.inactivity2text()])" : "(AFK)"
 		else
 			active_staff++
 		if(can_investigate)
 			if(isghost(C.mob))
-				msg += " - Observing"
+				line += " - Observing"
 			else if(istype(C.mob,/mob/new_player))
-				msg += " - Lobby"
+				line += " - Lobby"
 			else
-				msg += " - Playing"
-		msg += "\n"
+				line += " - Playing"
+			if(C.is_stealthed())
+				line += " (Stealthed)"
+		line = jointext(line,null)
+		if(check_rights(R_ADMIN,0,C))
+			msg.Insert(1, line)
+		else
+			msg += line
 
 	if(config.admin_irc)
 		to_chat(src, "<span class='info'>Adminhelps are also sent to IRC. If no admins are available in game try anyway and an admin on IRC may see it and respond.</span>")
 	to_chat(src, "<b>Current Staff ([active_staff]/[total_staff]):</b>")
-	to_chat(src, jointext(msg,null))
+	to_chat(src, jointext(msg,"\n"))

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -107,7 +107,7 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 /client/Stat()
 	. = ..()
 	var/stealth_status = is_stealthed()
-	if(statpanel("Status") && stealth_status)
+	if(usr && stealth_status && statpanel("Status"))
 		stat("Stealth", "Engaged [holder.stealthy_ == STEALTH_AUTO ? "(Auto)" : "(Manual)"]")
 
 /client/proc/is_stealthed()
@@ -141,7 +141,7 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 		to_chat(src, "<span class='notice'>You are no longer stealthed.</span>")
 
 	log_and_message_admins("has turned stealth mode [holder.stealthy_ ? "ON" : "OFF"]")
-	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!´
+	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 #undef STEALTH_OFF
 #undef STEALTH_MANUAL

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -70,5 +70,5 @@
 
 	return ..()
 
-/datum/category_item/player_setup_item/player_global/ui/proc/can_select_ooc_color(var/mob/user)
+/proc/can_select_ooc_color(var/mob/user)
 	return config.allow_admin_ooccolor && check_rights(R_ADMIN, 0, user)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

staffwho should again say "X is a Y"
Staff can now see stealthed staff members when using staffwho.
Once again only admins get custom OOC colors.
usr can somehow be null during client/Stat() apparently. We have similar checks in other client/Stat() overrides.

```
Runtime in holder2.dm,110: bad usr
   proc name: Stat (/client/Stat)
   src: XXX (/client)
   call stack:
   XXX (/client): Stat()
   XXX (/client): Stat()
   XXX (/client): Stat()
```
