### PR TITLE
fixes #7174

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -296,7 +296,6 @@
 		src.module_state_2:screen_loc = ui_inv2
 	if(src.module_state_3)
 		src.module_state_3:screen_loc = ui_inv3
-	updateicon()
 
 /mob/living/silicon/robot/proc/process_killswitch()
 	if(killswitch)


### PR DESCRIPTION
as said, fixes #7174

Technically half-fixes. Borgs no longer try to pointlessly update their icon every tick, however the base issue of typing indicators being wiped out whenever updateicon() is called exists. As that's a typing indicator as a whole issue and not specifically a borg issue, and is a far more minor issue... making this PR as-is instead of re-writing the indicator code.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
