### PR TITLE
Tweaks shock beams

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -11,9 +11,9 @@
 	modifystate = "energystun"
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="energystun", charge_cost=20),
-		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, modifystate="energyshock", charge_cost=30),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="energykill", charge_cost=20),
+		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="energystun"),
+		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, modifystate="energyshock"),
+		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="energykill"),
 		)
 
 /obj/item/weapon/gun/energy/gun/mounted
@@ -34,9 +34,9 @@
 	requires_two_hands = 1 //bulkier than an e-gun, but not quite the size of a carbine
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, charge_cost=20),
-		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, charge_cost=30),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, charge_cost=20),
+		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun),
+		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock),
+		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam),
 		)
 
 	var/fail_counter = 0

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -8,7 +8,7 @@
 
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun),
-		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, charge_cost=30)
+		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock),
 		)
 
 /obj/item/weapon/gun/energy/taser/mounted

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -154,6 +154,8 @@
 	name = "stun beam"
 	icon_state = "stun"
 	fire_sound = 'sound/weapons/Taser.ogg'
+	check_armour = "energy"
+	sharp = 0 //not a laser
 	taser_effect = 1
 	agony = 40
 	damage_type = STUN
@@ -165,6 +167,6 @@
 /obj/item/projectile/beam/stun/shock
 	name = "shock beam"
 	damage_type = ELECTROCUTE
-	damage = 10
-	agony = 50
+	damage = 20
+	agony = 20
 	fire_sound='sound/weapons/pulse.ogg'


### PR DESCRIPTION
Adjusts shock beams so that they now deal 20/20 ELECTROCUTE damage and halloss.

Shock beams are no longer considered concentrated burn sources, since they aren't lasers. They now count against "energy" armour, also because they aren't lasers and energy is kind of underused anyways.

Lastly, because they now deal 40 halloss total (instead of 60), they no longer need the odd charge cost (the main reason for this PR). 