### PR TITLE
Titles changes

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -22,7 +22,7 @@
 	screen.severity = severity
 
 	screens[category] = screen
-	if(client && stat != DEAD)
+	if(client && (stat != DEAD || screen.allstate))
 		client.screen += screen
 	return screen
 
@@ -66,6 +66,7 @@
 	plane = FULLSCREEN_PLANE
 	mouse_opacity = 0
 	var/severity = 0
+	var/allstate = 0 //shows if it should show up for dead people too
 
 /obj/screen/fullscreen/Destroy()
 	severity = 0
@@ -116,6 +117,18 @@
 	layer = FULLSCREEN_LAYER
 	alpha = 127
 
+/obj/screen/fullscreen/fadeout
+	icon = 'icons/mob/screen1.dmi'
+	icon_state = "black"
+	screen_loc = ui_entire_screen
+	layer = FULLSCREEN_LAYER
+	alpha = 0
+	allstate = 1
+
+/obj/screen/fullscreen/fadeout/Initialize()
+	. = ..()
+	animate(src, alpha = 255, time = 10)
+
 /obj/screen/fullscreen/scanline
 	icon = 'icons/effects/static.dmi'
 	icon_state = "scanlines"
@@ -125,3 +138,4 @@
 
 /obj/screen/fullscreen/fishbed
 	icon_state = "fishbed"
+	allstate = 1

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -403,7 +403,9 @@ var/global/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker/proc/declare_completion()
 	to_world("<br><br><br><H1>A round of [mode.name] has ended!</H1>")
-	roll_titles()
+	for(var/client/C)
+		if(!C.credits)
+			C.RollCredits()
 	for(var/mob/Player in GLOB.player_list)
 		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD)

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -1,14 +1,90 @@
-/proc/roll_titles()
-	set waitfor = 0
+#define CREDIT_ROLL_SPEED 125
+#define CREDIT_SPAWN_SPEED 10
+#define CREDIT_ANIMATE_HEIGHT (14 * world.icon_size)
+#define CREDIT_EASE_DURATION 22
 
-	for(var/mob/M in GLOB.player_list)
-		M.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
-		M.overlay_fullscreen("scanlines",/obj/screen/fullscreen/scanline)
-		M.overlay_fullscreen("whitenoise",/obj/screen/fullscreen/noise)
-		if(M.is_preference_enabled(/datum/client_preference/play_lobby_music))
-			sound_to(M, sound(null, channel = 1))
-			sound_to(M, sound('sound/music/THUNDERDOME.ogg', wait = 0, volume = 40, channel = 1))
+GLOBAL_LIST(end_titles)
 
+client
+	var/list/credits
+
+/client/proc/RollCredits()
+	set waitfor = FALSE
+
+	if(!GLOB.end_titles)
+		GLOB.end_titles = generate_titles()
+
+	LAZYINITLIST(credits)
+
+	mob.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
+	mob.overlay_fullscreen("fadeout",/obj/screen/fullscreen/fadeout)
+	
+	if(mob.is_preference_enabled(/datum/client_preference/play_lobby_music))
+		sound_to(mob, sound(null, channel = 1))
+		sound_to(mob, sound('sound/music/THUNDERDOME.ogg', wait = 0, volume = 40, channel = 1))
+
+	var/list/_credits = credits
+	verbs += /client/proc/ClearCredits
+	for(var/I in GLOB.end_titles)
+		if(!credits)
+			return
+		var/obj/screen/credit/T = new(null, I, src)
+		_credits += T
+		T.rollem()
+		sleep(CREDIT_SPAWN_SPEED)
+	sleep(CREDIT_ROLL_SPEED - CREDIT_SPAWN_SPEED)
+
+	ClearCredits()
+	verbs -= /client/proc/ClearCredits
+
+/client/proc/ClearCredits()
+	set name = "Stop End Titles"
+	set category = "OOC"
+	verbs -= /client/proc/ClearCredits
+	QDEL_NULL_LIST(credits)
+	mob.clear_fullscreen("fishbed")
+	mob.clear_fullscreen("fadeout")
+	sound_to(mob, sound(null, channel = 1))
+
+/obj/screen/credit
+	icon_state = "blank"
+	mouse_opacity = 0
+	alpha = 0
+	screen_loc = "1,1"
+	plane = HUD_PLANE
+	layer = HUD_ABOVE_ITEM_LAYER
+	var/client/parent
+	var/matrix/target
+
+/obj/screen/credit/Initialize(mapload, credited, client/P)
+	. = ..()
+	parent = P
+	maptext = credited
+	maptext_height = world.icon_size * 2
+	maptext_width = world.icon_size * 14
+
+/obj/screen/credit/proc/rollem()
+	var/matrix/M = matrix(transform)
+	M.Translate(0, CREDIT_ANIMATE_HEIGHT)
+	animate(src, transform = M, time = CREDIT_ROLL_SPEED)
+	target = M
+	animate(src, alpha = 255, time = CREDIT_EASE_DURATION, flags = ANIMATION_PARALLEL)
+	spawn(CREDIT_ROLL_SPEED - CREDIT_EASE_DURATION)
+		if(!QDELETED(src))
+			animate(src, alpha = 0, transform = target, time = CREDIT_EASE_DURATION)
+			sleep(CREDIT_EASE_DURATION)
+			qdel(src)
+	parent.screen += src
+
+/obj/screen/credit/Destroy()
+	var/client/P = parent
+	if(parent)
+		P.screen -= src
+	LAZYREMOVE(P.credits, src)
+	parent = null
+	return ..()
+
+/proc/generate_titles()
 	var/list/titles = list()
 	var/list/cast = list()
 	var/list/chunk = list()
