### PR TITLE
Virus stuff

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1312,6 +1312,7 @@
 #include "code\modules\events\sensor_suit_jamming.dm"
 #include "code\modules\events\shipping_error.dm"
 #include "code\modules\events\solar_storm.dm"
+#include "code\modules\events\space_cold.dm"
 #include "code\modules\events\spacevine.dm"
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"

--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -35,6 +35,7 @@
 #define CE_SPEEDBOOST "gofast" // Hyperzine
 #define CE_PULSE      "xcardic" // increases or decreases heart rate
 #define CE_NOPULSE    "heartstop" // stops heartbeat
+#define CE_ANTIVIRAL    "antiviral" // suppresses effects of virus effects
 
 //reagent flags
 #define IGNORE_MOB_SIZE 0x1

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -192,3 +192,9 @@
 
 #define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
 
+//Virus badness defines
+#define VIRUS_MILD			1
+#define VIRUS_COMMON		2	//Random events don't go higher (mutations aside)
+#define VIRUS_ENGINEERED	3
+#define VIRUS_EXOTIC		4	//Usually adminbus only
+

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -297,7 +297,8 @@
 		"lung_ruptured" = H.is_lung_ruptured(),
 		"external_organs" = H.organs.Copy(),
 		"internal_organs" = H.internal_organs.Copy(),
-		"species_organs" = H.species.has_organ //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
+		"species_organs" = H.species.has_organ, //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
+		"immunity" = round(H.virus_immunity()*100)
 		)
 	return occupant_data
 
@@ -326,6 +327,7 @@
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", ("<font color='[occ["brainloss"] < 1  ? "blue" : "red"]'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))
 	dat += text("Body Temperature: [occ["bodytemp"]-T0C]&deg;C ([occ["bodytemp"]*1.8-459.67]&deg;F)<br><HR>")
+	dat += "<font color='[occ["immunity"] > 25  ? "black" : "red"]'>Antibody levels and immune system perfomance are at [occ["immunity"] ]% of baseline.</font>"
 
 	if(occ["borer_present"])
 		dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -127,6 +127,9 @@ REAGENT SCANNER
 					++unknown
 			if(unknown)
 				to_chat(user, "<span class='warning'>Non-medical reagent[(unknown > 1)?"s":""] found in subject's stomach.</span>")
+		var/immunity = round(C.virus_immunity()*100)
+		if(immunity < 25)
+			user.show_message("<span class='warning'>Extremely low antibody levels - [immunity]% of baseline.</span>")
 		if(C.virus2.len)
 			for (var/ID in C.virus2)
 				if (ID in virusDB)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -30,7 +30,8 @@
 		/obj/item/device/healthanalyzer,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
 		/obj/item/stack/medical/ointment,
-		/obj/item/weapon/reagent_containers/pill/kelotane = 3,
+		/obj/item/weapon/storage/pill_bottle/kelotane,
+		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
 
 /obj/item/weapon/storage/firstaid/fire/New()
@@ -45,7 +46,13 @@
 		/obj/item/stack/medical/ointment = 2,
 		/obj/item/device/healthanalyzer,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
+		/obj/item/weapon/storage/pill_bottle/antidexafen,
+		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
+
+/obj/item/weapon/storage/firstaid/regular/New()
+	..()
+	make_exact_fit()
 
 /obj/item/weapon/storage/firstaid/toxin
 	name = "toxin first aid"
@@ -55,7 +62,7 @@
 
 	startswith = list(
 		/obj/item/weapon/reagent_containers/syringe/antitoxin = 3,
-		/obj/item/weapon/reagent_containers/pill/antitox = 3,
+		/obj/item/weapon/storage/pill_bottle/antitox,
 		/obj/item/device/healthanalyzer,
 		)
 
@@ -70,7 +77,7 @@
 	item_state = "firstaid-o2"
 
 	startswith = list(
-		/obj/item/weapon/reagent_containers/pill/dexalin = 4,
+		/obj/item/weapon/storage/pill_bottle/dexalin,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
 		/obj/item/weapon/reagent_containers/syringe/inaprovaline,
 		/obj/item/device/healthanalyzer,
@@ -87,7 +94,12 @@
 		/obj/item/stack/medical/advanced/bruise_pack = 3,
 		/obj/item/stack/medical/advanced/ointment = 2,
 		/obj/item/stack/medical/splint,
+		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
+
+/obj/item/weapon/storage/firstaid/adv/New()
+	..()
+	make_exact_fit()
 
 /obj/item/weapon/storage/firstaid/combat
 	name = "combat medical kit"
@@ -177,6 +189,12 @@
 
 	startswith = list(/obj/item/weapon/reagent_containers/pill/dexalin_plus = 7)
 
+/obj/item/weapon/storage/pill_bottle/dexalin
+	name = "bottle of Dexalin pills"
+	desc = "Contains pills used to treat oxygen deprivation."
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/dexalin = 7)
+
 /obj/item/weapon/storage/pill_bottle/dermaline
 	name = "bottle of Dermaline pills"
 	desc = "Contains pills used to treat burn wounds."
@@ -231,3 +249,15 @@
 	desc = "High-strength antidepressant. Only for use in severe depression. 10u dose per pill. <span class='warning'>WARNING: side-effects may include hallucinations.</span>"
 
 	startswith = list(/obj/item/weapon/reagent_containers/pill/paroxetine = 7)
+
+/obj/item/weapon/storage/pill_bottle/antidexafen
+	name = "bottle of cold medicine pills"
+	desc = "All-in-one cold medicine. 10u dose per pill. Safe for babies like you!"
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/antidexafen = 7)
+
+/obj/item/weapon/storage/pill_bottle/paracetamol
+	name = "bottle of paracetamol"
+	desc = "Mild painkiller, also known as Tylenol. Won't fix the cause of your headache (unlike cyanide), but might make it bearable."
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/paracetamol = 7)

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -157,6 +157,8 @@
 	item_to_spawn()
 		return pick(prob(4);/obj/item/stack/medical/bruise_pack,\
 					prob(4);/obj/item/stack/medical/ointment,\
+					prob(2);/obj/item/weapon/storage/pill_bottle/antidexafen,\
+					prob(2);/obj/item/weapon/storage/pill_bottle/paracetamol,\
 					prob(2);/obj/item/stack/medical/advanced/bruise_pack,\
 					prob(2);/obj/item/stack/medical/advanced/ointment,\
 					prob(1);/obj/item/stack/medical/splint,\

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -142,6 +142,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Electrical Storm",	/datum/event/electrical_storm, 	20,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 100)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Cold Outbreak",/datum/event/space_cold,		100,	list(ASSIGNMENT_MEDICAL = 20)),
 	)
 
 /datum/event_container/moderate

