### PR TITLE
Tweaks and Bugfixes to Rings

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -33,3 +33,8 @@
 	name = "Paralysis Pen"
 	item_cost = 24
 	path = /obj/item/weapon/pen/reagent/paralysis
+
+/datum/uplink_item/item/stealthy_weapons/sleepring
+	name = "Knockout Ring"
+	item_cost = 18
+	path = /obj/item/clothing/ring/reagent/sleepy

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -75,6 +75,7 @@
 		/obj/item/weapon/stamp/chameleon,
 		/obj/item/weapon/pen/chameleon,
 		/obj/item/device/destTagger,
+		/obj/item/clothing/ring/seal/signet/chameleon,
 		)
 
 /obj/item/weapon/storage/box/syndie_kit/spy

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -277,16 +277,16 @@ BLIND     // can't see anything
 		species_restricted -= SPECIES_TAJARA
 	return
 
-/obj/item/clothing/gloves/mob_can_equip(mob/user)
-	var/mob/living/carbon/human/H = user
+/obj/item/clothing/gloves/mob_can_equip(mob/user_mob, slot)
+	var/mob/living/carbon/human/H = user_mob
 
-	if(istype(H.gloves, /obj/item/clothing/ring))
+	if(istype(H.gloves, /obj/item/clothing/ring) && slot == slot_gloves)
 		ring = H.gloves
 		if(!ring.undergloves)
-			to_chat(user, "You are unable to wear \the [src] as \the [H.gloves] are in the way.")
+			to_chat(user_mob, "You are unable to wear \the [src] over \the [ring].")
 			ring = null
 			return 0
-		H.drop_from_inventory(ring)	//Remove the ring (or other under-glove item in the hand slot?) so you can put on the gloves.
+		H.drop_from_inventory(ring)	//Remove the ring so you can put on the gloves.
 		ring.forceMove(src)
 
 	if(!..())
@@ -296,7 +296,7 @@ BLIND     // can't see anything
 		return 0
 
 	if (ring)
-		to_chat(user, "You slip \the [src] on over \the [ring].")
+		to_chat(user_mob, "You slip \the [src] on over \the [ring].")
 	wearer = H //TODO clean this when magboots are cleaned
 	return 1
 

--- a/code/modules/clothing/rings/rings.dm
+++ b/code/modules/clothing/rings/rings.dm
@@ -19,30 +19,6 @@
 	icon_state = "mariner-grad"
 
 /////////////////////////////////////////
-//Magic Rings
-
-/obj/item/clothing/ring/magic
-	name = "magic ring"
-	desc = "A strange ring with symbols carved on it in some arcane language."
-	icon_state = "magic"
-
-/obj/item/clothing/ring/magic/equipped(var/mob/living/carbon/human/H)
-	..()
-	if(istype(H) && H.gloves==src)
-		H.cloaked = TRUE
-		H.update_icons()
-		H.visible_message("<span class='warning'>\[H.name] seems to disappear before your eyes!</span>", "<span class='notice'>You feel completely invisible.</span>")
-
-/obj/item/clothing/ring/magic/dropped(var/mob/living/carbon/human/H)
-	if(!..())
-		return 0
-
-	if(istype(H) && H.cloaked)
-		H.cloaked = FALSE
-		H.update_icons()
-		H.visible_message("<span class='warning'>\The [H] appears from thin air!</span>", "<span class='notice'>You have re-appeared.</span>")
-
-/////////////////////////////////////////
 //Reagent Rings
 
 /obj/item/clothing/ring/reagent
@@ -56,10 +32,9 @@
 /obj/item/clothing/ring/reagent/equipped(var/mob/living/carbon/human/H)
 	..()
 	if(istype(H) && H.gloves==src)
-		to_chat(H, "<font color='blue'><b>You feel a prick as you slip on the ring.</b></font>")
-
 		if(reagents.total_volume)
 			if(H.reagents)
+				to_chat(H, "<span class='danger'>You feel a prick as you slip on \the [src].</span>")
 				var/contained_reagents = reagents.get_reagents()
 				var/trans = reagents.trans_to_mob(H, 15, CHEM_BLOOD)
 				admin_inject_log(usr, H, src, contained_reagents, trans)
@@ -102,7 +77,16 @@
 		to_chat(user, "<span class='notice'>The [src] has already been claimed!</span>")
 		return
 
