### PR TITLE
Adjust Skrell Mechanics (darksight, cold/heat levels)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -158,6 +158,8 @@
 
 	min_age = 19
 	max_age = 90
+	
+	darksight = 4
 
 	spawn_flags = CAN_JOIN | IS_WHITELISTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR
@@ -165,6 +167,14 @@
 	flesh_color = "#8CD7A3"
 	blood_color = "#1D2CBF"
 	base_color = "#006666"
+	
+	cold_level_1 = 280 //Default 260 - Lower is better
+	cold_level_2 = 220 //Default 200
+	cold_level_3 = 130 //Default 120
+
+	heat_level_1 = 420 //Default 360 - Higher is better
+	heat_level_2 = 480 //Default 400
+	heat_level_3 = 1100 //Default 1000
 
 	reagent_tag = IS_SKRELL
 

--- a/html/changelogs/Datraen-SkrellMechanicUpdate2.yml
+++ b/html/changelogs/Datraen-SkrellMechanicUpdate2.yml
@@ -1,0 +1,7 @@
+author: Datraen
+
+delete-after: True
+
+changes: 
+  - tweak: "Skrell now have mild darksight."
+  - tweak: "Skrell now prefer slightly warmer temperatures."


### PR DESCRIPTION
Skrell now have higher darksight levels (4 vs default 2) and now have a preference for slightly higher temperature environments.

Changes were run past Paradoxon and approved.

The files were originally adjusted to go with #14343, but did not have approval until two days ago.

EDIT: The changes were not run past Paradoxon until two days ago, not that Paradoxon did not get back to me in a timely manner. It was through my own fault that they were not presented to him in a timely manner.