### PR TITLE
Stabilizes the test landmark acquirement.

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -265,10 +265,10 @@ datum/unit_test/landmark_check/start_test()
 
 	for(var/lm in landmarks_list)
 		var/obj/effect/landmark/landmark = lm
-		if(landmark.tag == "landmark*safe_turf")
+		if(istype(landmark, /obj/effect/landmark/test/safe_turf))
 			log_debug("Safe landmark found: [log_info_line(landmark)]")
 			safe_landmarks++
-		else if(landmark.tag == "landmark*space_turf")
+		else if(istype(landmark, /obj/effect/landmark/test/space_turf))
 			log_debug("Space landmark found: [log_info_line(landmark)]")
 			space_landmarks++
 		else if(istype(landmark, /obj/effect/landmark/test))

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -61,6 +61,9 @@ datum/unit_test
 	var/reported = 0	// If it's reported a success or failure.  Any tests that have not are assumed to be failures.
 	var/why_disabled = "No reason set."   // If we disable a unit test we will display why so it reminds us to check back on it later.
 
+	var/safe_landmark
+	var/space_landmark
+
 datum/unit_test/proc/log_debug(var/message)
 	log_unit_test("[ascii_yellow]---  DEBUG  --- \[[name]\]: [message][ascii_reset]")
 
@@ -90,11 +93,20 @@ datum/unit_test/proc/check_result()
 	return 1
 
 datum/unit_test/proc/get_safe_turf()
-	return locate("landmark*safe_turf")
+	if(!safe_landmark)
+		for(var/landmark in landmarks_list)
+			if(istype(landmark, /obj/effect/landmark/test/safe_turf))
+				safe_landmark = landmark
+				break
+	return safe_landmark
 
 datum/unit_test/proc/get_space_turf()
-	return locate("landmark*space_turf")
-
+	if(!space_landmark)
+		for(var/landmark in landmarks_list)
+			if(istype(landmark, /obj/effect/landmark/test/space_turf))
+				space_landmark = landmark
+				break
+	return space_landmark
 
 proc/load_unit_test_changes()
 /*

--- a/code/unit_tests/~unit_test_types.dm
+++ b/code/unit_tests/~unit_test_types.dm
@@ -8,21 +8,6 @@
 
 #ifdef UNIT_TEST
 
-
-/obj/effect/landmark/test/New()
-	..()
-	log_unit_test("[ascii_yellow]NEW: [log_info_line(src)][ascii_reset]")
-
-/obj/effect/landmark/test/Destroy()
-	log_unit_test("[ascii_yellow]DESTROY: [log_info_line(src)][ascii_reset]")
-	crash_with("DESTROY")
-	. = ..()
-
-/obj/effect/landmark/test/Del()
-	log_unit_test("[ascii_yellow]DEL: [log_info_line(src)][ascii_reset]")
-	crash_with("DEL")
-	..()
-
 /datum/fake_client
 
 /mob/fake_mob


### PR DESCRIPTION
We somehow broke BYOND's string comparison again.
As such we do type checking instead.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
