### PR TITLE
Fixes runtime error in email system

### DIFF
--- a/code/modules/modular_computers/NTNet/emails/email_message.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_message.dm
@@ -13,7 +13,8 @@
 	temp.source = source
 	temp.spam = spam
 	temp.timestamp = timestamp
-	temp.attachment = attachment.clone()
+	if(attachment)
+		temp.attachment = attachment.clone()
 	return temp
 
 


### PR DESCRIPTION
- Runtime error occured when sending an email with attachment to the broadcaster internal service address.
- Fixes #17142 (the actual cause of both problems)
- Fixes #17143 (directly caused by previous error)