### PR TITLE
Random items again spawn in New()

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -5,21 +5,23 @@
 	icon_state = "rup"
 	var/spawn_nothing_percentage = 0 // this variable determines the likelyhood that this random object will not spawn anything
 
+/obj/random/New()
+	..()
+	spawn_item()
 
 // creates a new object and deletes itself
 /obj/random/initialize()
-	..()
-	if (!prob(spawn_nothing_percentage))
-		spawn_item()
 	qdel(src)
 
 // this function should return a specific item to spawn
 /obj/random/proc/item_to_spawn()
 	return 0
 
-
 // creates the random item
 /obj/random/proc/spawn_item()
+	if(prob(spawn_nothing_percentage))
+		return
+
 	var/build_path = item_to_spawn()
 
 	var/atom/A = new build_path(src.loc)
@@ -1124,7 +1126,7 @@ var/list/random_useful_
 /proc/get_random_junk_type()
 	if(prob(20)) // Misc. clutter
 		return /obj/effect/decal/cleanable/generic
-		
+
 	// 80% chance that we reach here
 	if(prob(95)) // Misc. junk
 		if(!random_junk_)
@@ -1143,10 +1145,10 @@ var/list/random_useful_
 			random_junk_ -= /obj/item/trash/syndi_cakes
 			random_junk_ -= /obj/item/trash/tray
 		return pick(random_junk_)
-	
+
 	// Misc. actually useful stuff or perhaps even food
 	// 4% chance that we reach here
-	if(prob(75)) 
+	if(prob(75))
 		return get_random_useful_type()
 
 	// 1% chance that we reach here


### PR DESCRIPTION
Fixes #15731.
Seems to be the only reasonable way to spawn /obj/items before closets initialize, ensuring they get stored, save for maybe adding spawns in closets or a post-init init step.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
