### PR TITLE
Gibber tweaks.

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -1,6 +1,6 @@
 
 /obj/machinery/gibber
-	name = "gibber"
+	name = "meat grinder"
 	desc = "The name isn't descriptive enough?"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "grinder"
@@ -8,9 +8,9 @@
 	anchored = 1
 	req_access = list(access_kitchen,access_morgue)
 
-	var/operating = 0 //Is it on?
-	var/dirty = 0 // Does it need cleaning?
-	var/mob/living/occupant // Mob who has been put inside
+	var/operating = 0        //Is it on?
+	var/dirty = 0            // Does it need cleaning?
+	var/mob/living/occupant  // Mob who has been put inside
 	var/gib_time = 40        // Time from starting until meat appears
 	var/gib_throw_dir = WEST // Direction to spit meat and gibs in.
 
@@ -44,15 +44,14 @@
 	if(ismob(A))
 		var/mob/M = A
 
-		if(M.loc == input_plate
-		)
+		if(M.loc == input_plate)
 			M.loc = src
 			M.gib()
 
 
-/obj/machinery/gibber/New()
-	..()
-	src.overlays += image('icons/obj/kitchen.dmi', "grjam")
+/obj/machinery/gibber/initialize()
+	. = ..()
+	update_icon()
 
 /obj/machinery/gibber/update_icon()
 	overlays.Cut()
@@ -75,7 +74,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if(operating)
-		to_chat(user, "<span class='danger'>The gibber is locked and running, wait for it to finish.</span>")
+		to_chat(user, "<span class='danger'>\The [src] is locked and running, wait for it to finish.</span>")
 		return
 	else
 		src.startgibbing(user)
@@ -86,21 +85,23 @@
 
 /obj/machinery/gibber/emag_act(var/remaining_charges, var/mob/user)
 	emagged = !emagged
-	to_chat(user, "<span class='danger'>You [emagged ? "disable" : "enable"] the gibber safety guard.</span>")
+	to_chat(user, "<span class='danger'>You [emagged ? "disable" : "enable"] \the [src]'s safety guard.</span>")
 	return 1
 
 /obj/machinery/gibber/attackby(var/obj/item/W, var/mob/user)
-	var/obj/item/weapon/grab/G = W
-
-	if(!istype(G))
+	if(istype(W, /obj/item/weapon/grab))
+		var/obj/item/weapon/grab/G = W
+		if(G.state < GRAB_AGGRESSIVE)
+			to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
+			return
+		move_into_gibber(user,G.affecting)
+		user.drop_from_inventory(G)
+	else if(istype(W, /obj/item/organ))
+		user.drop_from_inventory(W)
+		qdel(W)
+		user.visible_message("<span class='danger'>\The [user] feeds \the [W] into \the [src], obliterating it.</span>")
+	else
 		return ..()
-
-	if(G.state < 2)
-		to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
-		return
-
-	move_into_gibber(user,G.affecting)
-	// Grab() process should clean up the grab item, no need to del it.
 
 /obj/machinery/gibber/MouseDrop_T(mob/target, mob/user)
 	if(user.stat || user.restrained())
@@ -110,30 +111,29 @@
 /obj/machinery/gibber/proc/move_into_gibber(var/mob/user,var/mob/living/victim)
 
 	if(src.occupant)
-		to_chat(user, "<span class='danger'>The gibber is full, empty it first!</span>")
+		to_chat(user, "<span class='danger'>\The [src] is full, empty it first!</span>")
 		return
 
 	if(operating)
-		to_chat(user, "<span class='danger'>The gibber is locked and running, wait for it to finish.</span>")
+		to_chat(user, "<span class='danger'>\The [src] is locked and running, wait for it to finish.</span>")
 		return
 
 	if(!(istype(victim, /mob/living/carbon)) && !(istype(victim, /mob/living/simple_animal)) )
-		to_chat(user, "<span class='danger'>This is not suitable for the gibber!</span>")
+		to_chat(user, "<span class='danger'>This is not suitable for \the [src]!</span>")
 		return
 
 	if(istype(victim,/mob/living/carbon/human) && !emagged)
-		to_chat(user, "<span class='danger'>The gibber safety guard is engaged!</span>")
+		to_chat(user, "<span class='danger'>\The [src] safety guard is engaged!</span>")
 		return
-
 
 	if(victim.abiotic(1))
-		to_chat(user, "<span class='danger'>Subject may not have abiotic items on.</span>")
+		to_chat(user, "<span class='danger'>\The [victim] may not have any abiotic items on.</span>")
 		return
 
-	user.visible_message("<span class='danger'>[user] starts to put [victim] into the gibber!</span>")
+	user.visible_message("<span class='danger'>\The [user] starts to put \the [victim] into \the [src]!</span>")
 	src.add_fingerprint(user)
 	if(do_after(user, 30, src) && victim.Adjacent(src) && user.Adjacent(src) && victim.Adjacent(user) && !occupant)
-		user.visible_message("<span class='danger'>\The [user] stuffs \the [victim] into the gibber!</span>")
+		user.visible_message("<span class='danger'>\The [user] stuffs \the [victim] into \the [src]!</span>")
 		if(victim.client)
 			victim.client.perspective = EYE_PERSPECTIVE
 			victim.client.eye = src
@@ -164,7 +164,6 @@
 	src.occupant = null
 	update_icon()
 	return
-
 
 /obj/machinery/gibber/proc/startgibbing(mob/user as mob)
 	if(src.operating)
@@ -223,14 +222,12 @@
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
 		operating = 0
 		for (var/obj/thing in contents)
-			// Todo: unify limbs and internal organs
 			// There's a chance that the gibber will fail to destroy some evidence.
-			if((istype(thing,/obj/item/organ) || istype(thing,/obj/item/organ)) && prob(80))
+			if(istype(thing,/obj/item/organ) && prob(80))
 				qdel(thing)
 				continue
 			thing.loc = get_turf(thing) // Drop it onto the turf for throwing.
 			thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(0,3),emagged ? 100 : 50) // Being pelted with bits of meat and bone would hurt.
-
 		update_icon()
 
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -265,7 +265,7 @@
 				if(card in affecting.implants)
 					affecting.take_damage(rand(30,50))
 					affecting.implants -= card
-					H.visible_message("<span class='danger'>\The [src] explodes out of \the [H]'s [affecting.name] in shower of gore!</span>")
+					H.visible_message("<span class='danger'>\The [src] explodes out of \the [H]'s [affecting.name] in a shower of gore!</span>")
 					break
 		holder.drop_from_inventory(card)
 	else if(istype(card.loc,/obj/item/device/pda))

--- a/html/changelogs/Zuhayr-gibber.yml
+++ b/html/changelogs/Zuhayr-gibber.yml
@@ -1,0 +1,6 @@
+author: Zuhayr
+delete-after: True
+changes: 
+  - tweak: "The gibber is now called a meat grinder, since that's what it is."
+  - tweak: "Eating a human organ or limb is now done in the exact same manner as any other food. If you try to eat a limb, though, it will not be usable in a transplant, for obvious reasons."
+  - tweak: "Human organs now fit into the reagent grinder."


### PR DESCRIPTION
- The gibber is now called a meat grinder, since that's what it is.
- Eating a human organ or limb is now done in the exact same manner as any other food. If you try to eat a limb, though, it will not be usable in a transplant, for obvious reasons.
- Human organs now fit into the reagent grinder.

Forgot to changelog this, but organs can be used on the meat grinder to completely destroy them.