### PR TITLE
Adds the ability to white/blacklist jobs, branches and ranks per species and map

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2418,6 +2418,7 @@
 #include "maps\torch\torch.dm"
 #include "maps\torch\torch_define.dm"
 #include "maps\~mapsystem\map_preferences.dm"
+#include "maps\~mapsystem\map_ranks.dm"
 #include "maps\~mapsystem\maps.dm"
 #include "maps\~mapsystem\maps_announcements.dm"
 #include "maps\~mapsystem\maps_areas.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2421,6 +2421,7 @@
 #include "maps\~mapsystem\maps.dm"
 #include "maps\~mapsystem\maps_announcements.dm"
 #include "maps\~mapsystem\maps_areas.dm"
+#include "maps\~mapsystem\maps_jobs.dm"
 #include "maps\~mapsystem\maps_unit_testing.dm"
 #include "maps\~unit_tests\unit_testing.dm"
 #include "~code\global_init.dm"

--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -593,7 +593,7 @@ datum
 				weight = 20
 
 				get_points(var/job)
-					if(job in science_positions || job in command_positions)
+					if((job in science_positions) || (job in command_positions))
 						return 20
 					return 40
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -123,6 +123,25 @@
 /datum/job/proc/has_alt_title(var/mob/H, var/supplied_title, var/desired_title)
 	return (supplied_title == desired_title) || (H.mind && H.mind.role_alt_title == desired_title)
 
+/datum/job/proc/is_restricted(var/datum/preferences/prefs, var/feedback)
+	if(!is_branch_allowed(prefs.char_branch))
+		to_chat(feedback, "<span class='boldannounce'>Wrong branch of service for [title]. Valid branches are: [get_branches()].</span>")
+		return TRUE
+
+	if(!is_rank_allowed(prefs.char_branch, prefs.char_rank))
+		to_chat(feedback, "<span class='boldannounce'>Wrong rank for [title]. Valid ranks in [prefs.char_branch] are: [get_ranks(prefs.char_branch)].</span>")
+		return TRUE
+
+	var/datum/species/S = all_species[prefs.species]
+	if(!is_species_allowed(S))
+		to_chat(feedback, "<span class='boldannounce'>Restricted species, [S], for [title].</span>")
+		return TRUE
+
+	return FALSE
+    
+/datum/job/proc/is_species_allowed(var/datum/species/S)
+	return !GLOB.using_map.is_species_job_restricted(S, src)
+    
 /**
  *  Check if members of the given branch are allowed in the job
  *

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -89,9 +89,7 @@ var/global/datum/controller/occupations/job_master
 				return 0
 			if(!job.player_old_enough(player.client))
 				return 0
-			if(!job.is_branch_allowed(player.get_branch_pref()))
-				return 0
-			if(!job.is_rank_allowed(player.get_branch_pref(), player.get_rank_pref()))
+			if(job.is_restricted(player.client.prefs))
 				return 0
 
 			var/position_limit = job.total_positions
@@ -421,7 +419,7 @@ var/global/datum/controller/occupations/job_master
 
 		if(!joined_late || job.latejoin_at_spawnpoints)
 			var/obj/S = get_roundstart_spawnpoint(rank)
-			
+
 			if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
 				H.forceMove(S.loc)
 			else

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -145,6 +145,9 @@ var/global/datum/controller/occupations/job_master
 			if(istype(job, GetJob("Assistant"))) // We don't want to give him assistant, that's boring!
 				continue
 
+			if(job.is_restricted(player.client.prefs))
+				continue
+
 			if(job.title in command_positions) //If you want a command position, select it!
 				continue
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -23,7 +23,7 @@ var/global/datum/controller/occupations/job_master
 			log_error("<span class='warning'>Error setting up jobs, no job datums found!</span>")
 			return 0
 		for(var/J in all_jobs)
-			var/datum/job/job = new J()
+			var/datum/job/job = decls_repository.get_decl(J)
 			if(!job)	continue
 			if(job.faction != faction)	continue
 			occupations += job

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -326,6 +326,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 			reset_limbs() // Safety for species with incompatible manufacturers; easier than trying to do it case by case.
 
+			prune_occupation_prefs()
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["hair_color"])

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -75,6 +75,7 @@
 	if(!job_master)
 		return
 
+	var/datum/species/S = preference_species()
 	var/datum/mil_branch/player_branch = null
 	var/datum/mil_rank/player_rank = null
 
@@ -128,6 +129,11 @@
 		if(job.minimum_character_age && user.client && (user.client.prefs.age < job.minimum_character_age))
 			. += "<del>[rank]</del></td><td> \[MINIMUM CHARACTER AGE: [job.minimum_character_age]]</td></tr>"
 			continue
+
+		if(!job.is_species_allowed(S))
+			. += "<del>[rank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
+			continue
+
 		if(job.allowed_branches)
 			if(!player_branch)
 				. += "<del>[rank]</del></td><td><a href='?src=\ref[src];show_branches=[rank]'><b> \[BRANCH RESTRICTED]</b></a></td></tr>"
@@ -305,24 +311,23 @@
 	return 0
 
 /**
- *  Prune a player's job preferences based on current branch and rank
+ *  Prune a player's job preferences based on current branch, rank and species
  *
  *  This proc goes through all the preferred jobs, and removes the ones incompatible with current rank or branch.
  */
 /datum/category_item/player_setup_item/occupation/proc/prune_job_prefs_for_rank()
 	for(var/datum/job/job in job_master.occupations)
 		if(job.title == pref.job_high)
