### PR TITLE
Fixes miniscule amounts of alcohol givin you LIVER HURT OH GOD messages

### DIFF
--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -16,7 +16,6 @@
 /obj/item/organ/internal/liver/process()
 
 	..()
-
 	if(!owner)
 		return
 
@@ -66,7 +65,8 @@
 
 		// If you drink alcohol, your liver won't heal.
 		if(owner.chem_effects[CE_ALCOHOL])
-			take_damage(owner.chem_effects[CE_ALCOHOL_TOXIC] * PROCESS_ACCURACY, prob(1)) // Chance to warn them
+			if(owner.chem_effects[CE_ALCOHOL_TOXIC])
+				take_damage(owner.chem_effects[CE_ALCOHOL_TOXIC] * PROCESS_ACCURACY, prob(90)) // Chance to warn them
 
 		// Heal a bit if needed. This allows recovery from low amounts of toxloss.
 		else if(damage < min_broken_damage && !owner.chem_effects[CE_TOXIN] && !owner.radiation)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -249,7 +249,6 @@ var/list/organ_cache = list()
 //Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(amount, var/silent=0)
 	amount = round(amount, 0.1)
-
 	if(src.robotic >= ORGAN_ROBOT)
 		src.damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else
@@ -259,7 +258,12 @@ var/list/organ_cache = list()
 		if(owner && parent_organ && (amount > 5 || prob(10)))
 			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 			if(parent && !silent)
-				owner.custom_pain("Something inside your [parent.name] hurts a lot.", amount, affecting = parent)
+				var/degree = ""
+				if(is_bruised())
+					degree = " a lot"
+				if(damage < 5)
+					degree = " a bit"
+				owner.custom_pain("Something inside your [parent.name] hurts[degree].", amount, affecting = parent)
 
 /obj/item/organ/proc/bruise()
 	damage = max(damage, min_bruised_damage)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -23,8 +23,10 @@ mob/living/carbon/proc/custom_pain(var/message, var/power, var/force, var/obj/it
 		last_pain_message = message
 		if(power >= 50)
 			to_chat(src, "<span class='danger'><font size=3>[message]</font></span>")
-		else
+		else if(power >= 10)
 			to_chat(src, "<span class='danger'>[message]</span>")
+		else
+			to_chat(src, "<span class='warning'>[message]</span>")
 	next_pain_time = world.time + (100-power)
 
 mob/living/carbon/human/proc/handle_pain()


### PR DESCRIPTION
It didn't do damage, but proc still sent a pain message, and there's no granurality between 0.1 and 30 damage there.
Added said granurality, 
made sure damage proc is only called when alcohol is in toxic dose, 
made low amount custom pain messages appear as warning span instead of bold red,
Made liver damage properly silent as comment suggests, it was inverted - 99% chance to be loud.

Fixes #18262
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
