### PR TITLE
Makes cigs less heart-racing

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -571,14 +571,15 @@
 	reagent_state = LIQUID
 	color = "#181818"
 	metabolism = REM * 0.002
-	overdose = REAGENTS_OVERDOSE * 0.5
+	overdose = 5
 	scannable = 1
 	data = 0
 
 /datum/reagent/nicotine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.add_chemical_effect(CE_PULSE, 1)
+	if(prob(volume*20))
+		M.add_chemical_effect(CE_PULSE, 1)
 	if(volume <= 0.02 && dose >= 0.05 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY * 0.3)
 		data = world.time
 		to_chat(M, "<span class='warning'>You feel antsy, your concentration wavers...</span>")
@@ -586,6 +587,10 @@
 		if(world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY * 0.3)
 			data = world.time
 			to_chat(M, "<span class='notice'>You feel invigorated and calm.</span>")
+
+/datum/reagent/nicotine/overdose(var/mob/living/carbon/M, var/alien)
+	..()
+	M.add_chemical_effect(CE_PULSE, 2)
 
 /datum/reagent/menthol
 	name = "Menthol"


### PR DESCRIPTION
Now instead of any amount of nicotine increasing pulse, there's a chance based on amount present in bloodstream, 20% at full cig.
Makes overdose increase pulse a lot too.
Lowers overdose from 15 cigs worth to 5.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
