### PR TITLE
Fixes some light runtimes

### DIFF
--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -20,16 +20,19 @@
 	var/needs_update = FALSE
 
 /atom/movable/lighting_overlay/New(var/atom/loc, var/no_update = FALSE)
-	. = ..()
-	verbs.Cut()
-	total_lighting_overlays++
-
 	var/turf/T = loc //If this runtimes atleast we'll know what's creating overlays outside of turfs.
-	T.lighting_overlay = src
-	T.luminosity = 0
-	if(no_update)
-		return
-	update_overlay()
+	if(T.dynamic_lighting)
+		. = ..()
+		verbs.Cut()
+		total_lighting_overlays++
+
+		T.lighting_overlay = src
+		T.luminosity = 0
+		if(no_update)
+			return
+		update_overlay()
+	else
+		qdel(src)
 
 /atom/movable/lighting_overlay/proc/update_overlay()
 	set waitfor = FALSE
@@ -40,6 +43,10 @@
 			log_debug("A lighting overlay realised its loc was NOT a turf (actual loc: [loc][loc ? ", " + loc.type : "null"]) in update_overlay() and got qdel'ed!")
 		else
 			log_debug("A lighting overlay realised it was in nullspace in update_overlay() and got pooled!")
+		qdel(src)
+		return
+	if(!T.dynamic_lighting)
+		log_debug("A lighting overlay found it's way onto a statically lit turf! loc: [loc] , [loc.type]")
 		qdel(src)
 		return
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -65,13 +65,10 @@
 	total_lighting_sources--
 	destroyed = TRUE
 	force_update()
-	if(source_atom)
-		if(!source_atom.light_sources)
-			log_runtime(EXCEPTION("Atom [source_atom] was a light source, but lacked a light source list!\n"), source_atom)
-		else
-			source_atom.light_sources -= src
+	if(source_atom && source_atom.light_sources)
+		source_atom.light_sources -= src
 
-	if(top_atom)
+	if(top_atom && top_atom.light_sources)
 		top_atom.light_sources    -= src
 
 // Call it dirty, I don't care.


### PR DESCRIPTION
None of these are front-facing.

lighting_overlays shouldn't spawn on statically lit turfs, includes check for update_overlay as a precaution

Fixes runtimes for removing things from null lists and removes exception related to light sources that are lacking a light source list, as statically-lit turfs did end up with those light sources on occasion during ChangeTurf(shuttle transports).

Fixes #17174 and fixes #17175, they are handled by the changes in lighting_source.dm
Tentatively fixes #17216, it is addressed by changes in lighting_overlay.dm, attempting to ensure that statically lit turfs do not get lighting overlays, and logging when an overlay attempts to update if one manages to make it onto the turf.