### PR TITLE
Adds cable coil to autolathe recipes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -102,10 +102,9 @@
 				material_string += ".<br></td>"
 				//Build list of multipliers for sheets.
 				if(R.is_stack)
-					var/obj/item/stack/R_stack = new R.path
-					max_sheets = min(max_sheets, R_stack.max_amount)
+					var/obj/item/stack/R_stack = R.path
+					max_sheets = min(max_sheets, initial(R_stack.max_amount))
 					//do not allow lathe to print more sheets than the max amount that can fit in one stack
-					qdel(R_stack)
 					if(max_sheets && max_sheets > 0)
 						multiplier_string  += "<br>"
 						for(var/i = 5;i<max_sheets;i*=2) //5,10,20,40...

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -39,7 +39,7 @@
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(src)
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(src)
 	RefreshParts()
-	
+
 /obj/machinery/autolathe/Destroy()
 	qdel(wires)
 	wires = null
@@ -102,6 +102,10 @@
 				material_string += ".<br></td>"
 				//Build list of multipliers for sheets.
 				if(R.is_stack)
+					var/obj/item/stack/R_stack = new R.path
+					max_sheets = min(max_sheets, R_stack.max_amount)
+					//do not allow lathe to print more sheets than the max amount that can fit in one stack
+					qdel(R_stack)
 					if(max_sheets && max_sheets > 0)
 						multiplier_string  += "<br>"
 						for(var/i = 5;i<max_sheets;i*=2) //5,10,20,40...
@@ -273,6 +277,7 @@
 		if(multiplier > 1 && istype(I, /obj/item/stack))
 			var/obj/item/stack/S = I
 			S.amount = multiplier
+			S.update_icon()
 
 	updateUsrDialog()
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -505,3 +505,8 @@
 	name = "device cell"
 	path = /obj/item/weapon/cell/device/standard
 	category = "Devices and Components"
+
+/datum/autolathe/recipe/cable_coil
+	name = "cable coil"
+	path = /obj/item/stack/cable_coil
+	category = "Devices and Components"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -350,10 +350,9 @@ var/const/EXTRA_COST_FACTOR = 1.25
 
 /datum/autolathe/recipe/cable_coil
 	name = "cable coil"
-	path = /obj/item/stack/cable_coil
+	path = /obj/item/stack/cable_coil/single
 	category = "Devices and Components"
-	resources = list(DEFAULT_WALL_MATERIAL = 50 * 30 * EXTRA_COST_FACTOR, "glass" = 20 * 30 * EXTRA_COST_FACTOR)
-	//the machine will print a stack of 30 coils, so the cost should be multiplied by 30
+	is_stack = 1
 
 /datum/autolathe/recipe/tube/large
 	name = "spotlight tube"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -1,6 +1,9 @@
 /var/global/list/autolathe_recipes
 /var/global/list/autolathe_categories
 
+var/const/EXTRA_COST_FACTOR = 1.25
+// Items are more expensive to produce than they are to recycle.
+
 /proc/populate_lathe_recipes()
 
 	//Create global autolathe recipe list if it hasn't been made already.
@@ -15,7 +18,7 @@
 		if(I.matter && !recipe.resources) //This can be overidden in the datums.
 			recipe.resources = list()
 			for(var/material in I.matter)
-				recipe.resources[material] = I.matter[material]*1.25 // More expensive to produce than they are to recycle.
+				recipe.resources[material] = I.matter[material] * EXTRA_COST_FACTOR
 		qdel(I)
 
 /datum/autolathe/recipe
@@ -345,6 +348,13 @@
 	path = /obj/item/device/assembly/prox_sensor
 	category = "Devices and Components"
 
+/datum/autolathe/recipe/cable_coil
+	name = "cable coil"
+	path = /obj/item/stack/cable_coil
+	category = "Devices and Components"
+	resources = list(DEFAULT_WALL_MATERIAL = 50 * 30 * EXTRA_COST_FACTOR, "glass" = 20 * 30 * EXTRA_COST_FACTOR)
+	//the machine will print a stack of 30 coils, so the cost should be multiplied by 30
+
 /datum/autolathe/recipe/tube/large
 	name = "spotlight tube"
 	path = /obj/item/weapon/light/tube/large
@@ -504,9 +514,4 @@
 /datum/autolathe/recipe/cell_device
 	name = "device cell"
 	path = /obj/item/weapon/cell/device/standard
-	category = "Devices and Components"
-
-/datum/autolathe/recipe/cable_coil
-	name = "cable coil"
-	path = /obj/item/stack/cable_coil
 	category = "Devices and Components"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -492,6 +492,9 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/single
 	amount = 1
 
+/obj/item/stack/cable_coil/single/New(var/loc, var/length = 1, var/param_color = null)
+	..(loc, length, param_color)
+
 /obj/item/stack/cable_coil/cyborg
 	name = "cable coil synthesizer"
 	desc = "A device that makes cable."

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -489,6 +489,9 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stacktype = /obj/item/stack/cable_coil
 
+/obj/item/stack/cable_coil/single
+	amount = 1
+
 /obj/item/stack/cable_coil/cyborg
 	name = "cable coil synthesizer"
 	desc = "A device that makes cable."

--- a/html/changelogs/dryerlint-cableCoilsInAutolathe.yml
+++ b/html/changelogs/dryerlint-cableCoilsInAutolathe.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: dryerlint
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Autolathes can now print cable coils. They are under the Devices and Components category."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
The autolathe can now print cable coils. They are placed under the "Devices and Components" category, because even though they fit on toolbelts, a piece of cable isn't really a "tool". (Also, they are used as components in the construction of various machines.)