### PR TITLE
adds length check + warning in sanitize proc

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -23,11 +23,17 @@
  */
 
 //Used for preprocessing entered text
+//Added in an additional check to alert players if input is too long
 /proc/sanitize(var/input, var/max_length = MAX_MESSAGE_LEN, var/encode = 1, var/trim = 1, var/extra = 1)
 	if(!input)
 		return
 
 	if(max_length)
+		//testing shows that just looking for > max_length alone will actually cut off the final character if message is precisely max_length, so >= instead
+		if(length(input) >= max_length)
+			var/overflow = ((length(input)+1) - max_length)
+			to_chat(usr, "<span class='warning'>Your message is too long by [overflow] character\s.</span>")
+			return
 		input = copytext(input,1,max_length)
 
 	if(extra)


### PR DESCRIPTION
An indirect fix of #8247 , puts in a check in the sanitize proc to see if the message meets or exceeds max length and alerts the user if so instead of silently trimming off excess length.

Potential problem is that this will impact ALL sanitized messages. If someone uses a super long 'say' message it will fail it and alert the person that it was too long instead of letting part of the message through.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
