### PR TITLE
Make doors autolock when broken, add ability to break door bolts

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -780,7 +780,7 @@ About the new airlock wires panel:
 	return 1
 
 /obj/machinery/door/airlock/proc/cut_bolts(item, user)
-	var/cut_delay = 60
+	var/cut_delay = 150
 	var/cut_verb
 	var/cut_sound
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -784,7 +784,7 @@ About the new airlock wires panel:
 
 //returns 1 on success, 0 on failure
 /obj/machinery/door/airlock/proc/cut_bolts(item, user)
-	var/cut_delay = 150
+	var/cut_delay = 100
 	var/cut_verb
 	var/cut_sound
 
@@ -907,7 +907,7 @@ About the new airlock wires panel:
 		var/obj/item/weapon/pai_cable/cable = C
 		cable.plugin(src, user)
 	else if(!repairing && istype(C, /obj/item/weapon/crowbar))
-		if(src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN)))) )
+		if(src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && !src.locked)) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40,src))
@@ -948,15 +948,14 @@ About the new airlock wires panel:
 			else
 				spawn(0)	close(1)
 
-	else if (istype(C, /obj/item/weapon/material/twohanded/fireaxe) && !(stat & BROKEN) && user.a_intent == I_HURT)
+			//if door is unbroken, but at half health or less, hit with fire axe using harm intent
+	else if (istype(C, /obj/item/weapon/material/twohanded/fireaxe) && !(stat & BROKEN) && (src.health <= src.maxhealth / 2) && user.a_intent == I_HURT)
 		var/obj/item/weapon/material/twohanded/fireaxe/F = C
 		if (F.wielded)
-			to_chat(user, "You prepare an overhead swing...")
-			if (do_after(user, 20, src))
-				playsound(src, 'sound/weapons/smash.ogg', 100, 1)
-				user.visible_message("<span class='danger'>[user] smashes \the [C] into the airlock's control panel! It explodes in a shower of sparks!</span>", "<span class='danger'>You smash \the [C] into the airlock's control panel! It explodes in a shower of sparks!</span>")
-				src.health = 0
-				src.set_broken()
+			playsound(src, 'sound/weapons/smash.ogg', 100, 1)
+			user.visible_message("<span class='danger'>[user] smashes \the [C] into the airlock's control panel! It explodes in a shower of sparks!</span>", "<span class='danger'>You smash \the [C] into the airlock's control panel! It explodes in a shower of sparks!</span>")
+			src.health = 0
+			src.set_broken()
 		else
 			..()
 			return
@@ -990,7 +989,8 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/set_broken()
 	src.p_open = 1
 	stat |= BROKEN
-	lock()
+	if (secured_wires)
+		lock()
 	for (var/mob/O in viewers(src, null))
 		if ((O.client && !( O.blinded )))
 			O.show_message("[src.name]'s control panel bursts open, sparks spewing out!")

--- a/html/changelogs/boltcutting.yml
+++ b/html/changelogs/boltcutting.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.
+author: Soadreqm
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Made all doors bolt themselves when broken."
+  - rscadd: "Made it possible to cut the bolts of a broken door."
+  - rscadd: "As a side effect, it is possible to remove bolted, broken doors without an RCD."
+  - rscadd: "Also made the fire axe much more robust against doors."

--- a/html/changelogs/boltcutting.yml
+++ b/html/changelogs/boltcutting.yml
@@ -33,7 +33,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Made all doors bolt themselves when broken."
-  - rscadd: "Made it possible to cut the bolts of a broken door."
-  - rscadd: "As a side effect, it is possible to remove bolted, broken doors without an RCD."
-  - rscadd: "Also made the fire axe much more robust against doors."
+  - rscadd: "Alter procedure for dismantling broken, bolted doors"
+  - rscadd: "Made the fire axe more robust against doors."


### PR DESCRIPTION
~~Make all doors bolt themselves when broken, and add the ability to break door bolts. This makes door bolts less robust, but hopefully in a way that makes sense. I was aiming for the general ballpark of bolted doors being harder to dismantle than walls, but easier than r-walls. It took me just over a minute to break through a door with equipment available to everyone - a fire extinguisher to smash it, and a welding torch to cut it open afterwards. Other usable tools are plasma cutters, energy swords and circular saws.~~

~~The fire axe also gets a boost. It can smash the door electronics in a single swing, and bypass the first step of the two-step bolt removal process, giving it some more plausible deniability as an entry tool.~~

Do not make all doors bolt themselves when broken - just modify the process of dealing with bolted, broken doors. The ones with secure_wires bolt, as they did before.

Fire axe is buffed, but still requires multiple clicks to get through a door.