### PR TITLE
Radiation and Shield tweaks

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -41,6 +41,7 @@
 #define MODEFLAG_OVERCHARGE 256
 #define MODEFLAG_MODULATE 512
 #define MODEFLAG_MULTIZ 1024
+#define MODEFLAG_ANTIRAD 2048
 
 // Return codes for shield hits.
 #define SHIELD_ABSORBED 1			// The shield has completely absorbed the hit
@@ -54,3 +55,4 @@
 #define SHIELD_RUNNING 2			// The shield is running
 
 #define SHIELD_SHUTDOWN_DISPERSION_RATE (500 KILOWATTS)		// The rate at which shield energy disperses when shutdown is initiated.
+#define SHIELD_RAD_RESISTANCE 150	// How well shields protect against radiation. This should protect against almost anything, except for the strongest radiation sources.

--- a/code/controllers/Processes/radiation.dm
+++ b/code/controllers/Processes/radiation.dm
@@ -15,13 +15,13 @@
 		linked.irradiated_turfs[T] -= config.radiation_decay_rate
 		if(linked.irradiated_turfs[T] <= config.radiation_lower_limit)
 			linked.irradiated_turfs.Remove(T)
+		for(var/atom/A in T.contents)
+			A.rad_act(linked.irradiated_turfs[T])
 		SCHECK
 	for(var/mob/living/L in linked.irradiated_mobs)
 		if(!L)
 			linked.irradiated_mobs.Remove(L)
 			continue
-		if(get_turf(L) in linked.irradiated_turfs)
-			L.rad_act(linked.irradiated_turfs[get_turf(L)])
 		if(!L.radiation)
 			linked.irradiated_mobs.Remove(L)
 		SCHECK

--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -70,16 +70,14 @@ var/list/to_process = list()
 	var/turf/epicentre = locate(round(world.maxx / 2), round(world.maxy / 2), source.z)
 	flat_radiate(epicentre, power, world.maxx, respect_maint)
 
+/turf/
+	var/rad_resistance = 0
+
 /turf/proc/calc_rad_resistance()
 	rad_resistance = 0
-	for(var/obj/O in src.contents)
-		if(O.rad_resistance) //Override
-			rad_resistance += O.rad_resistance
+	for(var/atom/movable/A in contents)
+		rad_resistance += A.get_rad_resistance()
 
-		else if(O.density) //So doors don't get counted
-			var/material/M = O.get_material()
-			if(!M)	continue
-			rad_resistance += M.weight
 	radiation_repository.resistance_cache[src] = (length(contents) + 1)
 
 /turf/simulated/wall/calc_rad_resistance()
@@ -88,7 +86,16 @@ var/list/to_process = list()
 
 /atom
 	var/rad_power = 0
-	var/rad_resistance = 0
+
+/atom/movable/proc/get_rad_resistance()
+	return 0
+
+/obj/machinery/door/get_rad_resistance()
+	if(density)
+		var/material/M = get_material()
+		if(!M)
+			return 0
+		return M.weight
 
 /atom/Destroy()
 	if(rad_power)

--- a/code/modules/shield_generators/modes.dm
+++ b/code/modules/shield_generators/modes.dm
@@ -40,7 +40,7 @@
 
 /datum/shield_mode/atmosphere
 	mode_name = "Atmospheric Containment"
-	mode_desc = "This mode blocks air flow and acts as atmosphere containment."
+	mode_desc = "This mode blocks air flow and acts as atmosphere containment. It also protects against fire and similar atmospheric conditions."
 	mode_flag = MODEFLAG_ATMOSPHERIC
 	multiplier = 1.3
 
@@ -75,3 +75,9 @@
 	mode_desc = "Recalibrates the field projection array to increase the vertical height of the field, allowing it's usage on multi-deck stations or ships."
 	mode_flag = MODEFLAG_MULTIZ
 	multiplier = 1
+
+/datum/shield_mode/radiation
+	mode_name = "Radiation Dispersion"
+	mode_desc = "Reduces or completely removes most types of radiation."
+	mode_flag = MODEFLAG_ANTIRAD
+	multiplier = 1.1

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -73,7 +73,7 @@
 	if(!disabled_for && (duration > 1))
 		s.set_up(1, 1, src)
 		s.start()
