### PR TITLE
[WIP] Splits service department

### DIFF
--- a/code/_global_vars/radio.dm
+++ b/code/_global_vars/radio.dm
@@ -14,7 +14,8 @@ GLOBAL_LIST_INIT(default_internal_channels, list(
 	num2text(SEC_I_FREQ)=list(access_security),
 	num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
 	num2text(SUP_FREQ) = list(access_cargo),
-	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics)
+	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
+	num2text(UTL_FREQ) = list(access_heads),
 ))
 
 GLOBAL_LIST_INIT(default_medbay_channels, list(

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -119,6 +119,7 @@ var/const/MED_FREQ = 1355
 var/const/SCI_FREQ = 1351
 var/const/SRV_FREQ = 1349
 var/const/SUP_FREQ = 1347
+var/const/UTL_FREQ = 1346
 
 // internal department channels
 var/const/MED_I_FREQ = 1485
@@ -135,6 +136,7 @@ var/list/radiochannels = list(
 	"Special Ops" 	= DTH_FREQ,
 	"Mercenary" 	= SYND_FREQ,
 	"Raider"		= RAID_FREQ,
+	"Utility"		= UTL_FREQ,
 	"Supply" 		= SUP_FREQ,
 	"Service" 		= SRV_FREQ,
 	"AI Private"	= AI_FREQ,
@@ -150,7 +152,7 @@ var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 var/list/ANTAG_FREQS = list(SYND_FREQ, RAID_FREQ)
 
 //Department channels, arranged lexically
-var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ, ENT_FREQ)
+var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ, UTL_FREQ, ENT_FREQ)
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1
@@ -177,6 +179,8 @@ var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, MED_FREQ, SEC_FREQ, SCI
 		return "sciradio"
 	if(frequency == MED_FREQ)
 		return "medradio"
+	if(frequency == UTL_FREQ) // utility
+		return "utlradio"
 	if(frequency == SUP_FREQ) // cargo
 		return "supradio"
 	if(frequency == SRV_FREQ) // service

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -30,6 +30,7 @@
 	var/list/misc = new()
 	var/list/srv = new()
 	var/list/sup = new()
+	var/list/utl = new()
 	var/list/isactive = new()
 	var/list/mil_ranks = list() // HTML to prepend to name
 	var/dat = {"
@@ -88,6 +89,9 @@
 			department = 1
 		if(real_rank in science_positions)
 			sci[name] = rank
+			department = 1
+		if(real_rank in utility_positions)
+			utl[name] = rank
 			department = 1
 		if(real_rank in cargo_positions)
 			car[name] = rank
@@ -149,6 +153,11 @@
 	if(sup.len > 0)
 		dat += "<tr><th colspan=3>Supply</th></tr>"
 		for(name in sup)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[sup[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+	if(utl.len > 0)
+		dat += "<tr><th colspan=3>Utility</th></tr>"
+		for(name in utl)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[mil_ranks[name]][name]</td><td>[sup[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 	if(srv.len > 0)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -45,6 +45,8 @@ var/global/datum/controller/occupations/job_master
 				medical_positions |= job.title
 			if(job.department_flag & SCI)
 				science_positions |= job.title
+			if(job.department_flag & UTL)
+				utility_positions |= job.title
 			if(job.department_flag & SUP)
 				supply_positions |= job.title
 			if(job.department_flag & SRV)

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -9,6 +9,7 @@ var/const/MSC               =(1<<7)
 var/const/SRV               =(1<<8)
 var/const/SUP               =(1<<9)
 var/const/SPT               =(1<<10)
+var/const/UTL				=(1<<11)
 
 var/list/assistant_occupations = list(
 )
@@ -46,6 +47,9 @@ var/list/supply_positions = list(
 )
 
 var/list/support_positions = list(
+)
+
+var/list/utility_positions = list(
 )
 
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -377,6 +377,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.msg_cargo += blackbox_msg
 				if(SRV_FREQ)
 					blackbox.msg_service += blackbox_msg
+				if(UTL_FREQ)
+					blackbox.msg_utility += blackbox_msg
 				else
 					blackbox.messages += blackbox_msg
 
@@ -554,6 +556,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.msg_cargo += blackbox_msg
 				if(SRV_FREQ)
 					blackbox.msg_service += blackbox_msg
+				if(UTL_FREQ)
+					blackbox.msg_utility += blackbox_msg
 				else
 					blackbox.messages += blackbox_msg
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -64,7 +64,7 @@
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub", "relay", "c_relay", "s_relay", "m_relay", "r_relay", "b_relay", "1_relay", "2_relay", "3_relay", "4_relay", "5_relay", "s_relay", "science", "medical",
-	"supply", "service", "common", "command", "engineering", "security", "unused",
+	"supply", "service", "common", "command", "engineering", "security", "utility", "unused",
 	"receiverA", "broadcasterA")
 
 /obj/machinery/telecomms/hub/preset_cent
@@ -80,7 +80,7 @@
 	id = "Receiver A"
 	network = "tcommsat"
 	autolinkers = list("receiverA") // link to relay
-	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ)
+	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, UTL_FREQ)
 
 	//Common and other radio frequencies for people to freely use
 	New()
@@ -107,7 +107,7 @@
 /obj/machinery/telecomms/bus/preset_two
 	id = "Bus 2"
 	network = "tcommsat"
-	freq_listening = list(SUP_FREQ, SRV_FREQ)
+	freq_listening = list(SUP_FREQ, SRV_FREQ, UTL_FREQ)
 	autolinkers = list("processor2", "supply", "service", "unused")
 
 /obj/machinery/telecomms/bus/preset_two/New()
@@ -187,8 +187,13 @@
 
 /obj/machinery/telecomms/server/presets/service
 	id = "Service Server"
-	freq_listening = list(SRV_FREQ)
-	autolinkers = list("service")
+	freq_listening = list(SRV_FREQ, UTL_FREQ)
+	autolinkers = list("service", "utility")
+
+/obj/machinery/telecomms/server/presets/utility
+	id = "Utility Server"
+	freq_listening = list(UTL_FREQ)
+	autolinkers = list("utility")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"

--- a/code/game/objects/items/devices/PDA/manifest.dm
+++ b/code/game/objects/items/devices/PDA/manifest.dm
@@ -26,6 +26,7 @@ name updates also zero the list; although they are not in data_core, synths are 
 	var/sci[0]
 	var/car[0]
 	var/sup[0]
+	var/utl[0]
 	var/srv[0]
 	var/civ[0]
 	var/bot[0]
@@ -134,6 +135,16 @@ name updates also zero the list; although they are not in data_core, synths are 
 			if(depthead && sup.len != 1)
 				sup.Swap(1,sup.len)
 
+		if(real_rank in utility_positions)
+			utl[++utl.len] = list("name" = name,
+				"rank" = rank,
+				"active" = isactive,
+				"mil_branch" = mil_branch,
+				"mil_rank" = mil_rank)
+			department = 1
+			if(depthead && utl.len != 1)
+				utl.Swap(1,utl.len)
+
 		if(real_rank in service_positions)
 			srv[++srv.len] = list("name" = name,
 				"rank" = rank,
@@ -183,6 +194,7 @@ name updates also zero the list; although they are not in data_core, synths are 
 		"sci" = sci,\
 		"car" = car,\
 		"sup" = sup,\
+		"utl" = utl,\
 		"srv" = srv,\
 		"civ" = civ,\
 		"bot" = bot,\

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -16,6 +16,7 @@ var/list/department_radio_keys = list(
 	  ":v" = "Service",		".v" = "Service",
 	  ":p" = "AI Private",	".p" = "AI Private",
 	  ":z" = "Entertainment",".z" = "Entertainment",
+	  ":y" = "Utility",		".y" = "Utility",
 
 	  ":R" = "right ear",	".R" = "right ear",
 	  ":L" = "left ear",	".L" = "left ear",
@@ -33,6 +34,7 @@ var/list/department_radio_keys = list(
 	  ":V" = "Service",		".V" = "Service",
 	  ":P" = "AI Private",	".P" = "AI Private",
 	  ":Z" = "Entertainment",".Z" = "Entertainment",
+	  ":Y" = "Utility",		".Y" = "Utility",
 
 	  //kinda localization -- rastaf0
 	  //same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -48,6 +48,7 @@
 	data["medical_jobs"] = format_jobs(medical_positions)
 	data["science_jobs"] = format_jobs(science_positions)
 	data["security_jobs"] = format_jobs(security_positions)
+	data["utility_jobs"] = format_jobs(utility_positions)
 	data["service_jobs"] = format_jobs(service_positions)
 	data["supply_jobs"] = format_jobs(supply_positions)
 	data["civilian_jobs"] = format_jobs(civilian_positions)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -242,6 +242,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 	var/list/msg_raider = list()
 	var/list/msg_cargo = list()
 	var/list/msg_service = list()
+	var/list/msg_utility = list()
 
 	var/list/datum/feedback_variable/feedback = new()
 

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -69,6 +69,7 @@
 		interpreter.SetVar("$engineering",ENG_FREQ)
 		interpreter.SetVar("$security",	SEC_FREQ)
 		interpreter.SetVar("$supply",	SUP_FREQ)
+		interpreter.SetVar("$utility",	UTL_FREQ)
 
 		// Signal data
 

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -57,6 +57,7 @@ em						{font-style: normal;font-weight: bold;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
 .srvradio				{color: #6eaa2c;}
+.utlradio				{color: #42d1ae;}
 
 /* Miscellaneous */
 .name					{font-weight: bold;}

--- a/html/changelogs/sabiram - utility.yml
+++ b/html/changelogs/sabiram - utility.yml
@@ -1,0 +1,4 @@
+author: ThatOneGuy
+delete-after: True
+changes:
+  - rscadd: "Service department split. The Sol Pilot, Pathfinder and Explorer are now in the Utility department, with their own department radio. The hotkey for the utility department is 'y'."

--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -1,12 +1,12 @@
 /obj/item/device/encryptionkey/heads/torchcaptain
 	name = "commanding officer's encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Utility" = 1)
 
 /obj/item/device/encryptionkey/heads/torchxo
 	name = "executive officer's encryption key"
 	icon_state = "hop_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Utility" = 1)
 
 /obj/item/device/encryptionkey/headset_torchnt
 	name = "nanotrasen radio encryption key"
@@ -27,9 +27,14 @@
 /obj/item/device/encryptionkey/pilot
 	name = "pilot's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list( "Command" = 1, "Engineering" = 1)
+	channels = list( "Command" = 1, "Engineering" = 1, "Utility" = 1)
+
+/obj/item/device/encryptionkey/utility
+	name = "utility encryption key"
+	icon_state = "srv_cypherkey"
+	channels = list("Utility" = 1)
 
 /obj/item/device/encryptionkey/pathfinder
 	name = "pathfinder's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Service" = 1, "Command" = 1)
+	channels = list("Utility" = 1, "Command" = 1)

--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -28,3 +28,8 @@
 	name = "pilot's encryption key"
 	icon_state = "com_cypherkey"
 	channels = list( "Command" = 1, "Engineering" = 1)
+
+/obj/item/device/encryptionkey/pathfinder
+	name = "pathfinder's encryption key"
+	icon_state = "com_cypherkey"
+	channels = list("Service" = 1, "Command" = 1)

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -54,3 +54,10 @@
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/pilot
+
+/obj/item/device/radio/headset/pathfinder
+	name = "pathfinder's headset"
+	desc = "A headset with access to the command and service channels."
+	icon_state = "com_headset"
+	item_state = "headset"
+	ks2type = /obj/item/device/encryptionkey/pathfinder

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -47,17 +47,23 @@
 	desc = "A box full of executive officer headsets."
 	startswith = list(/obj/item/device/radio/headset/heads/torchxo = 7)
 
-
 /obj/item/device/radio/headset/pilot
 	name = "pilot's headset"
-	desc = "A headset with access to the command and engineering channels."
+	desc = "A headset with access to the command, engineering and utility channels."
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/pilot
 
+/obj/item/device/radio/headset/utility
+	name = "utility headset"
+	desc = "A headset for real tools, with access to the utility  channel."
+	icon_state = "srv_headset"
+	item_state = "headset"
+	ks2type = /obj/item/device/encryptionkey/utility
+
 /obj/item/device/radio/headset/pathfinder
 	name = "pathfinder's headset"
-	desc = "A headset with access to the command and service channels."
+	desc = "A headset with access to the command and utility channels."
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/pathfinder

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -316,8 +316,8 @@
 
 /datum/job/solgov_pilot
 	title = "SolGov Pilot"
-	department = "Support"
-	department_flag = SPT
+	department = "Utility"
+	department_flag = UTL
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -344,8 +344,8 @@
 
 /datum/job/pathfinder
 	title = "Pathfinder"
-	department = "Service"
-	department_flag = SRV
+	department = "Utility"
+	department_flag = UTL
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -369,8 +369,8 @@
 
 /datum/job/explorer
 	title = "Explorer"
-	department = "Service"
-	department_flag = SRV
+	department = "Utility"
+	department_flag = UTL
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Commanding Officer, Executive Officer, and Pathfinder"

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -651,12 +651,12 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 
 /decl/hierarchy/outfit/job/torch/crew/service/pathfinder
 	name = OUTFIT_JOB_NAME("Pathfinder")
-	uniform = /obj/item/clothing/under/utility/expeditionary/officer/service 
+	uniform = /obj/item/clothing/under/utility/expeditionary/officer/service
 	shoes = /obj/item/clothing/shoes/dutyboots
 	head = /obj/item/clothing/head/soft/sol/expedition
 	id_type = /obj/item/weapon/card/id/torch/crew/pathfinder
 	pda_type = /obj/item/device/pda
-	l_ear = /obj/item/device/radio/headset/pilot
+	l_ear = /obj/item/device/radio/headset/pathfinder
 
 /decl/hierarchy/outfit/job/torch/crew/service/explorer
 	name = OUTFIT_JOB_NAME("Explorer")
@@ -665,7 +665,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_type = /obj/item/weapon/card/id/torch/crew/explorer
 	pda_type = /obj/item/device/pda
-	l_ear = /obj/item/device/radio/headset
+	l_ear = /obj/item/device/radio/headset/headset_service
 
 //Passenger Outfits
 

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -665,7 +665,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_type = /obj/item/weapon/card/id/torch/crew/explorer
 	pda_type = /obj/item/device/pda
-	l_ear = /obj/item/device/radio/headset/headset_service
+	l_ear = /obj/item/device/radio/headset/utility
 
 //Passenger Outfits
 

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -650,6 +650,12 @@ th.srv {
     color: #ffffff;
 }
 
+th.utl {
+    background: #42d1ae;
+    font-weight: bold;
+    color: #ffffff;
+}
+
 th.misc {
     background: #666666;
     font-weight: bold;

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -117,7 +117,7 @@
 			</td>
 		  </tr>
 		  <tr>
-			<th style="color: '#800080';">Science</th>
+			<th style="color: '#a65ba6';">Science</th>
 			<td>
 			  {{for data.science_jobs}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
@@ -133,7 +133,7 @@
 			</td>
 		  </tr>
 		  <tr>
-			<th style="color: '#800080';">Supply</th>
+			<th style="color: '#bb9040';">Supply</th>
 			<td>
 			  {{for data.supply_jobs}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
@@ -141,7 +141,16 @@
 			</td>
 		  </tr>
 		  <tr>
-			<th style="color: '#800080';">Service</th>
+			<th style="color: '#42d1ae';">Utility</th>
+			<td>
+			  {{for data.utility_jobs}}
+				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
+			  {{/for}}
+			</td>
+		  </tr>
+		  
+		  <tr>
+			<th style="color: '#88b764';">Service</th>
 			<td>
 			  {{for data.service_jobs}}
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -373,6 +373,16 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         {{/if}}
                     {{/for}}
                 {{/if}}
+				{{if data.manifest.utl.length}}
+                    <tr><th colspan="3" class="utl">Utility</th></tr>
+                    {{for data.manifest["utl"]}}
+                        {{if value.rank == "Head of Personnel"}}
+                            <tr><td><span class="good">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="good">{{:value.rank}}</span></td><td><span class="good">{{:value.active}}</span></td></tr>
+                        {{else}}
+                            <tr><td><span class="average">{{if (value.mil_rank && value.mil_rank.short)}}<abbr title="{{:value.mil_rank.full}}, {{:value.mil_branch.full}}">{{:value.mil_rank.short}}</abbr> {{/if}}{{:value.name}}</span></td><td><span class="average">{{:value.rank}}</span></td><td><span class="average">{{:value.active}}</span></td></tr>
+                        {{/if}}
+                    {{/for}}
+                {{/if}}
 				{{if data.manifest.srv.length}}
                     <tr><th colspan="3" class="srv">Service</th></tr>
                     {{for data.manifest["srv"]}}


### PR DESCRIPTION
Splits the service department's radio network and manifest listing into:

Service

- Cook
- Bartender
- Janitor
- Crewman

Utility - new department, new radio network; retains service dept. uniforms

- SolGov Pilot (retains command, engineering radio)
- Pathfinder (retains command, I guess)
- Explorer



To-do:
- [x] Add the utility department
- [x] Move the jobs to utility
- [x] Add to manifest, PDA manifest
- [x] Add to ID computer
- [x] Add new radio network (oh my god)
- [x] Encryption keys, headsets
- [x] Find a hotkey that isn't taken (:y)
- [x] Find a colour that isn't taken for radio & manfiest