### PR TITLE
Roundstart report changes

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -987,6 +987,8 @@
 			return global.player_list;
 		if("point_source_descriptions")
 			return global.point_source_descriptions;
+		if("points_of_interest")
+			return global.points_of_interest;
 		if("possible_cable_coil_colours")
 			return global.possible_cable_coil_colours;
 		if("possible_changeling_IDs")
@@ -1459,7 +1461,7 @@
 			return global.z_state;
 		if("zone_blocked")
 			return global.zone_blocked;
-
+		
 /proc/writeglobal(which, newval)
 	switch(which)
 		if("ALL_ANTIGENS")
@@ -2448,6 +2450,8 @@
 			global.player_list=newval;
 		if("point_source_descriptions")
 			global.point_source_descriptions=newval;
+		if("points_of_interest")
+			global.points_of_interest=newval;
 		if("possible_cable_coil_colours")
 			global.possible_cable_coil_colours=newval;
 		if("possible_changeling_IDs")
@@ -2920,7 +2924,7 @@
 			global.z_state=newval;
 		if("zone_blocked")
 			global.zone_blocked=newval;
-
+		
 /var/list/_all_globals=list(
 	"ALL_ANTIGENS",
 	"ANTAG_FREQS",
@@ -3250,7 +3254,6 @@
 	"hands_state",
 	"hazard_overlays",
 	"hidden_skill_types",
-	"highlanders",
 	"hiss_sound",
 	"hit_appends",
 	"hivemind_bank",
@@ -3416,6 +3419,7 @@
 	"playable_species",
 	"player_list",
 	"point_source_descriptions",
+	"points_of_interest",
 	"possible_cable_coil_colours",
 	"possible_changeling_IDs",
 	"poster_designs",

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -32,6 +32,8 @@
 			event.name = overmap_event.name
 			event.icon_state = pick(overmap_event.event_icon_states)
 
+		points_of_interest += overmap_event.name
+
 /decl/overmap_event_handler/proc/get_event_turfs_by_z_level(var/z_level)
 	var/z_level_text = num2text(z_level)
 	. = event_turfs_by_z_level[z_level_text]

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -1,6 +1,8 @@
 //===================================================================================
 //Overmap object representing zlevel(s)
 //===================================================================================
+var/list/points_of_interest = list()
+
 /obj/effect/overmap
 	name = "map object"
 	icon = 'icons/obj/overmap.dmi'
@@ -49,6 +51,8 @@
 			if(!landing_areas)
 				landing_areas = list()
 			landing_areas |= console.shuttle_area
+
+	points_of_interest += name
 
 /obj/effect/overmap/sector
 	name = "generic sector"

--- a/html/changelogs/mustafakalash-SystemInfo.yml
+++ b/html/changelogs/mustafakalash-SystemInfo.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mkalash
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Added distance to Sol to roundstart report, as well as replaced random planets with actual overmap system info."

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -54,9 +54,22 @@
 	welcome_text += "Report generated on [stationdate2text()] at [stationtime2text()]</center><br /><br />"
 	welcome_text += "Current system:<br /><b>[system_name()]</b><br />"
 	welcome_text += "Next system targeted for jump:<br /><b>[generate_system_name()]</b><br />"
-	welcome_text += "Planets in current system:<br />"
-	for(var/i = 0, i < rand(0, 3), i++)
-		welcome_text += "<b>[generate_planet_name()]</b>, \a [generate_planet_type()]<br />"
+	welcome_text += "Travel time to Sol:<br /><b>[rand(5,12)] days</b><br />"
+	welcome_text += "Scan results:<br />"
+	var/list/scan_results = list()
+	for(var/poi in points_of_interest)
+		if(poi == "SEV Torch")
+			continue
+		if(isnull(scan_results[poi]))
+			scan_results[poi] = 1
+		else
+			scan_results[poi] += 1
+	for(var/result in scan_results)
+		var/count = scan_results[result]
+		if(count == 1)
+			welcome_text += "\A <b>[result]</b><br />"
+		else
+			welcome_text += "[count] <b>[result]\s</b><br />"
 
 	post_comm_message("SEV Torch Sensor Readings", welcome_text)
 	minor_announcement.Announce(message = "New [using_map.company_name] Update available at all communication consoles.")


### PR DESCRIPTION
Adds distance to Sol to roundstart reports as well as replaces random planets with actual overmap system info.

![image](https://cloud.githubusercontent.com/assets/313146/25472151/0dd00d68-2af8-11e7-87df-fd8852ca6c96.png)

This will probably be more cool once we add more away sites / make them more random.