### PR TITLE
Cleans up loadout code, relocates preference vars, fixes sanitation

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -353,8 +353,8 @@ var/global/datum/controller/occupations/job_master
 			//Equip custom gear loadout.
 			var/list/custom_equip_slots = list() //If more than one item takes the same slot, all after the first one spawn in storage.
 			var/list/custom_equip_leftovers = list()
-			if(H.client.prefs.gear && H.client.prefs.gear.len && job.title != "Cyborg" && job.title != "AI")
-				for(var/thing in H.client.prefs.gear)
+			if(H.client.prefs.Gear() && job.title != "Cyborg" && job.title != "AI")
+				for(var/thing in H.client.prefs.Gear())
 					var/datum/gear/G = gear_datums[thing]
 					if(G)
 						var/permitted
@@ -375,7 +375,7 @@ var/global/datum/controller/occupations/job_master
 						if(G.slot && !(G.slot in custom_equip_slots))
 							// This is a miserable way to fix the loadout overwrite bug, but the alternative requires
 							// adding an arg to a bunch of different procs. Will look into it after this merge. ~ Z
-							var/metadata = H.client.prefs.gear[G.display_name]
+							var/metadata = H.client.prefs.Gear()[G.display_name]
 							if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
 								custom_equip_leftovers += thing
 							else if(H.equip_to_slot_or_del(G.spawn_item(H, metadata), G.slot))
@@ -408,7 +408,7 @@ var/global/datum/controller/occupations/job_master
 				if(G.slot in custom_equip_slots)
 					spawn_in_storage += thing
 				else
-					var/metadata = H.client.prefs.gear[G.display_name]
+					var/metadata = H.client.prefs.Gear()[G.display_name]
 					if(H.equip_to_slot_or_del(G.spawn_item(H, metadata), G.slot))
 						to_chat(H, "<span class='notice'>Equipping you with \the [thing]!</span>")
 						custom_equip_slots.Add(G.slot)
@@ -470,7 +470,7 @@ var/global/datum/controller/occupations/job_master
 			//Deferred item spawning.
 			for(var/thing in spawn_in_storage)
 				var/datum/gear/G = gear_datums[thing]
-				var/metadata = H.client.prefs.gear[G.display_name]
+				var/metadata = H.client.prefs.Gear()[G.display_name]
 				var/item = G.spawn_item(null, metadata)
 
 				var/atom/placed_in = H.equip_to_storage(item)

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -1,3 +1,8 @@
+/datum/preferences
+	var/list/never_be_special_role
+	var/list/sometimes_be_special_role
+	var/list/be_special_role
+
 /datum/category_item/player_setup_item/antagonism/candidacy
 	name = "Candidacy"
 	sort_order = 1

--- a/code/modules/client/preference_setup/antagonism/02_setup.dm
+++ b/code/modules/client/preference_setup/antagonism/02_setup.dm
@@ -1,5 +1,9 @@
 var/global/list/uplink_locations = list("PDA", "Headset", "None")
 
+/datum/preferences
+	var/uplinklocation = "PDA"
+	var/exploit_record = ""
+
 /datum/category_item/player_setup_item/antagonism/basic
 	name = "Setup"
 	sort_order = 2

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -1,5 +1,10 @@
 datum/preferences
+	var/real_name						//our character's name
+	var/be_random_name = 0				//whether we are a random name every round
 	var/gender = MALE					//gender of character (well duh)
+	var/age = 30						//age of character
+	var/spawnpoint = "Default" 			//where this character will spawn (0-2).
+	var/metadata = ""
 
 /datum/category_item/player_setup_item/general/basic
 	name = "Basic"

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -1,3 +1,7 @@
+/datum/preferences
+	var/list/alternate_languages //Secondary language(s)
+	var/list/language_prefixes   //Language prefix keys
+
 /datum/category_item/player_setup_item/general/language
 	name = "Language"
 	sort_order = 2
@@ -73,6 +77,8 @@
 	return FALSE
 
 /datum/category_item/player_setup_item/general/language/proc/sanitize_alt_languages()
