### PR TITLE
Restores on-join announcements for all jobs, with a twist

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -246,6 +246,6 @@
 		medical.fields["b_dna"]		= I.dna_hash
 
 	var/datum/job/job = job_master.GetJob(general.fields["rank"])
-	if(job && job.announced)
-		AnnounceArrivalSimple(general.fields["name"], general.fields["rank"])
+	if(istype(job) && job.announced)
+		AnnounceArrivalSimple(general.fields["name"], general.fields["rank"], get_announcement_frequency(job))
 	. = ..()

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -18,7 +18,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	ideal_character_age = 70 // Old geezer captains ftw
 	outfit_type = /decl/hierarchy/outfit/job/captain
-	announced = 1
 
 /datum/job/captain/equip(var/mob/living/carbon/human/H)
 	. = ..()
@@ -56,4 +55,3 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
 	outfit_type = /decl/hierarchy/outfit/job/hop
-	announced = 1

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -128,7 +128,6 @@
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
 	minimal_player_age = 10
 	outfit_type = /decl/hierarchy/outfit/job/internal_affairs_agent
-	announced = 1
 
 /datum/job/lawyer/equip(var/mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -24,7 +24,6 @@
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_player_age = 14
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
-	announced = 1
 
 /datum/job/engineer
 	title = "Engineer"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -30,9 +30,9 @@
 	var/list/allowed_branches             // For maps using branches and ranks, also expandable for other purposes
 	var/list/allowed_ranks                // Ditto
 
-	var/announced                         //If their arrival is announced on radio
+	var/announced = TRUE                  //If their arrival is announced on radio
 	var/latejoin_at_spawnpoints           //If this job should use roundstart spawnpoints for latejoin (offstation jobs etc)
-    
+
 /datum/job/dd_SortValue()
     return title
 
@@ -142,10 +142,10 @@
 		return TRUE
 
 	return FALSE
-    
+
 /datum/job/proc/is_species_allowed(var/datum/species/S)
 	return !GLOB.using_map.is_species_job_restricted(S, src)
-    
+
 /**
  *  Check if members of the given branch are allowed in the job
  *

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -20,7 +20,6 @@
 	minimal_player_age = 14
 	ideal_character_age = 50
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
-	announced = 1
 
 /datum/job/doctor
 	title = "Medical Doctor"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -21,7 +21,6 @@
 	minimal_player_age = 14
 	ideal_character_age = 50
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
-	announced = 1
 
 /datum/job/scientist
 	title = "Scientist"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -20,7 +20,6 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimal_player_age = 14
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
-	announced = 1
 
 /datum/job/hos/equip(var/mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -11,7 +11,6 @@
 	account_allowed = 0
 	economic_modifier = 0
 	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
-	announced = 1
 	loadout_allowed = FALSE
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -207,8 +207,6 @@
 	var/datum/radio_frequency/connection = null
 	if(channel && channels && channels.len > 0)
 		if (channel == "department")
-//			log_debug(channel=\"[channel]\" switching to \"[channels[1]]\"")
-
 			channel = channels[1]
 		connection = secure_radio_connections[channel]
 	else
@@ -216,14 +214,10 @@
 		channel = null
 	if (!istype(connection))
 		return
-	if (!connection)
-		return
-
 	var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(src, null, null, 1)
 	A.fully_replace_character_name(from)
 	talk_into(A, message, channel,"states")
 	qdel(A)
-	return
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum
 /obj/item/device/radio/proc/handle_message_mode(mob/living/M as mob, message, message_mode)
@@ -273,8 +267,6 @@
 	//#### Grab the connection datum ####//
 	var/datum/radio_frequency/connection = handle_message_mode(M, message, channel)
 	if (!istype(connection))
-		return 0
-	if (!connection)
 		return 0
 
 	var/turf/position = get_turf(src)
@@ -329,7 +321,6 @@
 
 
   /* ###### Radio headsets can only broadcast through subspace ###### */
-
 	if(subspace_transmission)
 		// First, we want to generate a new radio signal
 		var/datum/signal/signal = new
@@ -438,7 +429,6 @@
 
 	//THIS IS TEMPORARY. YEAH RIGHT
 	if(!connection)	return 0	//~Carn
-
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
 					  filter_type, signal.data["compression"], list(position.z), connection.frequency,verb,speaking)
@@ -721,7 +711,7 @@
 	invisibility = 101
 	listening = 0
 	canhear_range = 0
-	channels=list("Engineering","Security", "Medical", "Command")
+	channels=list("Engineering" = 1, "Security" = 1, "Medical" = 1, "Command" = 1, "Common" = 1, "Science" = 1, "Supply" = 1, "Service" = 1)
 
 /obj/item/device/radio/announcer/Destroy()
 	crash_with("attempt to delete a [src.type] detected, and prevented.")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -371,9 +371,9 @@
 		if(character.mind.assigned_role != "Cyborg")
 			GLOB.data_core.manifest_inject(character)
 			ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
