### PR TITLE
Removes Xenomorphs from add antag rotation

### DIFF
--- a/code/game/antagonist/alien/xenomorph.dm
+++ b/code/game/antagonist/alien/xenomorph.dm
@@ -5,7 +5,7 @@ var/datum/antagonist/xenos/xenomorphs
 	role_text = "Xenomorph"
 	role_text_plural = "Xenomorphs"
 	mob_path = /mob/living/carbon/alien/larva
-	flags = ANTAG_OVERRIDE_MOB | ANTAG_RANDSPAWN | ANTAG_OVERRIDE_JOB | ANTAG_VOTABLE
+	flags = ANTAG_OVERRIDE_MOB | ANTAG_RANDSPAWN | ANTAG_OVERRIDE_JOB
 	welcome_text = "Hiss! You are a larval alien. Hide and bide your time until you are ready to evolve."
 	antaghud_indicator = "hudalien"
 	antag_indicator = "alien"

--- a/html/changelogs/atlantiscze-noxenos.yml
+++ b/html/changelogs/atlantiscze-noxenos.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscdel: "Xenomorphs have been removed from the add-antagonist rotation."


### PR DESCRIPTION
- As it says on the tin - due to how generally broken they are. Lonefly asked for this.
