### PR TITLE
Puts PDA in pocket instead of belt slot on spawn

### DIFF
--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -12,6 +12,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	l_ear = /obj/item/device/radio/headset
 	shoes = /obj/item/clothing/shoes/black
 	pda_type = /obj/item/device/pda
+	pda_slot = slot_l_store
 
 /decl/hierarchy/outfit/job/torch/crew
 	name = OUTFIT_JOB_NAME("Torch Crew Outfit")


### PR DESCRIPTION
In case of loadout conflicts, like waist packs. Otherwise the PDA will not spawn at all.

Preemptive bugfix I guess.