### PR TITLE
Species-specific blood bags

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -227,6 +227,18 @@
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/rum,\
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/patron)
 
+/obj/random/bloodpack
+	name = "random BloodPack"
+	desc = "This is a random BloodPack."
+	icon = 'icons/obj/bloodpack.dmi'
+	icon_state = "empty"
+	item_to_spawn()
+		return pick(prob(5);/obj/item/weapon/reagent_containers/blood/random,\
+					prob(1);/obj/item/weapon/reagent_containers/blood/random/unathi,\
+					prob(1);/obj/item/weapon/reagent_containers/blood/random/tajara,\
+					prob(1);/obj/item/weapon/reagent_containers/blood/random/skrell,\
+					prob(1);/obj/item/weapon/reagent_containers/blood/random/resomi,\
+					prob(1);/obj/item/weapon/reagent_containers/blood/empty)
 
 /obj/random/energy
 	name = "Random Energy Weapon"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -104,7 +104,7 @@
 
 /datum/reagent/proc/initialize_data(var/newdata) // Called when the reagent is created.
 	if(!isnull(newdata))
-		data = newdata
+		data = newdata|data
 	return
 
 /datum/reagent/proc/mix_data(var/newdata, var/newamount) // You have a reagent with data, and new reagent with its own data get added, how do you deal with that?

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -19,13 +19,16 @@
 	icon_state = "empty"
 	volume = 200
 
+	var/species = "Human"
 	var/blood_type = null
 
 /obj/item/weapon/reagent_containers/blood/New()
 	..()
 	if(blood_type)
-		name = "BloodPack [blood_type]"
-		reagents.add_reagent("blood", 200, list("donor" = null, "blood_DNA" = null, "blood_type" = blood_type, "trace_chem" = null, "virus2" = list(), "antibodies" = list()))
+		name = "BloodPack ([species], [blood_type])"
+		var/datum/species/species_type = all_species[species]
+		var/blood_colour = species_type.blood_color
+		reagents.add_reagent("blood", 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"species"=species,"resistances"=null,"trace_chem"=null,"blood_colour"=blood_colour))
 		update_icon()
 
 /obj/item/weapon/reagent_containers/blood/on_reagent_change()
@@ -58,4 +61,33 @@
 /obj/item/weapon/reagent_containers/blood/OMinus
 	blood_type = "O-"
 
+/obj/item/weapon/reagent_containers/blood/OMinus/unathi
+	species = "Unathi"
+
+/obj/item/weapon/reagent_containers/blood/OMinus/tajara
+	species = "Tajaran"
+
+/obj/item/weapon/reagent_containers/blood/OMinus/skrell
+	species = "Skrell"
+
+/obj/item/weapon/reagent_containers/blood/OMinus/resomi
+	species = "Resomi"
+
+/obj/item/weapon/reagent_containers/blood/random/New()
+	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-")
+	..()
+
+/obj/item/weapon/reagent_containers/blood/random/unathi
+	species = "Unathi"
+
+/obj/item/weapon/reagent_containers/blood/random/tajara
+	species = "Tajaran"
+
+/obj/item/weapon/reagent_containers/blood/random/skrell
+	species = "Skrell"
+
+/obj/item/weapon/reagent_containers/blood/random/resomi
+	species = "Resomi"
+
 /obj/item/weapon/reagent_containers/blood/empty
+	species = null

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -28,7 +28,7 @@
 		name = "BloodPack ([species], [blood_type])"
 		var/datum/species/species_type = all_species[species]
 		var/blood_colour = species_type.blood_color
-		reagents.add_reagent("blood", 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"species"=species,"resistances"=null,"trace_chem"=null,"blood_colour"=blood_colour))
+		reagents.add_reagent("blood", 200, list("blood_type"=blood_type,"species"=species,"blood_colour"=blood_colour))
 		update_icon()
 
 /obj/item/weapon/reagent_containers/blood/on_reagent_change()

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -23,9 +23,8 @@
 			return
 		var/obj/item/weapon/reagent_containers/glass/beaker/product = new(src.loc)
 
-		var/list/data = list("donor" = null, "blood_DNA" = null, "blood_type" = null, "trace_chem" = null, "virus2" = list(), "antibodies" = list())
-		data["virus2"] |= I:virus2
-		product.reagents.add_reagent("blood",30,data)
+		var/obj/item/weapon/virusdish/V = I
+		product.reagents.add_reagent("blood",30,list("virus2" = V.virus2))
 
 		virusing = 1
 		spawn(1200) virusing = 0

--- a/html/changelogs/Hubblenaut-blood.yml
+++ b/html/changelogs/Hubblenaut-blood.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The bloodpacks that spawn on the map are now species-specific."
+  - rscadd: "Some bloodpacks will spawn with a random species and blood group."


### PR DESCRIPTION
- [x] Adds code for mapping species-specific blood bags
- [x] Adds code for randomised blood bags
- [x] Makes `add_reagent()` more coder-friendly for reagents with long lists of data (i.e. `reagent/blood`)
- [ ] Maps in the new blood bags *(which will be done after code is approved)*

Don't merge before this is mapped in.

**Old PR:** #15805 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
