### PR TITLE
Critical diona nymph buffs.

### DIFF
--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -147,7 +147,7 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 	return FALSE
 
 /mob/living/carbon/get_full_print()
-	if (mFingerprints in mutations)
+	if (!dna || (mFingerprints in mutations))
 		return FALSE
 	return md5(dna.uni_identity)
 

--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -19,10 +19,29 @@
 
 	holder_type = /obj/item/weapon/holder/diona
 	possession_candidate = 1
-	var/obj/item/hat
 
+	var/obj/item/hat
+	var/obj/item/holding_item
 	var/mob/living/carbon/alien/diona/next_nymph
 	var/mob/living/carbon/alien/diona/last_nymph
+
+/mob/living/carbon/alien/diona/examine(mob/user)
+	. = ..()
+	if(holding_item)
+		to_chat(user, "<span class='notice'>It is holding \icon[holding_item] \a [holding_item].</span>")
+	if(hat)
+		to_chat(user, "<span class='notice'>It is wearing \icon[hat] \a [hat].</span>")
+
+/mob/living/carbon/alien/diona/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
+	. = ..()
+	if(W == hat)
+		hat = null
+		update_icons()
+	else if(W == holding_item)
+		holding_item = null
+
+/mob/living/carbon/alien/diona/IsAdvancedToolUser()
+	return FALSE
 
 /mob/living/carbon/alien/diona/New()
 
@@ -32,16 +51,20 @@
 	add_language(LANGUAGE_GALCOM)
 	verbs += /mob/living/carbon/alien/diona/proc/merge
 
-/mob/living/carbon/alien/diona/put_in_hands(var/obj/item/W) // No hands.
-	W.forceMove(get_turf(src))
+/mob/living/carbon/alien/diona/put_in_hands(var/obj/item/W) // No hands. Use mouth.
+	if(can_collect(W))
+		collect(W)
+	else
+		W.forceMove(get_turf(src))
 	return 1
 
-/mob/living/carbon/alien/diona/proc/wear_hat(var/obj/item/new_hat)
-	if(hat)
-		return
+/mob/living/carbon/alien/diona/proc/wear_hat(var/obj/item/clothing/head/new_hat)
+	if(hat || !istype(new_hat))
+		return FALSE
 	hat = new_hat
-	new_hat.loc = src
+	new_hat.forceMove(src)
 	update_icons()
+	return TRUE
 
 /mob/living/carbon/alien/diona/proc/handle_npc(var/mob/living/carbon/alien/diona/D)
 	if(D.stat != CONSCIOUS)
@@ -50,3 +73,51 @@
 		step(D, pick(GLOB.cardinal))
 	if(prob(1))
 		D.emote(pick("scratch","jump","chirp","tail"))
