### PR TITLE
Meteors no longer destroy stuff that they don't actually collide with

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -6,7 +6,7 @@
 // Dust, used by space dust event and during earliest stages of meteor mode.
 /var/list/meteors_dust = list(/obj/effect/meteor/dust)
 
-// Standard meteors, used for the low severity meteor event, and during early stages of the meteor gamemode.
+// Standard meteors, used during early stages of the meteor gamemode.
 /var/list/meteors_normal = list(\
 		/obj/effect/meteor/medium=8,\
 		/obj/effect/meteor/dust=3,\
@@ -17,7 +17,7 @@
 		/obj/effect/meteor/silver=1\
 		)
 
-// Threatening meteors, used for medium severity meteor event, and during meteor gamemode.
+// Threatening meteors, used during the meteor gamemode.
 /var/list/meteors_threatening = list(\
 		/obj/effect/meteor/big=10,\
 		/obj/effect/meteor/medium=5,\
@@ -28,7 +28,7 @@
 		/obj/effect/meteor/emp=3\
 		)
 
-// Catastrophic meteors, pretty dangerous without shields and used for high severity meteor event, and during meteor gamemode.
+// Catastrophic meteors, pretty dangerous without shields and used during the meteor gamemode.
 /var/list/meteors_catastrophic = list(\
 		/obj/effect/meteor/big=75,\
 		/obj/effect/meteor/flaming=10,\

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -151,21 +151,25 @@
 	var/z_original
 	var/meteordrop = /obj/item/weapon/ore/iron
 	var/dropamt = 1
+	
+	var/move_count = 0
 
 /obj/effect/meteor/proc/get_shield_damage()
 	return max(((max(hits, 2)) * (heavy + 1) * rand(30, 60)) / hitpwr , 0)
-
 
 /obj/effect/meteor/New()
 	..()
 	z_original = z
 
-
 /obj/effect/meteor/Move()
-	if(z != z_original || loc == dest)
-		qdel(src)
-		return
 	. = ..() //process movement...
+	move_count++
+	if(loc == dest)
+		qdel(src)
+
+/obj/effect/meteor/touch_map_edge()
+	if(move_count > TRANSITIONEDGE)
+		qdel(src)
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -165,16 +165,7 @@
 	if(z != z_original || loc == dest)
 		qdel(src)
 		return
-
 	. = ..() //process movement...
-
-	if(.)
-		var/turf/T = get_turf(loc)
-		ram_turf(T)
-		if(prob(20) && !istype(loc, /turf/space/))
-			get_hit()
-
-	return .
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc
@@ -188,7 +179,7 @@
 	..()
 	if(A && !deleted(src))	// Prevents explosions and other effects when we were deleted by whatever we Bumped() - currently used by shields.
 		ram_turf(get_turf(A))
-		get_hit()
+		get_hit() //should only get hit once per move attempt
 
 /obj/effect/meteor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return istype(mover, /obj/effect/meteor) ? 1 : ..()
@@ -196,13 +187,12 @@
 /obj/effect/meteor/proc/ram_turf(var/turf/T)
 	//first bust whatever is in the turf
 	for(var/atom/A in T)
-		if(A != src)
+		if(A != src && !A.CanPass(src, src.loc, 0.5, 0)) //only ram stuff that would actually block us
 			A.ex_act(hitpwr)
 
 	//then, ram the turf if it still exists
-	if(T)
+	if(T && !T.CanPass(src, src.loc, 0.5, 0))
 		T.ex_act(hitpwr)
-
 
 //process getting 'hit' by colliding with a dense object
 //or randomly when ramming turfs

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -6,6 +6,7 @@
 	var/waves = 1
 	var/start_side
 
+
 /datum/event/meteor_wave/setup()
 	waves = severity * rand(5,15)
 	start_side = pick(cardinal)
@@ -27,7 +28,7 @@
 
 	if(waves && activeFor >= next_meteor)
 		var/pick_side = prob(80) ? start_side : (prob(50) ? turn(start_side, 90) : turn(start_side, -90))
-		spawn() spawn_meteors(severity * rand(4,8), get_meteors(), pick_side)
+		spawn() spawn_meteors(severity * rand(2,4), get_meteors(), pick_side)
 		next_meteor += rand(10, 20) / severity
 		waves--
 		endWhen = worst_case_end()
@@ -45,8 +46,41 @@
 /datum/event/meteor_wave/proc/get_meteors()
 	switch(severity)
 		if(EVENT_LEVEL_MAJOR)
-			return meteors_catastrophic
+			return meteors_major
 		if(EVENT_LEVEL_MODERATE)
-			return meteors_threatening
+			return meteors_moderate
 		else
-			return meteors_normal
+			return meteors_minor
+
+/var/list/meteors_minor = list(
+	/obj/effect/meteor/medium     = 80,
+	/obj/effect/meteor/dust       = 30,
+	/obj/effect/meteor/irradiated = 30,
+	/obj/effect/meteor/big        = 30,
+	/obj/effect/meteor/flaming    = 10,
+	/obj/effect/meteor/golden     = 10,
+	/obj/effect/meteor/silver     = 10,
+)
+
+/var/list/meteors_moderate = list(
+	/obj/effect/meteor/medium     = 80,
+	/obj/effect/meteor/big        = 30,
+	/obj/effect/meteor/dust       = 30,
+	/obj/effect/meteor/irradiated = 30,
+	/obj/effect/meteor/flaming    = 10,
+	/obj/effect/meteor/golden     = 10,
+	/obj/effect/meteor/silver     = 10,
+	/obj/effect/meteor/emp        = 10,
+)
+
+/var/list/meteors_major = list(
+	/obj/effect/meteor/medium     = 80,
+	/obj/effect/meteor/big        = 30,
+	/obj/effect/meteor/dust       = 30,
+	/obj/effect/meteor/irradiated = 30,
+	/obj/effect/meteor/emp        = 30,
+	/obj/effect/meteor/flaming    = 10,
+	/obj/effect/meteor/golden     = 10,
+	/obj/effect/meteor/silver     = 10,
+	/obj/effect/meteor/tunguska   = 1,
+)

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -8,7 +8,10 @@
 
 
 /datum/event/meteor_wave/setup()
-	waves = severity * rand(5,15)
+	waves = 0
+	for(var/n in 1 to severity)
+		waves += rand(5,15)
+
 	start_side = pick(cardinal)
 	endWhen = worst_case_end()
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -39,7 +39,7 @@
 		return 0
 
 	for(var/atom/A in destination)
-		if(!A.CanPass(src, start))
+		if(!A.CanPass(src, start, 1.5, 0))
 			to_chat(usr, "<span class='warning'>\The [A] blocks you.</span>")
 			return 0
 	Move(destination)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -103,7 +103,7 @@
 /obj/structure/ladder/proc/climbLadder(var/mob/M, var/target_ladder)
 	var/turf/T = get_turf(target_ladder)
 	for(var/atom/A in T)
-		if(!A.CanPass(M))
+		if(!A.CanPass(M, M.loc, 1.5, 0))
 			to_chat(M, "<span class='notice'>\The [A] is blocking \the [src].</span>")
 			return FALSE
 	return M.Move(T)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -119,7 +119,7 @@
 	//If this is a shrapnel explosion, allow mobs that are prone to get hit, too
 	if(. && !base_spread && isturf(loc))
 		for(var/mob/living/M in loc)
-			if(M.lying || !M.CanPass(src, loc)) //Bump if lying or if we would normally Bump.
+			if(M.lying || !M.CanPass(src, loc, 0.5, 0)) //Bump if lying or if we would normally Bump.
 				if(Bump(M)) //Bump will make sure we don't hit a mob multiple times
 					return
 

--- a/html/changelogs/HarpyEagle-changelog-20170204.yml
+++ b/html/changelogs/HarpyEagle-changelog-20170204.yml
@@ -1,0 +1,11 @@
+author: HarpyEagle
+delete-after: True
+changes: 
+  - bugfix: "Fixed bluespace jump lag."
+  - bugfix: "Fixed latejoins during bluespace jump not being affected by it."
+  - bugfix: "Fixed being able to enter/leave the vessel zlevels during bluespace jump."
+  - rscadd: "Moving in straight lines during a bluspace jump is now more difficult."
+  - tweak:  "The amount of toxin damage gained from low blood levels is now limited to around 18."
+  - bugfix: "Various defibrillator fixes."
+  - bugfix: "Difference between the two cult ghost whisper verbs should be clearer now."
+  - bugfix: "Meteors no longer destroy floors or anything else that doesn't block their movement."


### PR DESCRIPTION
Meteors no longer destroy stuff that they don't actually collide with, floors in particular.

In testing I noticed that meteors don't get deleted if they touch a map edge and are returned to the same zlevel, I'm going to try and fix that too.

Also I'm going to tone down down the number of meteors created per event. While the numbers made sense for oldmeteors that weren't actually that destructive, 20-120 meteors spawned PER SEVERITY LEVEL is way, way, too much.

Also adds some missing changelogs.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
