### PR TITLE
Adjusts Torch evac delay

### DIFF
--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -20,6 +20,7 @@ var/datum/evacuation_controller/evacuation_controller
 	var/evac_launch_delay =  3 MINUTES
 	var/evac_transit_delay = 2 MINUTES
 
+	var/autotransfer_prep_additional_delay = 0 MINUTES
 	var/emergency_prep_additional_delay = 0 MINUTES
 	var/transfer_prep_additional_delay = 0 MINUTES
 
@@ -54,7 +55,7 @@ var/datum/evacuation_controller/evacuation_controller
 		CRASH("[esp] has already been added as an evacuation predicate")
 	evacuation_predicates += esp
 
-/datum/evacuation_controller/proc/call_evacuation(var/mob/user, var/_emergency_evac, var/forced, var/skip_announce)
+/datum/evacuation_controller/proc/call_evacuation(var/mob/user, var/_emergency_evac, var/forced, var/skip_announce, var/autotransfer)
 
 	if(!can_evacuate(user, forced))
 		return 0
@@ -65,7 +66,13 @@ var/datum/evacuation_controller/evacuation_controller
 	if(ticker && ticker.mode)
 		evac_prep_delay_multiplier = ticker.mode.shuttle_delay
 
-	var/additional_delay = (emergency_evacuation ? emergency_prep_additional_delay : transfer_prep_additional_delay)
+	var/additional_delay
+	if(_emergency_evac)
+		additional_delay = emergency_prep_additional_delay
+	else if(autotransfer)
+		additional_delay = autotransfer_prep_additional_delay
+	else
+		additional_delay = transfer_prep_additional_delay
 
 	evac_called_at =    world.time
 	evac_no_return =    evac_called_at +    round(evac_prep_delay/2) + additional_delay

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -8,7 +8,13 @@
 /datum/evacuation_controller/starship
 	name = "escape pod controller"
 
