### PR TITLE
Neural laces and MMIs

### DIFF
--- a/code/game/machinery/resleever.dm
+++ b/code/game/machinery/resleever.dm
@@ -281,9 +281,13 @@ obj/machinery/resleever/process()
 			break
 
 	if(!correct_type) return 0
-
+	
 	for(var/type in disallow_occupant_types)
 		if(istype(M, type))
 			return 0
+
+	var/mob/living/carbon/human/human = M
+	if(human && !human.can_have_stack())
+		return 0
 
 	return 1

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -42,44 +42,53 @@
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
 	var/obj/item/organ/internal/brain/brainobj = null	//The current brain organ.
 	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
+	var/obj/item/organ/internal/stack/loaded_stack = null // Used if config.use_cortical_stacks is on
+
+/obj/item/device/mmi/examine(mob/user)
+	..()
+	if(config.use_cortical_stacks && !istype(src, /obj/item/device/mmi/digital)) // Yes, this is ugly
+		if(loaded_stack)
+			user << "There is \a [loaded_stack] in the neural lace slot."
+		else
+			user << "The neural lace slot is empty."
 
 /obj/item/device/mmi/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(istype(O,/obj/item/organ/internal/brain) && !brainmob) //Time to stick a brain in it --NEO
+	if(istype(O,/obj/item/organ/internal/brain) && !brainobj)
 
 		var/obj/item/organ/internal/brain/B = O
 		if(B.health <= 0)
 			user << "<span class='warning'>That brain is well and truly dead.</span>"
 			return
-		else if(!B.brainmob)
+		else if(!config.use_cortical_stacks && !B.brainmob)
 			user << "<span class='notice'>You aren't sure where this brain came from, but you're pretty sure it's a useless brain.</span>"
 			return
 
 		user.visible_message("<span class='notice'>\The [user] sticks \a [O] into \the [src].</span>")
 
-		brainmob = B.brainmob
-		B.brainmob = null
-		brainmob.forceMove(src)
-		brainmob.container = src
-		brainmob.stat = 0
-		brainmob.switch_from_dead_to_living_mob_list() //Update dem lists
 
 		user.drop_item()
 		brainobj = O
 		brainobj.loc = src
-
-		name = "man-machine interface ([brainmob.real_name])"
-		icon_state = "mmi_full"
-
-		locked = 1
-
-		feedback_inc("cyborg_mmis_filled",1)
-
+		icon_state = "mmi_dead"  // brain in, but no sign of life
+		
+		activate_mind()
+		
+		return
+		
+	if(istype(O,/obj/item/organ/internal/stack) && !loaded_stack)
+		loaded_stack = O
+		user.drop_item()
+		loaded_stack.forceMove(src)
+		user.visible_message("<span class='notice'>\The [user] slots \a [O] into \the [src].</span>")
+		
+		activate_mind()
+		
 		return
 
 	if((istype(O,/obj/item/weapon/card/id)||istype(O,/obj/item/device/pda)) && brainmob)
 		if(allowed(user))
 			locked = !locked
-			user << "<span class='notice'>You [locked ? "lock" : "unlock"] the brain holder.</span>"
+			user << "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src].</span>"
 		else
 			user << "<span class='warning'>Access denied.</span>"
 		return
@@ -90,40 +99,198 @@
 
 	//TODO: ORGAN REMOVAL UPDATE. Make the brain remain in the MMI so it doesn't lose organ data.
 /obj/item/device/mmi/attack_self(mob/user as mob)
-	if(!brainmob)
-		user << "<span class='warning'>You upend the MMI, but there's nothing in it.</span>"
+	if(!brainobj && !loaded_stack)
+		user << "<span class='warning'>The MMI is empty.</span>"
 	else if(locked)
-		user << "<span class='warning'>You upend the MMI, but the brain is clamped into place.</span>"
+		user << "<span class='warning'>The MMI is locked. You will not be able to remove anything.</span>"
 	else
-		user << "<span class='notice'>You upend the MMI, spilling the brain onto the floor.</span>"
-		var/obj/item/organ/internal/brain/brain
-		if (brainobj)	//Pull brain organ out of MMI.
-			brainobj.loc = user.loc
-			brain = brainobj
+		var/list/removables = list()
+		if(loaded_stack)
+			removables.Add("lace")
+		if(brainobj)
+			removables.Add("brain")
+			
+		var/to_remove = input(user, "What do you wish to remove?") as null|anything in removables
+		
+		if(!to_remove || !(user.l_hand == src || user.r_hand == src))
+			return 0
+		
+		if(to_remove == "brain")
+			// prompt can be long-lived, so we need to recheck brain is still there
+			if(!brainobj)
+				return 0
+
+			deactivate_mind()
+			brainobj.forceMove(user.loc)
+			
+			user.visible_message("<span class='notice'>\The [user] upends \the [src], spilling \the [brainobj] onto the floor.</span>", \
+				"<span class='notice'>You upend \the [src], spilling \the [brainobj] onto the floor.</span>", \
+				"You hear a squishy thud.")
+
 			brainobj = null
