### PR TITLE
Puts in checks to let robots move between z-levels.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,7 +6,7 @@
 /mob/living/silicon/robot/Allow_Spacemove()
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
-			if(J && J.allow_thrust(0.01))
+			if(J.allow_thrust(0.01))
 				return 1
 	. = ..()
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -73,3 +73,15 @@
 			if(T.density)
 				return 1
 	return 0
+
+/mob/living/silicon/robot/can_ztravel()
+	if(incapacitated() || is_dead())
+		return 0
+
+	if(Allow_Spacemove()) //Checks for active jetpack
+		return 1
+
+		for(var/turf/simulated/T in trange(1,src)) //Robots get "magboots"
+			if(T.density)
+				return 1
+	return 0

--- a/html/changelogs/asanadas-robozmove.yml
+++ b/html/changelogs/asanadas-robozmove.yml
@@ -1,0 +1,6 @@
+author: Asanadas
+
+delete-after: True
+
+changes: 
+  - rscadd: "Silicon mobs (cyborgs, drones) can now move between z-levels."


### PR DESCRIPTION
"Works". Doesn't fix teleporting through floors when using Move-Upwards (feature).