### PR TITLE
Makes teleporter mishaps not mess with Z that much

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -206,9 +206,9 @@
 			O.show_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return
 	if (istype(M, /atom/movable))
-		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
+		if(prob(5) && !accurate) //oh dear a problem
 			var/turf/T = get_turf(M)
-			var/destination_z = T ? GLOB.using_map.get_transit_zlevel(T.z) : pick(GLOB.using_map.player_levels)
+			var/destination_z = T ? GetConnectedZlevels(T.z) : GetConnectedZlevels(z)
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), destination_z), 2)
 		else
 			do_teleport(M, com.locked) //dead-on precision


### PR DESCRIPTION
It was causing issues when people got teleported onto empty zlevels, which makes them impossible to rescue with overmap.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
