### PR TITLE
Significantly increases meteor difficulty

### DIFF
--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -56,9 +56,13 @@ var/datum/evacuation_controller/evacuation_controller
 
 	emergency_evacuation = _emergency_evac
 
+	var/evac_prep_delay_multiplier = 1
+	if(ticker && ticker.mode)
+		evac_prep_delay_multiplier = ticker.mode.shuttle_delay
+
 	evac_called_at =    world.time
 	evac_no_return =    evac_called_at +    round(evac_prep_delay/2)
-	evac_ready_time =   evac_called_at +    evac_prep_delay
+	evac_ready_time =   evac_called_at +    (evac_prep_delay*evac_prep_delay_multiplier)
 	evac_launch_time =  evac_ready_time +   evac_launch_delay
 	evac_arrival_time = evac_launch_time +  evac_transit_delay
 

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -36,14 +36,10 @@
 	. = ..()
 
 /datum/evacuation_controller/pods/shuttle/call_evacuation(var/mob/user, var/_emergency_evac, var/forced)
-	if(..(user, _emergency_evac, forced, skip_announce=1))
+	if(..(user, _emergency_evac, forced))
 		autopilot = 1
 		shuttle_launch_time = world.time + (evac_prep_delay/2)
-		evac_ready_time = world.time + evac_prep_delay + (shuttle.warmup_time*10)
-		if(emergency_evacuation)
-			evac_called.Announce(replacetext(using_map.emergency_shuttle_called_message, "%ETA%", "[round(get_eta()/60)] minute\s."))
-		else
-			priority_announcement.Announce(replacetext(replacetext(using_map.shuttle_called_message, "%dock_name%", "[dock_name]"),  "%ETA%", "[round(get_eta()/60)] minute\s"))
+		evac_ready_time += shuttle.warmup_time*10
 
 /datum/evacuation_controller/pods/shuttle/cancel_evacuation()
 	if(..() && shuttle.moving_status != SHUTTLE_INTRANSIT)

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -1,9 +1,6 @@
 // The following four defines can be used to tweak the difficulty of the gamemode
 #define METEOR_DELAY 30 MINUTES			// This should be enough for crew to set up.
-#define METEOR_DELAY_MULTIPLIER 4		// 4x larger duration between waves. That ensures the mode is less of a instant destruction of the station, and more of a continous stress.
-#define METEOR_ESCALATION_PROBABILITY 30// % chance to escalate to higher severity
-#define METEOR_MAXIMAL_SEVERITY 15		// Maximal severity value. Severity means how many meteors spawn, and what types of meteors are picked.
-#define METEOR_FAILSAFE_THRESHOLD 90 MINUTES	// Failsafe that guarantees Severity will be at least 5 when the round hits this time.
+#define METEOR_FAILSAFE_THRESHOLD 90 MINUTES	// Failsafe that guarantees Severity will be at least 15 when the round hits this time.
 
 // In general, a PVE oriented game mode. A middle ground between Extended and actual antagonist based rounds.
 /datum/game_mode/meteor
@@ -11,7 +8,7 @@
 	round_description = "The space station is about to enter an asteroid belt!"
 	extended_round_description = "The station is on an unavoidable collision course with an asteroid field. You have only a moment to prepare before the station is barraged by dust and meteors. As if it was not enough, all kinds of negative events seem to happen more frequently. Good Luck."
 	config_tag = "meteor"
-	required_players = 8				// Definitely not good for low-pop
+	required_players = 5				// Definitely not good for low-pop
 	votable = 1
 	shuttle_delay = 2
 	var/next_wave = INFINITY			// Set in post_setup() correctly to take into account potential longer pre-start times.
@@ -22,8 +19,14 @@
 	var/alert_text
 	var/start_text
 
+	// Moved these from defines to variables, to allow for in-round tweaking via varedit:
+	var/time_between_waves_minutes = 2
+	var/escalation_probability = 50
+	var/maximal_severity = 40
+	var/send_admin_broadcasts = FALSE	// Enables debugging/information mode, sending admin messages when waves occur and when severity escalates.
+
 	event_delay_mod_moderate = 0.5		// As a bonus, more frequent events.
-	event_delay_mod_major = 0.5
+	event_delay_mod_major = 0.3
 
 /datum/game_mode/meteor/post_setup()
 	..()
@@ -43,19 +46,23 @@
 		command_announcement.Announce(start_text, alert_title)
 		for(var/obj/machinery/shield_diffuser/SD in machines)
 			SD.meteor_alarm(INFINITY)
