### PR TITLE
Allows shuttles to generate magical invulnerable ceilings

### DIFF
--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -16,3 +16,6 @@
 
 /turf/unsimulated/floor/rescue_base
 	icon_state = "asteroidfloor"
+
+/turf/unsimulated/floor/shuttle_ceiling
+	icon_state = "reinforced"

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -141,10 +141,9 @@
 	// if there's a zlevel above our destination, paint in a ceiling on it so we retain our air
 	var/turf/some_dest_turf = locate() in destination
 	if (HasAbove(some_dest_turf.z))
-		var/dest_base_turf_type = get_base_turf_by_area(get_step(some_dest_turf, UP))
 		for (var/turf/TD in dstturfs)
 			var/turf/TA = GetAbove(TD)
-			if (TA && istype(TA, dest_base_turf_type))
+			if (TA && istype(TA, get_base_turf_by_area(TA)))
 				TA.ChangeTurf(ceiling_type, 1, 1)
 
 	origin.move_contents_to(destination, direction=direction)
@@ -152,11 +151,10 @@
 	// if there was a zlevel above our origin, erase our ceiling now we're gone
 	var/turf/some_origin_turf = locate() in origin
 	if (HasAbove(some_origin_turf.z))
-		var/origin_base_turf_type = get_base_turf_by_area(get_step(some_origin_turf, UP))
 		for (var/turf/TO in origin)
 			var/turf/TA = GetAbove(TO)
 			if (TA && istype(TA, ceiling_type))
-				TA.ChangeTurf(origin_base_turf_type, 1, 1)
+				TA.ChangeTurf(get_base_turf_by_area(TA), 1, 1)
 
 	for(var/mob/M in destination)
 		if(M.client)


### PR DESCRIPTION
Not a terrific fix for #15224, but a fix.

Shuttles will now generate an invincible unsimulated ceiling for themselves just before arriving, and will erase it just after they leave. The ceiling will only be placed on the above area's `base_turf` - usually space - so it won't eat other things that happen to be above the shuttle, such as other ships. Similarly, when the ship departs, it replaces its ceiling with the `base_turf` again.

The ceiling is invincible because there is currently no support here for retaining any changes or damage. You get a fresh new ceiling every time you move.