### PR TITLE
Lets you click on yourself to take a drag form cig

### DIFF
--- a/html/changelogs/chinsky - smoke.yml
+++ b/html/changelogs/chinsky - smoke.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Can now click yourself with cig to take a drag on it."


### PR DESCRIPTION
Alternative to standing around with it in mouth.
Also moves some code aroud randomly.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
