### PR TITLE
Adjusts thready pulse heartstop

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -40,7 +40,7 @@
 	var/should_stop = prob(80) && owner.get_blood_circulation() < BLOOD_VOLUME_SURVIVE //cardiovascular shock, not enough liquid to pump
 	should_stop = should_stop || prob(max(0, owner.getBrainLoss() - owner.maxHealth * 0.75)) //brain failing to work heart properly
 	should_stop = should_stop || (prob(10) && owner.shock_stage >= 120) //traumatic shock
-	should_stop = should_stop || (prob(60) && pulse == PULSE_THREADY) //erratic heart patterns, usually caused by oxyloss
+	should_stop = should_stop || (prob(10) && pulse == PULSE_THREADY) //erratic heart patterns, usually caused by oxyloss
 	if(should_stop) // The heart has stopped due to going into traumatic or cardiovascular shock.
 		if(pulse != PULSE_NONE)
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")


### PR DESCRIPTION
After talking to the voices in the head they agreed with techhead that it's really high, and also this way people would at least see said pulse in action rather than it going straight to the no pulse, and also there's  matter  of threshold being higher effectively than 100 oxyloss, so this compensates it a bit.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
