### PR TITLE
Cuts down on spooky shrooms.

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -93,6 +93,8 @@
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
 
+#define CanPhysicallyInteract(user) CanInteract(user, physical_state)
+
 #define qdel_null_list(x) if(x) { for(var/y in x) { qdel(y) } ; x = null }
 
 #define qdel_null(x) if(x) { qdel(x) ; x = null }

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -115,3 +115,11 @@
 		private_valid_special_roles += ghost_trap.pref_check
 
 	return private_valid_special_roles
+
+/client/proc/wishes_to_be_role(var/role)
+	if(!prefs)
+		return FALSE
+	if(role in prefs.be_special_role)
+		return 2
+	if(role in prefs.sometimes_be_special_role)
+		return 1

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -36,13 +36,14 @@ var/list/ghost_traps
 	..()
 
 // Check for bans, proper atom types, etc.
-/datum/ghosttrap/proc/assess_candidate(var/mob/observer/ghost/candidate, var/mob/target)
+/datum/ghosttrap/proc/assess_candidate(var/mob/observer/ghost/candidate, var/mob/target, var/feedback = TRUE)
 	if(!candidate.MayRespawn(1, minutes_since_death))
 		return 0
 	if(islist(ban_checks))
 		for(var/bantype in ban_checks)
 			if(jobban_isbanned(candidate, "[bantype]"))
-				to_chat(candidate, "You are banned from one or more required roles and hence cannot enter play as \a [object].")
+				if(feedback)
+					to_chat(candidate, "You are banned from one or more required roles and hence cannot enter play as \a [object].")
 				return 0
 	return 1
 
@@ -50,23 +51,21 @@ var/list/ghost_traps
 /datum/ghosttrap/proc/request_player(var/mob/target, var/request_string, var/request_timeout)
 	if(request_timeout)
 		request_timeouts[target] = world.time + request_timeout
-		destroyed_event.register(target, src, /datum/ghosttrap/proc/target_destroyed)
+		destroyed_event.register(target, src, /datum/ghosttrap/proc/unregister_target)
 	else
-		request_timeouts -= target
+		unregister_target(target)
 
 	for(var/mob/observer/ghost/O in player_list)
-		if(!O.MayRespawn())
-			continue
-		if(islist(ban_checks))
-			for(var/bantype in ban_checks)
-				if(jobban_isbanned(O, "[bantype]"))
-					continue
-		if(pref_check && !(pref_check in O.client.prefs.be_special_role))
+		if(!assess_candidate(O, target, FALSE))
+			return
+		if(pref_check && !O.client.wishes_to_be_role(pref_check))
 			continue
 		if(O.client)
 			to_chat(O, "[request_string] <a href='?src=\ref[src];candidate=\ref[O];target=\ref[target]'>(Occupy)</a> ([ghost_follow_link(target, O)])")
-/datum/ghosttrap/proc/target_destroyed(var/destroyed_target)
-	request_timeouts -= destroyed_target
+
+/datum/ghosttrap/proc/unregister_target(var/target)
+	request_timeouts -= target
+	destroyed_event.unregister(target, src, /datum/ghosttrap/proc/unregister_target)
 
 // Handles a response to request_player().
 /datum/ghosttrap/Topic(href, href_list)
@@ -91,7 +90,7 @@ var/list/ghost_traps
 
 // Shunts the ckey/mind into the target mob.
 /datum/ghosttrap/proc/transfer_personality(var/mob/candidate, var/mob/target)
-	if(!assess_candidate(candidate))
+	if(!assess_candidate(candidate, target))
 		return 0
 	target.ckey = candidate.ckey
 	if(target.mind)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -703,12 +703,15 @@
 					total_yield = get_trait(TRAIT_YIELD) + rand(yield_mod)
 				total_yield = max(1,total_yield)
 
+		. = list()
 		for(var/i = 0;i<total_yield;i++)
 			var/obj/item/product
 			if(has_mob_product)
 				product = new has_mob_product(get_turf(user),name)
 			else
 				product = new /obj/item/weapon/reagent_containers/food/snacks/grown(get_turf(user),name)
+			. += product
+				
 			if(get_trait(TRAIT_PRODUCT_COLOUR))
 				if(!istype(product, /mob))
 					product.color = get_trait(TRAIT_PRODUCT_COLOUR)

--- a/code/modules/hydroponics/seed_mobs.dm
+++ b/code/modules/hydroponics/seed_mobs.dm
@@ -1,16 +1,15 @@
 // The following procs are used to grab players for mobs produced by a seed (mostly for dionaea).
 /datum/seed/proc/handle_living_product(var/mob/living/host)
-
 	if(!host || !istype(host)) return
 
 	var/datum/ghosttrap/plant/P = get_ghost_trap("living plant")
-	P.request_player(host, "Someone is harvesting \a [display_name].")
+	P.request_player(host, "Someone is harvesting \a [display_name].", 15 SECONDS)
 
-	spawn(75)
+	spawn(15 SECONDS)
 		if(!host.ckey && !host.client)
 			host.death()  // This seems redundant, but a lot of mobs don't
 			host.set_stat(DEAD) // handle death() properly. Better safe than etc.
-			host.visible_message("<span class='danger'>[host] is malformed and unable to survive. It expires pitifully, leaving behind some seeds.</span>")
+			host.visible_message("<span class='danger'>\The [host] is malformed and unable to survive. It expires pitifully, leaving behind some seeds.</span>")
 
 			var/total_yield = rand(1,3)
 			for(var/j = 0;j<=total_yield;j++)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -130,17 +130,15 @@
 	return ..()
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_ghost(var/mob/observer/ghost/user)
-
 	if(!(harvest && seed && seed.has_mob_product))
 		return
 
-	var/datum/ghosttrap/plant/G = get_ghost_trap("living plant")
-	if(!G.assess_candidate(user))
+	if(!user.can_admin_interact())
 		return
+
 	var/response = alert(user, "Are you sure you want to harvest this [seed.display_name]?", "Living plant request", "Yes", "No")
 	if(response == "Yes")
 		harvest()
-	return
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_generic(var/mob/user)
 


### PR DESCRIPTION
Ghosts can no longer harvest their "own" plants. Fixes #16712.
Recruitment logic is non-trivial, preventing a quick-fix to maintain the feature, and the issue appears sufficiently serious to need a quick quelling.

However, this change does mean ghosts have to keep an eye on the chat window to note the occupy-plant message. To make up for it I've increased the time an observer have to accept the offer by a full 100%!