### PR TITLE
Replace species strings with defines

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -225,3 +225,13 @@
 
 #define CORPSE_CAN_REENTER 1
 #define CORPSE_CAN_REENTER_AND_RESPAWN 2
+
+#define SPECIES_HUMAN "Human"
+#define SPECIES_RESOMI "Resomi"
+#define SPECIES_TAJARA "Tajara"
+#define SPECIES_DIONA "Diona"
+#define SPECIES_VOX "Vox"
+#define SPECIES_VOXPARIAH "Vox Pariah"
+#define SPECIES_IPC "Machine"
+#define SPECIES_UNATHI "Unathi"
+#define SPECIES_SKRELL "Skrell"

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -30,8 +30,8 @@ var/global/list/turfs = list()						//list of all turfs
 var/global/list/all_species[0]
 var/global/list/all_languages[0]
 var/global/list/language_keys[0]					// Table of say codes for all languages
-var/global/list/whitelisted_species = list("Human") // Species that require a whitelist check.
-var/global/list/playable_species = list("Human")    // A list of ALL playable species, whitelisted, latejoin or otherwise.
+var/global/list/whitelisted_species = list(SPECIES_HUMAN) // Species that require a whitelist check.
+var/global/list/playable_species = list(SPECIES_HUMAN)    // A list of ALL playable species, whitelisted, latejoin or otherwise.
 
 var/list/mannequins_
 

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -27,7 +27,7 @@
 
 	return mobs
 
-proc/random_hair_style(gender, species = "Human")
+proc/random_hair_style(gender, species = SPECIES_HUMAN)
 	var/h_style = "Bald"
 
 	var/list/valid_hairstyles = list()
@@ -49,7 +49,7 @@ proc/random_hair_style(gender, species = "Human")
 
 	return h_style
 
-proc/random_facial_hair_style(gender, species = "Human")
+proc/random_facial_hair_style(gender, species = SPECIES_HUMAN)
 	var/f_style = "Shaved"
 
 	var/list/valid_facialhairstyles = list()
@@ -72,14 +72,14 @@ proc/random_facial_hair_style(gender, species = "Human")
 
 		return f_style
 
-proc/sanitize_name(name, species = "Human")
+proc/sanitize_name(name, species = SPECIES_HUMAN)
 	var/datum/species/current_species
 	if(species)
 		current_species = all_species[species]
 
 	return current_species ? current_species.sanitize_name(name) : sanitizeName(name)
 
-proc/random_name(gender, species = "Human")
+proc/random_name(gender, species = SPECIES_HUMAN)
 
 	var/datum/species/current_species
 	if(species)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -336,7 +336,7 @@
 //Used for new human mobs created by cloning/goleming/etc.
 /mob/living/carbon/human/proc/set_cloned_appearance()
 	f_style = "Shaved"
-	if(dna.species == "Human") //no more xenos losing ears/tentacles
+	if(dna.species == SPECIES_HUMAN) //no more xenos losing ears/tentacles
 		h_style = pick("Bedhead", "Bedhead 2", "Bedhead 3")
 	all_underwear.Cut()
 	regenerate_icons()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -203,7 +203,7 @@ var/list/gamemode_cache = list()
 
 	var/starlight = 0	// Whether space turfs have ambient light or not
 
-	var/list/ert_species = list("Human")
+	var/list/ert_species = list(SPECIES_HUMAN)
 
 	var/law_zero = "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010"
 
@@ -694,7 +694,7 @@ var/list/gamemode_cache = list()
 				if("ert_species")
 					config.ert_species = splittext(value, ";")
 					if(!config.ert_species.len)
-						config.ert_species += "Human"
+						config.ert_species += SPECIES_HUMAN
 
 				if("law_zero")
 					law_zero = value

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -277,7 +277,7 @@
 	G.fields["fingerprint"] = H ? md5(H.dna.uni_identity) : "Unknown"
 	G.fields["p_stat"] = "Active"
 	G.fields["m_stat"] = "Stable"
-	G.fields["species"] = H ? H.get_species() : "Human"
+	G.fields["species"] = H ? H.get_species() : SPECIES_HUMAN
 	G.fields["home_system"]	= H ? H.home_system : "Unknown"
 	G.fields["citizenship"]	= H ? H.citizenship : "Unknown"
 	G.fields["faction"]		= H ? H.personal_faction : "Unknown"

--- a/code/datums/trading/vox.dm
+++ b/code/datums/trading/vox.dm
@@ -68,10 +68,10 @@
 		var/mob/living/carbon/human/H = user
 		if(H.species)
 			switch(H.species.name)
-				if("Vox")
+				if(SPECIES_VOX)
 					disposition = 1000
 					hailed_vox = 1
-				if("Vox Pariah")
+				if(SPECIES_VOXPARIAH)
 					hailed_vox = -1
 					disposition = -1000
 			specific = H.species.name

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -53,7 +53,7 @@
 	var/show_objectives_on_creation = 1     // Whether or not objectives are shown when a player is added to this antag datum
 
 	// Used for setting appearance.
-	var/list/valid_species =       list("Unathi","Tajara","Skrell","Human")
+	var/list/valid_species =       list(SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_HUMAN)
 	var/min_player_age = 14
 
 	// Runtime vars.

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -169,7 +169,7 @@ var/datum/antagonist/ninja/ninjas
 		if(13)
 			directive += "Some disgruntled [using_map.company_name] employees have been supportive of our operations. Be wary of any mistreatment by command staff."
 		if(14)
-			var/xenorace = pick("Unathi","Tajara", "Skrell")
+			var/xenorace = pick(SPECIES_UNATHI,SPECIES_TAJARA, SPECIES_SKRELL)
 			directive += "A group of [xenorace] radicals have been loyal supporters of the Spider Clan. Favor [xenorace] crew whenever possible."
 		if(15)
 			directive += "The Spider Clan has recently been accused of religious insensitivity. Attempt to speak with the Chaplain and prove these accusations false."

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -201,7 +201,7 @@ var/datum/antagonist/raider/raiders
 	if(!..())
 		return 0
 
-	if(player.species && player.species.get_bodytype(player) == "Vox")
+	if(player.species && player.species.get_bodytype(player) == SPECIES_VOX)
 		equip_vox(player)
 	else
 		var/new_shoes =   pick(raider_shoes)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -83,7 +83,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	var/real_name          // Stores the real name of the person who originally got this dna datum. Used primarily for changelings,
 
 	// New stuff
-	var/species = "Human"
+	var/species = SPECIES_HUMAN
 
 // Make a copy of this strand.
 // USE THIS WHEN COPYING STUFF OR YOU'LL GET CORRUPTION!

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -742,7 +742,7 @@
 	//Departments that the cycler can paint suits to look like.
 	var/list/departments = list("Engineering","Mining","Medical","Security","Atmos","Science")
 	//Species that the suits can be configured to fit.
-	var/list/species = list("Human","Skrell","Unathi","Tajara","Resomi")
+	var/list/species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_RESOMI)
 
 	var/target_department
 	var/target_species
@@ -771,42 +771,42 @@
 	model_text = "Engineering"
 	req_access = list(access_construction)
 	departments = list("Engineering","Atmos")
-	species = list("Human","Tajara","Skrell","Unathi","Resomi") //Add Unathi when sprites exist for their suits.
+	species = list(SPECIES_HUMAN,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI) //Add Unathi when sprites exist for their suits.
 
 /obj/machinery/suit_cycler/mining
 	name = "Mining suit cycler"
 	model_text = "Mining"
 	req_access = list(access_mining)
 	departments = list("Mining")
-	species = list("Human","Tajara","Skrell","Unathi","Resomi")
+	species = list(SPECIES_HUMAN,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI)
 
 /obj/machinery/suit_cycler/science
 	name = "Excavation suit cycler"
 	model_text = "Excavation"
 	req_access = list(access_xenoarch)
 	departments = list("Science")
-	species = list("Human","Tajara","Skrell","Unathi","Resomi")
+	species = list(SPECIES_HUMAN,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI)
 
 /obj/machinery/suit_cycler/security
 	name = "Security suit cycler"
 	model_text = "Security"
 	req_access = list(access_security)
 	departments = list("Security")
-	species = list("Human","Tajara","Skrell","Unathi","Resomi")
+	species = list(SPECIES_HUMAN,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI)
 
 /obj/machinery/suit_cycler/medical
 	name = "Medical suit cycler"
 	model_text = "Medical"
 	req_access = list(access_medical)
 	departments = list("Medical")
-	species = list("Human","Tajara","Skrell","Unathi","Resomi")
+	species = list(SPECIES_HUMAN,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI)
 
 /obj/machinery/suit_cycler/syndicate
 	name = "Nonstandard suit cycler"
 	model_text = "Nonstandard"
 	req_access = list(access_syndicate)
 	departments = list("Mercenary")
-	species = list("Human","Tajara","Skrell","Unathi","Resomi")
+	species = list(SPECIES_HUMAN,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI)
 	can_repair = 1
 
 /obj/machinery/suit_cycler/attack_ai(mob/user as mob)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -66,7 +66,7 @@
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
 	sprite_sheets = list(
-		"Tajara" = 'icons/cat/are/bad'
+		SPECIES_TAJARA = 'icons/cat/are/bad'
 		)
 	If index term exists and icon_override is not set, this sprite sheet will be used.
 	*/

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -11,7 +11,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	item_state = "electronic"
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_ID | SLOT_BELT
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/id.dmi')
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/id.dmi')
 
 	//Main variables
 	var/owner = null

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -7,7 +7,7 @@
 	desc = "A kit containing all the needed tools and parts to modify a hardsuit for another user."
 	icon_state = "modkit"
 	var/parts = MODKIT_FULL
