### PR TITLE
Makes parapens not crit you forever

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -174,9 +174,14 @@
 	strength = 3
 	target_organ = BP_BRAIN
 
-/datum/reagent/toxin/zombiepowder/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/toxin/zombiepowder/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
 	..()
 	if(alien == IS_DIONA)
+		return
+	if(volume < 2*metabolism) //half-assed attempt to make it trigger on last tick
+		var/obj/item/organ/internal/heart/H = M.internal_organs_by_name[BP_HEART]
+		if(H && H.robotic < ORGAN_ROBOT && H.is_working())
+			H.pulse = PULSE_2FAST
 		return
 	M.status_flags |= FAKEDEATH
 	M.adjustOxyLoss(3 * removed)


### PR DESCRIPTION
Got tired of hearing about it
Problem was that heart stopped by zombie powder was never restarted.
Adds a jumpstart to it before clearing out.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
