### PR TITLE
Fixes #18511

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -321,6 +321,7 @@
 				break
 		if(!term)
 			to_chat(user, "<span class='warning'>There is no terminal on this tile.</span>")
+			building_terminal = 0
 			return 0
 		var/turf/tempTDir = get_turf(term)
 		if (istype(tempTDir))


### PR DESCRIPTION
- Fixes #18511 - SMES terminals should now be deconstructable again after a specific step fails.