### PR TITLE
Makes some lists lazy

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -148,11 +148,11 @@ var/global/list/image/splatter_cache=list()
 	icon_state = "1"
 	random_icon_states = list("1","2","3","4","5")
 	amount = 0
-	var/list/drips = list()
+	var/list/drips
 
-/obj/effect/decal/cleanable/blood/drip/New()
-	..()
-	drips |= icon_state
+/obj/effect/decal/cleanable/blood/drip/Initialize()
+	. = ..()
+	drips = list(icon_state)
 
 /obj/effect/decal/cleanable/blood/writing
 	icon_state = "tracks"
@@ -164,7 +164,7 @@ var/global/list/image/splatter_cache=list()
 
 /obj/effect/decal/cleanable/blood/writing/New()
 	..()
-	if(random_icon_states.len)
+	if(LAZYLEN(random_icon_states))
 		for(var/obj/effect/decal/cleanable/blood/writing/W in loc)
 			random_icon_states.Remove(W.icon_state)
 		icon_state = pick(random_icon_states)
@@ -239,7 +239,6 @@ var/global/list/image/splatter_cache=list()
 	anchored = 1
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mucus"
-	random_icon_states = list("mucus")
 
 	var/list/datum/disease2/disease/virus2 = list()
 	var/dry=0 // Keeps the lag down

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -1,5 +1,5 @@
 /obj/effect/decal/cleanable
-	var/list/random_icon_states = list()
+	var/list/random_icon_states
 
 /obj/effect/decal/cleanable/clean_blood(var/ignore = 0)
 	if(!ignore)
@@ -7,7 +7,7 @@
 		return
 	..()
 
-/obj/effect/decal/cleanable/New()
+/obj/effect/decal/cleanable/Initialize()
 	if (random_icon_states && length(src.random_icon_states) > 0)
 		src.icon_state = pick(src.random_icon_states)
-	..()
+	. = ..()


### PR DESCRIPTION
"Cleanables' random_icon_states list is now lazy. (eliminates ~4000 lists from dirt)"
Steals more optimizations by Lohikar

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
