### PR TITLE
Reverts changes to android/robot names

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -278,9 +278,9 @@
 		modtype = prefix
 
 	if(istype(mmi, /obj/item/device/mmi/digital/posibrain))
-		braintype = "Robot"
+		braintype = "Android"
 	else if(istype(mmi, /obj/item/device/mmi/digital/robot))
-		braintype = "Drone"
+		braintype = "Robot"
 	else
 		braintype = "Cyborg"
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Now that android is no longer needed for FBPs, we can safely revert to using the proper names for the different types of borg.

There is currently a lot of confusion around the changed names, this should return things to normal.
