### PR TITLE
Adds planet atmos stabilizing

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -34,6 +34,29 @@
 		generate_map()
 		generate_landing()
 		update_biome()
+		GLOB.processing_objects += src
+
+//Not that it should ever get deleted but just in case
+/obj/effect/overmap/sector/exoplanet/Destroy()
+		. = ..()
+		GLOB.processing_objects -= src
+
+/obj/effect/overmap/sector/exoplanet/process()
+	if(!atmosphere)
+		return
+	for(var/zlevel in map_z)
+		var/zone/Z
+		for(var/i = 1 to world.maxx)
+			var/turf/simulated/T = locate(i, 1, zlevel)
+			if(istype(T) && T.zone && T.zone.contents.len > (world.maxx*world.maxy*0.25)) //if it's a zone quarter of zlevel, good enough odds it's planetary main one
+				Z = T.zone
+				break
+		if(!Z.fire_tiles.len && !atmosphere.compare(Z.air)) //let fire die out first if there is one
+			var/datum/gas_mixture/daddy = new() //make a fake 'planet' zone gas
+			daddy.copy_from(atmosphere)
+			daddy.group_multiplier = Z.air.group_multiplier
+			Z.air.equalize(daddy)
+				
 
 /obj/effect/overmap/sector/exoplanet/proc/generate_map()
 


### PR DESCRIPTION
Now planet atmos will recover fairly well from tampering.
It will not try to fight fires though to prevent truly infinite ones, will wait till they die out.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
