### PR TITLE
Can rig assemblies to be triggered on opening crate.

### DIFF
--- a/html/changelogs/chinsky - jumpscare.yml
+++ b/html/changelogs/chinsky - jumpscare.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Can now rig assemblies/devices(e.g. radio signalers) to trigger when crate is opened. Click wires on open crate, then click with assemblies. It would trigger when opened next time. Use wirecutter to unrig."


### PR DESCRIPTION
Functinoality existed whole time but for extinct electropacks.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
