### PR TITLE
Misc Security-related Fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -133,6 +133,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/donut/,
 		/obj/item/weapon/melee/baton,
 		/obj/item/weapon/gun/energy/taser,
+		/obj/item/weapon/gun/energy/stunrevolver,
 		/obj/item/weapon/flame/lighter,
 		/obj/item/clothing/glasses/hud/security,
 		/obj/item/device/flashlight,

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -103,15 +103,7 @@
 /obj/item/weapon/storage/box/large/holobadge/solgov
 	name = "holobadge box"
 	desc = "A box claiming to contain holobadges, this one has 'Master at Arms' written on it in fine print."
-	New()
-		new /obj/item/clothing/accessory/badge/security(src)
-		new /obj/item/clothing/accessory/badge/security(src)
-		new /obj/item/clothing/accessory/badge/security(src)
-		new /obj/item/clothing/accessory/badge/security(src)
-		new /obj/item/clothing/accessory/badge/security(src)
-		new /obj/item/clothing/accessory/badge/security(src)
-		..()
-		return
+	startswith = list(/obj/item/clothing/accessory/badge/security = 6)
 
 
 /obj/item/clothing/accessory/badge/security

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -100,6 +100,20 @@
 		return
 
 
+/obj/item/weapon/storage/box/large/holobadge/solgov
+	name = "holobadge box"
+	desc = "A box claiming to contain holobadges, this one has 'Master at Arms' written on it in fine print."
+	New()
+		new /obj/item/clothing/accessory/badge/security(src)
+		new /obj/item/clothing/accessory/badge/security(src)
+		new /obj/item/clothing/accessory/badge/security(src)
+		new /obj/item/clothing/accessory/badge/security(src)
+		new /obj/item/clothing/accessory/badge/security(src)
+		new /obj/item/clothing/accessory/badge/security(src)
+		..()
+		return
+
+
 /obj/item/clothing/accessory/badge/security
 	name = "security forces badge"
 	desc = "A silver law enforcement badge. Stamped with the words 'Master at Arms'."

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -100,10 +100,11 @@
 		return
 
 
-/obj/item/weapon/storage/box/large/holobadge/solgov
+/obj/item/weapon/storage/box/holobadge/solgov
 	name = "holobadge box"
 	desc = "A box claiming to contain holobadges, this one has 'Master at Arms' written on it in fine print."
-	startswith = list(/obj/item/clothing/accessory/badge/security = 6)
+	startswith = list(/obj/item/clothing/accessory/badge/security = 4)
+	w_class = ITEM_SIZE_TINY
 
 
 /obj/item/clothing/accessory/badge/security

--- a/html/changelogs/lorwp-misc-fixes.yml
+++ b/html/changelogs/lorwp-misc-fixes.yml
@@ -1,0 +1,8 @@
+author: Lorwp
+
+delete-after: True
+
+changes: 
+    - tweak: "Change's Brig Officer's holobadge box to have Master At Arms Holobadges"
+    - tweak: "Allow Security Messenger Bags to be able to spawn in Security Lockers"
+    - tweak: "All Security and NT Guards spawn with Work Gloves now"

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -137,6 +137,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security/command
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
+	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/weapon/card/id/torch/silver/security
 	pda_type = /obj/item/device/pda/heads/hos
 	backpack = /obj/item/weapon/storage/backpack/security
@@ -294,6 +295,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
+	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/weapon/card/id/torch/crew/security/brigofficer
 	pda_type = /obj/item/device/pda/warden
 
@@ -314,6 +316,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
+	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/weapon/card/id/torch/crew/security/forensic
 	pda_type = /obj/item/device/pda/detective
 
@@ -334,6 +337,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
+	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/weapon/card/id/torch/crew/security
 	pda_type = /obj/item/device/pda/security
 
@@ -674,6 +678,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/rank/guard
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/soft/sec/corp/guard
+	gloves = /obj/item/clothing/gloves/thick
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel_one = /obj/item/weapon/storage/backpack/satchel_sec
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/guard

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -288,6 +288,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	l_ear = /obj/item/device/radio/headset/headset_sec
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel_one = /obj/item/weapon/storage/backpack/satchel_sec
+	gloves = /obj/item/clothing/gloves/thick
 	pda_slot = slot_l_store
 
 /decl/hierarchy/outfit/job/torch/crew/security/brig_officer
@@ -295,7 +296,6 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
-	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/weapon/card/id/torch/crew/security/brigofficer
 	pda_type = /obj/item/device/pda/warden
 
@@ -316,7 +316,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
-	gloves = /obj/item/clothing/gloves/thick
+	gloves = /obj/item/clothing/gloves/forensic
 	id_type = /obj/item/weapon/card/id/torch/crew/security/forensic
 	pda_type = /obj/item/device/pda/detective
 
@@ -337,7 +337,6 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dress
 	head = /obj/item/clothing/head/soft/sol/expedition
-	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/weapon/card/id/torch/crew/security
 	pda_type = /obj/item/device/pda/security
 
@@ -678,7 +677,6 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/rank/guard
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/soft/sec/corp/guard
-	gloves = /obj/item/clothing/gloves/thick
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel_one = /obj/item/weapon/storage/backpack/satchel_sec
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/guard

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -117,7 +117,7 @@
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/handcuffs,
 		/obj/item/device/hailer,
-		/obj/item/weapon/storage/box/large/holobadge/solgov,
+		/obj/item/weapon/storage/box/holobadge/solgov,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/clipboard,

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -41,6 +41,8 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)
 
 
 /obj/structure/closet/secure_closet/cos
@@ -86,6 +88,8 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)
 
 /obj/structure/closet/secure_closet/brigofficer
 	name = "brig officer's locker"
@@ -113,7 +117,7 @@
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/handcuffs,
 		/obj/item/device/hailer,
-		/obj/item/weapon/storage/box/holobadge,
+		/obj/item/weapon/storage/box/large/holobadge/solgov,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/clipboard,
@@ -130,6 +134,8 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)
 
 
 /obj/structure/closet/secure_closet/forensics
@@ -179,3 +185,5 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)


### PR DESCRIPTION
- Allows Stun Revolvers to be put in Security Belts
- Implements Master At Arms Holobadge Box (Fixes #15989)
- Adds Security Messenger bags to Security Lockers (Does NOT help #15927, that’s for the people who aren’t shamelessly copying code)
- Adds Work Gloves to ~~NT Guard~~ and Solgov Security ~~Standard Spawn~~ Lockers
