### PR TITLE
Rebalances Chemistry OD rates

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1003,18 +1003,6 @@
 	glass_name = "The Doctor's Delight"
 	glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place."
 
-/datum/reagent/drink/doctor_delight/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-	if(alien == IS_DIONA)
-		return
-	M.adjustOxyLoss(-4 * removed)
-	M.heal_organ_damage(2 * removed, 2 * removed)
-	M.adjustToxLoss(-2 * removed)
-	if(M.dizziness)
-		M.dizziness = max(0, M.dizziness - 15)
-	if(M.confused)
-		M.confused = max(0, M.confused - 5)
-
 /datum/reagent/drink/dry_ramen
 	name = "Dry Ramen"
 	id = "dry_ramen"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -7,7 +7,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#00BFFF"
-	overdose = REAGENTS_OVERDOSE * 2
+	overdose = REAGENTS_OVERDOSE
 	metabolism = REM * 0.5
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
@@ -32,7 +32,11 @@
 
 /datum/reagent/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(6 * removed, 0)
+		M.heal_organ_damage(6 * removed, 0) // haha holy shit this is OP
+		
+/datum/reagent/bicaridine/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien != IS_DIONA)
+		M.adjustBruteLoss(8)
 
 /datum/reagent/kelotane
 	name = "Kelotane"
@@ -49,6 +53,10 @@
 	if(alien != IS_DIONA)
 		M.heal_organ_damage(0, 6 * removed)
 
+/datum/reagent/kelotane/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien != IS_DIONA)
+		M.adjustBurnLoss(8)
+
 /datum/reagent/dermaline
 	name = "Dermaline"
 	id = "dermaline"
@@ -63,7 +71,11 @@
 
 /datum/reagent/dermaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 12 * removed)
+		M.heal_organ_damage(0, 12 * removed) // jesus h. christ
+
+/datum/reagent/dermaline/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien != IS_DIONA)
+		M.adjustBurnLoss(17) // watch your dosages 'tardlords
 
 /datum/reagent/dylovene
 	name = "Dylovene"
@@ -74,12 +86,17 @@
 	color = "#00A000"
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
+	overdose = REAGENTS_OVERDOSE * 0.5 // "m-muh easy access OD bypass ;_;" - Baystation Players
 
 /datum/reagent/dylovene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		M.drowsyness = max(0, M.drowsyness - 6 * removed)
 		M.hallucination = max(0, M.hallucination - 9 * removed)
 		M.adjustToxLoss(-4 * removed)
+
+/datum/reagent/dylovene/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien != IS_DIONA)
+		M.adjustToxLoss(8)
 
 /datum/reagent/dexalin
 	name = "Dexalin"
@@ -98,26 +115,9 @@
 	else if(alien != IS_DIONA)
 		M.adjustOxyLoss(-15 * removed)
 
-	holder.remove_reagent("lexorin", 2 * removed)
-
-/datum/reagent/dexalinp
-	name = "Dexalin Plus"
-	id = "dexalinp"
-	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective."
-	taste_description = "bitterness"
-	reagent_state = LIQUID
-	color = "#0040FF"
-	overdose = REAGENTS_OVERDOSE * 0.5
-	scannable = 1
-	flags = IGNORE_MOB_SIZE
-
-/datum/reagent/dexalinp/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_VOX)
-		M.adjustToxLoss(removed * 9)
-	else if(alien != IS_DIONA)
-		M.adjustOxyLoss(-300 * removed)
-
-	holder.remove_reagent("lexorin", 3 * removed)
+/datum/reagent/dexalin/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien != IS_DIONA)
+		M.adjustOxyLoss(30) // this seems like a lot but it turns into 15 because it's overpowering the effects from up there ^
 
 /datum/reagent/tricordrazine
 	name = "Tricordrazine"
@@ -128,12 +128,20 @@
 	color = "#8040FF"
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
+	overdose = REAGENTS_OVERDOSE * 0.5
 
 /datum/reagent/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		M.adjustOxyLoss(-6 * removed)
 		M.heal_organ_damage(3 * removed, 3 * removed)
 		M.adjustToxLoss(-3 * removed)
+
+/datum/reagent/tricordrazine/overdose(var/mob/living/carbon/M, var/alien)
+	if(alien != IS_DIONA)
+		M.adjustToxLoss(6)
+		M.adjustBruteLoss(6)
+		M.adjustFireLoss(6)
+		M.adjustOxyLoss(12)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1,3 +1,5 @@
+// this file gave Rich Evans AIDS - Iamgoofball
+
 
 //Chemical Reactions - Initialises all /datum/chemical_reaction into a list
 // It is filtered into multiple lists within a list.
@@ -325,13 +327,6 @@
 	id = "dermaline"
 	result = "dermaline"
 	required_reagents = list("acetone" = 1, "phosphorus" = 1, "kelotane" = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/dexalinp
-	name = "Dexalin Plus"
-	id = "dexalinp"
-	result = "dexalinp"
-	required_reagents = list("dexalin" = 1, "carbon" = 1, "iron" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/bicaridine


### PR DESCRIPTION
:cl: /tg/station13
fix: most healing chems now have overdoses
experimental: doctors delight doesn't heal
/:cl:

All the basic and advanced medical chems have ODs now. No more ignoring ODs completely by stacking tricord and antitox.

ODs now actually bite. Be careful you don't get sued for malpractice. Read your dosage amounts for once.

Dexalin Plus was removed. It was retarded. It makes oxygen loss trivial. It's gone now. You'll be better for it.

Upcoming changes:
removal of Doctor's Delight's healing benefits entirely

Tricord apologists need not comment or you'll have a crying baby pasted at you.

### Side note:

If you want people to take you seriously, you generally need to explain the logic behind your actions or not spew ad-homs about the coder. (only one of the two is needed)

"Denied by head-dev" doesn't cut it.
