### PR TITLE
Removes Last Minute auto-antag

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -2,7 +2,7 @@ var/datum/controller/transfer_controller/transfer_controller
 
 datum/controller/transfer_controller
 	var/timerbuffer = 0 //buffer for time check
-	var/currenttick = 0
+
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
 	processing_objects += src
@@ -11,7 +11,9 @@ datum/controller/transfer_controller/Destroy()
 	processing_objects -= src
 
 datum/controller/transfer_controller/proc/process()
-	currenttick = currenttick + 1
-	if (round_duration_in_ticks >= timerbuffer - 1 MINUTE)
+	if (time_till_transfer_vote() <= 0)
 		vote.autotransfer()
-		timerbuffer = timerbuffer + config.vote_autotransfer_interval
+		timerbuffer += config.vote_autotransfer_interval
+
+datum/controller/transfer_controller/proc/time_till_transfer_vote()
+	return timerbuffer - round_duration_in_ticks - (1 MINUTE)

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -6,8 +6,19 @@
 ///process()
 ///Called by the gameticker
 /datum/game_mode/proc/process()
-	if(round_autoantag && world.time >= next_spawn && !evacuation_controller.has_evacuated())
+	if(shall_process_autoantag())
 		process_autoantag()
+
+/datum/game_mode/proc/shall_process_autoantag()
+	if(!round_autoantag || world.time < next_spawn)
+		return FALSE
+	if(evacuation_controller.is_evacuating() || evacuation_controller.has_evacuated())
+		return FALSE
+	// Don't create auto-antags in the last twenty minutes of the round, but only if the vote interval is longer than 20 minutes
+	if((config.vote_autotransfer_interval > 20 MINUTES) && (transfer_controller.time_till_transfer_vote() < 20 MINUTES))
+		return FALSE
+
+	return TRUE
 
 //This can be overriden in case a game mode needs to do stuff when a player latejoins
 /datum/game_mode/proc/handle_latejoin(var/mob/living/carbon/human/character)


### PR DESCRIPTION
Auto-antags no longer spawn near or during the end of the game.
Based on https://github.com/PolarisSS13/Polaris/pull/2914 with the following improvements:
* Doesn't prevent admins from attempting to force auto-antag processing.
* Uses config settings and the transfer controller to calculate when the (expected) last 20 minutes of the round happen, rather than make assumptions.
* Uses the evacuation controller procs to find out when an evac is in process, rather than checking flags oneself.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