+	if(!istype(pref.alternate_languages)) pref.alternate_languages = list()
+
 	var/preference_mob = preference_mob()
 	for(var/L in pref.alternate_languages)
 		var/datum/language/lang = all_languages[L]

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -1,6 +1,30 @@
 var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-")
 
 /datum/preferences
+	var/species = SPECIES_HUMAN         //Species datum to use.
+	var/b_type = "A+"					//blood type (not-chooseable)
+	var/h_style = "Bald"				//Hair type
+	var/r_hair = 0						//Hair color
+	var/g_hair = 0						//Hair color
+	var/b_hair = 0						//Hair color
+	var/f_style = "Shaved"				//Face hair type
+	var/r_facial = 0					//Face hair color
+	var/g_facial = 0					//Face hair color
+	var/b_facial = 0					//Face hair color
+	var/s_tone = 0						//Skin tone
+	var/r_skin = 0						//Skin color
+	var/g_skin = 0						//Skin color
+	var/b_skin = 0						//Skin color
+	var/r_eyes = 0						//Eye color
+	var/g_eyes = 0						//Eye color
+	var/b_eyes = 0						//Eye color
+
+	// maps each organ to either null(intact), "cyborg" or "amputated"
+	// will probably not be able to do this for head and torso ;)
+	var/list/organ_data
+	var/list/rlimb_data
+	var/disabilities = 0
+
 	var/has_cortical_stack = TRUE
 	var/equip_preview_mob = EQUIP_PREVIEW_ALL
 
@@ -77,8 +101,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	pref.has_cortical_stack = sanitize_bool(pref.has_cortical_stack, initial(pref.has_cortical_stack))
 
 	pref.disabilities	= sanitize_integer(pref.disabilities, 0, 65535, initial(pref.disabilities))
-	if(!pref.organ_data) pref.organ_data = list()
-	if(!pref.rlimb_data) pref.rlimb_data = list()
+	if(!istype(pref.organ_data)) pref.organ_data = list()
+	if(!istype(pref.rlimb_data)) pref.rlimb_data = list()
 
 	if(pref.organ_data[BP_CHEST] != "cyborg")
 		pref.organ_data[BP_HEAD] = null

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -1,6 +1,7 @@
 /datum/preferences
 	var/list/all_underwear
 	var/list/all_underwear_metadata
+	var/backbag = 2						//backpack type
 
 /datum/category_item/player_setup_item/general/equipment
 	name = "Clothing"

--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -1,3 +1,16 @@
+/datum/preferences
+	var/med_record = ""
+	var/sec_record = ""
+	var/gen_record = ""
+	var/nanotrasen_relation = "Neutral"
+	var/memory = ""
+
+	//Some faction information.
+	var/home_system = "Unset"           //System of birth.
+	var/citizenship = "None"            //Current home system.
+	var/faction = "None"                //Antag faction/general associated faction.
+	var/religion = "None"               //Religious association.
+
 /datum/category_item/player_setup_item/general/background
 	name = "Background"
 	sort_order = 5

--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -1,3 +1,7 @@
+/datum/preferences
+	var/list/flavor_texts        = list()
+	var/list/flavour_texts_robot = list()
+
 /datum/category_item/player_setup_item/general/flavor
 	name = "Flavor"
 	sort_order = 6
@@ -34,7 +38,8 @@
 		S["flavour_texts_robot_[module]"] << pref.flavour_texts_robot[module]
 
 /datum/category_item/player_setup_item/general/flavor/sanitize_character()
-	return
+	if(!istype(pref.flavor_texts))        pref.flavor_texts = list()
+	if(!istype(pref.flavour_texts_robot)) pref.flavour_texts_robot = list()
 
 /datum/category_item/player_setup_item/general/flavor/content(var/mob/user)
 	. += "<b>Flavor:</b><br>"

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -1,5 +1,10 @@
 /datum/preferences
 	var/clientfps = 0
+	var/ooccolor = "#010000" //Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
+
+	var/UI_style = "Midnight"
+	var/UI_style_color = "#ffffff"
+	var/UI_style_alpha = 255
 
 /datum/category_item/player_setup_item/player_global/ui
 	name = "UI"

