### PR TITLE
Teleporter QOL and Tweaks

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -161,6 +161,9 @@
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))
 	return 1
 
+/obj/machinery/teleport/station/AIAltClick()
+	testfire()
+
 /atom/proc/AIMiddleClick(var/mob/living/silicon/user)
 	return 0
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -147,6 +147,9 @@
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()
 
+/obj/machinery/teleport/station/BorgAltClick()
+	testfire()
+
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/html/changelogs/Hubblenaut-teleporter.yml
+++ b/html/changelogs/Hubblenaut-teleporter.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds alt-click shortcut for initiating test-fire."
+  - rscadd: "Examining the teleporter console will reveal its current destination and accuracy."
+  - tweak: "Teleporter accuracy does no longer automatically reset after five minutes."
+  - tweak: "Teleporter accuracy resets after locking in to a different destination."


### PR DESCRIPTION
 - Adds AltClick shortcuts for test-firing.
 - Adds examining text for destination and test-firing.
 - No longer automatically resets accuracy after five minutes.
 - Accuracy solely resets when lockin in onto a different target or when the hub disengages.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
