### PR TITLE
Minor robot module and warrant tweaks

### DIFF
--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -42,7 +42,7 @@
 /obj/item/device/holowarrant/attackby(obj/item/weapon/W, mob/user)
 	if(active)
 		var/obj/item/weapon/card/id/I = W.GetIdCard()
-		if(I)
+		if(I && (access_security in I.access))
 			var/choice = alert(user, "Would you like to authorize this warrant?","Warrant authorization","Yes","No")
 			if(choice == "Yes")
 				active.fields["auth"] = "[I.registered_name] - [I.assignment ? I.assignment : "(Unknown)"]"

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -49,7 +49,9 @@
 			user.visible_message("<span class='notice'>You swipe \the [I] through the [src].</span>", \
 					"<span class='notice'>[user] swipes \the [I] through the [src].</span>")
 			broadcast_security_hud_message("\A [active.fields["arrestsearch"]] warrant for <b>[active.fields["namewarrant"]]</b> has been authorized by [I.assignment ? I.assignment+" " : ""][I.registered_name].", src)
-			return 1
+		else
+			to_chat(user, "<span class='notice'>A red \"Access Denied\" light blinks on \the [src]</span>")
+		return 1
 	..()
 
 //hit other people with it

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -318,7 +318,7 @@ var/global/list/robot_modules = list(
 	name = "engineering robot module"
 	channels = list("Engineering" = 1)
 	networks = list(NETWORK_ENGINEERING)
-	subsystems = list(/datum/nano_module/power_monitor)
+	subsystems = list(/datum/nano_module/power_monitor, /datum/nano_module/supermatter_monitor)
 	supported_upgrades = list(/obj/item/borg/upgrade/rcd)
 	sprites = list(
 					"Basic" = "Engineering",
@@ -399,7 +399,7 @@ var/global/list/robot_modules = list(
 	name = "security robot module"
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
-	subsystems = list(/datum/nano_module/crew_monitor)
+	subsystems = list(/datum/nano_module/crew_monitor, /datum/nano_module/digitalwarrant)
 	can_be_pushed = 0
 	supported_upgrades = list(/obj/item/borg/upgrade/tasercooler)
 
@@ -558,6 +558,7 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/miner
 	name = "miner robot module"
+	subsystems = list(/datum/nano_module/supply)
 	channels = list("Supply" = 1, "Science" = 1)
 	networks = list(NETWORK_MINE)
 	sprites = list(

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -18,13 +18,13 @@ var/warrant_uid = 0
 	available_on_ntnet = 1
 	required_access = access_security
 	usage_flags = PROGRAM_ALL
-	nanomodule_path = /datum/nano_module/program/digitalwarrant/
+	nanomodule_path = /datum/nano_module/digitalwarrant/
 
-/datum/nano_module/program/digitalwarrant/
+/datum/nano_module/digitalwarrant/
 	name = "Warrant Assistant"
 	var/datum/data/record/warrant/activewarrant
 
-/datum/nano_module/program/digitalwarrant/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
+/datum/nano_module/digitalwarrant/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
 	if(activewarrant)
@@ -64,7 +64,7 @@ var/warrant_uid = 0
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/program/digitalwarrant/Topic(href, href_list)
+/datum/nano_module/digitalwarrant/Topic(href, href_list)
 	if(..())
 		return 1
 
@@ -122,7 +122,7 @@ var/warrant_uid = 0
 
 	if(href_list["savewarrant"])
 		. = 1
-		broadcast_security_hud_message("\A [activewarrant.fields["arrestsearch"]] warrant for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in GLOB.data_core.warrants) ? "edited" : "uploaded"].", src.program.computer)
+		broadcast_security_hud_message("\A [activewarrant.fields["arrestsearch"]] warrant for <b>[activewarrant.fields["namewarrant"]]</b> has been [(activewarrant in GLOB.data_core.warrants) ? "edited" : "uploaded"].", nano_host())
 		GLOB.data_core.warrants |= activewarrant
 		activewarrant = null
 

--- a/html/changelogs/atlantiscze-botmodule.yml
+++ b/html/changelogs/atlantiscze-botmodule.yml
@@ -1,0 +1,8 @@
+author: Atlantiscze
+delete-after: True
+
+changes: 
+  - rscadd: "Security cyborgs now get access to warrant program"
+  - rscadd: "Engineering cyborgs now get access to supermatter monitor program"
+  - rscadd: "Mining cyborgs now get access to supply management program"
+  - tweak: "Holowarrant now checks for access when authorising, similar to how the program does it."


### PR DESCRIPTION
- Adds some (relatively) recently added nano modules to relevant cyborgs as subsytems:
+ Security now gets Digital Warrant program
+ Mining now gets Supply program
+ Engineering now gets Supermatter Monitor program
- Tweaked holowarrant to check for basic security access when authorizing, to bring it in line with the program which already does that.
- Converted digital warrant program to be a regular nano module, instead of program nano module.