### PR TITLE
Loadout gear allowed roles now use types rather than titles.

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -6,7 +6,7 @@
 	var/list/minimal_access = list()      // Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
 	var/list/access = list()              // Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
 	var/department_flag = 0
-	var/faction = "None"	              // Players will be allowed to spawn in as jobs that are set to "Station"
+	var/faction = "None"                  // Players will be allowed to spawn in as jobs that are set to "Station"
 	var/total_positions = 0               // How many players can be this job
 	var/spawn_positions = 0               // How many players can spawn in as this job
 	var/current_positions = 0             // How many players have this job
@@ -21,16 +21,20 @@
 	var/ideal_character_age = 30
 	var/create_record = 1                 // Do we announce/make records for people who spawn on this job?
 
-	var/account_allowed = 1				  // Does this job type come with a station account?
-	var/economic_modifier = 2			  // With how much does this job modify the initial account amount?
+	var/account_allowed = 1               // Does this job type come with a station account?
+	var/economic_modifier = 2             // With how much does this job modify the initial account amount?
 
 	var/outfit_type                       // The outfit the employee will be dressed in, if any
 
-	var/list/allowed_branches			  // For Torch, also expandable for other purposes
-	var/list/allowed_ranks				  // Ditto
+	var/loadout_allowed = TRUE            // Whether or not loadout equipment is allowed and to be created when joining.
+	var/list/allowed_branches             // For maps using branches and ranks, also expandable for other purposes
+	var/list/allowed_ranks                // Ditto
 
-	var/announced						  //If their arrival is announced on radio
-	var/latejoin_at_spawnpoints			  //If this job should use roundstart spawnpoints for latejoin (offstation jobs etc)
+	var/announced                         //If their arrival is announced on radio
+	var/latejoin_at_spawnpoints           //If this job should use roundstart spawnpoints for latejoin (offstation jobs etc)
+    
+/datum/job/dd_SortValue()
+    return title
 
 /datum/job/proc/equip(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch)
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -12,6 +12,7 @@
 	economic_modifier = 0
 	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
 	announced = 1
+	loadout_allowed = FALSE
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
@@ -32,6 +33,7 @@
 	alt_titles = list("Android", "Robot")
 	account_allowed = 0
 	economic_modifier = 0
+	loadout_allowed = FALSE
 	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -9,6 +9,8 @@ var/global/datum/controller/occupations/job_master
 	var/list/occupations = list()
 		//Associative list of all jobs, by type
 	var/list/occupations_by_type
+	//Associative list of all jobs, by title
+	var/list/occupations_by_title
 		//Players who need jobs
 	var/list/unassigned = list()
 		//Debug info
@@ -18,6 +20,7 @@ var/global/datum/controller/occupations/job_master
 	proc/SetupOccupations(var/faction = "Station", var/setup_titles = 0)
 		occupations = list()
 		occupations_by_type = list()
+		occupations_by_title = list()
 		var/list/all_jobs = list(/datum/job/assistant) | GLOB.using_map.allowed_jobs
 		if(!all_jobs.len)
 			log_error("<span class='warning'>Error setting up jobs, no job datums found!</span>")
@@ -28,6 +31,7 @@ var/global/datum/controller/occupations/job_master
 			if(job.faction != faction)	continue
 			occupations += job
 			occupations_by_type[job.type] = job
+			occupations_by_title[job.title] = job
 			if(!setup_titles) continue
 			if(job.department_flag & COM)
 				command_positions |= job.title
@@ -354,14 +358,14 @@ var/global/datum/controller/occupations/job_master
 			//Equip custom gear loadout.
 			var/list/custom_equip_slots = list() //If more than one item takes the same slot, all after the first one spawn in storage.
 			var/list/custom_equip_leftovers = list()
-			if(H.client.prefs.Gear() && job.title != "Cyborg" && job.title != "AI")
+			if(H.client.prefs.Gear() && job.loadout_allowed)
 				for(var/thing in H.client.prefs.Gear())
 					var/datum/gear/G = gear_datums[thing]
 					if(G)
 						var/permitted
 						if(G.allowed_roles)
