### PR TITLE
Adds crossfire gamemode (merc + heist)

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -408,6 +408,7 @@
 #include "code\game\gamemodes\meteor\meteors.dm"
 #include "code\game\gamemodes\mixed\bughunt.dm"
 #include "code\game\gamemodes\mixed\conflux.dm"
+#include "code\game\gamemodes\mixed\crossfire.dm"
 #include "code\game\gamemodes\mixed\infestation.dm"
 #include "code\game\gamemodes\mixed\intrigue.dm"
 #include "code\game\gamemodes\mixed\lizard.dm"

--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -1,0 +1,9 @@
+/datum/game_mode/crossfire
+	name = "Mercenary & Heist"
+	extended_round_description = "Mercenaries and raiders are preparing for a nice visit..."
+	config_tag = "crossfire"
+	required_players = 25
+	required_enemies = 6
+	end_on_antag_death = 0
+	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)
+	require_all_templates = 1

--- a/html/changelogs/Kasuobes-mercheist.yml
+++ b/html/changelogs/Kasuobes-mercheist.yml
@@ -1,0 +1,4 @@
+author: Haswell
+delete-after: True
+changes: 
+  - rscadd: "Added crossfire gamemode, mercenary + raiders. Requires 25 readied players and at least 6 antags to start."


### PR DESCRIPTION
Added ~~siege~~ crossfire gamemode, mercenary + raiders. Requires ~~15~~ 25 readied players and at least 6 antags to start.

If antags are outgunned on Torch because of the abundance of weapons, the solution is obviously to add more antags. /s