### PR TITLE
Fixes #15376

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -186,7 +186,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 				to_chat(src, "<span class='notice'>We stab [T] with the proboscis.</span>")
 				src.visible_message("<span class='danger'>[src] stabs [T] with the proboscis!</span>")
 				to_chat(T, "<span class='danger'>You feel a sharp stabbing pain!</span>")
-				affecting.take_damage(39,0,1,0,"large organic needle")
+				affecting.take_damage(39, 0, DAM_SHARP, "large organic needle")
 
 		feedback_add_details("changeling_powers","A[stage]")
 		if(!do_mob(src, T, 150))

--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -29,33 +29,21 @@
 		icon_state = off_icon
 		return
 
-	var/obj/item/organ/external/E
-	var/nopain
-	if(ishuman(victim) && user.zone_sel.selecting != BP_GROIN && user.zone_sel.selecting != BP_CHEST)
+	var/target_zone = user.zone_sel.selecting
+	if(ishuman(victim) && !(target_zone in list(BP_GROIN, BP_CHEST)))
 		var/mob/living/carbon/human/H = victim
-		E = H.get_organ(user.zone_sel.selecting)
-		if(!E || !E.can_feel_pain())
-			nopain = 2
-		else if(E.robotic >= ORGAN_ROBOT)
-			nopain = 1
+		var/obj/item/organ/external/E = H.get_organ(target_zone)
+		if(!E)
+			to_chat(user, "<span class='warning'>They are missing that body part!</span>")
+		else
+			visible_message("<span class='danger'>\The [user] shoves \the [victim][E ? "'s [E.name]" : ""] into \the [src]!</span>")
+			var/blocked = H.run_armor_check(target_zone, "energy")
+			H.apply_damage(rand(20,30), BURN, target_zone, blocked)
 
-	user.visible_message("<span class='danger'>\The [user] shoves \the [victim][E ? "'s [E.name]" : ""] into \the [src]!</span>")
-
-	if(E)
-		E.take_damage(0, rand(20,30))
-		if(E.children && E.children.len)
-			for(var/obj/item/organ/external/child in E.children)
-				if(nopain && nopain < 2 && !(child.robotic >= ORGAN_ROBOT))
-					nopain = 0
-				child.take_damage(0, rand(20,30))
 	else
-		victim.apply_damage(rand(30,40), BURN, user.zone_sel.selecting)
+		var/blocked = victim.run_armor_check(null, "energy")
+		victim.apply_damage(rand(30,40), BURN, null, blocked)
 
-	if(!nopain)
-		to_chat(victim, "<span class='danger'>Agony consumes you as searing hot oil scorches your [E ? E.name : "flesh"] horribly!</span>")
-		victim.emote("scream")
-	else
-		to_chat(victim, "<span class='danger'>Searing hot oil scorches your [E ? E.name : "flesh"]!</span>")
 	if(victim)
 		admin_attack_log(user, victim, "Has [cook_type] their victim in \a [src]", "Has been [cook_type] in \a [src] by the attacker.", "[cook_type], in \a [src], ")
 

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -37,46 +37,23 @@
 					melee_can_hit = 1
 				return
 			*/
-			if(istype(target, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = target
-	//			if (M.health <= 0) return
 
-				var/obj/item/organ/external/temp = H.get_organ(pick(BP_CHEST, BP_CHEST, BP_CHEST, BP_HEAD))
-				if(temp)
-					var/update = 0
-					switch(damtype)
-						if("brute")
-							H.Paralyse(1)
-							update |= temp.take_damage(rand(force/2, force), 0)
-						if("fire")
-							update |= temp.take_damage(0, rand(force/2, force))
-						if("tox")
-							if(H.reagents)
-								if(H.reagents.get_reagent_amount("carpotoxin") + force < force*2)
-									H.reagents.add_reagent("carpotoxin", force)
-								if(H.reagents.get_reagent_amount("cryptobiolin") + force < force*2)
-									H.reagents.add_reagent("cryptobiolin", force)
-						else
-							return
-					if(update)	H.UpdateDamageIcon()
-				H.updatehealth()
+			var/hit_zone = ran_zone()
+			switch(damtype)
+				if("brute")
+					var/blocked = M.run_armor_check(hit_zone, "melee")
+					if(M.apply_damage(rand(force/2, force), BRUTE, hit_zone, blocked))
+						M.Weaken(1)
+				if("fire")
+					var/blocked = M.run_armor_check(hit_zone, "energy")
+					M.apply_damage(rand(force/2, force), BRUTE, hit_zone, blocked)
+				if("tox")
+					if(M.reagents)
+						if(M.reagents.get_reagent_amount("carpotoxin") + force < force*2)
+							M.reagents.add_reagent("carpotoxin", force)
+						if(M.reagents.get_reagent_amount("cryptobiolin") + force < force*2)
+							M.reagents.add_reagent("cryptobiolin", force)
 
-			else
-				switch(damtype)
-					if("brute")
-						M.Paralyse(1)
-						M.take_overall_damage(rand(force/2, force))
-					if("fire")
-						M.take_overall_damage(0, rand(force/2, force))
-					if("tox")
-						if(M.reagents)
-							if(M.reagents.get_reagent_amount("carpotoxin") + force < force*2)
-								M.reagents.add_reagent("carpotoxin", force)
-							if(M.reagents.get_reagent_amount("cryptobiolin") + force < force*2)
-								M.reagents.add_reagent("cryptobiolin", force)
-					else
-						return
-				M.updatehealth()
 			src.occupant_message("You hit [target].")
 			src.visible_message("<font color='red'><b>[src.name] hits [target].</b></font>")
 		else

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -115,8 +115,7 @@ var/last_chew = 0
 	H.visible_message("<span class='warning'>\The [H] chews on \his [O.name]!</span>", "<span class='warning'>You chew on your [O.name]!</span>")
 	admin_attacker_log(H, "chewed on their [O.name]!")
 
-	if(O.take_damage(3,0,1,1,"teeth marks"))
-		H:UpdateDamageIcon()
+	O.take_damage(3,0, DAM_SHARP|DAM_EDGE ,"teeth marks")
 
 	last_chew = world.time
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -195,24 +195,7 @@ default behaviour is:
 
 //sort of a legacy burn method for /electrocute, /shock, and the e_chair
 /mob/living/proc/burn_skin(burn_amount)
-	if(istype(src, /mob/living/carbon/human))
-//		log_debug(burn_skin(), mutations=[mutations]")
-
-		if(mShock in src.mutations) //shockproof
-			return 0
-		if (COLD_RESISTANCE in src.mutations) //fireproof
-			return 0
-		var/mob/living/carbon/human/H = src	//make this damage method divide the damage to be done among all the body parts, then burn each body part for that much damage. will have better effect then just randomly picking a body part
-		var/divided_damage = (burn_amount)/(H.organs.len)
-		var/extradam = 0	//added to when organ is at max dam
-		for(var/obj/item/organ/external/affecting in H.organs)
-			if(!affecting)	continue
-			if(affecting.take_damage(0, divided_damage+extradam))	//TODO: fix the extradam stuff. Or, ebtter yet...rewrite this entire proc ~Carn
-				H.UpdateDamageIcon()
-		H.updatehealth()
-		return 1
-	else if(istype(src, /mob/living/silicon/ai))
-		return 0
+	take_overall_damage(0, burn_amount)
 
 /mob/living/proc/adjustBodyTemp(actual, desired, incrementboost)
 	var/temperature = actual

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -922,7 +922,7 @@ mob/proc/yank_out_object()
 
 		affected.implants -= selection
 		H.shock_stage+=20
-		affected.take_damage((selection.w_class * 3), 0, 0, 1, "Embedded object extraction")
+		affected.take_damage((selection.w_class * 3), 0, DAM_EDGE, "Embedded object extraction")
 
 		if(prob(selection.w_class * 5)) //I'M SO ANEMIC I COULD JUST -DIE-.
 			var/datum/wound/internal_bleeding/I = new (min(selection.w_class * 5, 15))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -286,7 +286,7 @@
 	//Continued damage to vital organs can kill you, and robot organs don't count towards total damage so no need to cap them.
 	return (vital || (robotic >= ORGAN_ROBOT) || brute_dam + burn_dam + additional_damage < max_damage)
 
-/obj/item/organ/external/take_damage(brute, burn, damage_flags, used_weapon = null, list/forbidden_limbs = list())
+/obj/item/organ/external/take_damage(brute, burn, damage_flags, used_weapon = null)
 	brute = round(brute * brute_mod, 0.1)
 	burn = round(burn * burn_mod, 0.1)
 	if((brute <= 0) && (burn <= 0))

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -174,8 +174,8 @@
 			owner.update_hair()
 	..()
 
-/obj/item/organ/external/head/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())
-	..(brute, burn, sharp, edge, used_weapon, forbidden_limbs)
+/obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon = null)
+	..()
 	if (!disfigured)
 		if (brute_dam > 40)
 			if (prob(50))


### PR DESCRIPTION
Updates a number of outdated calls to organ/external/take_damage(), fixing potential runtimes including #15376

Someday I'd like to see us get to a point where there are no longer outside of mob code any constructions like:
```
var/obj/item/organ/external/E = get_organ(user.zone_sel.selecting)
E.take_damage(...)
```
Since doing so bypasses important code that might be at the mob level, such as updating HUDs, damage icons, handling suit punctures, and especially checking armour protection. That will probably have to come with a consistent API for damaging mobs. Someday I guess.