### PR TITLE
Radiation Optimization 2

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -1389,8 +1389,6 @@
 			return global.ticker;
 		if("tickerProcess")
 			return global.tickerProcess;
-		if("to_process")
-			return global.to_process;
 		if("total_lighting_corners")
 			return global.total_lighting_corners;
 		if("total_lighting_overlays")
@@ -2890,8 +2888,6 @@
 			global.ticker=newval;
 		if("tickerProcess")
 			global.tickerProcess=newval;
-		if("to_process")
-			global.to_process=newval;
 		if("total_lighting_corners")
 			global.total_lighting_corners=newval;
 		if("total_lighting_overlays")
@@ -3696,7 +3692,6 @@
 	"tick_multiplier",
 	"ticker",
 	"tickerProcess",
-	"to_process",
 	"total_lighting_corners",
 	"total_lighting_overlays",
 	"total_lighting_sources",

--- a/code/controllers/Processes/radiation.dm
+++ b/code/controllers/Processes/radiation.dm
@@ -7,37 +7,50 @@
 	linked = radiation_repository
 
 /datum/controller/process/radiation/doWork()
-//	set background = 1
-	for(var/turf/T in linked.irradiated_turfs)
-		if(!T)
-			linked.irradiated_turfs.Remove(T)
+	sources_decay()
+	cache_expires()
+	irradiate_targets()
+
+// Step 1 - Sources Decay
+/datum/controller/process/radiation/proc/sources_decay()
+	var/list/sources = linked.sources
+	for(var/thing in sources)
+		var/datum/radiation_source/S = thing
+		if(QDELETED(S))
+			sources.Remove(S)
 			continue
-		linked.irradiated_turfs[T] -= config.radiation_decay_rate
-		if(linked.irradiated_turfs[T] <= config.radiation_lower_limit)
-			linked.irradiated_turfs.Remove(T)
-		SCHECK
-	for(var/mob/living/L in linked.irradiated_mobs)
-		if(!L)
-			linked.irradiated_mobs.Remove(L)
-			continue
-		if(get_turf(L) in linked.irradiated_turfs)
-			L.rad_act(linked.irradiated_turfs[get_turf(L)])
-		if(!L.radiation)
-			linked.irradiated_mobs.Remove(L)
-		SCHECK
-	for(var/thing in linked.sources)
-		if(!thing)
-			linked.sources.Remove(thing)
-			continue
-		var/atom/emitter = thing
-		linked.radiate(emitter, emitter.rad_power)
-		to_process.Cut()
-		SCHECK
-	for(var/thing in linked.resistance_cache)
-		if(!thing)
-			linked.resistance_cache.Remove(thing)
-			continue
+		if(S.decay)
+			S.update_rad_power(S.rad_power - config.radiation_decay_rate)
+		if(S.rad_power <= config.radiation_lower_limit)
+			sources.Remove(S)
+		SCHECK // This scheck probably just wastes resources, but better safe than sorry in this case.
+
+// Step 2 - Cache Expires
+/datum/controller/process/radiation/proc/cache_expires()
+	var/list/resistance_cache = linked.resistance_cache
+	for(var/thing in resistance_cache)
 		var/turf/T = thing
-		if((length(T.contents) + 1) != linked.resistance_cache[T])
-			T.calc_rad_resistance()
+		if(QDELETED(T))
+			resistance_cache.Remove(T)
+			continue
+		if((length(T.contents) + 1) != resistance_cache[T])
+			resistance_cache.Remove(T) // If its stale REMOVE it! It will get added if its needed.
 		SCHECK
+
+// Step 3 - Registered irradiatable things are checked for radiation
+/datum/controller/process/radiation/proc/irradiate_targets()
+	var/list/registered_listeners = living_mob_list_ // For now just use this. Nothing else is interested anyway.
+	if(length(linked.sources) > 0)
+		for(var/thing in registered_listeners)
+			var/atom/A = thing
+			if(QDELETED(A))
+				continue
+			var/turf/T = get_turf(thing)
+			var/rads = linked.get_rads_at_turf(T)
+			if(rads)
+				A.rad_act(rads)
+		SCHECK
+
+/datum/controller/process/radiation/statProcess()
+	..()
+	stat(null, "[linked.sources.len] sources, [linked.resistance_cache.len] cached turfs")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -733,6 +733,9 @@ var/list/gamemode_cache = list()
 				if("autostealth")
 					config.autostealth = text2num(value)
 
