### PR TITLE
Removes Entertainer

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -1026,7 +1026,6 @@
 		"Investor",
 		"Naturalist",
 		"Ecologist",
-		"Entertainer",
 		"Independent Observer",
 		"Sociologist",
 		"Off-Duty")


### PR DESCRIPTION
I'm suggesting this for several reasons:

Firstly, it's a snowflake title.  Really no point in it being there.  If you are on the Torch for the specific purpose of 'entertaining' and you get paid for that, I doubt SolGov would write 'entertainer' on your ID, they would write 'passenger'. 

This is also a job that encourages people to be annoying.  I have yet to see a decent entertainer.  They usually just run around doing random things that can't really be counted as 'entertaining'.

It does not make sense for SolGov to contract out people specifically to entertain.  That's not useful, it does not contribute to the mission.  They would not waste the money to bring such a person all the way to the farthest reaches of known space just so that they can do magic tricks for the Marines or something similar.

Lastly, I think with Overmap and roles like Merchant, it would make much more sense for the Entertainer to be tied to, if not an alt title of Merchant.  

Anyway, please keep it civil below.  PR's tend to be contentious, and just because I have a differing opinion than you on the title does not mean that I want to take away your fun or something.