### PR TITLE
Fix area teleport spell

### DIFF
--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -29,7 +29,7 @@
 		if(!thearea) return
 	else
 		thearea = pick(teleportlocs)
-	return(teleportlocs[thearea])
+	return list(teleportlocs[thearea])
 
 /spell/area_teleport/cast(area/thearea, mob/user)
 	if(!istype(thearea))


### PR DESCRIPTION
Title. Targets is a *list* of targets, not a target.

`Runtime in spell_code.dm,101: undefined variable /area/..../var/len`