### PR TITLE
PACMAN generator EMP tweaks

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -53,6 +53,8 @@
 	else
 		to_chat(usr, "<span class='notice'>The generator is off.</span>")
 /obj/machinery/power/port_gen/emp_act(severity)
+	if(!active)
+		return
 	var/duration = 6000 //ten minutes
 	switch(severity)
 		if(1)


### PR DESCRIPTION
- Turning off the PACMAN now protects it from EMP's effects. Among others, this includes the EMP-induced explosion, which could be commonly seen in engineering storage with the spare PACMAN that's stored there.