### PR TITLE
Fixes rooms showing wrong pressure after reaching equilibrium.

### DIFF
--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -120,6 +120,9 @@
 		temperature = ((temperature * our_heatcap) + (sharer.temperature * share_heatcap)) / (our_heatcap + share_heatcap)
 	sharer.temperature = temperature
 
+	update_values()
+	sharer.update_values()
+
 	return 1
 
 


### PR DESCRIPTION
Fixes rooms showing wrong pressure after reaching equilibrium by updating values after equalizing gas mixtures.

* If we do not do this, zones are left with the wrong total_moles (and therefore the wrong pressure readout) after equalizing.
* Equalizing happens when two connected zones get close enough to suspend processing. Thus the effect of this bug would be wrong pressure readings on rooms that are no longer being updated, thus locking in the wrong value!

Port of https://github.com/PolarisSS13/Polaris/pull/3091 

Verification that the bug is present on Baystation12 also:
![issue 1192 baystation](https://cloud.githubusercontent.com/assets/14110581/24011144/4dbbc0ac-0a50-11e7-8884-6c67c12cf5b9.png)

