### PR TITLE
Adjusts global var generation.

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -1,106 +1,1314 @@
 // THIS FILE IS AUTOMATICALLY CREATED BY tools/gen_globals.py
 /proc/readglobal(which)
 	switch(which)
-		if("tagger_locations")
-			return global.tagger_locations;
-		if("is_station_but_not_space_or_shuttle_area")
-			return global.is_station_but_not_space_or_shuttle_area;
+		if("ALL_ANTIGENS")
+			return global.ALL_ANTIGENS;
+		if("ANTAG_FREQS")
+			return global.ANTAG_FREQS;
+		if("BLENDBLOCK")
+			return global.BLENDBLOCK;
+		if("BLINDBLOCK")
+			return global.BLINDBLOCK;
+		if("BLOCKADD")
+			return global.BLOCKADD;
+		if("BSACooldown")
+			return global.BSACooldown;
+		if("BUMP_TELEPORTERS")
+			return global.BUMP_TELEPORTERS;
+		if("Banlist")
+			return global.Banlist;
+		if("CENT_FREQS")
+			return global.CENT_FREQS;
+		if("CLUMSYBLOCK")
+			return global.CLUMSYBLOCK;
+		if("CMinutes")
+			return global.CMinutes;
+		if("COUGHBLOCK")
+			return global.COUGHBLOCK;
+		if("DEAFBLOCK")
+			return global.DEAFBLOCK;
+		if("DEPT_FREQS")
+			return global.DEPT_FREQS;
+		if("DIFFMUT")
+			return global.DIFFMUT;
+		if("Debug2")
+			return global.Debug2;
+		if("EPILEPSYBLOCK")
+			return global.EPILEPSYBLOCK;
+		if("FAKEBLOCK")
+			return global.FAKEBLOCK;
+		if("FIREBLOCK")
+			return global.FIREBLOCK;
+		if("GLASSESBLOCK")
+			return global.GLASSESBLOCK;
+		if("HALLUCINATIONBLOCK")
+			return global.HALLUCINATIONBLOCK;
+		if("HEADACHEBLOCK")
+			return global.HEADACHEBLOCK;
+		if("HULKBLOCK")
+			return global.HULKBLOCK;
+		if("Holiday")
+			return global.Holiday;
+		if("IClog")
+			return global.IClog;
+		if("INCREASERUNBLOCK")
+			return global.INCREASERUNBLOCK;
+		if("MONKEYBLOCK")
+			return global.MONKEYBLOCK;
+		if("MORPHBLOCK")
+			return global.MORPHBLOCK;
+		if("NERVOUSBLOCK")
+			return global.NERVOUSBLOCK;
+		if("NOBREATHBLOCK")
+			return global.NOBREATHBLOCK;
+		if("NOPRINTSBLOCK")
+			return global.NOPRINTSBLOCK;
+		if("OOClog")
+			return global.OOClog;
+		if("PDA_Manifest")
+			return global.PDA_Manifest;
+		if("PDAs")
+			return global.PDAs;
+		if("REGENERATEBLOCK")
+			return global.REGENERATEBLOCK;
+		if("REMOTETALKBLOCK")
+			return global.REMOTETALKBLOCK;
+		if("REMOTEVIEWBLOCK")
+			return global.REMOTEVIEWBLOCK;
+		if("SHOCKIMMUNITYBLOCK")
+			return global.SHOCKIMMUNITYBLOCK;
+		if("SKILLS")
+			return global.SKILLS;
+		if("SMALLSIZEBLOCK")
+			return global.SMALLSIZEBLOCK;
+		if("TELEBLOCK")
+			return global.TELEBLOCK;
+		if("TWITCHBLOCK")
+			return global.TWITCHBLOCK;
+		if("Tier1Runes")
+			return global.Tier1Runes;
+		if("Tier2Runes")
+			return global.Tier2Runes;
+		if("Tier3Runes")
+			return global.Tier3Runes;
+		if("Tier4Runes")
+			return global.Tier4Runes;
+		if("WALLITEMS")
+			return global.WALLITEMS;
+		if("XRAYBLOCK")
+			return global.XRAYBLOCK;
+		if("_all_globals")
+			return global._all_globals;
+		if("_client_preferences")
+			return global._client_preferences;
+		if("_client_preferences_by_key")
+			return global._client_preferences_by_key;
+		if("_client_preferences_by_type")
+			return global._client_preferences_by_type;
+		if("_preloader")
+			return global._preloader;
+		if("account_hack_attempted")
+			return global.account_hack_attempted;
+		if("acting_rank_prefixes")
+			return global.acting_rank_prefixes;
+		if("active_diseases")
+			return global.active_diseases;
+		if("activeauth")
+			return global.activeauth;
+		if("activecharges")
+			return global.activecharges;
+		if("activename")
+			return global.activename;
+		if("activetype")
+			return global.activetype;
+		if("actor")
+			return global.actor;
+		if("additional_antag_types")
+			return global.additional_antag_types;
+		if("adjectives")
+			return global.adjectives;
+		if("admin_datums")
+			return global.admin_datums;
+		if("admin_departments")
+			return global.admin_departments;
+		if("admin_log")
+			return global.admin_log;
+		if("admin_pm_repository")
+			return global.admin_pm_repository;
+		if("admin_ranks")
+			return global.admin_ranks;
+		if("admin_secrets")
+			return global.admin_secrets;
+		if("admin_state")
+			return global.admin_state;
+		if("admin_verbs_admin")
+			return global.admin_verbs_admin;
+		if("admin_verbs_ban")
+			return global.admin_verbs_ban;
+		if("admin_verbs_debug")
+			return global.admin_verbs_debug;
+		if("admin_verbs_default")
+			return global.admin_verbs_default;
+		if("admin_verbs_fun")
+			return global.admin_verbs_fun;
+		if("admin_verbs_hideable")
+			return global.admin_verbs_hideable;
+		if("admin_verbs_mentor")
+			return global.admin_verbs_mentor;
+		if("admin_verbs_mod")
+			return global.admin_verbs_mod;
+		if("admin_verbs_paranoid_debug")
+			return global.admin_verbs_paranoid_debug;
+		if("admin_verbs_permissions")
+			return global.admin_verbs_permissions;
+		if("admin_verbs_possess")
+			return global.admin_verbs_possess;
+		if("admin_verbs_rejuv")
+			return global.admin_verbs_rejuv;
+		if("admin_verbs_server")
+			return global.admin_verbs_server;
+		if("admin_verbs_sounds")
+			return global.admin_verbs_sounds;
+		if("admin_verbs_spawn")
+			return global.admin_verbs_spawn;
+		if("adminfaxes")
+			return global.adminfaxes;
+		if("adminhelp_ignored_words")
+			return global.adminhelp_ignored_words;
+		if("adminlog")
+			return global.adminlog;
+		if("admins")
+			return global.admins;
+		if("ai_icons")
+			return global.ai_icons;
+		if("ai_list")
+			return global.ai_list;
+		if("ai_names")
+			return global.ai_names;
+		if("ai_status_emotions")
+			return global.ai_status_emotions;
+		if("ai_verbs_default")
+			return global.ai_verbs_default;
+		if("air_alarm_topic")
+			return global.air_alarm_topic;
+		if("air_blocked")
+			return global.air_blocked;
+		if("air_master")
+			return global.air_master;
+		if("air_processing_killed")
+			return global.air_processing_killed;
+		if("alarm_manager")
+			return global.alarm_manager;
+		if("alien_whitelist")
+			return global.alien_whitelist;
+		if("allCasters")
+			return global.allCasters;
+		if("allConsoles")
+			return global.allConsoles;
+		if("all_antag_spawnpoints")
+			return global.all_antag_spawnpoints;
+		if("all_antag_types")
+			return global.all_antag_types;
+		if("all_areas")
+			return global.all_areas;
+		if("all_languages")
+			return global.all_languages;
+		if("all_maps")
+			return global.all_maps;
+		if("all_money_accounts")
+			return global.all_money_accounts;
+		if("all_objectives")
+			return global.all_objectives;
+		if("all_observable_events")
+			return global.all_observable_events;
+		if("all_robolimbs")
+			return global.all_robolimbs;
+		if("all_species")
+			return global.all_species;
+		if("all_ui_styles")
+			return global.all_ui_styles;
+		if("all_unit_tests_passed")
+			return global.all_unit_tests_passed;
+		if("all_virtual_listeners")
+			return global.all_virtual_listeners;
+		if("alldepartments")
+			return global.alldepartments;
+		if("alldirs")
+			return global.alldirs;
+		if("allfaxes")
+			return global.allfaxes;
+		if("alphabet_uppercase")
+			return global.alphabet_uppercase;
+		if("announced_news_types")
+			return global.announced_news_types;
+		if("antag_add_finished")
+			return global.antag_add_finished;
+		if("antag_names_to_ids")
+			return global.antag_names_to_ids;
+		if("appearance_manager")
+			return global.appearance_manager;
+		if("area_repository")
+			return global.area_repository;
+		if("artefact_feedback")
+			return global.artefact_feedback;
+		if("ascii_esc")
+			return global.ascii_esc;
+		if("ascii_green")
+			return global.ascii_green;
+		if("ascii_red")
+			return global.ascii_red;
+		if("ascii_reset")
+			return global.ascii_reset;
+		if("ascii_yellow")
+			return global.ascii_yellow;
+		if("ashtray_cache")
+			return global.ashtray_cache;
+		if("asset_cache")
+			return global.asset_cache;
+		if("asset_datums")
+			return global.asset_datums;
+		if("assigned")
+			return global.assigned;
+		if("assigned_blocks")
+			return global.assigned_blocks;
+		if("assistant_occupations")
+			return global.assistant_occupations;
+		if("atmosphere_alarm")
+			return global.atmosphere_alarm;
+		if("attack_log_repository")
+			return global.attack_log_repository;
+		if("autolathe_categories")
+			return global.autolathe_categories;
+		if("autolathe_recipes")
+			return global.autolathe_recipes;
+		if("awaydestinations")
+			return global.awaydestinations;
+		if("backbaglist")
+			return global.backbaglist;
+		if("base_miss_chance")
+			return global.base_miss_chance;
+		if("basic_robolimb")
+			return global.basic_robolimb;
+		if("blackbox")
+			return global.blackbox;
+		if("blocked")
+			return global.blocked;
+		if("bomb_set")
+			return global.bomb_set;
+		if("bombers")
+			return global.bombers;
+		if("borers")
+			return global.borers;
+		if("breach_brute_descriptors")
+			return global.breach_brute_descriptors;
+		if("breach_burn_descriptors")
+			return global.breach_burn_descriptors;
+		if("cable_list")
+			return global.cable_list;
+		if("cached_icons")
+			return global.cached_icons;
+		if("cached_space")
+			return global.cached_space;
+		if("camera_alarm")
+			return global.camera_alarm;
+		if("camera_range_display_status")
+			return global.camera_range_display_status;
+		if("camera_repository")
+			return global.camera_repository;
+		if("cameranet")
+			return global.cameranet;
+		if("cameranet_")
+			return global.cameranet_;
+		if("can_call_ert")
+			return global.can_call_ert;
+		if("captain_announcement")
+			return global.captain_announcement;
+		if("cardinal")
+			return global.cardinal;
+		if("cargo_positions")
+			return global.cargo_positions;
+		if("cargo_supply_pack_root")
+			return global.cargo_supply_pack_root;
+		if("cargo_supply_packs")
+			return global.cargo_supply_packs;
+		if("changelog_hash")
+			return global.changelog_hash;
+		if("channel_to_radio_key")
+			return global.channel_to_radio_key;
+		if("chargen_robolimbs")
+			return global.chargen_robolimbs;
+		if("checked_for_inactives")
+			return global.checked_for_inactives;
+		if("chemical_reaction_logs")
+			return global.chemical_reaction_logs;
+		if("chemical_reactions_list")
+			return global.chemical_reactions_list;
+		if("chemical_reagents_list")
+			return global.chemical_reagents_list;
+		if("chemistryProcess")
+			return global.chemistryProcess;
+		if("chicken_count")
+			return global.chicken_count;
+		if("church_name")
+			return global.church_name;
+		if("citizenship_choices")
+			return global.citizenship_choices;
+		if("civilian_positions")
+			return global.civilian_positions;
+		if("client_preference_stats_")
+			return global.client_preference_stats_;
+		if("client_repository")
+			return global.client_repository;
+		if("clients")
+			return global.clients;
+		if("clown_names")
+			return global.clown_names;
+		if("clown_sound")
+			return global.clown_sound;
+		if("combatlog")
+			return global.combatlog;
+		if("comm_message_listeners")
+			return global.comm_message_listeners;
+		if("command_announcement")
+			return global.command_announcement;
+		if("command_name")
+			return global.command_name;
+		if("command_positions")
+			return global.command_positions;
+		if("commando_names")
+			return global.commando_names;
+		if("commandos")
+			return global.commandos;
+		if("common_tools")
+			return global.common_tools;
+		if("config")
+			return global.config;
+		if("conscious_state")
+			return global.conscious_state;
+		if("contained_state")
+			return global.contained_state;
+		if("contamination_overlay")
+			return global.contamination_overlay;
+		if("controller_iteration")
+			return global.controller_iteration;
+		if("cornerdirs")
+			return global.cornerdirs;
+		if("create_mob_html")
+			return global.create_mob_html;
+		if("create_object_html")
+			return global.create_object_html;
+		if("create_turf_html")
+			return global.create_turf_html;
+		if("created")
+			return global.created;
+		if("crew_repository")
+			return global.crew_repository;
+		if("cult")
+			return global.cult;
+		if("current_date_string")
+			return global.current_date_string;
+		if("currently_running_tests")
+			return global.currently_running_tests;
+		if("custom_event_msg")
+			return global.custom_event_msg;
+		if("custom_items")
+			return global.custom_items;
+		if("damage_icon_parts")
+			return global.damage_icon_parts;
+		if("data_core")
+			return global.data_core;
+		if("dbcon")
+			return global.dbcon;
+		if("dbcon_old")
+			return global.dbcon_old;
+		if("dead_mob_list_")
+			return global.dead_mob_list_;
+		if("death_event")
+			return global.death_event;
+		if("deathsquad")
+			return global.deathsquad;
+		if("debug_verbs")
+			return global.debug_verbs;
+		if("decls_repository")
+			return global.decls_repository;
+		if("deep_inventory_state")
+			return global.deep_inventory_state;
+		if("default_ai_icon")
+			return global.default_ai_icon;
+		if("default_internal_channels")
+			return global.default_internal_channels;
+		if("default_material_composition")
+			return global.default_material_composition;
+		if("default_medbay_channels")
+			return global.default_medbay_channels;
+		if("default_mobloc")
+			return global.default_mobloc;
+		if("default_onmob_icons")
+			return global.default_onmob_icons;
+		if("default_pai_software")
+			return global.default_pai_software;
+		if("default_state")
+			return global.default_state;
+		if("defer_powernet_rebuild")
+			return global.defer_powernet_rebuild;
+		if("delayed_garbage")
+			return global.delayed_garbage;
+		if("delta_index")
+			return global.delta_index;
+		if("density_set_event")
+			return global.density_set_event;
+		if("department_accounts")
+			return global.department_accounts;
+		if("department_radio_keys")
+			return global.department_radio_keys;
+		if("description_icons")
+			return global.description_icons;
+		if("destroyed_event")
+			return global.destroyed_event;
+		if("diary")
+			return global.diary;
+		if("dir_set_event")
+			return global.dir_set_event;
+		if("directory")
+			return global.directory;
+		if("dna_activity_bounds")
+			return global.dna_activity_bounds;
+		if("dna_genes")
+			return global.dna_genes;
+		if("doppler_arrays")
+			return global.doppler_arrays;
+		if("dreams")
+			return global.dreams;
+		if("dview_mob")
+			return global.dview_mob;
+		if("economic_species_modifier")
+			return global.economic_species_modifier;
+		if("economy_init")
+			return global.economy_init;
+		if("empty_playable_ai_cores")
+			return global.empty_playable_ai_cores;
+		if("endgame_exits")
+			return global.endgame_exits;
+		if("endgame_safespawns")
+			return global.endgame_safespawns;
+		if("engineering_positions")
+			return global.engineering_positions;
+		if("entered_event")
+			return global.entered_event;
+		if("error_cache")
+			return global.error_cache;
+		if("error_cooldown")
+			return global.error_cooldown;
+		if("error_last_seen")
+			return global.error_last_seen;
+		if("ert")
+			return global.ert;
+		if("ert_base_chance")
+			return global.ert_base_chance;
+		if("escape_pods")
+			return global.escape_pods;
+		if("escape_pods_by_name")
+			return global.escape_pods_by_name;
+		if("evacuation_controller")
+			return global.evacuation_controller;
+		if("event_last_fired")
+			return global.event_last_fired;
+		if("event_listen_count")
+			return global.event_listen_count;
+		if("event_manager")
+			return global.event_manager;
+		if("event_sources_count")
+			return global.event_sources_count;
+		if("eventchance")
+			return global.eventchance;
+		if("exclude_jobs")
+			return global.exclude_jobs;
+		if("explosion_in_progress")
+			return global.explosion_in_progress;
+		if("explosion_sound")
+			return global.explosion_sound;
+		if("explosion_turfs")
+			return global.explosion_turfs;
+		if("facial_hair_styles_female_list")
+			return global.facial_hair_styles_female_list;
+		if("facial_hair_styles_list")
+			return global.facial_hair_styles_list;
+		if("facial_hair_styles_male_list")
+			return global.facial_hair_styles_male_list;
+		if("faction_choices")
+			return global.faction_choices;
+		if("failed_db_connections")
+			return global.failed_db_connections;
+		if("failed_old_db_connections")
+			return global.failed_old_db_connections;
+		if("failed_unit_tests")
+			return global.failed_unit_tests;
+		if("file_uid")
+			return global.file_uid;
+		if("fileaccess_timer")
+			return global.fileaccess_timer;
+		if("finds_as_strings")
+			return global.finds_as_strings;
+		if("fire_alarm")
+			return global.fire_alarm;
+		if("first_names_female")
+			return global.first_names_female;
+		if("first_names_male")
+			return global.first_names_male;
+		if("flesh_hud_colours")
+			return global.flesh_hud_colours;
+		if("floorIsLava")
+			return global.floorIsLava;
+		if("floor_decals")
+			return global.floor_decals;
+		if("floor_light_cache")
+			return global.floor_light_cache;
+		if("flooring_cache")
+			return global.flooring_cache;
+		if("flooring_types")
+			return global.flooring_types;
+		if("fluidtrack_cache")
+			return global.fluidtrack_cache;
+		if("follow_repository")
+			return global.follow_repository;
+		if("forced_ambiance_list")
+			return global.forced_ambiance_list;
+		if("forum_activated_group")
+			return global.forum_activated_group;
+		if("forum_authenticated_group")
+			return global.forum_authenticated_group;
+		if("forumsqladdress")
+			return global.forumsqladdress;
+		if("forumsqldb")
+			return global.forumsqldb;
+		if("forumsqllogin")
+			return global.forumsqllogin;
+		if("forumsqlpass")
+			return global.forumsqlpass;
+		if("forumsqlport")
+			return global.forumsqlport;
+		if("fracture_sound")
+			return global.fracture_sound;
+		if("fruit_icon_cache")
+			return global.fruit_icon_cache;
+		if("fuel_injectors")
+			return global.fuel_injectors;
+		if("fusion_cores")
+			return global.fusion_cores;
+		if("fusion_reactions")
+			return global.fusion_reactions;
+		if("game_id")
+			return global.game_id;
+		if("game_version")
+			return global.game_version;
+		if("game_year")
+			return global.game_year;
+		if("gamemode_cache")
+			return global.gamemode_cache;
+		if("garbage_collector")
+			return global.garbage_collector;
+		if("gas_data")
+			return global.gas_data;
+		if("gear_datums")
+			return global.gear_datums;
+		if("gear_tweak_free_color_choice_")
+			return global.gear_tweak_free_color_choice_;
+		if("gender_datums")
+			return global.gender_datums;
+		if("ghost_darkness_images")
+			return global.ghost_darkness_images;
+		if("ghost_master")
+			return global.ghost_master;
+		if("ghost_sightless_images")
+			return global.ghost_sightless_images;
+		if("ghost_traps")
+			return global.ghost_traps;
+		if("global_announcer")
+			return global.global_announcer;
+		if("global_hud")
+			return global.global_hud;
+		if("global_huds")
+			return global.global_huds;
+		if("global_listen_count")
+			return global.global_listen_count;
+		if("global_map")
+			return global.global_map;
+		if("global_message_listener")
+			return global.global_message_listener;
+		if("global_modular_computers")
+			return global.global_modular_computers;
+		if("global_mutations")
+			return global.global_mutations;
+		if("global_underwear")
+			return global.global_underwear;
+		if("global_vars_")
+			return global.global_vars_;
+		if("gravity_is_on")
+			return global.gravity_is_on;
+		if("gyrotrons")
+			return global.gyrotrons;
+		if("hadevent")
+			return global.hadevent;
+		if("hair_styles_female_list")
+			return global.hair_styles_female_list;
+		if("hair_styles_list")
+			return global.hair_styles_list;
+		if("hair_styles_male_list")
+			return global.hair_styles_male_list;
+		if("hands_state")
+			return global.hands_state;
+		if("hazard_overlays")
+			return global.hazard_overlays;
+		if("hidden_skill_types")
+			return global.hidden_skill_types;
+		if("highlanders")
+			return global.highlanders;
+		if("hiss_sound")
+			return global.hiss_sound;
+		if("hit_appends")
+			return global.hit_appends;
+		if("hivemind_bank")
+			return global.hivemind_bank;
+		if("holder_mob_icon_cache")
+			return global.holder_mob_icon_cache;
+		if("home_system_choices")
+			return global.home_system_choices;
+		if("host")
+			return global.host;
+		if("href_logfile")
+			return global.href_logfile;
+		if("hud_icon_reference")
+			return global.hud_icon_reference;
+		if("human_icon_cache")
+			return global.human_icon_cache;
+		if("human_mob_list")
+			return global.human_mob_list;
+		if("id_card_states")
+			return global.id_card_states;
+		if("image_repository")
+			return global.image_repository;
+		if("inactive_keys")
+			return global.inactive_keys;
+		if("init")
+			return global.init;
+		if("initialization_stage")
+			return global.initialization_stage;
+		if("intents")
+			return global.intents;
+		if("interactive_state")
+			return global.interactive_state;
+		if("intercom_range_display_status")
+			return global.intercom_range_display_status;
+		if("invalid_zone")
+			return global.invalid_zone;
+		if("inventory_state")
+			return global.inventory_state;
 		if("is_contact_but_not_space_or_shuttle_area")
 			return global.is_contact_but_not_space_or_shuttle_area;
 		if("is_player_but_not_space_or_shuttle_area")
 			return global.is_player_but_not_space_or_shuttle_area;
-		if("delta_index")
-			return global.delta_index;
+		if("is_station_but_not_space_or_shuttle_area")
+			return global.is_station_but_not_space_or_shuttle_area;
+		if("item_equipped_event")
+			return global.item_equipped_event;
+		if("item_unequipped_event")
+			return global.item_unequipped_event;
+		if("jobMax")
+			return global.jobMax;
+		if("job_master")
+			return global.job_master;
+		if("jobban_keylist")
+			return global.jobban_keylist;
+		if("jobban_runonce")
+			return global.jobban_runonce;
+		if("joblist")
+			return global.joblist;
+		if("join_motd")
+			return global.join_motd;
+		if("landmarks_list")
+			return global.landmarks_list;
+		if("language_keys")
+			return global.language_keys;
+		if("last_chew")
+			return global.last_chew;
+		if("last_message_id")
+			return global.last_message_id;
+		if("last_names")
+			return global.last_names;
+		if("last_round_duration")
+			return global.last_round_duration;
+		if("last_tick_duration")
+			return global.last_tick_duration;
+		if("lastsignalers")
+			return global.lastsignalers;
+		if("latejoin")
+			return global.latejoin;
+		if("latejoin_cryo")
+			return global.latejoin_cryo;
+		if("latejoin_cyborg")
+			return global.latejoin_cyborg;
+		if("latejoin_gateway")
+			return global.latejoin_gateway;
+		if("lawchanges")
+			return global.lawchanges;
+		if("license_to_url")
+			return global.license_to_url;
+		if("life_event")
+			return global.life_event;
+		if("light_overlay_cache")
+			return global.light_overlay_cache;
+		if("light_type_cache")
+			return global.light_type_cache;
+		if("lighter_sound")
+			return global.lighter_sound;
+		if("lighting_update_lights")
+			return global.lighting_update_lights;
+		if("lighting_update_overlays")
+			return global.lighting_update_overlays;
+		if("limb_icon_cache")
+			return global.limb_icon_cache;
+		if("list_of_ais")
+			return global.list_of_ais;
+		if("listening_objects")
+			return global.listening_objects;
+		if("living_mob_list_")
+			return global.living_mob_list_;
+		if("loadout_categories")
+			return global.loadout_categories;
+		if("lobby_image")
+			return global.lobby_image;
+		if("log_end")
+			return global.log_end;
+		if("logged_in_event")
+			return global.logged_in_event;
+		if("logged_out_event")
+			return global.logged_out_event;
+		if("loyalists")
+			return global.loyalists;
+		if("lunchables_drink_reagents_")
+			return global.lunchables_drink_reagents_;
+		if("lunchables_drinks_")
+			return global.lunchables_drinks_;
+		if("lunchables_ethanol_reagents_")
+			return global.lunchables_ethanol_reagents_;
+		if("lunchables_lunches_")
+			return global.lunchables_lunches_;
+		if("lunchables_snacks_")
+			return global.lunchables_snacks_;
+		if("machinery_sort_required")
+			return global.machinery_sort_required;
+		if("machines")
+			return global.machines;
+		if("magazine_icondata_keys")
+			return global.magazine_icondata_keys;
+		if("magazine_icondata_states")
+			return global.magazine_icondata_states;
+		if("maint_all_access")
+			return global.maint_all_access;
+		if("malf")
+			return global.malf;
+		if("mannequins_")
+			return global.mannequins_;
+		if("map_count")
+			return global.map_count;
+		if("map_sectors")
+			return global.map_sectors;
+		if("maploader")
+			return global.maploader;
+		if("mark")
+			return global.mark;
+		if("master_controller")
+			return global.master_controller;
+		if("master_mode")
+			return global.master_mode;
+		if("matchmaker")
+			return global.matchmaker;
+		if("max_explosion_range")
+			return global.max_explosion_range;
+		if("maze_cell_count")
+			return global.maze_cell_count;
+		if("mechas_list")
+			return global.mechas_list;
+		if("mechtoys")
+			return global.mechtoys;
+		if("med_hud_users")
+			return global.med_hud_users;
+		if("medical_positions")
+			return global.medical_positions;
+		if("mercs")
+			return global.mercs;
+		if("merged")
+			return global.merged;
+		if("message_delay")
+			return global.message_delay;
+		if("message_servers")
+			return global.message_servers;
+		if("meteors_armageddon")
+			return global.meteors_armageddon;
+		if("meteors_cataclysm")
+			return global.meteors_cataclysm;
+		if("meteors_catastrophic")
+			return global.meteors_catastrophic;
 		if("meteors_dust")
 			return global.meteors_dust;
 		if("meteors_normal")
 			return global.meteors_normal;
 		if("meteors_threatening")
 			return global.meteors_threatening;