-
-			if(job.announced)
-				AnnounceArrival(character, job.title, spawnpoint.msg)
+			AnnounceArrival(character, job, spawnpoint.msg)
+		else
+			AnnounceCyborg(character, job, spawnpoint.msg)
 		matchmaker.do_matchmaking()
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 	qdel(src)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -56,7 +56,8 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 		return
 
 	if(A.lost_in_space())
-		qdel(A)
+		if(!QDELETED(A))
+			qdel(A)
 		return
 
 	var/nx = 1

--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -103,11 +103,39 @@ datum/announcement/proc/NewsCast(message as text, message_title as text)
 /proc/ion_storm_announcement()
 	command_announcement.Announce("It has come to our attention that the [station_name()] passed through an ion storm.  Please monitor all electronic equipment for malfunctions.", "Anomaly Alert")
 
-/proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank, var/join_message)
-	if (ticker.current_state == GAME_STATE_PLAYING)
-		if(character.mind.role_alt_title)
-			rank = character.mind.role_alt_title
-		AnnounceArrivalSimple(character.real_name, rank, join_message)
+/proc/AnnounceArrival(var/mob/living/carbon/human/character, var/datum/job/job, var/join_message)
+	if(!istype(job) || !job.announced)
+		return
+	if (ticker.current_state != GAME_STATE_PLAYING)
+		return
+	var/rank = job.title
+	if(character.mind.role_alt_title)
+		rank = character.mind.role_alt_title
 
-/proc/AnnounceArrivalSimple(var/name, var/rank = "visitor", var/join_message = "has arrived on the [station_name()]")
-	GLOB.global_announcer.autosay("[name], [rank], [join_message].", "Arrivals Announcement Computer")
+	AnnounceArrivalSimple(character.real_name, rank, join_message, get_announcement_frequency(job))
+
+/proc/AnnounceArrivalSimple(var/name, var/rank = "visitor", var/join_message = "has arrived on the [station_name()]", var/frequency)
+	GLOB.global_announcer.autosay("[name], [rank], [join_message].", "Arrivals Announcement Computer", frequency)
+
+/proc/get_announcement_frequency(var/datum/job/job)
+	// During red alert all jobs are announced on main frequency.
+	if(security_level >= SEC_LEVEL_RED)
+		return "Common"
+
+	if(job.department_flag & (COM | CIV | MSC))
+		return "Common"
+	if(job.department_flag & (SUP | CRG))
+		return "Supply"
+	if(job.department_flag & SPT)
+		return "Command"
+	if(job.department_flag & SEC)
+		return "Security"
+	if(job.department_flag & ENG)
+		return "Engineering"
+	if(job.department_flag & MED)
+		return "Medical"
+	if(job.department_flag & SCI)
+		return "Science"
+	if(job.department_flag & SRV)
+		return "Service"
+	return "Common"

--- a/html/changelogs/atlantiscze-announcements.yml
+++ b/html/changelogs/atlantiscze-announcements.yml
@@ -1,0 +1,7 @@
+author: Atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscadd: "Re-adds on-join announcements to all ranks."
+  - tweak: "Most jobs are announced on relevant departmental frequency (if they have one). During red alert all jobs are announced on main frequency."

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -226,7 +226,6 @@
 						access_mining, access_mining_office, access_mining_station, access_xenobiology,
 						access_xenoarch, access_nanotrasen, access_sec_guard,
 						access_hangar, access_petrov, access_petrov_helm)
-	announced = 1
 
 /datum/job/representative
 	title = "SolGov Representative"
@@ -247,7 +246,6 @@
 			            access_heads, access_cargo, access_solgov_crew, access_hangar)
 	minimal_access = list(access_representative, access_security,access_medical, access_engine,
 			            access_heads, access_cargo, access_solgov_crew, access_hangar)
-	announced = 1
 
 
 /datum/job/sea
@@ -1081,9 +1079,9 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/civ)
 	latejoin_at_spawnpoints = 1
-
 	access = list(access_merchant)
 	minimal_access = list(access_merchant)
+	announced = FALSE
 
 /datum/job/stowaway
 	title = "Stowaway"
@@ -1102,3 +1100,4 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/civ)
 	latejoin_at_spawnpoints = 1
+	announced = FALSE


### PR DESCRIPTION
- Majority of jobs are now announced on respective departmental channel, instead of public channel.
- During red alert, all jobs are announced on main channel regardless of the above. This lets people know when possibly required emergency personnel arrives when situation is seriously screwed up already.
- Vote: https://baystation12.net/forums/threads/vote-restore-on-join-announcements-for-non-command-crew.5091/
- Vote results: 16% for full revert (all jobs announced on main frequency), 60% this (departmental frequencies for most jobs), 24% no change(only few select jobs announced)
- Bonus: Partially/Mostly fixes #18094 - resolves qdel loops caused by overmap edges.