### PR TITLE
Partly reverts #17737

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -6,7 +6,6 @@ GLOBAL_LIST_EMPTY(processing_power_items)
 GLOBAL_LIST_EMPTY(active_diseases)
 GLOBAL_LIST_EMPTY(med_hud_users)          // List of all entities using a medical HUD.
 GLOBAL_LIST_EMPTY(sec_hud_users)          // List of all entities using a security HUD.
-GLOBAL_LIST_EMPTY(holowarrant_users)
 GLOBAL_LIST_EMPTY(hud_icon_reference)
 GLOBAL_LIST_EMPTY(traders)                //List of all nearby traders
 

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -48,7 +48,7 @@
 				active.fields["auth"] = "[I.registered_name] - [I.assignment ? I.assignment : "(Unknown)"]"
 			user.visible_message("<span class='notice'>You swipe \the [I] through the [src].</span>", \
 					"<span class='notice'>[user] swipes \the [I] through the [src].</span>")
-			broadcast_holowarrant_message("\A [active.fields["arrestsearch"]] warrant for <b>[active.fields["namewarrant"]]</b> has been authorized by [I.assignment ? I.assignment+" " : ""][I.registered_name].", src)
+			broadcast_security_hud_message("\A [active.fields["arrestsearch"]] warrant for <b>[active.fields["namewarrant"]]</b> has been authorized by [I.assignment ? I.assignment+" " : ""][I.registered_name].", src)
 			return 1
 	..()
 
@@ -63,14 +63,6 @@
 		icon_state = "holowarrant_filled"
 	else
 		icon_state = "holowarrant"
-
-/obj/item/device/holowarrant/equipped(var/mob/user, var/slot)
-	GLOB.holowarrant_users += user
-	return ..()
-
-/obj/item/device/holowarrant/dropped(mob/user)
-	GLOB.holowarrant_users -= user
-	return ..()
 
 /obj/item/device/holowarrant/proc/show_content(mob/user, forceshow)
 	if(!active)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -399,9 +399,6 @@ proc/is_blind(A)
 /proc/broadcast_medical_hud_message(var/message, var/broadcast_source)
 	broadcast_hud_message(message, broadcast_source, GLOB.med_hud_users, /obj/item/clothing/glasses/hud/health)
 
-/proc/broadcast_holowarrant_message(var/message, var/broadcast_source)
-	broadcast_hud_message(message, broadcast_source, GLOB.holowarrant_users, /obj/item/device/holowarrant)
-
 /proc/broadcast_hud_message(var/message, var/broadcast_source, var/list/targets, var/icon)
 	var/turf/sourceturf = get_turf(broadcast_source)
 	for(var/mob/M in targets)

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -122,7 +122,7 @@ var/warrant_uid = 0
 
 	if(href_list["savewarrant"])
 		. = 1
-		broadcast_holowarrant_message("\A [activewarrant.fields["arrestsearch"]] warrant for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in GLOB.data_core.warrants) ? "edited" : "uploaded"].", src.program.computer)
+		broadcast_security_hud_message("\A [activewarrant.fields["arrestsearch"]] warrant for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in GLOB.data_core.warrants) ? "edited" : "uploaded"].", src.program.computer)
 		GLOB.data_core.warrants |= activewarrant
 		activewarrant = null
 


### PR DESCRIPTION
Partly reverts #17737.

Holowarrants will broadcast over the security HUD, since the list management for digital warrants is bugged and I realize receiving a broadcast on your screen for a device that is in your pocket rather than directly infront of your eyes does not make sense anyway for game logic.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
