### PR TITLE
makes mousetraps orderable from cargo

### DIFF
--- a/code/datums/supplypacks/miscellaneous.dm
+++ b/code/datums/supplypacks/miscellaneous.dm
@@ -245,3 +245,11 @@
 					/obj/item/weapon/storage/fancy/candle_box = 3)
 	cost = 10
 	containername = "\improper Chaplain equipment crate"
+
+/decl/hierarchy/supply_pack/miscellaneous/mousetrap
+	num_contained = 3
+	contains = list(/obj/item/weapon/storage/box/mousetraps)
+	name = "\improper Pest Control Crate"
+	cost = 10
+	containername = "\improper Pest Control Crate"
+	

--- a/html/changelogs/mousetrap.yml
+++ b/html/changelogs/mousetrap.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes: 
+  - rscadd: "Mousetraps are now orderable from cargo."


### PR DESCRIPTION
mousetraps are now orderable from cargo in a crate named "pest control crate". per request in the little things thread on the forum.