### PR TITLE
Normalizes all multi-antag gamemode player requirements

### DIFF
--- a/code/game/gamemodes/mixed/paranoia.dm
+++ b/code/game/gamemodes/mixed/paranoia.dm
@@ -3,7 +3,7 @@
 	round_description = "The AI has malfunctioned, and subversive elements infest the crew..."
 	extended_round_description = "Rampant AIs, renegades and changelings spawn in this mode."
 	config_tag = "paranoia"
-	required_players = 2
+	required_players = 15
 	required_enemies = 1
 	end_on_antag_death = 0
 	antag_tags = list(MODE_MALFUNCTION, MODE_RENEGADE, MODE_CHANGELING)

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -3,7 +3,7 @@
 	round_description = "There are traitors and alien changelings on the station. Do not let the changelings succeed!"
 	extended_round_description = "Traitors and changelings both spawn during this mode."
 	config_tag = "traitorling"
-	required_players = 10
+	required_players = 15
 	required_enemies = 5
 	end_on_antag_death = 0
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)

--- a/code/game/gamemodes/mixed/visitors.dm
+++ b/code/game/gamemodes/mixed/visitors.dm
@@ -3,7 +3,7 @@
 	round_description = "A space wizard and a ninja have invaded the station!"
 	extended_round_description = "A ninja and wizard spawn during this round."
 	config_tag = "visitors"
-	required_players = 10
+	required_players = 15
 	required_enemies = 2
 	end_on_antag_death = 0
 	antag_tags = list(MODE_WIZARD, MODE_NINJA)


### PR DESCRIPTION
- Ninja+Wizard and Traitor+Changeling  minimal players 10->15
- Changeling+Malf+Renegade minimal players 2->15

This should hopefully reserve these modes for high-pop, where there is enough population to ensure the combined antagonists have certain level of balance. As for Changeling+Malf+Renegade, i feel this one was actually a bug, as having three antag types with only two players simply doesn't work out.

Fixes #15369