### PR TITLE
Fixes turbolift menu order, tweaks Torch lift button text

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -433,7 +433,7 @@
 
 			// Find adjacent space/shuttle tiles and cover them. Shuttles won't be blocked if shield diffuser is mapped in and turned on.
 			for(var/turf/TN in orange(1, T))
-				if(istype(TN, /turf/space) || (istype(get_area(TN), /area/shuttle/) && !istype(get_area(TN), /area/shuttle/turbolift/)))
+				if(istype(TN, /turf/space) || (istype(get_area(TN), /area/shuttle/) && !istype(get_area(TN), /area/turbolift/)))
 					out |= TN
 					continue
 	return out

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -53,7 +53,7 @@
 		close_doors()
 		return 1
 
-	var/area/shuttle/turbolift/origin = locate(current_floor.area_ref)
+	var/area/turbolift/origin = locate(current_floor.area_ref)
 
 	if(target_floor == current_floor)
 
@@ -75,7 +75,7 @@
 	else
 		next_floor = floors[current_floor_index-1]
 
-	var/area/shuttle/turbolift/destination = locate(next_floor.area_ref)
+	var/area/turbolift/destination = locate(next_floor.area_ref)
 
 	if(!istype(origin) || !istype(destination) || (origin == destination))
 		return 0

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -1,7 +1,9 @@
 // Used for creating the exchange areas.
-/area/shuttle/turbolift
+/area/turbolift
 	name = "Turbolift"
 	base_turf = /turf/simulated/open
+	sound_env = SMALL_ENCLOSED
+	base_turf = /turf/space
 
 	var/lift_floor_label = null
 	var/lift_floor_name = null

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -3,5 +3,7 @@
 	name = "Turbolift"
 	base_turf = /turf/simulated/open
 
+	var/lift_floor_label = null
+	var/lift_floor_name = null
 	var/lift_announce_str = "Ding!"
 	var/arrival_sound = 'sound/machines/ding.ogg'

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -2,6 +2,7 @@
 /area/turbolift
 	name = "Turbolift"
 	base_turf = /turf/simulated/open
+	requires_power = 0
 	sound_env = SMALL_ENCLOSED
 	base_turf = /turf/space
 

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -117,7 +117,7 @@
 	dat += "<a href='?src=\ref[src];emergency_stop=1'>Emergency Stop</a>"
 	dat += "<hr></body></html>"
 
-	var/datum/browser/popup = new(user, "turbolift_panel", "Lift Panel", 200, 260)
+	var/datum/browser/popup = new(user, "turbolift_panel", "Lift Panel", 230, 260)
 	popup.set_content(jointext(dat, null))
 	popup.open()
 	return

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -99,12 +99,15 @@
 
 	var/dat = list()
 	dat += "<html><body><hr><b>Lift panel</b><hr>"
-	var/i = 0
-	for(var/datum/turbolift_floor/floor in lift.floors)
+
+	//the floors list stores levels in order of increasing Z
+	//therefore, to display upper levels at the top of the menu and
+	//lower levels at the bottom, we need to go through the list in reverse
+	for(var/i in lift.floors.len to 1 step -1)
+		var/datum/turbolift_floor/floor = lift.floors[i]
 		var/area/A = locate(floor.area_ref)
 		dat += "<font color = '[(floor in lift.queued_floors) ? COLOR_YELLOW : COLOR_WHITE]'>"
-		dat += "<a href='?src=\ref[src];move_to_floor=["\ref[floor]"]'>[i==0 ? "Ground Floor" : "Floor #[i]"]</a>: [A.name]</font><br>"
-		i++
+		dat += "<a href='?src=\ref[src];move_to_floor=["\ref[floor]"]'>Level #[i]</a>: [A.name]</font><br>"
 
 	dat += "<hr>"
 	if(lift.doors_are_open())

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -105,9 +105,9 @@
 	//lower levels at the bottom, we need to go through the list in reverse
 	for(var/i in lift.floors.len to 1 step -1)
 		var/datum/turbolift_floor/floor = lift.floors[i]
-		var/area/A = locate(floor.area_ref)
+		var/label = floor.label? floor.label : "Level #[i]"
 		dat += "<font color = '[(floor in lift.queued_floors) ? COLOR_YELLOW : COLOR_WHITE]'>"
-		dat += "<a href='?src=\ref[src];move_to_floor=["\ref[floor]"]'>Level #[i]</a>: [A.name]</font><br>"
+		dat += "<a href='?src=\ref[src];move_to_floor=["\ref[floor]"]'>[label]</a>: [floor.name]</font><br>"
 
 	dat += "<hr>"
 	if(lift.doors_are_open())

