### PR TITLE
Distance related stuff

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -278,6 +278,7 @@
 	if(!item) return
 
 	var/throw_range = item.throw_range
+	var/itemsize
 	if (istype(item, /obj/item/grab))
 		var/obj/item/grab/G = item
 		item = G.throw_held() //throw the person instead of the grab
@@ -286,7 +287,7 @@
 
 			//limit throw range by relative mob size
 			throw_range = round(M.throw_range * min(src.mob_size/M.mob_size, 1))
-
+			itemsize = round(M.mob_size/4)
 			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 			var/turf/end_T = get_turf(target)
 			if(start_T && end_T)
@@ -294,12 +295,16 @@
 				var/end_T_descriptor = "<font color='#6b4400'>[start_T] \[[end_T.x],[end_T.y],[end_T.z]\] ([end_T.loc])</font>"
 				admin_attack_log(usr, M, "Threw the victim from [start_T_descriptor] to [end_T_descriptor].", "Was from [start_T_descriptor] to [end_T_descriptor].", "threw, from [start_T_descriptor] to [end_T_descriptor], ")
 
+	else if (istype(item, /obj/item/))
+		var/obj/item/I = item
+		itemsize = I.w_class
+
 	src.drop_from_inventory(item)
 	if(!item || !isturf(item.loc))
 		return
 
 	//actually throw it!
-	src.visible_message("<span class='warning'>[src] has thrown [item].</span>")
+	src.visible_message("<span class='warning'>[src] has thrown [item].</span>", range = min(itemsize*2,world.view))
 
 	if(!src.lastarea)
 		src.lastarea = get_area(src.loc)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -23,6 +23,10 @@
 
 	if(wear_mask)
 		skipface |= wear_mask.flags_inv & HIDEFACE
+	
+	//no accuately spotting headsets from across the room.
+	if(get_dist(user, src) > 3)
+		skipears = 1
 
 	var/list/msg = list("<span class='info'>*---------*\nThis is ")
 


### PR DESCRIPTION
Makes throwing show message at range depending on size of things thrown
Thrown up right before I had to bolt, it compiles but not sure about anything above that, gotta test first.
Opening PR to let people get their muh balance concerns going.

Range is twice the size of item, so 2 tiles for pens etc, 4 tiles for pocket sized items, 6 for normal items, and always visible for bigger items.

Also made headsets not show up on examine unless oyu're 3 tiles away or closer. It generated fair bit of salt on some occasions, when people go Y U SEE KIND OF HEADSET FROM ANOTHER END FO ROOM and I think that's fair.