### PR TITLE
Allows boot blades to be drawn easier

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -505,6 +505,11 @@ BLIND     // can't see anything
 	update_icon()
 	return
 
+/obj/item/clothing/shoes/attack_hand(var/mob/living/M)
+	if(can_hold_knife && holding && src.loc == M)
+		draw_knife()
+		return
+	..()
 
 /obj/item/clothing/shoes/attackby(var/obj/item/I, var/mob/user)
 	if(can_hold_knife && is_type_in_list(I, list(/obj/item/weapon/material/shard, /obj/item/weapon/material/butterfly, /obj/item/weapon/material/kitchen/utensil, /obj/item/weapon/material/hatchet/tacknife)))

--- a/html/changelogs/Kasuobes-bootknife.yml
+++ b/html/changelogs/Kasuobes-bootknife.yml
@@ -1,0 +1,4 @@
+author: Haswell
+delete-after: True
+changes: 
+  - tweak: "Clicking on worn or held boots containing a concealed blade will now draw the blade out directly, similar to gun holsters."


### PR DESCRIPTION
Clicking on worn or held boots containing a concealed blade will now draw the blade out directly, similar to gun holsters.

Port of PolarisSS13/Polaris#2920