### PR TITLE
Removes APC from Construction Site

### DIFF
--- a/maps/torch/torch-8.dmm
+++ b/maps/torch/torch-8.dmm
@@ -165,7 +165,7 @@
 "di" = (/obj/structure/cable/blue{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/blue{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/autolathe,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)
 "dj" = (/obj/structure/window/basic,/obj/machinery/portable_atmospherics/canister/air/airlock,/obj/machinery/atmospherics/portables_connector{tag = "icon-map_connector (EAST)"; icon_state = "map_connector"; dir = 4},/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)
 "dk" = (/obj/machinery/atmospherics/pipe/simple/hidden/blue{tag = "icon-intact (NORTHWEST)"; icon_state = "intact"; dir = 9},/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)
-"dl" = (/obj/structure/cable/blue,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/obj/machinery/power/apc/high{dir = 1; name = "south bump"; pixel_y = -24},/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)
+"dl" = (/obj/structure/cable/blue,/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/obj/machinery/power/apc/high/inactive{dir = 2; name = "south bump"; pixel_y = -24},/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)
 "dm" = (/turf/space,/area/calypso_hangar/salvage)
 "dn" = (/obj/machinery/pipedispenser,/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)
 "do" = (/obj/machinery/pipedispenser/disposal,/turf/simulated/floor/tiled/dark,/area/constructionsite/teleporter)


### PR DESCRIPTION
... and adds an APC frame item in its place.
No more constant power alerts from a nearby known Construction Site that shouldn't be there anymore.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
