### PR TITLE
Only conscious silicons are now considered to have access.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -221,6 +221,8 @@
 #undef HUMAN_ID_CARDS
 
 /mob/living/silicon/GetIdCard()
+	if(stat || (ckey && !client))
+		return // Unconscious, dead or once possessed but now client-less silicons are not considered to have id access.
 	return idcard
 
 /proc/FindNameFromID(var/mob/M, var/missing_id_name = "Unknown")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

This is the most AI (as in; NPC control, not the mob type) agnostic method I could think of. Currently it:
- Outright treats non-conscious silicons as without access.
- Treats silicons as without access if they have once been possessed but are currently lacking a client.

The secondary check may be unnecessary but I've been unable to confirm that drones are properly marked as unconscious on logout.