+				if("radiation_lower_limit")
+					radiation_lower_limit = text2num(value)
+
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -38,6 +38,8 @@ var/global/repository/radiation/radiation_repository = new()
 		var/datum/radiation_source/source = value
 		if(source.rad_power < .)
 			continue // Already being affected by a stronger source
+		if(source.source_turf.z != T.z)
+			continue // Radiation is not multi-z
 		var/dist = get_dist(source.source_turf, T)
 		if(dist > source.range)
 			continue // Too far to possibly affect

--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -1,114 +1,131 @@
-//#define RADDBG
-
-var/repository/radiation/radiation_repository = new()
-
-var/list/to_process = list()
+var/global/repository/radiation/radiation_repository = new()
 
 /repository/radiation
-	var/list/sources = list() //All the radiation sources we know about
-	var/list/irradiated_turfs = list()
-	var/list/irradiated_mobs = list()
-	var/list/resistance_cache = list()
+	var/list/sources = list()			// all radiation source datums
+	var/list/sources_assoc = list()		// Sources indexed by turf for de-duplication.
+	var/list/resistance_cache = list()	// Cache of turf's radiation resistance.
 
-/repository/radiation/proc/report_rads(var/turf/T as turf)
-	return irradiated_turfs[T]
+// Describes a point source of radiation.  Created either in response to a pulse of radiation, or over an irradiated atom.
+// Sources will decay over time, unless something is renewing their power!
+/datum/radiation_source
+	var/turf/source_turf		// Location of the radiation source.
+	var/rad_power				// Strength of the radiation being emitted.
+	var/decay = TRUE			// True for automatic decay.  False if owner promises to handle it (i.e. supermatter)
+	var/respect_maint = FALSE	// True for not affecting RAD_SHIELDED areas.
+	var/flat = FALSE			// True for power falloff with distance.
+	var/range					// Cached maximum range, used for quick checks against mobs.
 
+/datum/radiation_source/Destroy()
+	radiation_repository.sources -= src
+	if(radiation_repository.sources_assoc[src.source_turf] == src)
+		radiation_repository.sources -= src.source_turf
+	src.source_turf = null
+	. = ..()
+
+/datum/radiation_source/proc/update_rad_power(var/new_power = null)
+	if(new_power != null && new_power != rad_power)
+		rad_power = new_power
+		. = 1
+	if(. && !flat)
+		range = min(round(sqrt(rad_power / config.radiation_lower_limit)), 31)  // R = rad_power / dist**2 - Solve for dist
+
+// Ray trace from all active radiation sources to T and return the strongest effect.
+/repository/radiation/proc/get_rads_at_turf(var/turf/T)
+	if(!istype(T)) return 0
+
+	. = 0
+	for(var/value in sources)
+		var/datum/radiation_source/source = value
+		if(source.rad_power < .)
+			continue // Already being affected by a stronger source
+		var/dist = get_dist(source.source_turf, T)
+		if(dist > source.range)
+			continue // Too far to possibly affect
+		if(source.respect_maint)
+			var/atom/A = T.loc
+			if(A.flags & AREA_RAD_SHIELDED)
+				continue // In shielded area
+		if(source.flat)
+			. = max(., source.rad_power)
+			continue // No need to ray trace for flat  field
+
+		// Okay, now ray trace to find resistence!
+		var/turf/origin = source.source_turf
+		var/working = source.rad_power
+		while(origin != T)
+			origin = get_step_towards(origin, T) //Raytracing
+			if(!(origin in resistance_cache)) //Only get the resistance if we don't already know it.
+				origin.calc_rad_resistance()
+			working = max((working - (origin.cached_rad_resistance * config.radiation_resistance_multiplier)), 0)
+			if(working <= .)
+				break // Already affected by a stronger source (or its zero...)
+		. = max((working * (1 / (dist ** 2))), .) //Butchered version of the inverse square law. Works for this purpose
+
+// Add a radiation source instance to the repository.  It will override any existing source on the same turf.
+/repository/radiation/proc/add_source(var/datum/radiation_source/S)
+	var/datum/radiation_source/existing = sources_assoc[S.source_turf]
+	if(existing)
+		qdel(existing)
+	sources += S
+	sources_assoc[S.source_turf] = S
+
+// Creates a temporary radiation source that will decay
 /repository/radiation/proc/radiate(source, power) //Sends out a radiation pulse, taking walls into account
 	if(!(source && power)) //Sanity checking
 		return