-							for(var/job_name in G.allowed_roles)
-								if(job.title == job_name)
+							for(var/job_type in G.allowed_roles)
+								if(job.type == job_type)
 									permitted = 1
 						else
 							permitted = 1

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -146,11 +146,12 @@ var/list/gear_datums = list()
 	. += "<tr><td colspan=3><b><center>[LC.category]</center></b></td></tr>"
 	. += "<tr><td colspan=3><hr></td></tr>"
 	var/jobs = list()
-	if(pref.job_high || pref.job_medium || pref.job_low)
-		if(pref.job_high) //Is not a list like the others so a check just in case
-			jobs += pref.job_high
-		jobs += pref.job_medium
-		jobs += pref.job_low
+	if(job_master)
+		for(var/job_title in (pref.job_medium|pref.job_low|pref.job_high))
+			var/datum/job/J = job_master.occupations_by_title[job_title]
+			if(J)
+				dd_insertObjectList(jobs, J)
+
 	for(var/gear_name in LC.gear)
 		if(!(gear_name in valid_gear_choices()))
 			continue
@@ -162,17 +163,14 @@ var/list/gear_datums = list()
 		if(G.allowed_roles)
 			. += "<br><i>"
 			var/ind = 0
-			for(var/J in jobs)
-				if(J in G.allowed_roles)
-					++ind
-					if(ind > 1)
-						. += ", "
-					. += "<font color=55cc55>[J]</font>"
+			for(var/datum/job/J in jobs)
+				++ind
+				if(ind > 1)
+					. += ", "
+				if(J.type in G.allowed_roles)
+					. += "<font color=55cc55>[J.title]</font>"
 				else
-					++ind
-					if(ind > 1)
-						. += ", "
-					. += "<font color=cc5555>[J]</font>"
+					. += "<font color=cc5555>[J.title]</font>"
 			. += "</i>"
 		.+= "</tr>"
 		if(ticked)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -215,8 +215,8 @@ datum/preferences
 				var/permitted = 0
 				if(G.allowed_roles && G.allowed_roles.len)
 					if(previewJob)
-						for(var/job_name in G.allowed_roles)
-							if(previewJob.title == job_name)
+						for(var/job_type in G.allowed_roles)
+							if(previewJob.type == job_type)
 								permitted = 1
 				else
 					permitted = 1

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -1,67 +1,67 @@
 //The following is a list of defs to be used for the Torch loadout.
 
 //For all SolGov personnel, representative included
-#define SOLGOV_ROLES list("Commanding Officer", "Executive Officer", "Chief Medical Officer", "Chief Engineer", "Chief of Security", "Bridge Officer", "Senior Enlisted Advisor", "Senior Engineer", "Engineer", "Brig Officer", "Forensic Technician", "Master at Arms", "Physician", "Corpsman", "Deck Officer", "Deck Technician", "Sanitation Technician", "Cook", "Crewman", "SolGov Representative", "SolGov Pilot")
+#define SOLGOV_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/representative, /datum/job/solgov_pilot)
 
 //For EC/Fleet/Marines
-#define MILITARY_ROLES list("Commanding Officer", "Executive Officer", "Chief Medical Officer", "Chief Engineer", "Chief of Security", "Bridge Officer", "Senior Enlisted Advisor", "Senior Engineer", "Engineer", "Brig Officer", "Forensic Technician", "Master at Arms", "Physician", "Corpsman", "Deck Officer", "Deck Technician", "Sanitation Technician", "Cook", "Crewman", "SolGov Pilot")
+#define MILITARY_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/solgov_pilot)
 
 //For EC/Fleet/Marine Officers
-#define MILITARY_OFFICER_ROLES list("Commanding Officer", "Executive Officer", "Chief Medical Officer", "Chief Engineer", "Chief of Security", "Bridge Officer", "Physician", "Deck Officer", "SolGov Pilot")
+#define MILITARY_OFFICER_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/senior_doctor, /datum/job/qm, /datum/job/solgov_pilot)
 
 //For EC/Fleet/Marine Enlisted
