### PR TITLE
Use ignore_role for in-round antag conversions

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -1,8 +1,9 @@
 /datum/antagonist
 
 	// Text shown when becoming this antagonist.
-	var/list/restricted_jobs =     list()   // Jobs that cannot be this antagonist (depending on config)
-	var/list/protected_jobs =      list()   // As above.
+	var/list/restricted_jobs = 		list()   // Jobs that cannot be this antagonist at roundstart (depending on config)
+	var/list/protected_jobs = 		list()   // As above.
+	var/list/blacklisted_jobs =		list()   // Jobs that can NEVER be this antagonist
 
 	// Strings.
 	var/welcome_text = "Cry havoc and let slip the dogs of war!"

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -21,7 +21,7 @@
 		to_chat(src, "<span class='warning'>\The [player.current]'s loyalties seem to be elsewhere...</span>")
 		return
 
-	if(!faction.can_become_antag(player))
+	if(!faction.can_become_antag(player, 1))
 		to_chat(src, "<span class='warning'>\The [player.current] cannot be \a [faction.faction_role_text]!</span>")
 		return
 

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -2,6 +2,9 @@
 	if(player.current && jobban_isbanned(player.current, id))
 		return 0
 
+	if(player.assigned_role in blacklisted_jobs)
+		return 0
+
 	if(!ignore_role)
 		if(player.current && player.current.client)
 			var/client/C = player.current.client
@@ -9,8 +12,6 @@
 			if(C && config.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(min_player_age) && (C.player_age < min_player_age))
 				return 0
 		if(player.assigned_role in restricted_jobs)
-			return 0
-		if(config.protect_roles_from_antagonist && (player.assigned_role in protected_jobs))
 			return 0
 		if(player.current && (player.current.status_flags & NO_ANTAG))
 			return 0

--- a/code/game/antagonist/mutiny/mutineer.dm
+++ b/code/game/antagonist/mutiny/mutineer.dm
@@ -15,7 +15,7 @@ var/datum/antagonist/mutineer/mutineers
 
 /datum/antagonist/mutineer/proc/recruit()
 
-/datum/antagonist/mutineer/can_become_antag(var/datum/mind/player)
+/datum/antagonist/mutineer/can_become_antag(var/datum/mind/player, var/ignore_role)
 	if(!..())
 		return 0
 	if(!istype(player.current, /mob/living/carbon/human))

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -3,7 +3,7 @@
 	role_text = "Changeling"
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
-	restricted_jobs = list("AI", "Cyborg")
+	blacklisted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -10,8 +10,9 @@ var/datum/antagonist/cultist/cult
 	id = MODE_CULTIST
 	role_text = "Cultist"
 	role_text_plural = "Cultists"
-	restricted_jobs = list("Chaplain","AI", "Cyborg", "Internal Affairs Agent", "Head of Security", "Captain")
+	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain")
 	protected_jobs = list("Security Officer", "Warden", "Detective")
+	blacklisted_jobs = list("AI", "Cyborg", "Chaplain")
 	feedback_tag = "cult_objective"
 	antag_indicator = "cult"
 	welcome_text = "You have a talisman in your possession; one that will help you start the cult on this station. Use it well and remember - there are others."
@@ -83,7 +84,7 @@ var/datum/antagonist/cultist/cult
 	if(show_message)
 		player.current.visible_message("<FONT size = 3>[player.current] looks like they just reverted to their old faith!</FONT>")
 
-/datum/antagonist/cultist/add_antagonist(var/datum/mind/player)
+/datum/antagonist/cultist/add_antagonist(var/datum/mind/player, var/ignore_role)
 	. = ..()
 	if(.)
 		to_chat(player, "You catch a glimpse of the Realm of Nar-Sie, the Geometer of Blood. You now see how flimsy the world is, you see that it should be open to the knowledge of That Which Waits. Assist your new compatriots in their dark dealings. Their goals are yours, and yours are theirs. You serve the Dark One above all else. Bring It back.")
@@ -95,7 +96,7 @@ var/datum/antagonist/cultist/cult
 	if(. && player.current && !istype(player.current, /mob/living/simple_animal/construct))
 		player.current.remove_language(LANGUAGE_CULT)
 
-/datum/antagonist/cultist/can_become_antag(var/datum/mind/player)
+/datum/antagonist/cultist/can_become_antag(var/datum/mind/player, var/ignore_role)
 	if(!..())
 		return 0
 	for(var/obj/item/weapon/implant/loyalty/L in player.current)

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -26,7 +26,7 @@ var/datum/antagonist/loyalists/loyalists
 	faction_welcome = "Preserve NanoTrasen's interests against the traitorous recidivists amongst the crew. Protect the heads of staff with your life."
 	faction_indicator = "loyal"
 	faction_invisible = 1
-	restricted_jobs = list("AI", "Cyborg")
+	blacklisted_jobs = list("AI", "Cyborg")
 
 	faction = "loyalist"
 

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -28,7 +28,8 @@ var/datum/antagonist/revolutionary/revs
 	faction_invisible = 1
 	faction = "revolutionary"
 
-	restricted_jobs = list("Internal Affairs Agent", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
+	blacklisted_jobs = list("AI", "Cyborg")
+	restricted_jobs = list("Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent")
 	protected_jobs = list("Security Officer", "Warden", "Detective")
 
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -170,7 +170,7 @@ var/list/sacrificed = list()
 				if(!waiting_for_input[target]) //so we don't spam them with dialogs if they hesitate
 					waiting_for_input[target] = 1
 
-					if(!cult.can_become_antag(target.mind) || jobban_isbanned(target, MODE_CULTIST))//putting jobban check here because is_convertable uses mind as argument
+					if(!cult.can_become_antag(target.mind, 1))
 						//waiting_for_input ensures this is only shown once, so they basically auto-resist from here on out. They still need to find a way to get off the freaking rune if they don't want to burn to death, though.
 						to_chat(target, "<span class='cult'>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</span>")
 						to_chat(target, "<span class='danger'>And you were able to force it out of your mind. You now know the truth, there's something horrible out there, stop it and its minions at all costs.</span>")
@@ -179,7 +179,7 @@ var/list/sacrificed = list()
 						var/choice = alert(target,"Do you want to join the cult?","Submit to Nar'Sie","Resist","Submit")
 						waiting_for_input[target] = 0
 						if(choice == "Submit") //choosing 'Resist' does nothing of course.
-							cult.add_antagonist(target.mind)
+							cult.add_antagonist(target.mind, 1)
 							converting -= target
 							target.hallucination = 0 //sudden clarity
 

--- a/html/changelogs/xales - antag-conversion.yml
+++ b/html/changelogs/xales - antag-conversion.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.
+author: Ravenxales
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Allow protected roles (heads, IAA, etc.) to be converted to faction antags (cult and rev) mid-round"


### PR DESCRIPTION
This adds a blacklist to each antag faction, which controls jobs that can NEVER be that antag, regardless of by which method. The previous controls now only apply to rolls at roundstart.

Fixes #10913
Fixes #10596