@@ -22,7 +98,7 @@
 	possible_titles += "A VERY [pick("NANOTRASEN", "EXPEDITIONARY", "DIONA", "PHORON", "MARTIAN")] CHRISTMAS"
 	possible_titles += "[pick("GUNS, GUNS EVERYWHERE", "THE LITTLEST ARMALIS", "WHAT HAPPENS WHEN YOU MIX MAINTENANCE DRONES AND COMMERCIAL-GRADE PACKING FOAM", "ATTACK! ATTACK! ATTACK!", "SEX BOMB")]"
 	possible_titles += "[pick("SPACE", "SEXY", "DRAGON", "WARLOCK", "LAUNDRY", "GUN", "ADVERTISING", "DOG", "CARBON MONOXIDE", "NINJA", "WIZARD", "SOCRATIC", "JUVENILE DELIQUENCY", "POLITICALLY MOTIVATED", "RADTACULAR SICKNASTY")] [pick("QUEST", "FORCE", "ADVENTURE")]"
-
+	possible_titles += "[pick("THE DAY [uppertext(GLOB.using_map.station_short)] STOOD STILL", "HUNT FOR THE GREEN WEENIE", "ALIEN VS VENDOMAT", "SPACE TRACK")]"
 	titles += "<center><h1>EPISODE [rand(1,1000)]<br>[pick(possible_titles)]<h1></h1></h1></center>"
 	for(var/mob/living/carbon/human/H in world)
 		if(findtext(H.real_name,"(mannequin)"))
@@ -34,29 +110,46 @@
 		var/job = ""
 		if(GetAssignment(H) != "Unassigned")
 			job = ", [uppertext(GetAssignment(H))]"
-		chunk += "[H.species.get_random_name(H.gender)]\t\t\tas\t\t\t[uppertext(H.real_name)][job]"
+		var/used_name = H.real_name
+		var/datum/data/record/R = find_record("name", H.real_name, GLOB.data_core.general)
+		if(R && R.fields["mil_rank"])
+			var/datum/mil_rank/rank = mil_branches.get_rank(R.fields["mil_branch"], R.fields["mil_rank"])
+			if(rank.name_short)
+				used_name = "[rank.name_short] [used_name]"
+		if(prob(90))
+			var/actor_name = H.species.get_random_name(H.gender)
+			if(!(H.species.spawn_flags & SPECIES_CAN_JOIN) || prob(10)) //sometimes can't get actor of thos species
+				var/datum/species/S = all_species["Human"]
+				actor_name = S.get_random_name(H.gender)
+			chunk += "[actor_name]\t \t \t \t[uppertext(used_name)][job]"
+		else
+			var/datum/gender/G = gender_datums[H.gender]
+			chunk += "[used_name]\t \t \t \t[uppertext(G.him)]SELF"
 		chunksize++