-	var/target_species = "Human"
+	var/target_species = SPECIES_HUMAN
 
 	var/list/permitted_types = list(
 		/obj/item/clothing/head/helmet/space/void,
@@ -69,4 +69,4 @@
 /obj/item/device/modkit/tajaran
 	name = "tajaran hardsuit modification kit"
 	desc = "A kit containing all the needed tools and parts to modify a hardsuit for another user. This one looks like it's meant for Tajaran."
-	target_species = "Tajara"
+	target_species = SPECIES_TAJARA

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -17,7 +17,7 @@
 	var/ks1type = /obj/item/device/encryptionkey
 	var/ks2type = null
 
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/ears.dmi')
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/ears.dmi')
 
 /obj/item/device/radio/headset/New()
 	..()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -97,7 +97,7 @@ var/const/NO_EMAG_ACT = -50
 	item_state = "card-id"
 
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/id.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/id.dmi'
 		)
 
 	var/access = list()

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -17,7 +17,7 @@
 	var/breakouttime = 1200 //Deciseconds = 120s = 2 minutes
 	var/cuff_sound = 'sound/weapons/handcuffs.ogg'
 	var/cuff_type = "handcuffs"
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/handcuffs.dmi')
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/handcuffs.dmi')
 
 /obj/item/weapon/handcuffs/get_mob_overlay(mob/user_mob, slot)
 	var/image/ret = ..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -18,7 +18,7 @@
 		slot_r_hand_str = "backpack",
 		)
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/back.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/back.dmi'
 		)
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -8,7 +8,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined")
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/belt.dmi')
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/belt.dmi')
 	var/show_above_suit = 0
 
 /obj/item/weapon/storage/belt/verb/toggle_layer()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -23,7 +23,7 @@ var/list/global/tank_gauge_cache = list()
 
 
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/back.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/back.dmi'
 		)
 
 	var/datum/gas_mixture/air_contents = null

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -79,10 +79,10 @@
 
 /obj/structure/mirror/raider/attack_hand(var/mob/living/carbon/human/user)
 	if(istype(get_area(src),/area/syndicate_mothership))
-		if(istype(user) && user.mind && user.mind.special_role == "Raider" && user.species.name != "Vox" && is_alien_whitelisted(user, "Vox"))
+		if(istype(user) && user.mind && user.mind.special_role == "Raider" && user.species.name != SPECIES_VOX && is_alien_whitelisted(user, SPECIES_VOX))
 			var/choice = input("Do you wish to become a true Vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")
 			if(choice && choice == "Yes")
-				var/mob/living/carbon/human/vox/vox = new(get_turf(src),"Vox")
+				var/mob/living/carbon/human/vox/vox = new(get_turf(src),SPECIES_VOX)
 				vox.gender = user.gender
 				raiders.equip(vox)
 				if(user.mind)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -23,7 +23,7 @@
 	var/corpseidjob = null // Needs to be in quotes, such as "Clown" or "Chef." This just determines what the ID reads as, not their access
 	var/corpseidaccess = null //This is for access. See access.dm for which jobs give what access. Again, put in quotes. Use "Captain" if you want it to be all access.
 	var/corpseidicon = null //For setting it to be a gold, silver, centcomm etc ID
-	var/species = "Human"
+	var/species = SPECIES_HUMAN
 
 /obj/effect/landmark/corpse/initialize()
 	createCorpse()

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -22,8 +22,8 @@ datum/preferences
 	S["OOC_Notes"]				<< pref.metadata
 
 /datum/category_item/player_setup_item/general/basic/sanitize_character()
-	var/datum/species/S = all_species[pref.species ? pref.species : "Human"]
-	if(!S) S = all_species["Human"]
+	var/datum/species/S = all_species[pref.species ? pref.species : SPECIES_HUMAN]
+	if(!S) S = all_species[SPECIES_HUMAN]
 	pref.age                = sanitize_integer(pref.age, S.min_age, S.max_age, initial(pref.age))
 	pref.gender             = sanitize_inlist(pref.gender, S.genders, pick(S.genders))
 	pref.real_name          = sanitize_name(pref.real_name, pref.species)

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -79,7 +79,7 @@
 		if(!lang || !is_allowed_language(preference_mob, lang))
 			pref.alternate_languages -= L
 
-	var/datum/species/S = all_species[pref.species] || all_species["Human"]
+	var/datum/species/S = all_species[pref.species] || all_species[SPECIES_HUMAN]
 	if(pref.alternate_languages.len > S.num_alternate_languages)
 		pref.alternate_languages.Cut(S.num_alternate_languages + 1)
 

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -57,7 +57,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 /datum/category_item/player_setup_item/general/body/sanitize_character(var/savefile/S)
 	if(!pref.species || !(pref.species in playable_species))
-		pref.species = "Human"
+		pref.species = SPECIES_HUMAN
 	pref.r_hair			= sanitize_integer(pref.r_hair, 0, 255, initial(pref.r_hair))
 	pref.g_hair			= sanitize_integer(pref.g_hair, 0, 255, initial(pref.g_hair))
 	pref.b_hair			= sanitize_integer(pref.b_hair, 0, 255, initial(pref.b_hair))
@@ -471,7 +471,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 					pref.rlimb_data[second_limb] = null
 
 			if("Prosthesis")
-				var/tmp_species = pref.species ? pref.species : "Human"
+				var/tmp_species = pref.species ? pref.species : SPECIES_HUMAN
 				var/list/usable_manufacturers = list()
 				for(var/company in chargen_robolimbs)
 					var/datum/robolimb/M = chargen_robolimbs[company]
@@ -551,7 +551,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 /datum/category_item/player_setup_item/general/body/proc/SetSpecies(mob/user)
 	if(!pref.species_preview || !(pref.species_preview in all_species))
-		pref.species_preview = "Human"
+		pref.species_preview = SPECIES_HUMAN
 	var/datum/species/current_species = all_species[pref.species_preview]
 	var/dat = "<body>"
 	dat += "<center><h2>[current_species.name] \[<a href='?src=\ref[src];show_species=1'>change</a>\]</h2></center><hr/>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -46,7 +46,7 @@ datum/preferences
 	var/r_eyes = 0						//Eye color
 	var/g_eyes = 0						//Eye color
 	var/b_eyes = 0						//Eye color
-	var/species = "Human"               //Species datum to use.
+	var/species = SPECIES_HUMAN               //Species datum to use.
 	var/species_preview                 //Used for the species selection window.
 	var/list/alternate_languages = list() //Secondary language(s)
 	var/list/language_prefixes = list() //Kanguage prefix keys

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -79,8 +79,8 @@
 
 	//Set species_restricted list
 	switch(target_species)
-		if("Human", "Skrell")	//humanoid bodytypes
-			species_restricted = list("Human", "Skrell", "Machine") //skrell/humans/machines can wear each other's suits
+		if(SPECIES_HUMAN, SPECIES_SKRELL)	//humanoid bodytypes
+			species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_IPC) //skrell/humans/machines can wear each other's suits
 		else
 			species_restricted = list(target_species)
 
@@ -95,10 +95,10 @@
 
 	//Set species_restricted list
 	switch(target_species)
-		if("Skrell")
-			species_restricted = list("Human", "Skrell", "Machine") //skrell helmets fit humans too
-		if("Human")
-			species_restricted = list("Human", "Machine") //human helmets fit IPCs too
+		if(SPECIES_SKRELL)
+			species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_IPC) //skrell helmets fit humans too
+		if(SPECIES_HUMAN)
+			species_restricted = list(SPECIES_HUMAN, SPECIES_IPC) //human helmets fit IPCs too
 		else
 			species_restricted = list(target_species)
 
@@ -114,7 +114,7 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 2
 	slot_flags = SLOT_EARS
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/ears.dmi')
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/ears.dmi')
 
 /obj/item/clothing/ears/update_clothing_icon()
 	if (ismob(src.loc))
@@ -178,8 +178,8 @@ BLIND     // can't see anything
 	var/see_invisible = -1
 	var/light_protection = 0
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/eyes.dmi',
-		"Resomi" = 'icons/mob/species/resomi/eyes.dmi',
+		SPECIES_VOX = 'icons/mob/species/vox/eyes.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/eyes.dmi',
 		)
 
 /obj/item/clothing/glasses/get_mob_overlay(mob/user_mob, slot)
@@ -209,10 +209,10 @@ BLIND     // can't see anything
 	body_parts_covered = HANDS
 	slot_flags = SLOT_GLOVES
 	attack_verb = list("challenged")
-	species_restricted = list("exclude","Unathi","Tajara", "Vox")
+	species_restricted = list("exclude",SPECIES_UNATHI,SPECIES_TAJARA, SPECIES_VOX)
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/gloves.dmi',
-		"Resomi" = 'icons/mob/species/resomi/gloves.dmi',
+		SPECIES_VOX = 'icons/mob/species/vox/gloves.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/gloves.dmi',
 		)
 	blood_overlay_type = "bloodyhands"
 
@@ -256,8 +256,8 @@ BLIND     // can't see anything
 	name = "modified [name]"
 	desc = "[desc]<br>They have had the fingertips cut off of them."
 	if("exclude" in species_restricted)
-		species_restricted -= "Unathi"
-		species_restricted -= "Tajara"
+		species_restricted -= SPECIES_UNATHI
+		species_restricted -= SPECIES_TAJARA
 	return
 
 ///////////////////////////////////////////////////////////////////////
@@ -279,8 +279,8 @@ BLIND     // can't see anything
 	var/on = 0
 
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/head.dmi',
-		"Resomi" = 'icons/mob/species/resomi/head.dmi'
+		SPECIES_VOX = 'icons/mob/species/vox/head.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/head.dmi'
 		)
 	blood_overlay_type = "helmetblood"
 
@@ -389,8 +389,8 @@ BLIND     // can't see anything
 	slot_flags = SLOT_MASK
 	body_parts_covered = FACE|EYES
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/masks.dmi',
-		"Resomi" = 'icons/mob/species/resomi/masks.dmi',
+		SPECIES_VOX = 'icons/mob/species/vox/masks.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/masks.dmi',
 		)
 
 	var/voicechange = 0
@@ -477,10 +477,10 @@ BLIND     // can't see anything
 	permeability_coefficient = 0.50
 	force = 2
 	var/overshoes = 0
