### PR TITLE
Fixes objects using walk_to() not being able to be garbage collected.

### DIFF
--- a/code/game/gamemodes/events/clang.dm
+++ b/code/game/gamemodes/events/clang.dm
@@ -41,6 +41,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(clong && prob(25))
 			src.forceMove(clong.loc)
 
+	Destroy()
+		walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+		return ..()
+
 /proc/immovablerod()
 	var/startx = 0
 	var/starty = 0

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -90,6 +90,10 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 			walk_towards(src, goal, 1)
 		return
 
+	Destroy()
+		walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+		return ..()
+
 	touch_map_edge()
 		qdel(src)
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -173,7 +173,7 @@
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc
-	..()
+	return ..()
 
 /obj/effect/meteor/New()
 	..()

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -35,9 +35,11 @@
 		walk_to(src, destination)
 
 /obj/effect/effect/smoke/chem/Destroy()
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	set_opacity(0)
+	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
 	fadeOut()
-	..()
+	return ..()
 
 /obj/effect/effect/smoke/chem/Move()
 	var/list/oldlocs = view(1, src)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -153,6 +153,7 @@
 	if(dormant)
 		moved_event.unregister(src, src, /obj/effect/spider/spiderling/proc/disturbed)
 	processing_objects -= src
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	. = ..()
 
 /obj/effect/spider/spiderling/attackby(var/obj/item/weapon/W, var/mob/user)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -97,6 +97,10 @@
 				to_chat(M, "<span class='danger'>Your ears start to ring!</span>")
 		M.update_icons()
 
+/obj/item/weapon/grenade/flashbang/Destroy()
+	walk(src, 0) // Because we might have called walk_away, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	return ..()
+
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
 	desc = "Use of this weapon may constiute a war crime in your area, consult your local captain."
 	name = "clusterbang"


### PR DESCRIPTION
Ports VOREStation/VOREStation/pull/1734
* Okay evidently walk_to(A, B) doesn't stop when A reaches B, but keeps running in the background forever until it is manually canceled!  Therefore in order to be garbage collected, we must cancel walking on any object that might have initiated it.
* Fixes this on chemsmoke and spiders.
* The same story applies to walk_towards; fixed for dust, meteors and immovablerod, and also to walk_away; fixed for flashbangs.

This will fix `## TESTING: GC: -- /obj/effect/effect/smoke/chem was unable to be GC'd and was deleted --` for the objects listed.

*Extra Note* BayStation's smoke/chem code differs from Polaris.  I noticed that  it will sleep during Destroy().  Outside the scope of this PR, but something you'll want to fix eventually.