### PR TITLE
Fix operator precedence mistake.

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -78,9 +78,9 @@ obj/machinery/atmospherics/pipe/zpipe/proc/burst()
 	qdel(src) // NOT qdel.
 
 obj/machinery/atmospherics/pipe/zpipe/proc/normalize_dir()
-	if(dir==NORTH|SOUTH)
+	if(dir == (NORTH|SOUTH))
 		set_dir(NORTH)
-	else if(dir==EAST|WEST)
+	else if(dir == (EAST|WEST))
 		set_dir(EAST)
 
 obj/machinery/atmospherics/pipe/zpipe/Destroy()


### PR DESCRIPTION
In today's lesson we remember that `==` is more tightly bound than `|` and also that fixing things "while I was in the file" is usually a good idea but requires an extra test case. Sorry about that.