### PR TITLE
Removes input prompts on lathes/printers

### DIFF
--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -36,12 +36,13 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 	if(istype(O,/obj/item/stack/material))
 		var/obj/item/stack/material/stack = O
 		if(stack.material.name == DEFAULT_WALL_MATERIAL)
-			var/num = Clamp(round(input("How many sheets do you want to add?") as num), 0, min(maxMetal - metal, stack.amount))
-			if(num && stack.use(num))
-				to_chat(user, "<span class='notice'>You add [num] sheet\s to \the [src].</span>")
-				metal += num
-				updateUsrDialog()
-				return 1
+			var/num = min(maxMetal - metal, stack.amount)
+			if(do_after(usr, 16, src))
+				if(stack.use(num))
+					to_chat(user, "<span class='notice'>You add [num] sheet\s to \the [src].</span>")
+					metal += num
+					updateUsrDialog()
+					return 1
 	if(default_deconstruction_screwdriver(user, O))
 		new /obj/item/stack/material/steel(get_turf(loc), metal)
 		metal = 0

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -114,15 +114,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		return 1
 
 	var/obj/item/stack/material/stack = O
-	var/amount = round(input("How many sheets do you want to add?") as num)
-	if(!O)
-		return
-	if(amount <= 0)//No negative numbers
-		return
-	if(amount > stack.get_amount())
-		amount = stack.get_amount()
-	if(max_material_storage - TotalMaterials() < (amount * SHEET_MATERIAL_AMOUNT)) //Can't overfill
-		amount = min(stack.get_amount(), round((max_material_storage - TotalMaterials()) / SHEET_MATERIAL_AMOUNT))
+	var/amount = min(stack.get_amount(), round((max_material_storage - TotalMaterials()) / SHEET_MATERIAL_AMOUNT))
 
 	busy = 1
 	use_power(max(1000, (SHEET_MATERIAL_AMOUNT * amount / 10)))

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -111,15 +111,7 @@
 		return 1
 
 	var/obj/item/stack/material/stack = O
-	var/amount = round(input("How many sheets do you want to add?") as num)//No decimals
-	if(!O)
-		return
-	if(amount <= 0)//No negative numbers
-		return
-	if(amount > stack.get_amount())
-		amount = stack.get_amount()
-		if(max_material_storage - TotalMaterials() < (amount * SHEET_MATERIAL_AMOUNT)) //Can't overfill
-			amount = min(stack.get_amount(), round((max_material_storage - TotalMaterials()) / SHEET_MATERIAL_AMOUNT))
+	var/amount = min(stack.get_amount(), round((max_material_storage - TotalMaterials()) / SHEET_MATERIAL_AMOUNT))
 
 	var/t = stack.material.name
 	overlays += "protolathe_[t]"


### PR DESCRIPTION
Autolathe has no prompt either. If you'd want to insert less than the maximum amount of sheets possible, you have the option to split the stack in your hands first.

Kind of fixes the integrated circuit printer prompting for an input twice.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
