### PR TITLE
Fixes Dual Row Braid

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -629,7 +629,7 @@
 
 	rowdualbraid
 		name = "Row Dual Braid"
-		icon_state = "hair_rowdualbraid"
+		icon_state = "hair_rowdualtail"
 		gender = FEMALE
 
 	rowbraid


### PR DESCRIPTION
Naming on .dmi was inconsistent with naming on sprite_accessories.dm