### PR TITLE
Multi-ZAS Optimization

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -187,13 +187,3 @@
 
 #define WORLD_ICON_SIZE 32
 #define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32
-
-//MultiZ directions for ZAS checks.
-#define NORTHUP (NORTH|UP)
-#define EASTUP (EAST|UP)
-#define SOUTHUP (SOUTH|UP)
-#define WESTUP (WEST|UP)
-#define NORTHDOWN (NORTH|DOWN)
-#define EASTDOWN (EAST|DOWN)
-#define SOUTHDOWN (SOUTH|DOWN)
-#define WESTDOWN (WEST|DOWN)

--- a/code/global.dm
+++ b/code/global.dm
@@ -69,7 +69,9 @@ var/list/prisonwarped       = list() // List of players already warped.
 var/list/ninjastart         = list()
 
 var/list/cardinal    = list(NORTH, SOUTH, EAST, WEST)
+var/list/cardinalz   = list(NORTH, SOUTH, EAST, WEST, UP, DOWN)
 var/list/cornerdirs  = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+var/list/cornerdirsz = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST, NORTH|UP, EAST|UP, WEST|UP, SOUTH|UP, NORTH|DOWN, EAST|DOWN, WEST|DOWN, SOUTH|DOWN)
 var/list/alldirs     = list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
 var/list/reverse_dir = list( // reverse_dir[dir] = reverse of dir
 	 2,  1,  3,  8, 10,  9, 11,  4,  6,  5,  7, 12, 14, 13, 15, 32, 34, 33, 35, 40, 42,

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -56,10 +56,13 @@
 
 	var/check_dirs = get_zone_neighbours(src)
 	var/unconnected_dirs = check_dirs
-	var/to_check = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+
 	#ifdef MULTIZAS
-	to_check += list(NORTHUP, EASTUP, WESTUP, SOUTHUP, NORTHDOWN, EASTDOWN, WESTDOWN, SOUTHDOWN)
+	var/to_check = cornerdirsz
+	#else
+	var/to_check = cornerdirs
 	#endif
+
 	for(var/dir in to_check)
 
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
@@ -76,9 +79,10 @@
 /turf/simulated/proc/get_zone_neighbours(turf/simulated/T)
 	. = 0
 	if(istype(T) && T.zone)
-		var/to_check = cardinal.Copy()
 		#ifdef MULTIZAS
-		to_check += list(UP, DOWN)
+		var/to_check = cardinalz
+		#else
+		var/to_check = cardinal
 		#endif
 		for(var/dir in to_check)
 			var/turf/simulated/other = get_step(T, dir)


### PR DESCRIPTION
A simple optimization to can_safely_remove_from_zone() both with and without multi-zas.
Instead of allocating a new list every time we call get_zone_neighbours() (which gets called several times in a loop) we have a pre-built list we don't need to Copy().
Same story for the list to iterate over in can_safely_remove_from_zone()
There should be no semantic change whatsoever from this; it is purely a performance optimization.
