### PR TITLE
Allows dynamic name change in game window title

### DIFF
--- a/code/hub.dm
+++ b/code/hub.dm
@@ -4,7 +4,7 @@
  */
 //#define HUB_ENABLED 1
 	hub = "Exadv1.spacestation13"
-	name = "Space Station 13"
+	name = "Space Station 13 - Baystation 12"
 #ifdef HUB_ENABLED
 	hub_password = "kMZy3U5jJHSiBQjr"
 #else

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,5 +1,7 @@
 #define WORLD_ICON_SIZE 32
 
+/var/server_name = "Baystation 12"
+
 /var/game_id = null
 /hook/global_init/proc/generate_gameid()
 	if(game_id != null)
@@ -76,6 +78,9 @@
 
 #define RECOMMENDED_VERSION 510
 /world/New()
+	//set window title
+	name = "[server_name] - [using_map.full_name]"
+
 	//logs
 	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
 	href_logfile = file("data/logs/[date_string] hrefs.htm")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1832,7 +1832,6 @@ window "mainwindow"
 		right-click = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		on-size = ""
-		title = "Space Station 13"
 		titlebar = true
 		statusbar = true
 		can-close = true


### PR DESCRIPTION
Because having the title splash screen and the welcome messages aren't enough to remind people what server they are playing on.

![](http://i.imgur.com/W3d2kNa.png)