### PR TITLE
Fixes language ability checks. Adds EAL to more synthetics.

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -200,8 +200,10 @@
 		if(!(L.flags & NONGLOBAL))
 			if(L == default_language)
 				dat += "<b>[L.name] ([get_language_prefix()][L.key])</b> - default - <a href='byond://?src=\ref[src];default_lang=reset'>reset</a><br/>[L.desc]<br/><br/>"
-			else
+			else if (can_speak(L))
 				dat += "<b>[L.name] ([get_language_prefix()][L.key])</b> - <a href='byond://?src=\ref[src];default_lang=\ref[L]'>set default</a><br/>[L.desc]<br/><br/>"
+			else
+				dat += "<b>[L.name] ([get_language_prefix()][L.key])</b> - cannot speak!<br/>[L.desc]<br/><br/>"
 
 	src << browse(dat, "window=checklanguage")
 

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -4,6 +4,8 @@
 	src.brainmob = new(src)
 	src.brainmob.stat = CONSCIOUS
 	src.brainmob.add_language("Robot Talk")
+	src.brainmob.add_language("Encoded Audio Language")
+
 	src.brainmob.container = src
 	src.brainmob.silent = 0
 	PickName()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -57,8 +57,12 @@
 		canmove = 0
 	return canmove
 
-/mob/living/carbon/brain/binarycheck()
+/mob/living/carbon/brain/isSynthetic()
 	return istype(loc, /obj/item/device/mmi/digital)
+
+/mob/living/carbon/brain/binarycheck()
+	return isSynthetic()
 
 /mob/living/carbon/brain/check_has_mouth()
 	return 0
+

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -422,7 +422,7 @@
 		chem_effects[effect] = magnitude
 
 /mob/living/carbon/get_default_language()
-	if(default_language)
+	if(default_language && can_speak(default_language))
 		return default_language
 
 	if(!species)

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -5,6 +5,10 @@
 	set name = "Set Default Language"
 	set category = "IC"
 
+	if(language && !can_speak(language))
+		src << "<span class='notice'>You are unable to speak that language.</span>"
+		return
+
 	if(language)
 		to_chat(src, "<span class='notice'>You will now speak [language] if you do not specify a language when speaking.</span>")
 	else

--- a/html/changelogs/ForFoxSake-LanguageFixes.yml
+++ b/html/changelogs/ForFoxSake-LanguageFixes.yml
@@ -1,0 +1,9 @@
+author: ForFoxSake
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed a possible href exploit allowing any living player to speak any language."
+  - bugfix: "Organic beings can no longer speak Encoded Audio Language, although they can still understand it just fine."
+  - tweak: "Positronic brains can now speak Encoded Audio Language."
+  - tweak: "Station manufactured Full Body Prosthetics can now speak Encoded Audio Language."


### PR DESCRIPTION
* Organic creatures cannot speak EAL, however they can still learn and understand it.
* Along side this fix, Positronic Brains and Full Body Prosthetics that are created mid-round automatically understand EAL, but this does not effect FBPs made in the character setup.

Port of https://github.com/PolarisSS13/Polaris/pull/2821.
Fixes #14129.