### PR TITLE
Increases set_light range and strength for constructs

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -257,7 +257,7 @@
 	eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	eye_glow.layer = EYE_GLOW_LAYER
 	overlays += eye_glow
-	set_light(2, -2, l_color = "#FFFFFF")
+	set_light(3, -10, l_color = "#FFFFFF")
 
 ////////////////HUD//////////////////////
 


### PR DESCRIPTION
2, -2 is not sufficient for the changes to the lighting system

For reference, anti-photon grenades are 10, -10