### PR TITLE
Exosuit tweaks  - Fixes #8953

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -302,13 +302,18 @@
 	return
 
 /obj/mecha/proc/interface_action(obj/machinery/target)
-	if(istype(target, /obj/machinery/access_button))
+	if(istype(target, /obj/machinery/access_button) && target.Adjacent(src))
 		src.occupant_message("<span class='notice'>Interfacing with [target].</span>")
 		src.log_message("Interfaced with [target].")
 		target.attack_hand(src.occupant)
 		return 1
 	if(istype(target, /obj/machinery/embedded_controller))
-		target.ui_interact(src.occupant)
+		if(target in view(2,src))
+			src.occupant_message("<span class='notice'>Interfacing with [target]...</span>")
+			src.log_message("Interfaced with [target].")
+			target.ui_interact(src.occupant)
+		else
+			src.occupant_message("<span class='notice'>Unable to interface with [target], target out of range.</span>")
 		return 1
 	return 0
 
@@ -319,8 +324,6 @@
 		if(src_object == src || (src_object in src))
 			return STATUS_INTERACTIVE
 		if(src.Adjacent(src_object))
-			src.occupant_message("<span class='notice'>Interfacing with [src_object]...</span>")
-			src.log_message("Interfaced with [src_object].")
 			return STATUS_INTERACTIVE
 		if(src_object in view(2, src))
 			return STATUS_UPDATE //if they're close enough, allow the occupant to see the screen through the viewport or whatever.
@@ -717,7 +720,7 @@
 			else
 				to_chat(user, "You were unable to attach [W] to [src]")
 		return
-	
+
 	var/obj/item/weapon/card/id/id_card = W.GetIdCard()
 	if(id_card)
 		if(add_req_access || maint_access)

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -88,6 +88,9 @@
 /mob/living/carbon/human/default_can_use_topic(var/src_object)
 	. = shared_nano_interaction(src_object)
 	if(. != STATUS_CLOSE)
-		. = min(., shared_living_nano_distance(src_object))
+		if(loc)
+			. = min(., loc.contents_nano_distance(src_object, src))
+		else
+			. = min(., shared_living_nano_distance(src_object))
 		if(. == STATUS_UPDATE && (TK in mutations))	// If we have telekinesis and remain close enough, allow interaction.
 			return STATUS_INTERACTIVE

--- a/html/changelogs/ravensdale - viiiCMLIII.yml
+++ b/html/changelogs/ravensdale - viiiCMLIII.yml
@@ -1,0 +1,4 @@
+author: Ravensdale
+delete-after: True
+changes: 
+  - bugfix: "Exosuit/mecha pilots can once again operate airlocks from the safety of the cockpit"


### PR DESCRIPTION
Fixes #8953 , also re-ordered notifications to work with range checks.

- Tested: Exosuits/mecha's can view from 2 tiles away (though this still counts as 'interfacing' for logging purposes), interact at 1 tile away, must also be facing the button/airlock controller.
- /human mobs outside of a container just standing around appear to have their interactions unchanged, my attempts on consolidating certain checks to base /mob/living proc failed spectacularly.
- A human in a closet(locker) is unable to interact with nanoUI items outside the closet, as is current behaviour.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
