### PR TITLE
[SKIN FILE] Integration of Beginner's Lore Button

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -172,6 +172,9 @@
 		if(config.aggressive_changelog)
 			src.changes()
 
+	if(isnum(player_age) && player_age < 7)
+		src.lore_splash()
+		to_chat(src, "<span class = 'notice'>Greetings, and welcome to the server! A link to the beginner's lore page has been opened, please read through it! This window will stop automatically opening once your account here is greater than 7 days old.</span>")
 
 	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
 		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")

--- a/config/example/lore.html
+++ b/config/example/lore.html
@@ -1,0 +1,12 @@
+<html>
+<head><title>Beginner's Guide to Baystation 12 Lore</title></head>
+<body>
+
+<!--
+Example: baystation12 rules embed.
+<iframe width='100%' height='100%' src="http://wiki.baystation12.net/index.php?title=Beginning_Lore&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+-->
+
+
+</body>
+</html>

--- a/html/changelogs/asanadas-lore_splash.yml
+++ b/html/changelogs/asanadas-lore_splash.yml
@@ -1,0 +1,6 @@
+author: Asanadas
+
+delete-after: True
+
+changes: 
+  - rscadd: "There's now a neat lore splash window which will spam all new accounts under 7 days old. Read it!"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -31,6 +31,14 @@
 	src << browse(file(RULES_FILE), "window=rules;size=480x320")
 #undef RULES_FILE
 
+#define LORE_FILE "config/lore.html"
+/client/verb/lore_splash()
+	set name = "Lore"
+	set desc = "Links to the beginner Lore wiki."
+	set hidden = 1
+	src << browse(file(LORE_FILE), "window=lore;size=480x320")
+#undef LORE_FILE
+
 /client/verb/hotkeys_help()
 	set name = "hotkeys-help"
 	set category = "OOC"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -36,7 +36,7 @@
 	set name = "Lore"
 	set desc = "Links to the beginner Lore wiki."
 	set hidden = 1
-	src << browse(file(LORE_FILE), "window=lore;size=480x320")
+	show_browser(src, file(LORE_FILE), "window=lore;size=480x320")
 #undef LORE_FILE
 
 /client/verb/hotkeys_help()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -2240,6 +2240,34 @@ window "rpane"
 		is-checked = false
 		group = "rpanemode"
 		button-type = pushbutton
+	elem "Lore"
+		type = BUTTON
+		pos = 413,0
+		size = 67x16
+		anchor1 = none
+		anchor2 = none
+		font-family = ""
+		font-size = 0
+		font-style = ""
+		text-color = #000000
+		background-color = none
+		is-visible = true
+		is-disabled = false
+		is-transparent = false
+		is-default = false
+		border = none
+		drop-zone = false
+		right-click = false
+		saved-params = "is-checked"
+		on-size = ""
+		text = "Lore"
+		image = ""
+		command = "Lore"
+		is-flat = false
+		stretch = false
+		is-checked = false
+		group = "rpanemode"
+		button-type = pushbutton
 	elem "forumb"
 		type = BUTTON
 		pos = 215,0


### PR DESCRIPTION
Integrates a splash of <https://wiki.baystation12.net/Beginning_Lore>

Sourced from <https://baystation12.net/forums/threads/the-beginners-lore-handbook.4277/> and by request of @ThatOneGuy42 
![image](https://user-images.githubusercontent.com/1222532/26861852-cadb20b4-4b14-11e7-8a03-5443f6a4272e.png)

Sometimes BYOND throws an error when it opens the window. I've narrowed this down to a wiki script that appears on its own voilition. It happens sometimes with the Rules button, as well. There is no solution for it as far as I can tell: it's all on the wiki's side. Sometimes the script is on the page, and sometimes it is not. It makes no sense to me. 🌵 

Requires a lore.html to be put in the config folder.
[lore.zip](https://github.com/Baystation12/Baystation12/files/1056851/lore.zip)
