### PR TITLE
[READY]Adds NTNet Access Decrypter

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1804,6 +1804,7 @@
 #include "code\modules\modular_computers\file_system\news_article.dm"
 #include "code\modules\modular_computers\file_system\program.dm"
 #include "code\modules\modular_computers\file_system\program_events.dm"
+#include "code\modules\modular_computers\file_system\programs\antagonist\access_decrypter.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\dos.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\hacked_camera.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\revelation.dm"

--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -1,0 +1,111 @@
+/datum/computer_file/program/access_decrypter
+	filename = "nt_accrypt"
+	filedesc = "NTNet Access Decrypter"
+	program_icon_state = "hostile"
+	extended_desc = "This highly advanced script can very slowly decrypt operational codes used in almost any network. These codes can be downloaded to an ID card to expand the available access. The system administrator will probably notice this."
+	size = 34
+	requires_ntnet = 1
+	available_on_ntnet = 0
+	available_on_syndinet = 1
+	nanomodule_path = /datum/nano_module/program/access_decrypter/
+	var/message = ""
+	var/running = FALSE
+	var/progress = 0
+	var/target_progress = 300
+	var/list/access_list = null
+
+/datum/computer_file/program/access_decrypter/New()
+	..()
+	access_list = get_all_access_datums()
+
+/datum/computer_file/program/access_decrypter/kill_program(var/forced)
+	reset()
+	..(forced)
+
+/datum/computer_file/program/access_decrypter/proc/reset()
+	running = FALSE
+	message = ""
+	progress = 0
+
+/datum/computer_file/program/access_decrypter/process_tick()
+	. = ..()
+	if(!running)
+		return
+	var/obj/item/weapon/computer_hardware/processor_unit/CPU = computer.processor_unit
+	var/obj/item/weapon/computer_hardware/card_slot/RFID = computer.card_slot
+	if(!istype(CPU) || !CPU.check_functionality() || !istype(RFID) || !RFID.check_functionality())
+		message = "A fatal hardware error has been detected."
+		return
+	if(!istype(RFID.stored_card))
+		message = "RFID card has been removed from the device. Operation aborted."
+		return
+
+	progress += CPU.max_idle_programs
+	if(progress >= target_progress)
+		reset()
+		var/datum/access/A = pick(access_list)
+		RFID.stored_card.access |= A.id
+		if(ntnet_global.intrusion_detection_enabled)
+			ntnet_global.add_log("IDS WARNING - Unauthorised access to primary keycode database from device: [computer.network_card.get_network_tag()]  - downloaded access codes for: [A.desc].")
+			ntnet_global.intrusion_detection_alarm = 1
+		message = "Successfully decrypted and saved operational key codes. Downloaded access codes for: [A.desc]"
+
+/datum/computer_file/program/access_decrypter/Topic(href, href_list)
+	if(..())
+		return 1
+	if(href_list["PRG_reset"])
+		reset()
+		return 1
+	if(href_list["PRG_execute"])
+		if(running)
+			return 1
+		var/obj/item/weapon/computer_hardware/processor_unit/CPU = computer.processor_unit
+		var/obj/item/weapon/computer_hardware/card_slot/RFID = computer.card_slot
+		if(!istype(CPU) || !CPU.check_functionality() || !istype(RFID) || !RFID.check_functionality())
+			message = "A fatal hardware error has been detected."
+			return
+		if(!istype(RFID.stored_card))
+			message = "RFID card is not present in the device. Operation aborted."
+			return
+		running = TRUE
+		if(ntnet_global.intrusion_detection_enabled)
+			ntnet_global.add_log("IDS WARNING - Unauthorised access attempt to primary keycode database from device: [computer.network_card.get_network_tag()]")
+			ntnet_global.intrusion_detection_alarm = 1
+
+
+
+/datum/nano_module/program/access_decrypter
+	name = "NTNet Access Decrypter"
+
+/datum/nano_module/program/access_decrypter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
+	if(!ntnet_global)
+		return
+	var/datum/computer_file/program/access_decrypter/PRG = program
+	var/list/data = list()
+	if(!istype(PRG))
+		return
+	data = PRG.get_header_data()
+
+	if(PRG.message)
+		data["message"] = PRG.message
+	else if(PRG.running)
+		data["running"] = 1
+		data["rate"] = PRG.computer.processor_unit.max_idle_programs
+
+		// Stolen from DOS traffic generator, generates strings of 1s and 0s
+		var/percentage = (PRG.progress / PRG.target_progress) * 100
+		var/list/strings[0]
+		for(var/j, j<10, j++)
+			var/string = ""
+			for(var/i, i<20, i++)
+				string = "[string][prob(percentage)]"
+			strings.Add(string)
+		data["dos_strings"] = strings
+
+	ui = GLOB.nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "access_decrypter.tmpl", "NTNet Access Decrypter", 550, 400, state = state)
+		ui.auto_update_layout = 1
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)

