### PR TITLE
QOL changes in text editor program

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -377,4 +377,5 @@ proc/TextPreview(var/string,var/len=40)
 	t = replacetext(t, "\[row\]", "</td><tr>")
 	t = replacetext(t, "\[cell\]", "<td>")
 	t = replacetext(t, "\[logo\]", "<img src = ntlogo.png>")
+	t = replacetext(t, "\[editorbr\]", "")
 	return t

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -1,3 +1,5 @@
+#define MAX_TEXTFILE_LENGTH 128000		// 512GQ file
+
 /datum/computer_file/program/filemanager
 	filename = "filemanager"
 	filedesc = "NTOS File Manager"
@@ -85,10 +87,14 @@
 			return 1
 		if(F.do_not_edit && (alert("WARNING: This file is not compatible with editor. Editing it may result in permanently corrupted formatting or damaged data consistency. Edit anyway?", "Incompatible File", "No", "Yes") == "No"))
 			return 1
-		// 16384 is the limit for file length in characters. Currently, papers have value of 2048 so this is 8 times as long, since we can't edit parts of the file independently.
-		var/newtext = sanitize(html_decode(input(usr, "Editing file [open_file]. You may use most tags used in paper formatting:", "Text Editor", F.stored_data) as message|null), 16384)
+
+		var/oldtext = html_decode(F.stored_data)
+		oldtext = replacetext(oldtext, "\[editorbr\]", "\n")
+
+		var/newtext = sanitize(replacetext(input(usr, "Editing file [open_file]. You may use most tags used in paper formatting:", "Text Editor", oldtext) as message|null, "\n", "\[editorbr\]"), MAX_TEXTFILE_LENGTH)
 		if(!newtext)
 			return
+
 		if(F)
 			var/datum/computer_file/data/backup = F.clone()
 			HDD.remove_file(F)
@@ -98,7 +104,7 @@
 			// This is mostly intended to prevent people from losing texts they spent lot of time working on due to running out of space.
 			// They will be able to copy-paste the text from error screen and store it in notepad or something.
 			if(!HDD.store_file(F))
-				error = "I/O error: Unable to overwrite file. Hard drive is probably full. You may want to backup your changes before closing this window:<br><br>[F.stored_data]<br><br>"
+				error = "I/O error: Unable to overwrite file. Hard drive is probably full. You may want to backup your changes before closing this window:<br><br>[html_decode(F.stored_data)]<br><br>"
 				HDD.store_file(backup)
 	if(href_list["PRG_printfile"])
 		. = 1
@@ -199,5 +205,4 @@
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
-
-
+#undef MAX_TEXTFILE_LENGTH

--- a/nano/templates/file_manager.tmpl
+++ b/nano/templates/file_manager.tmpl
@@ -1,8 +1,8 @@
 {{if data.error}}
-	<h2>An error has occured and this program can not continue.</h2>
+	<h2>An error has occured:</h2>
 	Additional information: {{:data.error}}<br>
 	<i>Please try again. If the problem persists contact your system administrator for assistance.</i>
-	{{:helper.link('Restart program', null, { "PRG_closefile" : 1 })}}
+	{{:helper.link('Back to menu', null, { "PRG_closefile" : 1 })}}
 {{else}}
 	{{if data.filename}}
 		<h2>Viewing file {{:data.filename}}</h2>


### PR DESCRIPTION
- When editing files, newlines are now preserved (using a special tag). Makes editing a bit more comfortable.
- Before: https://i.imgur.com/gkmIot5.png
- After: https://i.imgur.com/dlL7Fph.png
- Maximal text file size increased to 128000 characters (which would produce a 512GQ file). This should hopefully be enough now.
- Minor tweak to the template's error display text, to make it a bit easier to understand.