### PR TITLE
Self-surgery and surgery success change

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -413,7 +413,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		creatures[name] = M
 
 	return creatures
-	
+
 /proc/get_follow_targets()
 	return follow_repository.get_follow_targets()
 
@@ -1032,22 +1032,27 @@ proc/is_hot(obj/item/W as obj)
 /obj/item/clothing/mask/smokable/cigarette/can_puncture()
 	return src.lit
 
-/proc/is_surgery_tool(obj/item/W as obj)
-	return (	\
-	istype(W, /obj/item/weapon/scalpel)			||	\
-	istype(W, /obj/item/weapon/hemostat)		||	\
-	istype(W, /obj/item/weapon/retractor)		||	\
-	istype(W, /obj/item/weapon/cautery)			||	\
-	istype(W, /obj/item/weapon/bonegel)			||	\
-	istype(W, /obj/item/weapon/bonesetter)
-	)
-
 //check if mob is lying down on something we can operate him on.
-/proc/can_operate(mob/living/carbon/M)
-	return (M.lying && \
-	locate(/obj/machinery/optable, M.loc) || \
-	(locate(/obj/structure/bed/roller, M.loc) && prob(75)) || \
-	(locate(/obj/structure/table/, M.loc) && prob(66)))
+/proc/can_operate(mob/living/carbon/M, mob/living/carbon/user)
+	var/turf/T = get_turf(M)
+	if(locate(/obj/machinery/optable, T))
+		. = TRUE
+	if(locate(/obj/structure/bed, T))
+		. = TRUE
+	if(locate(/obj/structure/table, T))
+		. = TRUE
+
+	if(M == user)
+		var/hitzone = check_zone(user.zone_sel.selecting)
+		var/list/badzones = list(BP_HEAD)
+		if(user.hand)
+			badzones += BP_L_ARM
+			badzones += BP_L_HAND
+		else
+			badzones += BP_R_ARM
+			badzones += BP_R_HAND
+		if(hitzone in badzones)
+			return FALSE
 
 /proc/reverse_direction(var/dir)
 	switch(dir)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -39,7 +39,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /mob/living/attackby(obj/item/I, mob/user)
 	if(!ismob(user))
 		return 0
-	if(can_operate(src) && I.do_surgery(src,user)) //Surgery
+	if(can_operate(src,user) && I.do_surgery(src,user)) //Surgery
 		return 1
 	return I.attack(src, user, user.zone_sel.selecting)
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -39,11 +39,6 @@
 		traumatic_shock += (1.7 * E.get_genetic_damage())
 		traumatic_shock += (  2 * E.get_pain())
 
-		if(E.is_broken())
-			traumatic_shock += 20
-		else if(E.is_dislocated())
-			traumatic_shock += 10
-
 	traumatic_shock += (-1*src.chem_effects[CE_PAINKILLER])
 
 	if(slurring)

--- a/code/modules/organs/organ_damage.dm
+++ b/code/modules/organs/organ_damage.dm
@@ -183,7 +183,13 @@
 /obj/item/organ/external/proc/get_pain(var/amount)
 	if(!can_feel_pain() || robotic >= ORGAN_ROBOT)
 		return 0
-	return pain
+	var/lasting_pain = 0
+	lasting_pain += open * 5
+	if(is_broken())
+		lasting_pain += 10
+	else if(is_dislocated())
+		lasting_pain += 5
+	return pain + lasting_pain
 
 /obj/item/organ/external/proc/remove_pain(var/amount)
 	if(!can_feel_pain() || robotic >= ORGAN_ROBOT)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -20,6 +20,7 @@
 
 	min_duration = 50
 	max_duration = 60
+	shock_level = 20
 
 /datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -60,6 +61,8 @@
 
 	min_duration = 60
 	max_duration = 70
+	shock_level = 40
+	delicate = 1
 
 /datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -91,6 +94,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in [target]'s [affected.name] with \the [tool]!</span>" , \
 		"<span class='warning'>Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in [target]'s [affected.name] with \the [tool]!</span>")
