### PR TITLE
Bloody matters

### DIFF
--- a/code/datums/repositories/crew/crew.dm
+++ b/code/datums/repositories/crew/crew.dm
@@ -53,16 +53,16 @@ var/global/datum/repository/crew/crew_repository = new()
 				if(H.w_uniform != C)
 					continue
 				var/pressure = H.get_blood_pressure()
-				var/blood_result = H.get_effective_blood_volume()
+				var/blood_result = H.get_blood_oxygenation()
 				if(blood_result > 110)
-					blood_result = "elevated"
+					blood_result = "increased"
 				else if(blood_result < 90)
 					blood_result = "low"
 				else if(blood_result < 60)
 					blood_result = "extremely low"
 				else
 					blood_result = "normal"
-				pressure += " ([blood_result])"
+				pressure += " ([blood_result] oxygenation)"
 
 				var/true_pulse = H.pulse()
 				var/pulse_span = "good"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -304,10 +304,9 @@
 	. += "<b>Pulse rate:</b> [pulse_result]bpm."
 
 	// Blood pressure. Based on the idea of a normal blood pressure being 120 over 80.
-	var/blood_result = H.get_effective_blood_volume()
-	if(blood_result <= 70)
+	if(H.get_blood_volume() <= 70)
 		. += "<span class='danger'>Severe blood loss detected.</span>"
-	. += "<b>Blood pressure:</b> [H.get_blood_pressure()] ([blood_result]% blood circulation)"
+	. += "<b>Blood pressure:</b> [H.get_blood_pressure()] ([H.get_blood_oxygenation()]% blood oxygenation)"
 	. += "<b>Blood volume:</b> [H.vessel.get_reagent_amount(/datum/reagent/blood)]/[H.species.blood_volume]u"
 
 	// Body temperature.

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -101,10 +101,9 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 	. += "<span class='notice'>Pulse rate: [pulse_result]bpm.</span>"
 
 	// Blood pressure. Based on the idea of a normal blood pressure being 120 over 80.
-	var/blood_result = H.get_effective_blood_volume()
-	if(blood_result <= 70)
+	if(H.get_blood_volume() <= 70)
 		. += "<span class='danger'>Severe blood loss detected.</span>"
-	. += "<span class='notice'>Blood pressure:</span> [H.get_blood_pressure()] ([blood_result]% blood circulation)"
+	. += "<b>Blood pressure:</b> [H.get_blood_pressure()] ([H.get_blood_oxygenation()]% blood oxygenation)"
 
 	// Body temperature.
 	. += "<span class='notice'>Body temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span>"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -278,7 +278,7 @@
 	if(!H.should_have_organ(BP_HEART))
 		return FALSE
 	var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
-	if(!heart || H.get_effective_blood_volume() < BLOOD_VOLUME_SURVIVE)
+	if(!heart || H.get_blood_volume() < BLOOD_VOLUME_SURVIVE)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1604,7 +1604,7 @@
 /mob/living/carbon/human/proc/get_blood_pressure()
 	if(status_flags & FAKEDEATH)
 		return "[Floor(120+rand(-5,5))*0.25]/[Floor(80+rand(-5,5)*0.25)]"
-	var/blood_result = get_effective_blood_volume()
+	var/blood_result = get_blood_circulation()
 	return "[Floor((120+rand(-5,5))*(blood_result/100))]/[Floor(80+rand(-5,5)*(blood_result/100))]"
 
 //Point at which you dun breathe no more. Separate from asystole crit, which is heart-related.

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -179,21 +179,11 @@
 		if(owner.should_have_organ(BP_HEART))
 
 			// No heart? You are going to have a very bad time. Not 100% lethal because heart transplants should be a thing.
-			var/blood_volume = owner.get_effective_blood_volume()
+			var/blood_volume = owner.get_blood_oxygenation()
 
 			if(owner.is_asystole()) // Heart is missing or isn't beating and we're not breathing (hardcrit)
-				blood_volume = min(blood_volume, BLOOD_VOLUME_SURVIVE)
 				owner.Paralyse(3)
 
-			else if(owner.need_breathe())
-				var/blood_volume_mod = max(0, 1 - owner.getOxyLoss()/(owner.maxHealth/2))
-				var/oxygenated_mult = 0
-				if(owner.chem_effects[CE_OXYGENATED] == 1) // Dexalin.
-					oxygenated_mult = 0.5
-				else if(owner.chem_effects[CE_OXYGENATED] >= 2) // Dexplus.
-					oxygenated_mult = 0.8
-				blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
-				blood_volume = blood_volume * blood_volume_mod
 			//Effects of bloodloss
 			switch(blood_volume)
 

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -39,7 +39,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 	if(owner.stat == DEAD || robotic >= ORGAN_ROBOT)
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
-	if(owner.shock_stage >= 120 || owner.getOxyLoss() >= 100 || owner.get_effective_blood_volume() < BLOOD_VOLUME_SURVIVE || prob(max(0, owner.getBrainLoss() - owner.maxHealth * 0.75))) // The heart has stopped due to going into traumatic or cardiovascular shock.
+	if(owner.shock_stage >= 120 || owner.getOxyLoss() >= 100 || owner.get_blood_circulation() < BLOOD_VOLUME_SURVIVE || prob(max(0, owner.getBrainLoss() - owner.maxHealth * 0.75))) // The heart has stopped due to going into traumatic or cardiovascular shock.
 		if(pulse != PULSE_NONE)
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE
@@ -48,7 +48,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 		var/pulse_mod = owner.chem_effects[CE_PULSE]
 		if(owner.shock_stage > 30)
 			pulse_mod++
-		if(owner.get_effective_blood_volume() <= BLOOD_VOLUME_BAD)	//how much blood do we have
+		if(owner.get_blood_circulation() <= BLOOD_VOLUME_BAD)	//how much blood do we have
 			pulse  = PULSE_THREADY	//not enough :(
 
 		else if(owner.status_flags & FAKEDEATH || owner.chem_effects[CE_NOPULSE])

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -82,7 +82,7 @@
 				B.volume += owner.chem_effects[CE_BLOODRESTORE]
 
 	// Blood loss or liver damage make you lose nutriments
-	var/blood_volume = owner.get_effective_blood_volume()
+	var/blood_volume = owner.get_blood_volume()
 	if(blood_volume < BLOOD_VOLUME_SAFE || is_bruised())
 		if(owner.nutrition >= 300)
 			owner.nutrition -= 10

--- a/code/modules/organs/subtypes/nabber.dm
+++ b/code/modules/organs/subtypes/nabber.dm
@@ -129,7 +129,7 @@
 		return
 
 	// No heart? You are going to have a very bad time. Not 100% lethal because heart transplants should be a thing.
-	var/blood_volume = owner.get_effective_blood_volume()
+	var/blood_volume = owner.get_blood_circulation()
 	if(!owner.internal_organs_by_name[BP_HEART])
 		if(blood_volume > BLOOD_VOLUME_SURVIVE)
 			blood_volume = BLOOD_VOLUME_SURVIVE

--- a/html/changelogs/chinsky - bloodyhell.yml
+++ b/html/changelogs/chinsky - bloodyhell.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Health analyzers, advanced scanners and suit sensors will now report blood oxygenation instead of just how well it flows in general."


### PR DESCRIPTION
Splits get_effective_blood_volume into three procs.
get_volume: straight up percentage of blood left
get_blood_circulation: what get_effective_blood_volume used to do, volume modified by heart condition
get_blood_oxygenation: thing that brain actually used, bu tthere was no way to see it anywhere in game.

Updates all usages to most relevant one.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
