### PR TITLE
Comeback of wet floors

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -152,10 +152,10 @@
 
 	else if(volume >= 10)
 		var/turf/simulated/S = T
-		if(!S.wet > 5)
+		if(!S.wet)
 			S.wet_floor(1)
 		else
-			S.wet = round(S.wet * 0.75)
+			S.wet = 1
 
 
 /datum/reagent/water/touch_obj(var/obj/O)

--- a/html/changelogs/Hubblenaut-wetfloor.yml
+++ b/html/changelogs/Hubblenaut-wetfloor.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Lubed floors can be cleaned with water."
+  - bugfix: "Wet floors make a comeback after three months of stealthy disappearance."


### PR DESCRIPTION
 - Fixes mistake in code that prevented water from wetting turfs.
 - Will get rid of lubed floors immediately opposed to removing one fourth of the remaining lube each time. Because how would someone know anything changed at all. :I

Makes custodial fun again.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
