### PR TITLE
Closet and Disposal Unit Tweaks/Fixes

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,10 +6,10 @@
 	almost anything into a trash can.
 */
 
-/atom/proc/CanMouseDrop(atom/over, var/mob/user = usr)
+/atom/proc/CanMouseDrop(atom/over, var/mob/user = usr, var/incapacitation_flags)
 	if(!user || !over)
 		return FALSE
-	if(user.incapacitated())
+	if(user.incapacitated(incapacitation_flags))
 		return FALSE
 	if(!src.Adjacent(user) || !over.Adjacent(user))
 		return FALSE // should stop you from dragging through windows
@@ -23,6 +23,6 @@
 		over.MouseDrop_T(src,usr)
 	return
 
-// recieve a mousedrop
+// Receive a mouse drop
 /atom/proc/MouseDrop_T(atom/dropping, mob/user)
 	return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -265,6 +265,7 @@
 			W.pixel_y = 0
 			W.pixel_z = 0
 			W.pixel_w = 0
+		return
 	else if(istype(W, /obj/item/weapon/melee/energy/blade))
 		if(emag_act(INFINITY, user, "<span class='danger'>The locker has been sliced open by [user] with \an [W]</span>!", "<span class='danger'>You hear metal being sliced and sparks flying.</span>"))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
@@ -484,7 +485,10 @@
 	return allowed(user) || (istype(id_card) && check_access_list(id_card.GetAccess()))
 
 /obj/structure/closet/AltClick(var/mob/user)
-	togglelock(user)
+	if(!src.opened)
+		togglelock(user)
+	else
+		return ..()
 
 /obj/structure/closet/emp_act(severity)
 	for(var/obj/O in src)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -24,6 +24,7 @@
 	var/flush_every_ticks = 30 //Every 30 ticks it will look whether it is ready to flush
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
 	var/last_sound = 0
+	var/list/allowed_objects = list(/obj/structure/closet)
 	active_power_usage = 2200	//the pneumatic pump power. 3 HP ~ 2200W
 	idle_power_usage = 100
 	flags = OBJ_CLIMBABLE
@@ -141,52 +142,66 @@
 
 	update_icon()
 
-// mouse drop another mob or self
-//
-/obj/machinery/disposal/MouseDrop_T(mob/target, mob/user)
-	if(user.stat || !user.canmove || !istype(target))
-		return
-	if(target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1)
+/obj/machinery/disposal/MouseDrop_T(atom/movable/AM, mob/user)
+	var/incapacitation_flags = INCAPACITATION_DEFAULT
+	if(AM == user)
+		incapacitation_flags &= ~INCAPACITATION_RESTRAINED
+
+	if(stat & BROKEN || !CanMouseDrop(AM, user, incapacitation_flags) || AM.anchored)
 		return
 
-	//animals cannot put mobs other than themselves into disposal
-	if(isanimal(user) && target != user)
+	// Animals can only put themself in
+	if(isanimal(user) && AM != user)
 		return
 
+	// Determine object type and run necessary checks
+	var/mob/M = AM
+	var/is_dangerous // To determine css style in messages
+	if(istype(M))
+		is_dangerous = TRUE
+		if(M.buckled)
+			return
+	else if(istype(AM, /obj/item))
+		attackby(AM, user)
+		return
+	else if(!is_type_in_list(AM, allowed_objects))
+		return
+
+	// Checks completed, start inserting
 	src.add_fingerprint(user)
-	var/target_loc = target.loc
-	var/msg
-	for (var/mob/V in viewers(usr))
-		if(target == user && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
-			V.show_message("[usr] starts climbing into the disposal.", 3)
-		if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
-			if(target.anchored) return
-			V.show_message("[usr] starts stuffing [target.name] into the disposal.", 3)
-	if(!do_after(usr, 20, src))
-		return
-	if(target_loc != target.loc)
-		return
-	if(target == user && !user.incapacitated(INCAPACITATION_ALL))	// if drop self, then climbed in
-											// must be awake, not stunned or whatever
-		msg = "\The [user] climbs into \the [src]."
-		to_chat(user, "You climb into \the [src].")
-	else if(target != user && !user.incapacitated())
-		msg = "\The [user] stuffs \the [target] into \the [src]!"
-		to_chat(user, "You stuff \the [target] into \the [src]!")
-		admin_attack_log(user, target, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
+	var/old_loc = AM.loc
+	if(AM == user)
+		user.visible_message("<span class='warning'>[user] starts climbing into [src].</span>", \
+							 "<span class='notice'>You start climbing into [src].</span>")
 	else
+		user.visible_message("<span class='[is_dangerous ? "warning" : "notice"]'>[user] starts stuffing [AM] into [src].</span>", \
+							 "<span class='notice'>You start stuffing [AM] into [src].</span>")
+
+	if(!do_after(user, 2 SECONDS, src))
 		return
-	if (target.client)
-		target.client.perspective = EYE_PERSPECTIVE
-		target.client.eye = src
 
-	target.forceMove(src)
+	// Repeat checks
+	if(stat & BROKEN || user.incapacitated(incapacitation_flags))
+		return
+	if(!AM || old_loc != AM.loc || AM.anchored)
+		return
+	if(istype(M) && M.buckled)
+		return
 
-	for (var/mob/C in viewers(src))
-		if(C == user)
-			continue
-		C.show_message(msg, 3)
+	// Messages and logging
+	if(AM == user)
+		user.visible_message("<span class='danger'>[user] climbs into [src].</span>", \
+							 "<span class='notice'>You climb into [src].</span>")
+	else
+		user.visible_message("<span class='[is_dangerous ? "danger" : "notice"]'>[user] stuffs [AM] into [src][is_dangerous ? "!" : "."]</span>", \
+							 "<span class='notice'>You stuff [AM] into [src].</span>")
+		if(ismob(M))
+			admin_attack_log(user, M, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
+			if (M.client)
+				M.client.perspective = EYE_PERSPECTIVE
+				M.client.eye = src
 
+	AM.forceMove(src)
 	update_icon()
 	return
 


### PR DESCRIPTION
 - Closet without lock will no longer close itself when an item is
   inserted.
 - Closet now reverts to parent altClick behavior if opened.
 - Rewritten disposal unit `MouseDrop_T()` to run more consistent checks and
   allow more items.
 - Added a list for allowed entities a disposal unit can take that are
   neither mob nor item.
 - Added `/obj/structure/closet` to the list of allowed entities.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
