### PR TITLE
Slashy sewy

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -34,17 +34,16 @@
 #define ORGAN_CUT_AWAY   (1<<0)
 #define ORGAN_BLEEDING   (1<<1)
 #define ORGAN_BROKEN     (1<<2)
-#define ORGAN_DESTROYED  (1<<3)
-#define ORGAN_DEAD       (1<<4)
-#define ORGAN_MUTATED    (1<<5)
+#define ORGAN_DEAD       (1<<3)
+#define ORGAN_MUTATED    (1<<4)
 
 #define DROPLIMB_EDGE 0
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
 
-// These control the amount of blood lost from burns. The loss is calculated so 
+// These control the amount of blood lost from burns. The loss is calculated so
 // that dealing just enough burn damage to kill the player will cause the given
-// proportion of their max blood volume to be lost 
+// proportion of their max blood volume to be lost
 // (e.g. 0.6 == 60% lost if 200 burn damage is taken).
 #define FLUIDLOSS_WIDE_BURN 0.6 //for burns from heat applied over a wider area, like from fire
 #define FLUIDLOSS_CONC_BURN 0.4 //for concentrated burns, like from lasers

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/tape_roll
-	name = "tape roll"
+	name = "duct tape"
 	desc = "A roll of sticky tape. Possibly for taping ducks... or was that ducts?"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "taperoll"
@@ -76,7 +76,7 @@
 	user.put_in_hands(tape)
 
 /obj/item/weapon/ducttape
-	name = "tape"
+	name = "piece of tape"
 	desc = "A piece of sticky tape."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "tape"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -931,7 +931,7 @@
 			if(ishuman(wearer.buckled))
 				var/obj/item/organ/external/l_hand = wearer.get_organ(BP_L_HAND)
 				var/obj/item/organ/external/r_hand = wearer.get_organ(BP_R_HAND)
-				if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
+				if((!l_hand || !l_hand.is_usable()) && (!r_hand || !r_hand.is_usable()))
 					return // No hands to drive your chair? Tough luck!
 			wearer_move_delay += 2
 			return wearer.buckled.relaymove(wearer,direction)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -280,8 +280,9 @@
 			else
 				if(!is_synth && E.robotic >= ORGAN_ROBOT && (E.parent && E.parent.robotic < ORGAN_ROBOT))
 					wound_flavor_text["[E.name]"] = "[T.He] [T.has] a [E.name].\n"
-				if(E.wounds.len || E.open || E.status)
-					wound_flavor_text["[E.name]"] += "[T.He] [T.has] [E.get_wounds_desc()] on [T.his] [E.name].<br>"
+				var/wounddesc = E.get_wounds_desc()
+				if(wounddesc != "nothing")
+					wound_flavor_text["[E.name]"] += "[T.He] [T.has] [wounddesc] on [T.his] [E.name].<br>"
 
 		if(!hidden || distance <=1)
 			if(E.dislocated > 0)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -280,7 +280,7 @@
 			else
 				if(!is_synth && E.robotic >= ORGAN_ROBOT && (E.parent && E.parent.robotic < ORGAN_ROBOT))
 					wound_flavor_text["[E.name]"] = "[T.He] [T.has] a [E.name].\n"
-				if(E.wounds.len || E.open)
+				if(E.wounds.len || E.open || E.status)
 					wound_flavor_text["[E.name]"] += "[T.He] [T.has] [E.get_wounds_desc()] on [T.his] [E.name].<br>"
 
 		if(!hidden || distance <=1)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -641,7 +641,7 @@
 /mob/living/carbon/human/eyecheck()
 	if(internal_organs_by_name[BP_EYES]) // Eyes are fucked, not a 'weak point'.
 		var/obj/item/organ/I = internal_organs_by_name[BP_EYES]
-		if(I.status & ORGAN_CUT_AWAY)
+		if(!I.is_usable())
 			return FLASH_PROTECTION_MAJOR
 	else // They can't be flashed if they don't have eyes.
 		return FLASH_PROTECTION_MAJOR
@@ -1310,7 +1310,7 @@
 /mob/living/carbon/human/has_eyes()
 	if(internal_organs_by_name[BP_EYES])
 		var/obj/item/organ/internal/eyes = internal_organs_by_name[BP_EYES]
-		if(eyes && istype(eyes) && !(eyes.status & ORGAN_CUT_AWAY))
+		if(eyes && eyes.is_usable())
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -157,7 +157,7 @@
 		eye_blind =  0
 		blinded =    0
 		eye_blurry = 0
-	else if(!vision || (vision && vision.is_broken()))   // Vision organs cut out or broken? Permablind.
+	else if(!vision || (vision && !vision.is_usable()))   // Vision organs cut out or broken? Permablind.
 		eye_blind =  1
 		blinded =    1
 		eye_blurry = 1

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -108,7 +108,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	// Replace completely missing limbs.
 	for(var/limb_type in has_limbs)
 		var/obj/item/organ/external/E = H.organs_by_name[limb_type]
