### PR TITLE
Enables roboticist to build TV camera

### DIFF
--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -122,6 +122,7 @@
 				to_chat(user, "<span class='notice'>You add the camera module to [src]</span>")
 				user.drop_item()
 				qdel(CA)
+				desc = "This TV camera assembly has a camera module."
 				buildstep++
 		if(1)
 			if(istype(W, /obj/item/device/taperecorder))
@@ -130,7 +131,7 @@
 				qdel(T)
 				buildstep++
 				to_chat(user, "<span class='notice'>You add the tape recorder to [src]</span>")
-				name = "TV camera assembly with visual/audio sensors."
+				desc = "This TV camera assembly has a camera and audio module."
 				return
 		if(2)
 			if(istype(W, /obj/item/stack/cable_coil))
@@ -142,13 +143,13 @@
 				C.use(3)
 				buildstep++
 				to_chat(user, "<span class='notice'>You wire the assembly</span>")
-				name = "TV camera assembly with wires sticking out."
+				desc = "This TV camera assembly has wires sticking out"
 				return
 		if(3)
 			if(istype(W, /obj/item/weapon/wirecutters))
 				to_chat(user, "<span class='notice'> You trim the wires.</span>")
 				buildstep++
-				name = "Barebones TV camera assembly."
+				desc = "This TV camera assembly needs casing."
 				return
 		if(4)
 			if(istype(W, /obj/item/stack/material/steel))

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -88,3 +88,78 @@
 	camera = null
 	radio = null
 	..()
+	
+//Assembly by roboticist
+	
+		
+/obj/item/robot_parts/head/attackby(var/obj/item/device/assembly/S, mob/user as mob)
+	if ((!istype(S, /obj/item/device/assembly/infra)))
+		..()
+		return
+	var/obj/item/weapon/TVAssembly/A = new(user)
+	qdel(S)
+	user.put_in_hands(A)
+	to_chat(user, "<span class='notice'>You add the infrared sensor to the robot head.</span>")
+	user.drop_from_inventory(src)
+	qdel(src)
+	
+//Using camcorder icon as I can't sprite. 
+//Using robohead because of restricting to roboticist		
+/obj/item/weapon/TVAssembly
+	name = "TV Camera assembly"
+	desc = "A robotic head with an infrared sensor inside"
+	icon = 'icons/obj/robot_parts.dmi'
+	icon_state = "head"
+	item_state = "head"
+	var/buildstep = 0
+	w_class = ITEM_SIZE_LARGE
+	
+/obj/item/weapon/TVAssembly/attackby(W, mob/user)
+	switch(buildstep)
+		if(0)
+			if(istype(W, /obj/item/robot_parts/robot_component/camera))
+				var/obj/item/robot_parts/robot_component/camera/CA = W
+				to_chat(user, "<span class='notice'>You add the camera module to [src]</span>")
+				user.drop_item()
+				qdel(CA)
+				buildstep++
+		if(1)
+			if(istype(W, /obj/item/device/taperecorder))
+				var/obj/item/device/taperecorder/T = W
+				user.drop_item()
+				qdel(T)
+				buildstep++
+				to_chat(user, "<span class='notice'>You add the tape recorder to [src]</span>")
+				name = "TV camera assembly with visual/audio sensors."
+				return
+		if(2)
+			if(istype(W, /obj/item/stack/cable_coil))
+				var/obj/item/stack/cable_coil/C = W
+				if(!C.use(3))
+					to_chat(user, "<span class='notice'>You need three cable coils to wire the devices.</span>")
+					..()
+					return
+				C.use(3)
+				buildstep++
+				to_chat(user, "<span class='notice'>You wire the assembly</span>")
+				name = "TV camera assembly with wires sticking out."
+				return
+		if(3)
+			if(istype(W, /obj/item/weapon/wirecutters))
+				to_chat(user, "<span class='notice'> You trim the wires.</span>")
+				buildstep++
+				name = "Barebones TV camera assembly."
+				return
+		if(4)
+			if(istype(W, /obj/item/stack/material/steel))
+				var/obj/item/stack/material/steel/S = W
+				buildstep++
+				S.use(1)
+				to_chat(user, "<span class='notice'>You encase the assembly in a Ward-Takeshi casing.</span>")
+				var/turf/T = get_turf(src)
+				new /obj/item/device/tvcamera(T)
+				user.drop_from_inventory(src)
+				qdel(src)
+				return
+				
+	..()

--- a/html/changelogs/RunaDacino-TVCameraAssembly.yml
+++ b/html/changelogs/RunaDacino-TVCameraAssembly.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Runa-Dacino
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added ability to build press cameras to roboticist"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

1. Get Robot head
2. Infrared sensor -> Makes the assembly. Looks like robot head.
3. Add robot camera
4. Add Tape recorder
5. Add 3 wires
6. Use wirecutters on assembly
7. Add 1 steel
8. Done


This affects the journalist drone, yes.