### PR TITLE
Changes overmap autopilot

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -35,11 +35,9 @@
 			else
 				linked.decelerate()
 
-		var/brake_path = linked.get_brake_path()
-
-		if(get_dist(linked.loc, T) > brake_path)
+		if(linked.is_still())
 			linked.accelerate(get_dir(linked.loc, T))
-		else
+		else if(get_dist(linked.loc, T) <= linked.get_brake_path())
 			linked.decelerate()
 
 		return


### PR DESCRIPTION
Insstead of SANIC strategy it instead burns once towards destination, then brakes as usual.
Much easier on fuel reserves. If you wanna go faster you can burn manually, and it would handle braking.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
