### PR TITLE
Digital Warrant Improvements

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -5,6 +5,7 @@
 /datum/data/record
 	var/name = "record"
 	var/size = 5
+	var/archived = FALSE // Only used by digital warrants so far. Hopefully does also find use for other records in future.
 	var/list/fields = list()
 
 /datum/datacore

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -27,7 +27,8 @@
 	var/list/warrants = list()
 	if(!isnull(data_core.general))
 		for(var/datum/data/record/warrant/W in data_core.warrants)
-			warrants += W.fields["namewarrant"]
+			if(!W.archived)
+				warrants += W.fields["namewarrant"]
 	if(warrants.len == 0)
 		to_chat(user,"<span class='notice'>There are no warrants available</span>")
 		return

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -8,6 +8,7 @@
 	throw_speed = 4
 	throw_range = 10
 	flags = CONDUCT
+	slot_flags = SLOT_BELT
 	var/datum/data/record/warrant/active
 
 //look at it

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -142,7 +142,8 @@
 		/obj/item/device/megaphone,
 		/obj/item/weapon/melee,
 		/obj/item/weapon/gun/projectile/sec,
-		/obj/item/taperoll
+		/obj/item/taperoll,
+		/obj/item/device/holowarrant
 		)
 
 /obj/item/weapon/storage/belt/soulstone

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -403,7 +403,7 @@ proc/is_blind(A)
 	var/turf/sourceturf = get_turf(broadcast_source)
 	for(var/mob/M in targets)
 		var/turf/targetturf = get_turf(M)
-		if((targetturf.z == sourceturf.z))
+		if(!sourceturf || (targetturf.z in GetConnectedZlevels(sourceturf.z)))
 			M.show_message("<span class='info'>\icon[icon] [message]</span>", 1)
 
 /proc/mobs_in_area(var/area/A)

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -96,6 +96,7 @@ var/warrant_uid = 0
 
 	if(href_list["savewarrant"])
 		. = 1
+		broadcast_security_hud_message("\A [activewarrant.fields["arrestsearch"]] for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in data_core.warrants) ? "edited" : "uploaded"].", src.program.computer)
 		data_core.warrants |= activewarrant
 		activewarrant = null
 

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -33,20 +33,30 @@ var/warrant_uid = 0
 		data["warrantauth"] = activewarrant.fields["auth"]
 		data["type"] = activewarrant.fields["arrestsearch"]
 	else
-		var/list/allwarrants = list()
+		var/list/arrestwarrants = list()
+		var/list/searchwarrants = list()
+		var/list/archivedwarrants = list()
 		for(var/datum/data/record/warrant/W in data_core.warrants)
