### PR TITLE
Makes Torch start on top of asteroid sector

### DIFF
--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -3,6 +3,8 @@
 	fore_dir = WEST
 	vessel_mass = 800
 	default_delay = 12 SECONDS
+	start_x = 4
+	start_y = 5
 
 	restricted_waypoints = list(
 		"Calypso" = list("nav_hangar_calypso"), 	//can't have random shuttles popping inside the ship
@@ -52,6 +54,8 @@
 		"nav_cluster_6",
 		"nav_cluster_7"
 	)
+	start_x = 4
+	start_y = 5
 
 /obj/effect/shuttle_landmark/cluster/guppy
 	name = "Asteroid Navpoint #1"


### PR DESCRIPTION
Cause apparently you babies are too weak to travel to one before your 300% shields are up.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