-		else	//Or make a new one if empty.
-			brain = new(user.loc)
-		brainmob.container = null//Reset brainmob mmi var.
-		brainmob.loc = brain//Throw mob into brain.
-		brainmob.remove_from_living_mob_list() //Get outta here
-		brain.brainmob = brainmob//Set the brain to use the brainmob
-		brainmob = null//Set mmi brainmob var to null
-
-		icon_state = "mmi_empty"
-		name = "man-machine interface"
-
-/obj/item/device/mmi/proc/transfer_identity(var/mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->robot people.
+			icon_state = "mmi_empty"
+			
+			return 1
+		
+		if(to_remove == "lace")
+			if(!loaded_stack)
+				return 0
+				
+			deactivate_mind()
+			user.put_in_hands(loaded_stack)
+			
+			user.visible_message("<span class='notice'>\The [user] removes \the [loaded_stack] from \the [src]</span>", \
+				"<span class='notice'>You remove \the [loaded_stack] from \the [src]</span>")
+				
+			loaded_stack = null
+			
+			return 1
+/**
+ *  Transfer the identity of a carbon/human directly to the MMI
+ *
+ *  This proc is chiefly useful for round start or admin robotizing of human mobs.
+ *  The human's actual brain is not involved.
+ */
+/obj/item/device/mmi/proc/transfer_identity(var/mob/living/carbon/human/H)
 	brainmob = new(src)
 	brainmob.name = H.real_name
 	brainmob.real_name = H.real_name
 	brainmob.dna = H.dna
 	brainmob.container = src
+	
+	// These aren't used by MMIs, but will be used if we put the mob elsewhere
+	brainmob.languages = H.languages.Copy()
+	brainmob.default_language = H.default_language
+	
+	brainobj = new(src)
+	
+	if(config.use_cortical_stacks)
+		loaded_stack = new(src)
+		// won't pass the attach_organ surgery step without being CUT_AWAY
+		loaded_stack.status |= ORGAN_CUT_AWAY  
+		backup_to_stack()
 
-	name = "Man-Machine Interface: [brainmob.real_name]"
+	name = "man-machine Interface: [brainmob.real_name]"
 	icon_state = "mmi_full"
 	locked = 1
 	return
 
+	
+/**
+ *  Move the appropriate mind into the MMI proper
+ *
+ *  This checks for config.use_cortical_stacks, and moves a player either from
+ *  the loaded brain, or from the stack into the MMI. Returns 1 on success. 
+ */
+/obj/item/device/mmi/proc/activate_mind()
+	if(brainmob)
+		return 0
+	
+	if(config.use_cortical_stacks && brainobj && loaded_stack && !loaded_stack.backup_inviable(brainmob))
+		var/mob/asked_mob = find_dead_player(loaded_stack.ownerckey, 1)
+		if(!asked_mob)
+			return 0
+			
+		var/asked_stack = loaded_stack
+		
+		var/response = input(asked_mob, "Your neural backup is being loaded into an MMI. Do you wish to return to life?", "Resleeving") as anything in list("Yes", "No")
+		
+		// prompt can be long-lived, so we check that the stack is still there
+		if(response == "No" || asked_stack != loaded_stack || !brainobj)
+			return 0
+		
+		brainmob = new(src)
+		brainmob.container = src
+		brainmob.stat = 0
+		
+		loaded_stack.backup.active = 1
+		loaded_stack.backup.transfer_to(brainmob)
+		if(loaded_stack.default_language)
+			brainmob.default_language = loaded_stack.default_language
+		brainmob.languages = loaded_stack.languages.Copy()
+		brainmob.name = loaded_stack.backup.name
+		brainmob.real_name = brainmob.name
+		
+		if(brainobj.brainmob)
+			// Active MMIs shouldn't have occupied brains. With stacks, we don't
+			// move the brain's occupant, so instead we just get rid of them. 
+			// If they were to come back, they'd have to use a stack anyway
+			brainobj.brainmob.ghostize(0)
+			brainobj.brainmob = null
+			
+		
+		feedback_inc("cyborg_mmis_filled",1)
+		brainmob << "<span class='notice'>Consciousness creeps over you, with the MMI reporting a successful transfer.</span>"
+		
+		locked = 1
+		icon_state = "mmi_full"
+		name = "man-machine interface: [brainmob.real_name]"
+		
+		return 1
+			
+	else if(!config.use_cortical_stacks && brainobj && brainobj.brainmob)
+		brainmob = brainobj.brainmob
+		brainobj.brainmob = null
+		
+		brainmob.forceMove(src)
+		brainmob.container = src
+		brainmob.stat = 0
+		brainmob.switch_from_dead_to_living_mob_list() //Update dem lists
+		
+		feedback_inc("cyborg_mmis_filled",1)
+		brainmob << "<span class='notice'>You regain consciosuness and find yourself inside an MMI.</span>"
+		
+		icon_state = "mmi_full"
+		name = "man-machine interface: [brainmob.real_name]"
+		locked = 1
+		
+		return 1
+	
+/**
+ *  Transfer mind out from the MMI to the appropriate places
+ * 
+ *  This backups the mind to the onboard stack if needed, and then transfers it
+ *  to the onboard brain, allowing either to be ejected. 
+ */
+/obj/item/device/mmi/proc/deactivate_mind()
+
+	if(!brainmob)
+		return 
+
+	if(config.use_cortical_stacks)
+		backup_to_stack()
+		loaded_stack.backup.active = 0
+
+	// the ghost always resides in the brain, even if the stack is how we bring people back
+	brainmob.forceMove(brainobj)
+	brainmob.container = null
+	brainobj.brainmob = brainmob
+		
+	brainmob.death()
+	
+	brainmob = null
+	
+	icon_state = "mmi_dead"
+	name = "man-machine interface"
+	
+	
+/**
+ *  Perform a backup to the onboard stack
+ * 
+ *  This is essentially an MMI version of the stack backup the stack organ does
+ *  on organics.
+ */
+/obj/item/device/mmi/proc/backup_to_stack()
+	if(!loaded_stack)
+		return
+	
+	loaded_stack.backup = brainmob.mind
+	loaded_stack.languages = brainmob.languages.Copy()
+	loaded_stack.default_language = brainmob.default_language
+	if(brainmob.ckey)
+		loaded_stack.ownerckey = brainmob.ckey
+		
+	
 /obj/item/device/mmi/relaymove(var/mob/user, var/direction)
 	if(user.stat || user.stunned)
 		return

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -28,7 +28,7 @@
 
 /obj/item/device/mmi
 	name = "man-machine interface"
-	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity."
+	desc = "The MMI provides a machine interface to a brain while also supporting its life functions outside of a body."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
 	w_class = 3
@@ -309,7 +309,7 @@
 
 /obj/item/device/mmi/radio_enabled
 	name = "radio-enabled man-machine interface"
-	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity. This one comes with a built-in radio."
+	desc = "The MMI provides a machine interface to a brain while also supporting its life functions outside of a body. This one comes with a built-in radio."
 	origin_tech = list(TECH_BIO = 4)
 
 	var/obj/item/device/radio/radio = null//Let's give it a radio.

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -112,7 +112,7 @@
 			
 		var/to_remove = input(user, "What do you wish to remove?") as null|anything in removables
 		
-		if(!to_remove || !(user.l_hand == src || user.r_hand == src))
+		if(!to_remove || !(user.l_hand == src || user.r_hand == src || istype(loc, /obj/item/weapon/gripper/research)))
 			return 0
 		
 		if(to_remove == "brain")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1473,6 +1473,17 @@
 		return 0
 	return (species && species.has_organ[organ_check])
 
+	
+/**
+ *  Return a true value if the mob can support a stack/neural lace
+ */
+/mob/living/carbon/human/proc/can_have_stack()
+	var/obj/item/organ/external/head = organs_by_name[BP_HEAD]
+	if(head && (head.robotic >= ORGAN_ROBOT))
+		return 0
+		
+	return species && species.spawns_with_stack
+	
 /mob/living/carbon/human/can_feel_pain(var/obj/item/organ/check_organ)
 	if(isSynthetic())
 		return 0

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -75,7 +75,7 @@
 	var/halloss_message = "slumps to the ground, too weak to continue fighting."
 	var/halloss_message_self = "You're in too much pain to keep going..."
 
-	var/spawns_with_stack = 0
+	var/spawns_with_stack = 1
 	// Environment tolerance/life processes vars.
 	var/reagent_tag                                   //Used for metabolizing reagents.
 	var/breath_pressure = 16                          // Minimum partial pressure safe for breathing, kPa
@@ -131,6 +131,7 @@
 	var/stomach_capacity = 5      // How much stuff they can stick in their stomach
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	                              // Determines the organs that the species spawns with and
+	
 	var/list/has_organ = list(    // which required-organ checks are conducted.
 		BP_HEART =    /obj/item/organ/internal/heart,
 		BP_LUNGS =    /obj/item/organ/internal/lungs,

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -73,6 +73,7 @@
 		/obj/item/borg/upgrade,
 		/obj/item/device/flash,
 		/obj/item/organ/internal/brain,
+		/obj/item/organ/internal/stack,
 		/obj/item/stack/cable_coil,
 		/obj/item/weapon/circuitboard,
 		/obj/item/slime_extract,

--- a/code/modules/organs/organ_stack.dm
+++ b/code/modules/organs/organ_stack.dm
@@ -1,9 +1,11 @@
 /mob/living/carbon/human/proc/create_stack()
 	set waitfor=0
 	sleep(10)
-	internal_organs_by_name[BP_STACK] = new /obj/item/organ/internal/stack(src,1)
-	src << "<span class='notice'>You feel a faint sense of vertigo as your neural lace boots.</span>"
-
+	
+	if(can_have_stack())
+		internal_organs_by_name[BP_STACK] = new /obj/item/organ/internal/stack(src,1)
+		src << "<span class='notice'>You feel a faint sense of vertigo as your neural lace boots.</span>"
+		
 /obj/item/organ/internal/stack
 	name = "neural lace"
 	parent_organ = BP_HEAD

--- a/code/modules/organs/organ_stack.dm
+++ b/code/modules/organs/organ_stack.dm
@@ -38,9 +38,13 @@
 	..()
 	do_backup()
 	robotize()
-
-/obj/item/organ/internal/stack/proc/backup_inviable()
-	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))
+/**
+ *  Determine if a backup can be used to relive someone
+ *
+ *  target - mob which the backup is supposed to be loaded to
+ */
+/obj/item/organ/internal/stack/proc/backup_inviable(var/mob/target = owner)
+	return (!istype(backup) || (target && backup == target.mind) || (backup.current && backup.current.stat != DEAD))
 
 /obj/item/organ/internal/stack/replaced()
 	if(!..()) return 0

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -36,6 +36,7 @@
 	..(new_owner, internal)
 	if(!stored_mmi)
 		stored_mmi = new(src)
