### PR TITLE
Engines stuff

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -11,6 +11,7 @@
 
 /obj/machinery/computer/helm/initialize()
 	..()
+	linked = map_sectors["[z]"]
 	get_known_sectors()
 
 /obj/machinery/computer/helm/proc/get_known_sectors()

--- a/code/modules/overmap/ships/engines/engine.dm
+++ b/code/modules/overmap/ships/engines/engine.dm
@@ -3,61 +3,47 @@
 var/list/ship_engines = list()
 /datum/ship_engine
 	var/name = "ship engine"
-	var/obj/machinery/engine	//actual engine object
-	var/zlevel = 0
+	var/obj/machinery/holder	//actual engine object
 
-/datum/ship_engine/New(var/obj/machinery/holder)
+/datum/ship_engine/New(var/obj/machinery/_holder)
 	..()
-	engine = holder
-	zlevel = holder.z
+	holder = _holder
 	ship_engines += src
-	for(var/obj/machinery/computer/engines/E in machines)
-		if (zlevel in E.zlevels)
-			E.engines |= src
-			break
+	var/obj/effect/overmap/ship/S = map_sectors["[holder.z]"]
+	if(istype(S))
+		S.engines |= src
 
-//Tries to fire the engine. If successfull, returns 1
+/datum/ship_engine/proc/can_burn()
+	return 0
+
+//Tries to fire the engine. Returns thrust
 /datum/ship_engine/proc/burn()
-	if(!engine)
-		die()
-	return 1
+	return 0
 
 //Returns status string for this engine
 /datum/ship_engine/proc/get_status()
-	if(!engine)
-		die()
 	return "All systems nominal"
 
 /datum/ship_engine/proc/get_thrust()
-	if(!engine)
-		die()
-	return 100
+	return 1
 
 //Sets thrust limiter, a number between 0 and 1
 /datum/ship_engine/proc/set_thrust_limit(var/new_limit)
-	if(!engine)
-		die()
 	return 1
 
 /datum/ship_engine/proc/get_thrust_limit()
-	if(!engine)
-		die()
 	return 1
 
 /datum/ship_engine/proc/is_on()
-	if(!engine)
-		die()
 	return 1
 
 /datum/ship_engine/proc/toggle()
-	if(!engine)
-		die()
 	return 1
 
-/datum/ship_engine/proc/die()
+/datum/ship_engine/Destroy()
+	..()
 	ship_engines -= src
-	for(var/obj/machinery/computer/engines/E in machines)
-		if (E.z == zlevel)
-			E.engines -= src
-			break
-	qdel(src)
+	var/obj/effect/overmap/ship/S = map_sectors["[holder.z]"]
+	if(istype(S))
+		S.engines -= src
+	holder = null

--- a/code/modules/overmap/ships/engines/thermal.dm
+++ b/code/modules/overmap/ships/engines/thermal.dm
@@ -1,44 +1,39 @@
 //Thermal nozzle engine
 /datum/ship_engine/thermal
 	name = "thermal engine"
+	var/obj/machinery/atmospherics/unary/engine/nozzle
+
+/datum/ship_engine/thermal/New(var/obj/machinery/_holder)
+	..()
+	nozzle = _holder
+
+/datum/ship_engine/thermal/Destroy()
+	..()
+	nozzle = null
 
 /datum/ship_engine/thermal/get_status()
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	return "Fuel pressure: [E.air_contents.return_pressure()]"
+	return nozzle.get_status()
 
 /datum/ship_engine/thermal/get_thrust()
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	if(!is_on())
-		return 0
-	var/pressurized_coef = E.air_contents.return_pressure()/E.effective_pressure
-	return round(E.thrust_limit * E.nominal_thrust * pressurized_coef)
+	return nozzle.get_thrust()
 
 /datum/ship_engine/thermal/burn()
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	return E.burn()
+	return nozzle.burn()
 
 /datum/ship_engine/thermal/set_thrust_limit(var/new_limit)
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	E.thrust_limit = new_limit
+	nozzle.thrust_limit = new_limit
 
 /datum/ship_engine/thermal/get_thrust_limit()
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	return E.thrust_limit
+	return nozzle.thrust_limit
 
 /datum/ship_engine/thermal/is_on()
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	return E.on
+	return nozzle.is_on()
 
 /datum/ship_engine/thermal/toggle()
