### PR TITLE
Subtype friendly method for populating closets.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -59,6 +59,7 @@
 #include "code\_helpers\names.dm"
 #include "code\_helpers\sanitize_values.dm"
 #include "code\_helpers\spawn_sync.dm"
+#include "code\_helpers\storage.dm"
 #include "code\_helpers\text.dm"
 #include "code\_helpers\time.dm"
 #include "code\_helpers\turfs.dm"

--- a/code/_helpers/storage.dm
+++ b/code/_helpers/storage.dm
@@ -1,0 +1,9 @@
+/proc/create_objects_in_loc(var/atom/loc, var/list/item_paths)
+	if(!istype(loc))
+		CRASH("Inappropriate loction given.")
+	if(!istype(item_paths))
+		CRASH("Inappropriate item path list given.")
+
+	for(var/item_path in item_paths)
+		for(var/i = 1 to max(1, item_paths[item_path]))
+			new item_path(loc)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -21,8 +21,13 @@
 	var/store_items = 1
 	var/store_mobs = 1
 
+	var/list/will_contain
+
 /obj/structure/closet/initialize()
 	..()
+	if(will_contain)
+		create_objects_in_loc(src, will_contain)
+
 	if(!opened)		// if closed, any item at the crate's loc is put in the contents
 		var/obj/item/I
 		for(I in src.loc)

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -8,20 +8,7 @@
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
 
-
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer( src )
-		return
+	will_contain = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer = 10)
 
 /obj/structure/closet/secure_closet/bar/update_icon()
 	if(broken)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Makes the bar cabinet utilize the new method as an example.
