### PR TITLE
Spawnpoints are now initialized on first request.

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -1005,8 +1005,6 @@
 			return global.spark_sound;
 		if("sparring_attack_cache")
 			return global.sparring_attack_cache;
-		if("spawntypes")
-			return global.spawntypes;
 		if("spells")
 			return global.spells;
 		if("splatter_cache")
@@ -2226,8 +2224,6 @@
 			global.spark_sound=newval;
 		if("sparring_attack_cache")
 			global.sparring_attack_cache=newval;
-		if("spawntypes")
-			global.spawntypes=newval;
 		if("spells")
 			global.spells=newval;
 		if("splatter_cache")
@@ -2944,7 +2940,6 @@
 	"spacevines_spawned",
 	"spark_sound",
 	"sparring_attack_cache",
-	"spawntypes",
 	"spells",
 	"splatter_cache",
 	"sqladdress",

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -60,9 +60,6 @@ datum/controller/game_controller/proc/setup_objects()
 
 	// Do these first since character setup will rely on them
 
-	//Set up spawn points.
-	populate_spawn_points()
-
 	initialization_stage |= INITIALIZATION_HAS_BEGUN
 
 	if(GLOB.using_map.use_overmap)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -629,7 +629,7 @@ var/global/datum/controller/occupations/job_master
 				to_chat(H, "<span class='warning'>Your chosen spawnpoint ([C.prefs.spawnpoint]) is unavailable for the current map. Spawning you at one of the enabled spawn points instead. To resolve this error head to your character's setup and choose a different spawn point.</span>")
 			spawnpos = null
 		else
-			spawnpos = spawntypes[spawnpoint]
+			spawnpos = spawntypes()[spawnpoint]
 
 	if(spawnpos && !spawnpos.check_job_spawning(rank))
 		if(H)
@@ -639,7 +639,7 @@ var/global/datum/controller/occupations/job_master
 	if(!spawnpos)
 		// Step through all spawnpoints and pick first appropriate for job
 		for(var/spawntype in GLOB.using_map.allowed_spawns)
-			var/datum/spawnpoint/candidate = spawntypes[spawntype]
+			var/datum/spawnpoint/candidate = spawntypes()[spawntype]
 			if(candidate.check_job_spawning(rank))
 				spawnpos = candidate
 				break
@@ -647,7 +647,7 @@ var/global/datum/controller/occupations/job_master
 	if(!spawnpos)
 		// Pick at random from all the (wrong) spawnpoints, just so we have one
 		warning("Could not find an appropriate spawnpoint for job [rank].")
-		spawnpos = spawntypes[pick(GLOB.using_map.allowed_spawns)]
+		spawnpos = spawntypes()[pick(GLOB.using_map.allowed_spawns)]
 
 	return spawnpos
 

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -34,7 +34,7 @@ datum/preferences
 	pref.real_name          = sanitize_name(pref.real_name, pref.species)
 	if(!pref.real_name)
 		pref.real_name      = random_name(pref.gender, pref.species)
-	pref.spawnpoint         = sanitize_inlist(pref.spawnpoint, spawntypes, initial(pref.spawnpoint))
+	pref.spawnpoint         = sanitize_inlist(pref.spawnpoint, spawntypes(), initial(pref.spawnpoint))
 	pref.be_random_name     = sanitize_integer(pref.be_random_name, 0, 1, initial(pref.be_random_name))
 
 /datum/category_item/player_setup_item/general/basic/content()
@@ -86,10 +86,10 @@ datum/preferences
 
 	else if(href_list["spawnpoint"])
 		var/list/spawnkeys = list()
-		for(var/spawntype in spawntypes)
+		for(var/spawntype in spawntypes())
 			spawnkeys += spawntype
 		var/choice = input(user, "Where would you like to spawn when late-joining?") as null|anything in spawnkeys
-		if(!choice || !spawntypes[choice] || !CanUseTopic(user))	return TOPIC_NOACTION
+		if(!choice || !spawntypes()[choice] || !CanUseTopic(user))	return TOPIC_NOACTION
 		pref.spawnpoint = choice
 		return TOPIC_REFRESH
 

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -1,12 +1,14 @@
-var/list/spawntypes = list()
+GLOBAL_VAR(spawntypes)
 
-/proc/populate_spawn_points()
-	spawntypes = list()
-	for(var/type in typesof(/datum/spawnpoint)-/datum/spawnpoint)
-		var/datum/spawnpoint/S = type
-		var/display_name = initial(S.display_name)
-		if((display_name in GLOB.using_map.allowed_spawns) || initial(S.always_visible))
-			spawntypes[display_name] = new S
+/proc/spawntypes()
+	if(!GLOB.spawntypes)
+		GLOB.spawntypes = list()
+		for(var/type in typesof(/datum/spawnpoint)-/datum/spawnpoint)
+			var/datum/spawnpoint/S = type
+			var/display_name = initial(S.display_name)
+			if((display_name in GLOB.using_map.allowed_spawns) || initial(S.always_visible))
+				GLOB.spawntypes[display_name] = new S
+	return GLOB.spawntypes
 
 /datum/spawnpoint
 	var/msg		  //Message to display on the arrivals computer.

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -199,7 +199,7 @@ datum/unit_test/correct_allowed_spawn_test/start_test()
 	var/failed = FALSE
 
 	for(var/spawn_name in GLOB.using_map.allowed_spawns)
-		var/datum/spawnpoint/spawnpoint = spawntypes[spawn_name]
+		var/datum/spawnpoint/spawnpoint = spawntypes()[spawn_name]
 		if(!spawnpoint)
 			log_unit_test("Map allows spawning in [spawn_name], but [spawn_name] is null!")
 			failed = TRUE
@@ -209,11 +209,11 @@ datum/unit_test/correct_allowed_spawn_test/start_test()
 
 	if(failed)
 		log_unit_test("Following spawn points exist:")
-		for(var/spawnpoint in spawntypes)
-			log_unit_test("\t[spawnpoint] ([any2ref(spawnpoint)])")	
+		for(var/spawnpoint in spawntypes())
+			log_unit_test("\t[spawnpoint] ([any2ref(spawnpoint)])")
 		log_unit_test("Following spawn points are allowed:")
 		for(var/spawnpoint in GLOB.using_map.allowed_spawns)
-			log_unit_test("\t[spawnpoint] ([any2ref(spawnpoint)])")	
+			log_unit_test("\t[spawnpoint] ([any2ref(spawnpoint)])")
 		fail("Some of the entries in allowed_spawns have no spawnpoint turfs.")
 	else
 		pass("All entries in allowed_spawns have spawnpoints.")

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -239,7 +239,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '456ffa108f98f41b4687f8398f405103 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '91304c16bd417660335cf73db8088e67 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Previously they were initialized by the master controller at a random point in time.
If a player joined before this point in time the spawnpoint preference would always be reset (due to not being in the still empty list of spawnpoints).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
