### PR TITLE
Adjusts AI display selection.

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -171,8 +171,6 @@
 			return global.adminhelp_ignored_words;
 		if("adminlog")
 			return global.adminlog;
-		if("ai_icons")
-			return global.ai_icons;
 		if("ai_list")
 			return global.ai_list;
 		if("ai_status_emotions")
@@ -389,8 +387,6 @@
 			return global.debug_verbs;
 		if("decls_repository")
 			return global.decls_repository;
-		if("default_ai_icon")
-			return global.default_ai_icon;
 		if("default_material_composition")
 			return global.default_material_composition;
 		if("default_mobloc")
@@ -1390,8 +1386,6 @@
 			global.adminhelp_ignored_words=newval;
 		if("adminlog")
 			global.adminlog=newval;
-		if("ai_icons")
-			global.ai_icons=newval;
 		if("ai_list")
 			global.ai_list=newval;
 		if("ai_status_emotions")
@@ -1608,8 +1602,6 @@
 			global.debug_verbs=newval;
 		if("decls_repository")
 			global.decls_repository=newval;
-		if("default_ai_icon")
-			global.default_ai_icon=newval;
 		if("default_material_composition")
 			global.default_material_composition=newval;
 		if("default_mobloc")
@@ -2523,7 +2515,6 @@
 	"admin_verbs_spawn",
 	"adminhelp_ignored_words",
 	"adminlog",
-	"ai_icons",
 	"ai_list",
 	"ai_status_emotions",
 	"ai_verbs_default",
@@ -2632,7 +2623,6 @@
 	"deathsquad",
 	"debug_verbs",
 	"decls_repository",
-	"default_ai_icon",
 	"default_material_composition",
 	"default_mobloc",
 	"default_onmob_icons",

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -112,8 +112,10 @@
 #define UNSETEMPTY(L) if (L && !L.len) L = null
 // Removes I from list L, and sets I to null if it is now empty
 #define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
-// Adds I to L, initalizing I if necessary
+// Adds I to L, initalizing L if necessary
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;
+// Sets L[A] to I, initalizing L if necessary
+#define LAZYADDASSOC(L, A, I) if(!L) { L = list(); } L[A] = I;
 // Reads I from L safely - Works with both associative and traditional lists.
 #define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
 // Reads the length of L, returning 0 if null

--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -90,7 +90,7 @@
 	return communicate(arglist(args))
 
 /proc/communicate(var/channel_type, var/communicator, var/message)
-	var/list/channels = decls_repository.decls_of_subtype(/decl/communication_channel)
+	var/list/channels = decls_repository.get_decls_of_subtype(/decl/communication_channel)
 	var/decl/communication_channel/channel = channels[channel_type]
 
 	var/list/new_args = list(communicator, message)

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -11,25 +11,25 @@
 	fetched_decl_types = list()
 	fetched_decl_subtypes = list()
 
-/repository/decls/proc/decls_of_type(var/decl_prototype)
-	. = fetched_decl_types[decl_prototype]
-	if(!.)
-		. = get_decls(typesof(decl_prototype))
-		fetched_decl_types[decl_prototype] = .
-
-/repository/decls/proc/decls_of_subtype(var/decl_prototype)
-	. = fetched_decl_subtypes[decl_prototype]
-	if(!.)
-		. = get_decls(subtypesof(decl_prototype))
-		fetched_decl_subtypes[decl_prototype] = .
-
 /repository/decls/proc/get_decl(var/decl_type)
 	. = fetched_decls[decl_type]
 	if(!.)
 		. = new decl_type()
 		fetched_decls[decl_type] = .
 
