### PR TITLE
Overmap Things

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -177,7 +177,6 @@ var/list/gamemode_cache = list()
 	var/announce_shuttle_dock_to_irc = FALSE
 	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
-	var/use_overmap = 0
 
 	// Event settings
 	var/expected_round_length = 3 * 60 * 60 * 10 // 3 hours
@@ -649,9 +648,6 @@ var/list/gamemode_cache = list()
 
 				if("max_maint_drones")
 					config.max_maint_drones = text2num(value)
-
-				if("use_overmap")
-					config.use_overmap = 1
 
 				if("expected_round_length")
 					config.expected_round_length = MinutesToTicks(text2num(value))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -258,7 +258,7 @@
 	if(!z || (z in using_map.sealed_levels))
 		return
 
-	if(config.use_overmap)
+	if(using_map.use_overmap)
 		overmap_spacetravel(get_turf(src), src)
 		return
 

--- a/code/modules/overmap/README.dm
+++ b/code/modules/overmap/README.dm
@@ -9,7 +9,7 @@ No actual turfs are moved, you would need exploration shuttles or teleports to m
 0. Map whatever.
 1. Make /obj/effect/overmap/sector/[whatever]
 	If you want explorations shuttles be able to dock here, remember to set *landing_area*
-2. Put /obj/effect/overmap/sector/[whatever] on the map. If it's multiz, only one is needed, on any z.
+2. Put /obj/effect/overmap/sector/[whatever] on the map. Even if it's multiz, only one is needed, on any z.
 3. Done.
 
 *************************************************************
@@ -33,9 +33,10 @@ Lets overmap know this place should be represented on the map as a sector/ship.
 If this zlevel (or any of connected ones for multiz) doesn't have this object, you won't be able to travel there by ovemap means.
 ### HOW TO USE
 1. Create subtype for your ship/sector. Use /ship one for ships.
-2. Put it anywhere on the ship/sector. It will do the rest on its own during init.
+2. Put it anywhere on the ship/sector map. It will do the rest on its own during init.
 If your thing is multiz, only one is needed per multiz sector/ship.
 
+If it's player's main base (e.g Exodus), set 'base' var to 1, so it adds itself to station_levels list.
 If you want exploration shuttles (look below) to be able to dock here, set *landing_area* var to the type of area they should use
 e.g. *landing_area* = /area/sector/shuttle/butts_inbound
 

--- a/code/modules/overmap/_defines.dm
+++ b/code/modules/overmap/_defines.dm
@@ -1,7 +1,6 @@
 //How far from the edge of overmap zlevel could randomly placed objects spawn
 #define OVERMAP_EDGE 2
 //Dimension of overmap (squares 4 lyfe)
-#define OVERMAP_SIZE 20
 var/global/list/map_sectors = list()
 
 /area/overmap/
@@ -26,26 +25,26 @@ var/global/list/map_sectors = list()
 	name = "[x]-[y]"
 	var/list/numbers = list()
 
-	if(x == 1 || x == OVERMAP_SIZE)
+	if(x == 1 || x == using_map.overmap_size)
 		numbers += list("[round(y/10)]","[round(y%10)]")
-		if(y == 1 || y == OVERMAP_SIZE)
+		if(y == 1 || y == using_map.overmap_size)
 			numbers += "-"
-	if(y == 1 || y == OVERMAP_SIZE)
+	if(y == 1 || y == using_map.overmap_size)
 		numbers += list("[round(x/10)]","[round(x%10)]")
 
-	for(var/i = 1 to numbers.len+1)
+	for(var/i = 1 to numbers.len)
 		var/image/I = image('icons/effects/numbers.dmi',numbers[i])
 		I.pixel_x = 5*i - 2
 		I.pixel_y = world.icon_size/2 - 3
 		if(y == 1)
 			I.pixel_y = 3
 			I.pixel_x = 5*i + 4
-		if(y == OVERMAP_SIZE)
+		if(y == using_map.overmap_size)
 			I.pixel_y = world.icon_size - 9
 			I.pixel_x = 5*i + 4
 		if(x == 1)
 			I.pixel_x = 5*i - 2
-		if(x == OVERMAP_SIZE)
+		if(x == using_map.overmap_size)
 			I.pixel_x = 5*i + 2
 		overlays += I
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -13,9 +13,10 @@
 	var/start_y			//overmap zlevel
 
 	var/known = 1		//shows up on nav computers automatically
