### PR TITLE
Tweaked fuel compressor to be borg compatible.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -22,7 +22,8 @@
 		/obj/item/weapon/tank,
 		/obj/item/weapon/circuitboard,
 		/obj/item/weapon/smes_coil,
-		/obj/item/weapon/computer_hardware
+		/obj/item/weapon/computer_hardware,
+		/obj/item/weapon/fuel_assembly
 		)
 
 	var/obj/item/wrapped = null // Item currently being held.

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -9,9 +9,12 @@
 /obj/machinery/fusion_fuel_compressor/MouseDrop_T(var/atom/movable/target, var/mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
-	return do_special_fuel_compression(target, user)
+	return do_fuel_compression(target, user)
 
-/obj/machinery/fusion_fuel_compressor/proc/do_special_fuel_compression(var/obj/item/thing, var/mob/user)
+/obj/machinery/fusion_fuel_compressor/attackby(var/obj/item/thing, var/mob/user)
+	return do_fuel_compression(thing, user) || ..()
+
+/obj/machinery/fusion_fuel_compressor/proc/do_fuel_compression(var/obj/item/thing, var/mob/user)
 	if(istype(thing) && thing.reagents && thing.reagents.total_volume && thing.is_open_container())
 		if(thing.reagents.reagent_list.len > 1)
 			to_chat(user, "<span class='warning'>The contents of \the [thing] are impure and cannot be used as fuel.</span>")
@@ -24,17 +27,14 @@
 		var/obj/item/weapon/fuel_assembly/F = new(get_turf(src), R.type, R.color)
 		thing.reagents.remove_reagent(R.type, R.volume)
 		user.put_in_hands(F)
-
+		return 1
 	else if(istype(thing, /obj/machinery/power/supermatter/shard))
 		var/obj/item/weapon/fuel_assembly/F = new(get_turf(src), "supermatter")
 		visible_message("<span class='notice'>\The [src] compresses the \[thing] into a new fuel assembly.</span>")
 		qdel(thing)
 		user.put_in_hands(F)
 		return 1
-	return 0
-
-/obj/machinery/fusion_fuel_compressor/attackby(var/obj/item/thing, var/mob/user)
-	if(istype(thing, /obj/item/stack/material))
+	else if(istype(thing, /obj/item/stack/material))
 		var/obj/item/stack/material/M = thing
 		var/material/mat = M.get_material()
 		if(!mat.is_fusion_fuel)
@@ -47,8 +47,5 @@
 		visible_message("<span class='notice'>\The [src] compresses the [mat.use_name] into a new fuel assembly.</span>")
 		M.use(25)
 		user.put_in_hands(F)
-
-	else if(do_special_fuel_compression(thing, user))
-		return
-
-	return ..()
+		return 1
+	return 0


### PR DESCRIPTION
Gripper can hold assemblies and mousedrop properly attempts to do regular fuel compression as well as special. Also means if you somehow manage to pick up a supermatter shard you will be able to make a rod out of it.
No changelog as these are fixes for oversights.