### PR TITLE
Supermatter radio, global announcer tweaks

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -178,6 +178,6 @@ var/static/list/scarySounds = list(
 var/max_explosion_range = 14
 
 // Announcer intercom, because too much stuff creates an intercom for one message then hard del()s it.
-var/global/obj/item/device/radio/intercom/global_announcer = new(null)
+var/global/obj/item/device/radio/intercom/global_announcer = new /obj/item/device/radio/intercom{channels=list("Engineering")}(null)
 
 var/list/station_departments = list("Command", "Medical", "Engineering", "Science", "Security", "Cargo", "Civilian")

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -96,17 +96,10 @@
 	//How much hallucination should it produce per unit of power?
 	var/config_hallucination_power = 0.1
 
-	var/obj/item/device/radio/radio
-
 	var/debug = 0
 
-/obj/machinery/power/supermatter/initialize()
-	..()
-	radio = new /obj/item/device/radio{channels=list("Engineering")}(src)
 
 /obj/machinery/power/supermatter/Destroy()
-	qdel(radio)
-	radio = null
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
@@ -204,13 +197,13 @@
 	else
 		alert_msg = null
 	if(alert_msg)
-		radio.autosay(alert_msg, "Supermatter Monitor", "Engineering")
+		global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering")
 		//Public alerts
 		if((damage > emergency_point) && !public_alert)
-			radio.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor")
+			global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT!", "Supermatter Monitor")
 			public_alert = 1
 		else if(safe_warned && public_alert)
-			radio.autosay(alert_msg, "Supermatter Monitor")
+			global_announcer.autosay(alert_msg, "Supermatter Monitor")
 			public_alert = 0
 
 

--- a/html/changelogs/Datraen-SupermatterRadio.yml
+++ b/html/changelogs/Datraen-SupermatterRadio.yml
@@ -1,0 +1,6 @@
+author: Datraen
+delete-after: True
+changes: 
+  - tweak: "Global announcer now has access to engineering channel."
+  - tweak: "Supermatter now uses the global announcer."
+  - bugfix: "Supermatter now sends out integrity alerts."


### PR DESCRIPTION
Resolves #14561

Allows global announcer to access the engineering channel, and utilizes this for the supermatter.