### PR TITLE
Continues breaking the bots

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -101,47 +101,35 @@
 	else
 		icon_state = "cleanbot[on]"
 
-/mob/living/bot/cleanbot/attack_hand(var/mob/user)
-	var/dat
-	dat += "<TT><B>Automatic Station Cleaner v1.0</B></TT><BR><BR>"
-	dat += "Status: <A href='?src=\ref[src];operation=start'>[on ? "On" : "Off"]</A><BR>"
-	dat += "Behaviour controls are [locked ? "locked" : "unlocked"]<BR>"
-	dat += "Maintenance panel is [open ? "opened" : "closed"]"
-	if(!locked || issilicon(user))
-		dat += "<BR>Cleans Blood: <A href='?src=\ref[src];operation=blood'>[blood ? "Yes" : "No"]</A><BR>"
-		dat += "<BR>Patrol station: <A href='?src=\ref[src];operation=patrol'>[will_patrol ? "Yes" : "No"]</A><BR>"
-	if(open && !locked)
-		dat += "Odd looking screw twiddled: <A href='?src=\ref[src];operation=screw'>[screwloose ? "Yes" : "No"]</A><BR>"
-		dat += "Weird button pressed: <A href='?src=\ref[src];operation=oddbutton'>[oddbutton ? "Yes" : "No"]</A>"
+/mob/living/bot/cleanbot/GetInteractTitle()
+	. = "<head><title>Cleanbot controls</title></head>"
+	. += "<b>Automatic Station Cleaner v1.0</b>"
 
-	user << browse("<HEAD><TITLE>Cleaner v1.0 controls</TITLE></HEAD>[dat]", "window=autocleaner")
-	onclose(user, "autocleaner")
-	return
+/mob/living/bot/cleanbot/GetInteractPanel()
+	. = "Cleans blood: <a href='?src=\ref[src];command=blood'>[blood ? "Yes" : "No"]</a>"
+	. += "<br>Patrol station: <a href='?src=\ref[src];command=patrol'>[will_patrol ? "Yes" : "No"]</a>"
 
-/mob/living/bot/cleanbot/Topic(href, href_list)
-	if(..())
-		return
-	usr.set_machine(src)
-	add_fingerprint(usr)
-	switch(href_list["operation"])
-		if("start")
-			if(on)
-				turn_off()
-			else
-				turn_on()
-		if("blood")
-			blood = !blood
-			get_targets()
-		if("patrol")
-			will_patrol = !will_patrol
-			patrol_path = null
-		if("screw")
-			screwloose = !screwloose
-			to_chat(usr, "<span class='notice'>You twiddle the screw.</span>")
-		if("oddbutton")
-			oddbutton = !oddbutton
-			to_chat(usr, "<span class='notice'>You press the weird button.</span>")
-	attack_hand(usr)
+/mob/living/bot/cleanbot/GetInteractMaintenance()
+	. = "Odd looking screw twiddled: <a href='?src=\ref[src];command=screw'>[screwloose ? "Yes" : "No"]</a>"
+	. += "<br>Weird button pressed: <a href='?src=\ref[src];command=oddbutton'>[oddbutton ? "Yes" : "No"]</a>"
+
+/mob/living/bot/cleanbot/ProcessCommand(var/mob/user, var/command, var/href_list)
+	..()
+	if(CanAccessPanel(user))
+		switch(command)
+			if("blood")
+				blood = !blood
+				get_targets()
+			if("patrol")
+				will_patrol = !will_patrol
+				patrol_path = null
+
+	if(CanAccessMaintenance(user))
+		switch(command)
+			if("screw")
+				screwloose = !screwloose
+			if("oddbutton")
+				oddbutton = !oddbutton
 
 /mob/living/bot/cleanbot/emag_act(var/remaining_uses, var/mob/user)
 	. = ..()

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -33,75 +33,67 @@
 	name = "Old Ben"
 	on = 0
 
