### PR TITLE
Accessories now look for the right thing when sleeves are rolled.

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -48,8 +48,8 @@
 			var/obj/item/clothing/under/C = loc
 			if(on_rolled["down"] && C.rolled_down > 0)
 				tmp_icon_state = on_rolled["down"]
-			else if(on_rolled["sleeves"] && C.rolled_sleeves > 0)
-				tmp_icon_state = on_rolled["sleeves"]
+			else if(on_rolled["rolled"] && C.rolled_sleeves > 0)
+				tmp_icon_state = on_rolled["rolled"]
 
 		var/use_sprite_sheet = accessory_icons[slot]
 		if(sprite_sheets[bodytype])


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
>Comment says it looks for "rolled"
>Actually looks for "sleeves"
>Only read comment and believe it
>Get called on it later
>mfw
![1473203532003](https://user-images.githubusercontent.com/13301593/29941081-a5ef93de-8e67-11e7-971f-d361ee050d82.jpg)

I blame Chinsky.