### PR TITLE
Fixes Material Duplication Glitch

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -51,6 +51,8 @@
 
 #define isorgan(A) istype(A, /obj/item/organ/external)
 
+#define isstack(A) istype(A, /obj/item/stack)
+
 #define isspace(A) istype(A, /area/space)
 
 #define ispAI(A) istype(A, /mob/living/silicon/pai)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -134,17 +134,13 @@
 		O.set_dir(user.dir)
 		O.add_fingerprint(user)
 
+		if (recipe.goes_in_hands)
+			user.put_in_hands(O)
+
 		if (istype(O, /obj/item/stack))
 			var/obj/item/stack/S = O
 			S.amount = produced
-			S.add_to_stacks(user)
-
-		if (recipe.goes_in_hands)
-			user.put_in_hands(O)
-			if (istype(O, /obj/item/stack))
-				var/obj/item/stack/S = O
-				S.amount = produced
-				S.add_to_stacks(user)
+			S.add_to_stacks(user, recipe.goes_in_hands)
 
 /obj/item/stack/Topic(href, href_list)
 	..()
@@ -288,8 +284,16 @@
 		return
 	return max_amount
 
-/obj/item/stack/proc/add_to_stacks(mob/user as mob)
+/obj/item/stack/proc/add_to_stacks(mob/user, check_hands)
+	var/list/stacks = list()
+	if(check_hands)
+		if(isstack(user.l_hand))
+			stacks += user.l_hand
+		if(isstack(user.r_hand))
+			stacks += user.r_hand
 	for (var/obj/item/stack/item in user.loc)
+		stacks += item
+	for (var/obj/item/stack/item in stacks)
 		if (item==src)
 			continue
 		var/transfer = src.transfer_to(item)


### PR DESCRIPTION
This will also fix the occurence of empty stacks. Stacks will now first attempt to stack into the user's hands on creation by recipe before checking for existing stacks on the floor.

Couldn't find any open Issues refering to this.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
