### PR TITLE
Relationships view info tweaks

### DIFF
--- a/code/modules/client/preference_setup/matchmaking/matchmaking.dm
+++ b/code/modules/client/preference_setup/matchmaking/matchmaking.dm
@@ -111,7 +111,7 @@ var/global/datum/matchmaker/matchmaker = new()
 	if(other && other.finalized)
 		var/datum/data/record/R1 = find_general_record("name", holder.name)
 		var/datum/data/record/R2 = find_general_record("name", other.holder.name)
-		var/info = prob(60) ? get_desc_string() : "[holder] and [other.holder] know each other, but the exact nature of their relationship is unclear."
+		var/info = prob(60) ? get_desc_string() : "[holder.original.real_name] and [other.holder.original.real_name] know each other, but the exact nature of their relationship is unclear."
 		if(R1)
 			R1.fields["connections"] |= info
 		if(R2)
@@ -138,10 +138,10 @@ var/global/datum/matchmaker/matchmaker = new()
 			if(prob(70))
 				M.mind.known_connections += get_desc_string()
 			else
-				M.mind.known_connections += "[holder] and [other.holder] seem to know each other, but you're not sure on the details."
+				M.mind.known_connections += "[holder.original.real_name] and [other.holder.original.real_name] seem to know each other, but you're not sure on the details."
 
 /datum/relation/proc/get_desc_string()
-	return "[holder] and [other.holder] know each other."
+	return "[holder.original.real_name] and [other.holder.original.real_name] know each other."
 
 /mob/living/verb/see_relationship_info()
 	set name = "See Relationship Info"
@@ -155,7 +155,9 @@ var/global/datum/matchmaker/matchmaker = new()
 		dat += "<b>Things they all know about you:</b><br>[mind.gen_relations_info]<br>"
 		dat += "<br>"
 	for(var/datum/relation/R in relations)
-		dat += "<b>[R.other.holder]</b>"
+		var/n = R.other.holder.original ? R.other.holder.original.real_name : R.other.holder
+		var/j = R.other.holder.original ? R.other.holder.original.job : R.other.holder
+		dat += "<b>[n]</b>[j ? ", [R.other.holder.original.job]":""]."
 		if (!R.finalized)
 			dat += " <a href='?src=\ref[src];del_relation=\ref[R]'>Remove</a>"
 			editable = 1

--- a/code/modules/client/preference_setup/matchmaking/relations_types.dm
+++ b/code/modules/client/preference_setup/matchmaking/relations_types.dm
@@ -4,7 +4,7 @@
 	incompatible = list("Enemy")
 
 /datum/relation/friend/get_desc_string()
-	return "[holder] and [other.holder] seem to be on good terms."
+	return "[holder.original.real_name] and [other.holder.original.real_name] seem to be on good terms."
 
 /datum/relation/enemy
 	name = "Enemy"
@@ -12,7 +12,7 @@
 	incompatible = list("Friend")
 
 /datum/relation/enemy/get_desc_string()
-	return "[holder] and [other.holder] do not get along well."
+	return "[holder.original.real_name] and [other.holder.original.real_name] do not get along well."
 
 /datum/relation/had_crossed
 	name = "Crossed"
@@ -20,7 +20,7 @@
 	can_connect_to = list("Was Crossed")
 
 /datum/relation/had_crossed/get_desc_string()
-	return "Something has happened between [holder] and [other.holder] in the past, and [other.holder] is upset about it."
+	return "Something has happened between [holder.original.real_name] and [other.holder.original.real_name] in the past, and [other.holder.original.real_name] is upset about it."
 
 /datum/relation/was_crossed
 	name = "Was Crossed"
@@ -28,14 +28,14 @@
 	can_connect_to = list("Crossed")
 
 /datum/relation/was_crossed/get_desc_string()
-	return "Something has happened between [holder] and [other.holder] in the past, and [holder] is upset about it."
+	return "Something has happened between [holder.original.real_name] and [other.holder.original.real_name] in the past, and [holder.original.real_name] is upset about it."
 
 /datum/relation/rival
 	name = "Rival"
 	desc = "You are engaged in a constant struggle to show who's number one."
 
 /datum/relation/rival/get_desc_string()
-	return "[holder] and [other.holder] are fiercely competitive towards one another."
+	return "[holder.original.real_name] and [other.holder.original.real_name] are fiercely competitive towards one another."
 
 /datum/relation/rival/get_candidates()
 	var/list/rest = ..()
@@ -59,11 +59,11 @@
 	desc = "You used to be romantically involved, but not anymore."
 
 /datum/relation/ex/get_desc_string()
-	return "[holder] and [other.holder] used to be an item, but not anymore."
+	return "[holder.original.real_name] and [other.holder.original.real_name] used to be an item, but not anymore."
 
 /datum/relation/spessnam
 	name = "Served Together"
 	desc = "You have crossed paths while in active military service."
 
 /datum/relation/spessnam/get_desc_string()
-	return "[holder] and [other.holder] served in military together at some point in the past."
+	return "[holder.original.real_name] and [other.holder.original.real_name] served in military together at some point in the past."


### PR DESCRIPTION
Can now see job of your partner in info screen.
Shows actual cyborg name instead of thier original character name.
Less robust than using minds, but most places it's used are only called when two matches are made.
Other one (info window) has sanity checks.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
