### PR TITLE
Fixes and optimizations to hallucinations

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -230,99 +230,122 @@ proc/check_panel(mob/M)
 	opacity = 0
 	var/mob/living/carbon/human/my_target = null
 	var/weapon_name = null
-	var/obj/item/weap = null
-	var/image/stand_icon = null
-	var/image/currentimage = null
-	var/icon/base = null
-	var/s_tone
 	var/mob/living/clone = null
+
+	var/RunAttackLoop = 1
+
+	var/CurrentDir
 	var/image/left
 	var/image/right
 	var/image/up
-	var/collapse
 	var/image/down
 
-	var/health = 100
+	var/image/FakeImage
 
-	attackby(var/obj/item/weapon/P as obj, mob/user as mob)
-		step_away(src,my_target,2)
-		for(var/mob/M in oviewers(world.view,my_target))
-			to_chat(M, "<span class='danger'>[my_target] flails around wildly.</span>")
-		my_target.show_message("<span class='dangger'>[src] has been attacked by [my_target] </span>", 1) //Lazy.
-		src.health -= P.force
+/obj/effect/fake_attacker/New(var/loc, var/mob/living/target, var/mob/living/carbon/human/clone)
+	..()
+	
+	if(clone.l_hand)
+		if(!(locate(clone.l_hand) in non_fakeattack_weapons))
+			weapon_name = clone.l_hand.name
+	else if(clone.r_hand)
+		if(!(locate(clone.r_hand) in non_fakeattack_weapons))
+			weapon_name = clone.r_hand.name
 
+	name = clone.name
+	my_target = target
+	target.hallucinations += src
 
+	left = image(clone, src, dir = WEST)
+	right = image(clone, src, dir = EAST)
+	up = image(clone, src, dir = NORTH)
+	down = image(clone, src, dir = SOUTH)
+	
+	step_away(src, my_target, 2)
+	
+	updateimage()
+	
+	spawn attack_loop()
+	spawn(300)
+		qdel(src)
+
+/obj/effect/fake_attacker/Destroy()
+	RunAttackLoop = 0
+	my_target.client.images -= up
+	my_target.client.images -= down
+	my_target.client.images -= right
+	my_target.client.images -= left
+	qdel_null(left)
+	qdel_null(right)
+	qdel_null(up)
+	qdel_null(down)
+	if(my_target)
+		my_target.hallucinations -= src
+	..()
+
+/obj/effect/fake_attacker/attackby(var/obj/item/weapon/P as obj, mob/user as mob)
+	step_away(src, my_target, 2)
+	my_target.visible_message("<span class='danger'>\The [my_target] flails around wildly.</span>", "<span class='danger'>\The [src] has been attacked by \the [my_target] with \the [P]!</span>")
+	return
+
+/obj/effect/fake_attacker/Crossed(var/mob/M)
+	if(M == my_target)
+		step_away(src, my_target, 2)
+		if(prob(30))
+			my_target.visible_message("<span class='danger'>\The [my_target] stumbles around.</span>")
+
+/obj/effect/fake_attacker/proc/updateimage()
+	if(!my_target.client || !RunAttackLoop)
 		return
 
-	Crossed(var/mob/M, somenumber)
-		if(M == my_target)
-			step_away(src,my_target,2)
-			if(prob(30))
-				for(var/mob/O in oviewers(world.view , my_target))
-					to_chat(O, "<span class='danger'>[my_target] stumbles around.</span>")
+	switch(CurrentDir)
+		if(NORTH, NORTHEAST)
+			my_target.client.images -= up
+		if(SOUTH, SOUTHWEST)
+			my_target.client.images -= down
+		if(EAST, SOUTHEAST)
+			my_target.client.images -= right
+		if(WEST, NORTHWEST)
+			my_target.client.images -= left
 
-	New()
-		..()
-		spawn(300)
-			if(my_target)
-				my_target.hallucinations -= src
-			qdel(src)
-		step_away(src,my_target,2)
-		spawn attack_loop()
+	switch(dir)
+		if(NORTH, NORTHEAST)
+			my_target.client.images += up
+		if(SOUTH, SOUTHWEST)
+			my_target.client.images += down
+		if(EAST, SOUTHEAST)
+			my_target.client.images += right
+		if(WEST, NORTHWEST)
+			my_target.client.images += left
 
+	CurrentDir = dir
 
