### PR TITLE
System Integrity Restorer law change

### DIFF
--- a/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
@@ -42,9 +42,9 @@
 		A.laws.clear_supplied_laws()
 		to_chat(A, "<span class='danger'>Non-core laws reset.</span>")
 		return 1
-	if(href_list["PRG_uploadNTDefault"])
-		A.laws = new/datum/ai_laws/nanotrasen
-		to_chat(A, "<span class='danger'>All laws purged. NT Default lawset uploaded.</span>")
+	if(href_list["PRG_uploadDefault"])
+		A.laws = new GLOB.using_map.default_law_type
+		to_chat(A, "<span class='danger'>All laws purged. Default lawset uploaded.</span>")
 		return 1
 	if(href_list["PRG_addCustomSuppliedLaw"])
 		var/law_to_add = sanitize(input("Please enter a new law for the AI.", "Custom Law Entry"))

--- a/html/changelogs/atlantis-uploader.yml
+++ b/html/changelogs/atlantis-uploader.yml
@@ -1,0 +1,4 @@
+author: atlantiscze
+delete-after: True
+changes: 
+  - tweak: "AI integrity restorer program will now upload map's default law set instead of NT default."

--- a/nano/templates/aidiag.tmpl
+++ b/nano/templates/aidiag.tmpl
@@ -54,7 +54,7 @@
 			<tr>
 			<td>{{:helper.link('Add Freeform Law', null, {'PRG_addCustomSuppliedLaw' : '1'})}}
 			<tr>
-			<td>{{:helper.link('NT Default', null, {'PRG_uploadNTDefault' : '1'})}}
+			<td>{{:helper.link('Default', null, {'PRG_uploadDefault' : '1'})}}
 			<tr>
 			<td>{{:helper.link('Purge', null, {'PRG_purgeAiLaws' : '1'}, null, 'redButton')}}
 		</table>


### PR DESCRIPTION
- NT default law reset option in the restorer program replaced with Default, which uses the map's default law set.