-		next_wave = round_duration_in_ticks + (meteor_wave_delay * METEOR_DELAY_MULTIPLIER)
-	if((round_duration_in_ticks >= METEOR_FAILSAFE_THRESHOLD) && (meteor_severity < 5) && !failsafe_triggered)
-		log_and_message_admins("Meteor mode severity failsafe triggered: Severity forced to 5.")
-		meteor_severity = 5
+		next_wave = round_duration_in_ticks + (meteor_wave_delay * time_between_waves_minutes)
+	if((round_duration_in_ticks >= METEOR_FAILSAFE_THRESHOLD) && (meteor_severity < 15) && !failsafe_triggered)
+		log_and_message_admins("Meteor mode severity failsafe triggered: Severity forced to 15.")
+		meteor_severity = 15
 		failsafe_triggered = 1
 
 	if(round_duration_in_ticks >= next_wave)
-		next_wave = round_duration_in_ticks + (meteor_wave_delay * METEOR_DELAY_MULTIPLIER)
+		next_wave = round_duration_in_ticks + (meteor_wave_delay * time_between_waves_minutes)
 		// Starts as barely noticeable dust impact, ends as barrage of most severe meteor types the code has to offer. Have fun.
 		spawn()
 			spawn_meteors(meteor_severity, get_meteor_types(), pick(cardinal))
-		if(prob(METEOR_ESCALATION_PROBABILITY))
-			meteor_severity = min(meteor_severity + 1, METEOR_MAXIMAL_SEVERITY)
+		var/escalated = FALSE
+		if(prob(escalation_probability) && (meteor_severity < maximal_severity))
+			meteor_severity++
+			escalated = TRUE
+		if(send_admin_broadcasts)
+			log_and_message_admins("Meteor: Wave fired. Escalation: [escalated ? "Yes" : "No"]. Severity: [meteor_severity]/[maximal_severity]")
 
 /datum/game_mode/meteor/proc/get_meteor_types()
 	switch(meteor_severity)
@@ -67,14 +74,13 @@
 			return meteors_threatening
 		if(10 to 12)
 			return meteors_catastrophic
-		if(13 to INFINITY)
+		if(13 to 19)
 			return meteors_armageddon
+		if(20 to INFINITY)
+			return meteors_cataclysm
 	// Just in case we /somehow/ get here (looking at you, varedit)
 	return meteors_normal
 
 
 #undef METEOR_DELAY
-#undef METEOR_DELAY_MULTIPLIER
-#undef METEOR_ESCALATION_PROBABILITY
-#undef METEOR_MAXIMAL_SEVERITY
 #undef METEOR_FAILSAFE_THRESHOLD

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -1,20 +1,69 @@
 /var/const/meteor_wave_delay = 1 MINUTE //minimum wait between waves in tenths of seconds
 //set to at least 100 unless you want evarr ruining every round
 
-//Meteors probability of spawning during a given wave
-/var/list/meteors_normal = list(/obj/effect/meteor/dust=3, /obj/effect/meteor/medium=8, /obj/effect/meteor/big=3, \
-						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3) //for normal meteor event
+//Meteor groups, used for various random events and the Meteor gamemode.
 
-/var/list/meteors_threatening = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=10, \
-						  /obj/effect/meteor/flaming=3, /obj/effect/meteor/irradiated=3, /obj/effect/meteor/emp=3) //for threatening meteor event
+// Dust, used by space dust event and during earliest stages of meteor mode.
+/var/list/meteors_dust = list(/obj/effect/meteor/dust)
 
-/var/list/meteors_catastrophic = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=75, \
-						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/emp=10, /obj/effect/meteor/tunguska = 1) //for catastrophic meteor event
+// Standard meteors, used for the low severity meteor event, and during early stages of the meteor gamemode.
+/var/list/meteors_normal = list(\
+		/obj/effect/meteor/medium=8,\
+		/obj/effect/meteor/dust=3,\
+		/obj/effect/meteor/irradiated=3,\
+		/obj/effect/meteor/big=3,\
+		/obj/effect/meteor/flaming=1,\
+		/obj/effect/meteor/golden=1,\
+		/obj/effect/meteor/silver=1\
+		)
 
-/var/list/meteors_armageddon = list(/obj/effect/meteor/medium=3, /obj/effect/meteor/big=25, \
-						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/emp=10, /obj/effect/meteor/tunguska = 3) //Meteor mode only. Good Luck.
+// Threatening meteors, used for medium severity meteor event, and during meteor gamemode.
+/var/list/meteors_threatening = list(\
+		/obj/effect/meteor/big=10,\
+		/obj/effect/meteor/medium=5,\
+		/obj/effect/meteor/golden=3,\
+		/obj/effect/meteor/silver=3,\
+		/obj/effect/meteor/flaming=3,\
+		/obj/effect/meteor/irradiated=3,\
+		/obj/effect/meteor/emp=3\
+		)
 
