### PR TITLE
Fixes #15951

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1081,8 +1081,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		organ.forceMove(src)
 
 	// Remove parent references
-	parent.children -= src
-	parent = null
+	if(parent)
+		parent.children -= src
+		parent = null
 
 	release_restraints(victim)
 	victim.organs -= src


### PR DESCRIPTION
Fixes #15951

parent can be null if for example someone is being gibbed.