### PR TITLE
Adjusts x,y,z VV edits.

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -635,9 +635,11 @@
 			var_value = text2num(var_value)
 		if(!is_num_predicate(var_value, client))
 			return
-		var/x = AM.x
-		var/y = AM.y
-		var/z = AM.z
+
+		// We set the default to 1,1,1 when at 0,0,0 (i.e. any non-turf location) to mimic the standard BYOND behaviour when adjusting x,y,z directly
+		var/x = AM.x || 1
+		var/y = AM.y || 1
+		var/z = AM.z || 1
 		switch(variable)
 			if("x")
 				x = var_value


### PR DESCRIPTION
If the current atom is in a non-turf location the default location is set to 1,1,1 (as opposed to 0,0,0) before applying the edit.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
