### PR TITLE
Shock bolt changes

### DIFF
--- a/code/modules/organs/subtypes/diona.dm
+++ b/code/modules/organs/subtypes/diona.dm
@@ -59,6 +59,12 @@
 	parent_organ = BP_CHEST
 	can_grasp = 1
 
+/obj/item/organ/external/diona/arm/stun_act(var/stun_amount, var/agony_amount)
+	if(!owner || (agony_amount < 5))
+		return
+	if(prob(25))
+		owner.grasp_damage_disarm(src)
+
 /obj/item/organ/external/diona/arm/right
 	name = "right upper tendril"
 	organ_tag = BP_R_ARM
@@ -76,6 +82,13 @@
 	icon_position = LEFT
 	parent_organ = BP_GROIN
 	can_stand = 1
+
+/obj/item/organ/external/diona/leg/stun_act(var/stun_amount, var/agony_amount)
+	if(!owner || agony_amount < 5)
+		return
+	if(prob(agony_amount*2))
+		to_chat(owner, "<span class='warning'>Your [src] buckles from the shock!</span>")
+		owner.Weaken(5)
 
 /obj/item/organ/external/diona/leg/right
 	name = "right lower tendril"
@@ -95,6 +108,13 @@
 	icon_position = LEFT
 	parent_organ = BP_L_LEG
 	can_stand = 1
+
+/obj/item/organ/external/diona/foot/stun_act(var/stun_amount, var/agony_amount)
+	if(!owner || agony_amount < 5)
+		return
+	if(prob(agony_amount*4))
+		to_chat(owner, "<span class='warning'>You lose your footing as your [src] spasms!</span>")
+		owner.Weaken(5)
 
 /obj/item/organ/external/diona/foot/right
 	name = "right foot"
@@ -116,6 +136,11 @@
 	body_part = HAND_LEFT
 	parent_organ = BP_L_ARM
 	can_grasp = 1
+
+/obj/item/organ/external/diona/hand/stun_act(var/stun_amount, var/agony_amount)
+	if(!owner || (agony_amount < 5))
+		return
+	owner.grasp_damage_disarm(src)
 
 /obj/item/organ/external/diona/hand/right
 	name = "right grasper"

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -56,7 +56,7 @@
 	arterial_bleed_severity = 0.75
 
 /obj/item/organ/external/arm/stun_act(var/stun_amount, var/agony_amount)
-	if(!owner || (!stun_amount && agony_amount < 5))
+	if(!owner || (agony_amount < 5))
 		return
 	if(prob(25))
 		owner.grasp_damage_disarm(src)
@@ -87,6 +87,13 @@
 	artery_name = "femoral artery"
 	arterial_bleed_severity = 0.75
 
+/obj/item/organ/external/leg/stun_act(var/stun_amount, var/agony_amount)
+	if(!owner || agony_amount < 5)
+		return
+	if(prob(agony_amount*2))
+		to_chat(owner, "<span class='warning'>Your [src] buckles from the shock!</span>")
+		owner.Weaken(5)
+
 /obj/item/organ/external/leg/right
 	organ_tag = BP_R_LEG
 	name = "right leg"
@@ -112,6 +119,13 @@
 	has_tendon = TRUE
 	tendon_name = "Achilles tendon"
 	arterial_bleed_severity = 0.5
+
+/obj/item/organ/external/foot/stun_act(var/stun_amount, var/agony_amount)
+	if(!owner || agony_amount < 5)
+		return
+	if(prob(agony_amount*4))
+		to_chat(owner, "<span class='warning'>You lose your footing as your [src] spasms!</span>")
+		owner.Weaken(5)
 
 /obj/item/organ/external/foot/removed()
 	if(owner) owner.drop_from_inventory(owner.shoes)
@@ -144,7 +158,7 @@
 	arterial_bleed_severity = 0.5
 
 /obj/item/organ/external/hand/stun_act(var/stun_amount, var/agony_amount)
-	if(!owner || (!stun_amount && agony_amount < 5))
+	if(!owner || (agony_amount < 5))
 		return
 	owner.grasp_damage_disarm(src)
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -185,11 +185,11 @@
 /obj/item/projectile/beam/stun/shock
 	name = "shock beam"
 	damage_type = ELECTROCUTE
-	damage = 15
-	agony = 25
+	damage = 10
+	agony  = 5
 	fire_sound='sound/weapons/pulse.ogg'
 
 /obj/item/projectile/beam/stun/shock/heavy
 	name = "heavy shock beam"
 	damage = 20
-	agony = 40
+	agony  = 10

--- a/html/changelogs/chinsky - zapzap.yml
+++ b/html/changelogs/chinsky - zapzap.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Made SHOCK mode on tasers literally useless, ruining security gameplay. Does bit less burn damage, and much less straight up stun damage. Not 'better tase mode' anymore."
+  - bugfix: "Fixed their primary function actually never working. If you hit arm or hand with the beam you can disarm someone (even diona, even robbit, pain reception doesn't matter). If you hit leg, they might drop, higher chance for foot."


### PR DESCRIPTION
Bopped it with the nerf bat. Less damage and considerably less separate agony damage. It was too much combined with halloss from burn damage.

Fixes stun_act on organs never actually doing anything.  Stun_amount was never passed, so it always returned, turning stun shots into shitty lethal guns.

Adds effects to legs, now if you score a shot to the leg they might drop, with twice the chance if you hit the foot (good luck with that).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
