### PR TITLE
Separates player and admin AOOC

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -82,7 +82,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/event_manager_panel,
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/empty_ai_core_toggle_latejoin,
-	/client/proc/aooc,
+	/client/proc/aoocsay,
 	/client/proc/change_human_appearance_admin,	// Allows an admin to change the basic appearance of human-based mobs ,
 	/client/proc/change_human_appearance_self,	// Allows the human-based mob itself change its basic appearance ,
 	/client/proc/change_security_level,
@@ -304,7 +304,7 @@ var/list/admin_verbs_mod = list(
 	/client/proc/check_antagonists,
 	/client/proc/jobbans,
 	/client/proc/cmd_admin_subtle_message, // send an message to somebody as a 'voice in their head',
-	/client/proc/aooc,
+	/client/proc/aoocsay,
 	/datum/admins/proc/paralyze_mob,
 	/datum/admins/proc/sendFax
 

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -3,20 +3,53 @@
 	set name = "AOOC"
 	set desc = "Antagonist OOC"
 
-	//if(!check_rights(R_ADMIN))	return
-
-
-	if(isghost(src.mob) && !check_rights(R_ADMIN|R_MOD, 0))
+	if(isghost(src.mob))
 		to_chat(src, "<span class='warning'>You cannot use AOOC while ghosting/observing!</span>")
 		return
 
 	msg = sanitize(msg)
-	if(!msg)	return
-	var/display_name = src.key
-	var/player_display = holder ? "[display_name]([usr.client.holder.rank])" : display_name
-	for(var/mob/M in mob_list)
-		if(check_rights(R_ADMIN|R_MOD, 0, M)) // What staff see
-			to_chat(M, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[get_options_bar(src, 0, 1, 1)]([admin_jump_link(usr, M.client.holder)]):</EM> <span class='message'>[msg]</span></span></span>")
-		else if(M.mind && M.mind.special_role && M.client) // What players see
-			to_chat(M, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.client)] <EM>[player_display]:</EM> <span class='message'>[msg]</span></span></span>")
-	log_ooc("(ANTAG) [key] : [msg]")
+	if(!msg)
+		return
+
+	var/list/antags = list() // Thought we could just use src.mob.mind.special_role? WRONG. First, people can be different antag types at the same time. Second, sometimes antags of the same type have different special roles, xenos being one example. Fucking mess.
+	for(var/antag_type in all_antag_types)
+		var/datum/antagonist/antag = all_antag_types[antag_type]
+		if(src.mob.mind in antag.current_antagonists)
+			antags += antag_type
+
+	handle_aooc(msg, src, 0, antags)
+
+/client/proc/aoocsay(var/msg as text)
+	set category = "Admin"
+	set name = "Aoocsay"
+	set desc = "Admin verb for AOOC"
+
+	if(!check_rights(R_ADMIN|R_MOD))
+		return
+
+	msg = sanitize(msg)
+	if(!msg)
+		return
+
+	handle_aooc(msg, src, 1)
+
+/proc/handle_aooc(var/msg, var/client/C, var/admin, var/list/antagonists = null)
+	var/player_display = admin ? "[C.key]([C.holder.rank])" : C.key
+	var/antag_list = antagonists ? english_list(antagonists) : "All"
+
+	for(var/antag_type in all_antag_types) // Antags
+		if(antagonists && !(antag_type in antagonists))
+			continue
+		var/datum/antagonist/antag = all_antag_types[antag_type]
+		for(var/datum/mind/M in antag.current_antagonists)
+			if(!M.current)
+				continue
+			if(M.current.client in admins)
+				continue
+			to_chat(M.current, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", M.current.client)] <EM>[player_display]:</EM> <span class='message'>[msg]</span></span></span>")
+
+	for(var/client/A in admins)
+		if((R_ADMIN|R_MOD) & A.holder.rights)
+			to_chat(A, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", A)] <EM>[get_options_bar(C, 0, 1, 1)]([admin_jump_link(C.mob, A.holder)])([antag_list]):</EM> <span class='message'>[msg]</span></span></span>")
+
+	log_ooc("(ANTAG)([antag_list]) [C.key] : [msg]")


### PR DESCRIPTION
Player AOOC is only visible to antags of the same type.
Admin AOOC is visible to all antags.
Admins can use player AOOC verb if they are antagonists.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
