### PR TITLE
Explosions make less of a mess with wires

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -227,16 +227,17 @@ var/list/possible_cable_coil_colours
 
 //explosion handling
 /obj/structure/cable/ex_act(severity)
+	var/turf/T = loc
 	switch(severity)
 		if(1.0)
 			qdel(src)
 		if(2.0)
-			if (prob(50))
+			if (prob(50) && T.is_plating())
 				new/obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, color)
 				qdel(src)
 
 		if(3.0)
-			if (prob(25))
+			if (prob(25) && T.is_plating())
 				new/obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, color)
 				qdel(src)
 	return


### PR DESCRIPTION
Now only breaks wires if their turf is exposed.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