-	..()
-	var/obj/machinery/atmospherics/unary/engine/E = engine
-	E.on = !E.on
+	nozzle.on = !nozzle.on
+
+/datum/ship_engine/thermal/can_burn()
+	return nozzle.is_on() && nozzle.check_fuel()
 
 //Actual thermal nozzle engine object
 
@@ -47,11 +42,15 @@
 	desc = "Simple thermal nozzle, uses heated gast to propell the ship."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle"
+	use_power = 0
+	idle_power_usage = 150		//internal circuitry, friction losses and stuff
+	power_rating = 7500			//7500 W ~ 10 HP
+	opacity = 1
+	density = 1
 	var/on = 1
-	var/thrust_limit = 1	//Value between 1 and 0 to limit the resulting thrust
-	var/nominal_thrust = 3000
-	var/effective_pressure = 3000
 	var/datum/ship_engine/thermal/controller
+	var/thrust_limit = 1	//Value between 1 and 0 to limit the resulting thrust
+	var/moles_per_burn = 10
 
 /obj/machinery/atmospherics/unary/engine/initialize()
 	..()
@@ -59,41 +58,66 @@
 
 /obj/machinery/atmospherics/unary/engine/Destroy()
 	..()
-	controller.die()
+	qdel_null(controller)
+
+/obj/machinery/atmospherics/unary/engine/proc/get_status()
+	. = list()
+	if(!powered())
+		.+= "Insufficient power to operate."
+	if(!check_fuel())
+		.+= "Insufficient fuel for a burn."
+
+	.+= "Propellant total mass: [round(air_contents.get_mass(),0.01)] kg."
+	.+= "Propellant used per burn: [round(air_contents.specific_mass() * moles_per_burn * thrust_limit,0.01)] kg."
+	.+= "Propellant pressure: [round(air_contents.return_pressure()/1000,0.1)] MPa."
+	. = jointext(.,"<br>")
+
+/obj/machinery/atmospherics/unary/engine/proc/is_on()
+	return on && powered()
+
+/obj/machinery/atmospherics/unary/engine/proc/check_fuel()
+	return air_contents.total_moles > moles_per_burn
+
+/obj/machinery/atmospherics/unary/engine/proc/get_thrust()
+	if(!is_on() || !check_fuel())
+		return 0
+	var/used_part = moles_per_burn/air_contents.get_total_moles() * thrust_limit
+	. = calculate_thrust(air_contents, used_part)
+	return
 
 /obj/machinery/atmospherics/unary/engine/proc/burn()
-	if (!on)
-		return
-	if(air_contents.temperature > 0)
-		var/transfer_moles = 100  * air_contents.volume/max(air_contents.temperature * R_IDEAL_GAS_EQUATION, 0,01)
-		transfer_moles = round(thrust_limit * transfer_moles, 0.01)
-		if(transfer_moles > air_contents.total_moles)
-			on = !on
-			return 0
+	if (!is_on())
+		return 0
+	if(!check_fuel())
+		audible_message(src,"<span class='warning'>[src] coughs once and goes silent!</span>")
+		on = !on
+		return 0
+	var/exhaust_dir = reverse_direction(dir)
+	var/datum/gas_mixture/removed = air_contents.remove(moles_per_burn * thrust_limit)
+	. = calculate_thrust(removed)
+	var/turf/T = get_step(src,exhaust_dir)
+	if(T)
+		T.assume_air(removed)
+		new/obj/effect/engine_exhaust(T,exhaust_dir,air_contents.temperature)
 
