### PR TITLE
Makes resomii actually light sensitive

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -176,6 +176,7 @@ BLIND     // can't see anything
 	var/vision_flags = 0
 	var/darkness_view = 0//Base human is 2
 	var/see_invisible = -1
+	var/light_protection = 0
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
 		"Resomi" = 'icons/mob/species/resomi/eyes.dmi',

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -142,6 +142,7 @@
 	name = "Scanning Goggles"
 	desc = "A very oddly shaped pair of goggles with bits of wire poking out the sides. A soft humming sound emanates from it."
 	icon_state = "uzenwa_sissra_1"
+	light_protection = 7
 
 /obj/item/clothing/glasses/regular/hipster
 	name = "Prescription Glasses"

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -93,6 +93,7 @@
 	var/equipment_vision_flags				// Extra vision flags from equipped items
 	var/equipment_see_invis					// Max see invibility level granted by equipped items
 	var/equipment_prescription				// Eye prescription granted by equipped items
+	var/equipment_light_protection
 	var/list/equipment_overlays = list()	// Extra overlays from equipped items
 
 	var/med_record = ""

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -47,6 +47,7 @@
 	equipment_see_invis	= 0
 	equipment_vision_flags = 0
 	equipment_prescription = 0
+	equipment_light_protection = 0
 	equipment_darkness_modifier = 0
 	equipment_overlays.Cut()
 
@@ -64,6 +65,7 @@
 		equipment_darkness_modifier += G.darkness_view
 		equipment_vision_flags |= G.vision_flags
 		equipment_prescription += G.prescription
+		equipment_light_protection += G.light_protection
 		if(G.overlay)
 			equipment_overlays |= G.overlay
 		if(G.see_invisible >= 0)

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -33,7 +33,7 @@
 	metabolism_mod = 2.0
 	mob_size = MOB_SMALL
 	holder_type = /obj/item/weapon/holder/human
-	short_sighted = 6
+	light_sensitive = 6
 	gluttonous = GLUT_TINY
 	blood_volume = 280
 	hunger_factor = 0.2

--- a/html/changelogs/Kelenius-Resomi.yml
+++ b/html/changelogs/Kelenius-Resomi.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Resomii 'nearsightedness' is now correctly prevented by equipment that blocks bright lights, not prescription glasses, and goes away in the dark."


### PR DESCRIPTION
Prescription glasses no longer work.
Equipment that gives flash protection does.
That includes sunglasses, welding equipment, and space helmets.
Scanning goggles specifically also work.
Lower light levels make overlay less severe.
Light level below 1/3 of the maximum removes it completely.
DNM pending feedback from Snapshot.