### PR TITLE
Lowers Hunger Degradation, Increases Spawn Nutrition

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -1,4 +1,4 @@
-#define DEFAULT_HUNGER_FACTOR 0.10 // Factor of how fast mob nutrition decreases
+#define DEFAULT_HUNGER_FACTOR 0.03 // Factor of how fast mob nutrition decreases
 
 #define REM 0.2 // Means 'Reagent Effect Multiplier'. This is how many units of reagent are consumed per tick
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -399,6 +399,9 @@ datum/preferences
 
 	character.skills = skills
 	character.used_skillpoints = used_skillpoints
+	
+	if(!character.isSynthetic())
+		character.nutrition = rand(140,360)
 
 /datum/preferences/proc/open_load_dialog(mob/user)
 	var/dat  = list()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -46,7 +46,6 @@
 		dna.real_name = real_name
 		sync_organ_dna()
 	make_blood()
-	nutrition = rand(50,200)
 
 /mob/living/carbon/human/Destroy()
 	human_mob_list -= src

--- a/html/changelogs/Datraen-NutritionTweak.yml
+++ b/html/changelogs/Datraen-NutritionTweak.yml
@@ -1,0 +1,5 @@
+author: Datraen
+delete-after: True
+changes: 
+  - tweak: "Raised the starting nutrition values."
+  - tweak: "Reset the rate of nutrition degradation to the default value."


### PR DESCRIPTION
https://baystation12.net/forums/threads/vote-hunger-slowdown.3823/
Ranges for nutrition put it just above "full" and just below red hunger.


Ranges for starting nutrition changed since you are always at least hungry when you spawn, rather than having a chance to not be hungry.