### PR TITLE
Spy cams now extremely unlikely to receive the same c_tag.

### DIFF
--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -150,7 +150,7 @@
 
 /obj/machinery/camera/spy/New()
 	..()
-	name = "DV-136ZB #[rand(1000,9999)]"
+	name = "DV-136ZB #[random_id(/obj/machinery/camera/spy, 1000,9999)]"
 	c_tag = name
 
 /obj/machinery/camera/spy/check_eye(var/mob/user as mob)


### PR DESCRIPTION
Wasn't very likely to begin with but evidently it happened.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
