### PR TITLE
Fixes some synth GC issues.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -55,9 +55,9 @@
 			MT.interact(aiMulti, src)
 			return
 
-	if(aiCamera.in_camera_mode)
-		aiCamera.camera_mode_off()
-		aiCamera.captureimage(A, usr)
+	if(silicon_camera.in_camera_mode)
+		silicon_camera.camera_mode_off()
+		silicon_camera.captureimage(A, usr)
 		return
 
 	/*

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -36,10 +36,10 @@
 
 	face_atom(A) // change direction to face what you clicked on
 
-	if(aiCamera.in_camera_mode)
-		aiCamera.camera_mode_off()
+	if(silicon_camera.in_camera_mode)
+		silicon_camera.camera_mode_off()
 		if(is_component_functioning("camera"))
-			aiCamera.captureimage(A, usr)
+			silicon_camera.captureimage(A, usr)
 		else
 			to_chat(src, "<span class='userdanger'>Your camera isn't functional.</span>")
 		return

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -213,7 +213,7 @@
 
 	transfer.aiRestorePowerRoutine = 0
 	transfer.control_disabled = 0
-	transfer.aiRadio.disabledAi = 0
+	transfer.ai_radio.disabledAi = 0
 	transfer.loc = get_turf(src)
 	transfer.create_eyeobj()
 	transfer.cancel_camera()

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -28,7 +28,7 @@
 		data["name"] = carded_ai.name
 		data["hardware_integrity"] = carded_ai.hardware_integrity()
 		data["backup_capacitor"] = carded_ai.backup_capacitor()
-		data["radio"] = !carded_ai.aiRadio.disabledAi
+		data["radio"] = !carded_ai.ai_radio.disabledAi
 		data["wireless"] = !carded_ai.control_disabled
 		data["operational"] = carded_ai.stat != DEAD
 		data["flushing"] = flush
@@ -66,9 +66,9 @@
 				sleep(10)
 			flush = 0
 	if (href_list["radio"])
-		carded_ai.aiRadio.disabledAi = text2num(href_list["radio"])
-		to_chat(carded_ai, "<span class='warning'>Your Subspace Transceiver has been [carded_ai.aiRadio.disabledAi ? "disabled" : "enabled"]!</span>")
-		to_chat(user, "<span class='notice'>You [carded_ai.aiRadio.disabledAi ? "disable" : "enable"] the AI's Subspace Transceiver.</span>")
+		carded_ai.ai_radio.disabledAi = text2num(href_list["radio"])
+		to_chat(carded_ai, "<span class='warning'>Your Subspace Transceiver has been [carded_ai.ai_radio.disabledAi ? "disabled" : "enabled"]!</span>")
+		to_chat(user, "<span class='notice'>You [carded_ai.ai_radio.disabledAi ? "disable" : "enable"] the AI's Subspace Transceiver.</span>")
 	if (href_list["wireless"])
 		carded_ai.control_disabled = text2num(href_list["wireless"])
 		to_chat(carded_ai, "<span class='warning'>Your wireless interface has been [carded_ai.control_disabled ? "disabled" : "enabled"]!</span>")

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -152,6 +152,10 @@
 	var/myAi = null    // Atlantis: Reference back to the AI which has this radio.
 	var/disabledAi = 0 // Atlantis: Used to manually disable AI's integrated radio via inteliCard menu.
 
+/obj/item/device/radio/headset/heads/ai_integrated/Destroy()
+	myAi = null
+	. = ..()
+
 /obj/item/device/radio/headset/heads/ai_integrated/receive_range(freq, level)
 	if (disabledAi)
 		return -1 //Transciever Disabled.
@@ -295,7 +299,7 @@
 		return attack_self(M)
 	return
 
-/obj/item/device/radio/headset/proc/recalculateChannels(var/setDescription = 0)
+/obj/item/device/radio/headset/recalculateChannels(var/setDescription = 0)
 	src.channels = list()
 	src.translate_binary = 0
 	src.translate_hive = 0

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -526,6 +526,9 @@
 	for (var/ch_name in channels)
 		channels[ch_name] = 0
 	..()
+    
+/obj/item/device/radio/proc/recalculateChannels()
+    return
 
 ///////////////////////////////
 //////////Borg Radios//////////
@@ -541,7 +544,24 @@
 	canhear_range = 0
 	subspace_transmission = 1
 
+/obj/item/device/radio/borg/ert
+	keyslot = /obj/item/device/encryptionkey/ert
+
+/obj/item/device/radio/borg/syndicate
+	keyslot = /obj/item/device/encryptionkey/syndicate
+
+/obj/item/device/radio/borg/New(var/mob/living/silicon/robot/loc)
+    if(!istype(loc))
+        CRASH("Invalid spawn location: [log_info_line(loc)]")
+    ..()
+    myborg = loc
+    
+/obj/item/device/radio/borg/Initialize()
+	. = ..()
+	recalculateChannels()
+
 /obj/item/device/radio/borg/Destroy()
+	QDEL_NULL(keyslot)
 	myborg = null
 	return ..()
 
@@ -596,7 +616,7 @@
 
 	return
 
-/obj/item/device/radio/borg/proc/recalculateChannels()
+/obj/item/device/radio/borg/recalculateChannels()
 	src.channels = list()
 	src.syndie = 0
 
@@ -619,14 +639,10 @@
 
 	for (var/ch_name in src.channels)
 		if(!radio_controller)
-			sleep(30) // Waiting for the radio_controller to be created.
-		if(!radio_controller)
 			src.name = "broken radio"
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
-
-	return
 
 /obj/item/device/radio/borg/Topic(href, href_list)
 	if(..())

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1886,7 +1886,7 @@ mob/living/carbon/human/can_centcom_reply()
 	return istype(l_ear, /obj/item/device/radio/headset) || istype(r_ear, /obj/item/device/radio/headset)
 
 mob/living/silicon/ai/can_centcom_reply()
-	return common_radio != null && !check_unable(2)
+	return silicon_radio != null && !check_unable(2)
 
 /datum/proc/extra_admin_link(var/prefix, var/sufix, var/short_links)
 	return list()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -106,7 +106,7 @@
 /mob/living/silicon/proc/law_channels()
 	var/list/channels = new()
 	channels += MAIN_CHANNEL
-	channels += common_radio.channels
+	channels += silicon_radio.channels
 	channels += additional_law_channels
 	channels += "Binary"
 	return channels

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -11,6 +11,7 @@
 	can_pull_mobs = MOB_PULL_SMALLER
 
 	idcard = /obj/item/weapon/card/id
+	silicon_radio = null // pAIs get their radio from the card they belong to.
 
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null
@@ -85,24 +86,26 @@
 	src.loc = paicard
 	card = paicard
 	sradio = new(src)
-	if(card)
-		if(!card.radio)
-			card.radio = new /obj/item/device/radio(src.card)
-		radio = card.radio
-		common_radio = radio
 
 	//As a human made device, we'll understand sol common without the need of the translator
 	add_language(LANGUAGE_SOL_COMMON, 1)
-	
+
 	verbs += /mob/living/silicon/pai/proc/choose_chassis
 	verbs += /mob/living/silicon/pai/proc/choose_verbs
 	verbs -= /mob/living/verb/ghost
 
 	..()
 
-/mob/living/silicon/pai/Login()
-	..()
+	if(card)
+		if(!card.radio)
+			card.radio = new /obj/item/device/radio(card)
+		silicon_radio = card.radio
 
+/mob/living/silicon/pai/Destroy()
+	QDEL_NULL(sradio)
+	card = null
+	silicon_radio = null // Because this radio actually belongs to another instance we simply null
+	. = ..()
 
 // this function shows the information about being silenced as a pAI in the Status panel
 /mob/living/silicon/pai/proc/show_silenced()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -50,6 +50,8 @@ var/list/mob_hat_cache = list()
 
 	laws = /datum/ai_laws/drone
 
+	silicon_camera = /obj/item/device/camera/siliconcam/drone_camera
+
 	//Used for self-mailing.
 	var/mail_destination = ""
 	var/module_type = /obj/item/weapon/robot_module/drone
@@ -141,7 +143,6 @@ var/list/mob_hat_cache = list()
 	update_icon()
 
 /mob/living/silicon/robot/drone/init()
-	aiCamera = new/obj/item/device/camera/siliconcam/drone_camera(src)
 	additional_law_channels["Drone"] = ":d"
 	if(!module) module = new module_type(src)
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -137,11 +137,11 @@
 	if (src.stat != 0)
 		uneq_all()
 
-	if(radio)
+	if(silicon_radio)
 		if(!is_component_functioning("radio"))
-			radio.on = 0
+			silicon_radio.on = 0
 		else
-			radio.on = 1
+			silicon_radio.on = 1
 
 	if(is_component_functioning("camera"))
 		src.blinded = 0

--- a/code/modules/mob/living/silicon/robot/photos.dm
+++ b/code/modules/mob/living/silicon/robot/photos.dm
@@ -1,12 +1,12 @@
 /mob/living/silicon/robot/proc/photosync()
-	var/obj/item/device/camera/siliconcam/master_cam = connected_ai ? connected_ai.aiCamera : null
+	var/obj/item/device/camera/siliconcam/master_cam = connected_ai && connected_ai.silicon_camera
 	if (!master_cam)
 		return
 
 	var/synced = 0
 	// Sync borg images to the master AI.
 	// We don't care about syncing the other way around
-	for(var/obj/item/weapon/photo/borg_photo in aiCamera.aipictures)
+	for(var/obj/item/weapon/photo/borg_photo in silicon_camera.aipictures)
 		var/copied = 0
 		for(var/obj/item/weapon/photo/ai_photo in master_cam.aipictures)
 			if(borg_photo.id == ai_photo.id)

--- a/code/modules/mob/living/silicon/robot/preset.dm
+++ b/code/modules/mob/living/silicon/robot/preset.dm
@@ -7,7 +7,7 @@
 	laws = /datum/ai_laws/syndicate_override
 	idcard = /obj/item/weapon/card/id/syndicate
 	module = /obj/item/weapon/robot_module/syndicate
-	radio_key_type = /obj/item/device/encryptionkey/syndicate
+	silicon_radio = /obj/item/device/radio/borg/syndicate
 	spawn_sound = 'sound/mecha/nominalsyndi.ogg'
 	cell = /obj/item/weapon/cell/super
 	pitch_toggle = 0
@@ -24,4 +24,4 @@
 /mob/living/silicon/robot/combat/nt
 	laws = /datum/ai_laws/nanotrasen_aggressive
 	idcard = /obj/item/weapon/card/id/centcom/ERT
-	radio_key_type = /obj/item/device/encryptionkey/ert
+	silicon_radio = /obj/item/device/radio/borg/ert

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -46,7 +46,9 @@
 	var/module_state_2 = null
 	var/module_state_3 = null
 
-	var/obj/item/device/radio/borg/radio = null
+	silicon_camera = /obj/item/device/camera/siliconcam
+	silicon_radio = /obj/item/device/radio/borg
+
 	var/mob/living/silicon/ai/connected_ai = null
 	var/obj/item/weapon/cell/cell = /obj/item/weapon/cell/high
 	var/obj/machinery/camera/camera = null
@@ -68,7 +70,7 @@
 	var/locked = 1
 	var/has_power = 1
 	var/spawn_module = null
-	var/radio_key_type = null
+
 	var/spawn_sound = 'sound/voice/liveagain.ogg'
 	var/pitch_toggle = 1
 	var/list/req_access = list(access_robotics)
@@ -114,9 +116,6 @@
 	icontype = "Basic"
 	updatename(modtype)
 	update_icon()
-
-	radio = new /obj/item/device/radio/borg(src)
-	common_radio = radio
 
 	if(!scrambledcodes && !camera)
 		camera = new /obj/machinery/camera(src)
@@ -165,13 +164,8 @@
 		M.set_multiplier(mult)
 
 /mob/living/silicon/robot/proc/init()
-	aiCamera = new/obj/item/device/camera/siliconcam/robot_camera(src)
 	if(ispath(module))
 		new module(src)
-	if(radio_key_type)
-		qdel(radio.keyslot)
-		radio.keyslot = new radio_key_type(radio)
-		radio.recalculateChannels()
 	if(lawupdate)
 		var/new_ai = select_active_ai_with_fewest_borgs()
 		if(new_ai)
@@ -219,20 +213,22 @@
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 //Improved /N
 /mob/living/silicon/robot/Destroy()
-	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
-		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
-		if(T)	mmi.loc = T
-		if(mmi.brainmob)
-			mind.transfer_to(mmi.brainmob)
+	if(mmi)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
+		if(mind)
+			mmi.dropInto(loc)
+			if(mmi.brainmob)
+				mind.transfer_to(mmi.brainmob)
+			else
+				to_chat(src, "<span class='danger'>Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug.</span>")
+				ghostize()
+				//ERROR("A borg has been destroyed, but its MMI lacked a brainmob, so the mind could not be transferred. Player: [ckey].")
+			mmi = null
 		else
-			to_chat(src, "<span class='danger'>Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug.</span>")
-			ghostize()
-			//ERROR("A borg has been destroyed, but its MMI lacked a brainmob, so the mind could not be transferred. Player: [ckey].")
-		mmi = null
+			QDEL_NULL(mmi)
 	if(connected_ai)
 		connected_ai.connected_robots -= src
-	qdel(wires)
-	wires = null
+	connected_ai = null
+	QDEL_NULL(wires)
 	return ..()
 
 /mob/living/silicon/robot/proc/set_module_sprites(var/list/new_sprites)
@@ -621,15 +617,15 @@
 		update_icon()
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && cell)	// radio
-		if(radio)
-			radio.attackby(W,user)//Push it to the radio to let it handle everything
+		if(silicon_radio)
+			silicon_radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else
 			to_chat(user, "Unable to locate a radio.")
 		update_icon()
 
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
-		if(radio)//sanityyyyyy
-			radio.attackby(W,user)//GTFO, you have your own procs
+		if(silicon_radio)//sanityyyyyy
+			silicon_radio.attackby(W,user)//GTFO, you have your own procs
 		else
 			to_chat(user, "Unable to locate a radio.")
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda)||istype(W, /obj/item/weapon/card/robot))			// trying to unlock the interface with an ID card
@@ -870,7 +866,7 @@
 	return
 
 /mob/living/silicon/robot/proc/radio_menu()
-	radio.interact(src)//Just use the radio's Topic() instead of bullshit special-snowflake code
+	silicon_radio.interact(src)//Just use the radio's Topic() instead of bullshit special-snowflake code
 
 
 /mob/living/silicon/robot/Move(a, b, flag)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -58,8 +58,8 @@ var/global/list/robot_modules = list(
 	add_subsystems(R)
 	apply_status_flags(R)
 
-	if(R.radio)
-		R.radio.recalculateChannels()
+	if(R.silicon_radio)
+		R.silicon_radio.recalculateChannels()
 
 	R.set_module_sprites(sprites)
 	R.choose_icon(R.module_sprites.len + 1, R.module_sprites)
@@ -73,8 +73,8 @@ var/global/list/robot_modules = list(
 	remove_subsystems(R)
 	remove_status_flags(R)
 
-	if(R.radio)
-		R.radio.recalculateChannels()
+	if(R.silicon_radio)
+		R.silicon_radio.recalculateChannels()
 	R.choose_icon(0, R.set_module_sprites(list("Default" = "robot")))
 
 /obj/item/weapon/robot_module/Destroy()

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -12,19 +12,19 @@
 			return 0
 		if(message_mode == "general")
 			message_mode = null
-		return radio.talk_into(src,message,message_mode,verb,speaking)
+		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
 
 /mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	..()
 	if(message_mode == "department")
 		return holopad_talk(message, verb, speaking)
 	else if(message_mode)
-		if (aiRadio.disabledAi || !has_power() || stat)
+		if (ai_radio.disabledAi || !has_power() || stat)
 			to_chat(src, "<span class='danger'>System Error - Transceiver Disabled.</span>")
 			return 0
 		if(message_mode == "general")
 			message_mode = null
-		return aiRadio.talk_into(src,message,message_mode,verb,speaking)
+		return ai_radio.talk_into(src,message,message_mode,verb,speaking)
 
 /mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -5,7 +5,7 @@
 	var/const/MAIN_CHANNEL = "Main Frequency"
 	var/lawchannel = MAIN_CHANNEL // Default channel on which to state laws
 	var/list/stating_laws = list()// Channels laws are currently being stated on
-	var/obj/item/device/radio/common_radio
+	var/obj/item/device/radio/silicon_radio
 
 	var/list/hud_list[10]
 	var/list/speech_synthesizer_langs = list()	//which languages can be vocalized by the speech synthesizer
@@ -15,7 +15,7 @@
 	var/speak_exclamation = "declares"
 	var/speak_query = "queries"
 	var/pose //Yes, now AIs can pose too.
-	var/obj/item/device/camera/siliconcam/aiCamera = null //photography
+	var/obj/item/device/camera/siliconcam/silicon_camera = null //photography
 	var/local_transmit //If set, can only speak to others of the same type within a short range.
 
 	var/sensor_mode = 0 //Determines the current HUD.
@@ -30,8 +30,14 @@
 	#define MED_HUD 2 //Medical HUD mode
 
 /mob/living/silicon/New()
-	GLOB.silicon_mob_list |= src
+	GLOB.silicon_mob_list += src
 	..()
+
+	if(silicon_radio)
+		silicon_radio = new silicon_radio(src)
+	if(silicon_camera)
+		silicon_camera = new silicon_camera(src)
+
 	add_language(LANGUAGE_GALCOM)
 	default_language = all_languages[LANGUAGE_GALCOM]
 	init_id()
@@ -39,6 +45,8 @@
 
 /mob/living/silicon/Destroy()
 	GLOB.silicon_mob_list -= src
+	QDEL_NULL(silicon_radio)
+	QDEL_NULL(silicon_camera)
 	for(var/datum/alarm_handler/AH in alarm_manager.all_handlers)
 		AH.unregister_alarm(src)
 	return ..()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -85,7 +85,7 @@
 
 		if(toner >= 5)
 			var/mob/living/silicon/tempAI = usr
-			var/obj/item/device/camera/siliconcam/camera = tempAI.aiCamera
+			var/obj/item/device/camera/siliconcam/camera = tempAI.silicon_camera
 
 			if(!camera)
 				return

--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -24,7 +24,7 @@
 /obj/item/device/camera/siliconcam/proc/injectmasteralbum(obj/item/weapon/photo/p) //stores image information to a list similar to that of the datacore
 	var/mob/living/silicon/robot/C = usr
 	if(C.connected_ai)
-		C.connected_ai.aiCamera.injectaialbum(p.copy(1), " (synced from [C.name])")
+		C.connected_ai.silicon_camera.injectaialbum(p.copy(1), " (synced from [C.name])")
 		to_chat(C.connected_ai, "<span class='unconscious'>Image uploaded by [C.name]</span>")
 		to_chat(usr, "<span class='unconscious'>Image synced to remote database</span>")//feedback to the Cyborg player that the picture was taken
 	else
@@ -145,12 +145,12 @@ obj/item/device/camera/siliconcam/proc/getsource()
 	var/mob/living/silicon/robot/C = usr
 	var/obj/item/device/camera/siliconcam/Cinfo
 	if(C.connected_ai)
-		Cinfo = C.connected_ai.aiCamera
+		Cinfo = C.connected_ai.silicon_camera
 	else
 		Cinfo = src
 	return Cinfo
 
 /mob/living/silicon/proc/GetPicture()
-	if(!aiCamera)
+	if(!silicon_camera)
 		return
-	return aiCamera.selectpicture()
+	return silicon_camera.selectpicture()


### PR DESCRIPTION
The base /silicon type is now solely responsible for QDELing cameras and radios, subtypes should only null their specialized vars.
AIs now clear their borg references (and their AI reference) upon being destroyed.
Borgs now define which radio they use, rather than radio encryption key.
Adds pAI Destroy() handling.