### PR TITLE
Floor decals reappear when tiling

### DIFF
--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -50,8 +50,8 @@
 		to_chat(user, "<span class='warning'>\The [src] can only be used on station flooring.</span>")
 		return
 
-	if(!F.flooring || !F.flooring.can_paint || F.broken || F.burnt)
-		to_chat(user, "<span class='warning'>\The [src] cannot paint broken or missing tiles.</span>")
+	if(!F.flooring.can_paint || F.broken || F.burnt)
+		to_chat(user, "<span class='warning'>\The [src] cannot paint broken tiles.</span>")
 		return
 
 	var/list/decal_data = decals[decal]

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -19,10 +19,11 @@ var/list/floor_decals = list()
 	if(supplied_dir) set_dir(supplied_dir)
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
+		plane = T.is_plating() ? ABOVE_PLATING_PLANE : ABOVE_TURF_PLANE
 		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[plane]-[layer]"
 		if(!floor_decals[cache_key])
 			var/image/I = image(icon = src.icon, icon_state = src.icon_state, dir = src.dir)
-			if(plane == PLATING_PLANE)
+			if(plane == ABOVE_PLATING_PLANE)
 				I.plating_decal_layerise()
 			else
 				I.turf_decal_layerise()
@@ -40,9 +41,8 @@ var/list/floor_decals = list()
 
 /obj/effect/floor_decal/reset/initialize()
 	var/turf/T = get_turf(src)
-	if(T.decals && T.decals.len)
-		T.decals.Cut()
-		T.update_icon()
+	T.remove_decals()
+	T.update_icon()
 	qdel(src)
 	return
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -44,9 +44,6 @@
 /turf/simulated/floor/proc/make_plating(var/place_product, var/defer_icon_update)
 
 	overlays.Cut()
-	if(islist(decals))
-		decals.Cut()
-		decals = null
 
 	name = base_name
 	desc = base_desc
@@ -73,6 +70,6 @@
 		O.hide(O.hides_under_flooring() && src.flooring)
 
 	if(flooring)
-		reset_plane_and_layer()
+		plane = TURF_PLANE
 	else
 		plane = PLATING_PLANE

--- a/code/game/turfs/simulated/floor_damage.dm
+++ b/code/game/turfs/simulated/floor_damage.dm
@@ -13,6 +13,7 @@
 		broken = rand(0,flooring.has_damage_range)
 	else
 		broken = 0
+	remove_decals()
 	update_icon()
 
 /turf/simulated/floor/proc/burn_tile(var/exposed_temperature)
@@ -22,4 +23,5 @@
 		burnt = rand(0,flooring.has_burn_range)
 	else
 		burnt = 0
+	remove_decals()
 	update_icon()

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -60,8 +60,14 @@ var/list/flooring_cache = list()
 						if(!(istype(T) && T.flooring && T.flooring.name == flooring.name))
 							overlays |= get_flooring_overlay("[flooring.icon_base]-corner-[SOUTHWEST]", "[flooring.icon_base]_corners", SOUTHWEST)
 
-	if(decals && decals.len)
-		overlays |= decals
+		if(decals && decals.len)
+			overlays |= decals
+
+	else if(decals && decals.len)
+		for(var/image/I in decals)
+			if(I.plane != ABOVE_PLATING_PLANE)
+				continue
+			overlays |= I
 
 	if(is_plating() && !(isnull(broken) && isnull(burnt))) //temp, todo
 		icon = 'icons/turf/flooring/plating.dmi'

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -246,3 +246,8 @@ var/const/enterloopsanity = 100
 
 /turf/proc/update_blood_overlays()
 	return
+
+/turf/proc/remove_decals()
+	if(decals && decals.len)
+		decals.Cut()
+		decals = null

--- a/html/changelogs/Hubblenaut-decals.yml
+++ b/html/changelogs/Hubblenaut-decals.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Floor painting reappears when putting on new plating."


### PR DESCRIPTION
 - Floor decal list won't get cut when untiling floor.
 - Floor decals will not render on untiled floor.

Effectively makes them reappear when putting new floor on, like it used to be before the decal changes.
I realize that they have the potential to reappear on another kind of flooring, but I believe that's preferable to having to repaint the floor every time a tile gets lifted.
If somebody might know a better solution to this, go ahead!

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