--- a/code/modules/client/preference_setup/global/03_language.dm
+++ b/code/modules/client/preference_setup/global/03_language.dm
@@ -52,4 +52,3 @@
 		if(istype(prefixes) && prefixes.len)
 			preferences["language_prefixes"] = prefixes.Copy()
 		return 1
-

--- a/code/modules/client/preference_setup/global/05_ooc.dm
+++ b/code/modules/client/preference_setup/global/05_ooc.dm
@@ -1,3 +1,7 @@
+/datum/preferences
+	// OOC Metadata:
+	var/list/ignored_players = list()
+
 /datum/category_item/player_setup_item/player_global/ooc
 	name = "OOC"
 	sort_order = 5

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -1,6 +1,13 @@
 var/list/loadout_categories = list()
 var/list/gear_datums = list()
 
+/datum/preferences
+	var/list/gear_list //Custom/fluff item loadouts.
+	var/gear_slot = 1  //The current gear save slot
+
+/datum/preferences/proc/Gear()
+	return gear_list[gear_slot]
+
 /datum/loadout_category
 	var/category = ""
 	var/list/gear = list()
@@ -40,14 +47,8 @@ var/list/gear_datums = list()
 /datum/category_item/player_setup_item/loadout/load_character(var/savefile/S)
 	from_file(S["gear_list"], pref.gear_list)
 	from_file(S["gear_slot"], pref.gear_slot)
-	if(pref.gear_list!=null && pref.gear_slot!=null)
-		pref.gear = pref.gear_list["[pref.gear_slot]"]
-	else
-		from_file(S["gear"], pref.gear)
-		pref.gear_slot = 1
 
 /datum/category_item/player_setup_item/loadout/save_character(var/savefile/S)
-	pref.gear_list["[pref.gear_slot]"] = pref.gear
 	to_file(S["gear_list"], pref.gear_list)
 	to_file(S["gear_slot"], pref.gear_slot)
 
@@ -70,36 +71,43 @@ var/list/gear_datums = list()
 		. += gear_name
 
 /datum/category_item/player_setup_item/loadout/sanitize_character()
-	if(!islist(pref.gear))
-		pref.gear = list()
-	if(!islist(pref.gear_list))
-		pref.gear_list = list()
+	pref.gear_slot = sanitize_integer(pref.gear_slot, 1, config.loadout_slots, initial(pref.gear_slot))
+	if(!islist(pref.gear_list)) pref.gear_list = list()
 
-	for(var/gear_name in pref.gear)
-		if(!(gear_name in gear_datums))
-			pref.gear -= gear_name
+	if(pref.gear_list.len < config.loadout_slots)
+		pref.gear_list.len = config.loadout_slots
 
-	var/total_cost = 0
-	for(var/gear_name in pref.gear)
-		if(!gear_datums[gear_name])
-			pref.gear -= gear_name
-		else if(!(gear_name in valid_gear_choices()))
-			pref.gear -= gear_name
+	for(var/index = 1 to config.loadout_slots)
+		var/list/gears = pref.gear_list[index]
+
+		if(gears)
+			for(var/gear_name in gears)
+				if(!(gear_name in gear_datums))
+					gears -= gear_name
+
+			var/total_cost = 0
+			for(var/gear_name in gears)
+				if(!gear_datums[gear_name])
+					gears -= gear_name
+				else if(!(gear_name in valid_gear_choices()))
+					gears -= gear_name
+				else
+					var/datum/gear/G = gear_datums[gear_name]
+					if(total_cost + G.cost > MAX_GEAR_COST)
+						gears -= gear_name
+					else
+						total_cost += G.cost
 		else
-			var/datum/gear/G = gear_datums[gear_name]
-			if(total_cost + G.cost > MAX_GEAR_COST)
-				pref.gear -= gear_name
-			else
-				total_cost += G.cost
+			pref.gear_list[index] = list()
 
 /datum/category_item/player_setup_item/loadout/content()
 	. = list()
 	var/total_cost = 0
