### PR TITLE
Prevent moderators from seeing admin memos

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -151,7 +151,8 @@
 
 	if(holder)
 		add_admin_verbs()
-		admin_memo_show()
+		if(holder.rights != R_MOD) // don't let mods see admin memos
+			admin_memo_show()
 
 	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
 	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)


### PR DESCRIPTION
Anyone with only the MOD permission can no longer see the admin memos, as they do not have access to the verb anyway.

This is something that I noticed during my current moderator trial: we can see the admin memos, but only by relogging after the role is set.

Mentioned it to Daaneesh, sounds like (at least trialmods) should not be able to see these at all.