### PR TITLE
Cult fixes

### DIFF
--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -1,16 +1,16 @@
-#define CULTINESS_PER_CULTIST 30
-#define CULTINESS_PER_SACRIFICE 30
+#define CULTINESS_PER_CULTIST 40
+#define CULTINESS_PER_SACRIFICE 40
 #define CULTINESS_PER_TURF 1
 
-#define CULT_RUNES_1 100
-#define CULT_RUNES_2 200
-#define CULT_RUNES_3 300
+#define CULT_RUNES_1 200
+#define CULT_RUNES_2 400
+#define CULT_RUNES_3 1000
 
-#define CULT_GHOSTS_1 150
-#define CULT_GHOSTS_2 250
-#define CULT_GHOSTS_3 350
+#define CULT_GHOSTS_1 400
+#define CULT_GHOSTS_2 800
+#define CULT_GHOSTS_3 1200
 
-#define CULT_MAX_CULTINESS 350 // When this value is reached, the game stops checking for updates so we don't recheck every time a tile is converted in endgame
+#define CULT_MAX_CULTINESS 1200 // When this value is reached, the game stops checking for updates so we don't recheck every time a tile is converted in endgame
 
 var/datum/antagonist/cultist/cult
 

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -26,6 +26,7 @@
 
 /turf/simulated/floor/proc/cultify_floor()
 	set_flooring(get_flooring_data(/decl/flooring/reinforced/cult))
+	cult.add_cultiness(CULTINESS_PER_TURF)
 
 
 /turf/proc/cultify_wall()
@@ -36,3 +37,4 @@
 		ChangeTurf(/turf/simulated/wall/cult/reinf)
 	else
 		ChangeTurf(/turf/simulated/wall/cult)
+	cult.add_cultiness(CULTINESS_PER_TURF)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -210,7 +210,7 @@ var/list/Tier4Runes = list(
 	set category = "Cult Magic"
 	set name = "Rune: Mass Defile"
 
-	make_rune(/obj/effect/rune/massdefile, cost= 80)
+	make_rune(/obj/effect/rune/massdefile, tome_required = 1, cost = 20)
 
 /mob/proc/armor_rune()
 	set category = "Cult Magic"

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -56,29 +56,3 @@
 	..()
 	pixel_x += rand(-10, 10)
 	pixel_y += rand(-10, 10)
-
-/obj/effect/overlay/cult/cultwall
-	name = "Corrupting glow"
-	desc = "You find yourself carrying an overwhelming urge to report the observability of this overlay to the bug tracker. Mention a \"cultwall\"."
-	icon = 'icons/effects/effects.dmi'
-	icon_state = "cultwall"
-	plane = ABOVE_TURF_PLANE
-	layer = ABOVE_TILE_LAYER
-	mouse_opacity = 0
-/obj/effect/overlay/cult/wallspawn/New()
-	..()
-	spawn(1)
-	qdel(src)
-
-/obj/effect/overlay/cult/cultfloor
-	icon = 'icons/effects/effects.dmi'
-	desc = "You find yourself carrying an overwhelming urge to report the observability of this overlay to the bug tracker. Mention a \"cultfloor\"."
-	icon_state = "cultfloor"
-	plane = ABOVE_TURF_PLANE
-	layer = ABOVE_TILE_LAYER
-	mouse_opacity = 0
-
-/obj/effect/overlay/cult/floorspawn/New()
-	..()
-	spawn(1)
-	qdel(src)

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -168,10 +168,6 @@ var/list/flooring_types
 	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_WRENCH
 	can_paint = null
 
-/decl/flooring/reinforced/cult/New()
-	..()
-	new /obj/effect/overlay/cult/cultfloor(src)
-
 /decl/flooring/reinforced/cult/on_remove()
 	cult.remove_cultiness(CULTINESS_PER_TURF)
 

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -105,10 +105,6 @@
 	icon_state = "cult"
 	initial_flooring = /decl/flooring/reinforced/cult
 
-/turf/simulated/floor/cult/New()
-	..()
-	new /obj/effect/overlay/cult/cultfloor(src)
-
 /turf/simulated/floor/cult/cultify()
 	return
 

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -12,13 +12,12 @@
 
 /turf/simulated/wall/cult
 	icon_state = "cult"
+
 /turf/simulated/wall/cult/New(var/newloc, var/reinforce = 0)
 	..(newloc,"cult",reinforce ? "cult2" : null)
-	new /obj/effect/overlay/cult/cultwall(src)
 
 /turf/simulated/wall/cult/reinf/New(var/newloc)
 	..(newloc, 1)
-	new /obj/effect/overlay/cult/cultwall(src)
 
 /turf/simulated/wall/cult/dismantle_wall()
 	cult.remove_cultiness(CULTINESS_PER_TURF)

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -215,6 +215,7 @@ datum/ghosttrap/pai/transfer_personality(var/mob/candidate, var/mob/living/silic
 	object = "cultist"
 	ban_checks = list("cultist")
 	pref_check = MODE_CULTIST
+	can_set_own_name = FALSE
 	ghost_trap_message = "They are occupying a cultist's body now."
 	ghost_trap_role = "Cultist"
 

--- a/html/changelogs/Kelenius-HandsOffMyBaby.yml
+++ b/html/changelogs/Kelenius-HandsOffMyBaby.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Defile counts towards rune unlock again, at a rate adjusted for Torch."
+  - tweak: "Mass defile rune won't kill you with bloodloss when you draw it more than once (cost lowered from 80 to 20)."
+  - bugfix: "Soulstones should work properly now."


### PR DESCRIPTION
Defiled tiles give cult rating again, at halved rate, to account for Torch's bigger maintenance. This change was very broken (they didn't add cult rating when they were created, but still reduced it when they were removed) and pointless. There was never an intention to prevent the cultists from using their runes in newcult.
Mass defile rune's blood requirement has been lowered from **80** to much more sane 20. For comparison, regular defile costs 5, and tear reality, the most expensive rune previously, costs 50.
Soulstones have been fixed and tested, now with more defines. I have absolutely no idea what @chaoko99 was trying to do with the code in #16931, because none of it makes sense, including comments.