### PR TITLE
Adds subsystem initialization

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -326,6 +326,7 @@
 #include "code\game\atoms.dm"
 #include "code\game\atoms_movable.dm"
 #include "code\game\base_turf.dm"
+#include "code\game\images.dm"
 #include "code\game\periodic_news.dm"
 #include "code\game\response_team.dm"
 #include "code\game\shuttle_engines.dm"

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -149,7 +149,11 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.
+#ifdef UNIT_TEST
+	world.sleep_offline = 0
+#else
 	world.sleep_offline = 1
+#endif
 	world.fps = config.fps
 	var/initialized_tod = REALTIMEOFDAY
 	sleep(1)

--- a/code/controllers/subsystems.dm
+++ b/code/controllers/subsystems.dm
@@ -178,7 +178,7 @@
 		if (SS_SLEEPING)
 			. = "S"
 		if (SS_IDLE)
-			. = "  "
+			. = " "
 
 //could be used to postpone a costly subsystem for (default one) var/cycles, cycles
 //for instance, during cpu intensive operations like explosions

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -6,9 +6,9 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	wait = 5
 	flags = SS_FIRE_IN_LOBBY|SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 
-	var/collection_timeout = 3000// deciseconds to wait to let running procs finish before we just say fuck it and force del() the object
-	var/delslasttick = 0		// number of del()'s we've done this tick
-	var/gcedlasttick = 0		// number of things that gc'ed last tick
+	var/collection_timeout = 3000 // deciseconds to wait to let running procs finish before we just say fuck it and force del() the object
+	var/delslasttick = 0          // number of del()'s we've done this tick
+	var/gcedlasttick = 0          // number of things that gc'ed last tick
 	var/totaldels = 0
 	var/totalgcs = 0
 
@@ -38,18 +38,17 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	NEW_SS_GLOBAL(SSgarbage)
 
 /datum/controller/subsystem/garbage_collector/stat_entry(msg)
-	msg += "Q:[queue.len]|D:[delslasttick]|G:[gcedlasttick]|"
-	msg += "GR:"
-	if (!(delslasttick+gcedlasttick))
-		msg += "n/a|"
-	else
-		msg += "[round((gcedlasttick/(delslasttick+gcedlasttick))*100, 0.01)]%|"
-
-	msg += "TD:[totaldels]|TG:[totalgcs]|"
+	msg += "Q:[queue.len]|TD:[totaldels]|TG:[totalgcs]|TGR:"
 	if (!(totaldels+totalgcs))
-		msg += "n/a|"
+		msg += "n/a"
 	else
-		msg += "TGR:[round((totalgcs/(totaldels+totalgcs))*100, 0.01)]%"
+		msg += "[round((totalgcs/(totaldels+totalgcs))*100, 0.01)]%"
+
+	msg += "|D:[delslasttick]|G:[gcedlasttick]|GR:"
+	if (!(delslasttick+gcedlasttick))
+		msg += "n/a"
+	else
+		msg += "[round((gcedlasttick/(delslasttick+gcedlasttick))*100, 0.01)]%"
 	..(msg)
 
 /datum/controller/subsystem/garbage_collector/fire()
@@ -349,8 +348,3 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 		SearchVar(readglobal(global_var))
 #undef SearchVar
 #endif
-
-
-/image/Destroy()
-	..()
-	return QDEL_HINT_HARDDEL_NOW

--- a/code/game/images.dm
+++ b/code/game/images.dm
@@ -1,0 +1,3 @@
+/image/Destroy()
+	..()
+	return QDEL_HINT_HARDDEL_NOW

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -104,11 +104,14 @@ NOTE: It checks usr by default. Supply the "user" argument if you wish to check 
 		//qdel(holder)
 	return 1
 
-/client/Stat()
+/mob/Stat()
 	. = ..()
-	var/stealth_status = is_stealthed()
-	if(usr && stealth_status && statpanel("Status"))
-		stat("Stealth", "Engaged [holder.stealthy_ == STEALTH_AUTO ? "(Auto)" : "(Manual)"]")
+	if(!client)
+		return
+
+	var/stealth_status = client.is_stealthed()
+	if(stealth_status && statpanel("Status"))
+		stat("Stealth", "Engaged [client.holder.stealthy_ == STEALTH_AUTO ? "(Auto)" : "(Manual)"]")
 
 /client/proc/is_stealthed()
 	if(!holder)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -300,6 +300,18 @@
 	var/seconds = inactivity/10
 	return "[round(seconds / 60)] minute\s, [seconds % 60] second\s"
 
+// Byond seemingly calls stat, each tick.
+// Calling things each tick can get expensive real quick.
+// So we slow this down a little.
+// See: http://www.byond.com/docs/ref/info.html#/client/proc/Stat
+/client/Stat()
+	. = ..()
+	if (holder)
+		sleep(1)
+	else
+		sleep(5)
+		stoplag()
+
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
 

