### PR TITLE
Slimetoxin changes

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -246,6 +246,7 @@
 #define SPECIES_UNATHI "Unathi"
 #define SPECIES_SKRELL "Skrell"
 #define SPECIES_NABBER "Giant Armoured Serpentid"
+#define SPECIES_PROMETHEAN "Promethean"
 
 #define SURGERY_CLOSED 0
 #define SURGERY_OPEN 1

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -3,7 +3,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 // Species definition follows.
 /datum/species/shapeshifter/promethean
 
-	name =             "Promethean"
+	name =             SPECIES_PROMETHEAN
 	name_plural =      "Prometheans"
 	blurb =            "What has Science done?"
 	show_ssd =         "totally quiescent"

--- a/code/modules/mob/living/carbon/xenobiological/slime_AI.dm
+++ b/code/modules/mob/living/carbon/xenobiological/slime_AI.dm
@@ -103,7 +103,7 @@
 	if(!invalidFeedTarget(M)) // Checks for those we want to eat
 		if(istype(M, /mob/living/carbon/human)) // Ignore slime(wo)men - player-controlled slimes still can attack them
 			var/mob/living/carbon/human/H = M
-			if(H.species.name == "Promethean")
+			if(H.species.name == SPECIES_PROMETHEAN)
 				return 0
 		return 1
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -559,7 +559,7 @@
 /datum/reagent/slimetoxin/affect_blood(var/mob/living/carbon/human/H, var/alien, var/removed)
 	if(!istype(H))
 		return
-	if(H.species.name == "Promethean")
+	if(H.species.name == SPECIES_PROMETHEAN)
 		return
 	H.adjustToxLoss(40 * removed)
 	if(dose < 1 || prob(30))
@@ -568,12 +568,12 @@
 	var/list/meatchunks = list()
 	for(var/limb_tag in list(BP_R_ARM, BP_L_ARM, BP_R_LEG,BP_L_LEG))
 		var/obj/item/organ/external/E = H.get_organ(limb_tag)
-		if(!E.is_stump() && E.robotic < ORGAN_ROBOT && E.species.name != "Promethean")
+		if(!E.is_stump() && E.robotic < ORGAN_ROBOT && E.species.name != SPECIES_PROMETHEAN)
 			meatchunks += E
 	if(!meatchunks.len)
 		if(prob(10))
 			to_chat(H, "<span class='danger'>Your flesh rapidly mutates!</span>")
-			H.set_species("Promethean")
+			H.set_species(SPECIES_PROMETHEAN)
 			H.shapeshifter_set_colour("#05FF9B")
 			H.verbs -= /mob/living/carbon/human/proc/shapeshifter_select_colour
 		return
@@ -583,7 +583,7 @@
 		wrapped_species_by_ref["\ref[H]"] = H.species.name
 	meatchunks = list(O) | O.children
 	for(var/obj/item/organ/external/E in meatchunks)
-		E.species = all_species["Promethean"]
+		E.species = all_species[SPECIES_PROMETHEAN]
 		E.s_tone = null
 		E.s_col = ReadRGB("#05FF9B")
 		E.status &= ~ORGAN_BROKEN

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -586,6 +586,7 @@
 		E.species = all_species[SPECIES_PROMETHEAN]
 		E.s_tone = null
 		E.s_col = ReadRGB("#05FF9B")
+		E.s_col_blend = ICON_ADD
 		E.status &= ~ORGAN_BROKEN
 		E.status |= ORGAN_MUTATED
 		E.cannot_break = 1

--- a/html/changelogs/chinsky - slimetox.yml
+++ b/html/changelogs/chinsky - slimetox.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Slimetoxin. Slimetoxin changed. Instead of pop and go slimeficiation it's now a life threatening process. Slime toxin metabolizes slowly, and deals fair bit of toxins damage. For every unit or so metabolized, it mutates one limb. Once every limb mutated, there's a 10% every tick to fully mutate into a slimegirl. If you're lucky, you might mutate right before death and that'd heal your all wounds! That' a great idea!"


### PR DESCRIPTION
Instead of pop and go slimeficiation it's now a life threatening process. Slime toxin metabolizes slowly, and deals fair bit of toxins damage. For every unit metabolized, it mutates one limb. Once every limb mutated, there's a 10% every tick to fully mutate into a slimegirl. If you're lucky, you might mutate right before death and that'd heal your all wounds! That' a great idea!

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
