### PR TITLE
Makes startRequirements() more robust

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -119,7 +119,24 @@
 		else if(player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
 		else
-			candidates += player
+			candidates |= player
+
+	return candidates
+
+// Builds a list of potential antags without actually setting them. Used to test mode viability.
+/datum/antagonist/proc/get_potential_candidates(var/datum/game_mode/mode, var/ghosts_only)
+	var/candidates = list()
+
+	// Keeping broken up for readability
+	for(var/datum/mind/player in mode.get_players_for_role(role_type, id))
+		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
+		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
+		else if(player.special_role)
+		else if (player in pending_antagonists)
+		else if(!can_become_antag(player))
+		else if(player_is_antag(player))
+		else
+			candidates |= player
 
 	return candidates
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -159,9 +159,6 @@ var/global/list/additional_antag_types = list()
 	if(playerC < required_players)
 		return "Not enough players, [src.required_players] players needed."
 
-	if(!(antag_templates && antag_templates.len))
-		return 0
-
 	var/enemy_count = 0
 	var/list/all_antag_types = all_antag_types()
 	if(antag_tags && antag_tags.len)
@@ -170,17 +167,22 @@ var/global/list/additional_antag_types = list()
 			if(!antag)
 				continue
 			var/list/potential = list()
-			if(antag.flags & ANTAG_OVERRIDE_JOB)
-				potential = antag.pending_antagonists
+			if(antag_templates && antag_templates.len)
+				if(antag.flags & ANTAG_OVERRIDE_JOB)
+					potential = antag.pending_antagonists
+				else
+					potential = antag.candidates
 			else
-				potential = antag.candidates
+				potential = antag.get_potential_candidates(src)
 			if(islist(potential))
 				if(require_all_templates && potential.len < antag.initial_spawn_req)
 					return "Not enough antagonists ([antag.role_text]), [antag.initial_spawn_req] required and [potential.len] available."
 				enemy_count += potential.len
 				if(enemy_count >= required_enemies)
 					return 0
-	return "Not enough antagonists, [required_enemies] required and [enemy_count] available."
+		return "Not enough antagonists, [required_enemies] required and [enemy_count] available."
+	else
+		return 0
 
 /datum/game_mode/proc/refresh_event_modifiers()
 	if(event_delay_mod_moderate || event_delay_mod_major)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -44,25 +44,14 @@ var/global/datum/controller/gameticker/ticker
 			if(!isnull(secondary_mode))
 				master_mode = secondary_mode
 				secondary_mode = null
-				to_world("Trying to start the second top game mode...")
-
-				if(!hide_mode)
-					to_world("<b>The game mode is now: [master_mode]</b>")
-
 			else if(!isnull(tertiary_mode))
 				master_mode = tertiary_mode
 				tertiary_mode = null
-				to_world("Trying to start the third top game mode...")
-
-				if(!hide_mode)
-					to_world("<b>The game mode is now: [master_mode]</b>")
-
 			else
 				master_mode = "extended"
-				to_world("<b>Forcing the game mode to extended...</b>")
 
+		to_world("<b>Trying to start [master_mode]...</b>")
 		to_world("<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
-
 		to_world("Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds")
 
 		while(current_state == GAME_STATE_PREGAME)
@@ -88,6 +77,8 @@ var/global/datum/controller/gameticker/ticker
 	//Create and announce mode
 	if(master_mode=="secret")
 		src.hide_mode = 1
+	else
+		src.hide_mode = 0
 
 	var/list/runnable_modes = config.get_runnable_modes()
 	if((master_mode=="random") || (master_mode=="secret"))


### PR DESCRIPTION
This should make it less likely (or impossible) for secret to attempt to start a game mode that will fail to start, by building and checking the viability of a list of potential antags before generating the official list. Additionally, this fixes a non-secret game mode erroneously being reported as secret after secret fails to start.

fixes #15484
fixes #12202
fixes #11390

I made this a while ago but didn't feel good about the code so never PRed. Do note that it this couldn't easily be thoroughly tested.