### PR TITLE
Stealthed staff no longer listed by "who"

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -8,7 +8,7 @@
 	var/list/Lines = list()
 
 	if(check_rights(R_INVESTIGATE, 0))
-		for(var/client/C in clients)
+		for(var/client/C)
 			var/entry = "\t[C.key]"
 			entry += " - Playing as [C.mob.real_name]"
 			switch(C.mob.stat)
@@ -44,14 +44,16 @@
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 			Lines += entry
 	else
-		for(var/client/C in clients)
-			Lines += C.key
+		for(var/client/C)
+			if(!C.is_stealthed())
+				Lines += C.key
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"
 
 	msg += "<b>Total Players: [length(Lines)]</b>"
 	to_chat(src, msg)
+
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"


### PR DESCRIPTION
Stealthed staff members are no longer listed when using either "who" or "staffwho".

Basically fulfilling an informal request based on a mention that some suspect griefers and other subversive elements were playing it low-key when they saw known staff names in the "who"-listing even if they were not listed in "staffwho" due to using stealth mode.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
