### PR TITLE
Restores the ErrorUid format.

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -16,7 +16,7 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 
 	GLOB.total_runtimes++
 
-	var/erroruid = "[E.file][E.line]"
+	var/erroruid = "[E.file],[E.line]"
 	var/last_seen = error_last_seen[erroruid]
 	var/cooldown = error_cooldown[erroruid] || 0
 

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -111,7 +111,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 	if (!istype(e))
 		return // Abnormal exception, don't even bother
 
-	var/erroruid = "[e.file][e.line]"
+	var/erroruid = "[e.file],[e.line]"
 	var/datum/error_viewer/error_source/error_source = error_sources[erroruid]
 	if (!error_source)
 		error_source = new(e)


### PR DESCRIPTION
The Runtime bot should no longer open old runtimes as new tickets after this.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