-	if(pref.gear && pref.gear.len)
-		for(var/i = 1; i <= pref.gear.len; i++)
-			var/datum/gear/G = gear_datums[pref.gear[i]]
-			if(G)
-				total_cost += G.cost
+	var/list/gears = pref.gear_list[pref.gear_slot]
+	for(var/i = 1; i <= gears.len; i++)
+		var/datum/gear/G = gear_datums[gears[i]]
+		if(G)
+			total_cost += G.cost
 
 	var/fcolor =  "#3366CC"
 	if(total_cost < MAX_GEAR_COST)
@@ -119,7 +127,7 @@ var/list/gear_datums = list()
 		var/datum/loadout_category/LC = loadout_categories[category]
 		var/category_cost = 0
 		for(var/gear in LC.gear)
-			if(gear in pref.gear)
+			if(gear in pref.gear_list[pref.gear_slot])
 				var/datum/gear/G = LC.gear[gear]
 				category_cost += G.cost
 
@@ -147,7 +155,7 @@ var/list/gear_datums = list()
 		if(!(gear_name in valid_gear_choices()))
 			continue
 		var/datum/gear/G = LC.gear[gear_name]
-		var/ticked = (G.display_name in pref.gear)
+		var/ticked = (G.display_name in pref.gear_list[pref.gear_slot])
 		. += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=[html_encode(G.display_name)]'>[G.display_name]</a></td>"
 		. += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
 		. += "<td><font size=2>[G.description]</font>"
@@ -176,10 +184,11 @@ var/list/gear_datums = list()
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/loadout/proc/get_gear_metadata(var/datum/gear/G)
-	. = pref.gear[G.display_name]
+	var/list/gear = pref.gear_list[pref.gear_slot]
+	. = gear[G.display_name]
 	if(!.)
 		. = list()
-		pref.gear[G.display_name] = .
+		gear[G.display_name] = .
 
 /datum/category_item/player_setup_item/loadout/proc/get_tweak_metadata(var/datum/gear/G, var/datum/gear_tweak/tweak)
 	var/list/metadata = get_gear_metadata(G)
@@ -195,15 +204,15 @@ var/list/gear_datums = list()
 /datum/category_item/player_setup_item/loadout/OnTopic(href, href_list, user)
 	if(href_list["toggle_gear"])
 		var/datum/gear/TG = gear_datums[href_list["toggle_gear"]]
-		if(TG.display_name in pref.gear)
-			pref.gear -= TG.display_name
+		if(TG.display_name in pref.gear_list[pref.gear_slot])
+			pref.gear_list[pref.gear_slot] -= TG.display_name
 		else
 			var/total_cost = 0
-			for(var/gear_name in pref.gear)
+			for(var/gear_name in pref.gear_list[pref.gear_slot])
 				var/datum/gear/G = gear_datums[gear_name]
 				if(istype(G)) total_cost += G.cost
 			if((total_cost+TG.cost) <= MAX_GEAR_COST)
-				pref.gear += TG.display_name
+				pref.gear_list[pref.gear_slot] += TG.display_name
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["gear"] && href_list["tweak"])
 		var/datum/gear/gear = gear_datums[href_list["gear"]]
@@ -215,36 +224,33 @@ var/list/gear_datums = list()
 			return TOPIC_NOACTION
 		set_tweak_metadata(gear, tweak, metadata)
 		return TOPIC_REFRESH_UPDATE_PREVIEW
-	if(href_list["next_slot"] || href_list["prev_slot"])
-		//Set the current slot in the gear list to the currently selected gear
-		pref.gear_list["[pref.gear_slot]"] = pref.gear
-		//If we're moving up a slot..
-		if(href_list["next_slot"])
-			//change the current slot number
-			pref.gear_slot = pref.gear_slot+1
-			if(pref.gear_slot>config.loadout_slots)
-				pref.gear_slot = 1
-		//If we're moving down a slot..
-		else if(href_list["prev_slot"])
-			//change current slot one down
-			pref.gear_slot = pref.gear_slot-1
-			if(pref.gear_slot<1)
-				pref.gear_slot = config.loadout_slots
-		// Set the currently selected gear to whatever's in the new slot
-		if(pref.gear_list["[pref.gear_slot]"])
-			pref.gear = pref.gear_list["[pref.gear_slot]"]
-		else
-			pref.gear = list()
-			pref.gear_list["[pref.gear_slot]"] = list()
-		// Refresh?
+	if(href_list["next_slot"])
+		pref.gear_slot = pref.gear_slot+1
+		if(pref.gear_slot > config.loadout_slots)
+			pref.gear_slot = 1
 		return TOPIC_REFRESH_UPDATE_PREVIEW
