### PR TITLE
Per gas combustion product defines

### DIFF
--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -304,8 +304,9 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 		//remove_by_flag() and adjust_gas() handle the group_multiplier for us.
 		remove_by_flag(XGM_GAS_OXIDIZER, used_oxidizers)
-		remove_by_flag(XGM_GAS_FUEL, used_gas_fuel)
-		adjust_gas("carbon_dioxide", used_oxidizers)
+		var/datum/gas_mixture/burned_fuel = remove_by_flag(XGM_GAS_FUEL, used_gas_fuel)
+		for(var/g in burned_fuel.gas)
+			adjust_gas(gas_data.burn_product[g], burned_fuel.gas[g])
 
 		if(zone)
 			zone.remove_liquidfuel(used_liquid_fuel, !check_combustability())

--- a/code/modules/xgm/gases.dm
+++ b/code/modules/xgm/gases.dm
@@ -80,6 +80,8 @@
 
 	flags = XGM_GAS_FUEL|XGM_GAS_FUSION_FUEL
 
+	burn_product = "watervapor"
+
 /decl/xgm_gas/helium
 	id = "helium"
 	name = "Helium"
@@ -140,3 +142,10 @@
 	specific_heat = 5	// J/(mol*K)
 	molar_mass = 0.017	// kg/mol
 	flags = XGM_GAS_CONTAMINANT
+
+/decl/xgm_gas/vapor
+	id = "watervapor"
+	name = "Water Vapor"
+
+	specific_heat = 30	// J/(mol*K)
+	molar_mass = 0.020	// kg/mol

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -15,6 +15,8 @@
 	var/list/overlay_limit = list()
 	//Flags.
 	var/list/flags = list()
+	//Products created when burned. For fuel only for now (not oxidizers)
+	var/list/burn_product = list()
 
 /decl/xgm_gas
 	var/id = ""
@@ -26,6 +28,7 @@
 	var/overlay_limit = null
 
 	var/flags = 0
+	var/burn_product = "carbon_dioxide"
 
 /hook/startup/proc/generateGasData()
 	gas_data = new
@@ -42,5 +45,6 @@
 		if(gas.tile_overlay) gas_data.tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
 		if(gas.overlay_limit) gas_data.overlay_limit[gas.id] = gas.overlay_limit
 		gas_data.flags[gas.id] = gas.flags
+		gas_data.burn_product[gas.id] = gas.burn_product
 
 	return 1


### PR DESCRIPTION
Currently only hydrogen and alium gas have  it different from CO2 (water vapor and random).

Also now amount of product spawned is decided by amount of fuel used rather than oxidizers. Overall it should make more product gas (1.5 with current defines for oxi/fuel usage in fire).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
