### PR TITLE
Fixes Vox overlays

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -706,5 +706,4 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		mob_icon = item_icons[slot]
 	else
 		mob_icon = default_onmob_icons[slot]
-	world << "[src]: [mob_icon], [mob_state]"
 	return overlay_image(mob_icon,mob_state,color,RESET_COLOR)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -695,15 +695,16 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 			mob_state = "[mob_state]_l"
 		if(slot == 	slot_r_hand_str || slot == slot_r_ear_str)
 			mob_state = "[mob_state]_r"
-	else if(sprite_sheets && sprite_sheets[bodytype] && !(slot == slot_r_hand_str || slot == slot_l_hand_str))
+	else if(sprite_sheets && sprite_sheets[bodytype] && (mob_state in icon_states(sprite_sheets[bodytype])) && !(slot == slot_r_hand_str || slot == slot_l_hand_str))
 		if(slot == slot_l_ear)
 			mob_state = "[mob_state]_l"
 		if(slot == slot_r_ear)
 			mob_state = "[mob_state]_r"
+
 		mob_icon = sprite_sheets[bodytype]
 	else if(item_icons && item_icons[slot])
 		mob_icon = item_icons[slot]
 	else
 		mob_icon = default_onmob_icons[slot]
-
+	world << "[src]: [mob_icon], [mob_state]"
 	return overlay_image(mob_icon,mob_state,color,RESET_COLOR)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Readds overlays defaulting to human overlays if they don't have overlays for the species in question.