-#define MILITARY_ENLISTED_ROLES list("Senior Enlisted Advisor", "Senior Engineer", "Engineer", "Brig Officer", "Forensic Technician", "Master at Arms", "Physician", "Corpsman", "Deck Officer", "Deck Technician", "Sanitation Technician", "Cook", "Crewman")
+#define MILITARY_ENLISTED_ROLES list(/datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew)
 
 //For all civilians or off-duty personnel, regardless of formality of dress or job.
-#define NON_MILITARY_ROLES list("Research Director", "NanoTrasen Liaison", "Senior Researcher", "NanoTrasen Pilot", "Scientist", "Prospector", "Security Guard", "Research Assistant", "SolGov Representative", "Passenger", "Maintenance Assistant", "Roboticist", "Medical Contractor", "Chemist", "Counselor", "Supply Assistant", "Bartender", "Merchant", "Off-Duty","Stowaway")
+#define NON_MILITARY_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway)
 
 //For jobs that allow for decorative or ceremonial clothing
-#define FORMAL_ROLES list("NanoTrasen Liaison", "Research Director", "Senior Researcher", "Scientist", "Research Assistant", "SolGov Representative", "Passenger", "Bartender", "Merchant", "Off-Duty","Stowaway")
+#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway)
 
 //For civilian jobs that may have a uniform, but not a strict one
-#define SEMIFORMAL_ROLES list("Passenger", "Prospector", "Research Assistant", "Counselor", "Bartender", "Merchant", "NanoTrasen Pilot", "Off-Duty","Stowaway", "Scientist", "Senior Researcher")
+#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/stowaway, /datum/job/scientist, /datum/job/senior_scientist)
 
 //For civilian jobs that may have a strict uniform.
-#define SEMIANDFORMAL_ROLES list("Passenger", "Prospector", "Research Assistant", "Counselor", "Bartender", "Merchant", "NanoTrasen Pilot", "Off-Duty", "NanoTrasen Liaison", "Research Director", "Senior Researcher", "Scientist", "SolGov Representative","Stowaway")
+#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway)
 
 //For NanoTrasen employees
-#define NANOTRASEN_ROLES list("Research Director", "NanoTrasen Liaison", "Senior Researcher", "NanoTrasen Pilot", "Scientist", "Prospector", "Security Guard", "Research Assistant")
+#define NANOTRASEN_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant)
 
 //For contractors
-#define CONTRACTOR_ROLES list("Maintenance Assistant", "Roboticist", "Medical Contractor", "Chemist", "Counselor", "Supply Assistant", "Bartender", "Cook", "Sanitation Technician")
+#define CONTRACTOR_ROLES list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/chef, /datum/job/janitor)
 
 //For corporate or government representatives
-#define REPRESENTATIVE_ROLES list("SolGov Representative", "NanoTrasen Liaison")
+#define REPRESENTATIVE_ROLES list(/datum/job/representative, /datum/job/liaison)
 
 //For roles with no uniform or formal clothing requirements
-#define RESTRICTED_ROLES list("Passenger", "Bartender", "Merchant", "Off-Duty","Stowaway")
+#define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant, "Off-Duty",/datum/job/stowaway)
 
 //For members of the command department
-#define COMMAND_ROLES list("Commanding Officer", "Executive Officer", "Research Director", "Chief Medical Officer", "Chief Engineer", "Chief of Security", "Bridge Officer", "Senior Enlisted Advisor")
+#define COMMAND_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea)
 
 //For members of the medical department
-#define MEDICAL_ROLES list("Chief Medical Officer", "Physician", "Corpsman", "Medical Contractor", "Chemist", "Counselor")
+#define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist)
 
 //For members of the medical department, roboticists, and some Research
-#define STERILE_ROLES list("Chief Medical Officer", "Physician", "Corpsman", "Medical Contractor", "Chemist", "Counselor", "Roboticist", "Research Director", "Senior Researcher", "Scientist", "Research Assistant")
+#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant)
 
 //For members of the engineering department
