### PR TITLE
Cult tweaks and fixes

### DIFF
--- a/code/game/gamemodes/cult/ghosts.dm
+++ b/code/game/gamemodes/cult/ghosts.dm
@@ -1,22 +1,26 @@
 /mob/observer/ghost/var/ghost_magic_cd = 0
 
 /datum/antagonist/cultist/proc/add_ghost_magic(var/mob/observer/ghost/M)
-	if(cult_level >= 2)
+	if(max_cult_rating >= CULT_GHOSTS_1)
 		M.verbs += /mob/observer/ghost/proc/flick_lights
 		M.verbs += /mob/observer/ghost/proc/bloody_doodle
 		M.verbs += /mob/observer/ghost/proc/shatter_glass
 		M.verbs += /mob/observer/ghost/proc/slice
-		if(cult_level >= 3)
+		if(max_cult_rating >= CULT_GHOSTS_2)
 			M.verbs += /mob/observer/ghost/proc/move_item
 			M.verbs += /mob/observer/ghost/proc/whisper_to_cultist
 			M.verbs += /mob/observer/ghost/proc/bite_someone
 			M.verbs += /mob/observer/ghost/proc/chill_someone
-			if(cult_level >= 4)
+			if(max_cult_rating >= CULT_GHOSTS_3)
 				M.verbs += /mob/observer/ghost/proc/whisper_to_anyone
 				M.verbs += /mob/observer/ghost/proc/bloodless_doodle
 				M.verbs += /mob/observer/ghost/proc/toggle_visiblity
 
 /mob/observer/ghost/proc/ghost_ability_check()
+	var/turf/T = get_turf(src)
+	if(T.holy)
+		to_chat(src, "<span class='notice'>You may not use your abilities on the blessed ground.</span>")
+		return 0
 	if(ghost_magic_cd > world.time)
 		to_chat(src, "<span class='notice'>You need [round((ghost_magic_cd - world.time) / 10)] more seconds before you can use your abilities.</span>")
 		return 0
@@ -35,12 +39,14 @@
 
 	ghost_magic_cd = world.time + 30 SECONDS
 
-//Used for drawing on walls with blood puddles as a spooky ghost.
-/mob/observer/ghost/proc/bloody_doodle(var/bloodless = 0)
+/mob/observer/ghost/proc/bloody_doodle()
 	set category = "Cult"
 	set name = "Write in blood"
 	set desc = "Write a short message in blood on the floor or a wall. Remember, no IC in OOC or OOC in IC."
 
+	bloody_doodle_proc(0)
+
+/mob/observer/ghost/proc/bloody_doodle_proc(var/bloodless = 0)
 	if(!ghost_ability_check())
 		return
 
@@ -157,11 +163,14 @@
 
 	ghost_magic_cd = world.time + 60 SECONDS
 
-/mob/observer/ghost/proc/whisper_to_cultist(var/anyone = 0)
+/mob/observer/ghost/proc/whisper_to_cultist()
 	set category = "Cult"
 	set name = "Whisper to mind"
 	set desc = "Whisper to a human of your choice. If they are adjusted enough, they'll hear you."
 
+	whisper_proc()
+
+/mob/observer/ghost/proc/whisper_proc(var/anyone = 0)
 	if(!ghost_ability_check())
 		return
 
@@ -186,7 +195,6 @@
 			to_chat(choice, "<span class='notice'>You hear a faint whisper, but you can't make out the words.</span>")
 			log_and_message_admins("used ghost magic to say '[message]' to \the [choice] but wasn't heard - [x]-[y]-[z]")
 		to_chat(src, "You whisper to \the [choice]. Perhaps they heard you.")
-
 
 	ghost_magic_cd = world.time + 100 SECONDS
 
@@ -251,14 +259,14 @@
 	set name = "Whisper loudly to mind"
 	set desc = "Whisper to a human of your choice."
 
