### PR TITLE
Must now maintain a grab all the way through cuffing someone

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -43,19 +43,19 @@
 			return
 
 		//check for an aggressive grab (or robutts)
-		var/can_place
-		if(istype(user, /mob/living/silicon/robot))
-			can_place = 1
-		else
-			for (var/obj/item/weapon/grab/G in C.grabbed_by)
-				if (G.loc == user && G.state >= GRAB_AGGRESSIVE)
-					can_place = 1
-					break
-
-		if(can_place)
+		if(can_place(C, user))
 			place_handcuffs(C, user)
 		else
 			user << "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>"
+
+/obj/item/weapon/handcuffs/proc/can_place(var/mob/target, var/mob/user)
+	if(istype(user, /mob/living/silicon/robot))
+		return 1
+	else
+		for (var/obj/item/weapon/grab/G in target.grabbed_by)
+			if (G.loc == user && G.state >= GRAB_AGGRESSIVE)
+				return 1
+	return 0
 
 /obj/item/weapon/handcuffs/proc/place_handcuffs(var/mob/living/carbon/target, var/mob/user)
 	playsound(src.loc, cuff_sound, 30, 1, -2)
@@ -75,6 +75,9 @@
 	user.visible_message("<span class='danger'>\The [user] is attempting to put [cuff_type] on \the [H]!</span>")
 
 	if(!do_after(user,30, target))
+		return 0
+
+	if(!can_place(target, user)) // victim may have resisted out of the grab in the meantime
 		return 0
 
 	admin_attack_log(user, H, "Attempted to handcuff the victim", "Was target of an attempted handcuff", "attempted to handcuff")


### PR DESCRIPTION
Previous behaviour was to only check for a grab when starting to cuff somebody, meaning that even if they resist out of the requisite grab during the cuff, they still get their shiny new metal bracelets (unless they also got some distance away).

A check has been added to ensure the attacker still has a hold of the victim by the end. If they don't, no cuff.

Might be a little controversial as this makes arrests directly easier to resistspam. However batons, tasers and pepperspray still inhibit resist - it's just flashes that won't be as useful in arrests, as the victim can still resist. Even so this should probably sit for a while until people can weigh in.
