### PR TITLE
Fixes #14907

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -38,7 +38,7 @@ var/bomb_set
 
 /obj/machinery/nuclearbomb/process()
 	if (timing)
-		timeleft = max(timeleft - process_schedule_interval("obj"), 0)
+		timeleft = max(timeleft - (process_schedule_interval("machinery") / 10), 0)
 		if (timeleft <= 0)
 			spawn
 				explode()


### PR DESCRIPTION
- Fixes #14907 - Nuke no longer counts down 10x faster. Process schedule intervals are in deciseconds, while the variable is in seconds.