### PR TITLE
Garbage and error handling tweaks.

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -112,7 +112,7 @@ SUBSYSTEM_DEF(garbage)
 
 			// Something's still referring to the qdel'd object.  Kill it.
 			var/type = A.type
-			report_progress("GC: -- \ref[A] | [type] was unable to be GC'd and was deleted --")
+			log_debug("GC: -- \ref[A] | [type] was unable to be GC'd and was deleted --")
 			didntgc["[type]"]++
 
 			HardDelete(A)
@@ -185,7 +185,7 @@ SUBSYSTEM_DEF(garbage)
 	if(!D)
 		return
 	if(!istype(D))
-		log_error("qdel() was passed '[log_info_line(D)]'. qdel() can only handle instances of (sub)type /datum.")
+		crash_with("qdel() was passed '[log_info_line(D)]'. qdel() can only handle instances of (sub)type /datum.")
 		del(D)
 		return
 #ifdef TESTING

--- a/code/modules/error_handler/error_reporting.dm
+++ b/code/modules/error_handler/error_reporting.dm
@@ -1,5 +1,6 @@
 // this proc will only work with DEBUG enabled
 #ifdef DEBUG
+
 /hook/roundend/proc/send_runtimes_to_ircbot()
 	if(!revdata.revision) return // we can't do much useful if we don't know what we are
 	var/list/errors = list()
@@ -9,8 +10,8 @@
 
 		var/data = list(
 			id = erruid,
-			name = err.name,
-			info = err.desc
+			name = err.info_name,
+			info = err.info
 		)
 
 		errors[++errors.len] = list2params(data)
@@ -18,4 +19,5 @@
 	runtimes2irc(list2params(errors), revdata.revision)
 
 	return 1
+
 #endif


### PR DESCRIPTION
Failure to GC is now reported to the debug log instead of as progress.
Restores the error viewer's Topic() handling.
The error reporter should again report using plain strings, rather than HTML enhanced ones.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