+		stored_mmi.loaded_stack = new(stored_mmi)
 	sleep(-1)
 	update_from_mmi()
 	persistantMind = owner.mind
@@ -58,8 +59,9 @@
 	icon = stored_mmi.icon
 
 	stored_mmi.icon_state = "mmi_full"
+	stored_mmi.locked = 1
 	icon_state = stored_mmi.icon_state
-
+	
 	if(owner && owner.stat == DEAD)
 		owner.stat = 0
 		owner.switch_from_dead_to_living_mob_list()
@@ -77,10 +79,12 @@
 		stored_mmi.forceMove(src.loc)
 		if(persistantMind)
 			persistantMind.transfer_to(stored_mmi.brainmob)
+			stored_mmi.backup_to_stack()
 		else
 			var/response = input(find_dead_player(ownerckey, 1), "Your [initial(stored_mmi.name)] has been removed from your body. Do you wish to return to life?", "Robotic Rebirth") as anything in list("Yes", "No")
 			if(response == "Yes")
 				persistantMind.transfer_to(stored_mmi.brainmob)
+				stored_mmi.backup_to_stack()
 	qdel(src)
 
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -280,6 +280,10 @@
 		organ_compatible = 1
 
 	else if(istype(O, /obj/item/organ/internal/stack))
+		if(!target.can_have_stack())
+			user << "<span class='warning'>\The [target] cannot support [o_a][O.organ_tag].</span>"
+			return SURGERY_FAILURE
+
 		if(!target.internal_organs_by_name[O.organ_tag])
 			organ_missing = 1
 		else

