### PR TITLE
Fixes whitespace cropping where it shouldn't be

### DIFF
--- a/code/modules/integrated_electronics/tools.dm
+++ b/code/modules/integrated_electronics/tools.dm
@@ -113,7 +113,7 @@
 	switch(type_to_use)
 		if("string")
 			accepting_refs = 0
-			new_data = sanitize(input("Now type in a string.","[src] string writing") as null|text)
+			new_data = sanitize(input("Now type in a string.","[src] string writing") as null|text, trim = 0)
 			if(istext(new_data) && CanInteract(user, physical_state))
 				data_to_write = new_data
 				to_chat(user, "<span class='notice'>You set \the [src]'s memory to \"[new_data]\".</span>")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -270,7 +270,7 @@
 			to_chat(usr, "<span class='info'>There isn't enough space left on \the [src] to write anything.</span>")
 			return
 
-		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0)
+		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
 
 		if(!t)
 			return

--- a/html/changelogs/Hubblenaut-trim.yml
+++ b/html/changelogs/Hubblenaut-trim.yml
@@ -1,0 +1,6 @@
+author: Hubblenaut
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes whitespace cropping when writing on paper or using the circuit debugger."


### PR DESCRIPTION
Specifically the whitespace when writing on a piece of paper and when entering a string for the integrated circuit debugger.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