-	else if(href_list["select_category"])
+	if(href_list["prev_slot"])
+		pref.gear_slot = pref.gear_slot-1
+		if(pref.gear_slot < 1)
+			pref.gear_slot = config.loadout_slots
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+	if(href_list["select_category"])
 		current_tab = href_list["select_category"]
 		return TOPIC_REFRESH
-	else if(href_list["clear_loadout"])
-		pref.gear.Cut()
+	if(href_list["clear_loadout"])
+		var/list/gear = pref.gear_list[pref.gear_slot]
+		LAZYCLEARLIST(gear)
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	return ..()
+
+/datum/category_item/player_setup_item/loadout/update_setup(var/savefile/preferences, var/savefile/character)
+	if(preferences["version"] < 14)
+		var/list/old_gear = character["gear"]
+		if(istype(old_gear)) // During updates data isn't sanitized yet, we have to do manual checks
+			if(!istype(pref.gear_list)) pref.gear_list = list()
+			if(!pref.gear_list.len) pref.gear_list.len++
+			pref.gear_list[1] = old_gear
+		return 1
 
 /datum/gear
 	var/display_name       //Name/index. Must be unique.

--- a/code/modules/client/preference_setup/matchmaking/relations.dm
+++ b/code/modules/client/preference_setup/matchmaking/relations.dm
@@ -1,3 +1,7 @@
+/datum/preferences
+	var/list/relations
+	var/list/relations_info
+
 /datum/category_item/player_setup_item/relations
 	name = "Matchmaking"
 	sort_order = 1

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -3,33 +3,44 @@
 #define BE_ASSISTANT 1
 #define RETURN_TO_LOBBY 2
 
+/datum/preferences
+	//Since there can only be 1 high job.
+	var/job_high = null
+	var/list/job_medium        //List of all things selected for medium weight
+	var/list/job_low           //List of all the things selected for low weight
+	var/list/player_alt_titles // the default name of a job like "Medical Doctor"
+	var/char_branch	= "None"   // military branch
+	var/char_rank = "None"     // military rank
+
+	//Keeps track of preferrence for not getting any wanted jobs
+	var/alternate_option = 2
+
 /datum/category_item/player_setup_item/occupation
 	name = "Occupation"
 	sort_order = 1
 
 /datum/category_item/player_setup_item/occupation/load_character(var/savefile/S)
-	S["alternate_option"]	>> pref.alternate_option
-	S["job_high"]	>> pref.job_high
-	S["job_medium"]	>> pref.job_medium
-	S["job_low"]	>> pref.job_low
-	if(!pref.job_medium)
-		pref.job_medium = list()
-	if(!pref.job_low)
-		pref.job_low = list()
-	S["player_alt_titles"]	>> pref.player_alt_titles
-	S["char_branch"] 			>> pref.char_branch
-	S["char_rank"] 				>> pref.char_rank
+	S["alternate_option"]  >> pref.alternate_option
+	S["job_high"]          >> pref.job_high
+	S["job_medium"]        >> pref.job_medium
+	S["job_low"]           >> pref.job_low
+	S["player_alt_titles"] >> pref.player_alt_titles
+	S["char_branch"]       >> pref.char_branch
+	S["char_rank"]         >> pref.char_rank
 
 /datum/category_item/player_setup_item/occupation/save_character(var/savefile/S)
