### PR TITLE
Makes non-dense object not count for explosion resistance

### DIFF
--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -26,7 +26,7 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 	//This steap handles the gathering of turfs which will be ex_act() -ed in the next step. It also ensures each turf gets the maximum possible amount of power dealt to it.
 	for(var/direction in GLOB.cardinal)
 		var/turf/T = get_step(epicenter, direction)
-		var/adj_power = power - epicenter.explosion_resistance
+		var/adj_power = power - epicenter.get_explosion_resistance()
 		if(shaped)
 			if (shaped == direction)
 				adj_power *= 3
@@ -44,7 +44,7 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 		if(!T) continue
 
 		//Wow severity looks confusing to calculate... Fret not, I didn't leave you with any additional instructions or help. (just kidding, see the line under the calculation)
-		var/severity = 4 - round(max(min( 3, ((explosion_turfs[T] - T.explosion_resistance) / (max(3,(power/3)))) ) ,1), 1)								//sanity			effective power on tile				divided by either 3 or one third the total explosion power
+		var/severity = 4 - round(max(min( 3, ((explosion_turfs[T] - T.get_explosion_resistance()) / (max(3,(power/3)))) ) ,1), 1)								//sanity			effective power on tile				divided by either 3 or one third the total explosion power
 								//															One third because there are three power levels and I
 								//															want each one to take up a third of the crater
 		var/x = T.x
@@ -81,10 +81,9 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 	if(power > 20)
 		M.color = "#FFCC00"
 */
-	var/spread_power = power - src.explosion_resistance //This is the amount of power that will be spread to the tile in the direction of the blast
+	var/spread_power = power - src.get_explosion_resistance() //This is the amount of power that will be spread to the tile in the direction of the blast
 	for(var/obj/O in src)
-		if(O.explosion_resistance)
-			spread_power -= O.explosion_resistance
+		spread_power -= O.get_explosion_resistance()
 
 	var/turf/T = get_step(src, direction)
 	if(T)
@@ -99,8 +98,10 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 /turf/unsimulated/explosion_spread(power)
 	return //So it doesn't get to the parent proc, which simulates explosions
 
-/obj/var/explosion_resistance
-/turf/var/explosion_resistance
+/atom/var/explosion_resistance
+/atom/proc/get_explosion_resistance()
+	if(simulated && density)
+		return explosion_resistance
 
 /turf/space
 	explosion_resistance = 3

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -264,6 +264,8 @@
 	else
 		explosion_resistance = 0
 
+/obj/effect/shield/get_explosion_resistance()
+	return explosion_resistance
 
 // Shield collision checks below
 


### PR DESCRIPTION
Mostly for open blastdoors to stop stopping tyhings.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
