### PR TITLE
Torch-updated supply crates, part one.

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -11,34 +11,277 @@
 	containername = "\improper Special Ops crate"
 	hidden = 1
 
-/decl/hierarchy/supply_pack/security/forensics
-	name = "Auxiliary forensic tools"
+/decl/hierarchy/supply_pack/security/lightarmor
+	name = "Armor - Light"
+	contains = list(/obj/item/clothing/suit/armor/vest = 4,
+					/obj/item/clothing/head/helmet =4)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Light armor crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/armor
+	name = "Armor - Unmarked"
+	contains = list(/obj/item/clothing/suit/storage/vest = 2,
+					/obj/item/clothing/head/helmet =2)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Armor crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/tacticalarmor
+	name = "Armor - Tactical"
+	contains = list(/obj/item/clothing/under/tactical,
+					/obj/item/clothing/suit/storage/vest/tactical,
+					/obj/item/clothing/head/helmet/tactical,
+					/obj/item/clothing/mask/balaclava/tactical,
+					/obj/item/clothing/glasses/tacgoggles,
+					/obj/item/weapon/storage/belt/security/tactical,
+					/obj/item/clothing/shoes/tactical,
+					/obj/item/clothing/gloves/tactical)
+	cost = 45
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Tactical armor crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/armguards
+	name = "Armor - Arm guards"
+	contains = list(/obj/item/clothing/gloves/guards = 4)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Arm guards crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/riotarmor
+	name = "Armor - Riot gear"
+	contains = list(/obj/item/weapon/shield/riot = 4,
+					/obj/item/clothing/head/helmet/riot = 4,
+					/obj/item/clothing/suit/armor/riot = 4,
+					/obj/item/weapon/storage/box/flashbangs,
+					/obj/item/weapon/storage/box/teargas)
+	cost = 80
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Riot armor crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/ballisticarmor
+	name = "Armor - Ballistic"
+	contains = list(/obj/item/clothing/head/helmet/ballistic = 4,
+					/obj/item/clothing/suit/armor/bulletproof = 4)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Ballistic suit crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/ablativearmor
+	name = "Armor - Ablative"
+	contains = list(/obj/item/clothing/head/helmet/ablative = 4,
+					/obj/item/clothing/suit/armor/laserproof = 4)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Ablative suit crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/weapons
+	name = "Weapons - Security basic"
+	contains = list(/obj/item/device/flash = 4,
+					/obj/item/weapon/reagent_containers/spray/pepper = 4,
+					/obj/item/weapon/melee/baton/loaded = 4,
+					/obj/item/weapon/gun/energy/taser = 4)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Weapons crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/egun
+	name = "Weapons - Energy sidearms"
+	contains = list(/obj/item/weapon/gun/energy/gun = 4)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Energy sidearms crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/ion
+	name = "Weapons - Electromagnetic"
+	contains = list(/obj/item/weapon/gun/energy/ionrifle = 2,
+					/obj/item/weapon/storage/box/emps)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Electromagnetic weapons crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/pistol
+	name = "Weapons - Ballistic sidearms"
+	contains = list(/obj/item/weapon/gun/projectile/sec = 4)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Ballistic sidearms crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/shotgun
+	name = "Weapons - Shotgun"
+	contains = list(/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Shotgun crate"
+	access = access_armory
+
+/decl/hierarchy/supply_pack/security/flashbang
+	name = "Weapons - Flashbangs"
+	contains = list(/obj/item/weapon/storage/box/flashbangs = 2)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Flashbang crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/teargas
+	name = "Weapons - Tear gas grenades"
+	contains = list(/obj/item/weapon/storage/box/teargas = 2)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Tear gas grenades crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/pistolammo
+	name = "Ammunition - .45 magazines"
+	contains = list(/obj/item/ammo_magazine/c45m = 4)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper .45 ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/pistolammorubber
+	name = "Ammunition - .45 rubber"
+	contains = list(/obj/item/ammo_magazine/c45m/rubber = 4)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper .45 rubber ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/pistolammopractice
+	name = "Ammunition - .45 practice"
+	contains = list(/obj/item/ammo_magazine/c45m/practice = 8)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper .45 practice ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/shotgunammo
+	name = "Ammunition - Lethal shells"
+	contains = list(/obj/item/weapon/storage/box/shotgunammo = 2,
+					/obj/item/weapon/storage/box/shotgunshells = 2)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Lethal shotgun shells crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/shotgunbeanbag
+	name = "Ammunition - Beanbag shells"
+	contains = list(/obj/item/weapon/storage/box/beanbags = 3)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Beanbag shotgun shells crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/pdwammo
+	name = "Ammunition - 9mm top mounted"
+	contains = list(/obj/item/ammo_magazine/mc9mmt = 4)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper 9mm ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/pdwammorubber
+	name = "Ammunition - 9mm top mounted rubber"
+	contains = list(/obj/item/ammo_magazine/mc9mmt/rubber = 4)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper 9mm rubber ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/pdwammopractice
+	name = "Ammunition - 9mm top mounted practice"
+	contains = list(/obj/item/ammo_magazine/mc9mmt/practice = 8)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper 9mm practice ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/bullpupammo
+	name = "Ammunition - 5.56"
+	contains = list(/obj/item/ammo_magazine/a556 = 4)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper 5.56 ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/bullpupammopractice
+	name = "Ammunition - 5.56 practice"
+	contains = list(/obj/item/ammo_magazine/a556/practice = 8)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper 5.56 practice ammunition crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/forensics //Not access-restricted so PIs can use it.
+	name = "Forensics - Auxiliary tools"
 	contains = list(/obj/item/weapon/forensics/sample_kit,
 					/obj/item/weapon/forensics/sample_kit/powder,
 					/obj/item/weapon/storage/box/swabs = 3,
 					/obj/item/weapon/reagent_containers/spray/luminol)
 	cost = 30
-	containername = "\improper Auxiliary forensic tools"
+	containername = "\improper Auxiliary forensic tools crate"
 
-/decl/hierarchy/supply_pack/security/beanbagammo
-	name = "Beanbag shells"
-	contains = list(/obj/item/weapon/storage/box/beanbags = 3)
-	cost = 30
-	containername = "\improper Beanbag shells"
+/decl/hierarchy/supply_pack/security/detectivegear
+	name = "Forensics - investigation equipment"
+	contains = list(/obj/item/weapon/storage/box/evidence = 2,
+					/obj/item/weapon/cartridge/detective,
+					/obj/item/device/radio/headset/headset_sec,
+					/obj/item/taperoll/police,
+					/obj/item/clothing/glasses/sunglasses,
+					/obj/item/device/camera,
+					/obj/item/weapon/folder/red,
+					/obj/item/weapon/folder/blue,
+					/obj/item/clothing/gloves/forensic,
+					/obj/item/device/taperecorder,
+					/obj/item/device/mass_spectrometer,
+					/obj/item/device/camera_film = 2,
+					/obj/item/weapon/storage/photo_album,
+					/obj/item/device/reagent_scanner,
+					/obj/item/weapon/storage/briefcase/crimekit = 2)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Forensic equipment crate"
+	access = access_forensics_lockers
 
-/decl/hierarchy/supply_pack/security/weapons
-	name = "Weapons crate"
-	contains = list(/obj/item/weapon/melee/baton = 2,
-					/obj/item/weapon/gun/energy/gun = 2,
-					/obj/item/weapon/gun/energy/taser = 2,
-					/obj/item/weapon/gun/projectile/sec = 2,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/teargas)
-	cost = 40
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Weapons crate"
+/decl/hierarchy/supply_pack/security/securitybarriers
+	name = "Misc - Barrier crate"
+	contains = list(/obj/machinery/deployable/barrier = 4)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/large
+	containername = "\improper Security barrier crate"
 	access = access_security
 
+/decl/hierarchy/supply_pack/security/securitybarriers
+	name = "Misc - Wall shield Generators"
+	contains = list(/obj/machinery/shieldwallgen = 2)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/large
+	containername = "\improper wall shield generators crate"
+	access = access_brig
+
+/decl/hierarchy/supply_pack/security/securitybiosuit
+	name = "Misc - Security biohazard gear"
+	contains = list(/obj/item/clothing/head/bio_hood/security,
+					/obj/item/clothing/suit/bio_suit/security,
+					/obj/item/clothing/mask/gas,
+					/obj/item/weapon/tank/oxygen,
+					/obj/item/clothing/gloves/latex)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Security biohazard gear crate"
+	access = access_security
+/*
 /decl/hierarchy/supply_pack/security/flareguns
 	name = "Flare guns crate"
 	contains = list(/obj/item/weapon/gun/projectile/sec/flash,
@@ -78,39 +321,12 @@
 	access = access_security
 	supply_method = /decl/supply_method/randomized
 
-/decl/hierarchy/supply_pack/security/riot
-	name = "Riot gear crate"
-	contains = list(/obj/item/weapon/melee/baton = 3,
-					/obj/item/weapon/shield/riot = 3,
-					/obj/item/weapon/handcuffs = 3,
-					/obj/item/clothing/head/helmet/riot = 3,
-					/obj/item/clothing/suit/armor/riot = 3,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/teargas,
-					/obj/item/weapon/storage/box/beanbags,
-					/obj/item/weapon/storage/box/handcuffs)
-	cost = 60
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Riot gear crate"
-	access = access_armory
-
 /decl/hierarchy/supply_pack/security/energyweapons
 	name = "Energy weapons crate"
 	contains = list(/obj/item/weapon/gun/energy/laser = 3)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper energy weapons crate"
-	access = access_armory
-
-/decl/hierarchy/supply_pack/security/shotgun
-	name = "Shotgun crate"
-	contains = list(/obj/item/clothing/suit/armor/bulletproof = 2,
-					/obj/item/weapon/storage/box/shotgunammo,
-					/obj/item/weapon/storage/box/shotgunshells,
-					/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2)
-	cost = 65
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Shotgun crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/erifle
@@ -120,24 +336,6 @@
 	cost = 90
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Energy marksman crate"
-	access = access_armory
-
-/decl/hierarchy/supply_pack/security/shotgunammo
-	name = "Ballistic ammunition crate"
-	contains = list(/obj/item/weapon/storage/box/shotgunammo = 2,
-					/obj/item/weapon/storage/box/shotgunshells = 2)
-	cost = 60
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper ballistic ammunition crate"
-	access = access_armory
-
-/decl/hierarchy/supply_pack/security/ionweapons
-	name = "Electromagnetic weapons crate"
-	contains = list(/obj/item/weapon/gun/energy/ionrifle = 2,
-					/obj/item/weapon/storage/box/emps)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper electromagnetic weapons crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/automatic
@@ -150,53 +348,6 @@
 	containername = "\improper Automatic weapon crate"
 	access = access_armory
 	supply_method = /decl/supply_method/randomized
-
-/decl/hierarchy/supply_pack/security/autoammo
-	name = "Automatic weapon ammunition crate"
-	num_contained = 6
-	contains = list(/obj/item/ammo_magazine/mc9mmt,
-					/obj/item/ammo_magazine/mc9mmt/rubber,
-					/obj/item/ammo_magazine/a556)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Automatic weapon ammunition crate"
-	access = access_armory
-	supply_method = /decl/supply_method/randomized
-
-/decl/hierarchy/supply_pack/security/expenergy
-	name = "Experimental energy gear crate"
-	contains = list(/obj/item/clothing/suit/armor/laserproof = 2,
-					/obj/item/weapon/gun/energy/gun = 2)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Experimental energy gear crate"
-	access = access_armory
-
-/decl/hierarchy/supply_pack/security/exparmor
-	name = "Experimental armor crate"
-	contains = list(/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/head/helmet/riot,
-					/obj/item/clothing/suit/armor/riot)
-	cost = 35
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Experimental armor crate"
-	access = access_armory
-
-/decl/hierarchy/supply_pack/security/securitybarriers
-	name = "Security barrier crate"
-	contains = list(/obj/machinery/deployable/barrier = 4)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper Security barrier crate"
-
-/decl/hierarchy/supply_pack/security/securitybarriers
-	name = "Wall shield Generators"
-	contains = list(/obj/machinery/shieldwallgen = 2)
-	cost = 10
-	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper wall shield generators crate"
-	access = access_teleporter
 
 /decl/hierarchy/supply_pack/security/holster
 	name = "Holster crate"
@@ -219,29 +370,6 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Security surplus equipment"
 	access = access_security
-
-/decl/hierarchy/supply_pack/security/detectivegear
-	name = "Forensic investigation equipment"
-	contains = list(/obj/item/weapon/storage/box/evidence = 2,
-					/obj/item/weapon/cartridge/detective,
-					/obj/item/device/radio/headset/headset_sec,
-					/obj/item/taperoll/police,
-					/obj/item/clothing/glasses/sunglasses,
-					/obj/item/device/camera,
-					/obj/item/weapon/folder/red,
-					/obj/item/weapon/folder/blue,
-					/obj/item/clothing/gloves/forensic,
-					/obj/item/device/taperecorder,
-					/obj/item/device/mass_spectrometer,
-					/obj/item/device/camera_film = 2,
-					/obj/item/weapon/storage/photo_album,
-					/obj/item/device/reagent_scanner,
-					/obj/item/weapon/storage/briefcase/crimekit = 2,
-					)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Forensic equipment"
-	access = access_forensics_lockers
 
 /decl/hierarchy/supply_pack/security/detectiveclothes
 	name = "Investigation apparel"
@@ -386,35 +514,6 @@
 	containername = "\improper Corporate security uniform crate"
 	access = access_security
 
-/decl/hierarchy/supply_pack/security/securitybiosuit
-	name = "Security biohazard gear"
-	contains = list(/obj/item/clothing/head/bio_hood/security,
-					/obj/item/clothing/under/rank/security,
-					/obj/item/clothing/suit/bio_suit/security,
-					/obj/item/clothing/shoes/white,
-					/obj/item/clothing/mask/gas,
-					/obj/item/weapon/tank/oxygen,
-					/obj/item/clothing/gloves/latex)
-	cost = 35
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Security biohazard gear"
-	access = access_security
-
-/decl/hierarchy/supply_pack/security/tactical
-	name = "Tactical suits"
-	contains = list(/obj/item/clothing/under/tactical,
-					/obj/item/clothing/suit/storage/vest/tactical,
-					/obj/item/clothing/head/helmet/tactical,
-					/obj/item/clothing/mask/balaclava/tactical,
-					/obj/item/clothing/glasses/tacgoggles,
-					/obj/item/weapon/storage/belt/security/tactical,
-					/obj/item/clothing/shoes/tactical,
-					/obj/item/clothing/gloves/tactical)
-	cost = 45
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Tactical Suit Locker"
-	access = access_armory
-
 /decl/hierarchy/supply_pack/security/practicelasers
 	name = "Practice Laser Carbines"
 	contains = list(/obj/item/weapon/gun/energy/laser/practice = 4)
@@ -422,3 +521,4 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Practice laser carbine crate"
 	access = access_brig
+*/

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -1,0 +1,146 @@
+/decl/hierarchy/supply_pack/security
+	name = "Security"
+
+/decl/hierarchy/supply_pack/security/lightarmorsol
+	name = "Armor - SCG light"
+	contains = list(/obj/item/clothing/suit/armor/vest/solgov = 4,
+					/obj/item/clothing/head/helmet/solgov =4)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper SolGov light armor crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/secarmor
+	name = "Armor - Security"
+	contains = list(/obj/item/clothing/suit/storage/vest/solgov/security = 2,
+					/obj/item/clothing/head/helmet/solgov/security =2)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Security armor crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/solarmor
+	name = "Armor - Peacekeeper"
+	contains = list(/obj/item/clothing/suit/storage/vest/solgov = 2,
+					/obj/item/clothing/head/helmet/solgov =2)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Peacekeeper armor crate"
+	access = access_emergency_armory
+
+/decl/hierarchy/supply_pack/security/comarmor
+	name = "Armor - Command"
+	contains = list(/obj/item/clothing/suit/storage/vest/solgov/command = 2,
+					/obj/item/clothing/head/helmet/solgov/command =2)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Command armor crate"
+	access = access_heads
+
+/decl/hierarchy/supply_pack/security/nanoarmor
+	name = "Armor - NanoTrasen"
+	contains = list(/obj/item/clothing/suit/storage/vest/nt = 2,
+					/obj/item/clothing/head/helmet/nt/guard =2)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper NanoTrasen armor crate"
+	access = access_nanotrasen
+
+/decl/hierarchy/supply_pack/security/lightnanoarmor
+	name = "Armor - NanoTrasen light"
+	contains = list(/obj/item/clothing/suit/armor/vest/nt = 2,
+					/obj/item/clothing/head/helmet/nt/guard =2)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper NanoTrasen light armor crate"
+	access = access_nanotrasen
+
+/decl/hierarchy/supply_pack/security/laser
+	name = "Weapons - Laser carbines"
+	contains = list(/obj/item/weapon/gun/energy/laser = 4)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Laser carbines crate"
+	access = access_emergency_armory
+
+/decl/hierarchy/supply_pack/security/advancedlaser
+	name = "Weapons - Advanced Laser Weapons"
+	contains = list(/obj/item/weapon/gun/energy/xray = 2,
+					/obj/item/weapon/gun/energy/xray/pistol = 2,
+					/obj/item/weapon/shield/energy = 2)
+	cost = 100
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Advanced Laser Weapons crate"
+	access = access_emergency_armory
+
+/decl/hierarchy/supply_pack/security/sniperlaser
+	name = "Weapons - Energy marksman"
+	contains = list(/obj/item/weapon/gun/energy/sniperrifle = 2)
+	cost = 70
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Energy marksman crate"
+	access = access_emergency_armory
+
+/decl/hierarchy/supply_pack/security/pdw
+	name = "Weapons - Ballistic PDWs"
+	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550 = 2)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Ballistic PDW crate"
+	access = access_emergency_armory
+
+/decl/hierarchy/supply_pack/security/bullpup
+	name = "Weapons - Ballistic rifles"
+	contains = list(/obj/item/weapon/gun/projectile/automatic/z8 = 2)
+	cost = 80 //Because 5.56 is OP as fuck right now.
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper Bullpup automatic rifle crate"
+	access = access_emergency_armory
+
+/decl/hierarchy/supply_pack/security/holster
+	name = "Misc - Holster crate"
+	contains = list(/obj/item/clothing/accessory/holster/hip = 4)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Holster crate"
+	access = access_solgov_crew
+
+/decl/hierarchy/supply_pack/security/securityextragear
+	name = "Misc - Security equipment"
+	contains = list(/obj/item/weapon/cartridge/security = 2,
+					/obj/item/weapon/storage/belt/security = 2,
+					/obj/item/device/radio/headset/headset_sec = 2,
+					/obj/item/clothing/glasses/sunglasses/sechud/goggles = 2,
+					/obj/item/taperoll/police = 2,
+					/obj/item/device/hailer = 2,
+					/obj/item/clothing/gloves/thick = 2,
+					/obj/item/device/holowarrant = 2,
+					/obj/item/device/flashlight/maglight = 2)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Security equipment crate"
+	access = access_security
+
+/decl/hierarchy/supply_pack/security/cosextragear
+	name = "Misc - Chief of Security equipment"
+	contains = list(/obj/item/weapon/cartridge/hos,
+					/obj/item/device/radio/headset/heads/cos,
+					/obj/item/clothing/glasses/sunglasses/sechud/goggles,
+					/obj/item/taperoll/police,
+					/obj/item/weapon/storage/belt/security,
+					/obj/item/device/hailer,
+					/obj/item/device/holowarrant,
+					/obj/item/clothing/gloves/thick,
+					/obj/item/device/flashlight/maglight,)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Chief of Security equipment crate"
+	access = access_hos
+
+/decl/hierarchy/supply_pack/security/practicelasers
+	name = "Misc - Practice Laser Carbines"
+	contains = list(/obj/item/weapon/gun/energy/laser/practice = 4)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper Practice laser carbine crate"
+	access = access_solgov_crew

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -16,6 +16,7 @@
 	#include "datums/uniforms_expedition.dm"
 	#include "datums/uniforms_fleet.dm"
 	#include "datums/uniforms_marine.dm"
