### PR TITLE
stops the making of Resomi FBP

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -134,3 +134,5 @@ var/datum/robolimb/basic_robolimb
 	icon = 'icons/mob/human_races/cyberlimbs/resomi/resomi_main.dmi'
 	restricted_to = list("Resomi")
 	species_cannot_use = list()
+	applies_to_part = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT, BP_L_HAND, BP_R_HAND)
+	

--- a/html/changelogs/TGW.yml
+++ b/html/changelogs/TGW.yml
@@ -1,0 +1,4 @@
+author: TheGreyWolf
+delete-after: True
+changes: 
+  - rscadd: "Restricted Resomi prosthetics to limbs only. No more Resomi FBP."


### PR DESCRIPTION
Because people kept doing it despite 1) They did not have torso or head sprites. 2) It was abuse of mechanics as it was never intended.
In basic it makes so you can only get hands/feet/legs/arms as Resomi prosthetics, no more torso or head.