### PR TITLE
Fix null deref in hear_say

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -41,7 +41,10 @@
 				else
 					message = stars(message)
 
-	var/speaker_name = speaker.name
+	var/speaker_name = "Unknown"
+	if(speaker)
+		speaker_name = speaker.name
+
 	if(istype(speaker, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = speaker
 		speaker_name = H.GetVoice()
@@ -222,7 +225,7 @@
 		var/length = length(message) * pick(0.8, 0.9, 1.0, 1.1, 1.2)	//Inserts a little fuzziness.
 		switch(length)
 			if(0 to 12) 	adverb = " briefly"
-			if(12 to 30)	adverb = " a short message" 
+			if(12 to 30)	adverb = " a short message"
 			if(30 to 48)	adverb = " a message"
 			if(48 to 90)	adverb = " a lengthy message"
 			else        	adverb = " a very lengthy message"


### PR DESCRIPTION
I found this one while playing on a local server :)

This fixes the ability to use `broadcast` from NT-script, thereby allowing servers to spew messages into various channels. It appears that messages originating from servers (sensibly) have a null "speaker", which makes sense--an alternative to this one would be to actually assign speakers to servers, which strikes me as wrong.