### PR TITLE
Probably fixes #15515

### DIFF
--- a/code/modules/mob/living/carbon/viruses.dm
+++ b/code/modules/mob/living/carbon/viruses.dm
@@ -11,6 +11,8 @@
 		for(var/obj/effect/decal/cleanable/O in view(1,src))
 			if(istype(O,/obj/effect/decal/cleanable/blood))
 				var/obj/effect/decal/cleanable/blood/B = O
+				if(isnull(B.virus2))
+					B.virus2 = list()
 				if(B.virus2.len)
 					for (var/ID in B.virus2)
 						var/datum/disease2/disease/V = B.virus2[ID]
@@ -18,6 +20,8 @@
 
 			else if(istype(O,/obj/effect/decal/cleanable/mucus))
 				var/obj/effect/decal/cleanable/mucus/M = O
+				if(isnull(M.virus2))
+					M.virus2 = list()
 				if(M.virus2.len)
 					for (var/ID in M.virus2)
 						var/datum/disease2/disease/V = M.virus2[ID]


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Hopefully fixes #15515, at long last. The only useful line in the stack trace (caught by process: mob) helped me narrow it down.
I'm still not sure where virus2 is getting set to null, though.