### PR TITLE
Allows comm consoles to handle arbitrary evacuation controller types

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -139,6 +139,7 @@
 #include "code\controllers\evacuation\evacuation.dm"
 #include "code\controllers\evacuation\evacuation_eta.dm"
 #include "code\controllers\evacuation\evacuation_helpers.dm"
+#include "code\controllers\evacuation\evacuation_option.dm"
 #include "code\controllers\evacuation\evacuation_pods.dm"
 #include "code\controllers\evacuation\evacuation_predicate.dm"
 #include "code\controllers\evacuation\evacuation_shuttle.dm"

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -29,6 +29,8 @@ var/datum/evacuation_controller/evacuation_controller
 
 	var/list/evacuation_predicates = list()
 
+	var/list/evacuation_options = list()
+
 	var/datum/announcement/priority/evac_waiting =  new(0)
 	var/datum/announcement/priority/evac_called =   new(0)
 	var/datum/announcement/priority/evac_recalled = new(0)
@@ -159,5 +161,11 @@ var/datum/evacuation_controller/evacuation_controller
 /datum/evacuation_controller/proc/available_evac_options()
 	return list()
 
-/datum/evacuation_controller/proc/handle_evac_option(var/option_target)
-	return
+/datum/evacuation_controller/proc/handle_evac_option(var/option_target, var/mob/user)
+	var/datum/evacuation_option/selected = evacuation_options[option_target]
+	if (!isnull(selected) && istype(selected))
+		selected.execute(user)
+
+/datum/evacuation_controller/proc/get_evac_option(var/option_target)
+	return null
+

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -20,6 +20,9 @@ var/datum/evacuation_controller/evacuation_controller
 	var/evac_launch_delay =  3 MINUTES
 	var/evac_transit_delay = 2 MINUTES
 
+	var/emergency_prep_additional_delay = 0 MINUTES
+	var/transfer_prep_additional_delay = 0 MINUTES
+
 	var/evac_cooldown_time
 	var/evac_called_at
 	var/evac_no_return
@@ -62,9 +65,11 @@ var/datum/evacuation_controller/evacuation_controller
 	if(ticker && ticker.mode)
 		evac_prep_delay_multiplier = ticker.mode.shuttle_delay
 
+	var/additional_delay = (emergency_evacuation ? emergency_prep_additional_delay : transfer_prep_additional_delay)
+
 	evac_called_at =    world.time
-	evac_no_return =    evac_called_at +    round(evac_prep_delay/2)
-	evac_ready_time =   evac_called_at +    (evac_prep_delay*evac_prep_delay_multiplier)
+	evac_no_return =    evac_called_at +    round(evac_prep_delay/2) + additional_delay
+	evac_ready_time =   evac_called_at +    (evac_prep_delay*evac_prep_delay_multiplier) + additional_delay
 	evac_launch_time =  evac_ready_time +   evac_launch_delay
 	evac_arrival_time = evac_launch_time +  evac_transit_delay
 

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -156,3 +156,8 @@ var/datum/evacuation_controller/evacuation_controller
 		if(world.time >= evac_cooldown_time)
 			state = EVAC_IDLE
 
+/datum/evacuation_controller/proc/available_evac_options()
+	return list()
+
+/datum/evacuation_controller/proc/handle_evac_option(var/option_target)
+	return

--- a/code/controllers/evacuation/evacuation_option.dm
+++ b/code/controllers/evacuation/evacuation_option.dm
@@ -1,5 +1,9 @@
 /datum/evacuation_option
 	var/option_text = "Generic evac option"
+	var/option_desc = "do something that should never be seen"
 	var/option_target = "generic"
 	var/needs_syscontrol = FALSE
 	var/silicon_allowed = TRUE
+
+/datum/evacuation_option/proc/execute(var/mob/user)
+	return

