### PR TITLE
Finally fixed that bug with mushroom limit.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -46,11 +46,11 @@
 	spore_explode()
 
 /mob/living/simple_animal/mushroom/death()
-	if(total_mushrooms < config.maximum_mushrooms && prob(30))
-		spore_explode()
-		return
-	total_mushrooms--
-	..()
+	. = ..()
+	if(.)
+		total_mushrooms--
+		if(total_mushrooms < config.maximum_mushrooms && prob(30))
+			spore_explode()
 
 /mob/living/simple_animal/mushroom/proc/spore_explode()
 	if(!seed)
@@ -60,6 +60,7 @@
 	for(var/turf/simulated/target_turf in orange(1,src))
 		if(prob(60) && !target_turf.density && src.Adjacent(target_turf))
 			new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(target_turf,seed)
+	death(0)
 	seed.thrown_at(src,get_turf(src),1)
 	if(src)
-		gib()
+		qdel(src)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -298,6 +298,7 @@
 /mob/living/simple_animal/death(gibbed, deathmessage = "dies!")
 	icon_state = icon_dead
 	density = 0
+	adjustBruteLoss(maxHealth) //Make sure dey dead.
 	walk_to(src,0)
 	return ..(gibbed,deathmessage)
 

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -23,7 +23,8 @@
 	aiming.cancel_aiming(no_message)
 
 /mob/living/death(gibbed,deathmessage="seizes up and falls limp...")
-	if(..())
+	. = ..()
+	if(.)
 		stop_aiming(no_message=1)
 
 /mob/living/update_canmove()


### PR DESCRIPTION
Holy cow that was harder than I thought.

So very basically this was an error on my part, and a fix of a few cumulative bugs.

1. I did not check for death when doing spore stuff. So it could proc more than once just because spore stuff procced death back.
2. the death proc does not return correctly after /mob/living due to a slight error in an aiming override.
3. Simple animals do not respect death. They will die, then just walk again because they don't give two craps about stat itself (but will set it). So now on death simple animals will have their health reduced by their maximum health, just to be on the safe side.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
