### PR TITLE
No clear vision when dead

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -55,7 +55,7 @@
 			client.screen -= screens[category]
 
 /mob/proc/reload_fullscreen()
-	if(client && stat != DEAD) //dead mob do not see any of the fullscreen overlays that he has.
+	if(client)
 		for(var/category in screens)
 			client.screen |= screens[category]
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -89,5 +89,5 @@
 
 	if(ticker && ticker.mode)
 		ticker.mode.check_win()
-
+	to_chat(src,"<span class='deadsay'>You are dead.</span>")
 	return 1

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,5 +1,4 @@
 /mob/living/death()
-	clear_fullscreens()
 	if(hiding)
 		hiding = FALSE
 	. = ..()

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -139,6 +139,7 @@ Works together with spawning an observer, noted above.
 		if(G.admin_ghosted)
 			return
 	if(key)
+		hide_fullscreens()
 		var/mob/observer/ghost/ghost = new(src)	//Transfer safety to observer spawning proc.
 		ghost.can_reenter_corpse = can_reenter_corpse
 		ghost.timeofdeath = src.stat == DEAD ? src.timeofdeath : world.time
@@ -213,6 +214,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	mind.current.ajourn=0
 	mind.current.key = key
 	mind.current.teleop = null
+	mind.current.reload_fullscreen()
 	if(!admin_ghosted)
 		announce_ghost_joinleave(mind, 0, "They now occupy their body again.")
 	return 1


### PR DESCRIPTION
Makes fullscreen overlays (oxydamage etc) go away when ghosting, not just when dead.
With defib revives it's kinda bad looking when you flip between seeing all and seeing nothing, make up your mind jeeze.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
