### PR TITLE
Makes taperecorder state behaviour similar to zippos.

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -1,7 +1,7 @@
 /obj/item/device/taperecorder
 	name = "universal recorder"
 	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content in playback."
-	icon_state = "taperecorder_empty"
+	icon_state = "taperecorder"
 	item_state = "analyzer"
 	w_class = ITEM_SIZE_SMALL
 
@@ -18,13 +18,17 @@
 	throwforce = 2
 	throw_speed = 4
 	throw_range = 20
+	var/base_state
 
 /obj/item/device/taperecorder/New()
 	..()
+	base_state = icon_state
+	icon_state = "[base_state]_empty"
 	if(ispath(mytape))
 		mytape = new mytape(src)
 		update_icon()
 	listening_objects += src
+
 
 /obj/item/device/taperecorder/empty
 	mytape = null
@@ -342,13 +346,13 @@
 
 /obj/item/device/taperecorder/update_icon()
 	if(!mytape)
-		icon_state = "taperecorder_empty"
+		icon_state = "[base_state]_empty"
 	else if(recording)
-		icon_state = "taperecorder_recording"
+		icon_state = "[base_state]_recording"
 	else if(playing)
-		icon_state = "taperecorder_playing"
+		icon_state = "[base_state]_playing"
 	else
-		icon_state = "taperecorder_idle"
+		icon_state = "[base_state]_idle"
 
 
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->


While applying for a custom item I noticed the icon_state values were hardcoded. This works as before but should allow for  replacing the original iconstate.

Zippo code was used as example and variable name was kept the same.