### PR TITLE
Adjusts when explosions affect below-floor objects.

### DIFF
--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -42,7 +42,7 @@
 		var/area/A = control_area
 		if(A && istype(A))
 			A.turret_controls -= src
-	..()
+	. = ..()
 
 /obj/machinery/turretid/Initialize()
 	if(!control_area)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -73,13 +73,13 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 				else if(dist < light_impact_range)	dist = 3
 				else								continue
 
+				T.ex_act(dist)
 				if(!T)
 					T = locate(x0,y0,z0)
 				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 					var/atom/movable/AM = atom_movable
-					if(AM && AM.simulated)	AM.ex_act(dist)
-
-				T.ex_act(dist)
+					if(AM && AM.simulated && !T.protects_atom(AM))
+						AM.ex_act(dist)
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -53,9 +53,11 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 		T.ex_act(severity)
 		if(!T)
 			T = locate(x,y,z)
+
 		for(var/atom_movable in T.contents)
 			var/atom/movable/AM = atom_movable
-			if(AM && AM.simulated)	AM.ex_act(severity)
+			if(AM && AM.simulated && !T.protects_atom(AM))
+				AM.ex_act(severity)
 
 	explosion_turfs.Cut()
 	explosion_in_progress = 0

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -25,6 +25,9 @@
 
 /turf/simulated/floor/is_plating()
 	return !flooring
+	
+/turf/simulated/floor/protects_atom(var/atom/A)
+	return (A.level <= 1 && !is_plating()) || ..()
 
 /turf/simulated/floor/New(var/newloc, var/floortype)
 	..(newloc)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -21,11 +21,6 @@
 	var/hitsound = 'sound/weapons/Genhit.ogg'
 	var/list/wall_connections = list("0", "0", "0", "0")
 
-// Walls always hide the stuff below them.
-/turf/simulated/wall/levelupdate()
-	for(var/obj/O in src)
-		O.hide(1)
-
 /turf/simulated/wall/New(var/newloc, var/materialtype, var/rmaterialtype)
 	..(newloc)
 	icon_state = "blank"
@@ -41,7 +36,16 @@
 /turf/simulated/wall/Destroy()
 	processing_turfs -= src
 	dismantle_wall(null,null,1)
-	..()
+	. = ..()
+
+// Walls always hide the stuff below them.
+/turf/simulated/wall/levelupdate()
+	for(var/obj/O in src)
+		O.hide(1)
+
+/turf/simulated/wall/protects_atom(var/atom/A)
+	var/obj/O = A
+	return (istype(O) && O.hides_under_flooring()) || ..()
 
 /turf/simulated/wall/process()
 	// Calling parent will kill processing

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -41,9 +41,6 @@
 	else
 		luminosity = 1
 
-/turf/proc/initialize()
-	return
-
 /turf/Destroy()
 	turfs -= src
 	remove_cleanables()
@@ -161,6 +158,9 @@ var/const/enterloopsanity = 100
 
 /turf/proc/is_plating()
 	return 0
+
+/turf/proc/protects_atom(var/atom/A)
+	return FALSE
 
 /turf/proc/inertial_drift(atom/movable/A)
 	if(!(A.last_move))	return

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -24,7 +24,7 @@
 
 /obj/machinery/atmospherics/valve/shutoff/Destroy()
 	GLOB.processing_objects -= src
-	..()
+	. = ..()
 
 /obj/machinery/atmospherics/valve/shutoff/attack_hand(mob/user as mob)
 	..()

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -38,7 +38,7 @@
 
 		node = null
 
-		..()
+		. = ..()
 
 	atmos_init()
 		..()

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -82,7 +82,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/Destroy()
 	unregister_radio(src, frequency)
-	..()
+	. = ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume
 	name = "Large Air Vent"

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -717,14 +717,18 @@
 /obj/machinery/atmospherics/pipe/manifold4w/Destroy()
 	if(node1)
 		node1.disconnect(src)
+		node1 = null
 	if(node2)
 		node2.disconnect(src)
+		node2 = null
 	if(node3)
 		node3.disconnect(src)
+		node3 = null
 	if(node4)
 		node4.disconnect(src)
+		node4 = null
 
-	..()
+	. = ..()
 
 /obj/machinery/atmospherics/pipe/manifold4w/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -227,20 +227,18 @@ var/list/possible_cable_coil_colours
 
 //explosion handling
 /obj/structure/cable/ex_act(severity)
-	var/turf/T = loc
 	switch(severity)
 		if(1.0)
 			qdel(src)
 		if(2.0)
-			if (prob(50) && T.is_plating())
+			if (prob(50))
 				new/obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, color)
 				qdel(src)
 
 		if(3.0)
-			if (prob(25) && T.is_plating())
+			if (prob(25))
 				new/obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, color)
 				qdel(src)
-	return
 
 obj/structure/cable/proc/cableColor(var/colorC)
 	var/color_n = "#DD0000"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -210,13 +210,11 @@ var/global/list/light_type_cache = list()
 
 /obj/machinery/light/Destroy()
 	var/area/A = get_area(src)
-	if(s)
-		qdel(s)
-		s = null
+	QDEL_NULL(s)
 	if(A)
 		on = 0
 //		A.update_lights()
-	..()
+	. = ..()
 
 /obj/machinery/light/update_icon()
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -692,13 +692,12 @@
 					AM.forceMove(T)
 					AM.pipe_eject(0)
 				qdel(H)
-				..()
-				return
+				return ..()
 
 			// otherwise, do normal expel from turf
 			if(H)
 				expel(H, T, 0)
-		..()
+		. = ..()
 
 	// returns the direction of the next pipe object, given the entrance dir
 	// by default, returns the bitmask of remaining directions
@@ -955,13 +954,12 @@
 				AM.forceMove(T)
 				AM.pipe_eject(0)
 			qdel(H)
-			..()
-			return
+			return ..()
 
 		// otherwise, do normal expel from turf
 		if(H)
 			expel(H, T, 0)
-	..()
+	. = ..()
 
 /obj/structure/disposalpipe/hides_under_flooring()
 	return 1


### PR DESCRIPTION
Explosions now only affect atoms on a turf if the turf is considered to be plating or the atom is on level 2 (i.e. not hidden below floor tiles).

Also fixes a few types which don't `qdel()` correctly when blown up.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
