### PR TITLE
Fixes floor decals appearing on unpaintable flooring

### DIFF
--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -60,7 +60,7 @@ var/list/flooring_cache = list()
 						if(!(istype(T) && T.flooring && T.flooring.name == flooring.name))
 							overlays |= get_flooring_overlay("[flooring.icon_base]-corner-[SOUTHWEST]", "[flooring.icon_base]_corners", SOUTHWEST)
 
-		if(decals && decals.len)
+		if(flooring.can_paint && decals && decals.len)
 			overlays |= decals
 
 	else if(decals && decals.len)


### PR DESCRIPTION
A quick fix that prevents decals to show up on wood, grass, cult floors and similar when they get placed.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