-	nameset = 1
 	to_chat(user, "<span class='notice'>You claim the [src] as your own!</span>")
-	name = "[user]'s signet ring"
-	desc = "A signet ring belonging to [user], for when you're too sophisticated to sign letters."
+	change_name(user)
+	nameset = 1
+
+/obj/item/clothing/ring/seal/signet/proc/change_name(var/signet_name = "Unknown")
+	name = "[signet_name]'s signet ring"
+	desc = "A signet ring belonging to [signet_name], for when you're too sophisticated to sign letters."
+
+//Chameleon Signet Ring
+/obj/item/clothing/ring/seal/signet/chameleon/attack_self(mob/user)
+	var/signet_name = sanitize(input("Enter name. Leave blank to use your own.", "Name", signet_name)) || user
+	to_chat(user, "<span class='notice'>The face of \the [src] shifts.</span>")
+	change_name(signet_name)

--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -36,3 +36,23 @@
 		user.adjustBruteLoss(-30)
 	else if(icon_state == "[name]1")
 		user.adjustBruteLoss(30)
+
+/////////////////////////Ring of Invisibility///////////////////////////
+/obj/item/clothing/ring/magic
+	name = "Ring of Invisibility"
+	desc = "A golden ring with symbols carved on it in some strange language."
+	icon_state = "magic"
+
+/obj/item/clothing/ring/magic/equipped(var/mob/living/carbon/human/H, var/slot)
+	..()
+	if(istype(H) && slot==slot_gloves && !H.cloaked)
+		H.cloaked = TRUE
+		H.update_icons()
+		H.visible_message("<span class='warning'>\The [H] seems to disappear before your eyes!</span>", "<span class='notice'>You feel completely invisible.</span>")
+
+/obj/item/clothing/ring/magic/dropped(var/mob/living/carbon/human/H)
+	..()
+	if(istype(H) && H.cloaked)
+		H.cloaked = FALSE
+		H.update_icons()
+		H.visible_message("<span class='warning'>\The [H] appears from thin air!</span>", "<span class='notice'>You have re-appeared.</span>")

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -26,6 +26,7 @@
 				/spell/targeted/projectile/dumbfire/fireball = 		2,
 				/spell/aoe_turf/conjure/forcewall = 				1,
 				/obj/item/weapon/magic_rock = 						1,
+				/obj/item/clothing/ring/magic =                     2,
 				/obj/item/weapon/gun/energy/staff/focus = 			2,
 				/obj/item/weapon/contract/apprentice = 				1
 				)

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -26,6 +26,7 @@
 				/spell/aoe_turf/conjure/summon/bats = 			3,
 				/obj/item/weapon/contract/wizard/tk = 			5,
 				/obj/item/weapon/dice/d20/cursed = 				1,
+				/obj/item/clothing/ring/magic =                 1,
 				/obj/structure/closet/wizard/scrying = 			2,
 				/obj/item/weapon/teleportation_scroll = 		1,
 				/obj/item/weapon/magic_rock = 					1,

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -30,6 +30,7 @@
 							/obj/structure/closet/wizard/armor = 				1,
 							/obj/item/weapon/gun/energy/staff/animate = 		1,
 							/obj/structure/closet/wizard/scrying = 				1,
+							/obj/item/clothing/ring/magic =                     2,
 							/obj/item/weapon/monster_manual = 					2,
 							/obj/item/weapon/magic_rock = 						1,
 							/obj/item/weapon/contract/apprentice = 				1

--- a/html/changelogs/ZeroBits - Ring-a-ling.yml
+++ b/html/changelogs/ZeroBits - Ring-a-ling.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: ZeroBits
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added invisibility ring and sleepy ring to Wiz spellbooks and traitor uplink respectively."
+  - rscadd: "Added chameleon signet ring to the Morphic Clerical Kit."
+  - bugfix: "Fixed invisibility ring functionality."
+  - bugfix: "Fixed a bug with rings, where equipping gloves in your pocket will make a ring on your hand dissappear."
+


### PR DESCRIPTION
Added invisibility ring and sleepy ring to Wiz spellbooks and traitor
uplink respectively.

Added chameleon signet ring to the Morphic Clerical Kit.

Fixed invisibility ring functionality.

Fixed a bug with rings, where equipping gloves in your pocket will make
a ring on your hand dissappear.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
