### PR TITLE
Changes how broken bones hurt organs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -53,10 +53,10 @@
 
 			if (!lying && !buckled && world.time - l_move_time < 15)
 			//Moving around with fractured ribs won't do you any good
-				if (E.is_broken() && E.internal_organs && E.internal_organs.len && prob(15))
-					var/obj/item/organ/I = pick(E.internal_organs)
-					custom_pain("You feel broken bones moving in your [E.name]!", 50)
-					I.take_damage(rand(3,5))
+				if (prob(10) && !stat && can_feel_pain() && chem_effects[CE_PAINKILLER] < 50 && E.is_broken() && E.internal_organs.len)
+					custom_pain("Pain jolts through your broken [E.encased ? E.encased : E.name], staggering you!", 50)
+					drop_item(loc)
+					Stun(2)
 
 				//Moving makes open wounds get infected much faster
 				if (E.wounds.len)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -300,12 +300,12 @@
 			I.take_damage(brute / 2)
 			brute -= brute / 2
 
-	if(status & ORGAN_BROKEN && prob(40) && brute)
-		if(!can_feel_pain() && robotic < ORGAN_ROBOT)
+	if(status & ORGAN_BROKEN && brute)
+		jostle_bone(brute)
+		if(can_feel_pain() && prob(40))
 			owner.emote("scream")	//getting hit on broken hand hurts
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
-
 	var/can_cut = (prob(brute*2) || sharp) && (robotic < ORGAN_ROBOT)
 	var/spillover = 0
 	var/pure_brute = brute
@@ -1014,6 +1014,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='danger'>You hear a loud cracking sound coming from \the [owner].</span>",\
 			"<span class='danger'>Something feels like it shattered in your [name]!</span>",\
 			"<span class='danger'>You hear a sickening crack.</span>")
+		jostle_bone()
 		if(can_feel_pain())
 			owner.emote("scream")
 
@@ -1228,6 +1229,16 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='danger'>Your [name] melts away!</span>",	\
 			"<span class='danger'>You hear a sickening sizzle.</span>")
 	disfigured = 1
+
+/obj/item/organ/external/proc/jostle_bone(force)
+	if(!(status & ORGAN_BROKEN)) //intact bones stay still
+		return
+	if(brute_dam + force < min_broken_damage/5)	//no papercuts moving bones
+		return
+	if(internal_organs.len && prob(brute_dam + force))
+		owner.custom_pain("A piece of bone in your [encased ? encased : name] moves painfully!", 50)
+		var/obj/item/organ/I = pick(internal_organs)
+		I.take_damage(rand(3,5))
 
 /obj/item/organ/external/proc/get_wounds_desc()
 	if(robotic >= ORGAN_ROBOT)


### PR DESCRIPTION
Now instead of continous damage they try to damage first when broken, then every time brute damage is applied again.
Walking around with them might make you stagger and drop whatever you have in hand still.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