-/var/list/meteors_dust = list(/obj/effect/meteor/dust) //for space dust event
+// Catastrophic meteors, pretty dangerous without shields and used for high severity meteor event, and during meteor gamemode.
+/var/list/meteors_catastrophic = list(\
+		/obj/effect/meteor/big=75,\
+		/obj/effect/meteor/flaming=10,\
+		/obj/effect/meteor/irradiated=10,\
+		/obj/effect/meteor/emp=10,\
+		/obj/effect/meteor/medium=5,\
+		/obj/effect/meteor/golden=4,\
+		/obj/effect/meteor/silver=4,\
+		/obj/effect/meteor/tunguska=1\
+		)
+
+// Armageddon meteors, very dangerous, and currently used only during the meteor gamemode.
+/var/list/meteors_armageddon = list(\
+		/obj/effect/meteor/big=25,\
+		/obj/effect/meteor/flaming=10,\
+		/obj/effect/meteor/irradiated=10,\
+		/obj/effect/meteor/emp=10,\
+		/obj/effect/meteor/medium=3,\
+		/obj/effect/meteor/tunguska=3,\
+		/obj/effect/meteor/golden=2,\
+		/obj/effect/meteor/silver=2\
+		)
+
+// Cataclysm meteor selection. Very very dangerous and effective even against shields. Used in late game meteor gamemode only.
+/var/list/meteors_cataclysm = list(\
+		/obj/effect/meteor/big=40,\
+		/obj/effect/meteor/emp=20,\
+		/obj/effect/meteor/tunguska=20,\
+		/obj/effect/meteor/irradiated=10,\
+		/obj/effect/meteor/golden=10,\
+		/obj/effect/meteor/silver=10,\
+		/obj/effect/meteor/flaming=10,\
+		/obj/effect/meteor/supermatter=1\
+		)
+
 
 
 ///////////////////////////////
@@ -101,7 +150,7 @@
 	var/heavy = 0
 	var/z_original
 	var/meteordrop = /obj/item/weapon/ore/iron
-	var/dropamt = 2
+	var/dropamt = 1
 
 /obj/effect/meteor/proc/get_shield_damage()
 	return max(((max(hits, 2)) * (heavy + 1) * rand(30, 60)) / hitpwr , 0)
@@ -199,12 +248,13 @@
 	pass_flags = PASSTABLE | PASSGRILLE
 	hits = 1
 	hitpwr = 3
+	dropamt = 1
 	meteordrop = /obj/item/weapon/ore/glass
 
 //Medium-sized
 /obj/effect/meteor/medium
 	name = "meteor"
-	dropamt = 3
+	dropamt = 2
 
 /obj/effect/meteor/medium/meteor_effect()
 	..()
@@ -216,7 +266,7 @@
 	icon_state = "large"
 	hits = 6
 	heavy = 1
-	dropamt = 4
+	dropamt = 3
 
 /obj/effect/meteor/big/meteor_effect()
 	..()
@@ -241,7 +291,6 @@
 	heavy = 1
 	meteordrop = /obj/item/weapon/ore/uranium
 
-
 /obj/effect/meteor/irradiated/meteor_effect()
 	..()
 	explosion(src.loc, 0, 0, 4, 3, 0)
@@ -249,13 +298,24 @@
 	for(var/mob/living/L in view(5, src))
 		L.apply_effect(40, IRRADIATE, blocked = L.getarmor(null, "rad"))
 
-//
+/obj/effect/meteor/golden
+	name = "golden meteor"
+	icon_state = "glowing"
+	desc = "Shiny! But also deadly."
+	meteordrop = /obj/item/weapon/ore/gold
+
+/obj/effect/meteor/silver
+	name = "silver meteor"
+	icon_state = "glowing_blue"
+	desc = "Shiny! But also deadly."
+	meteordrop = /obj/item/weapon/ore/silver
+
 /obj/effect/meteor/emp
 	name = "conducting meteor"
 	icon_state = "glowing_blue"
 	desc = "Hide your floppies!"
 	meteordrop = /obj/item/weapon/ore/osmium
-	dropamt = 3
+	dropamt = 2
 
 /obj/effect/meteor/emp/meteor_effect()
 	..()
@@ -274,9 +334,24 @@
 	hits = 10
 	hitpwr = 1
 	heavy = 1
-	dropamt = 15
 	meteordrop = /obj/item/weapon/ore/diamond	// Probably means why it penetrates the hull so easily before exploding.
 
 /obj/effect/meteor/tunguska/meteor_effect()
 	..()
 	explosion(src.loc, 3, 6, 9, 20, 0)