-	S["alternate_option"]	<< pref.alternate_option
-	S["job_high"]	<< pref.job_high
-	S["job_medium"]	<< pref.job_medium
-	S["job_low"]	<< pref.job_low
-	S["player_alt_titles"]	<< pref.player_alt_titles
-	S["char_branch"] 			<< pref.char_branch
-	S["char_rank"] 				<< pref.char_rank
+	S["alternate_option"]  << pref.alternate_option
+	S["job_high"]          << pref.job_high
+	S["job_medium"]        << pref.job_medium
+	S["job_low"]           << pref.job_low
+	S["player_alt_titles"] << pref.player_alt_titles
+	S["char_branch"]       << pref.char_branch
+	S["char_rank"]         << pref.char_rank
 
 /datum/category_item/player_setup_item/occupation/sanitize_character()
+	if(!istype(pref.job_medium)) pref.job_medium = list()
+	if(!istype(pref.job_low))    pref.job_low = list()
+
 	pref.alternate_option	= sanitize_integer(pref.alternate_option, 0, 2, initial(pref.alternate_option))
 	pref.job_high	        = sanitize(pref.job_high, null)
 	if(pref.job_medium && pref.job_medium.len)

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -79,7 +79,7 @@
 
 /datum/category_collection/player_setup_collection/proc/update_setup(var/savefile/preferences, var/savefile/character)
 	for(var/datum/category_group/player_setup_category/PS in categories)
-		. = . && PS.update_setup(preferences, character)
+		. = PS.update_setup(preferences, character) || .
 
 /datum/category_collection/player_setup_collection/proc/header()
 	var/dat = ""
@@ -126,8 +126,6 @@
 		PI.sanitize_character()
 
 /datum/category_group/player_setup_category/proc/load_character(var/savefile/S)
-	// Load all data, then sanitize it.
-	// Need due to, for example, the 01_basic module relying on species having been loaded to sanitize correctly but that isn't loaded until module 03_body.
 	for(var/datum/category_item/player_setup_item/PI in items)
 		PI.load_character(S)
 
@@ -150,7 +148,7 @@
 
 /datum/category_group/player_setup_category/proc/update_setup(var/savefile/preferences, var/savefile/character)
 	for(var/datum/category_item/player_setup_item/PI in items)
-		. = . && PI.update_setup(preferences, character)
+		. = PI.update_setup(preferences, character) || .
 
 /datum/category_group/player_setup_category/proc/content(var/mob/user)
 	. = "<table style='width:100%'><tr style='vertical-align:top'><td style='width:50%'>"

--- a/code/modules/client/preference_setup/skills/skills.dm
+++ b/code/modules/client/preference_setup/skills/skills.dm
@@ -1,3 +1,7 @@
+/datum/preferences
+	var/used_skillpoints = 0
+	var/list/skills          // skills can range from 0 to 3
+
 /datum/category_item/player_setup_item/skills
 	name = "Skills"
 	sort_order = 1
@@ -12,7 +16,7 @@
 
 /datum/category_item/player_setup_item/skills/sanitize_character()
 	if(SKILLS == null)				setup_skills()
-	if(!pref.skills)				pref.skills = list()
+	if(!istype(pref.skills))		pref.skills = list()
 	if(!pref.skills.len)			pref.ZeroSkills()
 	if(pref.used_skillpoints < 0)	pref.used_skillpoints = 0
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -16,90 +16,12 @@ datum/preferences
 
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
-	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
-	var/list/never_be_special_role = list()
-	var/list/sometimes_be_special_role = list()
-	var/list/be_special_role = list()		//Special role selection
-	var/UI_style = "Midnight"
-	var/UI_style_color = "#ffffff"
-	var/UI_style_alpha = 255
 
 	//character preferences
-	var/real_name						//our character's name
-	var/be_random_name = 0				//whether we are a random name every round
-	var/age = 30						//age of character
-	var/spawnpoint = "Default" 			//where this character will spawn (0-2).
-	var/b_type = "A+"					//blood type (not-chooseable)
-	var/backbag = 2						//backpack type
-	var/h_style = "Bald"				//Hair type
-	var/r_hair = 0						//Hair color
-	var/g_hair = 0						//Hair color
-	var/b_hair = 0						//Hair color
-	var/f_style = "Shaved"				//Face hair type
-	var/r_facial = 0					//Face hair color
-	var/g_facial = 0					//Face hair color
-	var/b_facial = 0					//Face hair color
-	var/s_tone = 0						//Skin tone
-	var/r_skin = 0						//Skin color
-	var/g_skin = 0						//Skin color
-	var/b_skin = 0						//Skin color
-	var/r_eyes = 0						//Eye color
-	var/g_eyes = 0						//Eye color
-	var/b_eyes = 0						//Eye color
-	var/species = SPECIES_HUMAN               //Species datum to use.
 	var/species_preview                 //Used for the species selection window.
