### PR TITLE
Adds a check to language sanitation for species languages.

### DIFF
--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -65,6 +65,9 @@
 /datum/category_item/player_setup_item/general/language/proc/is_allowed_language(var/mob/user, var/datum/language/lang)
 	if(!user)
 		return TRUE
+	var/datum/species/S = all_species[pref.species]
+	if(lang.name in S.secondary_langs)
+		return TRUE
 	if(!(lang.flags & RESTRICTED) && is_alien_whitelisted(user, lang))
 		return TRUE
 	return FALSE

--- a/html/changelogs/Datraen-SpeciesLang.yml
+++ b/html/changelogs/Datraen-SpeciesLang.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Datraen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Language sanitation now checks for species second languages in addition to whitelist status."


### PR DESCRIPTION
Just because you're whitelisted for the species doesn't necessarily mean you're whitelisted for the language itself.

Fixes #16358