### PR TITLE
Allow organics to have robotic organs

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -517,7 +517,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			if("Eyes")
 				organ = BP_EYES
 
-		var/list/organ_choices = list("Normal","Assisted")
+		var/list/organ_choices = list("Normal","Assisted","Synthetic")
 		if(pref.organ_data[BP_CHEST] == "cyborg")
 			organ_choices -= "Normal"
 			organ_choices += "Synthetic"

--- a/html/changelogs/wolf.yml
+++ b/html/changelogs/wolf.yml
@@ -1,0 +1,4 @@
+author: TheGreyWolf
+delete-after: True
+changes: 
+  - rscadd: "Fixed so people can once more have mechanican eyes and heart."


### PR DESCRIPTION
This fixes the bug that came with FBP so organics can once again use mechanical hearts and eyes. (Also I can't find where the bug report on this is but i'm pretty sure there was one.)

Resolves #15128