### PR TITLE
Uniform corrections.

### DIFF
--- a/code/modules/clothing/under/solgov.dm
+++ b/code/modules/clothing/under/solgov.dm
@@ -47,9 +47,6 @@
 	worn_state = "blackutility_crew"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 10)
 
-/obj/item/clothing/under/utility/expeditionary/pilot
-	starting_accessories = list(/obj/item/clothing/accessory/speciality/pilot)
-
 /obj/item/clothing/under/utility/expeditionary/medical
 	name = "expeditionary medical uniform"
 	desc = "The utility uniform of the SCG Expeditionary Corps, made from biohazard resistant material. This one has silver trim and blue blazes."
@@ -98,6 +95,9 @@
 	icon_state = "blackutility_com"
 	worn_state = "blackutility_com"
 
+/obj/item/clothing/under/utility/expeditionary/command/pilot
+	starting_accessories = list(/obj/item/clothing/accessory/speciality/pilot)
+
 
 /obj/item/clothing/under/utility/fleet
 	name = "fleet coveralls"
@@ -107,9 +107,6 @@
 	worn_state = "navyutility"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 10, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
-
-/obj/item/clothing/under/utility/fleet/pilot
-	starting_accessories = list(/obj/item/clothing/accessory/speciality/pilot)
 
 /obj/item/clothing/under/utility/fleet/medical
 	name = "fleet medical coveralls"
@@ -141,6 +138,9 @@
 	icon_state = "navyutility_com"
 	worn_state = "navyutility_com"
 
+/obj/item/clothing/under/utility/fleet/command/pilot
+	starting_accessories = list(/obj/item/clothing/accessory/speciality/pilot)
+
 
 /obj/item/clothing/under/utility/marine
 	name = "marine fatigues"
@@ -149,9 +149,6 @@
 	item_state = "gy_suit"
 	worn_state = "greyutility"
 	armor = list(melee = 10, bullet = 0, laser = 10,energy = 0, bomb = 0, bio = 0, rad = 0)
-
-/obj/item/clothing/under/utility/marine/pilot
-	starting_accessories = list(/obj/item/clothing/accessory/speciality/pilot)
 
 /obj/item/clothing/under/utility/marine/green
 	name = "green fatigues"
@@ -199,6 +196,9 @@
 	desc = "The utility uniform of the SCG Marine Corps, made from durable material. This one has gold markings."
 	icon_state = "greyutility_com"
 	worn_state = "greyutility_com"
+
+/obj/item/clothing/under/utility/marine/command/pilot
+	starting_accessories = list(/obj/item/clothing/accessory/speciality/pilot)
 
 //Service
 

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -477,7 +477,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/brig_officer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/brig_officer,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/brig_officer/fleet,
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/brig_officer/marine
 	)
 	allowed_ranks = list(

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -590,7 +590,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 
 /decl/hierarchy/outfit/job/torch/crew/service/solgov_pilot //until they get a better uniform
 	name = OUTFIT_JOB_NAME("SolGov Pilot")
-	uniform = /obj/item/clothing/under/utility/expeditionary/pilot
+	uniform = /obj/item/clothing/under/utility/expeditionary/command/pilot
 	shoes = /obj/item/clothing/shoes/dutyboots
 	head = /obj/item/clothing/head/soft/sol/expedition
 	id_type = /obj/item/weapon/card/id/torch/crew/solgov_pilot
@@ -599,13 +599,13 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 
 /decl/hierarchy/outfit/job/torch/crew/service/solgov_pilot/fleet
 	name = OUTFIT_JOB_NAME("Pilot - Fleet")
-	uniform = /obj/item/clothing/under/utility/fleet/pilot
+	uniform = /obj/item/clothing/under/utility/fleet/command/pilot
 	head = /obj/item/clothing/head/utility/fleet
 	shoes = /obj/item/clothing/shoes/dutyboots
 
 /decl/hierarchy/outfit/job/torch/crew/service/solgov_pilot/marine
 	name = OUTFIT_JOB_NAME("Pilot - Marine")
-	uniform = /obj/item/clothing/under/utility/marine/pilot
+	uniform = /obj/item/clothing/under/utility/marine/command/pilot
 	head = /obj/item/clothing/head/utility/marine
 	shoes = /obj/item/clothing/shoes/jungleboots
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Pilots, both Expeditionary Corps and Fleet, now spawn with a command variant of their uniform, rather than a general-issue variant.

Fleet Brig Officers now spawn with the correct Fleet uniform instead of expeditionary gear.

Fixes https://github.com/Baystation12/Baystation12/issues/18007