-		if("meteors_catastrophic")
-			return global.meteors_catastrophic;
-		if("meteors_armageddon")
-			return global.meteors_armageddon;
-		if("meteors_cataclysm")
-			return global.meteors_cataclysm;
+		if("mil_branches")
+			return global.mil_branches;
+		if("mining_floors")
+			return global.mining_floors;
+		if("mining_walls")
+			return global.mining_walls;
+		if("minor_air_alarms")
+			return global.minor_air_alarms;
+		if("mob_equipped_event")
+			return global.mob_equipped_event;
+		if("mob_hat_cache")
+			return global.mob_hat_cache;
+		if("mob_list")
+			return global.mob_list;
+		if("mob_repository")
+			return global.mob_repository;
+		if("mob_unequipped_event")
+			return global.mob_unequipped_event;
+		if("monkeystart")
+			return global.monkeystart;
+		if("motion_alarm")
+			return global.motion_alarm;
+		if("moved_event")
+			return global.moved_event;
+		if("moving_levels")
+			return global.moving_levels;
+		if("multi_point_spawns")
+			return global.multi_point_spawns;
+		if("name_to_material")
+			return global.name_to_material;
+		if("nanomanager")
+			return global.nanomanager;
+		if("narsie_behaviour")
+			return global.narsie_behaviour;
+		if("narsie_cometh")
+			return global.narsie_cometh;
+		if("narsie_list")
+			return global.narsie_list;
+		if("navbeacons")
+			return global.navbeacons;
+		if("newplayer_start")
+			return global.newplayer_start;
+		if("news_network")
+			return global.news_network;
+		if("newscaster_standard_feeds")
+			return global.newscaster_standard_feeds;
+		if("next_account_number")
+			return global.next_account_number;
+		if("next_duration_update")
+			return global.next_duration_update;
+		if("next_station_date_change")
+			return global.next_station_date_change;
+		if("ninja_names")
+			return global.ninja_names;
+		if("ninja_titles")
+			return global.ninja_titles;
+		if("ninjas")
+			return global.ninjas;
+		if("ninjastart")
+			return global.ninjastart;
+		if("non_fakeattack_weapons")
+			return global.non_fakeattack_weapons;
+		if("nonhuman_positions")
+			return global.nonhuman_positions;
+		if("not_incapacitated_turf_state")
+			return global.not_incapacitated_turf_state;
+		if("ntnet_card_uid")
+			return global.ntnet_card_uid;
+		if("ntnet_global")
+			return global.ntnet_global;
+		if("ntnrc_uid")
+			return global.ntnrc_uid;
+		if("nttransfer_uid")
+			return global.nttransfer_uid;
+		if("nuke_disks")
+			return global.nuke_disks;
+		if("num_financial_terminals")
+			return global.num_financial_terminals;
+		if("opacity_set_event")
+			return global.opacity_set_event;
+		if("ore_data")
+			return global.ore_data;
+		if("ores_by_type")
+			return global.ores_by_type;
+		if("organ_cache")
+			return global.organ_cache;
+		if("organ_rel_size")
+			return global.organ_rel_size;
+		if("outfits_decls_")
+			return global.outfits_decls_;
+		if("outfits_decls_by_type_")
+			return global.outfits_decls_by_type_;
+		if("outfits_decls_root_")
+			return global.outfits_decls_root_;
+		if("outside_state")
+			return global.outside_state;
+		if("page_sound")
+			return global.page_sound;
+		if("paiController")
+			return global.paiController;
+		if("pai_emotions")
+			return global.pai_emotions;
+		if("pai_software_by_key")
+			return global.pai_software_by_key;
+		if("paramslist_cache")
+			return global.paramslist_cache;
+		if("photo_count")
+			return global.photo_count;
+		if("physical_state")
+			return global.physical_state;
+		if("pipe_colors")
+			return global.pipe_colors;
+		if("pipe_networks")
+			return global.pipe_networks;
+		if("pipe_processing_killed")
+			return global.pipe_processing_killed;
+		if("plant_controller")
+			return global.plant_controller;
+		if("plant_seed_sprites")
+			return global.plant_seed_sprites;
+		if("playable_species")
+			return global.playable_species;
+		if("player_list")
+			return global.player_list;
+		if("point_source_descriptions")
+			return global.point_source_descriptions;
+		if("possible_cable_coil_colours")
+			return global.possible_cable_coil_colours;
+		if("possible_changeling_IDs")
+			return global.possible_changeling_IDs;
+		if("poster_designs")
+			return global.poster_designs;
+		if("power_alarm")
+			return global.power_alarm;
+		if("powerinstances")
+			return global.powerinstances;
+		if("powernets")
+			return global.powernets;
+		if("powers")
+			return global.powers;
+		if("preferences_datums")
+			return global.preferences_datums;
+		if("priority_air_alarms")
+			return global.priority_air_alarms;
+		if("priority_announcement")
+			return global.priority_announcement;
+		if("prisonsecuritywarp")
+			return global.prisonsecuritywarp;
+		if("prisonwarp")
+			return global.prisonwarp;
+		if("prisonwarped")
+			return global.prisonwarped;
+		if("priv_all_access")
+			return global.priv_all_access;
 		if("priv_all_access_datums")
 			return global.priv_all_access_datums;
 		if("priv_all_access_datums_id")
 			return global.priv_all_access_datums_id;
 		if("priv_all_access_datums_region")
 			return global.priv_all_access_datums_region;
-		if("priv_all_access")
-			return global.priv_all_access;
-		if("priv_station_access")
-			return global.priv_station_access;
 		if("priv_centcom_access")
 			return global.priv_centcom_access;
-		if("priv_syndicate_access")
-			return global.priv_syndicate_access;
 		if("priv_region_access")
 			return global.priv_region_access;
-		if("alien_whitelist")
-			return global.alien_whitelist;
-		if("acting_rank_prefixes")
-			return global.acting_rank_prefixes;
-		if("view_variables_hide_vars")
-			return global.view_variables_hide_vars;
-		if("view_variables_dont_expand")
-			return global.view_variables_dont_expand;
-		if("view_variables_no_assoc")
-			return global.view_variables_no_assoc;
-		if("custom_items")
-			return global.custom_items;
-		if("economic_species_modifier")
-			return global.economic_species_modifier;
-		if("lighting_update_lights")
-			return global.lighting_update_lights;
-		if("lighting_update_overlays")
-			return global.lighting_update_overlays;
-		if("gender_datums")
-			return global.gender_datums;
-		if("chemical_reaction_logs")
-			return global.chemical_reaction_logs;
-		if("server_name")
-			return global.server_name;
-		if("game_id")
-			return global.game_id;
-		if("log_end")
-			return global.log_end;
-		if("atmosphere_alarm")
-			return global.atmosphere_alarm;
-		if("camera_alarm")
-			return global.camera_alarm;
-		if("fire_alarm")
-			return global.fire_alarm;
-		if("motion_alarm")
-			return global.motion_alarm;
-		if("power_alarm")
-			return global.power_alarm;
-		if("admin_state")
-			return global.admin_state;
-		if("conscious_state")
-			return global.conscious_state;
-		if("contained_state")
-			return global.contained_state;
-		if("default_state")
-			return global.default_state;
-		if("outside_state")
-			return global.outside_state;
-		if("hands_state")
-			return global.hands_state;
-		if("interactive_state")
-			return global.interactive_state;
-		if("inventory_state")
-			return global.inventory_state;
-		if("deep_inventory_state")
-			return global.deep_inventory_state;
-		if("physical_state")
-			return global.physical_state;
+		if("priv_station_access")
+			return global.priv_station_access;
+		if("priv_syndicate_access")
+			return global.priv_syndicate_access;
+		if("processScheduler")
+			return global.processScheduler;
+		if("processing_objects")
+			return global.processing_objects;
+		if("processing_power_items")
+			return global.processing_power_items;
+		if("processing_turfs")
+			return global.processing_turfs;
+		if("prometheans")
+			return global.prometheans;
+		if("protected_objects")
+			return global.protected_objects;
+		if("punch_sound")
+			return global.punch_sound;
+		if("rad_collectors")
+			return global.rad_collectors;
+		if("radiation_repository")
+			return global.radiation_repository;
+		if("radio_controller")
+			return global.radio_controller;
+		if("radiochannels")
+			return global.radiochannels;
+		if("raiders")
+			return global.raiders;
+		if("random_junk_")
+			return global.random_junk_;
+		if("random_maps")
+			return global.random_maps;
+		if("random_useful_")
+			return global.random_useful_;
+		if("recentmessages")
+			return global.recentmessages;
+		if("reg_dna")
+			return global.reg_dna;
+		if("religion_choices")
+			return global.religion_choices;
+		if("religion_name")
+			return global.religion_name;
+		if("renegades")
+			return global.renegades;
+		if("req_console_assistance")
+			return global.req_console_assistance;
+		if("req_console_information")
+			return global.req_console_information;
+		if("req_console_supplies")
+			return global.req_console_supplies;
+		if("responsive_carriers")
+			return global.responsive_carriers;
+		if("restricted_camera_networks")
+			return global.restricted_camera_networks;
+		if("revdata")
+			return global.revdata;
+		if("reverse_dir")
+			return global.reverse_dir;
+		if("revs")
+			return global.revs;
+		if("robot_custom_icons")
+			return global.robot_custom_icons;
+		if("robot_hud_colours")
+			return global.robot_hud_colours;
+		if("robot_inventory")
+			return global.robot_inventory;
+		if("robot_module_types")
+			return global.robot_module_types;
+		if("robot_modules")
+			return global.robot_modules;
+		if("round_progressing")
+			return global.round_progressing;
+		if("round_start_time")
+			return global.round_start_time;
+		if("roundstart_hour")
+			return global.roundstart_hour;
+		if("rune_list")
+			return global.rune_list;
+		if("rustle_sound")
+			return global.rustle_sound;
+		if("same_wires")
+			return global.same_wires;
+		if("scarySounds")
+			return global.scarySounds;
+		if("scheduler")
+			return global.scheduler;
+		if("science_positions")
+			return global.science_positions;
+		if("sec_hud_users")
+			return global.sec_hud_users;
+		if("secondary_mode")
+			return global.secondary_mode;
+		if("secret_force_mode")
+			return global.secret_force_mode;
+		if("sector_shuttles")
+			return global.sector_shuttles;
+		if("security_announcement_down")
+			return global.security_announcement_down;
+		if("security_announcement_up")
+			return global.security_announcement_up;
+		if("security_level")
+			return global.security_level;
+		if("security_positions")
+			return global.security_positions;
+		if("see_in_dark_set_event")
+			return global.see_in_dark_set_event;
+		if("see_invisible_set_event")
+			return global.see_invisible_set_event;
+		if("seen_citizenships")
+			return global.seen_citizenships;
+		if("seen_factions")
+			return global.seen_factions;
+		if("seen_religions")
+			return global.seen_religions;
+		if("seen_systems")
+			return global.seen_systems;
 		if("self_state")
 			return global.self_state;
-		if("z_state")
-			return global.z_state;
+		if("send_emergency_team")
+			return global.send_emergency_team;
+		if("sent_spiders_to_station")
+			return global.sent_spiders_to_station;
+		if("server_name")
+			return global.server_name;
+		if("service_positions")
+			return global.service_positions;
+		if("severity_to_string")
+			return global.severity_to_string;
+		if("shatter_sound")
+			return global.shatter_sound;
+		if("ship_engines")
+			return global.ship_engines;
+		if("shuttle_controller")
+			return global.shuttle_controller;
+		if("side_effects")
+			return global.side_effects;
+		if("sight_set_event")
+			return global.sight_set_event;
+		if("silicon_mob_list")
+			return global.silicon_mob_list;
+		if("skin_styles_female_list")
+			return global.skin_styles_female_list;
+		if("skipped_unit_tests")
+			return global.skipped_unit_tests;
+		if("slot_equipment_priority")
+			return global.slot_equipment_priority;
+		if("slot_flags_enumeration")
+			return global.slot_flags_enumeration;
+		if("solar_gen_rate")
+			return global.solar_gen_rate;
+		if("solars_list")
+			return global.solars_list;
+		if("sounds_cache")
+			return global.sounds_cache;
+		if("spacevines_spawned")
+			return global.spacevines_spawned;
+		if("spark_sound")
+			return global.spark_sound;
+		if("sparring_attack_cache")
+			return global.sparring_attack_cache;
+		if("spawntypes")
+			return global.spawntypes;
+		if("specops_shuttle_at_station")
+			return global.specops_shuttle_at_station;
+		if("specops_shuttle_can_send")
+			return global.specops_shuttle_can_send;
+		if("specops_shuttle_moving_to_centcom")
+			return global.specops_shuttle_moving_to_centcom;
+		if("specops_shuttle_moving_to_station")
+			return global.specops_shuttle_moving_to_station;
+		if("specops_shuttle_time")
+			return global.specops_shuttle_time;
+		if("specops_shuttle_timeleft")
+			return global.specops_shuttle_timeleft;
+		if("spells")
+			return global.spells;
+		if("splatter_cache")
+			return global.splatter_cache;
+		if("sqladdress")
+			return global.sqladdress;
+		if("sqldb")
+			return global.sqldb;
+		if("sqlfdbkdb")
+			return global.sqlfdbkdb;
+		if("sqlfdbklogin")
+			return global.sqlfdbklogin;
+		if("sqlfdbkpass")
+			return global.sqlfdbkpass;
+		if("sqllogging")
+			return global.sqllogging;
+		if("sqllogin")
+			return global.sqllogin;
+		if("sqlpass")
+			return global.sqlpass;
+		if("sqlport")
+			return global.sqlport;
+		if("stat_set_event")
+			return global.stat_set_event;
+		if("station_account")
+			return global.station_account;
+		if("station_date")
+			return global.station_date;
+		if("station_departments")
+			return global.station_departments;
+		if("status_icons_to_colour")
+			return global.status_icons_to_colour;
+		if("stool_cache")
+			return global.stool_cache;
+		if("stored_shock_by_ref")
+			return global.stored_shock_by_ref;
+		if("storedwarrant")
+			return global.storedwarrant;
+		if("string_part_flags")
+			return global.string_part_flags;
+		if("string_slot_flags")
+			return global.string_slot_flags;
+		if("sun")
+			return global.sun;
+		if("supply_controller")
+			return global.supply_controller;
+		if("supply_drop")
+			return global.supply_drop;
+		if("supply_methods_")
+			return global.supply_methods_;
+		if("supply_positions")
+			return global.supply_positions;
+		if("surgery_steps")
+			return global.surgery_steps;
+		if("swapmaps_byname")
+			return global.swapmaps_byname;
+		if("swapmaps_compiled_maxx")
+			return global.swapmaps_compiled_maxx;
+		if("swapmaps_compiled_maxy")
+			return global.swapmaps_compiled_maxy;
+		if("swapmaps_compiled_maxz")
+			return global.swapmaps_compiled_maxz;
+		if("swapmaps_iconcache")
+			return global.swapmaps_iconcache;
+		if("swapmaps_initialized")
+			return global.swapmaps_initialized;
+		if("swapmaps_loaded")
+			return global.swapmaps_loaded;
+		if("swapmaps_mode")
+			return global.swapmaps_mode;
+		if("swing_hit_sound")
+			return global.swing_hit_sound;
+		if("syndicate_access")
+			return global.syndicate_access;
+		if("syndicate_code_phrase")
+			return global.syndicate_code_phrase;
+		if("syndicate_code_response")
+			return global.syndicate_code_response;
+		if("syndicate_elite_shuttle_at_station")
+			return global.syndicate_elite_shuttle_at_station;
+		if("syndicate_elite_shuttle_can_send")
+			return global.syndicate_elite_shuttle_can_send;
+		if("syndicate_elite_shuttle_moving_to_mothership")
+			return global.syndicate_elite_shuttle_moving_to_mothership;
+		if("syndicate_elite_shuttle_moving_to_station")
+			return global.syndicate_elite_shuttle_moving_to_station;
+		if("syndicate_elite_shuttle_time")
+			return global.syndicate_elite_shuttle_time;
+		if("syndicate_elite_shuttle_timeleft")
+			return global.syndicate_elite_shuttle_timeleft;
+		if("syndicate_name")
+			return global.syndicate_name;
+		if("tagger_locations")
+			return global.tagger_locations;
+		if("tail_icon_cache")
+			return global.tail_icon_cache;
+		if("tank_gauge_cache")
+			return global.tank_gauge_cache;
+		if("tape_roll_applications")
+			return global.tape_roll_applications;
+		if("task_triggered_event")
+			return global.task_triggered_event;
+		if("tdome1")
+			return global.tdome1;
+		if("tdome2")
+			return global.tdome2;
+		if("tdomeadmin")
+			return global.tdomeadmin;
+		if("tdomeobserve")
+			return global.tdomeobserve;
+		if("telecomms_list")
+			return global.telecomms_list;
+		if("tertiary_mode")
+			return global.tertiary_mode;
+		if("text_tag_icons")
+			return global.text_tag_icons;
 		if("tg_admin_state")
 			return global.tg_admin_state;
 		if("tg_always_state")
@@ -123,1435 +1331,1437 @@
 			return global.tg_not_contained_state;
 		if("tg_not_incapacitated_state")
 			return global.tg_not_incapacitated_state;
-		if("not_incapacitated_turf_state")
-			return global.not_incapacitated_turf_state;
 		if("tg_physical_state")
 			return global.tg_physical_state;
 		if("tg_self_state")
 			return global.tg_self_state;
 		if("tg_z_state")
 			return global.tg_z_state;
-		if("machinery_sort_required")
-			return global.machinery_sort_required;
-		if("autolathe_recipes")
-			return global.autolathe_recipes;
-		if("autolathe_categories")
-			return global.autolathe_categories;
-		if("PDA_Manifest")
-			return global.PDA_Manifest;
-		if("id_card_states")
-			return global.id_card_states;
-		if("asset_datums")
-			return global.asset_datums;
-		if("magazine_icondata_keys")
-			return global.magazine_icondata_keys;
-		if("magazine_icondata_states")
-			return global.magazine_icondata_states;
-		if("account_hack_attempted")
-			return global.account_hack_attempted;
-		if("spacevines_spawned")
-			return global.spacevines_spawned;
-		if("sent_spiders_to_station")
-			return global.sent_spiders_to_station;
-		if("text_tag_icons")
-			return global.text_tag_icons;
-		if("scheduler")
-			return global.scheduler;
-		if("security_announcement_up")
-			return global.security_announcement_up;
-		if("security_announcement_down")
-			return global.security_announcement_down;
-		if("priority_announcement")
-			return global.priority_announcement;
-		if("command_announcement")
-			return global.command_announcement;
-		if("gas_data")
-			return global.gas_data;
-		if("area_repository")
-			return global.area_repository;
-		if("decls_repository")
-			return global.decls_repository;
-		if("follow_repository")
-			return global.follow_repository;
-		if("image_repository")
-			return global.image_repository;
-		if("create_mob_html")
-			return global.create_mob_html;
-		if("create_object_html")
-			return global.create_object_html;
-		if("create_turf_html")
-			return global.create_turf_html;
-		if("global_vars_")
-			return global.global_vars_;
-		if("all_ui_styles")
-			return global.all_ui_styles;
-		if("lobby_image")
-			return global.lobby_image;
-		if("security_level")
-			return global.security_level;
-		if("default_mobloc")
-			return global.default_mobloc;
-		if("data_core")
-			return global.data_core;
-		if("all_areas")
-			return global.all_areas;
-		if("machines")
-			return global.machines;
-		if("processing_objects")
-			return global.processing_objects;
-		if("processing_power_items")
-			return global.processing_power_items;
-		if("active_diseases")
-			return global.active_diseases;
-		if("med_hud_users")
-			return global.med_hud_users;
-		if("sec_hud_users")
-			return global.sec_hud_users;
-		if("hud_icon_reference")
-			return global.hud_icon_reference;
-		if("traders")
-			return global.traders;
-		if("listening_objects")
-			return global.listening_objects;
-		if("global_mutations")
-			return global.global_mutations;
-		if("universe")
-			return global.universe;
-		if("global_map")
-			return global.global_map;
-		if("hit_appends")
-			return global.hit_appends;
-		if("diary")
-			return global.diary;
-		if("href_logfile")
-			return global.href_logfile;
-		if("game_version")
-			return global.game_version;
-		if("changelog_hash")
-			return global.changelog_hash;
-		if("game_year")
-			return global.game_year;
-		if("round_progressing")
-			return global.round_progressing;
-		if("master_mode")
-			return global.master_mode;
-		if("secondary_mode")
-			return global.secondary_mode;
-		if("tertiary_mode")
-			return global.tertiary_mode;
-		if("secret_force_mode")
-			return global.secret_force_mode;
-		if("host")
-			return global.host;
-		if("jobMax")
-			return global.jobMax;
-		if("bombers")
-			return global.bombers;
-		if("admin_log")
-			return global.admin_log;
-		if("lastsignalers")
-			return global.lastsignalers;
-		if("lawchanges")
-			return global.lawchanges;
-		if("reg_dna")
-			return global.reg_dna;
-		if("monkeystart")
-			return global.monkeystart;
-		if("wizardstart")
-			return global.wizardstart;
-		if("newplayer_start")
-			return global.newplayer_start;
-		if("latejoin")
-			return global.latejoin;
-		if("latejoin_gateway")
-			return global.latejoin_gateway;
-		if("latejoin_cryo")
-			return global.latejoin_cryo;
-		if("latejoin_cyborg")
-			return global.latejoin_cyborg;
-		if("prisonwarp")
-			return global.prisonwarp;
-		if("xeno_spawn")
-			return global.xeno_spawn;
-		if("tdome1")
-			return global.tdome1;
-		if("tdome2")
-			return global.tdome2;
-		if("tdomeobserve")
-			return global.tdomeobserve;
-		if("tdomeadmin")
-			return global.tdomeadmin;
-		if("prisonsecuritywarp")
-			return global.prisonsecuritywarp;
-		if("prisonwarped")
-			return global.prisonwarped;
-		if("ninjastart")
-			return global.ninjastart;
-		if("cardinal")
-			return global.cardinal;
-		if("cornerdirs")
-			return global.cornerdirs;
-		if("alldirs")
-			return global.alldirs;
-		if("reverse_dir")
-			return global.reverse_dir;
-		if("config")
-			return global.config;
-		if("sun")
-			return global.sun;
-		if("combatlog")
-			return global.combatlog;
-		if("IClog")
-			return global.IClog;
-		if("OOClog")
-			return global.OOClog;
-		if("adminlog")
-			return global.adminlog;
-		if("powernets")
-			return global.powernets;
-		if("Debug2")
-			return global.Debug2;
-		if("gravity_is_on")
-			return global.gravity_is_on;
-		if("join_motd")
-			return global.join_motd;
-		if("nanomanager")
-			return global.nanomanager;
-		if("event_manager")
-			return global.event_manager;
-		if("awaydestinations")
-			return global.awaydestinations;
-		if("sqladdress")
-			return global.sqladdress;
-		if("sqlport")
-			return global.sqlport;
-		if("sqldb")
-			return global.sqldb;
-		if("sqllogin")
-			return global.sqllogin;
-		if("sqlpass")
-			return global.sqlpass;
-		if("sqlfdbkdb")
-			return global.sqlfdbkdb;
-		if("sqlfdbklogin")
-			return global.sqlfdbklogin;
-		if("sqlfdbkpass")
-			return global.sqlfdbkpass;
-		if("sqllogging")
-			return global.sqllogging;
-		if("forumsqladdress")
-			return global.forumsqladdress;
-		if("forumsqlport")
-			return global.forumsqlport;
-		if("forumsqldb")
-			return global.forumsqldb;
-		if("forumsqllogin")
-			return global.forumsqllogin;
-		if("forumsqlpass")
-			return global.forumsqlpass;
-		if("forum_activated_group")
-			return global.forum_activated_group;
-		if("forum_authenticated_group")
-			return global.forum_authenticated_group;
-		if("fileaccess_timer")
-			return global.fileaccess_timer;
-		if("custom_event_msg")
-			return global.custom_event_msg;
-		if("dbcon")
-			return global.dbcon;
-		if("dbcon_old")
-			return global.dbcon_old;
-		if("alphabet_uppercase")
-			return global.alphabet_uppercase;
-		if("robot_module_types")
-			return global.robot_module_types;
-		if("scarySounds")
-			return global.scarySounds;
-		if("max_explosion_range")
-			return global.max_explosion_range;
-		if("global_announcer")
-			return global.global_announcer;
-		if("station_departments")
-			return global.station_departments;
-		if("ai_names")
-			return global.ai_names;
-		if("wizard_first")
-			return global.wizard_first;
-		if("wizard_second")
-			return global.wizard_second;
-		if("ninja_titles")
-			return global.ninja_titles;
-		if("ninja_names")
-			return global.ninja_names;
-		if("commando_names")
-			return global.commando_names;
-		if("first_names_male")
-			return global.first_names_male;
-		if("first_names_female")
-			return global.first_names_female;
-		if("last_names")
-			return global.last_names;
-		if("clown_names")
-			return global.clown_names;
-		if("verbs")
-			return global.verbs;
-		if("adjectives")
-			return global.adjectives;
-		if("world_topic_spam_protect_ip")
-			return global.world_topic_spam_protect_ip;
-		if("world_topic_spam_protect_time")
-			return global.world_topic_spam_protect_time;
-		if("failed_db_connections")
-			return global.failed_db_connections;
-		if("failed_old_db_connections")
-			return global.failed_old_db_connections;
-		if("ghost_master")
-			return global.ghost_master;
-		if("BLINDBLOCK")
-			return global.BLINDBLOCK;
-		if("DEAFBLOCK")
-			return global.DEAFBLOCK;
-		if("HULKBLOCK")
-			return global.HULKBLOCK;
-		if("TELEBLOCK")
-			return global.TELEBLOCK;
-		if("FIREBLOCK")
-			return global.FIREBLOCK;
-		if("XRAYBLOCK")
-			return global.XRAYBLOCK;
-		if("CLUMSYBLOCK")
-			return global.CLUMSYBLOCK;
-		if("FAKEBLOCK")
-			return global.FAKEBLOCK;
-		if("COUGHBLOCK")
-			return global.COUGHBLOCK;
-		if("GLASSESBLOCK")
-			return global.GLASSESBLOCK;
-		if("EPILEPSYBLOCK")
-			return global.EPILEPSYBLOCK;
-		if("TWITCHBLOCK")
-			return global.TWITCHBLOCK;
-		if("NERVOUSBLOCK")
-			return global.NERVOUSBLOCK;
-		if("MONKEYBLOCK")
-			return global.MONKEYBLOCK;
-		if("BLOCKADD")
-			return global.BLOCKADD;
-		if("DIFFMUT")
-			return global.DIFFMUT;
-		if("HEADACHEBLOCK")
-			return global.HEADACHEBLOCK;
-		if("NOBREATHBLOCK")
-			return global.NOBREATHBLOCK;
-		if("REMOTEVIEWBLOCK")
-			return global.REMOTEVIEWBLOCK;
-		if("REGENERATEBLOCK")
-			return global.REGENERATEBLOCK;
-		if("INCREASERUNBLOCK")
-			return global.INCREASERUNBLOCK;
-		if("REMOTETALKBLOCK")
-			return global.REMOTETALKBLOCK;
-		if("MORPHBLOCK")
-			return global.MORPHBLOCK;
-		if("BLENDBLOCK")
-			return global.BLENDBLOCK;
-		if("HALLUCINATIONBLOCK")
-			return global.HALLUCINATIONBLOCK;
-		if("NOPRINTSBLOCK")
-			return global.NOPRINTSBLOCK;
-		if("SHOCKIMMUNITYBLOCK")
-			return global.SHOCKIMMUNITYBLOCK;
-		if("SMALLSIZEBLOCK")
-			return global.SMALLSIZEBLOCK;
-		if("default_onmob_icons")
-			return global.default_onmob_icons;
-		if("defer_powernet_rebuild")
-			return global.defer_powernet_rebuild;
-		if("restricted_camera_networks")
-			return global.restricted_camera_networks;
-		if("gear_tweak_free_color_choice_")
-			return global.gear_tweak_free_color_choice_;
-		if("clients")
-			return global.clients;
-		if("admins")
-			return global.admins;
-		if("directory")
-			return global.directory;
-		if("player_list")
-			return global.player_list;
-		if("mob_list")
-			return global.mob_list;
-		if("human_mob_list")
-			return global.human_mob_list;
-		if("silicon_mob_list")
-			return global.silicon_mob_list;
-		if("living_mob_list_")
-			return global.living_mob_list_;
-		if("dead_mob_list_")
-			return global.dead_mob_list_;
-		if("cable_list")
-			return global.cable_list;
-		if("chemical_reactions_list")
-			return global.chemical_reactions_list;
-		if("chemical_reagents_list")
-			return global.chemical_reagents_list;
-		if("landmarks_list")
-			return global.landmarks_list;
-		if("surgery_steps")
-			return global.surgery_steps;
-		if("side_effects")
-			return global.side_effects;
-		if("mechas_list")
-			return global.mechas_list;
-		if("joblist")
-			return global.joblist;
-		if("turfs")
-			return global.turfs;
-		if("all_species")
-			return global.all_species;
-		if("all_languages")
-			return global.all_languages;
-		if("language_keys")
-			return global.language_keys;
-		if("whitelisted_species")
-			return global.whitelisted_species;
-		if("playable_species")
-			return global.playable_species;
-		if("mannequins_")
-			return global.mannequins_;
-		if("poster_designs")
-			return global.poster_designs;
-		if("world_uplinks")
-			return global.world_uplinks;
-		if("hair_styles_list")
-			return global.hair_styles_list;
-		if("hair_styles_male_list")
-			return global.hair_styles_male_list;
-		if("hair_styles_female_list")
-			return global.hair_styles_female_list;
-		if("facial_hair_styles_list")
-			return global.facial_hair_styles_list;
-		if("facial_hair_styles_male_list")
-			return global.facial_hair_styles_male_list;
-		if("facial_hair_styles_female_list")
-			return global.facial_hair_styles_female_list;
-		if("skin_styles_female_list")
-			return global.skin_styles_female_list;
-		if("global_underwear")
-			return global.global_underwear;
-		if("backbaglist")
-			return global.backbaglist;
-		if("exclude_jobs")
-			return global.exclude_jobs;
-		if("visual_nets")
-			return global.visual_nets;
-		if("cameranet")
-			return global.cameranet;
-		if("rune_list")
-			return global.rune_list;
-		if("endgame_exits")
-			return global.endgame_exits;
-		if("endgame_safespawns")
-			return global.endgame_safespawns;
-		if("syndicate_access")
-			return global.syndicate_access;
-		if("string_part_flags")
-			return global.string_part_flags;
-		if("string_slot_flags")
-			return global.string_slot_flags;
-		if("paramslist_cache")
-			return global.paramslist_cache;
-		if("church_name")
-			return global.church_name;
-		if("command_name")
-			return global.command_name;
-		if("religion_name")
-			return global.religion_name;
-		if("syndicate_name")
-			return global.syndicate_name;
-		if("syndicate_code_phrase")
-			return global.syndicate_code_phrase;
-		if("syndicate_code_response")
-			return global.syndicate_code_response;
-		if("roundstart_hour")
-			return global.roundstart_hour;
-		if("station_date")
-			return global.station_date;
-		if("next_station_date_change")
-			return global.next_station_date_change;
-		if("next_duration_update")
-			return global.next_duration_update;
-		if("last_round_duration")
-			return global.last_round_duration;
-		if("round_start_time")
-			return global.round_start_time;
-		if("common_tools")
-			return global.common_tools;
-		if("WALLITEMS")
-			return global.WALLITEMS;
-		if("dview_mob")
-			return global.dview_mob;
-		if("global_hud")
-			return global.global_hud;
-		if("global_huds")
-			return global.global_huds;
-		if("robot_inventory")
-			return global.robot_inventory;
-		if("transfer_controller")
-			return global.transfer_controller;
-		if("radiochannels")
-			return global.radiochannels;
-		if("CENT_FREQS")
-			return global.CENT_FREQS;
-		if("ANTAG_FREQS")
-			return global.ANTAG_FREQS;
-		if("DEPT_FREQS")
-			return global.DEPT_FREQS;
-		if("radio_controller")
-			return global.radio_controller;
-		if("gamemode_cache")
-			return global.gamemode_cache;
-		if("master_controller")
-			return global.master_controller;
-		if("controller_iteration")
-			return global.controller_iteration;
-		if("last_tick_duration")
-			return global.last_tick_duration;
-		if("air_processing_killed")
-			return global.air_processing_killed;
-		if("pipe_processing_killed")
-			return global.pipe_processing_killed;
-		if("initialization_stage")
-			return global.initialization_stage;
-		if("shuttle_controller")
-			return global.shuttle_controller;
-		if("vote")
-			return global.vote;
-		if("evacuation_controller")
-			return global.evacuation_controller;
-		if("list_of_ais")
-			return global.list_of_ais;
-		if("alarm_manager")
-			return global.alarm_manager;
-		if("chemistryProcess")
-			return global.chemistryProcess;
-		if("garbage_collector")
-			return global.garbage_collector;
-		if("delayed_garbage")
-			return global.delayed_garbage;
 		if("tgui_process")
 			return global.tgui_process;
