### PR TITLE
Removes ability to fax admins

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -137,8 +137,6 @@
 			return global.adjectives;
 		if("admin_datums")
 			return global.admin_datums;
-		if("admin_departments")
-			return global.admin_departments;
 		if("admin_log")
 			return global.admin_log;
 		if("admin_pm_repository")
@@ -179,8 +177,6 @@
 			return global.admin_verbs_sounds;
 		if("admin_verbs_spawn")
 			return global.admin_verbs_spawn;
-		if("adminfaxes")
-			return global.adminfaxes;
 		if("adminhelp_ignored_words")
 			return global.adminhelp_ignored_words;
 		if("adminlog")
@@ -1479,7 +1475,7 @@
 			return global.z_state;
 		if("zone_blocked")
 			return global.zone_blocked;
-		
+
 /proc/writeglobal(which, newval)
 	switch(which)
 		if("ALL_ANTIGENS")
@@ -1618,8 +1614,6 @@
 			global.adjectives=newval;
 		if("admin_datums")
 			global.admin_datums=newval;
-		if("admin_departments")
-			global.admin_departments=newval;
 		if("admin_log")
 			global.admin_log=newval;
 		if("admin_pm_repository")
@@ -1660,8 +1654,6 @@
 			global.admin_verbs_sounds=newval;
 		if("admin_verbs_spawn")
 			global.admin_verbs_spawn=newval;
-		if("adminfaxes")
-			global.adminfaxes=newval;
 		if("adminhelp_ignored_words")
 			global.adminhelp_ignored_words=newval;
 		if("adminlog")
@@ -2960,7 +2952,7 @@
 			global.z_state=newval;
 		if("zone_blocked")
 			global.zone_blocked=newval;
-		
+
 /var/list/_all_globals=list(
 	"ALL_ANTIGENS",
 	"ANTAG_FREQS",

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1321,11 +1321,11 @@ var/global/floorIsLava = 0
 		return 1
 	else
 		return 0
-	
+
 //Prevents SDQL2 commands from changing admin permissions
 /datum/admins/SDQL_update(var/const/var_name, var/new_value)
 	return 0
-	
+
 //
 //
 //ALL DONE
@@ -1489,9 +1489,6 @@ datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies
 	var/obj/item/rcvdcopy
 	rcvdcopy = destination.copy(P)
 	rcvdcopy.loc = null //hopefully this shouldn't cause trouble
-	adminfaxes += rcvdcopy
-
-
 
 	if(destination.recievefax(P))
 		to_chat(src.owner, "<span class='notice'>Message reply to transmitted successfully.</span>")

--- a/html/changelogs/ravensdale - faxes.yml
+++ b/html/changelogs/ravensdale - faxes.yml
@@ -1,0 +1,4 @@
+author: Ravensdale
+delete-after: True
+changes: 
+  - rscdel: "Removed the ability for players to fax admins."


### PR DESCRIPTION
What it says on tin.

Multiple admins have ranted about these, grumbled about these, they are rife with meta-game attempt issues and ICly the only real thing admins should answer with anyway is 'message received'. 

Kept them as a thing for cross-department faxes, just axed the ability to harass admins with 'is this guy legit?' You're supposed to be isolated enough that you have to trust your own IC judgement, not meta admins - besides if we say 'yes' you ignore us anyway.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
