### PR TITLE
fixes issues relating to being able to interact with cables and pipes on open turfs.

### DIFF
--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -37,6 +37,7 @@
 	..()
 	below = GetBelow(src)
 	ASSERT(HasBelow(z))
+	levelupdate()
 	update_icon()
 
 /turf/simulated/open/Entered(var/atom/movable/mover)
@@ -139,7 +140,6 @@
 		I.pixel_y = S.pixel_y
 		overlays += I
 
-// Straight copy from space.
 /turf/simulated/open/attackby(obj/item/C as obj, mob/user as mob)
 	if (istype(C, /obj/item/stack/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
@@ -165,4 +165,14 @@
 			return
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
+
+	//To lay cable.
+	if(istype(C, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/coil = C
+		coil.turf_place(src, user)
+		return
 	return
+
+//Most things use is_plating to test if there is a cover tile on top (like regular floors)
+/turf/simulated/open/is_plating()
+	return 1


### PR DESCRIPTION
Also fixes an issue where the icons for turf contents on open turfs aren't initialized.

is_plating is used by cables, pipes, and disposals to test whether a specific turf has a "cover plate" (aka is a regular tiled turf). By making sure open turfs are always treated like plated turfs, we can interact with objects on those turfs. attackby was also updated to include a check for if attacked by a cable_coil so we can lay multi-z cables.