### PR TITLE
Uplink Changes

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -25,10 +25,10 @@
 	item_cost = 16
 	path = /obj/item/weapon/plastique
 
-/datum/uplink_item/item/tools/heavy_vest
-	name = "Heavy Armor Vest"
+/datum/uplink_item/item/tools/heavy_armor
+	name = "Heavy Armor Vest and Helmet"
 	item_cost = 16
-	path = /obj/item/clothing/suit/storage/vest/merc
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
 
 /datum/uplink_item/item/tools/encryptionkey_radio
 	name = "Encrypted Radio Channel Key"

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -72,7 +72,7 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/clerical)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/space_suit, 50, 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/thermal)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/heavy_vest)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/heavy_armor)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/powersink, 10, 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/ai_module, 25, 0)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/teleporter, 10, 0)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -191,7 +191,7 @@
 	startswith = list(/obj/item/weapon/spacecash/bundle/c1000 = 10)
 
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
-	name = "Armor Satchel"
+	name = "armor satchel"
 	desc = "A satchel for when you don't want to try a diplomatic approach."
 	startswith = list(
 		/obj/item/clothing/suit/storage/vest/merc,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -56,8 +56,8 @@
 	//name = "\improper EVA gear pack"
 
 	startswith = list(
-		/obj/item/clothing/suit/space/syndicate,
-		/obj/item/clothing/head/helmet/space/syndicate,
+		/obj/item/clothing/suit/space/void/merc,
+		/obj/item/clothing/head/helmet/space/void/merc,
 		/obj/item/clothing/mask/gas/syndicate,
 		/obj/item/weapon/tank/emergency/oxygen/double,
 		)
@@ -190,3 +190,10 @@
 
 	startswith = list(/obj/item/weapon/spacecash/bundle/c1000 = 10)
 
+/obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
+	name = "Armor Box"
+	desc = "A box for when you don't want to try a diplomatic approach."
+	startswith = list(
+		/obj/item/clothing/suit/storage/vest/merc,
+		/obj/item/clothing/head/helmet/merc
+	)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -191,8 +191,8 @@
 	startswith = list(/obj/item/weapon/spacecash/bundle/c1000 = 10)
 
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
-	name = "Armor Box"
-	desc = "A box for when you don't want to try a diplomatic approach."
+	name = "Armor Satchel"
+	desc = "A satchel for when you don't want to try a diplomatic approach."
 	startswith = list(
 		/obj/item/clothing/suit/storage/vest/merc,
 		/obj/item/clothing/head/helmet/merc


### PR DESCRIPTION
This push does two things:
Firstly, it gives traitors access to the merc vest AND helmet, instead of only the vest. This spawns in a kit.
Secondly, it changes the uplink merc softsuit to the merc voidsuit instead. 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
