### PR TITLE
Allows ghosts to hear binary chatter

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -631,6 +631,8 @@
 			return global.ghost_darkness_images;
 		if("ghost_master")
 			return global.ghost_master;
+		if("ghost_mob_list_")
+			return global.ghost_mob_list_;
 		if("ghost_sightless_images")
 			return global.ghost_sightless_images;
 		if("ghost_traps")
@@ -2136,6 +2138,8 @@
 			global.ghost_darkness_images=newval;
 		if("ghost_master")
 			global.ghost_master=newval;
+		if("ghost_mob_list_")
+			global.ghost_mob_list_=newval;
 		if("ghost_sightless_images")
 			global.ghost_sightless_images=newval;
 		if("ghost_traps")
@@ -3325,6 +3329,7 @@
 	"gender_datums",
 	"ghost_darkness_images",
 	"ghost_master",
+	"ghost_mob_list_",
 	"ghost_sightless_images",
 	"ghost_traps",
 	"global_announcer",

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -11,6 +11,7 @@ var/global/list/human_mob_list = list()				//List of all human mobs and sub-type
 var/global/list/silicon_mob_list = list()			//List of all silicon mobs, including clientless
 var/global/list/living_mob_list_ = list()			//List of all alive mobs, including clientless. Excludes /mob/new_player
 var/global/list/dead_mob_list_ = list()				//List of all dead mobs, including clientless. Excludes /mob/new_player
+var/global/list/ghost_mob_list_ = list()			//List of all ghost mobs, including clientless. Excludes /mob/new_player
 
 var/global/list/cable_list = list()					//Index for all cables, so that powernets don't have to look through the entire world all the time
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -331,7 +331,7 @@
 	user.visible_message("<span class='warning'>\The [user]'s eyes glow blue as \he freezes in place, absolutely motionless.</span>", "<span class='warning'>The shadow that is your spirit separates itself from your body. You are now in the realm beyond. While this is a great sight, being here strains your mind and body. Hurry...</span>", "You hear only complete silence for a moment.")
 	announce_ghost_joinleave(user.ghostize(1), 1, "You feel that they had to use some [pick("dark", "black", "blood", "forgotten", "forbidden")] magic to [pick("invade", "disturb", "disrupt", "infest", "taint", "spoil", "blight")] this place!")
 	var/mob/observer/ghost/soul
-	for(var/mob/observer/ghost/O in dead_mob_list_)
+	for(var/mob/observer/ghost/O in ghost_mob_list_)
 		if(O.key == tmpkey)
 			soul = O
 			break

--- a/code/game/objects/structures/alien/egg.dm
+++ b/code/game/objects/structures/alien/egg.dm
@@ -29,9 +29,9 @@
 /obj/structure/alien/egg/process()
 	progress++
 	if(progress >= MAX_PROGRESS)
-		for(var/mob/M in dead_mob_list_)
-			if(isghost(M) && M.client && M.client.prefs && (MODE_XENOMORPH in M.client.prefs.be_special_role))
-				to_chat(M, "<span class='notice'>An alien is ready to hatch! ([ghost_follow_link(src, M)]) (<a href='byond://?src=\ref[src];spawn=1'>spawn</a>)</span>")
+		for(var/mob/observer/ghost/O in ghost_mob_list_)
+			if(O.client && O.client.prefs && (MODE_XENOMORPH in O.client.prefs.be_special_role))
+				to_chat(O, "<span class='notice'>An alien is ready to hatch! ([ghost_follow_link(src, O)]) (<a href='byond://?src=\ref[src];spawn=1'>spawn</a>)</span>")
 		processing_objects -= src
 		update_icon()
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -464,7 +464,7 @@
 	set name = "Debug Mob Lists"
 	set desc = "For when you just gotta know"
 
-	switch(input("Which list?") in list("Players","Admins","Mobs","Living Mobs","Dead Mobs", "Clients"))
+	switch(input("Which list?") in list("Players","Admins","Mobs","Living Mobs","Dead Mobs", "Ghost Mobs", "Clients"))
 		if("Players")
 			to_chat(usr, jointext(player_list,","))
 		if("Admins")
@@ -475,6 +475,8 @@
 			to_chat(usr, jointext(living_mob_list_,","))
 		if("Dead Mobs")
 			to_chat(usr, jointext(dead_mob_list_,","))
+		if("Ghost Mobs")
+			to_chat(usr, jointext(ghost_mob_list_,","))
 		if("Clients")
 			to_chat(usr, jointext(clients,","))
 

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -20,6 +20,9 @@
 	var/message_start = "<i><span class='game say'>[name], <span class='name'>[speaker.name]</span>"
 	var/message_body = "<span class='message'>[speaker.say_quote(message)], \"[message]\"</span></span></i>"
 
+	for (var/mob/observer/ghost/O in ghost_mob_list_)
+		O.show_message("[message_start] ([ghost_follow_link(speaker, O)]) [message_body]", 2)
+
 	for (var/mob/M in dead_mob_list_)
 		if(!istype(M,/mob/new_player) && !istype(M,/mob/living/carbon/brain)) //No meta-evesdropping
 			M.show_message("[message_start] ([ghost_follow_link(speaker, M)]) [message_body]", 2)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -69,9 +69,13 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		cult.add_ghost_magic(src)
 
 	ghost_multitool = new(src)
+
+	ghost_mob_list_ += src
+
 	..()
 
 /mob/observer/ghost/Destroy()
+	ghost_mob_list_ -= src
 	stop_following()
 	qdel(ghost_multitool)
 	ghost_multitool = null

--- a/html/changelogs/cyberghost.yml
+++ b/html/changelogs/cyberghost.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: thasc
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Ghosts can hear binary chatter again."


### PR DESCRIPTION
Fixes #13875. Ghosts stopped hearing robot talk a year or two ago. Now they can hear it again!

Adds a global `ghost_mob_list_` to explicitly track ghosts and use them in various places `dead_mob_list_` was being queried, since `dead_mob_list_` doesn't contain ghosts anymore. In terms of robot talk, adds the ghost list in addition to the dead list to match previous functionality.