### PR TITLE
Diona Nymphs Mind Transfer Upon Death

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1499,6 +1499,7 @@
 #include "code\modules\mob\living\carbon\alien\progression.dm"
 #include "code\modules\mob\living\carbon\alien\say.dm"
 #include "code\modules\mob\living\carbon\alien\update_icons.dm"
+#include "code\modules\mob\living\carbon\alien\diona\death.dm"
 #include "code\modules\mob\living\carbon\alien\diona\diona.dm"
 #include "code\modules\mob\living\carbon\alien\diona\diona_attacks.dm"
 #include "code\modules\mob\living\carbon\alien\diona\diona_powers.dm"

--- a/code/modules/mob/living/carbon/alien/diona/death.dm
+++ b/code/modules/mob/living/carbon/alien/diona/death.dm
@@ -1,0 +1,50 @@
+//This essentially makes dionaea spawned by splitting into a doubly linked
+//list that, when the nymph dies, transfers the controler's mind
+//to the next nymph in the list.
+
+/mob/living/carbon/alien/diona/proc/set_next_nymph(var/mob/living/carbon/alien/diona/D)
+	next_nymph = D
+
+/mob/living/carbon/alien/diona/proc/set_last_nymph(var/mob/living/carbon/alien/diona/D)
+	last_nymph = D
+// When there are only two nymphs left in a list and one is to be removed,
+// call this to null it out.
+/mob/living/carbon/alien/diona/proc/null_nymphs()
+	next_nymph = null
+	last_nymph = null
+
+/mob/living/carbon/alien/diona/proc/remove_from_list()
+	// Closes over the gap that's going to be made and removes references to
+	// the nymph this is called for.
+	last_nymph.set_next_nymph(next_nymph)
+	next_nymph.set_last_nymph(last_nymph)
+	// This bit checks if a nymphs is the only nymph in the list
+	// by seeing if it points to itself. If it is, it nulls it
+	// to stop list behaviour.
+	if ((last_nymph.next_nymph == last_nymph) || (next_nymph.last_nymph == next_nymph))
+		last_nymph.null_nymphs()
+		next_nymph.null_nymphs()
+	// Finally, remove the current nymph's references to other nymphs.
+	null_nymphs()
+
+/mob/living/carbon/alien/diona/death(gibbed)
+
+	if (next_nymph && next_nymph.stat == 0)
+
+		var/mob/living/carbon/alien/diona/S = next_nymph
+		transfer_languages(src, S)
+
+		if(mind)
+			to_chat(src, "<span class='info'>You have died and have been transfered to another of your nymphs.</span>")
+			mind.transfer_to(S)
+			message_admins("\The [src] has transfered to another nymph; player now controls [key_name_admin(S)]")
+			log_admin("\The [src] has transfered to another nymph; player now controls [key_name(S)]")
+
+	remove_from_list()
+
+	return ..(gibbed,death_msg)
+
+/mob/living/carbon/alien/diona/Destroy()
+	if (last_nymph || next_nymph)
+		remove_from_list()
+	..()

--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -21,6 +21,9 @@
 	possession_candidate = 1
 	var/obj/item/hat
 
+	var/mob/living/carbon/alien/diona/next_nymph
+	var/mob/living/carbon/alien/diona/last_nymph
+
 /mob/living/carbon/alien/diona/New()
 
 	..()

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -236,18 +236,28 @@
 	log_admin("\The [src] has split into nymphs; player now controls [key_name(S)]")
 
 	var/nymphs = 1
+	var/mob/living/carbon/alien/diona/L = S
 
 	for(var/mob/living/carbon/alien/diona/D in src)
 		nymphs++
 		D.forceMove(T)
 		transfer_languages(src, D, WHITELISTED|RESTRICTED)
 		D.set_dir(pick(NORTH, SOUTH, EAST, WEST))
+		L.set_next_nymph(D)
+		D.set_last_nymph(L)
+		L = D
 
 	if(nymphs < number_of_resulting_nymphs)
 		for(var/i in nymphs to (number_of_resulting_nymphs - 1))
-			var/mob/M = new /mob/living/carbon/alien/diona(T)
+			var/mob/living/carbon/alien/diona/M = new(T)
 			transfer_languages(src, M, WHITELISTED|RESTRICTED)
 			M.set_dir(pick(NORTH, SOUTH, EAST, WEST))
+			L.set_next_nymph(M)
+			M.set_last_nymph(L)
+			L = M
+
+	L.set_next_nymph(S)
+	S.set_last_nymph(L)
 
 	for(var/obj/item/W in src)
 		drop_from_inventory(W)


### PR DESCRIPTION
Now if, after a diona splits, you die while controlling one of the
nymphs, you will take over one of the other nymphs originally spawned if
it is alive.