### PR TITLE
Commented out ingame spawn error, due to torch not having (all) spawnpoints

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -602,8 +602,8 @@ var/global/datum/controller/occupations/job_master
 
 	if(C.prefs.spawnpoint)
 		if(!(C.prefs.spawnpoint in using_map.allowed_spawns))
-			if(H)
-				// to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead.</span>")
+			//if(H)
+			//	 to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead.</span>")
 
 			spawnpos = null
 		else

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -602,9 +602,6 @@ var/global/datum/controller/occupations/job_master
 
 	if(C.prefs.spawnpoint)
 		if(!(C.prefs.spawnpoint in using_map.allowed_spawns))
-			//if(H)
-			//	 to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead.</span>")
-
 			spawnpos = null
 		else
 			spawnpos = spawntypes[C.prefs.spawnpoint]

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -603,7 +603,7 @@ var/global/datum/controller/occupations/job_master
 	if(C.prefs.spawnpoint)
 		if(!(C.prefs.spawnpoint in using_map.allowed_spawns))
 			if(H)
-				to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead.</span>")
+				// to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead.</span>")
 
 			spawnpos = null
 		else

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -22,22 +22,22 @@ var/list/spawntypes = list()
 
 		return 1
 
-// /datum/spawnpoint/arrivals
-//	display_name = "Arrivals Shuttle"
-//	msg = "has arrived on the station"
-//
-// datum/spawnpoint/arrivals/New()
-//	..()
-//	turfs = latejoin
-//
-// /datum/spawnpoint/gateway
-//	display_name = "Gateway"
-//	msg = "has completed translation from offsite gateway"
-//
-// /datum/spawnpoint/gateway/New()
-//	..()
-//	turfs = latejoin_gateway
-//
+/datum/spawnpoint/arrivals
+	display_name = "Arrivals Shuttle"
+	msg = "has arrived on the station"
+
+/datum/spawnpoint/arrivals/New()
+	..()
+	turfs = latejoin
+
+/datum/spawnpoint/gateway
+	display_name = "Gateway"
+	msg = "has completed translation from offsite gateway"
+
+/datum/spawnpoint/gateway/New()
+	..()
+	turfs = latejoin_gateway
+
 /datum/spawnpoint/cryo
 	display_name = "Cryogenic Storage"
 	msg = "has completed cryogenic revival"

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -22,22 +22,22 @@ var/list/spawntypes = list()
 
 		return 1
 
-/datum/spawnpoint/arrivals
-	display_name = "Arrivals Shuttle"
-	msg = "has arrived on the station"
-
-/datum/spawnpoint/arrivals/New()
-	..()
-	turfs = latejoin
-
-/datum/spawnpoint/gateway
-	display_name = "Gateway"
-	msg = "has completed translation from offsite gateway"
-
-/datum/spawnpoint/gateway/New()
-	..()
-	turfs = latejoin_gateway
-
+// /datum/spawnpoint/arrivals
+//	display_name = "Arrivals Shuttle"
+//	msg = "has arrived on the station"
+//
+// datum/spawnpoint/arrivals/New()
+//	..()
+//	turfs = latejoin
+//
+// /datum/spawnpoint/gateway
+//	display_name = "Gateway"
+//	msg = "has completed translation from offsite gateway"
+//
+// /datum/spawnpoint/gateway/New()
+//	..()
+//	turfs = latejoin_gateway
+//
 /datum/spawnpoint/cryo
 	display_name = "Cryogenic Storage"
 	msg = "has completed cryogenic revival"

--- a/html/changelogs/Ornias1993 - PR - 17099.yml
+++ b/html/changelogs/Ornias1993 - PR - 17099.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Ornias1993
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Temporarily disabled the ingame spawn error message"


### PR DESCRIPTION
There currently aren't really other spawnpoints to choose from, so I … disabled all options except cryostorage and commented out the error. They are still there just commented out if need be.

Just a short temporary fix, till there is more clearity about spawn locations and options, but at least we dont have the error when joining anymore this way and players don't get non-active options in config.

Its quick and dirty, but others can build still build upon it, or not, for future spawn improvements.