### PR TITLE
Fixes *confirm and *deny IPC/FBP emotes stating name twice

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -51,7 +51,7 @@
 
 		if ("confirm")
 			if (src.isSynthetic())
-				message = "<B>[src]</B> emits an affirmative blip."
+				message = "emits an affirmative blip."
 				playsound(src.loc, 'sound/machines/synth_yes.ogg', 50, 0)
 				m_type = VISIBLE_MESSAGE
 			else
@@ -59,7 +59,7 @@
 
 		if ("deny")
 			if (src.isSynthetic())
-				message = "<B>[src]</B> emits a negative blip."
+				message = "emits a negative blip."
 				playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 				m_type = VISIBLE_MESSAGE
 			else


### PR DESCRIPTION
Corrects
**SHODAN SHODAN** emits an affirmative blip.
**SHODAN SHODAN** emits a negative blip.
to
**SHODAN** emits an affirmative blip.
**SHODAN** emits a negative blip.

I hope this goes better than the last time I tried to fix something that looked easy.

The reason the name is stated twice for IPC/FBP is because these emotes feed into `/mob/proc/custom_emote`, which already adds `<B>[src]</B>` before displaying. This should eliminate that redundancy.
