### PR TITLE
Runtime fixes

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -793,7 +793,7 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 
 					for(var/obj/O in T)
 
-						if(!istype(O,/obj))
+						if(!istype(O,/obj) || !O.simulated)
 							continue
 
 						objs += O
@@ -804,18 +804,18 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 
 
 					for(var/obj/O in newobjs)
-						O.loc = X
+						O.forceMove(X)
 
 					for(var/mob/M in T)
 
-						if(!istype(M,/mob) || isEye(M)) continue // If we need to check for more mobs, I'll add a variable
+						if(!istype(M,/mob) || !M.simulated) continue // If we need to check for more mobs, I'll add a variable
 						mobs += M
 
 					for(var/mob/M in mobs)
 						newmobs += DuplicateObject(M , 1)
 
 					for(var/mob/M in newmobs)
-						M.loc = X
+						M.forceMove(X
 
 					copiedobjs += newobjs
 					copiedobjs += newmobs

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -815,7 +815,7 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 						newmobs += DuplicateObject(M , 1)
 
 					for(var/mob/M in newmobs)
-						M.forceMove(X
+						M.forceMove(X)
 
 					copiedobjs += newobjs
 					copiedobjs += newmobs

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -195,6 +195,11 @@
 	var/obj/item/weapon/card/id/I = user.GetIdCard()
 	var/datum/data/record/random_general_record
 	var/datum/data/record/random_medical_record
+	
+	while(null in data_core.general)
+		data_core.general -= null
+		log_error("Found a null entry in data_core.general")
+	
 	if(data_core.general.len)
 		random_general_record	= pick(data_core.general)
 		random_medical_record	= find_medical_record("id", random_general_record.fields["id"])

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -208,6 +208,11 @@ var/const/POWER = 8
 	else
 		CRASH("[colour] is not a key in wires.")
 
+
+/datum/wires/proc/RandomPulse()
+	var/index = rand(1, wires.len)
+	PulseIndex(index)
+
 //
 // Is Index/Colour Cut procs
 //
@@ -257,7 +262,6 @@ var/const/POWER = 8
 		if(S == signallers[colour])
 			PulseColour(colour)
 			break
-
 
 //
 // Cut Wire Colour/Index procs

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -427,7 +427,7 @@ var/global/datum/controller/occupations/job_master
 			else
 				var/datum/spawnpoint/spawnpoint = get_spawnpoint_for(H.client, rank)
 				H.forceMove(pick(spawnpoint.turfs))
-			
+
 			// Moving wheelchair if they have one
 			if(H.buckled && istype(H.buckled, /obj/structure/bed/chair/wheelchair))
 				H.buckled.forceMove(H.loc)
@@ -502,7 +502,7 @@ var/global/datum/controller/occupations/job_master
 		//Gives glasses to the vision impaired
 		if(H.disabilities & NEARSIGHTED)
 			var/equipped = H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses)
-			if(equipped != 1)
+			if(equipped)
 				var/obj/item/clothing/glasses/G = H.glasses
 				G.prescription = 7
 
@@ -584,28 +584,28 @@ var/global/datum/controller/occupations/job_master
  *  preference is not set, or the preference is not appropriate for the rank, in
  *  which case a fallback will be selected.
  */
-/datum/controller/occupations/proc/get_spawnpoint_for(var/client/C, var/rank)	
+/datum/controller/occupations/proc/get_spawnpoint_for(var/client/C, var/rank)
 
 	if(!C)
 		CRASH("Null client passed to get_spawnpoint_for() proc!")
-		
+
 	var/mob/H = C.mob
 	var/datum/spawnpoint/spawnpos
-	
+
 	if(C.prefs.spawnpoint)
 		if(!(C.prefs.spawnpoint in using_map.allowed_spawns))
 			if(H)
 				to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead.</span>")
-				
+
 			spawnpos = null
 		else
 			spawnpos = spawntypes[C.prefs.spawnpoint]
-		
+
 	if(spawnpos && !spawnpos.check_job_spawning(rank))
 		if(H)
 			to_chat(H, "<span class='warning'>Your chosen spawnpoint ([spawnpos.display_name]) is unavailable for your chosen job ([rank]). Spawning you at another spawn point instead.</span>")
 		spawnpos = null
-	
+
 	if(!spawnpos)
 		// Step through all spawnpoints and pick first appropriate for job
 		for(var/spawntype in using_map.allowed_spawns)
@@ -613,12 +613,12 @@ var/global/datum/controller/occupations/job_master
 			if(candidate.check_job_spawning(rank))
 				spawnpos = candidate
 				break
-		
+
 	if(!spawnpos)
 		// Pick at random from all the (wrong) spawnpoints, just so we have one
 		warning("Could not find an appropriate spawnpoint for job [rank].")
 		spawnpos = spawntypes[pick(using_map.allowed_spawns)]
-		
+
 	return spawnpos
 
 /datum/controller/occupations/proc/GetJobByType(var/job_type)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -141,11 +141,11 @@
 	unload(0)
 	switch(severity)
 		if(2)
-			BITRESET(wires, rand(0,9))
-			BITRESET(wires, rand(0,9))
-			BITRESET(wires, rand(0,9))
+			wires.RandomCut()
+			wires.RandomCut()
+			wires.RandomCut()
 		if(3)
-			BITRESET(wires, rand(0,9))
+			wires.RandomCut()
 	..()
 	return
 
@@ -154,12 +154,7 @@
 		unload(0)
 	if(prob(25))
 		src.visible_message("<span class='warning'>Something shorts out inside [src]!</span>")
-		var/index = 1<< (rand(0,9))
-
-		if(wires & index)
-			wires &= ~index
-		else
-			wires |= index
+		wires.RandomPulse()
 	..()
 
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -608,7 +608,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		"type" = 4, // determines what type of radio input it is: test broadcast
 		"reject" = 0,
 		"done" = 0,
-		"level" = pos.z // The level it is being broadcasted at.
+		"level" = pos ? pos.z : 0 // The level it is being broadcasted at.
 	)
 	signal.frequency = PUB_FREQ// Common channel
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -204,7 +204,7 @@
 	if(isghost(user) || user.stat == DEAD) // ghosts can see anything
 		distance = 1
 	else
