### PR TITLE
Updates bluespace jump

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -379,6 +379,7 @@
 #include "code\game\gamemodes\cult\cultify\obj.dm"
 #include "code\game\gamemodes\cult\cultify\turf.dm"
 #include "code\game\gamemodes\endgame\endgame.dm"
+#include "code\game\gamemodes\endgame\bluespace_jump\bluespace_jump.dm"
 #include "code\game\gamemodes\endgame\nuclear_explosion\nuclear_explosion.dm"
 #include "code\game\gamemodes\endgame\supermatter_cascade\blob.dm"
 #include "code\game\gamemodes\endgame\supermatter_cascade\portal.dm"

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -3,7 +3,9 @@
 #define EVAC_OPT_CANCEL_ABANDON_SHIP "cancel_abandon_ship"
 #define EVAC_OPT_CANCEL_BLUESPACE_JUMP "cancel_bluespace_jump"
 
-/datum/evacuation_controller/pods
+// Apparently, emergency_evacuation --> "abandon ship" and !emergency_evacuation --> "bluespace jump"
+// That stuff should be moved to the evacuation option datums but someone can do that later
+/datum/evacuation_controller/starship
 	name = "escape pod controller"
 
 	transfer_prep_additional_delay = 10 MINUTES
@@ -14,9 +16,8 @@
 		EVAC_OPT_CANCEL_ABANDON_SHIP = new /datum/evacuation_option/cancel_abandon_ship(),
 		EVAC_OPT_CANCEL_BLUESPACE_JUMP = new /datum/evacuation_option/cancel_bluespace_jump()
 	)
-	var/list/bluespaced = list()
 
-/datum/evacuation_controller/pods/finish_preparing_evac()
+/datum/evacuation_controller/starship/finish_preparing_evac()
 	. = ..()
 	// Arm the escape pods.
 	if (emergency_evacuation)
@@ -24,53 +25,29 @@
 			if (pod.arming_controller)
 				pod.arming_controller.arm()
 
-/datum/evacuation_controller/pods/launch_evacuation()
+/datum/evacuation_controller/starship/launch_evacuation()
 
 	state = EVAC_IN_TRANSIT
 
-	// Launch the pods!
 	if (emergency_evacuation)
-		for (var/datum/shuttle/ferry/escape_pod/pod in escape_pods)
+		// Abondon Ship
+		for (var/datum/shuttle/ferry/escape_pod/pod in escape_pods) // Launch the pods!
 			if (!pod.arming_controller || pod.arming_controller.armed)
 				pod.move_time = (evac_transit_delay/10)
 				pod.launch(src)
