### PR TITLE
Medical supply balancing

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -87,10 +87,9 @@
 
 	startswith = list(
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
-		/obj/item/stack/medical/advanced/bruise_pack = 2,
+		/obj/item/stack/medical/advanced/bruise_pack = 3,
 		/obj/item/stack/medical/advanced/ointment = 2,
-		/obj/item/stack/medical/splint,
-		/obj/item/weapon/storage/pill_bottle/paracetamol
+		/obj/item/stack/medical/splint
 		)
 
 /obj/item/weapon/storage/firstaid/combat

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -37,7 +37,7 @@
 		/obj/item/weapon/clipboard,
 		/obj/item/weapon/folder/white,
 		/obj/item/device/holowarrant,
-		/obj/item/weapon/storage/firstaid/regular,
+		/obj/item/weapon/storage/firstaid/adv,
 		/obj/item/weapon/storage/box/armband/med,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med)),
@@ -71,7 +71,7 @@
 		/obj/item/clothing/glasses/hud/health,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
-		/obj/item/weapon/storage/firstaid/regular,
+		/obj/item/weapon/storage/firstaid/adv,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med)),
 		new /datum/atom_creator/weighted(list(
@@ -109,7 +109,7 @@
 		/obj/item/weapon/storage/box/autoinjectors,
 		/obj/item/device/healthanalyzer,
 		/obj/item/clothing/glasses/hud/health,
-		/obj/item/weapon/storage/firstaid/regular,
+		/obj/item/weapon/storage/firstaid/adv,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
 	)
@@ -136,6 +136,7 @@
 		/obj/item/weapon/storage/belt/medical/emt,
 		/obj/item/device/healthanalyzer,
 		/obj/item/clothing/glasses/hud/health,
+		/obj/item/weapon/storage/firstaid/adv,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
 	)


### PR DESCRIPTION
Replaces regular first aid kit spawns in lockers with advanced ones, and removes pain killers from them to make room for a third trauma kit.