### PR TITLE
Removes holder.dm access snatching.

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -62,16 +62,6 @@ var/list/holder_mob_icon_cache = list()
 		return loc.loc
 	return ..()
 
-/obj/item/weapon/holder/GetIdCard()
-	for(var/mob/M in contents)
-		var/obj/item/I = M.GetIdCard()
-		if(I)
-			return I
-	return null
-
-/obj/item/weapon/holder/GetAccess()
-	var/obj/item/I = GetIdCard()
-	return I ? I.GetAccess() : ..()
 
 /obj/item/weapon/holder/attack_self()
 	for(var/mob/M in contents)

--- a/html/changelogs/Asanadas-nerf_holder.yml
+++ b/html/changelogs/Asanadas-nerf_holder.yml
@@ -1,0 +1,6 @@
+author: Asanadas
+
+delete-after: True
+
+changes: 
+  - rscdel: "You can no longer pick up maintenance drones (and other mobs) to use their access as your own. If they have an ID, remove it and then use that."


### PR DESCRIPTION
Need dev / admin input on this. I believe this feature is way too exploitable, and considering maintenance drones have all-access, it amounts to one of them being equal to the captain's spare.

These line deletions should handle it? This is pretty much a reflexive request from seeing this live on the server, at any rate.
