### PR TITLE
Optimizes shield creation and deletion

### DIFF
--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -26,7 +26,6 @@
 	var/obj/machinery/power/shield_generator/gen = null
 	var/disabled_for = 0
 	var/diffused_for = 0
-	var/datum/effect/effect/system/spark_spread/s
 
 
 /obj/effect/shield/update_icon()
@@ -51,28 +50,24 @@
 /obj/effect/shield/New()
 	..()
 	update_nearby_tiles()
-	s = new /datum/effect/effect/system/spark_spread(src)
 
 
 /obj/effect/shield/Destroy()
 	. = ..()
-	if(gen && (src in gen.field_segments))
-		gen.field_segments -= src
-	if(gen && (src in gen.damaged_segments))
-		gen.damaged_segments -= src
-	gen = null
+	if(gen)
+		if(src in gen.field_segments)
+			gen.field_segments -= src
+		if(src in gen.damaged_segments)
+			gen.damaged_segments -= src
+		gen = null
 	update_nearby_tiles()
 	forceMove(null, 1)
-	qdel_null(s)
 
 
 // Temporarily collapses this shield segment.
 /obj/effect/shield/proc/fail(var/duration)
 	if(duration <= 0)
 		return
-	if(!disabled_for && (duration > 1))
-		s.set_up(1, 1, src)
-		s.start()
 		
 	gen.damaged_segments |= src
 	disabled_for += duration
@@ -105,10 +100,6 @@
 	if(gen.check_flag(MODEFLAG_BYPASS) && !diffused_for && !disabled_for)
 		take_damage(duration * rand(8, 12), SHIELD_DAMTYPE_EM)
 		return
-		
-	if(!diffused_for && !disabled_for)
-		s.set_up(1, 1, src)
-		s.start()
 		
 	diffused_for = max(duration, 0)
 	gen.damaged_segments |= src

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -419,7 +419,7 @@
 
 /obj/machinery/power/shield_generator/proc/fieldtype_hull()
 	set background = 1
-	var/list/out = list()
+	. = list()
 	var/list/base_turfs = get_base_turfs()
 
 
@@ -434,9 +434,8 @@
 			// Find adjacent space/shuttle tiles and cover them. Shuttles won't be blocked if shield diffuser is mapped in and turned on.
 			for(var/turf/TN in orange(1, T))
 				if(istype(TN, /turf/space) || (istype(get_area(TN), /area/shuttle/) && !istype(get_area(TN), /area/turbolift/)))
-					out |= TN
+					. |= TN
 					continue
-	return out
 
 // Returns a list of turfs from which a field will propagate. If multi-Z mode is enabled, this will return a "column" of turfs above and below the generator.
 /obj/machinery/power/shield_generator/proc/get_base_turfs()


### PR DESCRIPTION
Mostly deletion. Went from a total hangup for a few second to smoothness on my machine. Sorry, but making nice sparks when the shield is broken isn't worth server hangup when someone turns the generator off. Spark generators, being datums, don't qdel. For generation, I'm just making use of ``.``, which is supposedly faster. Difference wasn't noticeable in testing, but it should help a little.