### PR TITLE
Communication fixes

### DIFF
--- a/code/datums/communication/dsay.dm
+++ b/code/datums/communication/dsay.dm
@@ -29,8 +29,8 @@
 	for(var/mob/M in player_list)
 		if(!speech_method.can_receive(communicator, M))
 			continue
-		message = speech_method.get_message(communicator, M, message)
-		receive_communication(communicator, M, "<span class='deadsay'>" + create_text_tag("dead", "DEAD:", M.client) + " [message]</span>")
+		var/sent_message = speech_method.get_message(communicator, M, message)
+		receive_communication(communicator, M, "<span class='deadsay'>" + create_text_tag("dead", "DEAD:", M.client) + " [sent_message]</span>")
 
 /decl/dsay_communication/proc/can_communicate(var/client/communicator, var/message)
 	if(communicator.mob.stat != DEAD)

--- a/code/datums/communication/ooc.dm
+++ b/code/datums/communication/ooc.dm
@@ -46,8 +46,8 @@
 	for(var/client/target in clients)
 		if(target.is_key_ignored(communicator.key)) // If we're ignored by this person, then do nothing.
 			continue
-		message = "[create_text_tag("ooc", "OOC:", target)] <EM>[C.key]:</EM> <span class='message'>[message]</span>"
+		var/sent_message = "[create_text_tag("ooc", "OOC:", target)] <EM>[C.key]:</EM> <span class='message'>[message]</span>"
 		if(can_badmin)
-			receive_communication(communicator, target, "<font color='[ooc_color]'><span class='ooc'>[message]</font></span>")
+			receive_communication(communicator, target, "<font color='[ooc_color]'><span class='ooc'>[sent_message]</font></span>")
 		else
-			receive_communication(communicator, target, "<span class='ooc'><span class='[ooc_style]'>[message]</span></span>")
+			receive_communication(communicator, target, "<span class='ooc'><span class='[ooc_style]'>[sent_message]</span></span>")

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -21,7 +21,7 @@
 
 /atom/movable/New()
 	..()
-	if(auto_init && ticker && ticker.current_state == GAME_STATE_PLAYING)
+	if(auto_init && (initialization_stage & INITIALIZATION_COMPLETE))
 		initialize()
 
 /atom/movable/Del()

--- a/code/modules/mob/observer/ghost/say.dm
+++ b/code/modules/mob/observer/ghost/say.dm
@@ -1,18 +1,5 @@
 /mob/observer/ghost/say(var/message)
-	message = sanitize(message)
-
-	if (!message)
-		return
-
-	log_say("Ghost/[src.key] : [message]")
-
-	if (src.client)
-		if(src.client.prefs.muted & MUTE_DEADCHAT)
-			to_chat(src, "<span class='warning'>You cannot talk in deadchat (muted)</span>.")
-			return
-
-	. = src.say_dead(message)
-
+	sanitize_and_communicate(/decl/communication_channel/dsay, client, message)
 
 /mob/observer/ghost/emote(var/act, var/type, var/message)
 	//message = sanitize(message) - already sanitized in verb/me_verb()

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -26,7 +26,7 @@
 		usr.emote(message)
 
 /mob/proc/say_dead(var/message)
-	sanitize_and_communicate(/decl/communication_channel/dsay, client, message)
+	communicate(/decl/communication_channel/dsay, client, message)
 
 /mob/proc/say_understands(var/mob/other,var/datum/language/speaking = null)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

OOC no longer appends (prepends?) one OOC/name tag per receiving client. Same with DSAY.
Fixes DSAY double-sanitizing text due to the say_dead proc expecting already sanitized messages.