-		if(chunksize > 9)
+		if(chunksize > 5)
 			cast += "<center>[jointext(chunk,"<br>")]</center>"
 			chunk.Cut()
 			chunksize = 0
 	if(chunk.len)
 		cast += "<center>[jointext(chunk,"<br>")]</center>"
+
 	titles += cast
+
 	var/list/corpses = list()
 	var/list/monkies = list()
 	for(var/mob/living/carbon/human/H in GLOB.dead_mob_list_)
-		if(H.real_name)
-			corpses += H.real_name
 		if(H.isMonkey() && findtext(H.real_name,"[lowertext(H.species.name)]"))
 			monkies[H.species.name] += 1
+		else if(H.real_name)
+			corpses += H.real_name
 	for(var/spec in monkies)
 		var/datum/species/S = all_species[spec]
-		corpses += "[monkies[spec]] [monkies[spec] > 1 ? S.name : S.name_plural]"
+		corpses += "[monkies[spec]] [lowertext(monkies[spec] > 1 ? S.name_plural : S.name)]"
 	if(corpses.len)
 		titles += "<center>BASED ON REAL EVENTS<br>In memory of [english_list(corpses)].</center>"
 
 	var/list/staff = list("PRODUCTION STAFF:")
+	var/list/staffjobs = list("Coffe Fetcher", "Cameraman", "Angry Yeller", "Chair Operator", "Choreographer", "Historical Consultant", "Costume Designer", "Chief Editor", "Executive Assistant")
 	var/list/goodboys = list()
 	for(var/client/C)
 		if(!C.holder)
@@ -64,16 +157,16 @@
 		if(C.holder.rights & (R_DEBUG|R_ADMIN))
 			var/datum/species/S = all_species[pick(all_species)]
 			var/g = prob(50) ? MALE : FEMALE
-			staff += "[S.get_random_name(g)] a.k.a. '[C.key]'"
+			staff += "[uppertext(pick(staffjobs))] - [S.get_random_name(g)] a.k.a. '[C.key]'"
 		else if(C.holder.rights & R_MOD)
 			goodboys += "[C.key]"
+
 	titles += "<center>[jointext(staff,"<br>")]</center>"
 	if(goodboys.len)
 		titles += "<center>STAFF'S GOOD BOYS:<br>[english_list(goodboys)]</center>"
 
+	var/disclaimer = "Sponsored by [GLOB.using_map.company_name].<br>All rights reserved.<br>"
+	disclaimer += pick("Use for parody prohibited. Prohibited.", "All stunts were performed by underpaid interns. Do NOT try at home.", "[GLOB.using_map.company_name] does not endorse behaviour depicted. Attempt at your own risk.")
+	titles += "<center>[disclaimer]</center>"
 
-	titles += "<center>Sponsored by [GLOB.using_map.company_name].<br>All rights reserved. Use for parody prohibited. Prohibited.</center>"
-
-	for(var/part in titles)
-		Show2Group4Delay(ScreenText(null, titles[part] ? titles[part] : part,"1,CENTER"), null, 60)
-		sleep(65)
+	return titles

--- a/html/changelogs/chinsky - movies.yml
+++ b/html/changelogs/chinsky - movies.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+
+delete-after: True
+
+changes: 
+  - rscadd: "Can remove rolling end credits with Stop End Titles verb in OOC tab."

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -619,6 +619,7 @@
 
 /datum/mil_rank/civ/civ
 	name = "Civilian"
+	name_short = null
 
 /datum/mil_rank/civ/nt
 	name = "NanoTrasen Employee"
@@ -628,7 +629,6 @@
 
 /datum/mil_rank/civ/offduty
 	name = "Off-Duty Personnel"
-	name_short = "Off-Duty"
 
 /datum/mil_rank/civ/synthetic
 	name = "Synthetic"


### PR DESCRIPTION
Swiped TG's Cyberboss's implementation, now they actually roll.
Clients get verb to remove them.
Blackouts screen now for imporoved visibility.
Fixes monkeys sneaking into memorial section.
Randomizes last disclaimer bit slightly.
Other minor stuff in generating actual titles.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
