### PR TITLE
Fixes TARGET_THEM to use target_gender.him

### DIFF
--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -55,7 +55,7 @@
 	if(emote_message_1p)
 		if(target && emote_message_1p_target)
 			use_1p = get_emote_message_1p(user, target, extra_params)
-			use_1p = replacetext(use_1p, "TARGET_THEM", target_gender.he)
+			use_1p = replacetext(use_1p, "TARGET_THEM", target_gender.him)
 			use_1p = replacetext(use_1p, "TARGET_THEIR", target_gender.his)
 			use_1p = replacetext(use_1p, "TARGET", "<b>\the [target]</b>")
 		else
@@ -65,12 +65,12 @@
 	if(emote_message_3p)
 		if(target && emote_message_3p_target)
 			use_3p = get_emote_message_3p(user, target, extra_params)
-			use_3p = replacetext(use_3p, "TARGET_THEM", target_gender.he)
+			use_3p = replacetext(use_3p, "TARGET_THEM", target_gender.him)
 			use_3p = replacetext(use_3p, "TARGET_THEIR", target_gender.his)
 			use_3p = replacetext(use_3p, "TARGET", "<b>\the [target]</b>")
 		else
 			use_3p = get_emote_message_3p(user, null, extra_params)
-		use_3p = replacetext(use_3p, "USER_THEM", user_gender.he)
+		use_3p = replacetext(use_3p, "USER_THEM", user_gender.him)
 		use_3p = replacetext(use_3p, "USER_THEIR", user_gender.his)
 		use_3p = replacetext(use_3p, "USER", "<b>\the [user]</b>")
 		use_3p = capitalize(use_3p)

--- a/html/changelogs/RunaDacino-EmoteGenderFix.yml
+++ b/html/changelogs/RunaDacino-EmoteGenderFix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes preset emotes to write himself and herself instead of heself and sheself."

--- a/html/changelogs/RunaDacino-EmoteGenderFix.yml
+++ b/html/changelogs/RunaDacino-EmoteGenderFix.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Runa-Dacino
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Partly fixes https://github.com/Baystation12/Baystation12/issues/15035

* Fixes TARGET_THEM to use target_gender.him

TARGET_THEM used target_gender.he which caused emotes to appear as

"gives dabs to heself" and "gives dabs to sheself". Fix makes it appear as "gives dabs to himself" and "gives dabs to herself."

* Creates changelog. This time with .yml ending from getgo

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
