### PR TITLE
Fixes #14676

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -228,6 +228,7 @@ proc/get_radio_key_from_channel(var/channel)
 				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
 
 		if (speaking.flags & SIGNLANG)
+			log_say("[name]/[key] : SIGN: [message]")
 			return say_signlang(message, pick(speaking.signlang_verb), speaking)
 
 	if(T)


### PR DESCRIPTION
Admin logging for sign language. 
Fixes #14676

![signlang](https://cloud.githubusercontent.com/assets/1222532/20509838/83b28e3c-b039-11e6-97ba-9fa11ee6f314.png)


