### PR TITLE
Event Tweaks

### DIFF
--- a/code/modules/admin/secrets/random_events/gravity.dm
+++ b/code/modules/admin/secrets/random_events/gravity.dm
@@ -22,7 +22,7 @@
 
 	feedback_inc("admin_secrets_fun_used",1)
 	feedback_add_details("admin_secrets_fun_used","Grav")
-	log_and_message_admins("[key_name(user)] toggled gravity.", 1)
+	log_and_message_admins("toggled gravity.")
 	if(choice == "Yes")
 		if(gravity_is_on)
 			command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "Gravity Restored")

--- a/code/modules/admin/secrets/random_events/gravity.dm
+++ b/code/modules/admin/secrets/random_events/gravity.dm
@@ -15,17 +15,16 @@
 	if(!.)
 		return
 
+	var/choice = input(user, "Make Command Report?") in list("Yes", "No")
 	gravity_is_on = !gravity_is_on
 	for(var/area/A in world)
 		A.gravitychange(gravity_is_on)
 
 	feedback_inc("admin_secrets_fun_used",1)
 	feedback_add_details("admin_secrets_fun_used","Grav")
-	if(gravity_is_on)
-		log_admin("[key_name(user)] toggled gravity on.", 1)
-		message_admins("<span class='notice'>[key_name_admin(user)] toggled gravity on.", 1)
-		command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.</span>")
-	else
-		log_admin("[key_name(user)] toggled gravity off.", 1)
-		message_admins("<span class='notice'>[key_name_admin(usr)] toggled gravity off.", 1)
-		command_announcement.Announce("Feedback surge detected in mass-distributions systems. Artificial gravity has been disabled whilst the system reinitializes. Further failures may result in a gravitational collapse and formation of blackholes. Have a nice day.</span>")
+	log_and_message_admins("[key_name(user)] toggled gravity.", 1)
+	if(choice == "Yes")
+		if(gravity_is_on)
+			command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "Gravity Restored")
+		else
+			command_announcement.Announce("Feedback surge detected in mass-distributions systems. Artificial gravity has been disabled whilst the system reinitializes.", "Gravity Failure")

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -162,7 +162,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta/extended_penalty(EVENT_LEVEL_MODERATE, "Random Antagonist",/datum/event/random_antag,		2.5,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				20,		list(ASSIGNMENT_SECURITY = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Sensor Suit Jamming",		/datum/event/sensor_suit_jamming,		10,		list(ASSIGNMENT_MEDICAL = 20, ASSIGNMENT_AI = 20)),
-//		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",				/datum/event/solar_storm, 				10,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_SECURITY = 10), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",				/datum/event/solar_storm, 				10,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust	, 					30, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",			/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100)),

--- a/code/modules/events/money_lotto.dm
+++ b/code/modules/events/money_lotto.dm
@@ -5,21 +5,25 @@
 
 /datum/event/money_lotto/start()
 	winner_sum = pick(5000, 10000, 50000, 100000, 500000, 1000000, 1500000)
-	if(all_money_accounts.len)
-		var/datum/money_account/D = pick(all_money_accounts)
-		winner_name = D.owner_name
-		if(!D.suspended)
-			var/datum/transaction/T = new("Nyx Daily Grand Slam -Stellar- Lottery", "Winner!", winner_sum, "Biesel TCD Terminal #[rand(111,333)]")
-			D.do_transaction(T)
+	if(prob(50))
+		if(all_money_accounts.len)
+			var/datum/money_account/D = pick(all_money_accounts)
+			winner_name = D.owner_name
+			if(!D.suspended)
+				var/datum/transaction/T = new("Nyx Daily Grand Slam -Stellar- Lottery", "Winner!", winner_sum, "Biesel TCD Terminal #[rand(111,333)]")
+				D.do_transaction(T)
+				deposit_success = 1
 
-			deposit_success = 1
+	else
+		winner_name = random_name(pick(MALE,FEMALE), species = SPECIES_HUMAN)
+		deposit_success = pick(0,1)
 
 /datum/event/money_lotto/announce()
 	var/author = "[GLOB.using_map.company_name] Editor"
 	var/channel = "Nyx Daily"
 
-	var/body = "Nyx Daily wishes to congratulate <b>[winner_name]</b> for recieving the Nyx Stellar Slam Lottery, and receiving the out of this world sum of [winner_sum] credits!"
+	var/body = "Nyx Daily wishes to congratulate <b>[winner_name]</b> for recieving the Nyx Stellar Slam Lottery, and receiving the out of this world sum of [winner_sum] Thalers!"
 	if(!deposit_success)
-		body += "<br>Unfortunately, we were unable to verify the account details provided, so we were unable to transfer the money. Send a cheque containing the sum of 5000 Thalers to ND 'Stellar Slam' office on the Nyx gateway containing updated details, and your winnings'll be re-sent within the month."
+		body += "<br>Unfortunately, we were unable to verify the account details provided, so we were unable to transfer the money. In order to have your winnings re-sent, send a cheque containing a processing fee of 5000 Thalers to the ND 'Stellar Slam' office on the Nyx gateway with your updated details."
 
 	news_network.SubmitArticle(body, author, channel, null, 1)

--- a/code/modules/events/solar_storm.dm
+++ b/code/modules/events/solar_storm.dm
@@ -2,6 +2,8 @@
 	startWhen				= 45
 	announceWhen			= 1
 	var/const/rad_interval 	= 5  	//Same interval period as radiation storms.
+	var/const/temp_incr     = 100
+	var/const/fire_loss     = 40
 	var/base_solar_gen_rate
 
 
@@ -36,12 +38,15 @@
 		if(!istype(T.loc,/area/space) && !istype(T,/turf/space))	//Make sure you're in a space area or on a space turf
 			continue
 
-		//Todo: Apply some burn damage from the heat of the sun. Until then, enjoy some moderate radiation.
-		L.rad_act(rand(15, 30))
+		//Apply some heat or burn damage from the sun.
+		if(istype(L, /mob/living/carbon/human))
+			L.bodytemperature += temp_incr
+		else
+			L.adjustFireLoss(fire_loss)
 
 
 /datum/event/solar_storm/end()
-	command_announcement.Announce("The solar storm has passed the [station_name()]. It is now safe to resume EVA activities. Please report to medbay if you experience any unusual symptoms. ", "[station_name()] Sensor Array")
+	command_announcement.Announce("The solar storm has passed the [station_name()]. It is now safe to resume EVA activities. ", "[station_name()] Sensor Array")
 	adjust_solar_output()
 
 

--- a/html/changelogs/ZeroBits - Events.yml
+++ b/html/changelogs/ZeroBits - Events.yml
@@ -1,0 +1,8 @@
+author: ZeroBits
+delete-after: True
+
+changes: 
+  - rscadd: "Activated the Solar Storm random event, which roasts anyone who's EVA at the time."
+  - tweak: "Added rad-shielding to the bunk room so you can stop dying while AFK, also added rad-shielding to the saferooms."
+  - tweak: "Tweaks lottery chances."
+  - tweak: "Allows admins to choose whether or not to make an announcement when they toggle gravity from the secrets panel."

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -149,6 +149,7 @@
 
 /area/crew_quarters/safe_room/thirddeck
 	name = "\improper Third Deck Safe Room"
+	flags = AREA_RAD_SHIELDED
 
 
 //Second Deck (Z-3)
@@ -193,6 +194,7 @@
 
 /area/crew_quarters/safe_room/seconddeck
 	name = "\improper Second Deck Safe Room"
+	flags = AREA_RAD_SHIELDED
 
 
 //First Deck (Z-4)
@@ -246,6 +248,7 @@
 
 /area/crew_quarters/safe_room/firstdeck
 	name = "\improper First Deck Safe Room"
+	flags = AREA_RAD_SHIELDED
 
 /area/maintenance/substation/firstdeck // First Deck (Z-4)
 	name = "First Deck Substation"
@@ -288,6 +291,7 @@
 
 /area/crew_quarters/safe_room/bridge
 	name = "\improper Bridge Safe Room"
+	flags = AREA_RAD_SHIELDED
 
 /area/bridge/storage
 	name = "\improper Bridge Storage Room"
@@ -833,6 +837,7 @@
 	name = "\improper Bunk Room"
 	icon_state = "Sleep"
 	sound_env = SMALL_SOFTFLOOR
+	flags = AREA_RAD_SHIELDED
 
 /area/crew_quarters/sleep/cryo/aux
 	name = "\improper Auxiliary Cryogenic Storage"


### PR DESCRIPTION
Activates Solar Storms.

Makes Saferooms and the Bunk Room rad-shielded.

Allows admins to choose whether or not to make an announcement when they
toggle gravity.

Makes it just as likely for some random non-station character to win the
lottery as someone aboard.

Solar storms were tested, and they are consistently deadly over the course of several minutes without aid.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
