### PR TITLE
Moving a contructed airlock/firedoor/windoor causes it to deconstruct

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -974,7 +974,6 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/deconstruct(mob/user, var/moved = FALSE)
-
 	var/obj/structure/door_assembly/da = new assembly_type(src.loc)
 	if (istype(da, /obj/structure/door_assembly/multi_tile))
 		da.set_dir(src.dir)
@@ -984,7 +983,12 @@ About the new airlock wires panel:
 	else if(glass && !da.glass)
 		da.glass = 1
 
-	da.anchored = !moved
+	if(moved)
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(5, 1, src)
+		s.start()
+	else
+		da.anchored = 1
 	da.state = 1
 	da.created_name = src.name
 	da.update_state()
@@ -1001,7 +1005,6 @@ About the new airlock wires panel:
 	qdel(src)
 
 	return da
-
 /obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)
 	if(C)
 		ignite(is_hot(C))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -928,31 +928,7 @@ About the new airlock wires panel:
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40,src))
 				to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
-
-				var/obj/structure/door_assembly/da = new assembly_type(src.loc)
-				if (istype(da, /obj/structure/door_assembly/multi_tile))
-					da.set_dir(src.dir)
-
- 				da.anchored = 1
-				if(mineral)
-					da.glass = mineral
-				//else if(glass)
-				else if(glass && !da.glass)
-					da.glass = 1
-				da.state = 1
-				da.created_name = src.name
-				da.update_state()
-
-				if(operating == -1 || (stat & BROKEN))
-					new /obj/item/weapon/circuitboard/broken(src.loc)
-					operating = 0
-				else
-					if (!electronics) create_electronics()
-
-					electronics.dropInto(loc)
-					electronics = null
-
-				qdel(src)
+				deconstruct(user)
 				return
 		else if(arePowerSystemsOn())
 			to_chat(user, "<span class='notice'>The airlock's motors resist your efforts to force it.</span>")
@@ -996,6 +972,35 @@ About the new airlock wires panel:
 	else
 		..()
 	return
+
+/obj/machinery/door/airlock/deconstruct(mob/user, var/moved = FALSE)
+
+	var/obj/structure/door_assembly/da = new assembly_type(src.loc)
+	if (istype(da, /obj/structure/door_assembly/multi_tile))
+		da.set_dir(src.dir)
+	if(mineral)
+		da.glass = mineral
+	//else if(glass)
+	else if(glass && !da.glass)
+		da.glass = 1
+
+	da.anchored = !moved
+	da.state = 1
+	da.created_name = src.name
+	da.update_state()
+
+	if(operating == -1 || (stat & BROKEN))
+		new /obj/item/weapon/circuitboard/broken(src.loc)
+		operating = 0
+	else
+		if (!electronics) create_electronics()
+
+		electronics.dropInto(loc)
+		electronics = null
+
+	qdel(src)
+
+	return da
 
 /obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)
 	if(C)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -449,7 +449,8 @@
 			source.thermal_conductivity = initial(source.thermal_conductivity)
 
 /obj/machinery/door/Move(new_loc, new_dir)
-	//update_nearby_tiles()
+	update_nearby_tiles()
+
 	. = ..()
 	if(width > 1)
 		if(dir in list(EAST, WEST))
@@ -459,7 +460,12 @@
 			bound_width = world.icon_size
 			bound_height = width * world.icon_size
 
-	update_nearby_tiles()
+	if(.)
+		deconstruct(null, TRUE)
+
+
+/obj/machinery/door/proc/deconstruct(mob/user, var/moved = FALSE)
+	return null
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -214,18 +214,7 @@
 					playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 					user.visible_message("<span class='danger'>[user] has removed the electronics from \the [src].</span>",
 										"You have removed the electronics from [src].")
-
-					if (stat & BROKEN)
-						new /obj/item/weapon/circuitboard/broken(src.loc)
-					else
-						new/obj/item/weapon/airalarm_electronics(src.loc)
-
-					var/obj/structure/firedoor_assembly/FA = new/obj/structure/firedoor_assembly(src.loc)
-					FA.anchored = 1
-					FA.set_density(1)
-					FA.wired = 1
-					FA.update_icon()
-					qdel(src)
+					deconstruct(user)
 		return
 
 	if(blocked)
@@ -269,6 +258,21 @@
 			return
 
 	return ..()
+
+/obj/machinery/door/firedoor/deconstruct(mob/user, var/moved = FALSE)
+	if (stat & BROKEN)
+		new /obj/item/weapon/circuitboard/broken(src.loc)
+	else
+		new/obj/item/weapon/airalarm_electronics(src.loc)
+
+	var/obj/structure/firedoor_assembly/FA = new/obj/structure/firedoor_assembly(src.loc)
+	FA.anchored = !moved
+	FA.set_density(1)
+	FA.wired = 1
+	FA.update_icon()
+	qdel(src)
+
+	return FA
 
 // CHECK PRESSURE
 /obj/machinery/door/firedoor/process()

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -90,9 +90,11 @@
 
 /obj/machinery/door/unpowered/simple/set_broken()
 	..()
+	deconstruct(null)
+
+/obj/machinery/door/unpowered/simple/deconstruct(mob/user, moved = FALSE)
 	material.place_dismantled_product(get_turf(src))
 	qdel(src)
-
 
 /obj/machinery/door/unpowered/simple/attack_ai(mob/user as mob) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isAI(user)) //so the AI can't open it

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -57,6 +57,9 @@
 		visible_message("[src] shatters!")
 	qdel(src)
 
+/obj/machinery/door/window/deconstruct(mob/user, var/moved = FALSE)
+	shatter()
+
 /obj/machinery/door/window/Destroy()
 	set_density(0)
 	update_nearby_tiles()


### PR DESCRIPTION
Technically any door, but the base proc/deconstruct() does nothing.

Constructed doors are anchored and cannot normally be moved. However, in some rare cases such doors can be moved, and when it happens it's extremely bizarre - a constructed door is something that's integrated into the wall it's installed in, moving it as a whole makes no sense. So now a force bolt hitting an airlock will cause it to blow the airlock assembly right out of the frame, which is more dramatic anyways.