### PR TITLE
Add dynamic window damage

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -151,7 +151,7 @@
 	..()
 	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
-	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dmA
+	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dm
 		var/mob/I = AM
 		tforce = I.mob_size * 2 * I.throw_multiplier
 	else if(isobj(AM))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -144,15 +144,15 @@
 		return 1
 	if(get_dir(O.loc, target) == dir)
 		return 0
-	return 1
+	return 1 
 
 
 /obj/structure/window/hitby(AM as mob|obj)
 	..()
 	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
-	if(ismob(AM))
-		tforce = 40
+	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dmA
+		tforce = AM.mob_size * 2 * AM.throw_multiplier
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		tforce = I.throwforce

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -152,7 +152,8 @@
 	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
 	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dmA
-		tforce = AM.mob_size * 2 * AM.throw_multiplier
+		var/mob/I = AM
+		tforce = I.mob_size * 2 * I.throw_multiplier
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		tforce = I.throwforce

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -153,6 +153,7 @@
 	var/list/shouldnt_see = list()	//list of objects that this mob shouldn't see in the stat panel. this silliness is needed because of AI alt+click and cult blood runes
 
 	var/mob_size = MOB_MEDIUM
+	var/throw_multiplier = 1
 
 	var/paralysis = 0
 	var/stunned = 0


### PR DESCRIPTION
* Window damage is now calculated dynamically, using the equation (mob_size * 2) * throw_multiplier
* Adds the framework for new force calculations based on mobs.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
