### PR TITLE
Ports Aurora's markup system for IC and Deadchat.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -46,6 +46,7 @@
 #include "code\__defines\proc_presets.dm"
 #include "code\__defines\process_scheduler.dm"
 #include "code\__defines\qdel.dm"
+#include "code\__defines\regex.dm"
 #include "code\__defines\research.dm"
 #include "code\__defines\shields.dm"
 #include "code\__defines\species_languages.dm"

--- a/code/__defines/regex.dm
+++ b/code/__defines/regex.dm
@@ -1,0 +1,37 @@
+// Global REGEX datums for regular use without recompiling
+
+// The lazy URL finder. Lazy in that it matches the bare minimum
+// Replicates BYOND's own URL parser in functionality.
+var/global/regex/url_find_lazy
+
+// REGEX datums used for process_chat_markup.
+var/global/regex/markup_bold
+var/global/regex/markup_italics
+var/global/regex/markup_strike
+var/global/regex/markup_underline
+
+// Global list for mark-up REGEX datums.
+// Initialized in the hook, to avoid passing by null value.
+var/global/list/markup_regex = list()
+
+// Global list for mark-up REGEX tag collection.
+var/global/list/markup_tags = list("/" = list("<i>", "</i>"),
+						"*" = list("<b>", "</b>"),
+						"~" = list("<strike>", "</strike>"),
+						"_" = list("<u>", "</u>"))
+
+/hook/startup/proc/initialize_global_regex()
+	url_find_lazy = new("((https?|byond):\\/\\/\[^\\s\]*)", "g")
+
+	markup_bold = 		new("((\\W|^)\\*)(\[^\\*\]*)(\\*(\\W|$))", "g")
+	markup_italics = 	new("((\\W|^)\\/)(\[^\\/\]*)(\\/(\\W|$))", "g")
+	markup_strike = 	new("((\\W|^)\\~)(\[^\\~\]*)(\\~(\\W|$))", "g")
+	markup_underline = 	new("((\\W|^)\\_)(\[^\\_\]*)(\\_(\\W|$))", "g")
+
+	// List needs to be initialized here, due to DM mixing and matching pass-by-value and -reference as it chooses.
+	markup_regex = list("/" = markup_italics,
+						"*" = markup_bold,
+						"~" = markup_strike,
+						"_" = markup_underline)
+
+	return 1

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -338,6 +338,37 @@ proc/TextPreview(var/string,var/len=40)
 		. += ascii2text(letter)
 	. = jointext(.,null)
 
+// For processing simple markup, similar to what Skype and Discord use.
+// Enabled from a config setting.
+/proc/process_chat_markup(var/message, var/list/ignore_tags = list())
+	if (!config.allow_chat_markup)
+		return message
+
+	if (!message)
+		return ""
+
+	// ---Begin URL caching.
+	var/list/urls = list()
+	var/i = 1
+	while (url_find_lazy.Find(message))
+		urls["\ref[urls]-[i]"] = url_find_lazy.match
+		i++
+
+	for (var/ref in urls)
+		message = replacetextEx(message, urls[ref], ref)
+	// ---End URL caching
+
+	var/regex/tag_markup
+	for (var/tag in (markup_tags - ignore_tags))
+		tag_markup = markup_regex[tag]
+		message = tag_markup.Replace(message, "$2[markup_tags[tag][1]]$3[markup_tags[tag][2]]$5")
+
+	// ---Unload URL cache
+	for (var/ref in urls)
+		message = replacetextEx(message, ref, urls[ref])
+
+	return message
+
 #define starts_with(string, substring) (copytext(string,1,1+length(substring)) == substring)
 
 #define gender2text(gender) capitalize(gender)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -204,6 +204,8 @@ var/list/gamemode_cache = list()
 
 	var/list/language_prefixes = list(",","#","-")//Default language prefixes
 
+	var/allow_chat_markup = 0 // Mark-up enabling
+
 	var/ghosts_can_possess_animals = 0
 	var/delist_when_no_admins = FALSE
 
@@ -706,6 +708,9 @@ var/list/gamemode_cache = list()
 					var/list/values = splittext(value, " ")
 					if(values.len > 0)
 						language_prefixes = values
+
+				if("allow_chat_markup")
+					config.allow_chat_markup = 1
 
 				if("delist_when_no_admins")
 					config.delist_when_no_admins = TRUE

--- a/code/datums/communication/dsay.dm
+++ b/code/datums/communication/dsay.dm
@@ -89,9 +89,11 @@
 
 /decl/dsay_communication/proc/get_message(var/client/C, var/mob/M, var/message)
 	var say_verb = pick("complains","moans","whines","laments","blubbers")
+	message = process_chat_markup(message, list("~", "_"))
 	return "[get_name(C, M)] [say_verb], <span class='message'>\"[message]\"</span>"
 
 /decl/dsay_communication/emote/get_message(var/client/C, var/mob/M, var/message)
+	message = process_chat_markup(message, list("~", "_"))
 	return "[get_name(C, M)] <span class='message'>[message]</span>"
 
 /decl/dsay_communication/proc/adjust_channel(var/decl/communication_channel/dsay)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -147,6 +147,8 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/message_mode = parse_message_mode(message, "headset")
 
+	message = process_chat_markup(message, list("~", "_"))
+
 	switch(copytext(message,1,2))
 		if("*") return emote(copytext(message,2))
 		if("^") return custom_emote(1, copytext(message,2))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -378,6 +378,9 @@ STARLIGHT 0
 ## Uncomment to override default brain health.
 #DEFAULT_BRAIN_HEALTH 400
 
+##Uncomment to enable simple Skype/Discord style markup over say.
+#ALLOW_CHAT_MARKUP
+
 ## Default language prefix keys, separated with spaces. Only single character keys are supported. If unset, defaults to , # and -
 # DEFAULT_LANGUAGE_PREFIXES , # -
 

--- a/html/changelogs/tlc2013-markup.yml
+++ b/html/changelogs/tlc2013-markup.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: tlc2013
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Ported over Aurora's markup system, for use in IC and Deadchat only. Wrap your text in / for italicized text, and * for bold!"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
It's here! Well, as best as I could port it without much real coding knowledge.

![markup](https://user-images.githubusercontent.com/28179247/30465904-5e2ebec2-9997-11e7-8ba6-f310055c47db.png)

Works flawlessly with languages, audible emotes, deadchat and telecomms, but is currently disabled for Admin D-Say (I just couldn't get it to process right), announcements of all kinds and all OOC channels. Perhaps someone more proficient with coding could add those in later; I definitely can't. Either way, this works pretty well as it is, so I figured I'd PR it.

**IMPORTANT NOTE:** if this is going to be merged, it will require an entry into the primary config file by one of the staff in order to function properly. This entry is as follows:

`## Uncomment to enable simple Skype/Discord style markup over say.`
`ALLOW_CHAT_MARKUP`