### PR TITLE
Air Shutters will open more safely

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -51,6 +51,7 @@
 #include "code\__defines\tick.dm"
 #include "code\__defines\turfs.dm"
 #include "code\__defines\xenoarcheaology.dm"
+#include "code\__defines\ZAS.dm"
 #include "code\_global_vars\logging.dm"
 #include "code\_helpers\_global_objects.dm"
 #include "code\_helpers\areas.dm"

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -1,0 +1,8 @@
+//#define ZASDBG
+#define MULTIZAS
+
+#define AIR_BLOCKED 1
+#define ZONE_BLOCKED 2
+#define BLOCKED 3
+
+#define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -91,7 +91,8 @@
 					E.nextstate = FIREDOOR_OPEN
 				else if(E.density)
 					spawn(0)
-						E.open()
+						if(E.can_safely_open())
+							E.open()
 
 
 /area/proc/fire_alert()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -353,6 +353,26 @@
 	latetoggle()
 	return ..()
 
+// Only opens when all areas connecting with our turf have an air alarm and are cleared
+/obj/machinery/door/firedoor/proc/can_safely_open()
+	var/turf/neighbour
+	for(var/dir in cardinal)
+		neighbour = get_step(src.loc, dir)
+		if(neighbour.c_airblock(src.loc) & AIR_BLOCKED)
+			continue
+		for(var/obj/O in src.loc)
+			if(istype(O, /obj/machinery/door))
+				continue
+			. |= O.c_airblock(neighbour)
+		if(. & AIR_BLOCKED)
+			continue
+		var/area/A = get_area(neighbour)
+		if(!A.master_air_alarm)
+			return
+		if(A.atmosalm)
+			return
+	return TRUE
+
 /obj/machinery/door/firedoor/do_animate(animation)
 	switch(animation)
 		if("opening")

--- a/code/modules/ZAS/_docs.dm
+++ b/code/modules/ZAS/_docs.dm
@@ -26,12 +26,3 @@ Notes for people who used ZAS before:
 		var/zone/connected_zone = edge.get_connected_zone(zone)
 
 */
-
-//#define ZASDBG
-#define MULTIZAS
-
-#define AIR_BLOCKED 1
-#define ZONE_BLOCKED 2
-#define BLOCKED 3
-
-#define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct

--- a/html/changelogs/Hubblenaut - shutters.yml
+++ b/html/changelogs/Hubblenaut - shutters.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Hubblenaut
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Air shutters will not be automatically opened by a clearing air alarm when it would be dangerous to do."


### PR DESCRIPTION
 - Moves ZAS defines to their own file in `/__defines/`.
 - Air shutters will check for alarms in their adjacent areas before being
   automatically raised by a clearing alarm.

Tried to keep this efficient, have a second check.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