-		if("tickerProcess")
-			return global.tickerProcess;
-		if("processing_turfs")
-			return global.processing_turfs;
-		if("wirelessProcess")
-			return global.wirelessProcess;
-		if("processScheduler")
-			return global.processScheduler;
-		if("mil_branches")
-			return global.mil_branches;
-		if("appearance_manager")
-			return global.appearance_manager;
-		if("revdata")
-			return global.revdata;
-		if("all_observable_events")
-			return global.all_observable_events;
-		if("death_event")
-			return global.death_event;
-		if("density_set_event")
-			return global.density_set_event;
-		if("destroyed_event")
-			return global.destroyed_event;
-		if("dir_set_event")
-			return global.dir_set_event;
-		if("entered_event")
-			return global.entered_event;
-		if("mob_equipped_event")
-			return global.mob_equipped_event;
-		if("item_equipped_event")
-			return global.item_equipped_event;
-		if("life_event")
-			return global.life_event;
-		if("logged_in_event")
-			return global.logged_in_event;
-		if("logged_out_event")
-			return global.logged_out_event;
-		if("moved_event")
-			return global.moved_event;
-		if("opacity_set_event")
-			return global.opacity_set_event;
-		if("see_in_dark_set_event")
-			return global.see_in_dark_set_event;
-		if("see_invisible_set_event")
-			return global.see_invisible_set_event;
-		if("sight_set_event")
-			return global.sight_set_event;
-		if("stat_set_event")
-			return global.stat_set_event;
-		if("task_triggered_event")
-			return global.task_triggered_event;
-		if("turf_changed_event")
-			return global.turf_changed_event;
-		if("mob_unequipped_event")
-			return global.mob_unequipped_event;
-		if("item_unequipped_event")
-			return global.item_unequipped_event;
-		if("global_listen_count")
-			return global.global_listen_count;
-		if("event_sources_count")
-			return global.event_sources_count;
-		if("event_listen_count")
-			return global.event_listen_count;
-		if("outfits_decls_")
-			return global.outfits_decls_;
-		if("outfits_decls_root_")
-			return global.outfits_decls_root_;
-		if("outfits_decls_by_type_")
-			return global.outfits_decls_by_type_;
-		if("admin_pm_repository")
-			return global.admin_pm_repository;
-		if("attack_log_repository")
-			return global.attack_log_repository;
-		if("camera_repository")
-			return global.camera_repository;
-		if("client_repository")
-			return global.client_repository;
-		if("mob_repository")
-			return global.mob_repository;
-		if("radiation_repository")
-			return global.radiation_repository;
-		if("to_process")
-			return global.to_process;
-		if("uniqueness_repository")
-			return global.uniqueness_repository;
-		if("uplink_purchase_repository")
-			return global.uplink_purchase_repository;
-		if("crew_repository")
-			return global.crew_repository;
-		if("cargo_supply_pack_root")
-			return global.cargo_supply_pack_root;
-		if("cargo_supply_packs")
-			return global.cargo_supply_packs;
-		if("supply_methods_")
-			return global.supply_methods_;
-		if("uplink")
-			return global.uplink;
-		if("same_wires")
-			return global.same_wires;
-		if("wireColours")
-			return global.wireColours;
-		if("newscaster_standard_feeds")
-			return global.newscaster_standard_feeds;
-		if("announced_news_types")
-			return global.announced_news_types;
-		if("send_emergency_team")
-			return global.send_emergency_team;
-		if("ert_base_chance")
-			return global.ert_base_chance;
-		if("can_call_ert")
-			return global.can_call_ert;
-		if("shatter_sound")
-			return global.shatter_sound;
-		if("explosion_sound")
-			return global.explosion_sound;
-		if("spark_sound")
-			return global.spark_sound;
-		if("rustle_sound")
-			return global.rustle_sound;
-		if("punch_sound")
-			return global.punch_sound;
-		if("clown_sound")
-			return global.clown_sound;
-		if("swing_hit_sound")
-			return global.swing_hit_sound;
-		if("hiss_sound")
-			return global.hiss_sound;
-		if("page_sound")
-			return global.page_sound;
-		if("fracture_sound")
-			return global.fracture_sound;
-		if("lighter_sound")
-			return global.lighter_sound;
-		if("supply_controller")
-			return global.supply_controller;
-		if("mechtoys")
-			return global.mechtoys;
-		if("point_source_descriptions")
-			return global.point_source_descriptions;
-		if("all_antag_types")
-			return global.all_antag_types;
-		if("all_antag_spawnpoints")
-			return global.all_antag_spawnpoints;
-		if("antag_names_to_ids")
-			return global.antag_names_to_ids;
-		if("borers")
-			return global.borers;
-		if("xenomorphs")
-			return global.xenomorphs;
-		if("actor")
-			return global.actor;
-		if("commandos")
-			return global.commandos;
-		if("deathsquad")
-			return global.deathsquad;
-		if("ert")
-			return global.ert;
-		if("mercs")
-			return global.mercs;
-		if("ninjas")
-			return global.ninjas;
-		if("raiders")
-			return global.raiders;
-		if("wizards")
-			return global.wizards;
-		if("cult")
-			return global.cult;
-		if("highlanders")
-			return global.highlanders;
-		if("loyalists")
-			return global.loyalists;
-		if("renegades")
-			return global.renegades;
-		if("revs")
-			return global.revs;
-		if("malf")
-			return global.malf;
-		if("traitors")
-			return global.traitors;
-		if("forced_ambiance_list")
-			return global.forced_ambiance_list;
-		if("dna_activity_bounds")
-			return global.dna_activity_bounds;
-		if("assigned_blocks")
-			return global.assigned_blocks;
-		if("dna_genes")
-			return global.dna_genes;
-		if("eventchance")
-			return global.eventchance;
-		if("hadevent")
-			return global.hadevent;
-		if("antag_add_finished")
-			return global.antag_add_finished;
-		if("additional_antag_types")
-			return global.additional_antag_types;
+		if("tick_multiplier")
+			return global.tick_multiplier;
 		if("ticker")
 			return global.ticker;
-		if("all_objectives")
-			return global.all_objectives;
-		if("possible_changeling_IDs")
-			return global.possible_changeling_IDs;
-		if("hivemind_bank")
-			return global.hivemind_bank;
-		if("powers")
-			return global.powers;
-		if("powerinstances")
-			return global.powerinstances;
-		if("narsie_behaviour")
-			return global.narsie_behaviour;
-		if("narsie_cometh")
-			return global.narsie_cometh;
-		if("narsie_list")
-			return global.narsie_list;
-		if("Tier1Runes")
-			return global.Tier1Runes;
-		if("Tier2Runes")
-			return global.Tier2Runes;
-		if("Tier3Runes")
-			return global.Tier3Runes;
-		if("Tier4Runes")
-			return global.Tier4Runes;
-		if("universe_has_ended")
-			return global.universe_has_ended;
-		if("Holiday")
-			return global.Holiday;
-		if("nuke_disks")
-			return global.nuke_disks;
-		if("job_master")
-			return global.job_master;
-		if("assistant_occupations")
-			return global.assistant_occupations;
-		if("command_positions")
-			return global.command_positions;
-		if("engineering_positions")
-			return global.engineering_positions;
-		if("medical_positions")
-			return global.medical_positions;
-		if("science_positions")
-			return global.science_positions;
-		if("cargo_positions")
-			return global.cargo_positions;
-		if("civilian_positions")
-			return global.civilian_positions;
-		if("security_positions")
-			return global.security_positions;
-		if("nonhuman_positions")
-			return global.nonhuman_positions;
-		if("service_positions")
-			return global.service_positions;
-		if("supply_positions")
-			return global.supply_positions;
-		if("whitelist")
-			return global.whitelist;
-		if("captain_announcement")
-			return global.captain_announcement;
-		if("doppler_arrays")
-			return global.doppler_arrays;
-		if("floor_light_cache")
-			return global.floor_light_cache;
-		if("navbeacons")
-			return global.navbeacons;
-		if("news_network")
-			return global.news_network;
-		if("allCasters")
-			return global.allCasters;
-		if("bomb_set")
-			return global.bomb_set;
-		if("turret_icons")
-			return global.turret_icons;
-		if("req_console_assistance")
-			return global.req_console_assistance;
-		if("req_console_supplies")
-			return global.req_console_supplies;
-		if("req_console_information")
-			return global.req_console_information;
-		if("allConsoles")
-			return global.allConsoles;
-		if("status_icons_to_colour")
-			return global.status_icons_to_colour;
-		if("ai_status_emotions")
-			return global.ai_status_emotions;
-		if("priority_air_alarms")
-			return global.priority_air_alarms;
-		if("minor_air_alarms")
-			return global.minor_air_alarms;
-		if("air_alarm_topic")
-			return global.air_alarm_topic;
-		if("specops_shuttle_moving_to_station")
-			return global.specops_shuttle_moving_to_station;
-		if("specops_shuttle_moving_to_centcom")
-			return global.specops_shuttle_moving_to_centcom;
-		if("specops_shuttle_at_station")
-			return global.specops_shuttle_at_station;
-		if("specops_shuttle_can_send")
-			return global.specops_shuttle_can_send;
-		if("specops_shuttle_time")
-			return global.specops_shuttle_time;
-		if("specops_shuttle_timeleft")
-			return global.specops_shuttle_timeleft;
-		if("syndicate_elite_shuttle_moving_to_station")
-			return global.syndicate_elite_shuttle_moving_to_station;
-		if("syndicate_elite_shuttle_moving_to_mothership")
-			return global.syndicate_elite_shuttle_moving_to_mothership;
-		if("syndicate_elite_shuttle_at_station")
-			return global.syndicate_elite_shuttle_at_station;
-		if("syndicate_elite_shuttle_can_send")
-			return global.syndicate_elite_shuttle_can_send;
-		if("syndicate_elite_shuttle_time")
-			return global.syndicate_elite_shuttle_time;
-		if("syndicate_elite_shuttle_timeleft")
-			return global.syndicate_elite_shuttle_timeleft;
-		if("recentmessages")
-			return global.recentmessages;
-		if("message_delay")
-			return global.message_delay;
-		if("telecomms_list")
-			return global.telecomms_list;
-		if("explosion_turfs")
-			return global.explosion_turfs;
-		if("explosion_in_progress")
-			return global.explosion_in_progress;
-		if("slot_flags_enumeration")
-			return global.slot_flags_enumeration;
-		if("BUMP_TELEPORTERS")
-			return global.BUMP_TELEPORTERS;
-		if("splatter_cache")
-			return global.splatter_cache;
-		if("fluidtrack_cache")
-			return global.fluidtrack_cache;
-		if("storedwarrant")
-			return global.storedwarrant;
-		if("activename")
-			return global.activename;
-		if("activecharges")
-			return global.activecharges;
-		if("activeauth")
-			return global.activeauth;
-		if("activetype")
-			return global.activetype;
-		if("uplink_random_selections_")
-			return global.uplink_random_selections_;
-		if("PDAs")
-			return global.PDAs;
-		if("default_internal_channels")
-			return global.default_internal_channels;
-		if("default_medbay_channels")
-			return global.default_medbay_channels;
-		if("last_chew")
-			return global.last_chew;
-		if("cached_icons")
-			return global.cached_icons;
-		if("hazard_overlays")
-			return global.hazard_overlays;
-		if("tape_roll_applications")
-			return global.tape_roll_applications;
-		if("ashtray_cache")
-			return global.ashtray_cache;
-		if("tank_gauge_cache")
-			return global.tank_gauge_cache;
-		if("multi_point_spawns")
-			return global.multi_point_spawns;
-		if("random_junk_")
-			return global.random_junk_;
-		if("random_useful_")
-			return global.random_useful_;
-		if("stool_cache")
-			return global.stool_cache;
-		if("flooring_types")
-			return global.flooring_types;
-		if("floor_decals")
-			return global.floor_decals;
-		if("flooring_cache")
-			return global.flooring_cache;
-		if("BSACooldown")
-			return global.BSACooldown;
-		if("floorIsLava")
-			return global.floorIsLava;
-		if("admin_ranks")
-			return global.admin_ranks;
-		if("admin_secrets")
-			return global.admin_secrets;
-		if("admin_verbs_default")
-			return global.admin_verbs_default;
-		if("admin_verbs_admin")
-			return global.admin_verbs_admin;
-		if("admin_verbs_ban")
-			return global.admin_verbs_ban;
-		if("admin_verbs_sounds")
-			return global.admin_verbs_sounds;
-		if("admin_verbs_fun")
-			return global.admin_verbs_fun;
-		if("admin_verbs_spawn")
-			return global.admin_verbs_spawn;
-		if("admin_verbs_server")
-			return global.admin_verbs_server;
-		if("admin_verbs_debug")
-			return global.admin_verbs_debug;
-		if("admin_verbs_paranoid_debug")
-			return global.admin_verbs_paranoid_debug;
-		if("admin_verbs_possess")
-			return global.admin_verbs_possess;
-		if("admin_verbs_permissions")
-			return global.admin_verbs_permissions;
-		if("admin_verbs_rejuv")
-			return global.admin_verbs_rejuv;
-		if("admin_verbs_hideable")
-			return global.admin_verbs_hideable;
-		if("admin_verbs_mod")
-			return global.admin_verbs_mod;
-		if("admin_verbs_mentor")
-			return global.admin_verbs_mentor;
-		if("jobban_runonce")
-			return global.jobban_runonce;
-		if("jobban_keylist")
-			return global.jobban_keylist;
-		if("admin_datums")
-			return global.admin_datums;
-		if("CMinutes")
-			return global.CMinutes;
-		if("Banlist")
-			return global.Banlist;
-		if("adminhelp_ignored_words")
-			return global.adminhelp_ignored_words;
-		if("checked_for_inactives")
-			return global.checked_for_inactives;
-		if("inactive_keys")
-			return global.inactive_keys;
-		if("camera_range_display_status")
-			return global.camera_range_display_status;
-		if("intercom_range_display_status")
-			return global.intercom_range_display_status;
-		if("debug_verbs")
-			return global.debug_verbs;
-		if("sounds_cache")
-			return global.sounds_cache;
-		if("pipe_colors")
-			return global.pipe_colors;
-		if("pipe_networks")
-			return global.pipe_networks;
-		if("asset_cache")
-			return global.asset_cache;
-		if("preferences_datums")
-			return global.preferences_datums;
-		if("seen_citizenships")
-			return global.seen_citizenships;
-		if("seen_systems")
-			return global.seen_systems;
-		if("seen_factions")
-			return global.seen_factions;
-		if("seen_religions")
-			return global.seen_religions;
-		if("citizenship_choices")
-			return global.citizenship_choices;
-		if("home_system_choices")
-			return global.home_system_choices;
-		if("faction_choices")
-			return global.faction_choices;
-		if("religion_choices")
-			return global.religion_choices;
-		if("spawntypes")
-			return global.spawntypes;
-		if("client_preference_stats_")
-			return global.client_preference_stats_;
-		if("uplink_locations")
-			return global.uplink_locations;
-		if("valid_bloodtypes")
-			return global.valid_bloodtypes;
-		if("_client_preferences")
-			return global._client_preferences;
-		if("_client_preferences_by_key")
-			return global._client_preferences_by_key;
-		if("_client_preferences_by_type")
-			return global._client_preferences_by_type;
-		if("loadout_categories")
-			return global.loadout_categories;
-		if("gear_datums")
-			return global.gear_datums;
-		if("matchmaker")
-			return global.matchmaker;
-		if("breach_brute_descriptors")
-			return global.breach_brute_descriptors;
-		if("breach_burn_descriptors")
-			return global.breach_burn_descriptors;
-		if("current_date_string")
-			return global.current_date_string;
-		if("vendor_account")
-			return global.vendor_account;
-		if("station_account")
-			return global.station_account;
-		if("department_accounts")
-			return global.department_accounts;
-		if("num_financial_terminals")
-			return global.num_financial_terminals;
-		if("next_account_number")
-			return global.next_account_number;
-		if("all_money_accounts")
-			return global.all_money_accounts;
-		if("economy_init")
-			return global.economy_init;
-		if("weighted_randomevent_locations")
-			return global.weighted_randomevent_locations;
-		if("weighted_mundaneevent_locations")
-			return global.weighted_mundaneevent_locations;
-		if("error_last_seen")
-			return global.error_last_seen;
-		if("error_cooldown")
-			return global.error_cooldown;
+		if("tickerProcess")
+			return global.tickerProcess;
+		if("to_process")
+			return global.to_process;
 		if("total_runtimes")
 			return global.total_runtimes;
 		if("total_runtimes_skipped")
 			return global.total_runtimes_skipped;
-		if("error_cache")
-			return global.error_cache;
-		if("severity_to_string")
-			return global.severity_to_string;
-		if("event_last_fired")
-			return global.event_last_fired;
-		if("description_icons")
-			return global.description_icons;
-		if("dreams")
-			return global.dreams;
-		if("non_fakeattack_weapons")
-			return global.non_fakeattack_weapons;
-		if("ghost_traps")
-			return global.ghost_traps;
-		if("fruit_icon_cache")
-			return global.fruit_icon_cache;
-		if("plant_controller")
-			return global.plant_controller;
-		if("plant_seed_sprites")
-			return global.plant_seed_sprites;
-		if("wax_recipes")
-			return global.wax_recipes;
-		if("worths")
-			return global.worths;
-		if("license_to_url")
-			return global.license_to_url;
-		if("maploader")
-			return global.maploader;
-		if("_preloader")
-			return global._preloader;
-		if("swapmaps_iconcache")
-			return global.swapmaps_iconcache;
-		if("swapmaps_mode")
-			return global.swapmaps_mode;
-		if("swapmaps_compiled_maxx")
-			return global.swapmaps_compiled_maxx;
-		if("swapmaps_compiled_maxy")
-			return global.swapmaps_compiled_maxy;
-		if("swapmaps_compiled_maxz")
-			return global.swapmaps_compiled_maxz;
-		if("swapmaps_initialized")
-			return global.swapmaps_initialized;
-		if("swapmaps_loaded")
-			return global.swapmaps_loaded;
-		if("swapmaps_byname")
-			return global.swapmaps_byname;
-		if("name_to_material")
-			return global.name_to_material;
-		if("mining_walls")
-			return global.mining_walls;
-		if("mining_floors")
-			return global.mining_floors;
-		if("ore_data")
-			return global.ore_data;
-		if("ores_by_type")
-			return global.ores_by_type;
-		if("holder_mob_icon_cache")
-			return global.holder_mob_icon_cache;
-		if("slot_equipment_priority")
-			return global.slot_equipment_priority;
-		if("base_miss_chance")
-			return global.base_miss_chance;
-		if("organ_rel_size")
-			return global.organ_rel_size;
-		if("intents")
-			return global.intents;
-		if("department_radio_keys")
-			return global.department_radio_keys;
-		if("channel_to_radio_key")
-			return global.channel_to_radio_key;
-		if("sparring_attack_cache")
-			return global.sparring_attack_cache;
-		if("human_icon_cache")
-			return global.human_icon_cache;
-		if("tail_icon_cache")
-			return global.tail_icon_cache;
-		if("light_overlay_cache")
-			return global.light_overlay_cache;
-		if("damage_icon_parts")
-			return global.damage_icon_parts;
-		if("stored_shock_by_ref")
-			return global.stored_shock_by_ref;
-		if("wrapped_species_by_ref")
-			return global.wrapped_species_by_ref;
-		if("prometheans")
-			return global.prometheans;
-		if("ai_list")
-			return global.ai_list;
-		if("ai_verbs_default")
-			return global.ai_verbs_default;
-		if("default_ai_icon")
-			return global.default_ai_icon;
-		if("ai_icons")
-			return global.ai_icons;
-		if("empty_playable_ai_cores")
-			return global.empty_playable_ai_cores;
-		if("paiController")
-			return global.paiController;
-		if("pai_emotions")
-			return global.pai_emotions;
-		if("pai_software_by_key")
-			return global.pai_software_by_key;
-		if("default_pai_software")
-			return global.default_pai_software;
-		if("robot_custom_icons")
-			return global.robot_custom_icons;
-		if("robot_modules")
-			return global.robot_modules;
-		if("mob_hat_cache")
-			return global.mob_hat_cache;
-		if("chicken_count")
-			return global.chicken_count;
-		if("protected_objects")
-			return global.protected_objects;
-		if("hidden_skill_types")
-			return global.hidden_skill_types;
-		if("SKILLS")
-			return global.SKILLS;
-		if("cameranet_")
-			return global.cameranet_;
-		if("ghost_darkness_images")
-			return global.ghost_darkness_images;
-		if("ghost_sightless_images")
-			return global.ghost_sightless_images;
-		if("all_virtual_listeners")
-			return global.all_virtual_listeners;
-		if("global_modular_computers")
-			return global.global_modular_computers;
-		if("file_uid")
-			return global.file_uid;
-		if("comm_message_listeners")
-			return global.comm_message_listeners;
-		if("global_message_listener")
-			return global.global_message_listener;
-		if("last_message_id")
-			return global.last_message_id;
-		if("warrant_uid")
-			return global.warrant_uid;
-		if("nttransfer_uid")
-			return global.nttransfer_uid;
-		if("ntnet_card_uid")
-			return global.ntnet_card_uid;
-		if("ntnet_global")
-			return global.ntnet_global;
-		if("ntnrc_uid")
-			return global.ntnrc_uid;
-		if("z_levels")
-			return global.z_levels;
-		if("organ_cache")
-			return global.organ_cache;
-		if("limb_icon_cache")
-			return global.limb_icon_cache;
-		if("flesh_hud_colours")
-			return global.flesh_hud_colours;
-		if("robot_hud_colours")
-			return global.robot_hud_colours;
-		if("all_robolimbs")
-			return global.all_robolimbs;
-		if("chargen_robolimbs")
-			return global.chargen_robolimbs;
-		if("basic_robolimb")
-			return global.basic_robolimb;
-		if("map_sectors")
-			return global.map_sectors;
-		if("moving_levels")
-			return global.moving_levels;
-		if("sector_shuttles")
-			return global.sector_shuttles;
-		if("cached_space")
-			return global.cached_space;
-		if("ship_engines")
-			return global.ship_engines;
-		if("allfaxes")
-			return global.allfaxes;
-		if("admin_departments")
-			return global.admin_departments;
-		if("alldepartments")
-			return global.alldepartments;
-		if("adminfaxes")
-			return global.adminfaxes;
-		if("photo_count")
-			return global.photo_count;
-		if("possible_cable_coil_colours")
-			return global.possible_cable_coil_colours;
-		if("light_type_cache")
-			return global.light_type_cache;
-		if("solar_gen_rate")
-			return global.solar_gen_rate;
-		if("solars_list")
-			return global.solars_list;
-		if("fusion_reactions")
-			return global.fusion_reactions;
-		if("fusion_cores")
-			return global.fusion_cores;
-		if("fuel_injectors")
-			return global.fuel_injectors;
-		if("gyrotrons")
-			return global.gyrotrons;
-		if("rad_collectors")
-			return global.rad_collectors;
-		if("random_maps")
-			return global.random_maps;
-		if("map_count")
-			return global.map_count;
-		if("supply_drop")
-			return global.supply_drop;
-		if("maze_cell_count")
-			return global.maze_cell_count;
-		if("lunchables_lunches_")
-			return global.lunchables_lunches_;
-		if("lunchables_snacks_")
-			return global.lunchables_snacks_;
-		if("lunchables_drinks_")
-			return global.lunchables_drinks_;
-		if("lunchables_drink_reagents_")
-			return global.lunchables_drink_reagents_;
-		if("lunchables_ethanol_reagents_")
-			return global.lunchables_ethanol_reagents_;
-		if("message_servers")
-			return global.message_servers;
-		if("blackbox")
-			return global.blackbox;
-		if("default_material_composition")
-			return global.default_material_composition;
-		if("maint_all_access")
-			return global.maint_all_access;
-		if("escape_pods")
-			return global.escape_pods;
-		if("escape_pods_by_name")
-			return global.escape_pods_by_name;
-		if("spells")
-			return global.spells;
-		if("artefact_feedback")
-			return global.artefact_feedback;
-		if("turbolifts")
-			return global.turbolifts;
-		if("turbolift_controller")
-			return global.turbolift_controller;
-		if("ventcrawl_machinery")
-			return global.ventcrawl_machinery;
-		if("ALL_ANTIGENS")
-			return global.ALL_ANTIGENS;
-		if("virusDB")
-			return global.virusDB;
-		if("responsive_carriers")
-			return global.responsive_carriers;
-		if("finds_as_strings")
-			return global.finds_as_strings;
-		if("air_master")
-			return global.air_master;
-		if("tick_multiplier")
-			return global.tick_multiplier;
-		if("assigned")
-			return global.assigned;
-		if("created")
-			return global.created;
-		if("merged")
-			return global.merged;
-		if("invalid_zone")
-			return global.invalid_zone;
-		if("air_blocked")
-			return global.air_blocked;
-		if("zone_blocked")
-			return global.zone_blocked;
-		if("blocked")
-			return global.blocked;
-		if("mark")
-			return global.mark;
-		if("contamination_overlay")
-			return global.contamination_overlay;
-		if("vsc")
-			return global.vsc;
-		if("all_unit_tests_passed")
-			return global.all_unit_tests_passed;
-		if("failed_unit_tests")
-			return global.failed_unit_tests;
-		if("skipped_unit_tests")
-			return global.skipped_unit_tests;
 		if("total_unit_tests")
 			return global.total_unit_tests;
