### PR TITLE
Changes access requirements to unlock sidearm cabinets.

### DIFF
--- a/html/changelogs/AtomicWorm-NRA-on-suicide-watch.yml
+++ b/html/changelogs/AtomicWorm-NRA-on-suicide-watch.yml
@@ -1,0 +1,6 @@
+author: Broseph Stylin
+
+delete-after: True
+
+changes: 
+  - tweak: "Changed sidearm cabinet access requirements. Only line officers, the RD, the SEA, and the Brig Officer can unlock them now."

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -87,7 +87,7 @@
 /obj/structure/closet/secure_closet/guncabinet/sidearm
 	name = "sidearm cabinet"
 	req_access = list()
-	req_one_access = list(access_armory,access_heads)
+	req_one_access = list(access_armory,access_emergency_armory,access_hos,access_hop,access_ce,access_cmo,access_rd,access_senadv)
 
 	will_contain = list(
 		/obj/item/weapon/gun/energy/gun = 3


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
This is meant to curb a pervasive issue, that of bridge staff that are not issued weaponry in their lockers easily going to the bridge storage room or a safe room and arming themselves with the energy guns found inside the cabinets, which are meant for emergencies only, and only to be used when authorized.

Sidearm cabinets can now only be unlocked by a line officer, the RD, the SEA, or the Brig Officer.

I realize this is very much an IC issue, but it continues to happen, so I feel it requires some intervention.