+	var/datum/radiation_source/S = new()
+	S.source_turf = get_turf(source)
+	S.update_rad_power(power)
+	add_source(S)
 
-	var/range = min(round(sqrt(power / config.radiation_lower_limit)), 31)
-	var/turf/epicentre = get_turf(source)
-	to_process = list()
-
-	range = min(epicentre.x, world.maxx - epicentre.x, epicentre.y, world.maxy - epicentre.y, range)
-
-	to_process = trange(range, epicentre)
-	to_process[epicentre] = power
-
-	for(var/turf/spot in to_process)
-		var/turf/origin = get_turf(epicentre)
-		var/working = power
-		while(origin != spot)
-			origin = get_step_towards(origin, spot) //Raytracing
-			if(!(origin in resistance_cache)) //Only get the resistance if we don't already know it.
-				origin.calc_rad_resistance()
-			working = max((working - (origin.rad_resistance * config.radiation_resistance_multiplier)), 0)
-			if(!working)
-				break //Don't bother continuing to trace
-			if(!to_process[origin])
-				to_process[origin] = working
-
-			else
-				to_process[origin] = max(to_process[origin], working)
-
-	for(var/turf/spot in to_process)
-		irradiated_turfs[spot] = max(((to_process[spot]) * (1 / (get_dist(epicentre, spot) ** 2))), irradiated_turfs[spot]) //Butchered version of the inverse square law. Works for this purpose
-		#ifdef RADDBG
-		var/x = Clamp( irradiated_turfs[spot], 0, 255)
-		spot.color = rgb(5,x,5)
-		#endif
-
-/repository/radiation/proc/flat_radiate(source, power, range, var/respect_maint=0) //Sets the radiation in a range to a constant value.
+// Sets the radiation in a range to a constant value.
+/repository/radiation/proc/flat_radiate(source, power, range, var/respect_maint = FALSE)
 	if(!(source && power && range))
 		return
-	var/turf/epicentre = get_turf(source)
-	range = min(epicentre.x, world.maxx - epicentre.x, epicentre.y, world.maxy - epicentre.y, range)
-	if(!respect_maint)
-		for(var/turf/T in trange(range, epicentre))
-			irradiated_turfs[T] = max(power, irradiated_turfs[T])
-	else
-		for(var/turf/T in trange(range, epicentre))
-			var/area/A = T.loc
-			if(A.flags & AREA_RAD_SHIELDED)
-				continue
-			irradiated_turfs[T] = max(power, irradiated_turfs[T])
+	var/datum/radiation_source/S = new()
+	S.flat = TRUE
+	S.range = range
+	S.respect_maint = respect_maint
+	S.source_turf = get_turf(source)
+	S.update_rad_power(power)
+	add_source(S)
 
-/repository/radiation/proc/z_radiate(var/atom/source, power, var/respect_maint=0) //Irradiates a full Z-level. Hacky way of doing it, but not too expensive.
+// Irradiates a full Z-level. Hacky way of doing it, but not too expensive.
+/repository/radiation/proc/z_radiate(var/atom/source, power, var/respect_maint = FALSE)
 	if(!(power && source))
 		return
 	var/turf/epicentre = locate(round(world.maxx / 2), round(world.maxy / 2), source.z)
 	flat_radiate(epicentre, power, world.maxx, respect_maint)
 
+/turf
+	var/cached_rad_resistance = 0
+
 /turf/proc/calc_rad_resistance()
-	rad_resistance = 0
+	cached_rad_resistance = 0
 	for(var/obj/O in src.contents)
 		if(O.rad_resistance) //Override
