### PR TITLE
Falling fixes and cleanup

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -88,7 +88,7 @@
 //Holds fall checks that should not be overriden by children
 /atom/movable/proc/fall()
 	var/turf/simulated/open/below = loc
-	if(!istype(loc))
+	if(!istype(below))
 		return
 
 	below = below.below

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -87,15 +87,15 @@
 
 //Holds fall checks that should not be overriden by children
 /atom/movable/proc/fall()
-	var/turf/simulated/open/below = loc
-	if(!istype(below))
+	if(!isturf(loc))
 		return
 
-	below = below.below
+	var/turf/below = GetBelow(src)
 	if(!below)
 		return
 
-	if(!below.CanZPass(src,DOWN))
+	var/turf/T = loc
+	if(!T.CanZPass(src, DOWN) && !below.CanZPass(src, DOWN))
 		return
 
 	// No gravity in space, apparently.
@@ -111,25 +111,19 @@
 
 //For children to override
 /atom/movable/proc/can_fall()
-	var/turf/simulated/open/below = loc
-	below = below.below
-
 	if(anchored)
 		return FALSE
 
 	if(locate(/obj/structure/lattice, loc))
 		return FALSE
-	return TRUE
 
 	// See if something prevents us from falling.
+	var/turf/below = GetBelow(src)
 	for(var/atom/A in below)
-		if(A.density)
-			if(!istype(A, /obj/structure/window))
-				return  FALSE
-			else
-				var/obj/structure/window/W = A
-				if(W.is_fulltile())
-					return FALSE
+		if(!A.CanPass(src, src.loc))
+			return FALSE
+
+	return TRUE
 
 /obj/effect/can_fall()
 	return FALSE

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -55,11 +55,9 @@
 		O.hide(0)
 
 /turf/simulated/open/update_icon()
-	underlays.Cut()
-	overlays.Cut()
 	if(below)
-		underlays += image(icon = below.icon, icon_state = below.icon_state)
-//		underlays += below.overlays
+		underlays = image(icon = below.icon, icon_state = below.icon_state)
+
 	var/list/noverlays = list()
 	if(!istype(below,/turf/space))
 		noverlays += image(icon =icon, icon_state = "empty", layer = ABOVE_WIRE_LAYER)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -56,7 +56,7 @@
 
 /turf/simulated/open/update_icon()
 	if(below)
-		underlays = image(icon = below.icon, icon_state = below.icon_state)
+		underlays = list(image(icon = below.icon, icon_state = below.icon_state))
 
 	var/list/noverlays = list()
 	if(!istype(below,/turf/space))


### PR DESCRIPTION
* Fixes runtime due to checking `!istype(loc)` instead of `!istype(below)`
* `fall()` is no longer hardcoded to depend on open space.
* Fixes dead code in `can_fall()` after the `return TRUE`

