### PR TITLE
Adds unit test for roundstart cable connectivity

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2245,6 +2245,7 @@
 #include "code\unit_tests\movement_tests.dm"
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\organ_tests.dm"
+#include "code\unit_tests\power_tests.dm"
 #include "code\unit_tests\reagent_tests.dm"
 #include "code\unit_tests\shuttle_tests.dm"
 #include "code\unit_tests\test_obj.dm"

--- a/code/unit_tests/power_tests.dm
+++ b/code/unit_tests/power_tests.dm
@@ -1,0 +1,49 @@
+datum/unit_test/roundstart_cable_connectivity
+	name = "POWER: Roundstart Cables that are Connected Share Powernets"
+
+datum/unit_test/roundstart_cable_connectivity/proc/find_connected_neighbours(var/obj/structure/cable/C)
+	. = list()
+	if(C.d1 != 0)
+		. += get_connected_neighbours(C, C.d1)
+	if(C.d2 != 0)
+		. += get_connected_neighbours(C, C.d2)
+
+datum/unit_test/roundstart_cable_connectivity/proc/get_connected_neighbours(var/obj/structure/cable/self, var/dir)
+	var/turf/T = get_step(get_turf(self), dir)
+	var/reverse = reverse_dir[dir]
+
+	. = list() //can have multiple connected neighbours for a dir, e.g. Y-junctions
+	for(var/obj/structure/cable/other in T)
+		if(other.d1 == reverse || other.d2 == reverse)
+			. += other
+
+datum/unit_test/roundstart_cable_connectivity/start_test()
+	var/failed = 0
+	var/list/found_cables = list()
+
+	//there is a cable list, but for testing purposes we search every cable in the world
+	for(var/obj/structure/cable/C in world)
+		if(C in found_cables)
+			continue
+		var/list/to_search = list(C)
+		var/list/searched = list()
+		while(to_search.len)
+			var/obj/structure/cable/next = to_search[to_search.len]
+			to_search.len--
+			searched += next
+			for(var/obj/structure/cable/other in get_connected_neighbours(next))
+				if(other in searched)
+					continue
+				if(next.powernet != other.powernet)
+					fail("Cable at ([next.x], [next.y], [next.z]) did not share powernet with connected neighbour at ([other.x], [other.y], [other.z])")
+					failed++
+				to_search += other
+		
+		found_cables += searched
+
+	if(failed)
+		fail("Found [failed] bad cables.")
+	else
+		pass("All connected roundstart cables have matching powernets.")
+
+	return 1


### PR DESCRIPTION
Tested it on the example map, haven't run it on Torch or Exodus yet.