-		if("currently_running_tests")
-			return global.currently_running_tests;
-		if("ascii_esc")
-			return global.ascii_esc;
-		if("ascii_red")
-			return global.ascii_red;
-		if("ascii_green")
-			return global.ascii_green;
-		if("ascii_yellow")
-			return global.ascii_yellow;
-		if("ascii_reset")
-			return global.ascii_reset;
+		if("traders")
+			return global.traders;
+		if("traitors")
+			return global.traitors;
+		if("transfer_controller")
+			return global.transfer_controller;
+		if("turbolift_controller")
+			return global.turbolift_controller;
+		if("turbolifts")
+			return global.turbolifts;
+		if("turf_changed_event")
+			return global.turf_changed_event;
+		if("turfs")
+			return global.turfs;
+		if("turret_icons")
+			return global.turret_icons;
+		if("uniqueness_repository")
+			return global.uniqueness_repository;
+		if("universe")
+			return global.universe;
+		if("universe_has_ended")
+			return global.universe_has_ended;
+		if("uplink")
+			return global.uplink;
+		if("uplink_locations")
+			return global.uplink_locations;
+		if("uplink_purchase_repository")
+			return global.uplink_purchase_repository;
+		if("uplink_random_selections_")
+			return global.uplink_random_selections_;
 		if("using_map")
 			return global.using_map;
-		if("all_maps")
-			return global.all_maps;
-		if("init")
-			return global.init;
+		if("valid_bloodtypes")
+			return global.valid_bloodtypes;
+		if("vendor_account")
+			return global.vendor_account;
+		if("ventcrawl_machinery")
+			return global.ventcrawl_machinery;
+		if("verbs")
+			return global.verbs;
+		if("view_variables_dont_expand")
+			return global.view_variables_dont_expand;
+		if("view_variables_hide_vars")
+			return global.view_variables_hide_vars;
+		if("view_variables_no_assoc")
+			return global.view_variables_no_assoc;
+		if("virusDB")
+			return global.virusDB;
+		if("visual_nets")
+			return global.visual_nets;
+		if("vote")
+			return global.vote;
+		if("vsc")
+			return global.vsc;
+		if("warrant_uid")
+			return global.warrant_uid;
+		if("wax_recipes")
+			return global.wax_recipes;
+		if("weighted_mundaneevent_locations")
+			return global.weighted_mundaneevent_locations;
+		if("weighted_randomevent_locations")
+			return global.weighted_randomevent_locations;
+		if("whitelist")
+			return global.whitelist;
+		if("whitelisted_species")
+			return global.whitelisted_species;
+		if("wireColours")
+			return global.wireColours;
+		if("wirelessProcess")
+			return global.wirelessProcess;
+		if("wizard_first")
+			return global.wizard_first;
+		if("wizard_second")
+			return global.wizard_second;
+		if("wizards")
+			return global.wizards;
+		if("wizardstart")
+			return global.wizardstart;
+		if("world_topic_spam_protect_ip")
+			return global.world_topic_spam_protect_ip;
+		if("world_topic_spam_protect_time")
+			return global.world_topic_spam_protect_time;
+		if("world_uplinks")
+			return global.world_uplinks;
+		if("worths")
+			return global.worths;
+		if("wrapped_species_by_ref")
+			return global.wrapped_species_by_ref;
+		if("xeno_spawn")
+			return global.xeno_spawn;
+		if("xenomorphs")
+			return global.xenomorphs;
+		if("z_levels")
+			return global.z_levels;
+		if("z_state")
+			return global.z_state;
+		if("zone_blocked")
+			return global.zone_blocked;
 		
 /proc/writeglobal(which, newval)
 	switch(which)
-		if("tagger_locations")
-			global.tagger_locations=newval;
-		if("is_station_but_not_space_or_shuttle_area")
-			global.is_station_but_not_space_or_shuttle_area=newval;
+		if("ALL_ANTIGENS")
+			global.ALL_ANTIGENS=newval;
+		if("ANTAG_FREQS")
+			global.ANTAG_FREQS=newval;
+		if("BLENDBLOCK")
+			global.BLENDBLOCK=newval;
+		if("BLINDBLOCK")
+			global.BLINDBLOCK=newval;
+		if("BLOCKADD")
+			global.BLOCKADD=newval;
+		if("BSACooldown")
+			global.BSACooldown=newval;
+		if("BUMP_TELEPORTERS")
+			global.BUMP_TELEPORTERS=newval;
+		if("Banlist")
+			global.Banlist=newval;
+		if("CENT_FREQS")
+			global.CENT_FREQS=newval;
+		if("CLUMSYBLOCK")
+			global.CLUMSYBLOCK=newval;
+		if("CMinutes")
+			global.CMinutes=newval;
+		if("COUGHBLOCK")
+			global.COUGHBLOCK=newval;
+		if("DEAFBLOCK")
+			global.DEAFBLOCK=newval;
+		if("DEPT_FREQS")
+			global.DEPT_FREQS=newval;
+		if("DIFFMUT")
+			global.DIFFMUT=newval;
+		if("Debug2")
+			global.Debug2=newval;
+		if("EPILEPSYBLOCK")
+			global.EPILEPSYBLOCK=newval;
+		if("FAKEBLOCK")
+			global.FAKEBLOCK=newval;
+		if("FIREBLOCK")
+			global.FIREBLOCK=newval;
+		if("GLASSESBLOCK")
+			global.GLASSESBLOCK=newval;
+		if("HALLUCINATIONBLOCK")
+			global.HALLUCINATIONBLOCK=newval;
+		if("HEADACHEBLOCK")
+			global.HEADACHEBLOCK=newval;
+		if("HULKBLOCK")
+			global.HULKBLOCK=newval;
+		if("Holiday")
+			global.Holiday=newval;
+		if("IClog")
+			global.IClog=newval;
+		if("INCREASERUNBLOCK")
+			global.INCREASERUNBLOCK=newval;
+		if("MONKEYBLOCK")
+			global.MONKEYBLOCK=newval;
+		if("MORPHBLOCK")
+			global.MORPHBLOCK=newval;
+		if("NERVOUSBLOCK")
+			global.NERVOUSBLOCK=newval;
+		if("NOBREATHBLOCK")
+			global.NOBREATHBLOCK=newval;
+		if("NOPRINTSBLOCK")
+			global.NOPRINTSBLOCK=newval;
+		if("OOClog")
+			global.OOClog=newval;
+		if("PDA_Manifest")
+			global.PDA_Manifest=newval;
+		if("PDAs")
+			global.PDAs=newval;
+		if("REGENERATEBLOCK")
+			global.REGENERATEBLOCK=newval;
+		if("REMOTETALKBLOCK")
+			global.REMOTETALKBLOCK=newval;
+		if("REMOTEVIEWBLOCK")
+			global.REMOTEVIEWBLOCK=newval;
+		if("SHOCKIMMUNITYBLOCK")
+			global.SHOCKIMMUNITYBLOCK=newval;
+		if("SKILLS")
+			global.SKILLS=newval;
+		if("SMALLSIZEBLOCK")
+			global.SMALLSIZEBLOCK=newval;
+		if("TELEBLOCK")
+			global.TELEBLOCK=newval;
+		if("TWITCHBLOCK")
+			global.TWITCHBLOCK=newval;
+		if("Tier1Runes")
+			global.Tier1Runes=newval;
+		if("Tier2Runes")
+			global.Tier2Runes=newval;
+		if("Tier3Runes")
+			global.Tier3Runes=newval;
+		if("Tier4Runes")
+			global.Tier4Runes=newval;
+		if("WALLITEMS")
+			global.WALLITEMS=newval;
+		if("XRAYBLOCK")
+			global.XRAYBLOCK=newval;
+		if("_all_globals")
+			global._all_globals=newval;
+		if("_client_preferences")
+			global._client_preferences=newval;
+		if("_client_preferences_by_key")
+			global._client_preferences_by_key=newval;
+		if("_client_preferences_by_type")
+			global._client_preferences_by_type=newval;
+		if("_preloader")
+			global._preloader=newval;
+		if("account_hack_attempted")
+			global.account_hack_attempted=newval;
+		if("acting_rank_prefixes")
+			global.acting_rank_prefixes=newval;
+		if("active_diseases")
+			global.active_diseases=newval;
+		if("activeauth")
+			global.activeauth=newval;
+		if("activecharges")
+			global.activecharges=newval;
+		if("activename")
+			global.activename=newval;
+		if("activetype")
+			global.activetype=newval;
+		if("actor")
+			global.actor=newval;
+		if("additional_antag_types")
+			global.additional_antag_types=newval;
+		if("adjectives")
+			global.adjectives=newval;
+		if("admin_datums")
+			global.admin_datums=newval;
+		if("admin_departments")
+			global.admin_departments=newval;
+		if("admin_log")
+			global.admin_log=newval;
+		if("admin_pm_repository")
+			global.admin_pm_repository=newval;
+		if("admin_ranks")
+			global.admin_ranks=newval;
+		if("admin_secrets")
+			global.admin_secrets=newval;
+		if("admin_state")
+			global.admin_state=newval;
+		if("admin_verbs_admin")
+			global.admin_verbs_admin=newval;
+		if("admin_verbs_ban")
+			global.admin_verbs_ban=newval;
+		if("admin_verbs_debug")
+			global.admin_verbs_debug=newval;
+		if("admin_verbs_default")
+			global.admin_verbs_default=newval;
+		if("admin_verbs_fun")
+			global.admin_verbs_fun=newval;
+		if("admin_verbs_hideable")
+			global.admin_verbs_hideable=newval;
+		if("admin_verbs_mentor")
+			global.admin_verbs_mentor=newval;
+		if("admin_verbs_mod")
+			global.admin_verbs_mod=newval;
+		if("admin_verbs_paranoid_debug")
+			global.admin_verbs_paranoid_debug=newval;
+		if("admin_verbs_permissions")
+			global.admin_verbs_permissions=newval;
+		if("admin_verbs_possess")
+			global.admin_verbs_possess=newval;
+		if("admin_verbs_rejuv")
+			global.admin_verbs_rejuv=newval;
+		if("admin_verbs_server")
+			global.admin_verbs_server=newval;
+		if("admin_verbs_sounds")
+			global.admin_verbs_sounds=newval;
+		if("admin_verbs_spawn")
+			global.admin_verbs_spawn=newval;
+		if("adminfaxes")
+			global.adminfaxes=newval;
+		if("adminhelp_ignored_words")
+			global.adminhelp_ignored_words=newval;
+		if("adminlog")
+			global.adminlog=newval;
+		if("admins")
+			global.admins=newval;
+		if("ai_icons")
+			global.ai_icons=newval;
+		if("ai_list")
+			global.ai_list=newval;
+		if("ai_names")
+			global.ai_names=newval;
+		if("ai_status_emotions")
+			global.ai_status_emotions=newval;
+		if("ai_verbs_default")
+			global.ai_verbs_default=newval;
+		if("air_alarm_topic")
+			global.air_alarm_topic=newval;
+		if("air_blocked")
+			global.air_blocked=newval;
+		if("air_master")
+			global.air_master=newval;
+		if("air_processing_killed")
+			global.air_processing_killed=newval;
+		if("alarm_manager")
+			global.alarm_manager=newval;
+		if("alien_whitelist")
+			global.alien_whitelist=newval;
+		if("allCasters")
+			global.allCasters=newval;
+		if("allConsoles")
+			global.allConsoles=newval;
+		if("all_antag_spawnpoints")
+			global.all_antag_spawnpoints=newval;
+		if("all_antag_types")
+			global.all_antag_types=newval;
+		if("all_areas")
+			global.all_areas=newval;
+		if("all_languages")
+			global.all_languages=newval;
+		if("all_maps")
+			global.all_maps=newval;
+		if("all_money_accounts")
+			global.all_money_accounts=newval;
+		if("all_objectives")
+			global.all_objectives=newval;
+		if("all_observable_events")
+			global.all_observable_events=newval;
+		if("all_robolimbs")
+			global.all_robolimbs=newval;
+		if("all_species")
+			global.all_species=newval;
+		if("all_ui_styles")
+			global.all_ui_styles=newval;
+		if("all_unit_tests_passed")
+			global.all_unit_tests_passed=newval;
+		if("all_virtual_listeners")
+			global.all_virtual_listeners=newval;
+		if("alldepartments")
+			global.alldepartments=newval;
+		if("alldirs")
+			global.alldirs=newval;
+		if("allfaxes")
+			global.allfaxes=newval;
+		if("alphabet_uppercase")
+			global.alphabet_uppercase=newval;
+		if("announced_news_types")
+			global.announced_news_types=newval;
+		if("antag_add_finished")
+			global.antag_add_finished=newval;
+		if("antag_names_to_ids")
+			global.antag_names_to_ids=newval;
+		if("appearance_manager")
+			global.appearance_manager=newval;
+		if("area_repository")
+			global.area_repository=newval;
+		if("artefact_feedback")
+			global.artefact_feedback=newval;
+		if("ascii_esc")
+			global.ascii_esc=newval;
+		if("ascii_green")
+			global.ascii_green=newval;
+		if("ascii_red")
+			global.ascii_red=newval;
+		if("ascii_reset")
+			global.ascii_reset=newval;
+		if("ascii_yellow")
+			global.ascii_yellow=newval;
+		if("ashtray_cache")
+			global.ashtray_cache=newval;
+		if("asset_cache")
+			global.asset_cache=newval;
+		if("asset_datums")
+			global.asset_datums=newval;
+		if("assigned")
+			global.assigned=newval;
+		if("assigned_blocks")
+			global.assigned_blocks=newval;
+		if("assistant_occupations")
+			global.assistant_occupations=newval;
+		if("atmosphere_alarm")
+			global.atmosphere_alarm=newval;
+		if("attack_log_repository")
+			global.attack_log_repository=newval;
+		if("autolathe_categories")
+			global.autolathe_categories=newval;
+		if("autolathe_recipes")
+			global.autolathe_recipes=newval;
+		if("awaydestinations")
+			global.awaydestinations=newval;
+		if("backbaglist")
+			global.backbaglist=newval;
+		if("base_miss_chance")
+			global.base_miss_chance=newval;
+		if("basic_robolimb")
+			global.basic_robolimb=newval;
+		if("blackbox")
+			global.blackbox=newval;
+		if("blocked")
+			global.blocked=newval;
+		if("bomb_set")
+			global.bomb_set=newval;
+		if("bombers")
+			global.bombers=newval;
+		if("borers")
+			global.borers=newval;
+		if("breach_brute_descriptors")
+			global.breach_brute_descriptors=newval;
+		if("breach_burn_descriptors")
+			global.breach_burn_descriptors=newval;
+		if("cable_list")
+			global.cable_list=newval;
+		if("cached_icons")
+			global.cached_icons=newval;
+		if("cached_space")
+			global.cached_space=newval;
+		if("camera_alarm")
+			global.camera_alarm=newval;
+		if("camera_range_display_status")
+			global.camera_range_display_status=newval;
+		if("camera_repository")
+			global.camera_repository=newval;
+		if("cameranet")
+			global.cameranet=newval;
+		if("cameranet_")
+			global.cameranet_=newval;
+		if("can_call_ert")
+			global.can_call_ert=newval;
+		if("captain_announcement")
+			global.captain_announcement=newval;
+		if("cardinal")
+			global.cardinal=newval;
+		if("cargo_positions")
+			global.cargo_positions=newval;
+		if("cargo_supply_pack_root")
+			global.cargo_supply_pack_root=newval;
+		if("cargo_supply_packs")
+			global.cargo_supply_packs=newval;
+		if("changelog_hash")
+			global.changelog_hash=newval;
+		if("channel_to_radio_key")
+			global.channel_to_radio_key=newval;
+		if("chargen_robolimbs")
+			global.chargen_robolimbs=newval;
+		if("checked_for_inactives")
+			global.checked_for_inactives=newval;
+		if("chemical_reaction_logs")
+			global.chemical_reaction_logs=newval;
+		if("chemical_reactions_list")
+			global.chemical_reactions_list=newval;
+		if("chemical_reagents_list")
+			global.chemical_reagents_list=newval;
+		if("chemistryProcess")
+			global.chemistryProcess=newval;
+		if("chicken_count")
+			global.chicken_count=newval;
+		if("church_name")
+			global.church_name=newval;
+		if("citizenship_choices")
+			global.citizenship_choices=newval;
+		if("civilian_positions")
+			global.civilian_positions=newval;
+		if("client_preference_stats_")
+			global.client_preference_stats_=newval;
+		if("client_repository")
+			global.client_repository=newval;
+		if("clients")
+			global.clients=newval;
+		if("clown_names")
+			global.clown_names=newval;
+		if("clown_sound")
+			global.clown_sound=newval;
+		if("combatlog")
+			global.combatlog=newval;
+		if("comm_message_listeners")
+			global.comm_message_listeners=newval;
+		if("command_announcement")
+			global.command_announcement=newval;
+		if("command_name")
+			global.command_name=newval;
+		if("command_positions")
+			global.command_positions=newval;
+		if("commando_names")
+			global.commando_names=newval;
+		if("commandos")
+			global.commandos=newval;
+		if("common_tools")
+			global.common_tools=newval;
+		if("config")
+			global.config=newval;
+		if("conscious_state")
+			global.conscious_state=newval;
+		if("contained_state")
+			global.contained_state=newval;
+		if("contamination_overlay")
+			global.contamination_overlay=newval;
+		if("controller_iteration")
+			global.controller_iteration=newval;
+		if("cornerdirs")
+			global.cornerdirs=newval;
+		if("create_mob_html")
+			global.create_mob_html=newval;
+		if("create_object_html")
+			global.create_object_html=newval;
+		if("create_turf_html")
+			global.create_turf_html=newval;
+		if("created")
+			global.created=newval;
+		if("crew_repository")
+			global.crew_repository=newval;
+		if("cult")
+			global.cult=newval;
+		if("current_date_string")
+			global.current_date_string=newval;
+		if("currently_running_tests")
+			global.currently_running_tests=newval;
+		if("custom_event_msg")
+			global.custom_event_msg=newval;
+		if("custom_items")
+			global.custom_items=newval;
+		if("damage_icon_parts")
+			global.damage_icon_parts=newval;
+		if("data_core")
+			global.data_core=newval;
+		if("dbcon")
+			global.dbcon=newval;
+		if("dbcon_old")
+			global.dbcon_old=newval;
+		if("dead_mob_list_")
+			global.dead_mob_list_=newval;
+		if("death_event")
+			global.death_event=newval;
+		if("deathsquad")
+			global.deathsquad=newval;
+		if("debug_verbs")
+			global.debug_verbs=newval;
+		if("decls_repository")
+			global.decls_repository=newval;
+		if("deep_inventory_state")
+			global.deep_inventory_state=newval;
+		if("default_ai_icon")
+			global.default_ai_icon=newval;
+		if("default_internal_channels")
+			global.default_internal_channels=newval;
+		if("default_material_composition")
+			global.default_material_composition=newval;
+		if("default_medbay_channels")
+			global.default_medbay_channels=newval;
+		if("default_mobloc")
+			global.default_mobloc=newval;
+		if("default_onmob_icons")
+			global.default_onmob_icons=newval;
+		if("default_pai_software")
+			global.default_pai_software=newval;
+		if("default_state")
+			global.default_state=newval;
+		if("defer_powernet_rebuild")
+			global.defer_powernet_rebuild=newval;
+		if("delayed_garbage")
+			global.delayed_garbage=newval;
+		if("delta_index")
+			global.delta_index=newval;
+		if("density_set_event")
+			global.density_set_event=newval;
+		if("department_accounts")
+			global.department_accounts=newval;
+		if("department_radio_keys")
+			global.department_radio_keys=newval;
+		if("description_icons")
+			global.description_icons=newval;
+		if("destroyed_event")
+			global.destroyed_event=newval;
+		if("diary")
+			global.diary=newval;
+		if("dir_set_event")
+			global.dir_set_event=newval;
+		if("directory")
+			global.directory=newval;
+		if("dna_activity_bounds")
+			global.dna_activity_bounds=newval;
+		if("dna_genes")
+			global.dna_genes=newval;
+		if("doppler_arrays")
+			global.doppler_arrays=newval;
+		if("dreams")
+			global.dreams=newval;
+		if("dview_mob")
+			global.dview_mob=newval;
+		if("economic_species_modifier")
+			global.economic_species_modifier=newval;
+		if("economy_init")
+			global.economy_init=newval;
+		if("empty_playable_ai_cores")
+			global.empty_playable_ai_cores=newval;
+		if("endgame_exits")
+			global.endgame_exits=newval;
+		if("endgame_safespawns")
+			global.endgame_safespawns=newval;
+		if("engineering_positions")
+			global.engineering_positions=newval;
+		if("entered_event")
+			global.entered_event=newval;
+		if("error_cache")
+			global.error_cache=newval;
+		if("error_cooldown")
+			global.error_cooldown=newval;
+		if("error_last_seen")
+			global.error_last_seen=newval;
+		if("ert")
+			global.ert=newval;
+		if("ert_base_chance")
+			global.ert_base_chance=newval;
+		if("escape_pods")
+			global.escape_pods=newval;
+		if("escape_pods_by_name")
+			global.escape_pods_by_name=newval;
+		if("evacuation_controller")
+			global.evacuation_controller=newval;
+		if("event_last_fired")
+			global.event_last_fired=newval;
+		if("event_listen_count")
+			global.event_listen_count=newval;
+		if("event_manager")
+			global.event_manager=newval;
+		if("event_sources_count")
+			global.event_sources_count=newval;
+		if("eventchance")
+			global.eventchance=newval;
+		if("exclude_jobs")
+			global.exclude_jobs=newval;
+		if("explosion_in_progress")
+			global.explosion_in_progress=newval;
+		if("explosion_sound")
+			global.explosion_sound=newval;
+		if("explosion_turfs")
+			global.explosion_turfs=newval;
+		if("facial_hair_styles_female_list")
+			global.facial_hair_styles_female_list=newval;
+		if("facial_hair_styles_list")
+			global.facial_hair_styles_list=newval;
+		if("facial_hair_styles_male_list")
+			global.facial_hair_styles_male_list=newval;
+		if("faction_choices")
+			global.faction_choices=newval;
+		if("failed_db_connections")
+			global.failed_db_connections=newval;
+		if("failed_old_db_connections")
+			global.failed_old_db_connections=newval;
+		if("failed_unit_tests")
+			global.failed_unit_tests=newval;
+		if("file_uid")
+			global.file_uid=newval;
+		if("fileaccess_timer")
+			global.fileaccess_timer=newval;
+		if("finds_as_strings")
+			global.finds_as_strings=newval;
+		if("fire_alarm")
+			global.fire_alarm=newval;
+		if("first_names_female")
+			global.first_names_female=newval;
+		if("first_names_male")
+			global.first_names_male=newval;
+		if("flesh_hud_colours")
+			global.flesh_hud_colours=newval;
+		if("floorIsLava")
+			global.floorIsLava=newval;
+		if("floor_decals")
+			global.floor_decals=newval;
+		if("floor_light_cache")
+			global.floor_light_cache=newval;
+		if("flooring_cache")
+			global.flooring_cache=newval;
+		if("flooring_types")
+			global.flooring_types=newval;
+		if("fluidtrack_cache")
+			global.fluidtrack_cache=newval;
+		if("follow_repository")
+			global.follow_repository=newval;
+		if("forced_ambiance_list")
+			global.forced_ambiance_list=newval;
+		if("forum_activated_group")
+			global.forum_activated_group=newval;
+		if("forum_authenticated_group")
+			global.forum_authenticated_group=newval;
+		if("forumsqladdress")
+			global.forumsqladdress=newval;
+		if("forumsqldb")
+			global.forumsqldb=newval;
+		if("forumsqllogin")
+			global.forumsqllogin=newval;
+		if("forumsqlpass")
+			global.forumsqlpass=newval;
+		if("forumsqlport")
+			global.forumsqlport=newval;
+		if("fracture_sound")
+			global.fracture_sound=newval;
+		if("fruit_icon_cache")
+			global.fruit_icon_cache=newval;
+		if("fuel_injectors")
+			global.fuel_injectors=newval;
+		if("fusion_cores")
+			global.fusion_cores=newval;
+		if("fusion_reactions")
+			global.fusion_reactions=newval;
+		if("game_id")
+			global.game_id=newval;
+		if("game_version")
+			global.game_version=newval;
+		if("game_year")
+			global.game_year=newval;
+		if("gamemode_cache")
+			global.gamemode_cache=newval;
+		if("garbage_collector")
+			global.garbage_collector=newval;
+		if("gas_data")
+			global.gas_data=newval;
+		if("gear_datums")
+			global.gear_datums=newval;
+		if("gear_tweak_free_color_choice_")
+			global.gear_tweak_free_color_choice_=newval;
+		if("gender_datums")
+			global.gender_datums=newval;
+		if("ghost_darkness_images")
+			global.ghost_darkness_images=newval;
+		if("ghost_master")
+			global.ghost_master=newval;
+		if("ghost_sightless_images")
+			global.ghost_sightless_images=newval;
+		if("ghost_traps")
+			global.ghost_traps=newval;
+		if("global_announcer")
+			global.global_announcer=newval;
+		if("global_hud")
+			global.global_hud=newval;
+		if("global_huds")
+			global.global_huds=newval;
+		if("global_listen_count")
+			global.global_listen_count=newval;
+		if("global_map")
+			global.global_map=newval;
+		if("global_message_listener")
+			global.global_message_listener=newval;
+		if("global_modular_computers")
+			global.global_modular_computers=newval;
+		if("global_mutations")
+			global.global_mutations=newval;
+		if("global_underwear")
+			global.global_underwear=newval;
+		if("global_vars_")
+			global.global_vars_=newval;
+		if("gravity_is_on")
+			global.gravity_is_on=newval;
+		if("gyrotrons")
+			global.gyrotrons=newval;
+		if("hadevent")
+			global.hadevent=newval;
+		if("hair_styles_female_list")
+			global.hair_styles_female_list=newval;
+		if("hair_styles_list")
+			global.hair_styles_list=newval;
+		if("hair_styles_male_list")
+			global.hair_styles_male_list=newval;
+		if("hands_state")
+			global.hands_state=newval;
+		if("hazard_overlays")
+			global.hazard_overlays=newval;
+		if("hidden_skill_types")
+			global.hidden_skill_types=newval;
+		if("highlanders")
+			global.highlanders=newval;
+		if("hiss_sound")
+			global.hiss_sound=newval;
+		if("hit_appends")
+			global.hit_appends=newval;
+		if("hivemind_bank")
+			global.hivemind_bank=newval;
+		if("holder_mob_icon_cache")
+			global.holder_mob_icon_cache=newval;
+		if("home_system_choices")
+			global.home_system_choices=newval;
+		if("host")
+			global.host=newval;
+		if("href_logfile")
+			global.href_logfile=newval;
+		if("hud_icon_reference")
+			global.hud_icon_reference=newval;
+		if("human_icon_cache")
+			global.human_icon_cache=newval;
+		if("human_mob_list")
+			global.human_mob_list=newval;
+		if("id_card_states")
+			global.id_card_states=newval;
+		if("image_repository")
+			global.image_repository=newval;
+		if("inactive_keys")
+			global.inactive_keys=newval;
+		if("init")
+			global.init=newval;
+		if("initialization_stage")
+			global.initialization_stage=newval;
+		if("intents")
+			global.intents=newval;
+		if("interactive_state")
+			global.interactive_state=newval;
+		if("intercom_range_display_status")
+			global.intercom_range_display_status=newval;
+		if("invalid_zone")
+			global.invalid_zone=newval;
+		if("inventory_state")
+			global.inventory_state=newval;
 		if("is_contact_but_not_space_or_shuttle_area")
 			global.is_contact_but_not_space_or_shuttle_area=newval;
 		if("is_player_but_not_space_or_shuttle_area")
 			global.is_player_but_not_space_or_shuttle_area=newval;
