### PR TITLE
Updates a few config defaults

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -113,11 +113,11 @@ var/list/gamemode_cache = list()
 	//game_options.txt configs
 
 	var/health_threshold_softcrit = 0
-	var/health_threshold_crit = 0
+	var/health_threshold_crit = -50
 	var/health_threshold_dead = -100
 
-	var/organ_health_multiplier = 1
-	var/organ_regeneration_multiplier = 1
+	var/organ_health_multiplier = 0.9
+	var/organ_regeneration_multiplier = 0.25
 	var/organs_decay
 	var/default_brain_health = 400
 
@@ -125,8 +125,8 @@ var/list/gamemode_cache = list()
 	//so that it's similar to PAIN. Lowered it a bit since hitting paincrit takes much longer to wear off than a halloss stun.
 	var/organ_damage_spillover_multiplier = 0.5
 
-	var/bones_can_break = 0
-	var/limbs_can_break = 0
+	var/bones_can_break = 1
+	var/limbs_can_break = 1
 
 	var/revival_pod_plants = 1
 	var/revival_cloning = 1
@@ -140,8 +140,8 @@ var/list/gamemode_cache = list()
 
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
-	var/run_speed = 0
-	var/walk_speed = 0
+	var/run_speed = 2
+	var/walk_speed = 1
 
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
 	var/human_delay = 0

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -18,11 +18,11 @@ LIMBS_CAN_BREAK 1
 
 ## multiplier which enables organs to take more damage before bones breaking or limbs being destroyed
 ## 100 means normal, 50 means half
-ORGAN_HEALTH_MULTIPLIER 100
+ORGAN_HEALTH_MULTIPLIER 90
 
 ## multiplier which influences how fast organs regenerate naturally
 ## 100 means normal, 50 means half
-ORGAN_REGENERATION_MULTIPLIER 75
+ORGAN_REGENERATION_MULTIPLIER 25
 
 ### REVIVAL ###
 
@@ -46,7 +46,7 @@ REVIVAL_BRAIN_LIFE -1
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied. 
 RUN_SPEED 2
-WALK_SPEED 5
+WALK_SPEED 1
 
 
 ## The variables below affect the movement of specific mob types.


### PR DESCRIPTION
Updates a few config default values to match what is used on the server.

The reason for this is that certain systems (such as medical and wounding) are more or less balanced against and using feedback from our own server, so it makes sense that what we use there should be the default, for when people test things on their own local server.

For example, with `organ_regeneration_multiplier = 1`, the oxyloss damage taken from being in hardcrit literally cannot keep up with the natural damage autoheal.