### PR TITLE
Adds Rad Shielding and Fixes Typo

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -302,7 +302,7 @@ obj/structure/closet/crate
 	)
 
 /obj/structure/closet/crate/secure/biohazard
-	name = "biohazarad cart"
+	name = "biohazard cart"
 	desc = "A heavy cart with extensive sealing. You shouldn't eat things you find in it."
 	icon_state = "biohazard"
 	icon_opened = "biohazardopen"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -787,6 +787,7 @@
 /area/rnd/blanks
 	name = "\improper Aux Custodial Supplies"
 	icon_state = "decontamination"
+	flags = AREA_RAD_SHIELDED
 
 // Crew areas
 /area/crew_quarters/bar
@@ -842,6 +843,7 @@
 /area/crew_quarters/sleep/cryo/aux
 	name = "\improper Auxiliary Cryogenic Storage"
 	icon_state = "Sleep"
+	flags = AREA_RAD_SHIELDED
 
 /area/crew_quarters/diplomat
 	name = "\improper Diplomatic Quarters"
@@ -1406,6 +1408,7 @@
 /area/crew_quarters/sleep/cryo
 	name = "\improper Cryogenic Storage"
 	icon_state = "Sleep"
+	flags = AREA_RAD_SHIELDED
 
 /area/hydroponics
 	name = "\improper Hydroponics"


### PR DESCRIPTION
Adds radiation shielding to both cryos to stop people who join during a rad storm from getting microwaved for the entire duration.

Also adds radiation shielding to auxilliary custodial in Research so that we stop microwaving the clones too. Equality!

Took away a vowel from the research Biohazarad crates in auxiliary custodial. Now they're just biohazard crates.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
