### PR TITLE
Magazine Tweaks

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -148,6 +148,23 @@
 	stored_ammo.Cut()
 	update_icon()
 
+
+/obj/item/ammo_magazine/attack_hand(mob/user)
+	if(user.get_inactive_hand() == src)
+		if(!stored_ammo.len)
+			to_chat(user, "<span class='notice'>[src] is already empty!</span>")
+		else
+			var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
+			stored_ammo.len-=C
+			user.put_in_hands(C)
+			user.visible_message("[user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
+
+	else
+		..()
+		return
+
+	update_icon()
+
 /obj/item/ammo_magazine/update_icon()
 	if(multiple_sprites)
 		//find the lowest key greater than or equal to stored_ammo.len

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -157,13 +157,11 @@
 			var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
 			stored_ammo.len-=C
 			user.put_in_hands(C)
-			user.visible_message("[user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
-
+			user.visible_message("\The [user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
+			update_icon()
 	else
 		..()
 		return
-
-	update_icon()
 
 /obj/item/ammo_magazine/update_icon()
 	if(multiple_sprites)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -133,7 +133,7 @@
 			return
 		user.remove_from_mob(C)
 		C.forceMove(src)
-		stored_ammo.Insert(1, C) //add to the head of the list
+		stored_ammo.Add(C)
 		update_icon()
 	else ..()
 
@@ -155,7 +155,7 @@
 			to_chat(user, "<span class='notice'>[src] is already empty!</span>")
 		else
 			var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
-			stored_ammo.len-=C
+			stored_ammo-=C
 			user.put_in_hands(C)
 			user.visible_message("\The [user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
 			update_icon()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -59,7 +59,7 @@
 		if(handle_casings != HOLD_CASINGS)
 			loaded -= chambered
 	else if(ammo_magazine && ammo_magazine.stored_ammo.len)
-		chambered = ammo_magazine.stored_ammo[1]
+		chambered = ammo_magazine.stored_ammo[ammo_magazine.stored_ammo.len]
 		if(handle_casings != HOLD_CASINGS)
 			ammo_magazine.stored_ammo -= chambered
 


### PR DESCRIPTION
Allows magazines to be unloaded round by round via hands. Ammo now uses 'first in, last out' system.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
