### PR TITLE
expands the functionality of holopads by enabling holocalls

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -33,7 +33,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 /obj/machinery/hologram/holopad
 	name = "\improper AI holopad"
-	desc = "It's a floor-mounted device for projecting holographic images. It is activated remotely."
+	desc = "It's a floor-mounted device for projecting holographic images."
 	icon_state = "holopad0"
 
 	plane = ABOVE_TURF_PLANE
@@ -47,19 +47,88 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	var/last_request = 0 //to prevent request spam. ~Carn
 	var/holo_range = 5 // Change to change how far the AI can move away from the holopad before deactivating.
 
+	var/incoming_connection = 0
+	var/mob/living/caller_id
+	var/obj/machinery/hologram/holopad/sourcepad
+	var/obj/machinery/hologram/holopad/targetpad
+	var/last_message
+
+/obj/machinery/hologram/holopad/New()
+	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[loc.loc]'"
+
 /obj/machinery/hologram/holopad/attack_hand(var/mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))
 		return
-	if(alert(user,"Would you like to request an AI's presence?",,"Yes","No") == "Yes")
-		if(last_request + 200 < world.time) //don't spam the AI with requests you jerk!
-			last_request = world.time
-			to_chat(user, "<span class='notice'>You request an AI's presence.</span>")
-			var/area/area = get_area(src)
-			for(var/mob/living/silicon/ai/AI in living_mob_list_)
-				if(!AI.client)	continue
-				to_chat(AI, "<span class='info'>Your presence is requested at <a href='?src=\ref[AI];jumptoholopad=\ref[src]'>\the [area]</a>.</span>")
-		else
-			to_chat(user, "<span class='notice'>A request for AI presence was already sent recently.</span>")
+	if(incoming_connection&&caller_id)
+		visible_message("The pad hums quietly as it establishes a connection.")
+		if(caller_id.loc!=sourcepad.loc)
+			visible_message("The pad flashes an error message. The caller has left their holopad.")
+			return
+		take_call(user)
+		return
+	else if(caller_id && !incoming_connection)
+		visible_message("Severing connection to distant holopad.")
+		end_call(user)
+		return
+	switch(alert(user,"Would you like to request an AI's presence or establish communications with another pad?", "Holopad","AI","Holocomms","Cancel"))
+		if("AI")
+			if(last_request + 200 < world.time) //don't spam the AI with requests you jerk!
+				last_request = world.time
+				to_chat(user, "<span class='notice'>You request an AI's presence.</span>")
+				var/area/area = get_area(src)
+				for(var/mob/living/silicon/ai/AI in living_mob_list_)
+					if(!AI.client)	continue
+					to_chat(AI, "<span class='info'>Your presence is requested at <a href='?src=\ref[AI];jumptoholopad=\ref[src]'>\the [area]</a>.</span>")
+			else
+				to_chat(user, "<span class='notice'>A request for AI presence was already sent recently.</span>")
+		if("Holocomms")
+			if(user.loc != src.loc)
+				to_chat(user, "<span class='info'>Please step unto the holopad.</span>")
+				return
+			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
+				last_request = world.time
+				var/list/holopadlist = list()
+				for(var/obj/machinery/hologram/holopad/H in machines)
+					if((H.z in using_map.station_levels) && H.operable())
+						holopadlist["[H.loc.loc.name]"] = H	//Define a list and fill it with the area of every holopad in the world
+				holopadlist = sortAssoc(holopadlist)
+				var/temppad = input(user, "Which holopad would you like to contact?", "holopad list") as null|anything in holopadlist
+				targetpad = holopadlist["[temppad]"]
+				if(targetpad==src)
+					to_chat(user, "<span class='info'>Using such sophisticated technology, just to talk to yourself seems a bit silly.</span>")
+					return
+				if(targetpad)
+					make_call(targetpad, user)
+
+/obj/machinery/hologram/holopad/proc/make_call(var/obj/machinery/hologram/holopad/targetpad, var/mob/living/carbon/user)
+	targetpad.last_request = world.time
+	targetpad.sourcepad = src //This marks the holopad you are making the call from
+	targetpad.caller_id = user //This marks you as the caller
+	targetpad.incoming_connection = 1
+	playsound(targetpad.loc, 'sound/machines/chime.ogg', 25, 5)
+	targetpad.icon_state = "holopad1"
+	targetpad.audible_message("<b>\The [src]</b> announces, \"Incoming communications request from [targetpad.sourcepad.loc.loc].\"")
+	to_chat(user, "<span class='notice'>Trying to establish a connection to the holopad in [targetpad.loc.loc]... Please await confirmation from recipient.</span>")
+
+
+/obj/machinery/hologram/holopad/proc/take_call(mob/living/carbon/user)
+	incoming_connection = 0
+	caller_id.machine = sourcepad
+	caller_id.reset_view(src)
+	if(!masters[caller_id])//If there is no hologram, possibly make one.
+		activate_holocall(caller_id)
+	log_admin("[key_name(caller_id)] just established a holopad connection from [sourcepad.loc.loc] to [src.loc.loc]")
+
+/obj/machinery/hologram/holopad/proc/end_call(mob/user)
+	caller_id.unset_machine()
+	caller_id.reset_view() //Send the caller back to his body
+	clear_holo(caller_id) // destroy the hologram
+	caller_id = null //Reset caller_id
+	sourcepad.targetpad = null
+	sourcepad = null //Reset source
+
+/obj/machinery/hologram/holopad/check_eye(mob/user)
+	return 0
 
 /obj/machinery/hologram/holopad/attack_ai(mob/living/silicon/ai/user)
 	if (!istype(user))
