### PR TITLE
Makes the loadout unit test more descriptive of the problem

### DIFF
--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -38,7 +38,8 @@ datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 			for(var/path_name in p.valid_paths)
 				var/path_type = p.valid_paths[path_name]
 				if(!type_has_valid_icon_state(path_type))
-					LOADOUT_BAD_STATE_HELPER(G)
+					var/atom/A = path_type
+					log_unit_test("[G] - [path_type] ('[path_name]'): Did not find a gear_tweak's icon_state '[initial(A.icon_state)]' in the icon '[initial(A.icon)]'.")
 					failed = TRUE
 
 	if(failed)

--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -25,14 +25,13 @@ datum/unit_test/loadout_test_shall_have_name_cost_path/start_test()
 datum/unit_test/loadout_test_shall_have_valid_icon_states
 	name = "LOADOUT: Entries shall have valid icon states"
 
-#define LOADOUT_BAD_STATE_HELPER(bad_gear) var/atom/A = bad_gear.path ; log_unit_test("[bad_gear] - [bad_gear.path]: Did not find the icon state '[initial(A.icon_state)]' in the icon '[initial(A.icon)]'.")
-
 datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 	var/failed = FALSE
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
 		if(!type_has_valid_icon_state(G.path))
-			LOADOUT_BAD_STATE_HELPER(G)
+			var/atom/A = G.path
+			log_unit_test("[G] - [G.path]: Did not find the icon state '[initial(A.icon_state)]' in the icon '[initial(A.icon)]'.")
 			failed = TRUE
 		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
 			for(var/path_name in p.valid_paths)
@@ -47,8 +46,6 @@ datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 	else
 		pass("All /datum/gear definitions had correct icon states.")
 	return  1
-
-#undef LOADOUT_BAD_STATE_HELPER
 
 /proc/type_has_valid_icon_state(var/atom/type)
 	var/atom/A = type


### PR DESCRIPTION
There's two ways it can fail, so there should be two ways for it to report.