### PR TITLE
Allows player to rename and describe the ninja voidsuit

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -59,6 +59,7 @@
 #define MAX_BOOK_MESSAGE_LEN  9216
 #define MAX_LNAME_LEN         64
 #define MAX_NAME_LEN          26
+#define MAX_DESC_LEN          128
 
 // Event defines.
 #define EVENT_LEVEL_MUNDANE  1

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -78,17 +78,21 @@
 
 /obj/item/clothing/gloves/lightrig/hacker
 	siemens_coefficient = 0
-
+	
 /obj/item/weapon/rig/light/ninja
-	name = "ominous suit control module"
+	name = "Ominous voidsuit control module"
+	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for assassins."
 	suit_type = "ominous"
-	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."
 	icon_state = "ninja_rig"
 	armor = list(melee = 50, bullet = 15, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 30)
 	siemens_coefficient = 0.2 //heavy hardsuit level shock protection
 	emp_protection = 40 //change this to 30 if too high.
 	online_slowdown = 0
 	aimove_power_usage = 50
+	var/has_custom_name = 0
+	var/has_custom_desc = 0
+	var/unique_name 
+	var/unique_desc	
 
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja
@@ -116,6 +120,42 @@
 	)
 
 	..()
+	
+/obj/item/weapon/rig/light/ninja/verb/rename_suit()
+	set name = "Name Ninja Suit"
+	set desc = "Rename your black voidsuit."
+	set category = "Object"
+	var/mob/M = usr
+	if(has_custom_name)
+		to_chat(M, "Got to live with your choices, pal.")
+		return 
+	if(!M.mind) return 0
+	if(M.incapacitated()) return 0
+	var/input = sanitizeSafe(input("What do you want to name your suit?", "Rename suit"), MAX_NAME_LEN)
+	if(src && input && !M.incapacitated() && in_range(M,src))
+		if(!findtext(input, "the", 1, 4))
+			input = "\improper [input]"
+		name = input
+		to_chat(M, "Suit naming succesful!")
+		return 1
+	has_custom_name = 1
+	
+/obj/item/weapon/rig/light/ninja/verb/rewrite_suit_desc()
+	set name = "Describe Ninja suit"
+	set desc = "Give your voidsuit a custom description."
+	set category = "Object"
+	var/mob/M = usr
+	if(has_custom_desc)
+		to_chat(M, "Got to live with your choices, pal.")
+		return 
+	if(!M.mind) return 0
+	if(M.incapacitated()) return 0
+	var/input = sanitizeSafe(input("Please describe your voidsuit in 128 letters or less.", "write description"), MAX_DESC_LEN)
+	if(src && input && !M.incapacitated() && in_range(M,src))
+		desc = input
+		to_chat(M, "Suit description succesful!")
+		return 1
+	has_custom_desc = 1
 
 /obj/item/clothing/gloves/rig/light/ninja
 	name = "insulated gloves"

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -80,7 +80,7 @@
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/light/ninja
-	name = "ominous voidsuit control module"
+	name = "ominous suit control module"
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for assassins."
 	suit_type = "ominous"
 	icon_state = "ninja_rig"
@@ -121,9 +121,6 @@
 	set desc = "Rename your black voidsuit."
 	set category = "Object"
 	var/mob/M = usr
-	if(has_custom_name)
-		to_chat(M, "Got to live with your choices, pal.")
-		return 
 	if(!M.mind) return 0
 	if(M.incapacitated()) return 0
 	var/input = sanitizeSafe(input("What do you want to name your suit?", "Rename suit"), MAX_NAME_LEN)
@@ -141,9 +138,6 @@
 	set desc = "Give your voidsuit a custom description."
 	set category = "Object"
 	var/mob/M = usr
-	if(has_custom_desc)
-		to_chat(M, "Got to live with your choices, pal.")
-		return 
 	if(!M.mind) return 0
 	if(M.incapacitated()) return 0
 	var/input = sanitizeSafe(input("Please describe your voidsuit in 128 letters or less.", "write description"), MAX_DESC_LEN)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -78,9 +78,9 @@
 
 /obj/item/clothing/gloves/lightrig/hacker
 	siemens_coefficient = 0
-	
+
 /obj/item/weapon/rig/light/ninja
-	name = "Ominous voidsuit control module"
+	name = "ominous voidsuit control module"
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for assassins."
 	suit_type = "ominous"
 	icon_state = "ninja_rig"
@@ -88,12 +88,7 @@
 	siemens_coefficient = 0.2 //heavy hardsuit level shock protection
 	emp_protection = 40 //change this to 30 if too high.
 	online_slowdown = 0
-	aimove_power_usage = 50
-	var/has_custom_name = 0
-	var/has_custom_desc = 0
-	var/unique_name 
-	var/unique_desc	
-
+	aimove_power_usage = 50	
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja
 	cell_type =  /obj/item/weapon/cell/hyper
@@ -137,8 +132,9 @@
 			input = "\improper [input]"
 		name = input
 		to_chat(M, "Suit naming succesful!")
+		verbs -= /obj/item/weapon/rig/light/ninja/verb/rename_suit
 		return 1
-	has_custom_name = 1
+	
 	
 /obj/item/weapon/rig/light/ninja/verb/rewrite_suit_desc()
 	set name = "Describe Ninja suit"
@@ -154,8 +150,8 @@
 	if(src && input && !M.incapacitated() && in_range(M,src))
 		desc = input
 		to_chat(M, "Suit description succesful!")
+		verbs -= /obj/item/weapon/rig/light/ninja/verb/rename_suit
 		return 1
-	has_custom_desc = 1
 
 /obj/item/clothing/gloves/rig/light/ninja
 	name = "insulated gloves"

--- a/html/changelogs/RunaDacino-Ninjafluffing.yml
+++ b/html/changelogs/RunaDacino-Ninjafluffing.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Runa-Dacino
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds ability for the player to change the name and description of ninja voidsuit to assist in ninja gimmicks"
+  - rscdel: "Removed references to the spider clan from ninja voidsuit."


### PR DESCRIPTION
* Adds MAX_DEFINE_LEN to code/__defines/misc.dm
It is capped at 128 letters.
* Adds Object verbs for renaming and describing the ninja voidsuit.
* Removes spider clan references from the default voidsuit description.

NOTE: ADDING CHANGELOG, SORRY
Edit: Added changelog. Why do I always forget the goddamned changelog or mess it up or grmgrmrmgl.


Furthermore, I would like to make special thanks to @BlueNexus and the #Codershuttle for helping turn the monstrous brainchild of mine into actual working code. If I could, I'd invite you lot for drinks.

P.S: I'll try to refractor the whole customizable name and description code. But later. It's midnight. And I'm glad I made this work at least.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
