### PR TITLE
sign language autohiss fix

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -53,7 +53,7 @@
 	autohiss_basic_map = list(
 			"r" = list("rr", "rrr", "rrrr")
 		)
-	autohiss_exempt = list(LANGUAGE_SIIK_MAAS)
+	autohiss_exempt = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR)
 	
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -47,13 +47,13 @@
 	autohiss_extra_map = list(
 			"x" = list("ks", "kss", "ksss")
 		)
-	autohiss_exempt = list(LANGUAGE_UNATHI)
+	autohiss_exempt = list(LANGUAGE_UNATHI, LANGUAGE_SIGN)
 
 /datum/species/tajaran
 	autohiss_basic_map = list(
 			"r" = list("rr", "rrr", "rrrr")
 		)
-	autohiss_exempt = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR)
+	autohiss_exempt = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR, LANGUAGE_SIGN)
 	
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)

--- a/html/changelogs/Wolf.yml
+++ b/html/changelogs/Wolf.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes: 
+  - bugfix: "fixed taj having R's extended when speaking Siik'tajr."


### PR DESCRIPTION
fixes  that R's were extended for Taj in Siik'tajr (taj sign language) and general one for both Unathi and Taj for normal sign language.

I will squash it later, currently my program for it is down.