### PR TITLE
Adds hints for ranks/branches for jobs

### DIFF
--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -29,6 +29,14 @@ var/datum/mil_branches/mil_branches = new()
 		return branches[branch_name]
 
 /**
+ *  Retrieve branch object by branch type
+ */
+/datum/mil_branches/proc/get_branch_by_type(var/branch_type)
+	for(var/name in branches)
+		if (istype(branches[name], branch_type))
+			return branches[name]
+
+/**
  *  Retrieve a rank object from given branch by name
  */
 /datum/mil_branches/proc/get_rank(var/branch_name, var/rank_name)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -168,3 +168,23 @@
 		return 1
 	else
 		return 0
+
+//Returns human-readable list of branches this job allows.
+/datum/job/proc/get_branches()
+	var/list/res = list()
+	for(var/T in allowed_branches)
+		var/datum/mil_branch/B = mil_branches.get_branch_by_type(T)
+		res += B.name
+	return english_list(res)
+
+//Same as above but ranks
+/datum/job/proc/get_ranks(branch)
+	var/list/res = list()
+	var/datum/mil_branch/B = mil_branches.get_branch(branch)
+	for(var/T in allowed_ranks)
+		var/datum/mil_rank/R = new T
+		if(B && !(R.name in B.ranks))
+			continue
+		res += R.name
+		qdel(R)
+	return english_list(res)

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -119,19 +119,19 @@
 			continue
 		if(job.allowed_branches)
 			if(!player_branch)
-				. += "<del>[rank]</del></td><td><b> \[BRANCH RESTRICTED]</b></td></tr>"
+				. += "<del>[rank]</del></td><td><a href='?src=\ref[src];show_branches=[rank]'><b> \[BRANCH RESTRICTED]</b></a></td></tr>"
 				continue
 			if(!is_type_in_list(player_branch, job.allowed_branches))
-				. += "<del>[rank]</del></td><td><b> \[NOT FOR [player_branch.name_short]]</b></td></tr>"
+				. += "<del>[rank]</del></td><td><a href='?src=\ref[src];show_branches=[rank]'><b> \[NOT FOR [player_branch.name_short]]</b></a></td></tr>"
 				continue
 
 		if(job.allowed_ranks)
 			if(!player_rank)
-				. += "<del>[rank]</del></td><td><b> \[RANK RESTRICTED]</b></td></tr>"
+				. += "<del>[rank]</del></td><td><a href='?src=\ref[src];show_ranks=[rank]'><b> \[RANK RESTRICTED]</b></a></td></tr>"
 				continue
 
 			if(!is_type_in_list(player_rank, job.allowed_ranks))
-				. += "<del>[rank]</del></td><td><b> \[NOT FOR [player_rank.name_short || player_rank.name]]</b></td></tr>"
+				. += "<del>[rank]</del></td><td><a href='?src=\ref[src];show_ranks=[rank]'><b> \[NOT FOR [player_rank.name_short || player_rank.name]]</b></a></td></tr>"
 				continue
 
 		if(("Assistant" in pref.job_low) && (rank != "Assistant"))
@@ -225,6 +225,14 @@
 			pref.char_rank = choice
 			prune_job_prefs_for_rank()
 			return TOPIC_REFRESH
+	else if(href_list["show_branches"])
+		var/rank = href_list["show_branches"]
+		var/datum/job/job = job_master.GetJob(rank)
+		to_chat(user, "<span clas='notice'>Valid branches for [rank]: [job.get_branches()]</span>")
+	else if(href_list["show_ranks"])
+		var/rank = href_list["show_ranks"]
+		var/datum/job/job = job_master.GetJob(rank)
+		to_chat(user, "<span clas='notice'>Valid ranks for [rank] ([pref.char_branch]): [job.get_ranks(pref.char_branch)]</span>")
 
 	return ..()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -282,8 +282,6 @@
 	if(!job.is_position_available()) return 0
 	if(jobban_isbanned(src,rank))	return 0
 	if(!job.player_old_enough(src.client))	return 0
-	if(!job.is_branch_allowed(client.prefs.char_branch)) return 0
-	if(!job.is_rank_allowed(client.prefs.char_branch, client.prefs.char_rank)) return 0
 
 	return 1
 
@@ -297,7 +295,14 @@
 		to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 		return 0
 	if(!IsJobAvailable(rank))
-		to_chat(src, alert("[rank] is not available. Please try another."))
+		alert("[rank] is not available. Please try another.")
+		return 0
+	var/datum/job/job = job_master.GetJob(rank)
+	if(!job.is_branch_allowed(client.prefs.char_branch))
+		alert("Wrong branch of service for [rank]. Valid branches are: [job.get_branches()].")
+		return 0
+	if(!job.is_rank_allowed(client.prefs.char_branch, client.prefs.char_rank))
+		alert("Wrong rank for [rank]. Valid ranks in [client.prefs.char_branch] are: [job.get_ranks(client.prefs.char_branch)].")
 		return 0
 
 

--- a/html/changelogs/chinsky-fukdapolice.yml
+++ b/html/changelogs/chinsky-fukdapolice.yml
@@ -1,0 +1,8 @@
+author: Chinsky
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added some hints for filthy civilian scum. Gosh, some people"
+  - rscadd: "You can click on [WRONG BRANCH KIDDO] type messages to get info on what branch/rank is right for this job."
+  - rscadd: "All open jobslots can be seen again in latejoin, but if you try to pick one with wrong branchrank, you get message about it with hints."


### PR DESCRIPTION
Because it's utterly unusable without keeping a list of which one of 9000 ranks can do the job, and you cannot see general overview of open jobslots.

Shown when clicking on [NO GO] tabs in occupation setup and when trying to latejoin with wrong rank/branhc combo.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
