### PR TITLE
Updates dmitool.py to use Python 3.6+

### DIFF
--- a/tools/dmitool/dmitool.py
+++ b/tools/dmitool/dmitool.py
@@ -9,12 +9,7 @@ _DMITOOL_CMD = ["-jar", "dmitool.jar"]
 
 
 def _dmitool_call(*dmitool_args, **popen_args):
-    return Popen(_JAVA_PATH + _DMITOOL_CMD + [str(arg) for arg in dmitool_args], **popen_args)
-
-
-def decode_octets(bytes):
-    decoded_string = bytes.decode(encoding = os.sys.getdefaultencoding())
-    return decoded_string
+    return Popen(_JAVA_PATH + _DMITOOL_CMD + [str(arg) for arg in dmitool_args], **popen_args, encoding=os.sys.getdefaultencoding())
 
 
 def _safe_parse(dict, key, deferred_value):
@@ -29,13 +24,13 @@ def _safe_parse(dict, key, deferred_value):
 def version():
     """ Returns the version as a string. """
     stdout, stderr = _dmitool_call("version", stdout=PIPE).communicate()
-    return decode_octets(stdout).strip()
+    return str(stdout).strip()
 
 
 def help():
     """ Returns the help text as a string. """
     stdout, stderr = _dmitool_call("help", stdout=PIPE).communicate()
-    return decode_octets(stdout).strip()
+    return str(stdout).strip()
 
 
 def info(filepath):
@@ -44,7 +39,6 @@ def info(filepath):
     """
     subproc = _dmitool_call("info", filepath, stdout=PIPE)
     stdout, stderr = subproc.communicate()
-    stdout = decode_octets(stdout)
 
     result = {}
     data = stdout.split(os.linesep)[1:]

--- a/tools/dmitool/dmitool.py
+++ b/tools/dmitool/dmitool.py
@@ -11,10 +11,12 @@ _DMITOOL_CMD = ["-jar", "dmitool.jar"]
 def _dmitool_call(*dmitool_args, **popen_args):
     return Popen(_JAVA_PATH + _DMITOOL_CMD + [str(arg) for arg in dmitool_args], **popen_args)
 
-def decode_bytes(bytes):
+
+def decode_octets(bytes):
     decoded_string = bytes.decode(encoding = os.sys.getdefaultencoding())
     return decoded_string
-	
+
+
 def _safe_parse(dict, key, deferred_value):
     try:
         dict[key] = deferred_value()
@@ -27,13 +29,14 @@ def _safe_parse(dict, key, deferred_value):
 def version():
     """ Returns the version as a string. """
     stdout, stderr = _dmitool_call("version", stdout=PIPE).communicate()
-    return decode_bytes(stdout).strip()
+    return decode_octets(stdout).strip()
 
 
 def help():
     """ Returns the help text as a string. """
     stdout, stderr = _dmitool_call("help", stdout=PIPE).communicate()
-    return decode_bytes(stdout).strip()
+    return decode_octets(stdout).strip()
+
 
 def info(filepath):
     """ Totally not a hack that parses the output from dmitool into a dictionary. 
@@ -41,8 +44,7 @@ def info(filepath):
     """
     subproc = _dmitool_call("info", filepath, stdout=PIPE)
     stdout, stderr = subproc.communicate()
-    stdout = decode_bytes(stdout)
-    stderr = decode_bytes(stdout)
+    stdout = decode_octets(stdout)
 
     result = {}
     data = stdout.split(os.linesep)[1:]

--- a/tools/dmitool/dmitool.py
+++ b/tools/dmitool/dmitool.py
@@ -1,4 +1,4 @@
-""" Python 2.7 wrapper for dmitool.
+""" Python 3.x wrapper for dmitool.
 """
 
 import os
@@ -16,7 +16,7 @@ def _safe_parse(dict, key, deferred_value):
     try:
         dict[key] = deferred_value()
     except Exception as e: 
-        print "Could not parse property '%s': %s" % (key, e)
+        print("Could not parse property '%s': %s" % (key, e))
         return e
     return False
 

--- a/tools/dmitool/dmitool.py
+++ b/tools/dmitool/dmitool.py
@@ -1,4 +1,4 @@
-""" Python 3.x wrapper for dmitool.
+""" Python 3.6+ wrapper for dmitool.
 """
 
 import os

--- a/tools/dmitool/dmitool.py
+++ b/tools/dmitool/dmitool.py
@@ -11,7 +11,10 @@ _DMITOOL_CMD = ["-jar", "dmitool.jar"]
 def _dmitool_call(*dmitool_args, **popen_args):
     return Popen(_JAVA_PATH + _DMITOOL_CMD + [str(arg) for arg in dmitool_args], **popen_args)
 
-
+def decode_bytes(bytes):
+    decoded_string = bytes.decode(encoding = os.sys.getdefaultencoding())
+    return decoded_string
+	
 def _safe_parse(dict, key, deferred_value):
     try:
         dict[key] = deferred_value()
@@ -24,14 +27,13 @@ def _safe_parse(dict, key, deferred_value):
 def version():
     """ Returns the version as a string. """
     stdout, stderr = _dmitool_call("version", stdout=PIPE).communicate()
-    return str(stdout).strip()
+    return decode_bytes(stdout).strip()
 
 
 def help():
     """ Returns the help text as a string. """
     stdout, stderr = _dmitool_call("help", stdout=PIPE).communicate()
-    return str(stdout).strip()
-
+    return decode_bytes(stdout).strip()
 
 def info(filepath):
     """ Totally not a hack that parses the output from dmitool into a dictionary. 
@@ -39,6 +41,8 @@ def info(filepath):
     """
     subproc = _dmitool_call("info", filepath, stdout=PIPE)
     stdout, stderr = subproc.communicate()
+    stdout = decode_bytes(stdout)
+    stderr = decode_bytes(stdout)
 
     result = {}
     data = stdout.split(os.linesep)[1:]


### PR DESCRIPTION
It seemed a little weird that every other python script in the tools folder was using the Python3 print statements, and this was basically the only thing left that was stuck using Python2.7. So I ran it through the 2to3 tool, and changed the docstring up at the top. 