### PR TITLE
Fixes attack messages being produced when clicking on an item with other items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -221,7 +221,6 @@
 					S.gather_all(src.loc, user)
 			else if(S.can_be_inserted(src, user))
 				S.handle_item_insertion(src)
-	return ..()
 
 /obj/item/proc/talk_into(mob/M as mob, text)
 	return


### PR DESCRIPTION
Including those produced when placing items inside backpacks and other storage containers.