### PR TITLE
Quick-Fix for shield lag problems

### DIFF
--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -70,9 +70,10 @@
 /obj/effect/shield/proc/fail(var/duration)
 	if(duration <= 0)
 		return
-	if(!disabled_for)
+	if(!disabled_for && (duration > 1))
 		s.set_up(1, 1, src)
 		s.start()
+		
 	gen.damaged_segments |= src
 	disabled_for += duration
 	density = 0
@@ -104,11 +105,11 @@
 	if(gen.check_flag(MODEFLAG_BYPASS) && !diffused_for && !disabled_for)
 		take_damage(duration * rand(8, 12), SHIELD_DAMTYPE_EM)
 		return
-
+		
 	if(!diffused_for && !disabled_for)
 		s.set_up(1, 1, src)
 		s.start()
-
+		
 	diffused_for = max(duration, 0)
 	gen.damaged_segments |= src
 	density = 0


### PR DESCRIPTION
- Hopefully fixes #15050
- Shields will no longer spark when shut down due to power outage, only segments that fail due to damage/diffuser effect do.