### PR TITLE
Runtime fixes

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -160,6 +160,7 @@
 		param = "\ref[ref]"
 
 	spawn(2)
+		if(!user.client) return
 		winset(user, windowid, "on-close=\".windowclose [param]\"")
 
 //	log_debug("OnClose [user]: [windowid] : ["on-close=\".windowclose [param]\""]")

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -177,7 +177,7 @@ var/list/outfits_decls_by_type_
 	check_and_try_equip_xeno(H)
 
 /decl/hierarchy/outfit/proc/equip_id(mob/living/carbon/human/H, rank, assignment)
-	if(!id_slot)
+	if(!id_slot || !id_type)
 		return
 	var/obj/item/weapon/card/id/W = new id_type(H)
 	if(id_desc)
@@ -191,7 +191,7 @@ var/list/outfits_decls_by_type_
 		return W
 
 /decl/hierarchy/outfit/proc/equip_pda(mob/living/carbon/human/H, rank, assignment)
-	if(!pda_slot)
+	if(!pda_slot || !pda_type)
 		return
 	var/obj/item/device/pda/heads/pda = new pda_type(H)
 	pda.set_owner_rank_job(H.real_name, rank, assignment)

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -139,7 +139,7 @@
 	return ..() + list("bound_x", "bound_y", "bound_height", "bound_width", "bounds", "step_x", "step_y", "step_size")
 
 /client/VV_static()
-	return ..() + list("holder")
+	return ..() + list("holder", "prefs")
 
 /datum/admins/VV_static()
 	return vars

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -69,7 +69,7 @@
 /datum/category_item/player_setup_item/general/language/proc/is_allowed_language(var/mob/user, var/datum/language/lang)
 	if(!user)
 		return TRUE
-	var/datum/species/S = all_species[pref.species]
+	var/datum/species/S = all_species[pref.species] || all_species[SPECIES_HUMAN]
 	if(lang.name in S.secondary_langs)
 		return TRUE
 	if(!(lang.flags & RESTRICTED) && is_alien_whitelisted(user, lang))

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -81,8 +81,11 @@
 	return ..()
 
 /client/proc/is_preference_enabled(var/preference)
-	var/datum/client_preference/cp = get_client_preference(preference)
-	return cp && (cp.key in prefs.preferences_enabled)
+	if(prefs)
+		var/datum/client_preference/cp = get_client_preference(preference)
+		return cp && (cp.key in prefs.preferences_enabled)
+	else
+		log_error("Client is lacking preferences: [log_info_line(src)]")	
 
 /client/proc/is_preference_disabled(var/preference)
 	return !is_preference_enabled(preference)

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -113,7 +113,10 @@
 			continue
 		else
 			path = 	contents[metadata[i]]
-		new path(I)
+		if(path)
+			new path(I)
+		else
+			log_debug("Failed to tweak item: Index [i] in [json_encode(metadata)] did not result in a valid path. Valid contents: [json_encode(valid_contents)]")
 
 /*
 * Ragent adjustment


### PR DESCRIPTION
Adds a null check of id_type/pda_type in outfits.dm
Fixes #17795.
Fixes #17796.
Fixes #17851.
Fixes #17852.

Adds some type checking and debug information in loadout gear tweaking.
Fixes #16636.

Adds extra species checks in the language preference checkup.
Fixes #17864.

Adds an error message for when client preferences are missing.
Fixes #17865.

Adds a client check before opening the browser, required due to the recently added spawn-delay
Fixes #17863.