### PR TITLE
Changes when liver's death spiral kicks in

### DIFF
--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -49,18 +49,16 @@
 
 		// Get the effectiveness of the liver.
 		var/filter_effect = 3
-		if(is_bruised())
-			filter_effect -= 1
 		if(is_broken())
-			filter_effect -= 2
+			filter_effect = 0
 		if(owner.reagents.has_reagent("anti_toxin"))
 			filter_effect += 1
 		if(robotic >= ORGAN_ROBOT)
 			filter_effect += 1
 
 		// If you're not filtering well, you're going to take damage. Even more if you have alcohol in you.
-		if(filter_effect < 3)
-			owner.adjustToxLoss(PROCESS_ACCURACY * 0.5 * (3 - filter_effect) * (1 + owner.chem_effects[CE_ALCOHOL_TOXIC] + (owner.chem_effects[CE_ALCOHOL] / 2)))
+		if(is_broken())
+			owner.adjustToxLoss(PROCESS_ACCURACY * 0.5 * (2 - filter_effect) * (1 + owner.chem_effects[CE_ALCOHOL_TOXIC] + (owner.chem_effects[CE_ALCOHOL] / 2)))
 
 		// If you drink alcohol, your liver won't heal.
 		if(owner.chem_effects[CE_ALCOHOL])


### PR DESCRIPTION
Instead of bruised level, it now sets in when it's broken.
Self-perpetuating damage is now a bit lower.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
