### PR TITLE
Nerf deathsting by making it display to surroundings

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -15,6 +15,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/purchasedpowers = list()
 	var/mimicing = ""
 
+
 /datum/changeling/New()
 	..()
 	if(possible_changeling_IDs.len)
@@ -668,7 +669,7 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 	return 1
 
 //Handles the general sting code to reduce on copypasta (seeming as somebody decided to make SO MANY dumb abilities)
-/mob/proc/changeling_sting(var/required_chems=0, var/verb_path)
+/mob/proc/changeling_sting(var/required_chems=0, var/verb_path, var/loud)
 	var/datum/changeling/changeling = changeling_power(required_chems)
 	if(!changeling)								return
 
@@ -689,8 +690,10 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 	changeling.sting_range = 1
 	src.verbs -= verb_path
 	spawn(10)	src.verbs += verb_path
-
-	to_chat(src, "<span class='notice'>We stealthily sting [T].</span>")
+	if(!loud)
+		to_chat(src, "<span class='notice'>We stealthily sting [T].</span>")
+	else
+		visible_message("<span class='danger'>[src] fires an organic shard into [T]'s chest, puncturing the stinger into their skin!</span>")
 	if(!T.mind || !T.mind.changeling)	return T	//T will be affected by the sting
 	to_chat(T, "<span class='warning'>You feel a tiny prick.</span>")
 	return
@@ -795,12 +798,11 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 	set category = "Changeling"
 	set name = "Death Sting (40)"
 	set desc = "Causes spasms onto death."
+	var/loud = 1
 
-	var/mob/living/carbon/human/T = changeling_sting(40,/mob/proc/changeling_DEATHsting)
+	var/mob/living/carbon/human/T = changeling_sting(40,/mob/proc/changeling_DEATHsting,loud)
 	if(!T)	return 0
-	visible_message("<span class='warning'>[src] brushes against [T], driving a stinger into their skin!</span>")
 	to_chat(T, "<span class='danger'>You feel a small prick and your chest becomes tight.</span>")
-
 	T.make_jittery(1000)
 	if(T.reagents)	T.reagents.add_reagent("lexorin", 40)
 	feedback_add_details("changeling_powers","DTHS")

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -791,18 +791,6 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 	feedback_add_details("changeling_powers","TS")
 	return 1
 
-/mob/proc/changeling_unfat_sting()
-	set category = "Changeling"
-	set name = "Unfat sting (5)"
-	set desc = "Sting target"
-
-	var/mob/living/carbon/human/T = changeling_sting(5,/mob/proc/changeling_unfat_sting)
-	if(!T)	return 0
-	to_chat(T, "<span class='danger'>you feel a small prick as stomach churns violently and you become to feel skinnier.</span>")
-	T.nutrition -= 100
-	feedback_add_details("changeling_powers","US")
-	return 1
-
 /mob/proc/changeling_DEATHsting()
 	set category = "Changeling"
 	set name = "Death Sting (40)"
@@ -810,7 +798,9 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 
 	var/mob/living/carbon/human/T = changeling_sting(40,/mob/proc/changeling_DEATHsting)
 	if(!T)	return 0
+	visible_message("<span class='warning'>[src] brushes against [T], driving a stinger into their skin!</span>")
 	to_chat(T, "<span class='danger'>You feel a small prick and your chest becomes tight.</span>")
+
 	T.make_jittery(1000)
 	if(T.reagents)	T.reagents.add_reagent("lexorin", 40)
 	feedback_add_details("changeling_powers","DTHS")

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -116,6 +116,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/DeathSting
 	name = "Death Sting"
 	desc = "We sting a human, filling them with potent chemicals. Their rapid death is all but assured, but our crime will be obvious."
+	helptext = "It will be clear to any surrounding witnesses if you use this power."
 	genomecost = 10
 	verbpath = /mob/proc/changeling_DEATHsting
 

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -115,15 +115,10 @@ var/list/datum/power/changeling/powerinstances = list()
 
 /datum/power/changeling/DeathSting
 	name = "Death Sting"
-	desc = "We silently sting a human, filling them with potent chemicals. Their rapid death is all but assured."
+	desc = "We sting a human, filling them with potent chemicals. Their rapid death is all but assured, but our crime will be obvious."
 	genomecost = 10
 	verbpath = /mob/proc/changeling_DEATHsting
 
-///datum/power/changeling/unfat_sting
-//	name = "Unfat Sting"
-//	desc = "We silently sting a human, forcing them to rapidly metabolize their fat."
-//	genomecost = 1
-//	verbpath = /mob/proc/changeling_unfat_sting
 
 /datum/power/changeling/boost_range
 	name = "Boost Range"

--- a/html/changelogs/asanadas-nerf_deathsting.yml
+++ b/html/changelogs/asanadas-nerf_deathsting.yml
@@ -1,0 +1,6 @@
+author: Asanadas
+
+delete-after: True
+
+changes: 
+  - experiment: "A changeling's deathsting now gives a message to the surrounding area."


### PR DESCRIPTION
After observing a changeling round (another reactionary suggestion).

Cold wind still blows to this day 😰  ❄️ 🎐 🌬 💨 ☃️ 

Adds message that displays to surrounding area when deathsting is used.
![image](https://cloud.githubusercontent.com/assets/1222532/24813913/d81fb8ee-1b9d-11e7-9beb-af4b9942b2ec.png)

[Thread is up here.](https://baystation12.net/forums/threads/suggestion-nerf-deathsting-by-making-it-loud.4118/)