### PR TITLE
Disabled Tcomms metagaming

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -543,14 +543,14 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				log.parameters["realname"] = signal.data["realname"]
 				log.parameters["language"] = signal.data["language"]
 
-				var/race = "unknown"
+				var/race = "Unknown"
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
-					race = "[H.species.name]"
+					race = "Sapient Race"
 					log.parameters["intelligible"] = 1
 				else if(isbrain(M))
 					var/mob/living/carbon/brain/B = M
-					race = "[B.species.name]"
+					race = "Sapient Race"
 					log.parameters["intelligible"] = 1
 				else if(M.isMonkey())
 					race = "Monkey"

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -545,11 +545,9 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 				var/race = "Unknown"
 				if(ishuman(M))
-					var/mob/living/carbon/human/H = M
 					race = "Sapient Race"
 					log.parameters["intelligible"] = 1
 				else if(isbrain(M))
-					var/mob/living/carbon/brain/B = M
 					race = "Sapient Race"
 					log.parameters["intelligible"] = 1
 				else if(M.isMonkey())

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -544,10 +544,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				log.parameters["language"] = signal.data["language"]
 
 				var/race = "Unknown"
-				if(ishuman(M))
-					race = "Sapient Race"
-					log.parameters["intelligible"] = 1
-				else if(isbrain(M))
+				if(ishuman(M) || isbrain(M))
 					race = "Sapient Race"
 					log.parameters["intelligible"] = 1
 				else if(M.isMonkey())

--- a/html/changelogs/Superbee29-voicerace.yml
+++ b/html/changelogs/Superbee29-voicerace.yml
@@ -1,0 +1,4 @@
+author: Superbee29
+delete-after: True
+changes: 
+  - tweak: "Telecommunications servers no longer know the exact race of a speaker."


### PR DESCRIPTION
The telecoms server will no longer know the exact race of the speaker. All other non-human checks are the same, if the mob is a sapient race (a subtype of human), it will log as `Sapient Race`.

This could be used for metagaming against characters who change their voice, but are of different race. Literally, I have seen people use this against non-human lings who didn't transform, just changed their voice.