### PR TITLE
Makes xenos able to spawn with modified versions of restricted gloves from selected job/outfit

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -80,6 +80,33 @@ var/list/outfits_decls_by_type_
 		J.toggle()
 		J.toggle_valve()
 
+// A proc for non-human species, specially Unathi and Tajara, since they e.g.
+// can't normally wear gloves as humans. Correct this issue by trying again, but
+// apply some changes to the said item.
+//
+// Currently checks for gloves
+//
+// If you want to add more items that has species restriction, consider follow-
+// ing the same format as the gloves shown in the code below. Thanks.
+/decl/hierarchy/outfit/proc/check_and_try_equip_xeno(mob/living/carbon/human/H)
+	var/datum/species/S = H.species
+	if (!S || istype(S, /datum/species/human)) // null failcheck & get out here you damn humans
+		return
+
+	// Gloves
+	if (gloves && !H.get_equipped_item(slot_gloves)) // does mob not have gloves, despite the outfit has one specified?
+		var/obj/item/clothing/gloves/G = new gloves(H) // we've no use of a null object, instantize one
+		if (S.get_bodytype() in G.species_restricted) // what was the problem?
+			if ("exclude" in G.species_restricted) // are they excluded?
+				G.cut_fingertops()
+				// I could optimize this bit when we are trying to apply the gloves to e.g. Vox, a species still restricted despite G.cut_fingertops(). But who cares if this is codebase is like a plate of spaghetti twice over the brim, right? RIGHT?
+				H.equip_to_slot_or_del(G,slot_gloves) // try again
+		else
+			qdel(G)
+	// end Gloves
+
+// end of check_and_try_equip_xeno
+
 /decl/hierarchy/outfit/proc/equip(mob/living/carbon/human/H, var/rank, var/assignment)
 	equip_base(H)
 
@@ -143,6 +170,7 @@ var/list/outfits_decls_by_type_
 		H.put_in_r_hand(new r_hand(H))
 	if(H.species)
 		H.species.equip_survival_gear(H, flags&OUTFIT_EXTENDED_SURVIVAL)
+	check_and_try_equip_xeno(H)
 
 /decl/hierarchy/outfit/proc/equip_id(mob/living/carbon/human/H, rank, assignment)
 	if(!id_slot)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -242,13 +242,22 @@ BLIND     // can't see anything
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		user.visible_message("<span class='warning'>\The [user] cuts the fingertips off of \the [src].</span>","<span class='warning'>You cut the fingertips off of \the [src].</span>")
 
-		clipped = 1
-		name = "modified [name]"
-		desc = "[desc]<br>They have had the fingertips cut off of them."
-		if("exclude" in species_restricted)
-			species_restricted -= "Unathi"
-			species_restricted -= "Tajara"
+		cut_fingertops() // apply change, so relevant xenos can wear these
 		return
+
+// Applies "clipped" and removes relevant restricted species from the list,
+// making them wearable by the specified species, does nothing if already cut
+/obj/item/clothing/gloves/proc/cut_fingertops()
+	if (clipped)
+		return
+
+	clipped = 1
+	name = "modified [name]"
+	desc = "[desc]<br>They have had the fingertips cut off of them."
+	if("exclude" in species_restricted)
+		species_restricted -= "Unathi"
+		species_restricted -= "Tajara"
+	return
 
 ///////////////////////////////////////////////////////////////////////
 //Head

--- a/html/changelogs/Irrationalist-glove-clip.yml
+++ b/html/changelogs/Irrationalist-glove-clip.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Irrationalist
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Unathi and Tajara can now spawn and show preview with gloves included in outfit of [HIGH] selected job"
+  - tweak: "/obj/item/clothing/gloves has new proc: cut_fingertops - for easier adminbus"


### PR DESCRIPTION
```
This commit adds code that checks if the human mob has no item despite it
being included in the outfit manifest for specified job. It tries by cases
and adapts the item to the cirumstances to make it possible for said mob
to wear missing (and now corrected) items. The code then attempts once
again using "equip_to_slot_or_del". It fails finding the cause, it cleans
up after itself.

Gloves now have the "cut_fingertops" proc for [barely] shorter code and easy adminbus.
```
Message from commit `71467e2`

Right now, this does not work with loadout items, since they are processed in a radically different way.