### PR TITLE
Alternative to #18447

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -549,6 +549,7 @@ BLIND     // can't see anything
 	holding.forceMove(get_turf(usr))
 
 	if(usr.put_in_hands(holding))
+		usr.visible_message("<span class='danger'>\The [usr] pulls a knife out of their boot!</span>", range = 1)
 		holding = null
 	else
 		to_chat(usr, "<span class='warning'>Your need an empty, unbroken hand to do that.</span>")
@@ -574,6 +575,7 @@ BLIND     // can't see anything
 		user.unEquip(I)
 		I.forceMove(src)
 		holding = I
+		user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>", range = 1)
 		verbs |= /obj/item/clothing/shoes/proc/draw_knife
 		update_icon()
 	else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -549,7 +549,7 @@ BLIND     // can't see anything
 	holding.forceMove(get_turf(usr))
 
 	if(usr.put_in_hands(holding))
-		usr.visible_message("<span class='warning'>\The [usr] pulls \an [holding] out of their boot!</span>", range = 1)
+		usr.visible_message("<span class='warning'>\The [usr] pulls \the [holding] out of \the [src]!</span>", range = 1)
 		holding = null
 	else
 		to_chat(usr, "<span class='warning'>Your need an empty, unbroken hand to do that.</span>")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -549,7 +549,7 @@ BLIND     // can't see anything
 	holding.forceMove(get_turf(usr))
 
 	if(usr.put_in_hands(holding))
-		usr.visible_message("<span class='danger'>\The [usr] pulls a knife out of their boot!</span>", range = 1)
+		usr.visible_message("<span class='warning'>\The [usr] pulls \an [holding] out of their boot!</span>", range = 1)
 		holding = null
 	else
 		to_chat(usr, "<span class='warning'>Your need an empty, unbroken hand to do that.</span>")

--- a/html/changelogs/Atlantiscze-ReStab.yml
+++ b/html/changelogs/Atlantiscze-ReStab.yml
@@ -1,0 +1,6 @@
+author: Atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Pulling a knife out of your boot or putting it in produces a message once again, but only if you are adjacent to the person."


### PR DESCRIPTION
- Reverts #18447 and re-implements an alternative that was suggested in that PR, and was in general much better accepted than the original.
- Boot knife visible message range was reduced to 1 tile.