### PR TITLE
Vegetable and Nettle Soup Flavour Text Updates

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1458,12 +1458,12 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablesoup
 	name = "Vegetable soup"
-	desc = "A true vegan meal." //TODO
+	desc = "A highly nutritious blend of vegetative goodness. Guaranteed to leave you with a, er, \"souped-up\" sense of wellbeing."
 	icon_state = "vegetablesoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"
 	center_of_mass = "x=16;y=8"
-	nutriment_desc = list("carot" = 2, "corn" = 2, "eggplant" = 2, "potato" = 2)
+	nutriment_desc = list("carrot" = 2, "corn" = 2, "eggplant" = 2, "potato" = 2)
 	nutriment_amt = 8
 	New()
 		..()
@@ -1472,7 +1472,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/nettlesoup
 	name = "Nettle soup"
-	desc = "To think, the botanist would've beat you to death with one of these."
+	desc = "A mean, green, calorically lean dish derived from a poisonous plant. It has a rather acidic bite to its taste."
 	icon_state = "nettlesoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"


### PR DESCRIPTION
1. Updates the vegetable soup item's description, which was barebones and marked "TODO", with a full description.
2. Changes one of the vegetable soup item's nutriment flavour names from "carot" (a misspelling) to "carrot".
3. Updates the nettle soup item's description, which was outdated on two counts^, with a more current description.

^ = The old description joked about botanists using nettles as weapons. The ability to use nettles as weapons was removed from Bay's code in 2015, while the botanist job was removed from mainstream gameplay in the switch to the Torch (although it does technically remain on the Exodus, as well as being a passenger alt-title on the Torch).