### PR TITLE
Fixes soem first aid boxes not accepting random shit

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -42,17 +42,13 @@
 	icon_state = "firstaid"
 
 	startswith = list(
-		/obj/item/stack/medical/bruise_pack = 3,
-		/obj/item/stack/medical/ointment = 2,
+		/obj/item/stack/medical/bruise_pack = 2,
+		/obj/item/stack/medical/ointment = 1,
 		/obj/item/device/healthanalyzer,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
 		/obj/item/weapon/storage/pill_bottle/antidexafen,
 		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
-
-/obj/item/weapon/storage/firstaid/regular/New()
-	..()
-	make_exact_fit()
 
 /obj/item/weapon/storage/firstaid/toxin
 	name = "toxin first aid"
@@ -91,15 +87,11 @@
 
 	startswith = list(
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
-		/obj/item/stack/medical/advanced/bruise_pack = 3,
+		/obj/item/stack/medical/advanced/bruise_pack = 2,
 		/obj/item/stack/medical/advanced/ointment = 2,
 		/obj/item/stack/medical/splint,
 		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
-
-/obj/item/weapon/storage/firstaid/adv/New()
-	..()
-	make_exact_fit()
 
 /obj/item/weapon/storage/firstaid/combat
 	name = "combat medical kit"


### PR DESCRIPTION
Didn't know make exact fit also set can_hold list, and turns out it isn't even needed - boxes have just enough space.

EDIT: NOPE THEY DIDN'T.
Removed 1 bruise pack, 1 ointment from usual first aid kits, removed 1 bruise pack form advanced ones.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
