### PR TITLE
Adds Departmental Armband Boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -433,9 +433,9 @@
 //Spare Armbands
 
 /obj/item/weapon/storage/box/armband
-	name = "box of spare security armbands"
+	name = "box of spare military police armbands"
 	desc = "A box full of security armbands. For use in emergencies when provisional security personnel are needed."
-	startswith = list(/obj/item/clothing/accessory/armband = 5)
+	startswith = list(/obj/item/clothing/accessory/armband/mp = 5)
 
 /obj/item/weapon/storage/box/armband/engine
 	name = "box of spare engineering armbands"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -429,3 +429,24 @@
 	name = "box of spare headsets"
 	desc = "A box full of headsets."
 	startswith = list(/obj/item/device/radio/headset = 7)
+
+//Spare Armbands
+
+/obj/item/weapon/storage/box/armband
+	name = "box of spare armbands"
+	desc = "If you see this, ahelp."
+
+/obj/item/weapon/storage/box/armband/sec
+	name = "box of spare security armbands"
+	desc = "A box full of security armbands. For use in emergencies when provisional security personnel are needed."
+	startswith = list(/obj/item/clothing/accessory/armband = 5)
+
+/obj/item/weapon/storage/box/armband/engine
+	name = "box of spare engineering armbands"
+	desc = "A box full of engineering armbands. For use in emergencies when provisional engineering peronnel are needed."
+	startswith = list(/obj/item/clothing/accessory/armband/engine = 5)
+
+/obj/item/weapon/storage/box/armband/med
+	name = "box of spare medical armbands"
+	desc = "A box full of medical armbands. For use in emergencies when provisional medical personnel are needed."
+	startswith = list(/obj/item/clothing/accessory/armband/med = 5)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -433,10 +433,6 @@
 //Spare Armbands
 
 /obj/item/weapon/storage/box/armband
-	name = "box of spare armbands"
-	desc = "If you see this, ahelp."
-
-/obj/item/weapon/storage/box/armband/sec
 	name = "box of spare security armbands"
 	desc = "A box full of security armbands. For use in emergencies when provisional security personnel are needed."
 	startswith = list(/obj/item/clothing/accessory/armband = 5)

--- a/html/changelogs/RedStryker - ArmbandBoxes.yml
+++ b/html/changelogs/RedStryker - ArmbandBoxes.yml
@@ -1,0 +1,6 @@
+author: RedStryker
+
+delete-after: True
+ 
+changes: 
+  - rscadd: "Added boxes of armbands for emergencies to the heads of the Security, Medical, and Engineering departments."

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -39,6 +39,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/folder/yellow,
+		/obj/item/weapon/storage/box/armband/engine,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel_eng)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))
 	)

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -37,6 +37,7 @@
 		/obj/item/weapon/folder/white,
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/storage/firstaid/regular,
+		/obj/item/weapon/storage/box/armband/med,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med)),
 		new /datum/atom_creator/weighted(list(

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -71,7 +71,7 @@
 		/obj/item/weapon/folder/red,
 		/obj/item/device/holowarrant,
 		/obj/item/clothing/gloves/thick,
-		/obj/item/weapon/storage/box/armband/sec,
+		/obj/item/weapon/storage/box/armband,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -71,6 +71,7 @@
 		/obj/item/weapon/folder/red,
 		/obj/item/device/holowarrant,
 		/obj/item/clothing/gloves/thick,
+		/obj/item/weapon/storage/box/armband/sec,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)


### PR DESCRIPTION
I realize this will probably be contentious.

The idea is that these are to be used for emergencies when, for example, there's a single surgeon and no corpsmen, but a few people trained as EMT's who can work during the emergency.  The Head gives them an armband so that they can be ID'd as personnel of that department.