--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -12,11 +12,6 @@
 	var/running = FALSE
 	var/progress = 0
 	var/target_progress = 300
-	var/list/access_list = null
-
-/datum/computer_file/program/access_decrypter/New()
-	..()
-	access_list = get_all_access_datums()
 
 /datum/computer_file/program/access_decrypter/kill_program(var/forced)
 	reset()
@@ -43,7 +38,7 @@
 	progress += CPU.max_idle_programs
 	if(progress >= target_progress)
 		reset()
-		var/datum/access/A = pick(access_list)
+		var/datum/access/A = get_access_by_id(pick(get_all_station_access()))
 		RFID.stored_card.access |= A.id
 		if(ntnet_global.intrusion_detection_enabled)
 			ntnet_global.add_log("IDS WARNING - Unauthorised access to primary keycode database from device: [computer.network_card.get_network_tag()]  - downloaded access codes for: [A.desc].")
@@ -71,8 +66,7 @@
 		if(ntnet_global.intrusion_detection_enabled)
 			ntnet_global.add_log("IDS WARNING - Unauthorised access attempt to primary keycode database from device: [computer.network_card.get_network_tag()]")
 			ntnet_global.intrusion_detection_alarm = 1
-
-
+		return 1
 
 /datum/nano_module/program/access_decrypter
 	name = "NTNet Access Decrypter"

--- a/html/changelogs/atlantiscze-hacknet.yml
+++ b/html/changelogs/atlantiscze-hacknet.yml
@@ -1,0 +1,5 @@
+author: Atlantiscze
+delete-after: True
+
+changes: 
+  - rscadd: "Added new program to the modular computer framework: NTNet Access Decrypter. This program is available for download on all emagged devices, but relies on ID card slot hardware. When executed it slowly (takes about 3-6 minutes, depending on the device's CPU) hacks the network and when finished adds a random access to the ID. ID must be kept inside the device while running. Can be repeatedly used to get multiple accesses. Has chance of yielding access that's already present on the ID, and therefore will do nothing wasting some time."

--- a/nano/templates/access_decrypter.tmpl
+++ b/nano/templates/access_decrypter.tmpl
@@ -1,0 +1,12 @@
+{{:helper.syndicateMode()}}
+{{if data.message}}
+	##INFO: {{:data.message}}<br><br>{{:helper.link('RESET', null, { 'PRG_reset' : 1 })}}
+{{else data.running}}
+	##Attempting to decrypt network access codes. Please wait. Rate: {{:data.rate}} PHash/s<br>
+	{{for data.dos_strings}}
+		{{:value}}<br>
+	{{/for}}
+	{{:helper.link('ABORT', null, { 'PRG_reset' : 1 })}}
+{{else}}
+	##System ready<br><br>{{:helper.link('EXECUTE', null, { 'PRG_execute' : 1 })}}
+{{/if}}


### PR DESCRIPTION
- A new antag tool that may be downloaded on emagged devices
- Requires NTNet connection, ID slot hardware, and benefits from more powerful CPUs.
- When executed attempts to download a random access to the ID card. It may end up downloading something that you already have, so this is most useful if you are playing a job that has access to only few places (as there's low chance of getting a duplicate). May be executed repeatedly.
- IDS system will detect when this program is activated, or when it finishes it's operation. It will also log what access has been downloaded. If the IDS system is disabled no logs or alerts will be produced.
- Yes, this is highly luck based. You could be extremely lucky (about 1% chance with current amount of accesses) and get access to modify IDs on first run. Then it's easy to create a full access ID. On the other hand, you could get multiple low use or even duplicate accesses.