### PR TITLE
Prevents False Walls from Bypassing MultiZAS

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -56,10 +56,18 @@ turf/c_airblock(turf/other)
 	#endif
 	if(((blocks_air & AIR_BLOCKED) || (other.blocks_air & AIR_BLOCKED)))
 		return BLOCKED
-		
+	
+	#ifdef MultiZAS
 	if(((blocks_air & ZONE_BLOCKED) || (other.blocks_air & ZONE_BLOCKED)))
 		return ZONE_BLOCKED
-
+	#endif
+	
+	if(((blocks_air & ZONE_BLOCKED) || (other.blocks_air & ZONE_BLOCKED)))
+		if(z == other.z)
+			return ZONE_BLOCKED
+		else
+			return AIR_BLOCKED
+	
 	//Z-level handling code. Always block if there isn't an open space.
 	#ifdef MULTIZAS
 	if(other.z != src.z)

--- a/html/changelogs/Datraen-FalseWallHotfix.yml
+++ b/html/changelogs/Datraen-FalseWallHotfix.yml
@@ -1,0 +1,4 @@
+author: Datraen
+delete-after: true
+changes: 
+  - bugfix: "Added a MultiZAS check for turf airchecking."


### PR DESCRIPTION
Resolves #14906 by adding a check to z levels and a check for MultiZAS.

Sorry about any accidental breaching that was done.