### PR TITLE
Allows AI to track most faceless mobs via radio again

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -422,8 +422,9 @@ var/list/ai_verbs_default = list(
 
 	if (href_list["track"])
 		var/mob/target = locate(href_list["track"]) in GLOB.mob_list
+		var/mob/living/carbon/human/H = target
 
-		if(target && (!istype(target, /mob/living/carbon/human) || html_decode(href_list["trackname"]) == target:get_face_name()))
+		if(!istype(H) || (html_decode(href_list["trackname"]) == H.get_visible_name()) || (html_decode(href_list["trackname"]) == H.get_id_name()))
 			ai_actual_track(target)
 		else
 			to_chat(src, "<span class='warning'>System error. Cannot locate [html_decode(href_list["trackname"])].</span>")

--- a/html/changelogs/atlantiscze-pleaseletmeseeyou.yml
+++ b/html/changelogs/atlantiscze-pleaseletmeseeyou.yml
@@ -1,0 +1,6 @@
+author: Atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "AI can once again track people by clicking their name from radio messages, even when their face is obstructed, assuming they are at least wearing a matching ID."


### PR DESCRIPTION
- Functionally partially reverts #17560
- This has proven to be a MASSIVE annoyance for AI, when everyone is shouting orders to open doors at you, yet you can't track them by clicking the name in chat. You can, however, still track them via the track with camera verb, they are just listed as Unknown (as YOURNAMEHERE). Opening up the verb and picking a target costs you a lot of valuable time, which is annoying when everyone actually expects you to play as an actual AI, multitasking ten things at once.
- This resolves most of the situations where you want to track someone legit (like a security officer or engineer in voidsuit). If you can't track them by face, you will try to track them by worn ID.