### PR TITLE
License memes! (Updates readme.md to match changelog header + other information)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,24 @@
 ---
 
 ### LICENSE
-Baystation12 is licensed under the GNU Affero General Public License version 3, which can be found in full in LICENSE-AGPL3.txt.
+The code for Baystation12 is licensed under the [GNU Affero General Public License v3](http://www.gnu.org/licenses/agpl.html), which can be found in full in LICENSE-AGPL3.txt.
 
-Commits with a git authorship date prior to `1420675200 +0000` (2015/01/08 00:00) are licensed under the GNU General Public License version 3, which can be found in full in LICENSE-GPL3.txt.
+Code with a git authorship date prior to `1420675200 +0000` (2015/01/08 00:00) are licensed under the GNU General Public License version 3, which can be found in full in LICENSE-GPL3.txt.
 
-All commits whose authorship dates are not prior to `1420675200 +0000` are assumed to be licensed under AGPL v3, if you wish to license under GPL v3 please make this clear in the commit message and any added files.
+All code where the authorship dates are not prior to `1420675200 +0000` are assumed to be licensed under AGPL v3, if you wish to license under GPL v3 please make this clear in the commit message and any added files.
 
 If you wish to develop and host this codebase in a closed source manner you may use all commits prior to `1420675200 +0000`, which are licensed under GPL v3.  The major change here is that if you host a server using any code licensed under AGPLv3 you are required to provide full source code for your servers users as well including addons and modifications you have made.
 
 See [here](https://www.gnu.org/licenses/why-affero-gpl.html) for more information.
+
+tgui clientside is licensed as a subproject under the MIT license.
+Font Awesome font files, used by tgui, are licensed under the SIL Open Font License v1.1
+tgui assets are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+
+See tgui/LICENSE.md for the MIT license.
+See tgui/assets/fonts/SIL-OFL-1.1-LICENSE.md for the SIL Open Font License.
+
+All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](http://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.
 
 ### GETTING THE CODE
 The simplest way to obtain the code is using the github .zip feature.


### PR DESCRIPTION
@Neerti brought up a fun point on Discord. The licensing of assets in the Baystation12 codebase is ambiguous. Unlike the [/tg/station README](https://github.com/tgstation/tgstation/#license), which is clear as day.

Things amended:
* tgUI license notification added, as per [this file](https://github.com/Baystation12/Baystation12/blob/dev/tgui/LICENSE.md).
* Clarifies that all assets/content/w/e is licensed under CC-BY-SA 3.0, as [per line 29 of the changelog header](https://github.com/Baystation12/Baystation12/blob/dev/html/templates/header.html#L29). Anything else would create a mahoosive incompatibility with the /tg/ codebase, as CC-BY-SA 3.0 and AGPL are in no way compatible with eachother. (I guess you're free to pursue the intent that **all** content is licensed under AGPL3, but then all the icons already licensed under it would be incompatible and aaaaaaaaaaaaaaaa. (Oh and please actually update the header to reflect that then.))

Why:
Because clarity is important and questions regarding this stuff should be minimal.