### PR TITLE
Defibrilators now check for low blood volume

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -263,7 +263,7 @@
 	if(H.stat != DEAD)
 		return "buzzes, \"Patient is not in a valid state. Operation aborted.\""
 
-	if(check_contact(H))
+	if(!check_contact(H))
 		return "buzzes, \"Patient's chest is obstructed. Operation aborted.\""
 
 	return null
@@ -281,7 +281,10 @@
 	if(bad_vital_organ)
 		return bad_vital_organ
 
-	//this needs to be last since if any of the 'further attempts futile' conditions are met their messages take precedence
+	if(check_blood_level())
+		return "buzzes, \"Resuscitation failed - Patient is in hypovolemic shock.\""
+
+	//this needs to be last since if any of the 'other conditions are met their messages take precedence
 	if(H.ssd_check())
 		return "buzzes, \"Resuscitation failed - Mental interface error. Further attempts may be successful.\""
 
@@ -291,8 +294,8 @@
 	if(!combat)
 		for(var/obj/item/clothing/cloth in list(H.wear_suit, H.w_uniform))
 			if((cloth.body_parts_covered & UPPER_TORSO) && (cloth.item_flags & THICKMATERIAL))
-				return TRUE
-	return FALSE
+				return FALSE
+	return TRUE
 
 /obj/item/weapon/shockpaddles/proc/check_vital_organs(mob/living/carbon/human/H)
 	for(var/organ_tag in H.species.has_organ)
@@ -306,6 +309,19 @@
 			if(O.damage > O.max_damage)
 				return "buzzes, \"Resuscitation failed - Excessive damage to vital organ ([name]). Further attempts futile.\""
 	return null
+
+/obj/item/weapon/shockpaddles/proc/check_blood_level(mob/living/carbon/human/H)
+	if(!H.should_have_organ(BP_HEART))
+		return FALSE
+
+	var/obj/item/organ/internal/heart/heart = H.get_organ(BP_HEART)
+	if(!heart)
+		return TRUE
+
+	if(heart.get_effective_blood_volume() < BLOOD_VOLUME_SURVIVE)
+		return TRUE
+
+	return FALSE
 
 /obj/item/weapon/shockpaddles/proc/check_charge(var/charge_amt)
 	return 0

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -281,9 +281,6 @@
 	if(bad_vital_organ)
 		return bad_vital_organ
 
-	if(check_blood_level())
-		return "buzzes, \"Resuscitation failed - Patient is in hypovolemic shock.\""
-
 	//this needs to be last since if any of the 'other conditions are met their messages take precedence
 	if(H.ssd_check())
 		return "buzzes, \"Resuscitation failed - Mental interface error. Further attempts may be successful.\""
@@ -377,6 +374,9 @@
 		make_announcement(error, "warning")
 		playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
 		return
+
+	if(check_blood_level())
+		make_announcement("buzzes, \"Warning - Patient is in hypovolemic shock.\"", "warning") //also includes heart damage
 
 	//placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 	if(!do_after(user, chargetime, H))

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -1,7 +1,7 @@
 //Blood levels. These are percentages based on the species blood_volume far.
-var/const/BLOOD_VOLUME_SAFE =    85
-var/const/BLOOD_VOLUME_OKAY =    75
-var/const/BLOOD_VOLUME_BAD =     60
+var/const/BLOOD_VOLUME_SAFE    = 85
+var/const/BLOOD_VOLUME_OKAY    = 75
+var/const/BLOOD_VOLUME_BAD     = 60
 var/const/BLOOD_VOLUME_SURVIVE = 40
 
 /obj/item/organ/internal/heart
@@ -60,12 +60,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 		else
 			heartbeat++
 
-/obj/item/organ/internal/heart/proc/handle_blood()
-	if(!owner)
-		return
-	if(owner.stat == DEAD || owner.bodytemperature < 170)	//Dead or cryosleep people do not pump the blood.
-		return
-
+/obj/item/organ/internal/heart/proc/get_effective_blood_volume()
 	var/blood_volume_raw = owner.vessel.get_reagent_amount("blood")
 	var/blood_volume = round((blood_volume_raw/species.blood_volume)*100) // Percentage.
 
@@ -78,6 +73,16 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 		blood_volume *= 0.6
 	else if(damage > 1)
 		blood_volume *= 0.8
+
+	return blood_volume
+
+/obj/item/organ/internal/heart/proc/handle_blood()
+	if(!owner)
+		return
+	if(owner.stat == DEAD || owner.bodytemperature < 170)	//Dead or cryosleep people do not pump the blood.
+		return
+
+	var/blood_volume = get_effective_blood_volume()
 
 	//Effects of bloodloss
 	switch(blood_volume)
@@ -104,6 +109,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 			owner.adjustOxyLoss(10)
 
 	//Blood regeneration if there is some space
+	var/blood_volume_raw = owner.vessel.get_reagent_amount("blood")
 	if(blood_volume_raw < species.blood_volume)
 		var/datum/reagent/blood/B = owner.get_blood(owner.vessel)
 		B.volume += 0.1 // regenerate blood VERY slowly

--- a/html/changelogs/HarpyEagle-defib.yml
+++ b/html/changelogs/HarpyEagle-defib.yml
@@ -1,0 +1,4 @@
+author: HarpyEagle
+delete-after: True
+changes: 
+  - rscadd: "Defibrillators will now notify when the patient cannot be revived due to excessive blood loss."


### PR DESCRIPTION
Given that blood loss is probably the single most common cause of death for spessmen these days (at least, when I'm observing), this seems like a sensible thing to check for.

This should hopefully cover the last major cause of people dying immediately after being defibed.

Also inverted check_contact() so that the returned value matches the name better.


