### PR TITLE
Runtime fix and qdel() tweaking

### DIFF
--- a/code/controllers/Processes/garbage.dm
+++ b/code/controllers/Processes/garbage.dm
@@ -114,12 +114,8 @@ world/loop_checks = 0
 	if(!A)
 		return
 	if(!istype(A))
-		warning("qdel() passed object of type [A.type]. qdel() can only handle /datum types.")
-		crash_with("qdel() passed object of type [A.type]. qdel() can only handle /datum types.")
-		del(A)
-		if(garbage_collector)
-			garbage_collector.total_dels++
-			garbage_collector.hard_dels++
+		log_error("qdel() was passed [log_info_line(A)]. qdel() can only handle instances of (sub)type /datum.")
+		crash_with("qdel() was passed [log_info_line(A)]. qdel() can only handle instances of (sub)type /datum.")
 	else if(isnull(A.gcDestroyed))
 		// Let our friend know they're about to get collected
 		. = !A.Destroy()

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -312,7 +312,6 @@ var/global/datum/controller/radio/radio_controller
 			devices_line -= null
 		if (devices_line.len==0)
 			devices -= devices_filter
-			qdel(devices_line)
 
 /datum/signal
 	var/obj/source


### PR DESCRIPTION
Removes qdel of list in the radio controller. Fixes #16315.
Makes qdel() more consistent with its own error message. It no longer does anything about unhandled input, rather than applying del.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