--- a/code/modules/turbolift/turbolift_floor.dm
+++ b/code/modules/turbolift/turbolift_floor.dm
@@ -1,5 +1,23 @@
 // Simple holder for each floor in the lift.
 /datum/turbolift_floor
 	var/area_ref
+	var/label
+	var/name
+	var/announce_str
+	var/arrival_sound
+
 	var/list/doors = list()
 	var/obj/structure/lift/button/ext_panel
+
+/datum/turbolift_floor/proc/set_area_ref(var/ref)
+	var/area/shuttle/turbolift/A = locate(ref)
+	if(!istype(A))
+		log_debug("Turbolift floor area was of the wrong type: ref=[ref]")
+		return
+
+	area_ref = ref
+	label = A.lift_floor_label
+	name = A.lift_floor_name ? A.lift_floor_name : A.name
+	announce_str = A.lift_announce_str
+	arrival_sound = A.arrival_sound
+

--- a/code/modules/turbolift/turbolift_floor.dm
+++ b/code/modules/turbolift/turbolift_floor.dm
@@ -10,7 +10,7 @@
 	var/obj/structure/lift/button/ext_panel
 
 /datum/turbolift_floor/proc/set_area_ref(var/ref)
-	var/area/shuttle/turbolift/A = locate(ref)
+	var/area/turbolift/A = locate(ref)
 	if(!istype(A))
 		log_debug("Turbolift floor area was of the wrong type: ref=[ref]")
 		return

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -214,7 +214,7 @@
 		for(var/thing in floor_turfs)
 			new area_path(thing)
 		var/area/A = locate(area_path)
-		cfloor.area_ref = "\ref[A]"
+		cfloor.set_area_ref("\ref[A]")
 		az++
 
 	// Place lift panel.

--- a/maps/exodus/exodus_areas.dm
+++ b/maps/exodus/exodus_areas.dm
@@ -477,38 +477,38 @@
 /////////////
 //ELEVATORS//
 /////////////
-/area/shuttle/turbolift/security_station
+/area/turbolift/security_station
 	name = "Station - By Security"
 	lift_announce_str = "Arriving at the station level, by the Security department."
 
-/area/shuttle/turbolift/security_maintenance
+/area/turbolift/security_maintenance
 	name = "Maintenance - Below Security"
 	lift_announce_str = "Arriving at the maintenance level, below the Security department."
 	base_turf = /turf/simulated/floor/plating
 
-/area/shuttle/turbolift/research_station
+/area/turbolift/research_station
 	name = "Station - By Research"
 	lift_announce_str = "Arriving at the station level, by the R&D department."
 
-/area/shuttle/turbolift/research_maintenance
+/area/turbolift/research_maintenance
 	name = "Maintenance - Below Research"
 	lift_announce_str = "Arriving at the maintenance level, below the R&D department."
 	base_turf = /turf/simulated/floor/plating
 
-/area/shuttle/turbolift/engineering_station
+/area/turbolift/engineering_station
 	name = "Station - By Engineering"
 	lift_announce_str = "Arriving at the station level, by the Engineering department."
 
-/area/shuttle/turbolift/engineering_maintenance
+/area/turbolift/engineering_maintenance
 	name = "Maintenance - Below Engineering"
 	lift_announce_str = "Arriving at the maintenance level, below the Engineering department."
 	base_turf = /turf/simulated/floor/plating
 
-/area/shuttle/turbolift/cargo_station
+/area/turbolift/cargo_station
 	name = "Station - By Cargo"
 	lift_announce_str = "Arriving at the station level, by the Cargo department."
 
-/area/shuttle/turbolift/cargo_maintenance
+/area/turbolift/cargo_maintenance
 	name = "Maintenance - Below Cargo"
 	lift_announce_str = "Arriving at the maintenance level, below the Cargo department."
 	base_turf = /turf/simulated/floor/plating

--- a/maps/exodus/exodus_elevator.dm
+++ b/maps/exodus/exodus_elevator.dm
@@ -9,8 +9,8 @@
 	dir = EAST
 
 	areas_to_use = list(
-		/area/shuttle/turbolift/security_maintenance,
-		/area/shuttle/turbolift/security_station
+		/area/turbolift/security_maintenance,
+		/area/turbolift/security_station
 		)
 
 /obj/turbolift_map_holder/exodus/research
@@ -18,8 +18,8 @@
 	dir = WEST
 
 	areas_to_use = list(
-		/area/shuttle/turbolift/research_maintenance,
-		/area/shuttle/turbolift/research_station
+		/area/turbolift/research_maintenance,
+		/area/turbolift/research_station
 		)
 
 /obj/turbolift_map_holder/exodus/engineering
