### PR TITLE
Nerfs to ninja modules

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -361,13 +361,13 @@
 	activate_string = "Enable Power Sink"
 	deactivate_string = "Disable Power Sink"
 
-	interface_name = "niling d-sink"
+	interface_name = "nulling d-sink"
 	interface_desc = "Colloquially known as a power siphon, this module drains power through the suit hands into the suit battery."
 
 	var/atom/interfaced_with // Currently draining power from this device.
 	var/total_power_drained = 0
 	var/drain_loc
-	var/max_draining_rate = 120 KILOWATTS // The same as unupgraded cyborg recharger.
+	var/max_draining_rate = 250 KILOWATTS
 
 /obj/item/rig_module/power_sink/deactivate()
 
@@ -436,6 +436,10 @@
 	holder.spark_system.start()
 	playsound(H.loc, 'sound/effects/sparks2.ogg', 50, 1)
 
+	var/target_drained = interfaced_with.drain_power(0,0,max_draining_rate)
+	holder.cell.give(target_drained * CELLRATE)
+	total_power_drained += target_drained
+
 	if(!holder.cell)
 		to_chat(H, "<span class = 'danger'>Your power sink flashes an error; there is no cell in your rig.</span>")
 		drain_complete(H)
@@ -451,14 +455,13 @@
 		drain_complete(H)
 		return
 
-	var/target_drained = interfaced_with.drain_power(0,0,max_draining_rate)
+
 	if(target_drained <= 0)
 		to_chat(H, "<span class = 'danger'>Your power sink flashes a red light; there is no power left in [interfaced_with].</span>")
 		drain_complete(H)
 		return
 
-	holder.cell.give(target_drained * CELLRATE)
-	total_power_drained += target_drained
+
 
 	return
 


### PR DESCRIPTION
Some changes based off of: https://github.com/ErosResearchPlatform/Eros/pull/150/files

-Changes teleporter and stealth module power consumption (not to same levels as examples).
-Changes power sink charge rate from 120 KW to 250 KW.
-Reordered check on power cell when charging, so powersink actually stops when full.
-Adds processing to stealth module, giving it small visual effects based on distance moved or probability over time.
-Tweaks ninja on-death self destruct so that you can reasonably decide to get out of dodge without being too meta.
-Fixes typo of 'niling d-sink' module to 'nulling d-sink' to match uplink item description ("A nulling power sink which drains energy from electrical systems.").


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
