### PR TITLE
Minor Tweaks and Fixes

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -180,9 +180,7 @@ datum/track/New(var/title_name, var/audio)
 	if(istype(W, /obj/item/weapon/wrench))
 		if(playing)
 			StopPlaying()
-		user.visible_message("<span class='warning'>[user] has [anchored ? "un" : ""]secured \the [src].</span>", "<span class='notice'>You [anchored ? "un" : ""]secure \the [src].</span>")
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		wrench_floor_bolts(user, 0)
 		power_change()
 		update_icon()
 		return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -189,15 +189,19 @@
 /obj/attackby(obj/item/O as obj, mob/user as mob)
 	if(flags & OBJ_ANCHORABLE)
 		if(istype(O, /obj/item/weapon/wrench))
-			playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
-			if(anchored)
-				user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
-			else
-				user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
-			if(do_after(user, 20, src))
-				if(!src) return
-				to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
-				anchored = !anchored
-				update_icon()
+			wrench_floor_bolts(user)
+			update_icon()
 			return
 	return ..()
+
+/obj/proc/wrench_floor_bolts(mob/user, delay=20)
+	playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
+	if(anchored)
+		user.visible_message("\The [user] begins unsecuring \the [src] from the floor.", "You start unsecuring \the [src] from the floor.")
+	else
+		user.visible_message("\The [user] begins securing \the [src] to the floor.", "You start securing \the [src] to the floor.")
+	if(do_after(user, delay, src))
+		if(!src) return
+		to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
+		anchored = !anchored
+	return 1

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -222,17 +222,9 @@
 			return 0
 		if(istype(W, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = W
-			if(!WT.remove_fuel(0,user))
-				if(!WT.isOn())
-					return
-				else
-					to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-					return
-			new /obj/item/stack/material/steel(src.loc)
-			for(var/mob/M in viewers(src))
-				M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 3, "You hear welding.", 2)
-			qdel(src)
-			return
+			if(WT.isOn())
+				slice_into_parts(WT, user)
+				return
 		if(istype(W, /obj/item/weapon/storage/laundry_basket) && W.contents.len)
 			var/obj/item/weapon/storage/laundry_basket/LB = W
 			var/turf/T = get_turf(src)
@@ -269,6 +261,16 @@
 	else
 		src.attack_hand(user)
 	return
+
+/obj/structure/closet/proc/slice_into_parts(obj/item/weapon/weldingtool/WT, mob/user)
+	if(!WT.remove_fuel(0,user))
+		to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+		return
+	new /obj/item/stack/material/steel(src.loc)
+	user.visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", \
+						 "<span class='notice'>You have cut \the [src] apart with \the [WT].</span>", \
+						 "You hear welding.")
+	qdel(src)
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 	if(istype(O, /obj/screen))	//fix for HUD elements making their way into the world	-Pete

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -63,7 +63,7 @@
 		to_chat(user, "<span class='notice'>Access Denied</span>")
 
 /obj/structure/closet/secure_closet/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(src.opened || istype(W,/obj/item/weapon/packageWrap) || istype(W,/obj/item/weapon/weldingtool))
+	if(src.opened || istype(W,/obj/item/weapon/packageWrap))
 		..()
 	else if(istype(W, /obj/item/weapon/melee/energy/blade))
 		if(emag_act(INFINITY, user, "<span class='danger'>The locker has been sliced open by [user] with \an [W]</span>!", "<span class='danger'>You hear metal being sliced and sparks flying.</span>"))
@@ -74,6 +74,10 @@
 			playsound(src.loc, "sparks", 50, 1)
 	else
 		togglelock(user)
+
+/obj/structure/closet/secure_closet/slice_into_parts(obj/item/weapon/weldingtool/WT, mob/user)
+	to_chat(user, "<span class='notice'>\The [src] is too strong to be taken apart.</span>")
+	return
 
 /obj/structure/closet/secure_closet/emag_act(var/remaining_charges, var/mob/user, var/emag_source, var/visual_feedback = "", var/audible_feedback = "")
 	if(!broken)


### PR DESCRIPTION
 - Puts wrenching floor bolts in its own proc.
 - Fixes childs of other vending products not be storable.
 - Fixes items that are unable to be stored in vending machines stealthily
   dropping to the floor.
 - Fixes being unable to put an offline welding tool into a locker.
 - Fixes secure closets being welded to metal sheets.
 - PDA messages that were failed to be sent will now be temporarily saved
   for the next message input screen to the same receiver.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
