### PR TITLE
Adds advanced mode to air analyzers

### DIFF
--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -31,7 +31,8 @@
 			else
 				. += "<span class='warning'>Pressure: [round(pressure,0.1)] kPa</span>"
 			for(var/mix in mixture.gas)
-				. += "<span class='notice'>[gas_data.name[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]%</span>"
+				var/percentage = round(mixture.gas[mix]/total_moles * 100, advanced ? 0.01 : 1)
+				. += "<span class='notice'>[gas_data.name[mix]]: [percentage]%</span>"
 				if(advanced)
 					var/list/traits = list()
 					if(gas_data.flags[mix] & XGM_GAS_FUEL)

--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -1,4 +1,4 @@
-/obj/proc/analyze_gases(var/obj/A, var/mob/user)
+/obj/proc/analyze_gases(var/obj/A, var/mob/user, advanced)
 	user.visible_message("<span class='notice'>\The [user] has used \an [src] on \the [A].</span>")
 	A.add_fingerprint(user)
 
@@ -7,7 +7,7 @@
 		to_chat(user, "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>")
 		return 0
 
-	var/list/result = atmosanalyzer_scan(A, air_contents)
+	var/list/result = atmosanalyzer_scan(A, air_contents, advanced)
 	print_atmos_analysis(user, result)
 	return 1
 
@@ -15,7 +15,7 @@
 	for(var/line in result)
 		to_chat(user, "<span class='notice'>[line]</span>")
 
-/proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture)
+/proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture, advanced)
 	. = list()
 	. += "<span class='notice'>Results of the analysis of \the [target]:</span>"
 	if(!mixture)
@@ -32,6 +32,17 @@
 				. += "<span class='warning'>Pressure: [round(pressure,0.1)] kPa</span>"
 			for(var/mix in mixture.gas)
 				. += "<span class='notice'>[gas_data.name[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]%</span>"
+				if(advanced)
+					var/list/traits = list()
+					if(gas_data.flags[mix] & XGM_GAS_FUEL)
+						traits += "can be used as combustion fuel" 
+					if(gas_data.flags[mix] & XGM_GAS_OXIDIZER)
+						traits += "can be used as oxidizer" 
+					if(gas_data.flags[mix] & XGM_GAS_CONTAMINANT)
+						traits += "contaminates clothing with toxic residue" 
+					if(gas_data.flags[mix] & XGM_GAS_FUSION_FUEL)
+						traits += "can be used to fuel fusion reaction" 
+					. += "\t<span class='notice'>Specific heat: [gas_data.specific_heat[mix]] J/(mol*K), Molar mass: [gas_data.molar_mass[mix]] kg/mol.[traits.len ? "\n\tThis gas [english_list(traits)]" : ""]</span>"
 			. += "<span class='notice'>Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K</span>"
 			return
 	. += "<span class='warning'>\The [target] has no gases!</span>"

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -130,9 +130,7 @@
 				to_chat(user, "<span class='notice'>Nothing happens.</span>")
 				return
 
-	else if ((istype(W, /obj/item/device/analyzer)) && Adjacent(user))
-		var/obj/item/device/analyzer/A = W
-		A.analyze_gases(src, user)
+	else if (istype(W, /obj/item/device/analyzer))
 		return
 
 	return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -310,6 +310,16 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 	analyze_gases(user.loc, user,advanced_mode)
 	return 1
 
+/obj/item/device/analyzer/afterattack(obj/O, mob/user, proximity)
+	if(!proximity)
+		return
+	if (user.incapacitated())
+		return
+	if (!user.IsAdvancedToolUser())
+		return
+	if(istype(O) && O.simulated)
+		analyze_gases(O, user, advanced_mode)
+
 /obj/item/device/mass_spectrometer
 	name = "mass spectrometer"
 	desc = "A hand-held mass spectrometer which identifies trace chemicals in a blood sample."

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -289,6 +289,16 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
+	var/advanced_mode = 0
+
+/obj/item/device/analyzer/verb/verbosity(mob/user as mob)
+	set name = "Toggle Advanced Gas Analysis"
+	set category = "Object"
+	set src in usr
+
+	if (!user.incapacitated())
+		advanced_mode = !advanced_mode
+		to_chat(usr, "You toggle advanced gas analysis [advanced_mode ? "on" : "off"].")
 
 /obj/item/device/analyzer/attack_self(mob/user as mob)
 
@@ -297,8 +307,8 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 	if (!user.IsAdvancedToolUser())
 		return
 