-		
+
 	gen.damaged_segments |= src
 	disabled_for += duration
 	set_density(0)
@@ -105,11 +105,11 @@
 	if(gen.check_flag(MODEFLAG_BYPASS) && !diffused_for && !disabled_for)
 		take_damage(duration * rand(8, 12), SHIELD_DAMTYPE_EM)
 		return
-		
+
 	if(!diffused_for && !disabled_for)
 		s.set_up(1, 1, src)
 		s.start()
-		
+
 	diffused_for = max(duration, 0)
 	gen.damaged_segments |= src
 	set_density(0)
@@ -140,7 +140,7 @@
 		// The closer we are to impact site, the longer it takes for shield to come back up.
 		S.fail(-(-range + get_dist(src, S)) * 2)
 
-/obj/effect/shield/proc/take_damage(var/damage, var/damtype, var/hitby)
+/obj/effect/shield/proc/take_damage(var/damage, var/damtype, var/hitby, var/no_flicker = 0)
 	if(!gen)
 		qdel(src)
 		return
@@ -150,7 +150,8 @@
 
 	damage = round(damage)
 
-	new/obj/effect/shield_impact(get_turf(src))
+	if(!no_flicker)
+		new/obj/effect/shield_impact(get_turf(src))
 
 	switch(gen.take_damage(damage, damtype))
 		if(SHIELD_ABSORBED)
@@ -194,23 +195,30 @@
 	return gen.check_flag(MODEFLAG_ATMOSPHERIC)
 
 
-// EMP. It may seem weak but keep in mind that multiple shield segments are likely to be affected.
+// EMP
 /obj/effect/shield/emp_act(var/severity)
-	if(!disabled_for)
-		take_damage(rand(30,60) / severity, SHIELD_DAMTYPE_EM)
+	if(is_disabled())
+		return
+	take_damage(rand(30,60) / severity, SHIELD_DAMTYPE_EM)
 
 
 // Explosions
 /obj/effect/shield/ex_act(var/severity)
-	if(!disabled_for)
-		take_damage(rand(10,15) / severity, SHIELD_DAMTYPE_PHYSICAL)
-
+	if(!gen || !gen.check_flag(MODEFLAG_HYPERKINETIC) || is_disabled())
+		return
+	take_damage(rand(10,15) / severity, SHIELD_DAMTYPE_PHYSICAL)
 
 // Fire
 /obj/effect/shield/fire_act()
-	if(!disabled_for)
-		take_damage(rand(5,10), SHIELD_DAMTYPE_HEAT)
+	if(!gen || !gen.check_flag(MODEFLAG_ATMOSPHERIC) || is_disabled())
+		return
+	take_damage(rand(5,10), SHIELD_DAMTYPE_HEAT)
 
+// Radiation
+/obj/effect/shield/rad_act(var/severity)
+	if(!gen || !gen.check_flag(MODEFLAG_ANTIRAD) || is_disabled())
+		return
+	take_damage(severity/100, SHIELD_DAMTYPE_HEAT, 0, (severity > 100 ? 0 : 1))
 
 // Projectiles
 /obj/effect/shield/bullet_act(var/obj/item/projectile/proj)
@@ -271,6 +279,13 @@
 	else
 		explosion_resistance = 0
 
+/obj/effect/shield/get_rad_resistance()
+	if(gen && gen.check_flag(MODEFLAG_ANTIRAD))
+		return SHIELD_RAD_RESISTANCE
+	return 0
+
+/obj/effect/shield/proc/is_disabled()
+	return (disabled_for || diffused_for)
 
 // Shield collision checks below
 


### PR DESCRIPTION
- Replaces rad_resistance var moved to /turf/ level, atom/movable types use proc/get_rad_resistance() which allows for more logic (like open/closed checks for doors)
- rad_act() is now called on all affected atom/movable types in irradiated turfs, not only on mobs.
- Adds shield mode that disperses radiation. Very strong radiation sources (supermatter charged to high levels, for example) can still get through the shield, but radiation will be reduced a lot. Does not protect against global radiation events (radiation/solar storm)
- Some minor shield code tidiness tweaks. Weird behavior should be prevented now (like shields being damaged by explosions when they don't block them due to mode configuration)