### PR TITLE
Adds junior alt-titles to Crewman job.

### DIFF
--- a/html/changelogs/Techhead-assist.yml
+++ b/html/changelogs/Techhead-assist.yml
@@ -1,0 +1,7 @@
+author: Techhead
+
+delete-after: True
+
+changes: 
+  - rscadd: "Moves Junior Enginner to a Crewman alt-title, accompanied by the new Junior Engineer."
+  - tweak: "Increased Crewman slots by one and removed age restriction."

--- a/html/changelogs/Techhead-assist.yml
+++ b/html/changelogs/Techhead-assist.yml
@@ -3,5 +3,5 @@ author: Techhead
 delete-after: True
 
 changes: 
-  - rscadd: "Moves Junior Enginner to a Crewman alt-title, accompanied by the new Junior Engineer."
+  - rscadd: "Moves Junior Enginner to a Crewman alt-title, accompanied by the new Junior Corpsman."
   - tweak: "Increased Crewman slots by one and removed age restriction."

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -346,7 +346,7 @@
 		"EVA Technician",
 		"Electrician",
 		"Atmospheric Technician",
-		"Junior Engineer")
+		)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -853,12 +853,15 @@
 	department = "Service"
 	department_flag = SRV
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 5
+	spawn_positions = 5
 	supervisors = "the Executive Officer and SolGov Personnel"
 	selection_color = "#515151"
 	ideal_character_age = 20
-	minimal_player_age = 3
+	alt_titles = list(
+		"Junior Engineer",
+		"Junior Corpsman",
+		)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,


### PR DESCRIPTION
Junior Engineer moved from Engineer alt-title. Junior Corpsman is new.
Also removes age restriction on Crewman and increases slots by one.

Enough dithering. Make the change you want to see.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
