### PR TITLE
De-snowflake thrown objects hitting turfs.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -110,12 +110,7 @@
 	else if(isturf(hit_atom))
 		src.throwing = 0
 		var/turf/T = hit_atom
-		if(T.density)
-			spawn(2)
-				step(src, turn(src.last_move, 180))
-			if(istype(src,/mob/living))
-				var/mob/living/M = src
-				M.turf_collision(T, speed)
+		T.hitby(src,speed)
 
 //decided whether a movable atom being thrown can pass through the turf it is in.
 /atom/movable/proc/hit_check(var/speed)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -253,3 +253,12 @@ var/const/enterloopsanity = 100
 	if(decals && decals.len)
 		decals.Cut()
 		decals = null
+
+// Called when turf is hit by a thrown object
+/turf/hitby(atom/movable/AM as mob|obj, var/speed)
+	if(src.density)
+		spawn(2)
+			step(AM, turn(AM.last_move, 180))
+		if(isliving(AM))
+			var/mob/living/M = AM
+			M.turf_collision(src, speed)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -49,6 +49,11 @@
 	..()
 	mover.fall()
 
+// Called when thrown object lands on this turf.
+/turf/simulated/open/hitby(var/atom/movable/AM, var/speed)
+	. = ..()
+	AM.fall()
+
 // override to make sure nothing is hidden
 /turf/simulated/open/levelupdate()
 	for(var/obj/O in src)


### PR DESCRIPTION
* Actually tell turfs when a thrown object hits them, and let them decide what to do about it!
  * We do this by calling hitby(), which is how it already works for obj and mob, so this makes behavior consistent.
* This allows us to cleanly solve the problem of a thrown object landing on open space without falling.


Design Note: For reference, the problem with landing on open space, was because at the point where the thrown object `Enter()`d the open space turf, it still has `throwing = 1` set on it, so fall doesn't happen.  I looked and found no proc at all being called on the turf for the final `throw_impact` on the destination turf.   Choice was to either snowflake in /turf/simulated/open, or use a generic solution like was already used for obj/mob.  The latter seemed the better choice for the future.