-			if(!job.is_branch_allowed(pref.char_branch) || !job.is_rank_allowed(pref.char_branch, pref.char_rank))
+			if(job.is_restricted(pref))
 				pref.job_high = null
 
 		else if(job.title in pref.job_medium)
-			if(!job.is_branch_allowed(pref.char_branch) || !job.is_rank_allowed(pref.char_branch, pref.char_rank))
+			if(job.is_restricted(pref))
 				pref.job_medium.Remove(job.title)
 
 		else if(job.title in pref.job_low)
-			if(!job.is_branch_allowed(pref.char_branch) || !job.is_rank_allowed(pref.char_branch, pref.char_rank))
+			if(job.is_restricted(pref))
 				pref.job_low.Remove(job.title)
-
 
 /datum/category_item/player_setup_item/occupation/proc/ResetJobs()
 	pref.job_high = null

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -51,17 +51,9 @@
 			pref.job_low[i]  = sanitize(pref.job_low[i])
 	if(!pref.player_alt_titles) pref.player_alt_titles = new()
 
-	if((GLOB.using_map.flags & MAP_HAS_BRANCH)\
-	   && (!pref.char_branch || !mil_branches.is_spawn_branch(pref.char_branch)))
-		pref.char_branch = "None"
-
-	if((GLOB.using_map.flags & MAP_HAS_RANK)\
-	   && (!pref.char_rank || !mil_branches.is_spawn_rank(pref.char_branch, pref.char_rank)))
-		pref.char_rank = "None"
-
 	// We could have something like Captain set to high while on a non-rank map,
 	// so we prune here to make sure we don't spawn as a PFC captain
-	prune_job_prefs_for_rank()
+	prune_occupation_prefs()
 
 	if(!job_master)
 		return
@@ -224,11 +216,11 @@
 		if(SetJob(user, href_list["set_job"])) return (pref.equip_preview_mob ? TOPIC_REFRESH_UPDATE_PREVIEW : TOPIC_REFRESH)
 
 	else if(href_list["char_branch"])
-		var/choice = input(user, "Choose your branch of service.", "Character Preference", pref.char_branch) as null|anything in mil_branches.spawn_branches
-		if(choice && CanUseTopic(user))
+		var/choice = input(user, "Choose your branch of service.", "Character Preference", pref.char_branch) as null|anything in mil_branches.spawn_branches(preference_species())
+		if(choice && CanUseTopic(user) && mil_branches.is_spawn_branch(choice, preference_species()))
 			pref.char_branch = choice
 			pref.char_rank = "None"
-			prune_job_prefs_for_rank()
+			prune_job_prefs()
 			return TOPIC_REFRESH
 
 	else if(href_list["char_rank"])
@@ -236,11 +228,11 @@
 		var/datum/mil_branch/current_branch = mil_branches.get_branch(pref.char_branch)
 
 		if(current_branch)
-			choice = input(user, "Choose your rank.", "Character Preference", pref.char_rank) as null|anything in current_branch.spawn_ranks
+			choice = input(user, "Choose your rank.", "Character Preference", pref.char_rank) as null|anything in mil_branches.spawn_ranks(pref.char_branch, preference_species())
 
-		if(choice && CanUseTopic(user))
+		if(choice && CanUseTopic(user) && mil_branches.is_spawn_rank(pref.char_branch, choice, preference_species()))
 			pref.char_rank = choice
