### PR TITLE
Makes ghost follow verb better

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -21,6 +21,8 @@ var/global/list/side_effects = list()				//list of all medical sideeffects types
 var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mobs target tracking.
 var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 
+var/global/list/GhostFollowObjects = list() // List of interesting objects for the ghosts to follow
+
 var/global/list/turfs = list()						//list of all turfs
 
 #define all_genders_define_list list(MALE,FEMALE,PLURAL,NEUTER)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -28,12 +28,14 @@ var/bomb_set
 	..()
 	r_code = "[rand(10000, 99999.0)]"//Creates a random code upon object spawn.
 	wires = new/datum/wires/nuclearbomb(src)
+	GhostFollowObjects.Add(src)
 
 /obj/machinery/nuclearbomb/Destroy()
 	qdel(wires)
 	wires = null
 	qdel(auth)
 	auth = null
+	GhostFollowObjects.Remove(src)
 	return ..()
 
 /obj/machinery/nuclearbomb/process()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -241,9 +241,15 @@ var/const/NO_EMAG_ACT = -50
 	item_state = "gold_id"
 	registered_name = "Captain"
 	assignment = "Captain"
+
 /obj/item/weapon/card/id/captains_spare/New()
 	access = get_all_station_access()
+	GhostFollowObjects.Add(src)
 	..()
+
+/obj/item/weapon/card/id/captains_spare/Destroy()
+	GhostFollowObjects.Remove(src)
+	return ..()
 
 /obj/item/weapon/card/id/synthetic
 	name = "\improper Synthetic ID"

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -185,10 +185,12 @@
 
 /obj/effect/blob/core/New(loc)
 	processing_objects.Add(src)
+	GhostFollowObjects.Add(src)
 	return ..(loc)
 
 /obj/effect/blob/core/Destroy()
 	processing_objects.Remove(src)
+	GhostFollowObjects.Remove(src)
 	return ..()
 
 /obj/effect/blob/core/process()

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -283,14 +283,99 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		ghost_to_turf(T)
 	else
 		to_chat(src, "<span class='warning'>Invalid coordinates.</span>")
-/mob/observer/ghost/verb/follow(input in getmobs())
+/mob/observer/ghost/verb/follow(input in GetTargetsToFollow())
 	set category = "Ghost"
 	set name = "Follow"
 	set desc = "Follow and haunt a mob."
 
-	var/target = getmobs()[input]
+	var/target = GetTargetsToFollow()[input]
 	if(!target) return
 	ManualFollow(target)
+
+/mob/observer/ghost/proc/GetTargetsToFollow()
+	var/list/result = list()
+	
+	var/list/sortmob = sortAtom(mob_list)
+	var/list/additions = list()
+	var/list/names = list()
+	var/list/mobs = list()
+	
+	for(var/mob/observer/eye/M in sortmob)
+		mobs += M
+		additions[M] = " \[Eye\]"
+	for(var/mob/living/silicon/ai/M in sortmob)
+		mobs += M
+		additions[M] = " \[AI\]"
+	for(var/mob/living/silicon/pai/M in sortmob)
+		mobs += M
+		additions[M] = " \[pAI\]"
+	for(var/mob/living/silicon/robot/M in sortmob)
+		mobs += M
+		additions[M] = " \[Synthetic\]"
+	for(var/mob/living/carbon/human/M in sortmob)
+		mobs += M
+		additions[M] = " \[[M.species.name]\]"
+	for(var/mob/living/carbon/brain/M in sortmob)
+		mobs += M
+		additions[M] = " \[Brain\]"
+	for(var/mob/living/carbon/alien/M in sortmob)
+		mobs += M
+		additions[M] = " \[Alien\]"
+	for(var/mob/observer/ghost/M in sortmob)
+		mobs += M
+		additions[M] = " \[Ghost\]"
+	for(var/mob/living/carbon/slime/M in sortmob)
+		mobs += M
+		additions[M] = " \[Slime\]"
+	for(var/mob/living/simple_animal/M in sortmob)
+		mobs += M
+		additions[M] = " \[Animal\]"
+
+	for(var/mob/M in mobs)
+		if(M.name in names)
+			additions[M] += " \[[++names[M.name]]\]"
+		else
+			names[M.name] = 1
+		if (M.real_name && M.real_name != M.name)
+			additions[M] += " \[[M.real_name]\]"
+		additions[M] += ""
+		if (M.stat == DEAD)
+			if(isobserver(M))
+				additions[M] += " \[Observer\]"
+			else
+				additions[M] += " \[Dead\]"
+		result["[M][additions[M]]"] = M
+
+	var/tmp
+	tmp = 1
+	for(var/obj/effect/blob/core/S in world)
+		if(S.type != /obj/effect/blob/core) // We don't care about secondary cores
+			continue
+		result["[S] ([tmp++])"] = S
+
+	tmp = 1
+	for(var/obj/machinery/power/supermatter/S in world)
+		result["[S] ([tmp++])"] = S
+
+	tmp = 1
+	for(var/obj/item/weapon/disk/nuclear/S in world)
+		result["[S] ([tmp++])"] = S
+
+	tmp = 1
+	for(var/obj/machinery/nuclearbomb/S in world)
+		result["[S] ([tmp++])"] = S
+
+	tmp = 1
+	for(var/obj/item/weapon/card/id/captains_spare/S in world)
+		result["[S] ([tmp++])"] = S
+
+	tmp = 1
+	for(var/obj/item/organ/internal/stack/S in world)
+		if(S.owner) // We don't care about implanted laces
+			continue
+		result["[S] \[[S.backup ? S.backup.name : "Empty"]\] ([tmp++])"] = S
+	
+	return result
 
 /mob/observer/ghost/proc/ghost_to_turf(var/turf/target_turf)
 	if(check_is_holy_turf(target_turf))

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -344,36 +344,41 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				additions[M] += " \[Observer\]"
 			else
 				additions[M] += " \[Dead\]"
