### PR TITLE
Removes spaces in taste flavour message

### DIFF
--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -56,6 +56,9 @@ calculate text size per text.
 				intensity_desc = ""
 			else if(percent > minimum_percent * 3)
 				intensity_desc = "the strong flavor of"
-			out += "[intensity_desc] [taste_desc]"
+			if(intensity_desc == "")
+				out += "[taste_desc]"
+			else
+				out += "[intensity_desc] [taste_desc]"
 
 	return english_list(out, "something indescribable")


### PR DESCRIPTION
:cl: coiax
fix: Removes excessive space characters in messages generated when you taste things.
/:cl:

So I'm in the process of porting taste to /tg/, and I figured I'd push this tiny fix I found back.