-/mob/living/bot/farmbot/attack_hand(var/mob/user as mob)
-	. = ..()
-	if(.)
-		return
-	var/dat = ""
-	dat += "<TT><B>Automatic Hyrdoponic Assisting Unit v1.0</B></TT><BR><BR>"
-	dat += "Status: <A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A><BR>"
-	dat += "Water Tank: "
-	if (tank)
-		dat += "[tank.reagents.total_volume]/[tank.reagents.maximum_volume]"
-	else
-		dat += "Error: Watertank not found"
-	dat += "<br>Behaviour controls are [locked ? "locked" : "unlocked"]<hr>"
-	if(!locked)
-		dat += "<TT>Watering controls:<br>"
-		dat += "Water plants : <A href='?src=\ref[src];water=1'>[waters_trays ? "Yes" : "No"]</A><BR>"
-		dat += "Refill watertank : <A href='?src=\ref[src];refill=1'>[refills_water ? "Yes" : "No"]</A><BR>"
-		dat += "<br>Weeding controls:<br>"
-		dat += "Weed plants: <A href='?src=\ref[src];weed=1'>[uproots_weeds ? "Yes" : "No"]</A><BR>"
-		dat += "<br>Nutriment controls:<br>"
-		dat += "Replace fertilizer: <A href='?src=\ref[src];replacenutri=1'>[replaces_nutriment ? "Yes" : "No"]</A><BR>"
-		dat += "<br>Plant controls:<br>"
-		dat += "Collect produce: <A href='?src=\ref[src];collect=1'>[collects_produce ? "Yes" : "No"]</A><BR>"
-		dat += "Remove dead plants: <A href='?src=\ref[src];removedead=1'>[removes_dead ? "Yes" : "No"]</A><BR>"
-		dat += "</TT>"
+/mob/living/bot/farmbot/GetInteractTitle()
+	. = "<head><title>Farmbot controls</title></head>"
+	. += "<b>Automatic Hyrdoponic Assisting Unit v1.0</b>"
 
-	user << browse("<HEAD><TITLE>Farmbot v1.0 controls</TITLE></HEAD>[dat]", "window=autofarm")
-	onclose(user, "autofarm")
-	return
+/mob/living/bot/farmbot/GetInteractStatus()
+	. = ..()
+	. += "<br>Water tank: "
+	if(tank)
+		. += "[tank.reagents.total_volume]/[tank.reagents.maximum_volume]"
+	else
+		. += "error: not found"
+
+/mob/living/bot/farmbot/GetInteractPanel()
+	. = "Water plants : <a href='?src=\ref[src];command=water'>[waters_trays ? "Yes" : "No"]</a>"
+	. += "<br>Refill watertank : <a href='?src=\ref[src];command=refill'>[refills_water ? "Yes" : "No"]</a>"
+	. += "<br>Weed plants: <a href='?src=\ref[src];command=weed'>[uproots_weeds ? "Yes" : "No"]</a>"
+	. += "<br>Replace fertilizer: <a href='?src=\ref[src];command=replacenutri'>[replaces_nutriment ? "Yes" : "No"]</a>"
+	. += "<br>Collect produce: <a href='?src=\ref[src];command=collect'>[collects_produce ? "Yes" : "No"]</a>"
+	. += "<br>Remove dead plants: <a href='?src=\ref[src];command=removedead'>[removes_dead ? "Yes" : "No"]</a>"
+
+/mob/living/bot/farmbot/GetInteractMaintenance()
+	. = "Plant identifier status: "
+	switch(emagged)
+		if(0)
+			. += "<a href='?src=\ref[src];command=emag'>Normal</a>"
+		if(1)
+			. += "<a href='?src=\ref[src];command=emag'>Scrambled (DANGER)</a>"
+		if(2)
+			. += "ERROROROROROR-----"
+
+/mob/living/bot/farmbot/ProcessCommand(var/mob/user, var/command, var/href_list)
+	..()
+	if(CanAccessPanel(user))
+		switch(command)
+			if("water")
+				waters_trays = !waters_trays
+			if("refill")
+				refills_water = !refills_water
+			if("weed")
+				uproots_weeds = !uproots_weeds
+			if("replacenutri")
+				replaces_nutriment = !replaces_nutriment
+			if("collect")
+				collects_produce = !collects_produce
+			if("removedead")
+				removes_dead = !removes_dead
+
+	if(CanAccessMaintenance(user))
+		switch(command)
+			if("emag")
+				if(emagged < 2)
+					emagged = !emagged
 
 /mob/living/bot/farmbot/emag_act(var/remaining_charges, var/mob/user)
 	. = ..()
 	if(!emagged)
 		if(user)
 			to_chat(user, "<span class='notice'>You short out [src]'s plant identifier circuits.</span>")
