### PR TITLE
Fixes soft caps custom items icon state

### DIFF
--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -10,19 +10,30 @@
 	siemens_coefficient = 0.9
 	body_parts_covered = 0
 
+/obj/item/clothing/head/soft/New()
+	..()
+	set_extension(src, /datum/extension/base_icon_state, /datum/extension/base_icon_state, icon_state)
+	update_icon()
+
+/obj/item/clothing/head/soft/update_icon()
+	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
+	if(flipped)
+		icon_state = "[bis.base_icon_state]_flipped"
+	else
+		icon_state = bis.base_icon_state
+
 /obj/item/clothing/head/soft/dropped()
-	src.icon_state = initial(icon_state)
 	src.flipped=0
+	update_icon()
 	..()
 
 /obj/item/clothing/head/soft/attack_self(mob/user)
 	src.flipped = !src.flipped
 	if(src.flipped)
-		icon_state = "[icon_state]_flipped"
 		to_chat(user, "You flip the hat backwards.")
 	else
-		src.icon_state = initial(icon_state)
 		to_chat(user, "You flip the hat back in normal position.")
+	update_icon()
 	update_clothing_icon()	//so our mob-overlays update
 
 /obj/item/clothing/head/soft/red


### PR DESCRIPTION
Switches soft caps to use `extension/base_icon_state` rather than calling `initial` (which broke when concerning custom items).