### PR TITLE
Ghost emotes are no longer double sanitized.

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -97,4 +97,4 @@
 
 /mob/observer/ghost/emote(var/act, var/type, var/message)
 	if(message && act == "me")
-		sanitize_and_communicate(/decl/communication_channel/dsay, client, message, /decl/dsay_communication/emote)
+		communicate(/decl/communication_channel/dsay, client, message, /decl/dsay_communication/emote)


### PR DESCRIPTION
No more `&amp;`s `&acute;`s or whatever odd characters people use these days.