### PR TITLE
Torch headset changes

### DIFF
--- a/html/changelogs/sabiram-headsets.yml
+++ b/html/changelogs/sabiram-headsets.yml
@@ -1,0 +1,7 @@
+author: sabiram
+delete-after: True
+changes: 
+  - rscadd: "The Roboticist now has access to both the Engineering and Research channels."
+  - rscadd: "Bridge Officers have gained the Service radio channel, in addition to the Command channel they previously had access to."
+  - rscdel: "The Senior Enlisted Advisor has lost the Engineering and Medical channels, leaving Command, Security, Service and Supply."
+  - rscdel: "The SolGov Pilot no longer has Command radio access, and have been given the standard Service radio headset."

--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -8,6 +8,11 @@
 	icon_state = "hop_cypherkey"
 	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)
 
+/obj/item/device/encryptionkey/heads/torchsea
+	name = "senior enlisted advisor's encryption key"
+	icon_state = "hop_cypherkey"
+	channels = list("Command" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)
+
 /obj/item/device/encryptionkey/headset_torchnt
 	name = "nanotrasen radio encryption key"
 	icon_state = "nt_cypherkey"
@@ -23,3 +28,8 @@
 	name = "deck officer's encryption key"
 	icon_state = "qm_cypherkey"
 	channels = list("Supply" = 1, "Command" = 1)
+
+/obj/item/device/encryptionkey/headset_bridgeofficer
+	name = "bridge officer's encryption key"
+	icon_state = "hop_cypherkey"
+	channels = list("Command" = 1, "Service" = 1)

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -33,7 +33,6 @@
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/heads/hos
 
-
 /obj/item/device/radio/headset/headset_deckofficer
 	name = "deck officer's radio headset"
 	desc = "The headset of the chief box pusher."
@@ -41,6 +40,21 @@
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/headset_deckofficer
 
+/obj/item/device/radio/headset/headset_bridgeofficer
+	name = "bridge officer's radio headset"
+	desc = "The headset of the captain's busybodies."
+	icon_state = "com_headset"
+	item_state = "headset"
+	ks2type = /obj/item/device/encryptionkey/headset_bridgeofficer
+
+/obj/item/device/radio/headset/heads/torchsea
+	name = "senior enlisted advistor's radio headset"
+	desc = "The designated headset to be used to advise with seniority while enlisted."
+	icon_state = "com_headset"
+	item_state = "headset"
+	ks2type = /obj/item/device/encryptionkey/heads/torchsea
+
+//* boxes of headsets *//
 
 /obj/item/weapon/storage/box/headset/torchxo
 	name = "box of spare executive officer headsets"

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -181,7 +181,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/command/sea
 	name = OUTFIT_JOB_NAME("Senior Enlisted Advisor")
 	uniform = /obj/item/clothing/under/utility/expeditionary/command
-	l_ear = /obj/item/device/radio/headset/heads/torchxo
+	l_ear = /obj/item/device/radio/headset/heads/torchsea
 	shoes = /obj/item/clothing/shoes/dutyboots
 	head = /obj/item/clothing/head/soft/sol/expedition
 	id_type = /obj/item/weapon/card/id/torch/crew/sea
@@ -202,6 +202,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
 	name = OUTFIT_JOB_NAME("Bridge Officer")
 	uniform = /obj/item/clothing/under/utility/expeditionary/command
+	l_ear = /obj/item/device/radio/headset/headset_bridgeofficer
 	shoes = /obj/item/clothing/shoes/dutyboots
 	head = /obj/item/clothing/head/soft/sol/expedition
 	id_type = /obj/item/weapon/card/id/torch/crew/bridgeofficer
@@ -280,6 +281,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	name = OUTFIT_JOB_NAME("Roboticist - Torch")
+	l_ear = /obj/item/device/radio/headset/headset_rob
 	uniform = /obj/item/clothing/under/rank/roboticist
 	shoes = /obj/item/clothing/shoes/black
 	head = null
@@ -595,7 +597,6 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	head = /obj/item/clothing/head/soft/sol/expedition
 	id_type = /obj/item/weapon/card/id/torch/crew/service/solgov_pilot
 	pda_type = /obj/item/device/pda
-	l_ear = /obj/item/device/radio/headset/headset_com
 
 /decl/hierarchy/outfit/job/torch/crew/service/solgov_pilot/fleet
 	name = OUTFIT_JOB_NAME("Pilot - Fleet")


### PR DESCRIPTION
### What
- Roboticist: Engineering and Research (was Engineering only)
- Bridge Officer: Command and Service (was Command only)
- Senior Enlisted Advisor: Command, Security, Service and Supply (was EVERYTHING BUT RESEARCH)
- SolGov Pilot: Service (was Command only)


### Why
- Roboticist: The mechanics of the role has been tied into the Research department too heavily to leave them out of this channel. They are a contractor so I think this department bridging should be OK.
- Bridge Officer: With this change the bridge officer will be able to order tea for the bridge staff, which is good, and they will be able to communicate with the Sol Pilot.
- Senior Enlisted Advisor: The Senior Enlisted Advisor presently has access to **every** radio channel in the game, except for the Research channel. This has resulted in people butting into business that is not theirs, and in the worst examples, stepping over the real and active head of staff, the XO, and even the CO. They have retained Security radio in this PR because they are a disciplinarian and they probably want to keep tabs on if people are being huge jerks.
- SolGov Pilot: The SolGov pilot as a job is basically not implemented. They are not relevant on the command radio channel, as they are not a head of staff or part of the command support team. They have been returned to their rightful place in the SERVICE department with this change. With the Bridge Officer changes, they can _still_ communicate with a large portion of the command team (CO, XO, SEA, BO x2) and this should hopefully curtail the trend of them becoming the de facto third bridge officer.