### PR TITLE
Adds circuit blueprinter creation via deconstructor

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -74,6 +74,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/integrated_printer
 	name = "Circuit board (Integrated Circuit Printer)"
 	build_path = /obj/machinery/integrated_circuit_printer
+	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
 	req_components = list(
 						/obj/item/weapon/circuitboard/integrated_printer = 1,

--- a/code/modules/integrated_electronics/_defines.dm
+++ b/code/modules/integrated_electronics/_defines.dm
@@ -17,11 +17,13 @@
 	icon = 'icons/obj/electronic_assemblies.dmi'
 	icon_state = "template"
 	w_class = ITEM_SIZE_TINY
+	matter = list(DEFAULT_WALL_MATERIAL = 10)
 	var/extended_desc = null
 	var/list/inputs = list()
 	var/list/outputs = list()
 	var/list/activators = list()
 	var/next_use = 0 //Uses world.time
+	var/removable = 1 //Whether this part can be removed from the assembly it is in.
 	var/complexity = 1 //This acts as a limitation on building machines, more resource-intensive components cost more 'space'.
 	var/size = 1       //This acts as a limitation on building machines, physically larger units take up more actual space.
 	var/cooldown_per_use = 1 SECOND
@@ -142,7 +144,8 @@
 
 	HTML += "<br><a href='?src=\ref[src];refresh=1'>\[Refresh\]</a>  |  "
 	HTML += "<a href='?src=\ref[src];rename=1'>\[Rename\]</a>  |  "
-	HTML += "<a href='?src=\ref[src];remove=1'>\[Remove\]</a><br>"
+	if(removable)
+		HTML += "<a href='?src=\ref[src];remove=1'>\[Remove\]</a><br>"
 
 	HTML += "<colgroup>"
 	HTML += "<col style='width: 121px'>"

--- a/code/modules/integrated_electronics/assemblies.dm
+++ b/code/modules/integrated_electronics/assemblies.dm
@@ -4,6 +4,7 @@
 	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/electronic_assemblies.dmi'
 	icon_state = "setup_small"
+	matter = list(DEFAULT_WALL_MATERIAL = 200)
 	var/max_components = 10
 	var/max_complexity = 40
 	var/opened = 0
@@ -13,6 +14,7 @@
 	name = "electronic mechanism"
 	desc = "It's a medium sized case, for building electronics with."
 	icon_state = "setup_medium"
+	matter = list(DEFAULT_WALL_MATERIAL = 400)
 	w_class = ITEM_SIZE_NORMAL
 	max_components = 20
 	max_complexity = 80
@@ -21,6 +23,7 @@
 	name = "electronic machine"
 	desc = "A large case, for building electronics with."
 	icon_state = "setup_large"
+	matter = list(DEFAULT_WALL_MATERIAL = 600)
 	w_class = ITEM_SIZE_LARGE
 	max_components = 30
 	max_complexity = 120
@@ -29,6 +32,7 @@
 	name = "electronic drone"
 	desc = "A little drone fit to be controlled via electronics."
 	icon_state = "setup_drone"
+	matter = list(DEFAULT_WALL_MATERIAL = 600)
 	w_class = ITEM_SIZE_NORMAL
 	max_components = 25
 	max_complexity = 100
@@ -91,7 +95,8 @@
 		HTML += "<td><a href=?src=\ref[circuit];examine=1>[circuit.name]</a></td>"
 		HTML += "<td><a href=?src=\ref[circuit];rename=1>\[Rename\]</a></td>"
 		HTML += "<td><a href=?src=\ref[src];bottom=\ref[circuit]>\[To Bottom\]</a></td>"
-		HTML += "<td><a href=?src=\ref[circuit];remove=1>\[Remove\]</a></td>"
+		if(circuit.removable)
+			HTML += "<td><a href=?src=\ref[circuit];remove=1>\[Remove\]</a></td>"
 		HTML += "</tr>"
 	HTML += "</table>"
 

--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -36,7 +36,7 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 	if(istype(O,/obj/item/stack/material))
 		var/obj/item/stack/material/stack = O
 		if(stack.material.name == DEFAULT_WALL_MATERIAL)
-			var/num = Clamp(round(input("How many sheets do you want to add?") as num), 0, maxMetal-metal)
+			var/num = Clamp(round(input("How many sheets do you want to add?") as num), 0, min(maxMetal - metal, stack.amount))
 			if(num && stack.use(num))
 				to_chat(user, "<span class='notice'>You add [num] sheet\s to \the [src].</span>")
 				metal += num

--- a/code/modules/integrated_electronics/prefab/prefab.dm
+++ b/code/modules/integrated_electronics/prefab/prefab.dm
@@ -1,3 +1,52 @@
+/proc/create_prefab_from_assembly(var/obj/item/device/electronic_assembly/assembly)
+	var/decl/prefab/ic_assembly/new_prefab = new() //We are making a prefabricated assembly. This is actually not too hard, just tedious.
+	new_prefab.assembly_name = assembly.name //Set easy stuff like name, type, shell, etc.
+	new_prefab.assembly_type = assembly.type
+	new_prefab.metal_amount = assembly.matter[DEFAULT_WALL_MATERIAL] //We base the metal amount off the matter used in the thing.
+	new_prefab.shell_type = assembly.applied_shell
+	new_prefab.integrated_circuits = list() //setup lists
+	new_prefab.value_presets = list()
+	new_prefab.connections = list()
+	for(var/circuit_count = 1, circuit_count <= assembly.contents.len, circuit_count++) //We parse each individual circuit.
+		var/obj/item/integrated_circuit/ic = assembly.contents[circuit_count]
+		var/datum/ic_assembly_integrated_circuits/circuit = new()
+		new_prefab.metal_amount += ic.matter[DEFAULT_WALL_MATERIAL] //Increase metal amount
+		circuit.circuit_type = ic.type //Setup type 'n name
+		circuit.circuit_name = ic.name
+		new_prefab.integrated_circuits += circuit //add to our list
+		var/list/list_to_use = list(ic.inputs, ic.outputs, ic.activators) //Next we must parse 3 different lists, the inputs, outputs, and activators of the current circuit
+		for(var/channel_count in 1 to 3)
+			var/list/current_list = list_to_use[channel_count] //Get the list we are on.
+			for(var/io_count in 1 to current_list.len) //Parse them!
+				var/datum/integrated_io/IO = current_list[io_count]
+				var/data = IO.get_data() //First we see if they have a premade value
+				if(data && channel_count != 3) //if we are not activators, save that data
+					var/datum/ic_assembly_value_preset/pres = new()
+					pres.circuit_index = circuit_count //Point to the right circuit
+					pres.pin_type = (channel_count == 1 ? IC_INPUT : IC_OUTPUT) //make sure our pin type is set correctly
+					pres.value = data
+					pres.io_pin_index = io_count //Point to the right input/output/etc list.
+					new_prefab.value_presets += pres
+				if(IO.linked && channel_count != 1) //if we are output/activators
+					for(var/linked_count in 1 to IO.linked.len) //We get what they are linkd to
+						var/datum/integrated_io/linked = IO.linked[linked_count]
+						var/other_count = assembly.contents.Find(linked.holder) //We figure out what circuit they are currently linked to.
+						if(channel_count == 3 && other_count > circuit_count) //Activators will show up twice if we don't do this.
+							continue
+						var/datum/ic_assembly_connection/output_to_input/connect = new()
+						if(channel_count == 3) //easier to do it this way
+							connect.pin_type_a = IC_ACTIVATOR
+							connect.pin_type_b = IC_ACTIVATOR
+							connect.io_pin_index_b = linked.holder.activators.Find(linked) //Find what we are linked to!
+						else
+							connect.io_pin_index_b = linked.holder.inputs.Find(linked) //A bit of a backwards way of finding the link's right input/output
+						connect.circuit_index_a = circuit_count //Connect the link by circuit now
+						connect.circuit_index_b = other_count
+						connect.io_pin_index_a = io_count
+						new_prefab.connections += connect //Add it!
+	return new_prefab //We are DONE!
+
+
 /decl/prefab/proc/create(var/atom/location)
 	if(!location)
 		CRASH("Invalid location supplied: [log_info_line(location)]")
@@ -6,6 +55,7 @@
 	var/assembly_name
 	var/assembly_type
 	var/shell_type
+	var/metal_amount = 1 //how much metal is used to make this prefab (used in designs only)
 	var/list/integrated_circuits = list()
 	var/list/value_presets = list()
 	var/list/connections = list()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1818,3 +1818,42 @@ CIRCUITS BELOW
 	materials = list(DEFAULT_WALL_MATERIAL = 120)
 	build_path = /obj/item/weapon/crowbar/brace_jack
 	sort_string = "VBAAS"
+
+/datum/design/prefab
+	name = "Device"
+	desc = "A blueprint made from a design built on station."
+	materials = list(DEFAULT_WALL_MATERIAL = 200)
+	id = "prefab"
+	build_type = PROTOLATHE
+	sort_string = "ZAAAA"
+	var/decl/prefab/ic_assembly/fabrication
+	var/global/count = 0
+
+/datum/design/prefab/New(var/research, var/fab)
+	if(fab)
+		fabrication = fab
+		materials = list(DEFAULT_WALL_MATERIAL = fabrication.metal_amount)
+		build_path = /obj/item/device/electronic_assembly //put this here so that the default made one doesn't show up in protolathe list
+		id = "prefab[++count]"
+	sort_string = "Z"
+	var/cur_count = count
+	while(cur_count > 25)
+		sort_string += ascii2text(cur_count%25+65)
+		cur_count = (cur_count - cur_count%25)/25
+	sort_string += ascii2text(cur_count + 65)
+	while(length(sort_string) < 5)
+		sort_string += "A"
+	..()
+
+/datum/design/prefab/AssembleDesignName()
+	..()
+	if(fabrication)
+		name = "Device ([fabrication.assembly_name])"
+
+/datum/design/prefab/Fabricate(var/newloc)
+	if(!fabrication)
+		return
+	var/obj/O = fabrication.create(newloc)
+	for(var/obj/item/integrated_circuit/circ in O.contents)
+		circ.removable = 0
+	return O

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -64,12 +64,18 @@ Note: Must be placed within 3 tiles of the R&D Console
 	if(!loaded_item)
 		if(isrobot(user)) //Don't put your module items in there!
 			return
-		if(!O.origin_tech)
-			to_chat(user, "<span class='notice'>This doesn't seem to have a tech origin.</span>")
-			return
-		if(O.origin_tech.len == 0)
-			to_chat(user, "<span class='notice'>You cannot deconstruct this item.</span>")
-			return
+		if(istype(O, /obj/item/device/electronic_assembly)) //A few things
+			var/obj/item/device/electronic_assembly/assembly = O
+			if(!assembly.contents.len) //Make sure they don't use this to get cheap assemblies.
+				return
+		else
+			if(!O.origin_tech)
+				to_chat(user, "<span class='notice'>This doesn't seem to have a tech origin.</span>")
+				return
+			if(O.origin_tech.len == 0)
+				to_chat(user, "<span class='notice'>You cannot deconstruct this item.</span>")
+				return
+
 		busy = 1
 		loaded_item = O
 		user.drop_item()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -97,6 +97,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				D.linked_console = src
 	return
 
+/obj/machinery/computer/rdconsole/proc/add_ic_design(var/obj/item/device/electronic_assembly/assembly)
+	files.AddDesign2Known(new /datum/design/prefab(files,create_prefab_from_assembly(assembly)))
+
 /obj/machinery/computer/rdconsole/proc/griefProtection() //Have it automatically push research to the centcomm server so wild griffins can't fuck up R&D's work
 	for(var/obj/machinery/r_n_d/server/centcom/C in machines)
 		for(var/datum/tech/T in files.known_tech)
@@ -237,9 +240,11 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							to_chat(usr, "<span class='notice'>The destructive analyzer appears to be empty.</span>")
 							screen = 1.0
 							return
-
-						for(var/T in linked_destroy.loaded_item.origin_tech)
-							files.UpdateTech(T, linked_destroy.loaded_item.origin_tech[T])
+						if(istype(linked_destroy.loaded_item, /obj/item/device/electronic_assembly))
+							add_ic_design(linked_destroy.loaded_item)
+						else
+							for(var/T in linked_destroy.loaded_item.origin_tech)
+								files.UpdateTech(T, linked_destroy.loaded_item.origin_tech[T])
 						if(linked_lathe && linked_destroy.loaded_item.matter) // Also sends salvaged materials to a linked protolathe, if any.
 							for(var/t in linked_destroy.loaded_item.matter)
 								if(t in linked_lathe.materials)
@@ -607,15 +612,19 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += "Deconstruction Menu<HR>"
 			dat += "Name: [linked_destroy.loaded_item.name]<BR>"
-			dat += "Origin Tech:"
-			dat += "<UL>"
-			for(var/T in linked_destroy.loaded_item.origin_tech)
-				dat += "<LI>[CallTechName(T)] [linked_destroy.loaded_item.origin_tech[T]]"
-				for(var/datum/tech/F in files.known_tech)
-					if(F.name == CallTechName(T))
-						dat += " (Current: [F.level])"
-						break
-			dat += "</UL>"
+			if(istype(linked_destroy.loaded_item, /obj/item/device/electronic_assembly))
+				dat += "Assembly Detected. Prepared for blueprint download."
+				dat += "Warning: Assemblies manafactured this way will not have removable circuits."
+			else
+				dat += "Origin Tech:"
+				dat += "<UL>"
+				for(var/T in linked_destroy.loaded_item.origin_tech)
+					dat += "<LI>[CallTechName(T)] [linked_destroy.loaded_item.origin_tech[T]]"
+					for(var/datum/tech/F in files.known_tech)
+						if(F.name == CallTechName(T))
+							dat += " (Current: [F.level])"
+							break
+				dat += "</UL>"
 			dat += "<HR><A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A> || "
 			dat += "<A href='?src=\ref[src];eject_item=1'>Eject Item</A> || "
 

--- a/html/changelogs/TheWelp - circuitBlueprinter.yml
+++ b/html/changelogs/TheWelp - circuitBlueprinter.yml
@@ -1,0 +1,13 @@
+author: TheWelp
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes circuit printer being a computer recipe instead of a machine"
+  - rscadd: "Adds ability to deconstruct an assembly and gain a protolathe recipe for it."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Title. Basically this PR fixes a bug (computer circuit board -> machine) and lets the destructive analyzer deconstruct assemblies. When it does this a design and recipe is created for the protolathe. This lets players mass produce their inventions (at a bit of a discount as well!)
As a side note, the assemblies created are 'non modifiable' in that you can't remove the circuits inside to get cheap recycling.