### PR TITLE
HUDs now less affected by its parent.

### DIFF
--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -4,6 +4,7 @@ the HUD updates properly! */
 
 // hud overlay image type, used for clearing client.images precisely
 /image/hud_overlay
+	appearance_flags = RESET_COLOR|RESET_TRANSFORM|KEEP_APART
 
 //Medical HUD outputs. Called by the Life() proc of the mob using it, usually.
 proc/process_med_hud(var/mob/M, var/local_scanner, var/mob/Alt)


### PR DESCRIPTION
HUDs no longer grab color, rotation, or other such effects from the parent object.
Avoids having odd things such as
![A fully red HUD](http://i.imgur.com/NZr90mz.png).

Currently alpha is not reset, because I didn't want to deal with ninjas crying over being exposed by Sec/MedHUDs and adding in the necessary code exceptions/handling at this time.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
