### PR TITLE
Base turf by Z-level is now setup per map datum

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -13,14 +13,18 @@
 			return global.delta_index;
 		if("acting_rank_prefixes")
 			return global.acting_rank_prefixes;
+		if("meteors_dust")
+			return global.meteors_dust;
 		if("meteors_normal")
 			return global.meteors_normal;
 		if("meteors_threatening")
 			return global.meteors_threatening;
 		if("meteors_catastrophic")
 			return global.meteors_catastrophic;
-		if("meteors_dust")
-			return global.meteors_dust;
+		if("meteors_armageddon")
+			return global.meteors_armageddon;
+		if("meteors_cataclysm")
+			return global.meteors_cataclysm;
 		if("priv_all_access_datums")
 			return global.priv_all_access_datums;
 		if("priv_all_access_datums_id")
@@ -161,6 +165,10 @@
 			return global.gas_data;
 		if("area_repository")
 			return global.area_repository;
+		if("decls_repository")
+			return global.decls_repository;
+		if("image_repository")
+			return global.image_repository;
 		if("create_mob_html")
 			return global.create_mob_html;
 		if("create_object_html")
@@ -495,6 +503,8 @@
 			return global.mechas_list;
 		if("joblist")
 			return global.joblist;
+		if("GhostFollowObjects")
+			return global.GhostFollowObjects;
 		if("turfs")
 			return global.turfs;
 		if("all_species")
@@ -643,6 +653,8 @@
 			return global.wirelessProcess;
 		if("processScheduler")
 			return global.processScheduler;
+		if("mil_branches")
+			return global.mil_branches;
 		if("appearance_manager")
 			return global.appearance_manager;
 		if("revdata")
@@ -669,8 +681,16 @@
 			return global.moved_event;
 		if("opacity_set_event")
 			return global.opacity_set_event;
+		if("see_in_dark_set_event")
+			return global.see_in_dark_set_event;
+		if("see_invisible_set_event")
+			return global.see_invisible_set_event;
+		if("sight_set_event")
+			return global.sight_set_event;
 		if("task_triggered_event")
 			return global.task_triggered_event;
+		if("turf_changed_event")
+			return global.turf_changed_event;
 		if("mob_unequipped_event")
 			return global.mob_unequipped_event;
 		if("item_unequipped_event")
@@ -717,8 +737,6 @@
 			return global.wireColours;
 		if("PDA_Manifest")
 			return global.PDA_Manifest;
-		if("base_turf_by_z")
-			return global.base_turf_by_z;
 		if("newscaster_standard_feeds")
 			return global.newscaster_standard_feeds;
 		if("announced_news_types")
@@ -751,6 +769,8 @@
 			return global.supply_controller;
 		if("mechtoys")
 			return global.mechtoys;
+		if("point_source_descriptions")
+			return global.point_source_descriptions;
 		if("all_antag_types")
 			return global.all_antag_types;
 		if("all_antag_spawnpoints")
@@ -861,6 +881,10 @@
 			return global.security_positions;
 		if("nonhuman_positions")
 			return global.nonhuman_positions;
+		if("service_positions")
+			return global.service_positions;
+		if("supply_positions")
+			return global.supply_positions;
 		if("whitelist")
 			return global.whitelist;
 		if("captain_announcement")
@@ -1191,6 +1215,12 @@
 			return global.light_overlay_cache;
 		if("damage_icon_parts")
 			return global.damage_icon_parts;
+		if("stored_shock_by_ref")
+			return global.stored_shock_by_ref;
+		if("wrapped_species_by_ref")
+			return global.wrapped_species_by_ref;
+		if("prometheans")
+			return global.prometheans;
 		if("ai_list")
 			return global.ai_list;
 		if("ai_verbs_default")
@@ -1237,6 +1267,8 @@
 			return global.ghost_darkness_images;
 		if("ghost_sightless_images")
 			return global.ghost_sightless_images;
+		if("all_virtual_listeners")
+			return global.all_virtual_listeners;
 		if("global_modular_computers")
 			return global.global_modular_computers;
 		if("file_uid")
@@ -1407,7 +1439,7 @@
 			return global.all_maps;
 		if("init")
 			return global.init;
-
+		
 /proc/writeglobal(which, newval)
 	switch(which)
 		if("tagger_locations")
@@ -1422,14 +1454,18 @@
 			global.delta_index=newval;
 		if("acting_rank_prefixes")
 			global.acting_rank_prefixes=newval;
+		if("meteors_dust")
+			global.meteors_dust=newval;
 		if("meteors_normal")
 			global.meteors_normal=newval;
 		if("meteors_threatening")
 			global.meteors_threatening=newval;
 		if("meteors_catastrophic")
 			global.meteors_catastrophic=newval;
