### PR TITLE
Makes drop pouches use slotless storage

### DIFF
--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -68,9 +68,9 @@
 					/obj/item/clothing/accessory/storage/black_vest,
 					/obj/item/clothing/accessory/storage/brown_vest,
 					/obj/item/clothing/accessory/storage/white_vest,
-					/obj/item/clothing/accessory/storage/black_drop_pouches,
-					/obj/item/clothing/accessory/storage/brown_drop_pouches,
-					/obj/item/clothing/accessory/storage/white_drop_pouches,
+					/obj/item/clothing/accessory/storage/drop_pouches/black,
+					/obj/item/clothing/accessory/storage/drop_pouches/brown,
+					/obj/item/clothing/accessory/storage/drop_pouches/white,
 					/obj/item/clothing/accessory/storage/webbing)
 	cost = 15
 	containername = "\improper Webbing crate"

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -94,3 +94,7 @@
 	storage_slots = slots
 	max_w_class = slot_size
 	..()
+
+/obj/item/weapon/storage/internal/pouch/New(var/newloc, var/storage_space)
+	max_storage_space = storage_space
+	..()

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -10,6 +10,9 @@
 
 /obj/item/clothing/accessory/storage/New()
 	..()
+	create_storage()
+
+/obj/item/clothing/accessory/storage/proc/create_storage()
 	hold = new/obj/item/weapon/storage/internal/pockets(src, slots, max_w_class)
 
 /obj/item/clothing/accessory/storage/attack_hand(mob/user as mob)
@@ -71,23 +74,26 @@
 	icon_state = "vest_white"
 	slots = 5
 
-/obj/item/clothing/accessory/storage/black_drop_pouches
+/obj/item/clothing/accessory/storage/drop_pouches
+	slots = 4 //to accomodate it being slotless
+
+/obj/item/clothing/accessory/storage/drop_pouches/create_storage()
+	hold = new/obj/item/weapon/storage/internal/pouch(src, slots*base_storage_cost(max_w_class))
+
+/obj/item/clothing/accessory/storage/drop_pouches/black
 	name = "black drop pouches"
 	desc = "Robust black synthcotton bags to hold whatever you need, but cannot hold in hands."
 	icon_state = "thigh_black"
-	slots = 5
 
-/obj/item/clothing/accessory/storage/brown_drop_pouches
+/obj/item/clothing/accessory/storage/drop_pouches/brown
 	name = "brown drop pouches"
 	desc = "Worn brownish synthcotton bags to hold whatever you need, but cannot hold in hands."
 	icon_state = "thigh_brown"
-	slots = 5
 
-/obj/item/clothing/accessory/storage/white_drop_pouches
+/obj/item/clothing/accessory/storage/drop_pouches/white
 	name = "white drop pouches"
 	desc = "Durable white synthcotton bags to hold whatever you need, but cannot hold in hands."
 	icon_state = "thigh_white"
-	slots = 5
 
 /obj/item/clothing/accessory/storage/knifeharness
 	name = "decorated harness"

--- a/maps/exodus/Loadout/loadout_accessories.dm
+++ b/maps/exodus/Loadout/loadout_accessories.dm
@@ -91,17 +91,17 @@
 
 /datum/gear/accessory/brown_drop_pouches
 	display_name = "drop pouches, engineering"
-	path = /obj/item/clothing/accessory/storage/brown_drop_pouches
+	path = /obj/item/clothing/accessory/storage/drop_pouches/brown
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer")
 
 /datum/gear/accessory/black_drop_pouches
 	display_name = "drop pouches, security"
-	path = /obj/item/clothing/accessory/storage/black_drop_pouches
+	path = /obj/item/clothing/accessory/storage/drop_pouches/black
 	allowed_roles = list("Security Officer","Head of Security","Warden")
 
 /datum/gear/accessory/white_drop_pouches
 	display_name = "drop pouches, medical"
-	path = /obj/item/clothing/accessory/storage/white_drop_pouches
+	path =/obj/item/clothing/accessory/storage/drop_pouches/white
 	allowed_roles = list("Paramedic","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/webbing

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -142,20 +142,20 @@
 
 /datum/gear/accessory/brown_drop_pouches
 	display_name = "drop pouches, engineering"
-	path = /obj/item/clothing/accessory/storage/brown_drop_pouches
+	path = /obj/item/clothing/accessory/storage/drop_pouches/brown
 	cost = 3
 	allowed_roles = list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Roboticist", "Deck Officer", "Deck Technician",
 						"Supply Assistant", "Prospector", "Sanitation Technician", "Research Assistant", "Merchant")
 
 /datum/gear/accessory/black_drop_pouches
 	display_name = "drop pouches, security"
-	path = /obj/item/clothing/accessory/storage/black_drop_pouches
+	path = /obj/item/clothing/accessory/storage/drop_pouches/black
 	cost = 3
 	allowed_roles = list("Chief of Security", "Brig Officer", "Forensic Technician", "Master at Arms", "Security Guard", "Merchant")
 
 /datum/gear/accessory/white_drop_pouches
 	display_name = "webbing, medical"
-	path = /obj/item/clothing/accessory/storage/white_drop_pouches
+	path = /obj/item/clothing/accessory/storage/drop_pouches/white
 	cost = 3
 	allowed_roles = list("Chief Medical Officer", "Senior Physician", "Physician", "Medical Assistant", "Merchant")
 


### PR DESCRIPTION
Makes drop pouches use slotless storage. In exchange they have slightly less total storage capacity.

For example, compared to a medical webbing vest, using medical drop pouches you can store 1 less bottle but 3 more syringes.

Or you can store more shotgun shells/PTR shells but less of the larger items, etc. In fact, a drop pouch full of shotgun shells holds exactly one full reload for a combat shotgun (8 rounds), pure coincidence.