### PR TITLE
Make turbolift doors more robust

### DIFF
--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -8,6 +8,7 @@
 	var/move_delay = 30                                 // Time between floor changes.
 	var/floor_wait_delay = 85                           // Time to wait at floor stops.
 	var/obj/structure/lift/panel/control_panel_interior // Lift control panel.
+	var/doors_closing = 0								// Whether doors are in the process of closing
 
 	var/tmp/moving_upwards
 	var/tmp/busy
@@ -48,8 +49,18 @@
 			moving_upwards = 0
 
 	if(doors_are_open())
-		close_doors()
-		return 1
+		if(!doors_closing)
+			close_doors()
+			doors_closing = 1
+			return 1
+		else // We failed to close the doors - probably, someone is blocking them; stop trying to move
+			doors_closing = 0
+			open_doors()
+			control_panel_interior.audible_message("\The [current_floor.ext_panel] buzzes loudly.")
+			playsound(control_panel_interior.loc, "sound/machines/buzz-two.ogg", 50, 1)
+			return 0
+
+	doors_closing = 0 // The doors weren't open, so they are done closing
 
 	var/area/turbolift/origin = locate(current_floor.area_ref)
 

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -73,6 +73,7 @@
 	light_up()
 	pressed(user)
 	if(floor == lift.current_floor)
+		lift.open_doors()
 		spawn(3)
 			reset()
 		return

--- a/code/modules/turbolift/turbolift_door.dm
+++ b/code/modules/turbolift/turbolift_door.dm
@@ -22,3 +22,23 @@
 
 /obj/machinery/door/airlock/lift/allowed(mob/M)
 	return FALSE //only the lift machinery is allowed to operate this door
+
+/obj/machinery/door/airlock/lift/close(var/forced=0)
+	for(var/turf/turf in locs)
+		for(var/mob/living/LM in turf)
+			if(LM.mob_size <= MOB_TINY)
+				var/moved = 0
+				for(dir in shuffle(cardinal.Copy()))
+					var/dest = get_step(LM,dir)
+					if(!(locate(/obj/machinery/door/airlock/lift) in dest))
+						if(LM.Move(dest))
+							moved = 1
+							LM.visible_message("\The [LM] scurries away from the closing doors.")
+							break
+				if(!moved) // nowhere to go....
+					LM.gib()
+			else // the mob is too big to just move, so we need to give up what we're doing
+				audible_message("\The [src]'s motors grind as they quickly reverse direction, unable to safely close.")
+				cur_command = null // the door will just keep trying otherwise
+				return 0
+	return ..()

--- a/code/modules/turbolift/turbolift_process.dm
+++ b/code/modules/turbolift/turbolift_process.dm
@@ -23,6 +23,9 @@ var/datum/controller/process/turbolift/turbolift_controller
 			if(!lift.do_move())
 				moving_lifts[liftref] = null
 				moving_lifts -= liftref
+				if(lift.target_floor)
+					lift.target_floor.ext_panel.reset()
+					lift.target_floor = null
 			else
 				lift_is_moving(lift)
 			lift.busy = 0

--- a/html/changelogs/xales-robust-elevator.yml
+++ b/html/changelogs/xales-robust-elevator.yml
@@ -1,0 +1,6 @@
+author: Ravenxales
+
+delete-after: True
+
+changes: 
+  - bugfix: "Made turbolift doors more robust. Small mobs will be displaced, large mobs will make the lift give up and reopen."


### PR DESCRIPTION
Turbolift doors will now displace small mobs, and will refuse to function if they encounter large mobs.

Fixes #15364