### PR TITLE
Adds/standardizes pressure checks

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -96,3 +96,6 @@
 #define ATMOSTANK_CO2           25000 // CO2 and PH are not critically important for station, only for toxins and alternative coolants, no need to store a lot of those.
 #define ATMOSTANK_PHORON        25000
 #define ATMOSTANK_NITROUSOXIDE  10000 // N2O doesn't have a real useful use, i guess it's on station just to allow refilling of sec's riot control canisters?
+
+#define MAX_PUMP_PRESSURE		15000	// Maximal pressure setting for pumps and vents
+#define MAX_OMNI_PRESSURE		7500	// Maximal output(s) pressure for omni devices (filters/mixers)

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -223,7 +223,7 @@ Max Output Pressure: [output_pressure] kPa<BR>"}
 
 	if(href_list["adj_pressure"])
 		var/change = text2num(href_list["adj_pressure"])
-		pressure_setting = between(0, pressure_setting + change, 50*ONE_ATMOSPHERE)
+		pressure_setting = between(0, pressure_setting + change, MAX_PUMP_PRESSURE)
 		spawn(1)
 			src.updateUsrDialog()
 		return 1
@@ -342,7 +342,7 @@ Min Core Pressure: [pressure_limit] kPa<BR>"}
 
 	if(href_list["adj_pressure"])
 		var/change = text2num(href_list["adj_pressure"])
-		pressure_setting = between(0, pressure_setting + change, 10*ONE_ATMOSPHERE)
+		pressure_setting = between(0, pressure_setting + change, MAX_PUMP_PRESSURE)
 		spawn(1)
 			src.updateUsrDialog()
 		return 1

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -14,7 +14,7 @@
 	interact_offline = 1
 	var/unlocked = 0	//If 0, then the valve is locked closed, otherwise it is open(-able, it's a one-way valve so it closes if gas would flow backwards).
 	var/target_pressure = ONE_ATMOSPHERE
-	var/max_pressure_setting = 15000	//kPa
+	var/max_pressure_setting = MAX_PUMP_PRESSURE
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 	var/regulate_mode = REGULATE_OUTPUT
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -28,7 +28,7 @@ Thus, the two variables affect pump operation are set in New():
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
 	power_rating = 7500			//7500 W ~ 10 HP
 
-	var/max_pressure_setting = 15000	//kPa
+	var/max_pressure_setting = MAX_PUMP_PRESSURE
 
 	var/frequency = 0
 	var/id = null

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -17,3 +17,12 @@
 		icon_state = "off"
 	else
 		icon_state = "[use_power ? "on" : "off"]"
+
+// For mapping purposes
+/obj/machinery/atmospherics/binary/pump/high_power/on/max_pressure/
+	target_pressure = MAX_PUMP_PRESSURE
+
+// A possible variant for Atmospherics distribution feed.
+/obj/machinery/atmospherics/binary/pump/high_power/on/distribution/New()
+	..()
+	target_pressure = round(3 * ONE_ATMOSPHERE)

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -8,6 +8,7 @@
 	var/list/filters = new()
 	var/datum/omni_port/input
 	var/datum/omni_port/output
+	var/max_output_pressure = MAX_OMNI_PRESSURE
 
 	use_power = 1
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
@@ -64,8 +65,14 @@
 	var/datum/gas_mixture/output_air = output.air	//BYOND doesn't like referencing "output.air.return_pressure()" so we need to make a direct reference
 	var/datum/gas_mixture/input_air = input.air		// it's completely happy with them if they're in a loop though i.e. "P.air.return_pressure()"... *shrug*
 
+	var/delta = between(0, (output_air ? (max_output_pressure - output_air.return_pressure()) : 0), max_output_pressure)
+	var/transfer_moles_max = calculate_transfer_moles(input_air, output_air, delta, (output && output.network && output.network.volume) ? output.network.volume : 0)
+	for(var/datum/omni_port/filter_output in filters)
+		delta = between(0, (filter_output.air ? (max_output_pressure - filter_output.air.return_pressure()) : 0), max_output_pressure)
+		transfer_moles_max = min(transfer_moles_max, (calculate_transfer_moles(input_air, filter_output.air, delta, (filter_output && filter_output.network && filter_output.network.volume) ? filter_output.network.volume : 0)))
+
 	//Figure out the amount of moles to transfer
-	var/transfer_moles = (set_flow_rate/input_air.volume)*input_air.total_moles
+	var/transfer_moles = between(0, ((set_flow_rate/input_air.volume)*input_air.total_moles), transfer_moles_max)
 
 	var/power_draw = -1
 	if (transfer_moles > MINIMUM_MOLES_TO_FILTER)

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -11,6 +11,7 @@
 
 	var/list/inputs = new()
 	var/datum/omni_port/output
+	var/max_output_pressure = MAX_OMNI_PRESSURE
 
 	//setup tags for initial concentration values (must be decimal)
 	var/tag_north_con
@@ -75,7 +76,7 @@
 	if(output)
 		output.air.volume = ATMOS_DEFAULT_VOLUME_MIXER * 0.75 * inputs.len
 		output.concentration = 1
-	
+
 	rebuild_mixing_inputs()
 
 /obj/machinery/atmospherics/omni/mixer/proc/mapper_set()
@@ -103,8 +104,14 @@
 
 	//Figure out the amount of moles to transfer
 	var/transfer_moles = 0
+	var/datum/gas_mixture/output_gas = output.air
+	var/delta = between(0, (output_gas ? (max_output_pressure - output_gas.return_pressure()) : 0), max_output_pressure)
+	var/transfer_moles_max = INFINITY
+
 	for (var/datum/omni_port/P in inputs)
 		transfer_moles += (set_flow_rate*P.concentration/P.air.volume)*P.air.total_moles
+		transfer_moles_max = min(transfer_moles_max, calculate_transfer_moles(P.air, output.air, delta, (output && output.network && output.network.volume) ? output.network.volume : 0))
+	transfer_moles = between(0, transfer_moles, transfer_moles_max)
 
 	var/power_draw = -1
 	if (transfer_moles > MINIMUM_MOLES_TO_FILTER)

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -64,8 +64,8 @@
 	icon_state = "map_vent_in"
 	external_pressure_bound = 0
 	external_pressure_bound_default = 0
-	internal_pressure_bound = 2000
-	internal_pressure_bound_default = 2000
+	internal_pressure_bound = MAX_PUMP_PRESSURE
+	internal_pressure_bound_default = MAX_PUMP_PRESSURE
 	pressure_checks = 2
 	pressure_checks_default = 2
 

--- a/html/changelogs/Atlantis-pressurechecks.yml
+++ b/html/changelogs/Atlantis-pressurechecks.yml
@@ -1,0 +1,6 @@
+author: Atlantiscze
+delete-after: True
+
+changes: 
+  - tweak: "Max pressure on omni filter/mixer output is now capped at approx. 7500kPa"
+  - tweak: "Atmospherics pressure tanks can now be set to output up to 15000kPa"


### PR DESCRIPTION
- Adds pressure checks to omni filters and mixers. Currently the max pressure on outputs is set to 7500kPa. As pipe burst pressures are generally higher than this, it should completely negate the need for buffer canister on air mixing output. I didn't remove the canister (yet) as that would be a map change commit, but it will be possible to remove it after this is merged.
- Standardizes pressures on devices to a define that is easier to manage (no client-facing change)
- Increases theoretical max pressure on pressure tank (those storage rooms in atmospherics) to 15MPa