### PR TITLE
Organ fixes.

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -51,14 +51,14 @@
 	if(is_bruised())
 		if(prob(2))
 			owner.visible_message(
-				"<B>\The [src]</B> coughs up blood!",
+				"<B>\The [owner]</B> coughs up blood!",
 				"<span class='warning'>You cough up blood!</span>",
 				"You hear someone coughing!",
 			)
 			owner.drip(10)
 		if(prob(4))
 			owner.visible_message(
-				"<B>\The [src]</B> gasps for air!",
+				"<B>\The [owner]</B> gasps for air!",
 				"<span class='danger'>You can't breathe!</span>",
 				"You hear someone gasp for air!",
 			)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1029,7 +1029,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!supplied_wound)
 		supplied_wound = createwound(PIERCE, W.w_class * 5)
 
-	if(W in supplied_wound.embedded_objects) // Just in case.
+	if(!supplied_wound || (W in supplied_wound.embedded_objects)) // Just in case.
 		return
 
 	supplied_wound.embedded_objects += W


### PR DESCRIPTION
I am not sure why `createwound` isn't always returning a wound in this instance so I thought a nullcheck would be the fastest/easiest solution. Will look into a proper fix with the other medical changes.

Fixes #16150

Also fixes:
![image](https://cloud.githubusercontent.com/assets/2468979/22860102/21c2edfc-f143-11e6-9f7d-47a72f8dc2d9.png)
@mwerezak might wanna review your recent changes in case these aren't the only mistaken `src` uses.