### PR TITLE
Magnetic gripper and research module changes

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -21,7 +21,8 @@
 		/obj/item/weapon/camera_assembly,
 		/obj/item/weapon/tank,
 		/obj/item/weapon/circuitboard,
-		/obj/item/weapon/smes_coil
+		/obj/item/weapon/smes_coil,
+		/obj/item/weapon/computer_hardware
 		)
 
 	var/obj/item/wrapped = null // Item currently being held.
@@ -78,7 +79,8 @@
 		/obj/item/slime_extract,
 		/obj/item/weapon/reagent_containers/glass,
 		/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
-		/obj/item/mecha_parts
+		/obj/item/mecha_parts,
+		/obj/item/weapon/computer_hardware
 		)
 
 /obj/item/weapon/gripper/service //Used to handle food, drinks, and seeds.
@@ -144,7 +146,7 @@
 		wrapped = null
 		return
 
-	to_chat(src.loc, "<span class='danger'>You drop \the [wrapped].</span>")
+	to_chat(src.loc, "<span class='warning'>You drop \the [wrapped].</span>")
 	wrapped.loc = get_turf(src)
 	wrapped = null
 	//update_icon()
@@ -200,7 +202,7 @@
 
 		//We can grab the item, finally.
 		if(grab)
-			to_chat(user, "You collect \the [I].")
+			to_chat(user, "<span class='notice'>You collect \the [I].</span>")
 			I.loc = src
 			wrapped = I
 			return

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -595,6 +595,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/card/robot(src)
 	src.modules += new /obj/item/weapon/wrench(src)
 	src.modules += new /obj/item/weapon/screwdriver(src)
+	src.modules += new /obj/item/weapon/wirecutters(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/weapon/scalpel/laser3(src)
 	src.modules += new /obj/item/weapon/circular_saw(src)

--- a/html/changelogs/sabiram-grippy.yml
+++ b/html/changelogs/sabiram-grippy.yml
@@ -1,0 +1,5 @@
+author: sabiram
+delete-after: True
+changes: 
+  - rscadd: "Standard and research magnetic grippers can now hold modular computer hardware."
+  - rscadd: "Research module robots now have access to wirecutters."


### PR DESCRIPTION
Standard and research magnetic grippers can now hold modular computer hardware. This makes it so they  can actually fix the things/build new ones.

Also made the gripper drop text stand out less, and the pick up text stand out more.

Previously, research module robots could not complete some builds, as they did not have wirecutters. They now have wirecutters.

Fixes #16455