-	species_restricted = list("exclude","Unathi","Tajara","Vox")
+	species_restricted = list("exclude",SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_VOX)
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/shoes.dmi',
-		"Resomi" = 'icons/mob/species/resomi/shoes.dmi',
+		SPECIES_VOX = 'icons/mob/species/vox/shoes.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/shoes.dmi',
 		)
 	blood_overlay_type = "shoeblood"
 
@@ -561,8 +561,8 @@ BLIND     // can't see anything
 	w_class = ITEM_SIZE_NORMAL
 
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/suit.dmi',
-		"Resomi" = 'icons/mob/species/resomi/suit.dmi'
+		SPECIES_VOX = 'icons/mob/species/vox/suit.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/suit.dmi'
 		)
 
 /obj/item/clothing/suit/update_clothing_icon()
@@ -610,8 +610,8 @@ BLIND     // can't see anything
 	var/rolled_down = -1 //0 = unrolled, 1 = rolled, -1 = cannot be toggled
 	var/rolled_sleeves = -1 //0 = unrolled, 1 = rolled, -1 = cannot be toggled
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/uniform.dmi',
-		"Resomi" = 'icons/mob/species/resomi/uniform.dmi'
+		SPECIES_VOX = 'icons/mob/species/vox/uniform.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/uniform.dmi'
 		)
 
 	//convenience var for defining the icon state for the overlay used when the clothing is worn.

--- a/code/modules/clothing/ears/skrell.dm
+++ b/code/modules/clothing/ears/skrell.dm
@@ -9,7 +9,7 @@
 	gender = PLURAL
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	species_restricted = list("Skrell")
+	species_restricted = list(SPECIES_SKRELL)
 
 /obj/item/clothing/ears/skrell/chain
 	name = "gold headtail chains"

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -10,8 +10,8 @@
 	desc = "an ultra rare hat. It commands a certain respect."
 	icon_state = "petehat"
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/head.dmi',
-		"Resomi" = 'icons/mob/species/resomi/head.dmi'
+		SPECIES_VOX = 'icons/mob/species/vox/head.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/head.dmi'
 		)
 
 /obj/item/clothing/head/collectable/slime

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -125,8 +125,8 @@
 	desc = "An armored helmet capable of being fitted with a multitude of attachments."
 	icon_state = "swathelm"
 	sprite_sheets = list(
-		"Tajara" = 'icons/mob/species/tajaran/helmet.dmi',
-		"Unathi" = 'icons/mob/species/unathi/helmet.dmi'
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/helmet.dmi',
+		SPECIES_UNATHI = 'icons/mob/species/unathi/helmet.dmi'
 		)
 
 	armor = list(melee = 62, bullet = 50, laser = 50,energy = 35, bomb = 10, bio = 2, rad = 0)

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -11,8 +11,8 @@
 	pull_mask = 1
 	w_class = ITEM_SIZE_SMALL
 	sprite_sheets = list(
-		"Tajara" = 'icons/mob/species/tajaran/mask.dmi',
-		"Unathi" = 'icons/mob/species/unathi/mask.dmi',
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/mask.dmi',
+		SPECIES_UNATHI = 'icons/mob/species/unathi/mask.dmi',
 		)
 
 /obj/item/clothing/mask/balaclava/tactical

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -57,7 +57,7 @@
 	name = "alien mask"
 	desc = "Clearly not designed for a human face."
 	body_parts_covered = 0 //Hack to allow vox to eat while wearing this mask.
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 
 /obj/item/clothing/mask/gas/syndicate
 	name = "tactical mask"
@@ -120,5 +120,5 @@
 	icon_state = "respirator"
 	flags_inv = 0
 	body_parts_covered = 0
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 	filtered_gases = list("phoron", "sleeping_agent", "oxygen")

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -4,7 +4,7 @@
 	desc = "Smoothly contoured and polished to a shine. Still looks like a fishbowl."
 	armor = list(melee = 20, bullet = 20, laser = 50,energy = 50, bomb = 50, bio = 100, rad = 100)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	species_restricted = list("Skrell","Human")
+	species_restricted = list(SPECIES_SKRELL,SPECIES_HUMAN)
 
 /obj/item/clothing/head/helmet/space/skrell/white
 	icon_state = "skrell_helmet_white"
@@ -19,7 +19,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	species_restricted = list("Skrell","Human")
+	species_restricted = list(SPECIES_SKRELL,SPECIES_HUMAN)
 
 /obj/item/clothing/suit/space/skrell/white
 	icon_state = "skrell_suit_white"
@@ -36,7 +36,7 @@
 	siemens_coefficient = 0.6
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 
 /obj/item/clothing/suit/space/vox/New()
 	..()
@@ -47,7 +47,7 @@
 	siemens_coefficient = 0.6
 	item_flags = STOPPRESSUREDAMAGE
 	flags_inv = 0
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 
 /obj/item/clothing/head/helmet/space/vox/pressure
 	name = "alien helmet"
@@ -91,7 +91,7 @@
 
 /obj/item/clothing/under/vox
 	has_sensor = 0
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 
 /obj/item/clothing/under/vox/vox_casual
 	name = "alien clothing"
@@ -113,7 +113,7 @@
 	item_state = "gloves-vox"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 
 /obj/item/clothing/shoes/magboots/vox
 
@@ -121,7 +121,7 @@
 	name = "vox magclaws"
 	item_state = "boots-vox"
 	icon_state = "boots-vox"
-	species_restricted = list("Vox")
+	species_restricted = list(SPECIES_VOX)
 
 	action_button_name = "Toggle the magclaws"
 

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -11,10 +11,10 @@
 	cold_protection =    HEAD|FACE|EYES
 	brightness_on = 4
 	sprite_sheets = list(
-		"Tajara" = 'icons/mob/species/tajaran/helmet.dmi',
-		"Skrell" = 'icons/mob/species/skrell/helmet.dmi',
-		"Unathi" = 'icons/mob/species/unathi/helmet.dmi',
-		"Resomi" = 'icons/mob/species/resomi/helmet.dmi'
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/helmet.dmi',
+		SPECIES_SKRELL = 'icons/mob/species/skrell/helmet.dmi',
+		SPECIES_UNATHI = 'icons/mob/species/unathi/helmet.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/helmet.dmi'
 		)
 	species_restricted = null
 
@@ -50,9 +50,9 @@
 	resilience = 0.2
 	can_breach = 1
 	sprite_sheets = list(
-		"Tajara" = 'icons/mob/species/tajaran/suit.dmi',
-		"Unathi" = 'icons/mob/species/unathi/suit.dmi',
-		"Resomi" = 'icons/mob/species/resomi/suit.dmi'
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi',
+		SPECIES_UNATHI = 'icons/mob/species/unathi/suit.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/suit.dmi'
 		)
 	var/list/supporting_limbs = list() //If not-null, automatically splints breaks. Checked when removing the suit.
 

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -24,15 +24,15 @@
 	vision_restriction = TINT_NONE //Still blind when offline. It is fully armoured after all
 
 /obj/item/clothing/head/helmet/space/rig/unathi
-	species_restricted = list("Unathi")
+	species_restricted = list(SPECIES_UNATHI)
 	force = 5
 	sharp = 1 //poking people with the horn
 
 /obj/item/clothing/suit/space/rig/unathi
-	species_restricted = list("Unathi")
+	species_restricted = list(SPECIES_UNATHI)
 
 /obj/item/clothing/shoes/magboots/rig/unathi
-	species_restricted = list("Unathi")
+	species_restricted = list(SPECIES_UNATHI)
 	
 /obj/item/clothing/gloves/rig/unathi
-	species_restricted = list("Unathi")
+	species_restricted = list(SPECIES_UNATHI)

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -19,16 +19,16 @@
 
 /obj/item/clothing/head/helmet/space/rig/combat
 	light_overlay = "helmet_light_dual_green"
-	species_restricted = list("Human")
+	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/suit/space/rig/combat
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/shoes/magboots/rig/combat
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/gloves/rig/combat
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/weapon/rig/combat/equipped
 	initial_modules = list(
@@ -64,16 +64,16 @@
 
 /obj/item/clothing/head/helmet/space/rig/military
 	light_overlay = "helmet_light_dual_green"
-	species_restricted = list("Human")
+	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/suit/space/rig/military
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/shoes/magboots/rig/military
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/gloves/rig/military
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/weapon/rig/military/equipped
 	initial_modules = list(

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -26,16 +26,16 @@
 /obj/item/clothing/head/helmet/space/rig/ert
 	light_overlay = "helmet_light_dual"
 	camera = /obj/machinery/camera/network/ert
-	species_restricted = list("Human","Skrell","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /obj/item/clothing/suit/space/rig/ert
-	species_restricted = list("Human","Skrell","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /obj/item/clothing/shoes/magboots/rig/ert
-	species_restricted = list("Human","Skrell","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /obj/item/clothing/gloves/rig/ert
-	species_restricted = list("Human","Skrell","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 
 /obj/item/weapon/rig/ert/engineer

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -29,14 +29,14 @@
 	name = "shoes"
 	
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/shoes.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/shoes.dmi'
 	)
 
 /obj/item/clothing/head/helmet/space/rig/light
 	name = "hood"
 	
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/helmet.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/helmet.dmi'
 	)
 
 /obj/item/weapon/rig/light/hacker
@@ -111,7 +111,7 @@
 		)
 	
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/back.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/back.dmi'
 	)
 
 	..()
@@ -152,14 +152,14 @@
 	siemens_coefficient = 0
 	
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/gloves.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/gloves.dmi'
 	)
 
 /obj/item/clothing/suit/space/rig/light/ninja
 	breach_threshold = 38 //comparable to regular hardsuits
 	
 	sprite_sheets = list(
-		"Resomi" = 'icons/mob/species/resomi/suit.dmi'
+		SPECIES_RESOMI = 'icons/mob/species/resomi/suit.dmi'
 	)
 
 /obj/item/weapon/rig/light/stealth

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -60,16 +60,16 @@
 
 /obj/item/clothing/head/helmet/space/rig/industrial
 	camera = /obj/machinery/camera/network/mining
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/suit/space/rig/industrial
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/shoes/magboots/rig/industrial
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/gloves/rig/industrial
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/industrial/equipped
@@ -105,16 +105,16 @@
 /obj/item/clothing/head/helmet/space/rig/eva
 	light_overlay = "helmet_light_dual"
 	camera = /obj/machinery/camera/network/engineering
-	species_restricted = list("Human")
+	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/suit/space/rig/eva
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/shoes/magboots/rig/eva
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/gloves/rig/eva
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/eva/equipped
@@ -137,7 +137,7 @@
 	offline_slowdown = 0
 	offline_vision_restriction = TINT_HEAVY
 
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/back.dmi')
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/back.dmi')
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ce
 	glove_type = /obj/item/clothing/gloves/rig/ce
@@ -188,16 +188,16 @@
 /obj/item/clothing/head/helmet/space/rig/hazmat
 	light_overlay = "helmet_light_dual"
 	camera = /obj/machinery/camera/network/research
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/suit/space/rig/hazmat
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/shoes/magboots/rig/hazmat
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/gloves/rig/hazmat
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/weapon/rig/hazmat/equipped
 
@@ -231,16 +231,16 @@
 
 /obj/item/clothing/head/helmet/space/rig/medical
 	camera = /obj/machinery/camera/network/medbay
-	species_restricted = list("Human")
+	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/suit/space/rig/medical
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/shoes/magboots/rig/medical
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/clothing/gloves/rig/medical
-	species_restricted = list("Human","Skrell")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL)
 
 /obj/item/weapon/rig/medical/equipped
 
