### PR TITLE
Adds a clicky shortcut to PDA id removal

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -954,6 +954,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			id.loc = get_turf(src)
 		id = null
 
+/obj/item/device/pda/AltClick()
+	if(Adjacent(usr))
+		verb_remove_id()
+
 /obj/item/device/pda/proc/create_message(var/mob/living/U = usr, var/obj/item/device/pda/P, var/tap = 1)
 	if(tap)
 		U.visible_message("<span class='notice'>\The [U] taps on \his PDA's screen.</span>")

--- a/html/changelogs/sabiram-click.yml
+++ b/html/changelogs/sabiram-click.yml
@@ -1,0 +1,4 @@
+author: sabiram
+delete-after: True
+changes: 
+  - rscadd: "You can now alt-click a PDA to remove an ID."


### PR DESCRIPTION
Alt click now removes the ID from the PDA if there's one in there.