### PR TITLE
Lite client repository improvements.

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -200,9 +200,10 @@
 	return t
 
 //Returns a string with reserved characters and spaces before the first letter removed
-/proc/trim_left(text)
+/proc/trim_left(text, filter_chars)
 	for (var/i = 1 to length(text))
-		if (text2ascii(text, i) > 32)
+		var/char = text2ascii(text, i)
+		if (char > 32 && (!filter_chars || !(ascii2text(char) in filter_chars)))
 			return copytext(text, i)
 	return ""
 

--- a/code/datums/repositories/_defines.dm
+++ b/code/datums/repositories/_defines.dm
@@ -1,1 +1,2 @@
-#define mob2unique(mob) "[mob ? mob.ckey : NO_CLIENT_CKEY][ascii2text(7)][mob ? (mob.real_name ? mob.real_name : mob.name) : ""][ascii2text(7)][any2ref(mob)]"
+#define mob2unique(mob) "[mob && mob.ckey ? trim_left(mob.ckey, list("@")) : NO_CLIENT_CKEY][ascii2text(11)][mob ? (mob.real_name || mob.name || "*no name*") : "*no mob*"][ascii2text(11)][mob ? any2ref(mob) : "*no mob*"][ascii2text(11)][mob ? (mob.ckey ? (mob.client ? (mob.client.holder ? mob.client.holder.rank : "*no rank*") : "*disconnected*") : "*no client*") : "*no mob*"]"
+#define client2unique(client) "[client ? client.ckey : NO_CLIENT_CKEY][ascii2text(11)][client ? any2ref(client) : "*no client*"][ascii2text(11)][client ? (client.holder ? client.holder.rank : "*no rank*") : "*no client*"]"

--- a/code/datums/repositories/admin_pm.dm
+++ b/code/datums/repositories/admin_pm.dm
@@ -25,7 +25,7 @@ var/repository/admin_pm/admin_pm_repository = new()
 	var/datum/client_lite/cl = irc_clients_by_name[key]
 	if(!cl)
 		cl = new/datum/client_lite()
-		cl.name = "IRC"
+		cl.mob_name = "IRC"
 		cl.key = key
 		irc_clients_by_name[key] = cl
 	return cl

--- a/code/datums/repositories/client.dm
+++ b/code/datums/repositories/client.dm
@@ -14,46 +14,51 @@ var/repository/client/client_repository = new()
 	if(isclient(M))
 		var/client/C = M // BYOND is supposed to ensure clients always have a mob
 		M = C.mob
-	. = clients_[mob2unique(M)]
+	var/client_key = client2unique(M.client)
+	. = clients_[client_key]
 	if(!.)
 		. = new/datum/client_lite(M)
-		clients_[mob2unique(M)] = .
+		clients_[client_key] = .
 
 /datum/client_lite
-	var/name = "*no mob*"
-	var/key  = "*no key*"
-	var/ckey = NO_CLIENT_CKEY
-	var/ref // If ref is unset but ckey is set that means the client wasn't logged in at the time
+	var/mob_name = "*no mob*"
+	var/key      = "*no key*"
+	var/ckey     = NO_CLIENT_CKEY
+	var/rank
+	var/ref      // If ref is unset but ckey is different from NO_CLIENT_KEY that means the client wasn't logged in at the time
 
 /datum/client_lite/New(var/mob/M)
 	if(!M)
 		return
+	if(!istype(M))
+		CRASH("Non-mob supplied: [log_info_line(M)]")
 
-	name = M.real_name ? M.real_name : M.name
-	key = M.key ? M.key : key
-	ckey = M.ckey ? M.ckey : ckey
-	ref = M.client ? any2ref(M.client) : ref
+	mob_name = M.real_name || M.name
+	key = M.key || key
+	ckey = trim_left(M.ckey, list("@"))  || ckey
+
+	set_client_values(M.client)
 
 /datum/client_lite/proc/key_name(var/pm_link = TRUE, var/check_if_offline = TRUE)
-	if(!ref && ckey != NO_CLIENT_CKEY)
-		var/client/C = client_by_ckey(ckey)
-		if(C)
-			ref = any2ref(C)
-
+	set_client_values()
 	if(!ref)
 		if(ckey == NO_CLIENT_CKEY)
-			return "[key]/([name])"
+			return "[key]/([mob_name])"
 		else
-			return "[key]/([name]) (DC)"
+			return "[key]/([mob_name]) (DC)"
 	if(check_if_offline && !client_by_ckey(ckey))
-		return "[key]/([name]) (DC)"
-	return pm_link ? "<a href='?priv_msg=[ref]'>[key]</a>/([name])[rank2text()]" : "[key]/([name])"
+		return "[key]/([mob_name]) (DC)"
+	return pm_link ? "<a href='?priv_msg=[ref]'>[key]</a>/([mob_name])[rank ? " \[[rank]\]" : ""]" : "[key]/([mob_name])"
 
-/datum/client_lite/proc/rank2text()
-	var/client/C = client_by_ckey(ckey)
-	if(!C || (C && !C.holder))
+/datum/client_lite/proc/set_client_values(var/client/C)
+	if(ref || ckey == NO_CLIENT_CKEY)
 		return
-	return " \[[C.holder.rank]\]"
+	C = C || client_by_ckey(ckey)
+	if(!C)
+		return
+	key = C.key // Update in case of an aghost having returned to its body.
+	ref = any2ref(C)
+	rank = (C.holder && C.holder.rank) || rank
 
 /proc/client_by_ckey(ckey)
 	for(var/client/C)

--- a/code/datums/repositories/mobs.dm
+++ b/code/datums/repositories/mobs.dm
@@ -9,19 +9,20 @@ var/repository/mob/mob_repository = new()
 
 // A lite mob is unique per ckey and mob real name/ref (ref conflicts possible.. but oh well)
 /repository/mob/proc/get_lite_mob(var/mob/M)
-	. = mobs_[mob2unique(M)]
+	var/mob_key = mob2unique(M)
+	. = mobs_[mob_key]
 	if(!.)
 		. = new/datum/mob_lite(M)
-		mobs_[mob2unique(M)] = .
+		mobs_[mob_key] = .
 
 /datum/mob_lite
-	var/name
+	var/name = "*no mob*"
 	var/ref
 	var/datum/client_lite/client
 
 /datum/mob_lite/New(var/mob/M)
-	name = M ? (M.real_name ? M.real_name : M.name) : name
-	ref = any2ref(M)
+	name =(M && (M.real_name || M.name)) || name
+	ref = (M && any2ref(M)) || ref
 	client = client_repository.get_lite_client(M)
 
 /datum/mob_lite/proc/key_name(var/pm_link = TRUE, var/check_if_offline = TRUE)


### PR DESCRIPTION
Lite clients now store their rank for posterity. A rank change now results in different lite mob/client entries.
Lite clients belonging to null-mobs are now shared (null-mobs may occur in some attack log creation circumstances).
Lite client re-use is improved in general.
Aghosted mobs no longer result in lite clients which cannot be re-attached to the original client due to the @-prefix.
Cleans up how lite client info is refreshed (occurs when a logged out client is found to have logged back in).
Makes it easier to tell how a given mob-uniqueness tag came to be.


A note to self: AdminPMs should be made to expect a ckey instead of ref. Clients are destroyed on loggout and recreated on login and ref re-use is fairly high. This will also further improve the ability to share lite clients as the ref will no longer needed as a uniqueness identifier.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