-		if("meteors_dust")
-			global.meteors_dust=newval;
+		if("meteors_armageddon")
+			global.meteors_armageddon=newval;
+		if("meteors_cataclysm")
+			global.meteors_cataclysm=newval;
 		if("priv_all_access_datums")
 			global.priv_all_access_datums=newval;
 		if("priv_all_access_datums_id")
@@ -1570,6 +1606,10 @@
 			global.gas_data=newval;
 		if("area_repository")
 			global.area_repository=newval;
+		if("decls_repository")
+			global.decls_repository=newval;
+		if("image_repository")
+			global.image_repository=newval;
 		if("create_mob_html")
 			global.create_mob_html=newval;
 		if("create_object_html")
@@ -1904,6 +1944,8 @@
 			global.mechas_list=newval;
 		if("joblist")
 			global.joblist=newval;
+		if("GhostFollowObjects")
+			global.GhostFollowObjects=newval;
 		if("turfs")
 			global.turfs=newval;
 		if("all_species")
@@ -2052,6 +2094,8 @@
 			global.wirelessProcess=newval;
 		if("processScheduler")
 			global.processScheduler=newval;
+		if("mil_branches")
+			global.mil_branches=newval;
 		if("appearance_manager")
 			global.appearance_manager=newval;
 		if("revdata")
@@ -2078,8 +2122,16 @@
 			global.moved_event=newval;
 		if("opacity_set_event")
 			global.opacity_set_event=newval;
+		if("see_in_dark_set_event")
+			global.see_in_dark_set_event=newval;
+		if("see_invisible_set_event")
+			global.see_invisible_set_event=newval;
+		if("sight_set_event")
+			global.sight_set_event=newval;
 		if("task_triggered_event")
 			global.task_triggered_event=newval;
+		if("turf_changed_event")
+			global.turf_changed_event=newval;
 		if("mob_unequipped_event")
 			global.mob_unequipped_event=newval;
 		if("item_unequipped_event")
@@ -2126,8 +2178,6 @@
 			global.wireColours=newval;
 		if("PDA_Manifest")
 			global.PDA_Manifest=newval;
-		if("base_turf_by_z")
-			global.base_turf_by_z=newval;
 		if("newscaster_standard_feeds")
 			global.newscaster_standard_feeds=newval;
 		if("announced_news_types")
@@ -2160,6 +2210,8 @@
 			global.supply_controller=newval;
 		if("mechtoys")
 			global.mechtoys=newval;
+		if("point_source_descriptions")
+			global.point_source_descriptions=newval;
 		if("all_antag_types")
 			global.all_antag_types=newval;
 		if("all_antag_spawnpoints")
@@ -2270,6 +2322,10 @@
 			global.security_positions=newval;
 		if("nonhuman_positions")
 			global.nonhuman_positions=newval;
+		if("service_positions")
+			global.service_positions=newval;
+		if("supply_positions")
+			global.supply_positions=newval;
 		if("whitelist")
 			global.whitelist=newval;
 		if("captain_announcement")
@@ -2600,6 +2656,12 @@
 			global.light_overlay_cache=newval;
 		if("damage_icon_parts")
 			global.damage_icon_parts=newval;
+		if("stored_shock_by_ref")
+			global.stored_shock_by_ref=newval;
+		if("wrapped_species_by_ref")
+			global.wrapped_species_by_ref=newval;
+		if("prometheans")
+			global.prometheans=newval;
 		if("ai_list")
 			global.ai_list=newval;
 		if("ai_verbs_default")
@@ -2646,6 +2708,8 @@
 			global.ghost_darkness_images=newval;
 		if("ghost_sightless_images")
 			global.ghost_sightless_images=newval;
+		if("all_virtual_listeners")
+			global.all_virtual_listeners=newval;
 		if("global_modular_computers")
 			global.global_modular_computers=newval;
 		if("file_uid")
@@ -2816,6 +2880,5 @@
 			global.all_maps=newval;
 		if("init")
 			global.init=newval;
