### PR TITLE
updateicon() is now update_icon()

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -72,7 +72,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	has_gravity = 0
 	ambience = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/main.ogg','sound/music/traitor.ogg')
 
-/area/space/updateicon()
+/area/space/update_icon()
 	return
 
 area/space/atmosalert()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -99,7 +99,7 @@
 /area/proc/fire_alert()
 	if(!fire)
 		fire = 1	//used for firedoor checks
-		updateicon()
+		update_icon()
 		mouse_opacity = 0
 		if(!all_doors)
 			return
@@ -114,7 +114,7 @@
 /area/proc/fire_reset()
 	if (fire)
 		fire = 0	//used for firedoor checks
-		updateicon()
+		update_icon()
 		mouse_opacity = 0
 		if(!all_doors)
 			return
@@ -129,19 +129,19 @@
 /area/proc/readyalert()
 	if(!eject)
 		eject = 1
-		updateicon()
+		update_icon()
 	return
 
 /area/proc/readyreset()
 	if(eject)
 		eject = 0
-		updateicon()
+		update_icon()
 	return
 
 /area/proc/partyalert()
 	if (!( party ))
 		party = 1
-		updateicon()
+		update_icon()
 		mouse_opacity = 0
 	return
 
@@ -149,7 +149,7 @@
 	if (party)
 		party = 0
 		mouse_opacity = 0
-		updateicon()
+		update_icon()
 		for(var/obj/machinery/door/firedoor/D in src)
 			if(!D.blocked)
 				if(D.operating)
@@ -159,7 +159,7 @@
 					D.open()
 	return
 
-/area/proc/updateicon()
+/area/update_icon()
 	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.
 		if(fire && !eject && !party)
 			icon_state = "blue"
@@ -202,7 +202,7 @@
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
 	if (fire || eject || party)
-		updateicon()
+		update_icon()
 
 /area/proc/usage(var/chan)
 	var/used = 0
@@ -234,7 +234,7 @@
 /area/proc/set_lightswitch(var/new_switch)
 	if(lightswitch != new_switch)
 		lightswitch = new_switch
-		updateicon()
+		update_icon()
 		power_change()
 
 /area/proc/set_emergency_lighting(var/enable)

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -86,7 +86,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 		if(!istype(A,/area) || istype(A, /area/space) || istype(A,/area/beach))
 			continue
 
-		A.updateicon()
+		A.update_icon()
 
 /datum/universal_state/supermatter_cascade/OverlayAndAmbientSet()
 	spawn(0)

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -20,17 +20,16 @@
 		hide(!T.is_plating())
 
 	Destroy()
-		if(Beacon)
-			qdel(Beacon)
-		..()
+		QDEL_NULL(Beacon)
+		. = ..()
 
 	// update the invisibility and icon
 	hide(var/intact)
 		invisibility = intact ? 101 : 0
-		updateicon()
+		update_icon()
 
 	// update the icon_state
-	proc/updateicon()
+	update_icon()
 		var/state="floor_beacon"
 
 		if(invisibility)
@@ -49,6 +48,6 @@
 			if(Beacon.loc != loc)
 				Beacon.loc = loc
 
-		updateicon()
+		update_icon()
 
 

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -46,10 +46,10 @@
 	// update the invisibility and icon
 	hide(var/intact)
 		invisibility = intact ? 101 : 0
-		updateicon()
+		update_icon()
 
 	// update the icon_state
-	proc/updateicon()
+	update_icon()
 		var/state="floor_magnet"
 		var/onstate=""
 		if(!on)
@@ -168,7 +168,7 @@
 						qdel(src)
 		*/
 
-		updateicon()
+		update_icon()
 
 
 	proc/magnetic_process() // proc that actually does the pulling

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -27,9 +27,9 @@ var/global/list/navbeacons = list()
 
 /obj/machinery/navbeacon/hide(var/intact)
 	invisibility = intact ? 101 : 0
-	updateicon()
+	update_icon()
 
-/obj/machinery/navbeacon/proc/updateicon()
+/obj/machinery/navbeacon/update_icon()
 	var/state="navbeacon[open]"
 
 	if(invisibility)
