### PR TITLE
Nerfs pulse rifle damage

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -62,17 +62,17 @@
 	name = "pulse"
 	icon_state = "u_laser"
 	fire_sound='sound/weapons/pulse.ogg'
-	damage = 20 //lower damage, but fires in bursts
+	damage = 15 //lower damage, but fires in bursts
 
 	muzzle_type = /obj/effect/projectile/laser_pulse/muzzle
 	tracer_type = /obj/effect/projectile/laser_pulse/tracer
 	impact_type = /obj/effect/projectile/laser_pulse/impact
 
 /obj/item/projectile/beam/pulse/mid
-	damage = 25
+	damage = 20
 
 /obj/item/projectile/beam/pulse/heavy
-	damage = 30
+	damage = 25
 
 /obj/item/projectile/beam/pulse/destroy
 	name = "destroyer pulse"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Because **60** damage per burst for a pistol, **75** for a carbine, and **90** for a rifle was not balanced, and made everything else obsolete, especially seeing how many of these weapons there are in the armoury.

Now it's less so.