### PR TITLE
adds Siik'Tajr as another Taj native language

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -195,3 +195,11 @@
 "le", "me", "nd", "ne", "ng", "nt", "on", "or", "ou", "re", "se", "st", "te", "th", "ti", "to",
 "ve", "wa", "all", "and", "are", "but", "ent", "era", "ere", "eve", "for", "had", "hat", "hen", "her", "hin",
 "his", "ing", "ion", "ith", "not", "ome", "oul", "our", "sho", "ted", "ter", "tha", "the", "thi")
+
+/datum/language/tajsign
+	name = LANGUAGE_SIIK_TAJR
+	desc = "A type of sign language mostly based on tail movements that was used during the Tajaran rebellion."
+	signlang_verb = list("uses their tail to convey", "gestures with their tail", "gestures with their tail elaborately")
+	colour = "tajaran"
+	key = "l"
+	flags = WHITELISTED | SIGNLANG | NO_STUTTER | NONVERBAL

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -96,7 +96,7 @@
 	burn_mod =  1.15
 	gluttonous = GLUT_TINY
 	num_alternate_languages = 2
-	secondary_langs = list(LANGUAGE_SIIK_MAAS)
+	secondary_langs = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR)
 	name_language = LANGUAGE_SIIK_MAAS
 	health_hud_intensity = 1.75
 

--- a/html/changelogs/TGW-SiikTajr.yml
+++ b/html/changelogs/TGW-SiikTajr.yml
@@ -1,0 +1,8 @@
+author: TheGreyWolf
+
+
+delete-after: True
+
+
+changes: 
+  - rscadd: "Added Siik'Tajr as a native Tajaran sign language."


### PR DESCRIPTION
This adds Siik'Tajr as a second native language to Taj, a sign language based nearly entirely on tail movements.

permission granted by Taj lore maintainer, Lonefly.
