### PR TITLE
Cargo department crew manifest tweaks

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -44,7 +44,7 @@
 /datum/job/qm
 	title = "Quartermaster"
 	department = "Cargo"
-	department_flag = CIV|CRG
+	department_flag = CRG
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -60,7 +60,7 @@
 /datum/job/cargo_tech
 	title = "Cargo Technician"
 	department = "Cargo"
-	department_flag = CIV|CRG
+	department_flag = CRG
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
@@ -73,7 +73,7 @@
 /datum/job/mining
 	title = "Shaft Miner"
 	department = "Cargo"
-	department_flag = CIV
+	department_flag = CRG
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3


### PR DESCRIPTION
Fixes #14920

Moves shaft miner from the civilian department to the cargo department.
Removes quartermaster and cargo technician from the civilian department.

Shaft Miner should really be in the cargo department, since their direct supervisor is the QM, then the HoP.
The HoP is already responsible for both the cargo and civilian divisions, so there's no reason for QM and CT to be in both on the crew manifest; especially when Cargo and Civilian are right next to each other, which results in this:

![ss_1481230372](https://cloud.githubusercontent.com/assets/8846073/21027344/6d989330-bd5e-11e6-95c4-53450842c6a4.png)
