### PR TITLE
Fixes the apply_visual/remove_visual runtimes

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -348,8 +348,8 @@ Class Procs:
 /obj/machinery/InsertedContents()
 	return (contents - component_parts)
 
-/obj/machinery/proc/apply_visual(mob/M)
+/datum/proc/apply_visual(mob/M)
 	return
 
-/obj/machinery/proc/remove_visual(mob/M)
+/datum/proc/remove_visual(mob/M)
 	return

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -182,10 +182,10 @@
 /datum/topic_manager/program/Topic(href, href_list)
 	return program && program.Topic(href, href_list)
 
-/datum/computer_file/program/proc/apply_visual(mob/M)
+/datum/computer_file/program/apply_visual(mob/M)
 	if(NM)
 		NM.apply_visual(M)
 
-/datum/computer_file/program/proc/remove_visual(mob/M)
+/datum/computer_file/program/remove_visual(mob/M)
 	if(NM)
 		NM.remove_visual(M)

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -44,9 +44,3 @@
 
 /datum/proc/update_layout()
 	return FALSE
-
-/datum/nano_module/proc/apply_visual(mob/M)
-	return
-
-/datum/nano_module/proc/remove_visual(mob/M)
-	return


### PR DESCRIPTION
An obvious band-aid, but it triggers every Life-tick when it happens.. makes monitoring runtimes on the server a bit annoying. Also does leave the base apply/remove_visual() proc in machinery.dm. Couldn't figure a better place at this time.
I still have a dream concerning how to deal with it proper.
Fixes #15796.
Fixes #16134.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