+	affected.fracture()
 	affected.createwound(BRUISE, 5)
 
 
@@ -105,6 +109,8 @@
 
 	min_duration = 60
 	max_duration = 70
+	shock_level = 40
+	delicate = 1
 
 /datum/surgery_step/mend_skull/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -144,6 +150,7 @@
 
 	min_duration = 50
 	max_duration = 60
+	shock_level = 20
 
 /datum/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -10,6 +10,8 @@
 	priority = 2
 	can_infect = 1
 	blood_level = 1
+	shock_level = 40
+	delicate = 1
 
 /datum/surgery_step/open_encased/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -29,6 +31,7 @@
 
 	min_duration = 50
 	max_duration = 70
+	shock_level = 60
 
 /datum/surgery_step/open_encased/saw/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -9,6 +9,7 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/generic/
 	can_infect = 1
+	shock_level = 10
 
 /datum/surgery_step/generic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (isslime(target))

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -9,6 +9,8 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/cavity
 	priority = 1
+	shock_level = 40
+	delicate = 1
 /datum/surgery_step/cavity/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!hasorgans(target))
 		return 0

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -10,6 +10,8 @@
 /datum/surgery_step/limb/
 	priority = 3 // Must be higher than /datum/surgery_step/internal
 	can_infect = 0
+	shock_level = 40
+	delicate = 1
 /datum/surgery_step/limb/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
 		return 0

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -6,6 +6,8 @@
 	priority = 2
 	can_infect = 1
 	blood_level = 1
+	shock_level = 40
+	delicate = 1
 
 /datum/surgery_step/internal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -17,6 +17,8 @@
 
 	min_duration = 70
 	max_duration = 90
+	shock_level = 40
+	delicate = 1
 
 /datum/surgery_step/fix_tendon/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!hasorgans(target))
@@ -58,6 +60,8 @@
 
 	min_duration = 70
 	max_duration = 90
+	shock_level = 40
+	delicate = 1
 
 /datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!hasorgans(target))

--- a/html/changelogs/chinsky - surgery.yml
+++ b/html/changelogs/chinsky - surgery.yml
@@ -1,0 +1,9 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Surgery changes. Cry, medical."
+  - rscadd: "Self-surgery is legal now. It was possible via a bug, it's a feature now."
+  - rscadd: "As a side effect, you don't have to lie down to be operated on. It is, however, a very bad idea unless it's basic steps like incision etc. Success chance will drop for delicate steps."
+  - rscadd: "Instead of randomly doing nothing, rollerbeds / tables are factored into surgery success chance calculation."
+  - rscadd: "Said success chance: surgery steps now can fail even if you don't move / drop tools etc. Ideal scenario is 'sober surgeon not in pain operating on another person who is lying on an optable'. Deviations from that add chance of failure. Some steps are more robust, some are more delicate. As a rule of a thumb, if you have to touch innards, that's delicate. If you perform internal organ surgery on yourself while sitting on a table piss drunk, nearly passing out from pain and also being blind, it's not going to go very smooth."
+  - rscadd: "Shock will advance fast when being surgery'd on, so take it slow or take some pills."


### PR DESCRIPTION
Accepts self-surgery as a feature. Fixes #16273 I guess.
Adds surgery step success chance calculation. Now it's not just a matter of having right tool, it's also lowered by these things:
1.Operating on yourself.
2.Being in pain.
3.Eye blurry/blindness.
For 'delicate' steps (internal organs surgery, bone setting actual setting step) also:
4.Not being on optable
5.Surgeon is drunk.
6.Victim not lying down properly.

Surgery steps will also set shock stage to a certain value, on top of just dealing pain. It was passing too fast.

Limbs now have additional pain if they are broken/fractured, behaves same way as before  because it's just moved from shock processing.
Also being cut open makes them hurty too.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
