### PR TITLE
Ventcrawl pipes now layer above lighting

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -160,7 +160,9 @@ var/list/ventcrawl_machinery = list(
 	for(var/datum/pipeline/pipeline in network.line_members)
 		for(var/obj/machinery/atmospherics/A in (pipeline.members || pipeline.edges))
 			if(!A.pipe_image)
-				A.pipe_image = image(A, A.loc, layer = 20, dir = A.dir)
+				A.pipe_image = image(A, A.loc, dir = A.dir)
+			A.pipe_image.layer = ABOVE_LIGHTING_LAYER
+			A.pipe_image.plane = LIGHTING_PLANE
 			pipes_shown += A.pipe_image
 			client.images += A.pipe_image
 


### PR DESCRIPTION
Still not visible in full dark when beyond your `see_in_dark` range, but at least now you can see where the hell you're going when in the maintenance.