### PR TITLE
Enables Autonomous Nymph Movement

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -40,3 +40,10 @@
 	new_hat.loc = src
 	update_icons()
 
+/mob/living/carbon/alien/diona/proc/handle_npc(var/mob/living/carbon/alien/diona/D)
+	if(D.stat != CONSCIOUS)
+		return
+	if(prob(33) && D.canmove && isturf(D.loc) && !D.pulledby) //won't move if being pulled
+		step(D, pick(cardinal))
+	if(prob(1))
+		D.emote(pick("scratch","jump","chirp","tail"))

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -20,3 +20,6 @@
 		adjustFireLoss(-1)
 		adjustToxLoss(-1)
 		adjustOxyLoss(-1)
+
+	if(!client)
+		handle_npc(src)


### PR DESCRIPTION
Nymphs without a controller will now move around and emote similar to
how monkeys move and emote. This means they won't be sitting all in a pile after a split.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
