### PR TITLE
increase fall damage

### DIFF
--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -124,7 +124,7 @@
 			// Handle people getting hurt, it's funny!
 			if (istype(mover, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = mover
-				var/damage = 5
+				var/damage = 10
 				H.apply_damage(rand(0, damage), BRUTE, BP_HEAD)
 				H.apply_damage(rand(0, damage), BRUTE, BP_CHEST)
 				H.apply_damage(rand(0, damage), BRUTE, BP_L_LEG)

--- a/html/changelogs/falldamage.yml
+++ b/html/changelogs/falldamage.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes: 
+  - rscadd: "Upped the damage from 5 to 10 brute possible per limb when falling down a z-level."


### PR DESCRIPTION
increases the damage from falling down a floor from 5 to 30 brute due to an agreement with Raptor.
Edit: the value is changed from 5 to 10 brute damage instead.