### PR TITLE
Fixes P2P program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/nttransfer.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/nttransfer.dm
@@ -29,6 +29,7 @@ var/global/nttransfer_uid = 0
 	..()
 
 /datum/computer_file/program/nttransfer/process_tick()
+	..()
 	// Server mode
 	if(provided_file)
 		for(var/datum/computer_file/program/nttransfer/C in connected_clients)


### PR DESCRIPTION
Guess no one noticed it being broken due to zero use.
Netspeed wasn't updated due to lack of parent call, so downloads progressed at 0 speed forever.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
