### PR TITLE
Adds null check for can_speak

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -159,6 +159,8 @@
 
 // Can we speak this language, as opposed to just understanding it?
 /mob/proc/can_speak(datum/language/speaking)
+	if(!speaking)
+		return 0
 	return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || speaking in src.languages))
 
 /mob/proc/get_language_prefix()


### PR DESCRIPTION
Fixes #14643. Occurs for instance if someone says '-- hello'. The initial '-' is seen as the language use indicator and the second then seen as a language key.