### PR TITLE
Adds rig procs and tweaks module damage.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -61,8 +61,10 @@
 /obj/item/rig_module/examine()
 	..()
 	switch(damage)
-		if(0 to damaged_threshold-1)
+		if(0)
 			to_chat(usr, "It is undamaged.")
+		if(1 to damaged_threshold-1)
+			to_chat(usr, "It is slightly damaged.")
 		if(damaged_threshold to destroyed_threshold-1)
 			to_chat(usr, "It is badly damaged.")
 		if(destroyed_threshold to INFINITY)
@@ -180,7 +182,7 @@
 // Proc for toggling on active abilities.
 /obj/item/rig_module/proc/activate()
 
-	if(has_damaged_use)
+	if(has_damaged_use && damage >= damaged_threshold)
 		activate_damaged()
 		return 0
 
@@ -228,7 +230,7 @@
 // Called when a disruptive action is taken.
 /obj/item/rig_module/proc/disrupted()
 	if(!disruptable)
-		return
+		return 0
 
 /obj/item/rig_module/proc/take_hit(hit_damage = 0, source = null, is_emp = 0) //can be used with things like cloak to decloak or whatnot on hit.
 	if(!hit_damage)
@@ -249,12 +251,10 @@
 
 	if(holder.wearer)
 		if(damage >= destroyed_threshold)
-			to_chat(holder.wearer, "<span class='danger'>The [source] has disabled your [interface_name]!</span>")
-			holder.wearer.visible_message("<span class='danger'>\The [interface_name] burst into a shower of sparks!</span>")
+			holder.wearer.visible_message("<span class='danger'>\The [interface_name] burst into a shower of sparks!</span>","<span class='danger'>The [source] has disabled your [interface_name]!</span>")
 			deactivate()
 		else if(damage >= damaged_threshold && initial_damage < damaged_threshold)
-			to_chat(holder.wearer, "<span class='warning'>The [source] has damaged your [interface_name]!</span>")
-			holder.wearer.visible_message("<span class='danger'>\The [interface_name] begins sparking!</span>")
+			holder.wearer.visible_message("<span class='danger'>\The [interface_name] begins sparking!</span>","<span class='danger'>The [source] has disabled your [interface_name]!</span>")
 			deactivate()
 	return
 

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -63,6 +63,8 @@
 		O.show_message("[H.name] appears from thin air!",1)
 	playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 75, 1)
 
+/obj/item/rig_module/stealth_field/disrupted()
+	deactivate()
 
 /obj/item/rig_module/teleporter
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -429,8 +429,8 @@
 	// This is largely for cancelling stealth and whatever.
 	if(mod && mod.disruptive)
 		for(var/obj/item/rig_module/module in (installed_modules - mod))
-			if(module.active && module.disruptable)
-				module.deactivate()
+			if(module.active)
+				module.disrupted()
 
 	cell.use(cost * CELLRATE)
 	return 1
@@ -745,7 +745,7 @@
 	if(cell) cell.emp_act(severity_class + 15)
 
 	//possibly damage some modules
-	take_hit((100/severity_class), "electrical pulse", 1)
+	take_hit((50/severity_class), "electrical pulse", 1)
 
 /obj/item/weapon/rig/proc/shock(mob/user)
 	if (electrocute_mob(user, cell, src)) //electrocute_mob() handles removing charge from the cell, no need to do that here.
@@ -767,38 +767,25 @@
 		//that way people designing hardsuits don't have to worry (as much) about how adding that extra module will affect emp resiliance by 'soaking' hits for other modules
 		chance = 2*max(0, damage - emp_protection)*min(installed_modules.len/15, 1)
 
-	if(!prob(chance))
-		return
 
-	//deal addition damage to already damaged module first.
-	//This way the chances of a module being disabled aren't so remote.
-	var/list/valid_modules = list()
-	var/list/damaged_modules = list()
-	for(var/obj/item/rig_module/module in installed_modules)
-		if(module.damage < 2)
-			valid_modules |= module
-			if(module.damage > 0)
-				damaged_modules |= module
-
-	var/obj/item/rig_module/dam_module = null
-	if(damaged_modules.len)
-		dam_module = pick(damaged_modules)
-	else if(valid_modules.len)
-		dam_module = pick(valid_modules)
-
-	if(!dam_module) return
-
-	dam_module.damage++
-
-	if(!source)
-		source = "hit"
-
-	if(wearer)
-		if(dam_module.damage >= 2)
-			to_chat(wearer, "<span class='danger'>The [source] has disabled your [dam_module.interface_name]!</span>")
+	for(var/obj/item/rig_module/module in installed_modules) //currently used to proc take_hit() on every module
+		var/probability = chance
+		if(chance <= 0)
+			break
+		if(module.damage >= module.destroyed_threshold)
+			continue
+		if(module.damage >= module.damaged_threshold)
+			probability *= 1.5
+		if(prob(probability))
+			if(is_emp)
+				chance -= 10
+			else
+				chance -= 50
+			damage *= 0.5
+			module.take_hit(damage, source, is_emp)
 		else
-			to_chat(wearer, "<span class='warning'>The [source] has damaged your [dam_module.interface_name]!</span>")
-	dam_module.deactivate()
+			module.take_hit(0, source, is_emp)
+
 
 /obj/item/weapon/rig/proc/malfunction_check(var/mob/living/carbon/human/user)
 	if(malfunction_delay)


### PR DESCRIPTION
- Creates procs for 'disrupted' modules, allowing disruptable modules to have additional effects when disrupted
- Changes 'take_hit' logic, passing damage onto all modules and creating a take_hit() proc for modules, allowing things to behave differently when hit (even by no damage at all).
- Gives modules health and health thresholds allowing them to not merely be 'not damaged', 'damaged', and 'unusable'.
- Affected how much damage EMPs do by giving individual modules their own health as unavoidable consequence.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