+
+/mob/living/carbon/alien/diona/hotkey_drop()
+	if(holding_item || hat)
+		drop_item()
+	else
+		to_chat(usr, "<span class='warning'>You have nothing to drop.</span>")
+
+/mob/living/carbon/alien/diona/UnarmedAttack(atom/A)
+	if(wear_hat(A))
+		return 1
+	if(!can_collect(A))
+		return ..()
+	collect(A)
+	return 1
+
+/mob/living/carbon/alien/diona/proc/can_collect(var/obj/item/collecting)
+	return (!holding_item && istype(collecting) && !collecting.anchored && collecting.simulated && collecting.w_class <= ITEM_SIZE_SMALL)
+
+/mob/living/carbon/alien/diona/proc/collect(var/obj/item/collecting)
+	collecting.forceMove(src)
+	holding_item = collecting
+	visible_message("<span class='notice'>\The [src] engulfs \the [holding_item].</span>")
+
+	// This means dionaea can hoover up beakers as a kind of impromptu chem disposal
+	// technique, so long as they're okay with the reagents reacting inside them.
+	if(holding_item.reagents && holding_item.reagents.total_volume)
+		holding_item.reagents.trans_to_mob(src, holding_item.reagents.total_volume, CHEM_INGEST)
+
+	// It also means they can do the old school cartoon schtick of eating and entire sandwich
+	// and spitting up an empty plate. Ptooie.
+	if(istype(holding_item, /obj/item/weapon/reagent_containers/food))
+		var/obj/item/weapon/reagent_containers/food/food = holding_item
+		holding_item = null
+		if(food.trash) holding_item = new food.trash(src)
+		qdel(food)
+
+/mob/living/carbon/alien/diona/drop_item()
+	if(holding_item)
+		visible_message("<span class='notice'>\The [src] regurgitates \the [holding_item].</span>")
+		holding_item.forceMove(get_turf(src))
+		holding_item = null
+	else if(hat)
+		visible_message("<span class='notice'>\The [src] wriggles out from under \the [hat].</span>")
+		hat.forceMove(get_turf(src))
+		hat = null
+		update_icons()
+	else
+		. = ..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -58,15 +58,16 @@
 				to_chat(usr, "<span class='warning'>This mob type cannot throw items.</span>")
 			return
 		if(NORTHWEST)
-			if(iscarbon(usr))
-				var/mob/living/carbon/C = usr
-				if(!C.get_active_hand())
-					to_chat(usr, "<span class='warning'>You have nothing to drop in your hand.</span>")
-					return
-				drop_item()
-			else
-				to_chat(usr, "<span class='warning'>This mob type cannot drop items.</span>")
-			return
+			mob.hotkey_drop()
+
+/mob/proc/hotkey_drop()
+	to_chat(usr, "<span class='warning'>This mob type cannot drop items.</span>")
+
+/mob/living/carbon/hotkey_drop()
+	if(!get_active_hand())
+		to_chat(usr, "<span class='warning'>You have nothing to drop in your hand.</span>")
+	else
+		drop_item()
 
 //This gets called when you press the delete button.
 /client/verb/delete_key_pressed()

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -8,7 +8,6 @@
 	min_broken_damage = 35
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
-	vital = 1
 	parent_organ = BP_CHEST
 	joint = "jaw"
 	amputation_point = "neck"

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -7,5 +7,4 @@
 	possible_transfer_amounts = null
 	volume = 50 //Sets the default container amount for all food items.
 	var/filling_color = "#FFFFFF" //Used by sandwiches.
-
-
+	var/trash = null

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -6,7 +6,6 @@
 	icon_state = null
 	var/bitesize = 1
 	var/bitecount = 0
-	var/trash = null
 	var/slice_path
 	var/slices_num
 	var/dried_type = null

--- a/html/changelogs/zuhayr-chirp.yml
+++ b/html/changelogs/zuhayr-chirp.yml
@@ -1,0 +1,5 @@
+author: Zuhayr
+delete-after: True
+changes: 
+  - rscadd: "Diona nymphs can now pick up and carry a small item. Use the drop_item command or the Home key to drop it. This can also be used to remove your hat."
+  - rscadd: "Losing your head is no longer necessarily lethal, unless you're the kind of fat nasty trash who has a brain or other vital head organ."


### PR DESCRIPTION
````
The diona nymph (951) engulfs Sandwich.
You can taste a hint of bread, a hint of cheese and some sort of protein
The diona nymph (951) regurgitates the plate.
````

![image](https://user-images.githubusercontent.com/2468979/29497043-9b56b178-861f-11e7-98a7-01b1ea2f272d.png)

- Diona nymphs can hold a single small or tiny item.
- They can use the drop_item command or hotkey (Home) to remove their hat/drop item.
- Held item and worn hat will show up in diona examined descs now.
- Heads are no longer vital organs by themselves. This won't mean much practically since anything that would reasonably be expected to die from beheading will still die from having their brain removed along with their head. It does allow IPC to wander around blind and headless, which is a net positive.