### PR TITLE
Tweaks to stun-batons and fixes #14470

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -56,16 +56,18 @@
 	else
 		set_light(0)
 
-// TODO: Change the description for the robot-module version - if you can figure that out
 /obj/item/weapon/melee/baton/examine(mob/user)
 	if(!..(user, 1))
 		return 0
+	examine_cell(user)
+	return 1
 
+// Addition made by Techhead0, thanks for fullfilling the todo!
+/obj/item/weapon/melee/baton/proc/examine_cell(mob/user)
 	if(bcell)
 		to_chat(user, "<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>")
 	if(!bcell)
 		to_chat(user, "<span class='warning'>The baton does not have a power source installed.</span>")
-	return 1
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/cell/device))
@@ -177,6 +179,10 @@
 /obj/item/weapon/melee/baton/robot
 	bcell = null
 	hitcost = 100
+
+// Addition made by Techhead0, thanks for fullfilling the todo!
+/obj/item/weapon/melee/baton/robot/examine_cell(mob/user)
+	to_chat(user, "<span class='notice'>The baton is running off an external power supply.</span>")
 
 // Override proc for the stun baton module, found in PC Security synthetics
 // Refactored to fix #14470 - old proc defination increased the hitcost beyond

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -178,8 +178,6 @@
 	bcell = null
 	hitcost = 100
 
-	var/min_hitcost = 100
-
 // Override proc for the stun baton module, found in PC Security synthetics
 // Refactored to fix #14470 - old proc defination increased the hitcost beyond
 // usability without proper checks.
@@ -198,11 +196,10 @@
 	return
 
 /obj/item/weapon/melee/baton/robot/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
-	update_cell(isrobot(user) ? user : null) // update the cost and status before we apply the effects
+	update_cell(isrobot(user) ? user : null) // update the status before we apply the effects
 	return ..()
 
-// Updates both the baton's cell to use user's own cell and update the hitcost
-// to cost 10% of cell's max capacity
+// Updates the baton's cell to use user's own cell
 // Otherwise, if null (when the user isn't a robot), render it unuseable
 /obj/item/weapon/melee/baton/robot/proc/update_cell(mob/living/silicon/robot/user)
 	if (!user)
@@ -210,9 +207,6 @@
 		set_status(0)
 	else if (!bcell || bcell != user.cell)
 		bcell = user.cell // if it is null, nullify it anyway
-		if (bcell) // null failcheck
-			var/new_cost = bcell.maxcharge/10 // 10% of the battery's max charge
-			hitcost = new_cost <= min_hitcost ? min_hitcost : new_cost // the new cost has to be at least 100 (see min_hitcost)
 
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/weapon/melee/baton/cattleprod

--- a/html/changelogs/Irrationalist-rbaton-fix.yml
+++ b/html/changelogs/Irrationalist-rbaton-fix.yml
@@ -1,0 +1,8 @@
+author: Irrationalist
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed stun-batons being unuseable by synthetics due to hitcost increasing each (de)activation"
+  - bugfix: "Fixed stun-batons not properly updating their icons"
+  - tweak: "Stun-batons now always cost 10% of user synthetic's max power capacity, per hit. With one exception; 100 for cells with rating of 1000 W or smaller"

--- a/html/changelogs/Irrationalist-rbaton-fix.yml
+++ b/html/changelogs/Irrationalist-rbaton-fix.yml
@@ -5,4 +5,3 @@ delete-after: True
 changes:
   - bugfix: "Fixed stun-batons being unuseable by synthetics due to hitcost increasing each (de)activation"
   - bugfix: "Fixed stun-batons not properly updating their icons"
-  - tweak: "Stun-batons now always cost 10% of user synthetic's max power capacity, per hit. With one exception; 100 for cells with rating of 1000 W or smaller"


### PR DESCRIPTION
Changelog included:
```
- bugfix: "Fixed stun-batons being unusable by synthetics due to the cost to hit increasing each (de)activation"
- bugfix: "Fixed stun-batons not properly updating their icons"
```

Obligatory reference: #14470 

Edit: These were removed per request:
~~- tweak: "Stun-batons now always cost 10% of user synthetic's max power capacity, per hit. With one exception; 100 for cells with rating of 1000 W or smaller"~~
~~- tweak: "Stun-batons provided to synthetics can't be interacted by organics. Take that cardborgs!~~