### PR TITLE
Un-nerfs evil vending machines.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -573,17 +573,20 @@
 
 //Somebody cut an important wire and now we're following a new definition of "pitch."
 /obj/machinery/vending/proc/throw_item()
-	var/obj/dispensed_item = null
-	for(var/datum/stored_items/vending_products/R in src.product_records)
-		dispensed_item = R.get_product(loc)
-		if (dispensed_item)
-			break
-
-	if (!dispensed_item)
+	var/obj/throw_item = null
+	var/mob/living/target = locate() in view(7,src)
+	if(!target)
 		return 0
 
-	dispensed_item.forceMove(get_turf(src))
-	visible_message("<span class='warning'>\The [src] shudders and \a [dispensed_item] falls out!</span>")
+	for(var/datum/stored_items/vending_products/R in src.product_records)
+		throw_item = R.get_product(loc)
+		if (throw_item)
+			break
+	if (!throw_item)
+		return 0
+	spawn(0)
+		throw_item.throw_at(target, rand(1,2), 3, src)
+	src.visible_message("<span class='warning'>\The [src] launches \a [throw_item] at \the [target]!</span>")
 	return 1
 
 /*

--- a/html/changelogs/Techhead-vend-or-die.yml
+++ b/html/changelogs/Techhead-vend-or-die.yml
@@ -1,0 +1,4 @@
+author: Techhead
+delete-after: True
+changes: 
+  - rscadd: "Brings back the evil to evil vending machines. However, their throwing arms aren't as good as they used to be, so if you don't walk up to them, you should be fine."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Partially reverts commit 7462027.
However, brings range on vending machines to 1-2 instead of a whopping 16.

Because honestly, all they do now is hand out free product and no one cares.