### PR TITLE
Removes the ability to ventcrawl through scrubbers.

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -1,6 +1,5 @@
 var/list/ventcrawl_machinery = list(
-	/obj/machinery/atmospherics/unary/vent_pump,
-	/obj/machinery/atmospherics/unary/vent_scrubber
+	/obj/machinery/atmospherics/unary/vent_pump
 	)
 
 // Vent crawling whitelisted items, whoo

--- a/html/changelogs/atlantiscze-noscrubbercrawling.yml
+++ b/html/changelogs/atlantiscze-noscrubbercrawling.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscdel: "It is no longer possible to ventcrawl through scrubbers."


### PR DESCRIPTION
- Due to the fact that scrubbers can not, unlike vents, be welded shut.
