### PR TITLE
Fixes #16806

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -365,7 +365,7 @@ var/global/datum/controller/occupations/job_master
 						else
 							permitted = 1
 
-						if(G.whitelisted && ((!(H.species.name in G.whitelisted)) || !is_species_whitelisted(H, G.whitelisted)))
+						if(G.whitelisted && (!(H.species.name in G.whitelisted)))
 							permitted = 0
 
 						if(!permitted)

--- a/html/changelogs/Datraen-Alienwhitelistitemfix.yml
+++ b/html/changelogs/Datraen-Alienwhitelistitemfix.yml
@@ -1,0 +1,4 @@
+author: Datraen
+delete-after: True
+changes: 
+  - bugfix: "Aliens can choose their corresponding xenowear once again."


### PR DESCRIPTION
The latter part of the or check was failing as the proc it was calling was expecting a string and not a list. Checking for the correct species is handled in the earlier part of the or check, and whitelist checking is done when selecting the species for the character in the first place.