### PR TITLE
Tweaks the mob damage unit test

### DIFF
--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -169,9 +169,6 @@ datum/unit_test/mob_damage/start_test()
 
 	H.apply_damage(damage_amount, damagetype, damage_location)
 
-	H.updatehealth() // Just in case, though at this time apply_damage does this for us.
-                         // We operate with the assumption that someone might mess with that proc one day.
-
 	var/ending_damage = damage_check(H, damagetype)
 
 	var/ending_health = H.health


### PR DESCRIPTION
If calling `apply_damage()` without calling `updatehealth()` after doesn't work, the unit test needs to fail.

We don't expect that `updatehealth()` will be called after `apply_damage()`, since it is just useless clutter. Therefore the test needs to ensure that `apply_damage()` will work on it's own.