### PR TITLE
Fix crash in turbolifts built on any z-level other than "1"

### DIFF
--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -221,7 +221,7 @@
 	var/turf/T = locate(int_panel_x, int_panel_y, uz)
 	lift.control_panel_interior = new(T, lift)
 	lift.control_panel_interior.set_dir(udir)
-	lift.current_floor = lift.floors[uz]
+	lift.current_floor = lift.floors[1]
 
 	lift.open_doors()
 


### PR DESCRIPTION
* Turbolift auto-mapping code assumed that all lift's first floor would be on z=1.  Fixed so it picks the first floor instead of the zth floor from the floor list.

Without this, depending on what z level, it will be either list index out of bounds, or it will have placed the panel object etc on a different floor from what the controller thinks is the current floor, causing all kinds of problems like the doors being half open etc.