### PR TITLE
Misc Security-related Fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -133,6 +133,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/donut/,
 		/obj/item/weapon/melee/baton,
 		/obj/item/weapon/gun/energy/taser,
+		/obj/item/weapon/gun/energy/stunrevolver,
 		/obj/item/weapon/flame/lighter,
 		/obj/item/clothing/glasses/hud/security,
 		/obj/item/device/flashlight,

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -103,7 +103,7 @@
 /obj/item/weapon/storage/box/holobadge_solgov
 	name = "holobadge box"
 	desc = "A box claiming to contain holobadges, this one has 'Master at Arms' written on it in fine print."
-	startswith = list(/obj/item/clothing/accessory/badge/security = 4)
+	startswith = list(/obj/item/clothing/accessory/badge/security = 6)
 
 
 /obj/item/clothing/accessory/badge/security

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -100,6 +100,12 @@
 		return
 
 
+/obj/item/weapon/storage/box/holobadge_solgov
+	name = "holobadge box"
+	desc = "A box claiming to contain holobadges, this one has 'Master at Arms' written on it in fine print."
+	startswith = list(/obj/item/clothing/accessory/badge/security = 4)
+
+
 /obj/item/clothing/accessory/badge/security
 	name = "security forces badge"
 	desc = "A silver law enforcement badge. Stamped with the words 'Master at Arms'."

--- a/html/changelogs/lorwp-misc-fixes.yml
+++ b/html/changelogs/lorwp-misc-fixes.yml
@@ -1,0 +1,8 @@
+author: Lorwp
+
+delete-after: True
+
+changes: 
+    - tweak: "Change's Brig Officer's holobadge box to have Master At Arms Holobadges"
+    - tweak: "Allow Security Messenger Bags to be able to spawn in Security Lockers"
+    - tweak: "All Security and NT Guards spawn with Work Gloves now"

--- a/html/changelogs/lorwp-misc-fixes.yml
+++ b/html/changelogs/lorwp-misc-fixes.yml
@@ -5,4 +5,4 @@ delete-after: True
 changes: 
     - tweak: "Change's Brig Officer's holobadge box to have Master At Arms Holobadges"
     - tweak: "Allow Security Messenger Bags to be able to spawn in Security Lockers"
-    - tweak: "All Security and NT Guards spawn with Work Gloves now"
+    - tweak: "All Security have Work Gloves in their lockers now"

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -29,6 +29,7 @@
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/device/megaphone,
+		/obj/item/clothing/gloves/thick,
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/device/holowarrant
 	)
@@ -41,6 +42,8 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)
 
 
 /obj/structure/closet/secure_closet/cos
@@ -75,7 +78,8 @@
 		/obj/item/device/hailer,
 		/obj/item/weapon/clipboard,
 		/obj/item/weapon/folder/red,
-		/obj/item/device/holowarrant
+		/obj/item/device/holowarrant,
+		/obj/item/clothing/gloves/thick
 	)
 
 /obj/structure/closet/secure_closet/cos/New()
@@ -86,6 +90,8 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)
 
 /obj/structure/closet/secure_closet/brigofficer
 	name = "brig officer's locker"
@@ -113,13 +119,14 @@
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/handcuffs,
 		/obj/item/device/hailer,
-		/obj/item/weapon/storage/box/holobadge,
+		/obj/item/weapon/storage/box/holobadge_solgov,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/clipboard,
 		/obj/item/weapon/folder/red,
 		/obj/item/weapon/hand_labeler,
-		/obj/item/device/holowarrant
+		/obj/item/device/holowarrant,
+		/obj/item/clothing/gloves/thick
 	)
 
 /obj/structure/closet/secure_closet/brigofficer/New()
@@ -130,6 +137,8 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)
 
 
 /obj/structure/closet/secure_closet/forensics
@@ -179,3 +188,5 @@
 		new /obj/item/weapon/storage/backpack/satchel_sec(src)
 	if(prob(50))
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
+	else
+		new /obj/item/weapon/storage/backpack/messenger/sec(src)


### PR DESCRIPTION
- Allows Stun Revolvers to be put in Security Belts
- Implements Master At Arms Holobadge Box (Fixes #15989)
- Adds Security Messenger bags to Security Lockers
- Adds Work Gloves to Solgov Security Lockers

Basically, a less shit version of #15990 