### PR TITLE
Adds language preference sanitation.

### DIFF
--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -10,6 +10,7 @@
 
 /datum/category_item/player_setup_item/general/language/sanitize_character()
 	if(!islist(pref.alternate_languages))	pref.alternate_languages = list()
+	sanitize_alt_languages()
 
 /datum/category_item/player_setup_item/general/language/content()
 	. += "<b>Languages</b><br>"
@@ -39,10 +40,11 @@
 		if(pref.alternate_languages.len >= S.num_alternate_languages)
 			alert(user, "You have already selected the maximum number of alternate languages for this species!")
 		else
+			var/preference_mob = preference_mob()
 			var/list/available_languages = S.secondary_langs.Copy()
 			for(var/L in all_languages)
 				var/datum/language/lang = all_languages[L]
-				if(!(lang.flags & RESTRICTED) && is_alien_whitelisted(user, lang))
+				if(is_allowed_language(preference_mob, lang))
 					available_languages |= L
 
 			// make sure we don't let them waste slots on the default languages
@@ -56,5 +58,26 @@
 				var/new_lang = input(user, "Select an additional language", "Character Generation", null) as null|anything in available_languages
 				if(new_lang)
 					pref.alternate_languages |= new_lang
+					sanitize_alt_languages()
 					return TOPIC_REFRESH
 	return ..()
+
+/datum/category_item/player_setup_item/general/language/proc/is_allowed_language(var/mob/user, var/datum/language/lang)
+	if(!user)
+		return TRUE
+	if(!(lang.flags & RESTRICTED) && is_alien_whitelisted(user, lang))
+		return TRUE
+	return FALSE
+
+/datum/category_item/player_setup_item/general/language/proc/sanitize_alt_languages()
+	var/preference_mob = preference_mob()
+	for(var/L in pref.alternate_languages)
+		var/datum/language/lang = all_languages[L]
+		if(!lang || !is_allowed_language(preference_mob, lang))
+			pref.alternate_languages -= L
+
+	var/datum/species/S = all_species[pref.species] || all_species["Human"]
+	if(pref.alternate_languages.len > S.num_alternate_languages)
+		pref.alternate_languages.Cut(S.num_alternate_languages + 1)
+
+	pref.alternate_languages = uniquelist(pref.alternate_languages)


### PR DESCRIPTION
When loading/saving/joining language preferences are now sanitized ensuring that a player only has allowed languages, and no more than the current species allow for.

Fixes #16338.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
