### PR TITLE
Fixes branches nulling alt-title outfits

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -39,8 +39,8 @@
 	if(alt_title && alt_titles)
 		. = alt_titles[alt_title]
 	if(allowed_branches && branch)
-		. = allowed_branches[branch.type]
-	. = . ? . : outfit_type
+		. = allowed_branches[branch.type] || .
+	. = . || outfit_type
 	. = outfit_by_type(.)
 
 /datum/job/proc/setup_account(var/mob/living/carbon/human/H)


### PR DESCRIPTION
allowed_branches would null alt-title outfits when branch lacked an outfit, causing alt-titles to be equipped with the standard job outfit.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