-			rad_resistance += O.rad_resistance
+			cached_rad_resistance += O.rad_resistance
 
-		else if(O.density) //So doors don't get counted
+		else if(O.density) //So open doors don't get counted
 			var/material/M = O.get_material()
 			if(!M)	continue
-			rad_resistance += M.weight
+			cached_rad_resistance += M.weight
+	// Looks like storing the contents length is meant to be a basic check if the cache is stale due to items enter/exiting.  Better than nothing so I'm leaving it as is. ~Leshana
 	radiation_repository.resistance_cache[src] = (length(contents) + 1)
 
 /turf/simulated/wall/calc_rad_resistance()
 	radiation_repository.resistance_cache[src] = (length(contents) + 1)
-	rad_resistance = (density ? material.weight : 0)
+	cached_rad_resistance = (density ? material.weight : 0)
 
-/atom
-	var/rad_power = 0
-	var/rad_resistance = 0
+/obj
+	var/rad_resistance = 0  // Allow overriding rad resistance
 
-/atom/Destroy()
-	if(rad_power)
-		radiation_repository.sources.Remove(src)
-	. = ..()
-
-/atom/proc/update_radiation() //For VV'ing something to make it radioactive at runtime
-	if((rad_power) && (!(src in radiation_repository.sources)))
-		radiation_repository.sources.Add(src)
-	else if((!rad_power) && (src in radiation_repository.sources))
-		radiation_repository.sources.Remove(src)
-
-/atom/proc/rad_act(var/severity) //If people expand the system, this may be useful. Here as a placeholder until then
+// If people expand the system, this may be useful. Here as a placeholder until then
+/atom/proc/rad_act(var/severity)
 	return 1
 
 /mob/living/rad_act(var/severity)
 	if(severity)
 		src.apply_effect(severity, IRRADIATE, src.getarmor(null, "rad"))
-		for(var/obj/I in src)
+		for(var/atom/I in src)
 			I.rad_act(severity)
-
-
-//#undef RADDBG

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -38,9 +38,6 @@
 		pulledby = null
 
 /atom/movable/proc/initialize()
-	if(rad_power)
-		radiation_repository.sources.Add(src)
-
 	if(QDELETED(src))
 		crash_with("GC: -- [type] had initialize() called after qdel() --")
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -330,7 +330,7 @@
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	mineral = "uranium"
 	var/last_event = 0
-	rad_power = 7.5
+	var/rad_power = 7.5
 
 /obj/machinery/door/airlock/process()
 	if(main_power_lost_until > 0 && world.time >= main_power_lost_until)
@@ -342,6 +342,13 @@
 	else if(electrified_until > 0 && world.time >= electrified_until)
 		electrify(0)
 
+	..()
+
+/obj/machinery/door/airlock/uranium/process()
+	if(world.time > last_event+20)
+		if(prob(50))
+			radiation_repository.radiate(src, rad_power)
+		last_event = world.time
 	..()
 
 /obj/machinery/door/airlock/phoron

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -68,8 +68,7 @@
 		icon_state = icon_state_closed
 	else
 		icon_state = icon_state_open
-	var/turf/T = get_turf(src)
-	T.calc_rad_resistance()
+	radiation_repository.resistance_cache.Remove(get_turf(src))
 	return
 
 // Proc: force_open()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -345,8 +345,7 @@
 		icon_state = "door1"
 	else
 		icon_state = "door0"
-	var/turf/T = get_turf(src)
-	T.calc_rad_resistance()
+	radiation_repository.resistance_cache.Remove(get_turf(src))
 	return
 
 

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -22,7 +22,7 @@
 /obj/item/device/geiger/process()
 	if(!scanning)
 		return
-	radiation_count = radiation_repository.report_rads(get_turf(src))
+	radiation_count = radiation_repository.get_rads_at_turf(get_turf(src))
 	update_icon()
 
 /obj/item/device/geiger/examine(mob/user)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -6,7 +6,7 @@
 	if(can_open == WALL_OPENING)
 		return
 
-	calc_rad_resistance()
+	radiation_repository.resistance_cache.Remove(src)
 
 	if(density)
 		can_open = WALL_OPENING

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -23,7 +23,7 @@
 
 	set_opacity(material.opacity >= 0.5)
 
