### PR TITLE
Fixes splicing failing silentl sometimes

### DIFF
--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -162,23 +162,26 @@
 
 	if(href_list["splice"])
 		if(dish)
-			var/target = text2num(href_list["splice"]) // target = 1 to 4 for effects, 5 for species
-			if(memorybank && 0 < target && target <= 4)
-				if(target < memorybank.stage) return // too powerful, catching this for href exploit prevention
+			var/target = text2num(href_list["splice"]) // target = 1+ for effects, -1 for species
+			if(memorybank && target > 0)
+				if(target < memorybank.stage)
+					return // too powerful, catching this for href exploit prevention
 
 				var/datum/disease2/effect/target_effect
 				var/list/illegal_types = list()
 				for(var/datum/disease2/effect/e in dish.virus2.effects)
 					if(e.stage == target)
 						target_effect = e
-					else
+					if(!e.allow_multiple)
 						illegal_types += e.type
-				if(memorybank.type in illegal_types) return
+				if(memorybank.type in illegal_types)
+					to_chat(user, "<span class='warning'>Virus DNA can't hold more than one [memorybank]</span>")
+					return 1
 				dish.virus2.effects -= target_effect
 				dish.virus2.effects += memorybank
 				qdel(target_effect)
 
-			else if(species_buffer && target == 5)
+			else if(species_buffer && target == -1)
 				dish.virus2.affected_species = species_buffer
 
 			else

--- a/nano/templates/disease_splicer.tmpl
+++ b/nano/templates/disease_splicer.tmpl
@@ -105,7 +105,7 @@
   </div>
   {{:helper.link('Save To Disk', 'disk', { 'disk' : 1 }, (data.buffer || data.species_buffer) ? null : 'disabled')}}
   {{if data.species_buffer}}
-    {{:helper.link('Splice Species', 'pencil', { 'splice' : 5 }, (data.species_buffer && !data.info) ? null : 'disabled')}}
+    {{:helper.link('Splice Species', 'pencil', { 'splice' : -1 }, (data.species_buffer && !data.info) ? null : 'disabled')}}
   {{else data.buffer}}
 	{{:helper.link('Splice #1', 'pencil', { 'splice' : 1 }, data.buffer.stage > 1 ? 'disabled' : null)}}
 	{{:helper.link('Splice #2', 'pencil', { 'splice' : 2 }, data.buffer.stage > 2 ? 'disabled' : null)}}


### PR DESCRIPTION
It will now tell you when you can't have duplicate syndromes.
Also removes hard limitation on 4 steps from splicer.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