@@ -276,16 +276,16 @@
 /obj/item/clothing/head/helmet/space/rig/hazard
 	light_overlay = "helmet_light_dual"
 	camera = /obj/machinery/camera/network/security
-	species_restricted = list("Human","Skrell","Tajara","Unathi") //still needs Resomi sprites
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI) //still needs Resomi sprites
 
 /obj/item/clothing/suit/space/rig/hazard
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/shoes/magboots/rig/hazard
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/clothing/gloves/rig/hazard
-	species_restricted = list("Human","Skrell","Tajara","Unathi")
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 
 /obj/item/weapon/rig/hazard/equipped
 

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -21,7 +21,7 @@
 	siemens_coefficient = 0.9
 	center_of_mass = null
 	randpixel = 0
-	species_restricted = list("exclude","Diona", "Xenomorph")
+	species_restricted = list("exclude",SPECIES_DIONA, "Xenomorph")
 	flash_protection = FLASH_PROTECTION_MAJOR
 
 	var/obj/machinery/camera/camera
@@ -82,7 +82,7 @@
 	siemens_coefficient = 0.9
 	center_of_mass = null
 	randpixel = 0
-	species_restricted = list("exclude","Diona", "Xenomorph")
+	species_restricted = list("exclude",SPECIES_DIONA, "Xenomorph")
 
 /obj/item/clothing/suit/space/New()
 	..()

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -6,7 +6,7 @@
 	item_state = "syndie_helm"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 35, bio = 100, rad = 60)
 	siemens_coefficient = 0.3
-	species_restricted = list("Human", "Machine")
+	species_restricted = list(SPECIES_HUMAN, SPECIES_IPC)
 	camera = /obj/machinery/camera/network/mercenary
 	light_overlay = "helmet_light_green" //todo: species-specific light overlays
 
@@ -22,7 +22,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 50, energy = 15, bomb = 35, bio = 100, rad = 60)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 	siemens_coefficient = 0.3
-	species_restricted = list("Human", "Skrell", "Machine")
+	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_IPC)
 
 /obj/item/clothing/suit/space/void/merc/New()
 	..()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -10,18 +10,18 @@
 	siemens_coefficient = 0.4
 
 	//Species-specific stuff.
-	species_restricted = list("Human", "Machine")
+	species_restricted = list(SPECIES_HUMAN, SPECIES_IPC)
 	sprite_sheets = list(
-		"Unathi" = 'icons/mob/species/unathi/helmet.dmi',
-		"Tajara" = 'icons/mob/species/tajaran/helmet.dmi',
-		"Skrell" = 'icons/mob/species/skrell/helmet.dmi',
-		"Resomi" = 'icons/mob/species/resomi/helmet.dmi',
+		SPECIES_UNATHI = 'icons/mob/species/unathi/helmet.dmi',
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/helmet.dmi',
+		SPECIES_SKRELL = 'icons/mob/species/skrell/helmet.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/helmet.dmi',
 		)
 	sprite_sheets_obj = list(
-		"Unathi" = 'icons/obj/clothing/species/unathi/hats.dmi',
-		"Tajara" = 'icons/obj/clothing/species/tajaran/hats.dmi',
-		"Skrell" = 'icons/obj/clothing/species/skrell/hats.dmi',
-		"Resomi" = 'icons/obj/clothing/species/resomi/hats.dmi',
+		SPECIES_UNATHI = 'icons/obj/clothing/species/unathi/hats.dmi',
+		SPECIES_TAJARA = 'icons/obj/clothing/species/tajaran/hats.dmi',
+		SPECIES_SKRELL = 'icons/obj/clothing/species/skrell/hats.dmi',
+		SPECIES_RESOMI = 'icons/obj/clothing/species/resomi/hats.dmi',
 		)
 
 	light_overlay = "helmet_light"
@@ -38,18 +38,18 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.4
 
-	species_restricted = list("Human", "Skrell", "Machine")
+	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_IPC)
 	sprite_sheets = list(
-		"Unathi" = 'icons/mob/species/unathi/suit.dmi',
-		"Tajara" = 'icons/mob/species/tajaran/suit.dmi',
-		"Skrell" = 'icons/mob/species/skrell/suit.dmi',
-		"Resomi" = 'icons/mob/species/resomi/suit.dmi',
+		SPECIES_UNATHI = 'icons/mob/species/unathi/suit.dmi',
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi',
+		SPECIES_SKRELL = 'icons/mob/species/skrell/suit.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/suit.dmi',
 		)
 	sprite_sheets_obj = list(
-		"Unathi" = 'icons/obj/clothing/species/unathi/suits.dmi',
-		"Tajara" = 'icons/obj/clothing/species/tajaran/suits.dmi',
-		"Skrell" = 'icons/obj/clothing/species/skrell/suits.dmi',
-		"Resomi" = 'icons/obj/clothing/species/resomi/suits.dmi',
+		SPECIES_UNATHI = 'icons/obj/clothing/species/unathi/suits.dmi',
+		SPECIES_TAJARA = 'icons/obj/clothing/species/tajaran/suits.dmi',
+		SPECIES_SKRELL = 'icons/obj/clothing/species/skrell/suits.dmi',
+		SPECIES_RESOMI = 'icons/obj/clothing/species/resomi/suits.dmi',
 		)
 
 	//Breach thresholds, should ideally be inherited by most (if not all) voidsuits.

--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -39,4 +39,4 @@
  	icon_open = "resomicoat_open"
  	icon_closed = "resomicoat"
  	body_parts_covered = UPPER_TORSO|ARMS|LOWER_TORSO|LEGS
- 	species_restricted = list("Resomi")
+ 	species_restricted = list(SPECIES_RESOMI)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -12,7 +12,7 @@
 	var/list/mob_overlay = list()
 	var/overlay_state = null
 	var/list/accessory_icons = list(slot_w_uniform_str = 'icons/mob/ties.dmi', slot_wear_suit_str = 'icons/mob/ties.dmi')
-	sprite_sheets = list("Resomi" = 'icons/mob/species/resomi/ties.dmi') // for species where human variants do not fit
+	sprite_sheets = list(SPECIES_RESOMI = 'icons/mob/species/resomi/ties.dmi') // for species where human variants do not fit
 	var/list/on_rolled = list()	//used when jumpsuit sleevels are rolled ("rolled" entry) or it's rolled down ("down"). Set to "none" to hide in those states.
 
 /obj/item/clothing/accessory/Destroy()

--- a/code/modules/clothing/under/xenos/resomi.dm
+++ b/code/modules/clothing/under/xenos/resomi.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/species/resomi/uniform.dmi'
 	icon_state = "resomi_grey"
 	worn_state = "resomi_grey"
-	species_restricted = list("Resomi")
+	species_restricted = list(SPECIES_RESOMI)
 
 /obj/item/clothing/under/resomi/white
 	name = "small smock"

--- a/code/modules/economy/Events_Mundane.dm
+++ b/code/modules/economy/Events_Mundane.dm
@@ -75,14 +75,14 @@
 			if(SONG_DEBUT)
 				body += "[pick("Singer","Singer/songwriter","Saxophonist","Pianist","Guitarist","TV personality","Star")] [random_name(pick(MALE,FEMALE))] \
 				announced the debut of their new [pick("single","album","EP","label")] '[pick("Everyone's","Look at the","Baby don't eye those","All of those","Dirty nasty")] \
-				[pick("roses","three stars","starships","nanobots","cyborgs","Skrell","Sren'darr")] \
+				[pick("roses","three stars","starships","nanobots","cyborgs",SPECIES_SKRELL,"Sren'darr")] \
 				[pick("on Venus","on Reade","on Moghes","in my hand","slip through my fingers","die for you","sing your heart out","fly away")]' \
 				with [pick("pre-puchases available","a release tour","cover signings","a launch concert")] on [affected_dest.name]."
 
 			if(MOVIE_RELEASE)
 				body += "From the [pick("desk","home town","homeworld","mind")] of [pick("acclaimed","award-winning","popular","stellar")] \
 				[pick("playwright","author","director","actor","TV star")] [random_name(pick(MALE,FEMALE))] comes the latest sensation: '\
-				[pick("Deadly","The last","Lost","Dead")] [pick("Starships","Warriors","outcasts","Tajarans","Unathi","Skrell")] \
+				[pick("Deadly","The last","Lost","Dead")] [pick("Starships","Warriors","outcasts","Tajarans",SPECIES_UNATHI,SPECIES_SKRELL)] \
 				[pick("of","from","raid","go hunting on","visit","ravage","pillage","destroy")] \
 				[pick("Moghes","Earth","Biesel","Ahdomai","S'randarr","the Void","the Edge of Space")]'.\
 				. Own it on webcast today, or visit the galactic premier on [affected_dest.name]!"
