### PR TITLE
Adds toggle and changes to ninja self destruct.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -161,28 +161,28 @@
 	return 0
 
 /obj/item/rig_module/self_destruct
-
 	name = "self-destruct module"
 	desc = "Oh my God, Captain. A bomb."
 	icon_state = "deadman"
 	usable = 1
-	active = 1
 	permanent = 1
+	toggleable = 1
+
+	activate_string = "Enable Auto Self-Destruct"
+	deactivate_string = "Disable Auto Self-Destruct"
 
 	engage_string = "Detonate"
 
 	interface_name = "dead man's switch"
-	interface_desc = "An integrated self-destruct module. When the wearer dies, so does the surrounding area. Do not press this button."
+	interface_desc = "An integrated automatic self-destruct module. When the wearer dies, so does the surrounding area. Can be triggered manually."
 	var/list/explosion_values = list(1,2,4,5)
+	var/blink_delay = 10
+	var/blink_time = 40
+	var/blink_rapid_time = 40
+	var/blink_solid_time = 20
 
 /obj/item/rig_module/self_destruct/small
 	explosion_values = list(0,0,3,4)
-
-/obj/item/rig_module/self_destruct/activate()
-	return
-
-/obj/item/rig_module/self_destruct/deactivate()
-	return
 
 /obj/item/rig_module/self_destruct/process()
 
@@ -192,11 +192,25 @@
 
 	//OH SHIT.
 	if(holder.wearer.stat == 2)
-		engage(1)
+		if(src.active)
+			engage(1)
 
 /obj/item/rig_module/self_destruct/engage(var/skip_check)
-	if(!skip_check && usr && alert(usr, "Are you sure you want to push that button?", "Self-destruct", "No", "Yes") == "No")
-		return
+	set waitfor = 0
+	if(!skip_check && usr)
+		if(alert(usr, "Are you sure you want to push that button?", "Self-destruct", "No", "Yes") == "No")
+			return
+		if(usr == holder.wearer)
+			holder.wearer.visible_message("<span class='warning'> \The [src.holder.wearer] flicks a small switch on the back of \the [src.holder].</span>",1)
+			sleep(blink_delay)
+
+	holder.visible_message("<span class='notice'>\The [src.holder] begins beeping.</span>","<span class='notice'> You hear beeping.</span>")
+	sleep(blink_time)
+	holder.visible_message("<span class='warning'>\The [src.holder] beeps rapidly!</span>","<span class='warning'> You hear rapid beeping!</span>")
+	sleep(blink_rapid_time)
+	holder.visible_message("<span class='danger'>\The [src.holder] emits a shrill tone!</span>","<span class='danger'> You hear a shrill tone!</span>")
+	sleep(blink_solid_time)
+
 	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
 	if(holder && holder.wearer)
 		holder.wearer.drop_from_inventory(src)

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -164,9 +164,9 @@
 	name = "self-destruct module"
 	desc = "Oh my God, Captain. A bomb."
 	icon_state = "deadman"
+	toggleable = 1
 	usable = 1
 	permanent = 1
-	toggleable = 1
 
 	activate_string = "Enable Auto Self-Destruct"
 	deactivate_string = "Disable Auto Self-Destruct"
@@ -176,16 +176,63 @@
 	interface_name = "dead man's switch"
 	interface_desc = "An integrated automatic self-destruct module. When the wearer dies, so does the surrounding area. Can be triggered manually."
 	var/list/explosion_values = list(1,2,4,5)
+	var/blinking = 0
+	var/blink_mode = 0
 	var/blink_delay = 10
 	var/blink_time = 40
 	var/blink_rapid_time = 40
 	var/blink_solid_time = 20
+	var/activation_check = 0 //used to detect whether proc was called via 'activate' or 'engage'
+	var/self_destructing = 0 //used to prevent toggling the switch, then dying and having it toggled again
 
 /obj/item/rig_module/self_destruct/small
 	explosion_values = list(0,0,3,4)
 
-/obj/item/rig_module/self_destruct/process()
 
