### PR TITLE
Fixes Icon Update Issues on Vending Machines and Jukebox

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -49,13 +49,11 @@ datum/track/New(var/title_name, var/audio)
 	StopPlaying()
 	. = ..()
 
+/obj/machinery/media/jukebox/powered()
+	return anchored && ..()
+
 /obj/machinery/media/jukebox/power_change()
 	. = ..()
-	if(!anchored)
-		stat |= NOPOWER
-	else
-		stat &= ~NOPOWER
-
 	if(stat & (NOPOWER|BROKEN) && playing)
 		StopPlaying()
 
@@ -178,11 +176,8 @@ datum/track/New(var/title_name, var/audio)
 	src.add_fingerprint(user)
 
 	if(istype(W, /obj/item/weapon/wrench))
-		if(playing)
-			StopPlaying()
 		wrench_floor_bolts(user, 0)
 		power_change()
-		update_icon()
 		return
 	return ..()
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -195,7 +195,6 @@
 	else if((flags & OBJ_ANCHORABLE) && istype(W, /obj/item/weapon/wrench))
 		wrench_floor_bolts(user)
 		power_change()
-		update_icon()
 		return
 	else if(istype(W, /obj/item/weapon/coin) && premium.len > 0)
 		user.drop_item()
@@ -535,12 +534,8 @@
 		O.show_message("<span class='game say'><span class='name'>\The [src]</span> beeps, \"[message]\"</span>",2)
 	return
 
-/obj/machinery/vending/power_change()
-	. = ..()
-	if(!anchored)
-		stat |= NOPOWER
-	else
-		stat &= ~NOPOWER
+/obj/machinery/vending/powered()
+	return anchored && ..()
 
 /obj/machinery/vending/update_icon()
 	if(stat & BROKEN)


### PR DESCRIPTION
Moves the `anchored`-check to `powered()`.

Fixes #17766
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
