### PR TITLE
Fixed an infinite-metal exploit

### DIFF
--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -44,8 +44,9 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 					updateUsrDialog()
 					return 1
 	if(default_deconstruction_screwdriver(user, O))
-		new /obj/item/stack/material/steel(get_turf(loc), metal)
-		metal = 0
+		if(metal)
+			new /obj/item/stack/material/steel(get_turf(loc), metal)
+			metal = 0
 		return
 	if(default_deconstruction_crowbar(user, O))
 		return

--- a/html/changelogs/cirra-metal.yml
+++ b/html/changelogs/cirra-metal.yml
@@ -1,0 +1,6 @@
+author: Cirra
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed an exploit which allowed for the creation of infinite metal, using the circuit printer."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
It was previously possible to create infinite metal by repeatedly using a screwdriver on a circuit printer, whether or not the printer actually contained any metal.