@@ -152,7 +152,7 @@
 	"'Here kitty kitty' no longer preferred tajaran retrieval technique.",\
 	"Man travels 7000 light years to retrieve lost hankie, 'It was my favourite'.",\
 	"New bowling lane that shoots mini-meteors at bowlers very popular.",\
-	"[pick("Unathi","Spacer")] gets tattoo of Nyx on chest '[pick("[using_map.boss_short]","star","starship","asteroid")] tickles most'.",\
+	"[pick(SPECIES_UNATHI,"Spacer")] gets tattoo of Nyx on chest '[pick("[using_map.boss_short]","star","starship","asteroid")] tickles most'.",\
 	"Skrell marries computer; wedding attended by 100 modems.",\
 	"Chef reports successfully using harmonica as cheese grater.",\
 	"[using_map.company_name] invents handkerchief that says 'Bless you' after sneeze.",\

--- a/code/modules/events/shipping_error.dm
+++ b/code/modules/events/shipping_error.dm
@@ -2,5 +2,5 @@
 	var/datum/supply_order/O = new /datum/supply_order()
 	O.ordernum = supply_controller.ordernum
 	O.object = pick(cargo_supply_packs)
-	O.orderedby = random_name(pick(MALE,FEMALE), species = "Human")
+	O.orderedby = random_name(pick(MALE,FEMALE), species = SPECIES_HUMAN)
 	supply_controller.shoppinglist += O

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -8,8 +8,8 @@ var/list/holder_mob_icon_cache = list()
 	slot_flags = SLOT_HEAD | SLOT_HOLSTER
 
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/head.dmi',
-		"Resomi" = 'icons/mob/species/resomi/head.dmi'
+		SPECIES_VOX = 'icons/mob/species/vox/head.dmi',
+		SPECIES_RESOMI = 'icons/mob/species/resomi/head.dmi'
 		)
 
 	origin_tech = null

--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -24,7 +24,7 @@
 /mob/living/carbon/alien/diona/New()
 
 	..()
-	species = all_species["Diona"]
+	species = all_species[SPECIES_DIONA]
 	add_language(LANGUAGE_ROOTGLOBAL)
 	add_language(LANGUAGE_GALCOM)
 	verbs += /mob/living/carbon/alien/diona/proc/merge

--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/alien/diona/get_scooped(var/mob/living/carbon/grabber)
-	if(grabber.species && grabber.species.name == "Diona" && do_merge(grabber))
+	if(grabber.species && grabber.species.name == SPECIES_DIONA && do_merge(grabber))
 		return
 	else return ..()
 

--- a/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
@@ -19,7 +19,7 @@
 
 		if(istype(C,/mob/living/carbon/human))
 			var/mob/living/carbon/human/D = C
-			if(D.species && D.species.name == "Diona")
+			if(D.species && D.species.name == SPECIES_DIONA)
 				choices += C
 
 	var/mob/living/M = input(src,"Who do you wish to merge with?") in null|choices

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/diona/confirm_evolution()
 
-	if(!is_species_whitelisted(src, "Diona"))
+	if(!is_species_whitelisted(src, SPECIES_DIONA))
 		to_chat(src, alert("You are currently not whitelisted to play as a full diona."))
 		return null
 
@@ -16,4 +16,4 @@
 		qdel(L)
 
 	src.visible_message("<span class='warning'>\The [src] begins to shift and quiver, and erupts in a shower of shed bark as it splits into a tangle of nearly a dozen new dionaea.</span>","<span class='warning'>You begin to shift and quiver, feeling your awareness splinter. All at once, we consume our stored nutrients to surge with growth, splitting into a tangle of at least a dozen new dionaea. We have attained our gestalt form.</span>")
-	return "Diona"
+	return SPECIES_DIONA

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1073,7 +1073,7 @@
 
 	if(!dna)
 		if(!new_species)
-			new_species = "Human"
+			new_species = SPECIES_HUMAN
 	else
 		if(!new_species)
 			new_species = dna.species
@@ -1082,7 +1082,7 @@
 
 	// No more invisible screaming wheelchairs because of set_species() typos.
 	if(!all_species[new_species])
-		new_species = "Human"
+		new_species = SPECIES_HUMAN
 
 	if(species)
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -93,7 +93,7 @@
 	T.Weaken(3)
 
 	// Pariahs are not good at leaping. This is snowflakey, pls fix.
-	if(species.name == "Vox Pariah" || src.handcuffed || stance_damage >= 2)
+	if(species.name == SPECIES_VOXPARIAH || src.handcuffed || stance_damage >= 2)
 		src.Weaken(5)
 		return
 

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -22,29 +22,29 @@
 
 /mob/living/carbon/human/resomi/New(var/new_loc)
 	h_style = "Resomi Plumage"
-	..(new_loc, "Resomi")
+	..(new_loc, SPECIES_RESOMI)
 
 /mob/living/carbon/human/skrell/New(var/new_loc)
 	h_style = "Skrell Male Tentacles"
-	..(new_loc, "Skrell")
+	..(new_loc, SPECIES_SKRELL)
 
 /mob/living/carbon/human/tajaran/New(var/new_loc)
 	h_style = "Tajaran Ears"
-	..(new_loc, "Tajara")
+	..(new_loc, SPECIES_TAJARA)
 
 /mob/living/carbon/human/unathi/New(var/new_loc)
 	h_style = "Unathi Horns"
-	..(new_loc, "Unathi")
+	..(new_loc, SPECIES_UNATHI)
 
 /mob/living/carbon/human/vox/New(var/new_loc)
 	h_style = "Short Vox Quills"
-	..(new_loc, "Vox")
+	..(new_loc, SPECIES_VOX)
 
 /mob/living/carbon/human/diona/New(var/new_loc)
-	..(new_loc, "Diona")
+	..(new_loc, SPECIES_DIONA)
 
 /mob/living/carbon/human/machine/New(var/new_loc)
-	..(new_loc, "Machine")
+	..(new_loc, SPECIES_IPC)
 
 /mob/living/carbon/human/monkey/New(var/new_loc)
 	..(new_loc, "Monkey")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -276,7 +276,7 @@
 					Weaken(3)
 					if(!lying)
 						emote("collapse")
-				if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT) && species.get_bodytype(src) == "Human") //apes go bald
+				if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT) && species.get_bodytype(src) == SPECIES_HUMAN) //apes go bald
 					if((h_style != "Bald" || f_style != "Shaved" ))
 						to_chat(src, "<span class='warning'>Your hair falls out.</span>")
 						h_style = "Bald"

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -1,6 +1,6 @@
 /datum/species/vox
-	name = "Vox"
-	name_plural = "Vox"
+	name = SPECIES_VOX
+	name_plural = SPECIES_VOX
 	icobase = 'icons/mob/human_races/r_vox.dmi'
 	deform = 'icons/mob/human_races/r_def_vox.dmi'
 	default_language = "Vox-pidgin"
@@ -92,7 +92,7 @@
 
 
 /datum/species/vox/pariah
-	name = "Vox Pariah"
+	name = SPECIES_VOXPARIAH
 	blurb = "Sickly biproducts of Vox society, these creatures are vilified by their own kind \
 	and taken advantage of by enterprising companies for cheap, disposable labor. \
 	They aren't very smart, smell worse than a vox, and vomit constantly, \
@@ -126,7 +126,7 @@
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 /datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)
-	return "Vox"
+	return SPECIES_VOX
 
 // No combat skills for you.
 /datum/species/vox/pariah/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -13,7 +13,7 @@ var/list/wrapped_species_by_ref = list()
 
 	var/list/valid_transform_species = list()
 	var/monochromatic
-	var/default_form = "Human"
+	var/default_form = SPECIES_HUMAN
 
 /datum/species/shapeshifter/get_valid_shapeshifter_forms(var/mob/living/carbon/human/H)
 	return valid_transform_species

--- a/code/modules/mob/living/carbon/human/species/station/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine.dm
@@ -1,5 +1,5 @@
 /datum/species/machine
-	name = "Machine"
+	name = SPECIES_IPC
 	name_plural = "machines"
 
 	blurb = "Positronic intelligence really took off in the 26th century, and it is not uncommon to see independant, free-willed \

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -10,7 +10,7 @@
 	blood_mask = 'icons/mob/human_races/masks/blood_monkey.dmi'
 	language = null
 	default_language = "Chimpanzee"
-	greater_form = "Human"
+	greater_form = SPECIES_HUMAN
 	mob_size = MOB_SMALL
 	show_ssd = null
 	health_hud_intensity = 1.75
@@ -89,7 +89,7 @@
 	icobase = 'icons/mob/human_races/monkeys/r_neaera.dmi'
 	deform = 'icons/mob/human_races/monkeys/r_neaera.dmi'
 
-	greater_form = "Skrell"
+	greater_form = SPECIES_SKRELL
 	default_language = "Neaera"
 	flesh_color = "#8CD7A3"
 	blood_color = "#1D2CBF"
@@ -105,7 +105,7 @@
 	deform = 'icons/mob/human_races/monkeys/r_stok.dmi'
 
 	tail = "stoktail"
-	greater_form = "Unathi"
+	greater_form = SPECIES_UNATHI
 	default_language = "Stok"
 	flesh_color = "#34AF10"
 	base_color = "#066000"

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -63,7 +63,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 		/mob/living/carbon/human/proc/shapeshifter_select_gender
 		)
 
-	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Resomi", "Monkey")
+	valid_transform_species = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_TAJARA, SPECIES_SKRELL, SPECIES_DIONA, SPECIES_RESOMI, "Monkey")
 	monochromatic = 1
 
 	var/heal_rate = 5 // Temp. Regen per tick.

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -1,5 +1,5 @@
 /datum/species/resomi
