### PR TITLE
Fixes human mobs of all species having see_in_dark=8

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -382,7 +382,7 @@
 		return 1
 
 	if(!H.druggy)
-		H.see_in_dark = (H.sight == SEE_TURFS|SEE_MOBS|SEE_OBJS) ? 8 : min(darksight + H.equipment_darkness_modifier, 8)
+		H.see_in_dark = (H.sight == (SEE_TURFS|SEE_MOBS|SEE_OBJS)) ? 8 : min(darksight + H.equipment_darkness_modifier, 8)
 		if(H.seer)
 			var/obj/effect/rune/R = locate() in H.loc
 			if(R && R.word1 == cultwords["see"] && R.word2 == cultwords["hell"] && R.word3 == cultwords["join"])


### PR DESCRIPTION
`H.sight == SEE_TURFS|SEE_MOBS|SEE_OBJS` equaled 12 due to unintuitive operator priorities, thus always returning true to the condition.
