### PR TITLE
Change Resomii minimum age limit

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -9,7 +9,7 @@
 	num_alternate_languages = 2
 	secondary_langs = list(LANGUAGE_RESOMI)
 	name_language = LANGUAGE_RESOMI
-	min_age = 12
+	min_age = 15
 	max_age = 45
 	health_hud_intensity = 3
 

--- a/html/changelogs/Resomii-age.yml
+++ b/html/changelogs/Resomii-age.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes: 
+ - tweak: "Changed Resomii minimum age to 15 years old."


### PR DESCRIPTION
Changes the minimum Resomii age limit to fifteen years old per agreement between Raptor and Snapshot.