### PR TITLE
Per-map admin fax destinations and logo selection

### DIFF
--- a/code/modules/paperwork/adminpaper.dm
+++ b/code/modules/paperwork/adminpaper.dm
@@ -16,6 +16,9 @@
 	var/footer = null
 	var/footerOn = FALSE
 
+	var/logo_list = list("ntlogo.png","sollogo.png")
+	var/logo = ""
+
 /obj/item/weapon/paper/admin/New()
 	..()
 	generateInteractions()
@@ -31,6 +34,7 @@
 	interactions += "<A href='?src=\ref[src];penmode=1'>Pen mode: [isCrayon ? "Crayon" : "Pen"]</A> "
 	interactions += "<A href='?src=\ref[src];cancel=1'>Cancel fax</A> "
 	interactions += "<BR>"
+	interactions += "<A href='?src=\ref[src];changelogo=1'>Change logo</A> "
 	interactions += "<A href='?src=\ref[src];toggleheader=1'>Toggle Header</A> "
 	interactions += "<A href='?src=\ref[src];togglefooter=1'>Toggle Footer</A> "
 	interactions += "<A href='?src=\ref[src];clear=1'>Clear page</A> "
@@ -41,7 +45,7 @@
 	var/challengehash = copytext(md5("[game_id]"),1,10) // changed to a hash of the game ID so it's more consistant but changes every round.
 	var/text = null
 	//TODO change logo based on who you're contacting.
-	text = "<center><img src = ntlogo.png></br>"
+	text = "<center><img src = [logo]></br>"
 	text += "<b>[origin] Quantum Uplink Signed Message</b><br>"
 	text += "<font size = \"1\">Encryption key: [originhash]<br>"
 	text += "Challenge: [challengehash]<br></font></center><hr>"
@@ -143,6 +147,12 @@ obj/item/weapon/paper/admin/proc/updateDisplay()
 
 	if(href_list["togglefooter"])
 		footerOn = !footerOn
+		updateDisplay()
+		return
+	
+	if(href_list["changelogo"])
+		logo = input(usr, "What logo?", "Choose a logo", "") as null|anything in (logo_list)
+		generateHeader()
 		updateDisplay()
 		return
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -1,5 +1,5 @@
 var/list/obj/machinery/photocopier/faxmachine/allfaxes = list()
-var/list/admin_departments = list("[using_map.boss_name]", "Colonial Marshal Service", "[using_map.boss_short] Supply")
+var/list/admin_departments = list("[using_map.boss_name]", "Colonial Marshal Service", "[using_map.boss_short] Supply") + using_map.map_admin_faxes
 var/list/alldepartments = list()
 
 var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
@@ -202,6 +202,8 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, destination, "#1F66A0")
 	else if (destination == "[using_map.boss_short] Supply")
 		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, destination, "#5F4519")
+	else if (destination in using_map.map_admin_faxes)
+		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, destination, "#510B74")
 	else
 		message_admins(sender, "[uppertext(destination)] FAX", rcvdcopy, "UNKNOWN")
 

--- a/html/changelogs/pobiega-faxtuallyaccurateupdates.yml
+++ b/html/changelogs/pobiega-faxtuallyaccurateupdates.yml
@@ -1,0 +1,8 @@
+author: Pobiega
+delete-after: True
+
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added new per-map admin fax destinations."
+  - rscadd: "Admins can now pick between the NT and the solgov logo when sending adminfaxes."

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -26,6 +26,8 @@
 	company_name  = "Sol Central Government"
 	company_short = "SolGov"
 
+	map_admin_faxes = list("NanoTrasen Central Office")
+
 	//These should probably be moved into the evac controller...
 	shuttle_docked_message = "Attention all hands: Jump preparation complete. The bluespace drive is now spooling up, secure all stations for departure. Time to jump: approximately %ETD%."
 	shuttle_leaving_dock = "Attention all hands: Jump initiated, exiting bluespace in %ETA%."

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -58,6 +58,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/company_short = "BM"
 	var/system_name = "Uncharted System"
 
+	var/map_admin_faxes = list()
+
 	var/shuttle_docked_message
 	var/shuttle_leaving_dock
 	var/shuttle_called_message


### PR DESCRIPTION
Adds a way to add per-map admin fax destinations and also lets admins change the NT logo for a solgov logo when they are sending faxes.

[gifv](http://i.imgur.com/m33H0gJ.gifv) of the logo selection process.