-		if(E && (E.is_stump() || (E.status & (ORGAN_DESTROYED|ORGAN_DEAD|ORGAN_MUTATED))))
+		if(E && !E.is_usable())
 			E.removed()
 			qdel(E)
 			E = null

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -30,7 +30,7 @@
 		if(!I)
 			to_chat(src, "<span class='danger'>Your [needs_organ] has been removed!</span>")
 			return
-		else if((I.status & ORGAN_CUT_AWAY) || I.is_broken())
+		else if(!I.is_usable() || I.is_broken())
 			to_chat(src, "<span class='danger'>Your [needs_organ] is too damaged to function!</span>")
 			return
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -30,7 +30,7 @@
 		if(!I)
 			to_chat(src, "<span class='danger'>Your [needs_organ] has been removed!</span>")
 			return
-		else if(!I.is_usable() || I.is_broken())
+		else if(!I.is_usable())
 			to_chat(src, "<span class='danger'>Your [needs_organ] is too damaged to function!</span>")
 			return
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -374,3 +374,6 @@ var/list/organ_cache = list()
 
 /obj/item/organ/proc/can_feel_pain()
 	return (robotic < ORGAN_ROBOT && (!species || !(species.flags & NO_PAIN)))
+
+/obj/item/organ/proc/is_usable()
+	return !(status & (ORGAN_CUT_AWAY|ORGAN_MUTATED|ORGAN_DEAD))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -450,7 +450,7 @@ This function completely restores a damaged organ to perfect condition.
 /obj/item/organ/external/proc/need_process()
 	if(get_pain())
 		return 1
-	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_DEAD|ORGAN_MUTATED))
+	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DEAD|ORGAN_MUTATED))
 		return 1
 	if((brute_dam || burn_dam) && (robotic < ORGAN_ROBOT)) //Robot limbs don't autoheal and thus don't need to process when damaged
 		return 1
@@ -1007,8 +1007,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 			return 1
 	return 0
 
-/obj/item/organ/external/proc/is_usable()
-	return (!can_feel_pain() || pain < pain_disability_threshold) && !(status & (ORGAN_MUTATED|ORGAN_DEAD))
+/obj/item/organ/external/is_usable()
+	return ..() && (!can_feel_pain() || pain < pain_disability_threshold)
 
 /obj/item/organ/external/proc/is_malfunctioning()
 	return ((robotic >= ORGAN_ROBOT) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
@@ -1142,7 +1142,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return english_list(descriptors)
 
 	var/list/flavor_text = list()
-	if((status & ORGAN_DESTROYED) && !is_stump())
+	if((status & ORGAN_CUT_AWAY) && !is_stump() && !(parent && parent.status & ORGAN_CUT_AWAY))
 		flavor_text += "a tear at the [amputation_point] so severe that it hangs by a scrap of flesh"
 
 	var/list/wound_descriptors = list()

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -33,6 +33,9 @@
 		if(istype(E)) E.internal_organs -= src
 	..()
 
+/obj/item/organ/internal/is_usable()
+	return ..() && !is_broken()
+
 // Brain is defined in brain_item.dm.
 /obj/item/organ/internal/kidneys
 	name = "kidneys"

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -13,7 +13,7 @@
 /datum/surgery_step/glue_bone
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/tape_roll = 75
 	)
 	can_infect = 1
 	blood_level = 1
@@ -29,16 +29,18 @@
 
 /datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
 	if (affected.stage == 0)
-		user.visible_message("[user] starts applying medication to the damaged bones in [target]'s [affected.name] with \the [tool]." , \
-		"You start applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].")
+		user.visible_message("[user] starts applying \the [tool] to the [bone]." , \
+		"You start applying \the [tool] to the [bone].")
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",50, affecting = affected)
 	..()
 
 /datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("<span class='notice'>[user] applies some [tool] to [target]'s bone in [affected.name]</span>", \
-		"<span class='notice'>You apply some [tool] to [target]'s bone in [affected.name] with \the [tool].</span>")
+	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
+	user.visible_message("<span class='notice'>[user] applies some [tool.name] to [bone]</span>", \
+		"<span class='notice'>You apply some [tool.name] to [bone].</span>")
 	affected.stage = 1
 
 /datum/surgery_step/glue_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -67,26 +69,28 @@
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] is beginning to set the bone in [target]'s [affected.name] in place with \the [tool]." , \
-		"You are beginning to set the bone in [target]'s [affected.name] in place with \the [tool].")
+	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
+	user.visible_message("[user] is beginning to set the [bone] in place with \the [tool]." , \
+		"You are beginning to set the [bone] in place with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",50, affecting = affected)
 	..()
 
 /datum/surgery_step/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
 	if (affected.status & ORGAN_BROKEN)