-	name = "Resomi"
+	name = SPECIES_RESOMI
 	name_plural = "Resomii"
 	blurb = "A race of feathered raptors who developed on a cold world, almost \
 	outside of the Goldilocks zone. Extremely fragile, they developed hunting skills \

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1,5 +1,5 @@
 /datum/species/human
-	name = "Human"
+	name = SPECIES_HUMAN
 	name_plural = "Humans"
 	primitive_form = "Monkey"
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
@@ -19,11 +19,11 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
 /datum/species/human/get_bodytype(var/mob/living/carbon/human/H)
-	return "Human"
+	return SPECIES_HUMAN
 
 /datum/species/unathi
-	name = "Unathi"
-	name_plural = "Unathi"
+	name = SPECIES_UNATHI
+	name_plural = SPECIES_UNATHI
 	icobase = 'icons/mob/human_races/r_lizard.dmi'
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	tail = "sogtail"
@@ -85,7 +85,7 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)
 
 /datum/species/tajaran
-	name = "Tajara"
+	name = SPECIES_TAJARA
 	name_plural = "Tajaran"
 	icobase = 'icons/mob/human_races/r_tajaran.dmi'
 	deform = 'icons/mob/human_races/r_def_tajaran.dmi'
@@ -144,8 +144,8 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)
 
 /datum/species/skrell
-	name = "Skrell"
-	name_plural = "Skrell"
+	name = SPECIES_SKRELL
+	name_plural = SPECIES_SKRELL
 	icobase = 'icons/mob/human_races/r_skrell.dmi'
 	deform = 'icons/mob/human_races/r_def_skrell.dmi'
 	primitive_form = "Neaera"
@@ -197,7 +197,7 @@
 		)
 
 /datum/species/diona