-	calc_rad_resistance()
+	radiation_repository.resistance_cache.Remove(src)
 	update_connections(1)
 	update_icon()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -138,11 +138,6 @@ var/const/enterloopsanity = 100
 
 	if(ismob(A))
 		var/mob/M = A
-		var/mob/living/L = A
-		if(istype(L))
-			if(!(L in radiation_repository.irradiated_mobs))
-				if(src in radiation_repository.irradiated_turfs)
-					radiation_repository.irradiated_mobs.Add(L)
 		if(!M.check_solid_ground())
 			inertial_drift(M)
 			//we'll end up checking solid ground again but we still need to check the other things.

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -664,11 +664,6 @@
 	handled_vars = list("dir" = /atom/proc/set_dir)
 	predicates = list(/proc/is_dir_predicate)
 
-/decl/vv_set_handler/rad_handler
-	handled_type = /atom
-	handled_vars = list("rad_power" = /atom/proc/update_radiation)
-	predicates = list(/proc/is_num_predicate)
-
 /decl/vv_set_handler/ghost_appearance_handler
 	handled_type = /mob/observer/ghost
 	handled_vars = list("appearance" = /mob/observer/ghost/proc/set_appearance)

--- a/code/modules/events/solar_storm.dm
+++ b/code/modules/events/solar_storm.dm
@@ -27,14 +27,18 @@
 		radiate()
 
 /datum/event/solar_storm/proc/radiate()
-	var/radiation_level = rand(15, 30)
-	for(var/area/A)
-		if(!(A.z in using_map.player_levels))
+	// Note: Too complicated to be worth trying to use the radiation system for this.  Its only in space anyway, so we make an exception in this case.
+	for(var/mob/living/L in living_mob_list_)
+		var/turf/T = get_turf(L)
+		if(!T || !(T.z in using_map.player_levels))
 			continue
-		for(var/turf/T in A)
-			if(!istype(T.loc,/area/space) && !istype(T,/turf/space))
-				continue
-			radiation_repository.irradiated_turfs[T] = radiation_level
+
+		if(!istype(T.loc,/area/space) && !istype(T,/turf/space))	//Make sure you're in a space area or on a space turf
+			continue
+
+		//Todo: Apply some burn damage from the heat of the sun. Until then, enjoy some moderate radiation.
+		L.rad_act(rand(15, 30))
+
 
 /datum/event/solar_storm/end()
 	command_announcement.Announce("The solar storm has passed the [station_name()]. It is now safe to resume EVA activities. Please report to medbay if you experience any unusual symptoms. ", "[station_name()] Sensor Array")

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -8,7 +8,6 @@
 	alpha = 50
 	layer = 4
 	light_color = COLOR_BLUE
-	rad_power = 1
 
 	var/size = 1
 	var/energy = 0
@@ -171,7 +170,8 @@
 
 	check_instability()
 	Radiate()
-	rad_power = radiation
+	if(radiation)
+		radiation_repository.radiate(src, radiation)
 	return 1
 
 /obj/effect/fusion_em_field/proc/check_instability()

--- a/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
@@ -6,7 +6,6 @@
 
 	var/material_name
 
-	rad_power = 1
 	var/percent_depleted = 1
 	var/list/rod_quantities = list()
 	var/fuel_type = "composite"
@@ -45,10 +44,10 @@
 
 /obj/item/weapon/fuel_assembly/process()
 	if(!radioactivity)
-		radiation_repository.sources.Remove(src)
+		return PROCESS_KILL
 
 	if(istype(loc, /turf))
-		rad_power = max(1,ceil(radioactivity/30))
+		radiation_repository.radiate(src, max(1,ceil(radioactivity/30)))
 
 /obj/item/weapon/fuel_assembly/Destroy()
 	processing_objects -= src

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -121,11 +121,8 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	qdel(holder)
 	var/radiation_level = rand(100, 200)
 
