### PR TITLE
Revert "Duct tape repairs supermatter"

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -401,10 +401,6 @@
 
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
-	if(istype(W, /obj/item/weapon/tape_roll))
-		to_chat(user, "You repair some of the damage to \the [src] with \the [W].")
-		damage = max(damage -10, 0)
-
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\
 		"<span class=\"danger\">You touch \the [W] to \the [src] when everything suddenly goes silent.\"</span>\n<span class=\"notice\">\The [W] flashes into dust as you flinch away from \the [src].</span>",\
 		"<span class=\"warning\">Everything suddenly goes silent.</span>")


### PR DESCRIPTION
Reverts Baystation12/Baystation12#16634

Why the hell was a joke PR like that one even merged in first place...

It makes literally zero sense, both from mechanical and from lore perspective, as has been stated by multiple people (apparently including the loremaster).

Bay isn't TG after all.