### PR TITLE
Bugfix for clipping long medical / security records via in-round editing.

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -319,7 +319,7 @@
 							src.active2.fields["cdi_d"] = t1
 					if("notes")
 						if (istype(src.active2, /datum/data/record))
-							var/t1 = sanitize(input("Please summarize notes:", "Med. records", html_decode(src.active2.fields["notes"]), null)  as message, extra = 0)
+							var/t1 = sanitize(input("Please summarize notes:", "Med. records", html_decode(src.active2.fields["notes"]), null)  as message, extra = 0, max_length = MAX_PAPER_MESSAGE_LEN)
 							if ((!( t1 ) || !( src.authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || src.active2 != a2))
 								return
 							src.active2.fields["notes"] = t1

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -484,7 +484,7 @@ What a mess.*/
 							active2.fields["ma_crim_d"] = t1
 					if("notes")
 						if (istype(active2, /datum/data/record))
-							var/t1 = sanitize(input("Please summarize notes:", "Secure. records", html_decode(active2.fields["notes"]), null)  as message, extra = 0)
+							var/t1 = sanitize(input("Please summarize notes:", "Secure. records", html_decode(active2.fields["notes"]), null)  as message, extra = 0, max_length = MAX_PAPER_MESSAGE_LEN)
 							if (!t1 || active2 != a2)
 								return
 							active2.fields["notes"] = t1

--- a/html/changelogs/asanadas-long_records.yml
+++ b/html/changelogs/asanadas-long_records.yml
@@ -1,0 +1,6 @@
+author: Asanadas
+
+delete-after: True
+
+changes: 
+  - bugfix: "In-game record editing (security and medical) will now respect the same character limits as it does in the character-setup panel. No more accidentally massacring those long records!"


### PR DESCRIPTION
If someone had a generously long character record (between the old max length and the defined max paper length), when edited in-game via a console, it would clip off the end of the record. This fixes that.

Employment record not necessary, as it cannot be edited in-game.
