### PR TITLE
Enables MultiZAS on Torch

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -58,7 +58,7 @@ turf/c_airblock(turf/other)
 		return BLOCKED
 
 	//Z-level handling code. Always block if there isn't an open space.
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	if(other.z != src.z)
 		if(other.z < src.z)
 			if(!istype(src, /turf/simulated/open)) return BLOCKED

--- a/code/ZAS/ConnectionManager.dm
+++ b/code/ZAS/ConnectionManager.dm
@@ -37,7 +37,7 @@ Class Procs:
 /connection_manager/var/connection/E
 /connection_manager/var/connection/W
 
-#ifdef ZLEVELS
+#ifdef MULTIZAS
 /connection_manager/var/connection/U
 /connection_manager/var/connection/D
 #endif
@@ -57,7 +57,7 @@ Class Procs:
 			if(check(W)) return W
 			else return null
 
-		#ifdef ZLEVELS
+		#ifdef MULTIZAS
 		if(UP)
 			if(check(U)) return U
 			else return null
@@ -73,7 +73,7 @@ Class Procs:
 		if(EAST) E = c
 		if(WEST) W = c
 
-		#ifdef ZLEVELS
+		#ifdef MULTIZAS
 		if(UP) U = c
 		if(DOWN) D = c
 		#endif
@@ -83,7 +83,7 @@ Class Procs:
 	if(check(S)) S.update()
 	if(check(E)) E.update()
 	if(check(W)) W.update()
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	if(check(U)) U.update()
 	if(check(D)) D.update()
 	#endif
@@ -93,7 +93,7 @@ Class Procs:
 	if(check(S)) S.erase()
 	if(check(E)) E.erase()
 	if(check(W)) W.erase()
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	if(check(U)) U.erase()
 	if(check(D)) D.erase()
 	#endif

--- a/code/ZAS/Diagnostic.dm
+++ b/code/ZAS/Diagnostic.dm
@@ -39,7 +39,7 @@ client/proc/Test_ZAS_Connection(var/turf/simulated/T as turf)
 	"South" = SOUTH,\
 	"East" = EAST,\
 	"West" = WEST,\
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	"Up" = UP,\
 	"Down" = DOWN,\
 	#endif

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -16,7 +16,7 @@
 		//dbg(blocked)
 		return 1
 
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	for(var/d = 1, d < 64, d *= 2)
 	#else
 	for(var/d = 1, d < 16, d *= 2)
@@ -52,27 +52,27 @@
 */
 
 /turf/simulated/proc/can_safely_remove_from_zone()
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	return 0 //TODO generalize this to multiz.
 	#else
-	
+
 	if(!zone) return 1
-	
+
 	var/check_dirs = get_zone_neighbours(src)
 	var/unconnected_dirs = check_dirs
-	
+
 	for(var/dir in list(NORTHWEST, NORTHEAST, SOUTHEAST, SOUTHWEST))
-		
+
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
 		if((dir & check_dirs) == dir)
 			//check that they are connected by the corner turf
 			var/connected_dirs = get_zone_neighbours(get_step(src, dir))
 			if(connected_dirs && (dir & turn(connected_dirs, 180)) == dir)
 				unconnected_dirs &= ~dir //they are, so unflag the cardinals in question
-	
+
 	//it is safe to remove src from the zone if all cardinals are connected by corner turfs
 	return !unconnected_dirs
-	
+
 	#endif
 
 //helper for can_safely_remove_from_zone()
@@ -111,7 +111,7 @@
 	open_directions = 0
 
 	var/list/postponed
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	for(var/d = 1, d < 64, d *= 2)
 	#else
 	for(var/d = 1, d < 16, d *= 2)
@@ -162,7 +162,7 @@
 				//Might have assigned a zone, since this happens for each direction.
 				if(!zone)
 
-					//We do not merge if 
+					//We do not merge if
 					//    they are blocking us and we are not blocking them, or if
 					//    we are blocking them and not blocking ourselves - this prevents tiny zones from forming on doorways.
 					if(((block & ZONE_BLOCKED) && !(r_block & ZONE_BLOCKED)) || ((r_block & ZONE_BLOCKED) && !(s_block & ZONE_BLOCKED)))

--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -28,7 +28,7 @@ Notes for people who used ZAS before:
 */
 
 //#define ZASDBG
-//#define MULTIZAS
+#define MULTIZAS
 
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2

--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -28,7 +28,7 @@ Notes for people who used ZAS before:
 */
 
 //#define ZASDBG
-//#define ZLEVELS
+//#define MULTIZAS
 
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -29,6 +29,8 @@
 
 	#define USING_MAP_DATUM /datum/map/torch
 
+	#define ZLEVELS
+
 #elif !defined(MAP_OVERRIDE)
 
 	#warn A map has already been included, ignoring Torch

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -29,8 +29,6 @@
 
 	#define USING_MAP_DATUM /datum/map/torch
 
-	#define MULTIZAS
-
 #elif !defined(MAP_OVERRIDE)
 
 	#warn A map has already been included, ignoring Torch

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -29,7 +29,7 @@
 
 	#define USING_MAP_DATUM /datum/map/torch
 
-	#define ZLEVELS
+	#define MULTIZAS
 
 #elif !defined(MAP_OVERRIDE)
 


### PR DESCRIPTION
Let's see if it breaks! There's already one function I spied where it's intentionally shortcircuiting back if multiZAS is enabled (`can_safely_remove_from_zone` in `code/ZAS/Turf.dm`), so will need to see if that causes issues.

Also renamed the `ZLEVELS` define to `MULTIZAS` for clarity, and moved the define over to the map datum (since it'd be pointless to have it active for Exodus).
