### PR TITLE
Fix typo in zpipe proc name.

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -48,7 +48,7 @@ obj/machinery/atmospherics/pipe/zpipe/New()
 		invisibility = i ? 101 : 0
 	update_icon()
 
-obj/machinery/atmospherics/pipe/up/process()
+obj/machinery/atmospherics/pipe/zpipe/process()
 	if(!parent) //This should cut back on the overhead calling build_network thousands of times per cycle
 		..()
 	else
@@ -78,10 +78,10 @@ obj/machinery/atmospherics/pipe/zpipe/proc/burst()
 	qdel(src) // NOT qdel.
 
 obj/machinery/atmospherics/pipe/zpipe/proc/normalize_dir()
-	if(dir==3)
-		set_dir(1)
-	else if(dir==12)
-		set_dir(4)
+	if(dir==NORTH|SOUTH)
+		set_dir(NORTH)
+	else if(dir==EAST|WEST)
+		set_dir(EAST)
 
 obj/machinery/atmospherics/pipe/zpipe/Destroy()
 	if(node1)


### PR DESCRIPTION
Correct me if I'm wrong, but it looks like the proc
`obj/machinery/atmospherics/pipe/up/process()` was supposed to be 
`obj/machinery/atmospherics/pipe/zpipe/process()`  So fixing this should marginally speed up zpipes and eliminate the spurious type from the object tree.
* I also changed hard coded integers to use constants while I was editing the file anyway.