### PR TITLE
Fixes #15112

### DIFF
--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -56,8 +56,7 @@
 	if(target_floor == current_floor)
 
 		playsound(control_panel_interior.loc, origin.arrival_sound, 50, 1)
-		open_doors(target_floor)
-		target_floor.ext_panel.reset()
+		target_floor.arrived(src)
 		target_floor = null
 
 		sleep(15)
@@ -99,7 +98,7 @@
 /datum/turbolift/proc/queue_move_to(var/datum/turbolift_floor/floor)
 	if(!floor || !(floor in floors) || (floor in queued_floors))
 		return // STOP PRESSING THE BUTTON.
-	floor.ext_panel.light_up()
+	floor.pending_move(src)
 	queued_floors |= floor
 	turbolift_controller.lift_is_moving(src)
 

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -57,6 +57,12 @@
 	var/light_up = FALSE
 	var/datum/turbolift_floor/floor
 
+/obj/structure/lift/button/Destroy()
+	if(floor && floor.ext_panel == src)
+		floor.ext_panel = null
+	floor = null
+	return ..()
+
 /obj/structure/lift/button/proc/reset()
 	light_up = FALSE
 	update_icon()

--- a/code/modules/turbolift/turbolift_floor.dm
+++ b/code/modules/turbolift/turbolift_floor.dm
@@ -21,3 +21,13 @@
 	announce_str = A.lift_announce_str
 	arrival_sound = A.arrival_sound
 
+//called when a lift has queued this floor as a destination
+/datum/turbolift_floor/proc/pending_move(var/datum/turbolift/lift)
+	if(ext_panel)
+		ext_panel.light_up()
+
+//called when a lift arrives at this floor
+/datum/turbolift_floor/proc/arrived(var/datum/turbolift/lift)
+	lift.open_doors(src)
+	if(ext_panel)
+		ext_panel.reset()


### PR DESCRIPTION
Fixes #15112

The buttons can get destroyed by explosions for example, so they need to be nullchecked.

~~The buttons will also never qdel properly, but I don't see a way around that.~~ could just have the button hold a reference to the floor datum I guess.
