### PR TITLE
Ladder tweaks

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -39,10 +39,28 @@
 	return ..()
 
 /obj/structure/ladder/attackby(obj/item/C as obj, mob/user as mob)
-	attack_hand(user)
-	return
+	climb(user)
 
 /obj/structure/ladder/attack_hand(var/mob/M)
+	climb(M)
+
+/obj/structure/ladder/attack_ai(var/mob/M)
+	var/mob/living/silicon/ai/ai = M
+	if(!istype(ai))
+		return
+	var/mob/observer/eye/AIeye = ai.eyeobj
+	if(istype(AIeye))
+		instant_climb(AIeye)
+
+/obj/structure/ladder/attack_robot(var/mob/M)
+	climb(M)
+
+/obj/structure/ladder/proc/instant_climb(var/mob/M)
+	var/target_ladder = getTargetLadder(M)
+	if(target_ladder)
+		M.forceMove(get_turf(target_ladder))
+
+/obj/structure/ladder/proc/climb(var/mob/M)
 	if(!M.may_climb_ladders(src))
 		return
 
@@ -69,11 +87,8 @@
 		for (var/obj/item/grab/G in M)
 			G.adjust_position(force = 1)
 
-
 /obj/structure/ladder/attack_ghost(var/mob/M)
-	var/target_ladder = getTargetLadder(M)
-	if(target_ladder)
-		M.forceMove(get_turf(target_ladder))
+	instant_climb(M)
 
 /obj/structure/ladder/proc/getTargetLadder(var/mob/M)
 	if((!target_up && !target_down) || (target_up && !istype(target_up.loc, /turf) || (target_down && !istype(target_down.loc,/turf))))

--- a/html/changelogs/atlantiscze-ladders.yml
+++ b/html/changelogs/atlantiscze-ladders.yml
@@ -1,0 +1,5 @@
+author: atlantiscze
+
+delete-after: True
+changes:
+  - tweak: "Cyborgs can now click ladders to climb. AIs can now click ladders to move their view to different Z."


### PR DESCRIPTION
- Synthetics are players too. Some QOL tweaks:
- Cyborgs can now climb ladders by clicking them - they could already do this, you just had to click with a tool selected.
- AI can now "climb" ladders with it's eye, without delay by clicking the ladder.