+
+// This is the final solution against shields - a single impact can bring down most shield generators.
+/obj/effect/meteor/supermatter
+	name = "supermatter shard"
+	desc = "Oh god, what will be next..?"
+	icon = 'icons/obj/engine.dmi'
+	icon_state = "darkmatter"
+
+/obj/effect/meteor/supermatter/meteor_effect()
+	..()
+	explosion(src.loc, 1, 2, 3, 4, 0)
+	for(var/obj/machinery/power/apc/A in range(rand(12, 20), src))
+		A.energy_fail(round(10 * rand(8, 12)))
+
+/obj/effect/meteor/supermatter/get_shield_damage()
+	return ..() * rand(80, 120)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -7,6 +7,6 @@
 	required_enemies = 3
 	auto_recall_shuttle = 0
 	end_on_antag_death = 0
-	shuttle_delay = 3
+	shuttle_delay = 2
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST)
 	require_all_templates = 1

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -7,7 +7,7 @@
 	var/start_side
 
 /datum/event/meteor_wave/setup()
-	waves = severity * rand(1,3)
+	waves = severity * rand(5,15)
 	start_side = pick(cardinal)
 	endWhen = worst_case_end()
 
@@ -27,8 +27,8 @@
 
 	if(waves && activeFor >= next_meteor)
 		var/pick_side = prob(80) ? start_side : (prob(50) ? turn(start_side, 90) : turn(start_side, -90))
-		spawn() spawn_meteors(severity * rand(1,2), get_meteors(), pick_side)
-		next_meteor += rand(15, 30) / severity
+		spawn() spawn_meteors(severity * rand(4,8), get_meteors(), pick_side)
+		next_meteor += rand(10, 20) / severity
 		waves--
 		endWhen = worst_case_end()
 

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -24,8 +24,7 @@
 		return
 	for(var/direction in cardinal)
 		var/turf/simulated/shielded_tile = get_step(get_turf(src), direction)
-		var/obj/effect/shield/S = locate() in shielded_tile
-		if(istype(S))
+		for(var/obj/effect/shield/S in shielded_tile)
 			S.diffuse(5)
 
 /obj/machinery/shield_diffuser/attackby(obj/item/O as obj, mob/user as mob)

--- a/code/modules/shield_generators/handheld_diffuser.dm
+++ b/code/modules/shield_generators/handheld_diffuser.dm
@@ -30,10 +30,10 @@
 
 	for(var/direction in cardinal)
 		var/turf/simulated/shielded_tile = get_step(get_turf(src), direction)
-		var/obj/effect/shield/S = locate() in shielded_tile
-		// 10kJ per pulse, but gap in the shield lasts for longer than regular diffusers.
-		if(istype(S) && !S.diffused_for && !S.disabled_for && cell.checked_use(10 KILOWATTS * CELLRATE))
-			S.diffuse(20)
+		for(var/obj/effect/shield/S in shielded_tile)
+			// 10kJ per pulse, but gap in the shield lasts for longer than regular diffusers.
+			if(istype(S) && !S.diffused_for && !S.disabled_for && cell.checked_use(10 KILOWATTS * CELLRATE))
+				S.diffuse(20)
 
 /obj/item/weapon/shield_diffuser/attack_self()
 	enabled = !enabled


### PR DESCRIPTION
- Note: Apparently people think it's not dangerous enough. It is now. Have fun.
- Tweak: Waves come 2x more often (4 minutes -> 2 minutes)
- Tweak: Maximal severity increased to 40. New group of meteors (Cataclysm) added that triggers at 20+ and is even more "fun" than armageddon, with about 40% chance of a tunguska or EMP meteor. In general, this group is one of the most dangerous things for a shield generator.
- Tweak: Major random events fire even more often in meteor mode(about 3x more often than default)
- Tweak: Escalation probability increased (30% -> 50%).
- Tweak: Some stuff moved from defines to variables, should allow for in-round tweaking/admin fun if necessary.
- Tweak: Failsafe updated accordingly, now forces severity 15 (pretty nasty, but with some luck, survivable.)
- Tweak: Reduced players needed to start back to 5. If people want the mode, let them, i guess.
- Tweak: Ore drops from meteors reduced accross the board. Meteor-shield mining is still very profitable (and dangerous), but not so massively.
- Added: Admin notifications, that can be enabled by enabling one var. Primarily used for debugging purposes, but i thought someone may find it interesting.
- Added: Golden and silver meteors, which drop a little of silver and gold ore on impact. Relatively harmless in comparison to other meteor types.
- Added: Supermatter shard meteor type. Relatively harmless against structures (comparable to big meteor combined with EMP meteor), but insanely powerful against shield generators. Very rare, and occurs only in late-game meteor gamemode.
- Tweak: Highly buffed the random meteor storm event, both in terms of duration and meteor count. In general meteor storms are once again pretty dangerous.
- Bugfix: Fixed shuttle_delay variable on gamemode doing nothing, it now correctly multiplies shuttle transit time.

May the gods be with you. Good luck.