-	transfer_prep_additional_delay = 10 MINUTES
+	evac_prep_delay    = 5 MINUTES
+	evac_launch_delay  = 3 MINUTES
+	evac_transit_delay = 2 MINUTES
+
+	transfer_prep_additional_delay     = 15 MINUTES
+	autotransfer_prep_additional_delay = 5 MINUTES
+	emergency_prep_additional_delay    = 0 MINUTES
 
 	evacuation_options = list(
 		EVAC_OPT_ABANDON_SHIP = new /datum/evacuation_option/abandon_ship(),

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -52,8 +52,8 @@
 			if (pod.arming_controller)
 				pod.arming_controller.arm()
 
-/datum/evacuation_controller/shuttle/call_evacuation(var/mob/user, var/_emergency_evac, var/forced)
-	if(..(user, _emergency_evac, forced))
+/datum/evacuation_controller/shuttle/call_evacuation(var/mob/user, var/_emergency_evac, var/forced, var/skip_announce, var/autotransfer)
+	if(..())
 		autopilot = 1
 		shuttle_launch_time = evac_no_return
 		evac_ready_time += shuttle.warmup_time*10

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -209,7 +209,7 @@ datum/controller/vote
 					tertiary_mode = .[3]
 				if("crew_transfer")
 					if(.[1] == "Initiate Crew Transfer")
-						init_shift_change(null, 1)
+						init_autotransfer()
 					else if(.[1] == "Add Antagonist")
 						spawn(10)
 							autoaddantag()

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -368,28 +368,12 @@ var/last_message_id = 0
 	if(evacuation_controller.call_evacuation(user, _emergency_evac = emergency))
 		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has called the shuttle.")
 
-/proc/init_shift_change(var/mob/user, var/force = 0)
+/proc/init_autotransfer()
 	if (!ticker || !evacuation_controller)
 		return
 
-	// if force is 0, some things may stop the shuttle call
-	if(!force)
-
-		if(evacuation_controller.deny)
-			to_chat(user, "[using_map.boss_short] does not currently have a shuttle available in your sector. Please try again later.")
-			return
-
-		if(world.time < 54000) // 30 minute grace period to let the game get going
-			to_chat(user, "The shuttle is refueling. Please wait another [round((54000-world.time)/60)] minutes before trying again.")
-			return
-
-		if(ticker.mode.auto_recall_shuttle)
-			//New version pretends to call the shuttle but cause the shuttle to return after a random duration.
-			evacuation_controller.auto_recall(1)
-
 	//delay events in case of an autotransfer
-	if (isnull(user))
-		event_manager.delay_events(EVENT_LEVEL_MODERATE, 10200) //17 minutes
-		event_manager.delay_events(EVENT_LEVEL_MAJOR, 10200)
+	event_manager.delay_events(EVENT_LEVEL_MODERATE, 10200) //17 minutes
+	event_manager.delay_events(EVENT_LEVEL_MAJOR, 10200)
 
-	return call_shuttle_proc(user, 0)
+	return evacuation_controller.call_evacuation(null, _emergency_evac = FALSE, autotransfer = TRUE)

--- a/code/modules/modular_computers/file_system/programs/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/comm.dm
@@ -372,8 +372,9 @@ var/last_message_id = 0
 	if (!ticker || !evacuation_controller)
 		return
 
-	//delay events in case of an autotransfer
-	event_manager.delay_events(EVENT_LEVEL_MODERATE, 10200) //17 minutes
-	event_manager.delay_events(EVENT_LEVEL_MAJOR, 10200)
-
-	return evacuation_controller.call_evacuation(null, _emergency_evac = FALSE, autotransfer = TRUE)
+	. = evacuation_controller.call_evacuation(null, _emergency_evac = FALSE, autotransfer = TRUE)
+	if(.)
+		//delay events in case of an autotransfer
+		var/delay = evacuation_controller.evac_arrival_time - world.time + (2 MINUTES)
+		event_manager.delay_events(EVENT_LEVEL_MODERATE, delay)
+		event_manager.delay_events(EVENT_LEVEL_MAJOR, delay)

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -24,9 +24,10 @@
 	company_name  = "Sol Central Government"
 	company_short = "SolGov"
 
-	shuttle_docked_message = "Attention all hands: the Bluespace drive has been spooled up, secure all stations for departure. Time to jump: approximately %ETD%."
-	shuttle_leaving_dock = "Attention all hands: Jump initiated, exiting Bluespace in %ETA%."
-	shuttle_called_message = "Attention all hands: the Bluespace drive is spooling up. Transit procedures are now in effect. Jump in %ETA%."
+	//These should probably be moved into the evac controller...
+	shuttle_docked_message = "Attention all hands: Jump preparation complete. The bluespace drive is now spooling up, secure all stations for departure. Time to jump: approximately %ETD%."
+	shuttle_leaving_dock = "Attention all hands: Jump initiated, exiting bluespace in %ETA%."
+	shuttle_called_message = "Attention all hands: Jump sequence initiated. Transit procedures are now in effect. Jump in %ETA%."
 	shuttle_recall_message = "Attention all hands: Jump sequence aborted, return to normal operating conditions."
 	emergency_shuttle_docked_message = "Attention all hands: the escape pods are now unlocked. You have %ETD% to board the escape pods."
 	emergency_shuttle_leaving_dock = "Attention all hands: the escape pods have been launched, arriving at rendezvous point in %ETA%."


### PR DESCRIPTION
* Cleans up some nonsensical logic in `init_shift_change()`, like how `forced` skips checks that are then checked for anyways in `return call_shuttle_proc(user, 0)`. Renamed the proc to `init_autotransfer()`, it calls the evac controller directly, nothing in `call_shuttle_proc()` was really relevant to autotransfer.
* Delays for transfer and autotransfer are specified separately. 
* For Torch: evac => 5 MINUTES, transfer => 20 MINUTES (as before), autotransfer => 10 MINUTES (like on Exodus), as discussed with @Raptor1628 
* Adjusted torch jump announcement messages to flow better. Saying the drive is "spooling up" sounds too immediate for the first message, gives people the wrong impression if they haven't been through a jump before.
