### PR TITLE
Quick fix for telecomms on station zlevel

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -7,7 +7,7 @@
 
 /obj/machinery/telecomms/relay/preset/station
 	id = "Station Relay"
-	listening_level = 1
+	listening_level = 2
 	autolinkers = list("s_relay")
 
 /obj/machinery/telecomms/relay/preset/telecomms


### PR DESCRIPTION
Station now lives on zlevel 2 as far as the game is concerned, need to retarget this preset so people can hear each other.