--- a/code/modules/events/space_cold.dm
+++ b/code/modules/events/space_cold.dm
@@ -1,0 +1,18 @@
+datum/event/space_cold/start()
+	var/list/candidates = list()	//list of candidate keys
+	for(var/mob/living/carbon/human/G in player_list)
+		if(G.client && G.stat != DEAD && !G.species.get_virus_immune(G))
+			candidates += G
+
+	if(!candidates.len)
+		return
+
+	var/datum/disease2/disease/sniffle = new
+	sniffle.max_stage = 3
+	sniffle.makerandom(1)
+	sniffle.spreadtype = "Airborne"
+
+	var/victims = min(rand(1,3), candidates.len)
+	while(victims)
+		infect_virus2(pick_n_take(candidates),sniffle,1)
+		victims--

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -321,7 +321,7 @@
 /mob/living/carbon/human/handle_post_breath(datum/gas_mixture/breath)
 	..()
 	//spread some viruses while we are at it
-	if(breath && virus2.len > 0 && prob(10))
+	if(breath && !internal && virus2.len > 0 && prob(10))
 		for(var/mob/living/carbon/M in view(1,src))
 			src.spread_disease_to(M)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -144,12 +144,12 @@ var/list/organ_cache = list()
 	//** Handle the effects of infections
 	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
 
-	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
+	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(owner.virus_immunity()*0.3))
 		germ_level--
 
 	if (germ_level >= INFECTION_LEVEL_ONE/2)
 		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes
-		if(antibiotics < 5 && prob(round(germ_level/6)))
+		if(antibiotics < 5 && prob(round(germ_level/6 * owner.immunity_weakness() * 0.01)))
 			germ_level++
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
@@ -159,7 +159,7 @@ var/list/organ_cache = list()
 	if (germ_level >= INFECTION_LEVEL_TWO)
 		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 		//spread germs
-		if (antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30) ))
+		if (antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(owner.immunity_weakness() * 0.3) ))
 			parent.germ_level++
 
 		if (prob(3))	//about once every 30 seconds
@@ -168,6 +168,8 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/handle_rejection()
 	// Process unsuitable transplants. TODO: consider some kind of
 	// immunosuppressant that changes transplant data to make it match.
+	if(owner.virus_immunity() < 10) //for now just having shit immunity will suppress it
+		return
 	if(dna)
 		if(!rejecting)
 			if(blood_incompatible(dna.b_type, owner.dna.b_type, species, owner.species))

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -178,6 +178,21 @@
 	organ_tag = BP_APPENDIX
 	var/inflamed = 0
 
+/obj/item/organ/internal/appendix/removed(var/mob/living/user, var/drop_organ=1, var/detach=1)
+	if(owner)
+		owner.immunity_norm -= 10
+	..()
+
+/obj/item/organ/internal/appendix/replaced(var/mob/living/carbon/human/target, var/obj/item/organ/external/affected)
+	..()
+	if(owner)
+		owner.immunity_norm += 10
+
+/obj/item/organ/internal/appendix/New(var/mob/living/carbon/holder)
+	..()
+	if(owner)
+		owner.immunity_norm += 10
+
 /obj/item/organ/internal/appendix/update_icon()
 	..()
 	if(inflamed)
@@ -186,7 +201,10 @@
 
 /obj/item/organ/internal/appendix/process()
 	..()
-	if(inflamed && owner)
+	if(!owner)
+		return
+	owner.immunity = min(owner.immunity + 0.025, owner.immunity_norm)
+	if(inflamed)
 		inflamed++
 		if(prob(5))
 			if(owner.can_feel_pain())

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -441,7 +441,7 @@
 // Juices
 /datum/reagent/drink/juice/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
-
+	M.immunity = min(M.immunity + 0.25, M.immunity_norm*1.5)
 	var/effective_dose = dose/2
 	if(alien == IS_UNATHI)
 		if(effective_dose < 2)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -414,9 +414,25 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#C1C1C1"
-	metabolism = REM * 0.05
-	overdose = REAGENTS_OVERDOSE
+	metabolism = REM * 0.1
+	overdose = REAGENTS_OVERDOSE/2
 	scannable = 1
+
+/datum/reagent/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.immunity = max(M.immunity - 0.1, 0)
+	M.add_chemical_effect(CE_ANTIVIRAL, VIRUS_COMMON)
+	if(volume > 10)
+		M.immunity = max(M.immunity - 0.3, 0)
+		M.add_chemical_effect(CE_ANTIVIRAL, VIRUS_ENGINEERED)
+	if(dose > 15)
+		M.immunity = max(M.immunity - 0.25, 0)
+
+/datum/reagent/spaceacillin/overdose(var/mob/living/carbon/M, var/alien)
+	..()
+	M.immunity = max(M.immunity - 0.25, 0)
+	M.add_chemical_effect(CE_ANTIVIRAL, VIRUS_EXOTIC)
+	if(prob(2))
+		M.immunity_norm = max(M.immunity_norm - 1, 0)
 
 /datum/reagent/sterilizine
 	name = "Sterilizine"
@@ -612,3 +628,23 @@
 
 	if(alien != IS_DIONA)
 		M.make_jittery(-50)
+
+/datum/reagent/antidexafen
+	name = "Antidexafen"
+	id = "antidexafen"
+	description = "All-in-one cold medicine. Fever, cough, sneeze, safe for babies."
+	taste_description = "cough syrup"
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	overdose = 60
+	scannable = 1
+	metabolism = 0.02
+	flags = IGNORE_MOB_SIZE
+
+/datum/reagent/antidexafen/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_PAINKILLER, 15)
+	M.add_chemical_effect(CE_ANTIVIRAL, 1)
+
+/datum/reagent/antidexafen/overdose(var/mob/living/carbon/M, var/alien)
+	..()
+	M.hallucination = max(M.hallucination, 2)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2202,3 +2202,10 @@
 	var/turf/T = get_turf(holder.my_atom)
 	if(istype(T)) new /obj/item/stack/material/deuterium(T, created_volume)
 	return
+
+/datum/chemical_reaction/antidexafen
+	name = "Antidexafen"
+	id = "antidexafen"
+	result = "antidexafen"
+	required_reagents = list("paracetamol" = 1, "sugar" = 1)
+	result_amount = 2

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -270,3 +270,14 @@ obj/item/weapon/reagent_containers/pill/noexcutite/New()
 /obj/item/weapon/reagent_containers/pill/paroxetine/New()
 		..()
 		reagents.add_reagent("paroxetine", 10)
+
+/obj/item/weapon/reagent_containers/pill/antidexafen
+	name = "cold medicine pill"
+	desc = "Safe for babies!"
+	icon_state = "pill20"
+
+/obj/item/weapon/reagent_containers/pill/antidexafen/New()
+		..()
+		reagents.add_reagent("antidexafen", 10)
+		reagents.add_reagent("lemonjuice", 5)
+		reagents.add_reagent("menthol", REM*0.2)

