### PR TITLE
Fixes Tower spells being super spammable.

### DIFF
--- a/code/modules/mob/living/deity/forms.dm
+++ b/code/modules/mob/living/deity/forms.dm
@@ -33,7 +33,7 @@ Each plays slightly different and has different challenges/benefits
 		O.vars[V] = svars[V]
 
 /datum/god_form/proc/take_charge(var/mob/living/user, var/charge)
-	return 1
+	return
 
 /datum/god_form/Destroy()
 	if(linked_god)
@@ -65,8 +65,6 @@ Each plays slightly different and has different challenges/benefits
 	starting_feats = list(DEITY_FORM_DARK_ART, DEITY_FORM_BLOOD_SAC, DEITY_FORM_DARK_MINION, DEITY_FORM_BLOOD_FORGE)
 
 /datum/god_form/narsie/take_charge(var/mob/living/user, var/charge)
-	if(!..())
-		return 0
 	charge *= 0.5
 	if(prob(charge))
 		to_chat(user, "<span class='warning'>You feel drained...</span>")
@@ -76,7 +74,6 @@ Each plays slightly different and has different challenges/benefits
 			H.vessel.remove_reagent("blood", charge)
 	else
 		user.adjustBruteLoss(charge)
-	return 1
 
 /datum/god_form/wizard
 	name = "The Tower"
@@ -99,6 +96,4 @@ Each plays slightly different and has different challenges/benefits
 	starting_feats = list(DEITY_TREE_TRANSMUTATION, DEITY_TREE_CONJURATION)
 
 /datum/god_form/wizard/take_charge(var/mob/living/user, var/charge)
-	if(!..())
-		return 0
 	linked_god.adjust_power(max(round(charge/100), 1),silent = 1)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -270,9 +270,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell/proc/take_charge(mob/user = user, var/skipcharge)
 	if(!skipcharge)
-		if(connected_god)
-			if(!connected_god.take_charge(user, max(1,charge_max/10))) //100 is 10 seconds
-				return 0
+		connected_god.take_charge(user, max(1,charge_max/10))
 		switch(charge_type)
 			if(Sp_RECHARGE)
 				charge_counter = 0 //doesn't start recharging until the targets selecting ends


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Basically just gets rid of the check to see if a deity's take_charge proc will return 0. Which, I think, it should never do anyways.

What was happening is that the Tower would return null, and that would make it so that take_charge would never go through. So the spells would not go on cooldown right.