### PR TITLE
AltClick Consistency Cleanup

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -182,5 +182,8 @@
 		return ..()
 
 /obj/item/weapon/reagent_containers/AltClick(var/mob/user)
-	if(CanPhysicallyInteract(user))
-		set_APTFT()
+	if(possible_transfer_amounts)
+		if(CanPhysicallyInteract(user))
+			set_APTFT()
+	else
+		return ..()


### PR DESCRIPTION
 - AltClick on a reagent container reverts to usual behavior if the container's transfer amount can not actually be adjusted.
 - Expands the functionality to reagent dispensers.
 - Full paths for reagent dispensers since I was at it.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