--- a/code/modules/virus2/admin.dm
+++ b/code/modules/virus2/admin.dm
@@ -9,16 +9,16 @@
 		to_chat(usr, "Infection chance: [infectionchance]; Speed: [speed]; Spread type: [spreadtype]")
 		to_chat(usr, "Affected species: [english_list(affected_species)]")
 		to_chat(usr, "Effects:")
-		for(var/datum/disease2/effectholder/E in effects)
-			to_chat(usr, "[E.stage]: [E.effect.name]; chance=[E.chance]; multiplier=[E.multiplier]")
+		for(var/datum/disease2/effect/E in effects)
+			to_chat(usr, "[E.stage]: [E.name]; chance=[E.chance]; multiplier=[E.multiplier]")
 		to_chat(usr, "Antigens: [antigens2string(antigen)]")
 
 		return 1
 
 /datum/disease2/disease/get_view_variables_header()
 	. = list()
-	for(var/datum/disease2/effectholder/E in effects)
-		. += "[E.stage]: [E.effect.name]"
+	for(var/datum/disease2/effect/E in effects)
+		. += "[E.stage]: [E.name]"
 	return {"
 		<b>[name()]</b><br><font size=1>
 		[jointext(., "<br>")]</font>
@@ -124,17 +124,17 @@
 					if(!E) return
 					s[stage] = E
 					// set a default chance and multiplier of half the maximum (roughly average)
-					s_chance[stage] = max(1, round(initial(E.chance_maxm)/2))
-					s_multiplier[stage] = max(1, round(initial(E.maxm)/2))
+					s_chance[stage] = max(1, round(initial(E.chance_max)/2))
+					s_multiplier[stage] = max(1, round(initial(E.multiplier_max)/2))
 				else if(href_list["chance"])
 					var/datum/disease2/effect/Eff = s[stage]
-					var/I = input("Chance, per tick, of this effect happening (min 0, max [initial(Eff.chance_maxm)])", "Effect Chance", s_chance[stage]) as null|num
-					if(I == null || I < 0 || I > initial(Eff.chance_maxm)) return
+					var/I = input("Chance, per tick, of this effect happening (min 0, max [initial(Eff.chance_max)])", "Effect Chance", s_chance[stage]) as null|num
+					if(I == null || I < 0 || I > initial(Eff.chance_max)) return
 					s_chance[stage] = I
 				else if(href_list["multiplier"])
 					var/datum/disease2/effect/Eff = s[stage]
-					var/I = input("Multiplier for this effect (min 1, max [initial(Eff.maxm)])", "Effect Multiplier", s_multiplier[stage]) as null|num
-					if(I == null || I < 1 || I > initial(Eff.maxm)) return
+					var/I = input("Multiplier for this effect (min 1, max [initial(Eff.multiplier_max)])", "Effect Multiplier", s_multiplier[stage]) as null|num
+					if(I == null || I < 1 || I > initial(Eff.multiplier_max)) return
 					s_multiplier[stage] = I
 			if("species")
 				if(href_list["toggle"])
@@ -196,10 +196,10 @@
 				D.affected_species = species
 				D.speed = speed
 				for(var/i in 1 to 4)
-					var/datum/disease2/effectholder/E = new
+					var/datum/disease2/effect/E = new
 					var/Etype = s[i]
-					E.effect = new Etype()
-					E.effect.generate()
+					E = new Etype()
+					E.generate()
 					E.chance = s_chance[i]
 					E.multiplier = s_multiplier[i]
 					E.stage = i

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -3,11 +3,10 @@
 	var/speed = 1
 	var/spreadtype = "Contact" // Can also be "Airborne"
 	var/stage = 1
-	var/stageprob = 10
 	var/dead = 0
 	var/clicks = 0
 	var/uniqueID = 0
-	var/list/datum/disease2/effectholder/effects = list()
+	var/list/datum/disease2/effect/effects = list()
 	var/antigen = list() // 16 bits describing the antigens, when one bit is set, a cure with that bit can dock here
 	var/max_stage = 4
 	var/list/affected_species = list(SPECIES_HUMAN,SPECIES_UNATHI,SPECIES_SKRELL,SPECIES_TAJARA)
@@ -16,19 +15,17 @@
 	uniqueID = rand(0,10000)
 	..()
 
-/datum/disease2/disease/proc/makerandom(var/severity=1)
+/datum/disease2/disease/proc/makerandom(var/severity=2)
 	var/list/excludetypes = list()
 	for(var/i=1 ; i <= max_stage ; i++ )
-		var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder
-		holder.stage = i
-		holder.getrandomeffect(severity, excludetypes)
-		excludetypes += holder.effect.type
-		effects += holder
+		var/datum/disease2/effect/E = get_random_virus2_effect(i, severity, excludetypes)
+		E.stage = i
+		if(!E.allow_multiple)
+			excludetypes += E.type
+		effects += E
 	uniqueID = rand(0,10000)
 	switch(severity)
-		if(1)
-			infectionchance = 1
-		if(2)
+		if(1,2)
 			infectionchance = rand(10,20)
 		else
 			infectionchance = rand(60,90)
@@ -45,33 +42,32 @@
 	var/list/res = list()
 	for (var/specie in all_species)
 		var/datum/species/S = all_species[specie]
-		if(!S.get_virus_immune())
+		if((S.spawn_flags & SPECIES_CAN_JOIN) && !S.get_virus_immune() && !S.greater_form)
 			meat += S
 	if(meat.len)
 		var/num = rand(1,meat.len)
 		for(var/i=0,i<num,i++)
 			var/datum/species/picked = pick_n_take(meat)
 			res |= picked.name
-			if(picked.greater_form)
-				res |= picked.greater_form
 			if(picked.primitive_form)
 				res |= picked.primitive_form
 	return res
 
-/datum/disease2/disease/proc/activate(var/mob/living/carbon/mob)
+/datum/disease2/disease/proc/process(var/mob/living/carbon/human/mob)
 	if(dead)
 		cure(mob)
 		return
 
-	if(mob.stat == 2)
+	if(mob.stat == DEAD)
 		return
+
 	if(stage <= 1 && clicks == 0) 	// with a certain chance, the mob may become immune to the disease before it starts properly
-		if(prob(5))
-			mob.antibodies |= antigen // 20% immunity is a good chance IMO, because it allows finding an immune person easily
+		if(prob(mob.virus_immunity() * 0.05))
+			cure(mob, 1)
+			return
 
 	// Some species are flat out immune to organic viruses.
-	var/mob/living/carbon/human/H = mob
-	if(istype(H) && H.species.get_virus_immune(H))
+	if(mob.species.get_virus_immune(mob))
 		cure(mob)
 		return
 
@@ -79,67 +75,76 @@
 		if(prob(1))
 			majormutate()
 
-	//Space antibiotics stop disease completely
-	if(mob.reagents.has_reagent("spaceacillin"))
+	if(prob(mob.virus_immunity()) && prob(stage)) // Increasing chance of curing as the virus progresses
+		cure(mob,1)
+	//Waiting out the disease the old way
+	if(stage == max_stage && clicks > max(stage*100, 300))
+		if(prob(mob.virus_immunity() * 0.05 + 100-infectionchance))
+			cure(mob, 1)
+
+	var/top_badness = 1
+	for(var/datum/disease2/effect/e in effects)
+		if(e.stage == stage)
+			top_badness = max(top_badness, e.badness)
+
+	//Space antibiotics might stop disease completely
+	if(mob.chem_effects[CE_ANTIVIRAL] > top_badness)
 		if(stage == 1 && prob(20))
-			src.cure(mob)
+			cure(mob)
 		return
 
+	clicks += speed
 	//Virus food speeds up disease progress
 	if(mob.reagents.has_reagent("virusfood"))
-		mob.reagents.remove_reagent("virusfood",0.1)
+		mob.reagents.remove_reagent("virusfood", REM)
 		clicks += 10
 
-	if(prob(1) && prob(stage)) // Increasing chance of curing as the virus progresses
-		src.cure(mob)
-		mob.antibodies |= src.antigen
-
 	//Moving to the next stage
-	if(clicks > max(stage*100, 200) && prob(10))
-		if((stage <= max_stage) && prob(20)) // ~60% of viruses will be cured by the end of S4 with this
-			src.cure(mob)
-			mob.antibodies |= src.antigen
-		stage++
-		clicks = 0
+	if(clicks > max(stage*100, 300))
+		if(stage < max_stage && prob(10))
+			stage++
+			clicks = 0
 
 	//Do nasty effects
-	for(var/datum/disease2/effectholder/e in effects)
-		if(prob(33))
-			e.runeffect(mob,stage)
-
-	//Short airborne spread
-	if(src.spreadtype == "Airborne")
-		for(var/mob/living/carbon/M in oview(1,mob))
-			if(airborne_can_reach(get_turf(mob), get_turf(M)))
-				infect_virus2(M,src)
+	for(var/datum/disease2/effect/e in effects)
+		e.fire(mob,stage)
 
 	//fever
-	mob.bodytemperature = max(mob.bodytemperature, min(310+5*min(stage,max_stage) ,mob.bodytemperature+5*min(stage,max_stage)))
-	clicks+=speed
+	if(!mob.chem_effects[CE_ANTIVIRAL])
+		mob.bodytemperature = max(mob.bodytemperature, min(310+5*min(stage,max_stage) ,mob.bodytemperature+5*min(stage,max_stage)))
 
-/datum/disease2/disease/proc/cure(var/mob/living/carbon/mob)
-	for(var/datum/disease2/effectholder/e in effects)
-		e.effect.deactivate(mob)
+/datum/disease2/disease/proc/cure(var/mob/living/carbon/mob, antigen)
+	for(var/datum/disease2/effect/e in effects)
+		e.deactivate(mob)
 	mob.virus2.Remove("[uniqueID]")
+	if(antigen)
+		mob.antibodies |= antigen
+
 	BITSET(mob.hud_updateflag, STATUS_HUD)
 
 /datum/disease2/disease/proc/minormutate()
-	//uniqueID = rand(0,10000)
-	var/datum/disease2/effectholder/holder = pick(effects)
-	holder.minormutate()
-	//infectionchance = min(50,infectionchance + rand(0,10))
+	var/datum/disease2/effect/E = pick(effects)
+	E.minormutate()
 
-/datum/disease2/disease/proc/majormutate()
+/datum/disease2/disease/proc/majormutate(badness = VIRUS_ENGINEERED)
 	uniqueID = rand(0,10000)
-	var/datum/disease2/effectholder/holder = pick(effects)
+	var/datum/disease2/effect/E = pick(effects)
 	var/list/exclude = list()
-	for(var/datum/disease2/effectholder/D in effects)
-		if(D != holder)
-			exclude += D.effect.type
-	holder.majormutate(exclude)
+	for(var/datum/disease2/effect/D in effects)
+		if(D != E)
+			exclude += D.type
+
+	var/effect_stage = E.stage
+	E.deactivate()
+	effects -= E
+	qdel(E)
+
+	effects += get_random_virus2_effect(effect_stage, badness, exclude)
+
 	if (prob(5))
 		antigen = list(pick(ALL_ANTIGENS))
 		antigen |= pick(ALL_ANTIGENS)
+
 	if (prob(5) && all_species.len)
 		affected_species = get_infectable_species()
 
@@ -147,39 +152,32 @@
 	var/datum/disease2/disease/disease = new /datum/disease2/disease
 	disease.infectionchance = infectionchance
 	disease.spreadtype = spreadtype
-	disease.stageprob = stageprob
+	disease.speed = speed
 	disease.antigen   = antigen
 	disease.uniqueID = uniqueID
 	disease.affected_species = affected_species.Copy()
-	for(var/datum/disease2/effectholder/holder in effects)
-		var/datum/disease2/effectholder/newholder = new /datum/disease2/effectholder
-		newholder.effect = new holder.effect.type
-		newholder.effect.generate(holder.effect.data)
-		newholder.chance = holder.chance
-		newholder.cure = holder.cure
-		newholder.multiplier = holder.multiplier
-		newholder.happensonce = holder.happensonce
-		newholder.stage = holder.stage
-		disease.effects += newholder
+	for(var/datum/disease2/effect/effect in effects)
+		var/datum/disease2/effect/neweffect = new effect.type
+		neweffect.generate(effect.data)
+		neweffect.chance = effect.chance
+		neweffect.multiplier = effect.multiplier
+		neweffect.oneshot = effect.oneshot
+		neweffect.stage = effect.stage
+		disease.effects += neweffect
 	return disease
 
 /datum/disease2/disease/proc/issame(var/datum/disease2/disease/disease)
+	. = 1
+
 	var/list/types = list()
-	var/list/types2 = list()
-	for(var/datum/disease2/effectholder/d in effects)
-		types += d.effect.type
-	var/equal = 1
-
-	for(var/datum/disease2/effectholder/d in disease.effects)
-		types2 += d.effect.type
-
-	for(var/type in types)
-		if(!(type in types2))
-			equal = 0
+	for(var/datum/disease2/effect/d in effects)
+		types += d.type
+	for(var/datum/disease2/effect/d in disease.effects)
+		if(!(d.type in types))
+			return 0
 
 	if (antigen != disease.antigen)
-		equal = 0
-	return equal
+		return 0
 
 /proc/virus_copylist(var/list/datum/disease2/disease/viruses)
 	var/list/res = list()
@@ -199,8 +197,8 @@ var/global/list/virusDB = list()
 
 /datum/disease2/disease/proc/get_basic_info()
 	var/t = ""
-	for(var/datum/disease2/effectholder/E in effects)
-		t += ", [E.effect.name]"
+	for(var/datum/disease2/effect/E in effects)
+		t += ", [E.name]"
 	return "[name()] ([copytext(t,3)])"
 
 /datum/disease2/disease/proc/get_info()
@@ -209,13 +207,13 @@ var/global/list/virusDB = list()
 	<u>Designation:</u> [name()]<br>
 	<u>Antigen:</u> [antigens2string(antigen)]<br>
 	<u>Transmitted By:</u> [spreadtype]<br>
-	<u>Rate of Progression:</u> [stageprob * 10]<br>
+	<u>Rate of Progression:</u> [speed * 100]%<br>
 	<u>Species Affected:</u> [jointext(affected_species, ", ")]<br>
 "}
 
 	r += "<u>Symptoms:</u><br>"
-	for(var/datum/disease2/effectholder/E in effects)
-		r += "([E.stage]) [E.effect.name]    "
+	for(var/datum/disease2/effect/E in effects)
+		r += "([E.stage]) [E.name]    "
 		r += "<small><u>Strength:</u> [E.multiplier >= 3 ? "Severe" : E.multiplier > 1 ? "Above Average" : "Average"]    "
 		r += "<u>Verosity:</u> [E.chance * 15]</small><br>"
 
@@ -233,30 +231,6 @@ var/global/list/virusDB = list()
 	virusDB["[uniqueID]"] = v
 	return 1
 
-proc/virus2_lesser_infection()
-	var/list/candidates = list()	//list of candidate keys
-
-	for(var/mob/living/carbon/human/G in player_list)
-		if(G.client && G.stat != DEAD)
-			candidates += G
-
-	if(!candidates.len)	return
-
-	candidates = shuffle(candidates)
-
-	infect_mob_random_lesser(candidates[1])
-
-proc/virus2_greater_infection()
-	var/list/candidates = list()	//list of candidate keys
-
-	for(var/mob/living/carbon/human/G in player_list)
-		if(G.client && G.stat != DEAD)
-			candidates += G
-	if(!candidates.len)	return
-
-	candidates = shuffle(candidates)
-
-	infect_mob_random_greater(candidates[1])
 
 proc/virology_letterhead(var/report_name)
 	return {"
@@ -266,8 +240,8 @@ proc/virology_letterhead(var/report_name)
 "}
 
 /datum/disease2/disease/proc/can_add_symptom(type)
-	for(var/datum/disease2/effectholder/H in effects)
-		if(H.effect.type == type)
+	for(var/datum/disease2/effect/H in effects)
+		if(H.type == type && !H.allow_multiple)
 			return 0
 
 	return 1

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -1,133 +1,117 @@
-/datum/disease2/effectholder
-	var/name = "Holder"
-	var/datum/disease2/effect/effect
-	var/chance = 0 //Chance in percentage each tick
-	var/cure = "" //Type of cure it requires
-	var/happensonce = 0
-	var/multiplier = 1 //The chance the effects are WORSE
-	var/stage = 0
-
-/datum/disease2/effectholder/proc/runeffect(var/mob/living/carbon/human/mob,var/stage)
-	if(happensonce > -1 && effect.stage <= stage && prob(chance))
-		effect.activate(mob, multiplier)
-		if(happensonce == 1)
-			happensonce = -1
-
-/datum/disease2/effectholder/proc/getrandomeffect(var/badness = 1, exclude_types=list())
-	var/list/datum/disease2/effect/list = list()
-	for(var/e in (typesof(/datum/disease2/effect) - /datum/disease2/effect))
-		var/datum/disease2/effect/f = e
-		if(e in exclude_types)
-			continue
-		if(initial(f.badness) > badness)	//we don't want such strong effects
-			continue
-		if(initial(f.stage) <= src.stage)
-			list += f
-	var/type = pick(list)
-	effect = new type()
-	effect.generate()
-	chance = rand(0,effect.chance_maxm)
-	multiplier = rand(1,effect.maxm)
-
-/datum/disease2/effectholder/proc/minormutate()
-	switch(pick(1,2,3,4,5))
-		if(1)
-			chance = rand(0,effect.chance_maxm)
-		if(2)
-			multiplier = rand(1,effect.maxm)
-
-/datum/disease2/effectholder/proc/majormutate(exclude_types=list())
-	getrandomeffect(3, exclude_types)
-
 ////////////////////////////////////////////////////////////////
 ////////////////////////EFFECTS/////////////////////////////////
 ////////////////////////////////////////////////////////////////
+/proc/get_random_virus2_effect(stage, badness, exclude)
+	var/list/datum/disease2/effect/candidates = list()
+	for(var/T in subtypesof(/datum/disease2/effect))
+		var/datum/disease2/effect/E = T
+		if(E in exclude)
+			continue
+		if(initial(E.badness) > badness)	//we don't want such strong effects
+			continue
+		if(initial(E.stage) <= stage)
+			candidates += T
+	var/type = pick(candidates)
+	var/datum/disease2/effect/effect = new type
+	effect.generate()
+	effect.chance = rand(0,effect.chance_max)
+	effect.multiplier = rand(1,effect.multiplier_max)
+	return effect
 
 /datum/disease2/effect
-	var/chance_maxm = 50 //note that disease effects only proc once every 3 ticks for humans
 	var/name = "Blanking effect"
-	var/stage = 4
-	var/maxm = 1
-	var/badness = 1
-	var/data = null // For semi-procedural effects; this should be generated in generate() if used
+	var/chance			//probality to fire every tick
+	var/chance_max = 50
+	var/multiplier = 1	//effect magnitude multiplier
+	var/multiplier_max = 1
+	var/stage = 4		//minimal stage
+	var/badness = VIRUS_MILD	//Used in random generation to limit how bad result should come out.
+	var/data = null 	//For semi-procedural effects; this should be generated in generate() if used
+	var/oneshot
+	var/delay = 5 SECONDS	//minimal time between activations
+	var/hold_until		//can only fire after this worldtime
+	var/allow_multiple	//allow to have more than 1 effect of this type in the same virus
 
-	proc/activate(var/mob/living/carbon/mob,var/multiplier)
-	proc/deactivate(var/mob/living/carbon/mob)
-	proc/generate(copy_data) // copy_data will be non-null if this is a copy; it should be used to initialise the data for this effect if present
+/datum/disease2/effect/proc/fire(var/mob/living/carbon/human/mob,var/current_stage)
+	if(oneshot == -1)
+		return
+	if(hold_until > world.time)
+		return
+	if(mob.chem_effects[CE_ANTIVIRAL] >= badness)
+		return
+	if(stage <= current_stage && prob(chance))
+		hold_until = world.time + delay
+		activate(mob)
+		if(oneshot == 1)
+			oneshot = -1
+
+/datum/disease2/effect/proc/minormutate()
+	switch(pick(1,2,3,4,5))
+		if(1)
+			chance = rand(0,chance_max)
+		if(2)
+			multiplier = rand(1,multiplier_max)
+
+/datum/disease2/effect/proc/activate(var/mob/living/carbon/human/mob)
+/datum/disease2/effect/proc/deactivate(var/mob/living/carbon/human/mob)
+/datum/disease2/effect/proc/generate(copy_data) // copy_data will be non-null if this is a copy; it should be used to initialise the data for this effect if present
 
 /datum/disease2/effect/invisible
 	name = "Waiting Syndrome"
 	stage = 1
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		return
 
 ////////////////////////STAGE 4/////////////////////////////////
-
-/datum/disease2/effect/nothing
-	name = "Nil Syndrome"
-	stage = 4
-	badness = 1
-	chance_maxm = 0
 
 /datum/disease2/effect/gibbingtons
 	name = "Gibbingtons Syndrome"
 	stage = 4
-	badness = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_EXOTIC
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		// Probabilities have been tweaked to kill in ~2-3 minutes, giving 5-10 messages.
 		// Probably needs more balancing, but it's better than LOL U GIBBED NOW, especially now that viruses can potentially have no signs up until Gibbingtons.
 		mob.adjustBruteLoss(10*multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			var/obj/item/organ/external/O = pick(H.organs)
-			if(prob(25))
-				to_chat(mob, "<span class='warning'>Your [O.name] feels as if it might burst!</span>")
-			if(prob(10))
-				spawn(50)
-					if(O)
-						O.droplimb(0,DROPLIMB_BLUNT)
-		else
-			if(prob(75))
-				to_chat(mob, "<span class='warning'>Your whole body feels like it might fall apart!</span>")
-			if(prob(10))
-				mob.adjustBruteLoss(25*multiplier)
+		var/obj/item/organ/external/O = pick(mob.organs)
+		if(prob(25))
+			to_chat(mob, "<span class='warning'>Your [O.name] feels as if it might burst!</span>")
+		if(prob(10))
+			spawn(50)
+				if(O)
+					O.droplimb(0,DROPLIMB_BLUNT)
 
 /datum/disease2/effect/radian
 	name = "Radian's Syndrome"
 	stage = 4
-	maxm = 3
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	multiplier_max = 3
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.apply_effect(2*multiplier, IRRADIATE, blocked = 0)
 
 /datum/disease2/effect/deaf
 	name = "Dead Ear Syndrome"
 	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.ear_deaf += 20
 
 /datum/disease2/effect/monkey
-	name = "Monkism Syndrome"
+	name = "Two Percent Syndrome"
 	stage = 4
-	badness = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob,/mob/living/carbon/human))
-			var/mob/living/carbon/human/h = mob
-			h.monkeyize()
+	badness = VIRUS_EXOTIC
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.monkeyize()
 
 /datum/disease2/effect/killertoxins
 	name = "Toxification Syndrome"
 	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.adjustToxLoss(15*multiplier)
 
 /datum/disease2/effect/dna
 	name = "Reverse Pattern Syndrome"
 	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_ENGINEERED
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.bodytemperature = max(mob.bodytemperature, 350)
 		scramble(0,mob,10)
 		mob.apply_damage(10, CLONE)
@@ -135,143 +119,119 @@
 /datum/disease2/effect/organs
 	name = "Shutdown Syndrome"
 	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			var/organ = pick(list(BP_R_ARM,BP_L_ARM,BP_R_LEG,BP_L_LEG))
-			var/obj/item/organ/external/E = H.organs_by_name[organ]
-			if (!(E.status & ORGAN_DEAD))
-				E.status |= ORGAN_DEAD
-				to_chat(H, "<span class='notice'>You can't feel your [E.name] anymore...</span>")
-				for (var/obj/item/organ/external/C in E.children)
-					C.status |= ORGAN_DEAD
-			H.update_body(1)
+	badness = VIRUS_ENGINEERED
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		var/organ = pick(list(BP_R_ARM,BP_L_ARM,BP_R_LEG,BP_L_LEG))
+		var/obj/item/organ/external/E = mob.organs_by_name[organ]
+		if (!(E.status & ORGAN_DEAD))
+			E.status |= ORGAN_DEAD
+			to_chat(mob, "<span class='notice'>You can't feel your [E.name] anymore...</span>")
+			for (var/obj/item/organ/external/C in E.children)
+				C.status |= ORGAN_DEAD
+		mob.update_body(1)
 		mob.adjustToxLoss(15*multiplier)
 
-	deactivate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			for (var/obj/item/organ/external/E in H.organs)
-				E.status &= ~ORGAN_DEAD
-				for (var/obj/item/organ/external/C in E.children)
-					C.status &= ~ORGAN_DEAD
-			H.update_body(1)
+	deactivate(var/mob/living/carbon/human/mob,var/multiplier)
+		for (var/obj/item/organ/external/E in mob.organs)
+			E.status &= ~ORGAN_DEAD
+			for (var/obj/item/organ/external/C in E.children)
+				C.status &= ~ORGAN_DEAD
+		mob.update_body(1)
 
 /datum/disease2/effect/immortal
 	name = "Longevity Syndrome"
 	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			for (var/obj/item/organ/external/E in H.organs)
-				if (E.status & ORGAN_BROKEN && prob(30))
-					E.status ^= ORGAN_BROKEN
+	badness = VIRUS_ENGINEERED
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		for (var/obj/item/organ/external/E in mob.organs)
+			if (E.status & ORGAN_BROKEN && prob(30))
+				to_chat(mob, "<span class='notice'>Your [E.name] suddenly feels much better!</span>")
+				E.status ^= ORGAN_BROKEN
+				break
+		for (var/obj/item/organ/internal/I in mob.internal_organs)
+			if (I.damage && prob(30))
+				to_chat(mob, "<span class='notice'>Your [mob.get_organ(I.parent_organ)] feels a bit warm...</span>")
+				I.take_damage(-2*multiplier)
+				break
 		var/heal_amt = -5*multiplier
 		mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
 
-	deactivate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			to_chat(H, "<span class='notice'>You suddenly feel hurt and old...</span>")
-			H.age += 8
+	deactivate(var/mob/living/carbon/human/mob,var/multiplier)
+		to_chat(mob, "<span class='notice'>You suddenly feel hurt and old...</span>")
+		mob.age += 8
 		var/backlash_amt = 5*multiplier
 		mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
 
 /datum/disease2/effect/bones
 	name = "Fragile Bones Syndrome"
 	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			for (var/obj/item/organ/external/E in H.organs)
-				E.min_broken_damage = max(5, E.min_broken_damage - 30)
+	badness = VIRUS_ENGINEERED
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		for (var/obj/item/organ/external/E in mob.organs)
+			E.min_broken_damage = max(5, E.min_broken_damage - 30)
 
-	deactivate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			for (var/obj/item/organ/external/E in H.organs)
-				E.min_broken_damage = initial(E.min_broken_damage)
+	deactivate(var/mob/living/carbon/human/mob,var/multiplier)
+		for (var/obj/item/organ/external/E in mob.organs)
+			E.min_broken_damage = initial(E.min_broken_damage)
 
 ////////////////////////STAGE 3/////////////////////////////////
 
 /datum/disease2/effect/toxins
 	name = "Hyperacidity"
 	stage = 3
-	maxm = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	multiplier_max = 3
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.adjustToxLoss((2*multiplier))
 
 /datum/disease2/effect/shakey
 	name = "World Shaking Syndrome"
 	stage = 3
-	maxm = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	multiplier_max = 3
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		shake_camera(mob,5*multiplier)
 
 /datum/disease2/effect/telepathic
 	name = "Telepathy Syndrome"
 	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.dna.SetSEState(REMOTETALKBLOCK,1)
 		domutcheck(mob, null, MUTCHK_FORCED)
 
 /datum/disease2/effect/mind
 	name = "Lazy Mind Syndrome"
 	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			var/obj/item/organ/internal/brain/B = H.internal_organs_by_name[BP_BRAIN]
-			if (B && B.damage < B.min_broken_damage)
-				B.take_damage(5)
-		else
-			mob.setBrainLoss(10)
-
-/datum/disease2/effect/hallucinations
-	name = "Hallucinational Syndrome"
-	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.hallucination += 25
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		var/obj/item/organ/internal/brain/B = mob.internal_organs_by_name[BP_BRAIN]
+		if (B && B.damage < B.min_broken_damage)
+			B.take_damage(5)
 
 /datum/disease2/effect/deaf
 	name = "Hard of Hearing Syndrome"
 	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.ear_deaf = 5
-
-/datum/disease2/effect/giggle
-	name = "Uncontrolled Laughter Effect"
-	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*giggle")
 
 /datum/disease2/effect/confusion
 	name = "Topographical Cretinism"
 	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		to_chat(mob, "<span class='notice'>You have trouble telling right and left apart all of a sudden.</span>")
 		mob.confused += 10
 
 /datum/disease2/effect/mutation
 	name = "DNA Degradation"
 	stage = 3
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.apply_damage(2, CLONE)
-
-/datum/disease2/effect/groan
-	name = "Groaning Syndrome"
-	stage = 3
-	chance_maxm = 25
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*groan")
 
 /datum/disease2/effect/chem_synthesis
 	name = "Chemical Synthesis"
 	stage = 3
-	chance_maxm = 25
+	badness = VIRUS_COMMON
+	chance_max = 25
 
 	generate(c_data)
 		if(c_data)
@@ -283,75 +243,87 @@
 		var/datum/reagent/R = chemical_reagents_list[data]
 		name = "[initial(name)] ([initial(R.name)])"
 
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		if (mob.reagents.get_reagent_amount(data) < 5)
 			mob.reagents.add_reagent(data, 2)
 
+/datum/disease2/effect/nothing
+	name = "Nil Syndrome"
+	stage = 1
+	badness = VIRUS_MILD
+	chance_max = 0
+	allow_multiple = 1
+
 ////////////////////////STAGE 2/////////////////////////////////
 
-/datum/disease2/effect/scream
-	name = "Loudness Syndrome"
+/datum/disease2/effect/emote
+	name = "Noise Syndrome"
 	stage = 2
-	chance_maxm = 25
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*scream")
+	chance_max = 25
+	delay = 35 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.emote(pick("scream","giggle","groan","gnarl","moan"))
 
 /datum/disease2/effect/drowsness
 	name = "Automated Sleeping Syndrome"
 	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.drowsyness += 10
 
 /datum/disease2/effect/sleepy
 	name = "Resting Syndrome"
 	stage = 2
-	chance_maxm = 15
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*collapse")
+	chance_max = 15
+	delay = 35 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.emote("collapse")
 
 /datum/disease2/effect/blind
 	name = "Blackout Syndrome"
 	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.eye_blind = max(mob.eye_blind, 4)
 
 /datum/disease2/effect/cough
 	name = "Anima Syndrome"
 	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*cough")
-		for(var/mob/living/carbon/M in oview(2,mob))
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.emote("cough")
+		for(var/mob/living/carbon/human/M in oview(2,mob))
 			mob.spread_disease_to(M)
 
 /datum/disease2/effect/hungry
 	name = "Appetiser Effect"
 	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.nutrition = max(0, mob.nutrition - 200)
 
 /datum/disease2/effect/fridge
 	name = "Refridgerator Syndrome"
 	stage = 2
-	chance_maxm = 25
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*shiver")
+	chance_max = 25
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.emote("shiver")
 
 /datum/disease2/effect/hair
 	name = "Hair Loss"
 	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			if(H.species.name == SPECIES_HUMAN && !(H.h_style == "Bald") && !(H.h_style == "Balding Hair"))
-				to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
-				spawn(50)
-					H.h_style = "Balding Hair"
-					H.update_hair()
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		if(mob.species.name == SPECIES_HUMAN && !(mob.h_style == "Bald") && !(mob.h_style == "Balding Hair"))
+			to_chat(mob, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
+			spawn(50)
+				mob.h_style = "Balding Hair"
+				mob.update_hair()
 
 /datum/disease2/effect/stimulant
 	name = "Adrenaline Extra"
 	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	badness = VIRUS_COMMON
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		to_chat(mob, "<span class='notice'>You feel a rush of energy inside you!</span>")
 		if (mob.reagents.get_reagent_amount("hyperzine") < 10)
 			mob.reagents.add_reagent("hyperzine", 4)
@@ -363,39 +335,66 @@
 /datum/disease2/effect/sneeze
 	name = "Coldingtons Effect"
 	stage = 1
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	delay = 15 SECONDS
+
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		if (prob(30))
 			to_chat(mob, "<span class='warning'>You feel like you are about to sneeze!</span>")
 		sleep(5)
-		mob.say("*sneeze")
-		for(var/mob/living/carbon/M in get_step(mob,mob.dir))
+		mob.emote("sneeze")
+		for(var/mob/living/carbon/human/M in get_step(mob,mob.dir))
 			mob.spread_disease_to(M)
-		if (prob(50))
+		if (prob(50) && !mob.wear_mask)
 			var/obj/effect/decal/cleanable/mucus/M = new(get_turf(mob))
 			M.virus2 = virus_copylist(mob.virus2)
 
 /datum/disease2/effect/gunck
 	name = "Flemmingtons"
 	stage = 1
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		to_chat(mob, "<span class='warning'>Mucous runs down the back of your throat.</span>")
 
 /datum/disease2/effect/drool
 	name = "Saliva Effect"
 	stage = 1
-	chance_maxm = 25
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*drool")
+	chance_max = 25
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.emote("drool")
 
 /datum/disease2/effect/twitch
 	name = "Twitcher"
 	stage = 1
-	chance_maxm = 25
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*twitch")
+	chance_max = 25
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		mob.emote("twitch")
 
 /datum/disease2/effect/headache
 	name = "Headache"
 	stage = 1
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		to_chat(mob, "<span class='warning'>Your head hurts a bit.</span>")
+
+/datum/disease2/effect/itch
+	name = "Itches"
+	stage = 1
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		to_chat(mob, "<span class='warning'>Your [pick(mob.organs_by_name)] itches like hell.</span>")
+
+/datum/disease2/effect/stomach
+	name = "Upset stomach"
+	stage = 1
+	delay = 25 SECONDS
+	activate(var/mob/living/carbon/human/mob,var/multiplier)
+		to_chat(mob, "<span class='warning'>Your stomach feels heavy.</span>")
+
+/datum/disease2/effect/stealth
+	name = "Silent Death Syndrome"
+	stage = 1
+	badness = VIRUS_EXOTIC
+	chance_max = 0
+	allow_multiple = 1

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -100,13 +100,12 @@
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "datadisk0"
 	w_class = ITEM_SIZE_TINY
-	var/datum/disease2/effectholder/effect = null
+	var/datum/disease2/effect/effect = null
 	var/list/species = null
 	var/stage = 1
 	var/analysed = 1
 
 /obj/item/weapon/diseasedisk/premade/New()
 	name = "blank GNA disk (stage: [stage])"
-	effect = new /datum/disease2/effectholder
-	effect.effect = new /datum/disease2/effect/invisible
+	effect = new /datum/disease2/effect/invisible
 	effect.stage = stage

--- a/html/changelogs/chinsky - viral.yml
+++ b/html/changelogs/chinsky - viral.yml
@@ -1,0 +1,18 @@
+ 
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Bunch of virus changes. Buckle up, kiddo. Praise Nurgle"
+  - rscadd: "Adds Space Cold event. Spawns a harmless virus that can be treated with cold medicine. Unless you're irradiated and it mutates to kill everyone I guess."
+  - rscadd: "Adds space cold medicine (dextra-something) to white first aid boxes. Can also be made by mixing paracetamol+sugar. Eating it will stop weak viruses symptoms from manifesting."
+  - rscadd: "Humans now have crude immune system simulation. Keeping your immunity high makes it easier to shrug off viruses, extremely low (15% and less) immunity can get you random space cold-level infections. Get lemons for boosting it, spaceacilin ruins it. It recovers to norm over time."
+  - tweak: "Spaceacillin now ODs at 15u instead of 30u."
+  - tweak: "Spaceacillin now metabolizes faster. It was 60+ minutes for 15u, 30 minutes now."
+  - tweak: "Spaceacillin boosts immune system effective rating. It acts as a multiplier to natural one, from 1x at none in blood to 2x at OD threshold (15u), and you can go higher if you don't mind ODing. Also if natural immunity is lower than the boost, boost would just replace it."
+  - tweak: "Spaceacillin has three stages now. Below 10 units it acts kinda like now, blocking badness 2 virus effects. Virus would still progress though, but effects won't fire. It's enough for any random event virus effects."
+  - tweak: "Above 10 units it would completely stop progression of badness 2 viruses and stop effects of badness 3 - which is usual stuff ou get from viro labs. Again, clock will still be ticking. Also at this stage it starts lowering your natural immunity value."
+  - tweak: "And then, there's OD. OD stops badness 4 (e.g. Gibbingtons) from manifesting, and stops ticking of lower viruses. It screws your immune system even stronger too."
+  - tweak: "It's also not 100% protecting you from infection now. 15u and above give old 100% protection, scaling with lower value in blood."
+  - tweak: "Some tweaks to virus annoyningness. Hard delay between firings (25-40 seconds between message-only syndromes), emote syndromes (groaning, moaning, screaming) are now single syndrome to make it rarer. Internals actually stopping you from spreading viruses. No airborne viruses in vacuum."
+  - tweak: "As an unrealated bonus, first aid (white and fire) boxes now have paracetamol bottles because damn it's easier to score opiates than that."
+  - tweak: "Oh also remember how when you graft yourself Tajaran arms it kills you? Not when your immunity is floored. Just saying."


### PR DESCRIPTION
#16917 reopened cause forcepushed.
https://github.com/comma/Baystation12/projects/13 for plannd stuff etc
Got wiki guide changes on standby.
https://wiki.baystation12.net/User:Chimpsky/Viroguide
https://wiki.baystation12.net/User:Chimpsky/Chemstuff
https://wiki.baystation12.net/User:Chimpsky/Medicalguide
Would like a review tho.

>Syndrome badness rearrangement. Now it goes like this: 1 is common cold, 2 is random but possibly bad virus, 3 is engineered only (or BAD virus), 4 is adminbus only.
Space Cold event. Mundane event, 1-3 people get a virus with weak syndromes (1 badness) and only 3 stages.
Space Cold Medicine. Added a medicine that stops weakest syndromes from manifesting.
Adds immune system strength tracking. Single 'power' var that meanders back to norm in Life(). Higher values mean less chance of infection and higher chance of self-curing virus. Also lower values mean infections from wounds etc progress faster and recover slower on its own. Very low values also mean no rejection no matter what kind of stuff you attach surgically! Lowered by antibiotics, boosted by any juice. Appendix gives slight boost to max value and regen speed too.
Made spaceacilline metabolize twice a fast. It's too crazy currently - single syringe will stay in system for 60-ish minutes. Cut that in half.
Mucking with effects - merged 'holder' and effect, axed some annoying ones (like hallucinations), merged other annoying ones (groan etc) into single syndrome. Added few more low-level syndromes.

New stuff is
Spaceacilline changes:
- Now it boosts effective immunity that is used in all calculations, while slowly eroding real one. Still useful a lot for boosting healthy people or providing SOME immunity for those with zero. 
- OD threshold set at 15 intead of 30. Half an hour worth.
- Doses under 5 units do not erode immunity (slow down regen only) but only block badness 2 syndromes - basically any random viruses.
- Above 5 units it blocks badness 3 syndromes, which is most 'bad' viruses you can make at the lab.
- To block badness 4 (gibbingtons anad such) you have to OD
- It doesn't completely prevent infection from happening now. Instead chance is scaled with amount of it in blood, with 100% block at OD threshold (15u)
- It doesn't stop progression of disease unless it blocks syndromes of badness 1 above whatever is active. So e.g. virus reached stage with 3 badness syndrome, 5+ units would stop syndrome form manfiesting, but clock would keep ticking to progress to next stage. If you OD it'll stop. For space colds that means that while you won't feel any effects of disease, it would keep ticking towards its death.

- Airborne reaching checks just check if we're in same air-filled air zone (with distance restriction) instead of dummy movement loop.
- Internals now prevent you from spreading airborne diseeases (who woulda thought)
- Random viruses outta nowhere. If your immunity is extremely low (less than 25% left), you can get spontaenous sniffle. Doesn't happen if you're already infected or have cold medicine or antibiotics.
- Syndromes have hard delays between on activations aside from RNG. Most have 5 seconds, more annoying ones without game effect (most stage 1 syndromes) have 25-40 seconds. Helps against message spam while not touching syndromes that could get nerfed by less activations.
- Added cold medicine and paracetamol to first aid boxes and lite med random spawns.