### PR TITLE
Changes ninja net. Changes 'can_unbuckle' check when resisting.

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -112,18 +112,18 @@
 	processing_objects.Add(src)
 
 /obj/effect/energy_net/Destroy()
-	if(istype(src.captured, /mob/living/carbon))
-		if(src.captured.handcuffed == src)
-			src.captured.handcuffed = null
-	if(src.captured)
+	if(istype(captured, /mob/living/carbon))
+		if(captured.handcuffed == src)
+			captured.handcuffed = null
+	if(captured)
 		unbuckle_mob()
 	processing_objects.Remove(src)
-	src.captured = null
+	captured = null
 	return ..()
 
 /obj/effect/energy_net/process()
 	countdown--
-	if(src.captured.buckled != src)
+	if(captured.buckled != src)
 		health = 0
 	if(get_turf(src) != get_turf(captured))  //just in case they somehow teleport around or
 		countdown = 0
@@ -134,7 +134,7 @@
 
 
 /obj/effect/energy_net/proc/capture_mob(mob/living/M)
-	src.captured = M
+	captured = M
 	if(M.buckled)
 		M.buckled.unbuckle_mob()
 	buckle_mob(M)
@@ -158,9 +158,9 @@
 	if(health <=0)
 		density = 0
 		if(countdown <= 0)
-			src.visible_message("<span class='warning'>\The [src] fades away!</span>")
+			visible_message("<span class='warning'>\The [src] fades away!</span>")
 		else
-			src.visible_message("<span class='danger'>\The [src] is torn apart!</span>")
+			visible_message("<span class='danger'>\The [src] is torn apart!</span>")
 		qdel(src)
 
 /obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
@@ -198,8 +198,7 @@
 	..()
 
 obj/effect/energy_net/user_unbuckle_mob(mob/user)
-	return src.escape_net(user)
-
+	return escape_net(user)
 
 
 /obj/effect/energy_net/proc/escape_net(mob/user as mob)
@@ -207,10 +206,9 @@ obj/effect/energy_net/user_unbuckle_mob(mob/user)
 		"<span class='danger'>\The [user] attempts to free themselves from \the [src]!</span>",
 		"<span class='warning'>You attempt to free yourself from \the [src]!</span>"
 		)
-	if(do_after(usr, rand(min_free_time, max_free_time), incapacitation_flags = INCAPACITATION_DEFAULT & ~(INCAPACITATION_RESTRAINED | INCAPACITATION_BUCKLED_FULLY)))
-		if(src)
-			src.health = 0
-			src.healthcheck()
-			return 1
+	if(do_after(user, rand(min_free_time, max_free_time), src, incapacitation_flags = INCAPACITATION_DISABLED))
+		health = 0
+		healthcheck()
+		return 1
 	else
 		return 0

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -112,23 +112,36 @@
 	processing_objects.Add(src)
 
 /obj/effect/energy_net/Destroy()
-	..()
+	if(istype(src.captured, /mob/living/carbon))
+		if(src.captured.handcuffed == src)
+			src.captured.handcuffed = null
+	if(src.captured)
+		unbuckle_mob()
 	processing_objects.Remove(src)
+	src.captured = null
+	..()
 
 /obj/effect/energy_net/process()
 	countdown--
+	if(src.captured.buckled != src)
+		health = 0
+	if(get_turf(src) != get_turf(captured))  //just in case they somehow teleport around or
+		countdown = 0
 	if(countdown <= 0)
 		health = 0
 	healthcheck()
 
 
-/obj/effect/energy_net/proc/capture_mob(mob/living/carbon/M)
+
+/obj/effect/energy_net/proc/capture_mob(mob/living/M)
 	src.captured = M
 	if(M.buckled)
 		M.buckled.unbuckle_mob()
 	buckle_mob(M)
 	if(istype(M, /mob/living/carbon))
-		M.handcuffed = src
+		var/mob/living/carbon/C = M
+		if(!C.handcuffed)
+			C.handcuffed = src
 	return 1
 
 /obj/effect/energy_net/post_buckle_mob(mob/living/M)
@@ -148,10 +161,7 @@
 			src.visible_message("<span class='warning'>\The [src] fades away!</span>")
 		else
 			src.visible_message("<span class='danger'>\The [src] is torn apart!</span>")
-		if(istype(src.captured, /mob/living/carbon))
-			src.captured.handcuffed = null
-		unbuckle_mob()
-		src.captured = null
+		qdel(src)
 
 /obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -197,6 +197,11 @@
 	healthcheck()
 	..()
 
