### PR TITLE
Fixes several grab bugs and a nab bug.

### DIFF
--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -165,8 +165,10 @@
 /obj/item/grab/proc/handle_resist()
 	current_grab.handle_resist(src)
 
-/obj/item/grab/proc/adjust_position()
-	if(!assailant.Adjacent(affecting))
+/obj/item/grab/proc/adjust_position(var/force = 0)
+	if(force)	affecting.forceMove(assailant.loc)
+
+	if(!assailant || !affecting || !assailant.Adjacent(affecting))
 		qdel(src)
 		return 0
 	else
@@ -174,7 +176,6 @@
 
 /obj/item/grab/proc/reset_position()
 	current_grab.reset_position(src)
-
 
 /*
 	This section is for the simple procs used to return things from current_grab.

--- a/code/modules/mob/grab/nab/nab_passive.dm
+++ b/code/modules/mob/grab/nab/nab_passive.dm
@@ -7,7 +7,6 @@
 
 	reverse_facing = 0
 	can_absorb = 0
-	can_throw = 1
 
 	grab_slowdown = 0
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -305,6 +305,7 @@
 
 	if(do_after(src, 30))
 		pulling_punches = !pulling_punches
+		nabbing = !pulling_punches
 
 		if(pulling_punches)
 			current_grab_type = all_grabobjects[GRAB_NORMAL]

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -353,7 +353,7 @@
 								M.other_mobs = null
 								M.animate_movement = 2
 								return
-
+					G.adjust_position()
 		else
 			if(mob.confused)
 				switch(mob.m_intent)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -67,7 +67,7 @@
 	if(do_after(M, climb_time, src))
 		climbLadder(M, target_ladder)
 		for (var/obj/item/grab/G in M)
-			G.adjust_position()
+			G.adjust_position(force = 1)
 
 
 /obj/structure/ladder/attack_ghost(var/mob/M)

--- a/html/changelogs/FTangSteve-grabDoor.yml
+++ b/html/changelogs/FTangSteve-grabDoor.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: FTangSteve
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes pulling grabs when the affected person can't move."
+  - bugfix: "Fixes GAS being able to use advanced tools when nabbing."
+  - bugfix: "Fixes grabs with the ladder_carry ability carrying people up ladders."
+  - tweak: "Stops GRAB_NAB base grabs from throwing people."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Fixes #17763 
Fixes ladder_carry in grabs.
Fixes advanced tool use in GAS when in hunting stance.
Fixes the assailant moving away from the affecting person from not breaking the grab.

![windoorgrab](https://user-images.githubusercontent.com/21090264/28996143-dde3fcbc-79c7-11e7-8b84-9d8d298ac2dc.gif)
