### PR TITLE
Fix for securitrons not being able to cuff people

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -49,7 +49,7 @@
 			user << "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>"
 
 /obj/item/weapon/handcuffs/proc/can_place(var/mob/target, var/mob/user)
-	if(istype(user, /mob/living/silicon/robot))
+	if(istype(user, /mob/living/silicon/robot) || istype(user, /mob/living/bot))
 		return 1
 	else
 		for (var/obj/item/weapon/grab/G in target.grabbed_by)


### PR DESCRIPTION
Not sure at what point the check ought to morph from 'is this person a borg or a bot' to 'is this person not a human', but I don't think we're there yet, nor should we be.
