### PR TITLE
Adds a custom modular laptop to the loadout menu

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -146,7 +146,11 @@
 		. = valid_reagents[metadata]
 	I.reagents.add_reagent(., I.reagents.get_free_space())
 
-/datum/gear_tweak/tablet
+/****************
+modular computers
+****************/
+
+/datum/gear_tweak/modular_computer
 	var/list/ValidProcessors = list(/obj/item/weapon/computer_hardware/processor_unit/small)
 	var/list/ValidBatteries = list(/obj/item/weapon/computer_hardware/battery_module/nano, /obj/item/weapon/computer_hardware/battery_module/micro, /obj/item/weapon/computer_hardware/battery_module)
 	var/list/ValidHardDrives = list(/obj/item/weapon/computer_hardware/hard_drive/micro, /obj/item/weapon/computer_hardware/hard_drive/small, /obj/item/weapon/computer_hardware/hard_drive)
@@ -155,7 +159,7 @@
 	var/list/ValidCardSlots = list(null, /obj/item/weapon/computer_hardware/card_slot)
 	var/list/ValidTeslaLinks = list(null, /obj/item/weapon/computer_hardware/tesla_link)
 
-/datum/gear_tweak/tablet/get_contents(var/list/metadata)
+/datum/gear_tweak/modular_computer/get_contents(var/list/metadata)
 	var/list/names = list()
 	var/obj/O = ValidProcessors[metadata[1]]
 	if(O)
@@ -180,7 +184,7 @@
 		names += initial(O.name)
 	return "[english_list(names, and_text = ", ")]"
 
-/datum/gear_tweak/tablet/get_metadata(var/user, var/metadata)
+/datum/gear_tweak/modular_computer/get_metadata(var/user, var/metadata)
 	. = list()
 
 	var/list/names = list()
@@ -267,10 +271,34 @@
 	entry = input(user, "Choose a tesla link.", "Character Preference") in names
 	. += names[entry]
 
-/datum/gear_tweak/tablet/get_default()
+/datum/gear_tweak/modular_computer/get_default()
 	return list(1, 1, 1, 1, 1, 1, 1)
 
-/datum/gear_tweak/tablet/tweak_item(var/obj/item/modular_computer/tablet/I, var/list/metadata)
+/datum/gear_tweak/modular_computer/tablet/tweak_item(var/obj/item/modular_computer/tablet/I, var/list/metadata)
+	if(ValidProcessors[metadata[1]])
+		var/t = ValidProcessors[metadata[1]]
+		I.processor_unit = new t(I)
+	if(ValidBatteries[metadata[2]])
+		var/t = ValidBatteries[metadata[2]]
+		I.battery_module = new t(I)
+		I.battery_module.charge_to_full()
+	if(ValidHardDrives[metadata[3]])
+		var/t = ValidHardDrives[metadata[3]]
+		I.hard_drive = new t(I)
+	if(ValidNetworkCards[metadata[4]])
+		var/t = ValidNetworkCards[metadata[4]]
+		I.network_card = new t(I)
+	if(ValidNanoPrinters[metadata[5]])
+		var/t = ValidNanoPrinters[metadata[5]]
+		I.nano_printer = new t(I)
+	if(ValidCardSlots[metadata[6]])
+		var/t = ValidCardSlots[metadata[6]]
+		I.card_slot = new t(I)
+	if(ValidTeslaLinks[metadata[7]])
+		var/t = ValidTeslaLinks[metadata[7]]
+		I.tesla_link = new t(I)
+
+/datum/gear_tweak/modular_computer/laptop/tweak_item(var/obj/item/modular_computer/laptop/I, var/list/metadata)
 	if(ValidProcessors[metadata[1]])
 		var/t = ValidProcessors[metadata[1]]
 		I.processor_unit = new t(I)

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -38,6 +38,10 @@
 	display_name = "personal AI device"
 	path = /obj/item/device/paicard
 
+/****************
+modular computers
+****************/
+
 /datum/gear/utility/cheaptablet
 	display_name = "tablet computer: cheap"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
@@ -55,4 +59,14 @@
 
 /datum/gear/utility/customtablet/New()
 	..()
-	gear_tweaks += new /datum/gear_tweak/tablet()
+	gear_tweaks += new /datum/gear_tweak/modular_computer/tablet()
+
+
+/datum/gear/utility/customlaptop
+	display_name = "laptop computer: custom"
+	path = /obj/item/modular_computer/laptop/
+	cost = 6
+
+/datum/gear/utility/customlaptop/New()
+	..()
+	gear_tweaks += new /datum/gear_tweak/modular_computer/laptop()

--- a/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
@@ -1,5 +1,5 @@
 /obj/item/modular_computer/laptop
-	anchored = TRUE
+	anchored = FALSE //the loadout will not spawn anchored items
 	name = "laptop computer"
 	desc = "A portable computer."
 	hardware_flag = PROGRAM_LAPTOP

--- a/html/changelogs/sabiram-laptop2loadout.yml
+++ b/html/changelogs/sabiram-laptop2loadout.yml
@@ -1,0 +1,4 @@
+author: sabiram
+delete-after: true
+changes:
+    - rscadd: "Added modular laptops to the loadout utility menu."


### PR DESCRIPTION
Uses the same customization process as the tablets, and the same parts, to ensure that purchased laptops will be more powerful.

They cost 6 instead of 4 because, even with the same components, they can run more powerful programs. I'd like some developer feedback on this.

I'm not sure if the ANCHORED thing will have any further implications; during my testing, everything worked as expected:

- [x] Laptop spawns & with correct components inside
- [x] Laptop works
- [x] Cannot drag an open laptop/Can drag a closed laptop
- [x] Cannot open/use laptop in-hand