### PR TITLE
Fixes #15199

### DIFF
--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -19,6 +19,7 @@
 /decl/emote/audible/gasp
 	key ="gasp"
 	emote_message_3p = "USER gasps."
+	conscious = 0
 
 /decl/emote/audible/scretch
 	key ="scretch"
@@ -27,10 +28,7 @@
 /decl/emote/audible/choke
 	key ="choke"
 	emote_message_3p = "USER chokes."
-
-/decl/emote/audible/moan
-	key ="moan"
-	emote_message_3p = "USER moans!"
+	conscious = 0
 
 /decl/emote/audible/gnarl
 	key ="gnarl"
@@ -77,6 +75,7 @@
 /decl/emote/audible/snore
 	key = "snore"
 	emote_message_3p = "USER snores."
+	conscious = 0
 
 /decl/emote/audible/whimper
 	key = "whimper"
@@ -97,6 +96,7 @@
 /decl/emote/audible/cough
 	key = "cough"
 	emote_message_3p = "USER coughs!"
+	conscious = 0
 
 /decl/emote/audible/cry
 	key = "cry"
@@ -121,10 +121,12 @@
 /decl/emote/audible/groan
 	key = "groan"
 	emote_message_3p = "USER groans!"
+	conscious = 0
 
 /decl/emote/audible/moan
 	key = "moan"
 	emote_message_3p = "USER moans!"
+	conscious = 0
 
 /decl/emote/audible/giggle
 	key = "giggle"

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -11,6 +11,7 @@
 /decl/emote/visible/drool
 	key ="drool"
 	emote_message_3p = "USER drools."
+	conscious = 0
 
 /decl/emote/visible/nod
 	key ="nod"
@@ -23,10 +24,6 @@
 /decl/emote/visible/sulk
 	key ="sulk"
 	emote_message_3p = "USER sulks down sadly."
-
-/decl/emote/visible/twitch
-	key ="twitch"
-	emote_message_3p = "USER twitches violently."
 
 /decl/emote/visible/dance
 	key ="dance"
@@ -53,6 +50,7 @@
 /decl/emote/visible/shiver
 	key ="shiver"
 	emote_message_3p = "USER shivers."
+	conscious = 0
 
 /decl/emote/visible/collapse
 	key ="collapse"
@@ -99,10 +97,6 @@
 	check_restraints = TRUE
 	emote_message_3p = "USER flaps USER_THEIR wings ANGRILY!"
 
-/decl/emote/visible/drool
-	key = "drool"
-	emote_message_3p = "USER drools."
-
 /decl/emote/visible/eyebrow
 	key = "eyebrow"
 	emote_message_3p = "USER raises an eyebrow."
@@ -110,10 +104,12 @@
 /decl/emote/visible/twitch
 	key = "twitch"
 	emote_message_3p = "USER twitches."
+	conscious = 0
 
 /decl/emote/visible/twitch_v
 	key = "twitch_v"
 	emote_message_3p = "USER twitches violently."
+	conscious = 0
 
 /decl/emote/visible/faint
 	key = "faint"

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -17,6 +17,7 @@
 	var/message_type = VISIBLE_MESSAGE // Audible/visual flag
 	var/targetted_emote                // Whether or not this emote needs a target.
 	var/check_restraints               // Can this emote be used while restrained?
+	var/conscious = 1				   // Do we need to be awake to emote this?
 
 /decl/emote/proc/get_emote_message_1p(var/atom/user, var/atom/target, var/extra_params)
 	if(target)

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -5,36 +5,35 @@
 	return (..() && !(silent && emote_type == AUDIBLE_MESSAGE))
 
 /mob/proc/emote(var/act, var/m_type, var/message)
-
-	if (client && (client.prefs.muted & MUTE_IC))
-		to_chat(src, "<span class='warning'>You cannot send IC messages (muted).</span>")
-		return
-
-	if(!can_emote(m_type))
-		to_chat(src, "<span class='warning'>You cannot currently [m_type == AUDIBLE_MESSAGE ? "audibly" : "visually"] emote!</span>")
-		return
-
-	if(act == "help")
-		to_chat(src,"<b>Usable emotes:</b> [english_list(usable_emotes)]")
-		return
-
 	// s-s-snowflake
 	if(src.stat == DEAD && act != "deathgasp")
 		return
-
-	if(act == "me")
-		return custom_emote(m_type, message)
-
-	if(act == "custom")
-		if(!message)
-			message = sanitize(input("Enter an emote to display.") as text|null)
-		if(!message)
+	if(usr == src) //client-called emote
+		if (client && (client.prefs.muted & MUTE_IC))
+			to_chat(src, "<span class='warning'>You cannot send IC messages (muted).</span>")
 			return
-		if(alert(src, "Is this an audible emote?", "Emote", "Yes", "No") == "No")
-			m_type = VISIBLE_MESSAGE
-		else
-			m_type = AUDIBLE_MESSAGE
-		return custom_emote(m_type, message)
+
+		if(act == "help")
+			to_chat(src,"<b>Usable emotes:</b> [english_list(usable_emotes)]")
+			return
+
+		if(!can_emote(m_type))
+			to_chat(src, "<span class='warning'>You cannot currently [m_type == AUDIBLE_MESSAGE ? "audibly" : "visually"] emote!</span>")
+			return
+
+		if(act == "me")
+			return custom_emote(m_type, message)
+
+		if(act == "custom")
+			if(!message)
+				message = sanitize(input("Enter an emote to display.") as text|null)
+			if(!message)
+				return
+			if(alert(src, "Is this an audible emote?", "Emote", "Yes", "No") == "No")
+				m_type = VISIBLE_MESSAGE
+			else
+				m_type = AUDIBLE_MESSAGE
+			return custom_emote(m_type, message)
 
 	var/splitpoint = findtext(act, " ")
 	if(splitpoint > 0)
@@ -47,7 +46,7 @@
 		to_chat(src, "<span class='warning'>Unknown emote '[act]'. Type <b>say *help</b> for a list of usable emotes.</span>")
 		return
 
-	if(m_type != use_emote.message_type && !can_emote(use_emote.message_type))
+	if(m_type != use_emote.message_type && use_emote.conscious && stat != CONSCIOUS)
 		to_chat(src, "<span class='warning'>You cannot currently [use_emote.message_type == AUDIBLE_MESSAGE ? "audibly" : "visually"] emote!</span>")
 		return
 


### PR DESCRIPTION
Some emotes now do not require you to be awake to show.
It mostly means emotes initiated by code, user-initiated still stop when they are KOd.
Death stops all emote (except deathgasp for suicide switch trigger code)
Also axed some duplicate emote defintion while in area.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
