### PR TITLE
Travis is now more helpful about where it expected to find missing loadout icon states

### DIFF
--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -25,18 +25,20 @@ datum/unit_test/loadout_test_shall_have_name_cost_path/start_test()
 datum/unit_test/loadout_test_shall_have_valid_icon_states
 	name = "LOADOUT: Entries shall have valid icon states"
 
+#define LOADOUT_BAD_STATE_HELPER(bad_gear) var/atom/A = bad_gear.path ; log_unit_test("[bad_gear] - [bad_gear.path]: Did not find the icon state '[initial(A.icon_state)]' in the icon '[initial(A.icon)]'.")
+
 datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 	var/failed = FALSE
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
 		if(!type_has_valid_icon_state(G.path))
-			log_unit_test("[G]: [G.path] has a missing icon state.")
+			LOADOUT_BAD_STATE_HELPER(G)
 			failed = TRUE
 		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
 			for(var/path_name in p.valid_paths)
 				var/path_type = p.valid_paths[path_name]
 				if(!type_has_valid_icon_state(path_type))
-					log_unit_test("[G]: [path_type] has a missing icon state.")
+					LOADOUT_BAD_STATE_HELPER(G)
 					failed = TRUE
 
 	if(failed)
@@ -44,6 +46,8 @@ datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 	else
 		pass("All /datum/gear definitions had correct icon states.")
 	return  1
+
+#undef LOADOUT_BAD_STATE_HELPER
 
 /proc/type_has_valid_icon_state(var/atom/type)
 	var/atom/A = type


### PR DESCRIPTION
Sample output in the case of missing icon states:
```
## UNIT_TEST ##: /datum/gear/suit/roles/poncho/security - /obj/item/clothing/suit/poncho/roles/security: Did not find the icon state 'secponcho' in the icon 'icons/obj/clothing/suits.dmi'.
## UNIT_TEST ##: /datum/gear/suit/roles/poncho/medical - /obj/item/clothing/suit/poncho/roles/medical: Did not find the icon state 'medponcho' in the icon 'icons/obj/clothing/suits.dmi'.
## UNIT_TEST ##: /datum/gear/suit/roles/poncho/engineering - /obj/item/clothing/suit/poncho/roles/engineering: Did not find the icon state 'engiponcho' in the icon 'icons/obj/clothing/suits.dmi'.
## UNIT_TEST ##: /datum/gear/suit/roles/poncho/science - /obj/item/clothing/suit/poncho/roles/science: Did not find the icon state 'sciponcho' in the icon 'icons/obj/clothing/suits.dmi'.
## UNIT_TEST ##: /datum/gear/suit/roles/poncho/cargo - /obj/item/clothing/suit/poncho/roles/cargo: Did not find the icon state 'cargoponcho' in the icon 'icons/obj/clothing/suits.dmi'.
```