### PR TITLE
Unfucks scooping

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -126,7 +126,7 @@ var/list/holder_mob_icon_cache = list()
 //Mob procs and vars for scooping up
 /mob/living/var/holder_type
 
-/mob/living/proc/get_scooped(var/mob/living/carbon/grabber, var/self_grab)
+/mob/living/proc/get_scooped(var/mob/living/carbon/human/grabber, var/self_grab)
 
 	if(!holder_type || buckled || pinned.len)
 		return
@@ -158,6 +158,20 @@ var/list/holder_mob_icon_cache = list()
 	grabber.status_flags |= PASSEMOTES
 	H.sync(src)
 	return H
+
+/mob/living/MouseDrop(var/mob/living/carbon/human/over_object)
+	if(istype(over_object) && Adjacent(over_object) && (usr == src || usr == over_object) && over_object.a_intent == I_HELP)
+		if(!scoop_check(over_object))
+			return
+		get_scooped(over_object, (usr == src))
+		return
+	return ..()
+
+/mob/living/proc/scoop_check(var/mob/living/scooper)
+	return 1
+
+/mob/living/carbon/human/scoop_check(var/mob/living/scooper)
+	return (scooper.mob_size > src.mob_size && a_intent == I_HELP)
 
 /obj/item/weapon/holder/human
 	icon = 'icons/mob/holder_complex.dmi'

--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -1,19 +1,20 @@
+/mob/living/carbon/alien/diona/get_scooped(var/mob/living/carbon/grabber)
+	if(grabber.species && grabber.species.name == "Diona" && do_merge(grabber))
+		return
+	else return ..()
+
 /mob/living/carbon/alien/diona/MouseDrop(atom/over_object)
 	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
-	if(H.a_intent == I_HELP)
-		if(H.species && H.species.name == "Diona" && do_merge(H))
-			return
-		get_scooped(H)
-		return
-	else if(H.a_intent == "grab" && hat && !(H.l_hand && H.r_hand))
-		hat.loc = get_turf(src)
+
+	if(istype(H) && Adjacent(H) && (usr == H) && (H.a_intent == "grab") && hat && !(H.l_hand && H.r_hand))
+		hat.forceMove(get_turf(src))
 		H.put_in_hands(hat)
 		H.visible_message("<span class='danger'>\The [H] removes \the [src]'s [hat].</span>")
 		hat = null
 		update_icons()
-	else
-		return ..()
+		return
+
+	return ..()
 
 /mob/living/carbon/alien/diona/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(user.a_intent == I_HELP && istype(W, /obj/item/clothing/head))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1388,13 +1388,6 @@
 		return 1
 	return 0
 
-/mob/living/carbon/human/MouseDrop(var/atom/over_object)
-	var/mob/living/carbon/human/H = over_object
-	if(holder_type && istype(H) && H.a_intent == I_HELP && !H.lying && !issmall(H) && Adjacent(H))
-		get_scooped(H, (usr == src))
-		return
-	return ..()
-
 /mob/living/carbon/human/verb/pull_punches()
 	set name = "Pull Punches"
 	set desc = "Try not to hurt them."

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -413,15 +413,6 @@
 	grabber.update_inv_r_hand()
 	return H
 
-/mob/living/silicon/pai/MouseDrop(atom/over_object)
-	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
-	if(H.a_intent == I_HELP)
-		get_scooped(H)
-		return
-	else
-		return ..()
-
 /mob/living/silicon/pai/verb/wipe_software()
 	set name = "Wipe Software"
 	set category = "OOC"

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -23,15 +23,13 @@
 
 /mob/living/silicon/robot/drone/MouseDrop(atom/over_object)
 	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
-	if(H.a_intent == I_HELP)
-		get_scooped(H)
-		return
-	else if(H.a_intent == "grab" && hat && !(H.l_hand && H.r_hand))
-		hat.loc = get_turf(src)
+
+	if(istype(H) && Adjacent(H) && (usr == H) && (H.a_intent == "grab") && hat && !(H.l_hand && H.r_hand))
+		hat.forceMove(get_turf(src))
 		H.put_in_hands(hat)
 		H.visible_message("<span class='danger'>\The [H] removes \the [src]'s [hat].</span>")
 		hat = null
-		updateicon()
-	else
-		return ..()
+		update_icons()
+		return
+
+	return ..()

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -8,7 +8,7 @@
 	response_disarm = "prods"
 	response_harm   = "stomps on"
 	icon_state = "brainslug"
-	item_state = "brainslug"
+	item_state = "voxslug" // For the lack of a better sprite...
 	icon_living = "brainslug"
 	icon_dead = "brainslug_dead"
 	speed = 5

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -117,16 +117,6 @@
 	icon = 'icons/mob/animal.dmi'
 	var/icon_rest //so that we can have resting little guys.
 
-/mob/living/simple_animal/familiar/pet/MouseDrop(atom/over_object)
-	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
-
-	if(H.a_intent == "help" && holder_type)
-		get_scooped(H)
-		return
-	else
-		return ..()
-
 /mob/living/simple_animal/familiar/pet/Life()
 	..()
 	if(!icon_rest)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -128,17 +128,6 @@
 	. = ..()
 	set_flee_target(AM.thrower? AM.thrower : src.loc)
 
-/mob/living/simple_animal/cat/MouseDrop(atom/over_object)
-
-	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
-
-	if(H.a_intent == I_HELP)
-		get_scooped(H)
-		return
-	else
-		return ..()
-
 //Basic friend AI
 /mob/living/simple_animal/cat/fluff
 	var/mob/living/carbon/human/friend

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -81,17 +81,6 @@
 	adjustBruteLoss(maxHealth)  // Enough damage to kill
 	src.death()
 
-/mob/living/simple_animal/mouse/MouseDrop(atom/over_object)
-
-	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
-
-	if(H.a_intent == I_HELP)
-		get_scooped(H)
-		return
-	else
-		return ..()
-
 /mob/living/simple_animal/mouse/Crossed(AM as mob|obj)
 	if( ishuman(AM) )
 		if(!stat)

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -45,16 +45,11 @@ Small, little HP, poisonous.
 
 	return L
 
-/mob/living/simple_animal/hostile/voxslug/MouseDrop(atom/over_object)
-	if(!Adjacent(over_object))
-		return ..()
-	if(istype(over_object,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = over_object
-		if(H.species.get_bodytype() == "Vox")
-			get_scooped(H)
-			return
-	to_chat(over_object, "<span class='warning'>\The [src] wriggles out of your hands before you can pick it up!</span>")
-	return ..()
+/mob/living/simple_animal/hostile/voxslug/get_scooped(var/mob/living/carbon/grabber)
+	if(grabber.species.get_bodytype() != "Vox")
+		to_chat(grabber, "<span class='warning'>\The [src] wriggles out of your hands before you can pick it up!</span>")
+		return
+	else return ..()
 
 /mob/living/simple_animal/hostile/voxslug/proc/attach(var/mob/living/carbon/human/H)
 	var/obj/item/organ/external/chest = H.organs_by_name["chest"]


### PR DESCRIPTION
Moves all MouseDrop to the same place.
No longer possible to forcefully scoop mob A onto mob B by click-dragging A onto B when you are neither A nor B (meaning a ghost could scoop a resomi into someone).
Borers can be scooped.
Only /mob/living/carbon/human can scoop. Others have no hands anyway.
Resomii on non-help intents now correctly resist being scooped.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