-		if("delta_index")
-			global.delta_index=newval;
+		if("is_station_but_not_space_or_shuttle_area")
+			global.is_station_but_not_space_or_shuttle_area=newval;
+		if("item_equipped_event")
+			global.item_equipped_event=newval;
+		if("item_unequipped_event")
+			global.item_unequipped_event=newval;
+		if("jobMax")
+			global.jobMax=newval;
+		if("job_master")
+			global.job_master=newval;
+		if("jobban_keylist")
+			global.jobban_keylist=newval;
+		if("jobban_runonce")
+			global.jobban_runonce=newval;
+		if("joblist")
+			global.joblist=newval;
+		if("join_motd")
+			global.join_motd=newval;
+		if("landmarks_list")
+			global.landmarks_list=newval;
+		if("language_keys")
+			global.language_keys=newval;
+		if("last_chew")
+			global.last_chew=newval;
+		if("last_message_id")
+			global.last_message_id=newval;
+		if("last_names")
+			global.last_names=newval;
+		if("last_round_duration")
+			global.last_round_duration=newval;
+		if("last_tick_duration")
+			global.last_tick_duration=newval;
+		if("lastsignalers")
+			global.lastsignalers=newval;
+		if("latejoin")
+			global.latejoin=newval;
+		if("latejoin_cryo")
+			global.latejoin_cryo=newval;
+		if("latejoin_cyborg")
+			global.latejoin_cyborg=newval;
+		if("latejoin_gateway")
+			global.latejoin_gateway=newval;
+		if("lawchanges")
+			global.lawchanges=newval;
+		if("license_to_url")
+			global.license_to_url=newval;
+		if("life_event")
+			global.life_event=newval;
+		if("light_overlay_cache")
+			global.light_overlay_cache=newval;
+		if("light_type_cache")
+			global.light_type_cache=newval;
+		if("lighter_sound")
+			global.lighter_sound=newval;
+		if("lighting_update_lights")
+			global.lighting_update_lights=newval;
+		if("lighting_update_overlays")
+			global.lighting_update_overlays=newval;
+		if("limb_icon_cache")
+			global.limb_icon_cache=newval;
+		if("list_of_ais")
+			global.list_of_ais=newval;
+		if("listening_objects")
+			global.listening_objects=newval;
+		if("living_mob_list_")
+			global.living_mob_list_=newval;
+		if("loadout_categories")
+			global.loadout_categories=newval;
+		if("lobby_image")
+			global.lobby_image=newval;
+		if("log_end")
+			global.log_end=newval;
+		if("logged_in_event")
+			global.logged_in_event=newval;
+		if("logged_out_event")
+			global.logged_out_event=newval;
+		if("loyalists")
+			global.loyalists=newval;
+		if("lunchables_drink_reagents_")
+			global.lunchables_drink_reagents_=newval;
+		if("lunchables_drinks_")
+			global.lunchables_drinks_=newval;
+		if("lunchables_ethanol_reagents_")
+			global.lunchables_ethanol_reagents_=newval;
+		if("lunchables_lunches_")
+			global.lunchables_lunches_=newval;
+		if("lunchables_snacks_")
+			global.lunchables_snacks_=newval;
+		if("machinery_sort_required")
+			global.machinery_sort_required=newval;
+		if("machines")
+			global.machines=newval;
+		if("magazine_icondata_keys")
+			global.magazine_icondata_keys=newval;
+		if("magazine_icondata_states")
+			global.magazine_icondata_states=newval;
+		if("maint_all_access")
+			global.maint_all_access=newval;
+		if("malf")
+			global.malf=newval;
+		if("mannequins_")
+			global.mannequins_=newval;
+		if("map_count")
+			global.map_count=newval;
+		if("map_sectors")
+			global.map_sectors=newval;
+		if("maploader")
+			global.maploader=newval;
+		if("mark")
+			global.mark=newval;
+		if("master_controller")
+			global.master_controller=newval;
+		if("master_mode")
+			global.master_mode=newval;
+		if("matchmaker")
+			global.matchmaker=newval;
+		if("max_explosion_range")
+			global.max_explosion_range=newval;
+		if("maze_cell_count")
+			global.maze_cell_count=newval;
+		if("mechas_list")
+			global.mechas_list=newval;
+		if("mechtoys")
+			global.mechtoys=newval;
+		if("med_hud_users")
+			global.med_hud_users=newval;
+		if("medical_positions")
+			global.medical_positions=newval;
+		if("mercs")
+			global.mercs=newval;
+		if("merged")
+			global.merged=newval;
+		if("message_delay")
+			global.message_delay=newval;
+		if("message_servers")
+			global.message_servers=newval;
+		if("meteors_armageddon")
+			global.meteors_armageddon=newval;
+		if("meteors_cataclysm")
+			global.meteors_cataclysm=newval;
+		if("meteors_catastrophic")
+			global.meteors_catastrophic=newval;
 		if("meteors_dust")
 			global.meteors_dust=newval;
 		if("meteors_normal")
 			global.meteors_normal=newval;
 		if("meteors_threatening")
 			global.meteors_threatening=newval;
-		if("meteors_catastrophic")
-			global.meteors_catastrophic=newval;
-		if("meteors_armageddon")
-			global.meteors_armageddon=newval;
-		if("meteors_cataclysm")
-			global.meteors_cataclysm=newval;
+		if("mil_branches")
+			global.mil_branches=newval;
+		if("mining_floors")
+			global.mining_floors=newval;
+		if("mining_walls")
+			global.mining_walls=newval;
+		if("minor_air_alarms")
+			global.minor_air_alarms=newval;
+		if("mob_equipped_event")
+			global.mob_equipped_event=newval;
+		if("mob_hat_cache")
+			global.mob_hat_cache=newval;
+		if("mob_list")
+			global.mob_list=newval;
+		if("mob_repository")
+			global.mob_repository=newval;
+		if("mob_unequipped_event")
+			global.mob_unequipped_event=newval;
+		if("monkeystart")
+			global.monkeystart=newval;
+		if("motion_alarm")
+			global.motion_alarm=newval;
+		if("moved_event")
+			global.moved_event=newval;
+		if("moving_levels")
+			global.moving_levels=newval;
+		if("multi_point_spawns")
+			global.multi_point_spawns=newval;
+		if("name_to_material")
+			global.name_to_material=newval;
+		if("nanomanager")
+			global.nanomanager=newval;
+		if("narsie_behaviour")
+			global.narsie_behaviour=newval;
+		if("narsie_cometh")
+			global.narsie_cometh=newval;
+		if("narsie_list")
+			global.narsie_list=newval;
+		if("navbeacons")
+			global.navbeacons=newval;
+		if("newplayer_start")
+			global.newplayer_start=newval;
+		if("news_network")
+			global.news_network=newval;
+		if("newscaster_standard_feeds")
+			global.newscaster_standard_feeds=newval;
+		if("next_account_number")
+			global.next_account_number=newval;
+		if("next_duration_update")
+			global.next_duration_update=newval;
+		if("next_station_date_change")
+			global.next_station_date_change=newval;
+		if("ninja_names")
+			global.ninja_names=newval;
+		if("ninja_titles")
+			global.ninja_titles=newval;
+		if("ninjas")
+			global.ninjas=newval;
+		if("ninjastart")
+			global.ninjastart=newval;
+		if("non_fakeattack_weapons")
+			global.non_fakeattack_weapons=newval;
+		if("nonhuman_positions")
+			global.nonhuman_positions=newval;
+		if("not_incapacitated_turf_state")
+			global.not_incapacitated_turf_state=newval;
+		if("ntnet_card_uid")
+			global.ntnet_card_uid=newval;
+		if("ntnet_global")
+			global.ntnet_global=newval;
+		if("ntnrc_uid")
+			global.ntnrc_uid=newval;
+		if("nttransfer_uid")
+			global.nttransfer_uid=newval;
+		if("nuke_disks")
+			global.nuke_disks=newval;
+		if("num_financial_terminals")
+			global.num_financial_terminals=newval;
+		if("opacity_set_event")
+			global.opacity_set_event=newval;
+		if("ore_data")
+			global.ore_data=newval;
+		if("ores_by_type")
+			global.ores_by_type=newval;
+		if("organ_cache")
+			global.organ_cache=newval;
+		if("organ_rel_size")
+			global.organ_rel_size=newval;
+		if("outfits_decls_")
+			global.outfits_decls_=newval;
+		if("outfits_decls_by_type_")
+			global.outfits_decls_by_type_=newval;
+		if("outfits_decls_root_")
+			global.outfits_decls_root_=newval;
+		if("outside_state")
+			global.outside_state=newval;
+		if("page_sound")
+			global.page_sound=newval;
+		if("paiController")
+			global.paiController=newval;
+		if("pai_emotions")
+			global.pai_emotions=newval;
+		if("pai_software_by_key")
+			global.pai_software_by_key=newval;
+		if("paramslist_cache")
+			global.paramslist_cache=newval;
+		if("photo_count")
+			global.photo_count=newval;
+		if("physical_state")
+			global.physical_state=newval;
+		if("pipe_colors")
+			global.pipe_colors=newval;
+		if("pipe_networks")
+			global.pipe_networks=newval;
+		if("pipe_processing_killed")
+			global.pipe_processing_killed=newval;
+		if("plant_controller")
+			global.plant_controller=newval;
+		if("plant_seed_sprites")
+			global.plant_seed_sprites=newval;
+		if("playable_species")
+			global.playable_species=newval;
+		if("player_list")
+			global.player_list=newval;
+		if("point_source_descriptions")
+			global.point_source_descriptions=newval;
+		if("possible_cable_coil_colours")
+			global.possible_cable_coil_colours=newval;
+		if("possible_changeling_IDs")
+			global.possible_changeling_IDs=newval;
+		if("poster_designs")
+			global.poster_designs=newval;
+		if("power_alarm")
+			global.power_alarm=newval;
+		if("powerinstances")
+			global.powerinstances=newval;
+		if("powernets")
+			global.powernets=newval;
+		if("powers")
+			global.powers=newval;
+		if("preferences_datums")
+			global.preferences_datums=newval;
+		if("priority_air_alarms")
+			global.priority_air_alarms=newval;
+		if("priority_announcement")
+			global.priority_announcement=newval;
+		if("prisonsecuritywarp")
+			global.prisonsecuritywarp=newval;
+		if("prisonwarp")
+			global.prisonwarp=newval;
+		if("prisonwarped")
+			global.prisonwarped=newval;
+		if("priv_all_access")
+			global.priv_all_access=newval;
 		if("priv_all_access_datums")
 			global.priv_all_access_datums=newval;
 		if("priv_all_access_datums_id")
 			global.priv_all_access_datums_id=newval;
 		if("priv_all_access_datums_region")
 			global.priv_all_access_datums_region=newval;
-		if("priv_all_access")
-			global.priv_all_access=newval;
-		if("priv_station_access")
-			global.priv_station_access=newval;
 		if("priv_centcom_access")
 			global.priv_centcom_access=newval;
-		if("priv_syndicate_access")
-			global.priv_syndicate_access=newval;
 		if("priv_region_access")
 			global.priv_region_access=newval;
-		if("alien_whitelist")
-			global.alien_whitelist=newval;
-		if("acting_rank_prefixes")
-			global.acting_rank_prefixes=newval;
-		if("view_variables_hide_vars")
-			global.view_variables_hide_vars=newval;
-		if("view_variables_dont_expand")
-			global.view_variables_dont_expand=newval;
-		if("view_variables_no_assoc")
-			global.view_variables_no_assoc=newval;
-		if("custom_items")
-			global.custom_items=newval;
-		if("economic_species_modifier")
-			global.economic_species_modifier=newval;
-		if("lighting_update_lights")
-			global.lighting_update_lights=newval;
-		if("lighting_update_overlays")
-			global.lighting_update_overlays=newval;
-		if("gender_datums")
-			global.gender_datums=newval;
-		if("chemical_reaction_logs")
-			global.chemical_reaction_logs=newval;
-		if("server_name")
-			global.server_name=newval;
-		if("game_id")
-			global.game_id=newval;
-		if("log_end")
-			global.log_end=newval;
-		if("atmosphere_alarm")
-			global.atmosphere_alarm=newval;
-		if("camera_alarm")
-			global.camera_alarm=newval;
-		if("fire_alarm")
-			global.fire_alarm=newval;
-		if("motion_alarm")
-			global.motion_alarm=newval;
-		if("power_alarm")
-			global.power_alarm=newval;
-		if("admin_state")
-			global.admin_state=newval;
-		if("conscious_state")
-			global.conscious_state=newval;
-		if("contained_state")
-			global.contained_state=newval;
-		if("default_state")
-			global.default_state=newval;
-		if("outside_state")
-			global.outside_state=newval;
-		if("hands_state")
-			global.hands_state=newval;
-		if("interactive_state")
-			global.interactive_state=newval;
-		if("inventory_state")
-			global.inventory_state=newval;
-		if("deep_inventory_state")
-			global.deep_inventory_state=newval;
-		if("physical_state")
-			global.physical_state=newval;
+		if("priv_station_access")
+			global.priv_station_access=newval;
+		if("priv_syndicate_access")
+			global.priv_syndicate_access=newval;
+		if("processScheduler")
+			global.processScheduler=newval;
+		if("processing_objects")
+			global.processing_objects=newval;
+		if("processing_power_items")
+			global.processing_power_items=newval;
+		if("processing_turfs")
+			global.processing_turfs=newval;
+		if("prometheans")
+			global.prometheans=newval;
+		if("protected_objects")
+			global.protected_objects=newval;
+		if("punch_sound")
+			global.punch_sound=newval;
+		if("rad_collectors")
+			global.rad_collectors=newval;
+		if("radiation_repository")
+			global.radiation_repository=newval;
+		if("radio_controller")
+			global.radio_controller=newval;
+		if("radiochannels")
+			global.radiochannels=newval;
+		if("raiders")
+			global.raiders=newval;
+		if("random_junk_")
+			global.random_junk_=newval;
+		if("random_maps")
+			global.random_maps=newval;
+		if("random_useful_")
+			global.random_useful_=newval;
+		if("recentmessages")
+			global.recentmessages=newval;
+		if("reg_dna")
+			global.reg_dna=newval;
+		if("religion_choices")
+			global.religion_choices=newval;
+		if("religion_name")
+			global.religion_name=newval;
+		if("renegades")
+			global.renegades=newval;
+		if("req_console_assistance")
+			global.req_console_assistance=newval;
+		if("req_console_information")
+			global.req_console_information=newval;
+		if("req_console_supplies")
+			global.req_console_supplies=newval;
+		if("responsive_carriers")
+			global.responsive_carriers=newval;
+		if("restricted_camera_networks")
+			global.restricted_camera_networks=newval;
+		if("revdata")
+			global.revdata=newval;
+		if("reverse_dir")
+			global.reverse_dir=newval;
+		if("revs")
+			global.revs=newval;
+		if("robot_custom_icons")
+			global.robot_custom_icons=newval;
+		if("robot_hud_colours")
+			global.robot_hud_colours=newval;
+		if("robot_inventory")
+			global.robot_inventory=newval;
+		if("robot_module_types")
+			global.robot_module_types=newval;
+		if("robot_modules")
+			global.robot_modules=newval;
+		if("round_progressing")
+			global.round_progressing=newval;
+		if("round_start_time")
+			global.round_start_time=newval;
+		if("roundstart_hour")
+			global.roundstart_hour=newval;
+		if("rune_list")
+			global.rune_list=newval;
+		if("rustle_sound")
+			global.rustle_sound=newval;
+		if("same_wires")
+			global.same_wires=newval;
+		if("scarySounds")
+			global.scarySounds=newval;
+		if("scheduler")
+			global.scheduler=newval;
+		if("science_positions")
+			global.science_positions=newval;
+		if("sec_hud_users")
+			global.sec_hud_users=newval;
+		if("secondary_mode")
+			global.secondary_mode=newval;
+		if("secret_force_mode")
+			global.secret_force_mode=newval;
+		if("sector_shuttles")
+			global.sector_shuttles=newval;
+		if("security_announcement_down")
+			global.security_announcement_down=newval;
+		if("security_announcement_up")
+			global.security_announcement_up=newval;
+		if("security_level")
+			global.security_level=newval;
+		if("security_positions")
+			global.security_positions=newval;
+		if("see_in_dark_set_event")
+			global.see_in_dark_set_event=newval;
+		if("see_invisible_set_event")
+			global.see_invisible_set_event=newval;
+		if("seen_citizenships")
+			global.seen_citizenships=newval;
+		if("seen_factions")
+			global.seen_factions=newval;
+		if("seen_religions")
+			global.seen_religions=newval;
+		if("seen_systems")
+			global.seen_systems=newval;
 		if("self_state")
 			global.self_state=newval;
-		if("z_state")
-			global.z_state=newval;
+		if("send_emergency_team")
+			global.send_emergency_team=newval;
+		if("sent_spiders_to_station")
+			global.sent_spiders_to_station=newval;
+		if("server_name")
+			global.server_name=newval;
+		if("service_positions")
+			global.service_positions=newval;
+		if("severity_to_string")
+			global.severity_to_string=newval;
+		if("shatter_sound")
+			global.shatter_sound=newval;
+		if("ship_engines")
+			global.ship_engines=newval;
+		if("shuttle_controller")
+			global.shuttle_controller=newval;
+		if("side_effects")
+			global.side_effects=newval;
+		if("sight_set_event")
+			global.sight_set_event=newval;
+		if("silicon_mob_list")
+			global.silicon_mob_list=newval;
+		if("skin_styles_female_list")
+			global.skin_styles_female_list=newval;
+		if("skipped_unit_tests")
+			global.skipped_unit_tests=newval;
+		if("slot_equipment_priority")
+			global.slot_equipment_priority=newval;
+		if("slot_flags_enumeration")
+			global.slot_flags_enumeration=newval;
+		if("solar_gen_rate")
+			global.solar_gen_rate=newval;
+		if("solars_list")
+			global.solars_list=newval;
+		if("sounds_cache")
+			global.sounds_cache=newval;
+		if("spacevines_spawned")
+			global.spacevines_spawned=newval;
+		if("spark_sound")
+			global.spark_sound=newval;
+		if("sparring_attack_cache")
+			global.sparring_attack_cache=newval;
+		if("spawntypes")
+			global.spawntypes=newval;
+		if("specops_shuttle_at_station")
+			global.specops_shuttle_at_station=newval;
+		if("specops_shuttle_can_send")
+			global.specops_shuttle_can_send=newval;
+		if("specops_shuttle_moving_to_centcom")
+			global.specops_shuttle_moving_to_centcom=newval;
+		if("specops_shuttle_moving_to_station")
+			global.specops_shuttle_moving_to_station=newval;
+		if("specops_shuttle_time")
+			global.specops_shuttle_time=newval;
+		if("specops_shuttle_timeleft")
+			global.specops_shuttle_timeleft=newval;
+		if("spells")
+			global.spells=newval;
+		if("splatter_cache")
+			global.splatter_cache=newval;
+		if("sqladdress")
+			global.sqladdress=newval;
+		if("sqldb")
+			global.sqldb=newval;
+		if("sqlfdbkdb")
+			global.sqlfdbkdb=newval;
+		if("sqlfdbklogin")
+			global.sqlfdbklogin=newval;
+		if("sqlfdbkpass")
+			global.sqlfdbkpass=newval;
+		if("sqllogging")
+			global.sqllogging=newval;
+		if("sqllogin")
+			global.sqllogin=newval;
+		if("sqlpass")
+			global.sqlpass=newval;
+		if("sqlport")
+			global.sqlport=newval;
+		if("stat_set_event")
+			global.stat_set_event=newval;
+		if("station_account")
+			global.station_account=newval;
+		if("station_date")
+			global.station_date=newval;
+		if("station_departments")
+			global.station_departments=newval;
+		if("status_icons_to_colour")
+			global.status_icons_to_colour=newval;
+		if("stool_cache")
+			global.stool_cache=newval;
+		if("stored_shock_by_ref")
+			global.stored_shock_by_ref=newval;
+		if("storedwarrant")
+			global.storedwarrant=newval;
+		if("string_part_flags")
+			global.string_part_flags=newval;
+		if("string_slot_flags")
+			global.string_slot_flags=newval;
+		if("sun")
+			global.sun=newval;
+		if("supply_controller")
+			global.supply_controller=newval;
+		if("supply_drop")
+			global.supply_drop=newval;
+		if("supply_methods_")
+			global.supply_methods_=newval;
+		if("supply_positions")
+			global.supply_positions=newval;
+		if("surgery_steps")
+			global.surgery_steps=newval;
+		if("swapmaps_byname")
+			global.swapmaps_byname=newval;
+		if("swapmaps_compiled_maxx")
+			global.swapmaps_compiled_maxx=newval;
+		if("swapmaps_compiled_maxy")
+			global.swapmaps_compiled_maxy=newval;
+		if("swapmaps_compiled_maxz")
+			global.swapmaps_compiled_maxz=newval;
+		if("swapmaps_iconcache")
+			global.swapmaps_iconcache=newval;
+		if("swapmaps_initialized")
+			global.swapmaps_initialized=newval;
+		if("swapmaps_loaded")
+			global.swapmaps_loaded=newval;
+		if("swapmaps_mode")
+			global.swapmaps_mode=newval;
+		if("swing_hit_sound")
+			global.swing_hit_sound=newval;
+		if("syndicate_access")
+			global.syndicate_access=newval;
+		if("syndicate_code_phrase")
+			global.syndicate_code_phrase=newval;
+		if("syndicate_code_response")
+			global.syndicate_code_response=newval;
+		if("syndicate_elite_shuttle_at_station")
+			global.syndicate_elite_shuttle_at_station=newval;
+		if("syndicate_elite_shuttle_can_send")
+			global.syndicate_elite_shuttle_can_send=newval;
+		if("syndicate_elite_shuttle_moving_to_mothership")
+			global.syndicate_elite_shuttle_moving_to_mothership=newval;
+		if("syndicate_elite_shuttle_moving_to_station")
+			global.syndicate_elite_shuttle_moving_to_station=newval;
+		if("syndicate_elite_shuttle_time")
+			global.syndicate_elite_shuttle_time=newval;
+		if("syndicate_elite_shuttle_timeleft")
+			global.syndicate_elite_shuttle_timeleft=newval;
+		if("syndicate_name")
+			global.syndicate_name=newval;
+		if("tagger_locations")
+			global.tagger_locations=newval;
+		if("tail_icon_cache")
+			global.tail_icon_cache=newval;
+		if("tank_gauge_cache")
+			global.tank_gauge_cache=newval;
+		if("tape_roll_applications")
+			global.tape_roll_applications=newval;
+		if("task_triggered_event")
+			global.task_triggered_event=newval;
+		if("tdome1")
+			global.tdome1=newval;
+		if("tdome2")
+			global.tdome2=newval;
+		if("tdomeadmin")
+			global.tdomeadmin=newval;
+		if("tdomeobserve")
+			global.tdomeobserve=newval;
+		if("telecomms_list")
+			global.telecomms_list=newval;
+		if("tertiary_mode")
+			global.tertiary_mode=newval;
+		if("text_tag_icons")
+			global.text_tag_icons=newval;
 		if("tg_admin_state")
 			global.tg_admin_state=newval;
 		if("tg_always_state")
@@ -1574,1331 +2784,850 @@
 			global.tg_not_contained_state=newval;
 		if("tg_not_incapacitated_state")
 			global.tg_not_incapacitated_state=newval;
-		if("not_incapacitated_turf_state")
-			global.not_incapacitated_turf_state=newval;
 		if("tg_physical_state")
 			global.tg_physical_state=newval;
 		if("tg_self_state")
 			global.tg_self_state=newval;
 		if("tg_z_state")
 			global.tg_z_state=newval;
