### PR TITLE
Makes stack recipes to spawn carriable objects in hand, not ground

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -144,6 +144,18 @@
 			for (var/obj/item/I in O)
 				qdel(I)
 
+		if (recipe.goes_in_hands)
+			user.put_in_hands(O)
+			if (istype(O, /obj/item/stack))
+				var/obj/item/stack/S = O
+				S.amount = produced
+				S.add_to_stacks(user)
+
+			if (istype(O, /obj/item/weapon/storage)) //BubbleWrap - so newly formed boxes are empty
+				for (var/obj/item/I in O)
+					qdel(I)
+
+
 /obj/item/stack/Topic(href, href_list)
 	..()
 	if ((usr.restrained() || usr.stat || usr.get_active_hand() != src))
@@ -343,8 +355,9 @@
 	var/one_per_turf = 0
 	var/on_floor = 0
 	var/use_material
+	var/goes_in_hands = 0
 
-	New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, supplied_material = null)
+	New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, supplied_material = null, goes_in_hands = 0)
 		src.title = title
 		src.result_type = result_type
 		src.req_amount = req_amount
@@ -354,6 +367,7 @@
 		src.one_per_turf = one_per_turf
 		src.on_floor = on_floor
 		src.use_material = supplied_material
+		src.goes_in_hands = goes_in_hands
 
 /*
  * Recipe list datum

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -7,9 +7,9 @@
 	recipes = list()
 
 	// If is_brittle() returns true, these are only good for a single strike.
-	recipes += new/datum/stack_recipe("[display_name] baseball bat", /obj/item/weapon/material/twohanded/baseballbat, 10, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
-	recipes += new/datum/stack_recipe("[display_name] ashtray", /obj/item/weapon/material/ashtray, 2, one_per_turf = 1, on_floor = 1, supplied_material = "[name]")
-	recipes += new/datum/stack_recipe("[display_name] spoon", /obj/item/weapon/material/kitchen/utensil/spoon/plastic, 1, on_floor = 1, supplied_material = "[name]")
+	recipes += new/datum/stack_recipe("[display_name] baseball bat", /obj/item/weapon/material/twohanded/baseballbat, 10, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("[display_name] ashtray", /obj/item/weapon/material/ashtray, 2, one_per_turf = 1, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("[display_name] spoon", /obj/item/weapon/material/kitchen/utensil/spoon/plastic, 1, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
 
 	if(integrity>50)
 		recipes += new/datum/stack_recipe("[display_name] door", /obj/machinery/door/unpowered/simple, 10, time = 50, one_per_turf = 1, on_floor = 1, supplied_material = "[name]")
@@ -20,9 +20,9 @@
 		recipes += new/datum/stack_recipe("[display_name] lock",/obj/item/weapon/material/lock_construct, 1, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
 
 	if(hardness>50)
-		recipes += new/datum/stack_recipe("[display_name] fork", /obj/item/weapon/material/kitchen/utensil/fork/plastic, 1, on_floor = 1, supplied_material = "[name]")
-		recipes += new/datum/stack_recipe("[display_name] knife", /obj/item/weapon/material/kitchen/utensil/knife/plastic, 1, on_floor = 1, supplied_material = "[name]")
-		recipes += new/datum/stack_recipe("[display_name] blade", /obj/item/weapon/material/butterflyblade, 6, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
+		recipes += new/datum/stack_recipe("[display_name] fork", /obj/item/weapon/material/kitchen/utensil/fork/plastic, 1, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
+		recipes += new/datum/stack_recipe("[display_name] knife", /obj/item/weapon/material/kitchen/utensil/knife/plastic, 1, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
+		recipes += new/datum/stack_recipe("[display_name] blade", /obj/item/weapon/material/butterflyblade, 6, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
 
 /material/steel/generate_recipes()
 	..()
@@ -41,14 +41,14 @@
 		new/datum/stack_recipe("purple comfy chair", /obj/structure/bed/chair/comfy/purp, 2, one_per_turf = 1, on_floor = 1), \
 		new/datum/stack_recipe("green comfy chair", /obj/structure/bed/chair/comfy/green, 2, one_per_turf = 1, on_floor = 1), \
 		))
-	recipes += new/datum/stack_recipe("key", /obj/item/weapon/key, 1, time = 10, one_per_turf = 0, on_floor = 1)
+	recipes += new/datum/stack_recipe("key", /obj/item/weapon/key, 1, time = 10, one_per_turf = 0, on_floor = 1, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("table frame", /obj/structure/table, 1, time = 10, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("rack", /obj/structure/table/rack, 1, time = 5, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("cannon frame", /obj/item/weapon/cannonframe, 10, time = 15, one_per_turf = 0, on_floor = 0)
-	recipes += new/datum/stack_recipe("regular floor tile", /obj/item/stack/tile/floor, 1, 4, 20)
-	recipes += new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60)
+	recipes += new/datum/stack_recipe("regular floor tile", /obj/item/stack/tile/floor, 1, 4, 20, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("computer frame", /obj/structure/computerframe, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("machine frame", /obj/machinery/constructable_frame/machine_frame, 5, time = 25, one_per_turf = 1, on_floor = 1)
@@ -72,12 +72,12 @@
 		new/datum/stack_recipe("multi-tile airlock assembly", /obj/structure/door_assembly/multi_tile, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 		))
 
-	recipes += new/datum/stack_recipe("grenade casing", /obj/item/weapon/grenade/chem_grenade)
-	recipes += new/datum/stack_recipe("light fixture frame", /obj/item/frame/light, 2)
-	recipes += new/datum/stack_recipe("small light fixture frame", /obj/item/frame/light/small, 1)
-	recipes += new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2)
-	recipes += new/datum/stack_recipe("air alarm frame", /obj/item/frame/air_alarm, 2)
-	recipes += new/datum/stack_recipe("fire alarm frame", /obj/item/frame/fire_alarm, 2)
+	recipes += new/datum/stack_recipe("grenade casing", /obj/item/weapon/grenade/chem_grenade, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("light fixture frame", /obj/item/frame/light, 2, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("small light fixture frame", /obj/item/frame/light/small, 1, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("apc frame", /obj/item/frame/apc, 2, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("air alarm frame", /obj/item/frame/air_alarm, 2, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("fire alarm frame", /obj/item/frame/fire_alarm, 2, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("modular console frame", /obj/machinery/modular_computer/console/buildable, 20)
 	recipes += new/datum/stack_recipe("modular laptop frame", /obj/machinery/modular_computer/laptop/buildable, 10)
 	recipes += new/datum/stack_recipe("modular tablet frame", /obj/item/modular_computer/tablet, 5)
@@ -86,7 +86,7 @@
 	..()
 	recipes += new/datum/stack_recipe("AI core", /obj/structure/AIcore, 4, time = 50, one_per_turf = 1)
 	recipes += new/datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1)
-	recipes += new/datum/stack_recipe("knife grip", /obj/item/weapon/material/butterflyhandle, 4, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
+	recipes += new/datum/stack_recipe("knife grip", /obj/item/weapon/material/butterflyhandle, 4, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]", goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("dark floor tile", /obj/item/stack/tile/floor_dark, 1, 4, 20)
 
 /material/stone/generate_recipes()
@@ -97,7 +97,7 @@
 	..()
 	recipes += new/datum/stack_recipe("plastic crate", /obj/structure/closet/crate/plastic, 10, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("plastic bag", /obj/item/weapon/storage/bag/plasticbag, 3, on_floor = 1)
-	recipes += new/datum/stack_recipe("blood pack", /obj/item/weapon/reagent_containers/blood/empty, 4, on_floor = 0)
+	recipes += new/datum/stack_recipe("blood pack", /obj/item/weapon/reagent_containers/blood/empty, 4, on_floor = 0, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("reagent dispenser cartridge (large)", /obj/item/weapon/reagent_containers/chem_disp_cartridge,        5, on_floor=0) // 500u
 	recipes += new/datum/stack_recipe("reagent dispenser cartridge (med)",   /obj/item/weapon/reagent_containers/chem_disp_cartridge/medium, 3, on_floor=0) // 250u
 	recipes += new/datum/stack_recipe("reagent dispenser cartridge (small)", /obj/item/weapon/reagent_containers/chem_disp_cartridge/small,  1, on_floor=0) // 100u
@@ -106,32 +106,33 @@
 
 /material/wood/generate_recipes()
 	..()
-	recipes += new/datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1)
+	recipes += new/datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20)
 	recipes += new/datum/stack_recipe("wooden chair", /obj/structure/bed/chair/wood, 3, time = 10, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("fancy wooden chair", /obj/structure/bed/chair/wood/wings, 3, time = 10, one_per_turf = 1, on_floor = 1)
-	recipes += new/datum/stack_recipe("crossbow frame", /obj/item/weapon/crossbowframe, 5, time = 25, one_per_turf = 0, on_floor = 0)
+	recipes += new/datum/stack_recipe("crossbow frame", /obj/item/weapon/crossbowframe, 5, time = 25, one_per_turf = 0, on_floor = 0, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("coffin", /obj/structure/closet/coffin, 5, time = 15, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("beehive assembly", /obj/item/beehive_assembly, 4)
 	recipes += new/datum/stack_recipe("beehive frame", /obj/item/honey_frame, 1)
 	recipes += new/datum/stack_recipe("book shelf", /obj/structure/bookcase, 5, time = 15, one_per_turf = 1, on_floor = 1)
+	recipes += new/datum/stack_recipe("zip gun frame", /obj/item/weapon/zipgunframe, 5, goes_in_hands = 1)
 
 /material/cardboard/generate_recipes()
 	..()
-	recipes += new/datum/stack_recipe("box", /obj/item/weapon/storage/box)
+	recipes += new/datum/stack_recipe("box", /obj/item/weapon/storage/box, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("large box", /obj/item/weapon/storage/box/large, 2)
-	recipes += new/datum/stack_recipe("donut box", /obj/item/weapon/storage/box/donut/empty)
-	recipes += new/datum/stack_recipe("egg box", /obj/item/weapon/storage/fancy/egg_box)
-	recipes += new/datum/stack_recipe("light tubes box", /obj/item/weapon/storage/box/lights/tubes)
-	recipes += new/datum/stack_recipe("light bulbs box", /obj/item/weapon/storage/box/lights/bulbs)
-	recipes += new/datum/stack_recipe("mouse traps box", /obj/item/weapon/storage/box/mousetraps)
+	recipes += new/datum/stack_recipe("donut box", /obj/item/weapon/storage/box/donut/empty, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("egg box", /obj/item/weapon/storage/fancy/egg_box, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("light tubes box", /obj/item/weapon/storage/box/lights/tubes, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("light bulbs box", /obj/item/weapon/storage/box/lights/bulbs, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("mouse traps box", /obj/item/weapon/storage/box/mousetraps, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3)
-	recipes += new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg)
-	recipes += new/datum/stack_recipe("pizza box", /obj/item/pizzabox)
+	recipes += new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg, goes_in_hands = 1)
+	recipes += new/datum/stack_recipe("pizza box", /obj/item/pizzabox, goes_in_hands = 1)
 	recipes += new/datum/stack_recipe_list("folders",list( \
-		new/datum/stack_recipe("blue folder", /obj/item/weapon/folder/blue), \
-		new/datum/stack_recipe("grey folder", /obj/item/weapon/folder), \
-		new/datum/stack_recipe("red folder", /obj/item/weapon/folder/red), \
-		new/datum/stack_recipe("white folder", /obj/item/weapon/folder/white), \
-		new/datum/stack_recipe("yellow folder", /obj/item/weapon/folder/yellow), \
+		new/datum/stack_recipe("blue folder", /obj/item/weapon/folder/blue, goes_in_hands = 1), \
+		new/datum/stack_recipe("grey folder", /obj/item/weapon/folder, goes_in_hands = 1), \
+		new/datum/stack_recipe("red folder", /obj/item/weapon/folder/red, goes_in_hands = 1), \
+		new/datum/stack_recipe("white folder", /obj/item/weapon/folder/white, goes_in_hands = 1), \
+		new/datum/stack_recipe("yellow folder", /obj/item/weapon/folder/yellow, goes_in_hands = 1), \
 		))

--- a/html/changelogs/RunaDacino-Stackrecipechange.yml
+++ b/html/changelogs/RunaDacino-Stackrecipechange.yml
@@ -1,0 +1,9 @@
+  
+author: Runa-Dacino
+
+
+delete-after: True
+
+
+  - tweak: "Makes stack recipes spawn carriable objects in the user's hands. Spawns on the ground if full/cyborg like previously"
+


### PR DESCRIPTION
* Makes a new variable in /code/game/objects/item/stacks/stack.dm called goes_in_hands
* Uses said variable in /code/modules/materials/material_recipes.dm everywhere, where an object can be held in hands. 
* Adds changelog

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
