### PR TITLE
Renames a warning sign.

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -84,7 +84,6 @@
 	icon_state = "securearea"
 
 /obj/structure/sign/warning/detailed
-	name = "\improper WARNING 2"
 	icon_state = "securearea2"
 
 /obj/structure/sign/warning/New()


### PR DESCRIPTION
See no need to call it "WARNING 2".

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
