### PR TITLE
Changes bluespace jump effects

### DIFF
--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -1,6 +1,7 @@
 /datum/universal_state/bluespace_jump
 	name = "Bluespace Jump"
 	var/list/bluespaced = list()
+	var/list/bluegoasts = list()
 	var/list/affected_levels
 	var/list/old_accessible_z_levels
 
@@ -18,8 +19,10 @@
 					M.forceMove(T)
 			else
 				apply_bluespaced(M)
-				bluespaced += M
-
+	for(var/mob/goast in ghost_mob_list_)
+		goast.mouse_opacity = 0	//can't let you click that Dave
+		goast.invisibility = SEE_INVISIBLE_LIVING
+		goast.alpha = 255
 	old_accessible_z_levels = using_map.accessible_z_levels.Copy()
 	for(var/z in affected_levels)
 		using_map.accessible_z_levels -= "[z]" //not accessible during the jump
@@ -44,39 +47,89 @@
 		return FALSE
 	return TRUE
 
-/datum/universal_state/bluespace_jump/proc/check_density(var/mob/living/M)
-	var/turf/T = get_turf(M)
-	if(T && T.density)
-		return T
-	var/obj/machinery/door/airlock/A = locate() in T
-	if(A && A.density && M.blocks_airlock())
-		return A
-	return null
-
 /datum/universal_state/bluespace_jump/proc/apply_bluespaced(var/mob/living/M)
+	bluespaced += M
 	if(M.client)
 		to_chat(M,"<span class='notice'>You feel oddly light, and somewhat disoriented as everything around you shimmers and warps ever so slightly.</span>")
 		M.overlay_fullscreen("bluespace", /obj/screen/fullscreen/bluespace_overlay)
-	M.incorporeal_move = 1
-	M.confused = INFINITY //needed since normally confused ticks down own it's own
+	M.confused = 20
+	bluegoasts += new/obj/effect/bluegoast/(get_turf(M),M)
 
 /datum/universal_state/bluespace_jump/proc/clear_bluespaced(var/mob/living/M)
 	if(M.client)
 		to_chat(M,"<span class='notice'>You feel rooted in material world again.</span>")
 		M.clear_fullscreen("bluespace")
-
-	M.incorporeal_move = 0
 	M.confused = 0
+	for(var/mob/goast in ghost_mob_list_)
+		goast.mouse_opacity = initial(goast.mouse_opacity)
+		goast.invisibility = initial(goast.invisibility)
+		goast.alpha = initial(goast.alpha)
+	for(var/G in bluegoasts)
+		qdel(G)
+	bluegoasts.Cut()
 
-	var/atom/dense = check_density(M)
-	if(dense)
-		to_chat(M,"<span class='danger'>\The [dense] suddenly appears inside you!</span>")
-		M.gib()
+/obj/effect/bluegoast
+	name = "bluespace echo"
+	desc = "It's not going to punch you, is it?"
+	var/mob/living/carbon/human/daddy
+	anchored = 1
+	var/reality = 0
+	simulated = 0
+	
+/obj/effect/bluegoast/New(nloc, ndaddy)
+	..(nloc)
+	if(!ndaddy)
+		qdel(src)
+		return
+	daddy = ndaddy
+	appearance = daddy.appearance
+	moved_event.register(daddy, src,/obj/effect/bluegoast/proc/mirror)
+	destroyed_event.register(daddy, src, /datum/proc/qdel_self)
+
+/obj/effect/bluegoast/Destroy()
+	destroyed_event.unregister(daddy,src)
+	moved_event.unregister(daddy, src)
+	daddy = null
+	. = ..()
+
+/obj/effect/bluegoast/proc/mirror(var/atom/movable/am, var/old_loc, var/new_loc)
+	var/ndir = get_dir(new_loc,old_loc)
+	appearance = daddy.appearance
+	set_dir(ndir)
+	var/nloc = get_step(src, ndir)
+	if(nloc)
+		forceMove(nloc)
+	if(nloc == new_loc)
+		reality++
+		if(reality > 5)
+			to_chat(daddy, "<span class='notice'>Yep, it's certainly the other one. Your existance was a glitch, and it's finally being mended...</span>")
+			blueswitch()
+		else if(reality > 3)
+			to_chat(daddy, "<span class='danger'>Something is definitely wrong. Why do you think YOU are the original?</span>")
+		else
+			to_chat(daddy, "<span class='warning'>You feel a bit less real. Which one of you two was original again?..</span>")
+
+/obj/effect/bluegoast/examine(user)
+	return daddy.examine(user)
+
+/obj/effect/bluegoast/proc/blueswitch()
+	var/mob/living/carbon/human/H = new(get_turf(src), daddy.species.name)
+	H.real_name = daddy.real_name
+	H.dna = daddy.dna.Clone()
+	H.sync_organ_dna()
+	H.flavor_text = daddy.flavor_text
+	H.UpdateAppearance()
+	var/datum/job/job = job_master.GetJob(daddy.job)
+	if(job)
+		job.equip(H)
+	daddy.dust()
+	qdel(src)
 
 /obj/screen/fullscreen/bluespace_overlay
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "mfoam"
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	color = "#FF9900"
+	alpha = 100
 	blend_mode = BLEND_SUBTRACT
 	layer = FULLSCREEN_LAYER

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -533,6 +533,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	plane = pre_plane
 	layer = pre_layer
 	invisibility = pre_invis
+	transform = null	//make goast stand up
 
 /mob/observer/ghost/verb/respawn()
 	set name = "Respawn"

--- a/html/changelogs/chinsky - abloobloo.yml
+++ b/html/changelogs/chinsky - abloobloo.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Bluespace jump effects have changed. Engineers found that some duct tape got unstuck because of a WD40 leak, so they fixed it. Now you can't zoom through the walls, and visibility is a bit better. You also don't get confused forever, just for a minute or so. There are some... unforseen side effects, but they seem harmless. A word from Chief Tech (before his disappearace) - KEEP IT REAL."


### PR DESCRIPTION
Makes overlay less thick so you can see somehow through it.
Removes wall zooming mechanic. Makes confusion finite, lasting only minute or so.

Makes all ghosts visible an non-transparent during the jump.
Spawns bluespace doubles for all people. It mirrors original's movements. If you cross with it too many times, bad stuff can happen.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
