### PR TITLE
Miscellanious ability master fix.

### DIFF
--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -13,7 +13,7 @@
 
 	var/mob/my_mob = null // The mob that possesses this hud object.
 
-/obj/screen/movable/ability_master/New(owner)
+/obj/screen/movable/ability_master/New(newloc,owner)
 	if(owner)
 		my_mob = owner
 		update_abilities(0, owner)
@@ -164,7 +164,7 @@
 
 /mob/New()
 	..()
-	ability_master = new /obj/screen/movable/ability_master(src)
+	ability_master = new /obj/screen/movable/ability_master(null,src)
 
 ///////////ACTUAL ABILITIES////////////
 //This is what you click to do things//

--- a/code/modules/spells/spells.dm
+++ b/code/modules/spells/spells.dm
@@ -16,6 +16,16 @@
 				if(Sp_HOLDVAR)
 					statpanel(S.panel,"[S.holder_var_type] [S.holder_var_amount]",S.connected_button)
 
+//A fix for when a spell is created before a mob is created
+/mob/Login()
+	. = ..()
+	if(mind)
+		if(!mind.learned_spells)
+			mind.learned_spells = list()
+		if(ability_master && ability_master.spell_objects)
+			for(var/obj/screen/ability/spell/screen in ability_master.spell_objects)
+				var/spell/S = screen.spell
+				mind.learned_spells |= S
 
 proc/restore_spells(var/mob/H)
 	if(H.mind && H.mind.learned_spells)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -9,7 +9,8 @@ var/list/ventcrawl_machinery = list(
 	/obj/item/device/radio/borg,
 	/obj/item/weapon/holder,
 	/obj/machinery/camera,
-	/mob/living/simple_animal/borer
+	/mob/living/simple_animal/borer,
+	/obj/screen
 	)
 
 /mob/living/var/list/icon/pipes_shown = list()
@@ -46,7 +47,7 @@ var/list/ventcrawl_machinery = list(
 		return !get_inventory_slot(carried_item)
 
 /mob/living/carbon/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	if(carried_item in internal_organs)
+	if((carried_item in internal_organs) || (carried_item in stomach_contents))
 		return 1
 	return ..()
 
@@ -58,7 +59,7 @@ var/list/ventcrawl_machinery = list(
 /mob/living/simple_animal/spiderbot/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if(carried_item in list(held_item, radio, connected_ai, cell, camera, mmi))
 		return 1
-	return 0
+	return ..()
 
 /mob/living/proc/ventcrawl_carry()
 	for(var/atom/A in contents)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -9,8 +9,7 @@ var/list/ventcrawl_machinery = list(
 	/obj/item/device/radio/borg,
 	/obj/item/weapon/holder,
 	/obj/machinery/camera,
-	/mob/living/simple_animal/borer,
-	/obj/screen
+	/mob/living/simple_animal/borer
 	)
 
 /mob/living/var/list/icon/pipes_shown = list()


### PR DESCRIPTION
Fixes ability master causing vent crawl to not work.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Changes a few things with ventcrawl and adds a login with spells so that it will make sure that mobs with premade spells will hand those to the client's mind.