### PR TITLE
Pending events that are cleared are no longer lost.

### DIFF
--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -272,6 +272,7 @@
 		var/datum/event_container/EC = locate(href_list["clear"])
 		if(EC.next_event)
 			log_and_message_admins("has dequeued the [severity_to_string[EC.severity]] event '[EC.next_event.name]'.")
+			EC.available_events += EC.next_event
 			EC.next_event = null
 
 	Interact(usr)


### PR DESCRIPTION
Instead they go back to the relevant event queue.
Curious how no one has noticed. Not enough adminbus.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
