### PR TITLE
Can no longer relocate emergency oxygen pumps.

### DIFF
--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -2,6 +2,8 @@
 	name = "emergency oxygen pump"
 	icon = 'icons/obj/walllocker.dmi'
 	icon_state = "emerg"
+	
+	anchored = TRUE
 
 	var/obj/item/weapon/tank/tank
 	var/obj/item/clothing/mask/gas/contained


### PR DESCRIPTION
Bit silly to be able to relocate wall-mounted objects in general.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
