### PR TITLE
Cigarette packet fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -130,7 +130,7 @@
 /obj/item/weapon/storage/fancy/cigarettes/New()
 	..()
 	flags |= NOREACT
-	create_reagents(5 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	create_reagents(5 * max_storage_space)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 	flags |= OPENCONTAINER
 
 /obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -134,10 +134,7 @@
 	pack.desc += " 'S' has been scribbled on it."
 
 	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list("potassium" = 1, "nitrogen" = 1, "silicon" = 1))
-	// Mindbreaker
-	fill_cigarre_package(pack, list("silicon" = 1.5, "hydrogen" = 1.5))
-
+	fill_cigarre_package(pack, list("anti_toxin" = 1, "silicon" = 1, "hydrazine" = 1))
 	pack.desc += " 'MB' has been scribbled on it."
 
 	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
@@ -148,7 +145,7 @@
 
 /proc/fill_cigarre_package(var/obj/item/weapon/storage/fancy/cigarettes/C, var/list/reagents)
 	for(var/reagent in reagents)
-		C.reagents.add_reagent(reagent, reagents[reagent] * C.storage_slots)
+		C.reagents.add_reagent(reagent, reagents[reagent] * C.max_storage_space)
 
 //Rig Electrowarfare and Voice Synthesiser kit
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/ewar_voice


### PR DESCRIPTION
Cigarette packets had an error that made their create_reagents argument zero, so you couldn't inject anything into them to spike. This also broke _every_ packet in the tricky smokes traitor item. Also changed the mindbreaker toxin tricky packet reagents so they actually react properly into MB toxin. 

Partially fixes #13833
I noticed during a testing run that a cigar spiked with 9u phoron has a -1,-1,0 explosion, i.e. the cigar explodes in your face without harming you, the hull, or anyone around. Hilariously, 4u welding fuel in a cigarette just creates sparks. My code-fu is bad, so someone else might have to look into that part.