+	#include "datums/supplypacks/security.dm"
 
 	#include "items/cards_ids.dm"
 	#include "items/clothing.dm"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
This updates the supply crates available in the security section to be in line with the Torch, rather than the Exodus.

Among the changes are:
-Weapons, ammunition and armor are never found within the same crate, with the sole exception of the riot gear crate, which comes with one box of flashbangs and one box of tear gas grenades;
-Prices for weaponry have been adjusted according to the potential each one has for damage. Lighter weapons have been balanced with four people in mind, and heavier weapons with two. More damaging weapons can only be opened by people with emergency armory access, with the sole exception of shotguns, which require security armory access;
-All ammunition type crates require only basic security access. Security can not use the ammunition on its own, but should be able to refill their ammunition stocks if necessary;
-Armor has been balanced with two people in mind for normal armor, four for light armor, and four for specialty armor;
-All crates are now prefixed with a type, which helps to group crates used for similar situations together;
-Prices were adjusted in most crates in which items have been added to or subtracted from;
-Crates of items with a low potential for danger and/or common availability can be unlocked by anybody posessing basic SolGov access;
-The excessive amount of uniforms security could order has been done away with;
-"Experimental gear" crates have been done away with. It's not experimental if it's available inside security's armory.

I have not tested this exhaustively, meaning I haven't ordered and opened every single crate, but I can assure that this works exactly as intended.

I plan to overhaul the other supply categories as well, although most of them are not as outdated.