### PR TITLE
HUD-utilizing glasses now qdel better.

### DIFF
--- a/code/controllers/Processes/garbage.dm
+++ b/code/controllers/Processes/garbage.dm
@@ -4,7 +4,6 @@
 #define GC_COLLECTION_TIMEOUT (30 SECONDS)
 #define GC_FORCE_DEL_PER_RUN 30
 
-
 var/datum/controller/process/garbage_collector/garbage_collector
 var/list/delayed_garbage = list()
 
@@ -163,11 +162,20 @@ world/loop_checks = 0
 
 var/list/unwrappable_lists = list("contents","verbs","overlays","underlays","screen")
 
-/mob/verb/create_and_delete_thing() // Prevents the hidden reference counter from holding our thing
+// BYOND keeps a hidden reference to objects used in a verb for a few minutes
+//  which often results in items deleted by Right Click->Delete not GCing properly. Thus, this proc.
+/mob/verb/create_and_delete(path_text as text)
 	set category = "Debug"
-	set name = "Create And Delete Thing"
+	set name = "Create And Delete"
 
-	var/path = input("Enter path")
+	path_text = sanitize(path_text)
+	if(!path_text)
+		return
+
+	var/path = text2path(path_text)
+	if(!path)
+		to_chat(src, "Unable to find the path [path_text]")
+
 	var/atom/thing = new path(loc)
 	qdel(thing)
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -14,6 +14,16 @@
 	var/obj/screen/overlay = null
 	var/obj/item/clothing/glasses/hud/hud = null	// Hud glasses, if any
 
+/obj/item/clothing/glasses/New()
+	..()
+	if(ispath(hud))
+		hud = new hud(src)
+
+/obj/item/clothing/glasses/Destroy()
+	qdel(hud)
+	hud = null
+	. = ..()
+
 /obj/item/clothing/glasses/attack_self(mob/user)
 	if(toggleable && !user.incapacitated())
 		if(active)
@@ -231,11 +241,7 @@
 	name = "HUDSunglasses"
 	desc = "Sunglasses with a HUD."
 	icon_state = "sunhud"
-
-	New()
-		..()
-		src.hud = new/obj/item/clothing/glasses/hud/security(src)
-		return
+	hud = /obj/item/clothing/glasses/hud/security
 
 /obj/item/clothing/glasses/sunglasses/sechud/goggles //now just a more "military" set of HUDglasses for the Torch
 	name = "HUD goggles"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Used to never clean-up its HUD reference.
Also cleans up how they're initialized.
