### PR TITLE
Adds multiple loadout slots per character.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -220,17 +220,11 @@ var/list/gear_datums = list()
 		//If we're moving up a slot..
 		if(href_list["next_slot"])
 			//change the current slot number
-			pref.gear_slot = pref.gear_slot+1
-			//The three is completely arbitrary
-			if(pref.gear_slot>3)
-				pref.gear_slot = 1
+			pref.gear_slot = ((pref.gear_slot+1) % 3) + 1
 		//If we're moving down a slot..
 		else if(href_list["prev_slot"])
 			//change current slot one down
-			pref.gear_slot = pref.gear_slot-1
-			//once again, completely arbitrary limit
-			if(pref.gear_slot<1)
-				pref.gear_slot = 3
+			pref.gear_slot = ((pref.gear_slot-1) % 3) + 1
 		// Set the currently selected gear to whatever's in the new slot
 		if(pref.gear_list["[pref.gear_slot]"])
 			pref.gear = pref.gear_list["[pref.gear_slot]"]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -50,7 +50,9 @@ datum/preferences
 	var/species_preview                 //Used for the species selection window.
 	var/list/alternate_languages = list() //Secondary language(s)
 	var/list/language_prefixes = list() //Kanguage prefix keys
-	var/list/gear						//Custom/fluff item loadout.
+	var/list/gear						//Left in for Legacy reasons, will no longer save.
+	var/list/gear_list = list()			//Custom/fluff item loadouts.
+	var/gear_slot = 1					//The current gear save slot
 
 		//Some faction information.
 	var/home_system = "Unset"           //System of birth.

--- a/html/changelogs/ZeroBits - loadout.yml
+++ b/html/changelogs/ZeroBits - loadout.yml
@@ -1,0 +1,4 @@
+author: ZeroBits
+delete-after: True
+changes: 
+  - rscadd: "Added the ability to have multiple loadouts per character."


### PR DESCRIPTION
Currently there's an arbitrary limit of 3 slots. This being for two reasons primarily;
One: I don't want to make a more complex interface for it.
Two: I don't want to touch configs

If this is less than ideal, you're more than welcome to make a pull against it, or make a PR after its merged, but this has already been enough of a pain for _me_.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
