### PR TITLE
switches spritesheet logic to a proc instead of a long if statement. Easier to read.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -674,6 +674,17 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill
 
+/obj/item/proc/use_spritesheet(var/bodytype, var/slot, var/icon_state)
+	if(!sprite_sheets || !sprite_sheets[bodytype])
+		return 0
+	if(slot == slot_r_hand_str || slot == slot_l_hand_str)
+		return 0
+
+	if(icon_state in icon_states(sprite_sheets[bodytype]))
+		return 1
+
+	return (slot != slot_wear_suit_str && slot != slot_head_str)
+
 /obj/item/proc/get_mob_overlay(mob/user_mob, slot)
 	var/bodytype = "Default"
 	if(ishuman(user_mob))
@@ -695,7 +706,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 			mob_state = "[mob_state]_l"
 		if(slot == 	slot_r_hand_str || slot == slot_r_ear_str)
 			mob_state = "[mob_state]_r"
-	else if(sprite_sheets && sprite_sheets[bodytype] && ((slot != slot_wear_suit && slot != slot_head) || (mob_state in icon_states(sprite_sheets[bodytype]))) && !(slot == slot_r_hand_str || slot == slot_l_hand_str))
+	else if(use_spritesheet(bodytype, slot, mob_state))
 		if(slot == slot_l_ear)
 			mob_state = "[mob_state]_l"
 		if(slot == slot_r_ear)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Title. By request from Psi.
