### PR TITLE
Structures can now very rarely be replaced by mimics - Take two

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -45,6 +45,10 @@
 			return
 
 /obj/structure/New()
+	if(prob(0.85)) //Relatively high since windows and tables aren't eligible
+		if(!is_type_in_list(src, protected_objects))
+			spawn(-1) new /mob/living/simple_animal/hostile/mimic(src.loc, src, null)
+			qdel(src)
 	..()
 	if(climbable)
 		verbs += /obj/structure/proc/climb_on

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -49,6 +49,7 @@
 		if(!is_type_in_list(src, protected_objects))
 			new /mob/living/simple_animal/hostile/mimic(src.loc, src, null)
 			qdel(src)
+			return
 	..()
 	if(climbable)
 		verbs += /obj/structure/proc/climb_on

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -45,7 +45,7 @@
 			return
 
 /obj/structure/New()
-	if(prob(0.85)) //Relatively high since windows and tables aren't eligible
+	if(!usr && prob(0.85)) //Relatively high since windows and tables aren't eligible
 		if(!is_type_in_list(src, protected_objects))
 			new /mob/living/simple_animal/hostile/mimic(src.loc, src, null)
 			qdel(src)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -47,7 +47,7 @@
 /obj/structure/New()
 	if(prob(0.85)) //Relatively high since windows and tables aren't eligible
 		if(!is_type_in_list(src, protected_objects))
-			spawn(-1) new /mob/living/simple_animal/hostile/mimic(src.loc, src, null)
+			new /mob/living/simple_animal/hostile/mimic(src.loc, src, null)
 			qdel(src)
 	..()
 	if(climbable)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -2,7 +2,7 @@
 // Abstract Class
 //
 
-var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/cable, /obj/structure/window, /obj/structure/disposalpipe, /obj/item/projectile/animate)
+var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/cable, /obj/structure/ladder, /obj/structure/stairs, /obj/structure/window, /obj/structure/disposalpipe, /obj/item/projectile/animate)
 
 /mob/living/simple_animal/hostile/mimic
 	name = "crate"

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -2,7 +2,7 @@
 // Abstract Class
 //
 
-var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/cable, /obj/structure/window, /obj/item/projectile/animate)
+var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/cable, /obj/structure/window, /obj/structure/disposalpipe, /obj/item/projectile/animate)
 
 /mob/living/simple_animal/hostile/mimic
 	name = "crate"

--- a/html/changelogs/cirra-mimics.yml
+++ b/html/changelogs/cirra-mimics.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cirra
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Structures (Excluding windows, tables, cables, and disposal pipes) can now very rarely be replaced by a mimic."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Take two!
Should be relatively rare, since tables/windows/cables/disposal pipes aren't eligible. I can lower the chance if requested. Needs to be squashed.


A̬̥͔̰͇ͮ̎͜p͈ͯ̑̿̽̋ͩr̦î͎͚̣̪̃̑̌ͪͫ͞l͔̿ͥͧ ̤͕̘ͮ͒ͩͭͫ̐̅͞ḟ̪̼o͇̠̍͟o̻̜l̛̥̟̞̘̹̇̎ͫ̈̽͌̚ͅs̠̠͕̦̰̊