### PR TITLE
Adjusts statpanel handling.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -250,7 +250,6 @@
 */
 /mob/proc/AltClickOn(var/atom/A)
 	A.AltClick(src)
-	return
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
@@ -264,6 +263,11 @@
 
 /mob/proc/TurfAdjacent(var/turf/T)
 	return T.AdjacentQuick(src)
+    
+/mob/observer/ghost/TurfAdjacent(var/turf/T)
+	if(!isturf(loc) || !client)
+		return FALSE
+	return z == T.z && (get_dist(loc, T) <= client.view)
 
 /*
 	Control+Shift click

--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -27,9 +27,16 @@
 /mob/observer/ghost/ClickOn(var/atom/A, var/params)
 	if(!canClick()) return
 	setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
-	A.attack_ghost(src)
+	var/list/modifiers = params2list(params)
+	if(modifiers["alt"])
+		var/target_turf = get_turf(A)
+		if(target_turf)
+			AltClickOn(target_turf)
+	else
+		A.attack_ghost(src)
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
 /atom/proc/attack_ghost(mob/observer/ghost/user as mob)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -305,12 +305,11 @@
 // So we slow this down a little.
 // See: http://www.byond.com/docs/ref/info.html#/client/proc/Stat
 /client/Stat()
+	// Add always-visible stat panel calls here, to define a consistent display order.
+	statpanel("Status")
+
 	. = ..()
-	if (holder)
-		sleep(1)
-	else
-		sleep(5)
-		stoplag()
+	sleep(1)
 
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()


### PR DESCRIPTION
/client/Stat() no longer sleeps 5 ticks for non-admin clients.
/client/Stat() now makes statpanel() calls, to ensure a consistent display order.
Fixes #17245

Also re-adds the ability for ghosts to alt-click turfs.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