-		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
-
-		loc.assume_air(removed)
-		if(air_contents.temperature > PHORON_MINIMUM_BURN_TEMPERATURE)
-			var/exhaust_dir = reverse_direction(dir)
-			var/turf/T = get_step(src,exhaust_dir)
-			if(T)
-				new/obj/effect/engine_exhaust(T,exhaust_dir,air_contents.temperature)
-		return 1
+/obj/machinery/atmospherics/unary/engine/proc/calculate_thrust(datum/gas_mixture/propellant, used_part = 1)
+	return round(sqrt(propellant.get_mass() * used_part * air_contents.return_pressure()/100),0.1)
 
 //Exhaust effect
 /obj/effect/engine_exhaust
 	name = "engine exhaust"
 	icon = 'icons/effects/effects.dmi'
-	icon_state = "exhaust"
+	icon_state = "smoke"
+	light_color = "#ED9200"
 	anchored = 1
 
-	New(var/turf/nloc, var/ndir, var/temp)
-		set_dir(ndir)
-		..(nloc)
-
-		if(nloc)
-			nloc.hotspot_expose(temp,125)
-
-		spawn(20)
-			loc = null
+/obj/effect/engine_exhaust/New(var/turf/nloc, var/ndir, var/temp)
+	..(nloc)
+	if(temp > PHORON_MINIMUM_BURN_TEMPERATURE)
+		icon_state = "exhaust"
+		set_light(5, 2)
+	set_dir(ndir)
+	nloc.hotspot_expose(temp,125)
+	playsound(loc, 'sound/effects/spray.ogg', 50, 1, -1)
+	spawn(20)
+		qdel(src)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -2,24 +2,24 @@
 	name = "generic ship"
 	desc = "Space faring vessel."
 	icon_state = "ship"
-	var/vessel_mass = 9000 				//tonnes, arbitrary number, affects acceleration provided by engines
-	var/default_delay = 6 				//deciseconds it takes to move to next tile on overmap
+	var/vessel_mass = 100 				//tonnes, arbitrary number, affects acceleration provided by engines
+	var/default_delay = 6 SECONDS 		//time it takes to move to next tile on overmap
 	var/list/speed = list(0,0)			//speed in x,y direction
 	var/last_burn = 0					//worldtime when ship last acceleated
 	var/list/last_movement = list(0,0)	//worldtime when ship last moved in x,y direction
 	var/fore_dir = NORTH				//what dir ship flies towards for purpose of moving stars effect procs
 
 	var/obj/machinery/computer/helm/nav_control
-	var/obj/machinery/computer/engines/eng_control
+	var/list/engines = list()
 
 /obj/effect/overmap/ship/initialize()
 	..()
+	for(var/datum/ship_engine/E in ship_engines)
+		if (E.holder.z in map_z)
+			engines |= E
 	for(var/obj/machinery/computer/engines/E in machines)
 		if (E.z in map_z)
-			eng_control = E
 			E.linked = src
-			E.zlevels = map_z
-			E.refresh_engines()
 			testing("Engines console at level [E.z] linked to overmap object '[name]'.")
 	for(var/obj/machinery/computer/helm/H in machines)
 		if (H.z in map_z)
@@ -35,8 +35,13 @@
 /obj/effect/overmap/ship/proc/is_still()
 	return !(speed[1] || speed[2])
 
+//Projected acceleration based on information from engines
 /obj/effect/overmap/ship/proc/get_acceleration()
-	return round(eng_control.get_total_thrust()/vessel_mass, 0.1)
+	return round(get_total_thrust()/vessel_mass, 0.1)
+
+//Does actual burn and returns the resulting acceleration
+/obj/effect/overmap/ship/proc/get_burn_acceleration()
+	return round(burn() / vessel_mass, 0.1)
 
 /obj/effect/overmap/ship/proc/get_speed()
 	return round(sqrt(speed[1]*speed[1] + speed[2]*speed[2]), 0.1)
@@ -65,15 +70,6 @@
 			toggle_move_stars(zz, fore_dir)
 	update_icon()
 
