### PR TITLE
Obscures the admin's character name when they take on an adminhelp.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1167,7 +1167,7 @@
 			for(var/client/X in admins)
 				if((R_ADMIN|R_MOD|R_MENTOR) & X.holder.rights)
 					to_chat(X, take_msg)
-			to_chat(M, "<span class='notice'><b>Your adminhelp is being attended to by [key_name(usr.client)]. Thanks for your patience!</b></span>")
+			to_chat(M, "<span class='notice'><b>Your adminhelp is being attended to by [usr.client]. Thanks for your patience!</b></span>")
 		else
 			to_chat(usr, "<span class='warning'>Unable to locate mob.</span>")
 


### PR DESCRIPTION
#15928

References the client rather than getting the key_name of the client that presses the "TAKE" button.
![Bottom, bold line is what prints to person who ahelped.](http://i.imgur.com/6d0jEuI.png)