### PR TITLE
Make windows harder to destroy...

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -152,7 +152,9 @@
 	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
 	if(ismob(AM))
-		tforce = 40
+		tforce = 3
+		if(ishuman(AM))
+			tforce = 40
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		tforce = I.throwforce


### PR DESCRIPTION
...By throwing mice at them.
This is a quickfix ported from my quickfix on urist mcstation (baystation fork).
Will be later replaced with dynamic damage calculations to make this even better

* Makes windows take only 3 damage when a mob is thrown at them unless it is accepted by ishuman(mob)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