@@ -30,14 +30,14 @@
 	lift_size_y = 4
 
 	areas_to_use = list(
-		/area/shuttle/turbolift/engineering_maintenance,
-		/area/shuttle/turbolift/engineering_station
+		/area/turbolift/engineering_maintenance,
+		/area/turbolift/engineering_station
 		)
 
 /obj/turbolift_map_holder/exodus/cargo
 	name = "Exodus turbolift map placeholder - Cargo"
 
 	areas_to_use = list(
-		/area/shuttle/turbolift/cargo_maintenance,
-		/area/shuttle/turbolift/cargo_station
+		/area/turbolift/cargo_maintenance,
+		/area/turbolift/cargo_station
 		)

--- a/maps/exodus/exodus_unit_testing.dm
+++ b/maps/exodus/exodus_unit_testing.dm
@@ -42,6 +42,7 @@
 		/area/rnd/test_area = NO_SCRUBBER|NO_VENT,
 		/area/server = 0,
 		/area/shuttle = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/turbolift = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/skipjack_station = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/solar = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/space = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -727,25 +727,25 @@
 /area/turbolift/torch_top
 	name = "lift (upper deck)"
 	lift_floor_label = "Deck 1"
-	lift_floor_name = "Operations"
+	lift_floor_name = "Operations Deck"
 	lift_announce_str = "Arriving at Operations Deck: Bridge. Command Offices. Emergency Armory. Infirmary. Research Wing."
 
 /area/turbolift/torch_second
 	name = "lift (maintenance)"
 	lift_floor_label = "Deck 2"
-	lift_floor_name = "Maintenance"
+	lift_floor_name = "Maintenance Deck"
 	lift_announce_str = "Arriving at Maintenance Deck: Engineering. Atmospherics. AI Core. Sanitation."
 
 /area/turbolift/torch_first
 	name = "lift (second deck)"
 	lift_floor_label = "Deck 3"
-	lift_floor_name = "Habitation"
+	lift_floor_name = "Habitation Deck"
 	lift_announce_str = "Arriving at Habitation Deck: EVA. Security Wing. Telecommunications. Hydroponics. Mess Hall. Cryogenic Storage."
 
 /area/turbolift/torch_ground
 	name = "lift (lower deck)"
 	lift_floor_label = "Deck 4"
-	lift_floor_name = "Hangar"
+	lift_floor_name = "Hangar Deck"
 	lift_announce_str = "Arriving at Hangar Deck: Shuttle Docks. Storage. Main Hangar. Supply Office."
 	base_turf = /turf/simulated/floor
 

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -724,25 +724,25 @@
 	base_turf = /turf/space/bluespace
 
 // Elevator areas.
-/area/shuttle/turbolift/torch_top
+/area/turbolift/torch_top
 	name = "lift (upper deck)"
 	lift_floor_label = "Deck 3"
 	lift_floor_name = "Operations Deck"
 	lift_announce_str = "Arriving at Operations Deck: Bridge. Command Offices. Emergency Armory. Infirmary. Research Wing."
 
-/area/shuttle/turbolift/torch_second
+/area/turbolift/torch_second
 	name = "lift (maintenance)"
 	lift_floor_label = "Maint."
 	lift_floor_name = "Maintenance Access"
 	lift_announce_str = "Arriving at Maintenance Deck: Engineering. Atmospherics. AI Core. Sanitation."
 
-/area/shuttle/turbolift/torch_first
+/area/turbolift/torch_first
 	name = "lift (second deck)"
 	lift_floor_label = "Deck 2"
 	lift_floor_name = "Habitation Deck"
 	lift_announce_str = "Arriving at Habitation Deck: EVA. Security Wing. Telecommunications. Hydroponics. Mess Hall. Cryogenic Storage."
 
-/area/shuttle/turbolift/torch_ground
+/area/turbolift/torch_ground
 	name = "lift (lower deck)"
 	lift_floor_label = "Deck 1"
 	lift_floor_name = "Hanger Deck"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -726,26 +726,26 @@
 // Elevator areas.
 /area/turbolift/torch_top
 	name = "lift (upper deck)"
-	lift_floor_label = "Deck 3"
-	lift_floor_name = "Operations Deck"
+	lift_floor_label = "Deck 1"
+	lift_floor_name = "Operations"
 	lift_announce_str = "Arriving at Operations Deck: Bridge. Command Offices. Emergency Armory. Infirmary. Research Wing."
 
 /area/turbolift/torch_second
 	name = "lift (maintenance)"
-	lift_floor_label = "Maint."
-	lift_floor_name = "Maintenance Access"
+	lift_floor_label = "Deck 2"
+	lift_floor_name = "Maintenance"
 	lift_announce_str = "Arriving at Maintenance Deck: Engineering. Atmospherics. AI Core. Sanitation."
 
 /area/turbolift/torch_first
 	name = "lift (second deck)"
