### PR TITLE
More qdel hints and cleanup

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -13,11 +13,6 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	unacidable = 1//So effect are not targeted by alien acid.
 	pass_flags = PASSTABLE | PASSGRILLE
 
-/obj/effect/Destroy()
-	if(reagents)
-		reagents.delete()
-	return ..()
-
 /datum/effect/effect/system
 	var/number = 3
 	var/cardinals = 0

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -33,6 +33,10 @@
 	var/message2
 	var/list/stored_data = list()
 
+/obj/item/weapon/cartridge/Destroy()
+	qdel_null(radio)
+	return ..()
+
 /obj/item/weapon/cartridge/engineering
 	name = "\improper Power-ON cartridge"
 	icon_state = "cart-e"
@@ -113,10 +117,6 @@
 /obj/item/weapon/cartridge/signal/initialize()
     radio = new /obj/item/radio/integrated/signal(src)
     ..()
-
-/obj/item/weapon/cartridge/signal/Destroy()
-	qdel(radio)
-	..()
 
 /obj/item/weapon/cartridge/quartermaster
 	name = "\improper Space Parts & Space Vendors cartridge"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -95,7 +95,7 @@
 
 /obj/item/device/radio/intercom/Destroy()
 	processing_objects -= src
-	..()
+	return ..()
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/modules/atmospherics/datum_pipe_network.dm
+++ b/code/modules/atmospherics/datum_pipe_network.dm
@@ -16,6 +16,15 @@ datum/pipe_network
 
 		..()
 
+	Destroy()
+		pipe_networks -= src
+		for(var/datum/pipeline/line_member in line_members)
+			line_member.network = null
+		for(var/obj/machinery/atmospherics/normal_member in normal_members)
+			normal_member.reassign_network(src, null)
+		gases.Cut()  // Do not qdel the gases, we don't own them
+		return ..()
+
 	proc/process()
 		//Equalize gases amongst pipe if called for
 		if(update)

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -19,6 +19,8 @@ datum/pipeline
 		if(air && air.volume)
 			temporarily_store_air()
 			qdel(air)
+		for(var/obj/machinery/atmospherics/pipe/P in members)
+			P.parent = null
 
 		. = ..()
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -468,4 +468,4 @@
 		assailant = null
 	qdel(hud)
 	hud = null
-	..()
+	return ..()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -79,12 +79,6 @@
 			total_volume += R.volume
 	return
 
-/datum/reagents/proc/delete()
-	for(var/datum/reagent/R in reagent_list)
-		R.holder = null
-	if(my_atom)
-		my_atom.reagents = null
-
 /datum/reagents/proc/handle_reactions()
 	if(chemistryProcess)
 		chemistryProcess.mark_for_update(src)


### PR DESCRIPTION
Take care of runtimes and failed GC by fixing a few more Destroy() procs to return qdel hints and clear references.

#### Reagents Cleanup
* /datum/reagents/Destroy() does everything /datum/reagents/delete() does and more, and delete() is called only from /obj/effect/Destroy() which is *itself* redundant with its parent /atom/movable/Destroy()

#### Pipe Network Datum
* Every pipe in a pipeline has a reference to the pipeline.  This needs to be cleared, both so the pipeline can be gc'd, and also so the pipes don't try and keep using the qdel'd pipeline.
* Same story for each pipeline in a pipe network, and each machine in a pipe network.
* Pipe networks are also in the pipe_networks global list.  While the controller would detect and remove it from the list on the next tick, cleaning up ourselves is the responsible thing to do.

#### A couple others while we're here.