+/obj/item/rig_module/self_destruct/activate()
+	activation_check = 1
+	if(!..())
+		return 0
+
+/obj/item/rig_module/self_destruct/engage(var/skip_check = 0)
+	set waitfor = 0
+
+	if(self_destructing) //prevents repeat calls
+		return 0
+
+	if(activation_check)
+		activation_check = 0
+		return 1
+
+	if(!skip_check)
+		if(!usr || alert(usr, "Are you sure you want to push that button?", "Self-destruct", "No", "Yes") == "No")
+			return
+
+		if(usr == holder.wearer)
+			holder.wearer.visible_message("<span class='warning'> \The [src.holder.wearer] flicks a small switch on the back of \the [src.holder].</span>",1)
+			sleep(blink_delay)
+
+	self_destructing = 1
+	src.blink_mode = 1
+	src.blink()
+	holder.visible_message("<span class='notice'>\The [src.holder] begins beeping.</span>","<span class='notice'> You hear beeping.</span>")
+	sleep(blink_time)
+	src.blink_mode = 2
+	holder.visible_message("<span class='warning'>\The [src.holder] beeps rapidly!</span>","<span class='warning'> You hear rapid beeping!</span>")
+	sleep(blink_rapid_time)
+	src.blink_mode = 3
+	holder.visible_message("<span class='danger'>\The [src.holder] emits a shrill tone!</span>","<span class='danger'> You hear a shrill tone!</span>")
+	sleep(blink_solid_time)
+	src.blink_mode = 0
+	src.holder.set_light(0, 0, "#000000")
+
+	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
+	if(holder && holder.wearer)
+		holder.wearer.drop_from_inventory(src)
+		qdel(holder)
+	qdel(src)
+
+/obj/item/rig_module/self_destruct/process()
 	// Not being worn, leave it alone.
 	if(!holder || !holder.wearer || !holder.wearer.wear_suit == holder)
 		return 0
@@ -195,24 +242,20 @@
 		if(src.active)
 			engage(1)
 
-/obj/item/rig_module/self_destruct/engage(var/skip_check)
+/obj/item/rig_module/self_destruct/proc/blink()
 	set waitfor = 0
-	if(!skip_check && usr)
-		if(alert(usr, "Are you sure you want to push that button?", "Self-destruct", "No", "Yes") == "No")
+	switch (blink_mode)
+		if(0)
 			return
-		if(usr == holder.wearer)
-			holder.wearer.visible_message("<span class='warning'> \The [src.holder.wearer] flicks a small switch on the back of \the [src.holder].</span>",1)
-			sleep(blink_delay)
-
-	holder.visible_message("<span class='notice'>\The [src.holder] begins beeping.</span>","<span class='notice'> You hear beeping.</span>")
-	sleep(blink_time)
-	holder.visible_message("<span class='warning'>\The [src.holder] beeps rapidly!</span>","<span class='warning'> You hear rapid beeping!</span>")
-	sleep(blink_rapid_time)
-	holder.visible_message("<span class='danger'>\The [src.holder] emits a shrill tone!</span>","<span class='danger'> You hear a shrill tone!</span>")
-	sleep(blink_solid_time)
-
-	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
-	if(holder && holder.wearer)
-		holder.wearer.drop_from_inventory(src)
-		qdel(holder)
-	qdel(src)
+		if(1)
+			src.holder.set_light(1.5, 8.5, "#FF0A00")
+			sleep(6)
+			src.holder.set_light(0, 0, "#000000")
+			spawn(6) .()
+		if(2)
+			src.holder.set_light(1.5, 8.5, "#FF0A00")
+			sleep(2)
+			src.holder.set_light(0, 0, "#000000")
+			spawn(2) .()
+		if(3)
+			src.holder.set_light(1.5, 8.5, "#FF0A00")

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -194,7 +194,7 @@
 	if(!..())
 		return 0
 
-/obj/item/rig_module/self_destruct/engage(var/skip_check = 0)
+/obj/item/rig_module/self_destruct/engage(var/skip_check = FALSE)
 	set waitfor = 0
 
 	if(self_destructing) //prevents repeat calls
@@ -238,7 +238,7 @@
 		return 0
 
 	//OH SHIT.
-	if(holder.wearer.stat == 2)
+	if(holder.wearer.stat == DEAD)
 		if(src.active)
 			engage(1)
 

--- a/html/changelogs/LorenLuke-NinjaSelfDestruct.yml
+++ b/html/changelogs/LorenLuke-NinjaSelfDestruct.yml
@@ -1,5 +1,5 @@
 author: LorenLuke
 delete-after: True
 changes:
-  - rscadd: "Added a toggle to the ninja's self-destruct."
-  - tweak: "Adds a delay and visible messages after the self destruct is activated."
+  - rscadd: "Added a toggle to the ninja's self-destruct. Default starting is 'off'."
+  - tweak: "Adds a delay and visible messages (and now a blinking effect!) after the self destruct is activated."

--- a/html/changelogs/LorenLuke-NinjaSelfDestruct.yml
+++ b/html/changelogs/LorenLuke-NinjaSelfDestruct.yml
@@ -1,0 +1,5 @@
+author: LorenLuke
+delete-after: True
+changes:
+  - rscadd: "Added a toggle to the ninja's self-destruct."
+  - tweak: "Adds a delay and visible messages after the self destruct is activated."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Gives Ninja self-destruct a toggle. Also, gives a 10-ish second visible delay to the self-destruct in the form of a beeping.