-		if("machinery_sort_required")
-			global.machinery_sort_required=newval;
-		if("autolathe_recipes")
-			global.autolathe_recipes=newval;
-		if("autolathe_categories")
-			global.autolathe_categories=newval;
-		if("PDA_Manifest")
-			global.PDA_Manifest=newval;
-		if("id_card_states")
-			global.id_card_states=newval;
-		if("asset_datums")
-			global.asset_datums=newval;
-		if("magazine_icondata_keys")
-			global.magazine_icondata_keys=newval;
-		if("magazine_icondata_states")
-			global.magazine_icondata_states=newval;
-		if("account_hack_attempted")
-			global.account_hack_attempted=newval;
-		if("spacevines_spawned")
-			global.spacevines_spawned=newval;
-		if("sent_spiders_to_station")
-			global.sent_spiders_to_station=newval;
-		if("text_tag_icons")
-			global.text_tag_icons=newval;
-		if("scheduler")
-			global.scheduler=newval;
-		if("security_announcement_up")
-			global.security_announcement_up=newval;
-		if("security_announcement_down")
-			global.security_announcement_down=newval;
-		if("priority_announcement")
-			global.priority_announcement=newval;
-		if("command_announcement")
-			global.command_announcement=newval;
-		if("gas_data")
-			global.gas_data=newval;
-		if("area_repository")
-			global.area_repository=newval;
-		if("decls_repository")
-			global.decls_repository=newval;
-		if("follow_repository")
-			global.follow_repository=newval;
-		if("image_repository")
-			global.image_repository=newval;
-		if("create_mob_html")
-			global.create_mob_html=newval;
-		if("create_object_html")
-			global.create_object_html=newval;
-		if("create_turf_html")
-			global.create_turf_html=newval;
-		if("global_vars_")
-			global.global_vars_=newval;
-		if("all_ui_styles")
-			global.all_ui_styles=newval;
-		if("lobby_image")
-			global.lobby_image=newval;
-		if("security_level")
-			global.security_level=newval;
-		if("default_mobloc")
-			global.default_mobloc=newval;
-		if("data_core")
-			global.data_core=newval;
-		if("all_areas")
-			global.all_areas=newval;
-		if("machines")
-			global.machines=newval;
-		if("processing_objects")
-			global.processing_objects=newval;
-		if("processing_power_items")
-			global.processing_power_items=newval;
-		if("active_diseases")
-			global.active_diseases=newval;
-		if("med_hud_users")
-			global.med_hud_users=newval;
-		if("sec_hud_users")
-			global.sec_hud_users=newval;
-		if("hud_icon_reference")
-			global.hud_icon_reference=newval;
-		if("traders")
-			global.traders=newval;
-		if("listening_objects")
-			global.listening_objects=newval;
-		if("global_mutations")
-			global.global_mutations=newval;
-		if("universe")
-			global.universe=newval;
-		if("global_map")
-			global.global_map=newval;
-		if("hit_appends")
-			global.hit_appends=newval;
-		if("diary")
-			global.diary=newval;
-		if("href_logfile")
-			global.href_logfile=newval;
-		if("game_version")
-			global.game_version=newval;
-		if("changelog_hash")
-			global.changelog_hash=newval;
-		if("game_year")
-			global.game_year=newval;
-		if("round_progressing")
-			global.round_progressing=newval;
-		if("master_mode")
-			global.master_mode=newval;
-		if("secondary_mode")
-			global.secondary_mode=newval;
-		if("tertiary_mode")
-			global.tertiary_mode=newval;
-		if("secret_force_mode")
-			global.secret_force_mode=newval;
-		if("host")
-			global.host=newval;
-		if("jobMax")
-			global.jobMax=newval;
-		if("bombers")
-			global.bombers=newval;
-		if("admin_log")
-			global.admin_log=newval;
-		if("lastsignalers")
-			global.lastsignalers=newval;
-		if("lawchanges")
-			global.lawchanges=newval;
-		if("reg_dna")
-			global.reg_dna=newval;
-		if("monkeystart")
-			global.monkeystart=newval;
-		if("wizardstart")
-			global.wizardstart=newval;
-		if("newplayer_start")
-			global.newplayer_start=newval;
-		if("latejoin")
-			global.latejoin=newval;
-		if("latejoin_gateway")
-			global.latejoin_gateway=newval;
-		if("latejoin_cryo")
-			global.latejoin_cryo=newval;
-		if("latejoin_cyborg")
-			global.latejoin_cyborg=newval;
-		if("prisonwarp")
-			global.prisonwarp=newval;
-		if("xeno_spawn")
-			global.xeno_spawn=newval;
-		if("tdome1")
-			global.tdome1=newval;
-		if("tdome2")
-			global.tdome2=newval;
-		if("tdomeobserve")
-			global.tdomeobserve=newval;
-		if("tdomeadmin")
-			global.tdomeadmin=newval;
-		if("prisonsecuritywarp")
-			global.prisonsecuritywarp=newval;
-		if("prisonwarped")
-			global.prisonwarped=newval;
-		if("ninjastart")
-			global.ninjastart=newval;
-		if("cardinal")
-			global.cardinal=newval;
-		if("cornerdirs")
-			global.cornerdirs=newval;
-		if("alldirs")
-			global.alldirs=newval;
-		if("reverse_dir")
-			global.reverse_dir=newval;
-		if("config")
-			global.config=newval;
-		if("sun")
-			global.sun=newval;
-		if("combatlog")
-			global.combatlog=newval;
-		if("IClog")
-			global.IClog=newval;
-		if("OOClog")
-			global.OOClog=newval;
-		if("adminlog")
-			global.adminlog=newval;
-		if("powernets")
-			global.powernets=newval;
-		if("Debug2")
-			global.Debug2=newval;
-		if("gravity_is_on")
-			global.gravity_is_on=newval;
-		if("join_motd")
-			global.join_motd=newval;
-		if("nanomanager")
-			global.nanomanager=newval;
-		if("event_manager")
-			global.event_manager=newval;
-		if("awaydestinations")
-			global.awaydestinations=newval;
-		if("sqladdress")
-			global.sqladdress=newval;
-		if("sqlport")
-			global.sqlport=newval;
-		if("sqldb")
-			global.sqldb=newval;
-		if("sqllogin")
-			global.sqllogin=newval;
-		if("sqlpass")
-			global.sqlpass=newval;
-		if("sqlfdbkdb")
-			global.sqlfdbkdb=newval;
-		if("sqlfdbklogin")
-			global.sqlfdbklogin=newval;
-		if("sqlfdbkpass")
-			global.sqlfdbkpass=newval;
-		if("sqllogging")
-			global.sqllogging=newval;
-		if("forumsqladdress")
-			global.forumsqladdress=newval;
-		if("forumsqlport")
-			global.forumsqlport=newval;
-		if("forumsqldb")
-			global.forumsqldb=newval;
-		if("forumsqllogin")
-			global.forumsqllogin=newval;
-		if("forumsqlpass")
-			global.forumsqlpass=newval;
-		if("forum_activated_group")
-			global.forum_activated_group=newval;
-		if("forum_authenticated_group")
-			global.forum_authenticated_group=newval;
-		if("fileaccess_timer")
-			global.fileaccess_timer=newval;
-		if("custom_event_msg")
-			global.custom_event_msg=newval;
-		if("dbcon")
-			global.dbcon=newval;
-		if("dbcon_old")
-			global.dbcon_old=newval;
-		if("alphabet_uppercase")
-			global.alphabet_uppercase=newval;
-		if("robot_module_types")
-			global.robot_module_types=newval;
-		if("scarySounds")
-			global.scarySounds=newval;
-		if("max_explosion_range")
-			global.max_explosion_range=newval;
-		if("global_announcer")
-			global.global_announcer=newval;
-		if("station_departments")
-			global.station_departments=newval;
-		if("ai_names")
-			global.ai_names=newval;
-		if("wizard_first")
-			global.wizard_first=newval;
-		if("wizard_second")
-			global.wizard_second=newval;
-		if("ninja_titles")
-			global.ninja_titles=newval;
-		if("ninja_names")
-			global.ninja_names=newval;
-		if("commando_names")
-			global.commando_names=newval;
-		if("first_names_male")
-			global.first_names_male=newval;
-		if("first_names_female")
-			global.first_names_female=newval;
-		if("last_names")
-			global.last_names=newval;
-		if("clown_names")
-			global.clown_names=newval;
-		if("verbs")
-			global.verbs=newval;
-		if("adjectives")
-			global.adjectives=newval;
-		if("world_topic_spam_protect_ip")
-			global.world_topic_spam_protect_ip=newval;
-		if("world_topic_spam_protect_time")
-			global.world_topic_spam_protect_time=newval;
-		if("failed_db_connections")
-			global.failed_db_connections=newval;
-		if("failed_old_db_connections")
-			global.failed_old_db_connections=newval;
-		if("ghost_master")
-			global.ghost_master=newval;
-		if("BLINDBLOCK")
-			global.BLINDBLOCK=newval;
-		if("DEAFBLOCK")
-			global.DEAFBLOCK=newval;
-		if("HULKBLOCK")
-			global.HULKBLOCK=newval;
-		if("TELEBLOCK")
-			global.TELEBLOCK=newval;
-		if("FIREBLOCK")
-			global.FIREBLOCK=newval;
-		if("XRAYBLOCK")
-			global.XRAYBLOCK=newval;
-		if("CLUMSYBLOCK")
-			global.CLUMSYBLOCK=newval;
-		if("FAKEBLOCK")
-			global.FAKEBLOCK=newval;
-		if("COUGHBLOCK")
-			global.COUGHBLOCK=newval;
-		if("GLASSESBLOCK")
-			global.GLASSESBLOCK=newval;
-		if("EPILEPSYBLOCK")
-			global.EPILEPSYBLOCK=newval;
-		if("TWITCHBLOCK")
-			global.TWITCHBLOCK=newval;
-		if("NERVOUSBLOCK")
-			global.NERVOUSBLOCK=newval;
-		if("MONKEYBLOCK")
-			global.MONKEYBLOCK=newval;
-		if("BLOCKADD")
-			global.BLOCKADD=newval;
-		if("DIFFMUT")
-			global.DIFFMUT=newval;
-		if("HEADACHEBLOCK")
-			global.HEADACHEBLOCK=newval;
-		if("NOBREATHBLOCK")
-			global.NOBREATHBLOCK=newval;
-		if("REMOTEVIEWBLOCK")
-			global.REMOTEVIEWBLOCK=newval;
-		if("REGENERATEBLOCK")
-			global.REGENERATEBLOCK=newval;
-		if("INCREASERUNBLOCK")
-			global.INCREASERUNBLOCK=newval;
-		if("REMOTETALKBLOCK")
-			global.REMOTETALKBLOCK=newval;
-		if("MORPHBLOCK")
-			global.MORPHBLOCK=newval;
-		if("BLENDBLOCK")
-			global.BLENDBLOCK=newval;
-		if("HALLUCINATIONBLOCK")
-			global.HALLUCINATIONBLOCK=newval;
-		if("NOPRINTSBLOCK")
-			global.NOPRINTSBLOCK=newval;
-		if("SHOCKIMMUNITYBLOCK")
-			global.SHOCKIMMUNITYBLOCK=newval;
-		if("SMALLSIZEBLOCK")
-			global.SMALLSIZEBLOCK=newval;
-		if("default_onmob_icons")
-			global.default_onmob_icons=newval;
-		if("defer_powernet_rebuild")
-			global.defer_powernet_rebuild=newval;
-		if("restricted_camera_networks")
-			global.restricted_camera_networks=newval;
-		if("gear_tweak_free_color_choice_")
-			global.gear_tweak_free_color_choice_=newval;
-		if("clients")
-			global.clients=newval;
-		if("admins")
-			global.admins=newval;
-		if("directory")
-			global.directory=newval;
-		if("player_list")
-			global.player_list=newval;
-		if("mob_list")
-			global.mob_list=newval;
-		if("human_mob_list")
-			global.human_mob_list=newval;
-		if("silicon_mob_list")
-			global.silicon_mob_list=newval;
-		if("living_mob_list_")
-			global.living_mob_list_=newval;
-		if("dead_mob_list_")
-			global.dead_mob_list_=newval;
-		if("cable_list")
-			global.cable_list=newval;
-		if("chemical_reactions_list")
-			global.chemical_reactions_list=newval;
-		if("chemical_reagents_list")
-			global.chemical_reagents_list=newval;
-		if("landmarks_list")
-			global.landmarks_list=newval;
-		if("surgery_steps")
-			global.surgery_steps=newval;
-		if("side_effects")
-			global.side_effects=newval;
-		if("mechas_list")
-			global.mechas_list=newval;
-		if("joblist")
-			global.joblist=newval;
-		if("turfs")
-			global.turfs=newval;
-		if("all_species")
-			global.all_species=newval;
-		if("all_languages")
-			global.all_languages=newval;
-		if("language_keys")
-			global.language_keys=newval;
-		if("whitelisted_species")
-			global.whitelisted_species=newval;
-		if("playable_species")
-			global.playable_species=newval;
-		if("mannequins_")
-			global.mannequins_=newval;
-		if("poster_designs")
-			global.poster_designs=newval;
-		if("world_uplinks")
-			global.world_uplinks=newval;
-		if("hair_styles_list")
-			global.hair_styles_list=newval;
-		if("hair_styles_male_list")
-			global.hair_styles_male_list=newval;
-		if("hair_styles_female_list")
-			global.hair_styles_female_list=newval;
-		if("facial_hair_styles_list")
-			global.facial_hair_styles_list=newval;
-		if("facial_hair_styles_male_list")
-			global.facial_hair_styles_male_list=newval;
-		if("facial_hair_styles_female_list")
-			global.facial_hair_styles_female_list=newval;
-		if("skin_styles_female_list")
-			global.skin_styles_female_list=newval;
-		if("global_underwear")
-			global.global_underwear=newval;
-		if("backbaglist")
-			global.backbaglist=newval;
-		if("exclude_jobs")
-			global.exclude_jobs=newval;
-		if("visual_nets")
-			global.visual_nets=newval;
-		if("cameranet")
-			global.cameranet=newval;
-		if("rune_list")
-			global.rune_list=newval;
-		if("endgame_exits")
-			global.endgame_exits=newval;
-		if("endgame_safespawns")
-			global.endgame_safespawns=newval;
-		if("syndicate_access")
-			global.syndicate_access=newval;
-		if("string_part_flags")
-			global.string_part_flags=newval;
-		if("string_slot_flags")
-			global.string_slot_flags=newval;
-		if("paramslist_cache")
-			global.paramslist_cache=newval;
-		if("church_name")
-			global.church_name=newval;
-		if("command_name")
-			global.command_name=newval;
-		if("religion_name")
-			global.religion_name=newval;
-		if("syndicate_name")
-			global.syndicate_name=newval;
-		if("syndicate_code_phrase")
-			global.syndicate_code_phrase=newval;
-		if("syndicate_code_response")
-			global.syndicate_code_response=newval;
-		if("roundstart_hour")
-			global.roundstart_hour=newval;
-		if("station_date")
-			global.station_date=newval;
-		if("next_station_date_change")
-			global.next_station_date_change=newval;
-		if("next_duration_update")
-			global.next_duration_update=newval;
-		if("last_round_duration")
-			global.last_round_duration=newval;
-		if("round_start_time")
-			global.round_start_time=newval;
-		if("common_tools")
-			global.common_tools=newval;
-		if("WALLITEMS")
-			global.WALLITEMS=newval;
-		if("dview_mob")
-			global.dview_mob=newval;
-		if("global_hud")
-			global.global_hud=newval;
-		if("global_huds")
-			global.global_huds=newval;
-		if("robot_inventory")
-			global.robot_inventory=newval;
-		if("transfer_controller")
-			global.transfer_controller=newval;
-		if("radiochannels")
-			global.radiochannels=newval;
-		if("CENT_FREQS")
-			global.CENT_FREQS=newval;
-		if("ANTAG_FREQS")
-			global.ANTAG_FREQS=newval;
-		if("DEPT_FREQS")
-			global.DEPT_FREQS=newval;
-		if("radio_controller")
-			global.radio_controller=newval;
-		if("gamemode_cache")
-			global.gamemode_cache=newval;
-		if("master_controller")
-			global.master_controller=newval;
-		if("controller_iteration")
-			global.controller_iteration=newval;
-		if("last_tick_duration")
-			global.last_tick_duration=newval;
-		if("air_processing_killed")
-			global.air_processing_killed=newval;
-		if("pipe_processing_killed")
-			global.pipe_processing_killed=newval;
-		if("initialization_stage")
-			global.initialization_stage=newval;
-		if("shuttle_controller")
-			global.shuttle_controller=newval;
-		if("vote")
-			global.vote=newval;
-		if("evacuation_controller")
-			global.evacuation_controller=newval;
-		if("list_of_ais")
-			global.list_of_ais=newval;
-		if("alarm_manager")
-			global.alarm_manager=newval;
-		if("chemistryProcess")
-			global.chemistryProcess=newval;
-		if("garbage_collector")
-			global.garbage_collector=newval;
-		if("delayed_garbage")
-			global.delayed_garbage=newval;
 		if("tgui_process")
 			global.tgui_process=newval;
-		if("tickerProcess")
-			global.tickerProcess=newval;
-		if("processing_turfs")
-			global.processing_turfs=newval;
-		if("wirelessProcess")
-			global.wirelessProcess=newval;
-		if("processScheduler")
-			global.processScheduler=newval;
-		if("mil_branches")
-			global.mil_branches=newval;
-		if("appearance_manager")
-			global.appearance_manager=newval;
-		if("revdata")
-			global.revdata=newval;
-		if("all_observable_events")
-			global.all_observable_events=newval;
-		if("death_event")
-			global.death_event=newval;
-		if("density_set_event")
-			global.density_set_event=newval;
-		if("destroyed_event")
-			global.destroyed_event=newval;
-		if("dir_set_event")
-			global.dir_set_event=newval;
-		if("entered_event")
-			global.entered_event=newval;
-		if("mob_equipped_event")
-			global.mob_equipped_event=newval;
-		if("item_equipped_event")
-			global.item_equipped_event=newval;
-		if("life_event")
-			global.life_event=newval;
-		if("logged_in_event")
-			global.logged_in_event=newval;
-		if("logged_out_event")
-			global.logged_out_event=newval;
-		if("moved_event")
-			global.moved_event=newval;
-		if("opacity_set_event")
-			global.opacity_set_event=newval;
-		if("see_in_dark_set_event")
-			global.see_in_dark_set_event=newval;
-		if("see_invisible_set_event")
-			global.see_invisible_set_event=newval;
-		if("sight_set_event")
-			global.sight_set_event=newval;
-		if("stat_set_event")
-			global.stat_set_event=newval;
-		if("task_triggered_event")
-			global.task_triggered_event=newval;
-		if("turf_changed_event")
-			global.turf_changed_event=newval;
-		if("mob_unequipped_event")
-			global.mob_unequipped_event=newval;
-		if("item_unequipped_event")
-			global.item_unequipped_event=newval;
-		if("global_listen_count")
-			global.global_listen_count=newval;
-		if("event_sources_count")
-			global.event_sources_count=newval;
-		if("event_listen_count")
-			global.event_listen_count=newval;
-		if("outfits_decls_")
-			global.outfits_decls_=newval;
-		if("outfits_decls_root_")
-			global.outfits_decls_root_=newval;
-		if("outfits_decls_by_type_")
-			global.outfits_decls_by_type_=newval;
-		if("admin_pm_repository")
-			global.admin_pm_repository=newval;
-		if("attack_log_repository")
-			global.attack_log_repository=newval;
-		if("camera_repository")
-			global.camera_repository=newval;
-		if("client_repository")
-			global.client_repository=newval;
-		if("mob_repository")
-			global.mob_repository=newval;
-		if("radiation_repository")
-			global.radiation_repository=newval;
-		if("to_process")
-			global.to_process=newval;
-		if("uniqueness_repository")
-			global.uniqueness_repository=newval;
-		if("uplink_purchase_repository")
-			global.uplink_purchase_repository=newval;
-		if("crew_repository")
-			global.crew_repository=newval;
-		if("cargo_supply_pack_root")
-			global.cargo_supply_pack_root=newval;
-		if("cargo_supply_packs")
-			global.cargo_supply_packs=newval;
-		if("supply_methods_")
-			global.supply_methods_=newval;
-		if("uplink")
-			global.uplink=newval;
-		if("same_wires")
-			global.same_wires=newval;
-		if("wireColours")
-			global.wireColours=newval;
-		if("newscaster_standard_feeds")
-			global.newscaster_standard_feeds=newval;
-		if("announced_news_types")
-			global.announced_news_types=newval;
-		if("send_emergency_team")
-			global.send_emergency_team=newval;
-		if("ert_base_chance")
-			global.ert_base_chance=newval;
-		if("can_call_ert")
-			global.can_call_ert=newval;
-		if("shatter_sound")
-			global.shatter_sound=newval;
-		if("explosion_sound")
-			global.explosion_sound=newval;
-		if("spark_sound")
-			global.spark_sound=newval;
-		if("rustle_sound")
-			global.rustle_sound=newval;
-		if("punch_sound")
-			global.punch_sound=newval;
-		if("clown_sound")
-			global.clown_sound=newval;
-		if("swing_hit_sound")
-			global.swing_hit_sound=newval;
-		if("hiss_sound")
-			global.hiss_sound=newval;
-		if("page_sound")
-			global.page_sound=newval;
-		if("fracture_sound")
-			global.fracture_sound=newval;
-		if("lighter_sound")
-			global.lighter_sound=newval;
-		if("supply_controller")
-			global.supply_controller=newval;
-		if("mechtoys")
-			global.mechtoys=newval;
-		if("point_source_descriptions")
-			global.point_source_descriptions=newval;
-		if("all_antag_types")
-			global.all_antag_types=newval;
-		if("all_antag_spawnpoints")
-			global.all_antag_spawnpoints=newval;
-		if("antag_names_to_ids")
-			global.antag_names_to_ids=newval;
-		if("borers")
-			global.borers=newval;
-		if("xenomorphs")
-			global.xenomorphs=newval;
-		if("actor")
-			global.actor=newval;
-		if("commandos")
-			global.commandos=newval;
-		if("deathsquad")
-			global.deathsquad=newval;
-		if("ert")
-			global.ert=newval;
-		if("mercs")
-			global.mercs=newval;
-		if("ninjas")
-			global.ninjas=newval;
-		if("raiders")
-			global.raiders=newval;
-		if("wizards")
-			global.wizards=newval;
-		if("cult")
-			global.cult=newval;
-		if("highlanders")
-			global.highlanders=newval;
-		if("loyalists")
-			global.loyalists=newval;
-		if("renegades")
-			global.renegades=newval;
-		if("revs")
-			global.revs=newval;
-		if("malf")
-			global.malf=newval;
-		if("traitors")
-			global.traitors=newval;
-		if("forced_ambiance_list")
-			global.forced_ambiance_list=newval;
-		if("dna_activity_bounds")
-			global.dna_activity_bounds=newval;
-		if("assigned_blocks")
-			global.assigned_blocks=newval;
-		if("dna_genes")
-			global.dna_genes=newval;
-		if("eventchance")
-			global.eventchance=newval;
-		if("hadevent")
-			global.hadevent=newval;
-		if("antag_add_finished")
-			global.antag_add_finished=newval;
-		if("additional_antag_types")
-			global.additional_antag_types=newval;
+		if("tick_multiplier")
+			global.tick_multiplier=newval;
 		if("ticker")
 			global.ticker=newval;
