### PR TITLE
Fixed robots in space.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -328,6 +328,7 @@ var/global/list/robot_modules = list(
 					"Drone" = "drone-engineer",
 					"Eyebot" = "eyebot-engineering"
 					)
+	no_slip = 1
 
 /obj/item/weapon/robot_module/engineering/general/New()
 	src.modules += new /obj/item/device/flash(src)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -3,6 +3,11 @@
 		return 0
 	..(prob_slip)
 
+/mob/living/silicon/robot/Check_Shoegrip()
+	if(module && module.no_slip)
+		return 1
+	return 0
+
 /mob/living/silicon/robot/Allow_Spacemove()
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)


### PR DESCRIPTION
Robots no longer float/slip in space even if they have no_slip = 1, and engineering modules get this be default.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
