### PR TITLE
Fixes PDA update not updating job title

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -613,7 +613,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			id_check(U, 1)
 		if("UpdateInfo")
 			if(id)
-				set_rank_job(id.rank, ownjob)
+				set_rank_job(id.rank, id.assignment)
 		if("Eject")//Ejects the cart, only done from hub.
 			verb_remove_cartridge()
 


### PR DESCRIPTION
One line changed. Fixes the PDA update function ignoring the job title on the ID it is supposed get the new info from