### PR TITLE
refactor typing indicator code, fix #15596 #15601

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -236,8 +236,7 @@
 	anchored = 1
 
 /atom/movable/overlay/New()
-	for(var/x in src.verbs)
-		src.verbs -= x
+	src.verbs.Cut()
 	..()
 
 /atom/movable/overlay/Destroy()

--- a/code/modules/client/preference_setup/global/preference_datums.dm
+++ b/code/modules/client/preference_setup/global/preference_datums.dm
@@ -111,8 +111,8 @@ var/list/_client_preferences_by_type
 	disabled_description = "Hide"
 
 /datum/client_preference/show_typing_indicator/toggled(var/mob/preference_mob, var/enabled)
-	if(!enabled)
-		preference_mob.destroy_typing_indicator()
+	if(!enabled && preference_mob.typing_indicator)
+		preference_mob.typing_indicator.destroy_self()
 
 /datum/client_preference/show_ooc
 	description ="OOC chat"

--- a/code/modules/client/preference_setup/global/preference_datums.dm
+++ b/code/modules/client/preference_setup/global/preference_datums.dm
@@ -112,7 +112,7 @@ var/list/_client_preferences_by_type
 
 /datum/client_preference/show_typing_indicator/toggled(var/mob/preference_mob, var/enabled)
 	if(!enabled && preference_mob.typing_indicator)
-		preference_mob.typing_indicator.destroy_self()
+		qdel(preference_mob.typing_indicator)
 
 /datum/client_preference/show_ooc
 	description ="OOC chat"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -150,7 +150,6 @@
 /mob/proc/Life()
 //	if(organStructure)
 //		organStructure.ProcessOrgans()
-	//handle_typing_indicator() //You said the typing indicator would be fine. The test determined that was a lie.
 	return
 
 #define UNBUCKLED 0

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -11,7 +11,7 @@
 	set category = "IC"
 	
 	if(typing_indicator)
-		typing_indicator.destroy_self()
+		qdel(typing_indicator)
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)
@@ -21,7 +21,7 @@
 	message = sanitize(message)
 
 	if(typing_indicator)
-		typing_indicator.destroy_self()
+		qdel(typing_indicator)
 	if(use_me)
 		usr.emote("me",usr.emote_type,message)
 	else

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -9,8 +9,9 @@
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
-
-	destroy_typing_indicator()
+	
+	if(typing_indicator)
+		typing_indicator.destroy_self()
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)
@@ -19,7 +20,8 @@
 
 	message = sanitize(message)
 
-	destroy_typing_indicator()
+	if(typing_indicator)
+		typing_indicator.destroy_self()
 	if(use_me)
 		usr.emote("me",usr.emote_type,message)
 	else

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,43 +1,56 @@
+/*Typing indicators, when a mob uses the F3/F4 keys to bring the say/emote input boxes up this little buddy is
+made and follows them around until they are done (or something bad happens), helps tell nearby people that 'hey!
+I IS TYPIN'!'
+*/
+
+/mob
+	var/atom/movable/overlay/typing_indicator/typing_indicator = null
+
 /atom/movable/overlay/typing_indicator
 	icon = 'icons/mob/talk.dmi'
 	icon_state = "typing"
+
+/atom/movable/overlay/typing_indicator/New(var/newloc, var/mob/master)
+	..(newloc)
+	if(master.typing_indicator)
+		qdel(master.typing_indicator)
 	
-/atom/movable/overlay/typing_indicator/proc/follow_master()
-	//master is the mob that creates the indicator and calls the follow proc
-	name = master
-	invisibility = master.invisibility
-	moved_event.register(master, src, /atom/movable/proc/move_to_turf)
-	destroyed_event.register(master, src, /atom/movable/overlay/typing_indicator/proc/destroy_self)
+	master.typing_indicator = src
+	src.master = master
+	name = master.name
 	
-/atom/movable/overlay/typing_indicator/proc/destroy_self(var/mob/M)
-	M = master
-	moved_event.unregister(M, src)
-	destroyed_event.unregister(M, src)
-	if(M)
-		M.typing_indicator = null
-		M = null
+	moved_event.register(master, src, /atom/movable/proc/move_to_turf_or_null)
+	death_event.register(master, src, /atom/movable/overlay/typing_indicator/proc/qdel_self)
+	destroyed_event.register(master, src, /atom/movable/overlay/typing_indicator/proc/qdel_self)
+
+//Make this a general helper proc
+/atom/movable/overlay/typing_indicator/proc/qdel_self()
 	qdel(src)
 
-mob/var/atom/movable/overlay/typing_indicator/typing_indicator = null
-	
+/atom/movable/overlay/typing_indicator/Destroy()
+	var/mob/M = master
+	moved_event.unregister(master, src)
+	death_event.unregister(master, src)
+	destroyed_event.unregister(master, src)
+	M.typing_indicator = null
+	master = null
+	..()
+
 /mob/proc/create_typing_indicator()
-	if(client && !stat && is_preference_enabled(/datum/client_preference/show_typing_indicator))
-		if(!typing_indicator)
-			typing_indicator = new(loc)
-			typing_indicator.master = usr
-		typing_indicator.follow_master()
-	else 
-		if(typing_indicator)
-			typing_indicator.destroy_self()
-		
+	var/turf/T = get_turf(src)
+	if(client && !stat && T && is_preference_enabled(/datum/client_preference/show_typing_indicator))
+		new/atom/movable/overlay/typing_indicator(T, src)
+
+/mob/proc/remove_typing_indicator() // A bit excessive, but goes with the creation of the indicator I suppose
+	qdel_null(typing_indicator)
+
 /mob/verb/say_wrapper()
 	set name = ".Say"
 	set hidden = 1
-	
+
 	create_typing_indicator()
 	var/message = input("","say (text)") as text
-	if(typing_indicator)
-		typing_indicator.destroy_self()
+	remove_typing_indicator()
 	if(message)
 		say_verb(message)
 
@@ -47,17 +60,11 @@ mob/var/atom/movable/overlay/typing_indicator/typing_indicator = null
 
 	create_typing_indicator()
 	var/message = input("","me (text)") as text
-	if(typing_indicator)
-		typing_indicator.destroy_self()
+	remove_typing_indicator()
 	if(message)
 		me_verb(message)
 
+// Make this an event
 /mob/Logout()
 	..()
-	if(typing_indicator)
-		typing_indicator.destroy_self()
-	
-/mob/death()
-	..()
-	if(typing_indicator)
-		typing_indicator.destroy_self()
+	qdel_null(typing_indicator)


### PR DESCRIPTION
Fixes the code to something it maybe, kinda, possibly, potentially, should've been more like.
Also fixes #15596 and #15601 , I have no rightly idea about #15600, if it is related to typing indicators it was likely fixed as well, could not replicate on tests.

Cleaned up a leftover commented out proc as well.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
