### PR TITLE
Bodybags can now be scanned by handheld health scanners.

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -59,9 +59,17 @@
 	//..() //Doesn't need to run the parent. Since when can fucking bodybags be welded shut? -Agouri
 		return
 	else if(istype(W, /obj/item/weapon/wirecutters))
-		to_chat(user, "You cut the tag off the bodybag")
 		src.name = "body bag"
 		src.overlays.Cut()
+		to_chat(user, "You cut the tag off \the [src].")
+		return
+	else if(istype(W, /obj/item/device/healthanalyzer/) && !opened)
+		if(contains_body)
+			var/obj/item/device/healthanalyzer/HA = W
+			for(var/mob/living/L in contents)
+				HA.scan_mob(L, user)
+		else
+			to_chat(user, "\The [W] reports that \the [src] is empty.")
 		return
 
 /obj/structure/closet/body_bag/store_mobs(var/stored_units)
@@ -163,14 +171,3 @@
 		to_chat(user, "<span class='info'>You peer into \the [src].</span>")
 		for(var/mob/living/L in contents)
 			L.examine(user)
-
-/obj/structure/closet/body_bag/cryobag/attackby(obj/item/W, mob/user)
-	if(opened)
-		..()
-	else //Allows the bag to respond to a health analyzer by analyzing the mob inside without needing to open it.
-		if(istype(W,/obj/item/device/healthanalyzer))
-			var/obj/item/device/healthanalyzer/analyzer = W
-			for(var/mob/living/L in contents)
-				analyzer.attack(L,user)
-		else
-			..()

--- a/html/changelogs/Techhead-baggage-scan.yml
+++ b/html/changelogs/Techhead-baggage-scan.yml
@@ -1,0 +1,13 @@
+
+author: Techhead
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The occupants of bodybags can now be scanned without opening them using health scanners, similar to cryobags."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

That's more or less it. That's all.
Should be handy for ~critical patients in cryobags, or~ browsing the morgue without opening bags everywhere.