@@ -86,6 +155,14 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 		to_chat(user, "<span class='danger'>ERROR:</span> Unable to project hologram.")
 	return
 
+/obj/machinery/hologram/holopad/proc/activate_holocall(mob/living/carbon/caller_id)
+	if(caller_id)
+		create_holo(0,caller_id)//Create one.
+		src.visible_message("A holographic image of [caller_id] flicks to life right before your eyes!")
+	else
+		to_chat(caller_id, "<span class='danger'>ERROR:</span> Unable to project hologram.")
+	return
+
 /*This is the proc for special two-way communication between AI and holopad/people talking near holopad.
 For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/hear_talk(mob/living/M, text, verb, datum/language/speaking)
@@ -104,6 +181,15 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			else
 				rendered = "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [verb], <span class='message'>\"[text]\"</span></span></i>"
 			master.show_message(rendered, 2)
+	var/name_used = M.GetVoice()
+	if(targetpad) //If this is the pad you're making the call from
+		var/message = "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [speaking.format_message(text, verb)]</span></i>"
+		targetpad.audible_message(message)
+		targetpad.last_message = message
+	if(sourcepad) //If this is a pad receiving a call
+		if(name_used==caller_id||text==last_message||findtext(text, "Holopad received")) //prevent echoes
+			return
+		sourcepad.audible_message("<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [speaking.format_message(text, verb)]</span></i>")
 
 /obj/machinery/hologram/holopad/see_emote(mob/living/M, text)
 	if(M)
@@ -112,39 +198,73 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			var/rendered = "<i><span class='game say'>Holopad received, <span class='message'>[text]</span></span></i>"
 			//The lack of name_used is needed, because message already contains a name.  This is needed for simple mobs to emote properly.
 			master.show_message(rendered, 2)
-	return
+		for(var/mob/living/carbon/master in masters)
+			//var/name_used = M.GetVoice()
+			var/rendered = "<i><span class='game say'>Holopad received, <span class='message'>[text]</span></span></i>"
+			//The lack of name_used is needed, because message already contains a name.  This is needed for simple mobs to emote properly.
+			master.show_message(rendered, 2)
+		if(targetpad)
+			targetpad.visible_message("<i><span class='message'>[text]</span></i>")
 
 /obj/machinery/hologram/holopad/show_message(msg, type, alt, alt_type)
 	for(var/mob/living/silicon/ai/master in masters)
-		var/rendered = "<i><span class='game say'>Holopad received, <span class='message'>[msg]</span></span></i>"
+		var/rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
 		master.show_message(rendered, type)
-	return
+	if(findtext(msg, "Holopad received,"))
+		return
+	for(var/mob/living/carbon/master in masters)
+		var/rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
+		master.show_message(rendered, type)
+	if(targetpad)
+		for(var/mob/living/carbon/master in view(targetpad))
+			var/rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
+			master.show_message(rendered, type)
 
-/obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, turf/T = loc)
+/obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, mob/living/carbon/caller_id, turf/T = loc)
 	var/obj/effect/overlay/hologram = new(T)//Spawn a blank effect at the location.
-	hologram.overlays += A.holo_icon // Add it as an overlay to keep coloration!
+	if(caller_id)
+		var/tempicon = 0
+		for(var/datum/data/record/t in data_core.locked)
+			if(t.fields["name"]==caller_id.name)
+				tempicon = t.fields["image"]
+		hologram.overlays += getHologramIcon(icon(tempicon)) // Add the callers image as an overlay to keep coloration!
+	else
+		hologram.overlays += A.holo_icon // Add the AI's configured holo Icon
 	hologram.mouse_opacity = 0//So you can't click on it.
 	hologram.plane = ABOVE_HUMAN_PLANE
 	hologram.layer = ABOVE_HUMAN_LAYER //Above all the other objects/mobs. Or the vast majority of them.
 	hologram.anchored = 1//So space wind cannot drag it.
-	hologram.name = "[A.name] (Hologram)"//If someone decides to right click.
+	if(caller_id)
+		hologram.name = "[caller_id.name] (Hologram)"
+		hologram.loc = get_step(src,1)
+		masters[caller_id] = hologram
+	else
+		hologram.name = "[A.name] (Hologram)"//If someone decides to right click.
+		A.holo = src
+		masters[A] = hologram
 	hologram.set_light(2)	//hologram lighting
 	hologram.color = color //painted holopad gives coloured holograms
-	masters[A] = hologram
 	set_light(2)			//pad lighting
 	icon_state = "holopad1"
-	A.holo = src
 	return 1
 
-/obj/machinery/hologram/holopad/proc/clear_holo(mob/living/silicon/ai/user)
-	if(user.holo == src)
+/obj/machinery/hologram/holopad/proc/clear_holo(mob/living/silicon/ai/user, mob/living/carbon/caller_id)
+	if(user)
+		qdel(masters[user])//Get rid of user's hologram
 		user.holo = null
-	qdel(masters[user])//Get rid of user's hologram
-	masters -= user //Discard AI from the list of those who use holopad
+		masters -= user //Discard AI from the list of those who use holopad
+	if(caller_id)
+		qdel(masters[caller_id])//Get rid of user's hologram
+		masters -= caller_id //Discard the caller from the list of those who use holopad
 	if (!masters.len)//If no users left
 		set_light(0)			//pad lighting (hologram lighting will be handled automatically since its owner was deleted)
 		icon_state = "holopad0"
+		if(sourcepad)
+			sourcepad = null
+			sourcepad.targetpad = null
+			caller_id = null
 	return 1
+
 
 /obj/machinery/hologram/holopad/process()
 	for (var/mob/living/silicon/ai/master in masters)
@@ -158,6 +278,17 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			continue
 
 		use_power(power_per_hologram)
+	if(last_request + 200 < world.time&&incoming_connection==1)
+		incoming_connection = 0
+		end_call()
+		if(sourcepad)
+			sourcepad.audible_message("<i><span class='game say'>The holopad connection timed out</span></i>")
+			sourcepad = 0
+	if (caller_id&&sourcepad)
+		if(caller_id.loc!=sourcepad.loc)
+			sourcepad.visible_message("Severing connection to distant holopad.")
+			visible_message("The connection has been terminated by [caller_id].")
+			end_call()
 	return 1
 
 /obj/machinery/hologram/holopad/proc/move_hologram(mob/living/silicon/ai/user)
@@ -180,6 +311,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			if(hologram_area != holo_area)
 				clear_holo(user)
 	return 1
+
 
 /obj/machinery/hologram/holopad/proc/set_dir_hologram(new_dir, mob/living/silicon/ai/user)
 	if(masters[user])
@@ -212,7 +344,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	return
 
 /obj/machinery/hologram/holopad/Destroy()
-	for (var/mob/living/silicon/ai/master in masters)
+	for (var/mob/living/master in masters)
 		clear_holo(master)
 	..()
 

--- a/html/changelogs/Nero-07-holocomms.yml
+++ b/html/changelogs/Nero-07-holocomms.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nero07
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added communications functionality to AI holopads. To use, stand on a holopad and click it. Make a new holocall and select the target pad from the list. The targetpad will light up, emit a sound and inform nearby players about the incoming call. To pick it up, just click the pad. The caller is projected above the holopad and can talk to/emote with all people in view of the holopad. To end the call, step off the holopad. The call can also be ended from the other side by clicking the active holopad."


### PR DESCRIPTION
We have these holopads all over the ship and if you think about it, during the typical round, maybe two of them see use for like 2 minutes and thats it.

Not anymore!

It is now possible to call other holopads and have them display a hologram of your ugly mug for all to see.

How to:
1. stand on the holopad or you'll get an error
2. choose to start a new holocall
3. choose your desired target holopad from the sorted list of all holopads on board
4. the target holopad will light up, emit a sound and inform nearby personnel about the identity and source holopad of the caller
5. If someone picks up, you are projected above the target holopad and can talk and emote with everyone in range of it.
6. The call can be ended either by the other party clicking the pad or you yourself moving, so you're no longer on the sourcepad.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