-#define ENGINEERING_ROLES list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Roboticist")
+#define ENGINEERING_ROLES list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist)
 
 //For members of Engineering, Cargo, and Research
-#define TECHNICAL_ROLES list("Senior Engineer", "Engineer", "Maintenance Assistant", "Roboticist", "Deck Officer", "Deck Technician", "Supply Assistant", "Prospector", "Research Assistant", "Merchant", "Research Director", "Senior Researcher", "Scientist", "Chief Engineer", "Sanitation Technician")
+#define TECHNICAL_ROLES list(/datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/chief_engineer, /datum/job/janitor)
 
 //For members of the security department
-#define SECURITY_ROLES list("Chief of Security", "Brig Officer", "Forensic Technician", "Master at Arms")
+#define SECURITY_ROLES list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer)
 
 //For members of the supply department
-#define SUPPLY_ROLES list("Deck Officer", "Deck Technician", "Supply Assistant")
+#define SUPPLY_ROLES list(/datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor)
 
 //For members of the service department
-#define SERVICE_ROLES list("Sanitation Technician", "Cook", "Crewman", "Bartender")
+#define SERVICE_ROLES list(/datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/bartender)
 
 //For members of the research department and jobs that are scientific
-#define RESEARCH_ROLES list("Research Director", "NanoTrasen Liaison", "Scientist", "Prospector", "Security Guard", "Research Assistant", "Passenger", "NanoTrasen Pilot", "Senior Researcher", "Chemist", "Roboticist", "Virologist")
+#define RESEARCH_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/assistant, /datum/job/nt_pilot, /datum/job/senior_scientist, /datum/job/chemist, /datum/job/roboticist)
 
 //For jobs that spawn with weapons in their lockers
-#define ARMED_ROLES list("Commanding Officer", "Executive Officer", "Chief Medical Officer", "Chief Engineer", "Chief of Security", "Senior Enlisted Advisor", "Master at Arms", "Brig Officer", "Forensic Technician", "Security Guard", "Merchant")
+#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/guard, /datum/job/merchant)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -87,7 +87,7 @@
 /datum/gear/accessory/armband_mp
 	display_name = "military police armband"
 	path = /obj/item/clothing/accessory/armband/mp
-	allowed_roles = list("Master at Arms", "Brig Officer", "Chief of Security", "Forensic Technician")
+	allowed_roles = list(/datum/job/officer, /datum/job/warden, /datum/job/hos, /datum/job/detective)
 
 /datum/gear/accessory/armband_cargo
 	display_name = "cargo armband"
@@ -102,12 +102,12 @@
 /datum/gear/accessory/armband_emt
 	display_name = "EMT armband"
 	path = /obj/item/clothing/accessory/armband/medgreen
-	allowed_roles = list("Corpsman", "Medical Contractor")
+	allowed_roles = list(/datum/job/doctor, /datum/job/doctor_contractor)
 
 /datum/gear/accessory/armband_corpsman
 	display_name = "medical corps armband"
 	path = /obj/item/clothing/accessory/armband/medblue
-	allowed_roles = list("Chief Medical Officer", "Physician", "Corpsman")
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor)
 
 /datum/gear/accessory/armband_engineering
 	display_name = "engineering armband"
@@ -117,12 +117,12 @@
 /datum/gear/accessory/armband_hydro
 	display_name = "hydroponics armband"
 	path = /obj/item/clothing/accessory/armband/hydro
-	allowed_roles = list("Research Director", "Scientist", "Research Assistant", "Passenger")
+	allowed_roles = list(/datum/job/rd, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/assistant)
 
 /datum/gear/accessory/armband_nt
 	display_name = "NanoTrasen armband"
 	path = /obj/item/clothing/accessory/armband/whitered