-
-/var/list/_all_globals=list("tagger_locations","is_station_but_not_space_or_shuttle_area","is_contact_but_not_space_or_shuttle_area","is_player_but_not_space_or_shuttle_area","delta_index","acting_rank_prefixes","meteors_normal","meteors_threatening","meteors_catastrophic","meteors_dust","priv_all_access_datums","priv_all_access_datums_id","priv_all_access_datums_region","priv_all_access","priv_station_access","priv_centcom_access","priv_syndicate_access","priv_region_access","alien_whitelist","view_variables_hide_vars","view_variables_dont_expand","view_variables_no_assoc","custom_items","economic_species_modifier","lighting_update_lights","lighting_update_overlays","gender_datums","chemical_reaction_logs","game_id","log_end","atmosphere_alarm","camera_alarm","fire_alarm","motion_alarm","power_alarm","admin_state","conscious_state","contained_state","default_state","outside_state","hands_state","interactive_state","inventory_state","deep_inventory_state","physical_state","self_state","z_state","tg_admin_state","tg_always_state","tg_conscious_state","tg_contained_state","tg_deep_inventory_state","tg_default_state","tg_hands_state","tg_human_adjacent_state","tg_inventory_state","tg_not_contained_state","tg_not_incapacitated_state","not_incapacitated_turf_state","tg_physical_state","tg_self_state","tg_z_state","machinery_sort_required","autolathe_recipes","autolathe_categories","id_card_states","asset_datums","magazine_icondata_keys","magazine_icondata_states","account_hack_attempted","spacevines_spawned","sent_spiders_to_station","text_tag_icons","scheduler","priority_announcement","command_announcement","security_announcement_up","security_announcement_down","gas_data","area_repository","create_mob_html","create_object_html","create_turf_html","global_vars_","all_ui_styles","lobby_image","security_level","default_mobloc","data_core","all_areas","machines","processing_objects","processing_power_items","active_diseases","med_hud_users","sec_hud_users","hud_icon_reference","traders","listening_objects","global_mutations","universe","global_map","hit_appends","diary","href_logfile","station_name","station_short","game_version","changelog_hash","game_year","round_progressing","master_mode","secondary_mode","tertiary_mode","secret_force_mode","host","jobMax","bombers","admin_log","lastsignalers","lawchanges","reg_dna","monkeystart","wizardstart","newplayer_start","latejoin","latejoin_gateway","latejoin_cryo","latejoin_cyborg","prisonwarp","xeno_spawn","tdome1","tdome2","tdomeobserve","tdomeadmin","prisonsecuritywarp","prisonwarped","ninjastart","cardinal","cornerdirs","alldirs","reverse_dir","config","sun","combatlog","IClog","OOClog","adminlog","powernets","Debug2","gravity_is_on","join_motd","nanomanager","event_manager","awaydestinations","sqladdress","sqlport","sqldb","sqllogin","sqlpass","sqlfdbkdb","sqlfdbklogin","sqlfdbkpass","sqllogging","forumsqladdress","forumsqlport","forumsqldb","forumsqllogin","forumsqlpass","forum_activated_group","forum_authenticated_group","fileaccess_timer","custom_event_msg","dbcon","dbcon_old","alphabet_uppercase","robot_module_types","scarySounds","max_explosion_range","global_announcer","station_departments","ai_names","wizard_first","wizard_second","ninja_titles","ninja_names","commando_names","first_names_male","first_names_female","last_names","clown_names","verbs","adjectives","world_topic_spam_protect_ip","world_topic_spam_protect_time","failed_db_connections","failed_old_db_connections","ghost_master","BLINDBLOCK","DEAFBLOCK","HULKBLOCK","TELEBLOCK","FIREBLOCK","XRAYBLOCK","CLUMSYBLOCK","FAKEBLOCK","COUGHBLOCK","GLASSESBLOCK","EPILEPSYBLOCK","TWITCHBLOCK","NERVOUSBLOCK","MONKEYBLOCK","BLOCKADD","DIFFMUT","HEADACHEBLOCK","NOBREATHBLOCK","REMOTEVIEWBLOCK","REGENERATEBLOCK","INCREASERUNBLOCK","REMOTETALKBLOCK","MORPHBLOCK","BLENDBLOCK","HALLUCINATIONBLOCK","NOPRINTSBLOCK","SHOCKIMMUNITYBLOCK","SMALLSIZEBLOCK","default_onmob_icons","defer_powernet_rebuild","restricted_camera_networks","gear_tweak_free_color_choice_","clients","admins","directory","player_list","mob_list","human_mob_list","silicon_mob_list","living_mob_list_","dead_mob_list_","cable_list","chemical_reactions_list","chemical_reagents_list","landmarks_list","surgery_steps","side_effects","mechas_list","joblist","turfs","all_species","all_languages","language_keys","whitelisted_species","playable_species","mannequins_","poster_designs","world_uplinks","hair_styles_list","hair_styles_male_list","hair_styles_female_list","facial_hair_styles_list","facial_hair_styles_male_list","facial_hair_styles_female_list","skin_styles_female_list","global_underwear","backbaglist","exclude_jobs","visual_nets","cameranet","rune_list","endgame_exits","endgame_safespawns","syndicate_access","string_part_flags","string_slot_flags","paramslist_cache","church_name","command_name","religion_name","syndicate_name","syndicate_code_phrase","syndicate_code_response","roundstart_hour","station_date","next_station_date_change","next_duration_update","last_round_duration","round_start_time","common_tools","WALLITEMS","dview_mob","global_hud","global_huds","robot_inventory","pipe_colors","pipe_networks","transfer_controller","radiochannels","CENT_FREQS","ANTAG_FREQS","DEPT_FREQS","radio_controller","gamemode_cache","master_controller","controller_iteration","last_tick_duration","air_processing_killed","pipe_processing_killed","initialization_stage","shuttle_controller","vote","evacuation_controller","list_of_ais","alarm_manager","chemistryProcess","garbage_collector","delayed_garbage","tgui_process","tickerProcess","processing_turfs","wirelessProcess","processScheduler","appearance_manager","revdata","all_observable_events","death_event","destroyed_event","dir_set_event","entered_event","mob_equipped_event","item_equipped_event","life_event","logged_in_event","moved_event","opacity_set_event","task_triggered_event","mob_unequipped_event","item_unequipped_event","global_listen_count","event_sources_count","event_listen_count","outfits_decls_","outfits_decls_root_","outfits_decls_by_type_","admin_pm_repository","attack_log_repository","camera_repository","client_repository","mob_repository","uniqueness_repository","uplink_purchase_repository","crew_repository","cargo_supply_pack_root","cargo_supply_packs","supply_methods_","uplink","same_wires","wireColours","PDA_Manifest","base_turf_by_z","newscaster_standard_feeds","announced_news_types","send_emergency_team","ert_base_chance","can_call_ert","shatter_sound","explosion_sound","spark_sound","rustle_sound","punch_sound","clown_sound","swing_hit_sound","hiss_sound","page_sound","supply_controller","mechtoys","all_antag_types","all_antag_spawnpoints","antag_names_to_ids","borers","xenomorphs","actor","commandos","deathsquad","ert","mercs","ninjas","raiders","wizards","cult","highlanders","loyalists","renegades","revs","malf","traitors","forced_ambiance_list","dna_activity_bounds","assigned_blocks","dna_genes","eventchance","hadevent","antag_add_finished","additional_antag_types","ticker","all_objectives","possible_changeling_IDs","hivemind_bank","powers","powerinstances","narsie_behaviour","narsie_cometh","narsie_list","cultwords","runedec","engwords","rnwords","sacrificed","universe_has_ended","Holiday","nuke_disks","job_master","assistant_occupations","command_positions","engineering_positions","medical_positions","science_positions","cargo_positions","civilian_positions","security_positions","nonhuman_positions","whitelist","captain_announcement","doppler_arrays","floor_light_cache","navbeacons","news_network","allCasters","bomb_set","turret_icons","req_console_assistance","req_console_supplies","req_console_information","allConsoles","status_icons_to_colour","ai_status_emotions","priority_air_alarms","minor_air_alarms","air_alarm_topic","specops_shuttle_moving_to_station","specops_shuttle_moving_to_centcom","specops_shuttle_at_station","specops_shuttle_can_send","specops_shuttle_time","specops_shuttle_timeleft","syndicate_elite_shuttle_moving_to_station","syndicate_elite_shuttle_moving_to_mothership","syndicate_elite_shuttle_at_station","syndicate_elite_shuttle_can_send","syndicate_elite_shuttle_time","syndicate_elite_shuttle_timeleft","recentmessages","message_delay","telecomms_list","word_to_uristrune_table","uristrune_cache","explosion_turfs","explosion_in_progress","slot_flags_enumeration","BUMP_TELEPORTERS","splatter_cache","fluidtrack_cache","uplink_random_selections_","chatrooms","PDAs","default_internal_channels","default_medbay_channels","last_chew","cached_icons","hazard_overlays","tape_roll_applications","ashtray_cache","tank_gauge_cache","multi_point_spawns","random_junk_","random_useful_","stool_cache","flooring_types","floor_decals","flooring_cache","BSACooldown","floorIsLava","admin_ranks","admin_secrets","admin_verbs_default","admin_verbs_admin","admin_verbs_ban","admin_verbs_sounds","admin_verbs_fun","admin_verbs_spawn","admin_verbs_server","admin_verbs_debug","admin_verbs_paranoid_debug","admin_verbs_possess","admin_verbs_permissions","admin_verbs_rejuv","admin_verbs_hideable","admin_verbs_mod","admin_verbs_mentor","jobban_runonce","jobban_keylist","admin_datums","CMinutes","Banlist","adminhelp_ignored_words","checked_for_inactives","inactive_keys","camera_range_display_status","intercom_range_display_status","debug_verbs","sounds_cache","asset_cache","preferences_datums","seen_citizenships","seen_systems","seen_factions","seen_religions","citizenship_choices","home_system_choices","faction_choices","religion_choices","spawntypes","client_preference_stats_","uplink_locations","valid_bloodtypes","_client_preferences","_client_preferences_by_key","_client_preferences_by_type","loadout_categories","gear_datums","breach_brute_descriptors","breach_burn_descriptors","current_date_string","vendor_account","station_account","department_accounts","num_financial_terminals","next_account_number","all_money_accounts","economy_init","weighted_randomevent_locations","weighted_mundaneevent_locations","error_last_seen","error_cooldown","total_runtimes","total_runtimes_skipped","error_cache","severity_to_string","event_last_fired","description_icons","dreams","non_fakeattack_weapons","ghost_traps","fruit_icon_cache","plant_controller","plant_seed_sprites","wax_recipes","worths","license_to_url","maploader","_preloader","swapmaps_iconcache","swapmaps_mode","swapmaps_compiled_maxx","swapmaps_compiled_maxy","swapmaps_compiled_maxz","swapmaps_initialized","swapmaps_loaded","swapmaps_byname","name_to_material","mining_walls","mining_floors","ore_data","ores_by_type","holder_mob_icon_cache","slot_equipment_priority","base_miss_chance","organ_rel_size","intents","department_radio_keys","channel_to_radio_key","sparring_attack_cache","human_icon_cache","tail_icon_cache","light_overlay_cache","damage_icon_parts","ai_list","ai_verbs_default","default_ai_icon","ai_icons","empty_playable_ai_cores","paiController","pai_emotions","pai_software_by_key","default_pai_software","robot_custom_icons","robot_modules","mob_hat_cache","chicken_count","protected_objects","SKILLS","SKILL_ENGINEER","SKILL_ORGAN_ROBOTICIST","SKILL_SECURITY_OFFICER","SKILL_CHEMIST","SKILL_PRE","cameranet_","ghost_darkness_images","ghost_sightless_images","global_modular_computers","file_uid","comm_message_listeners","global_message_listener","last_message_id","nttransfer_uid","ntnet_card_uid","ntnet_global","ntnrc_uid","z_levels","organ_cache","limb_icon_cache","flesh_hud_colours","robot_hud_colours","all_robolimbs","chargen_robolimbs","basic_robolimb","map_sectors","moving_levels","cached_space","sector_shuttles","ship_engines","allfaxes","admin_departments","alldepartments","adminfaxes","photo_count","possible_cable_coil_colours","light_type_cache","solar_gen_rate","solars_list","fusion_reactions","fusion_cores","fuel_injectors","gyrotrons","rad_collectors","random_maps","map_count","supply_drop","maze_cell_count","lunchables_lunches_","lunchables_snacks_","lunchables_drinks_","lunchables_drink_reagents_","lunchables_ethanol_reagents_","message_servers","blackbox","default_material_composition","maint_all_access","escape_pods","escape_pods_by_name","spells","artefact_feedback","turbolifts","turbolift_controller","ventcrawl_machinery","ALL_ANTIGENS","virusDB","responsive_carriers","finds_as_strings","all_unit_tests_passed","failed_unit_tests","skipped_unit_tests","total_unit_tests","currently_running_tests","ascii_esc","ascii_red","ascii_green","ascii_yellow","ascii_reset","air_master","tick_multiplier","assigned","created","merged","invalid_zone","air_blocked","zone_blocked","blocked","mark","contamination_overlay","vsc","using_map","all_maps","init")
-
+		
+/var/list/_all_globals=list("tagger_locations","is_station_but_not_space_or_shuttle_area","is_contact_but_not_space_or_shuttle_area","is_player_but_not_space_or_shuttle_area","delta_index","acting_rank_prefixes","meteors_dust","meteors_normal","meteors_threatening","meteors_catastrophic","meteors_armageddon","meteors_cataclysm","priv_all_access_datums","priv_all_access_datums_id","priv_all_access_datums_region","priv_all_access","priv_station_access","priv_centcom_access","priv_syndicate_access","priv_region_access","alien_whitelist","view_variables_hide_vars","view_variables_dont_expand","view_variables_no_assoc","custom_items","economic_species_modifier","lighting_update_lights","lighting_update_overlays","gender_datums","chemical_reaction_logs","game_id","log_end","atmosphere_alarm","camera_alarm","fire_alarm","motion_alarm","power_alarm","admin_state","conscious_state","contained_state","default_state","outside_state","hands_state","interactive_state","inventory_state","deep_inventory_state","physical_state","self_state","z_state","tg_admin_state","tg_always_state","tg_conscious_state","tg_contained_state","tg_deep_inventory_state","tg_default_state","tg_hands_state","tg_human_adjacent_state","tg_inventory_state","tg_not_contained_state","tg_not_incapacitated_state","not_incapacitated_turf_state","tg_physical_state","tg_self_state","tg_z_state","machinery_sort_required","autolathe_recipes","autolathe_categories","id_card_states","asset_datums","magazine_icondata_keys","magazine_icondata_states","account_hack_attempted","spacevines_spawned","sent_spiders_to_station","text_tag_icons","scheduler","priority_announcement","command_announcement","security_announcement_up","security_announcement_down","gas_data","area_repository","decls_repository","image_repository","create_mob_html","create_object_html","create_turf_html","global_vars_","all_ui_styles","lobby_image","security_level","default_mobloc","data_core","all_areas","machines","processing_objects","processing_power_items","active_diseases","med_hud_users","sec_hud_users","hud_icon_reference","traders","listening_objects","global_mutations","universe","global_map","hit_appends","diary","href_logfile","station_name","station_short","game_version","changelog_hash","game_year","round_progressing","master_mode","secondary_mode","tertiary_mode","secret_force_mode","host","jobMax","bombers","admin_log","lastsignalers","lawchanges","reg_dna","monkeystart","wizardstart","newplayer_start","latejoin","latejoin_gateway","latejoin_cryo","latejoin_cyborg","prisonwarp","xeno_spawn","tdome1","tdome2","tdomeobserve","tdomeadmin","prisonsecuritywarp","prisonwarped","ninjastart","cardinal","cornerdirs","alldirs","reverse_dir","config","sun","combatlog","IClog","OOClog","adminlog","powernets","Debug2","gravity_is_on","join_motd","nanomanager","event_manager","awaydestinations","sqladdress","sqlport","sqldb","sqllogin","sqlpass","sqlfdbkdb","sqlfdbklogin","sqlfdbkpass","sqllogging","forumsqladdress","forumsqlport","forumsqldb","forumsqllogin","forumsqlpass","forum_activated_group","forum_authenticated_group","fileaccess_timer","custom_event_msg","dbcon","dbcon_old","alphabet_uppercase","robot_module_types","scarySounds","max_explosion_range","global_announcer","station_departments","ai_names","wizard_first","wizard_second","ninja_titles","ninja_names","commando_names","first_names_male","first_names_female","last_names","clown_names","verbs","adjectives","world_topic_spam_protect_ip","world_topic_spam_protect_time","failed_db_connections","failed_old_db_connections","ghost_master","BLINDBLOCK","DEAFBLOCK","HULKBLOCK","TELEBLOCK","FIREBLOCK","XRAYBLOCK","CLUMSYBLOCK","FAKEBLOCK","COUGHBLOCK","GLASSESBLOCK","EPILEPSYBLOCK","TWITCHBLOCK","NERVOUSBLOCK","MONKEYBLOCK","BLOCKADD","DIFFMUT","HEADACHEBLOCK","NOBREATHBLOCK","REMOTEVIEWBLOCK","REGENERATEBLOCK","INCREASERUNBLOCK","REMOTETALKBLOCK","MORPHBLOCK","BLENDBLOCK","HALLUCINATIONBLOCK","NOPRINTSBLOCK","SHOCKIMMUNITYBLOCK","SMALLSIZEBLOCK","default_onmob_icons","defer_powernet_rebuild","restricted_camera_networks","gear_tweak_free_color_choice_","clients","admins","directory","player_list","mob_list","human_mob_list","silicon_mob_list","living_mob_list_","dead_mob_list_","cable_list","chemical_reactions_list","chemical_reagents_list","landmarks_list","surgery_steps","side_effects","mechas_list","joblist","GhostFollowObjects","turfs","all_species","all_languages","language_keys","whitelisted_species","playable_species","mannequins_","poster_designs","world_uplinks","hair_styles_list","hair_styles_male_list","hair_styles_female_list","facial_hair_styles_list","facial_hair_styles_male_list","facial_hair_styles_female_list","skin_styles_female_list","global_underwear","backbaglist","exclude_jobs","visual_nets","cameranet","rune_list","endgame_exits","endgame_safespawns","syndicate_access","string_part_flags","string_slot_flags","paramslist_cache","church_name","command_name","religion_name","syndicate_name","syndicate_code_phrase","syndicate_code_response","roundstart_hour","station_date","next_station_date_change","next_duration_update","last_round_duration","round_start_time","common_tools","WALLITEMS","dview_mob","global_hud","global_huds","robot_inventory","pipe_colors","pipe_networks","transfer_controller","radiochannels","CENT_FREQS","ANTAG_FREQS","DEPT_FREQS","radio_controller","gamemode_cache","master_controller","controller_iteration","last_tick_duration","air_processing_killed","pipe_processing_killed","initialization_stage","shuttle_controller","vote","evacuation_controller","list_of_ais","alarm_manager","chemistryProcess","garbage_collector","delayed_garbage","tgui_process","tickerProcess","processing_turfs","wirelessProcess","processScheduler","mil_branches","appearance_manager","revdata","all_observable_events","death_event","destroyed_event","dir_set_event","entered_event","mob_equipped_event","item_equipped_event","life_event","logged_in_event","moved_event","opacity_set_event","see_in_dark_set_event","see_invisible_set_event","sight_set_event","task_triggered_event","turf_changed_event","mob_unequipped_event","item_unequipped_event","global_listen_count","event_sources_count","event_listen_count","outfits_decls_","outfits_decls_root_","outfits_decls_by_type_","admin_pm_repository","attack_log_repository","camera_repository","client_repository","mob_repository","uniqueness_repository","uplink_purchase_repository","crew_repository","cargo_supply_pack_root","cargo_supply_packs","supply_methods_","uplink","same_wires","wireColours","PDA_Manifest","newscaster_standard_feeds","announced_news_types","send_emergency_team","ert_base_chance","can_call_ert","shatter_sound","explosion_sound","spark_sound","rustle_sound","punch_sound","clown_sound","swing_hit_sound","hiss_sound","page_sound","supply_controller","mechtoys","point_source_descriptions","all_antag_types","all_antag_spawnpoints","antag_names_to_ids","borers","xenomorphs","actor","commandos","deathsquad","ert","mercs","ninjas","raiders","wizards","cult","highlanders","loyalists","renegades","revs","malf","traitors","forced_ambiance_list","dna_activity_bounds","assigned_blocks","dna_genes","eventchance","hadevent","antag_add_finished","additional_antag_types","ticker","all_objectives","possible_changeling_IDs","hivemind_bank","powers","powerinstances","narsie_behaviour","narsie_cometh","narsie_list","cultwords","runedec","engwords","rnwords","sacrificed","universe_has_ended","Holiday","nuke_disks","job_master","assistant_occupations","command_positions","engineering_positions","medical_positions","science_positions","cargo_positions","civilian_positions","security_positions","nonhuman_positions","service_positions","supply_positions","whitelist","captain_announcement","doppler_arrays","floor_light_cache","navbeacons","news_network","allCasters","bomb_set","turret_icons","req_console_assistance","req_console_supplies","req_console_information","allConsoles","status_icons_to_colour","ai_status_emotions","priority_air_alarms","minor_air_alarms","air_alarm_topic","specops_shuttle_moving_to_station","specops_shuttle_moving_to_centcom","specops_shuttle_at_station","specops_shuttle_can_send","specops_shuttle_time","specops_shuttle_timeleft","syndicate_elite_shuttle_moving_to_station","syndicate_elite_shuttle_moving_to_mothership","syndicate_elite_shuttle_at_station","syndicate_elite_shuttle_can_send","syndicate_elite_shuttle_time","syndicate_elite_shuttle_timeleft","recentmessages","message_delay","telecomms_list","word_to_uristrune_table","uristrune_cache","explosion_turfs","explosion_in_progress","slot_flags_enumeration","BUMP_TELEPORTERS","splatter_cache","fluidtrack_cache","uplink_random_selections_","chatrooms","PDAs","default_internal_channels","default_medbay_channels","last_chew","cached_icons","hazard_overlays","tape_roll_applications","ashtray_cache","tank_gauge_cache","multi_point_spawns","random_junk_","random_useful_","stool_cache","flooring_types","floor_decals","flooring_cache","BSACooldown","floorIsLava","admin_ranks","admin_secrets","admin_verbs_default","admin_verbs_admin","admin_verbs_ban","admin_verbs_sounds","admin_verbs_fun","admin_verbs_spawn","admin_verbs_server","admin_verbs_debug","admin_verbs_paranoid_debug","admin_verbs_possess","admin_verbs_permissions","admin_verbs_rejuv","admin_verbs_hideable","admin_verbs_mod","admin_verbs_mentor","jobban_runonce","jobban_keylist","admin_datums","CMinutes","Banlist","adminhelp_ignored_words","checked_for_inactives","inactive_keys","camera_range_display_status","intercom_range_display_status","debug_verbs","sounds_cache","asset_cache","preferences_datums","seen_citizenships","seen_systems","seen_factions","seen_religions","citizenship_choices","home_system_choices","faction_choices","religion_choices","spawntypes","client_preference_stats_","uplink_locations","valid_bloodtypes","_client_preferences","_client_preferences_by_key","_client_preferences_by_type","loadout_categories","gear_datums","breach_brute_descriptors","breach_burn_descriptors","current_date_string","vendor_account","station_account","department_accounts","num_financial_terminals","next_account_number","all_money_accounts","economy_init","weighted_randomevent_locations","weighted_mundaneevent_locations","error_last_seen","error_cooldown","total_runtimes","total_runtimes_skipped","error_cache","severity_to_string","event_last_fired","description_icons","dreams","non_fakeattack_weapons","ghost_traps","fruit_icon_cache","plant_controller","plant_seed_sprites","wax_recipes","worths","license_to_url","maploader","_preloader","swapmaps_iconcache","swapmaps_mode","swapmaps_compiled_maxx","swapmaps_compiled_maxy","swapmaps_compiled_maxz","swapmaps_initialized","swapmaps_loaded","swapmaps_byname","name_to_material","mining_walls","mining_floors","ore_data","ores_by_type","holder_mob_icon_cache","slot_equipment_priority","base_miss_chance","organ_rel_size","intents","department_radio_keys","channel_to_radio_key","sparring_attack_cache","human_icon_cache","tail_icon_cache","light_overlay_cache","damage_icon_parts","stored_shock_by_ref","wrapped_species_by_ref","prometheans","ai_list","ai_verbs_default","default_ai_icon","ai_icons","empty_playable_ai_cores","paiController","pai_emotions","pai_software_by_key","default_pai_software","robot_custom_icons","robot_modules","mob_hat_cache","chicken_count","protected_objects","SKILLS","SKILL_ENGINEER","SKILL_ORGAN_ROBOTICIST","SKILL_SECURITY_OFFICER","SKILL_CHEMIST","SKILL_PRE","cameranet_","ghost_darkness_images","ghost_sightless_images","all_virtual_listeners","global_modular_computers","file_uid","comm_message_listeners","global_message_listener","last_message_id","nttransfer_uid","ntnet_card_uid","ntnet_global","ntnrc_uid","z_levels","organ_cache","limb_icon_cache","flesh_hud_colours","robot_hud_colours","all_robolimbs","chargen_robolimbs","basic_robolimb","map_sectors","moving_levels","cached_space","sector_shuttles","ship_engines","allfaxes","admin_departments","alldepartments","adminfaxes","photo_count","possible_cable_coil_colours","light_type_cache","solar_gen_rate","solars_list","fusion_reactions","fusion_cores","fuel_injectors","gyrotrons","rad_collectors","random_maps","map_count","supply_drop","maze_cell_count","lunchables_lunches_","lunchables_snacks_","lunchables_drinks_","lunchables_drink_reagents_","lunchables_ethanol_reagents_","message_servers","blackbox","default_material_composition","maint_all_access","escape_pods","escape_pods_by_name","spells","artefact_feedback","turbolifts","turbolift_controller","ventcrawl_machinery","ALL_ANTIGENS","virusDB","responsive_carriers","finds_as_strings","all_unit_tests_passed","failed_unit_tests","skipped_unit_tests","total_unit_tests","currently_running_tests","ascii_esc","ascii_red","ascii_green","ascii_yellow","ascii_reset","air_master","tick_multiplier","assigned","created","merged","invalid_zone","air_blocked","zone_blocked","blocked","mark","contamination_overlay","vsc","using_map","all_maps","init")

