### PR TITLE
Radiation Fluff

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1265,7 +1265,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 				user.show_message("<span class='notice'>Analyzing Results for [C]:</span>")
 				if(C.radiation)
-					user.show_message("<span class='notice'>Radiation Level: [C.radiation]</span>")
+					user.show_message("<span class='notice'>Radiation Level: [C.radiation] mSv</span>")
 				else
 					user.show_message("<span class='notice'>No radiation detected.</span>")
 

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -24,7 +24,11 @@
 
 /obj/item/device/geiger/examine(mob/user)
 	. = ..(user)
-	to_chat(user, "<span class='warning'>[scanning ? "ambient" : "stored"] radiation level: [radiation_count ? radiation_count : "0"]Bq.</span>")
+	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: [radiation_count ? radiation_count : "0"] Bq."
+	if(radiation_count > RAD_LEVEL_LOW)
+		to_chat(user, "<span class='warning'>[msg]</span>")
+	else
+		to_chat(user, "<span class='notice'>[msg]</span>")
 
 /obj/item/device/geiger/attack_self(var/mob/user)
 	scanning = !scanning


### PR DESCRIPTION
 - Radiation dosis is now using Sievert.
 - Geiger counter's output text uses notice-class for undangerous amounts
   of radiation.
 - Proper spelling in the output text.

Usually one would also measure radiation in uSv/s, but since this is a game and characters are gaining massive loads of radiation exposure, I guess it's better off leaving it as Becquerel for now to not have to display unrealistic amounts of radiation.

That said, 1 Bq of gamma radiation is totally negligible as well. Perhaps someone will give radiation more consistency in the future so it makes more sense.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
