### PR TITLE
Hides people's first names

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -47,7 +47,7 @@
 
 	if(istype(speaker, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = speaker
-		speaker_name = H.GetVoice()
+		speaker_name = H.rank_prefix_name(H.GetVoice())
 
 	if(italics)
 		message = "<i>[message]</i>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -291,6 +291,14 @@
 		else
 			return if_no_id
 
+/mob/living/carbon/human/proc/rank_prefix_name(name)
+	var/obj/item/weapon/card/id/id = get_idcard()
+	if(id && id.military_rank && id.military_rank.name_short) //only milnerds for now
+		if(findtext(name, " "))
+			name = copytext(name, findtext(name, " ")+1)
+		name = "[id.military_rank.name_short] [name]"
+	return name
+
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
 /mob/living/carbon/human/proc/get_visible_name()
 	var/face_name = get_face_name()

--- a/html/changelogs/chinsky - who.yml
+++ b/html/changelogs/chinsky - who.yml
@@ -1,0 +1,5 @@
+  
+author: Chinsky
+delete-after: True
+changes: 
+  - experiment: "When you speak now, your first name is replaced by your rank in messages. Only affects those with military rank and wearing ID with it."

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -631,7 +631,6 @@
 
 /datum/mil_rank/civ/offduty
 	name = "Off-Duty Personnel"
-	name_short = "Off-Duty"
 
 /datum/mil_rank/civ/synthetic
 	name = "Synthetic"


### PR DESCRIPTION
How it does:
When you speak, the name in resulting message is changed depending on your ID.
If you have miltary rank on ID, it replaces your first name with it.
Otherwise it replaces your first name with job.
If there's no ID, you show up as just plain named joe.

Idea stolen from Eris.
I just think it's kinda cool, and makes first name basis somewhat bit more meaningful since you can't learn their first name from just hearing them on radio.
Only displayed name when spoken is modified, visible etc is still same. AIs get non-modified name cause they got all the special handling, so tracking is unaffected.

Here's example of it working for military rank, no rank, no ID


![](http://i.imgur.com/ArKSaed.png)


It's pretty damn conentious so feel free to spread this shit
https://strawpoll.com/wkzze14y
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
