### PR TITLE
Makes table frames connect to finished tables and each other

### DIFF
--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -5,7 +5,7 @@
 	var/obj/structure/table/T
 	for(var/angle in list(-90,90))
 		T = locate() in get_step(src.loc,turn(direction,angle))
-		if(T && T.flipped == 0 && T.material && material && T.material.name == material.name)
+		if(T && T.flipped == 0 && is_same_material(T))
 			return 0
 	T = locate() in get_step(src.loc,direction)
 	if (!T || T.flipped == 1 || T.material != material)
@@ -50,7 +50,7 @@
 		L.Add(turn(src.dir,90))
 	for(var/new_dir in L)
 		var/obj/structure/table/T = locate() in get_step(src.loc,new_dir)
-		if(T && T.material && material && T.material.name == material.name)
+		if(T && is_same_material(T))
 			if(T.flipped == 1 && T.dir == src.dir && !T.unflipping_check(new_dir))
 				return 0
 	return 1
@@ -91,7 +91,7 @@
 	flags |= ON_BORDER
 	for(var/D in list(turn(direction, 90), turn(direction, -90)))
 		var/obj/structure/table/T = locate() in get_step(src,D)
-		if(T && T.can_connect() && T.flipped == 0 && material && T.material && T.material.name == material.name)
+		if(T && T.can_connect() && T.flipped == 0 && is_same_material(T))
 			T.flip(direction)
 	take_damage(rand(5, 10))
 	update_connections(1)

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -45,6 +45,10 @@
 
 	health += maxhealth - old_maxhealth
 
+// Returns True when either both tables have the same material or if either is a frame
+/obj/structure/table/proc/is_same_material(var/obj/structure/table/T)
+	return (material && T.material && material.name == T.material.name || !material || !T.material)
+
 /obj/structure/table/proc/take_damage(amount)
 	// If the table is made of a brittle material, and is *not* reinforced with a non-brittle material, damage is multiplied by TABLE_BRITTLE_MATERIAL_MULTIPLIER
 	if(material && material.is_brittle())
@@ -333,7 +337,7 @@
 		var/tabledirs = 0
 		for(var/direction in list(turn(dir,90), turn(dir,-90)) )
 			var/obj/structure/table/T = locate(/obj/structure/table ,get_step(src,direction))
-			if (T && T.flipped == 1 && T.dir == src.dir && material && T.material && T.material.name == material.name)
+			if (T && T.flipped == 1 && T.dir == src.dir && is_same_material(T))
 				type++
 				tabledirs |= direction
 
@@ -368,14 +372,6 @@
 
 // set propagate if you're updating a table that should update tables around it too, for example if it's a new table or something important has changed (like material).
 /obj/structure/table/proc/update_connections(propagate=0)
-	if(!material)
-		connections = list("0", "0", "0", "0")
-
-		if(propagate)
-			for(var/obj/structure/table/T in oview(src, 1))
-				T.update_connections()
-		return
-
 	var/list/blocked_dirs = list()
 	for(var/obj/structure/window/W in get_turf(src))
 		if(W.is_fulltile())
@@ -413,7 +409,7 @@
 		if(!T.can_connect()) continue
 		var/T_dir = get_dir(src, T)
 		if(T_dir in blocked_dirs) continue
-		if(material && T.material && material.name == T.material.name && flipped == T.flipped)
+		if(is_same_material(T) && flipped == T.flipped)
 			connection_dirs |= T_dir
 		if(propagate)
 			spawn(0)


### PR DESCRIPTION
Looks like so:
![Image](http://i.imgur.com/gsiLbU0.png)
The icons were already there for this, wondering why they never found usage. Doesn't look bad IMO.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
