### PR TITLE
Reduces flashfires

### DIFF
--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -355,7 +355,7 @@ datum/gas_mixture/proc/check_recombustability(list/fuel_objs)
 
 	. = 0
 	for(var/g in gas)
-		if(gas_data.flags[g] & XGM_GAS_FUEL && QUANTIZE(gas[g] * vsc.fire_consuption_rate) >= 0.005)
+		if(gas_data.flags[g] & XGM_GAS_FUEL && QUANTIZE(gas[g] * vsc.fire_consuption_rate) >= 0.1)
 			. = 1
 			break
 


### PR DESCRIPTION
- Fixes flashfires occuring due to very tiny amounts of phoron in the air. These tiny amounts can not be scrubbed, so an area which had a phoron spill would have flashfires occuring until server restart or complete atmosphere replacement (through breaching it into vacuum).