-/obj/effect/overmap/ship/proc/can_burn()
-	if (!eng_control)
-		return 0
-	if (world.time < last_burn + 10)
-		return 0
-	if (!eng_control.burn())
-		return 0
-	return 1
-
 /obj/effect/overmap/ship/proc/get_brake_path()
 	if(!get_acceleration())
 		return INFINITY
@@ -82,9 +78,9 @@
 /obj/effect/overmap/ship/proc/decelerate()
 	if(!is_still() && can_burn())
 		if (speed[1])
-			adjust_speed(-SIGN(speed[1]) * min(get_acceleration(),abs(speed[1])), 0)
+			adjust_speed(-SIGN(speed[1]) * min(get_burn_acceleration(),abs(speed[1])), 0)
 		if (speed[2])
-			adjust_speed(0, -SIGN(speed[2]) * min(get_acceleration(),abs(speed[2])))
+			adjust_speed(0, -SIGN(speed[2]) * min(get_burn_acceleration(),abs(speed[2])))
 		last_burn = world.time
 
 /obj/effect/overmap/ship/proc/accelerate(direction)
@@ -92,14 +88,13 @@
 		last_burn = world.time
 
 		if(direction & EAST)
-			adjust_speed(get_acceleration(), 0)
+			adjust_speed(get_burn_acceleration(), 0)
 		if(direction & WEST)
-			adjust_speed(-get_acceleration(), 0)
+			adjust_speed(-get_burn_acceleration(), 0)
 		if(direction & NORTH)
-			adjust_speed(0, get_acceleration())
+			adjust_speed(0, get_burn_acceleration())
 		if(direction & SOUTH)
-			adjust_speed(0, -get_acceleration())
-
+			adjust_speed(0, -get_burn_acceleration())
 
 /obj/effect/overmap/ship/process()
 	if(!is_still())
@@ -119,3 +114,17 @@
 		dir = get_heading()
 	else
 		icon_state = "ship"
+
+/obj/effect/overmap/ship/proc/burn()
+	for(var/datum/ship_engine/E in engines)
+		. += E.burn()
+
+/obj/effect/overmap/ship/proc/get_total_thrust()
+	for(var/datum/ship_engine/E in engines)
+		. += E.get_thrust()
+
+/obj/effect/overmap/ship/proc/can_burn()
+	if (world.time < last_burn + 10)
+		return 0
+	for(var/datum/ship_engine/E in engines)
+		. |= E.can_burn()

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -444,7 +444,6 @@
 /datum/gas_mixture/proc/share_space(datum/gas_mixture/unsim_air)
 	return share_ratio(unsim_air, unsim_air.group_multiplier, max(1, max(group_multiplier + 3, 1) + unsim_air.group_multiplier), one_way = 1)
 
-
 //Equalizes a list of gas mixtures.  Used for pipe networks.
 /proc/equalize_gases(datum/gas_mixture/list/gases)
 	//Calculate totals from individual components
@@ -484,3 +483,10 @@
 			gasmix.multiply(gasmix.volume)
 
 	return 1
+
+/datum/gas_mixture/proc/get_mass()
+	for(var/g in gas)
+		. += gas[g] * gas_data.molar_mass[g] * group_multiplier
+
+/datum/gas_mixture/proc/specific_mass()
+	. = get_mass()/get_total_moles()


### PR DESCRIPTION
Moves a lot of logic from engine interface datum into machinery object
Moves a lot of logic from engine control console into the ship object
can_burn() doesn't do actual burn now, so no fuel going poof.
burn() now returns actual thrust of the burn, get_thrust() estimates it.
Removed a lot of paranoid sanity from engine datum. Let us beieve in Destroy()

Changed thrust calculations. It is no longer just pressure, but sqrt(mass * pressure / 100). Different gasses give different thrust, worst being nitrogen, best being plasma.

I think that'll do for now, numbers and shit will need to be tweaked once engines are mapped in, since only hard limit is mapping space really.