### PR TITLE
Allows cyborgs to use IV drips

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -132,6 +132,10 @@
 	else
 		return ..()
 
+/obj/machinery/iv_drip/attack_robot(var/mob/user)
+	if(Adjacent(user))
+		attack_hand(user)
+
 obj/machinery/iv_drip/attack_ai(mob/user as mob)
 	return
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -59,7 +59,8 @@
 	can_hold = list(
 		/obj/item/weapon/reagent_containers/glass,
 		/obj/item/weapon/reagent_containers/pill,
-		/obj/item/weapon/storage/pill_bottle
+		/obj/item/weapon/reagent_containers/blood,
+		/obj/item/weapon/storage/pill_bottle,
 		)
 
 /obj/item/weapon/gripper/research //A general usage gripper, used for toxins/robotics/xenobio/etc

--- a/html/changelogs/atlantiscze-mediborgs.yml
+++ b/html/changelogs/atlantiscze-mediborgs.yml
@@ -1,0 +1,6 @@
+author: Atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscadd: "Cyborgs can now manipulate IV drips and chemistry grippers can now hold blood packs."


### PR DESCRIPTION
- All cyborgs can now eject the blood pack from drip, if adjacent to it.
- Chemistry gripper can now hold blood packs. Technically allows crisis cyborgs to perform transfusions via the IV drip without needing human to swap the blood bags.