### PR TITLE
Reverts all gun cabinets back to only armory and bridge access.

### DIFF
--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -94,7 +94,6 @@
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/small
 	name = "personal sidearm cabinet"
-	req_one_access = list(access_solgov_crew)
 	will_contain = list(
 		/obj/item/weapon/gun/energy/gun/small = 6
 	)


### PR DESCRIPTION
On behalf of @Spookerton. Apparently, the change was controversial and undocumented/undiscussed.