### PR TITLE
Tweaks ninja stealth

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -16,10 +16,10 @@
 	disruptable = 1
 	disruptive = 0
 
-	use_power_cost = 5 KILOWATTS
-	active_power_cost = 500
+	use_power_cost = 250 KILOWATTS
+	active_power_cost = 6 KILOWATTS		// 30 min battery life /w best (3kWh) cell
 	passive_power_cost = 0
-	module_cooldown = 30
+	module_cooldown = 10 SECONDS
 
 	activate_string = "Enable Cloak"
 	deactivate_string = "Disable Cloak"


### PR DESCRIPTION
- Passive power usage 500W -> 6kW. This equals roughly 30 minutes for a full 3kWh battery (without other modules and activation cost)
- Activation cost 5kW -> 250kW. Cloak should be quite expensive (power-wise) when frequently toggled on and off (such as, during combat)
- Cooldown 3s -> 10s. Should hopefully make it a bit harder to use decloak-stab-cloak tactics.

Power usage tweaks suggested by multiple people on the forums, including @Raptor1628