### PR TITLE
Removes Hunger Speed Effects

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -1,4 +1,4 @@
-#define DEFAULT_HUNGER_FACTOR 0.05 // Factor of how fast mob nutrition decreases
+#define DEFAULT_HUNGER_FACTOR 0.10 // Factor of how fast mob nutrition decreases
 
 #define REM 0.2 // Means 'Reagent Effect Multiplier'. This is how many units of reagent are consumed per tick
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -18,9 +18,6 @@
 	if(can_feel_pain())
 		if(getHalLoss() >= 10) tally += (getHalLoss() / 10) //halloss shouldn't slow you down if you can't even feel it
 
-	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
-	if (hungry >= 70) tally += hungry/50
-
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(organ_name)

--- a/html/changelogs/Datraen-FluffNutrition.yml
+++ b/html/changelogs/Datraen-FluffNutrition.yml
@@ -1,0 +1,5 @@
+author: Datraen
+delete-after: True
+changes: 
+  - rscdel: "Removed the hunger section of movement code."
+  - tweak: "Doubled the rate of nutrition degradation."


### PR DESCRIPTION
Based on comments from #16498

Removes hunger having an effect on a user's speed, doubles default metabolism.