-	whisper_to_cultist(1)
+	whisper_proc(1)
 
 /mob/observer/ghost/proc/bloodless_doodle()
 	set category = "Cult"
 	set name = "Write in own blood"
 	set desc = "Write a short message in blood on the floor or a wall. You don't need blood nearby to use this."
 
-	bloody_doodle(1)
+	bloody_doodle_proc(1)
 
 /mob/observer/ghost/proc/toggle_visiblity()
 	set category = "Cult"

--- a/code/game/gamemodes/cult/manifest.dm
+++ b/code/game/gamemodes/cult/manifest.dm
@@ -17,7 +17,7 @@
 
 /datum/species/human/cult/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.s_tone = 35
-	H.r_eyes = 138
+	H.r_eyes = 230
 	H.b_eyes = 7
 	H.g_eyes = 7
 	H.update_eyes()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -145,7 +145,7 @@
 /obj/effect/rune/convert/Topic(href, href_list)
 	if(href_list["join"])
 		if(usr.loc == loc && !iscultist(usr))
-			cult.add_antagonist(usr.mind, 1)
+			cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"
@@ -309,6 +309,8 @@
 	else if(I.force)
 		user.visible_message("<span class='notice'>\The [user] hits \the [src] with \the [I].</span>", "<span class='notice'>You hit \the [src] with \the [I].</span>")
 		take_damage(I.force)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
 
 /obj/effect/cultwall/bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
@@ -373,13 +375,13 @@
 	visible_message("<span class='warning'>\The [src] disappears with a flash of red light, and a set of armor appears on \the [user].</span>", "<span class='warning'>You are blinded by the flash of red light. After you're able to see again, you see that you are now wearing a set of armor.</span>")
 
 	var/obj/O = user.get_equipped_item(slot_head) // This will most likely kill you if you are wearing a spacesuit, and it's 100% intended
-	if(O)
+	if(O && !istype(O, /obj/item/clothing/head/culthood))
 		user.unEquip(O)
 	O = user.get_equipped_item(slot_wear_suit)
-	if(O)
+	if(O && !istype(O, /obj/item/clothing/suit/cultrobes))
 		user.unEquip(O)
 	O = user.get_equipped_item(slot_shoes)
-	if(O)
+	if(O && !istype(O, /obj/item/clothing/shoes/cult))
 		user.unEquip(O)
 
 	user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
@@ -387,13 +389,16 @@
 	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 
 	O = user.get_equipped_item(slot_back)
-	if(istype(O, /obj/item/weapon/storage)) // We don't want to make the vox drop their nitrogen tank, though
+	if(istype(O, /obj/item/weapon/storage) && !istype(O, /obj/item/weapon/storage/backpack/cultpack)) // We don't want to make the vox drop their nitrogen tank, though
 		user.unEquip(O)
 		var/obj/item/weapon/storage/backpack/cultpack/C = new /obj/item/weapon/storage/backpack/cultpack(user)
 		user.equip_to_slot_or_del(C, slot_back)
 		if(C)
 			for(var/obj/item/I in O)
 				I.forceMove(C)
+	else if(!O)
+		var/obj/item/weapon/storage/backpack/cultpack/C = new /obj/item/weapon/storage/backpack/cultpack(user)
+		user.equip_to_slot_or_del(C, slot_back)
 
 	user.update_icons()
 
@@ -476,7 +481,7 @@
 
 /obj/effect/rune/manifest/Destroy()
 	if(puppet)
-		puppet.dust()
+		puppet.death()
 		puppet = null
 	return ..()
 
