### PR TITLE
Add dynamic window damage calculations

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -152,7 +152,13 @@
 	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
 	if(ismob(AM))
-		tforce = 40
+		if(isliving(AM))
+			tforce = AM.mob_size
+		else
+			// TODO:
+			// Dont do defaulting. Ever.
+			tforce = 40 
+			log_debug("[AM] ([AM.type]) does not have a mob_size value and hit a window. Report this to a developer")
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		tforce = I.throwforce


### PR DESCRIPTION
Dynamicism based on mob_size actually works. Check it's defines.

* Windows damaged by having mobs thrown at them is now dynamic
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