-	allowed_roles = list("Research Director", "NanoTrasen Liaison", "Senior Researcher", "NanoTrasen Pilot", "Scientist", "Prospector", "Security Guard", "Research Assistant", "Maintenance Assistant", "Roboticist", "Medical Assistant", "Virologist", "Chemist", "Counselor", "Supply Assistant", "Sanitation Technician", "Cook", "Bartender")
+	allowed_roles = list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist, /datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/janitor, /datum/job/chef, /datum/job/bartender)
 
 /datum/gear/accessory/armband_solgov
 	display_name = "peacekeeper armband"
@@ -187,39 +187,39 @@
 	display_name = "webbing, engineering"
 	path = /obj/item/clothing/accessory/storage/brown_vest
 	cost = 3
-	allowed_roles = list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Roboticist", "Deck Officer", "Deck Technician",
-						"Supply Assistant", "Prospector", "Sanitation Technician", "Research Assistant", "Merchant", "SolGov Pilot", "NanoTrasen Pilot")
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
+						/datum/job/cargo_contractor, /datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/solgov_pilot, /datum/job/nt_pilot)
 
 /datum/gear/accessory/black_vest
 	display_name = "webbing, security"
 	path = /obj/item/clothing/accessory/storage/black_vest
 	cost = 3
-	allowed_roles = list("Chief of Security", "Brig Officer", "Forensic Technician", "Master at Arms", "Security Guard", "Merchant")
+	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/guard, /datum/job/merchant)
 
 /datum/gear/accessory/white_vest
 	display_name = "webbing, medical"
 	path = /obj/item/clothing/accessory/storage/white_vest
 	cost = 3
-	allowed_roles = list("Chief Medical Officer", "Physician", "Corpsman", "Medical Contractor", "Merchant")
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/merchant)
 
 /datum/gear/accessory/brown_drop_pouches
 	display_name = "drop pouches, engineering"
 	path = /obj/item/clothing/accessory/storage/drop_pouches/brown
 	cost = 3
-	allowed_roles = list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Roboticist", "Deck Officer", "Deck Technician",
-						"Supply Assistant", "Prospector", "Sanitation Technician", "Research Assistant", "Merchant")
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
+						/datum/job/cargo_contractor, /datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant)
 
 /datum/gear/accessory/black_drop_pouches
 	display_name = "drop pouches, security"
 	path = /obj/item/clothing/accessory/storage/drop_pouches/black
 	cost = 3
-	allowed_roles = list("Chief of Security", "Brig Officer", "Forensic Technician", "Master at Arms", "Security Guard", "Merchant")
+	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/guard, /datum/job/merchant)
 
 /datum/gear/accessory/white_drop_pouches
 	display_name = "drop pouches, medical"
 	path = /obj/item/clothing/accessory/storage/drop_pouches/white
 	cost = 3
-	allowed_roles = list("Chief Medical Officer", "Physician", "Corpsman", "Medical Contractor", "Merchant")
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/merchant)
 
 /datum/gear/accessory/webbing
 	display_name = "webbing, simple"

--- a/maps/torch/loadout/loadout_eyes.dm
+++ b/maps/torch/loadout/loadout_eyes.dm
@@ -61,17 +61,17 @@
 /datum/gear/eyes/meson
 	display_name = "Meson Goggles"
 	path = /obj/item/clothing/glasses/meson
-	allowed_roles = list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Prospector", "Research Assistant")
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/mining, /datum/job/scientist_assistant)
 
 /datum/gear/eyes/meson/prescription
 	display_name = "Meson Goggles, prescription"
 	path = /obj/item/clothing/glasses/meson/prescription
-	allowed_roles = list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Prospector", "Research Assistant")
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/mining, /datum/job/scientist_assistant)
 
 /datum/gear/eyes/material
 	display_name = "Material Goggles"
 	path = /obj/item/clothing/glasses/material
-	allowed_roles = list("Chief Engineer", "Senior Engineer", "Engineer", "Maintenance Assistant", "Prospector", "Research Assistant")
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/mining, /datum/job/scientist_assistant)
 
 /datum/gear/eyes/shades/
 	display_name = "sunglasses"

