### PR TITLE
re-write typing indicators to atoms

### DIFF
--- a/code/modules/client/preference_setup/global/preference_datums.dm
+++ b/code/modules/client/preference_setup/global/preference_datums.dm
@@ -112,7 +112,7 @@ var/list/_client_preferences_by_type
 
 /datum/client_preference/show_typing_indicator/toggled(var/mob/preference_mob, var/enabled)
 	if(!enabled)
-		preference_mob.set_typing_indicator(0)
+		preference_mob.destroy_typing_indicator()
 
 /datum/client_preference/show_ooc
 	description ="OOC chat"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -10,7 +10,7 @@
 	set name = "Say"
 	set category = "IC"
 
-	set_typing_indicator(0)
+	destroy_typing_indicator()
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)
@@ -19,7 +19,7 @@
 
 	message = sanitize(message)
 
-	set_typing_indicator(0)
+	destroy_typing_indicator()
 	if(use_me)
 		usr.emote("me",usr.emote_type,message)
 	else

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,44 +1,49 @@
-#define TYPING_INDICATOR_LIFETIME 30 * 10	//grace period after which typing indicator disappears regardless of text in chatbar
+/atom/movable/overlay/typing_indicator
+	icon = 'icons/mob/talk.dmi'
+	icon_state = "typing"
+	
+/atom/movable/overlay/typing_indicator/proc/destroy_self(var/mob/master)
+	if(master)
+		master.typing_indicator = null
+		master = null
+	qdel(src)
 
-mob/var/hud_typing = 0 //set when typing in an input window instead of chatline
-mob/var/typing
-mob/var/last_typed
-mob/var/last_typed_time
+mob/var/atom/movable/overlay/typing_indicator = null
 
-mob/var/obj/effect/decal/typing_indicator
+/mob/proc/typing_indicator_follow_me(var/atom/movable/overlay/typing_indicator/follower)
+	if(follower)
+		return
+	
+	follower = typing_indicator
+	moved_event.register(src, follower, /atom/movable/proc/move_to_turf)
+	destroyed_event.register(src, follower, /atom/movable/overlay/typing_indicator/proc/destroy_self)
 
-/mob/proc/set_typing_indicator(var/state)
-
-	if(!typing_indicator)
-		typing_indicator = new
-		typing_indicator.icon = 'icons/mob/talk.dmi'
-		typing_indicator.icon_state = "typing"
-		typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-
-	if(client && !stat)
-		typing_indicator.invisibility = invisibility
-		if(!is_preference_enabled(/datum/client_preference/show_typing_indicator))
-			overlays -= typing_indicator
-		else
-			if(state)
-				if(!typing)
-					overlays += typing_indicator
-					typing = 1
-			else
-				if(typing)
-					overlays -= typing_indicator
-					typing = 0
-			return state
-
+	move_to_turf(follower, loc, usr.loc)
+	
+/mob/proc/create_typing_indicator()
+	if(client && !stat && is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		if(!typing_indicator)
+			typing_indicator = new /atom/movable/overlay/typing_indicator(loc)
+			typing_indicator.name = name
+			typing_indicator.invisibility = invisibility
+			typing_indicator.master = usr
+		typing_indicator_follow_me()
+	else 
+		if(typing_indicator)
+			destroy_typing_indicator()
+			
+/mob/proc/destroy_typing_indicator()
+	if(typing_indicator)
+		qdel(typing_indicator)
+		typing_indicator = null
+		
 /mob/verb/say_wrapper()
 	set name = ".Say"
 	set hidden = 1
 
-	set_typing_indicator(1)
-	hud_typing = 1
+	create_typing_indicator()
 	var/message = input("","say (text)") as text
-	hud_typing = 0
-	set_typing_indicator(0)
+	destroy_typing_indicator()
 	if(message)
 		say_verb(message)
 
@@ -46,29 +51,18 @@ mob/var/obj/effect/decal/typing_indicator
 	set name = ".Me"
 	set hidden = 1
 
-	set_typing_indicator(1)
-	hud_typing = 1
+	create_typing_indicator()
 	var/message = input("","me (text)") as text
-	hud_typing = 0
-	set_typing_indicator(0)
+	destroy_typing_indicator()
 	if(message)
 		me_verb(message)
 
-/mob/proc/handle_typing_indicator()
-	if(is_preference_enabled(/datum/client_preference/show_typing_indicator) && !hud_typing)
-		var/temp = winget(client, "input", "text")
-
-		if (temp != last_typed)
-			last_typed = temp
-			last_typed_time = world.time
-
-		if (world.time > last_typed_time + TYPING_INDICATOR_LIFETIME)
-			set_typing_indicator(0)
-			return
-		if(length(temp) > 5 && findtext(temp, "Say \"", 1, 7))
-			set_typing_indicator(1)
-		else if(length(temp) > 3 && findtext(temp, "Me ", 1, 5))
-			set_typing_indicator(1)
-
-		else
-			set_typing_indicator(0)
+/mob/Logout()
+	..()
+	if(typing_indicator)
+		destroy_typing_indicator()
+	
+/mob/death()
+	..()
+	if(typing_indicator)
+		destroy_typing_indicator()


### PR DESCRIPTION
I will slay this bug, git issues and code issues be damned.

Typing indicators moved to atoms, making them immune to updateicon(), making this a fix for #7174.
Functions roughly as identical as current typing indicators. 

Only issue I can find thus far now is that status changes (going from OK to sleeping/KO'd) does not remove the indicator, but someone believes that that is current typing indicator behaviour as well.

Also code is likely ugly as hell.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
