### PR TITLE
Gives some dresses icon_states to satisfy Travis's new test

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -277,6 +277,9 @@
 //dress
 /obj/item/clothing/under/dress
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	icon_state = "dress_fire"
+	item_state = "bl_suit"
+	worn_state = "dress_fire"
 
 /obj/item/clothing/under/dress/dress_fire
 	name = "flame dress"
@@ -373,8 +376,11 @@
 	worn_state = "plaid_purple"
 
 //wedding stuff
-/obj/item/clothing/under/wedding/
+/obj/item/clothing/under/wedding
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
+	icon_state = "bride_orange"
+	item_state = "y_suit"
+	worn_state = "bride_orange"
 
 /obj/item/clothing/under/wedding/bride_orange
 	name = "orange wedding dress"


### PR DESCRIPTION
The icon_states aren't new - just borrowed from other dresses. This issue was previously hidden by Torch's `/obj/item/clothing/under/dress` being present for dress uniforms, accidentally providing a default icon_state for dresses while the test was added. Now the dress uniforms are under `mildress` instead and the test is whining that it's lost its icon_states. Hence dis.