### PR TITLE
Add compressed matter implant safety.

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -8,23 +8,47 @@
 	w_class = ITEM_SIZE_SMALL
 	var/obj/item/weapon/implant/imp = null
 
-/obj/item/weapon/implanter/attack_self(var/mob/user)
-	if(!imp)
-		return ..()
-	imp.loc = get_turf(src)
-	user.put_in_hands(imp)
-	to_chat(user, "<span class='notice'>You remove \the [imp] from \the [src].</span>")
-	name = "implanter"
-	imp = null
-	update()
-	return
-
 /obj/item/weapon/implanter/proc/update()
 	if (src.imp)
 		src.icon_state = "implanter1"
 	else
 		src.icon_state = "implanter0"
 	return
+
+/obj/item/weapon/implanter/verb/remove_implant()
+	set category = "Object"
+	set name = "Remove implant"
+	set src in usr
+
+	if(issilicon(usr))
+		return
+
+	if(can_use(usr))
+		if(!imp)
+			to_chat(usr, "<span class='notice'>There is no implant to remove.</span>")
+			return
+		imp.forceMove(get_turf(src))
+		usr.put_in_hands(imp)
+		to_chat(usr, "<span class='notice'>You remove \the [imp] from \the [src].</span>")
+		name = "implanter"
+		imp = null
+		update()
+		return
+	else
+		to_chat(usr, "<span class='notice'>You cannot do this in your current condition.</span>")
+
+/obj/item/weapon/implanter/proc/can_use()
+
+	if(!ismob(loc))
+		return 0
+
+	var/mob/M = loc
+
+	if(M.incapacitated())
+		return 0
+	if((src in M.contents) || (istype(loc, /turf) && in_range(src, M)))
+		return 1
+	return 0
 
 /obj/item/weapon/implanter/attack(mob/M as mob, mob/user as mob)
 	if (!istype(M, /mob/living/carbon))
@@ -89,6 +113,8 @@
 /obj/item/weapon/implanter/compressed
 	name = "implanter (C)"
 	icon_state = "cimplanter1"
+	desc = "The matter compressor safety is on."
+	var/safe = 1
 
 /obj/item/weapon/implanter/compressed/New()
 	imp = new /obj/item/weapon/implant/compressed( src )
@@ -111,7 +137,7 @@
 	var/obj/item/weapon/implant/compressed/c = imp
 	if (!c)	return
 	if (c.scanned == null)
-		to_chat(user, "Please scan an object with the implanter first.")
+		to_chat(user, "Please compress an object with the implanter first.")
 		return
 	..()
 
@@ -121,7 +147,12 @@
 	if(istype(A,/obj/item) && imp)
 		var/obj/item/weapon/implant/compressed/c = imp
 		if (c.scanned)
-			to_chat(user, "<span class='warning'>Something is already scanned inside the implant!</span>")
+			if (!istype(A,/obj/item/weapon/storage))
+				to_chat(user, "<span class='warning'>Something is already compressed inside the implant!</span>")
+			return
+		else if(safe)
+			if (!istype(A,/obj/item/weapon/storage))
+				to_chat(user, "<span class='warning'>The matter compressor safeties prevent you from doing that.</span>")
 			return
 		c.scanned = A
 		if(istype(A.loc,/mob/living/carbon/human))
@@ -131,4 +162,14 @@
 			var/obj/item/weapon/storage/S = A.loc
 			S.remove_from_storage(A)
 		A.loc.contents.Remove(A)
+		safe = 2
+		desc = "It currently contains some matter."
 		update()
+
+/obj/item/weapon/implanter/compressed/attack_self(var/mob/user)
+	if(!imp || safe == 2)
+		return ..()
+
+	safe = !safe
+	to_chat(user, "<span class='notice'>You [safe ? "enable" : "disable"] the matter compressor safety.</span>")
+	src.desc = "The matter compressor safety is [safe ? "on" : "off"]."

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -131,6 +131,14 @@
 				to_chat(user, "<span class='notice'>\The [src] has no more space specifically for \the [W].</span>")
 			return 0
 
+	// Don't allow insertion of unsafed compressed matter implants
+	// Since they are sucking something up now, their afterattack will delete the storage
+	if(istype(W, /obj/item/weapon/implanter/compressed))
+		var/obj/item/weapon/implanter/compressed/impr = W
+		if(!impr.safe)
+			stop_messages = 1
+			return 0
+
 	if(cant_hold.len && is_type_in_list(W, cant_hold))
 		if(!stop_messages)
 			to_chat(user, "<span class='notice'>\The [src] cannot hold \the [W].</span>")

--- a/html/changelogs/xales-safe-implantc.yml
+++ b/html/changelogs/xales-safe-implantc.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.
+author: Ravenxales
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Add toggleable safety for compressed matter implant, to prevent inadvertant usage and facilitate storage."
+  - bugfix: "Fix compressed matter implants that are placed in storage from destroying the storage with itself inside."


### PR DESCRIPTION
Fix compressed matter implants from destroying themselves and storage when used on storage, by adding a safety, toggled by attack_self.

Also, make removing the implant from the implantor a verb - this is almost never what you want, since right now, it cannot go back in.