### PR TITLE
Fixes #17135, Runtime in who.dm,13: Cannot read null.real_name

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -8,8 +8,13 @@
 	var/list/Lines = list()
 
 	if(check_rights(R_INVESTIGATE, 0))
-		for(var/client/C)
+		for(var/client/C in clients)
 			var/entry = "\t[C.key]"
+			if(!C.mob) //If mob is null, print error and skip rest of info for client.
+				entry += " - <font color='red'><i>HAS NO MOB</i></font>"
+				Lines += entry
+				continue
+
 			entry += " - Playing as [C.mob.real_name]"
 			switch(C.mob.stat)
 				if(UNCONSCIOUS)
@@ -44,7 +49,7 @@
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 			Lines += entry
 	else
-		for(var/client/C)
+		for(var/client/C in clients)
 			if(!C.is_stealthed())
 				Lines += C.key
 


### PR DESCRIPTION
Fixes #17135 

Lines 13-17 should be unnecessary if 'clients' can be trusted to be accurate. 🦈 