-		get_dist(user,src)
+		distance = get_dist(user,src)
 	if (src.stat)
 		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span>\n"
 		if((stat == DEAD || src.losebreath) && distance <= 3)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -200,21 +200,23 @@
 	if(mSmallsize in mutations)
 		msg += "[T.He] [T.is] small halfling!\n"
 
-	var/distance = get_dist(usr,src)
-	if(isghost(usr) || usr.stat == DEAD) // ghosts can see anything
+	var/distance = 0
+	if(isghost(user) || user.stat == DEAD) // ghosts can see anything
 		distance = 1
+	else
+		get_dist(user,src)
 	if (src.stat)
 		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span>\n"
 		if((stat == DEAD || src.losebreath) && distance <= 3)
 			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span>\n"
-		if(istype(usr, /mob/living/carbon/human) && !usr.stat && Adjacent(usr))
-			usr.visible_message("<b>[usr]</b> checks [src]'s pulse.", "You check [src]'s pulse.")
-		spawn(15)
-			if(distance <= 1 && usr.stat != 1)
+		if(ishuman(user) && !user.incapacitated() && Adjacent(user))
+			user.visible_message("<b>\The [user]</b> checks \the [src]'s pulse.", "You check \the [src]'s pulse.")
+		spawn(0)
+			if(do_after(user, 15, src))
 				if(pulse() == PULSE_NONE)
-					to_chat(usr, "<span class='deadsay'>[T.He] [T.has] no pulse[src.client ? "" : " and [T.his] soul has departed"]...</span>")
+					to_chat(user, "<span class='deadsay'>[T.He] [T.has] no pulse[src.client ? "" : " and [T.his] soul has departed"]...</span>")
 				else
-					to_chat(usr, "<span class='deadsay'>[T.He] [T.has] a pulse!</span>")
+					to_chat(user, "<span class='deadsay'>[T.He] [T.has] a pulse!</span>")
 
 	if(fire_stacks)
 		msg += "[T.He] [T.is] covered in some liquid.\n"
@@ -226,7 +228,7 @@
 	if(nutrition < 100)
 		msg += "[T.He] [T.is] severely malnourished.\n"
 	else if(nutrition >= 500)
-		/*if(usr.nutrition < 100)
+		/*if(user.nutrition < 100)
 			msg += "[T.He] [T.is] plump and delicious looking - Like a fat little piggy. A tasty piggy.\n"
 		else*/
 		msg += "[T.He] [T.is] quite chubby.\n"
@@ -297,7 +299,7 @@
 	if(digitalcamo)
 		msg += "[T.He] [T.is] repulsively uncanny!\n"
 
-	if(hasHUD(usr,"security"))
+	if(hasHUD(user,"security"))
 		var/perpname = "wot"
 		var/criminal = "None"
 
@@ -320,7 +322,7 @@
 			msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
 			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"
 
-	if(hasHUD(usr,"medical"))
+	if(hasHUD(user,"medical"))
 		var/perpname = "wot"
 		var/medical = "None"
 


### PR DESCRIPTION
Holodeck should no longer copy non-simulated instances
Fixes #14994. Fixes #14995.

Fixes #14992.

Corrects the was-equipped check for glasses when joining the round.
Fixes #14936.

Cleans up human/examine
Should fix #14923.

Radio broadcasts from sources in null space should now runtime a little less.
Fixes #14863.

Corrects some old wire-code in the mulebot.
Fixes #14814. Fixes #14815.
