### PR TITLE
Restructures new diona death mechanics to prevent runtimes

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/death.dm
+++ b/code/modules/mob/living/carbon/alien/diona/death.dm
@@ -16,14 +16,24 @@
 /mob/living/carbon/alien/diona/proc/remove_from_list()
 	// Closes over the gap that's going to be made and removes references to
 	// the nymph this is called for.
-	last_nymph.set_next_nymph(next_nymph)
-	next_nymph.set_last_nymph(last_nymph)
+	var/need_links_null = 0
+
+	if (last_nymph)
+		last_nymph.set_next_nymph(next_nymph)
+		if (last_nymph.next_nymph == last_nymph)
+			need_links_null = 1
+	if (next_nymph)
+		next_nymph.set_last_nymph(last_nymph)
+		if (next_nymph.last_nymph == next_nymph)
+			need_links_null = 1
 	// This bit checks if a nymphs is the only nymph in the list
 	// by seeing if it points to itself. If it is, it nulls it
 	// to stop list behaviour.
-	if ((last_nymph.next_nymph == last_nymph) || (next_nymph.last_nymph == next_nymph))
-		last_nymph.null_nymphs()
-		next_nymph.null_nymphs()
+	if (need_links_null)
+		if (last_nymph)
+			last_nymph.null_nymphs()
+		if (next_nymph)
+			next_nymph.null_nymphs()
 	// Finally, remove the current nymph's references to other nymphs.
 	null_nymphs()
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -242,8 +242,8 @@
 	if(mind)
 		mind.transfer_to(S)
 
-	message_admins("\The [src] has split into nymphs; player now controls [key_name_admin(S)]")
-	log_admin("\The [src] has split into nymphs; player now controls [key_name(S)]")
+		message_admins("\The [src] has split into nymphs; player now controls [key_name_admin(S)]")
+		log_admin("\The [src] has split into nymphs; player now controls [key_name(S)]")
 
 	var/nymphs = 1
 	var/mob/living/carbon/alien/diona/L = S

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -295,24 +295,16 @@
 	return ..()
 
 /datum/species/diona/handle_death(var/mob/living/carbon/human/H)
-	H.diona_split_into_nymphs(0)
-
-	var/mob/living/carbon/alien/diona/S = new(get_turf(H))
-
-	if(H.mind)
-		H.mind.transfer_to(S)
 
 	if(H.isSynthetic())
+		var/mob/living/carbon/alien/diona/S = new(get_turf(H))
+
+		if(H.mind)
+			H.mind.transfer_to(S)
 		H.visible_message("<span class='danger'>\The [H] collapses into parts, revealing a solitary diona nymph at the core.</span>")
 		return
-
-	for(var/mob/living/carbon/alien/diona/D in H.contents)
-		if(D.client)
-			D.forceMove(get_turf(H))
-		else
-			qdel(D)
-
-	H.visible_message("<span class='danger'>\The [H] splits apart with a wet slithering noise!</span>")
+	else
+		H.diona_split_nymph()
 
 /datum/species/diona/get_blood_name()
 	return "sap"


### PR DESCRIPTION
Went through, tested it a bunch, fixed all the runtimes. Also I fixed the fact that dying vs splitting only spawned one nymph which was also causing runtimes. Fixes this #17000