### PR TITLE
Fix phoron recipes; fix cryo cells claiming bottles are unlabeled

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -124,10 +124,8 @@
 	data["beakerLabel"] = null
 	data["beakerVolume"] = 0
 	if(beaker)
-		data["beakerLabel"] = beaker.label_text ? beaker.label_text : null
-		if (beaker.reagents && beaker.reagents.reagent_list.len)
-			for(var/datum/reagent/R in beaker.reagents.reagent_list)
-				data["beakerVolume"] += R.volume
+		data["beakerLabel"] = beaker.name
+		data["beakerVolume"] = beaker.reagents.total_volume
 
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -317,7 +317,6 @@
 	id = "dexalin"
 	result = "dexalin"
 	required_reagents = list("acetone" = 2, "phoron" = 0.1)
-	catalysts = list("phoron" = 1)
 	inhibitors = list("water" = 1) // Messes with cryox
 	result_amount = 1
 
@@ -369,7 +368,6 @@
 	id = "clonexadone"
 	result = "clonexadone"
 	required_reagents = list("cryoxadone" = 1, "sodium" = 1, "phoron" = 0.1)
-	catalysts = list("phoron" = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/spaceacillin


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Recipes involving phoron as both catalyst and ingredient were changed by slow-chemistry; they don't fully react any more, because as soon as the catalyst ticks under the limit for the reaction, the reaction stops. Removed phoron catalysts for the two recipes that had phoron as both catalyst and ingredient; recipes which used phoron either only as a catalyst or only as an ingredient are unchanged.

Cryo cells used to require a beaker/bottle be labeled with a pen to show up correctly; bottles labeled with the chemmaster showed up as "No label". Changed this to use the name of the beaker/bottle instead as it's more likely to result in a useful UI. Also changed the loop-over-reagents-and-sum-volume loop, since reagent holders store their total used volume.