-	var/list/alternate_languages = list() //Secondary language(s)
-	var/list/language_prefixes = list() //Kanguage prefix keys
-	var/list/gear						//Left in for Legacy reasons, will no longer save.
-	var/list/gear_list = list()			//Custom/fluff item loadouts.
-	var/gear_slot = 1					//The current gear save slot
 
-		//Some faction information.
-	var/home_system = "Unset"           //System of birth.
-	var/citizenship = "None"            //Current home system.
-	var/faction = "None"                //Antag faction/general associated faction.
-	var/religion = "None"               //Religious association.
-
-	var/char_branch	= "None"            // military branch
-	var/char_rank = "None"              // military rank
 		//Mob preview
 	var/icon/preview_icon = null
-
-
-	//Since there can only be 1 high job.
-	var/job_high = null
-	var/list/job_medium = list() //List of all things selected for medium weight
-	var/list/job_low    = list() //List of all the things selected for low weight
-
-	//Keeps track of preferrence for not getting any wanted jobs
-	var/alternate_option = 2
-
-	var/used_skillpoints = 0
-	var/list/skills = list() // skills can range from 0 to 3
-
-	// maps each organ to either null(intact), "cyborg" or "amputated"
-	// will probably not be able to do this for head and torso ;)
-	var/list/organ_data = list()
-	var/list/rlimb_data = list()
-	var/list/player_alt_titles = new()		// the default name of a job like "Medical Doctor"
-
-	var/list/flavor_texts = list()
-	var/list/flavour_texts_robot = list()
-
-	var/med_record = ""
-	var/sec_record = ""
-	var/gen_record = ""
-	var/exploit_record = ""
-	var/memory = ""
-	var/disabilities = 0
-
-	var/nanotrasen_relation = "Neutral"
-
-	var/uplinklocation = "PDA"
-
-	// OOC Metadata:
-	var/metadata = ""
-	var/list/ignored_players = list()
 
 	var/client/client = null
 	var/client_ckey = null
@@ -109,19 +31,11 @@ datum/preferences
 	var/datum/category_collection/player_setup_collection/player_setup
 	var/datum/browser/panel
 
-	var/list/relations
-	var/list/relations_info
-
-
 /datum/preferences/New(client/C)
 	player_setup = new(src)
 	gender = pick(MALE, FEMALE)
 	real_name = random_name(gender,species)
 	b_type = RANDOM_BLOOD_TYPE
-
-	gear = list()
-	gear_list = list()
-	gear_slot = 1
 
 	if(istype(C))
 		client = C

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN	8
-#define SAVEFILE_VERSION_MAX	13
+#define SAVEFILE_VERSION_MAX	14
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)	return

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -209,7 +209,7 @@ datum/preferences
 
 	if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && (previewJob.type == /datum/job/ai || previewJob.type == /datum/job/cyborg)))
 		var/list/equipped_slots = list() //If more than one item takes the same slot only spawn the first
-		for(var/thing in gear)
+		for(var/thing in Gear())
 			var/datum/gear/G = gear_datums[thing]
 			if(G)
 				var/permitted = 0
@@ -228,7 +228,7 @@ datum/preferences
 					continue
 
 				if(G.slot && !(G.slot in equipped_slots))
-					var/metadata = gear[G.display_name]
+					var/metadata = gear_list[gear_slot][G.display_name]
 					if(mannequin.equip_to_slot_or_del(G.spawn_item(mannequin, metadata), G.slot))
 						equipped_slots += G.slot
 						update_icon = TRUE


### PR DESCRIPTION
Also adds an update path for loadout equipment and fixes the update path in general as it previously would abort early.
The old gear list is now saved to gear slot 1 and is then forgotten forever.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
