### PR TITLE
Makes loadout preference sanitation a little more aggressive.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -252,6 +252,20 @@ var/list/gear_datums = list()
 			pref.gear_list[1] = old_gear
 		return 1
 
+	if(preferences["version"] < 15)
+		if(istype(pref.gear_list))
+			// Checks if the key of the pref.gear_list is a list.
+			// If not the key is replaced with the corresponding value.
+			// This will convert the loadout slot data to a reasonable and (more importantly) compatible format.
+			// I.e. list("1" = loadout_data1, "2" = loadout_data2, "3" = loadout_data3) becomes list(loadout_data1, loadout_data2, loadaout_data3)
+			for(var/index = 1 to pref.gear_list.len)
+				var/key = pref.gear_list[index]
+				if(islist(key))
+					continue
+				var/value = pref.gear_list[key]
+				pref.gear_list[index] = value
+		return 1
+
 /datum/gear
 	var/display_name       //Name/index. Must be unique.
 	var/description        //Description of this gear. If left blank will default to the description of the pathed item.

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -80,7 +80,7 @@ var/list/gear_datums = list()
 	for(var/index = 1 to config.loadout_slots)
 		var/list/gears = pref.gear_list[index]
 
-		if(gears)
+		if(istype(gears))
 			for(var/gear_name in gears)
 				if(!(gear_name in gear_datums))
 					gears -= gear_name
@@ -239,7 +239,7 @@ var/list/gear_datums = list()
 		return TOPIC_REFRESH
 	if(href_list["clear_loadout"])
 		var/list/gear = pref.gear_list[pref.gear_slot]
-		LAZYCLEARLIST(gear)
+		gear.Cut()
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	return ..()
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN	8
-#define SAVEFILE_VERSION_MAX	14
+#define SAVEFILE_VERSION_MAX	15
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)	return


### PR DESCRIPTION
Fixes #17704.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