@@ -48,7 +48,7 @@ var/global/list/navbeacons = list()
 
 		user.visible_message("\The [user] [open ? "opens" : "closes"] cover of \the [src].", "You [open ? "open" : "close"] cover of \the [src].")
 
-		updateicon()
+		update_icon()
 
 	else if(I.GetIdCard())
 		if(open)

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -29,7 +29,7 @@
 		if(metal)
 			var/obj/structure/foamedmetal/M = new(src.loc)
 			M.metal = metal
-			M.updateicon()
+			M.update_icon()
 		flick("[icon_state]-disolve", src)
 		sleep(5)
 		qdel(src)
@@ -141,7 +141,7 @@
 	update_nearby_tiles(1)
 	..()
 
-/obj/structure/foamedmetal/proc/updateicon()
+/obj/structure/foamedmetal/update_icon()
 	if(metal == 1)
 		icon_state = "metalfoam"
 	else

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -26,7 +26,7 @@
 				icon = R.icon
 	else
 		name = "robot [initial(name)]"
-	
+
 /obj/item/robot_parts/proc/can_install(mob/user)
 	return TRUE
 
@@ -71,7 +71,7 @@
 	bp_tag = BP_CHEST
 	var/wires = 0.0
 	var/obj/item/weapon/cell/cell = null
-	
+
 /obj/item/robot_parts/chest/can_install(mob/user)
 	var/success = TRUE
 	if(!wires)
@@ -91,7 +91,7 @@
 	bp_tag = BP_HEAD
 	var/obj/item/device/flash/flash1 = null
 	var/obj/item/device/flash/flash2 = null
-	
+
 /obj/item/robot_parts/head/can_install(mob/user)
 	var/success = TRUE;
 	if(!(flash1 && flash2))
@@ -108,9 +108,9 @@
 
 /obj/item/robot_parts/robot_suit/New()
 	..()
-	src.updateicon()
+	src.update_icon()
 
-/obj/item/robot_parts/robot_suit/proc/updateicon()
+/obj/item/robot_parts/robot_suit/update_icon()
 	src.overlays.Cut()
 	if(src.parts[BP_L_ARM])
 		src.overlays += "l_arm+o"
@@ -153,7 +153,7 @@
 			user.drop_item()
 			part.loc = src
 			src.parts[part.bp_tag] = part
-			src.updateicon()
+			src.update_icon()
 
 	if(istype(W, /obj/item/device/mmi))
 		var/obj/item/device/mmi/M = W
@@ -257,7 +257,7 @@
 		success &= can_install(user)
 		success &= head_part.can_install(user)
 		if (success)
-			
+
 			// Species selection.
 			var/species = input(user, "Select a species for the prosthetic.") as null|anything in GetCyborgSpecies()
 			if(!species)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -332,7 +332,7 @@
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
-/obj/structure/closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
+/obj/structure/closet/update_icon()//Putting the welded stuff in update_icon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.Cut()
 	if(!opened)
 		icon_state = icon_closed

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -121,7 +121,7 @@
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
-/obj/structure/closet/secure_closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
+/obj/structure/closet/secure_closet/update_icon()//Putting the welded stuff in update_icon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.Cut()
 
 	if(!opened)

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -58,7 +58,7 @@
 		return
 	A.use_power(EQUIP, 5000)
 	var/light = A.power_light
-	A.updateicon()
+	A.update_icon()
 
 	flick("echair1", src)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
@@ -73,5 +73,5 @@
 	visible_message("<span class='danger'>The electric chair went off!</span>", "<span class='danger'>You hear a deep sharp shock!</span>")
 
 	A.power_light = light
-	A.updateicon()
+	A.update_icon()
 	return

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -80,7 +80,7 @@
 
 /decl/vv_set_handler/virtual_ability_handler/handle_set_var(var/mob/observer/virtual/virtual, variable, var_value, client)
 	..()
-	virtual.updateicon()
+	virtual.update_icon()
 
 /decl/vv_set_handler/mob_see_invisible_handler
 	handled_type = /mob

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -85,7 +85,7 @@
 	if(mind) mind.store_memory("Time of death: [stationtime2text()]", 0)
 	switch_from_living_to_dead_mob_list()
 
