### PR TITLE
Shield related tweaks and additions

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -40,6 +40,7 @@
 #define MODEFLAG_BYPASS 128
 #define MODEFLAG_OVERCHARGE 256
 #define MODEFLAG_MODULATE 512
+#define MODEFLAG_MULTIZ 1024
 
 // Return codes for shield hits.
 #define SHIELD_ABSORBED 1			// The shield has completely absorbed the hit

--- a/code/modules/shield_generators/modes.dm
+++ b/code/modules/shield_generators/modes.dm
@@ -69,3 +69,9 @@
 	mode_flag = MODEFLAG_OVERCHARGE
 	multiplier = 3
 	hacked_only = 1
+
+/datum/shield_mode/multiz
+	mode_name = "Multi-Dimensional Field Warp"
+	mode_desc = "Recalibrates the field projection array to increase the vertical height of the field, allowing it's usage on multi-deck stations or ships."
+	mode_flag = MODEFLAG_MULTIZ
+	multiplier = 1


### PR DESCRIPTION
- Emergency Shutdown has been tweaked. It now requires a confirmation via popup, to prevent accidents. It's EMP is also slightly more severe, and has higher chance of occuring when used at high charge % levels.
- Adds a new shield mode: Multi-Dimensional Field Warp. The mode doesn't use any extra energy, but it extends the field to all linked Z levels (this should mean a single generator is enough, even on maps like torch). The power usage will however grow considerably, as the field will cover larger surface.
- Fixes #14951 - Turbolifts will no longer be considered as valid tiles for shield generation.