-		if("all_objectives")
-			global.all_objectives=newval;
-		if("possible_changeling_IDs")
-			global.possible_changeling_IDs=newval;
-		if("hivemind_bank")
-			global.hivemind_bank=newval;
-		if("powers")
-			global.powers=newval;
-		if("powerinstances")
-			global.powerinstances=newval;
-		if("narsie_behaviour")
-			global.narsie_behaviour=newval;
-		if("narsie_cometh")
-			global.narsie_cometh=newval;
-		if("narsie_list")
-			global.narsie_list=newval;
-		if("Tier1Runes")
-			global.Tier1Runes=newval;
-		if("Tier2Runes")
-			global.Tier2Runes=newval;
-		if("Tier3Runes")
-			global.Tier3Runes=newval;
-		if("Tier4Runes")
-			global.Tier4Runes=newval;
-		if("universe_has_ended")
-			global.universe_has_ended=newval;
-		if("Holiday")
-			global.Holiday=newval;
-		if("nuke_disks")
-			global.nuke_disks=newval;
-		if("job_master")
-			global.job_master=newval;
-		if("assistant_occupations")
-			global.assistant_occupations=newval;
-		if("command_positions")
-			global.command_positions=newval;
-		if("engineering_positions")
-			global.engineering_positions=newval;
-		if("medical_positions")
-			global.medical_positions=newval;
-		if("science_positions")
-			global.science_positions=newval;
-		if("cargo_positions")
-			global.cargo_positions=newval;
-		if("civilian_positions")
-			global.civilian_positions=newval;
-		if("security_positions")
-			global.security_positions=newval;
-		if("nonhuman_positions")
-			global.nonhuman_positions=newval;
-		if("service_positions")
-			global.service_positions=newval;
-		if("supply_positions")
-			global.supply_positions=newval;
-		if("whitelist")
-			global.whitelist=newval;
-		if("captain_announcement")
-			global.captain_announcement=newval;
-		if("doppler_arrays")
-			global.doppler_arrays=newval;
-		if("floor_light_cache")
-			global.floor_light_cache=newval;
-		if("navbeacons")
-			global.navbeacons=newval;
-		if("news_network")
-			global.news_network=newval;
-		if("allCasters")
-			global.allCasters=newval;
-		if("bomb_set")
-			global.bomb_set=newval;
-		if("turret_icons")
-			global.turret_icons=newval;
-		if("req_console_assistance")
-			global.req_console_assistance=newval;
-		if("req_console_supplies")
-			global.req_console_supplies=newval;
-		if("req_console_information")
-			global.req_console_information=newval;
-		if("allConsoles")
-			global.allConsoles=newval;
-		if("status_icons_to_colour")
-			global.status_icons_to_colour=newval;
-		if("ai_status_emotions")
-			global.ai_status_emotions=newval;
-		if("priority_air_alarms")
-			global.priority_air_alarms=newval;
-		if("minor_air_alarms")
-			global.minor_air_alarms=newval;
-		if("air_alarm_topic")
-			global.air_alarm_topic=newval;
-		if("specops_shuttle_moving_to_station")
-			global.specops_shuttle_moving_to_station=newval;
-		if("specops_shuttle_moving_to_centcom")
-			global.specops_shuttle_moving_to_centcom=newval;
-		if("specops_shuttle_at_station")
-			global.specops_shuttle_at_station=newval;
-		if("specops_shuttle_can_send")
-			global.specops_shuttle_can_send=newval;
-		if("specops_shuttle_time")
-			global.specops_shuttle_time=newval;
-		if("specops_shuttle_timeleft")
-			global.specops_shuttle_timeleft=newval;
-		if("syndicate_elite_shuttle_moving_to_station")
-			global.syndicate_elite_shuttle_moving_to_station=newval;
-		if("syndicate_elite_shuttle_moving_to_mothership")
-			global.syndicate_elite_shuttle_moving_to_mothership=newval;
-		if("syndicate_elite_shuttle_at_station")
-			global.syndicate_elite_shuttle_at_station=newval;
-		if("syndicate_elite_shuttle_can_send")
-			global.syndicate_elite_shuttle_can_send=newval;
-		if("syndicate_elite_shuttle_time")
-			global.syndicate_elite_shuttle_time=newval;
-		if("syndicate_elite_shuttle_timeleft")
-			global.syndicate_elite_shuttle_timeleft=newval;
-		if("recentmessages")
-			global.recentmessages=newval;
-		if("message_delay")
-			global.message_delay=newval;
-		if("telecomms_list")
-			global.telecomms_list=newval;
-		if("explosion_turfs")
-			global.explosion_turfs=newval;
-		if("explosion_in_progress")
-			global.explosion_in_progress=newval;
-		if("slot_flags_enumeration")
-			global.slot_flags_enumeration=newval;
-		if("BUMP_TELEPORTERS")
-			global.BUMP_TELEPORTERS=newval;
-		if("splatter_cache")
-			global.splatter_cache=newval;
-		if("fluidtrack_cache")
-			global.fluidtrack_cache=newval;
-		if("storedwarrant")
-			global.storedwarrant=newval;
-		if("activename")
-			global.activename=newval;
-		if("activecharges")
-			global.activecharges=newval;
-		if("activeauth")
-			global.activeauth=newval;
-		if("activetype")
-			global.activetype=newval;
-		if("uplink_random_selections_")
-			global.uplink_random_selections_=newval;
-		if("PDAs")
-			global.PDAs=newval;
-		if("default_internal_channels")
-			global.default_internal_channels=newval;
-		if("default_medbay_channels")
-			global.default_medbay_channels=newval;
-		if("last_chew")
-			global.last_chew=newval;
-		if("cached_icons")
-			global.cached_icons=newval;
-		if("hazard_overlays")
-			global.hazard_overlays=newval;
-		if("tape_roll_applications")
-			global.tape_roll_applications=newval;
-		if("ashtray_cache")
-			global.ashtray_cache=newval;
-		if("tank_gauge_cache")
-			global.tank_gauge_cache=newval;
-		if("multi_point_spawns")
-			global.multi_point_spawns=newval;
-		if("random_junk_")
-			global.random_junk_=newval;
-		if("random_useful_")
-			global.random_useful_=newval;
-		if("stool_cache")
-			global.stool_cache=newval;
-		if("flooring_types")
-			global.flooring_types=newval;
-		if("floor_decals")
-			global.floor_decals=newval;
-		if("flooring_cache")
-			global.flooring_cache=newval;
-		if("BSACooldown")
-			global.BSACooldown=newval;
-		if("floorIsLava")
-			global.floorIsLava=newval;
-		if("admin_ranks")
-			global.admin_ranks=newval;
-		if("admin_secrets")
-			global.admin_secrets=newval;
-		if("admin_verbs_default")
-			global.admin_verbs_default=newval;
-		if("admin_verbs_admin")
-			global.admin_verbs_admin=newval;
-		if("admin_verbs_ban")
-			global.admin_verbs_ban=newval;
-		if("admin_verbs_sounds")
-			global.admin_verbs_sounds=newval;
-		if("admin_verbs_fun")
-			global.admin_verbs_fun=newval;
-		if("admin_verbs_spawn")
-			global.admin_verbs_spawn=newval;
-		if("admin_verbs_server")
-			global.admin_verbs_server=newval;
-		if("admin_verbs_debug")
-			global.admin_verbs_debug=newval;
-		if("admin_verbs_paranoid_debug")
-			global.admin_verbs_paranoid_debug=newval;
-		if("admin_verbs_possess")
-			global.admin_verbs_possess=newval;
-		if("admin_verbs_permissions")
-			global.admin_verbs_permissions=newval;
-		if("admin_verbs_rejuv")
-			global.admin_verbs_rejuv=newval;
-		if("admin_verbs_hideable")
-			global.admin_verbs_hideable=newval;
-		if("admin_verbs_mod")
-			global.admin_verbs_mod=newval;
-		if("admin_verbs_mentor")
-			global.admin_verbs_mentor=newval;
-		if("jobban_runonce")
-			global.jobban_runonce=newval;
-		if("jobban_keylist")
-			global.jobban_keylist=newval;
-		if("admin_datums")
-			global.admin_datums=newval;
-		if("CMinutes")
-			global.CMinutes=newval;
-		if("Banlist")
-			global.Banlist=newval;
-		if("adminhelp_ignored_words")
-			global.adminhelp_ignored_words=newval;
-		if("checked_for_inactives")
-			global.checked_for_inactives=newval;
-		if("inactive_keys")
-			global.inactive_keys=newval;
-		if("camera_range_display_status")
-			global.camera_range_display_status=newval;
-		if("intercom_range_display_status")
-			global.intercom_range_display_status=newval;
-		if("debug_verbs")
-			global.debug_verbs=newval;
-		if("sounds_cache")
-			global.sounds_cache=newval;
-		if("pipe_colors")
-			global.pipe_colors=newval;
-		if("pipe_networks")
-			global.pipe_networks=newval;
-		if("asset_cache")
-			global.asset_cache=newval;
-		if("preferences_datums")
-			global.preferences_datums=newval;
-		if("seen_citizenships")
-			global.seen_citizenships=newval;
-		if("seen_systems")
-			global.seen_systems=newval;
-		if("seen_factions")
-			global.seen_factions=newval;
-		if("seen_religions")
-			global.seen_religions=newval;
-		if("citizenship_choices")
-			global.citizenship_choices=newval;
-		if("home_system_choices")
-			global.home_system_choices=newval;
-		if("faction_choices")
-			global.faction_choices=newval;
-		if("religion_choices")
-			global.religion_choices=newval;
-		if("spawntypes")
-			global.spawntypes=newval;
-		if("client_preference_stats_")
-			global.client_preference_stats_=newval;
-		if("uplink_locations")
-			global.uplink_locations=newval;
-		if("valid_bloodtypes")
-			global.valid_bloodtypes=newval;
-		if("_client_preferences")
-			global._client_preferences=newval;
-		if("_client_preferences_by_key")
-			global._client_preferences_by_key=newval;
-		if("_client_preferences_by_type")
-			global._client_preferences_by_type=newval;
-		if("loadout_categories")
-			global.loadout_categories=newval;
-		if("gear_datums")
-			global.gear_datums=newval;
-		if("matchmaker")
-			global.matchmaker=newval;
-		if("breach_brute_descriptors")
-			global.breach_brute_descriptors=newval;
-		if("breach_burn_descriptors")
-			global.breach_burn_descriptors=newval;
-		if("current_date_string")
-			global.current_date_string=newval;
-		if("vendor_account")
-			global.vendor_account=newval;
-		if("station_account")
-			global.station_account=newval;
-		if("department_accounts")
-			global.department_accounts=newval;
-		if("num_financial_terminals")
-			global.num_financial_terminals=newval;
-		if("next_account_number")
-			global.next_account_number=newval;
-		if("all_money_accounts")
-			global.all_money_accounts=newval;
-		if("economy_init")
-			global.economy_init=newval;
-		if("weighted_randomevent_locations")
-			global.weighted_randomevent_locations=newval;
-		if("weighted_mundaneevent_locations")
-			global.weighted_mundaneevent_locations=newval;
-		if("error_last_seen")
-			global.error_last_seen=newval;
-		if("error_cooldown")
-			global.error_cooldown=newval;
+		if("tickerProcess")
+			global.tickerProcess=newval;
+		if("to_process")
+			global.to_process=newval;
 		if("total_runtimes")
 			global.total_runtimes=newval;
 		if("total_runtimes_skipped")
 			global.total_runtimes_skipped=newval;
-		if("error_cache")
-			global.error_cache=newval;
-		if("severity_to_string")
-			global.severity_to_string=newval;
-		if("event_last_fired")
-			global.event_last_fired=newval;
-		if("description_icons")
-			global.description_icons=newval;
-		if("dreams")
-			global.dreams=newval;
-		if("non_fakeattack_weapons")
-			global.non_fakeattack_weapons=newval;
-		if("ghost_traps")
-			global.ghost_traps=newval;
-		if("fruit_icon_cache")
-			global.fruit_icon_cache=newval;
-		if("plant_controller")
-			global.plant_controller=newval;
-		if("plant_seed_sprites")
-			global.plant_seed_sprites=newval;
-		if("wax_recipes")
-			global.wax_recipes=newval;
-		if("worths")
-			global.worths=newval;
-		if("license_to_url")
-			global.license_to_url=newval;
-		if("maploader")
-			global.maploader=newval;
-		if("_preloader")
-			global._preloader=newval;
-		if("swapmaps_iconcache")
-			global.swapmaps_iconcache=newval;
-		if("swapmaps_mode")
-			global.swapmaps_mode=newval;
-		if("swapmaps_compiled_maxx")
-			global.swapmaps_compiled_maxx=newval;
-		if("swapmaps_compiled_maxy")
-			global.swapmaps_compiled_maxy=newval;
-		if("swapmaps_compiled_maxz")
-			global.swapmaps_compiled_maxz=newval;
-		if("swapmaps_initialized")
-			global.swapmaps_initialized=newval;
-		if("swapmaps_loaded")
-			global.swapmaps_loaded=newval;
-		if("swapmaps_byname")
-			global.swapmaps_byname=newval;
-		if("name_to_material")
-			global.name_to_material=newval;
-		if("mining_walls")
-			global.mining_walls=newval;
-		if("mining_floors")
-			global.mining_floors=newval;
-		if("ore_data")
-			global.ore_data=newval;
-		if("ores_by_type")
-			global.ores_by_type=newval;
-		if("holder_mob_icon_cache")
-			global.holder_mob_icon_cache=newval;
-		if("slot_equipment_priority")
-			global.slot_equipment_priority=newval;
-		if("base_miss_chance")
-			global.base_miss_chance=newval;
-		if("organ_rel_size")
-			global.organ_rel_size=newval;
-		if("intents")
-			global.intents=newval;
-		if("department_radio_keys")
-			global.department_radio_keys=newval;
-		if("channel_to_radio_key")
-			global.channel_to_radio_key=newval;
-		if("sparring_attack_cache")
-			global.sparring_attack_cache=newval;
-		if("human_icon_cache")
-			global.human_icon_cache=newval;
-		if("tail_icon_cache")
-			global.tail_icon_cache=newval;
-		if("light_overlay_cache")
-			global.light_overlay_cache=newval;
-		if("damage_icon_parts")
-			global.damage_icon_parts=newval;
-		if("stored_shock_by_ref")
-			global.stored_shock_by_ref=newval;
-		if("wrapped_species_by_ref")
-			global.wrapped_species_by_ref=newval;
-		if("prometheans")
-			global.prometheans=newval;
-		if("ai_list")
-			global.ai_list=newval;
-		if("ai_verbs_default")
-			global.ai_verbs_default=newval;
-		if("default_ai_icon")
-			global.default_ai_icon=newval;
-		if("ai_icons")
-			global.ai_icons=newval;
-		if("empty_playable_ai_cores")
-			global.empty_playable_ai_cores=newval;
-		if("paiController")
-			global.paiController=newval;
-		if("pai_emotions")
-			global.pai_emotions=newval;
-		if("pai_software_by_key")
-			global.pai_software_by_key=newval;
-		if("default_pai_software")
-			global.default_pai_software=newval;
-		if("robot_custom_icons")
-			global.robot_custom_icons=newval;
-		if("robot_modules")
-			global.robot_modules=newval;
-		if("mob_hat_cache")
-			global.mob_hat_cache=newval;
-		if("chicken_count")
-			global.chicken_count=newval;
-		if("protected_objects")
-			global.protected_objects=newval;
-		if("hidden_skill_types")
-			global.hidden_skill_types=newval;
-		if("SKILLS")
-			global.SKILLS=newval;
-		if("cameranet_")
-			global.cameranet_=newval;
-		if("ghost_darkness_images")
-			global.ghost_darkness_images=newval;
-		if("ghost_sightless_images")
-			global.ghost_sightless_images=newval;
-		if("all_virtual_listeners")
-			global.all_virtual_listeners=newval;
-		if("global_modular_computers")
-			global.global_modular_computers=newval;
-		if("file_uid")
-			global.file_uid=newval;
-		if("comm_message_listeners")
-			global.comm_message_listeners=newval;
-		if("global_message_listener")
-			global.global_message_listener=newval;
-		if("last_message_id")
-			global.last_message_id=newval;
-		if("warrant_uid")
-			global.warrant_uid=newval;
-		if("nttransfer_uid")
-			global.nttransfer_uid=newval;
-		if("ntnet_card_uid")
-			global.ntnet_card_uid=newval;
-		if("ntnet_global")
-			global.ntnet_global=newval;
-		if("ntnrc_uid")
-			global.ntnrc_uid=newval;
-		if("z_levels")
-			global.z_levels=newval;
-		if("organ_cache")
-			global.organ_cache=newval;
-		if("limb_icon_cache")
-			global.limb_icon_cache=newval;
-		if("flesh_hud_colours")
-			global.flesh_hud_colours=newval;
-		if("robot_hud_colours")
-			global.robot_hud_colours=newval;
-		if("all_robolimbs")
-			global.all_robolimbs=newval;
-		if("chargen_robolimbs")
-			global.chargen_robolimbs=newval;
-		if("basic_robolimb")
-			global.basic_robolimb=newval;
-		if("map_sectors")
-			global.map_sectors=newval;
-		if("moving_levels")
-			global.moving_levels=newval;
-		if("sector_shuttles")
-			global.sector_shuttles=newval;
-		if("cached_space")
-			global.cached_space=newval;
-		if("ship_engines")
-			global.ship_engines=newval;
-		if("allfaxes")
-			global.allfaxes=newval;
-		if("admin_departments")
-			global.admin_departments=newval;
-		if("alldepartments")
-			global.alldepartments=newval;
-		if("adminfaxes")
-			global.adminfaxes=newval;
-		if("photo_count")
-			global.photo_count=newval;
-		if("possible_cable_coil_colours")
-			global.possible_cable_coil_colours=newval;
-		if("light_type_cache")
-			global.light_type_cache=newval;
-		if("solar_gen_rate")
-			global.solar_gen_rate=newval;
-		if("solars_list")
-			global.solars_list=newval;
-		if("fusion_reactions")
-			global.fusion_reactions=newval;
-		if("fusion_cores")
-			global.fusion_cores=newval;
-		if("fuel_injectors")
-			global.fuel_injectors=newval;
-		if("gyrotrons")
-			global.gyrotrons=newval;
-		if("rad_collectors")
-			global.rad_collectors=newval;
-		if("random_maps")
-			global.random_maps=newval;
-		if("map_count")
-			global.map_count=newval;
-		if("supply_drop")
-			global.supply_drop=newval;
-		if("maze_cell_count")
-			global.maze_cell_count=newval;
-		if("lunchables_lunches_")
-			global.lunchables_lunches_=newval;
-		if("lunchables_snacks_")
-			global.lunchables_snacks_=newval;
-		if("lunchables_drinks_")
-			global.lunchables_drinks_=newval;
-		if("lunchables_drink_reagents_")
-			global.lunchables_drink_reagents_=newval;
-		if("lunchables_ethanol_reagents_")
-			global.lunchables_ethanol_reagents_=newval;
-		if("message_servers")
-			global.message_servers=newval;
-		if("blackbox")
-			global.blackbox=newval;
-		if("default_material_composition")
-			global.default_material_composition=newval;
-		if("maint_all_access")
-			global.maint_all_access=newval;
-		if("escape_pods")
-			global.escape_pods=newval;
-		if("escape_pods_by_name")
-			global.escape_pods_by_name=newval;
-		if("spells")
-			global.spells=newval;
-		if("artefact_feedback")
-			global.artefact_feedback=newval;
-		if("turbolifts")
-			global.turbolifts=newval;
-		if("turbolift_controller")
-			global.turbolift_controller=newval;
-		if("ventcrawl_machinery")
-			global.ventcrawl_machinery=newval;
-		if("ALL_ANTIGENS")
-			global.ALL_ANTIGENS=newval;
-		if("virusDB")
-			global.virusDB=newval;
-		if("responsive_carriers")
-			global.responsive_carriers=newval;
-		if("finds_as_strings")
-			global.finds_as_strings=newval;
-		if("air_master")
-			global.air_master=newval;
-		if("tick_multiplier")
-			global.tick_multiplier=newval;
-		if("assigned")
-			global.assigned=newval;
-		if("created")
-			global.created=newval;
-		if("merged")
-			global.merged=newval;
-		if("invalid_zone")
-			global.invalid_zone=newval;
-		if("air_blocked")
-			global.air_blocked=newval;
-		if("zone_blocked")
-			global.zone_blocked=newval;
-		if("blocked")
-			global.blocked=newval;
-		if("mark")
-			global.mark=newval;
-		if("contamination_overlay")
-			global.contamination_overlay=newval;
-		if("vsc")
-			global.vsc=newval;
-		if("all_unit_tests_passed")
-			global.all_unit_tests_passed=newval;
-		if("failed_unit_tests")
-			global.failed_unit_tests=newval;
-		if("skipped_unit_tests")
-			global.skipped_unit_tests=newval;
 		if("total_unit_tests")
 			global.total_unit_tests=newval;
-		if("currently_running_tests")
-			global.currently_running_tests=newval;
-		if("ascii_esc")
-			global.ascii_esc=newval;
-		if("ascii_red")
-			global.ascii_red=newval;
-		if("ascii_green")
-			global.ascii_green=newval;
-		if("ascii_yellow")
-			global.ascii_yellow=newval;
-		if("ascii_reset")
-			global.ascii_reset=newval;
+		if("traders")
+			global.traders=newval;
+		if("traitors")
+			global.traitors=newval;
+		if("transfer_controller")
+			global.transfer_controller=newval;
+		if("turbolift_controller")
+			global.turbolift_controller=newval;
+		if("turbolifts")
+			global.turbolifts=newval;
+		if("turf_changed_event")
+			global.turf_changed_event=newval;
+		if("turfs")
+			global.turfs=newval;
+		if("turret_icons")
+			global.turret_icons=newval;
+		if("uniqueness_repository")
+			global.uniqueness_repository=newval;
+		if("universe")
+			global.universe=newval;
+		if("universe_has_ended")
+			global.universe_has_ended=newval;
+		if("uplink")
+			global.uplink=newval;
+		if("uplink_locations")
+			global.uplink_locations=newval;
+		if("uplink_purchase_repository")
+			global.uplink_purchase_repository=newval;
+		if("uplink_random_selections_")
+			global.uplink_random_selections_=newval;
 		if("using_map")
 			global.using_map=newval;
-		if("all_maps")
-			global.all_maps=newval;
-		if("init")
-			global.init=newval;
+		if("valid_bloodtypes")
+			global.valid_bloodtypes=newval;
+		if("vendor_account")
+			global.vendor_account=newval;
+		if("ventcrawl_machinery")
+			global.ventcrawl_machinery=newval;
+		if("verbs")
+			global.verbs=newval;
+		if("view_variables_dont_expand")
+			global.view_variables_dont_expand=newval;
+		if("view_variables_hide_vars")
+			global.view_variables_hide_vars=newval;
+		if("view_variables_no_assoc")
+			global.view_variables_no_assoc=newval;
+		if("virusDB")
+			global.virusDB=newval;
+		if("visual_nets")
+			global.visual_nets=newval;
+		if("vote")
+			global.vote=newval;
+		if("vsc")
+			global.vsc=newval;
+		if("warrant_uid")
+			global.warrant_uid=newval;
+		if("wax_recipes")
+			global.wax_recipes=newval;
+		if("weighted_mundaneevent_locations")
+			global.weighted_mundaneevent_locations=newval;
+		if("weighted_randomevent_locations")
+			global.weighted_randomevent_locations=newval;
+		if("whitelist")
+			global.whitelist=newval;
+		if("whitelisted_species")
+			global.whitelisted_species=newval;
+		if("wireColours")
+			global.wireColours=newval;
+		if("wirelessProcess")
+			global.wirelessProcess=newval;
+		if("wizard_first")
+			global.wizard_first=newval;
+		if("wizard_second")
+			global.wizard_second=newval;
+		if("wizards")
+			global.wizards=newval;
+		if("wizardstart")
+			global.wizardstart=newval;
+		if("world_topic_spam_protect_ip")
+			global.world_topic_spam_protect_ip=newval;
+		if("world_topic_spam_protect_time")
+			global.world_topic_spam_protect_time=newval;
+		if("world_uplinks")
+			global.world_uplinks=newval;
+		if("worths")
+			global.worths=newval;
+		if("wrapped_species_by_ref")
+			global.wrapped_species_by_ref=newval;
+		if("xeno_spawn")
+			global.xeno_spawn=newval;
+		if("xenomorphs")
+			global.xenomorphs=newval;
+		if("z_levels")
+			global.z_levels=newval;
+		if("z_state")
+			global.z_state=newval;
+		if("zone_blocked")
+			global.zone_blocked=newval;
 		
