### PR TITLE
Fixes cerulean, pyrite, sepia, bluespace slime core loot

### DIFF
--- a/code/modules/mob/living/carbon/xenobiological/subtypes.dm
+++ b/code/modules/mob/living/carbon/xenobiological/subtypes.dm
@@ -64,6 +64,14 @@
 			return /obj/item/slime_extract/gold
 		if("green")
 			return /obj/item/slime_extract/green
+		if("sepia")
+			return /obj/item/slime_extract/sepia
+		if("bluespace")
+			return /obj/item/slime_extract/bluespace
+		if("cerulean")
+			return /obj/item/slime_extract/cerulean
+		if("pyrite")
+			return /obj/item/slime_extract/pyrite
 		//Tier 5
 		if("light pink")
 			return /obj/item/slime_extract/lightpink

--- a/html/changelogs/sabiram - core.yml
+++ b/html/changelogs/sabiram - core.yml
@@ -1,0 +1,4 @@
+author: sabiram
+delete-after: True
+changes:
+  - bugfix: "Cerulean, pyrite, bluespace and sepia slimes now drop the correct slime core."


### PR DESCRIPTION
Fixes #18281 
I didn't know what tier these were in or how xenobiology works but they all spawned from tier 3 things so I put them under the tier 4 comment. Like it matters.