### PR TITLE
Makes cameras suck less.

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -219,13 +219,10 @@ var/global/photo_count = 0
 
 //Proc for capturing check
 /mob/living/proc/can_capture_turf(turf/T)
-	var/mob/dummy = new(T)	//Go go visibility check dummy
 	var/viewer = src
 	if(src.client)		//To make shooting through security cameras possible
 		viewer = src.client.eye
-	var/can_see = (dummy in viewers(world.view, viewer))
-
-	qdel(dummy)
+	var/can_see = (T in view(viewer))
 	return can_see
 
 /obj/item/device/camera/proc/captureimage(atom/target, mob/living/user, flag)
@@ -233,8 +230,8 @@ var/global/photo_count = 0
 	var/y_c = target.y + (size-1)/2
 	var/z_c	= target.z
 	var/mobs = ""
-	for(var/i = 1; i <= size; i++)
-		for(var/j = 1; j <= size; j++)
+	for(var/i = 1 to size)
+		for(var/j = 1 to size)
 			var/turf/T = locate(x_c, y_c, z_c)
 			if(user.can_capture_turf(T))
 				mobs += get_mobs(T)

--- a/html/changelogs/Datraen-CameraTweak.yml
+++ b/html/changelogs/Datraen-CameraTweak.yml
@@ -1,0 +1,4 @@
+author: Datraen
+delete-after: True
+changes: 
+  - tweak: "Removes a large portion of camera bloat."


### PR DESCRIPTION
Removes a large portion of bloat from cameras.

My more conservative estimate eliminates ~48%, whereas other estimates could be as high as 85%.

(Profiler comparison)
Before:
![](http://i.imgur.com/41kk7u0.png)
After:
![](http://i.imgur.com/c3kTupB.png)

Picture taken in both cases:
![](http://i.imgur.com/uI01C5n.png)

Please note, the lack of lighting on the RIG was fixed for the second test, and that is as a result of selecting equipment for each mob while not in their body.