### PR TITLE
Adds exciting RNG element to tabling weakening

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -109,7 +109,7 @@
 							M.standard_weapon_hit_effects(S, G.assailant, S.force*2, blocked, BP_HEAD) //standard weapon hit effects include damage and embedding
 				else
 					G.affecting.forceMove(src.loc)
-					G.affecting.Weaken(5)
+					G.affecting.Weaken(rand(2,5))
 					visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
 				qdel(W)
 			return


### PR DESCRIPTION
Now it only weakens by `rand(2,5)` instead of a straight `5`!

Mainly done because it's currently pretty spammable - grab, agg grab, table, grab, agg grab, table, ad infinitum - which doesn't look like too much fun. I picked the lower limit as /tg/'s current weaken amount and the upper as ours, which feels numerologically fine.
