### PR TITLE
[DNM]  Torch ID console and crew manifest tweaks

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -18,6 +18,7 @@
 
 /datum/datacore/proc/get_manifest(monochrome, OOC)
 	var/list/heads = new()
+	var/list/spt = new()
 	var/list/sec = new()
 	var/list/eng = new()
 	var/list/med = new()
@@ -72,6 +73,9 @@
 		if(real_rank in command_positions)
 			heads[name] = rank
 			department = 1
+		if(real_rank in support_positions)
+			spt[name] = rank
+			department = 1
 		if(real_rank in security_positions)
 			sec[name] = rank
 			department = 1
@@ -112,9 +116,14 @@
 
 
 	if(heads.len > 0)
-		dat += "<tr><th colspan=3>Heads</th></tr>"
+		dat += "<tr><th colspan=3>Heads of Staff</th></tr>"
 		for(name in heads)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[heads[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+	if(spt.len > 0)
+		dat += "<tr><th colspan=3>Command Support</th></tr>"
+		for(name in spt)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[spt[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 	if(sec.len > 0)
 		dat += "<tr><th colspan=3>Security</th></tr>"
@@ -132,7 +141,7 @@
 			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[med[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 	if(sci.len > 0)
-		dat += "<tr><th colspan=3>Science</th></tr>"
+		dat += "<tr><th colspan=3>Research</th></tr>"
 		for(name in sci)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[sci[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -136,6 +136,16 @@
 		for(name in sci)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[sci[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+	if(sup.len > 0)
+		dat += "<tr><th colspan=3>Supply</th></tr>"
+		for(name in sup)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[sup[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+	if(srv.len > 0)
+		dat += "<tr><th colspan=3>Service</th></tr>"
+		for(name in srv)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[srv[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
 	if(car.len > 0)
 		dat += "<tr><th colspan=3>Cargo</th></tr>"
 		for(name in car)
@@ -159,17 +169,6 @@
 			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[misc[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 
-	if(srv.len > 0)
-		dat += "<tr><th colspan=3Service</th></tr>"
-		for(name in srv)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[srv[name]]</td><td>[isactive[name]]</td></tr>"
-			even = !even
-
-	if(sup.len > 0)
-		dat += "<tr><th colspan=3Supply</th></tr>"
-		for(name in sup)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[sup[name]]</td><td>[isactive[name]]</td></tr>"
-			even = !even
 
 	dat += "</table>"
 	dat = replacetext(dat, "\n", "") // so it can be placed on paper correctly

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -49,6 +49,8 @@ var/global/datum/controller/occupations/job_master
 				service_positions |= job.title
 			if(job.department_flag & SUP)
 				supply_positions |= job.title
+			if(job.department_flag & SPT)
+				support_positions |= job.title
 
 		return 1
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -31,6 +31,8 @@ var/global/datum/controller/occupations/job_master
 			if(!setup_titles) continue
 			if(job.department_flag & COM)
 				command_positions |= job.title
+			if(job.department_flag & SPT)
+				support_positions |= job.title
 			if(job.department_flag & SEC)
 				security_positions |= job.title
 			if(job.department_flag & ENG)
@@ -39,18 +41,16 @@ var/global/datum/controller/occupations/job_master
 				medical_positions |= job.title
 			if(job.department_flag & SCI)
 				science_positions |= job.title
+			if(job.department_flag & SUP)
+				supply_positions |= job.title
+			if(job.department_flag & SRV)
+				service_positions |= job.title
 			if(job.department_flag & CRG)
 				cargo_positions |= job.title
 			if(job.department_flag & CIV)
 				civilian_positions |= job.title
 			if(job.department_flag & MSC)
 				nonhuman_positions |= job.title
-			if(job.department_flag & SRV)
-				service_positions |= job.title
-			if(job.department_flag & SUP)
-				supply_positions |= job.title
-			if(job.department_flag & SPT)
-				support_positions |= job.title
 
 		return 1
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -8,7 +8,7 @@ var/const/CRG               =(1<<6)
 var/const/MSC               =(1<<7)
 var/const/SRV               =(1<<8)
 var/const/SUP               =(1<<9)
-var/const/SPT				=(1<<10)
+var/const/SPT               =(1<<10)
 
 var/list/assistant_occupations = list(
 )

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -8,6 +8,7 @@ var/const/CRG               =(1<<6)
 var/const/MSC               =(1<<7)
 var/const/SRV               =(1<<8)
 var/const/SUP               =(1<<9)
+var/const/SPT				=(1<<10)
 
 var/list/assistant_occupations = list(
 )
@@ -42,6 +43,9 @@ var/list/service_positions = list(
 )
 
 var/list/supply_positions = list(
+)
+
+var/list/support_positions = list(
 )
 
 

--- a/code/game/objects/items/devices/PDA/manifest.dm
+++ b/code/game/objects/items/devices/PDA/manifest.dm
@@ -24,6 +24,8 @@ name updates also zero the list; although they are not in data_core, synths are 
 	var/med[0]
 	var/sci[0]
 	var/car[0]
+	var/sup[0]
+	var/srv[0]
 	var/civ[0]
 	var/bot[0]
 	var/misc[0]
@@ -111,6 +113,26 @@ name updates also zero the list; although they are not in data_core, synths are 
 			if(depthead && car.len != 1)
 				car.Swap(1,car.len)
 
+		if(real_rank in supply_positions)
+			sup[++sup.len] = list("name" = name,
+				"rank" = rank,
+				"active" = isactive,
+				"mil_branch" = mil_branch,
+				"mil_rank" = mil_rank)
+			department = 1
+			if(depthead && sup.len != 1)
+				sup.Swap(1,sup.len)
+
+		if(real_rank in service_positions)
+			srv[++srv.len] = list("name" = name,
+				"rank" = rank,
+				"active" = isactive,
+				"mil_branch" = mil_branch,
+				"mil_rank" = mil_rank)
+			department = 1
+			if(depthead && srv.len != 1)
+				srv.Swap(1,srv.len)
+
 		if(real_rank in civilian_positions)
 			civ[++civ.len] = list("name" = name,
 				"rank" = rank,
@@ -148,6 +170,8 @@ name updates also zero the list; although they are not in data_core, synths are 
 		"med" = med,\
 		"sci" = sci,\
 		"car" = car,\
+		"sup" = sup,\
+		"srv" = srv,\
 		"civ" = civ,\
 		"bot" = bot,\
 		"misc" = misc\

--- a/code/game/objects/items/devices/PDA/manifest.dm
+++ b/code/game/objects/items/devices/PDA/manifest.dm
@@ -30,7 +30,6 @@ name updates also zero the list; although they are not in data_core, synths are 
 	var/civ[0]
 	var/bot[0]
 	var/misc[0]
-
 	for(var/datum/data/record/t in data_core.general)
 		var/name = sanitize(t.fields["name"])
 		var/rank = sanitize(t.fields["rank"])
@@ -175,7 +174,7 @@ name updates also zero the list; although they are not in data_core, synths are 
 		bot[++bot.len] = list("name" = robot.name, "rank" = "[robot.modtype] [robot.braintype]", "active" = null)
 
 
-	PDA_Manifest = list(
+	PDA_Manifest = list(\
 		"heads" = heads,\
 		"spt" = spt,\
 		"sec" = sec,\

--- a/code/game/objects/items/devices/PDA/manifest.dm
+++ b/code/game/objects/items/devices/PDA/manifest.dm
@@ -19,6 +19,7 @@ name updates also zero the list; although they are not in data_core, synths are 
 	if(PDA_Manifest.len)
 		return
 	var/heads[0]
+	var/spt[0]
 	var/sec[0]
 	var/eng[0]
 	var/med[0]
@@ -29,6 +30,7 @@ name updates also zero the list; although they are not in data_core, synths are 
 	var/civ[0]
 	var/bot[0]
 	var/misc[0]
+
 	for(var/datum/data/record/t in data_core.general)
 		var/name = sanitize(t.fields["name"])
 		var/rank = sanitize(t.fields["rank"])
@@ -62,6 +64,16 @@ name updates also zero the list; although they are not in data_core, synths are 
 			depthead = 1
 			if(rank=="Captain" && heads.len != 1)
 				heads.Swap(1,heads.len)
+
+		if(real_rank in support_positions)
+			spt[++spt.len] = list("name" = name,
+				"rank" = rank,
+				"active" = isactive,
+				"mil_branch" = mil_branch,
+				"mil_rank" = mil_rank)
+			department = 1
+			if(depthead && spt.len != 1)
+				spt.Swap(1,spt.len)
 
 		if(real_rank in security_positions)
 			sec[++sec.len] = list("name" = name,
@@ -163,8 +175,9 @@ name updates also zero the list; although they are not in data_core, synths are 
 		bot[++bot.len] = list("name" = robot.name, "rank" = "[robot.modtype] [robot.braintype]", "active" = null)
 
 
-	PDA_Manifest = list(\
+	PDA_Manifest = list(
 		"heads" = heads,\
+		"spt" = spt,\
 		"sec" = sec,\
 		"eng" = eng,\
 		"med" = med,\

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -43,6 +43,7 @@
 		data["id_name"] = id_card ? id_card.name : "-----"
 
 	data["command_jobs"] = format_jobs(command_positions)
+	data["support_jobs"] = format_jobs(support_positions)
 	data["engineering_jobs"] = format_jobs(engineering_positions)
 	data["medical_jobs"] = format_jobs(medical_positions)
 	data["science_jobs"] = format_jobs(science_positions)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -42,12 +42,13 @@
 		data["id_owner"] = id_card && id_card.registered_name ? id_card.registered_name : "-----"
 		data["id_name"] = id_card ? id_card.name : "-----"
 
-
+	data["command_jobs"] = format_jobs(command_positions)
 	data["engineering_jobs"] = format_jobs(engineering_positions)
 	data["medical_jobs"] = format_jobs(medical_positions)
 	data["science_jobs"] = format_jobs(science_positions)
 	data["security_jobs"] = format_jobs(security_positions)
-	data["cargo_jobs"] = format_jobs(cargo_positions)
+	data["service_jobs"] = format_jobs(service_positions)
+	data["supply_jobs"] = format_jobs(supply_positions)
 	data["civilian_jobs"] = format_jobs(civilian_positions)
 	data["centcom_jobs"] = format_jobs(get_all_centcom_jobs())
 

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -185,8 +185,8 @@
 
 /datum/job/liaison
 	title = "NanoTrasen Liaison"
-	department = "Command"
-	department_flag = COM
+	department = "Support"
+	department_flag = SPT
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -209,8 +209,8 @@
 
 /datum/job/representative
 	title = "SolGov Representative"
-	department = "Command"
-	department_flag = COM
+	department = "Support"
+	department_flag = SPT
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -230,8 +230,8 @@
 
 /datum/job/sea
 	title = "Senior Enlisted Advisor"
-	department = "Command"
-	department_flag = COM
+	department = "Support"
+	department_flag = SPT
 	faction = "Station"
 	total_positions = 0
 	spawn_positions = 0
@@ -265,8 +265,8 @@
 
 /datum/job/bridgeofficer
 	title = "Bridge Officer"
-	department = "Command"
-	department_flag = COM
+	department = "Support"
+	department_flag = SPT
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -596,6 +596,12 @@ th.command {
     color: #ffffff;
 }
 
+th.spt {
+    background: #3333FF;
+    font-weight: bold;
+    color: #ffffff;
+}
+
 th.sec {
     background: #8e0000;
     font-weight: bold;
@@ -626,7 +632,19 @@ th.car {
     color: #ffffff;
 }
 
+th.sup {
+    background: #bb9040;
+    font-weight: bold;
+    color: #ffffff;
+}
+
 th.civ {
+    background: #a32800;
+    font-weight: bold;
+    color: #ffffff;
+}
+
+th.srv {
     background: #a32800;
     font-weight: bold;
     color: #ffffff;
@@ -637,6 +655,7 @@ th.misc {
     font-weight: bold;
     color: #ffffff;
 }
+
 th.bot {
     background: #414249;
     font-weight: bold;

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -94,7 +94,13 @@
 			</td>
 		  </tr>
 		  <tr>
-		  
+			<th style="color: '#800080';">Support</th>
+			<td>
+			  {{for data.support_jobs}}
+				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
+			  {{/for}}
+			</td>
+		  </tr>	  
 		  <tr>
 			<th style="color: '#FFA500';">Engineering</th>
 			<td>
@@ -136,7 +142,6 @@
 			</td>
 		  </tr>
 		  <tr>
-		  <tr>
 			<th style="color: '#800080';">Service</th>
 			<td>
 			  {{for data.service_jobs}}
@@ -145,12 +150,10 @@
 			</td>
 		  </tr>
 		  <tr>
-		  <tr>
 			<th style="color: '#808080';">Civilian</th>
 			<td>
 			  {{for data.civilian_jobs}}
 				{{if index && index % 6 === 0}}
-				  </td></tr><tr><th></th><td>
 				{{/if}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -85,17 +85,15 @@
 			  {{:helper.link("Custom", '', {'action' : 'assign', 'assign_target' : 'Custom'})}}
 			</td>
 		  </tr>
-		  	<tr>
-			<th style="color: '#cc6600';">Command</th>
+		  <tr>
+			<th style="color: '#800080';">Command</th>
 			<td>
 			  {{for data.command_jobs}}
-				{{if index && index % 6 === 0}}
-				  </td></tr><tr><th></th><td>
-				{{/if}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}
 			</td>
 		  </tr>
+		  <tr>
 		  
 		  <tr>
 			<th style="color: '#FFA500';">Engineering</th>
@@ -125,32 +123,28 @@
 			<th style="color: '#DD0000';">Security</th>
 			<td>
 			  {{for data.security_jobs}}
-				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
+			{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}
 			</td>
 		  </tr>
 		  <tr>
-			<th style="color: '#cc6600';">Supply</th>
+			<th style="color: '#800080';">Supply</th>
 			<td>
 			  {{for data.supply_jobs}}
-				{{if index && index % 6 === 0}}
-				  </td></tr><tr><th></th><td>
-				{{/if}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}
 			</td>
 		  </tr>
 		  <tr>
-			<th style="color: '#cc6600';">Service</th>
+		  <tr>
+			<th style="color: '#800080';">Service</th>
 			<td>
 			  {{for data.service_jobs}}
-				{{if index && index % 6 === 0}}
-				  </td></tr><tr><th></th><td>
-				{{/if}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}
 			</td>
 		  </tr>
+		  <tr>
 		  <tr>
 			<th style="color: '#808080';">Civilian</th>
 			<td>

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -85,6 +85,18 @@
 			  {{:helper.link("Custom", '', {'action' : 'assign', 'assign_target' : 'Custom'})}}
 			</td>
 		  </tr>
+		  	<tr>
+			<th style="color: '#cc6600';">Command</th>
+			<td>
+			  {{for data.command_jobs}}
+				{{if index && index % 6 === 0}}
+				  </td></tr><tr><th></th><td>
+				{{/if}}
+				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
+			  {{/for}}
+			</td>
+		  </tr>
+		  
 		  <tr>
 			<th style="color: '#FFA500';">Engineering</th>
 			<td>
@@ -118,9 +130,20 @@
 			</td>
 		  </tr>
 		  <tr>
-			<th style="color: '#cc6600';">Cargo</th>
+			<th style="color: '#cc6600';">Supply</th>
 			<td>
-			  {{for data.cargo_jobs}}
+			  {{for data.supply_jobs}}
+				{{if index && index % 6 === 0}}
+				  </td></tr><tr><th></th><td>
+				{{/if}}
+				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
+			  {{/for}}
+			</td>
+		  </tr>
+		  <tr>
+			<th style="color: '#cc6600';">Service</th>
+			<td>
+			  {{for data.service_jobs}}
 				{{if index && index % 6 === 0}}
 				  </td></tr><tr><th></th><td>
 				{{/if}}

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -298,7 +298,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 	    <div class="item">
             <center><table class="pmon"><tbody>
                 {{if data.manifest.heads.length}}
-                    <tr><th colspan="3" class="command">Command</th></tr>
+                    <tr><th colspan="3" class="command">Heads of Staff</th></tr>
                     {{for data.manifest["heads"]}}
                         {{if value.rank == "Captain"}}
                             <tr><td><span class="good">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
@@ -307,6 +307,12 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         {{/if}}
                     {{/for}}
                 {{/if}}
+				{{if data.manifest.spt.length}}
+                    <tr><th colspan="3" class="spt">Command Support</th></tr>
+                    {{for data.manifest["spt"]}}
+                            <tr><td><span class="average">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
+                    {{/for}}
+                {{/if}}				
                 {{if data.manifest.sec.length}}
                     <tr><th colspan="3" class="sec">Security</th></tr>
                     {{for data.manifest["sec"]}}
@@ -351,6 +357,26 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                     <tr><th colspan="3" class="car">Cargo</th></tr>
                     {{for data.manifest["car"]}}
                         {{if value.rank == "Quartermaster"}}
+                            <tr><td><span class="good">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
+                        {{else}}
+                            <tr><td><span class="average">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
+                        {{/if}}
+                    {{/for}}
+                {{/if}}
+				{{if data.manifest.sup.length}}
+                    <tr><th colspan="3" class="sup">Supply</th></tr>
+                    {{for data.manifest["sup"]}}
+                        {{if value.rank == "Quartermaster"}}
+                            <tr><td><span class="good">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
+                        {{else}}
+                            <tr><td><span class="average">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
+                        {{/if}}
+                    {{/for}}
+                {{/if}}
+				{{if data.manifest.srv.length}}
+                    <tr><th colspan="3" class="srv">Service</th></tr>
+                    {{for data.manifest["srv"]}}
+                        {{if value.rank == "Head of Personnel"}}
                             <tr><td><span class="good">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
                         {{else}}
                             <tr><td><span class="average">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>


### PR DESCRIPTION
Will fix #15871

![ss_1485730334](https://cloud.githubusercontent.com/assets/8846073/22408743/cf7bb878-e64b-11e6-9d8e-51eca60d4c5f.png)


- [x] Adds supply department to manifest and computer
- [x] Adds service department to manifest and computer
- [x] Adds the new 'support' category, a branch of the 'Heads' department, to differentiate between them and true heads of staff. This is for the Sol and NT representatives, the senior enlisted dude, and the bridge officers.
- [x] Add the above to the PDA crew manifest, too

Putting this up in the hopes that someone with a brain will be able to tell me why it's not working.
