### PR TITLE
Character saves are now per map.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2244,6 +2244,7 @@
 #include "maps\exodus\exodus_define.dm"
 #include "maps\overmap_example\overmap_example_define.dm"
 #include "maps\torch\torch_define.dm"
+#include "maps\~mapsystem\map_preferences.dm"
 #include "maps\~mapsystem\maps.dm"
 #include "maps\~mapsystem\maps_areas.dm"
 #include "maps\~mapsystem\maps_unit_testing.dm"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -406,7 +406,7 @@ datum/preferences
 		dat += "<b>Select a character slot to load</b><hr>"
 		var/name
 		for(var/i=1, i<= config.character_slots, i++)
-			S.cd = "/character[i]"
+			S.cd = using_map.character_load_path(S, i)
 			S["real_name"] >> name
 			if(!name)	name = "Character[i]"
 			if(i==default_slot)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -46,11 +46,11 @@
 		S["default_slot"] << default_slot
 
 	if(slot != SAVE_RESET)
-		S.cd = "/character[slot]"
+		S.cd = using_map.character_load_path(S, slot)
 		player_setup.load_character(S)
 	else
 		player_setup.load_character(S)
-		S.cd = "/character[default_slot]"
+		S.cd = using_map.character_load_path(S, default_slot)
 
 	loaded_character = S
 
@@ -60,7 +60,7 @@
 	if(!path)				return 0
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
-	S.cd = "/character[default_slot]"
+	S.cd = using_map.character_save_path(default_slot)
 
 	S["version"] << SAVEFILE_VERSION_MAX
 	player_setup.save_character(S)

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -6,6 +6,8 @@
 
 	lobby_icon = 'maps/exodus/exodus_lobby.dmi'
 
+	load_legacy_saves = TRUE
+
 	station_levels = list(1, 2)
 	admin_levels = list(3)
 	contact_levels = list(1,2,4,6)

--- a/maps/~mapsystem/map_preferences.dm
+++ b/maps/~mapsystem/map_preferences.dm
@@ -1,0 +1,19 @@
+/datum/map
+	var/load_legacy_saves = FALSE
+
+/datum/map/proc/character_save_path(var/slot)
+	return "/[path]/character[slot]"
+
+/datum/map/proc/character_load_path(var/savefile/S, var/slot)
+	var/original_cd = S.cd
+	S.cd = "/"
+	. = private_use_legacy_saves(S, slot) ? "/character[slot]" : "/[path]/character[slot]"
+	S.cd = original_cd // Attempting to make this call as side-effect free as possible
+
+/datum/map/proc/private_use_legacy_saves(var/savefile/S, var/slot)
+	if(!load_legacy_saves) // Check if we're bothering with legacy saves at all
+		return FALSE
+	if(!S.dir.Find(path)) // If we cannot find the map path folder, load the legacy save
+		return TRUE
+	S.cd = "/[path]" // Finally, if we cannot find the character slot in the map path folder, load the legacy save
+	return !S.dir.Find("character[slot]")


### PR DESCRIPTION
Also includes support for loading files from the legacy directory, utilized by the Exodus map.
These legacy saves should not be overwritten or otherwise affected at any point, so a simple revert should suffice to restore them should I've missed testing some case.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