-			prune_job_prefs_for_rank()
+			prune_job_prefs()
 			return TOPIC_REFRESH
 	else if(href_list["show_branches"])
 		var/rank = href_list["show_branches"]
@@ -315,7 +307,7 @@
  *
  *  This proc goes through all the preferred jobs, and removes the ones incompatible with current rank or branch.
  */
-/datum/category_item/player_setup_item/occupation/proc/prune_job_prefs_for_rank()
+/datum/category_item/player_setup_item/proc/prune_job_prefs()
 	for(var/datum/job/job in job_master.occupations)
 		if(job.title == pref.job_high)
 			if(job.is_restricted(pref))
@@ -328,6 +320,18 @@
 		else if(job.title in pref.job_low)
 			if(job.is_restricted(pref))
 				pref.job_low.Remove(job.title)
+
+datum/category_item/player_setup_item/proc/prune_occupation_prefs()
+	var/datum/species/S = preference_species()
+	if((GLOB.using_map.flags & MAP_HAS_BRANCH)\
+	   && (!pref.char_branch || !mil_branches.is_spawn_branch(pref.char_branch, S)))
+		pref.char_branch = "None"
+
+	if((GLOB.using_map.flags & MAP_HAS_RANK)\
+	   && (!pref.char_rank || !mil_branches.is_spawn_rank(pref.char_branch, pref.char_rank, S)))
+		pref.char_rank = "None"
+
+	prune_job_prefs()
 
 /datum/category_item/player_setup_item/occupation/proc/ResetJobs()
 	pref.job_high = null

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -251,3 +251,6 @@
 
 	if(pref.client)
 		return pref.client.mob
+
+/datum/category_item/player_setup_item/proc/preference_species()
+	return all_species[pref.species] || all_species[SPECIES_HUMAN]

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -88,4 +88,5 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_r_hand)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H.back), slot_in_backpack)
 		H.internal = H.r_hand
-	H.internals.icon_state = "internal1"
+	if(H.internals)
+		H.internals.icon_state = "internal1"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -163,11 +163,16 @@
 		ViewManifest()
 
 	if(href_list["SelectedJob"])
+		var/datum/job/job = job_master.GetJob(href_list["SelectedJob"])
+
+		if(!job)
+			to_chat(usr, "<span class='danger'>The job '[href_list["SelectedJob"]]' doesn't exist!</span>")
+			return
 
 		if(!config.enter_allowed)
 			to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 			return
-		else if(ticker && ticker.mode && ticker.mode.explosion_in_progress)
+		if(ticker && ticker.mode && ticker.mode.explosion_in_progress)
 			to_chat(usr, "<span class='danger'>The [station_name()] is currently exploding. Joining would go poorly.</span>")
 			return
 
@@ -175,7 +180,7 @@
 		if(!check_species_allowed(S))
 			return 0
 
-		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
+		AttemptLateSpawn(job, client.prefs.spawnpoint)
 		return
 
 	if(href_list["privacy_poll"])
@@ -285,13 +290,6 @@
 
 	return 1
 
-/mob/new_player/proc/IsJobRestricted(var/datum/job/job, var/branch_pref, var/rank_pref)
-	if(!job.is_branch_allowed(branch_pref))
-		return 1
-	if(!job.is_rank_allowed(branch_pref, rank_pref))
-		return 1
-	return 0
-
 /mob/new_player/proc/get_branch_pref()
 	if(client)
 		return client.prefs.char_branch
@@ -300,7 +298,7 @@
 	if(client)
 		return client.prefs.char_rank
 
-/mob/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
+/mob/new_player/proc/AttemptLateSpawn(var/datum/job/job, var/spawning_at)
 	if(src != usr)
 		return 0
 	if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
@@ -309,22 +307,17 @@
 	if(!config.enter_allowed)
 		to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 		return 0
-	var/datum/job/job = job_master.GetJob(rank)
+
 	if(!IsJobAvailable(job))
-		alert("[rank] is not available. Please try another.")
+		alert("[job.title] is not available. Please try another.")
 		return 0
-	if(!job.is_branch_allowed(client.prefs.char_branch))
-		alert("Wrong branch of service for [rank]. Valid branches are: [job.get_branches()].")
-		return 0
-	if(!job.is_rank_allowed(client.prefs.char_branch, client.prefs.char_rank))
-		alert("Wrong rank for [rank]. Valid ranks in [client.prefs.char_branch] are: [job.get_ranks(client.prefs.char_branch)].")
-		return 0
+	if(job.is_restricted(client.prefs, src))
+		return
 
