### PR TITLE
Fixes runtime errors causing issues #14704, #14705, #14706, #14710, and #14711

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -57,7 +57,7 @@
 	else
 		to_chat(victim, "<span class='danger'>Searing hot oil scorches your [E ? E.name : "flesh"]!</span>")
 	if(victim)
-		admin_attack_log("Has [cook_type] their victim in \a [src]", "Has been [cook_type] in \a [src] by the attacker.", "[cook_type], in \a [src], ")
+		admin_attack_log(user, victim, "Has [cook_type] their victim in \a [src]", "Has been [cook_type] in \a [src] by the attacker.", "[cook_type], in \a [src], ")
 
 	icon_state = off_icon
 	cooking = 0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -905,14 +905,14 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(i>=25 && i<=40) //Smoke
 		var/datum/effect/effect/system/smoke_spread/chem/S = new /datum/effect/effect/system/smoke_spread/chem
 		S.attach(P.loc)
-		S.set_up(P, 10, 0, P.loc)
+		S.set_up(10, 0, P.loc)
 		playsound(P.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 		S.start()
 		message += "Large clouds of smoke billow forth from your [P]!"
 	if(i>=40 && i<=45) //Bad smoke
 		var/datum/effect/effect/system/smoke_spread/bad/B = new /datum/effect/effect/system/smoke_spread/bad
 		B.attach(P.loc)
-		B.set_up(P, 10, 0, P.loc)
+		B.set_up(10, 0, P.loc)
 		playsound(P.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 		B.start()
 		message += "Large clouds of noxious smoke billow forth from your [P]!"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -903,7 +903,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		empulse(P.loc, 3, 6, 1)
 		message += "Your [P] emits a wave of electromagnetic energy!"
 	if(i>=25 && i<=40) //Smoke
-		var/datum/effect/effect/system/smoke_spread/chem/S = new /datum/effect/effect/system/smoke_spread/chem
+		var/datum/effect/effect/system/smoke_spread/S = new /datum/effect/effect/system/smoke_spread
 		S.attach(P.loc)
 		S.set_up(10, 0, P.loc)
 		playsound(P.loc, 'sound/effects/smoke.ogg', 50, 1, -3)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -86,6 +86,7 @@
 		if(!card.radio)
 			card.radio = new /obj/item/device/radio(src.card)
 		radio = card.radio
+		common_radio = radio
 
 	//Default languages without universal translator software
 	add_language("Sol Common", 1)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -167,6 +167,11 @@
 /datum/surgery_step/cavity/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/obj/item/organ/internal/brain/sponge = target.internal_organs_by_name[BP_BRAIN]
+
+	// targetted a missing limb/organ
+	if(!affected)
+		return 0
+
 	if(sponge && sponge.parent_organ == affected.organ_tag && sponge.damage)
 		return 0
 	return ..()


### PR DESCRIPTION
For #14704:
* This was an argument mismatch, should have been (attacker, victim, attacker_message, victim_message, admin_message)

For #14705:
* common_radio is a variable that is used for some reason in the law manager and was not being defined when a new pAI was created

For #14706:
* If the limb is missing it seems target.get_organ(target_zone) would return null. Hopefully this was caused by trying to do surgery on a missing limb and not something else, since all I had to work with was the runtime error.

For #14710:
* This was another argument mismatch

For #14711:
* This was fixed by changing the effect type to a regular smoke instead of chemsmoke, which I think is what the original author intended.