### PR TITLE
The power monitor now scans all connected Z-levels.

### DIFF
--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -78,6 +78,7 @@
 
 /obj/get_view_variables_options()
 	return ..() + {"
+		<option value='?_src_=vars;delthis=\ref[src]'>Delete instance</option>
 		<option value='?_src_=vars;delall=\ref[src]'>Delete all of type</option>
 		<option value='?_src_=vars;explode=\ref[src]'>Trigger explosion</option>
 		<option value='?_src_=vars;emp=\ref[src]'>Trigger EM pulse</option>

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -162,6 +162,15 @@
 
 		H.ChangeToSkeleton()
 		href_list["datumrefresh"] = href_list["make_skeleton"]
+		
+	else if(href_list["delthis"])
+		if(!check_rights(R_DEBUG|R_SERVER))	return
+		
+		var/obj/O = locate(href_list["delthis"])
+		if(!isobj(O))
+			to_chat(usr, "This can only be used on instances of type /obj")
+			return
+		cmd_admin_delete(O)
 
 	else if(href_list["delall"])
 		if(!check_rights(R_DEBUG|R_SERVER))	return

--- a/html/changelogs/PsiOmegaDelta-PowerToThePeople.yml
+++ b/html/changelogs/PsiOmegaDelta-PowerToThePeople.yml
@@ -1,0 +1,7 @@
+author: PsiOmegaDelta
+
+delete-after: True
+
+changes: 
+  - rscadd: "Admins can now delete specific obj instances from the VV menu, not only all of the same type."
+  - bugfix: "Power monitors now list all powernet sensors belonging to the current and connected Z-levels."


### PR DESCRIPTION
Fixes #15361.
Now also qdels and handles destroyed sensors much better.

Can now delete specific obj instances in the VV menu. Was handy during debugging, so you get this as a bonus free of charge.