### PR TITLE
Changes a lot of the ranks. 

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -445,8 +445,8 @@
 	icon_state = "fleetrank_officer"
 
 /obj/item/clothing/accessory/rank/fleet/officer/o2
-	name = "ranks (O-2 lieutenant junior grade)"
-	desc = "Insignia denoting the rank of Lieutenant Junior Grade."
+	name = "ranks (O-2 second lieutenant)"
+	desc = "Insignia denoting the rank of Second Lieutenant."
 
 /obj/item/clothing/accessory/rank/fleet/officer/o3
 	name = "ranks (O-3 lieutenant)"
@@ -466,13 +466,13 @@
 	icon_state = "fleetrank_command"
 
 /obj/item/clothing/accessory/rank/fleet/flag
-	name = "ranks (O-7 rear admiral lower half)"
-	desc = "Insignia denoting the rank of Rear Admiral Lower Half."
+	name = "ranks (O-7 commodore"
+	desc = "Insignia denoting the rank of Commodore."
 	icon_state = "fleetrank_command"
 
 /obj/item/clothing/accessory/rank/fleet/flag/o8
-	name = "ranks (O-8 rear admiral upper half)"
-	desc = "Insignia denoting the rank of Rear Admiral Upper Half."
+	name = "ranks (O-8 rear admiral)"
+	desc = "Insignia denoting the rank of Rear Admiral."
 
 /obj/item/clothing/accessory/rank/fleet/flag/o9
 	name = "ranks (O-9 vice admiral)"
@@ -492,21 +492,21 @@
 	icon_state = "marinerank_enlisted"
 
 /obj/item/clothing/accessory/rank/marine/enlisted
-	name = "ranks (E-1 private)"
-	desc = "Insignia denoting the rank of Private."
+	name = "ranks (E-1 mariner apprentice)"
+	desc = "Insignia denoting the rank of Mariner Apprentice."
 	icon_state = "marinerank_enlisted"
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e2
-	name = "ranks (E-2 private first class)"
-	desc = "Insignia denoting the rank of Private First Class."
+	name = "ranks (E-2 mariner second class)"
+	desc = "Insignia denoting the rank of Mariner Second Class."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e3
-	name = "ranks (E-3 lance corporal)"
-	desc = "Insignia denoting the rank of Lance Corporal."
+	name = "ranks (E-3 mariner first class)"
+	desc = "Insignia denoting the rank of Mariner First Class."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e4
-	name = "ranks (E-4 corporal)"
-	desc = "Insignia denoting the rank of Corporal."
+	name = "ranks (E-4 master mariner)"
+	desc = "Insignia denoting the rank of Master Mariner."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e5
 	name = "ranks (E-5 sergeant)"
@@ -517,8 +517,8 @@
 	desc = "Insignia denoting the rank of Staff Sergeant."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e7
-	name = "ranks (E-7 gunnery sergeant)"
-	desc = "Insignia denoting the rank of Gunnery Sergeant."
+	name = "ranks (E-7 colour sergeant)"
+	desc = "Insignia denoting the rank of Colour Sergeant."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e8
 	name = "ranks (E-8 master sergeant)"
@@ -529,8 +529,8 @@
 	desc = "Insignia denoting the rank of First Sergeant."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e9
-	name = "ranks (E-9 master gunnery sergeant)"
-	desc = "Insignia denoting the rank of Master Gunnery Sergeant."
+	name = "ranks (E-9 master colour sergeant)"
+	desc = "Insignia denoting the rank of Master Colour Sergeant."
 
 /obj/item/clothing/accessory/rank/marine/enlisted/e9_alt1
 	name = "ranks (E-9 sergeant major)"
@@ -541,17 +541,17 @@
 	desc = "Insignia denoting the rank of Sergeant Major of the Marine Corps."
 
 /obj/item/clothing/accessory/rank/marine/officer
-	name = "ranks (O-1 second lieutenant)"
-	desc = "Insignia denoting the rank of Second Lieutenant."
+	name = "ranks (O-1 ensign)"
+	desc = "Insignia denoting the rank of Ensign."
 	icon_state = "marinerank_officer"
 
 /obj/item/clothing/accessory/rank/marine/officer/o2
-	name = "ranks (O-2 first lieutenant)"
-	desc = "Insignia denoting the rank of First Lieutenant."
+	name = "ranks (O-2 second lieutenant)"
+	desc = "Insignia denoting the rank of Second Lieutenant."
 
 /obj/item/clothing/accessory/rank/marine/officer/o3
-	name = "ranks (O-3 captain)"
-	desc = "Insignia denoting the rank of Captain."
+	name = "ranks (O-3 lieutenant)"
+	desc = "Insignia denoting the rank of Lieutenant."
 
 /obj/item/clothing/accessory/rank/marine/officer/o4
 	name = "ranks (O-4 major)"
