### PR TITLE
Disables MULTIZAS + Meteor Tweaks/Fixes

### DIFF
--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -28,7 +28,7 @@ Notes for people who used ZAS before:
 */
 
 //#define ZASDBG
-#define MULTIZAS
+//#define MULTIZAS
 
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -21,8 +21,8 @@
 /datum/game_mode/meteor/post_setup()
 	..()
 	alert_title = "Automated Beacon AB-[rand(10, 99)]"
-	alert_text = "This is an automatic warning. Your facility: [using_map.full_name] is on a collision course with a nearby asteroid belt. Estimated time until impact is: [METEOR_DELAY / 240] MINUTES. Please perform necessary actions to secure your ship or station from the threat. Have a nice day."
-	start_text = "This is an automatic warning. Your facility: [using_map.full_name] has entered an asteroid belt. For your safety, please consider changing course or using protective equipment. Have a nice day."
+	alert_text = "This is an automatic warning. Your facility: [using_map.full_name] is on a collision course with a nearby asteroid belt. Estimated time until impact is: [METEOR_DELAY / 1200] MINUTES. Please perform necessary actions to secure your ship or station from the threat. Have a nice day."
+	start_text = "This is an automatic warning. Your facility: [using_map.full_name] has entered an asteroid belt. Estimated time until you leave the belt is: [rand(20,30)] HOURS and [rand(1, 59)] MINUTES. For your safety, please consider changing course or using protective equipment. Have a nice day."
 	next_wave = round_duration_in_ticks + METEOR_DELAY
 
 /datum/game_mode/meteor/process()
@@ -34,6 +34,9 @@
 	if((round_duration_in_ticks >= next_wave) && (alert_sent == 1))
 		alert_sent = 2
 		command_announcement.Announce(start_text, alert_title)
+		for(var/obj/machinery/shield_diffuser/SD in machines)
+			SD.meteor_alarm(INFINITY)
+		next_wave = round_duration_in_ticks + (meteor_wave_delay * METEOR_DELAY_MULTIPLIER)
 
 	if(round_duration_in_ticks >= next_wave)
 		next_wave = round_duration_in_ticks + (meteor_wave_delay * METEOR_DELAY_MULTIPLIER)


### PR DESCRIPTION
- Fixes Meteor mode not spawning meteors and transphasic small mobs teleporting around (Fixes #14544)
- Meteor mode alert now broadcasts a correct time (15 minutes instead of 75)
- Meteor mode now triggers shield diffuser's integrated meteor proximity alarm mode, permanently. They can be reset by clicking them.
- The warning message now states that the meteors will fly for a very long time. Makes it harder to mistake for the generic meteor storm announcements.