### PR TITLE
Small Xenoarch changes

### DIFF
--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -10,6 +10,7 @@
 	var/datum/geosample/geological_data
 	var/datum/artifact_find/artifact_find
 	var/last_act = 0
+	var/delay = 10 //Spam protection
 
 /obj/structure/boulder/New()
 	..()
@@ -76,6 +77,47 @@
 			else
 				user.visible_message("<span class='warning'>\The [src] suddenly crumbles away.</span>", "<span class='notice'>\The [src] has been whittled away under your careful excavation, but there was nothing of interest inside.</span>")
 			qdel(src)
+
+	if(istype(I, /obj/item/weapon/wrench))
+		if(last_act + delay > world.time)
+			return
+		last_act = world.time
+		
+		if(!anchored)
+			to_chat(user, "<span class='notice'>The [src] is already dislodged.</span>")
+			return
+	
+		else
+			playsound(src, 'sound/weapons/Genhit.ogg', 75, 1)
+			to_chat(user, "You slowly chip the [src] loose...")
+			
+			if(do_after(user, 120,src)) //Why a wrench? Because Xenoarchs have enough junk to lug around.
+				if(!src) return
+				to_chat(user, "<span class='notice'>You've broken the [src] free!</span>")
+				playsound(src, 'sound/weapons/Genhit.ogg', 75, 1)
+				anchored = !anchored
+			return
+
+
+	if(istype(I, /obj/item/weapon/crowbar))
+		if(last_act + delay > world.time)
+			return
+		last_act = world.time
+		
+		if(!anchored)
+			to_chat(user, "<span class='notice'>The [src] is already dislodged.</span>")
+			return
+			
+		else
+			playsound(src, 'sound/items/Crowbar.ogg', 75, 1)
+			to_chat(user, "You begin to pry the [src] loose...")
+			
+			if(do_after(user, 40,src)) //Much faster than a wrench, obviously.
+				if(!src) return
+				to_chat(user, "<span class='notice'>You've broken the [src] free!</span>")
+				playsound(src, 'sound/weapons/Genhit.ogg', 75, 1)
+				anchored = !anchored
+			return
 
 /obj/structure/boulder/Bumped(AM)
 	. = ..()

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -84,7 +84,7 @@
 		last_act = world.time
 		
 		if(!anchored)
-			to_chat(user, "<span class='notice'>The [src] is already dislodged.</span>")
+			to_chat(user, "<span class='notice'>\The [src] is already dislodged.</span>")
 			return
 	
 		else
@@ -92,8 +92,7 @@
 			to_chat(user, "You slowly chip the [src] loose...")
 			
 			if(do_after(user, 120,src)) //Why a wrench? Because Xenoarchs have enough junk to lug around.
-				if(!src) return
-				to_chat(user, "<span class='notice'>You've broken the [src] free!</span>")
+				to_chat(user, "<span class='notice'>You've broken \the [src] free.</span>")
 				playsound(src, 'sound/weapons/Genhit.ogg', 75, 1)
 				anchored = !anchored
 			return
@@ -105,16 +104,15 @@
 		last_act = world.time
 		
 		if(!anchored)
-			to_chat(user, "<span class='notice'>The [src] is already dislodged.</span>")
+			to_chat(user, "<span class='notice'>\The [src] is already dislodged.</span>")
 			return
 			
 		else
 			playsound(src, 'sound/items/Crowbar.ogg', 75, 1)
-			to_chat(user, "You begin to pry the [src] loose...")
+			to_chat(user, "You begin to pry \the [src] loose...")
 			
 			if(do_after(user, 40,src)) //Much faster than a wrench, obviously.
-				if(!src) return
-				to_chat(user, "<span class='notice'>You've broken the [src] free!</span>")
+				to_chat(user, "<span class='notice'>You've broken \the [src] free.</span>")
 				playsound(src, 'sound/weapons/Genhit.ogg', 75, 1)
 				anchored = !anchored
 			return

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -32,6 +32,7 @@
 	desc = "Can hold various excavation gear."
 	icon_state = "gearbelt"
 	item_state = "utility"
+	max_w_class = ITEM_SIZE_HUGE
 	can_hold = list(
 		/obj/item/weapon/storage/box/samplebags,
 		/obj/item/device/core_sampler,
@@ -52,6 +53,7 @@
 		/obj/item/weapon/anodevice,
 		/obj/item/clothing/glasses,
 		/obj/item/weapon/wrench,
+		/obj/item/weapon/crowbar,
 		/obj/item/weapon/storage/excavation,
 		/obj/item/weapon/anobattery,
 		/obj/item/device/ano_scanner,

--- a/html/changelogs/ZXeno.yml
+++ b/html/changelogs/ZXeno.yml
@@ -1,0 +1,36 @@
+
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: ZCaliber
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Rocky debris can now be dislodged. Use a crowbar or a wrench."
+  - bugfix: "Excavation belt can now hold pickaxes/drills."


### PR DESCRIPTION
- Rocky debris can now be moved. 

 Why is this important? When things switch over to the Torch, if this was not put in, you would be dragging potentially atmospheric activated anomalies into the shuttle. Exodus doesn't have this issue (Much.) since it has an on-site facility. Now you will have the option of unearthing the artifact in a controlled environment.

- Excavation belt now can hold drills and pickaxes (Bugfix, believe it or not.)
// Increased slots to 14. (Two rows should hold everything a Xenoarch needs. Was originally 10, but meant having weird empty spaces...)
- Can now hold a crowbar. (The far better tool for dislodging debris.)