### PR TITLE
Attempts to stop the slaughter

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -312,6 +312,9 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if (affected == null)
 		return 0
+	if (affected.open())
+		to_chat(user,"<span class='warning'>You can't get a clean cut with incisions getting in the way.</span>")
+		return SURGERY_FAILURE
 	return !affected.cannot_amputate
 
 /datum/surgery_step/generic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
Now amputation step will not trigger if there's open incision. Should help against all these cases of decapitations while trying to open skull.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
