### PR TITLE
Adjusts job preference pruning.

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -308,7 +308,12 @@
  *  This proc goes through all the preferred jobs, and removes the ones incompatible with current rank or branch.
  */
 /datum/category_item/player_setup_item/proc/prune_job_prefs()
-	for(var/datum/job/job in job_master.occupations)
+	var/allowed_titles = list()
+
+	for(var/job_type in GLOB.using_map.allowed_jobs)
+		var/datum/job/job = decls_repository.get_decl(job_type)
+		allowed_titles += job.title
+
 		if(job.title == pref.job_high)
 			if(job.is_restricted(pref))
 				pref.job_high = null
@@ -320,6 +325,17 @@
 		else if(job.title in pref.job_low)
 			if(job.is_restricted(pref))
 				pref.job_low.Remove(job.title)
+
+	if(pref.job_high && !(pref.job_high in allowed_titles))
+		pref.job_high = null
+
+	for(var/job_title in pref.job_medium)
+		if(!(job_title in allowed_titles))
+			pref.job_medium -= job_title
+
+	for(var/job_title in pref.job_low)
+		if(!(job_title in allowed_titles))
+			pref.job_low -= job_title
 
 datum/category_item/player_setup_item/proc/prune_occupation_prefs()
 	var/datum/species/S = preference_species()


### PR DESCRIPTION
Now acquires the jobs using the decls repository. Fixes #17930.
Now also prunes jobs no longer allowed by the map.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
