### PR TITLE
Modifies Radio Distortion

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -413,7 +413,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 		if (length(heard_gibberish))
 			for (var/mob/R in heard_gibberish)
-				R.hear_radio(message, verbage, speaking, part_a, part_b, part_c, M, 1)
+				R.hear_radio(message, verbage, speaking, part_a, part_b, part_c, M, compression)
 
 	return 1
 

--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -101,8 +101,11 @@ proc/RadioChat(mob/living/user, message, distortion_chance = 60, distortion_spee
 	if(input_size < 20) // Short messages get distorted too. Bit hacksy.
 		distortion += (20-input_size)/2
 	while(lentext <= input_size)
-		if(!prob(distortion_chance)) continue
 		var/newletter=copytext(message, lentext, lentext+1)
+		if(!prob(distortion_chance))
+			new_message += newletter
+			lentext += 1
+			continue
 		if(newletter != " ")
 			if(prob(0.08 * distortion)) // Major cutout
 				newletter = "*zzzt*"
@@ -144,6 +147,20 @@ proc/RadioChat(mob/living/user, message, distortion_chance = 60, distortion_spee
 					newletter = "srgt%$hjc< -BZZT-"
 				new_message += newletter
 				break
+			else if(prob(2.5 * distortion)) // Sound distortion. Still recognisable, mostly.
+				switch(lowertext(newletter))
+					if("s")
+						newletter = "$"
+					if("e")
+						newletter = "€"
+					if("w")
+						newletter = "ø"
+					if("y")
+						newletter = "¡"
+					if("x")
+						newletter = "æ"
+					if("u")
+						newletter = "µ"
 		else
 			if(prob(0.2 * distortion))
 				newletter = " *crackle* "

--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -81,3 +81,67 @@ proc/Ellipsis(original_msg, chance = 50)
 	new_msg = jointext(new_words," ")
 
 	return new_msg
+/*
+RadioChat Filter.
+args:
+message - returns a distorted version of this
+distortion_chance - the chance of a filter being applied to each character.
+distortion_speed - multiplier for the chance increase.
+english_only - whether to use traditional english letters (for use in NanoUI)
+*/
+proc/RadioChat(mob/living/user, message, distortion_chance = 60, distortion_speed = 1, english_only = 0)
+	var/datum/language/language
+	if(user)
+		language = user.get_default_language()
+	message = html_decode(message)
+	var/new_message = ""
+	var/distortion = 1
+	var/input_size = length(message)
+	var/lentext = length(new_message)
+	while(lentext < input_size)
+		if(!prob(distortion_chance)) continue
+		var/newletter=copytext(message, lentext, lentext+1)
+		if(newletter != " ")
+			if(prob(0.1 * distortion)) // Major cutout
+				newletter = "*zzzt*"
+				lentext += rand(1, (length(message) - lentext)) // Skip some characters
+				distortion += 1 * distortion_speed
+			else if(prob(1 * distortion)) // Minor cut out
+				newletter = "..."
+				distortion += 0.25 * distortion_speed
+			else if(prob(2 * distortion)) // Mishearing
+				if(language && language.syllables && prob(50))
+					newletter = pick(language.syllables)
+				else
+					newletter =	pick("a","e","i","o","u")
+				distortion += 0.25 * distortion_speed
+			else if(prob(1.5 * distortion)) // Mishearing
+				if(language && prob(50))
+					if(language.syllables)
+						newletter = pick (language.syllables)
+					else
+						newletter = "*"
+				else
+					if(english_only)
+						newletter += "*"
+					else
+						newletter = pick("ø", "Ð", "%", "æ", "µ")
+				distortion += 0.5 * distortion_speed
+			else if(prob(1 * distortion)) // Incomprehensible
+				newletter = pick("<", ">", "!", "$", "%", "^", "&", "*", "~", "#")
+				distortion += 0.75 * distortion_speed
+			else if(prob(0.05 * distortion)) // Total cut out
+				if(!english_only)
+					newletter = "¦w¡¼b»%> -BZZT-"
+				else
+					newletter = "srgt%$hjc< -BZZT-"
+				new_message += newletter
+				break
+		else
+			if(prob(0.2 * distortion))
+				newletter = " *crackle* "
+				distortion += 0.25 * distortion_speed
+		new_message += newletter
+		lentext += 1
+	return new_message
+

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -112,7 +112,10 @@
 					message = stars(message)
 
 		if(hard_to_hear)
-			message = stars(message)
+			if(hard_to_hear <= 5)
+				message = stars(message)
+			else // Used for compression
+				message = RadioChat(null, message, 80, 1+(hard_to_hear/10))
 
 	var/speaker_name = speaker.name
 

--- a/html/changelogs/inforsaken-radio_distortion.yml
+++ b/html/changelogs/inforsaken-radio_distortion.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Inforsaken
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Radio Distortion is now linear and uses more than just the * character."


### PR DESCRIPTION
I've always thought that the asterisk stuff was really damn **boring**. I've tried to rectify that. It also has other uses beyond telecommunications for just general distortion.

Obviously, the args passed to it for radio failure can be modified to be more or less severe than I've set it at initially.

Demonstration image; http://i.imgur.com/8IfQf6X.png?1 (that's with a compression of 49, AKA the processor is turned off.)

So:
- Adds in RadioChat() text filter
- Telecomms passes radio message compression onto hear_radio() in the var hard_to_hear
- Applies RadioChat() text filter if hard_to_hear is higher than 5

Short messages are given starting distortion so that typing multiple short messages does not allow you to get the message across easier. (Discourages spamming) It usually ends up being about the same number of characters as the normal message, so it doesn't elongate anything. 

Distortion increases as the message goes on, but if the end of the message (completely incomprehensible in most cases) just looks too messy I could make it cut off the message after a certain point. (Using the picture as an example, after the second _crackle_ there is absolutely no similarity between the original and the distorted version.)
