### PR TITLE
Removes stun baton beating when set to DISARM.

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -133,7 +133,7 @@
 		var/mob/living/carbon/human/H = target
 		affecting = H.get_organ(hit_zone)
 
-	if(user.a_intent == I_HURT || user.a_intent == I_DISARM)
+	if(user.a_intent == I_HURT)
 		. = ..()
 		if (!.)	//item/attack() does it's own messaging and logs
 			return 0	// item/attack() will return 1 if they hit, 0 if they missed.


### PR DESCRIPTION
So, this is made for a few reasons. First off, this prevents officers from beating people unless they REALLY want to. This is probably a good thing and will prevent a lot of accidental beatings.

Secondly, when using an E-gun on stun setting, you need to have it on something other than help. If you then switch to a baton, if it's on disarm, you will begin to beat the shit out of the person. This isn't good game design and sends mixed signals.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