--- a/code/controllers/evacuation/evacuation_option.dm
+++ b/code/controllers/evacuation/evacuation_option.dm
@@ -1,0 +1,5 @@
+/datum/evacuation_option
+	var/option_text = "Generic evac option"
+	var/option_target = "generic"
+	var/needs_syscontrol = FALSE
+	var/silicon_allowed = TRUE

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -24,3 +24,33 @@
 	else
 		priority_announcement.Announce(replacetext(replacetext(using_map.shuttle_leaving_dock, "%dock_name%", "[dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
 
+/datum/evacuation_controller/pods/available_evac_options()
+	if (is_idle())
+		return list(new /datum/evacuation_option/abandon_ship())
+	else
+		return list(new /datum/evacuation_option/cancel_abandon_ship())
+
+#define EVAC_OPT_ABANDON_SHIP "abandon_ship"
+#define EVAC_OPT_CANCEL_ABANDON_SHIP "cancel_abandon_ship"
+
+/datum/evacuation_controller/pods/handle_evac_option(var/option_target)
+	switch (option_target)
+		if (EVAC_OPT_ABANDON_SHIP)
+			call_evacuation(usr, 1)
+		if (EVAC_OPT_CANCEL_ABANDON_SHIP)
+			cancel_evacuation()
+
+/datum/evacuation_option/abandon_ship
+	option_text = "Abandon ship"
+	option_target = EVAC_OPT_ABANDON_SHIP
+	needs_syscontrol = FALSE
+	silicon_allowed = TRUE
+
+/datum/evacuation_option/cancel_abandon_ship
+	option_text = "Cancel abandonment"
+	option_target = EVAC_OPT_CANCEL_ABANDON_SHIP
+	needs_syscontrol = FALSE
+	silicon_allowed = FALSE
+
+#undef EVAC_OPT_ABANDON_SHIP
+#undef EVAC_OPT_CANCEL_ABANDON_SHIP

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -6,6 +6,8 @@
 /datum/evacuation_controller/pods
 	name = "escape pod controller"
 
+	transfer_prep_additional_delay = 10 MINUTES
+
 	evacuation_options = list(
 		EVAC_OPT_ABANDON_SHIP = new /datum/evacuation_option/abandon_ship(),
 		EVAC_OPT_BLUESPACE_JUMP = new /datum/evacuation_option/bluespace_jump(),

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -39,12 +39,15 @@
 		priority_announcement.Announce(replacetext(replacetext(using_map.shuttle_leaving_dock, "%dock_name%", "[dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
 
 /datum/evacuation_controller/pods/available_evac_options()
+	if (is_on_cooldown())
+		return list()
 	if (is_idle())
-		return list(evacuation_options[EVAC_OPT_ABANDON_SHIP], evacuation_options[EVAC_OPT_BLUESPACE_JUMP])
-	else if (emergency_evacuation)
-		return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
-	else
-		return list(evacuation_options[EVAC_OPT_CANCEL_BLUESPACE_JUMP])
+		return list(evacuation_options[EVAC_OPT_BLUESPACE_JUMP], evacuation_options[EVAC_OPT_ABANDON_SHIP])
+	if (is_evacuating())
+		if (emergency_evacuation)
+			return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
+		else
+			return list(evacuation_options[EVAC_OPT_CANCEL_BLUESPACE_JUMP])
 
 /datum/evacuation_option/abandon_ship
 	option_text = "Abandon spacecraft"
@@ -98,9 +101,7 @@
 	silicon_allowed = FALSE
 
 /datum/evacuation_option/cancel_abandon_ship/execute(mob/user)
-	if (!ticker || !evacuation_controller)
-		return
-	if (evacuation_controller.cancel_evacuation())
+	if (ticker && evacuation_controller && evacuation_controller.cancel_evacuation())
 		log_and_message_admins("[key_name(user)] has cancelled abandonment of the spacecraft.")
 
 /datum/evacuation_option/cancel_bluespace_jump
@@ -111,9 +112,7 @@
 	silicon_allowed = FALSE
 
 /datum/evacuation_option/cancel_bluespace_jump/execute(mob/user)
-	if (!ticker || !evacuation_controller)
-		return
-	if (evacuation_controller.cancel_evacuation())
+	if (ticker && evacuation_controller && evacuation_controller.cancel_evacuation())
 		log_and_message_admins("[key_name(user)] has cancelled the bluespace jump.")
 
 #undef EVAC_OPT_ABANDON_SHIP

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -1,5 +1,17 @@
+#define EVAC_OPT_ABANDON_SHIP "abandon_ship"
+#define EVAC_OPT_BLUESPACE_JUMP "bluespace_jump"
+#define EVAC_OPT_CANCEL_ABANDON_SHIP "cancel_abandon_ship"
+#define EVAC_OPT_CANCEL_BLUESPACE_JUMP "cancel_bluespace_jump"
+
 /datum/evacuation_controller/pods
 	name = "escape pod controller"
+
+	evacuation_options = list(
+		EVAC_OPT_ABANDON_SHIP = new /datum/evacuation_option/abandon_ship(),
+		EVAC_OPT_BLUESPACE_JUMP = new /datum/evacuation_option/bluespace_jump(),
+		EVAC_OPT_CANCEL_ABANDON_SHIP = new /datum/evacuation_option/cancel_abandon_ship(),
+		EVAC_OPT_CANCEL_BLUESPACE_JUMP = new /datum/evacuation_option/cancel_bluespace_jump()
+	)
 
 /datum/evacuation_controller/pods/finish_preparing_evac()
 	. = ..()
@@ -26,31 +38,83 @@
 
 /datum/evacuation_controller/pods/available_evac_options()
 	if (is_idle())
-		return list(new /datum/evacuation_option/abandon_ship())
+		return list(evacuation_options[EVAC_OPT_ABANDON_SHIP], evacuation_options[EVAC_OPT_BLUESPACE_JUMP])
+	else if (emergency_evacuation)
+		return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
 	else
-		return list(new /datum/evacuation_option/cancel_abandon_ship())
-
-#define EVAC_OPT_ABANDON_SHIP "abandon_ship"
-#define EVAC_OPT_CANCEL_ABANDON_SHIP "cancel_abandon_ship"
-
-/datum/evacuation_controller/pods/handle_evac_option(var/option_target)
-	switch (option_target)
-		if (EVAC_OPT_ABANDON_SHIP)
-			call_evacuation(usr, 1)
-		if (EVAC_OPT_CANCEL_ABANDON_SHIP)
-			cancel_evacuation()
+		return list(evacuation_options[EVAC_OPT_CANCEL_BLUESPACE_JUMP])
 
 /datum/evacuation_option/abandon_ship
-	option_text = "Abandon ship"
+	option_text = "Abandon spacecraft"
+	option_desc = "abandon the spacecraft"
 	option_target = EVAC_OPT_ABANDON_SHIP
-	needs_syscontrol = FALSE
+	needs_syscontrol = TRUE
 	silicon_allowed = TRUE
+
+/datum/evacuation_option/abandon_ship/execute(mob/user)
+	if (!ticker || !evacuation_controller)
+		return
+	if (evacuation_controller.deny)
+		to_chat(user, "Unable to initiate escape procedures.")
+		return
+	if (evacuation_controller.is_on_cooldown())
+		to_chat(user, evacuation_controller.get_cooldown_message())
+		return
+	if (evacuation_controller.is_evacuating())
+		to_chat(user, "Escape procedures already in progress.")
+		return
+	if (evacuation_controller.call_evacuation(user, 1))
+		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated abandonment of the spacecraft.")
+
+/datum/evacuation_option/bluespace_jump
+	option_text = "Initiate bluespace jump"
+	option_desc = "initiate a bluespace jump"
+	option_target = EVAC_OPT_BLUESPACE_JUMP
+	needs_syscontrol = TRUE
+	silicon_allowed = TRUE
+
+/datum/evacuation_option/bluespace_jump/execute(mob/user)
+	if (!ticker || !evacuation_controller)
+		return
+	if (evacuation_controller.deny)
+		to_chat(user, "Unable to initiate jump preparation.")
+		return
+	if (evacuation_controller.is_on_cooldown())
+		to_chat(user, evacuation_controller.get_cooldown_message())
+		return
+	if (evacuation_controller.is_evacuating())
+		to_chat(user, "Jump preparation already in progress.")
+		return
+	if (evacuation_controller.call_evacuation(user, 0))
+		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated bluespace jump preparation.")
 
 /datum/evacuation_option/cancel_abandon_ship
 	option_text = "Cancel abandonment"
+	option_desc = "cancel abandonment of the spacecraft"
 	option_target = EVAC_OPT_CANCEL_ABANDON_SHIP
-	needs_syscontrol = FALSE
+	needs_syscontrol = TRUE
 	silicon_allowed = FALSE
 
+/datum/evacuation_option/cancel_abandon_ship/execute(mob/user)
+	if (!ticker || !evacuation_controller)
+		return
+	if (evacuation_controller.cancel_evacuation())
+		log_and_message_admins("[key_name(user)] has cancelled abandonment of the spacecraft.")
+
+/datum/evacuation_option/cancel_bluespace_jump
+	option_text = "Cancel bluespace jump"
+	option_desc = "cancel the jump preparation"
+	option_target = EVAC_OPT_CANCEL_BLUESPACE_JUMP
+	needs_syscontrol = TRUE
+	silicon_allowed = FALSE
+
+/datum/evacuation_option/cancel_bluespace_jump/execute(mob/user)
+	if (!ticker || !evacuation_controller)
+		return
+	if (evacuation_controller.cancel_evacuation())
+		log_and_message_admins("[key_name(user)] has cancelled the bluespace jump.")
+
 #undef EVAC_OPT_ABANDON_SHIP
+#undef EVAC_OPT_BLUESPACE_JUMP
 #undef EVAC_OPT_CANCEL_ABANDON_SHIP
+#undef EVAC_OPT_CANCEL_BLUESPACE_JUMP

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -1,3 +1,6 @@
+#define EVAC_OPT_CALL_SHUTTLE "call_shuttle"
+#define EVAC_OPT_RECALL_SHUTTLE "recall_shuttle"
+
 /datum/evacuation_controller/pods/shuttle
 	name = "escape shuttle controller"
 	evac_waiting =  new(0, new_sound = sound('sound/AI/shuttledock.ogg'))
@@ -8,6 +11,11 @@
 	var/autopilot = 1
 	var/datum/shuttle/ferry/emergency/shuttle // Set in shuttle_emergency.dm
 	var/shuttle_launch_time
+
+	evacuation_options = list(
+		EVAC_OPT_CALL_SHUTTLE = new /datum/evacuation_option/call_shuttle(),
+		EVAC_OPT_RECALL_SHUTTLE = new /datum/evacuation_option/recall_shuttle()
+	)
 
 /datum/evacuation_controller/pods/shuttle/has_evacuated()
 	return departed
@@ -91,31 +99,29 @@
 	if (!shuttle.location)
 		return list()
 	if (is_idle())
-		return list(new /datum/evacuation_option/call_shuttle())
+		return list(evacuation_options[EVAC_OPT_CALL_SHUTTLE])
 	else
-		return list(new /datum/evacuation_option/recall_shuttle())
-
-#define EVAC_OPT_CALL_SHUTTLE "call_shuttle"
-#define EVAC_OPT_RECALL_SHUTTLE "recall_shuttle"
-
-/datum/evacuation_controller/pods/shuttle/handle_evac_option(var/option_target)
-	switch (option_target)
-		if (EVAC_OPT_CALL_SHUTTLE)
-			call_shuttle_proc(usr)
-		if (EVAC_OPT_RECALL_SHUTTLE)
-			cancel_call_proc(usr)
+		return list(evacuation_options[EVAC_OPT_RECALL_SHUTTLE])
 
 /datum/evacuation_option/call_shuttle
 	option_text = "Call emergency shuttle"
+	option_desc = "call the emergency shuttle"
 	option_target = EVAC_OPT_CALL_SHUTTLE
 	needs_syscontrol = TRUE
 	silicon_allowed = TRUE
 
+/datum/evacuation_option/call_shuttle/execute(mob/user)
+	call_shuttle_proc(user)
+
 /datum/evacuation_option/recall_shuttle
 	option_text = "Cancel shuttle call"
+	option_desc = "recall the emergency shuttle"
 	option_target = EVAC_OPT_RECALL_SHUTTLE
 	needs_syscontrol = TRUE
 	silicon_allowed = FALSE
+
+/datum/evacuation_option/recall_shuttle/execute(mob/user)
+	cancel_call_proc(user)
 
 #undef EVAC_OPT_CALL_SHUTTLE
 #undef EVAC_OPT_RECALL_SHUTTLE

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -86,3 +86,36 @@
 		return round(evac_prep_delay/10)/2
 	else
 		return round(evac_transit_delay/10)
+
+/datum/evacuation_controller/pods/shuttle/available_evac_options()
+	if (!shuttle.location)
+		return list()
+	if (is_idle())
+		return list(new /datum/evacuation_option/call_shuttle())
+	else
+		return list(new /datum/evacuation_option/recall_shuttle())
+
+#define EVAC_OPT_CALL_SHUTTLE "call_shuttle"
+#define EVAC_OPT_RECALL_SHUTTLE "recall_shuttle"
+
+/datum/evacuation_controller/pods/shuttle/handle_evac_option(var/option_target)
+	switch (option_target)
+		if (EVAC_OPT_CALL_SHUTTLE)
+			call_shuttle_proc(usr)
+		if (EVAC_OPT_RECALL_SHUTTLE)
+			cancel_call_proc(usr)
+
+/datum/evacuation_option/call_shuttle
+	option_text = "Call emergency shuttle"
+	option_target = EVAC_OPT_CALL_SHUTTLE
+	needs_syscontrol = TRUE
+	silicon_allowed = TRUE
+
+/datum/evacuation_option/recall_shuttle
+	option_text = "Cancel shuttle call"
+	option_target = EVAC_OPT_RECALL_SHUTTLE
+	needs_syscontrol = TRUE
+	silicon_allowed = FALSE
+
+#undef EVAC_OPT_CALL_SHUTTLE
+#undef EVAC_OPT_RECALL_SHUTTLE

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -172,10 +172,17 @@
 						centcomm_message_cooldown = 0
 		if("evac")
 			. = 1
-			if(is_autenthicated(user) && ntn_cont)
-				var/confirm = alert("Are you sure?", name, "No", "Yes")
+			if(is_autenthicated(user))
+				var/datum/evacuation_option/selected_evac_option = evacuation_controller.evacuation_options[href_list["target"]]
+				if (isnull(selected_evac_option) || !istype(selected_evac_option))
+					return
+				if (!selected_evac_option.silicon_allowed && issilicon(user))
+					return
+				if (selected_evac_option.needs_syscontrol && !ntn_cont)
+					return
+				var/confirm = alert("Are you sure you want to [selected_evac_option.option_desc]?", name, "No", "Yes")
 				if (confirm == "Yes" && can_still_topic())
-					evacuation_controller.handle_evac_option(href_list["target"])
+					evacuation_controller.handle_evac_option(selected_evac_option.option_target, user)
 		if("setstatus")
 			. = 1
 			if(is_autenthicated(user) && ntn_cont)

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -40,11 +40,6 @@
 
 /datum/nano_module/program/comm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 
-	var/datum/evacuation_controller/pods/shuttle/evac_control = evacuation_controller
-	if(!istype(evac_control))
-		to_chat(user, "<span class='danger'>This console should not in use on this map. Please report this to a developer.</span>")
-		return
-
 	var/list/data = host.initial_data()
 
 	if(program)
@@ -81,14 +76,16 @@
 	if(current_viewing_message)
 		data["message_current"] = current_viewing_message
 
-	if(evac_control.shuttle.location)
-		data["have_shuttle"] = 1
-		if(evac_control.is_idle())
-			data["have_shuttle_called"] = 0
-		else
-			data["have_shuttle_called"] = 1
-	else
-		data["have_shuttle"] = 0
+	var/list/processed_evac_options = list()
+	if(!isnull(evacuation_controller))
+		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
+			var/list/option = list()
+			option["option_text"] = EO.option_text
+			option["option_target"] = EO.option_target
+			option["needs_syscontrol"] = EO.needs_syscontrol
+			option["silicon_allowed"] = EO.silicon_allowed
+			processed_evac_options[++processed_evac_options.len] = option
+	data["evac_options"] = processed_evac_options
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
@@ -173,18 +170,12 @@
 					centcomm_message_cooldown = 1
 					spawn(300) //30 second cooldown
 						centcomm_message_cooldown = 0
-		if("shuttle")
+		if("evac")
 			. = 1
 			if(is_autenthicated(user) && ntn_cont)
-				if(href_list["target"] == "call")
-					var/confirm = alert("Are you sure you want to call the shuttle?", name, "No", "Yes")
-					if(confirm == "Yes" && can_still_topic())
-						call_shuttle_proc(usr)
-
-				if(href_list["target"] == "cancel" && !issilicon(usr))
-					var/confirm = alert("Are you sure you want to cancel the shuttle?", name, "No", "Yes")
-					if(confirm == "Yes" && can_still_topic())
-						cancel_call_proc(usr)
+				var/confirm = alert("Are you sure?", name, "No", "Yes")
+				if (confirm == "Yes" && can_still_topic())
+					evacuation_controller.handle_evac_option(href_list["target"])
 		if("setstatus")
 			. = 1
 			if(is_autenthicated(user) && ntn_cont)

--- a/nano/templates/communication.tmpl
+++ b/nano/templates/communication.tmpl
@@ -1,19 +1,34 @@
 {{if data.authenticated}}
 	{{if data.state === 1}}
-		<div class=item>{{:helper.link('Make An Announcement', null, {'action' : 'announce'}, data.isAI || !data.net_comms ? 'disabled' : null)}} </div>
-		<div class=item>{{if data.emagged}}
-			{{:helper.link('Send an emergency message to [UNKNOWN]', null, {'action' : 'message', 'target' : 'emagged'}, data.isAI || !data.net_comms ? 'disabled' : null)}}
-		{{else}}
-			{{:helper.link('Send an emergency message to ' + data.boss_short, null, {'action' : 'message', 'target' : 'regular'}, data.isAI || !data.net_comms ? 'disabled' : null)}}
-		{{/if}} </div>
-		<div class=item>{{:helper.link('Change alert level', null, {'action' : 'sw_menu', 'target' : 5}, data.isAI || !data.net_syscont || !data.net_comms ? 'disabled' : null)}} </div>
-		<div class=item>{{if data.have_shuttle && data.have_shuttle_called}}
-			{{:helper.link('Cancel Shuttle Call', null, {'action' : 'shuttle', 'target' : 'cancel'}, data.isAI || !data.net_syscont ? 'disabled' : null)}}
-		{{else data.have_shuttle && !data.have_shuttle_called}}
-			{{:helper.link('Call Emergency Shuttle', null, {'action' : 'shuttle', 'target' : 'call'}, !data.net_syscont ? 'disabled' : null)}}
-		{{/if}} </div>
-		<div class=item>{{:helper.link('Set Status Display', null, {'action' : 'sw_menu', 'target' : 4}, !data.net_syscont ? 'disabled' : null)}} </div>
-		<div class=item>{{:helper.link('Message List', null, {'action' : 'sw_menu', 'target' : 2}, !data.net_comms ? 'disabled' : null)}} </div>
+	
+		<h4>Command</h4>
+		<div class=itemGroup>
+			<div class=item>{{:helper.link('Make an announcement', null, {'action' : 'announce'}, data.isAI || !data.net_comms ? 'disabled' : null)}} </div>
+			<div class=item>{{:helper.link('Change alert level', null, {'action' : 'sw_menu', 'target' : 5}, data.isAI || !data.net_syscont || !data.net_comms ? 'disabled' : null)}} </div>
+			<div class=item>{{:helper.link('Set status display', null, {'action' : 'sw_menu', 'target' : 4}, !data.net_syscont ? 'disabled' : null)}} </div>
+		</div>
+		
+		<h4>Communications</h4>
+		<div class=itemGroup>
+			<div class=item>{{:helper.link('Message list', null, {'action' : 'sw_menu', 'target' : 2}, !data.net_comms ? 'disabled' : null)}} </div>
+			<div class=item>{{if data.emagged}}
+				{{:helper.link('Send an emergency message to [UNKNOWN]', null, {'action' : 'message', 'target' : 'emagged'}, data.isAI || !data.net_comms ? 'disabled' : null)}}
+			{{else}}
+				{{:helper.link('Send an emergency message to ' + data.boss_short, null, {'action' : 'message', 'target' : 'regular'}, data.isAI || !data.net_comms ? 'disabled' : null)}}
+			{{/if}} </div>
+		</div>
+		
+		<h4>Evacuation</h4>
+		<div class=itemGroup>
+			{{for data.evac_options}}
+				<div class="item">
+					{{:helper.link(value.option_text, null, {'action' : 'evac', 'target' : value.option_target}, ((value.needs_syscontrol && !data.net_syscont) || (!value.silicon_allowed && data.isAI)) ? 'disabled' : null, 'redButton')}}
+				</div>
+			{{empty}}
+				<div class=bad>No evacuation options available.</div>
+			{{/for}}
+		</div>
+		
 	{{else data.state === 2}}
 		Messages:
 		{{for data.messages}}

--- a/nano/templates/communication.tmpl
+++ b/nano/templates/communication.tmpl
@@ -18,14 +18,14 @@
 			{{/if}} </div>
 		</div>
 		
-		<h4>Evacuation</h4>
+		<h4>Additional</h4>
 		<div class=itemGroup>
 			{{for data.evac_options}}
 				<div class="item">
 					{{:helper.link(value.option_text, null, {'action' : 'evac', 'target' : value.option_target}, ((value.needs_syscontrol && !data.net_syscont) || (!value.silicon_allowed && data.isAI)) ? 'disabled' : null, 'redButton')}}
 				</div>
 			{{empty}}
-				<div class=bad>No evacuation options available.</div>
+				<div class=bad>No further options available.</div>
 			{{/for}}
 		</div>
 		

--- a/nano/templates/communication.tmpl
+++ b/nano/templates/communication.tmpl
@@ -25,7 +25,7 @@
 					{{:helper.link(value.option_text, null, {'action' : 'evac', 'target' : value.option_target}, ((value.needs_syscontrol && !data.net_syscont) || (!value.silicon_allowed && data.isAI)) ? 'disabled' : null, 'redButton')}}
 				</div>
 			{{empty}}
-				<div class=bad>No further options available.</div>
+				<div class=bad>No further options currently available.</div>
 			{{/for}}
 		</div>
 		


### PR DESCRIPTION
This change removes the command and communication console's explicit understanding of evacuation. Instead, it calls `evacuation_controller.available_evac_options()` to obtain a list of available `evacuation_options` for the current situation, renders them naively into the UI, and allows the selected option to decide what happens next via `evacuation_option.execute()`.

This also gently updates the styling on the command and communication program, and adds an option for initiating a bluespace jump on Torch's pods-type controller. It also adds the possibility to add an additional delay to crew transfer or emergency evac for any given evac controller (to enable Torch jump prep to take longer than abandoning ship).

Fixes #15163, long story short.

_Hurt me good, peer review, daddy likes it_