+	var/in_space = 1	//can be accessed via lucky EVA
 
 /obj/effect/overmap/initialize()
-	if(!config.use_overmap)
+	if(!using_map.use_overmap)
 		qdel(src)
 		return
 
@@ -27,9 +28,9 @@
 		map_sectors["[zlevel]"] = src
 
 	if(!start_x)
-		start_x = rand(OVERMAP_EDGE, OVERMAP_SIZE - OVERMAP_EDGE)
+		start_x = rand(OVERMAP_EDGE, using_map.overmap_size - OVERMAP_EDGE)
 	if(!start_y)
-		start_y = rand(OVERMAP_EDGE, OVERMAP_SIZE - OVERMAP_EDGE)
+		start_y = rand(OVERMAP_EDGE, using_map.overmap_size - OVERMAP_EDGE)
 
 	forceMove(locate(start_x, start_y, using_map.overmap_z))
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")
@@ -52,16 +53,16 @@
 		H.get_known_sectors()
 
 /proc/build_overmap()
-	if(!config.use_overmap)
+	if(!using_map.use_overmap)
 		return 1
 
 	testing("Building overmap...")
 	world.maxz++
 	using_map.overmap_z = world.maxz
 	var/list/turfs = list()
-	for (var/square in block(locate(1,1,using_map.overmap_z), locate(OVERMAP_SIZE,OVERMAP_SIZE,using_map.overmap_z)))
+	for (var/square in block(locate(1,1,using_map.overmap_z), locate(using_map.overmap_size,using_map.overmap_size,using_map.overmap_z)))
 		var/turf/T = square
-		if(T.x == OVERMAP_SIZE || T.y == OVERMAP_SIZE)
+		if(T.x == using_map.overmap_size || T.y == using_map.overmap_size)
 			T = T.ChangeTurf(/turf/unsimulated/map/edge)
 		else
 			T = T.ChangeTurf(/turf/unsimulated/map/)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -12,6 +12,7 @@
 	var/start_x			//coordinates on the
 	var/start_y			//overmap zlevel
 
+	var/base = 0		//starting sector, counts as station_levels
 	var/known = 1		//shows up on nav computers automatically
 
 /obj/effect/overmap/initialize()
@@ -21,6 +22,7 @@
 
 	if(!using_map.overmap_z)
 		build_overmap()
+	using_map.sealed_levels |= using_map.overmap_z
 
 	map_z = GetConnectedZlevels(z)
 	for(var/zlevel in map_z)
@@ -33,6 +35,11 @@
 
 	forceMove(locate(start_x, start_y, using_map.overmap_z))
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")
+
+	using_map.contact_levels |= map_z
+	using_map.player_levels |= map_z
+	if(base)
+		using_map.station_levels |= map_z
 
 	for(var/obj/machinery/computer/shuttle_control/explore/console in machines)
 		if(console.z in map_z)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -45,10 +45,24 @@ proc/get_deepspace(x,y)
 		world.maxz++
 		return new /obj/effect/overmap/sector/temporary(x, y, world.maxz)
 
+/atom/movable/proc/lost_in_space()
+	return TRUE
+
+/mob/lost_in_space()
+	return isnull(client)
+
 proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
+	if (!T || !A)
+		return
+
 	var/obj/effect/overmap/M = map_sectors["[T.z]"]
 	if (!M)
 		return
+
+	if(A.lost_in_space())
+		qdel(A)
+		return
+
 	var/nx = 1
 	var/ny = 1
 	var/nz = 1
@@ -74,8 +88,9 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	var/turf/map = locate(M.x,M.y,using_map.overmap_z)
 	var/obj/effect/overmap/TM
 	for(var/obj/effect/overmap/O in map)
-		if(TM != M && prob(5))
+		if(O != M && O.in_space && prob(5))
 			TM = O
+			break
 	if(!TM)
 		TM = get_deepspace(M.x,M.y)
 	nz = pick(TM.map_z)
@@ -83,6 +98,10 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	var/turf/dest = locate(nx,ny,nz)
 	if(dest)
 		A.forceMove(dest)
+		if(ismob(A))
+			var/mob/D = A
+			if(D.pulling)
+				D.pulling.forceMove(dest)
 
 	if(istype(M, /obj/effect/overmap/sector/temporary))
 		var/obj/effect/overmap/sector/temporary/source = M

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -293,9 +293,6 @@ REQ_CULT_GHOSTWRITER 6
 ## Sets the number of available character slots
 CHARACTER_SLOTS 10
 
