### PR TITLE
Fix for busted turbolifts

### DIFF
--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -22,7 +22,7 @@
 /turf/simulated/open/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
 	if(!istype(N,/turf/simulated/open))
 		update_cliff(src)
-	..()
+	return ..()
 
 /turf/simulated/open/proc/update_cliff(turf/ignore)
 	var/turf/simulated/open/O = get_step(src,SOUTH)

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -185,4 +185,6 @@
 	lift.control_panel_interior.set_dir(udir)
 	lift.current_floor = lift.floors[uz]
 
+	lift.open_doors()
+
 	qdel(src) // We're done.


### PR DESCRIPTION
Fixes #14055.

Also starts the turbolift doors open on its initial floor for consistency/accessibility.
