### PR TITLE
Fixes some runtimes with zero-capacity cells.

### DIFF
--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -62,16 +62,17 @@
 /obj/item/device/suit_sensor_jammer/update_icon()
 	overlays.Cut()
 	if(bcell)
-		switch(bcell.charge/bcell.maxcharge)
-			if(0 to 0.25)
+		var/percent = bcell.percent()
+		switch(percent)
+			if(0 to 25)
 				overlays += "forth_quarter"
-			if(0.25 to 0.50)
+			if(25 to 50)
 				overlays += "one_quarter"
 				overlays += "third_quarter"
-			if(0.50 to 0.75)
+			if(50 to 75)
 				overlays += "two_quarters"
 				overlays += "second_quarter"
-			if(0.75 to 0.99)
+			if(75 to 99)
 				overlays += "three_quarters"
 				overlays += "first_quarter"
 			else
@@ -104,7 +105,7 @@ obj/item/device/suit_sensor_jammer/examine(var/user)
 		var/list/message = list()
 		message += "This device appears to be [active ? "" : "in"]active and "
 		if(bcell)
-			message += "displays a charge level of [bcell.charge * 100 / bcell.maxcharge]%."
+			message += "displays a charge level of [bcell.percent()]%."
 		else
 			message += "is lacking a cell."
 		to_chat(user, jointext(message,.))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -456,7 +456,7 @@
 
 	data["charge"] =       cell ? round(cell.charge,1) : 0
 	data["maxcharge"] =    cell ? cell.maxcharge : 0
-	data["chargestatus"] = cell ? Floor((cell.charge/cell.maxcharge)*50) : 0
+	data["chargestatus"] = cell ? Floor(cell.percent()/2) : 0
 
 	data["emagged"] =       subverted
 	data["coverlock"] =     locked

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -215,18 +215,8 @@
 
 	if (src.cells)
 		if (src.cell)
-			var/cellcharge = src.cell.charge/src.cell.maxcharge
-			switch(cellcharge)
-				if(0.75 to INFINITY)
-					src.cells.icon_state = "charge4"
-				if(0.5 to 0.75)
-					src.cells.icon_state = "charge3"
-				if(0.25 to 0.5)
-					src.cells.icon_state = "charge2"
-				if(0 to 0.25)
-					src.cells.icon_state = "charge1"
-				else
-					src.cells.icon_state = "charge0"
+			var/chargeNum = Clamp(0, 4, ceil(cell.percent()/25))	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
+			src.cells.icon_state = "charge[chargeNum]"
 		else
 			src.cells.icon_state = "charge-empty"
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -43,7 +43,7 @@
 /obj/item/weapon/cell/update_icon()
 
 	var/new_overlay_state = null
-	if(charge/maxcharge >= 0.95)
+	if(percent() >= 95)
 		new_overlay_state = "cell-o2"
 	else if(charge >= 0.05)
 		new_overlay_state = "cell-o1"
@@ -55,7 +55,7 @@
 			overlays += image('icons/obj/power.dmi', overlay_state)
 
 /obj/item/weapon/cell/proc/percent()		// return % charge of cell
-	return 100.0*charge/maxcharge
+	return maxcharge && (100.0*charge/maxcharge)
 
 /obj/item/weapon/cell/proc/fully_charged()
 	return (charge == maxcharge)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -90,13 +90,13 @@
 /obj/item/weapon/gun/energy/update_icon()
 	..()
 	if(charge_meter)
-		var/ratio = power_supply.charge / power_supply.maxcharge
+		var/ratio = power_supply.percent()
 
 		//make sure that rounding down will not give us the empty state even if we have charge for a shot left.
 		if(power_supply.charge < charge_cost)
 			ratio = 0
 		else
-			ratio = max(round(ratio, 0.25) * 100, 25)
+			ratio = max(round(ratio, 25), 25)
 
 		if(modifystate)
 			icon_state = "[modifystate][ratio]"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -45,20 +45,20 @@
 	if(charge_tick < 4) return 0
 	charge_tick = 0
 	if(!power_supply) return 0
-	if((power_supply.charge / power_supply.maxcharge) != 1)
+	if(power_supply.percent() < 100)
 		power_supply.give(charge_cost)
 		update_icon()
 	return 1
 
 /obj/item/weapon/gun/energy/gun/nuclear/proc/update_charge()
-	var/ratio = power_supply.charge / power_supply.maxcharge
-	ratio = round(ratio, 0.25) * 100
+	var/ratio = power_supply.percent()
+	ratio = round(ratio, 25)
 	overlays += "nucgun-[ratio]"
 
 /obj/item/weapon/gun/energy/gun/nuclear/proc/update_reactor()
 	if(lightfail)
 		overlays += "nucgun-medium"
-	else if ((power_supply.charge/power_supply.maxcharge) <= 0.5)
+	else if (power_supply.percent() <= 50)
 		overlays += "nucgun-light"
 	else
 		overlays += "nucgun-clean"

--- a/code/modules/spells/aoe_turf/charge.dm
+++ b/code/modules/spells/aoe_turf/charge.dm
@@ -46,10 +46,10 @@
 
 	if(istype(target, /obj/item/weapon/cell/))
 		var/obj/item/weapon/cell/C = target
-		if(prob(80))
+		if(prob(80) && C.maxcharge)
 			C.maxcharge -= 200
-			if(C.maxcharge <= 1) //Div by 0 protection
-				C.maxcharge = 1
+			if(C.maxcharge <= 0) //maxcharge of 0! Madness!
+				C.maxcharge = 0
 			C.charge = C.maxcharge
 			charged_item = C
 

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -40,11 +40,12 @@
 	var/dat = "<b>Multi-phase mobile suspension field generator MK II \"Steadfast\"</b><br>"
 	if(cell)
 		var/colour = "red"
-		if(cell.charge / cell.maxcharge > 0.66)
+		var/percent = cell.percent()
+		if(percent > 66)
 			colour = "green"
-		else if(cell.charge / cell.maxcharge > 0.33)
+		else if(percent > 33)
 			colour = "orange"
-		dat += "<b>Energy cell</b>: <font color='[colour]'>[100 * cell.charge / cell.maxcharge]%</font><br>"
+		dat += "<b>Energy cell</b>: <font color='[colour]'>[percent]%</font><br>"
 	else
 		dat += "<b>Energy cell</b>: None<br>"
 	if(auth_card)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Zero-capacity cells are occasionally found as part of a xenoarch find.
Capacity-lowering effects may also cause them.