### PR TITLE
Replaces slime's disoriented var with carbon's confused var.

### DIFF
--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -31,7 +31,6 @@
 	var/mob/living/Target = null // AI variable - tells the slime to hunt this down
 	var/mob/living/Leader = null // AI variable - tells the slime to follow this person
 
-	var/disoriented = 0 // Cooldown until the slime can act again
 	var/attacked = 0 // Determines if it's been attacked recently. Can be any number, is a cooloff-ish variable
 	var/rabid = 0 // If set to 1, the slime will attack and eat anything it comes in contact with
 	var/holding_still = 0 // AI variable, cooloff-ish for how long it's going to stay in one place
@@ -203,7 +202,7 @@
 				visible_message("<span class='warning'>\The [M] manages to wrestle \the [src] off!</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-				disoriented = max(disoriented, 2)
+				confused = max(confused, 2)
 				Feedstop()
 				UpdateFace()
 				step_away(src, M)
@@ -218,7 +217,7 @@
 				visible_message("<span class='warning'>\The [M] manages to wrestle \the [src] off \the [Victim]!</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-				disoriented = max(disoriented, 2)
+				confused = max(confused, 2)
 				Feedstop()
 				UpdateFace()
 				step_away(src, M)
@@ -233,7 +232,7 @@
 			var/success = prob(40)
 			visible_message("<span class='warning'>\The [M] pushes \the [src]![success ? " \The [src] looks momentarily disoriented!" : ""]</span>")
 			if(success)
-				disoriented = max(disoriented, 2)
+				confused = max(confused, 2)
 				UpdateFace()
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			else

--- a/code/modules/mob/living/carbon/metroid/slime_AI.dm
+++ b/code/modules/mob/living/carbon/metroid/slime_AI.dm
@@ -7,8 +7,8 @@
 			attacked = 50 // Let's not get into absurdly long periods of rage
 		--attacked
 
-	if(disoriented > 0)
-		--disoriented
+	if(confused > 0)
+		--confused
 		return
 
 	if(nutrition < get_starve_nutrition()) // If a slime is starving, it starts losing its friends
@@ -114,7 +114,7 @@
 		AIproc = 0
 		return // If we're dead or have a client, we don't need AI, if we're feeding, we continue feeding
 
-	if(disoriented)
+	if(confused)
 		AIproc = 0
 		return
 
@@ -187,7 +187,7 @@
 /mob/living/carbon/slime/proc/UpdateFace()
 	var/newmood = ""
 	a_intent = I_HELP
-	if(disoriented)
+	if(confused)
 		newmood = "pout"
 	else if(rabid || attacked)
 		newmood = "angry"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -71,7 +71,7 @@
 		if(vlist.len)
 			for(var/ID in vlist)
 				var/datum/disease2/disease/V = vlist[ID]
-				if(V.spreadtype == "Contact")
+				if(V && V.spreadtype == "Contact")
 					infect_virus2(M, V.getcopy())
 
 /datum/reagent/blood/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
@@ -173,16 +173,16 @@
 /datum/reagent/water/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(!istype(M, /mob/living/carbon/slime) && alien != IS_SLIME)
 		return
+	M.adjustToxLoss(10 * removed)	// Babies have 150 health, adults have 200; So, 15 units and 20
 	var/mob/living/carbon/slime/S = M
-	S.adjustToxLoss(10 * removed) // Babies have 150 health, adults have 200; So, 15 units and 20
-	if(!S.client)
+	if(!S.client && istype(S))
 		if(S.Target) // Like cats
 			S.Target = null
 		if(S.Victim)
 			S.Feedstop()
 	if(dose == removed)
-		S.visible_message("<span class='warning'>[S]'s flesh sizzles where the water touches it!</span>", "<span class='danger'>Your flesh burns in the water!</span>")
-		S.disoriented = max(S.disoriented, 2)
+		M.visible_message("<span class='warning'>[S]'s flesh sizzles where the water touches it!</span>", "<span class='danger'>Your flesh burns in the water!</span>")
+		M.confused = max(M.confused, 2)
 
 /datum/reagent/fuel
 	name = "Welding fuel"


### PR DESCRIPTION
Also fixes a few runtime errors.
Fixes #15831
Fixes #16505
Fixes #16506

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