--- a/html/changelogs/daranz - mmi stack.yml
+++ b/html/changelogs/daranz - mmi stack.yml
@@ -1,0 +1,7 @@
+author: Daranz
+delete-after: True
+
+changes: 
+  - tweak: "MMIs now both accept and require neural laces. All FBPs and non-humanoid cyborgs spawn with MMIs with laces in them."
+  - tweak: "In order to put someone in an MMI, put both a brain and a neural lace in it. Brain can be anyone's, neural lace should be from the the person to be put in the MMI."
+  - tweak: "Removal of lace or brain from the MMI deactivates the MMI. The lace can be used to resleeve the individual in either an MMI or an organic sleeve."


### PR DESCRIPTION
This PR makes MMIs take and require stacks if `use_cortical_stacks` is on.

MMIs accept both a brain and a lace. When both a brain and a lace are inserted, the lace backup's player gets a resleeving prompt, similar to the one offered for organic resleeving. If they answer yes, they are placed inside the MMI, and the MMI can be used as usual. 

All cyborgs (robot kind) and FBPs spawn with MMIs with cortical stacks. FBPs also spawn without a lace slot—their lace is in their MMI. FBPs no longer take stacks in their heads.

As a side effect, `spawns_with_stack` now has an effect: it makes species with it set to 0 spawn without a stack regardless of the character setup setting, and makes stacks unimplantable in them. All species are 1 by default (they were previously 0), with the exception of Diona who are 0 (who were previously explicitly also 0). 
