### PR TITLE
Fixes mop bucket holding less reagents than janicart

### DIFF
--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -11,7 +11,7 @@
 
 
 /obj/structure/mopbucket/New()
-	create_reagents(100)
+	create_reagents(180)
 	..()
 
 /obj/structure/mopbucket/examine(mob/user)


### PR DESCRIPTION
At some point the janicart mop bucket's volume was increased along with the mop's volume, but the regular mop bucket was never touched.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
