### PR TITLE
Makes turbolift doors refuse to be operated manually

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -18,13 +18,16 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 
 	if(id_tag != signal.data["tag"] || !signal.data["command"]) return
 
-	cur_command = signal.data["command"]
+	command(signal.data["command"])
 
 	//if there's no power, recieve the signal but just don't do anything. This allows airlocks to continue to work normally once power is restored
 	if (!arePowerSystemsOn()) return //no power
 
 	spawn()
 		execute_current_command()
+
+obj/machinery/door/airlock/proc/command(var/new_command)
+	cur_command = new_command
 
 obj/machinery/door/airlock/proc/execute_current_command()
 	if(operating)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -20,14 +20,13 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 
 	command(signal.data["command"])
 
-	//if there's no power, recieve the signal but just don't do anything. This allows airlocks to continue to work normally once power is restored
-	if (!arePowerSystemsOn()) return //no power
-
-	spawn()
-		execute_current_command()
-
 obj/machinery/door/airlock/proc/command(var/new_command)
 	cur_command = new_command
+
+	//if there's no power, recieve the signal but just don't do anything. This allows airlocks to continue to work normally once power is restored
+	if(arePowerSystemsOn())
+		spawn()
+			execute_current_command()
 
 obj/machinery/door/airlock/proc/execute_current_command()
 	if(operating)

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -25,12 +25,12 @@
 
 /datum/turbolift/proc/open_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		door.command("secure_open")
+		door.command("open")
 	return
 
 /datum/turbolift/proc/close_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		door.command("secure_close")
+		door.command("close")
 	return
 
 /datum/turbolift/proc/do_move()

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -25,14 +25,12 @@
 
 /datum/turbolift/proc/open_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		spawn(0)
-			door.open()
+		door.command("secure_open")
 	return
 
 /datum/turbolift/proc/close_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		spawn(0)
-			door.close()
+		door.command("secure_close")
 	return
 
 /datum/turbolift/proc/do_move()

--- a/code/modules/turbolift/turbolift_door.dm
+++ b/code/modules/turbolift/turbolift_door.dm
@@ -7,10 +7,6 @@
 	glass = 1
 	icon = 'icons/obj/doors/doorlift.dmi'
 
-	//start bolted
-	icon_state = "door_locked"
-	locked = 1
-
 	var/datum/turbolift/lift
 	var/datum/turbolift_floor/floor
 
@@ -23,3 +19,6 @@
 
 /obj/machinery/door/airlock/lift/bumpopen(var/mob/user)
 	return // No accidental sprinting into open elevator shafts.
+
+/obj/machinery/door/airlock/lift/allowed(mob/M)
+	return FALSE //only the lift machinery is allowed to operate this door

--- a/code/modules/turbolift/turbolift_door.dm
+++ b/code/modules/turbolift/turbolift_door.dm
@@ -7,6 +7,10 @@
 	glass = 1
 	icon = 'icons/obj/doors/doorlift.dmi'
 
+	//start bolted
+	icon_state = "door_locked"
+	locked = 1
+
 	var/datum/turbolift/lift
 	var/datum/turbolift_floor/floor
 

--- a/html/changelogs/HarpyEagle-turbolift-doors.yml
+++ b/html/changelogs/HarpyEagle-turbolift-doors.yml
@@ -1,0 +1,6 @@
+author: HarpyEagle
+
+delete-after: True
+
+changes:
+  - bugfix: "Doors leading to open elevator shafts now require a little more effort to open."


### PR DESCRIPTION
~~The doors now spawn bolted, `open_doors()` and `close_doors()` use the secure_open and secure_close commands.~~

Lift doors refuse all access, meaning they can only be operated by the lift or by robot/AI interfacing. They do not bolt, so that they can still be opened during power failures.

Instead of calling `open()` and `close()` directly, turbolifts use `command()`. This proc should be used when electronically commanding doors to open or close on it's own (i.e. not physically opening or closing it).