### PR TITLE
Ruins antags forever

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -1,8 +1,8 @@
 /datum/antagonist/proc/can_become_antag(var/datum/mind/player, var/ignore_role)
 	if(player.current && jobban_isbanned(player.current, id))
 		return 0
-
-	if(player.assigned_role in blacklisted_jobs)
+	var/datum/job/J = job_master.GetJob(player.assigned_role)
+	if(is_type_in_list(J,blacklisted_jobs))
 		return 0
 
 	if(!ignore_role)
@@ -11,7 +11,7 @@
 			// Limits antag status to clients above player age, if the age system is being used.
 			if(C && config.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(min_player_age) && (C.player_age < min_player_age))
 				return 0
-		if(player.assigned_role in restricted_jobs)
+		if(is_type_in_list(J,restricted_jobs))
 			return 0
 		if(player.current && (player.current.status_flags & NO_ANTAG))
 			return 0

--- a/code/game/antagonist/mutiny/mutineer.dm
+++ b/code/game/antagonist/mutiny/mutineer.dm
@@ -6,7 +6,7 @@ var/datum/antagonist/mutineer/mutineers
 	role_text_plural = "Mutineers"
 	id = MODE_MUTINEER
 	antag_indicator = "hudmutineer"
-	restricted_jobs = list("Captain")
+	restricted_jobs = list(/datum/job/captain)
 
 /datum/antagonist/mutineer/New(var/no_reference)
 	..()
@@ -23,45 +23,3 @@ var/datum/antagonist/mutineer/mutineers
 	if(M.special_role)
 		return 0
 	return 1
-
-/*
-	var/list/directive_candidates = get_directive_candidates()
-	if(!directive_candidates || directive_candidates.len == 0)
-		to_world("<span class='warning'>Mutiny mode aborted: no valid candidates for Directive X.</span>")
-
-		return 0
-
-	head_loyalist = pick(loyalist_candidates)
-	head_mutineer = pick(mutineer_candidates)
-	current_directive = pick(directive_candidates)
-
-
-	// Returns an array in case we want to expand on this later.
-	proc/get_head_loyalist_candidates()
-		var/list/candidates[0]
-		for(var/mob/loyalist in player_list)
-			if(loyalist.mind && loyalist.mind.assigned_role == "Captain")
-				candidates.Add(loyalist.mind)
-		return candidates
-
-	proc/get_head_mutineer_candidates()
-		var/list/candidates[0]
-		for(var/mob/mutineer in player_list)
-			if(mutineer.client.prefs.be_special & BE_MUTINEER)
-				for(var/job in command_positions - "Captain")
-					if(mutineer.mind && mutineer.mind.assigned_role == job)
-						candidates.Add(mutineer.mind)
-		return candidates
-
-	proc/get_directive_candidates()
-		var/list/candidates[0]
-		for(var/T in typesof(/datum/directive) - /datum/directive)
-			var/datum/directive/D = new T(src)
-			if (D.meets_prerequisites())
-				candidates.Add(D)
-		return candidates
-
-
-	return 1
-
-*/

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -3,8 +3,8 @@
 	role_text = "Changeling"
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
-	blacklisted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/hos) 
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"

--- a/code/game/antagonist/station/cult_god.dm
+++ b/code/game/antagonist/station/cult_god.dm
@@ -4,9 +4,9 @@ var/datum/antagonist/godcultist/godcult
 	id = MODE_GODCULTIST
 	role_text = "God Cultist"
 	role_text_plural = "Cultists"
-	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain")
-	protected_jobs = list("Security Officer", "Warden", "Detective")
-	blacklisted_jobs = list("AI", "Cyborg", "Chaplain")
+	restricted_jobs = list(/datum/job/lawyer, /datum/job/captain, /datum/job/hos)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain)
 	feedback_tag = "godcult_objective"
 	antag_indicator = "hudcultist"
 	welcome_text = "You are under the guidance of a powerful otherwordly being. Spread its will and keep your faith."

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -24,9 +24,9 @@ var/datum/antagonist/cultist/cult
 	id = MODE_CULTIST
 	role_text = "Cultist"
 	role_text_plural = "Cultists"
