### PR TITLE
Fix calls to AI on_mob_init

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -176,6 +176,7 @@
 				else
 					var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )
 					if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
+						A.on_mob_init()
 						A.rename_self("ai", 1)
 				feedback_inc("cyborg_ais_created",1)
 				qdel(src)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -160,8 +160,6 @@ var/list/ai_verbs_default = list(
 			if (B.brainmob.mind)
 				B.brainmob.mind.transfer_to(src)
 
-			on_mob_init()
-
 	create_powersupply()
 
 	hud_list[HEALTH_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -350,6 +350,8 @@
 		empty_playable_ai_cores -= C
 
 		character.forceMove(C.loc)
+		var/mob/living/silicon/ai/A = character
+		A.on_mob_init()
 
 		AnnounceCyborg(character, rank, "has been downloaded to the empty core in \the [character.loc.loc]")
 		ticker.mode.handle_latejoin(character)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -97,8 +97,7 @@
 				if (sloc.name == "AI")
 					loc_landmark = sloc
 		O.forceMove(loc_landmark.loc)
-
-	O.on_mob_init()
+		O.on_mob_init()
 
 	O.add_ai_verbs()
 


### PR DESCRIPTION
This fixes the issue where latejoining AIs didn't get an icon or proper camera location. It also fixes a runtime when a new AI is built containing a mind.

Fixes #13834
Fixes #15451