### PR TITLE
Fixes multiZ cable connection problems

### DIFF
--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -105,13 +105,13 @@
 	NC.cableColor("red")
 	NC.d1 = 0
 	NC.d2 = fdirn
-	NC.updateicon()
+	NC.update_icon()
 
 	var/datum/powernet/PN
 	if(last_piece && last_piece.d2 != M_Dir)
 		last_piece.d1 = min(last_piece.d2, M_Dir)
 		last_piece.d2 = max(last_piece.d2, M_Dir)
-		last_piece.updateicon()
+		last_piece.update_icon()
 		PN = last_piece.powernet
 
 	if(!PN)

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1260,13 +1260,13 @@
 	NC.cableColor("red")
 	NC.d1 = 0
 	NC.d2 = fdirn
-	NC.updateicon()
+	NC.update_icon()
 
 	var/datum/powernet/PN
 	if(last_piece && last_piece.d2 != chassis.dir)
 		last_piece.d1 = min(last_piece.d2, chassis.dir)
 		last_piece.d2 = max(last_piece.d2, chassis.dir)
-		last_piece.updateicon()
+		last_piece.update_icon()
 		PN = last_piece.powernet
 
 	if(!PN)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -121,12 +121,12 @@ var/list/possible_cable_coil_colours
 /obj/structure/cable/hide(var/i)
 	if(istype(loc, /turf))
 		invisibility = i ? 101 : 0
-	updateicon()
+	update_icon()
 
 /obj/structure/cable/hides_under_flooring()
 	return 1
 
-/obj/structure/cable/proc/updateicon()
+/obj/structure/cable/update_icon()
 	icon_state = "[d1]-[d2]"
 	alpha = invisibility ? 127 : 255
 
@@ -664,33 +664,28 @@ obj/structure/cable/proc/cableColor(var/colorC)
 				if((LC.d1 == dirn && LC.d2 == 11 ) || ( LC.d2 == dirn && LC.d1 == 11))
 					to_chat(user, "<span class='warning'>There's already a cable at that position.</span>")
 					return
+			if(!use(2))
+				to_chat(user, "You don't have enough cable to do this!")
+				return
 
 			var/obj/structure/cable/C = new(F)
 			var/obj/structure/cable/D = new(GetBelow(F))
 
 			C.cableColor(color)
-
 			C.d1 = 11
 			C.d2 = dirn
 			C.add_fingerprint(user)
-			C.updateicon()
+			C.update_icon()
 
-			var/datum/powernet/PN = new()
-			PN.add_cable(C)
-
-			C.mergeConnectedNetworks(C.d2)
-			C.mergeConnectedNetworksOnTurf()
 
 			D.cableColor(color)
-
 			D.d1 = 12
 			D.d2 = 0
 			D.add_fingerprint(user)
-			D.updateicon()
+			D.update_icon()
 
-			PN.add_cable(D)
-			D.mergeConnectedNetworksOnTurf()
-
+			var/datum/powernet/PN = new()
+			propagate_network(C, PN)
 		// do the normal stuff
 		else
 ///// Z-Level Stuff
@@ -707,7 +702,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 			C.d1 = 0 //it's a O-X node cable
 			C.d2 = dirn
 			C.add_fingerprint(user)
-			C.updateicon()
+			C.update_icon()
 
 			//create a new powernet with the cable, if needed it will be merged later
 			var/datum/powernet/PN = new()
@@ -770,7 +765,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 			NC.d1 = 0
 			NC.d2 = fdirn
 			NC.add_fingerprint()
-			NC.updateicon()
+			NC.update_icon()
 
 			//create a new powernet with the cable, if needed it will be merged later
 			var/datum/powernet/newPN = new()
@@ -817,7 +812,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		C.d2 = nd2
 
 		C.add_fingerprint()
-		C.updateicon()
+		C.update_icon()
 
 
 		C.mergeConnectedNetworks(C.d1) //merge the powernets...


### PR DESCRIPTION
- Cross-Z cables should now connect correctly when being built. Fixes #14958   Fixes #14966 and possibly fixes #14980
- Building a multiZ cable now uses 2 pieces of cable from the coil. Fixes duplication bug.
- Converts cable proc/updateicon() to code-wise standardized update_icon().