### PR TITLE
Adds a Circuit Kit crate to save trouble for admins.

### DIFF
--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -83,3 +83,9 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Shaft miner equipment"
 	access = access_mining
+
+/decl/hierarchy/supply_pack/supply/circuit_kit
+	name = "Circuit Kits"
+	contains = list(/obj/item/weapon/storage/bag/circuits/basic/New() = 4)
+	cost = 20
+	containername = "\improper Circuit Kit crate"

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -86,6 +86,6 @@
 
 /decl/hierarchy/supply_pack/supply/circuit_kit
 	name = "Circuit Kits"
-	contains = list(/obj/item/weapon/storage/bag/circuits/basic/New() = 4)
+	contains = list(/obj/item/weapon/storage/bag/circuits/basic = 4)
 	cost = 20
 	containername = "\improper Circuit Kit crate"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Adds a crate that contains four Circuit Kits, so that admins don't have to spawn them in. Refer to discussion in general staff titled "RE: Circuit board kits".

This is my first attempt at contributing to bay, but it seemed pretty easy to do. Wasn't sure exactly which object path I should have used for the actual contents, but the new() one seemed to actually contain the circuits and stuff. 