### PR TITLE
Small ZAS Optimization

### DIFF
--- a/code/modules/ZAS/ConnectionManager.dm
+++ b/code/modules/ZAS/ConnectionManager.dm
@@ -24,11 +24,15 @@ Class Procs:
 	erase_all()
 		Called when the turf is changed with ChangeTurf(). Erases all existing connections.
 
+Macros:
 	check(connection/c)
 		Checks for connection validity. It's possible to have a reference to a connection that has been erased.
 
 
 */
+
+// macro-ized to cut down on proc calls
+#define check(c) (c && c.valid())
 
 /turf/var/tmp/connection_manager/connections
 
@@ -98,5 +102,4 @@ Class Procs:
 	if(check(D)) D.erase()
 	#endif
 
-/connection_manager/proc/check(connection/c)
-	return c && c.valid()
+#undef check


### PR DESCRIPTION
Minor optimization; eliminates a few proc calls when managing zone connections by turning check() into a macro.

This should be safe; `check()` is only called from within this one file today, and there is no real reason why it would be called from anywhere else in the future either.

I am pretty sure that two datum-var-accesses is still faster than one datum-var-access + proc-call.   Please correct me if I'm wrong.