--- a/code/game/base_turf.dm
+++ b/code/game/base_turf.dm
@@ -1,12 +1,10 @@
 // Returns the lowest turf available on a given Z-level
-var/global/list/base_turf_by_z = list(
-	"5" = /turf/simulated/floor/asteroid // Moonbase.
-	)
 
-proc/get_base_turf(var/z)
-	if(!base_turf_by_z["[z]"])
-		base_turf_by_z["[z]"] = /turf/space
-	return base_turf_by_z["[z]"]
+proc/get_base_turf(var/z_num)
+	var/z = num2text(z_num)
+	if(!using_map.base_turf_by_z[z])
+		using_map.base_turf_by_z[z] = world.turf
+	return using_map.base_turf_by_z[z]
 
 //An area can override the z-level base turf, so our solar array areas etc. can be space-based.
 proc/get_base_turf_by_area(var/turf/T)
@@ -29,6 +27,6 @@ proc/get_base_turf_by_area(var/turf/T)
 	var/new_base_path = input("Please select a turf path (cancel to reset to /turf/space).") as null|anything in typesof(/turf)
 	if(!new_base_path)
 		new_base_path = /turf/space
-	base_turf_by_z["[choice]"] = new_base_path
+	using_map.base_turf_by_z["[choice]"] = new_base_path
 	message_admins("[key_name_admin(usr)] has set the base turf for z-level [choice] to [get_base_turf(choice)].")
 	log_admin("[key_name(usr)] has set the base turf for z-level [choice] to [get_base_turf(choice)].")

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -10,7 +10,9 @@
 	admin_levels = list(3)
 	contact_levels = list(1,2,4,6)
 	player_levels = list(1,2,4,5,6,7)
+	sealed_levels = list(6)
 	accessible_z_levels = list("1" = 5, "2" = 5, "4" = 10, "5" = 15, "7" = 60)
+	base_turf_by_z = list("6" = /turf/simulated/floor/asteroid) // Moonbase
 
 	shuttle_docked_message = "The scheduled Crew Transfer Shuttle to %Dock_name% has docked with the station. It will depart in approximately %ETD%"
 	shuttle_leaving_dock = "The Crew Transfer Shuttle has left the station. Estimate %ETA% until the shuttle docks at %dock_name%."

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -31,6 +31,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/list/player_levels = list()  // Z-levels a character can typically reach
 	var/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
 	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
+	var/list/base_turf_by_z = list() // Custom base turf by Z-level. Defaults to world.turf for unlisted Z-levels
 
 	//This list contains the z-level numbers which can be accessed via space travel and the percentile chances to get there.
 	var/list/accessible_z_levels = list()


### PR DESCRIPTION
Also corrects the asteroid Z-level used by Exodus. Fixes #15152.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