-
-	var/datum/spawnpoint/spawnpoint = job_master.get_spawnpoint_for(client, rank)
+	var/datum/spawnpoint/spawnpoint = job_master.get_spawnpoint_for(client, job.title)
 	var/turf/spawn_turf = pick(spawnpoint.turfs)
 	if(job.latejoin_at_spawnpoints)
-		var/obj/S = job_master.get_roundstart_spawnpoint(rank)
+		var/obj/S = job_master.get_roundstart_spawnpoint(job.title)
 		spawn_turf = get_turf(S)
 	var/airstatus = IsTurfAtmosUnsafe(spawn_turf)
 	if(airstatus)
@@ -339,16 +332,16 @@
 
 		// Just in case someone stole our position while we were waiting for input from alert() proc
 		if(!IsJobAvailable(job))
-			to_chat(src, alert("[rank] is not available. Please try another."))
+			to_chat(src, alert("[job.title] is not available. Please try another."))
 			return 0
 
-	job_master.AssignRole(src, rank, 1)
+	job_master.AssignRole(src, job.title, 1)
 
 	var/mob/living/character = create_character(spawn_turf)	//creates the human and transfers vars and mind
 	if(!character)
 		return 0
 
-	character = job_master.EquipRank(character, rank, 1)					//equips the human
+	character = job_master.EquipRank(character, job.title, 1)					//equips the human
 	UpdateFactionList(character)
 	equip_custom_items(character)
 
@@ -365,7 +358,7 @@
 		var/mob/living/silicon/ai/A = character
 		A.on_mob_init()
 
-		AnnounceCyborg(character, rank, "has been downloaded to the empty core in \the [character.loc.loc]")
+		AnnounceCyborg(character, job.title, "has been downloaded to the empty core in \the [character.loc.loc]")
 		ticker.mode.handle_latejoin(character)
 
 		qdel(C)
@@ -374,13 +367,13 @@
 
 	ticker.mode.handle_latejoin(character)
 	GLOB.universe.OnPlayerLatejoin(character)
-	if(job_master.ShouldCreateRecords(rank))
+	if(job_master.ShouldCreateRecords(job.title))
 		if(character.mind.assigned_role != "Cyborg")
 			GLOB.data_core.manifest_inject(character)
 			ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 
 			if(job.announced)
-				AnnounceArrival(character, rank, spawnpoint.msg)
+				AnnounceArrival(character, job.title, spawnpoint.msg)
 		matchmaker.do_matchmaking()
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 	qdel(src)
@@ -420,7 +413,7 @@
 			for(var/mob/M in GLOB.player_list) if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
 				active++
 
