### PR TITLE
Dress swords

### DIFF
--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -21,6 +21,8 @@
 	return 0
 
 /obj/item/weapon/material/sword/replica
+	edge = 0
+	sharp = 0
 	force_divisor = 0.2
 	thrown_force_divisor = 0.2
 
@@ -32,5 +34,7 @@
 	slot_flags = SLOT_BELT | SLOT_BACK
 
 /obj/item/weapon/material/sword/katana/replica
+	edge = 0
+	sharp = 0
 	force_divisor = 0.2
 	thrown_force_divisor = 0.2

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -32,27 +32,26 @@
 	icon_state = "chain"
 	item_state = "whip"
 
-/obj/item/weapon/melee/officersword
+/obj/item/weapon/material/sword/replica/officersword
 	name = "fleet officer's sword"
 	desc = "A polished sword issued to officers of the fleet."
 	icon_state = "officersword"
 	item_state = "officersword"
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT
+	applies_material_colour = FALSE
 
-/obj/item/weapon/melee/officersword/marine
+/obj/item/weapon/material/sword/replica/officersword/marine
 	name = "marine NCO's sword"
 	desc = "A polished sword issued to SCG Marine NCOs."
 	icon_state = "marinesword"
 
-/obj/item/weapon/melee/officersword/marineofficer
+/obj/item/weapon/material/sword/replica/officersword/marineofficer
 	name = "marine officer's sword"
 	desc = "A curved sword issued to SCG Marine officers."
 	icon_state = "marineofficersword"
 	item_state = "marineofficersword"
 
-/obj/item/weapon/melee/officersword/pettyofficer
+/obj/item/weapon/material/sword/replica/officersword/pettyofficer
 	name = "chief petty officer's cutlass"
 	desc = "A polished cutlass issued to chief petty officers of the fleet."
 	icon_state = "pettyofficersword"


### PR DESCRIPTION
Makes dress swords a type of material weapon. This means that they are now a type of sword and can parry melee attacks. No need for special attack_verb because it's inherited. Dress swords are now large items much like other swords.

Also blunted replica/ceremonial swords in general. (Or should they be kept sharp?)