-## Uncomment to use overmap system for zlevel travel
-#USE_OVERMAP
-
 ## Expected round length in minutes
 EXPECTED_ROUND_LENGTH 180
 

--- a/maps/overmap_example/bearcat/bearcat.dm
+++ b/maps/overmap_example/bearcat/bearcat.dm
@@ -4,6 +4,7 @@
 	landing_areas = list(/area/ship/scrap/shuttle/ingoing, /area/ship/scrap/shuttle/pod)
 	start_x = 4
 	start_y = 4
+	base = 1
 
 /obj/machinery/computer/shuttle_control/explore/bearcat
 	name = "exploration shuttle console"

--- a/maps/overmap_example/overmap_example.dm
+++ b/maps/overmap_example/overmap_example.dm
@@ -1,4 +1,6 @@
 #if !defined(USING_MAP_DATUM)
+	#include "overmap_unit_testing.dm"
+
 	#include "bearcat/bearcat.dm"
 	#include "bearcat/bearcat_areas.dm"
 	#include "bearcat/bearcat-1.dmm"

--- a/maps/overmap_example/overmap_example_define.dm
+++ b/maps/overmap_example/overmap_example_define.dm
@@ -6,6 +6,7 @@
 	lobby_icon = 'maps/overmap_example/overmap_example_lobby.dmi'
 
 	allowed_spawns = list("Arrivals Shuttle")
+	use_overmap = 1
 
 /datum/map/overmap_example/setup_map()
 	..()

--- a/maps/overmap_example/overmap_example_define.dm
+++ b/maps/overmap_example/overmap_example_define.dm
@@ -6,11 +6,3 @@
 	lobby_icon = 'maps/overmap_example/overmap_example_lobby.dmi'
 
 	allowed_spawns = list("Arrivals Shuttle")
-
-/datum/map/overmap_example/setup_map()
-	..()
-	station_levels = list()
-	for(var/zz in map_sectors)
-		station_levels |= text2num(zz)
-	contact_levels = station_levels.Copy()
-	player_levels = station_levels.Copy()

--- a/maps/overmap_example/overmap_unit_testing.dm
+++ b/maps/overmap_example/overmap_unit_testing.dm
@@ -1,0 +1,15 @@
+/datum/map/overmap_example
+	// Unit test exemptions
+	apc_test_exempt_areas = list(
+		/area/space = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/ship/scrap/shuttle/ = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/sector/shuttle/ = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/ship/scrap/cargo/lower = NO_SCRUBBER|NO_VENT,
+		/area/ship/scrap/maintenance/engine/lower = NO_VENT,
+		/area/ship/scrap/maintenance/engine/aft = NO_SCRUBBER,
+		/area/ship/scrap/maintenance/engine/port = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/ship/scrap/maintenance/engine/starboard = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/ship/scrap/maintenance/atmos = NO_SCRUBBER,
+		/area/ship/scrap/crew/hallway/port= NO_SCRUBBER|NO_VENT,
+		/area/ship/scrap/crew/hallway/starboard= NO_SCRUBBER|NO_VENT|NO_APC,
+	)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -63,6 +63,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage")
 	var/flags = 0
 	var/evac_controller_type = /datum/evacuation_controller
+	var/use_overmap = 0		//If overmap should be used (including overmap space travel override)
+	var/overmap_size = 20		//Dimensions of overmap zlevel if overmap is used.
 	var/overmap_z = 0		//If 0 will generate overmap zlevel on init. Otherwise will populate the zlevel provided.
 
 	var/lobby_icon = 'maps/exodus/exodus_lobby.dmi' // The icon which contains the lobby image(s)


### PR DESCRIPTION
Stops items from eternally travelling in space, which potenitally created more zlevels if you kept dropping stuff in space. Now everything just gets qdeled when it leaves zlevel via spacemove.
Exception is client-carrying mobs. They even get things they were pulling teleported with them.
More exceptions can be added by overriding 'lost_in_space' proc.

Moved some stuff from config/defines into map vars.
Flag to use overmap should really be per map, because it's easy to forget to set up, and screws up everything on overmap maps if disabled, and would fuck up EVA on normal maps if left enabled.



Also made it populate sealed-players-contact etc zlevels lists during overmap building, as it was completely failing to catch any sectors during setup_map run, which would break stuff.