--- a/code/modules/client/preferences_toggle.dm
+++ b/code/modules/client/preferences_toggle.dm
@@ -25,11 +25,11 @@ var/list/client_preference_stats_
 	if(istype(scp))
 		scp.Click()
 
-/client/Stat()
+/mob/Stat()
 	. = ..()
-	if(!mob || !statpanel("Preferences"))
+	if(!client || !statpanel("Preferences"))
 		return
-	var/list/preferences = client_preference_stats_for_usr(mob)
+	var/list/preferences = client_preference_stats_for_usr(src)
 	for(var/client_preference_description in preferences)
 		var/stat_client_preference/scp = client_preference_stats_[client_preference_description]
 		stat(scp.client_preference.description, scp)

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -49,17 +49,17 @@
 	description_holders["icon"] = "\icon[A]"
 	description_holders["desc"] = A.desc
 
-/client/Stat()
+/mob/Stat()
 	. = ..()
-	if(usr && statpanel("Examine"))
-		stat(null,"[description_holders["icon"]]    <font size='5'>[description_holders["name"]]</font>") //The name, written in big letters.
-		stat(null,"[description_holders["desc"]]") //the default examine text.
-		if(description_holders["info"])
-			stat(null,"<font color='#084B8A'><b>[description_holders["info"]]</b></font>") //Blue, informative text.
-		if(description_holders["fluff"])
-			stat(null,"<font color='#298A08'><b>[description_holders["fluff"]]</b></font>") //Yellow, fluff-related text.
-		if(description_holders["antag"])
-			stat(null,"<font color='#8A0808'><b>[description_holders["antag"]]</b></font>") //Red, malicious antag-related text
+	if(client && statpanel("Examine"))
+		stat(null,"[client.description_holders["icon"]]    <font size='5'>[client.description_holders["name"]]</font>") //The name, written in big letters.
+		stat(null,"[client.description_holders["desc"]]") //the default examine text.
+		if(client.description_holders["info"])
+			stat(null,"<font color='#084B8A'><b>[client.description_holders["info"]]</b></font>") //Blue, informative text.
+		if(client.description_holders["fluff"])
+			stat(null,"<font color='#298A08'><b>[client.description_holders["fluff"]]</b></font>") //Yellow, fluff-related text.
+		if(client.description_holders["antag"])
+			stat(null,"<font color='#8A0808'><b>[client.description_holders["antag"]]</b></font>") //Red, malicious antag-related text
 
 //override examinate verb to update description holders when things are examined
 /mob/examinate(atom/A as mob|obj|turf in view())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -621,14 +621,26 @@
 			stat("Round Duration", roundduration2text())
 		if(client.holder || isghost(client.mob))
 			stat("Location:", "([x], [y], [z]) [loc]")
-		if(client.holder)
+
+	if(client.holder)
+		if(statpanel("Processes") && processScheduler)
+			processScheduler.statProcesses()
+		if(statpanel("MC"))
 			stat("CPU:","[world.cpu]")
 			stat("Instances:","[world.contents.len]")
-
-	if(client.holder && statpanel("Processes"))
-		if(processScheduler)
-			processScheduler.statProcesses()
-		sleep(1 SECOND)
+			stat(null)
+			if(Master)
+				Master.stat_entry()
+			else
+				stat("Master Controller:", "ERROR")
+			if(Failsafe)
+				Failsafe.stat_entry()
+			else
+				stat("Failsafe Controller:", "ERROR")
+			if(Master)
+				stat(null)
+				for(var/datum/controller/subsystem/SS in Master.subsystems)
+					SS.stat_entry()
 
 	if(listed_turf && client)
 		if(!TurfAdjacent(listed_turf))

--- a/code/world.dm
+++ b/code/world.dm
@@ -111,11 +111,7 @@
 
 	. = ..()
 
-#ifndef UNIT_TEST
-
-	sleep_offline = 1
-
-#else
+#ifdef UNIT_TEST
 	log_unit_test("Unit Tests Enabled.  This will destroy the world when testing is complete.")
 	load_unit_test_changes()
 #endif
@@ -138,6 +134,9 @@
 
 	processScheduler = new
 	master_controller = new /datum/controller/game_controller()
+
+	Master.Initialize(10, FALSE)
+
 	spawn(1)
 		processScheduler.deferSetupFor(/datum/controller/process/ticker)
 		processScheduler.setup()
@@ -153,8 +152,6 @@
 			ToRban_autoupdate()
 
 #undef RECOMMENDED_VERSION
-
-	return
 
 var/world_topic_spam_protect_ip = "0.0.0.0"
 var/world_topic_spam_protect_time = world.timeofday


### PR DESCRIPTION
Subsystem initialization seems like a handy thing to have.
Is now also correctly kicked at round start.
Fixes #17183.

Also adjusts MC and other stat output (and actually displays the MC stats).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
