### PR TITLE
Fix for edge case runtime in mob damage unit test

### DIFF
--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -67,11 +67,7 @@ proc/create_test_mob_with_mind(var/turf/mobloc = null, var/mobtype = /mob/living
 
 	if(isnull(mobloc))
 		if(!default_mobloc)
-			for(var/turf/simulated/floor/tiled/T in world)
-				var/pressure = T.zone.air.return_pressure()
-				if(90 < pressure && pressure < 120) // Find a turf between 90 and 120
-					default_mobloc = T
-					break
+			default_mobloc = get_safe_turf()
 		mobloc = default_mobloc
 	if(!mobloc)
 		test_result["msg"] = "Unable to find a location to create test mob"

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -61,9 +61,6 @@ datum/unit_test
 	var/reported = 0	// If it's reported a success or failure.  Any tests that have not are assumed to be failures.
 	var/why_disabled = "No reason set."   // If we disable a unit test we will display why so it reminds us to check back on it later.
 
-	var/safe_landmark
-	var/space_landmark
-
 datum/unit_test/proc/log_debug(var/message)
 	log_unit_test("[ascii_yellow]---  DEBUG  --- \[[name]\]: [message][ascii_reset]")
 
@@ -91,22 +88,6 @@ datum/unit_test/proc/start_test()
 datum/unit_test/proc/check_result()
 	fail("No check results proc")
 	return 1
-
-datum/unit_test/proc/get_safe_turf()
-	if(!safe_landmark)
-		for(var/landmark in landmarks_list)
-			if(istype(landmark, /obj/effect/landmark/test/safe_turf))
-				safe_landmark = landmark
-				break
-	return get_turf(safe_landmark)
-
-datum/unit_test/proc/get_space_turf()
-	if(!space_landmark)
-		for(var/landmark in landmarks_list)
-			if(istype(landmark, /obj/effect/landmark/test/space_turf))
-				space_landmark = landmark
-				break
-	return get_turf(space_landmark)
 
 proc/load_unit_test_changes()
 /*

--- a/code/unit_tests/~helpers.dm
+++ b/code/unit_tests/~helpers.dm
@@ -5,3 +5,19 @@
 		var/mob/M = am
 		M.real_name = name
 	return am
+
+/proc/get_safe_turf()
+	var/obj/effect/landmark/test/safe_turf/safe_landmark
+	for(var/landmark in landmarks_list)
+		if(istype(landmark, /obj/effect/landmark/test/safe_turf))
+			safe_landmark = landmark
+			break
+	return get_turf(safe_landmark)
+
+/proc/get_space_turf()
+	var/obj/effect/landmark/test/space_turf/space_landmark
+	for(var/landmark in landmarks_list)
+		if(istype(landmark, /obj/effect/landmark/test/space_turf))
+			space_landmark = landmark
+			break
+	return get_turf(space_landmark)


### PR DESCRIPTION
Mob damage unit tests currently check for an instance of /turf/simulated/floor/tiled on the map to spawn the dummy mobs on in an unsafe manner. In the majority of cases (99%+) tiled floors safely hold atmosphere but there is at least one edge case where they do not: when a tiled floor is placed underneath an airlock which is adjacent to a vacuum tile on the south side. Due to the way the ZAS algorithm connects turfs, in that situation the tiled turf under the airlock will have a null zone which will runtime the unit test if that airlock is the closest tiled turf to the bottom left of the time. It was pretty unlikely that we discovered this and bugged the hell out of me for several days. 

This fix will check if the tiled turf has atmosphere then continue until it finds a tiled turf which does. In the event it finds no tiled turfs with atmosphere on the whole map, it will gracefully return failure with the message "Unable to find a location to create test mob"

Reference: https://travis-ci.org/HaloSpaceStation/HaloSpaceStation13/jobs/270757553#L429 (there is various other Travis clutter there). 