-	name = "Diona"
+	name = SPECIES_DIONA
 	name_plural = "Dionaea"
 	icobase = 'icons/mob/human_races/r_diona.dmi'
 	deform = 'icons/mob/human_races/r_def_plant.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -24,14 +24,14 @@ Small, little HP, poisonous.
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	holder_type = /obj/item/weapon/holder/voxslug
-	faction = "Vox"
+	faction = SPECIES_VOX
 
 /mob/living/simple_animal/hostile/voxslug/ListTargets(var/dist = 7)
 	var/list/L = list()
 	for(var/a in hearers(src, dist))
 		if(istype(a,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = a
-			if(H.species.get_bodytype() == "Vox")
+			if(H.species.get_bodytype() == SPECIES_VOX)
 				continue
 		if(isliving(a))
 			var/mob/living/M = a
@@ -46,7 +46,7 @@ Small, little HP, poisonous.
 	return L
 
 /mob/living/simple_animal/hostile/voxslug/get_scooped(var/mob/living/carbon/grabber)
-	if(grabber.species.get_bodytype() != "Vox")
+	if(grabber.species.get_bodytype() != SPECIES_VOX)
 		to_chat(grabber, "<span class='warning'>\The [src] wriggles out of your hands before you can pick it up!</span>")
 		return
 	else return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -589,7 +589,7 @@
 /mob/proc/is_mechanical()
 	if(mind && (mind.assigned_role == "Cyborg" || mind.assigned_role == "AI"))
 		return 1
-	return istype(src, /mob/living/silicon) || get_species() == "Machine"
+	return istype(src, /mob/living/silicon) || get_species() == SPECIES_IPC
 
 /mob/proc/is_ready()
 	return client && !!mind

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -514,7 +514,7 @@ proc/is_blind(A)
 		if(istype(belt, /obj/item/weapon/gun) || istype(belt, /obj/item/weapon/melee))
 			threatcount += 2
 
-		if(species.name != "Human")
+		if(species.name != SPECIES_HUMAN)
 			threatcount += 2
 
 	if(check_records || check_arrest)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -533,7 +533,7 @@
 		chosen_species = all_species[client.prefs.species]
 
 	if(!chosen_species || !check_species_allowed(chosen_species, 0))
-		return "Human"
+		return SPECIES_HUMAN
 
 	return chosen_species.name
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -2,7 +2,7 @@ datum/preferences
 	//The mob should have a gender you want before running this proc. Will run fine without H
 	proc/randomize_appearance_and_body_for(var/mob/living/carbon/human/H)
 		var/datum/species/current_species = all_species[species]
-		if(!current_species) current_species = all_species["Human"]
+		if(!current_species) current_species = all_species[SPECIES_HUMAN]
 		gender = pick(current_species.genders)
 
 		h_style = random_hair_style(gender, species)

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -29,7 +29,7 @@
 	var/gender = NEUTER
 
 	// Restrict some styles to specific species
-	var/list/species_allowed = list("Human")
+	var/list/species_allowed = list(SPECIES_HUMAN)
 
 	// Whether or not the accessory can be affected by colouration
 	var/do_colouration = 1
@@ -52,7 +52,7 @@
 		name = "Bald"
 		icon_state = "bald"
 		gender = MALE
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 		veryshort = 1
 
 	short
@@ -71,63 +71,63 @@
 	resomi
 		name = "Resomi Plumage"
 		icon_state = "resomi_default"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_ears
 		name = "Resomi Ears"
 		icon_state = "resomi_ears"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_excited
 		name = "Resomi Spiky"
 		icon_state = "resomi_spiky"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 
 	resomi_hedgehog
 		name = "Resomi Hedgehog"
 		icon_state = "resomi_hedge"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_long
 		name = "Resomi Unpruned"
 		icon_state = "resomi_long"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_sunburst
 		name = "Resomi Sunburst" // kill me
 		icon_state = "resomi_burst_short"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_mohawk
 		name = "Resomi Mohawk"
 		icon_state = "resomi_mohawk"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_pointy
 		name = "Resomi Pointy"
 		icon_state = "resomi_pointy"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_upright
 		name = "Resomi Upright"
 		icon_state = "resomi_upright"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_mane
 		name = "Resomi Mane"
 		icon_state = "resomi_mane"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_droopy
 		name = "Resomi Droopy"
 		icon_state = "resomi_droopy"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	resomi_mushroom
 		name = "Resomi Mushroom"
 		icon_state = "resomi_mushroom"
-		species_allowed = list("Resomi")
+		species_allowed = list(SPECIES_RESOMI)
 
 	cut
 		name = "Cut Hair"
@@ -248,19 +248,19 @@
 		name = "Bobcurl"
 		icon_state = "hair_bobcurl"
 		gender = FEMALE
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 	bob
 		name = "Bob"
 		icon_state = "hair_bobcut"
 		gender = FEMALE
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 	bobcutalt
 		name = "Chin Length Bob"
 		icon_state = "hair_bobcutalt"
 		gender = FEMALE
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 	bowl
 		name = "Bowl"
@@ -271,7 +271,7 @@
 		name = "Buzzcut"
 		icon_state = "hair_buzzcut"
 		gender = MALE
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 		veryshort = 1
 
 	crew
@@ -373,7 +373,7 @@
 	mohawk
 		name = "Mohawk"
 		icon_state = "hair_d"
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 	jensen
 		name = "Adam Jensen Hair"
 		icon_state = "hair_jensen"
@@ -392,7 +392,7 @@
 	spiky
 		name = "Spiky"
 		icon_state = "hair_spikey"
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 	kusangi
 		name = "Kusanagi Hair"
 		icon_state = "hair_kusanagi"
@@ -640,7 +640,7 @@
 		name = "Shaved"
 		icon_state = "bald"
 		gender = NEUTER
-		species_allowed = list("Human","Unathi","Tajara","Skrell","Vox","Machine")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_VOX,SPECIES_IPC)
 
 	watson
 		name = "Watson Mustache"
@@ -681,7 +681,7 @@
 	elvis
 		name = "Elvis Sideburns"
 		icon_state = "facial_elvis"
-		species_allowed = list("Human","Unathi")
+		species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 	abe
 		name = "Abraham Lincoln Beard"
@@ -759,145 +759,145 @@
 	una_spines_long
 		name = "Long Unathi Spines"
 		icon_state = "soghun_longspines"
-		species_allowed = list("Unathi")
+		species_allowed = list(SPECIES_UNATHI)
 
 	una_spines_short
 		name = "Short Unathi Spines"
 		icon_state = "soghun_shortspines"
-		species_allowed = list("Unathi")
+		species_allowed = list(SPECIES_UNATHI)
 
 	una_frills_long
 		name = "Long Unathi Frills"
 		icon_state = "soghun_longfrills"
-		species_allowed = list("Unathi")
+		species_allowed = list(SPECIES_UNATHI)
 
 	una_frills_short
 		name = "Short Unathi Frills"
 		icon_state = "soghun_shortfrills"
-		species_allowed = list("Unathi")
+		species_allowed = list(SPECIES_UNATHI)
 
 	una_horns
 		name = "Unathi Horns"
 		icon_state = "soghun_horns"
-		species_allowed = list("Unathi")
+		species_allowed = list(SPECIES_UNATHI)
 
 	skr_tentacle_m
 		name = "Skrell Male Tentacles"
 		icon_state = "skrell_hair_m"
-		species_allowed = list("Skrell")
+		species_allowed = list(SPECIES_SKRELL)
 		gender = MALE
 
 	skr_tentacle_f
 		name = "Skrell Female Tentacles"
 		icon_state = "skrell_hair_f"
-		species_allowed = list("Skrell")
+		species_allowed = list(SPECIES_SKRELL)
 		gender = FEMALE
 
 	taj_ears
 		name = "Tajaran Ears"
 		icon_state = "ears_plain"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_clean
 		name = "Tajara Clean"
 		icon_state = "hair_clean"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_bangs
 		name = "Tajara Bangs"
 		icon_state = "hair_bangs"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_braid
 		name = "Tajara Braid"
 		icon_state = "hair_tbraid"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_shaggy
 		name = "Tajara Shaggy"
 		icon_state = "hair_shaggy"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_mohawk
 		name = "Tajaran Mohawk"
 		icon_state = "hair_mohawk"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_plait
 		name = "Tajara Plait"
 		icon_state = "hair_plait"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_straight
 		name = "Tajara Straight"
 		icon_state = "hair_straight"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_long
 		name = "Tajara Long"
 		icon_state = "hair_long"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_rattail
 		name = "Tajara Rat Tail"
 		icon_state = "hair_rattail"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_spiky
 		name = "Tajara Spiky"
 		icon_state = "hair_tajspiky"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_ears_messy
 		name = "Tajara Messy"
 		icon_state = "hair_messy"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	vox_quills_short
 		name = "Short Vox Quills"
 		icon_state = "vox_shortquills"
-		species_allowed = list("Vox")
+		species_allowed = list(SPECIES_VOX)
 
 	vox_quills_kingly
 		name = "Kingly Vox Quills"
 		icon_state = "vox_kingly"
-		species_allowed = list("Vox")
+		species_allowed = list(SPECIES_VOX)
 
 	vox_quills_mohawk
 		name = "Quill Mohawk"
 		icon_state = "vox_mohawk"
-		species_allowed = list("Vox")
+		species_allowed = list(SPECIES_VOX)
 /datum/sprite_accessory/facial_hair
 
 	taj_sideburns
 		name = "Tajara Sideburns"
 		icon_state = "facial_sideburns"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_mutton
 		name = "Tajara Mutton"
 		icon_state = "facial_mutton"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_pencilstache
 		name = "Tajara Pencilstache"
 		icon_state = "facial_pencilstache"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_moustache
 		name = "Tajara Moustache"
 		icon_state = "facial_moustache"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_goatee
 		name = "Tajara Goatee"
 		icon_state = "facial_goatee"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	taj_smallstache
 		name = "Tajara Smallsatche"
 		icon_state = "facial_smallstache"
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 //skin styles - WIP
 //going to have to re-integrate this with surgery
@@ -908,27 +908,27 @@
 	human
 		name = "Default human skin"
 		icon_state = "default"
-		species_allowed = list("Human")
+		species_allowed = list(SPECIES_HUMAN)
 
 	human_tatt01
 		name = "Tatt01 human skin"
 		icon_state = "tatt1"
-		species_allowed = list("Human")
+		species_allowed = list(SPECIES_HUMAN)
 
 	tajaran
 		name = "Default tajaran skin"
 		icon_state = "default"
 		icon = 'icons/mob/human_races/r_tajaran.dmi'
-		species_allowed = list("Tajara")
+		species_allowed = list(SPECIES_TAJARA)
 
 	unathi
 		name = "Default Unathi skin"
 		icon_state = "default"
 		icon = 'icons/mob/human_races/r_lizard.dmi'
-		species_allowed = list("Unathi")
+		species_allowed = list(SPECIES_UNATHI)
 
 	skrell
 		name = "Default skrell skin"
 		icon_state = "default"
 		icon = 'icons/mob/human_races/r_skrell.dmi'
-		species_allowed = list("Skrell")
+		species_allowed = list(SPECIES_SKRELL)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -54,7 +54,7 @@ var/list/organ_cache = list()
 			dna = holder.dna.Clone()
 			species = all_species[dna.species]
 		else
-			species = all_species["Human"]
+			species = all_species[SPECIES_HUMAN]
 			log_debug("[src] spawned in [holder] without a proper DNA.")
 
 	if(dna)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -60,7 +60,7 @@ var/list/limb_icon_cache = list()
 		gender = "_f"
 
 	icon_state = "[icon_name][gender]"
-	icon_cache_key = "[icon_state]_[species ? species.name : "Human"]"
+	icon_cache_key = "[icon_state]_[species ? species.name : SPECIES_HUMAN]"
 
 	if(force_icon)
 		icon = force_icon
@@ -184,7 +184,7 @@ var/list/robot_hud_colours = list("#FFFFFF","#CCCCCC","#AAAAAA","#888888","#6666
 
 	if(nonsolid)
 		applying.MapColors("#4D4D4D","#969696","#1C1C1C", "#000000")
-		if(species && species.get_bodytype(owner) != "Human")
+		if(species && species.get_bodytype(owner) != SPECIES_HUMAN)
 			applying.SetIntensity(1.5)
 		else
 			applying.SetIntensity(0.7)

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -20,7 +20,7 @@ var/datum/robolimb/basic_robolimb
 	var/use_eye_icon = "eyes_s"
 	var/can_feel_pain
 	var/skintone
-	var/list/species_cannot_use = list("Resomi")
+	var/list/species_cannot_use = list(SPECIES_RESOMI)
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
 
@@ -39,7 +39,7 @@ var/datum/robolimb/basic_robolimb
 /datum/robolimb/bishop/alt/monitor
 	company = "Bishop Monitor."
 	icon = 'icons/mob/human_races/cyberlimbs/bishop/bishop_monitor.dmi'
-	restricted_to = list("Machine")
+	restricted_to = list(SPECIES_IPC)
 	unavailable_at_fab = 1
 
 /datum/robolimb/hephaestus
@@ -57,7 +57,7 @@ var/datum/robolimb/basic_robolimb
 /datum/robolimb/hesphiastos/alt/monitor
 	company = "Hephaestus Monitor."
 	icon = 'icons/mob/human_races/cyberlimbs/hephaestus/hephaestus_monitor.dmi'
-	restricted_to = list("Machine")
+	restricted_to = list(SPECIES_IPC)
 	can_eat = null
 	unavailable_at_fab = 1
 
@@ -83,7 +83,7 @@ var/datum/robolimb/basic_robolimb
 /datum/robolimb/xion/alt/monitor
 	company = "Xion Monitor."
 	icon = 'icons/mob/human_races/cyberlimbs/xion/xion_monitor.dmi'
-	restricted_to = list("Machine")
+	restricted_to = list(SPECIES_IPC)
 	can_eat = null
 	unavailable_at_fab = 1
 
@@ -108,7 +108,7 @@ var/datum/robolimb/basic_robolimb
 /datum/robolimb/wardtakahashi/alt/monitor
 	company = "Ward-Takahashi Monitor."
 	icon = 'icons/mob/human_races/cyberlimbs/wardtakahashi/wardtakahashi_monitor.dmi'
-	restricted_to = list("Machine")
+	restricted_to = list(SPECIES_IPC)
 	can_eat = null
 	unavailable_at_fab = 1
 
@@ -116,7 +116,7 @@ var/datum/robolimb/basic_robolimb
 	company = "Morpheus"
 	desc = "This limb is simple and functional; no effort has been made to make it look human."
 	icon = 'icons/mob/human_races/cyberlimbs/morpheus/morpheus_main.dmi'
-	restricted_to = list("Machine")
+	restricted_to = list(SPECIES_IPC)
 	use_eye_icon = "blank_eyes"
 	unavailable_at_fab = 1
 
@@ -138,7 +138,7 @@ var/datum/robolimb/basic_robolimb
 	company = "Small prosthetic"
 	desc = "This prosthetic is small and fit for nonhuman proportions."
 	icon = 'icons/mob/human_races/cyberlimbs/resomi/resomi_main.dmi'
-	restricted_to = list("Resomi")
+	restricted_to = list(SPECIES_RESOMI)
 	species_cannot_use = list()
 	applies_to_part = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT, BP_L_HAND, BP_R_HAND)
 	

--- a/code/modules/projectiles/guns/launcher/alien.dm
+++ b/code/modules/projectiles/guns/launcher/alien.dm
@@ -35,7 +35,7 @@
 /obj/item/weapon/gun/launcher/alien/special_check(user)
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		if(H.species && H.species.get_bodytype(H) != "Vox")
+		if(H.species && H.species.get_bodytype(H) != SPECIES_VOX)
 			to_chat(user, "<span class='warning'>\The [src] does not respond to you!</span>")
 			return 0
 	return ..()

--- a/code/modules/projectiles/guns/launcher/slugsling.dm
+++ b/code/modules/projectiles/guns/launcher/slugsling.dm
@@ -22,11 +22,11 @@
 	if(isliving(AM))
 		if(istype(AM,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = AM
-			if(H.species && H.species.get_bodytype() == "Vox")
+			if(H.species && H.species.get_bodytype() == SPECIES_VOX)
 				return
 		else
 			var/mob/living/L = AM
-			if(L.faction == "Vox")
+			if(L.faction == SPECIES_VOX)
 				return
 		squish()
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -1,5 +1,5 @@
 /datum/reagent/blood
-	data = new/list("donor" = null, "species" = "Human", "blood_DNA" = null, "blood_type" = null, "blood_colour" = "#A10808", "trace_chem" = null, "virus2" = list(), "antibodies" = list())
+	data = new/list("donor" = null, "species" = SPECIES_HUMAN, "blood_DNA" = null, "blood_type" = null, "blood_colour" = "#A10808", "trace_chem" = null, "virus2" = list(), "antibodies" = list())
 	name = "Blood"
 	id = "blood"
 	reagent_state = LIQUID

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -9,9 +9,9 @@
 	throw_speed = 1
 	throw_range = 3
 	force = 15
-	var/list/potentials = list("Resomi" = /spell/aoe_turf/conjure/summon/resomi, "Human" = /obj/item/weapon/storage/bag/cash/infinite, "Vox" = /spell/targeted/shapeshift/true_form,
-		"Tajara" = /spell/messa_shroud, "Unathi" = /spell/moghes_blessing, "Diona" = /spell/aoe_turf/conjure/grove/gestalt, "Skrell" = /obj/item/weapon/contract/apprentice/skrell,
-		"Machine" = /spell/camera_connection)
+	var/list/potentials = list(SPECIES_RESOMI = /spell/aoe_turf/conjure/summon/resomi, SPECIES_HUMAN = /obj/item/weapon/storage/bag/cash/infinite, SPECIES_VOX = /spell/targeted/shapeshift/true_form,
+		SPECIES_TAJARA = /spell/messa_shroud, SPECIES_UNATHI = /spell/moghes_blessing, SPECIES_DIONA = /spell/aoe_turf/conjure/grove/gestalt, SPECIES_SKRELL = /obj/item/weapon/contract/apprentice/skrell,
+		SPECIES_IPC = /spell/camera_connection)
 
 /obj/item/weapon/magic_rock/attack_self(mob/user)
 	if(!istype(user,/mob/living/carbon/human))

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -10,7 +10,7 @@
 	var/list/datum/disease2/effectholder/effects = list()
 	var/antigen = list() // 16 bits describing the antigens, when one bit is set, a cure with that bit can dock here
 	var/max_stage = 4
-	var/list/affected_species = list("Human","Unathi","Skrell","Tajara")
+	var/list/affected_species = list(SPECIES_HUMAN,SPECIES_UNATHI,SPECIES_SKRELL,SPECIES_TAJARA)
 
 /datum/disease2/disease/New()
 	uniqueID = rand(0,10000)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -342,7 +342,7 @@
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		if(istype(mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = mob
-			if(H.species.name == "Human" && !(H.h_style == "Bald") && !(H.h_style == "Balding Hair"))
+			if(H.species.name == SPECIES_HUMAN && !(H.h_style == "Bald") && !(H.h_style == "Balding Hair"))
 				to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
 				spawn(50)
 					H.h_style = "Balding Hair"

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -100,7 +100,7 @@
 
 /datum/unit_test/observation/moved_observer_shall_register_on_follow/conduct_test()
 	var/turf/T = locate(20,20,1)
-	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, "Human")
+	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, SPECIES_HUMAN)
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
 
 	O.ManualFollow(H)
@@ -118,7 +118,7 @@
 
 /datum/unit_test/observation/moved_observer_shall_unregister_on_nofollow/conduct_test()
 	var/turf/T = locate(20,20,1)
-	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, "Human")
+	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, SPECIES_HUMAN)
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
 
 	O.ManualFollow(H)
@@ -137,7 +137,7 @@
 
 /datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/conduct_test()
 	var/turf/T = locate(20,20,1)
-	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, "Human")
+	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, SPECIES_HUMAN)
 	qdel(H.virtual_mob)
 	H.virtual_mob = null
 
