### PR TITLE
Don't allow upward movement if there's gravity

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -69,6 +69,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	power_light = 0
 	power_equip = 0
 	power_environ = 0
+	has_gravity = 0
 	ambience = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/main.ogg','sound/music/traitor.ogg')
 
 /area/space/updateicon()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -33,6 +33,11 @@
 		to_chat(usr, "<span class='warning'>You bump against \the [destination].</span>")
 		return 0
 
+	var/area/area = get_area(src)
+	if(direction == UP && area.has_gravity)
+		to_chat(usr, "<span class='warning'>Gravity stops you from moving upward.</span>")
+		return 0
+
 	for(var/atom/A in destination)
 		if(!A.CanPass(src, start))
 			to_chat(usr, "<span class='warning'>\The [A] blocks you.</span>")


### PR DESCRIPTION
Stops people from easily hurting themselves, accidentally or otherwise.

Fixes #15343 

This probably needs a bit more work and/or testing, to make sure that the turf changes don't do something horrible.