-/var/list/_all_globals=list("tagger_locations","is_station_but_not_space_or_shuttle_area","is_contact_but_not_space_or_shuttle_area","is_player_but_not_space_or_shuttle_area","delta_index","meteors_dust","meteors_normal","meteors_threatening","meteors_catastrophic","meteors_armageddon","meteors_cataclysm","priv_all_access_datums","priv_all_access_datums_id","priv_all_access_datums_region","priv_all_access","priv_station_access","priv_centcom_access","priv_syndicate_access","priv_region_access","alien_whitelist","acting_rank_prefixes","view_variables_hide_vars","view_variables_dont_expand","view_variables_no_assoc","custom_items","economic_species_modifier","lighting_update_lights","lighting_update_overlays","gender_datums","chemical_reaction_logs","server_name","game_id","log_end","atmosphere_alarm","camera_alarm","fire_alarm","motion_alarm","power_alarm","admin_state","conscious_state","contained_state","default_state","outside_state","hands_state","interactive_state","inventory_state","deep_inventory_state","physical_state","self_state","z_state","tg_admin_state","tg_always_state","tg_conscious_state","tg_contained_state","tg_deep_inventory_state","tg_default_state","tg_hands_state","tg_human_adjacent_state","tg_inventory_state","tg_not_contained_state","tg_not_incapacitated_state","not_incapacitated_turf_state","tg_physical_state","tg_self_state","tg_z_state","machinery_sort_required","autolathe_recipes","autolathe_categories","PDA_Manifest","id_card_states","asset_datums","magazine_icondata_keys","magazine_icondata_states","account_hack_attempted","spacevines_spawned","sent_spiders_to_station","text_tag_icons","scheduler","security_announcement_up","security_announcement_down","priority_announcement","command_announcement","gas_data","area_repository","decls_repository","follow_repository","image_repository","create_mob_html","create_object_html","create_turf_html","global_vars_","all_ui_styles","lobby_image","security_level","default_mobloc","data_core","all_areas","machines","processing_objects","processing_power_items","active_diseases","med_hud_users","sec_hud_users","hud_icon_reference","traders","listening_objects","global_mutations","universe","global_map","hit_appends","diary","href_logfile","game_version","changelog_hash","game_year","round_progressing","master_mode","secondary_mode","tertiary_mode","secret_force_mode","host","jobMax","bombers","admin_log","lastsignalers","lawchanges","reg_dna","monkeystart","wizardstart","newplayer_start","latejoin","latejoin_gateway","latejoin_cryo","latejoin_cyborg","prisonwarp","xeno_spawn","tdome1","tdome2","tdomeobserve","tdomeadmin","prisonsecuritywarp","prisonwarped","ninjastart","cardinal","cornerdirs","alldirs","reverse_dir","config","sun","combatlog","IClog","OOClog","adminlog","powernets","Debug2","gravity_is_on","join_motd","nanomanager","event_manager","awaydestinations","sqladdress","sqlport","sqldb","sqllogin","sqlpass","sqlfdbkdb","sqlfdbklogin","sqlfdbkpass","sqllogging","forumsqladdress","forumsqlport","forumsqldb","forumsqllogin","forumsqlpass","forum_activated_group","forum_authenticated_group","fileaccess_timer","custom_event_msg","dbcon","dbcon_old","alphabet_uppercase","robot_module_types","scarySounds","max_explosion_range","global_announcer","station_departments","ai_names","wizard_first","wizard_second","ninja_titles","ninja_names","commando_names","first_names_male","first_names_female","last_names","clown_names","verbs","adjectives","world_topic_spam_protect_ip","world_topic_spam_protect_time","failed_db_connections","failed_old_db_connections","ghost_master","BLINDBLOCK","DEAFBLOCK","HULKBLOCK","TELEBLOCK","FIREBLOCK","XRAYBLOCK","CLUMSYBLOCK","FAKEBLOCK","COUGHBLOCK","GLASSESBLOCK","EPILEPSYBLOCK","TWITCHBLOCK","NERVOUSBLOCK","MONKEYBLOCK","BLOCKADD","DIFFMUT","HEADACHEBLOCK","NOBREATHBLOCK","REMOTEVIEWBLOCK","REGENERATEBLOCK","INCREASERUNBLOCK","REMOTETALKBLOCK","MORPHBLOCK","BLENDBLOCK","HALLUCINATIONBLOCK","NOPRINTSBLOCK","SHOCKIMMUNITYBLOCK","SMALLSIZEBLOCK","default_onmob_icons","defer_powernet_rebuild","restricted_camera_networks","gear_tweak_free_color_choice_","clients","admins","directory","player_list","mob_list","human_mob_list","silicon_mob_list","living_mob_list_","dead_mob_list_","cable_list","chemical_reactions_list","chemical_reagents_list","landmarks_list","surgery_steps","side_effects","mechas_list","joblist","turfs","all_species","all_languages","language_keys","whitelisted_species","playable_species","mannequins_","poster_designs","world_uplinks","hair_styles_list","hair_styles_male_list","hair_styles_female_list","facial_hair_styles_list","facial_hair_styles_male_list","facial_hair_styles_female_list","skin_styles_female_list","global_underwear","backbaglist","exclude_jobs","visual_nets","cameranet","rune_list","endgame_exits","endgame_safespawns","syndicate_access","string_part_flags","string_slot_flags","paramslist_cache","church_name","command_name","religion_name","syndicate_name","syndicate_code_phrase","syndicate_code_response","roundstart_hour","station_date","next_station_date_change","next_duration_update","last_round_duration","round_start_time","common_tools","WALLITEMS","dview_mob","global_hud","global_huds","robot_inventory","transfer_controller","radiochannels","CENT_FREQS","ANTAG_FREQS","DEPT_FREQS","radio_controller","gamemode_cache","master_controller","controller_iteration","last_tick_duration","air_processing_killed","pipe_processing_killed","initialization_stage","shuttle_controller","vote","evacuation_controller","list_of_ais","alarm_manager","chemistryProcess","garbage_collector","delayed_garbage","tgui_process","tickerProcess","processing_turfs","wirelessProcess","processScheduler","mil_branches","appearance_manager","revdata","all_observable_events","death_event","density_set_event","destroyed_event","dir_set_event","entered_event","mob_equipped_event","item_equipped_event","life_event","logged_in_event","logged_out_event","moved_event","opacity_set_event","see_in_dark_set_event","see_invisible_set_event","sight_set_event","stat_set_event","task_triggered_event","turf_changed_event","mob_unequipped_event","item_unequipped_event","global_listen_count","event_sources_count","event_listen_count","outfits_decls_","outfits_decls_root_","outfits_decls_by_type_","admin_pm_repository","attack_log_repository","camera_repository","client_repository","mob_repository","radiation_repository","to_process","uniqueness_repository","uplink_purchase_repository","crew_repository","cargo_supply_pack_root","cargo_supply_packs","supply_methods_","uplink","same_wires","wireColours","newscaster_standard_feeds","announced_news_types","send_emergency_team","ert_base_chance","can_call_ert","shatter_sound","explosion_sound","spark_sound","rustle_sound","punch_sound","clown_sound","swing_hit_sound","hiss_sound","page_sound","fracture_sound","lighter_sound","supply_controller","mechtoys","point_source_descriptions","all_antag_types","all_antag_spawnpoints","antag_names_to_ids","borers","xenomorphs","actor","commandos","deathsquad","ert","mercs","ninjas","raiders","wizards","cult","highlanders","loyalists","renegades","revs","malf","traitors","forced_ambiance_list","dna_activity_bounds","assigned_blocks","dna_genes","eventchance","hadevent","antag_add_finished","additional_antag_types","ticker","all_objectives","possible_changeling_IDs","hivemind_bank","powers","powerinstances","narsie_behaviour","narsie_cometh","narsie_list","Tier1Runes","Tier2Runes","Tier3Runes","Tier4Runes","universe_has_ended","Holiday","nuke_disks","job_master","assistant_occupations","command_positions","engineering_positions","medical_positions","science_positions","cargo_positions","civilian_positions","security_positions","nonhuman_positions","service_positions","supply_positions","whitelist","captain_announcement","doppler_arrays","floor_light_cache","navbeacons","news_network","allCasters","bomb_set","turret_icons","req_console_assistance","req_console_supplies","req_console_information","allConsoles","status_icons_to_colour","ai_status_emotions","priority_air_alarms","minor_air_alarms","air_alarm_topic","specops_shuttle_moving_to_station","specops_shuttle_moving_to_centcom","specops_shuttle_at_station","specops_shuttle_can_send","specops_shuttle_time","specops_shuttle_timeleft","syndicate_elite_shuttle_moving_to_station","syndicate_elite_shuttle_moving_to_mothership","syndicate_elite_shuttle_at_station","syndicate_elite_shuttle_can_send","syndicate_elite_shuttle_time","syndicate_elite_shuttle_timeleft","recentmessages","message_delay","telecomms_list","explosion_turfs","explosion_in_progress","slot_flags_enumeration","BUMP_TELEPORTERS","splatter_cache","fluidtrack_cache","storedwarrant","activename","activecharges","activeauth","activetype","uplink_random_selections_","PDAs","default_internal_channels","default_medbay_channels","last_chew","cached_icons","hazard_overlays","tape_roll_applications","ashtray_cache","tank_gauge_cache","multi_point_spawns","random_junk_","random_useful_","stool_cache","flooring_types","floor_decals","flooring_cache","BSACooldown","floorIsLava","admin_ranks","admin_secrets","admin_verbs_default","admin_verbs_admin","admin_verbs_ban","admin_verbs_sounds","admin_verbs_fun","admin_verbs_spawn","admin_verbs_server","admin_verbs_debug","admin_verbs_paranoid_debug","admin_verbs_possess","admin_verbs_permissions","admin_verbs_rejuv","admin_verbs_hideable","admin_verbs_mod","admin_verbs_mentor","jobban_runonce","jobban_keylist","admin_datums","CMinutes","Banlist","adminhelp_ignored_words","checked_for_inactives","inactive_keys","camera_range_display_status","intercom_range_display_status","debug_verbs","sounds_cache","pipe_colors","pipe_networks","asset_cache","preferences_datums","seen_citizenships","seen_systems","seen_factions","seen_religions","citizenship_choices","home_system_choices","faction_choices","religion_choices","spawntypes","client_preference_stats_","uplink_locations","valid_bloodtypes","_client_preferences","_client_preferences_by_key","_client_preferences_by_type","loadout_categories","gear_datums","matchmaker","breach_brute_descriptors","breach_burn_descriptors","current_date_string","vendor_account","station_account","department_accounts","num_financial_terminals","next_account_number","all_money_accounts","economy_init","weighted_randomevent_locations","weighted_mundaneevent_locations","error_last_seen","error_cooldown","total_runtimes","total_runtimes_skipped","error_cache","severity_to_string","event_last_fired","description_icons","dreams","non_fakeattack_weapons","ghost_traps","fruit_icon_cache","plant_controller","plant_seed_sprites","wax_recipes","worths","license_to_url","maploader","_preloader","swapmaps_iconcache","swapmaps_mode","swapmaps_compiled_maxx","swapmaps_compiled_maxy","swapmaps_compiled_maxz","swapmaps_initialized","swapmaps_loaded","swapmaps_byname","name_to_material","mining_walls","mining_floors","ore_data","ores_by_type","holder_mob_icon_cache","slot_equipment_priority","base_miss_chance","organ_rel_size","intents","department_radio_keys","channel_to_radio_key","sparring_attack_cache","human_icon_cache","tail_icon_cache","light_overlay_cache","damage_icon_parts","stored_shock_by_ref","wrapped_species_by_ref","prometheans","ai_list","ai_verbs_default","default_ai_icon","ai_icons","empty_playable_ai_cores","paiController","pai_emotions","pai_software_by_key","default_pai_software","robot_custom_icons","robot_modules","mob_hat_cache","chicken_count","protected_objects","hidden_skill_types","SKILLS","cameranet_","ghost_darkness_images","ghost_sightless_images","all_virtual_listeners","global_modular_computers","file_uid","comm_message_listeners","global_message_listener","last_message_id","warrant_uid","nttransfer_uid","ntnet_card_uid","ntnet_global","ntnrc_uid","z_levels","organ_cache","limb_icon_cache","flesh_hud_colours","robot_hud_colours","all_robolimbs","chargen_robolimbs","basic_robolimb","map_sectors","moving_levels","sector_shuttles","cached_space","ship_engines","allfaxes","admin_departments","alldepartments","adminfaxes","photo_count","possible_cable_coil_colours","light_type_cache","solar_gen_rate","solars_list","fusion_reactions","fusion_cores","fuel_injectors","gyrotrons","rad_collectors","random_maps","map_count","supply_drop","maze_cell_count","lunchables_lunches_","lunchables_snacks_","lunchables_drinks_","lunchables_drink_reagents_","lunchables_ethanol_reagents_","message_servers","blackbox","default_material_composition","maint_all_access","escape_pods","escape_pods_by_name","spells","artefact_feedback","turbolifts","turbolift_controller","ventcrawl_machinery","ALL_ANTIGENS","virusDB","responsive_carriers","finds_as_strings","air_master","tick_multiplier","assigned","created","merged","invalid_zone","air_blocked","zone_blocked","blocked","mark","contamination_overlay","vsc","all_unit_tests_passed","failed_unit_tests","skipped_unit_tests","total_unit_tests","currently_running_tests","ascii_esc","ascii_red","ascii_green","ascii_yellow","ascii_reset","using_map","all_maps","init")
+/var/list/_all_globals=list(
+	"ALL_ANTIGENS",
+	"ANTAG_FREQS",
+	"BLENDBLOCK",
+	"BLINDBLOCK",
+	"BLOCKADD",
+	"BSACooldown",
+	"BUMP_TELEPORTERS",
+	"Banlist",
+	"CENT_FREQS",
+	"CLUMSYBLOCK",
+	"CMinutes",
+	"COUGHBLOCK",
+	"DEAFBLOCK",
+	"DEPT_FREQS",
+	"DIFFMUT",
+	"Debug2",
+	"EPILEPSYBLOCK",
+	"FAKEBLOCK",
+	"FIREBLOCK",
+	"GLASSESBLOCK",
+	"HALLUCINATIONBLOCK",
+	"HEADACHEBLOCK",
+	"HULKBLOCK",
+	"Holiday",
+	"IClog",
+	"INCREASERUNBLOCK",
+	"MONKEYBLOCK",
+	"MORPHBLOCK",
+	"NERVOUSBLOCK",
+	"NOBREATHBLOCK",
+	"NOPRINTSBLOCK",
+	"OOClog",
+	"PDA_Manifest",
+	"PDAs",
+	"REGENERATEBLOCK",
+	"REMOTETALKBLOCK",
+	"REMOTEVIEWBLOCK",
+	"SHOCKIMMUNITYBLOCK",
+	"SKILLS",
+	"SMALLSIZEBLOCK",
+	"TELEBLOCK",
+	"TWITCHBLOCK",
+	"Tier1Runes",
+	"Tier2Runes",
+	"Tier3Runes",
+	"Tier4Runes",
+	"WALLITEMS",
+	"XRAYBLOCK",
+	"_all_globals",
+	"_client_preferences",
+	"_client_preferences_by_key",
+	"_client_preferences_by_type",
+	"_preloader",
+	"account_hack_attempted",
+	"acting_rank_prefixes",
+	"active_diseases",
+	"activeauth",
+	"activecharges",
+	"activename",
+	"activetype",
+	"actor",
+	"additional_antag_types",
+	"adjectives",
+	"admin_datums",
+	"admin_departments",
+	"admin_log",
+	"admin_pm_repository",
+	"admin_ranks",
+	"admin_secrets",
+	"admin_state",
+	"admin_verbs_admin",
+	"admin_verbs_ban",
+	"admin_verbs_debug",
+	"admin_verbs_default",
+	"admin_verbs_fun",
+	"admin_verbs_hideable",
+	"admin_verbs_mentor",
+	"admin_verbs_mod",
+	"admin_verbs_paranoid_debug",
+	"admin_verbs_permissions",
+	"admin_verbs_possess",
+	"admin_verbs_rejuv",
+	"admin_verbs_server",
+	"admin_verbs_sounds",
+	"admin_verbs_spawn",
+	"adminfaxes",
+	"adminhelp_ignored_words",
+	"adminlog",
+	"admins",
+	"ai_icons",
+	"ai_list",
+	"ai_names",
+	"ai_status_emotions",
+	"ai_verbs_default",
+	"air_alarm_topic",
+	"air_blocked",
+	"air_master",
+	"air_processing_killed",
+	"alarm_manager",
+	"alien_whitelist",
+	"allCasters",
+	"allConsoles",
+	"all_antag_spawnpoints",
+	"all_antag_types",
+	"all_areas",
+	"all_languages",
+	"all_maps",
+	"all_money_accounts",
+	"all_objectives",
+	"all_observable_events",
+	"all_robolimbs",
+	"all_species",
+	"all_ui_styles",
+	"all_unit_tests_passed",
+	"all_virtual_listeners",
+	"alldepartments",
+	"alldirs",
+	"allfaxes",
+	"alphabet_uppercase",
+	"announced_news_types",
+	"antag_add_finished",
+	"antag_names_to_ids",
+	"appearance_manager",
+	"area_repository",
+	"artefact_feedback",
+	"ascii_esc",
+	"ascii_green",
+	"ascii_red",
+	"ascii_reset",
+	"ascii_yellow",
+	"ashtray_cache",
+	"asset_cache",
+	"asset_datums",
+	"assigned",
+	"assigned_blocks",
+	"assistant_occupations",
+	"atmosphere_alarm",
+	"attack_log_repository",
+	"autolathe_categories",
+	"autolathe_recipes",
+	"awaydestinations",
+	"backbaglist",
+	"base_miss_chance",
+	"basic_robolimb",
+	"blackbox",
+	"blocked",
+	"bomb_set",
+	"bombers",
+	"borers",
+	"breach_brute_descriptors",
+	"breach_burn_descriptors",
+	"cable_list",
+	"cached_icons",
+	"cached_space",
+	"camera_alarm",
+	"camera_range_display_status",
+	"camera_repository",
+	"cameranet",
+	"cameranet_",
+	"can_call_ert",
+	"captain_announcement",
+	"cardinal",
+	"cargo_positions",
+	"cargo_supply_pack_root",
+	"cargo_supply_packs",
+	"changelog_hash",
+	"channel_to_radio_key",
+	"chargen_robolimbs",
+	"checked_for_inactives",
+	"chemical_reaction_logs",
+	"chemical_reactions_list",
+	"chemical_reagents_list",
+	"chemistryProcess",
+	"chicken_count",
+	"church_name",
+	"citizenship_choices",
+	"civilian_positions",
+	"client_preference_stats_",
+	"client_repository",
+	"clients",
+	"clown_names",
+	"clown_sound",
+	"combatlog",
+	"comm_message_listeners",
+	"command_announcement",
+	"command_name",
+	"command_positions",
+	"commando_names",
+	"commandos",
+	"common_tools",
+	"config",
+	"conscious_state",
+	"contained_state",
+	"contamination_overlay",
+	"controller_iteration",
+	"cornerdirs",
+	"create_mob_html",
+	"create_object_html",
+	"create_turf_html",
+	"created",
+	"crew_repository",
+	"cult",
+	"current_date_string",
+	"currently_running_tests",
+	"custom_event_msg",
+	"custom_items",
+	"damage_icon_parts",
+	"data_core",
+	"dbcon",
+	"dbcon_old",
+	"dead_mob_list_",
+	"death_event",
+	"deathsquad",
+	"debug_verbs",
+	"decls_repository",
+	"deep_inventory_state",
+	"default_ai_icon",
+	"default_internal_channels",
+	"default_material_composition",
+	"default_medbay_channels",
+	"default_mobloc",
+	"default_onmob_icons",
+	"default_pai_software",
+	"default_state",
+	"defer_powernet_rebuild",
+	"delayed_garbage",
+	"delta_index",
+	"density_set_event",
+	"department_accounts",
+	"department_radio_keys",
+	"description_icons",
+	"destroyed_event",
+	"diary",
+	"dir_set_event",
+	"directory",
+	"dna_activity_bounds",
+	"dna_genes",
+	"doppler_arrays",
+	"dreams",
+	"dview_mob",
+	"economic_species_modifier",
+	"economy_init",
+	"empty_playable_ai_cores",
+	"endgame_exits",
+	"endgame_safespawns",
+	"engineering_positions",
+	"entered_event",
+	"error_cache",
+	"error_cooldown",
+	"error_last_seen",
+	"ert",
+	"ert_base_chance",
+	"escape_pods",
+	"escape_pods_by_name",
+	"evacuation_controller",
+	"event_last_fired",
+	"event_listen_count",
+	"event_manager",
+	"event_sources_count",
+	"eventchance",
+	"exclude_jobs",
+	"explosion_in_progress",
+	"explosion_sound",
+	"explosion_turfs",
+	"facial_hair_styles_female_list",
+	"facial_hair_styles_list",
+	"facial_hair_styles_male_list",
+	"faction_choices",
+	"failed_db_connections",
+	"failed_old_db_connections",
+	"failed_unit_tests",
+	"file_uid",
+	"fileaccess_timer",
+	"finds_as_strings",
+	"fire_alarm",
+	"first_names_female",
+	"first_names_male",
+	"flesh_hud_colours",
+	"floorIsLava",
+	"floor_decals",
+	"floor_light_cache",
+	"flooring_cache",
+	"flooring_types",
+	"fluidtrack_cache",
+	"follow_repository",
+	"forced_ambiance_list",
+	"forum_activated_group",
+	"forum_authenticated_group",
+	"forumsqladdress",
+	"forumsqldb",
+	"forumsqllogin",
+	"forumsqlpass",
+	"forumsqlport",
+	"fracture_sound",
+	"fruit_icon_cache",
+	"fuel_injectors",
+	"fusion_cores",
+	"fusion_reactions",
+	"game_id",
+	"game_version",
+	"game_year",
+	"gamemode_cache",
+	"garbage_collector",
+	"gas_data",
+	"gear_datums",
+	"gear_tweak_free_color_choice_",
+	"gender_datums",
+	"ghost_darkness_images",
+	"ghost_master",
+	"ghost_sightless_images",
+	"ghost_traps",
+	"global_announcer",
+	"global_hud",
+	"global_huds",
+	"global_listen_count",
+	"global_map",
+	"global_message_listener",
+	"global_modular_computers",
+	"global_mutations",
+	"global_underwear",
+	"global_vars_",
+	"gravity_is_on",
+	"gyrotrons",
+	"hadevent",
+	"hair_styles_female_list",
+	"hair_styles_list",
+	"hair_styles_male_list",
+	"hands_state",
+	"hazard_overlays",
+	"hidden_skill_types",
+	"highlanders",
+	"hiss_sound",
+	"hit_appends",
+	"hivemind_bank",
+	"holder_mob_icon_cache",
+	"home_system_choices",
+	"host",
+	"href_logfile",
+	"hud_icon_reference",
+	"human_icon_cache",
+	"human_mob_list",
+	"id_card_states",
+	"image_repository",
+	"inactive_keys",
+	"init",
+	"initialization_stage",
+	"intents",
+	"interactive_state",
+	"intercom_range_display_status",
+	"invalid_zone",
+	"inventory_state",
+	"is_contact_but_not_space_or_shuttle_area",
+	"is_player_but_not_space_or_shuttle_area",
+	"is_station_but_not_space_or_shuttle_area",
+	"item_equipped_event",
+	"item_unequipped_event",
+	"jobMax",
+	"job_master",
+	"jobban_keylist",
+	"jobban_runonce",
+	"joblist",
+	"join_motd",
+	"landmarks_list",
+	"language_keys",
+	"last_chew",
+	"last_message_id",
+	"last_names",
+	"last_round_duration",
+	"last_tick_duration",
+	"lastsignalers",
+	"latejoin",
+	"latejoin_cryo",
+	"latejoin_cyborg",
+	"latejoin_gateway",
+	"lawchanges",
+	"license_to_url",
+	"life_event",
+	"light_overlay_cache",
+	"light_type_cache",
+	"lighter_sound",
+	"lighting_update_lights",
+	"lighting_update_overlays",
+	"limb_icon_cache",
+	"list_of_ais",
+	"listening_objects",
+	"living_mob_list_",
+	"loadout_categories",
+	"lobby_image",
+	"log_end",
+	"logged_in_event",
+	"logged_out_event",
+	"loyalists",
+	"lunchables_drink_reagents_",
+	"lunchables_drinks_",
+	"lunchables_ethanol_reagents_",
+	"lunchables_lunches_",
+	"lunchables_snacks_",
+	"machinery_sort_required",
+	"machines",
+	"magazine_icondata_keys",
+	"magazine_icondata_states",
+	"maint_all_access",
+	"malf",
+	"mannequins_",
+	"map_count",
+	"map_sectors",
+	"maploader",
+	"mark",
+	"master_controller",
+	"master_mode",
+	"matchmaker",
+	"max_explosion_range",
+	"maze_cell_count",
+	"mechas_list",
+	"mechtoys",
+	"med_hud_users",
+	"medical_positions",
+	"mercs",
+	"merged",
+	"message_delay",
+	"message_servers",
+	"meteors_armageddon",
+	"meteors_cataclysm",
+	"meteors_catastrophic",
+	"meteors_dust",
+	"meteors_normal",
+	"meteors_threatening",
+	"mil_branches",
+	"mining_floors",
+	"mining_walls",
+	"minor_air_alarms",
+	"mob_equipped_event",
+	"mob_hat_cache",
+	"mob_list",
+	"mob_repository",
+	"mob_unequipped_event",
+	"monkeystart",
+	"motion_alarm",
+	"moved_event",
+	"moving_levels",
+	"multi_point_spawns",
+	"name_to_material",
+	"nanomanager",
+	"narsie_behaviour",
+	"narsie_cometh",
+	"narsie_list",
+	"navbeacons",
+	"newplayer_start",
+	"news_network",
+	"newscaster_standard_feeds",
+	"next_account_number",
+	"next_duration_update",
+	"next_station_date_change",
+	"ninja_names",
+	"ninja_titles",
+	"ninjas",
+	"ninjastart",
+	"non_fakeattack_weapons",
+	"nonhuman_positions",
+	"not_incapacitated_turf_state",
+	"ntnet_card_uid",
+	"ntnet_global",
+	"ntnrc_uid",
+	"nttransfer_uid",
+	"nuke_disks",
+	"num_financial_terminals",
+	"opacity_set_event",
+	"ore_data",
+	"ores_by_type",
+	"organ_cache",
+	"organ_rel_size",
+	"outfits_decls_",
+	"outfits_decls_by_type_",
+	"outfits_decls_root_",
+	"outside_state",
+	"page_sound",
+	"paiController",
+	"pai_emotions",
+	"pai_software_by_key",
+	"paramslist_cache",
+	"photo_count",
+	"physical_state",
+	"pipe_colors",
+	"pipe_networks",
+	"pipe_processing_killed",
+	"plant_controller",
+	"plant_seed_sprites",
+	"playable_species",
+	"player_list",
+	"point_source_descriptions",
+	"possible_cable_coil_colours",
+	"possible_changeling_IDs",
+	"poster_designs",
+	"power_alarm",
+	"powerinstances",
+	"powernets",
+	"powers",
+	"preferences_datums",
+	"priority_air_alarms",
+	"priority_announcement",
+	"prisonsecuritywarp",
+	"prisonwarp",
+	"prisonwarped",
+	"priv_all_access",
+	"priv_all_access_datums",
+	"priv_all_access_datums_id",
+	"priv_all_access_datums_region",
+	"priv_centcom_access",
+	"priv_region_access",
+	"priv_station_access",
+	"priv_syndicate_access",
+	"processScheduler",
+	"processing_objects",
+	"processing_power_items",
+	"processing_turfs",
+	"prometheans",
+	"protected_objects",
+	"punch_sound",
+	"rad_collectors",
+	"radiation_repository",
+	"radio_controller",
+	"radiochannels",
+	"raiders",
+	"random_junk_",
+	"random_maps",
+	"random_useful_",
+	"recentmessages",
+	"reg_dna",
+	"religion_choices",
+	"religion_name",
+	"renegades",
+	"req_console_assistance",
+	"req_console_information",
+	"req_console_supplies",
+	"responsive_carriers",
+	"restricted_camera_networks",
+	"revdata",
+	"reverse_dir",
+	"revs",
+	"robot_custom_icons",
+	"robot_hud_colours",
+	"robot_inventory",
+	"robot_module_types",
+	"robot_modules",
+	"round_progressing",
+	"round_start_time",
+	"roundstart_hour",
+	"rune_list",
+	"rustle_sound",
+	"same_wires",
+	"scarySounds",
+	"scheduler",
+	"science_positions",
+	"sec_hud_users",
+	"secondary_mode",
+	"secret_force_mode",
+	"sector_shuttles",
+	"security_announcement_down",
+	"security_announcement_up",
+	"security_level",
+	"security_positions",
+	"see_in_dark_set_event",
+	"see_invisible_set_event",
+	"seen_citizenships",
+	"seen_factions",
+	"seen_religions",
+	"seen_systems",
+	"self_state",
+	"send_emergency_team",
+	"sent_spiders_to_station",
+	"server_name",
+	"service_positions",
+	"severity_to_string",
+	"shatter_sound",
+	"ship_engines",
+	"shuttle_controller",
+	"side_effects",
+	"sight_set_event",
+	"silicon_mob_list",
+	"skin_styles_female_list",
+	"skipped_unit_tests",
+	"slot_equipment_priority",
+	"slot_flags_enumeration",
+	"solar_gen_rate",
+	"solars_list",
+	"sounds_cache",
+	"spacevines_spawned",
+	"spark_sound",
+	"sparring_attack_cache",
+	"spawntypes",
+	"specops_shuttle_at_station",
+	"specops_shuttle_can_send",
+	"specops_shuttle_moving_to_centcom",
+	"specops_shuttle_moving_to_station",
+	"specops_shuttle_time",
+	"specops_shuttle_timeleft",
+	"spells",
+	"splatter_cache",
+	"sqladdress",
+	"sqldb",
+	"sqlfdbkdb",
+	"sqlfdbklogin",
+	"sqlfdbkpass",
+	"sqllogging",
+	"sqllogin",
+	"sqlpass",
+	"sqlport",
+	"stat_set_event",
+	"station_account",
+	"station_date",
+	"station_departments",
+	"status_icons_to_colour",
+	"stool_cache",
+	"stored_shock_by_ref",
+	"storedwarrant",
+	"string_part_flags",
+	"string_slot_flags",
+	"sun",
+	"supply_controller",
+	"supply_drop",
+	"supply_methods_",
+	"supply_positions",
+	"surgery_steps",
+	"swapmaps_byname",
+	"swapmaps_compiled_maxx",
+	"swapmaps_compiled_maxy",
+	"swapmaps_compiled_maxz",
+	"swapmaps_iconcache",
+	"swapmaps_initialized",
+	"swapmaps_loaded",
+	"swapmaps_mode",
+	"swing_hit_sound",
+	"syndicate_access",
+	"syndicate_code_phrase",
+	"syndicate_code_response",
+	"syndicate_elite_shuttle_at_station",
+	"syndicate_elite_shuttle_can_send",
+	"syndicate_elite_shuttle_moving_to_mothership",
+	"syndicate_elite_shuttle_moving_to_station",
+	"syndicate_elite_shuttle_time",
+	"syndicate_elite_shuttle_timeleft",
+	"syndicate_name",
+	"tagger_locations",
+	"tail_icon_cache",
+	"tank_gauge_cache",
+	"tape_roll_applications",
+	"task_triggered_event",
+	"tdome1",
+	"tdome2",
+	"tdomeadmin",
+	"tdomeobserve",
+	"telecomms_list",
+	"tertiary_mode",
+	"text_tag_icons",
+	"tg_admin_state",
+	"tg_always_state",
+	"tg_conscious_state",
+	"tg_contained_state",
+	"tg_deep_inventory_state",
+	"tg_default_state",
+	"tg_hands_state",
+	"tg_human_adjacent_state",
+	"tg_inventory_state",
+	"tg_not_contained_state",
+	"tg_not_incapacitated_state",
+	"tg_physical_state",
+	"tg_self_state",
+	"tg_z_state",
+	"tgui_process",
+	"tick_multiplier",
+	"ticker",
+	"tickerProcess",
+	"to_process",
+	"total_runtimes",
+	"total_runtimes_skipped",
+	"total_unit_tests",
+	"traders",
+	"traitors",
+	"transfer_controller",
+	"turbolift_controller",
+	"turbolifts",
+	"turf_changed_event",
+	"turfs",
+	"turret_icons",
+	"uniqueness_repository",
+	"universe",
+	"universe_has_ended",
+	"uplink",
+	"uplink_locations",
+	"uplink_purchase_repository",
+	"uplink_random_selections_",
+	"using_map",
+	"valid_bloodtypes",
+	"vendor_account",
+	"ventcrawl_machinery",
+	"verbs",
+	"view_variables_dont_expand",
+	"view_variables_hide_vars",
+	"view_variables_no_assoc",
+	"virusDB",
+	"visual_nets",
+	"vote",
+	"vsc",
+	"warrant_uid",
+	"wax_recipes",
+	"weighted_mundaneevent_locations",
+	"weighted_randomevent_locations",
+	"whitelist",
+	"whitelisted_species",
+	"wireColours",
+	"wirelessProcess",
+	"wizard_first",
+	"wizard_second",
+	"wizards",
+	"wizardstart",
+	"world_topic_spam_protect_ip",
+	"world_topic_spam_protect_time",
+	"world_uplinks",
+	"worths",
+	"wrapped_species_by_ref",
+	"xeno_spawn",
+	"xenomorphs",
+	"z_levels",
+	"z_state",
+	"zone_blocked")

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -77,7 +77,8 @@
 #define to_world(message)                                   world << message
 #define to_world_log(message)                               world.log << message
 #define sound_to(target, sound)                             target << sound
-#define to_file(file_entry, file_content)                   file_entry << file_content
+#define to_file(file_entry, source_var)                     file_entry << source_var
+#define from_file(file_entry, target_var)                   file_entry >> target_var
 #define show_browser(target, browser_content, browser_name) target << browse(browser_content, browser_name)
 #define send_rsc(target, rsc_content, rsc_name)             target << browse_rsc(rsc_content, rsc_name)
 


### PR DESCRIPTION
The global var generation script now outputs each entry in the global var list on individual lines, in a sorted manner, as well as with consistent newlines for all OSes. Also prints current md5.
Most of this is in hope to make casual merging easier.

Adds a from_file() macro to go with the to_file macro(). Expected to be used with preference settings, etc.