### PR TITLE
Fix winset on-close for 511

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -153,7 +153,8 @@
 	if(ref)
 		param = "\ref[ref]"
 
-	winset(user, windowid, "on-close=\".windowclose [param]\"")
+	spawn(2)
+		winset(user, windowid, "on-close=\".windowclose [param]\"")
 
 //	log_debug("OnClose [user]: [windowid] : ["on-close=\".windowclose [param]\""]")
 

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -461,7 +461,8 @@ nanoui is used to open and update nano browser uis
 		return
 	var/params = "\ref[src]"
 
-	winset(user, window_id, "on-close=\"nanoclose [params]\"")
+	spawn(2)
+		winset(user, window_id, "on-close=\"nanoclose [params]\"")
 
  /**
   * Push data to an already open UI window

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -100,7 +100,8 @@
 	var/debugable = check_rights(R_DEBUG, 0, user)
 	user << browse(get_html(debugable), "window=[window_id];[window_size][list2params(window_options)]") // Open the window.
 	if (!custom_browser_id)
-		winset(user, window_id, "on-close=\"uiclose \ref[src]\"") // Instruct the client to signal UI when the window is closed.
+		spawn(2)
+			winset(user, window_id, "on-close=\"uiclose \ref[src]\"") // Instruct the client to signal UI when the window is closed.
 	tgui_process.on_open(src)
 
  /**


### PR DESCRIPTION
For some reason winset on-close on a never-before-seen window ID fails now, where it didn't before.