### PR TITLE
Defibs now check all forms of lethal damage except oxyloss

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -274,7 +274,8 @@
 	if (deadtime > DEFIB_TIME_LIMIT)
 		return "buzzes, \"Resuscitation failed - Excessive neural degeneration. Further attempts futile.\""
 
-	if((H.getFireLoss() + H.getBruteLoss() + H.getCloneLoss() + burn_damage_amt) >= (H.maxHealth - config.health_threshold_dead) || HUSK in H.mutations)
+	H.updatehealth()
+	if(H.health + H.getOxyLoss() <= config.health_threshold_dead || (HUSK in H.mutations))
 		return "buzzes, \"Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator. Further attempts futile.\""
 
 	var/bad_vital_organ = check_vital_organs(H)


### PR DESCRIPTION
...when deciding whether or not revival succeeds. Lethal damage of course is damage that is compared against `config.health_threshold_dead`.

I'm not sure if something like toxloss makes sense for "severe tissue damage", don't really care anymore.