### PR TITLE
Adds powernet debug verb

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -503,3 +503,25 @@
 		return
 
 	error_cache.showTo(usr)
+
+/obj/effect/debugmarker
+	icon = 'icons/effects/lighting_overlay.dmi'
+	icon_state = "light1"
+	plane = ABOVE_TURF_PLANE
+	layer = HOLOMAP_LAYER
+	alpha = 127
+
+/client/verb/visualpower()
+	set category = "Debug"
+	set name = "Visualize Powernets"
+	set desc = "Do not use on live server, visible to all players."
+
+	for(var/datum/powernet/PN in powernets)
+		var/netcolor = rgb(rand(100,255),rand(100,255),rand(100,255))
+		for(var/obj/structure/cable/C in PN.cables)
+			var/turf/T = get_turf(C)
+			var/obj/effect/debugmarker/D = locate(/obj/effect/debugmarker) in T
+			if(!D)
+				D = new(T)
+			D.color = netcolor
+			D.name = "\ref[PN]"


### PR DESCRIPTION
Draws colored stuff over powernets, different colors / names of objects for different powernets.
Handy for spotting non-connecting ones. 
Will be visible for all players and have to manually mass-delete it, so not really for live server use.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
