### PR TITLE
Defibrillator Fixes

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -288,11 +288,10 @@
 	return null
 
 /obj/item/weapon/shockpaddles/proc/check_contact(mob/living/carbon/human/H)
-	if(combat) return TRUE //can be used through any clothing
-
-	for(var/obj/item/clothing/cloth in list(H.wear_suit, H.w_uniform))
-		if((cloth.body_parts_covered & UPPER_TORSO) && (cloth.item_flags & THICKMATERIAL))
-			return TRUE
+	if(!combat)
+		for(var/obj/item/clothing/cloth in list(H.wear_suit, H.w_uniform))
+			if((cloth.body_parts_covered & UPPER_TORSO) && (cloth.item_flags & THICKMATERIAL))
+				return TRUE
 	return FALSE
 
 /obj/item/weapon/shockpaddles/proc/check_vital_organs(mob/living/carbon/human/H)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -390,6 +390,13 @@
 	var/adjust_health = barely_in_crit - H.health //need to increase health by this much
 	H.adjustOxyLoss(-adjust_health)
 
+	//if removing oxyloss wasn't enough, remove some toxloss too
+	if(H.health < barely_in_crit)
+		//but not so much that either toxloss goes below H.maxHealth/2, or that we cure more than 25% of their current toxloss
+		var/cure_limit = min(H.getToxLoss() - H.maxHealth/2, H.getToxLoss()*0.25)
+		adjust_health = Clamp(barely_in_crit - H.health, 0, cure_limit)
+		H.adjustToxLoss(-adjust_health)
+
 	make_announcement("pings, \"Resuscitation successful.\"", "notice")
 	playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -437,6 +437,8 @@
 	admin_attack_log(user, H, "Electrocuted using \a [src]", "Was electrocuted with \a [src]", "used \a [src] to electrocute")
 
 /obj/item/weapon/shockpaddles/proc/make_alive(mob/living/carbon/human/M) //This revives the mob
+	var/deadtime = world.time - M.timeofdeath
+
 	M.switch_from_dead_to_living_mob_list()
 	M.tod = null
 	M.timeofdeath = 0
@@ -448,7 +450,6 @@
 	M.emote("gasp")
 	M.Weaken(rand(10,25))
 
-	var/deadtime = world.time - M.timeofdeath
 	apply_brain_damage(M, deadtime)
 
 /obj/item/weapon/shockpaddles/proc/apply_brain_damage(mob/living/carbon/human/H, var/deadtime)


### PR DESCRIPTION
* Fixes inverted logic when handling combat defibrillators.
* Fixes timeofdeath being reset to 0 right before being used to determine defib brain damage. Fixes #15508
* Allows defibrillators to cure a limited amount of toxloss when reviving someone, if necessary.