-	analyze_gases(user.loc, user)
-	return
+	analyze_gases(user.loc, user,advanced_mode)
+	return 1
 
 /obj/item/device/mass_spectrometer
 	name = "mass spectrometer"

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -39,14 +39,14 @@ var/list/global/tank_gauge_cache = list()
 	description_info = "These tanks are utilised to store any of the various types of gaseous substances. \
 	They can be attached to various portable atmospheric devices to be filled or emptied. <br>\
 	<br>\
-	Each tank is fitted with an emergency relief valve. This relief valve will open if the tank is pressurised to over ~3000kPa or heated to over 173ºC. \
+	Each tank is fitted with an emergency relief valve. This relief valve will open if the tank is pressurised to over ~3000kPa or heated to over 173ï¿½C. \
 	The valve itself will close after expending most or all of the contents into the air.<br>\
 	<br>\
 	Filling a tank such that experiences ~4000kPa of pressure will cause the tank to rupture, spilling out its contents and destroying the tank. \
 	Tanks filled over ~5000kPa will rupture rather violently, exploding with significant force."
 
-	description_antag = "Each tank may be incited to burn by attaching wires and an igniter assembly, though the igniter can only be used once and the mixture only burn if the igniter pushes a flammable gas mixture above the minimum burn temperature (126ºC). \
-	Wired and assembled tanks may be disarmed with a set of wirecutters. Any exploding or rupturing tank will generate shrapnel, assuming their relief valves have been welded beforehand. Even if not, they can be incited to expel hot gas on ignition if pushed above 173ºC. \
+	description_antag = "Each tank may be incited to burn by attaching wires and an igniter assembly, though the igniter can only be used once and the mixture only burn if the igniter pushes a flammable gas mixture above the minimum burn temperature (126ï¿½C). \
+	Wired and assembled tanks may be disarmed with a set of wirecutters. Any exploding or rupturing tank will generate shrapnel, assuming their relief valves have been welded beforehand. Even if not, they can be incited to expel hot gas on ignition if pushed above 173ï¿½C. \
 	Relatively easy to make, the single tank bomb requries no tank transfer valve, and is still a fairly formidable weapon that can be manufactured from any tank."
 
 /obj/item/weapon/tank/proc/init_proxy()
@@ -112,9 +112,8 @@ var/list/global/tank_gauge_cache = list()
 	if (istype(src.loc, /obj/item/assembly))
 		icon = src.loc
 
-	if ((istype(W, /obj/item/device/analyzer)) && get_dist(user, src) <= 1)
-		var/obj/item/device/analyzer/A = W
-		A.analyze_gases(src, user)
+	if (istype(W, /obj/item/device/analyzer))
+		return
 	else if (istype(W,/obj/item/latexballon))
 		var/obj/item/latexballon/LB = W
 		LB.blow(src)

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -57,6 +57,8 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/attackby(atom/A, mob/user as mob)
 	if(istype(A, /obj/item/device/pipe_painter))
 		return
+	if(istype(A, /obj/item/device/analyzer))
+		return
 	..()
 
 /obj/machinery/atmospherics/proc/add_underlay(var/turf/T, var/obj/machinery/atmospherics/node, var/direction, var/icon_connect_type)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -1144,9 +1144,8 @@
 	if(istype(W, /obj/item/device/pipe_painter))
 		return
 
-	if(istype(W, /obj/item/device/analyzer) && in_range(user, src))
-		var/obj/item/device/analyzer/A = W
-		A.analyze_gases(src, user)
+	if(istype(W, /obj/item/device/analyzer))
+		return
 
 /obj/machinery/atmospherics/pipe/tank/air
 	name = "Pressure Tank (Air)"

--- a/html/changelogs/chinsky - air.yml
+++ b/html/changelogs/chinsky - air.yml
@@ -1,0 +1,5 @@
+
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Air analysers now have verb to be toggled into advanced mode. It displays gas properties like specific heat and molar mass."

--- a/html/changelogs/chinsky - air.yml
+++ b/html/changelogs/chinsky - air.yml
@@ -3,3 +3,4 @@ author: Chinsky
 delete-after: True
 changes: 
   - rscadd: "Air analysers now have verb to be toggled into advanced mode. It displays gas properties like specific heat and molar mass."
+  - rscadd: "Air analysers can also now be used on pipes and various atmos machinery to inspect the contents."


### PR DESCRIPTION
Using a verb you can toggle air analyzer into advanced mode, where it prints out things like moral mass and specific heat and some traits of every gas it scans.
Both needed for FUTURE stuff and air analysers were basically unused so gives them some purpose in life.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
