### PR TITLE
Adds specialized modules to the Janitorial ERT hardsuit

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -90,6 +90,14 @@
 	new_grenade.activate(H)
 	new_grenade.throw_at(target,fire_force,fire_distance)
 
+/obj/item/rig_module/grenade_launcher/cleaner
+	name = "mounted cleaning grenade launcher"
+	desc = "A specialty shoulder-mounted micro-explosive dispenser."
+
+	charges = list(
+		list("cleaning grenade",   "cleaning grenade",   /obj/item/weapon/grenade/chem_grenade/cleaner,  9),
+		)
+
 /obj/item/rig_module/mounted
 
 	name = "mounted laser cannon"
@@ -248,3 +256,13 @@
 			H.put_in_hands(new_weapon)
 
 	return 1
+
+/obj/item/rig_module/fabricator/wf_sign
+	name = "wet floor sign fabricator"
+	use_power_cost = 50 KILOWATTS
+	engage_string = "Fabricate Sign"
+
+	interface_name = "work saftey launcher"
+	interface_desc = "An integrated microfactory that produces wet floor signs from thin air and electricity."
+
+	fabrication_type = /obj/item/weapon/caution

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -450,3 +450,12 @@
 			device = iastamp
 			to_chat(holder.wearer, "<span class='notice'>Switched to internal affairs stamp.</span>")
 		return 1
+
+/obj/item/rig_module/device/decompiler
+	name = "mounted matter decompiler"
+	desc = "A drone matter decompiler reconfigured for hardsuit use."
+	icon_state = "ewar"
+	interface_name = "mounted matter decompiler"
+	interface_desc = "Eats trash like no one's business."
+
+	device_type = /obj/item/weapon/matter_decompiler

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -67,6 +67,9 @@
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/fabricator/wf_sign,
+		/obj/item/rig_module/grenade_launcher/cleaner,
+		/obj/item/rig_module/device/decompiler
 		)
 
 /obj/item/weapon/rig/ert/medical

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -1309,7 +1309,7 @@
 "zi" = (/obj/structure/table/reinforced,/turf/unsimulated/floor{icon_state = "dark"},/area/centcom/specops)
 "zj" = (/obj/machinery/door/airlock/external{frequency = 1380; icon_state = "door_locked"; id_tag = "specops_centcom_dock_door"; locked = 1},/turf/unsimulated/floor{icon_state = "dark"},/area/centcom/specops)
 "zk" = (/obj/structure/sign/warning/nosmoking_2,/turf/unsimulated/wall,/area/centcom/control)
-"zl" = (/obj/structure/table/rack,/obj/item/device/lightreplacer,/obj/item/device/lightreplacer,/turf/unsimulated/floor{icon_state = "vault"; dir = 1},/area/centcom/specops)
+"zl" = (/obj/structure/table/rack,/obj/item/device/lightreplacer,/obj/item/device/lightreplacer,/obj/item/weapon/rig/ert/janitor,/obj/item/weapon/rig/ert/janitor,/turf/unsimulated/floor{icon_state = "vault"; dir = 1},/area/centcom/specops)
 "zm" = (/obj/effect/floor_decal/corner/red{dir = 9},/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/holding)
 "zn" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/belt/medical,/obj/item/weapon/storage/belt/medical,/obj/item/weapon/storage/belt/medical,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/reagent_containers/hypospray,/obj/item/weapon/storage/box/syringes,/turf/unsimulated/floor{icon_state = "vault"; dir = 1},/area/centcom/specops)
 "zo" = (/obj/effect/floor_decal/corner/green{dir = 1},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/unsimulated/floor{icon_state = "steel"},/area/centcom/holding)


### PR DESCRIPTION
- Cleaning grenade launcher loading with 9 cleaner grenades
- Wet floor sign fabricator based off ninja star launcher
- Mounted matter decompiler

Changelog omitted because the asset protection sanitation hardsuit remains adminspawn.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
