### PR TITLE
Various Fixes, catches.

### DIFF
--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -286,6 +286,8 @@ var/global/list/narsie_list = list()
 		if(food.stat)
 			continue
 		var/turf/pos = get_turf(food)
+		if(!pos)	//Catches failure of get_turf.
+			continue
 		if(pos.z != src.z)
 			continue
 		cultists += food

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -96,7 +96,9 @@
 	if(gcDestroyed) // GC is trying to delete us, we'll kill our processing so we can cleanly GC
 		return PROCESS_KILL
 
-	confirm()
+	if(!confirm())
+		return PROCESS_KILL	//qdel'd in confirm.
+		
 	if(!assailant)
 		qdel(src) // Same here, except we're trying to delete ourselves.
 		return PROCESS_KILL

--- a/maps/torch/items/uniform_vendor.dm
+++ b/maps/torch/items/uniform_vendor.dm
@@ -56,7 +56,10 @@
 	if(href_list["ID"])
 		var/mob/M = usr
 		if(ID)
-			M.put_in_hands(ID)
+			if(!issilicon(usr))
+				M.put_in_hands(ID)
+			else
+				ID.dropInto(loc)
 			ID = null
 			selected_outfit.Cut()
 		else


### PR DESCRIPTION
Fixes #16666 by adding a dropInto method of removal for ID cards when a silicon user removes an ID card from the uniform vendor.

Catches cases that cause #16677 by checking to make sure that the turf is valid. I'm not entirely sure what caused the runtime, but the target human may have been qdel'd while processing.

Tentatively fixes #16674 by checking the returned value of confirm(), returning PROCESS_KILL. Grabs are qdel'd in confirm().
