### PR TITLE
Remove turbolift base_turf

### DIFF
--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -4,7 +4,6 @@
 	base_turf = /turf/simulated/open
 	requires_power = 0
 	sound_env = SMALL_ENCLOSED
-	base_turf = /turf/space
 
 	var/lift_floor_label = null
 	var/lift_floor_name = null


### PR DESCRIPTION
This seems to prevent atmosphere loss when moving, because there's no longer space turf being created.

Fixes #15356