### PR TITLE
Restricts Merchants from Most Antags

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -4,7 +4,7 @@
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg)
-	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/hos) 
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/hos)
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -10,6 +10,7 @@
 	#include "torch_shuttles.dm"
 	#include "torch_unit_testing.dm"
 	#include "torch_gamemodes.dm"
+	#include "torch_antagonism.dm"
 
 	#include "datums/uniforms.dm"
 	#include "datums/uniforms_expedition.dm"

--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -1,0 +1,18 @@
+//Makes sure we don't get any merchant antags as a balance concern. Can also be used for future Torch specific antag restrictions.
+/datum/antagonist/changeling
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
+
+/datum/antagonist/godcultist
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/merchant)
+
+/datum/antagonist/cultist
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/merchant)
+
+/datum/antagonist/loyalists
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
+
+/datum/antagonist/revolutionary
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
+
+/datum/antagonist/traitor
+	blacklisted_jobs = list(/datum/job/merchant)


### PR DESCRIPTION
Merchant antags are a serious balance issue. With the ability to buy adminspawn only mechs in exchange for a dead human, and an unreachable base they can hide in. This restricts them from most on-station antag roles.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
