### PR TITLE
Removes staff of change from wizard's spellbook / wizard trader.

### DIFF
--- a/code/datums/trading/unique.dm
+++ b/code/datums/trading/unique.dm
@@ -111,7 +111,6 @@
 								/obj/item/clothing/suit/space/void/wizard        = TRADER_THIS_TYPE,
 								/obj/item/toy/figure/wizard                      = TRADER_THIS_TYPE,
 								/obj/item/weapon/staff                           = TRADER_ALL,
-								/obj/item/weapon/gun/energy/staff                = TRADER_ALL
 								) //Probably see about getting some more wizard based shit
 
 	speech = list("hail_generic"     = "Hello! Are you here on pleasure or business?",

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -25,7 +25,6 @@
 							/spell/targeted/ethereal_jaunt = 					1,
 							/spell/aoe_turf/knock = 							1,
 							/spell/noclothes = 									2,
-							/obj/item/weapon/gun/energy/staff = 				1,
 							/obj/item/weapon/gun/energy/staff/focus = 			1,
 							/obj/structure/closet/wizard/souls = 				1,
 							/obj/structure/closet/wizard/armor = 				1,

--- a/html/changelogs/asanadas_staff-of-change.yml
+++ b/html/changelogs/asanadas_staff-of-change.yml
@@ -1,0 +1,6 @@
+author: Asanadas
+
+delete-after: True
+
+changes: 
+  - rscdel: "Staff of change has been removed from the wizard's arsenal."


### PR DESCRIPTION
Yet another reactionary push. if mamma ain't happy ain't nobody happy 👩 

Staff of change creates terrible fake-RP that drags the entire round down. Removal by fixing has been working well so far.

Of course staff of change can still be spawned in for special requesting wizards who will be monitored by admins so as to not turn the round into a golem shadowman xenomorph orgy.