-	// Copied from the SM for proof of concept. //Not any more --Cirra
-	for(var/area/A)
-		if(A.z == holder.z)
-			for(var/turf/T in A)
-				radiation_repository.irradiated_turfs[T] = radiation_level
+	// Copied from the SM for proof of concept. //Not any more --Cirra //Use the whole z proc --Leshana
+	radiation_repository.z_radiate(locate(1, 1, holder.z), radiation_level, 1)
 
 	for(var/mob/living/mob in living_mob_list_)
 		var/turf/T = get_turf(mob)

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -30,9 +30,10 @@ var/global/list/rad_collectors = list()
 	last_power = last_power_new
 	last_power_new = 0
 
-	var/turf/T = get_turf(src)
-	if(T in radiation_repository.irradiated_turfs)
-		receive_pulse((radiation_repository.irradiated_turfs[T] * 5)) //Maths is hard
+	if(P && active)
+		var/rads = radiation_repository.get_rads_at_turf(get_turf(src))
+		if(rads)
+			receive_pulse(rads * 5) //Maths is hard
 
 	if(P)
 		if(P.air_contents.gas["phoron"] == 0)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -49,7 +49,6 @@
 
 	layer = ABOVE_OBJ_LAYER
 
-	rad_power = 1 //So it gets added to the repository
 	var/gasefficency = 0.25
 
 	var/base_icon_state = "darkmatter"
@@ -382,7 +381,7 @@
 			l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
 
 
-	rad_power = power * 1.5 //Better close those shutters!
+	radiation_repository.radiate(src, power * 1.5) //Better close those shutters!
 	power -= (power/DECAY_FACTOR)**3		//energy losses due to radiation
 	handle_admin_warnings()
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -32,6 +32,9 @@ JOBS_HAVE_MINIMAL_ACCESS
 ## Unhash this to use recursive explosions, keep it hashed to use circle explosions. Recursive explosions react to walls, airlocks and blast doors, making them look a lot cooler than the boring old circular explosions. They require more CPU and are (as of january 2013) experimental
 #USE_RECURSIVE_EXPLOSIONS
 
+## Radiation weakens with distance from the source; stop calculating when the strength falls below this value.   Lower values mean radiation reaches smaller (with increasingly trivial damage) at the cost of more CPU usage.  Max range =  DISTANCE^2 * POWER / RADIATION_LOWER_LIMIT
+# RADIATION_LOWER_LIMIT	0.35
+
 ## log OOC channel
 LOG_OOC
 

--- a/html/changelogs/Leshana-Radiation.yml
+++ b/html/changelogs/Leshana-Radiation.yml
@@ -1,0 +1,5 @@
+author: Leshana
+delete-after: True
+changes: 
+  - tweak: "Optimized the unified radiation system.  Made the radiation cutoff level configurable."
+  - bugfix: "Standing still won't save you from radiation storms."


### PR DESCRIPTION
https://github.com/Baystation12/Baystation12/pull/17362 returns with dramatically fewer infinite loops on multi-z maps.
Un-reverts the revert and adds in the patch to fix the infinite loop problem.

#### Original notes:
Back-ported optimization changes from Polaris port at request of @BlueNexus 

* The performance of the radiation controller as-is was not fast enough for inclusion in production servers, but it has some nice features, so rewrote it to be more performant.
* Instead of storing the radiation strength for every turf, we only store the sources of radiation, and calculate the strength only for mobs who might be in range.
   * Old method was ray-tracing to every turf in range whether anything was there to be irradiated or not.  Could be hundreds of turfs.  New method only lazily calcualtes strength at a turf if we actually need to know it.   Often times this is zero turfs if nobody is standing in engineering.
  * Removed the automatic processing of objects with "rad_power" set.  Objects are responsible for calling the repository to create/update their radiation sources.   Saves some extra overhead that in practice was redundant with other process controllers.
  * Also tweaked to be more respectful of qdel'd objects and added some comments.
* Updated fusion related items to use the new procs.
* Made the RADIATION_LOWER_LIMIT configurable (option for people to save some cpu time)


Old:
![with supermatter](https://cloud.githubusercontent.com/assets/14110581/26473870/c92974fc-417b-11e7-8f3f-344d4d2eb66c.PNG)
New:
![perf](https://cloud.githubusercontent.com/assets/14110581/26473986/7a8ae44c-417c-11e7-929a-6c942accd3bd.PNG)