-/repository/decls/proc/get_decls(var/list/decl_types)
+/repository/decls/proc/get_decls_of_type(var/decl_prototype)
+	. = fetched_decl_types[decl_prototype]
+	if(!.)
+		. = priv_get_decls(typesof(decl_prototype))
+		fetched_decl_types[decl_prototype] = .
+
+/repository/decls/proc/get_decls_of_subtype(var/decl_prototype)
+	. = fetched_decl_subtypes[decl_prototype]
+	if(!.)
+		. = priv_get_decls(subtypesof(decl_prototype))
+		fetched_decl_subtypes[decl_prototype] = .
+
+/repository/decls/proc/priv_get_decls(var/list/decl_types)
 	. = list()
 	for(var/decl_type in decl_types)
 		.[decl_type] =  get_decl(decl_type)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -203,9 +203,8 @@
 	state = 20//So it doesn't interact based on the above. Not really necessary.
 
 /obj/structure/AIcore/deactivated/Destroy()
-	if(src in empty_playable_ai_cores)
-		empty_playable_ai_cores -= src
-	..()
+	empty_playable_ai_cores -= src
+	. = ..()
 
 /obj/structure/AIcore/deactivated/proc/load_ai(var/mob/living/silicon/ai/transfer, var/obj/item/weapon/aicard/card, var/mob/user)
 

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -85,7 +85,7 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 		S.update_seed()
 
 	//Might as well mask the gene types while we're at it.
-	var/list/gene_datums = decls_repository.decls_of_subtype(/decl/plantgene)
+	var/list/gene_datums = decls_repository.get_decls_of_subtype(/decl/plantgene)
 	var/list/used_masks = list()
 	var/list/plant_traits = ALL_GENES
 	while(plant_traits && plant_traits.len)
@@ -94,9 +94,9 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 
 		while(gene_mask in used_masks)
 			gene_mask = "[uppertext(num2hex(rand(0,255)))]"
-			
+
 		var/decl/plantgene/G