-		result["[M][additions[M]]"] = M
+		result["[M][additions[M]] \[[M.x], [M.y], [M.z]\]"] = M
 
 	var/tmp
+
 	tmp = 1
-	for(var/obj/effect/blob/core/S in world)
+	for(var/obj/mecha/S in mechas_list)
+		result["[S] \[[S.occupant ? "[S.occupant]" : "Empty"]\] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
+
+	tmp = 1
+	for(var/obj/effect/blob/core/S in GhostFollowObjects)
 		if(S.type != /obj/effect/blob/core) // We don't care about secondary cores
 			continue
-		result["[S] ([tmp++])"] = S
+		result["[S] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
 
 	tmp = 1
-	for(var/obj/machinery/power/supermatter/S in world)
-		result["[S] ([tmp++])"] = S
+	for(var/obj/machinery/power/supermatter/S in GhostFollowObjects)
+		result["[S] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
 
 	tmp = 1
-	for(var/obj/item/weapon/disk/nuclear/S in world)
-		result["[S] ([tmp++])"] = S
+	for(var/obj/item/weapon/disk/nuclear/S in nuke_disks)
+		result["[S] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
 
 	tmp = 1
-	for(var/obj/machinery/nuclearbomb/S in world)
-		result["[S] ([tmp++])"] = S
+	for(var/obj/machinery/nuclearbomb/S in GhostFollowObjects)
+		result["[S] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
 
 	tmp = 1
-	for(var/obj/item/weapon/card/id/captains_spare/S in world)
-		result["[S] ([tmp++])"] = S
+	for(var/obj/item/weapon/card/id/captains_spare/S in GhostFollowObjects)
+		result["[S] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
 
 	tmp = 1
-	for(var/obj/item/organ/internal/stack/S in world)
+	for(var/obj/item/organ/internal/stack/S in GhostFollowObjects)
 		if(S.owner) // We don't care about implanted laces
 			continue
-		result["[S] \[[S.backup ? S.backup.name : "Empty"]\] ([tmp++])"] = S
+		result["[S] \[[S.backup ? S.backup.name : "Empty"]\] \[[S.x], [S.y], [S.z]\] ([tmp++])"] = S
 	
 	return result
 

--- a/code/modules/organs/organ_stack.dm
+++ b/code/modules/organs/organ_stack.dm
@@ -38,6 +38,11 @@
 	..()
 	do_backup()
 	robotize()
+	GhostFollowObjects.Add(src)
+
+/obj/item/organ/internal/stack/Destroy()
+	GhostFollowObjects.Remove(src)
+	return ..()
 
 /obj/item/organ/internal/stack/proc/backup_inviable()
 	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -99,7 +99,12 @@
 	var/debug = 0
 
 
+/obj/machinery/power/supermatter/New()
+	. = ..()
+	GhostFollowObjects.Add(src)
+
 /obj/machinery/power/supermatter/Destroy()
+	GhostFollowObjects.Remove(src)
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()

--- a/html/changelogs/Kelenius-GhostFollow.yml
+++ b/html/changelogs/Kelenius-GhostFollow.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Ghosts can now follow all sorts of interesting things from their verb, including mechs, dat fukken disk, and the spare ID."
+  - tweak: "Ghost follow list is now also a bit more detailed about the things to follow."


### PR DESCRIPTION
Ghosts can't follow ``new_player``s now. That's duuuuuuumb.
Ghosts get species name of humans in the list.
Ghosts can follow nuke disks, blob cores, supermatters, nuke bombs, and extracted laces from the verb.