### PR TITLE
Adds circuit recycling, anchors IC printer.

### DIFF
--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -46,7 +46,6 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 		to_chat(user, "<span class='notice'>You insert the circuit into [src]. </span>")
 		user.unEquip(O)
 		qdel(O)
-		metal += 1
 		metal = min(metal+1,maxMetal)
 		return 1
 	return ..()

--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -9,7 +9,8 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "integrated"
 	density = 1
-	var/metal = 100
+	anchored = 1
+	var/metal = 0
 	var/maxMetal = 100
 	var/metal_mult = 0.5
 	use_power = 1
@@ -41,6 +42,12 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 				metal += num
 				updateUsrDialog()
 				return 1
+	if(istype(O,/obj/item/integrated_circuit))
+		to_chat(user, "<span class='notice'>You insert the circuit into [src]. </span>")
+		user.unEquip(O)
+		qdel(O)
+		metal += 1
+		return 1
 	return ..()
 
 /obj/machinery/integrated_circuit_printer/attack_hand(var/mob/user)

--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -47,6 +47,7 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 		user.unEquip(O)
 		qdel(O)
 		metal += 1
+		metal = min(metal+1,maxMetal)
 		return 1
 	return ..()
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
* Lets you insert circuits into the IC printer to get back the metal spent.
* Anchors the IC printer to the ground, as it wasn't before.
* Sets the initial var/metal to 0, to avoid an exploit of just re-constructing the IC printer to set it to 100 metal.

Currently there's no check to ensure the metal does not go above maxMetal, I tried adding it, but I've no idea how.

Circuit assembly recycling is also unknown to me.