### PR TITLE
Allows Chef, Bartender and Passenger characters to select botanical gloves in loadouts.

### DIFF
--- a/html/changelogs/ProfligateShampoo - BotanicalGlovesLoadoutPermsBuff.yml
+++ b/html/changelogs/ProfligateShampoo - BotanicalGlovesLoadoutPermsBuff.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: ProfligateShampoo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added the ability for characters with the Cook, Bartender or Passenger (i.e. Botanist) job to select botanical gloves in their loadouts."

--- a/maps/torch/loadout/loadout_gloves.dm
+++ b/maps/torch/loadout/loadout_gloves.dm
@@ -23,7 +23,7 @@
 	display_name = "gloves, botany"
 	path = /obj/item/clothing/gloves/thick/botany
 	cost = 3
-	allowed_roles = list("Research Director", "Scientist", "Research Assistant", "Merchant")
+	allowed_roles = list("Research Director", "Scientist", "Research Assistant", "Cook", "Bartender", "Passenger", "Merchant")
 
 /datum/gear/gloves/evening
 	allowed_roles = FORMAL_ROLES


### PR DESCRIPTION
1. Allows characters spawning with the Chef, Bartender and Passenger occupations to select botanical gloves in their loadouts. Before this change, these jobs may have need of grown nettles within their jobs^, but are unable to safely work with nettles due to a lack of protective gloves spawning in the map and an inability to select them in their loadouts. This means that they have to gradually feed the biogenerator mulch to make their gloves just to obtain gear necessary for part of their job.

2. Includes a changelog file, so that players can be notified of this change via the in-game changelog.

^ = Nettles themselves are used in the making of one of the Chef's dishes (nettle soup). Nettles can also be harvested for their sulphuric acid content. Chefs can use sulphuric acid to make soy sauce, while bartenders can use it to make the Acid Spit drink. Finally, the passenger job has an alt-title of Botanist, and this change will allow said botanists to spawn with the botanical gloves necessary to protect them from all plant hazards (most plants can mutate to be spiny and possibly dangerous) they might encounter in their job right off the bat.