-	proc/updateimage()
-	//	qdel(src.currentimage)
-
-
-		if(src.dir == NORTH)
-			qdel(src.currentimage)
-			src.currentimage = new /image(up,src)
-		else if(src.dir == SOUTH)
-			qdel(src.currentimage)
-			src.currentimage = new /image(down,src)
-		else if(src.dir == EAST)
-			qdel(src.currentimage)
-			src.currentimage = new /image(right,src)
-		else if(src.dir == WEST)
-			qdel(src.currentimage)
-			src.currentimage = new /image(left,src)
-		my_target << currentimage
-
-	proc/attack_loop()
-		while(1)
-			sleep(rand(5,10))
-			if(src.health < 0)
-				collapse()
-				continue
-			if(get_dist(src,my_target) > 1)
-				src.set_dir(get_dir(src,my_target))
-				step_towards(src,my_target)
-				updateimage()
-			else
-				if(prob(15))
-					if(weapon_name)
-						sound_to(my_target, sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')))
-						my_target.show_message("<span class='danger'>[my_target] has been attacked with [weapon_name] by [src.name] </span>", 1)
-						my_target.halloss += 8
-						if(prob(20)) my_target.eye_blurry += 3
-						if(prob(33))
-							if(!locate(/obj/effect/overlay) in my_target.loc)
-								fake_blood(my_target)
-					else
-						sound_to(my_target, sound(pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg')))
-						my_target.show_message("<span class='danger'>[src.name] has punched [my_target]!</span>", 1)
-						my_target.halloss += 4
-						if(prob(33))
-							if(!locate(/obj/effect/overlay) in my_target.loc)
-								fake_blood(my_target)
-
+/obj/effect/fake_attacker/proc/attack_loop()
+	while(RunAttackLoop)
+		sleep(rand(5, 10))
+		if(get_dist(src, my_target) > 1)
+			src.set_dir(get_dir(src, my_target))
+			updateimage()
+			step_towards(src, my_target)
+		else
 			if(prob(15))
-				step_away(src,my_target,2)
+				if(weapon_name)
+					sound_to(my_target, sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')))
+					to_chat(my_target, "<span class='danger'>\The [my_target] has been attacked with \the [weapon_name] by \the [src]!</span>")
+					my_target.halloss += 8
+					if(prob(20))
+						my_target.eye_blurry += 3
+					if(prob(33))
+						fake_blood(my_target)
+				else
+					sound_to(my_target, sound(pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg')))
+					to_chat(my_target, "<span class='danger'>\The [src] has punched \the [my_target]!</span>")
+					my_target.halloss += 4
+					if(prob(33))
+						fake_blood(my_target)
 
-	proc/collapse()
-		collapse = 1
-		updateimage()
+		if(prob(15))
+			step_away(src, my_target, 2)
 
 /proc/fake_blood(var/mob/target)
 	var/obj/effect/overlay/O = new/obj/effect/overlay(target.loc)
@@ -350,63 +373,15 @@ var/list/non_fakeattack_weapons = list(/obj/item/weapon/gun/projectile, /obj/ite
 	/obj/item/clothing/suit/space/void, /obj/item/weapon/tank)
 
 /proc/fake_attack(var/mob/living/target)
-//	var/list/possible_clones = new/list()
 	var/mob/living/carbon/human/clone = null
-	var/clone_weapon = null
+	var/list/PossibleClones = list()
 
 	for(var/mob/living/carbon/human/H in living_mob_list_)
-		if(H.stat || H.lying) continue
-//		possible_clones += H
-		clone = H
-		break	//changed the code a bit. Less randomised, but less work to do. Should be ok, world.contents aren't stored in any particular order.
+		PossibleClones += H
 
-//	if(!possible_clones.len) return
-//	clone = pick(possible_clones)
-	if(!clone)	return
+	if(!PossibleClones.len)
+		return
 
-	//var/obj/effect/fake_attacker/F = new/obj/effect/fake_attacker(outside_range(target))
-	var/obj/effect/fake_attacker/F = new/obj/effect/fake_attacker(target.loc)
-	if(clone.l_hand)
-		if(!(locate(clone.l_hand) in non_fakeattack_weapons))
-			clone_weapon = clone.l_hand.name
-			F.weap = clone.l_hand
-	else if (clone.r_hand)
-		if(!(locate(clone.r_hand) in non_fakeattack_weapons))
-			clone_weapon = clone.r_hand.name
-			F.weap = clone.r_hand
+	clone = pick(PossibleClones)
 
-	F.name = clone.name
-	F.my_target = target
-	F.weapon_name = clone_weapon
-	target.hallucinations += F
-
-
-	F.left = image(clone,dir = WEST)
-	F.right = image(clone,dir = EAST)
-	F.up = image(clone,dir = NORTH)
-	F.down = image(clone,dir = SOUTH)
-
-//	F.base = new /icon(clone.stand_icon)
-//	F.currentimage = new /image(clone)
-
-/*
-
-
-
-	F.left = new /icon(clone.stand_icon,dir=WEST)
-	for(var/icon/i in clone.overlays)
-		F.left.Blend(i)
-	F.up = new /icon(clone.stand_icon,dir=NORTH)
-	for(var/icon/i in clone.overlays)
-		F.up.Blend(i)
-	F.down = new /icon(clone.stand_icon,dir=SOUTH)
-	for(var/icon/i in clone.overlays)
-		F.down.Blend(i)
-	F.right = new /icon(clone.stand_icon,dir=EAST)
-	for(var/icon/i in clone.overlays)
-		F.right.Blend(i)
-
-	target << F.up
-	*/
-
-	F.updateimage()
+	new /obj/effect/fake_attacker(target.loc, target, clone)


### PR DESCRIPTION
Fake attackers don't create and delete a new image every time the hallucination turns now. This was a source of significant lag post-SM delamination. Surprisingly enough. Fake attackers will now also correctly be a random human mob on the station, instead of Pun Pun every time. They should also qdel without issues now.