### PR TITLE
Two runtime fixes.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -196,8 +196,11 @@ proc/age2agedescription(age)
 	if(!user)
 		return 0
 	var/atom/target_loc = null
+	var/target_type = null
+	
 	if(target)
 		target_loc = target.loc
+		target_type = target.type
 
 	var/atom/original_loc = user.loc
 
@@ -219,7 +222,7 @@ proc/age2agedescription(age)
 			. = 0
 			break
 
-		if(target_loc && (!target || deleted(target) || target_loc != target.loc))
+		if(target_loc && (!target || deleted(target) || target_loc != target.loc || target_type != target.type))
 			. = 0
 			break
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -145,6 +145,8 @@
 
 //Like grab-putting, but for mouse-drop.
 /obj/machinery/dna_scannernew/MouseDrop_T(var/mob/target, var/mob/user)
+	if(!istype(target))
+		return
 	if (!CanMouseDrop(target, user))
 		return
 	if (src.occupant)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -94,6 +94,8 @@
 
 //Like grap-put, but for mouse-drop.
 /obj/machinery/bodyscanner/MouseDrop_T(var/mob/target, var/mob/user)
+	if(!istype(target))
+		return
 	if (!CanMouseDrop(target, user))
 		return
 	if (src.occupant)


### PR DESCRIPTION
The body and DNA scanners now checks the type of what's being dropped into them.
Fixes #15047. Fixes #15057. #15075. Fixes #15101. Fixes #15155. Fixes #15194. Fixes #15269. Fixes #15336. Fixes #15414. Fixes #15423.

do_after() now checks the type of the target object. This should catch most (but certainly not all) turf changes.
Typically do_after() handles when a target is deleted, however since BYOND never truly delete turfs we need this additional type check to at least handle sudden verb/proc changes.
Fixes #14816. Fixes #15061. Fixes #15382. Fixes #15421.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
