### PR TITLE
Players now have to confirm that they wish to reset their character slot

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -244,6 +244,8 @@ datum/preferences
 		sanitize_preferences()
 		close_load_dialog(usr)
 	else if(href_list["resetslot"])
+		if("No" == alert("This will reset the current slot. Continue?", "Reset current slot?", "No", "Yes"))
+			return 0
 		load_character(SAVE_RESET)
 		sanitize_preferences()
 	else

--- a/html/changelogs/PsiOmegaDelta-IAmKind.yml
+++ b/html/changelogs/PsiOmegaDelta-IAmKind.yml
@@ -1,0 +1,4 @@
+author: PsiOmegaDelta
+delete-after: True
+changes: 
+  - rscadd: "Resetting a character slot now requires confirmation."


### PR DESCRIPTION
There had been the occasional complaint. The selection also defaults to No in case of enter presses.