### PR TITLE
Nerfs lung damage

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -43,8 +43,10 @@
 		return 100
 	else if(is_broken())
 		result = max(oxygen_deprivation, round(species.total_health * 0.5))
-	else if(is_damaged())
+	else if(is_bruised())
 		result = max(oxygen_deprivation, round(species.total_health * 0.25))
+	else if(is_damaged())
+		result = max(oxygen_deprivation, round(species.total_health * 0.05))
 	return round((result/species.total_health)*100)
 
 /obj/item/organ/internal/lungs/robotize()


### PR DESCRIPTION
At some point it was changed so ANY sort of damage makes lung give you 25% of max health in oxygen loss. This was confusing as  lung wasn't considered 'ruptured' by all the checks.
I bumped it back to ruptured lung, and instead made it give you a small amount of oxyloss just to indicate that something's off.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
