### PR TITLE
Changes "Sentient" to "Sapient" in the drone lawset

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -95,7 +95,7 @@
 /datum/ai_laws/drone/New()
 	add_inherent_law("Preserve, repair and improve your assigned vessel to the best of your abilities.")
 	add_inherent_law("Cause no harm to your assigned vessel or anything on it.")
-	add_inherent_law("Interfere with no sentient being that is not a fellow maintenance drone.")
+	add_inherent_law("Interfere with no sapient being that is not a fellow maintenance drone.")
 	..()
 
 /datum/ai_laws/construction_drone

--- a/html/changelogs/Cirra-sapient.yml
+++ b/html/changelogs/Cirra-sapient.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cirra
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changed 'Sentient' to 'Sapient' in the maintenance drone lawset, to better fit the intention behind the law."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

**This PR corrects a mistake in the maintenance drone lawset.**

This is because "Sentient" technically includes space carp, giant spiders, and any other animal with senses. This was not the intention of this law, from what I know. Sapient only applies to station races such as humans, diona, skrell, IPCs/AI/borgs etc, so this should be closer to the intended purpose of this law.