### PR TITLE
Possible fix for Travis fails

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -7,6 +7,8 @@
 	in_space = 0
 	var/maxx
 	var/maxy
+	var/landmark_type = /obj/effect/shuttle_landmark/automatic
+
 
 /obj/effect/overmap/sector/exoplanet/New()
 	if(!GLOB.using_map.use_overmap)
@@ -74,7 +76,7 @@
 /obj/effect/overmap/sector/exoplanet/proc/generate_landing()
 	var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])
 	if(T)
-		var/obj/effect/shuttle_landmark/automatic/A = new(T)
+		var/obj/effect/shuttle_landmark/automatic/A = new landmark_type(T)
 		A.base_area = T.loc
 	return T
 

--- a/code/modules/overmap/exoplanets/mountain.dm
+++ b/code/modules/overmap/exoplanets/mountain.dm
@@ -1,6 +1,7 @@
 /obj/effect/overmap/sector/exoplanet/rocks
 	name = "rocky exoplanet"
 	desc = "A planet with rocky formations on the surface, exposing minerals. Rest of terrain varies."
+	landmark_type = /obj/effect/shuttle_landmark/automatic/clearing
 
 /obj/effect/overmap/sector/exoplanet/rocks/generate_map()
 	if(prob(50))
@@ -18,11 +19,6 @@
 				if(istype(T,/turf/simulated/mineral))
 					var/turf/simulated/mineral/MT = T
 					MT.mined_turf = A.base_turf
-
-/obj/effect/overmap/sector/exoplanet/rocks/generate_landing()
-	. = ..()
-	if(.)
-		explosion(., 10, adminlog = 0)
 
 /datum/random_map/automata/cave_system/mountains
 	iterations = 2

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -76,6 +76,20 @@
 	else
 		O.generic_waypoints  += src
 
+//Subtype that calls explosion on init to clear space for shuttles
+/obj/effect/shuttle_landmark/automatic/clearing
+	var/radius = 10
+
+/obj/effect/shuttle_landmark/automatic/clearing/Initialize()
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/shuttle_landmark/automatic/clearing/LateInitialize()
+	var/list/victims = circlerangeturfs(get_turf(src),radius)
+	for(var/turf/T in victims)
+		if(T.density)
+			T.ChangeTurf(get_base_turf_by_area(T))
+
 /obj/item/device/spaceflare
 	name = "bluespace flare"
 	desc = "Burst transmitter used to broadcast all needed information for shuttle navigation systems. Has a flare attached for marking the spot where you probably shouldn't be standing."


### PR DESCRIPTION
My wild guess is that init tests fail because of landmark generation explosion.
Now it explodes on init instead of during New phase.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
