### PR TITLE
Fixes immortal AI bug

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1673,6 +1673,7 @@
 #include "code\modules\mob\living\silicon\silicon.dm"
 #include "code\modules\mob\living\silicon\subsystems.dm"
 #include "code\modules\mob\living\silicon\ai\ai.dm"
+#include "code\modules\mob\living\silicon\ai\ai_damage.dm"
 #include "code\modules\mob\living\silicon\ai\ai_movement.dm"
 #include "code\modules\mob\living\silicon\ai\death.dm"
 #include "code\modules\mob\living\silicon\ai\examine.dm"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -49,6 +49,7 @@ var/list/ai_verbs_default = list(
 	density = 1
 	status_flags = CANSTUN|CANPARALYSE|CANPUSH
 	shouldnt_see = list(/obj/effect/rune)
+	maxHealth = 200
 	var/list/network = list("Exodus")
 	var/obj/machinery/camera/camera = null
 	var/list/connected_robots = list()

--- a/code/modules/mob/living/silicon/ai/ai_damage.dm
+++ b/code/modules/mob/living/silicon/ai/ai_damage.dm
@@ -1,0 +1,57 @@
+/mob/living/silicon/ai
+	var/fireloss = 0
+	var/bruteloss = 0
+	var/oxyloss = 0
+
+/mob/living/silicon/ai/getFireLoss()
+	return fireloss
+
+/mob/living/silicon/ai/getBruteLoss()
+	return bruteloss
+
+/mob/living/silicon/ai/getOxyLoss()
+	return oxyloss
+
+/mob/living/silicon/ai/adjustFireLoss(var/amount)
+	if(status_flags & GODMODE) return
+	fireloss = max(0, fireloss + min(amount, health))
+
+/mob/living/silicon/ai/adjustBruteLoss(var/amount)
+	if(status_flags & GODMODE) return
+	bruteloss = max(0, bruteloss + min(amount, health))
+
+/mob/living/silicon/ai/adjustOxyLoss(var/amount)
+	if(status_flags & GODMODE) return
+	oxyloss = max(0, oxyloss + min(amount, maxHealth - oxyloss))
+
+/mob/living/silicon/ai/setFireLoss(var/amount)
+	if(status_flags & GODMODE)
+		fireloss = 0
+		return
+	fireloss = max(0, amount)
+
+/mob/living/silicon/ai/setOxyLoss(var/amount)
+	if(status_flags & GODMODE)
+		oxyloss = 0
+		return
+	oxyloss = max(0, amount)
+
+/mob/living/silicon/ai/updatehealth()
+	if(status_flags & GODMODE)
+		health = maxHealth
+		set_stat(CONSCIOUS)
+		setOxyLoss(0)
+	else
+		health = maxHealth - getFireLoss() - getBruteLoss() // Oxyloss is not part of health as it represents AIs backup power. AI is immune against ToxLoss as it is machine.
+
+/mob/living/silicon/ai/rejuvenate()
+	..()
+	add_ai_verbs(src)
+
+// Returns percentage of AI's remaining backup capacitor charge (maxhealth - oxyloss).
+/mob/living/silicon/ai/proc/backup_capacitor()
+	return ((getOxyLoss() - maxHealth) / maxHealth) * (-100)
+
+// Returns percentage of AI's remaining hardware integrity (maxhealth - (bruteloss + fireloss))
+/mob/living/silicon/ai/proc/hardware_integrity()
+	return (health / maxHealth) * 100

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -8,7 +8,7 @@
 
 	src.updatehealth()
 
-	if (!hardware_integrity() || !backup_capacitor())
+	if ((hardware_integrity() <= 0) || (backup_capacitor() <= 0))
 		death()
 		return
 
@@ -44,19 +44,6 @@
 			process_sec_hud(src,0,src.eyeobj)
 		if (MED_HUD)
 			process_med_hud(src,0,src.eyeobj)
-
-
-/mob/living/silicon/ai/updatehealth()
-	if(status_flags & GODMODE)
-		health = 100
-		set_stat(CONSCIOUS)
-		setOxyLoss(0)
-	else
-		health = 100 - getFireLoss() - getBruteLoss() // Oxyloss is not part of health as it represents AIs backup power. AI is immune against ToxLoss as it is machine.
-
-/mob/living/silicon/ai/rejuvenate()
-	..()
-	add_ai_verbs(src)
 
 /mob/living/silicon/ai/update_living_sight()
 	if(!has_power() || self_shutdown)

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -112,14 +112,6 @@
 			to_chat(src, "Shutting down APU... DONE")
 		log_ability_use(src, "Switched to external power", null, 0)
 
-// Returns percentage of AI's remaining backup capacitor charge (maxhealth - oxyloss).
-/mob/living/silicon/ai/proc/backup_capacitor()
-	return ((200 - getOxyLoss()) / 2)
-
-// Returns percentage of AI's remaining hardware integrity (maxhealth - (bruteloss + fireloss))
-/mob/living/silicon/ai/proc/hardware_integrity()
-	return (health-config.health_threshold_dead)/2
-
 // Shows capacitor charge and hardware integrity information to the AI in Status tab.
 /mob/living/silicon/ai/show_system_integrity()
 	if(!src.stat)


### PR DESCRIPTION
- Apparently, when brainmed came, AIs became immortal as someone thought it'd be good idea to get rid of original damage proc implementation for living mobs. This restores this implementation, however only for AIs as i currently don't feel like doing thorough testing of whether all mobs take damage as they should.
- Tested: AI takes damage correctly when beaten with blunt object, shot with energy weapon or left w/o power. AI correctly dies when integrity or capacitor goes to 0%. AI can be correctly revived via the integrity restorer. The AI's relative health did not change, as both death threshold and max health have changed by the same amount.