### PR TITLE
A couple pAI fixes

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -91,11 +91,9 @@
 		radio = card.radio
 		common_radio = radio
 
-	//Default languages without universal translator software
-	add_language("Sol Common", 1)
-	add_language("Tradeband", 1)
-	add_language("Gutter", 1)
-
+	//As a human made device, we'll understand sol common without the need of the translator
+	add_language(LANGUAGE_SOL_COMMON, 1)
+	
 	verbs += /mob/living/silicon/pai/proc/choose_chassis
 	verbs += /mob/living/silicon/pai/proc/choose_verbs
 	verbs -= /mob/living/verb/ghost

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -100,11 +100,6 @@
 	verbs += /mob/living/silicon/pai/proc/choose_verbs
 	verbs -= /mob/living/verb/ghost
 
-	//PDA
-	pda = new(src)
-	spawn(5)
-		pda.set_owner_rank_job(text("[]", src), "Personal Assistant")
-		pda.toff = 1
 	..()
 
 /mob/living/silicon/pai/Login()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -122,6 +122,7 @@ var/global/list/default_pai_software = list()
 		if(S && (ram >= S.ram_cost))
 			ram -= S.ram_cost
 			software[S.id] = S
+			S.on_purchase(src)
 		return 1
 
 	else if(href_list["image"])

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -20,6 +20,9 @@
 
 	proc/is_active(mob/living/silicon/pai/user)
 		return 0
+	
+	proc/on_purchase(mob/living/silicon/pai/user)
+		return
 
 /datum/pai_software/directives
 	name = "Directives"
@@ -140,7 +143,13 @@
 	ram_cost = 5
 	id = "messenger"
 	toggle = 0
-
+	
+	on_purchase(mob/living/silicon/pai/user)
+		if(user && !user.pda)
+			user.pda = new(user)
+			spawn(5)
+				user.pda.set_owner_rank_job(text("[]", user), "Personal Assistant")
+		
 	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
 		var/data[0]
 

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -144,12 +144,6 @@
 	id = "messenger"
 	toggle = 0
 	
-	on_purchase(mob/living/silicon/pai/user)
-		if(user && !user.pda)
-			user.pda = new(user)
-			spawn(5)
-				user.pda.set_owner_rank_job(text("[]", user), "Personal Assistant")
-		
 	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
 		var/data[0]
 
@@ -223,6 +217,11 @@
 					return alert("Failed to send message: the recipient could not be reached.")
 				return 1
 
+/datum/pai_software/messenger/on_purchase(mob/living/silicon/pai/user)
+	if(user && !user.pda)
+		user.pda = new(user)
+		user.pda.set_owner_rank_job(text("[]", user), "Personal Assistant")
+				
 /datum/pai_software/med_records
 	name = "Medical Records"
 	ram_cost = 15

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -33,6 +33,7 @@
 	GLOB.silicon_mob_list |= src
 	..()
 	add_language(LANGUAGE_GALCOM)
+	default_language = all_languages[LANGUAGE_GALCOM]
 	init_id()
 	init_subsystems()
 


### PR DESCRIPTION
Fixes #8962 and Fixes #10041 
pAI's will no longer even have a PDA until they download the messenger program.
Adds a new proc to pAI code that allows the above to be possible.
ALL synthetics now speak galcom as their default language, from AI to pAI unless their default language is redefined elsewhere.
Removed tradeband and gutter from pAI language list.
Added Sol common, as presumably pAI's are a human invention, they'd understand the default human language without need of extra software.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