-		user.visible_message("<span class='notice'>[user] sets the bone in [target]'s [affected.name] in place with \the [tool].</span>", \
-			"<span class='notice'>You set the bone in [target]'s [affected.name] in place with \the [tool].</span>")
+		user.visible_message("<span class='notice'>[user] sets the [bone] n place with \the [tool].</span>", \
+			"<span class='notice'>You set the [bone] in place with \the [tool].</span>")
 		affected.stage = 2
 	else
-		user.visible_message("<span class='notice'>[user] sets the bone in [target]'s [affected.name]</span> <span class='warning'>in the WRONG place with \the [tool].</span>", \
-			"<span class='notice'>You set the bone in [target]'s [affected.name]</span> <span class='warning'>in the WRONG place with \the [tool].</span>")
+		user.visible_message("<span class='notice'>[user] sets the [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>", \
+			"<span class='notice'>You set the [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>")
 		affected.fracture()
 
 /datum/surgery_step/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("<span class='warning'>[user]'s hand slips, damaging the bone in [target]'s [affected.name] with \the [tool]!</span>" , \
-		"<span class='warning'>Your hand slips, damaging the bone in [target]'s [affected.name] with \the [tool]!</span>")
+	user.visible_message("<span class='warning'>[user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in [target]'s [affected.name] with \the [tool]!</span>" , \
+		"<span class='warning'>Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in [target]'s [affected.name] with \the [tool]!</span>")
 	affected.createwound(BRUISE, 5)
 
 
@@ -133,7 +137,7 @@
 /datum/surgery_step/finish_bone
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/tape_roll = 75
 	)
 	can_infect = 1
 	blood_level = 1
@@ -149,14 +153,16 @@
 
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts to finish mending the damaged bones in [target]'s [affected.name] with \the [tool].", \
-	"You start to finish mending the damaged bones in [target]'s [affected.name] with \the [tool].")
+	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
+	user.visible_message("[user] starts to finish mending the damaged [bone] with \the [tool].", \
+	"You start to finish mending the damaged [bone] with \the [tool].")
 	..()
 
 /datum/surgery_step/finish_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("<span class='notice'>[user] has mended the damaged bones in [target]'s [affected.name] with \the [tool].</span>"  , \
-		"<span class='notice'>You have mended the damaged bones in [target]'s [affected.name] with \the [tool].</span>" )
+	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
+	user.visible_message("<span class='notice'>[user] has mended the damaged [bone] with \the [tool].</span>"  , \
+		"<span class='notice'>You have mended the damaged [bone] with \the [tool].</span>" )
 	affected.status &= ~ORGAN_BROKEN
 	affected.stage = 0
 

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -65,7 +65,7 @@
 
 /datum/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
-	return E && !E.is_stump() && (E.status & ORGAN_DESTROYED)
+	return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
 
 /datum/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
@@ -76,10 +76,10 @@
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
 	"<span class='notice'>You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
-	E.status &= ~ORGAN_DESTROYED
+	E.status &= ~ORGAN_CUT_AWAY
 	if(E.children)
 		for(var/obj/item/organ/external/C in E.children)
-			C.status &= ~ORGAN_DESTROYED
+			C.status &= ~ORGAN_CUT_AWAY
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -18,7 +18,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if (affected == null)
 		return 0
-	if (affected.status & ORGAN_DESTROYED)
+	if (affected.status & ORGAN_CUT_AWAY)
 		return 0
 	if (!(affected.robotic >= ORGAN_ROBOT))
 		return 0

--- a/html/changelogs/chinsky-surgery.yml
+++ b/html/changelogs/chinsky-surgery.yml
@@ -1,5 +1,5 @@
 author: Chinsky
 delete-after: True
 changes: 
-  - rscfix: "When reattaching limb, hemostat finish step is REQUIRED now. On the other hand, limbs are now properly reattached without leaving cut-away status forever."
-  - rscadd: "For bone gel steps you can use duct tape now. Screwdrivers aren't used anymore. Also reworded messages there to be less awkward."
+  - bugfix: "When reattaching limb, hemostat finish step is REQUIRED now. On the other hand, limbs are now properly reattached without leaving cut-away status forever."
+  - tweak: "For bone gel steps you can use duct tape now. Screwdrivers aren't used anymore. Also reworded messages there to be less awkward."

--- a/html/changelogs/chinsky-surgery.yml
+++ b/html/changelogs/chinsky-surgery.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscfix: "When reattaching limb, hemostat finish step is REQUIRED now. On the other hand, limbs are now properly reattached without leaving cut-away status forever."
+  - rscadd: "For bone gel steps you can use duct tape now. Screwdrivers aren't used anymore. Also reworded messages there to be less awkward."


### PR DESCRIPTION
Fixes #15623
Remvoes ORGAN_DESTOYED flag, as nothing sets it anywhere, replaces some of its usages with ORGAN_CUT_AWAY.
Also replaces explicit status checks with is_usable() procs where appropriate
Fixes cut-away organs not showing message about it unless they also have wounds.
Adjusted said message so it only lists uppermost organ, so no hands hanging on strip of flesh off arms hanging on strip of flesh (since children get autoset/unset flag when parent does)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
