### PR TITLE
Fixes the Hull Wrap-mode of the Shield Generator

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -428,12 +428,13 @@
 	for(var/turf/gen_turf in base_turfs)
 		for(var/turf/T in trange(field_radius, gen_turf))
 			// Don't expand to space or on shuttle areas.
-			if(istype(T, /turf/space) || istype(get_area(T), /area/space) || istype(get_area(T), /area/shuttle/))
+			if(istype(T, /turf/space) || istype(get_area(T), /area/shuttle/))
 				continue
 
 			// Find adjacent space/shuttle tiles and cover them. Shuttles won't be blocked if shield diffuser is mapped in and turned on.
 			for(var/turf/TN in orange(1, T))
-				if(istype(TN, /turf/space) || (istype(get_area(TN), /area/shuttle/) && !istype(get_area(TN), /area/turbolift/)))
+				if(((istype(TN, /turf/space) || istype(TN, /turf/simulated/open)) && istype(get_area(TN), /area/space))\
+				 || (istype(get_area(TN), /area/shuttle/) && !istype(get_area(TN), /area/turbolift/)))\
 					. |= TN
 					continue
 

--- a/html/changelogs/Hubblenaut-shieldgen.yml
+++ b/html/changelogs/Hubblenaut-shieldgen.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "The hull wrap mode of the shield generator will now actually cover the entire ship."


### PR DESCRIPTION
Fixes by doing the following:
 - Shields will now be placed on `turf/simulated/open`.
 - Checks for`area/space` when placing the shield rather when checking for hull turfs.

**This effectively means:**
 - Shields will appear on holes in ceiling to space.
 - Shields will not appear on hole in floor to space when indoors.
 - Shields will wrap around structures in space in its radius of influence.

The shield will now completely wrap around the Torch.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