-	lift_floor_label = "Deck 2"
-	lift_floor_name = "Habitation Deck"
+	lift_floor_label = "Deck 3"
+	lift_floor_name = "Habitation"
 	lift_announce_str = "Arriving at Habitation Deck: EVA. Security Wing. Telecommunications. Hydroponics. Mess Hall. Cryogenic Storage."
 
 /area/turbolift/torch_ground
 	name = "lift (lower deck)"
-	lift_floor_label = "Deck 1"
-	lift_floor_name = "Hanger Deck"
+	lift_floor_label = "Deck 4"
+	lift_floor_name = "Hangar"
 	lift_announce_str = "Arriving at Hangar Deck: Shuttle Docks. Storage. Main Hangar. Supply Office."
 	base_turf = /turf/simulated/floor
 

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -725,19 +725,27 @@
 
 // Elevator areas.
 /area/shuttle/turbolift/torch_top
-	name = "First Deck"
+	name = "lift (upper deck)"
+	lift_floor_label = "Deck 3"
+	lift_floor_name = "Operations Deck"
 	lift_announce_str = "Arriving at Operations Deck: Bridge. Command Offices. Emergency Armory. Infirmary. Research Wing."
 
 /area/shuttle/turbolift/torch_second
-	name = "Second Deck"
+	name = "lift (maintenance)"
+	lift_floor_label = "Maint."
+	lift_floor_name = "Maintenance Access"
 	lift_announce_str = "Arriving at Maintenance Deck: Engineering. Atmospherics. AI Core. Sanitation."
 
 /area/shuttle/turbolift/torch_first
-	name = "Third Deck"
+	name = "lift (second deck)"
+	lift_floor_label = "Deck 2"
+	lift_floor_name = "Habitation Deck"
 	lift_announce_str = "Arriving at Habitation Deck: EVA. Security Wing. Telecommunications. Hydroponics. Mess Hall. Cryogenic Storage."
 
 /area/shuttle/turbolift/torch_ground
-	name = "Fourth Deck"
+	name = "lift (lower deck)"
+	lift_floor_label = "Deck 1"
+	lift_floor_name = "Hanger Deck"
 	lift_announce_str = "Arriving at Hangar Deck: Shuttle Docks. Storage. Main Hangar. Supply Office."
 	base_turf = /turf/simulated/floor
 

--- a/maps/torch/torch_elevator.dm
+++ b/maps/torch/torch_elevator.dm
@@ -5,9 +5,9 @@
 	lift_size_y = 4
 
 	areas_to_use = list(
-		/area/shuttle/turbolift/torch_ground,
-		/area/shuttle/turbolift/torch_first,
-		/area/shuttle/turbolift/torch_second,
-		/area/shuttle/turbolift/torch_top
+		/area/turbolift/torch_ground,
+		/area/turbolift/torch_first,
+		/area/turbolift/torch_second,
+		/area/turbolift/torch_top
 		)
 

--- a/maps/torch/torch_unit_testing.dm
+++ b/maps/torch/torch_unit_testing.dm
@@ -33,6 +33,7 @@
 		/area/ninja_dojo = NO_SCRUBBER |NO_VENT | NO_APC,
 		/area/outpost/abandoned = NO_SCRUBBER,
 		/area/rescue_base = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/turbolift = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/shuttle = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/shuttle/merchant = NO_SCRUBBER|NO_APC,
 		/area/shuttle/merchant/away = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/torch/torch_unit_testing.dm
+++ b/maps/torch/torch_unit_testing.dm
@@ -77,7 +77,7 @@
 		/area/overmap,
 		/area/shuttle/escape/centcom,
 		/area/shuttle/escape,
-		/area/shuttle/turbolift,
+		/area/turbolift,
 		/area/security/prison,
 		/area/shuttle/syndicate_elite/station,
 		/area/shuttle/escape/centcom,

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -39,7 +39,7 @@
 		/area/shuttle/syndicate_elite,
 		/area/shuttle/syndicate_elite/mothership,
 		/area/shuttle/syndicate_elite/station,
-		/area/shuttle/turbolift,
+		/area/turbolift,
 		/area/supply,
 		/area/supply/station,
 		/area/syndicate_mothership,


### PR DESCRIPTION
Fixes the order in which elevator buttons are displayed. Now buttons for upper floors are displayed on top, and buttons for lower floors are displayed on the bottom.

Also added the option to set the button text for each floor. By default, there is no more "ground floor" since it seems out of place on a space vessel or installation.

Adjusts the button text for the Torch main elevator. While it deviates from the first, second, third provided in the forum, I think it is more intuitive this way. The lowest deck (hanger) is now deck 1 (instead of third deck), and the uppermost deck (operations) is now deck 3.  Still need to pass this by @Raptor1628 