### PR TITLE
Fixes #15098

### DIFF
--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -43,12 +43,13 @@ var/datum/antagonist/xenos/borer/borers
 					break
 		if(istype(host))
 			var/obj/item/organ/external/head = host.get_organ(BP_HEAD)
-			borer.host = host
-			head.implants += borer
-			borer.forceMove(head)
-			if(!borer.host_brain)
-				borer.host_brain = new(borer)
-			borer.host_brain.name = host.name
-			borer.host_brain.real_name = host.real_name
-			return
+			if(head)
+				borer.host = host
+				head.implants += borer
+				borer.forceMove(head)
+				if(!borer.host_brain)
+					borer.host_brain = new(borer)
+				borer.host_brain.name = host.name
+				borer.host_brain.real_name = host.real_name
+				return
 	..() // Place them at a vent if they can't get a host.

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -170,6 +170,10 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		to_chat(src, "<span class='warning'>We are already absorbing!</span>")
 		return
 
+	var/obj/item/organ/external/affecting = T.get_organ(src.zone_sel.selecting)
+	if(!affecting)
+		to_chat(src, "<span class='warning'>They are missing that body part!</span>")
+
 	changeling.isabsorbing = 1
 	for(var/stage = 1, stage<=3, stage++)
 		switch(stage)
@@ -182,7 +186,6 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 				to_chat(src, "<span class='notice'>We stab [T] with the proboscis.</span>")
 				src.visible_message("<span class='danger'>[src] stabs [T] with the proboscis!</span>")
 				to_chat(T, "<span class='danger'>You feel a sharp stabbing pain!</span>")
-				var/obj/item/organ/external/affecting = T.get_organ(src.zone_sel.selecting)
 				if(affecting.take_damage(39,0,1,0,"large organic needle"))
 					T:UpdateDamageIcon()
 

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -186,8 +186,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 				to_chat(src, "<span class='notice'>We stab [T] with the proboscis.</span>")
 				src.visible_message("<span class='danger'>[src] stabs [T] with the proboscis!</span>")
 				to_chat(T, "<span class='danger'>You feel a sharp stabbing pain!</span>")
-				if(affecting.take_damage(39,0,1,0,"large organic needle"))
-					T:UpdateDamageIcon()
+				affecting.take_damage(39,0,1,0,"large organic needle")
 
 		feedback_add_details("changeling_powers","A[stage]")
 		if(!do_mob(src, T, 150))

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -19,9 +19,13 @@
 		return ..()
 
 	var/zone = (user.hand ? BP_L_ARM : BP_R_ARM)
+
+	var/obj/item/organ/external/affecting = null
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/affecting = H.get_organ(zone)
+		affecting = H.get_organ(zone)
+
+	if(affecting)
 		to_chat(user, "<span class='danger'>An unexplicable force rips through your [affecting.name], tearing the sword from your grasp!</span>")
 	else
 		to_chat(user, "<span class='danger'>An unexplicable force rips through you, tearing the sword from your grasp!</span>")

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -396,7 +396,7 @@ datum/objective/harm
 					return 1
 
 			var/obj/item/organ/external/head/head = H.get_organ(BP_HEAD)
-			if(head.disfigured)
+			if(!head || head.disfigured)
 				return 1
 		return 0
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -532,7 +532,8 @@ var/list/global/slot_flags_enumeration = list(
 			if (eyes.damage >= eyes.min_broken_damage)
 				if(M.stat != 2)
 					to_chat(M, "<span class='warning'>You go blind!</span>")
-		var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
+
+		var/obj/item/organ/external/affecting = H.get_organ(eyes.parent_organ)
 		if(affecting.take_damage(7))
 			M:UpdateDamageIcon()
 	else

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -25,6 +25,10 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
+		if(!affecting)
+			to_chat(user, "<span class='warning'>\The [M] is missing that body part!</span>")
+			return 1
+
 		if(affecting.organ_tag == BP_HEAD)
 			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
 				to_chat(user, "<span class='warning'>You can't apply [src] through [H.head]!</span>")
@@ -64,7 +68,7 @@
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
 		if(affecting.open)
 			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
@@ -124,7 +128,7 @@
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
 		if(affecting.open)
 			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
@@ -159,7 +163,7 @@
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
 		if(affecting.open)
 			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
@@ -219,7 +223,7 @@
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
 		if(affecting.open)
 			to_chat(user, "<span class='notice'>The [affecting.name] is cut open, you'll need more than a bandage!</span>")
@@ -255,7 +259,7 @@
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 		var/limb = affecting.name
 		if(!(affecting.organ_tag in splintable_organs))
 			to_chat(user, "<span class='danger'>You can't use \the [src] to apply a splint there!</span>")

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -28,6 +28,9 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 
+		if(!S)
+			to_chat(user, "<span class='warning'>\The [M] is missing that body part.</span>")
+
 		if(S.open >= 2)
 			if (S && (S.robotic >= ORGAN_ROBOT))
 				if(!S.get_damage())

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -20,6 +20,29 @@
 	proc/activate()
 		return
 
+	proc/can_implant(mob/M, mob/user, var/target_zone)
+		var/mob/living/carbon/human/H = M
+		if(istype(H) && !H.get_organ(target_zone))
+			to_chat(user, "<span class='warning'>\The [M] is missing that body part.</span>")
+			return FALSE
+		return TRUE
+
+	proc/implant_in_mob(mob/M, var/target_zone)
+		if (ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/organ/external/affected = H.get_organ(target_zone)
+			if(affected)
+				affected.implants += src
+				src.part = affected
+
+			BITSET(H.hud_updateflag, IMPLOYAL_HUD)
+
+		src.forceMove(M)
+		src.imp_in = M
+		src.implanted = 1
+
+		return TRUE
+
 	// What does the implant do upon injection?
 	// return 0 if the implant fails (ex. Revhead and loyalty implant.)
 	// return 1 if the implant succeeds (ex. Nonrevhead and loyalty implant.)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -59,24 +59,11 @@
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		user.do_attack_animation(M)
 
-		var/turf/T1 = get_turf(M)
-		if (T1 && ((M == user) || do_after(user, 50, M)))
-			if(user && M && (get_turf(M) == T1) && src && src.imp)
+		var/target_zone = user.zone_sel.selecting
+		if(src.imp.can_implant(M, user, target_zone))
+			if(do_after(user, 50, M) && src.imp.implant_in_mob(M, target_zone))
 				M.visible_message("<span class='warning'>[M] has been implanted by [user].</span>")
-
 				admin_attack_log(user, M, "Implanted using \the [src.name] ([src.imp.name])", "Implanted with \the [src.name] ([src.imp.name])", "used an implanter, [src.name] ([src.imp.name]), on")
-
-				if(src.imp.implanted(M))
-					src.imp.loc = M
-					src.imp.imp_in = M
-					src.imp.implanted = 1
-					if (ishuman(M))
-						var/mob/living/carbon/human/H = M
-						var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
-						affected.implants += src.imp
-						imp.part = affected
-
-						BITSET(H.hud_updateflag, IMPLOYAL_HUD)
 
 				src.imp = null
 				update()


### PR DESCRIPTION
Corrects some cases where the returned value from `get_organ()` is not checked for null, which is returned when the human in question no longer has the body part.

I tried checking all sites where `get_organ()` is called, but I only got through about a third of them before giving up. It's a proc that is used a lot.

For future reference, anytime someone uses `get_organ()`, they have to make sure that the case where null return is handled unless they can reason that it is impossible for that to happen.