@@ -566,8 +566,8 @@
 	desc = "Insignia denoting the rank of Colonel."
 
 /obj/item/clothing/accessory/rank/marine/flag
-	name = "ranks (O-7 brigadier general)"
-	desc = "Insignia denoting the rank of Brigadier General."
+	name = "ranks (O-7 brigadier)"
+	desc = "Insignia denoting the rank of Brigadier."
 	icon_state = "marinerank_command"
 
 /obj/item/clothing/accessory/rank/marine/flag/o8

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -333,8 +333,8 @@
 	sort_order = 11
 
 /datum/mil_rank/fleet/o2
-	name = "Lieutenant (junior grade)"
-	name_short = "LTJG"
+	name = "Second Lieutenant"
+	name_short = "2Lt"
 	accessory = list(/obj/item/clothing/accessory/rank/fleet/officer/o2, /obj/item/clothing/accessory/specialty/officer)
 	sort_order = 12
 
@@ -363,8 +363,8 @@
 	sort_order = 16
 
 /datum/mil_rank/fleet/o7
-	name = "Rear Admiral (lower half)"
-	name_short = "RDML"
+	name = "Commodore"
+	name_short = "CDRE"
 	accessory = list(/obj/item/clothing/accessory/rank/fleet/flag, /obj/item/clothing/accessory/specialty/officer)
 	sort_order = 17
 
@@ -399,26 +399,26 @@
  */
 
 /datum/mil_rank/marine/e1
-	name = "Private"
-	name_short = "Pvt"
+	name = "Mariner Apprentice"
+	name_short = "MA"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/enlisted)
 	sort_order = 1
 
 /datum/mil_rank/marine/e2
-	name = "Private First Class"
-	name_short = "PFC"
+	name = "Mariner Second Class"
+	name_short = "MSC"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/enlisted/e2)
 	sort_order = 2
 
 /datum/mil_rank/marine/e3
-	name = "Lance Corporal"
-	name_short = "LCpl"
+	name = "Mariner First Class"
+	name_short = "MFC"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/enlisted/e3)
 	sort_order = 3
 
 /datum/mil_rank/marine/e4
-	name = "Corporal"
-	name_short = "Cpl"
+	name = "Master Mariner"
+	name_short = "MMR"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/enlisted/e4)
 	sort_order = 4
 
@@ -435,8 +435,8 @@
 	sort_order = 6
 
 /datum/mil_rank/marine/e7
-	name = "Gunnery Sergeant"
-	name_short = "GySgt"
+	name = "Colour Sergeant"
+	name_short = "CSgt"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/enlisted/e7)
 	sort_order = 7
 
@@ -452,8 +452,8 @@
 	sort_order = 8
 
 /datum/mil_rank/marine/e9
-	name = "Master Gunnery Sergeant"
-	name_short = "MGySgt"
+	name = "Master Colour Sergeant"
+	name_short = "MCSgt"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/enlisted/e9)
 	sort_order = 8
 
@@ -495,20 +495,20 @@
 	sort_order = -5
 
 /datum/mil_rank/marine/o1
-	name = "Second Lieutenant"
-	name_short = "2ndLt"
+	name = "Ensign"
+	name_short = "ENS"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/officer)
 	sort_order = 11
 
 /datum/mil_rank/marine/o2
-	name = "First Lieutenant"
-	name_short = "1stLt"
+	name = "Second Lieutenant"
+	name_short = "2Lt"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/officer/o2)
 	sort_order = 12
 
 /datum/mil_rank/marine/o3
-	name = "Captain"
-	name_short = "Capt"
+	name = "Lieutenant"
+	name_short = "Lt"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/officer/o3)
 	sort_order = 13
 
@@ -531,8 +531,8 @@
 	sort_order = 16
 
 /datum/mil_rank/marine/o7
-	name = "Brigadier General"
-	name_short = "BGen"
+	name = "Brigadier"
+	name_short = "BRG"
 	accessory = list(/obj/item/clothing/accessory/rank/marine/flag)
 	sort_order = 17
 


### PR DESCRIPTION
This makes whatever the the Torch marines are supposed to be actually unique. It abolishes what was previously a copy/paste job of the American marines rank structure. 

**Fleet/EC**

- Replaces 'junior grade' and 'lower half' with sensible alternatives (2nd Lieutenant, Commodore)

**Marines**

- Replaces Private and Corporal with something made up; Mariner, with 0 connotations, positive or negative, beyond the poem and the corresponding Iron Maiden song.
- Replaces Gunnery with Colour across the board. I don't know why I did this; probably because Gunnery has the word Gun in it.

- 2nd Lieutenant to Ensign (matches EC/fleet)
- First Lieutenant to Second Lieutenant (matches EC/fleet)
- Captain to Lieutenant (matches EC/fleet; no more double or triple captains)
- Brigadiers aren't generals anymore. I don't know why I did this.