+obj/effect/energy_net/user_unbuckle_mob(mob/user)
+	return src.escape_net(user)
+
+
+
 /obj/effect/energy_net/proc/escape_net(mob/user as mob)
 	visible_message(
 		"<span class='danger'>\The [user] attempts to free themselves from \the [src]!</span>",
@@ -206,3 +211,6 @@
 		if(src)
 			src.health = 0
 			src.healthcheck()
+			return 1
+	else
+		return 0

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -199,7 +199,7 @@
 
 /obj/effect/energy_net/proc/escape_net(mob/user as mob)
 	visible_message(
-		"<span class='danger'>[usr] attempts to free themselves from \the [src]!</span>",
+		"<span class='danger'>\The [user] attempts to free themselves from \the [src]!</span>",
 		"<span class='warning'>You attempt to free yourself from \the [src]!</span>"
 		)
 	if(do_after(usr, rand(min_free_time, max_free_time), incapacitation_flags = INCAPACITATION_DEFAULT & ~(INCAPACITATION_RESTRAINED | INCAPACITATION_BUCKLED_FULLY)))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -99,31 +99,59 @@
 	can_buckle = 0 //no manual buckling or unbuckling
 
 	var/health = 25
-	var/countdown = -1
+	var/countdown = 15
+	var/mob/living/carbon/captured = null
+	var/min_free_time = 50
+	var/max_free_time = 85
 
 /obj/effect/energy_net/teleport
 	countdown = 60
 
-/obj/effect/energy_net/proc/capture_mob(mob/living/M)
+/obj/effect/energy_net/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/effect/energy_net/Destroy()
+	..()
+	processing_objects.Remove(src)
+
+/obj/effect/energy_net/process()
+	countdown--
+	if(countdown <= 0)
+		health = 0
+	healthcheck()
+
+
+/obj/effect/energy_net/proc/capture_mob(mob/living/carbon/M)
+	src.captured = M
 	if(M.buckled)
 		M.buckled.unbuckle_mob()
 	buckle_mob(M)
+	if(istype(M, /mob/living/carbon))
+		M.handcuffed = src
+	return 1
 
 /obj/effect/energy_net/post_buckle_mob(mob/living/M)
 	if(buckled_mob)
 		plane = ABOVE_HUMAN_PLANE
 		layer = ABOVE_HUMAN_LAYER
-		visible_message("\The [M] was caught in an energy net!")
+		visible_message("\The [M] was caught in [src]!")
 	else
-		to_chat(M, "You are free of the net!")
+		to_chat(M,"<span class='warning'>You are free of the net!</span>")
 		reset_plane_and_layer()
 		qdel(src)
 
 /obj/effect/energy_net/proc/healthcheck()
 	if(health <=0)
 		density = 0
-		src.visible_message("The energy net is torn apart!")
+		if(countdown <= 0)
+			src.visible_message("<span class='warning'>\The [src] fades away!</span>")
+		else
+			src.visible_message("<span class='danger'>\The [src] is torn apart!</span>")
+		if(istype(src.captured, /mob/living/carbon))
+			src.captured.handcuffed = null
 		unbuckle_mob()
+		src.captured = null
 
 /obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()
@@ -149,7 +177,7 @@
 	else
 		health -= rand(5,8)
 
-	to_chat(H, "<span class='danger'>You claw at the energy net.</span>")
+	to_chat(H,"<span class='danger'>You claw at the energy net.</span>")
 
 	healthcheck()
 	return
@@ -158,3 +186,13 @@
 	health -= W.force
 	healthcheck()
 	..()
+
+/obj/effect/energy_net/proc/escape_net(mob/user as mob)
+	visible_message(
+		"<span class='danger'>[usr] attempts to free themselves from \the [src]!</span>",
+		"<span class='warning'>You attempt to free yourself from \the [src]!</span>"
+		)
+	if(do_after(usr, rand(min_free_time, max_free_time), incapacitation_flags = INCAPACITATION_DEFAULT & ~(INCAPACITATION_RESTRAINED | INCAPACITATION_BUCKLED_FULLY)))
+		if(src)
+			src.health = 0
+			src.healthcheck()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -119,7 +119,7 @@
 		unbuckle_mob()
 	processing_objects.Remove(src)
 	src.captured = null
-	..()
+	return ..()
 
 /obj/effect/energy_net/process()
 	countdown--

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -138,6 +138,7 @@
 
 	return 1
 
+
 /obj/item/rig_module/fabricator/energy_net
 
 	name = "net projector"

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -143,6 +143,7 @@
 	name = "net projector"
 	desc = "Some kind of complex energy projector with a hardsuit mount."
 	icon_state = "enet"
+	module_cooldown = 100
 
 	interface_name = "energy net launcher"
 	interface_desc = "An advanced energy-patterning projector used to capture targets."

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -157,7 +157,8 @@
 /mob/living/carbon/escape_buckle()
 	if(src.handcuffed && istype(src.buckled, /obj/effect/energy_net))
 		var/obj/effect/energy_net/N = src.buckled
-		spawn N.escape_net() //super snowflake but is literally used NOWHERE ELSE.-Luke
+		N.escape_net() //super snowflake but is literally used NOWHERE ELSE.-Luke
+		return
 
 	setClickCooldown(100)
 	if(!buckled) return

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -158,7 +158,6 @@
 	if(src.handcuffed && istype(src.buckled, /obj/effect/energy_net))
 		var/obj/effect/energy_net/N = src.buckled
 		spawn N.escape_net() //super snowflake but is literally used NOWHERE ELSE.-Luke
-		return
 
 	setClickCooldown(100)
 	if(!buckled) return

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -155,6 +155,11 @@
 	return ..()
 
 /mob/living/carbon/escape_buckle()
+	if(src.handcuffed && istype(src.handcuffed, /obj/effect/energy_net))
+		var/obj/effect/energy_net/N = handcuffed
+		spawn N.escape_net() //super snowflake but is literally used NOWHERE ELSE.-Luke
+		return
+
 	setClickCooldown(100)
 	if(!buckled) return
 

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -155,8 +155,8 @@
 	return ..()
 
 /mob/living/carbon/escape_buckle()
-	if(src.handcuffed && istype(src.handcuffed, /obj/effect/energy_net))
-		var/obj/effect/energy_net/N = handcuffed
+	if(src.handcuffed && istype(src.buckled, /obj/effect/energy_net))
+		var/obj/effect/energy_net/N = src.buckled
 		spawn N.escape_net() //super snowflake but is literally used NOWHERE ELSE.-Luke
 		return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,10 +659,6 @@ default behaviour is:
 
 /mob/living/proc/escape_buckle()
 	if(buckled)
-		if(istype(buckled, /obj/effect/energy_net))
-			var/obj/effect/energy_net/B = buckled
-			B.escape_net(src)
-		else if(buckled.can_buckle)
 			buckled.user_unbuckle_mob(src)
 		else
 			to_chat(usr, "<span class='warning'>You can't seem to escape from \the [buckled]!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,7 +659,14 @@ default behaviour is:
 
 /mob/living/proc/escape_buckle()
 	if(buckled)
-		buckled.user_unbuckle_mob(src)
+		if(istype(buckled, /obj/effect/energy_net))
+			var/obj/effect/energy_net/B = buckled
+			B.escape_net(src)
+		else if(buckled.can_buckle)
+			buckled.user_unbuckle_mob(src)
+		else
+			to_chat(usr, "<span class='warning'>You can't seem to escape from \the [buckled]!</span>")
+			return
 
 /mob/living/proc/resist_grab()
 	var/resisting = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,6 +659,7 @@ default behaviour is:
 
 /mob/living/proc/escape_buckle()
 	if(buckled)
+		if(buckled.can_buckle)
 			buckled.user_unbuckle_mob(src)
 		else
 			to_chat(usr, "<span class='warning'>You can't seem to escape from \the [buckled]!</span>")

--- a/html/changelogs/LorenLuke-NinjaNet.yml
+++ b/html/changelogs/LorenLuke-NinjaNet.yml
@@ -1,0 +1,11 @@
+
+author: LorenLuke
+
+delete-after: True
+
+changes: 
+  - bugfix: "Keeps people from just using 'resist' to escape from nets instantly."
+  - tweak: "Makes resist time random between 5 and 9 seconds to exit net."
+  - tweak: "Sets net fabricator cooldown to 10 seconds (greater than max net resist time)."
+  - rscadd: "Makes nets fade away even if not resisted out of after 15 processing_objects ticks."
+  - tweak: "Makes it so that netted people cannot use items (and shoot/baton you while 'restrained' by the net) until freed."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Fixes people using 'resist' to escape from nets instantly, instead creates a resist time random between 5 and 9 seconds to exit net. Changes net fabricator cooldown to 10 seconds (greater than max net resist time) to prevent effective single target spam. Makes nets fade away even if not resisted out of after 15 processing_objects ticks in case they can't resist for some reason. And prevents netted people using weapons or items until breaking out of the net.
