### PR TITLE
IRC/Discord Admin PM fixes/adjustments

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -127,9 +127,9 @@
 	adminmsg2adminirc(src, sender, html_decode(msg))
 	admin_pm_repository.store_pm(src, "IRC-[sender]", msg)
 
-	to_chat(src, "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "", src) + " to <span class='name'>IRC-[sender]</span>: <span class='message'>[msg]</span></span></span>")
+	to_chat(src, "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "PM", src) + " to <span class='name'>[sender]</span>: <span class='message'>[msg]</span></span></span>")
 	for(var/client/X in admins)
 		if(X == src)
 			continue
 		if(X.holder.rights & R_ADMIN|R_MOD)
-			to_chat(X, "<span class='pm'><span class='other'>" + create_text_tag("pm_other", "PM:", X) + " <span class='name'>[key_name(src, X, 0)]</span> to <span class='name'>IRC-[sender]</span>: <span class='message'>[msg]</span></span></span>")
+			to_chat(X, "<span class='pm'><span class='other'>" + create_text_tag("pm_other", "PM:", X) + " <span class='name'>[key_name(src, X, 0)]</span> to <span class='name'>[sender]</span>: <span class='message'>[msg]</span></span></span>")

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -62,9 +62,9 @@
 				send2adminirc("Reply: [key_name(source)]->[key_name(target)]: [msg]")
 			else if(istext(target))
 				var/rank = source.holder ? source.holder.rank : "Player"
-				send2adminirc("[rank]PM to [target] from [key_name(source)]: [msg]")
+				send2adminirc("[rank] PM to [target] from [key_name(source)]: [msg]")
 			else
-				send2adminirc("Request for Help from [key_name(source)]: [msg]")
+				send2adminirc("HELP from [key_name(source)]: [msg]")
 
 /hook/startup/proc/ircNotify()
 	send2mainirc("Server starting up on byond://[config.serverurl ? config.serverurl : (config.server ? config.server : "[world.address]:[world.port]")]")

--- a/code/world.dm
+++ b/code/world.dm
@@ -398,9 +398,11 @@ var/world_topic_spam_protect_time = world.timeofday
 		var/rank = input["rank"]
 		if(!rank)
 			rank = "Admin"
+		if(rank == "Unknown")
+			rank = "Staff"
 
-		var/message =	"<font color='red'>IRC-[rank] PM from <b><a href='?irc_msg=[input["sender"]]'>IRC-[input["sender"]]</a></b>: [input["msg"]]</font>"
-		var/amessage =  "<font color='blue'>IRC-[rank] PM from <a href='?irc_msg=[input["sender"]]'>IRC-[input["sender"]]</a> to <b>[key_name(C)]</b> : [input["msg"]]</font>"
+		var/message =	"<font color='red'>[rank] PM from <b><a href='?irc_msg=[input["sender"]]'>[input["sender"]]</a></b>: [input["msg"]]</font>"
+		var/amessage =  "<font color='blue'>[rank] PM from <a href='?irc_msg=[input["sender"]]'>[input["sender"]]</a> to <b>[key_name(C)]</b> : [input["msg"]]</font>"
 
 		C.received_irc_pm = world.time
 		C.irc_admin = input["sender"]


### PR DESCRIPTION
- Removes unnecessary "IRC-" before the name of IRC/Discord users - if used from discord, causes the name to become rediculously long because of the discord bridge. Also it's inaccurate.
- Fixes misformatting when chat tags are disabled.
- Corrects formatting of inbound IRC PMs. Changes original ahelp text to match server text
- Removes unnecessary "IRC-" displayed before the adminPM ranks from irc, as they're not always from irc, but occasionally from discord too!
- If the rank is unknown (caused when PMing from discord), just displays "Staff".

These are all aesthetic changes, as far as I can tell, there's no functional changes.