--- a/maps/torch/loadout/loadout_gloves.dm
+++ b/maps/torch/loadout/loadout_gloves.dm
@@ -67,7 +67,7 @@
 	display_name = "gloves, botany"
 	path = /obj/item/clothing/gloves/thick/botany
 	cost = 3
-	allowed_roles = list("Research Director", "Scientist", "Research Assistant", "Cook", "Bartender", "Passenger", "Merchant")
+	allowed_roles = list(/datum/job/rd, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/chef, /datum/job/bartender, /datum/job/assistant, /datum/job/merchant)
 
 /datum/gear/gloves/dress
 	display_name = "gloves, dress"

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -34,7 +34,7 @@
 /datum/gear/head/whitentberet
 	display_name = "beret, NanoTrasen security"
 	path = /obj/item/clothing/head/beret/guard
-	allowed_roles = list("Security Guard")
+	allowed_roles = list(/datum/job/guard)
 
 /datum/gear/head/solhat
 	display_name = "Sol Central Government Cap"

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -49,19 +49,19 @@
 	allowed_roles = RESTRICTED_ROLES
 
 /datum/gear/suit/roles/poncho/security
-	allowed_roles = list("Security Guard", "Merchant")
+	allowed_roles = list(/datum/job/guard, /datum/job/merchant)
 
 /datum/gear/suit/roles/poncho/medical
-	allowed_roles = list("Medical Contractor", "Chemist", "Counselor", "Merchant")
+	allowed_roles = list(/datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/merchant)
 
 /datum/gear/suit/roles/poncho/engineering
-	allowed_roles = list("Maintenance Assistant", "Roboticist", "Merchant")
+	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/suit/roles/poncho/science
-	allowed_roles = list("Scientist", "Research Assistant", "Merchant")
+	allowed_roles = list(/datum/job/scientist, /datum/job/scientist_assistant, /datum/job/merchant)
 
 /datum/gear/suit/roles/poncho/cargo
-	allowed_roles = list("Supply Assistant", "Merchant")
+	allowed_roles = list(/datum/job/cargo_contractor, /datum/job/merchant)
 
 /datum/gear/suit/suit_jacket
 	allowed_roles = FORMAL_ROLES

--- a/maps/torch/loadout/loadout_uniform.dm
+++ b/maps/torch/loadout/loadout_uniform.dm
@@ -23,7 +23,7 @@
 /datum/gear/uniform/roboticist_skirt
 	display_name = "skirt, roboticist"
 	path = /obj/item/clothing/under/rank/roboticist/skirt
-	allowed_roles = list("Roboticist")
+	allowed_roles = list(/datum/job/roboticist)
 
 /datum/gear/uniform/suit
 	display_name = "clothes selection"
@@ -159,9 +159,9 @@
 /datum/gear/uniform/corporate
 	display_name = "corporate uniform selection"
 	path = /obj/item/clothing/under/mbill
-	allowed_roles = list("Scientist", "Prospector", "Security Guard", "Research Assistant",
-						"Passenger", "Maintenance Assistant", "Roboticist", "Medical Contractor",
-						"Chemist", "Counselor", "Supply Assistant", "Bartender", "Merchant")
+	allowed_roles = list(/datum/job/scientist, /datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant,
+						/datum/job/scientist_assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor,
+						/datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant)
 
 /datum/gear/uniform/corporate/New()
 	..()

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -129,5 +129,5 @@
 	whitelisted = list(SPECIES_TAJARA)
 	sort_category = "Xenowear"
 	cost = 1
-	allowed_roles = list("Maintenance Assistant", "Prospector", "Research Assistant")
+	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/mining, /datum/job/scientist_assistant)
 


### PR DESCRIPTION
The compiler will now slap people in the face when a utilized job type is removed or renamed, or they simply make a typo.
Ensures people no longer incorrectly believe alt-titles are taken into consideration in any way, shape or form.

Jobs now define whether they allow loadout equipment or not, rather than there being an explicit check for the AI and cyborg titles.

Never use strings to compare anything when better options exist.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
