### PR TITLE
Protolathe fixes

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -531,12 +531,13 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/gun/energy/toxgun
 	sort_string = "TAAAD"
 
-/datum/design/item/weapon/decloner
-	id = "decloner"
-	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
-	materials = list("gold" = 5000,"uranium" = 10000, "mutagen" = 40)
-	build_path = /obj/item/weapon/gun/energy/decloner
-	sort_string = "TAAAE"
+ /datum/design/item/weapon/decloner
+ 	id = "decloner"
+ 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
+ 	materials = list("gold" = 5000,"uranium" = 10000)
+ 	chemicals = list(/datum/reagent/mutagen = 40)
+ 	build_path = /obj/item/weapon/gun/energy/decloner
+ 	sort_string = "TAAAE"
 
 /datum/design/item/weapon/smg
 	id = "smg"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -533,7 +533,7 @@ other types of metals and chemistry for reagents).
 
  /datum/design/item/weapon/decloner
  	id = "decloner"
- 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
+ 	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
  	materials = list("gold" = 5000,"uranium" = 10000)
  	chemicals = list(/datum/reagent/mutagen = 40)
  	build_path = /obj/item/weapon/gun/energy/decloner

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -91,7 +91,7 @@
 	if(default_part_replacement(user, O))
 		return
 	if(O.is_open_container())
-		return 1
+		return 0
 	if(panel_open)
 		to_chat(user, "<span class='notice'>You can't load \the [src] while it's opened.</span>")
 		return 1

--- a/html/changelogs/Sirlordington-Protolathefixes.yml
+++ b/html/changelogs/Sirlordington-Protolathefixes.yml
@@ -1,0 +1,10 @@
+ 
+author: SirLordington
+
+
+delete-after: True
+
+
+changes: 
+  - bugfix: "You can now load reagents into protolathes (Thanks Mkalash!)."
+  - tweak: "Decloners can now actually be produced."


### PR DESCRIPTION
Allows loading chemical reagents into the protolathe (credit Mkalash). Also tweaks the decloner recipe to both make it work and actually make it feasible to produce.

