### PR TITLE
Fixes CompileFile returning bytes instead of string

### DIFF
--- a/tools/GenerateGlobalVarAccess/gen_globals.py
+++ b/tools/GenerateGlobalVarAccess/gen_globals.py
@@ -49,7 +49,7 @@ def main():
 
 	else:
 		tree = CompileFile(namespace.projectfile)
-		with open("dump.txt", "wb") as f:
+		with open("dump.txt", "wt") as f:
 			f.write(tree)
 
 
@@ -66,7 +66,7 @@ def main():
 def CompileFile(filename):
 	compiler_path = FindCompiler()
 
-	return subprocess.check_output([compiler_path, "-code_tree", filename])
+	return subprocess.check_output([compiler_path, "-code_tree", filename], universal_newlines=True)
 
 def FindCompiler():
 	compiler_path = None;


### PR DESCRIPTION
See title. It's bad because then tree becomes a mixed type variable and errors result from mixing strings and bytes further on.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