-		spawn(rand(30, 50))
-			visible_message("<span class='warning'>[src] buzzes oddly.</span>")
-			emagged = 1
+			ignore_list |= user
+		emagged = 2
 		return 1
-
-/mob/living/bot/farmbot/Topic(href, href_list)
-	if(..())
-		return
-	usr.machine = src
-	add_fingerprint(usr)
-	if((href_list["power"]) && (access_scanner.allowed(usr)))
-		if(on)
-			turn_off()
-		else
-			turn_on()
-
-	if(locked)
-		return
-
-	if(href_list["water"])
-		waters_trays = !waters_trays
-	else if(href_list["refill"])
-		refills_water = !refills_water
-	else if(href_list["weed"])
-		uproots_weeds = !uproots_weeds
-	else if(href_list["replacenutri"])
-		replaces_nutriment = !replaces_nutriment
-	else if(href_list["collect"])
-		collects_produce = !collects_produce
-	else if(href_list["removedead"])
-		removes_dead = !removes_dead
-
-	attack_hand(usr)
-	return
 
 /mob/living/bot/farmbot/update_icons()
 	if(on && action)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -114,8 +114,7 @@
 	var/turf/simulated/floor/T = A
 	if(istype(T))
 		if(emagged)
-			if(T.flooring)
-				return 1
+			return 1
 		else
 			return (amount && (T.broken || T.burnt || (improvefloors && !T.flooring)))
 
@@ -137,6 +136,11 @@
 			visible_message("<span class='warning'>[src] begins to tear the floor tile from the floor.</span>")
 			if(do_after(src, 50, F))
 				F.break_tile_to_plating()
+				addTiles(1)
+		else
+			visible_message("<span class='danger'>[src] begins to tear through the floor!</span>")
+			if(do_after(src, 150, F)) // Extra time because this can and will kill.
+				F.ReplaceWithLattice()
 				addTiles(1)
 		target = null
 		busy = 0

--- a/html/changelogs/Kelenius-MoreBots.yml
+++ b/html/changelogs/Kelenius-MoreBots.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed issues where you were unable to turn the bots on and off when you should have been. Farmbot specifically."
+  - tweak: "Synthetics can always control all bot settings."
+  - tweak: "Synthetics and anyone who opens the bot's panel (screwdriver) can toggle bot safeties, giving it a 'temporal' emag effect that can be fixed in the same way. Emags break them permanently, but this is obvious when the panel is open."
+  - tweak: "Emagged floorbots don't breach the station anymore. That was too deadly. They'll just tear up the tiles."

--- a/html/changelogs/Kelenius-MoreBots.yml
+++ b/html/changelogs/Kelenius-MoreBots.yml
@@ -36,4 +36,3 @@ changes:
   - bugfix: "Fixed issues where you were unable to turn the bots on and off when you should have been. Farmbot specifically."
   - tweak: "Synthetics can always control all bot settings."
   - tweak: "Synthetics and anyone who opens the bot's panel (screwdriver) can toggle bot safeties, giving it a 'temporal' emag effect that can be fixed in the same way. Emags break them permanently, but this is obvious when the panel is open."
-  - tweak: "Emagged floorbots don't breach the station anymore. That was too deadly. They'll just tear up the tiles."


### PR DESCRIPTION
Separates their interact panel into four procs
Synths can now toggle everything in bots even if the bots are locked
Added nanoUI-looking interface to all bots, not just securitrons
Added an ability to temporally "emag" bots by either accessing the panel
or being a synthetic
Mulebots don't dash off immediately after having target set
Nerfed emagged floorbots a little
Removed Some Text That Was Written Like This!
Tweaks