@@ -158,7 +158,7 @@
 
 /datum/unit_test/observation/moved_shall_register_recursively_on_new_listener/conduct_test()
 	var/turf/T = locate(20,20,1)
-	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, "Human")
+	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, SPECIES_HUMAN)
 	var/obj/structure/closet/C = get_named_instance(/obj/structure/closet, T, "Closet")
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
 
@@ -181,7 +181,7 @@
 
 /datum/unit_test/observation/moved_shall_register_recursively_with_existing_listener/conduct_test()
 	var/turf/T = locate(20,20,1)
-	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, "Human")
+	var/mob/living/carbon/human/H = get_named_instance(/mob/living/carbon/human, T, SPECIES_HUMAN)
 	var/obj/structure/closet/C = get_named_instance(/obj/structure/closet, T, "Closet")
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
 

--- a/maps/exodus/Loadout/loadout_head.dm
+++ b/maps/exodus/Loadout/loadout_head.dm
@@ -50,7 +50,7 @@
 /datum/gear/head/zhan_scarf
 	display_name = "Zhan headscarf"
 	path = /obj/item/clothing/head/tajaran/scarf
-	whitelisted = list("Tajara")
+	whitelisted = list(SPECIES_TAJARA)
 
 /datum/gear/head/welding
 	allowed_roles = list("Roboticist","Station Engineer","Atmospheric Technician","Chief Engineer")

--- a/maps/exodus/Loadout/loadout_xeno.dm
+++ b/maps/exodus/Loadout/loadout_xeno.dm
@@ -2,14 +2,14 @@
 /datum/gear/suit/zhan_furs
 	display_name = "Zhan-Khazan furs (Tajara)"
 	path = /obj/item/clothing/suit/tajaran/furs
-	whitelisted = list("Tajara")
+	whitelisted = list(SPECIES_TAJARA)
 	sort_category = "Xenowear"
 
 /datum/gear/suit/unathi_mantle
 	display_name = "hide mantle (Unathi)"
 	path = /obj/item/clothing/suit/unathi/mantle
 	cost = 1
-	whitelisted = list("Unathi")
+	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear"
 
 //Skrell Chains
@@ -17,7 +17,7 @@
 	display_name = "headtail chain selection (Skrell)"
 	path = /obj/item/clothing/ears/skrell/chain
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/chains/New()
 	..()
@@ -31,7 +31,7 @@
 	display_name = "colored headtail chain (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/chain
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 	flags = GEAR_HAS_COLOR_SELECTION
 
 //Skrell Bands
@@ -39,7 +39,7 @@
 	display_name = "headtail band selection (Skrell)"
 	path = /obj/item/clothing/ears/skrell/band
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/bands/New()
 	..()
@@ -53,7 +53,7 @@
 	display_name = "colored headtail bands (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/band
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 	flags = GEAR_HAS_COLOR_SELECTION
 
 //Skrell Cloth
@@ -61,7 +61,7 @@
 	display_name = "male colored headtail cloth (Skrell)"
 	path = /obj/item/clothing/ears/skrell/cloth_male
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/cloth/male/New()
 	..()
@@ -72,7 +72,7 @@
 	display_name = "female colored headtail cloth (Skrell)"
 	path = /obj/item/clothing/ears/skrell/cloth_female
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/cloth/female/New()
 	..()
@@ -83,7 +83,7 @@
 	display_name = "smock, grey (Resomi)"
 	path = /obj/item/clothing/under/resomi
 	sort_category = "Xenowear"
-	whitelisted = list("Resomi")
+	whitelisted = list(SPECIES_RESOMI)
 
 /datum/gear/uniform/resomi/rainbow
 	display_name = "smock, rainbow (Resomi)"
@@ -121,7 +121,7 @@
 	display_name = "display monitor (IPC)"
 	path = /obj/item/clothing/mask/monitor
 	sort_category = "Xenowear"
-	whitelisted = list("Machine")
+	whitelisted = list(SPECIES_IPC)
 	cost = 1
 
 /datum/gear/shoes/toeless

--- a/maps/shared/exodus_torch/loadout/loadout_xeno.dm
+++ b/maps/shared/exodus_torch/loadout/loadout_xeno.dm
@@ -2,4 +2,4 @@
 	display_name = "small coat (Resomi)"
 	path = /obj/item/clothing/suit/storage/toggle/Resomicoat
 	sort_category = "Xenowear"
-	whitelisted = list("Resomi")
+	whitelisted = list(SPECIES_RESOMI)

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -2,27 +2,27 @@
 /datum/gear/suit/zhan_furs
 	display_name = "Zhan-Khazan furs (Tajara)"
 	path = /obj/item/clothing/suit/tajaran/furs
-	whitelisted = list("Tajara")
+	whitelisted = list(SPECIES_TAJARA)
 	sort_category = "Xenowear"
 
 /datum/gear/head/zhan_scarf
 	display_name = "Zhan headscarf (Tajara)"
 	path = /obj/item/clothing/head/tajaran/scarf
-	whitelisted = list("Tajara")
+	whitelisted = list(SPECIES_TAJARA)
 	sort_category = "Xenowear"
 
 /datum/gear/suit/unathi_mantle
 	display_name = "hide mantle (Unathi)"
 	path = /obj/item/clothing/suit/unathi/mantle
 	cost = 1
-	whitelisted = list("Unathi")
+	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear"
 
 /datum/gear/suit/unathi_robe
 	display_name = "roughspun robe (Unathi)"
 	path = /obj/item/clothing/suit/unathi/robe
 	cost = 1
-	whitelisted = list("Unathi")
+	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear"
 
 //Skrell Chains
@@ -30,7 +30,7 @@
 	display_name = "headtail chain selection (Skrell)"
 	path = /obj/item/clothing/ears/skrell/chain
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/chains/New()
 	..()
@@ -44,7 +44,7 @@
 	display_name = "colored headtail chain (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/chain
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 	flags = GEAR_HAS_COLOR_SELECTION
 
 //Skrell Bands
@@ -52,7 +52,7 @@
 	display_name = "headtail band selection (Skrell)"
 	path = /obj/item/clothing/ears/skrell/band
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/bands/New()
 	..()
@@ -66,7 +66,7 @@
 	display_name = "colored headtail bands (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/band
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 	flags = GEAR_HAS_COLOR_SELECTION
 
 //Skrell Cloth
@@ -74,7 +74,7 @@
 	display_name = "male colored headtail cloth (Skrell)"
 	path = /obj/item/clothing/ears/skrell/cloth_male
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/cloth/male/New()
 	..()
@@ -85,7 +85,7 @@
 	display_name = "female colored headtail cloth (Skrell)"
 	path = /obj/item/clothing/ears/skrell/cloth_female
 	sort_category = "Xenowear"
-	whitelisted = list("Skrell")
+	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/cloth/female/New()
 	..()
@@ -96,7 +96,7 @@
 	display_name = "smock, grey (Resomi)"
 	path = /obj/item/clothing/under/resomi
 	sort_category = "Xenowear"
-	whitelisted = list("Resomi")
+	whitelisted = list(SPECIES_RESOMI)
 
 /datum/gear/uniform/resomi/rainbow
 	display_name = "smock, rainbow (Resomi)"
@@ -131,13 +131,13 @@
 	display_name = "gear harness (Full Body Prosthetic, IPC, Diona)"
 	path = /obj/item/clothing/under/harness
 	sort_category = "Xenowear"
-	whitelisted = list("Machine","Diona")
+	whitelisted = list(SPECIES_IPC,SPECIES_DIONA)
 
 /datum/gear/mask/ipc_monitor
 	display_name = "display monitor (IPC)"
 	path = /obj/item/clothing/mask/monitor
 	sort_category = "Xenowear"
-	whitelisted = list("Machine")
+	whitelisted = list(SPECIES_IPC)
 	cost = 1
 
 /datum/gear/shoes/toeless


### PR DESCRIPTION
Mass replaced species strings with defines because string matching in itself is evil, at least this way there might be less typos and easier errors to spot.