### PR TITLE
Adds cargo drone datum to Torch

### DIFF
--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -345,3 +345,12 @@
 	dock_target_station = "specops_centcom_dock"
 	dock_target_offsite = "specops_dock_airlock"
 
+//Cargo drone
+
+/datum/shuttle/ferry/supply/drone
+	name = "Supply Drone"
+	location = 1
+	warmup_time = 10
+	area_offsite = /area/supply/dock
+	area_station = /area/supply/station
+	docking_controller_tag = "" // lands, doesn't dock


### PR DESCRIPTION
Allows the cargo drone to initialise properly. Cargo should run more smoothly now. Fixes #15230.