### PR TITLE
Ticket fixes/changes

### DIFF
--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -23,6 +23,10 @@ var/list/ticket_panels = list()
 	if(status == TICKET_ASSIGNED && !((closed_by.ckey in assigned_admin_ckeys()) || owner.ckey == closed_by.ckey) && alert(client_by_ckey(closed_by.ckey), "You are not assigned to this ticket. Are you sure you want to close it?",  "Close ticket?" , "Yes" , "No") != "Yes")
 		return
 
+	var/client/real_client = client_by_ckey(closed_by.ckey)
+	if(status == TICKET_ASSIGNED && !real_client.holder) // non-admins can only close a ticket if no admin has taken it
+		return
+
 	src.status = TICKET_CLOSED
 	src.closed_by = closed_by
 
@@ -123,7 +127,8 @@ proc/get_open_ticket_by_client(var/datum/client_lite/owner)
 				ticket_dat += " - <a href='byond://?src=\ref[src];action=pm;ticket=\ref[ticket]'>PM</a>"
 				if(C.holder)
 					ticket_dat += " - <a href='byond://?src=\ref[src];action=take;ticket=\ref[ticket]'>[(open == 1) ? "TAKE" : "JOIN"]</a>"
-				ticket_dat += " - <a href='byond://?src=\ref[src];action=close;ticket=\ref[ticket]'>CLOSE</a>"
+				if(ticket.status != TICKET_CLOSED && (C.holder || ticket.status == TICKET_OPEN))
+					ticket_dat += " - <a href='byond://?src=\ref[src];action=close;ticket=\ref[ticket]'>CLOSE</a>"
 			if(open_ticket && open_ticket == ticket)
 				ticket_dat += "</i>"
 			ticket_dat += "</li>"

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -24,7 +24,7 @@ var/list/ticket_panels = list()
 		return
 
 	var/client/real_client = client_by_ckey(closed_by.ckey)
-	if(status == TICKET_ASSIGNED && !real_client.holder) // non-admins can only close a ticket if no admin has taken it
+	if(status == TICKET_ASSIGNED && (!real_client || !real_client.holder)) // non-admins can only close a ticket if no admin has taken it
 		return
 
 	src.status = TICKET_CLOSED

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -121,8 +121,19 @@
 					else
 						adminhelp(reply)													//sender has left, adminhelp instead
 				return
-	to_chat(src, "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "PM", src) + " to <span class='name'>[get_options_bar(C, holder ? 1 : 0, holder ? 1 : 0, 1)]</span>[holder ? " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) " : " "][holder ? "(<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>)" : ""]: <span class='message'>[msg]</span></span></span>")
-	to_chat(C, "<span class='pm'><span class='in'>" + create_text_tag("pm_in", "", C) + " <b>\[[recieve_pm_type] PM\]</b> <span class='name'>[get_options_bar(src, C.holder ? 1 : 0, C.holder ? 1 : 0, 1)]</span>[C.holder ? " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) " : " "][C.holder ? "(<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>)" : ""]: <span class='message'>[msg]</span></span></span>")
+
+	var/sender_message = "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "PM", src) + " to <span class='name'>[get_options_bar(C, holder ? 1 : 0, holder ? 1 : 0, 1)]</span>"
+	if(holder)
+		sender_message += " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>)"
+	sender_message += ": <span class='message'>[msg]</span></span></span>"
+	to_chat(src, sender_message)
+
+	var/receiver_message = "<span class='pm'><span class='in'>" + create_text_tag("pm_in", "", C) + " <b>\[[recieve_pm_type] PM\]</b> <span class='name'>[get_options_bar(src, C.holder ? 1 : 0, C.holder ? 1 : 0, 1)]</span>"
+	if(C.holder)
+		receiver_message += " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>)"
+	receiver_message += ": <span class='message'>[msg]</span></span></span>"
+	to_chat(C, receiver_message)
+
 	//play the recieving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
 	if(C.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -86,18 +86,20 @@
 
 
 	if(isnull(ticket)) // finally, accept that no ticket exists
-		if(holder)
+		if(holder && sender_lite.ckey != receiver_lite.ckey)
 			ticket = new /datum/ticket(receiver_lite)
 			ticket.take(sender_lite)
 		else
 			to_chat(src, "<span class='notice'>You do not have an open ticket. Please use the adminhelp verb to open a ticket.</span>")
 			return
-	else if(ticket.status != TICKET_ASSIGNED && !holder)
+	else if(ticket.status != TICKET_ASSIGNED && sender_lite.ckey == ticket.owner.ckey)
 		to_chat(src, "<span class='notice'>Your ticket is not open for conversation. Please wait for an administrator to receive your adminhelp.</span>")
 		return
 
-	if(holder && !(sender_lite.ckey in ticket.assigned_admin_ckeys() || sender_lite.ckey == ticket.owner.ckey) && !ticket.take(sender_lite))
-		return
+	// if the sender is an admin and they're not assigned to the ticket, ask them if they want to take/join it, unless the admin is responding to their own ticket
+	if(holder && !(sender_lite.ckey in ticket.assigned_admin_ckeys()))
+		if(sender_lite.ckey != ticket.owner.ckey && !ticket.take(sender_lite))
+			return
 
 	var/recieve_message
 
@@ -119,8 +121,8 @@
 					else
 						adminhelp(reply)													//sender has left, adminhelp instead
 				return
-	to_chat(src, "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "PM", src) + " to <span class='name'>[get_options_bar(C, holder ? 1 : 0, holder ? 1 : 0, 1)]</span>[holder ? " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) " : " "](<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): <span class='message'>[msg]</span></span></span>")
-	to_chat(C, "<span class='pm'><span class='in'>" + create_text_tag("pm_in", "", C) + " <b>\[[recieve_pm_type] PM\]</b> <span class='name'>[get_options_bar(src, C.holder ? 1 : 0, C.holder ? 1 : 0, 1)]</span>[C.holder ? " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) " : " "](<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): <span class='message'>[msg]</span></span></span>")
+	to_chat(src, "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "PM", src) + " to <span class='name'>[get_options_bar(C, holder ? 1 : 0, holder ? 1 : 0, 1)]</span>[holder ? " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) " : " "][holder ? "(<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>)" : ""]: <span class='message'>[msg]</span></span></span>")
+	to_chat(C, "<span class='pm'><span class='in'>" + create_text_tag("pm_in", "", C) + " <b>\[[recieve_pm_type] PM\]</b> <span class='name'>[get_options_bar(src, C.holder ? 1 : 0, C.holder ? 1 : 0, 1)]</span>[C.holder ? " (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) " : " "][C.holder ? "(<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>)" : ""]: <span class='message'>[msg]</span></span></span>")
 	//play the recieving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
 	if(C.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))


### PR DESCRIPTION
Fixes #17815 
Prevents staff from PMing themselves, making empty tickets
Forbids non-staff from closing their tickets once they've been assigned