-			if(IsJobRestricted(job, client.prefs.char_branch, client.prefs.char_rank))
+			if(job.is_restricted(client.prefs))
 				dat += "<a style='text-decoration: line-through' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [active])</a><br>"
 			else
 				dat += "<a href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [active])</a><br>"

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -75,6 +75,7 @@ h1.alert, h2.alert		{color: #000000;}
 
 .danger					{color: #ff0000; font-weight: bold;}
 .warning				{color: #ff0000; font-style: italic;}
+.boldannounce			{color: #ff0000; font-weight: bold;}
 .rose					{color: #ff5050;}
 .info					{color: #0000CC;}
 .notice					{color: #000099;}

--- a/html/changelogs/PsiOmegaDelta-YouAreOverQualified.yml
+++ b/html/changelogs/PsiOmegaDelta-YouAreOverQualified.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: PsiOmegaDelta
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Species may now be restricted from joining as certain roles."

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -1,5 +1,8 @@
 /datum/map/torch
-	species_to_job_whitelist = list(/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway))
+	species_to_job_whitelist = list(
+		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant),
+		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway)
+	)
 
 	allowed_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos,
 						/datum/job/liaison, /datum/job/representative, /datum/job/sea, /datum/job/bridgeofficer, /datum/job/solgov_pilot,

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -19,6 +19,20 @@
 						)
 
 
+/datum/map/torch/setup_map()
+	..()
+	for(var/job_type in GLOB.using_map.allowed_jobs)
+		var/datum/job/job = decls_repository.get_decl(job_type)
+		// Most species are restricted from SCG security and command roles
+		if((job.department_flag & (SEC|COM)) && job.allowed_branches.len && !(/datum/mil_branch/civilian in job.allowed_branches))
+			for(var/species_name in list(SPECIES_IPC, SPECIES_TAJARA, SPECIES_SKRELL, SPECIES_UNATHI))
+				var/datum/species/S = all_species[species_name]
+				var/species_blacklist = species_to_job_blacklist[S.type]
+				if(!species_blacklist)
+					species_blacklist = list()
+					species_to_job_blacklist[S.type] = species_blacklist
+				species_blacklist |= job.type
+
 /datum/job/captain
 	title = "Commanding Officer"
 	supervisors = "the Sol Central Government and the Sol Code of Military Justice"

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -1,4 +1,6 @@
 /datum/map/torch
+	species_to_job_whitelist = list(/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway))
+
 	allowed_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos,
 						/datum/job/liaison, /datum/job/representative, /datum/job/sea, /datum/job/bridgeofficer, /datum/job/solgov_pilot,
 						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist,

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -13,6 +13,57 @@
 		/datum/mil_branch/civilian
 	)
 
+	species_to_branch_whitelist = list(
+		/datum/species/diona   = list(/datum/mil_branch/civilian),
+		/datum/species/nabber  = list(/datum/mil_branch/civilian),
+		/datum/species/tajaran = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/skrell  = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/unathi  = list(/datum/mil_branch/civilian),
+		/datum/species/vox     = list()
+	)
+
+	species_to_branch_blacklist = list(
+		/datum/species/machine = list(/datum/mil_branch/marine_corps)
+	)
+
+	species_to_rank_whitelist = list(
+		/datum/species/machine = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/fleet/e1,
+				/datum/mil_rank/fleet/e2,
+				/datum/mil_rank/fleet/e3,
+				/datum/mil_rank/fleet/e4,
+				/datum/mil_rank/fleet/e5,
+				/datum/mil_rank/fleet/o1
+			),
+			/datum/mil_branch/fleet = list(
+				/datum/mil_rank/fleet/e1,
+				/datum/mil_rank/fleet/e2,
+				/datum/mil_rank/fleet/e3,
+				/datum/mil_rank/fleet/e4,
+				/datum/mil_rank/fleet/e5,
+				/datum/mil_rank/fleet/o1
+			)
+		),
+		/datum/species/tajaran = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/fleet/e1,
+				/datum/mil_rank/fleet/e2,
+				/datum/mil_rank/fleet/e3,
+				/datum/mil_rank/fleet/e4,
+				/datum/mil_rank/fleet/o1
+			)
+		),
+		/datum/species/skrell = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/fleet/e1,
+				/datum/mil_rank/fleet/e2,
+				/datum/mil_rank/fleet/e3,
+				/datum/mil_rank/fleet/e4,
+				/datum/mil_rank/fleet/o1
+			)
+		)
+	)
 
 
 /*

--- a/maps/~mapsystem/map_ranks.dm
+++ b/maps/~mapsystem/map_ranks.dm
@@ -1,0 +1,40 @@
+/datum/map
+	var/list/branch_types                         // list of branch datum paths for military branches available on this map
+	var/list/spawn_branch_types                   // subset of above for branches a player can spawn in with
+
+	var/list/species_to_branch_whitelist = list() // List of branches which are allowed, per species. Overrules blacklist (i.e. there is no point setting up a blacklist for a species if there's a whitelist).
+	var/list/species_to_branch_blacklist = list() // List of branches which are restricted, per species.
+
+	var/list/species_to_rank_whitelist = list()   // List of ranks which are allowed, per branch and species. Overrules blacklist, see above.
+	var/list/species_to_rank_blacklist = list()   // Lists of ranks which are restricted, per species.
+
+// The white, and blacklist are type specific, any subtypes (of both species and jobs) have to be added explicitly
+/datum/map/proc/is_species_branch_restricted(var/datum/species/S, var/datum/mil_branch/MB)
+	if(!istype(S) || !istype(MB))
+		return TRUE
+
+	var/list/whitelist = species_to_branch_whitelist[S.type]
+	if(whitelist)
+		return !(MB.type in whitelist)
+
+	var/list/blacklist = species_to_branch_blacklist[S.type]
+	if(blacklist)
+		return (MB.type in blacklist)
+
+	return FALSE
+
+/datum/map/proc/is_species_rank_restricted(var/datum/species/S, var/datum/mil_branch/MB, var/datum/mil_rank/MR)
+	if(!istype(S) || !istype(MB) || !istype(MR))
+		return TRUE
+
+	var/list/whitelist_by_branch = species_to_rank_whitelist[S.type]
+	if(whitelist_by_branch)
+		var/list/whitelist = whitelist_by_branch[MB.type]
+		return whitelist && !(MR.type in whitelist)
+
+	var/list/blacklist_by_branch = species_to_rank_blacklist[S.type]
+	if(blacklist_by_branch)
+		var/list/blacklist = blacklist_by_branch[MB.type]
+		return blacklist && (MR.type in blacklist)
+
+	return FALSE

--- a/maps/~mapsystem/map_ranks.dm
+++ b/maps/~mapsystem/map_ranks.dm
@@ -2,10 +2,10 @@
 	var/list/branch_types                         // list of branch datum paths for military branches available on this map
 	var/list/spawn_branch_types                   // subset of above for branches a player can spawn in with
 
-	var/list/species_to_branch_whitelist = list() // List of branches which are allowed, per species. Overrules blacklist (i.e. there is no point setting up a blacklist for a species if there's a whitelist).
+	var/list/species_to_branch_whitelist = list() // List of branches which are allowed, per species. Checked before the blacklist.
 	var/list/species_to_branch_blacklist = list() // List of branches which are restricted, per species.
 
-	var/list/species_to_rank_whitelist = list()   // List of ranks which are allowed, per branch and species. Overrules blacklist, see above.
+	var/list/species_to_rank_whitelist = list()   // List of ranks which are allowed, per branch and species. Checked before the blacklist.
 	var/list/species_to_rank_blacklist = list()   // Lists of ranks which are restricted, per species.
 
 // The white, and blacklist are type specific, any subtypes (of both species and jobs) have to be added explicitly
@@ -14,8 +14,8 @@
 		return TRUE
 
 	var/list/whitelist = species_to_branch_whitelist[S.type]
-	if(whitelist)
-		return !(MB.type in whitelist)
+	if(whitelist && (MB.type in whitelist))
+		return FALSE
 
 	var/list/blacklist = species_to_branch_blacklist[S.type]
 	if(blacklist)
@@ -30,7 +30,8 @@
 	var/list/whitelist_by_branch = species_to_rank_whitelist[S.type]
 	if(whitelist_by_branch)
 		var/list/whitelist = whitelist_by_branch[MB.type]
-		return whitelist && !(MR.type in whitelist)
+		if(whitelist && (MR.type in whitelist))
+			return FALSE
 
 	var/list/blacklist_by_branch = species_to_rank_blacklist[S.type]
 	if(blacklist_by_branch)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -89,9 +89,6 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/list/lobby_screens = list()                 // The list of lobby screen to pick() from. If left unset the first icon state is always selected.
 	var/lobby_music/lobby_music                     // The track that will play in the lobby screen. Handed in the /setup_map() proc.
 
-	var/list/branch_types  // list of branch datum paths for military branches available on this map
-	var/list/spawn_branch_types  // subset of above for branches a player can spawn in with
-
 	var/default_law_type = /datum/ai_laws/nanotrasen // The default lawset use by synth units, if not overriden by their laws var.
 
 	var/id_hud_icons = 'icons/mob/hud.dmi' // Used by the ID HUD (primarily sechud) overlay.

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -97,7 +97,6 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/id_hud_icons = 'icons/mob/hud.dmi' // Used by the ID HUD (primarily sechud) overlay.
 
 /datum/map/New()
-	..()
 	if(!map_levels)
 		map_levels = station_levels.Copy()
 	if(!allowed_jobs)

--- a/maps/~mapsystem/maps_jobs.dm
+++ b/maps/~mapsystem/maps_jobs.dm
@@ -1,0 +1,18 @@
+/datum/map
+	var/species_to_job_whitelist = list(/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg))
+	var/species_to_job_blacklist = list()
+
+// The white, and blacklist are type specific, any subtypes (of both species and jobs) have to be added explicitly
+/datum/map/proc/is_species_job_restricted(var/datum/species/S, var/datum/job/J)
+	if(!istype(S) || !istype(J))
+		return TRUE
+
+	var/list/whitelist = species_to_job_whitelist[S.type]
+	if(whitelist)
+		return !(J.type in whitelist)
+
+	var/list/blacklist = species_to_job_blacklist[S.type]
+	if(blacklist)
+		return (J.type in blacklist)
+
+	return FALSE


### PR DESCRIPTION
By default Vox may only join as AI or cyborg. For Torch the merchant and stowaway roles are also added.
Makes job restriction checks more re-used, rather than copy-pasted all over the place.

Also adds the missing boldannounce span class.

Also added branch and rank restrictions. For the current setup see https://github.com/Baystation12/Baystation12/pull/17896#issuecomment-316495502

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
