### PR TITLE
Runtimes fixes

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -976,7 +976,7 @@ var/global/floorIsLava = 0
 
 	var/list/possible_items = custom_items[owner]
 	var/datum/custom_item/item_to_spawn = input("Select an item to spawn.", "Spawn Custom Item") as null|anything in possible_items
-	if(!item_to_spawn)
+	if(!item_to_spawn || !item_to_spawn.is_valid(usr))
 		return
 
 	item_to_spawn.spawn_item(get_turf(usr))

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -25,12 +25,22 @@
 	var/item_desc
 	var/name
 	var/item_path = /obj/item
+	var/item_path_as_string
 	var/req_access = 0
 	var/list/req_titles = list()
 	var/kit_name
 	var/kit_desc
 	var/kit_icon
 	var/additional_data
+	
+/datum/custom_item/proc/is_valid(var/checker)
+	if(!item_path)
+		to_chat(checker, "<span class='warning'>The given item path, [item_path_as_string], is invalid and does not exist.</span>")
+		return FALSE
+	if(item_icon && !(item_icon in icon_states(CUSTOM_ITEM_OBJ)))
+		to_chat(checker, "<span class='warning'>The given item icon, [item_icon], is invalid and does not exist.</span>")
+		return FALSE
+	return TRUE
 
 /datum/custom_item/proc/spawn_item(var/newloc)
 	var/obj/item/citem = new item_path(newloc)
@@ -162,6 +172,7 @@
 				current_data.character_name = lowertext(field_data)
 			if("item_path")
 				current_data.item_path = text2path(field_data)
+				current_data.item_path_as_string = field_data
 			if("item_name")
 				current_data.name = field_data
 			if("item_icon")
@@ -195,6 +206,10 @@
 		// Check for requisite ckey and character name.
 		if((lowertext(citem.assoc_key) != lowertext(M.ckey)) || (lowertext(citem.character_name) != lowertext(M.real_name)))
 			continue
+			
+		// Once we've decided that the custom item belongs to this player, validate it
+		if(!citem.is_valid(M))
+			return
 
 		// Check for required access.
 		var/obj/item/weapon/card/id/current_id = M.wear_id
@@ -230,7 +245,7 @@
 /proc/place_custom_item(mob/living/carbon/human/M, var/datum/custom_item/citem)
 
 	if(!citem) return
-	var/obj/item/newitem = citem.spawn_item()
+	var/obj/item/newitem = citem.spawn_item(M.loc)
 
 	if(M.equip_to_appropriate_slot(newitem))
 		return newitem
@@ -238,5 +253,4 @@
 	if(M.equip_to_storage(newitem))
 		return newitem
 
-	newitem.loc = get_turf(M.loc)
 	return newitem

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -195,7 +195,7 @@ datum/preferences
 	copy_to(mannequin, TRUE)
 
 	var/datum/job/previewJob
-	if(equip_preview_mob)
+	if(equip_preview_mob && job_master)
 		// Determine what job is marked as 'High' priority, and dress them up as such.
 		if("Assistant" in job_low)
 			previewJob = job_master.GetJob("Assistant")


### PR DESCRIPTION
'Fixes' a runtime caused by opening the character preview early during server setup. Fixes #14668.
Custom items are now validated before spawning. Fixes #14663. Fixes #14664.