+
 		priority_announcement.Announce(replacetext(replacetext(using_map.emergency_shuttle_leaving_dock, "%dock_name%", "[using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
 	else
-		//Bluespace'd!
+		// Bluespace Jump
 		priority_announcement.Announce(replacetext(replacetext(using_map.shuttle_leaving_dock, "%dock_name%", "[using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
+		SetUniversalState(/datum/universal_state/bluespace_jump, arguments=list(using_map.station_levels))
 
-		world.maxz++	//create a place for stragglers
-		using_map.sealed_levels |= world.maxz
-		for(var/mob/living/M in mob_list)
-			if(M.z in using_map.station_levels)
-				var/area/A = get_area(M)
-				if(istype(A,/area/space)) //straggler
-					var/turf/T = locate(M.x,M.y,world.maxz)
-					if(T)
-						M.forceMove(T)
-				else
-					if(M.client)
-						to_chat(M,"<span class='notice'>You feel oddly light.</span>")
-						M.overlay_fullscreen("bluespace", /obj/screen/fullscreen/bluespace_overlay)
-					M.incorporeal_move = 1
-					bluespaced |= M
-
-/datum/evacuation_controller/pods/finish_evacuation()
+/datum/evacuation_controller/starship/finish_evacuation()
 	..()
-	if (emergency_evacuation)
-		return
-	for(var/mob/living/M in bluespaced)
-		if(M.client)
-			to_chat(M,"<span class='notice'>You feel rooted in material world again.</span>")
-			M.clear_fullscreen("bluespace")
-		M.incorporeal_move = 0
-		var/turf/T = get_turf(M)
-		if(T.density)
-			to_chat(M,"<span class='danger'>[T] suddenly appears inside you!</span>")
-			M.gib()
-		bluespaced -= M
+	if(!emergency_evacuation) //bluespace jump
+		SetUniversalState(/datum/universal_state) //clear jump state
 
-/datum/evacuation_controller/pods/available_evac_options()
+/datum/evacuation_controller/starship/available_evac_options()
 	if (is_on_cooldown())
 		return list()
 	if (is_idle())

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -1,7 +1,7 @@
 #define EVAC_OPT_CALL_SHUTTLE "call_shuttle"
 #define EVAC_OPT_RECALL_SHUTTLE "recall_shuttle"
 
-/datum/evacuation_controller/pods/shuttle
+/datum/evacuation_controller/shuttle
 	name = "escape shuttle controller"
 	evac_waiting =  new(0, new_sound = sound('sound/AI/shuttledock.ogg'))
 	evac_called =   new(0, new_sound = sound('sound/AI/shuttlecalled.ogg'))
@@ -20,13 +20,13 @@
 	var/datum/shuttle/ferry/emergency/shuttle // Set in shuttle_emergency.dm
 	var/shuttle_launch_time
 
-/datum/evacuation_controller/pods/shuttle/has_evacuated()
+/datum/evacuation_controller/shuttle/has_evacuated()
 	return departed
 
-/datum/evacuation_controller/pods/shuttle/waiting_to_leave()
+/datum/evacuation_controller/shuttle/waiting_to_leave()
 	return (!autopilot || (shuttle && shuttle.is_launching()))
 
-/datum/evacuation_controller/pods/shuttle/launch_evacuation()
+/datum/evacuation_controller/shuttle/launch_evacuation()
 
 	if(waiting_to_leave())
 		return
@@ -41,12 +41,18 @@
 		shuttle.launch(src)
 	// Announcements, state changes and such are handled by the shuttle itself to prevent desync.
 
-/datum/evacuation_controller/pods/shuttle/finish_preparing_evac()
+/datum/evacuation_controller/shuttle/finish_preparing_evac()
 	departed = 1
 	evac_launch_time = world.time + evac_launch_delay
-	. = ..()
 
-/datum/evacuation_controller/pods/shuttle/call_evacuation(var/mob/user, var/_emergency_evac, var/forced)
+	. = ..()
+	// Arm the escape pods.
+	if (emergency_evacuation)
+		for (var/datum/shuttle/ferry/escape_pod/pod in escape_pods)
+			if (pod.arming_controller)
+				pod.arming_controller.arm()
+
+/datum/evacuation_controller/shuttle/call_evacuation(var/mob/user, var/_emergency_evac, var/forced)
 	if(..(user, _emergency_evac, forced))
 		autopilot = 1
 		shuttle_launch_time = evac_no_return
@@ -54,25 +60,25 @@
 		return 1
 	return 0
 
-/datum/evacuation_controller/pods/shuttle/cancel_evacuation()
+/datum/evacuation_controller/shuttle/cancel_evacuation()
 	if(..() && shuttle.moving_status != SHUTTLE_INTRANSIT)
 		shuttle_launch_time = null
 		shuttle.cancel_launch(src)
 		return 1
 	return 0
 
-/datum/evacuation_controller/pods/shuttle/get_eta()
+/datum/evacuation_controller/shuttle/get_eta()
 	if (shuttle && shuttle.has_arrive_time())
 		return (shuttle.arrive_time-world.time)/10
 	return ..()
 
-/datum/evacuation_controller/pods/shuttle/get_status_panel_eta()
+/datum/evacuation_controller/shuttle/get_status_panel_eta()
 	if(has_eta() && waiting_to_leave())
 		return "Launching..."
 	return ..()
 
 // This is largely handled by the emergency shuttle datum.
-/datum/evacuation_controller/pods/shuttle/process()
+/datum/evacuation_controller/shuttle/process()
 	if(state == EVAC_PREPPING)
 		if(!isnull(shuttle_launch_time) && world.time > shuttle_launch_time && shuttle.moving_status == SHUTTLE_IDLE)
 			shuttle.launch()
@@ -82,25 +88,25 @@
 		return
 	return ..()
 
-/datum/evacuation_controller/pods/shuttle/can_cancel()
+/datum/evacuation_controller/shuttle/can_cancel()
 	return (shuttle.moving_status == SHUTTLE_IDLE && shuttle.location && ..())
 
-/datum/evacuation_controller/pods/shuttle/proc/shuttle_leaving()
+/datum/evacuation_controller/shuttle/proc/shuttle_leaving()
 	state = EVAC_IN_TRANSIT
 
-/datum/evacuation_controller/pods/shuttle/proc/shuttle_evacuated()
+/datum/evacuation_controller/shuttle/proc/shuttle_evacuated()
 	state = EVAC_COMPLETE
 
-/datum/evacuation_controller/pods/shuttle/proc/shuttle_preparing()
+/datum/evacuation_controller/shuttle/proc/shuttle_preparing()
 	state = EVAC_PREPPING
 
-/datum/evacuation_controller/pods/shuttle/proc/get_long_jump_time()
+/datum/evacuation_controller/shuttle/proc/get_long_jump_time()
 	if (shuttle.location)
 		return round(evac_prep_delay/10)/2
 	else
 		return round(evac_transit_delay/10)
 
-/datum/evacuation_controller/pods/shuttle/available_evac_options()
+/datum/evacuation_controller/shuttle/available_evac_options()
 	if (!shuttle.location)
 		return list()
 	if (is_idle())

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -257,6 +257,9 @@
 	if(!z || (z in using_map.sealed_levels))
 		return
 
+	if(!universe.OnTouchMapEdge(src))
+		return
+
 	if(using_map.use_overmap)
 		overmap_spacetravel(get_turf(src), src)
 		return

--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -1,0 +1,82 @@
+/datum/universal_state/bluespace_jump
+	name = "Bluespace Jump"
+	var/list/bluespaced = list()
+	var/list/affected_levels
+	var/list/old_accessible_z_levels
+
+/datum/universal_state/bluespace_jump/New(var/list/zlevels)
+	affected_levels = zlevels
+
+/datum/universal_state/bluespace_jump/OnEnter()
+	var/space_zlevel = using_map.get_empty_zlevel() //get a place for stragglers
+	for(var/mob/living/M in mob_list)
+		if(M.z in affected_levels)
+			var/area/A = get_area(M)
+			if(istype(A,/area/space)) //straggler
+				var/turf/T = locate(M.x, M.y, space_zlevel)
+				if(T)
+					M.forceMove(T)
+			else
+				apply_bluespaced(M)
+				bluespaced += M
+
+	old_accessible_z_levels = using_map.accessible_z_levels.Copy()
+	for(var/z in affected_levels)
+		using_map.accessible_z_levels -= "[z]" //not accessible during the jump
+
+/datum/universal_state/bluespace_jump/OnExit()
+	for(var/M in bluespaced)
+		clear_bluespaced(M)
+
+	bluespaced.Cut()
+	using_map.accessible_z_levels = old_accessible_z_levels
+	old_accessible_z_levels = null
+
+/datum/universal_state/bluespace_jump/OnPlayerLatejoin(var/mob/living/M)
+	if(M.z in affected_levels)
+		apply_bluespaced(M)
+
+/datum/universal_state/bluespace_jump/OnTouchMapEdge(var/atom/A)
+	if((A.z in affected_levels) && (A in bluespaced))
+		if(ismob(A))
+			to_chat(A,"<span class='warning'>You drift away into the shifting expanse, never to be seen again.</span>")
+		qdel(A) //lost in bluespace
+		return FALSE
+	return TRUE
+
+/datum/universal_state/bluespace_jump/proc/check_density(var/mob/living/M)
+	var/turf/T = get_turf(M)
+	if(T && T.density)
+		return T
+	var/obj/machinery/door/airlock/A = locate() in T
+	if(A && A.density && M.blocks_airlock())
+		return A
+	return null
+
+/datum/universal_state/bluespace_jump/proc/apply_bluespaced(var/mob/living/M)
+	if(M.client)
+		to_chat(M,"<span class='notice'>You feel oddly light, and somewhat disoriented as everything around you shimmers and warps ever so slightly.</span>")
+		M.overlay_fullscreen("bluespace", /obj/screen/fullscreen/bluespace_overlay)
+	M.incorporeal_move = 1
+	M.confused = INFINITY //needed since normally confused ticks down own it's own
+
+/datum/universal_state/bluespace_jump/proc/clear_bluespaced(var/mob/living/M)
+	if(M.client)
+		to_chat(M,"<span class='notice'>You feel rooted in material world again.</span>")
+		M.clear_fullscreen("bluespace")
+
+	M.incorporeal_move = 0
+	M.confused = 0
+
+	var/atom/dense = check_density(M)
+	if(dense)
+		to_chat(M,"<span class='danger'>\The [dense] suddenly appears inside you!</span>")
+		M.gib()
+
+/obj/screen/fullscreen/bluespace_overlay
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "mfoam"
+	screen_loc = "WEST,SOUTH to EAST,NORTH"
+	color = "#FF9900"
+	blend_mode = BLEND_SUBTRACT
+	layer = FULLSCREEN_LAYER

--- a/code/game/gamemodes/endgame/endgame.dm
+++ b/code/game/gamemodes/endgame/endgame.dm
@@ -63,6 +63,12 @@
 /datum/universal_state/proc/OverlayAndAmbientSet()
 	return
 
+/datum/universal_state/proc/OnPlayerLatejoin(var/mob/living/M)
+	return
+
+/datum/universal_state/proc/OnTouchMapEdge(var/atom/A)
+	return TRUE //return FALSE to cancel map edge handling
+
 /proc/SetUniversalState(var/newstate,var/on_exit=1, var/on_enter=1, list/arguments=null)
 	if(on_exit)
 		universe.OnExit()

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -11,7 +11,7 @@
 	attackby(var/obj/item/weapon/card/W as obj, var/mob/user as mob)
 		if(stat & (BROKEN|NOPOWER))	return
 
-		var/datum/evacuation_controller/pods/shuttle/evac_control = evacuation_controller
+		var/datum/evacuation_controller/shuttle/evac_control = evacuation_controller
 		if(!istype(evac_control))
 			to_chat(user, "<span class='danger'>This console should not in use on this map. Please report this to a developer.</span>")
 			return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -391,6 +391,15 @@
 ///Called by client/Move()
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
+	if(mob.confused)
+		switch(mob.m_intent)
+			if("run")
+				if(prob(75))
+					direct = turn(direct, pick(90, -90))
+			if("walk")
+				if(prob(25))
+					direct = turn(direct, pick(90, -90))
+
 	var/turf/T = get_step(mob, direct)
 	if(mob.check_is_holy_turf(T))
 		to_chat(mob, "<span class='warning'>You cannot enter holy grounds while you are in this plane of existence!</span>")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -370,6 +370,7 @@
 		character.buckled.set_dir(character.dir)
 
 	ticker.mode.handle_latejoin(character)
+	universe.OnPlayerLatejoin(character)
 	if(job_master.ShouldCreateRecords(rank))
 		if(character.mind.assigned_role != "Cyborg")
 			data_core.manifest_inject(character)

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -1,7 +1,7 @@
 /datum/shuttle/ferry/emergency
 	category = /datum/shuttle/ferry/emergency
 	move_time = 10 MINUTES
-	var/datum/evacuation_controller/pods/shuttle/emergency_controller
+	var/datum/evacuation_controller/shuttle/emergency_controller
 
 /datum/shuttle/ferry/emergency/New()
 	. = ..()

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -13,6 +13,7 @@
 	contact_levels = list(1,2,4,6)
 	player_levels = list(1,2,4,5,6,7)
 	sealed_levels = list(6)
+	empty_levels = list(6)
 	accessible_z_levels = list("1" = 5, "2" = 5, "4" = 10, "5" = 15, "7" = 60)
 	base_turf_by_z = list("6" = /turf/simulated/floor/asteroid) // Moonbase
 
@@ -56,7 +57,7 @@
 							NETWORK_TELECOM
 							)
 
-	evac_controller_type = /datum/evacuation_controller/pods/shuttle
+	evac_controller_type = /datum/evacuation_controller/shuttle
 
 /datum/map/exodus/perform_map_generation()
 	new /datum/random_map/automata/cave_system(null, 1, 1, 6, 255, 255) // Create the mining Z-level.

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -10,6 +10,7 @@
 	contact_levels = list(1,2,3,4,5)
 	player_levels = list(1,2,3,4,5,6,7,8,9)
 	admin_levels = list(10,11)
+	empty_levels = list(6)
 	accessible_z_levels = list("1"=1,"2"=1,"3"=1,"4"=1,"5"=1,"6"=30,"7"=10,"8"=10)
 	base_turf_by_z = list("9" = /turf/simulated/floor/asteroid)
 
@@ -32,7 +33,7 @@
 	emergency_shuttle_called_message = "Attention all hands: emergecy evacuation procedures are now in effect. Escape pods will unlock in %ETA%"
 	emergency_shuttle_recall_message = "Attention all hands: emergency evacuation sequence aborted. Return to normal operating conditions."
 
-	evac_controller_type = /datum/evacuation_controller/pods
+	evac_controller_type = /datum/evacuation_controller/starship
 
 	default_law_type = /datum/ai_laws/solgov
 

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -30,6 +30,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/list/contact_levels = list() // Z-levels that can be contacted from the station, for eg announcements
 	var/list/player_levels = list()  // Z-levels a character can typically reach
 	var/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
+	var/list/empty_levels = null     // Empty Z-levels that may be used for various things (currently used by bluespace jump)
+
 	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
 	var/list/base_turf_by_z = list() // Custom base turf by Z-level. Defaults to world.turf for unlisted Z-levels
 
@@ -126,3 +128,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		return current_z_level
 	return text2num(pickweight(candidates))
 
+/datum/map/proc/get_empty_zlevel()
+	if(empty_levels == null)
+		world.maxz++
+		empty_levels = list(world.maxz)
+	return pick(empty_levels)


### PR DESCRIPTION
* Being in bluespace is now a endgame/universal_state datum
* Exodus evac controller is no longer a subtype of the torch one. Being a subtype made changes more complicated and it didn't really help much with code reuse anyways.
* Being in bluespace now is a bit disorienting, should make taking advantage of the incorporeal move a little more risky now.
* Handles mobs latespawning in.
* Handles zlevel transitions a bit better.

Might make it so that the map datum specifies a zlevel to use for empty space, and people left behind get put there instead of creating a whole new z, might save on lag I dunno.

Also shuttles departing/arriving during a bluespace jump is strange, but that will probably be seen to elsewhere.