-	updateicon()
+	update_icon()
 
 	if(ticker && ticker.mode)
 		ticker.mode.check_win()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -237,7 +237,7 @@ var/list/ai_verbs_default = list(
 			selected_sprite = new/datum/ai_icon("Custom", "[src.ckey]-ai", "4", "[ckey]-ai-crash", "#FFFFFF", "#FFFFFF", "#FFFFFF")
 		else
 			selected_sprite = default_ai_icon
-	updateicon()
+	update_icon()
 
 /mob/living/silicon/ai/pointed(atom/A as mob|obj|turf in view())
 	set popup_menu = 0
@@ -265,7 +265,7 @@ var/list/ai_verbs_default = list(
 	if (!custom_sprite)
 		var/new_sprite = input("Select an icon!", "AI", selected_sprite) as null|anything in ai_icons
 		if(new_sprite) selected_sprite = new_sprite
-	updateicon()
+	update_icon()
 
 // this verb lets the ai see the stations manifest
 /mob/living/silicon/ai/proc/ai_roster()
@@ -649,7 +649,7 @@ var/list/ai_verbs_default = list(
 	multitool_mode = !multitool_mode
 	to_chat(src, "<span class='notice'>Multitool mode: [multitool_mode ? "E" : "Dise"]ngaged</span>")
 
-/mob/living/silicon/ai/updateicon()
+/mob/living/silicon/ai/update_icon()
 	if(!selected_sprite) selected_sprite = default_ai_icon
 
 	if(stat == DEAD)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -60,7 +60,7 @@
 
 /mob/living/silicon/ai/update_living_sight()
 	if(!has_power() || self_shutdown)
-		updateicon()
+		update_icon()
 		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		set_sight(sight&(~SEE_TURFS)&(~SEE_MOBS)&(~SEE_OBJS))
 		set_see_in_dark(0)

--- a/code/modules/mob/living/silicon/ai/power.dm
+++ b/code/modules/mob/living/silicon/ai/power.dm
@@ -24,7 +24,7 @@
 		if(has_power(0))
 			to_chat(src, "<span class='notice'>Main power restored. All systems returning to normal mode.</span>")
 			aiRestorePowerRoutine = AI_RESTOREPOWER_IDLE
-			updateicon()
+			update_icon()
 			return
 
 		if(aiRestorePowerRoutine == AI_RESTOREPOWER_FAILED)
@@ -105,7 +105,7 @@
 	A.failure_timer = 0
 	A.update()
 
-	updateicon()
+	update_icon()
 
 /mob/living/silicon/ai/proc/calculate_power_usage()
 	if(admin_powered)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -137,7 +137,7 @@ var/list/mob_hat_cache = list()
 		C.max_damage = 10
 
 	verbs -= /mob/living/silicon/robot/verb/Namepick
-	updateicon()
+	update_icon()
 
 /mob/living/silicon/robot/drone/init()
 	aiCamera = new/obj/item/device/camera/siliconcam/drone_camera(src)
@@ -157,7 +157,7 @@ var/list/mob_hat_cache = list()
 	real_name = "maintenance drone ([random_id(type,100,999)])"
 	name = real_name
 
-/mob/living/silicon/robot/drone/updateicon()
+/mob/living/silicon/robot/drone/update_icon()
 
 	overlays.Cut()
 	if(stat == 0)
@@ -178,7 +178,7 @@ var/list/mob_hat_cache = list()
 		return
 	hat = new_hat
 	new_hat.forceMove(src)
-	updateicon()
+	update_icon()
 
 //Drones cannot be upgraded with borg modules so we need to catch some items before they get used in ..().
 /mob/living/silicon/robot/drone/attackby(var/obj/item/weapon/W, var/mob/user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -243,7 +243,7 @@
 
 				A.cell.add_fingerprint(user)
 				A.cell.update_icon()
-				A.updateicon()
+				A.update_icon()
 				A.cell.loc = src
 				A.cell = null
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -51,7 +51,7 @@
 		module_state_3:loc = module
 		module_state_3 = null
 		inv3.icon_state = "inv3"
-	updateicon()
+	update_icon()
 
 /mob/living/silicon/robot/proc/uneq_all()
 	module_active = null
@@ -83,7 +83,7 @@
 		module_state_3:loc = module
 		module_state_3 = null
 		inv3.icon_state = "inv3"
-	updateicon()
+	update_icon()
 
 /mob/living/silicon/robot/proc/activated(obj/item/O)
 	if(module_state_1 == O)
@@ -94,7 +94,7 @@
 		return 1
 	else
 		return 0
-	updateicon()
+	update_icon()
 
 //Helper procs for cyborg modules on the UI.
 //These are hackish but they help clean up code elsewhere.

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -296,7 +296,7 @@
 		src.module_state_2:screen_loc = ui_inv2
 	if(src.module_state_3)
 		src.module_state_3:screen_loc = ui_inv3
-	updateicon()
+	update_icon()
 
 /mob/living/silicon/robot/proc/process_killswitch()
 	if(killswitch)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -113,7 +113,7 @@
 	module_sprites["Basic"] = "robot"
 	icontype = "Basic"
 	updatename(modtype)
-	updateicon()
+	update_icon()
 
 	radio = new /obj/item/device/radio/borg(src)
 	common_radio = radio
@@ -253,7 +253,7 @@
 		else
 			icontype = module_sprites[1]
 		icon_state = module_sprites[icontype]
-	updateicon()
+	update_icon()
 	return module_sprites
 
 /mob/living/silicon/robot/proc/pick_module()
@@ -339,7 +339,7 @@
 			custom_name = newname
 
 		updatename()
-		updateicon()
+		update_icon()
 
 // this verb lets cyborgs see the stations manifest
 /mob/living/silicon/robot/verb/cmd_station_manifest()
@@ -523,7 +523,7 @@
 				if(do_after(user, 50, src))
 					to_chat(user, "<span class='notice'>You close \the [src]'s maintenance hatch.</span>")
 					opened = 0
-					updateicon()
+					update_icon()
 
 			else if(wiresexposed && wires.IsAllCut())
 				//Cell is out, wires are exposed, remove MMI, produce damaged chassis, baleet original mob.
@@ -539,7 +539,7 @@
 					C.parts[BP_R_LEG] = new/obj/item/robot_parts/r_leg(C)
 					C.parts[BP_L_ARM] = new/obj/item/robot_parts/l_arm(C)
 					C.parts[BP_R_ARM] = new/obj/item/robot_parts/r_arm(C)
-					C.updateicon()
+					C.update_icon()
 					new/obj/item/robot_parts/chest(loc)
 					qdel(src)
 
@@ -576,7 +576,7 @@
 				if(do_after(user, 50, src))
 					to_chat(user, "<span class='notice'>You open \the [src]'s maintenance hatch.</span>")
 					opened = 1
-					updateicon()
+					update_icon()
 
 	else if (istype(W, /obj/item/weapon/stock_parts/matter_bin) && opened) // Installing/swapping a matter bin
 		if(storage)
@@ -618,14 +618,14 @@
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
-		updateicon()
+		update_icon()
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else
 			to_chat(user, "Unable to locate a radio.")
-		updateicon()
+		update_icon()
 
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
@@ -641,7 +641,7 @@
 			if(allowed(usr))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
-				updateicon()
+				update_icon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 	else if(istype(W, /obj/item/borg/upgrade/))
@@ -685,7 +685,7 @@
 			cell = null
 			cell_component.wrapped = null
 			cell_component.installed = 0
-			updateicon()
+			update_icon()
 		else if(cell_component.installed == -1)
 			cell_component.installed = 0
 			var/obj/item/broken_device = cell_component.wrapped
@@ -725,7 +725,7 @@
 			return 1
 	return 0
 
-/mob/living/silicon/robot/updateicon()
+/mob/living/silicon/robot/update_icon()
 	overlays.Cut()
 	if(stat == CONSCIOUS)
 		var/eye_icon_state = "eyes-[module_sprites[icontype]]"
@@ -975,7 +975,7 @@
 	else
 		icontype = input("Select an icon! [triesleft ? "You have [triesleft] more chance\s." : "This is your last try."]", "Robot Icon", icontype, null) in module_sprites
 	icon_state = module_sprites[icontype]
-	updateicon()
+	update_icon()
 
 	if (module_sprites.len > 1 && triesleft >= 1 && client)
 		icon_selection_tries--
@@ -1107,7 +1107,7 @@
 						if(rebuild)
 							src.module.modules += new /obj/item/weapon/pickaxe/diamonddrill(src.module)
 							src.module.rebuild()
-					updateicon()
+					update_icon()
 			else
 				to_chat(user, "You fail to hack [src]'s interface.")
 				to_chat(src, "Hack attempt detected.")

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -48,7 +48,7 @@
 	add_language("Occult")
 	for(var/spell in construct_spells)
 		src.add_spell(new spell, "const_spell_ready")
-	updateicon()
+	update_icon()
 
 /mob/living/simple_animal/construct/death(gibbed, deathmessage, show_dead_message)
 	new /obj/item/weapon/ectoplasm (src.loc)
@@ -56,7 +56,7 @@
 	ghostize()
 	qdel(src)
 
-/mob/living/simple_animal/construct/updateicon()
+/mob/living/simple_animal/construct/update_icon()
 	overlays.Cut()
 	..()
 	add_glow()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -957,7 +957,7 @@ mob/proc/yank_out_object()
 
 	return 0
 
-/mob/proc/updateicon()
+/mob/update_icon()
 	return
 
 /mob/verb/face_direction()

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -26,7 +26,7 @@ var/list/all_virtual_listeners = list()
 	GLOB.mob_list -= src
 	all_virtual_listeners += src
 
-	updateicon()
+	update_icon()
 
 /mob/observer/virtual/Destroy()
 	GLOB.moved_event.unregister(host, src, /atom/movable/proc/move_to_turf_or_null)
@@ -34,7 +34,7 @@ var/list/all_virtual_listeners = list()
 	host = null
 	return ..()
 
-/mob/observer/virtual/updateicon()
+/mob/observer/virtual/update_icon()
 	if(!overlay_icons)
 		overlay_icons = list()
 		for(var/i_state in icon_states(icon))

--- a/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
@@ -70,7 +70,7 @@
 		A.lying = 0
 		A.switch_from_dead_to_living_mob_list()
 		A.add_ai_verbs()
-		A.updateicon()
+		A.update_icon()
 		var/obj/item/weapon/aicard/AC = A.loc
 		if(AC)
 			AC.update_icon()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -55,7 +55,7 @@
 				circ1 = null
 				circ2 = null
 
-/obj/machinery/power/generator/proc/updateicon()
+/obj/machinery/power/generator/update_icon()
 	if(stat & (NOPOWER|BROKEN))
 		overlays.Cut()
 	else
@@ -131,7 +131,7 @@
 		genlev = 1
 	if(genlev != lastgenlev)
 		lastgenlev = genlev
-		updateicon()
+		update_icon()
 	add_avail(effective_gen)
 
 /obj/machinery/power/generator/attack_ai(mob/user)

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -287,7 +287,7 @@
 							P.base_icon_state = base_state
 							P.set_dir(dir)
 							P.dpdir = dpdir
-							P.updateicon()
+							P.update_icon()
 
 							//Needs some special treatment ;)
 							if(ptype==9 || ptype==10)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -722,13 +722,13 @@
 	// change visibility status and force update of icon
 	hide(var/intact)
 		invisibility = intact ? 101: 0	// hide if floor is intact
-		updateicon()
+		update_icon()
 
 	// update actual icon_state depending on visibility
 	// if invisible, append "f" to icon_state to show faded version
 	// this will be revealed if a T-scanner is used
 	// if visible, use regular icon_state
-	proc/updateicon()
+	update_icon()
 /*		if(invisibility)	//we hide things with alpha now, no need for transparent icons
 			icon_state = "[base_icon_state]f"
 		else


### PR DESCRIPTION
Now all /atom subtypes have the same call, ensuring one don't have to get annoyed when `update_icon()` calls don't compile.