### PR TITLE
Scrubbers scrub Phoron and N2O on round-start.

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -19,7 +19,7 @@
 
 	var/hibernate = 0 //Do we even process?
 	var/scrubbing = 1 //0 = siphoning, 1 = scrubbing
-	var/list/scrubbing_gas = list("carbon_dioxide")
+	var/list/scrubbing_gas = list("carbon_dioxide", "phoron", "sleeping_agent")
 
 	var/panic = 0 //is this scrubber panicked?
 

--- a/html/changelogs/asanadas-scrubbers.yml
+++ b/html/changelogs/asanadas-scrubbers.yml
@@ -1,0 +1,5 @@
+author: Asanadas
+
+delete-after: True
+changes: 
+  - tweak: "Scrubbers now scrub N2O and Phoron by default."


### PR DESCRIPTION

Seems like a good balance change to make the phoron flash-fires more tolerable and the giggling in surgery go away. This won't affect "serious" problems because the atmospheric systems will still just shut down in those cases.

![scrubbers](https://cloud.githubusercontent.com/assets/1222532/22808605/d0abf598-eefa-11e6-8ee2-b82ad20aba2d.png)


![image](https://cloud.githubusercontent.com/assets/1222532/22808683/55b051c6-eefb-11e6-8f55-cdad06e1728d.png)