-			
+
 		for(var/D in gene_datums)
 			var/decl/plantgene/P = gene_datums[D]
 			if(gene_tag == P.gene_tag)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -89,10 +89,12 @@ var/list/ai_verbs_default = list(
 	var/override_CPURate = 0					// Bonus/Penalty CPU generation rate. For use by admins/testers.
 
 	var/datum/ai_icon/selected_sprite			// The selected icon set
-	var/custom_sprite 	= 0 					// Whether the selected icon is custom
 	var/carded
 
 	var/multitool_mode = 0
+
+	var/default_ai_icon = /datum/ai_icon/blue
+	var/static/list/custom_ai_icons_by_ckey_and_name
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	src.verbs |= ai_verbs_default
@@ -206,7 +208,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/Destroy()
 	ai_list -= src
-	
+
 	. = ..()
 
 	QDEL_NULL(announcement)
@@ -219,8 +221,16 @@ var/list/ai_verbs_default = list(
 	hack = null
 
 /mob/living/silicon/ai/proc/setup_icon()
+	if(LAZYACCESS(custom_ai_icons_by_ckey_and_name, "[ckey][real_name]"))
+		return
+	var/list/custom_icons = list()
+	LAZYADDASSOC(custom_ai_icons_by_ckey_and_name, "[ckey][real_name]", custom_icons)
+
 	var/file = file2text("config/custom_sprites.txt")
 	var/lines = splittext(file, "\n")
+
+	var/custom_index = 1
+	var/custom_icon_states = icon_states(CUSTOM_ITEM_SYNTH)
 
 	for(var/line in lines)
 	// split & clean up
@@ -229,14 +239,23 @@ var/list/ai_verbs_default = list(
 			Entry[i] = trim(Entry[i])
 
 		if(Entry.len < 2)
-			continue;
+			continue
+		if(Entry.len == 2) // This is to handle legacy entries
+			Entry[++Entry.len] = Entry[1]
 
 		if(Entry[1] == src.ckey && Entry[2] == src.real_name)
-			icon = CUSTOM_ITEM_SYNTH
-			custom_sprite = 1
-			selected_sprite = new/datum/ai_icon("Custom", "[src.ckey]-ai", "4", "[ckey]-ai-crash", "#FFFFFF", "#FFFFFF", "#FFFFFF")
-		else
-			selected_sprite = default_ai_icon
+			var/alive_icon_state = "[Entry[3]]-ai"
+			var/dead_icon_state = "[Entry[3]]-ai-crash"
+
+			if(!(alive_icon_state in custom_icon_states))
+				to_chat(src, "<span class='warning'>Custom display entry found but the icon state '[alive_icon_state]' is missing!</span>")
+				continue
+
+			if(!(dead_icon_state in custom_icon_states))
+				dead_icon_state = ""
+
+			selected_sprite = new/datum/ai_icon("Custom Icon [custom_index++]", alive_icon_state, dead_icon_state, COLOR_WHITE, CUSTOM_ITEM_SYNTH)
+			custom_icons += selected_sprite
 	update_icon()
 
 /mob/living/silicon/ai/pointed(atom/A as mob|obj|turf in view())
@@ -255,6 +274,7 @@ var/list/ai_verbs_default = list(
 		aiPDA.set_owner_rank_job(pickedName, "AI")
 
 	GLOB.data_core.ResetPDAManifest()
+	setup_icon()
 
 /mob/living/silicon/ai/proc/pick_icon()
 	set category = "Silicon Commands"
@@ -262,10 +282,22 @@ var/list/ai_verbs_default = list(
 	if(stat || !has_power())
 		return
 
-	if (!custom_sprite)
-		var/new_sprite = input("Select an icon!", "AI", selected_sprite) as null|anything in ai_icons
-		if(new_sprite) selected_sprite = new_sprite
+	var/new_sprite = input("Select an icon!", "AI", selected_sprite) as null|anything in available_icons()
+	if(new_sprite)
+		selected_sprite = new_sprite
+
 	update_icon()
+
+/mob/living/silicon/ai/proc/available_icons()
+	. = list()
+	var/all_ai_icons = decls_repository.get_decls_of_subtype(/datum/ai_icon)
+	for(var/ai_icon_type in all_ai_icons)
+		var/datum/ai_icon/ai_icon = all_ai_icons[ai_icon_type]
+		if(ai_icon.may_used_by_ai(src))
+			dd_insertObjectList(., ai_icon)
+
+	// Placing custom icons first to have them be at the top
+	. = LAZYACCESS(custom_ai_icons_by_ckey_and_name, "[ckey][real_name]") | .
 
 // this verb lets the ai see the stations manifest
 /mob/living/silicon/ai/proc/ai_roster()
@@ -509,7 +541,7 @@ var/list/ai_verbs_default = list(
 
 	else
 		var/list/hologramsAICanUse = list()
-		var/holograms_by_type = decls_repository.decls_of_subtype(/decl/ai_holo)
+		var/holograms_by_type = decls_repository.get_decls_of_subtype(/decl/ai_holo)
 		for (var/holo_type in holograms_by_type)
 			var/decl/ai_holo/holo = holograms_by_type[holo_type]
 			if (holo.may_be_used_by_ai(src))
@@ -650,8 +682,10 @@ var/list/ai_verbs_default = list(
 	to_chat(src, "<span class='notice'>Multitool mode: [multitool_mode ? "E" : "Dise"]ngaged</span>")
 
 /mob/living/silicon/ai/update_icon()
-	if(!selected_sprite) selected_sprite = default_ai_icon
+	if(!selected_sprite || !(selected_sprite in available_icons()))
+		selected_sprite = decls_repository.get_decl(default_ai_icon)
 
+	icon = selected_sprite.icon
 	if(stat == DEAD)
 		icon_state = selected_sprite.dead_icon
 		set_light(3, 1, selected_sprite.dead_light)

--- a/code/modules/mob/living/silicon/ai/icons.dm
+++ b/code/modules/mob/living/silicon/ai/icons.dm
@@ -1,28 +1,34 @@
-var/datum/ai_icon/default_ai_icon = new/datum/ai_icon/blue()
-var/list/datum/ai_icon/ai_icons
-
 /datum/ai_icon
 	var/name
+	var/icon = 'icons/mob/AI.dmi'
 	var/alive_icon
-	var/alive_light = "#FFFFFF"
+	var/alive_light = COLOR_WHITE
 	var/nopower_icon = "4"
-	var/nopower_light = "#FFFFFF"
+	var/nopower_light = COLOR_WHITE
 	var/dead_icon = "ai-crash"
 	var/dead_light = "#000099"
 
-/datum/ai_icon/New(var/name, var/alive_icon, var/nopower_icon, var/dead_icon, var/alive_light, var/nopower_light, var/dead_light)
-	if(name)
-		src.name = name
-		src.alive_icon = alive_icon
-		src.nopower_icon = nopower_icon
-		src.dead_icon = dead_icon
-		src.alive_light = alive_light
-		src.nopower_light = nopower_light
-		src.dead_light = dead_light
-	if(!ai_icons)
-		ai_icons = list()
-		init_subtypes(/datum/ai_icon, ai_icons)
+/datum/ai_icon/New(var/name, var/alive_icon, var/dead_icon, var/dead_light, var/icon)
+	src.name          = name       || src.name
+	src.icon          = icon       || src.icon
+	src.alive_icon    = alive_icon || src.alive_icon
+	src.dead_icon     = dead_icon  || src.dead_icon
+	src.dead_light    = dead_light || src.dead_light
+
+/datum/ai_icon/proc/may_used_by_ai(var/mob/user)
+	return TRUE
+
+/datum/ai_icon/malf
+	name = "Unlawed"
+	alive_icon = "ai-malf"
+	alive_light = "#45644b"
+
+/datum/ai_icon/malf/New()
 	..()
+	name = "[name] (Malf)"
+
+/datum/ai_icon/malf/may_used_by_ai(var/mob/living/silicon/ai/AI)
+	return istype(AI) && AI.is_malf_or_traitor()
 
 /datum/ai_icon/red
 	name = "Red"
@@ -158,3 +164,8 @@ var/list/datum/ai_icon/ai_icons
 	name = "Dancing Hotdog"
 	alive_icon = "ai-hotdog"
 	alive_light = "#81DDFF"
+
+/datum/ai_icon/malf/clown
+	name = "Clown"
+	alive_icon = "ai-clown2"
+	alive_light = "#E50213"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -42,6 +42,12 @@
 		AH.unregister_alarm(src)
 	return ..()
 
+/mob/living/silicon/fully_replace_character_name(new_name)
+	..()
+	if(istype(idcard))
+		idcard.registered_name = new_name
+		idcard.update_name()
+
 /mob/living/silicon/proc/init_id()
 	if(ispath(idcard))
 		idcard = new idcard(src)

--- a/html/changelogs/PsiOmegaDelta-SoFabulous.yml
+++ b/html/changelogs/PsiOmegaDelta-SoFabulous.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: PsiOmegaDelta
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Players with custom AI displays can now have multiple entries, should they desire."
+  - rscadd: "Players with custom AI displays can now freely select between their custom and available displays."
+  - rscadd: "Players with custom AI displays no longer have to supply the crashed/dead AI state."
+  - rscadd: "Traitor/Malfunctioning AIs now have access to additional AI displays."

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -239,7 +239,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '91304c16bd417660335cf73db8088e67 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '219da80dfc00a6b58952b6afd8b104ab *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Players with custom displays can now have multiple entries, should they desire.
Players with custom displays can now freely select between their custom and available displays.
Players with custom displays no longer have to supply the crashed state.
Adds the ability to have some AI displays only be available during certain circumstances.
Adds antag-only AI displays as proof-of-concept.

Adds missing ID card refresh when changing a silicon's name.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
