### PR TITLE
Changes taperecorder to accept custom item states

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -1,7 +1,7 @@
 /obj/item/device/taperecorder
 	name = "universal recorder"
 	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content in playback."
-	icon_state = "taperecorder_empty"
+	icon_state = "taperecorder"
 	item_state = "analyzer"
 	w_class = ITEM_SIZE_SMALL
 
@@ -18,13 +18,17 @@
 	throwforce = 2
 	throw_speed = 4
 	throw_range = 20
+	var/base_state
 
 /obj/item/device/taperecorder/New()
 	..()
+	base_state = icon_state
+	icon_state = "[base_state]_empty"
 	if(ispath(mytape))
 		mytape = new mytape(src)
 		update_icon()
 	listening_objects += src
+
 
 /obj/item/device/taperecorder/empty
 	mytape = null
@@ -342,13 +346,13 @@
 
 /obj/item/device/taperecorder/update_icon()
 	if(!mytape)
-		icon_state = "taperecorder_empty"
+		icon_state = "[base_state]_empty"
 	else if(recording)
-		icon_state = "taperecorder_recording"
+		icon_state = "[base_state]_recording"
 	else if(playing)
-		icon_state = "taperecorder_playing"
+		icon_state = "[base_state]_playing"
 	else
-		icon_state = "taperecorder_idle"
+		icon_state = "[base_state]_idle"
 
 
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -19,11 +19,13 @@
 	throw_speed = 4
 	throw_range = 20
 	var/base_state
+	var/prev_state
 
 /obj/item/device/taperecorder/New()
 	..()
 	base_state = icon_state
 	icon_state = "[base_state]_empty"
+	prev_state = icon_state
 	if(ispath(mytape))
 		mytape = new mytape(src)
 		update_icon()
@@ -345,6 +347,8 @@
 
 
 /obj/item/device/taperecorder/update_icon()
+	if(prev_state != icon_state)
+		base_state = icon_state
 	if(!mytape)
 		icon_state = "[base_state]_empty"
 	else if(recording)
@@ -353,7 +357,7 @@
 		icon_state = "[base_state]_playing"
 	else
 		icon_state = "[base_state]_idle"
-
+	prev_state = icon_state
 
 
 /obj/item/device/tape

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -18,14 +18,12 @@
 	throwforce = 2
 	throw_speed = 4
 	throw_range = 20
-	var/base_state
-	var/prev_state
+	var/base_state = "taperecorder"
 
 /obj/item/device/taperecorder/New()
 	..()
 	base_state = icon_state
 	icon_state = "[base_state]_empty"
-	prev_state = icon_state
 	if(ispath(mytape))
 		mytape = new mytape(src)
 		update_icon()
@@ -347,8 +345,6 @@
 
 
 /obj/item/device/taperecorder/update_icon()
-	if(prev_state != icon_state)
-		base_state = icon_state
 	if(!mytape)
 		icon_state = "[base_state]_empty"
 	else if(recording)
@@ -357,7 +353,7 @@
 		icon_state = "[base_state]_playing"
 	else
 		icon_state = "[base_state]_idle"
-	prev_state = icon_state
+
 
 
 /obj/item/device/tape

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -22,7 +22,6 @@
 
 /obj/item/device/taperecorder/New()
 	..()
-	base_state = copytext(icon_state, 1, findtext(icon_state, "_",1,0))
 	if(ispath(mytape))
 		mytape = new mytape(src)
 		update_icon()
@@ -344,6 +343,7 @@
 
 
 /obj/item/device/taperecorder/update_icon()
+	base_state = copytext(icon_state, 1, findtext(icon_state, "_",1,0))
 	if(!mytape)
 		icon_state = "[base_state]_empty"
 	else if(recording)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -1,7 +1,7 @@
 /obj/item/device/taperecorder
 	name = "universal recorder"
 	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content in playback."
-	icon_state = "taperecorder"
+	icon_state = "taperecorder_empty"
 	item_state = "analyzer"
 	w_class = ITEM_SIZE_SMALL
 
@@ -22,8 +22,7 @@
 
 /obj/item/device/taperecorder/New()
 	..()
-	base_state = icon_state
-	icon_state = "[base_state]_empty"
+	base_state = copytext(icon_state, 1, findtext(icon_state, "_",1,0))
 	if(ispath(mytape))
 		mytape = new mytape(src)
 		update_icon()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Correction from previous pull attempt. It now checks for differences between current and expected iconstate. I don't know if the check will be a performance hit.

If there's any current custom item that works with multiple-animation items, do tell.