### PR TITLE
Fixes #14730

### DIFF
--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -61,6 +61,7 @@
 /mob/living/carbon/human
 	default_emotes = list(
 		/decl/emote/visible/blink,
+		/decl/emote/audible/synth,
 		/decl/emote/audible/synth/ping,
 		/decl/emote/audible/synth/buzz,
 		/decl/emote/audible/synth/confirm,

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -29,8 +29,8 @@
 		for(var/obj/item/organ/external/E in organs)
 			if(E.robotic >= ORGAN_ROBOT)
 				robolimb_count++
-		if(robolimb_count == organs.len)
-			full_prosthetic = 1
+		full_prosthetic = (robolimb_count == organs.len)
+		update_emotes()
 	return full_prosthetic
 
 /mob/living/silicon/isSynthetic()


### PR DESCRIPTION
Fixes #14730

Also fixes an oversight resulting in isSynthetic() always looping over all organs when called on a meatbag.