@@ -498,11 +503,9 @@
 		return fizzle(user)
 	user.say("Gal'h'rfikk harfrandid mud[pick("'","`")]gib!")
 	visible_message("<span class='warning'>A shape forms in the center of the rune. A shape of... a man.</span>", "You hear liquid flow.")
-	puppet = new(get_turf(src))
-	puppet.set_species("Cult")
-	puppet.name = puppet.species.get_random_name()
+	puppet = new(get_turf(src), "Cult")
 	puppet.key = ghost.key
-	cult.add_antagonist(puppet.mind)
+	cult.add_antagonist(puppet.mind, do_not_equip = 1)
 
 	log_and_message_admins("used a manifest rune.")
 
@@ -525,6 +528,7 @@
 	admin_attack_log(user, victim, "Used a blood drain rune.", "Was victim of a blood drain rune.", "used a blood drain rune on")
 	user.say("Yu[pick("'","`")]gular faras desdae. Havas mithum javara. Umathar uf'kal thenar!")
 	user.visible_message("<span class='warning'>Blood flows from \the [src] into \the [user]!</span>", "<span class='cult'>The blood starts flowing from \the [src] into your frail mortal body. [capitalize(english_list(heal_user(user), nothing_text = "you feel no different"))].</span>", "You hear liquid flow.")
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 /obj/effect/rune/drain/proc/heal_user(var/mob/living/carbon/human/user)
 	if(!istype(user))
@@ -541,7 +545,7 @@
 			return statuses
 	if(user.getBruteLoss() || user.getFireLoss())
 		var/healbrute = user.getBruteLoss()
-		var/healburn = user.getBruteLoss()
+		var/healburn = user.getFireLoss()
 		if(healbrute < healburn)
 			healbrute = min(healbrute, charges / 2)
 			charges -= healbrute
@@ -567,7 +571,7 @@
 		for(var/obj/item/organ/external/e in user.organs)
 			if(e && e.status & ORGAN_BROKEN)
 				e.status &= ~ORGAN_BROKEN
-				statuses += "bones in your [e] snap into place"
+				statuses += "bones in your [e.name] snap into place"
 				charges -= 15
 				if(charges < 15)
 					break
@@ -684,7 +688,6 @@
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
 			C.eye_blurry += 50
-			C.eye_blind += 20
 			C.Weaken(3)
 			C.Stun(5)
 		else if(issilicon(M))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -38,6 +38,14 @@
 
 	..()
 
+/obj/item/weapon/nullrod/afterattack(var/atom/A, var/mob/user, var/proximity)
+	if(!proximity)
+		return
+	if(istype(A, /turf/simulated/wall/cult))
+		var/turf/simulated/wall/cult/W = A
+		user.visible_message("<span class='notice'>\The [user] touches \the [A] with \the [src] and it starts fizzling and shifting.</span>", "<span class='notice'>You touch \the [A] with \the [src] and it starts fizzling and shifting.</span>")
+		W.ChangeTurf(/turf/simulated/wall)
+
 /obj/item/weapon/energy_net
 	name = "energy net"
 	desc = "It's a net made of green energy."

--- a/html/changelogs/Kelenius-MoreCultFixes.yml
+++ b/html/changelogs/Kelenius-MoreCultFixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Ghosts can't use their abilities in holy places (non-defiled chapel or anything touched by holy water) anymore."
+  - tweak: "Confuse rune doesn't blind people, only blurries their vision. It still stuns as before."
+  - tweak: "It takes longer to unlock tear reality rune and ghost abilities."
+  - bugfix: "Many cult-related bugfixes."


### PR DESCRIPTION
Ghosts can't use their abilities in holy places anymore.
Confuse doesn't blind people anymore.
Tear reality rune and ghost abilities are unlocked more slowly (100,
200, 300 -> 100, 200, 500 for cultists, 100, 200, 300 -> 200, 400, 600
for ghosts).
Cult walls now have an attack animation and cooldown.
Armor rune now gives you a cult bag even if you have nothing on your
back.
Armor rune doesn't create armor you already have.
Writing in blood and whispering to cultists actually works now.
Manifested ghosts don't spawn with tomes and have correct names now.
Manifested ghosts don't leave two sets of bones now.
Converts don't spawn with tomes.
Blood drain now sets click cooldown.
Blood drain now heals burns correctly.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
