### PR TITLE
Dead people process reagents

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -595,7 +595,7 @@
 					H.emote("gasp")
 					if(tplus > tloss)
 						H.setBrainLoss( max(0, min(99, (100 -((tlimit - tplus) / (tlimit-1200) * 100)))))
-					H.apply_damage(15, BURN, BP_CHEST)
+					H.apply_damage(20, BURN, BP_CHEST)
 					H.Weaken(rand(10,25))
 					log_game(user, M, "revived", defib)
 				if(req_defib)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -595,7 +595,7 @@
 					H.emote("gasp")
 					if(tplus > tloss)
 						H.setBrainLoss( max(0, min(99, (100 -((tlimit - tplus) / (tlimit-1200) * 100)))))
-					H.apply_damage(20, BURN, BP_CHEST)
+					H.apply_damage(15, BURN, BP_CHEST)
 					H.Weaken(rand(10,25))
 					log_game(user, M, "revived", defib)
 				if(req_defib)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -34,6 +34,11 @@
 		handle_stomach()
 
 		. = 1
+	else if(timeofdeath && (world.time - timeofdeath < 150))
+		//This is to make dead people process reagents for a few ticks, so they can be treated and defibrilated
+		handle_chemicals_in_body()
+
+		. = 1
 
 	//Handle temperature/pressure differences between body and environment
 	if(environment)
@@ -210,7 +215,7 @@
 		update_dead_sight()
 	else
 		update_living_sight()
-	
+
 /mob/living/proc/update_living_sight()
 	set_sight(sight&(~(SEE_TURFS|SEE_MOBS|SEE_OBJS)))
 	set_see_in_dark(initial(see_in_dark))

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -4,18 +4,18 @@
 
 /datum/reagents/metabolism/New(var/max = 100, mob/living/carbon/parent_mob, var/met_class)
 	..(max, parent_mob)
-	
+
 	metabolism_class = met_class
 	if(istype(parent_mob))
 		parent = parent_mob
 
 /datum/reagents/metabolism/proc/metabolize()
-	
+
 	var/metabolism_type = 0 //non-human mobs
 	if(ishuman(parent))
 		var/mob/living/carbon/human/H = parent
 		metabolism_type = H.species.reagent_tag
-	
+
 	for(var/datum/reagent/current in reagent_list)
 		current.on_mob_life(parent, metabolism_type, metabolism_class)
 	update_total()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -52,7 +52,7 @@
 /datum/reagent/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/location) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
 	if(!istype(M))
 		return
-	if(!(flags & AFFECTS_DEAD) && M.stat == DEAD)
+	if(!(flags & AFFECTS_DEAD) && M.stat == DEAD && (world.time - M.timeofdeath > 150))
 		return
 	if(overdose && (location != CHEM_TOUCH))
 		var/overdose_threshold = overdose * (flags & IGNORE_MOB_SIZE? 1 : MOB_MEDIUM/M.mob_size)

--- a/html/changelogs/Nero-07-defib_balance.yml
+++ b/html/changelogs/Nero-07-defib_balance.yml
@@ -33,5 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Lowered defib burn damage by 5."
   - rscadd: "Dead people now keep processing reagents for 15 seconds after they died"

--- a/html/changelogs/Nero-07-defib_balance.yml
+++ b/html/changelogs/Nero-07-defib_balance.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nero07
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Lowered defib burn damage by 5."
+  - rscadd: "Dead people now keep processing reagents for 15 seconds after they died"


### PR DESCRIPTION
Dead mobs now keep processing reagents for 15 seconds after they died. 

Defib burn damage lowered by 5.

These changes will hopefully prevent cases where people just instantly die again by making it possible to coax them back to survivable health levels through liberal application of medicine and electroshocks.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
