### PR TITLE
Fix cats and mice being stuck in a perpetual kill-revive loop

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -77,10 +77,9 @@
 	desc = "It's a small [body_color] rodent, often seen hiding in maintenance areas and making a nuisance of itself."
 
 /mob/living/simple_animal/mouse/proc/splat()
-	src.health = 0
+	icon_dead = "mouse_[body_color]_splat"
+	adjustBruteLoss(maxHealth)  // Enough damage to kill
 	src.death()
-	src.icon_dead = "mouse_[body_color]_splat"
-	src.icon_state = "mouse_[body_color]_splat"
 
 /mob/living/simple_animal/mouse/MouseDrop(atom/over_object)
 


### PR DESCRIPTION
Mouse's `splat()` used to set `health` to 0, but `health` [gets recalculated when `updatehealth()` runs](https://github.com/Baystation12/Baystation12/blob/dev/code/modules/mob/living/living.dm#L187), so mouse would get revived.

Instead, this sets enough brute to the mouse to kill it.

Resolves #15344
