### PR TITLE
Tweaks how radiation protection is handled

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -205,3 +205,5 @@
 #define RAD_LEVEL_MODERATE 5
 #define RAD_LEVEL_HIGH 25
 #define RAD_LEVEL_VERY_HIGH 75
+
+#define RADIATION_THRESHOLD_CUTOFF 0.1	// Radiation will not affect a tile when below this value.

--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -61,10 +61,13 @@ var/global/repository/radiation/radiation_repository = new()
 			origin = get_step_towards(origin, T) //Raytracing
 			if(!(origin in resistance_cache)) //Only get the resistance if we don't already know it.
 				origin.calc_rad_resistance()
-			working = max((working - (origin.cached_rad_resistance * config.radiation_resistance_multiplier)), 0)
-			if(working <= .)
+			if(origin.cached_rad_resistance)
+				working = max(round((working / (origin.cached_rad_resistance * config.radiation_resistance_multiplier)), 0.1), 0)
+			if((working <= .) || (working <= RADIATION_THRESHOLD_CUTOFF))
 				break // Already affected by a stronger source (or its zero...)
 		. = max((working * (1 / (dist ** 2))), .) //Butchered version of the inverse square law. Works for this purpose
+		if(. <= RADIATION_THRESHOLD_CUTOFF)
+			. = 0
 
 // Add a radiation source instance to the repository.  It will override any existing source on the same turf.
 /repository/radiation/proc/add_source(var/datum/radiation_source/S)

--- a/html/changelogs/atlantis-RadAway.yml
+++ b/html/changelogs/atlantis-RadAway.yml
@@ -1,0 +1,6 @@
+author: atlantiscze
+
+delete-after: True
+
+changes: 
+  - tweak: "Walls and similar dense objects are now much better when protecting against radiation, especially at higher levels."


### PR DESCRIPTION
- In short, walls, doors and similar dense
- This is more in line with how real world radiation works, where X thick wall stops Y% of radiation, rather than Y Bq of radiation.
- Various dense obstacles's radiation resistance now divides radiation strength, rather than substract from it. In other words:
+ One tile thick plasteel wall is enough to stop most weak radiation sources (N2 cooled supermatter for example)
+ Two tiles thick plasteel wall is enough to stop nearly any radiation source (PH cooled supermatter for example)
+ Three tiles thick plasteel wall is pretty much guaranteed protection against any radiation source currently in the game.