### PR TITLE
Adds spotlight light tubes to the autolathe, boxes

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -341,6 +341,11 @@
 	path = /obj/item/device/assembly/prox_sensor
 	category = "Devices and Components"
 
+/datum/autolathe/recipe/tube/large
+	name = "spotlight tube"
+	path = /obj/item/weapon/light/tube/large
+	category = "General"
+
 /datum/autolathe/recipe/tube
 	name = "light tube"
 	path = /obj/item/weapon/light/tube

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -362,13 +362,15 @@
 /obj/item/weapon/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	icon_state = "lighttube"
-	startswith = list(/obj/item/weapon/light/tube = 21)
+	startswith = list(/obj/item/weapon/light/tube = 17,
+					/obj/item/weapon/light/tube/large = 4)
 
 /obj/item/weapon/storage/box/lights/mixed
 	name = "box of replacement lights"
 	icon_state = "lightmixed"
-	startswith = list(/obj/item/weapon/light/tube = 14,
-					/obj/item/weapon/light/bulb = 7)
+	startswith = list(/obj/item/weapon/light/tube = 12,
+					/obj/item/weapon/light/tube/large = 4,
+					/obj/item/weapon/light/bulb = 5)
 
 /obj/item/weapon/storage/box/glowsticks
 	name = "box of mixed glowsticks"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -185,6 +185,7 @@ var/global/list/light_type_cache = list()
 
 /obj/machinery/light/spot
 	name = "spotlight"
+	desc = "A more robust socket for light tubes that demand more power."
 	light_type = /obj/item/weapon/light/tube/large
 
 // create a new lighting fixture

--- a/html/changelogs/sabiram-lights.yml
+++ b/html/changelogs/sabiram-lights.yml
@@ -1,0 +1,4 @@
+author: sabiram
+delete-after: True
+changes: 
+  - rscadd: "Replacement tubes for spotlight fixtures are now available in the autolathe and in most light tube boxes."


### PR DESCRIPTION
Fixes #15632

Available now in:
Autolathe
Light tube boxes at spawn
Light tube boxes in cargo crate