-	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain", "Chief of Security", "Commanding Officer")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Brig Officer", "Forensic Technician", "Master at Arms")
-	blacklisted_jobs = list("AI", "Cyborg", "Chaplain", "Counselor")
+	restricted_jobs = list(/datum/job/lawyer, /datum/job/captain, /datum/job/hos)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/psychiatrist)
 	feedback_tag = "cult_objective"
 	antag_indicator = "hudcultist"
 	welcome_text = "You have a tome in your possession; one that will help you start the cult. Use it well and remember - there are others."

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -6,7 +6,6 @@ var/datum/antagonist/loyalists/loyalists
 	role_text_plural = "Loyalists"
 	feedback_tag = "loyalist_objective"
 	antag_indicator = "hudheadloyalist"
-	welcome_text = "You belong to the Company, body and soul. Preserve its interests against the conspirators amongst the crew."
 	victory_text = "The heads of staff remained at their posts! The loyalists win!"
 	loss_text = "The heads of staff did not stop the revolution!"
 	victory_feedback_tag = "win - rev heads killed"
@@ -21,18 +20,20 @@ var/datum/antagonist/loyalists/loyalists
 
 	// Inround loyalists.
 	faction_role_text = "Loyalist"
-	faction_descriptor = "Company"
+	faction_descriptor = "COMPANY"
 	faction_verb = /mob/living/proc/convert_to_loyalist
-	faction_welcome = "Preserve NanoTrasen's interests against the traitorous recidivists amongst the crew. Protect the heads of staff with your life."
 	faction_indicator = "hudloyalist"
 	faction_invisible = 1
-	blacklisted_jobs = list("AI", "Cyborg")
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg)
 
 	faction = "loyalist"
 
 /datum/antagonist/loyalists/New()
 	..()
 	loyalists = src
+	welcome_text = "You belong to the [using_map.company_name], body and soul. Preserve its interests against the conspirators amongst the crew."
+	faction_welcome = "Preserve [using_map.company_short]'s interests against the traitorous recidivists amongst the crew. Protect the heads of staff with your life."
+	faction_descriptor = "[using_map.company_name]"
 
 /datum/antagonist/loyalists/create_global_objectives()
 	if(!..())

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -28,9 +28,9 @@ var/datum/antagonist/revolutionary/revs
 	faction_invisible = 1
 	faction = "revolutionary"
 
-	blacklisted_jobs = list("AI", "Cyborg")
-	restricted_jobs = list("Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent")
-	protected_jobs = list("Security Officer", "Warden", "Detective")
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo, /datum/job/lawyer)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
 
 
 /datum/antagonist/revolutionary/New()

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -3,7 +3,7 @@ var/datum/antagonist/traitor/traitors
 // Inherits most of its vars from the base datum.
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Internal Affairs Agent", "Head of Security", "Captain")
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 
 /datum/antagonist/traitor/New()

--- a/html/changelogs/chinsky - captainlol.yml
+++ b/html/changelogs/chinsky - captainlol.yml
@@ -1,0 +1,6 @@
+
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "SCG had mastered the secret art of 'background check'. CO and XO are no longer be eligible for roundstart antag roles on Torch. Can still be converted in round"
+  - bugfix: "As a side effect, they aren't going to get rev'd anymore, that was a bug."

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -9,6 +9,7 @@
 	#include "torch_ranks.dm"
 	#include "torch_shuttles.dm"
 	#include "torch_unit_testing.dm"
+	#include "torch_gamemodes.dm"
 
 	#include "datums/uniforms.dm"
 	#include "datums/uniforms_expedition.dm"

--- a/maps/torch/torch_gamemodes.dm
+++ b/maps/torch/torch_gamemodes.dm
@@ -1,0 +1,4 @@
+/datum/antagonist/changeling/restricted_jobs = list(/datum/job/captain, /datum/job/hop)
+/datum/antagonist/traitor/restricted_jobs = list(/datum/job/captain, /datum/job/hop)
+/datum/antagonist/cultist/restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos)
+/datum/antagonist/godcultist/restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos)


### PR DESCRIPTION
Makes CO and XO not elligible for on-station roundstart antags. Conversion is ok.
Also refactors antag datums to use job paths instead of names. This is what caused COs getting revved I think. As a side effect, removes bunch of torch-specific shit from antag datum definitions.

Also makes Loyalist blurb adjust itself on creation so people are loyal to their map-specific things rather thn NT.