### PR TITLE
Revert "Changes overmap autopilot"

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -35,9 +35,11 @@
 			else
 				linked.decelerate()
 
-		if(linked.is_still())
+		var/brake_path = linked.get_brake_path()
+
+		if(get_dist(linked.loc, T) > brake_path)
 			linked.accelerate(get_dir(linked.loc, T))
-		else if(get_dist(linked.loc, T) <= linked.get_brake_path())
+		else
 			linked.decelerate()
 
 		return


### PR DESCRIPTION
Reverts Baystation12/Baystation12#16638

The above changes made autopilot unuseable if you activated it while moving.
This method is less fuel efficient, but at least it's guaranteed to actually work.