### PR TITLE
Tweaks to add(-random) antagonist random event

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -41,3 +41,4 @@
 #define ADDANTAG_PLAYER 1	// Any player may call the add antagonist vote.
 #define ADDANTAG_ADMIN 2	// Any player with admin privilegies may call the add antagonist vote.
 #define ADDANTAG_AUTO 4		// The add antagonist vote is available as an alternative for transfer vote.
+#define ADDANTAG_EVENT 8	// A random (low probability) event may call add antagonist vote during the round.

--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -27,6 +27,7 @@
 #define ANTAG_SET_APPEARANCE    0x400 // Causes antagonists to use an appearance modifier on spawn.
 
 // Mode/antag template macros.
+#define MODE_EXTENDED "extended"
 #define MODE_BORER "borer"
 #define MODE_XENOMORPH "xeno"
 #define MODE_LOYALIST "loyalist"
@@ -50,6 +51,7 @@
 #define MODE_TRAITOR "traitor"
 
 #define DEFAULT_TELECRYSTAL_AMOUNT 100
+#define DEFAULT_FALLBACK_GAMEMODE MODE_EXTENDED			// Gamemode that will be forced after first, second and third top voted modes fail to start.
 
 /////////////////
 ////WIZARD //////

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -334,7 +334,7 @@ datum/controller/vote
 						if (config.allow_extra_antags && is_addantag_allowed(1))
 							choices.Add("Add Antagonist")
 				if("add_antagonist")
-					if(!is_addantag_allowed(automatic))
+					if(!is_addantag_allowed(automatic == 1, automatic == 2))
 						if(!automatic)
 							to_chat(usr, "The add antagonist vote is unavailable at this time. The game may not have started yet, the game mode may disallow adding antagonists, or you don't have required permissions.")
 						return 0
@@ -535,10 +535,12 @@ datum/controller/vote
 		usr.vote()
 
 // Helper proc for determining whether addantag vote can be called.
-datum/controller/vote/proc/is_addantag_allowed(var/automatic)
+datum/controller/vote/proc/is_addantag_allowed(var/automatic = 0, var/event = 0)
 	// Gamemode has to be determined before we can add antagonists, so we can respect gamemode's add antag vote settings.
 	if((ticker.current_state <= 2) || !ticker.mode)
 		return 0
+	if(event)
+		return (ticker.mode.addantag_allowed & ADDANTAG_EVENT) && !antag_add_finished
 	if(automatic)
 		return (ticker.mode.addantag_allowed & ADDANTAG_AUTO) && !antag_add_finished
 	if(check_rights(R_ADMIN, 0))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -27,7 +27,7 @@ var/global/list/additional_antag_types = list()
 	var/round_autoantag = 0                  // Will this round attempt to periodically spawn more antagonists?
 	var/antag_scaling_coeff = 5              // Coefficient for scaling max antagonists to player count.
 	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
-	var/addantag_allowed = ADDANTAG_ADMIN | ADDANTAG_AUTO
+	var/addantag_allowed = ADDANTAG_ADMIN | ADDANTAG_AUTO | ADDANTAG_EVENT
 
 	var/station_was_nuked = 0                // See nuclearbomb.dm and malfunction.dm.
 	var/explosion_in_progress = 0            // Sit back and relax

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -40,7 +40,7 @@ var/global/datum/controller/gameticker/ticker
 		if(!gamemode_voted)
 			pregame_timeleft = 180
 		else
-			pregame_timeleft = 15
+			pregame_timeleft = 60
 			if(!isnull(secondary_mode))
 				master_mode = secondary_mode
 				secondary_mode = null
@@ -58,7 +58,7 @@ var/global/datum/controller/gameticker/ticker
 					to_world("<b>The game mode is now: [master_mode]</b>")
 
 			else
-				master_mode = "extended"
+				master_mode = gamemode_cache[DEFAULT_FALLBACK_GAMEMODE]
 				to_world("<b>Forcing the game mode to extended...</b>")
 
 		to_world("<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
@@ -88,6 +88,8 @@ var/global/datum/controller/gameticker/ticker
 	//Create and announce mode
 	if(master_mode=="secret")
 		src.hide_mode = 1
+	else
+		src.hide_mode = 0
 
 	var/list/runnable_modes = config.get_runnable_modes()
 	if((master_mode=="random") || (master_mode=="secret"))

--- a/code/modules/events/random_antagonist.dm
+++ b/code/modules/events/random_antagonist.dm
@@ -3,11 +3,6 @@
 	return
 
 /datum/event/random_antag/start()
-	var/list/valid_types = list()
-	for(var/antag_type  in all_antag_types)
-		var/datum/antagonist/antag = all_antag_types[antag_type]
-		if(antag.flags & ANTAG_RANDSPAWN)
-			valid_types |= antag
-	if(valid_types.len)
-		var/datum/antagonist/antag = pick(valid_types)
-		antag.attempt_random_spawn()
+	if(vote && vote.is_addantag_allowed(0, 1))
+		log_and_message_admins("Calling add antag vote as part of random event.")
+		vote.initiate_vote("add_antagonist","the server", 2)

--- a/html/changelogs/atlantiscze-addantag2.yml
+++ b/html/changelogs/atlantiscze-addantag2.yml
@@ -1,0 +1,7 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Tweaked Random Antagonist random event. Instead of silently spawning an antagonist, it calls an add antagonist vote instead, allowing players to choose if, and which antag should be picked. Antagonists added via this method are also properly displayed in the Lobby tab when joining the game, so no nasty surprises. This event is disabled in Extended gamemode."
+  - tweak: "When a mode fails to start, time until next mode is tried has been increased from 15 to 60 seconds, to allow for picking of different character/job/etc"


### PR DESCRIPTION
- Adds new ADDANTAG flag that checks whether random event can actually add an antagonist for this mode. It is permitted for all modes except for extended, as extended is suposed to be a mode without antags, period.
- Antagonist is no longer randomly picked and silently spawned. Instead, add antagonist vote is called, therefore allowing for admins to easily veto it if they deem situation to be tense enough, and allow for players to know what type of antagonist will/has been added as it will show in the "Added antagonists" section of the lobby tab when joining.
- Probability of the random event was not changed.
- Extended is now correctly forced when first, second and third top mode fail to start. No impact from player perspective, but fixes issues with gamemode being null.
- When secret fails to start, the second/third gamemode are no longer incorrectly reported as secret on the lobby panel.
- When a mode fails to start, time for second/third/extended mode to start has been increased from 15 seconds to 60 seconds, to allow players to switch characters and perform quick changes. Sometimes (due to lag as everyone tries to jump into setup panel and do stuff) 15 seconds isn't even enough to unready if a mode you don't want to participate in is voted.