### PR TITLE
Disables click macros.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -197,7 +197,7 @@ proc/age2agedescription(age)
 		return 0
 	var/atom/target_loc = null
 	var/target_type = null
-	
+
 	if(target)
 		target_loc = target.loc
 		target_type = target.type
@@ -276,3 +276,9 @@ proc/age2agedescription(age)
 // Returns true if the mob was removed form the dead list
 /mob/proc/remove_from_dead_mob_list()
 	return dead_mob_list_.Remove(src)
+
+// Disables click ma
+/mob/verb/ClickSubstitute()
+	set hidden = 1
+	set name = ".click"
+	log_and_message_admins("attempted to ues a .click macro.")


### PR DESCRIPTION
It is apparently possible to utilize click macros for exploits according to https://github.com/ParadiseSS13/Paradise/pull/6631.
Click macros are fully disabled until we know more, and can see if these exploits can be prevented by less extreme measures.