-			allwarrants.Add(list(list(
+			var/warrant = list(
 			"warrantname" = W.fields["namewarrant"],
 			"charges" = "[copytext(W.fields["charges"],1,min(length(W.fields["charges"]) + 1, 50))]...",
 			"auth" = W.fields["auth"],
 			"id" = W.warrant_id,
-			"arrestsearch" = W.fields["arrestsearch"]
-		)))
-		data["allwarrants"] = allwarrants
+			"arrestsearch" = W.fields["arrestsearch"],
+			"archived" = W.archived)
+			if (warrant["archived"])
+				archivedwarrants.Add(list(warrant))
+			else if(warrant["arrestsearch"] == "arrest")
+				arrestwarrants.Add(list(warrant))
+			else
+				searchwarrants.Add(list(warrant))
+		data["arrestwarrants"] = arrestwarrants.len ? arrestwarrants : null
+		data["searchwarrants"] = searchwarrants.len ? searchwarrants : null
+		data["archivedwarrants"] = archivedwarrants.len? archivedwarrants :null
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "digitalwarrant.tmpl", name, 500, 350, state = state)
+		ui = new(user, src, ui_key, "digitalwarrant.tmpl", name, 700, 450, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
@@ -77,18 +87,31 @@ var/warrant_uid = 0
 		to_chat(user, "Authentication error: Unable to locate ID with apropriate access to allow this operation.")
 		return
 
+	if(href_list["sendtoarchive"])
+		. = 1
+		for(var/datum/data/record/warrant/W in data_core.warrants)
+			if(W.warrant_id == text2num(href_list["sendtoarchive"]))
+				W.archived = TRUE
+				break
+
+	if(href_list["restore"])
+		. = 1
+		for(var/datum/data/record/warrant/W in data_core.warrants)
+			if(W.warrant_id == text2num(href_list["restore"]))
+				W.archived = FALSE
+				break
+
 	if(href_list["addwarrant"])
 		. = 1
 		var/datum/data/record/warrant/W = new()
-		var/temp = sanitize(input(usr, "Do you want to create a search-, or an arrest warrant?") as null|anything in list("search","arrest"))
 		if(CanInteract(user, default_state))
-			if(temp == "arrest")
+			if(href_list["addwarrant"] == "arrest")
 				W.fields["namewarrant"] = "Unknown"
 				W.fields["charges"] = "No charges present"
 				W.fields["auth"] = "Unauthorized"
 				W.fields["arrestsearch"] = "arrest"
-			if(temp == "search")
-				W.fields["namewarrant"] = "No location given"
+			if(href_list["addwarrant"] == "search")
+				W.fields["namewarrant"] = "Unknown"
 				W.fields["charges"] = "No reason given"
 				W.fields["auth"] = "Unauthorized"
 				W.fields["arrestsearch"] = "search"
@@ -96,12 +119,17 @@ var/warrant_uid = 0
 
 	if(href_list["savewarrant"])
 		. = 1
-		broadcast_security_hud_message("\A [activewarrant.fields["arrestsearch"]] for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in data_core.warrants) ? "edited" : "uploaded"].", src.program.computer)
+		broadcast_security_hud_message("\A [activewarrant.fields["arrestsearch"]] warrant for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in data_core.warrants) ? "edited" : "uploaded"].", src.program.computer)
 		data_core.warrants |= activewarrant
 		activewarrant = null
 
 	if(href_list["deletewarrant"])
 		. = 1
+		if(!activewarrant)
+			for(var/datum/data/record/warrant/W in data_core.warrants)
+				if(W.warrant_id == text2num(href_list["deletewarrant"]))
+					activewarrant = W
+					break
 		data_core.warrants -= activewarrant
 		activewarrant = null
 

--- a/html/changelogs/Hubblenaut-warrants.yml
+++ b/html/changelogs/Hubblenaut-warrants.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Digital warrants can now be archived, so they don't have to be deleted."
+  - rscadd: "Security gets automatically notified on new warrants through their HUDs."
+  - tweak: "Improved the digital warrant interface."

--- a/nano/templates/digitalwarrant.tmpl
+++ b/nano/templates/digitalwarrant.tmpl
@@ -54,7 +54,7 @@
 				{{/if}}
 				<tr><td>{{:helper.link('Authorize', null, {'editwarrantauth' : 1})}}
 				<tr><td>{{:helper.link('Save', null, {'savewarrant' : 1})}}
-				<td>{{:helper.link('Delete', null, {'deletewarrant' : 1})}}
+				<td>{{:helper.link('Delete', 'trash', {'deletewarrant' : 1})}}
 				<tr><td>{{:helper.link('Back to Menu', null, {'back' : 1})}}
 			</table>
 		</div>
@@ -62,28 +62,51 @@
 
 {{else}}
 
-	{{:helper.link('Add a Warrant', null, {'addwarrant' : 1})}}<br><hr>
+	<hr>
 	<h2>Arrest warrants</h2>
-	<table>
-		<tr><th>Name<th>Charges<th>Authorized By
-		{{for data.allwarrants}}
-			{{if value.arrestsearch == "arrest"}}
-				<tr><td>{{:helper.link(value.warrantname, null, {'editwarrant' : value.id})}}</td>
+	<div class="itemContent">
+		{{:helper.link('Add a Warrant', null, {'addwarrant' : "arrest"})}}
+	</div>
+	{{if data.arrestwarrants}}
+		<table width=100%>
+			<tr><th width=20%>Name<th>Charges<th width=40%>Authorized By<th width=115px>
+			{{for data.arrestwarrants}}
+				<tr><td>{{:value.warrantname}}</td>
 				<td>{{:value.charges}}</td>
 				<td>{{:value.auth}}</td>
-			{{/if}}
-		{{/for}}		
-	</table>
+				<td>{{:helper.link('', 'pencil', {'editwarrant' : value.id})}}
+				{{:helper.link('Archive', null, {'sendtoarchive' : value.id})}}
+				{{:helper.link('', 'trash', {'deletewarrant' : value.id})}}</td>
+			{{/for}}		
+		</table>
+	{{/if}}
 	<h2>Search warrants</h2>
-	<table>
-		<tr><th>Location<th>Reason<th>Authorized By
-		{{for data.allwarrants}}
-			{{if value.arrestsearch == "search"}}
-				<tr><td>{{:helper.link(value.warrantname, null, {'editwarrant' : value.id})}}</td>
+	<div class="itemContent">{{:helper.link('Add a Warrant', null, {'addwarrant' : "search"})}}</div>
+	{{if data.searchwarrants}}
+		<table width=100%>
+			<tr><th width=20%>Location<th>Reason<th width=40%>Authorized By<th width=115px>
+			{{for data.searchwarrants}}
+				<tr><td>{{:value.warrantname}}</td>
 				<td>{{:value.charges}}</td>
 				<td>{{:value.auth}}</td>
-			{{/if}}
-		{{/for}}		
-	</table>
-
+				<td>{{:helper.link('', 'pencil', {'editwarrant' : value.id})}}
+				{{:helper.link('Archive', null, {'sendtoarchive' : value.id})}}
+				{{:helper.link('', 'trash', {'deletewarrant' : value.id})}}</td>
+			{{/for}}		
+		</table>
+	{{/if}}
+	<h2 style="color:#888888">Archived</h2>
+	{{if data.archivedwarrants}}
+		<table width=100% style="color:#888888">
+			<tr><th width=20%>Target<th>Reason<th width=40%>Authorized By<th width=115px>
+			{{for data.archivedwarrants}}
+				<tr><td>{{:value.warrantname}}</td>
+				<td>{{:value.charges}}</td>
+				<td>{{:value.auth}}</td>
+				<td>{{:helper.link('', 'pencil', {'editwarrant' : value.id})}}
+				{{:helper.link('Restore', null, {'restore' : value.id})}}
+				{{:helper.link('', 'trash', {'deletewarrant' : value.id})}}</td>
+			{{/for}}
+		</table>
+	{{/if}}
 {{/if}}


### PR DESCRIPTION
**Changes:**
 - Holowarrants can be worn on security belts and belt slots.
 - Warrants can now be archived.
 - Security HUDs notifies on new or edited warrants.
 - Made the warrant interface look nicer and more cleaned up.


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
