### PR TITLE
Updates overmap spacetravel

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -19,9 +19,6 @@ var/list/cached_space = list()
 /obj/effect/overmap/sector/temporary/Destroy()
 	map_sectors["[map_z]"] = null
 	testing("Temporary sector at [x],[y] was deleted.")
-	if (z == world.maxz && can_die())
-		testing("Associated zlevel disappeared.")
-		world.maxz--
 
 /obj/effect/overmap/sector/temporary/proc/can_die(var/mob/observer)
 	testing("Checking if sector at [map_z[1]] can die.")
@@ -42,8 +39,7 @@ proc/get_deepspace(x,y)
 		res.y = y
 		return res
 	else
-		world.maxz++
-		return new /obj/effect/overmap/sector/temporary(x, y, world.maxz)
+		return new /obj/effect/overmap/sector/temporary(x, y, using_map.get_empty_zlevel())
 
 /atom/movable/proc/lost_in_space()
 	return TRUE


### PR DESCRIPTION
Now uses empty zlevel getter Harpy added so it doesn't create new one when it's not needed.
Also removes screwing with maxz for cleanup since it actually never fires in effect.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
