### PR TITLE
Changes to security lockers and access.

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -522,10 +522,10 @@
 		/datum/mil_rank/marine/e5
 	)
 
-	access = list(access_security, access_forensics_lockers,
+	access = list(access_security, access_brig, access_forensics_lockers,
 			            access_maint_tunnels, access_emergency_storage,
 			            access_sec_doors, access_solgov_crew)
-	minimal_access = list(access_security, access_forensics_lockers,
+	minimal_access = list(access_security, access_brig, access_forensics_lockers,
 			            access_maint_tunnels, access_emergency_storage,
 			            access_sec_doors, access_solgov_crew)
 

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -73,6 +73,7 @@
 		/obj/item/weapon/folder/red,
 		/obj/item/device/holowarrant,
 		/obj/item/clothing/gloves/thick,
+		/obj/item/device/flashlight/maglight,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)
@@ -111,6 +112,7 @@
 		/obj/item/weapon/hand_labeler,
 		/obj/item/device/holowarrant,
 		/obj/item/clothing/gloves/thick,
+		/obj/item/device/flashlight/maglight,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)
@@ -130,19 +132,19 @@
 		/obj/item/clothing/gloves/forensic,
 		/obj/item/device/radio/headset/headset_sec,
 		/obj/item/clothing/suit/armor/vest/detective,
+		/obj/item/clothing/head/helmet/solgov/security,
+		/obj/item/clothing/suit/storage/vest/solgov/security,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/device/flash,
-		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/melee/baton/loaded,
 		/obj/item/weapon/reagent_containers/spray/pepper,
-		/obj/item/clothing/suit/armor/vest/solgov,
 		/obj/item/weapon/storage/belt/security,
 		/obj/item/taperoll/police,
 		/obj/item/weapon/storage/box/evidence,
 		/obj/item/weapon/storage/box/swabs,
 		/obj/item/weapon/storage/box/gloves,
 		/obj/item/weapon/storage/briefcase/crimekit,
-		/obj/item/weapon/clipboard,
 		/obj/item/weapon/folder/red,
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape/random = 3,
@@ -150,9 +152,11 @@
 		/obj/item/weapon/forensics/sample_kit,
 		/obj/item/device/uv_light,
 		/obj/item/weapon/reagent_containers/spray/luminol,
+		/obj/item/weapon/reagent_containers/syringe,
 		/obj/item/clothing/suit/storage/toggle/labcoat,
 		/obj/item/clothing/glasses/sunglasses/sechud/toggle,
 		/obj/item/device/holowarrant,
+		/obj/item/device/flashlight/maglight,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)


### PR DESCRIPTION
These are some really small changes, just QoL stuff.

-Brig Officer and CoS now get maglights in their lockers, so they can stop raiding MA lockers;
-Forensics Tech now gets equal armor and helmet to MAs, while keeping their shitty brown vest in case they really want to wear it;
-FT now gets a maglight and a stun baton as well, bringing their kit in line with that of MAs;
-FT locker no longer contains handcuffs by default, since nobody else got those in their lockers;
-FT locker starts with a syringe inside so the blood testing equipment can actually be used;
-FT now has access to the brig cells.

Addendum: Clipboard has been physically removed to please our Lord, Travis. No refunds will be offered.