### PR TITLE
A small change to IV drips and the Body Scanner console.

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -181,7 +181,7 @@
 	name = "Body Scanner Console"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scannerconsole"
-	density = 1
+	density = 0
 	anchored = 1
 
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -2,7 +2,7 @@
 	name = "\improper IV drip"
 	icon = 'icons/obj/iv_drip.dmi'
 	anchored = 0
-	density = 1
+	density = 0
 
 
 /obj/machinery/iv_drip/var/mob/living/carbon/human/attached = null

--- a/html/changelogs/AtomicWorm-medical-QoL.yml
+++ b/html/changelogs/AtomicWorm-medical-QoL.yml
@@ -1,0 +1,6 @@
+author: Broseph Stylin
+
+delete-after: True
+
+changes: 
+  - tweak: The Body Scanner console and IV drips are no longer dense and can now be walked through.


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Changes both to not be dense anymore, meaning they can be walked through.

The Body Scanner console's sprite barely occupies more than half of a 32x32 tile, and an IV drip is a rather thin object, easily carried around and held up in the same place you're standing on IRL.

This should make movement around the infirmary a little bit easier, I guess.