### PR TITLE
Fix rooms holding pressure when exposed to space.

### DIFF
--- a/code/modules/ZAS/ConnectionGroup.dm
+++ b/code/modules/ZAS/ConnectionGroup.dm
@@ -184,7 +184,8 @@ Class Procs:
 	air_master.mark_zone_update(B)
 
 /connection_edge/zone/recheck()
-	if(!A.air.compare(B.air))
+	// Edges with only one side being vacuum need processing no matter how close.
+	if(!A.air.compare(B.air, vacuum_exception = 1))
 		air_master.mark_edge_active(src)
 
 //Helper proc to get connections for a zone.
@@ -240,7 +241,10 @@ Class Procs:
 	air_master.mark_zone_update(A)
 
 /connection_edge/unsimulated/recheck()
-	if(!A.air.compare(air))
+	// Edges with only one side being vacuum need processing no matter how close.
+	// Note: This handles the glaring flaw of a room holding pressure while exposed to space, but
+	// does not specially handle the less common case of a simulated room exposed to an unsimulated pressurized turf.
+	if(!A.air.compare(air, vacuum_exception = 1))
 		air_master.mark_edge_active(src)
 
 proc/ShareHeat(datum/gas_mixture/A, datum/gas_mixture/B, connecting_tiles)

--- a/html/changelogs/Leshana-zas-settle-at-zero.yml
+++ b/html/changelogs/Leshana-zas-settle-at-zero.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes: 
+  - bugfix: "Fix rooms holding pressure when exposed to space."


### PR DESCRIPTION
This happens because edges cease processing when the delta between their
zones is small enough.  This is normally a fine optimization, but when
it results in a room at 4kPa with a window open to space, it breaks
imurshuns.

Two main changes to solve this problem without too much cpu cost:
1) Stop edges from sleeping if one side is a hard vacuum.  This ensures
that a zone doesn't freeze at a low-but-non-zero pressure when touching
hard vacuum.
2) Prevent #1 from causing the edge to stay alive for ages while
pressures asymptotically approach zero as they are repeatedly equalized
but only half is dumped to space. (Would happen if ZoneA---ZoneB---Space
arrangement exists) by detecting when the total amount of air left is
small enough that it would normally sleep anyway, and just setting it to
zero.

The end outcome is that behavior is mostly the same as before, except
when zones have an open path to unsimulated space, they will reach
equilibrium at zero instead of semi-random lowish values.

Port of https://github.com/PolarisSS13/Polaris/pull/3094  see there for details and testing procedure.
Resolves #16593 in at least one case.  Probably all.  See there for testing verification on this codebase.
