### PR TITLE
Removes debug tell about lighting overlays in non-dynamic lighting locs

### DIFF
--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -46,7 +46,6 @@
 		qdel(src)
 		return
 	if(!T.dynamic_lighting)
-		log_debug("A lighting overlay found it's way onto a statically lit turf! loc: [loc] , [loc.type]")
 		qdel(src)
 		return
 


### PR DESCRIPTION
I remember someone asking me to do this.

Might not need this debug line anymore, and it does get spammy.