### PR TITLE
Couple ChangeTurf-related fixes

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -192,7 +192,7 @@
 
 /decl/hierarchy/rcd_mode/proc/do_handle_work(var/atom/target)
 	var/result = get_work_result(target)
-	if(isturf(result))
+	if(ispath(result,/turf))
 		var/turf/T = target
 		T.ChangeTurf(result)
 	else if(result)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -95,7 +95,7 @@
 
 /turf/simulated/wall/ChangeTurf(var/newtype)
 	clear_plants()
-	..(newtype)
+	return ..(newtype)
 
 //Appearance
 /turf/simulated/wall/examine(mob/user)


### PR DESCRIPTION
Makes RCD use proper ChangeTurf. Apparently istype fails on types.
Also walls now do proper return so event is emitted 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
