### PR TITLE
Spiderlings are now filtered from the follow list.

### DIFF
--- a/code/datums/repositories/follow.dm
+++ b/code/datums/repositories/follow.dm
@@ -192,6 +192,10 @@
 	sort_order = 6
 	followed_type = /obj/effect/spider/spiderling
 
+/datum/follow_holder/spiderling/show_entry()
+	var/obj/effect/spider/spiderling/S = followed_instance
+	return ..() && S.amount_grown > 0
+
 /datum/follow_holder/bot
 	sort_order = 7
 	followed_type = /mob/living/bot


### PR DESCRIPTION
They are now only listed if they should be growing.
Adminbus-mass-var changes will now be very evident.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
