### PR TITLE
Chemistry mucking

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -11,7 +11,7 @@
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	var/list/datum/autopsy_data_scanner/wdata = list()
-	var/list/datum/autopsy_data_scanner/chemtraces = list()
+	var/list/chemtraces = list()
 	var/target_name = null
 	var/timeofdeath = null
 
@@ -38,7 +38,7 @@
 		return W
 
 /obj/item/weapon/autopsy_scanner/proc/add_data(var/obj/item/organ/external/O)
-	if(!O.autopsy_data.len && !O.trace_chemicals.len) return
+	if(!O.autopsy_data.len) return
 
 	for(var/V in O.autopsy_data)
 		var/datum/autopsy_data/W = O.autopsy_data[V]
@@ -70,10 +70,6 @@
 
 		qdel(D.organs_scanned[O.name])
 		D.organs_scanned[O.name] = W.copy()
-
-	for(var/V in O.trace_chemicals)
-		if(O.trace_chemicals[V] > 0 && !chemtraces.Find(V))
-			chemtraces += V
 
 /obj/item/weapon/autopsy_scanner/verb/print_data()
 	set category = "Object"
@@ -186,5 +182,8 @@
 	M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
 
 	src.add_data(S)
+	for(var/T in M.chem_doses)
+		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
+		chemtraces += R.name
 
 	return 1

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -12,6 +12,7 @@
 	//Active emote/pose
 	var/pose = null
 	var/list/chem_effects = list()
+	var/list/chem_doses = list()
 	var/datum/reagents/metabolism/bloodstr = null
 	var/datum/reagents/metabolism/ingested = null
 	var/datum/reagents/metabolism/touching = null

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -193,17 +193,6 @@
 		else
 			visible_message("<B>\The [src]</B> drops what they were holding in their [grasp_name]!")
 
-
-//Handles chem traces
-/mob/living/carbon/human/proc/handle_trace_chems()
-	for(var/T in chem_doses)
-		if(bloodstr.has_reagent(T) || ingested.has_reagent(T) || touching.has_reagent(T))
-			continue
-		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
-		chem_doses[T] -= R.metabolism*2
-		if(chem_doses[T] <= 0)
-			chem_doses -= T
-
 /mob/living/carbon/human/proc/sync_organ_dna()
 	var/list/all_bits = internal_organs|organs
 	for(var/obj/item/organ/O in all_bits)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -196,10 +196,13 @@
 
 //Handles chem traces
 /mob/living/carbon/human/proc/handle_trace_chems()
-	//New are added for reagents to random organs.
-	for(var/datum/reagent/A in reagents.reagent_list)
-		var/obj/item/organ/external/E = pick(organs)
-		E.trace_chemicals[A.name] = 100
+	for(var/T in chem_doses)
+		if(bloodstr.has_reagent(T) || ingested.has_reagent(T) || touching.has_reagent(T))
+			continue
+		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
+		chem_doses[T] -= R.metabolism*2
+		if(chem_doses[T] <= 0)
+			chem_doses -= T
 
 /mob/living/carbon/human/proc/sync_organ_dna()
 	var/list/all_bits = internal_organs|organs

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -511,116 +511,30 @@
 
 /mob/living/carbon/human/handle_chemicals_in_body()
 
+	chem_effects.Cut()
+
+	if(status_flags & GODMODE)	
+		return 0
+
 	if(in_stasis)
 		return
 
+	if(isSynthetic())
+		return
+
 	if(reagents)
-		chem_effects.Cut()
+		if(touching) touching.metabolize()
+		if(ingested) ingested.metabolize()
+		if(bloodstr) bloodstr.metabolize()
 
-		if(!isSynthetic())
-
-			if(touching) touching.metabolize()
-			if(ingested) ingested.metabolize()
-			if(bloodstr) bloodstr.metabolize()
-
-			var/total_phoronloss = 0
-			for(var/obj/item/I in src)
-				if(I.contaminated)
-					total_phoronloss += vsc.plc.CONTAMINATION_LOSS
-			if(!(status_flags & GODMODE)) adjustToxLoss(total_phoronloss)
-
-	if(status_flags & GODMODE)	return 0	//godmode
-
-	var/obj/item/organ/internal/diona/node/light_organ = locate() in internal_organs
-
-	if(!isSynthetic())
-		// Handles adding nutrient for light organs.
-		if(light_organ && !light_organ.is_broken())
-			var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
-			if(isturf(loc)) //else, there's considered to be no light
-				var/turf/T = loc
-				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-				if(L)
-					light_amount = max(0, min(14,(L.lum_r + L.lum_g + L.lum_b)) * 1.5) //hardcapped so it's not abused by having a ton of flashlights
-				else
-					light_amount =  5
-				light_amount = T.get_lumcount() * 10
-			nutrition += light_amount
-			shock_stage -= light_amount
-			nutrition = Clamp(nutrition, 0, 550)
-
-	if(species.light_dam)
-		var/light_amount = 0
-		if(isturf(loc))
-			var/turf/T = loc
-			light_amount = T.get_lumcount() * 10
-		if(light_amount > species.light_dam) //if there's enough light, start dying
-			take_overall_damage(1,1)
-		else //heal in the dark
-			heal_overall_damage(1,1)
-
-	// nutrition decrease
-	if (nutrition > 0 && stat != 2)
-		nutrition = max (0, nutrition - species.hunger_factor)
-
-	if(!isSynthetic() && (species.flags & IS_PLANT))
-
-		if(nutrition < 10)
-			take_overall_damage(2,0)
-			//traumatic_shock is updated every tick, incrementing that is pointless - shock_stage is the counter.
-			//Not that it matters much for diona, who have NO_PAIN.
-			shock_stage++
-		else if (innate_heal)
-			// Heals normal damage.
-			if(getBruteLoss())
-				adjustBruteLoss(-4)
-				nutrition -= 2
-			if(getFireLoss())
-				adjustFireLoss(-4)
-				nutrition -= 2
-			if(getToxLoss())
-				adjustToxLoss(-8)
-				nutrition -= 2
-			if(getOxyLoss())
-				adjustOxyLoss(-8)
-				nutrition -= 2
-
-			if (prob(10))
-				var/obj/item/organ/external/head/D = organs_by_name["head"]
-				if (D.disfigured && nutrition > 200 && !getBruteLoss() && !getFireLoss())
-					D.disfigured = 0
-					nutrition -= 20
-
-			for(var/obj/item/organ/I in internal_organs)
-				if(I.damage > 0)
-					I.damage = max(I.damage - 2, 0)
-					nutrition -= 2
-					if (prob(1))
-						to_chat(src, "<span class='warning'>You sense your [I.name] regenerating...</span>")
-
-			if (prob(10) && nutrition > 70)
-				for(var/limb_type in species.has_limbs)
-					var/obj/item/organ/external/E = organs_by_name[limb_type]
-					if(E && !E.is_usable())
-						E.removed()
-						qdel(E)
-						E = null
-					if(!E)
-						var/list/organ_data = species.has_limbs[limb_type]
-						var/limb_path = organ_data["path"]
-						var/obj/item/organ/O = new limb_path(src)
-						organ_data["descriptor"] = O.name
-						to_chat(src, "<span class='warning'>Some of your nymphs split and hurry to reform your [O.name].</span>")
-						nutrition -= 60
-						update_body()
-					else
-						for(var/datum/wound/W in E.wounds)
-							if (W.wound_damage() == 0 && prob(50))
-								E.wounds -= W
-
-	// TODO: stomach and bloodstream organ.
-	if(!isSynthetic())
-		handle_trace_chems()
+	// Trace chemicals
+	for(var/T in chem_doses)
+		if(bloodstr.has_reagent(T) || ingested.has_reagent(T) || touching.has_reagent(T))
+			continue
+		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
+		chem_doses[T] -= R.metabolism*2
+		if(chem_doses[T] <= 0)
+			chem_doses -= T
 
 	updatehealth()
 
@@ -731,6 +645,17 @@
 		// If you're dirty, your gloves will become dirty, too.
 		if(gloves && germ_level > gloves.germ_level && prob(10))
 			gloves.germ_level += 1
+
+		if(vsc.plc.CONTAMINATION_LOSS) 
+			var/total_phoronloss = 0
+			for(var/obj/item/I in src)
+				if(I.contaminated)
+					total_phoronloss += vsc.plc.CONTAMINATION_LOSS
+			adjustToxLoss(total_phoronloss)
+
+		// nutrition decrease
+		if (nutrition > 0)
+			nutrition = max (0, nutrition - species.hunger_factor)
 
 	return 1
 

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -7,7 +7,6 @@
 
 	language = "Sol Common" //todo?
 	unarmed_types = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/sharp)
-	light_dam = 2
 	darksight = 8
 	has_organ = list()
 	siemens_coefficient = 0
@@ -27,3 +26,15 @@
 	spawn(1)
 		new /obj/effect/decal/cleanable/ash(H.loc)
 		qdel(H)
+
+/datum/species/shadow/handle_environment_special(var/mob/living/carbon/human/H)
+	if(H.in_stasis || H.stat == DEAD || H.isSynthetic())
+		return
+	var/light_amount = 0
+	if(isturf(H.loc))
+		var/turf/T = H.loc
+		light_amount = T.get_lumcount() * 10
+	if(light_amount > 2) //if there's enough light, start dying
+		H.take_overall_damage(1,1)
+	else //heal in the dark
+		H.heal_overall_damage(1,1)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -105,7 +105,6 @@
 	var/warning_high_pressure = WARNING_HIGH_PRESSURE // High pressure warning.
 	var/warning_low_pressure = WARNING_LOW_PRESSURE   // Low pressure warning.
 	var/hazard_low_pressure = HAZARD_LOW_PRESSURE     // Dangerously low pressure.
-	var/light_dam                                     // If set, mob will be damaged in light over this value and heal in light below its negative.
 	var/body_temperature = 310.15	                  // Species will try to stabilize at this temperature.
 	                                                  // (also affects temperature processing)
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -374,3 +374,50 @@
 
 /datum/species/diona/get_blood_name()
 	return "sap"
+
+/datum/species/diona/handle_environment_special(var/mob/living/carbon/human/H)
+	if(H.in_stasis || H.stat == DEAD)
+		return
+	if(H.nutrition < 10)
+		H.take_overall_damage(2,0)
+	else if (H.innate_heal)
+		// Heals normal damage.
+		if(H.getBruteLoss())
+			H.adjustBruteLoss(-4)
+			H.nutrition -= 2
+		if(H.getFireLoss())
+			H.adjustFireLoss(-4)
+			H.nutrition -= 2
+
+		if(prob(10) && H.nutrition > 200 && !H.getBruteLoss() && !H.getFireLoss())
+			var/obj/item/organ/external/head/D = H.organs_by_name["head"]
+			if (D.disfigured)
+				D.disfigured = 0
+				H.nutrition -= 20
+
+		for(var/obj/item/organ/I in H.internal_organs)
+			if(I.damage > 0)
+				I.damage = max(I.damage - 2, 0)
+				H.nutrition -= 2
+				if (prob(1))
+					to_chat(H, "<span class='warning'>You sense your [I.name] regenerating...</span>")
+
+		if (prob(10) && H.nutrition > 70)
+			for(var/limb_type in has_limbs)
+				var/obj/item/organ/external/E = H.organs_by_name[limb_type]
+				if(E && !E.is_usable())
+					E.removed()
+					qdel(E)
+					E = null
+				if(!E)
+					var/list/organ_data = has_limbs[limb_type]
+					var/limb_path = organ_data["path"]
+					var/obj/item/organ/O = new limb_path(src)
+					organ_data["descriptor"] = O.name
+					to_chat(H, "<span class='warning'>Some of your nymphs split and hurry to reform your [O.name].</span>")
+					H.nutrition -= 60
+					H.update_body()
+				else
+					for(var/datum/wound/W in E.wounds)
+						if (W.wound_damage() == 0 && prob(50))
+							E.wounds -= W

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -31,11 +31,6 @@
 		handle_stomach()
 
 		. = 1
-	else if(timeofdeath && (world.time - timeofdeath < 150))
-		//This is to make dead people process reagents for a few ticks, so they can be treated and defibrilated
-		handle_chemicals_in_body()
-
-		. = 1
 
 	//Handle temperature/pressure differences between body and environment
 	if(environment)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -55,7 +55,6 @@
 
 	//Forensics stuff
 	var/list/autopsy_data = list()    // Trauma data for forensics.
-	var/list/trace_chemicals = list() // Traces of chemicals in the organ.
 
 	// Joint/state stuff.
 	var/can_grasp                      // It would be more appropriate if these two were named "affects_grasp" and "affects_stand" at this point
@@ -124,7 +123,6 @@
 			owner.organs -= null
 
 	if(autopsy_data)    autopsy_data.Cut()
-	if(trace_chemicals) trace_chemicals.Cut()
 
 	return ..()
 
@@ -508,13 +506,6 @@ This function completely restores a damaged organ to perfect condition.
 		// Process wounds, doing healing etc. Only do this every few ticks to save processing power
 		if(owner.life_tick % wound_update_accuracy == 0)
 			update_wounds()
-
-		//Chem traces slowly vanish
-		if(owner.life_tick % 10 == 0)
-			for(var/chemID in trace_chemicals)
-				trace_chemicals[chemID] = trace_chemicals[chemID] - 1
-				if(trace_chemicals[chemID] <= 0)
-					trace_chemicals.Remove(chemID)
 
 		//Infections
 		update_germs()

--- a/code/modules/organs/external/diona.dm
+++ b/code/modules/organs/external/diona.dm
@@ -244,5 +244,17 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "claw"
 
+/obj/item/organ/internal/diona/node/Process()
+	..()
+	if(is_broken() || !owner)
+		return
+	var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
+	if(isturf(owner.loc)) //else, there's considered to be no light
+		var/turf/T = owner.loc
+		light_amount = T.get_lumcount() * 10
+	owner.nutrition   += light_amount
+	owner.shock_stage -= light_amount
+	owner.nutrition    = Clamp(owner.nutrition, 0, 550)
+
 /obj/item/organ/internal/diona/node/removed(var/mob/user)
 	return ..(user, 1)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -20,8 +20,6 @@
 	var/metabolism = REM // This would be 0.2 normally
 	var/ingest_met = 0
 	var/touch_met = 0
-	var/dose = 0
-	var/max_dose = 0
 	var/overdose = 0
 	var/scannable = 0 // Shows up on health analyzers.
 	var/color = "#000000"
@@ -67,12 +65,10 @@
 
 	//adjust effective amounts - removed, dose, and max_dose - for mob size
 	var/effective = removed
-	max_dose = max(volume, max_dose)
 	if(!(flags & IGNORE_MOB_SIZE) && location != CHEM_TOUCH)
 		effective *= (MOB_MEDIUM/M.mob_size)
-		max_dose *= (MOB_MEDIUM/M.mob_size)
 
-	dose = min(dose + effective, max_dose)
+	M.chem_doses[type] = M.chem_doses[type] + effective
 	if(effective >= (metabolism * 0.1) || effective >= 0.1) // If there's too little chemical, don't affect the mob, just remove it
 		switch(location)
 			if(CHEM_BLOOD)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -6,6 +6,7 @@
 		"blood_type" = null,
 		"blood_colour" = COLOR_BLOOD_HUMAN,
 		"trace_chem" = null,
+		"dose_chem" = null,
 		"virus2" = list(),
 		"antibodies" = list(),
 		"has_oxy" = 1
@@ -39,6 +40,7 @@
 	for(var/datum/reagent/R in C.reagents.reagent_list)
 		temp_chem[R.type] = R.volume
 	data["trace_chem"] = list2params(temp_chem)
+	data["dose_chem"] = list2params(C.chem_doses)
 	data["blood_colour"] = C.species.get_blood_colour(C)
 	color = data["blood_colour"]
 
@@ -71,9 +73,9 @@
 
 /datum/reagent/blood/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 
-	if(dose > 5)
+	if(M.chem_doses[type] > 5)
 		M.adjustToxLoss(removed)
-	if(dose > 15)
+	if(M.chem_doses[type] > 15)
 		M.adjustToxLoss(removed)
 	if(data && data["virus2"])
 		var/list/vlist = data["virus2"]
@@ -189,7 +191,7 @@
 			S.Target = null
 		if(S.Victim)
 			S.Feedstop()
-	if(dose == removed)
+	if(M.chem_doses[type] == removed)
 		M.visible_message("<span class='warning'>[S]'s flesh sizzles where the water touches it!</span>", "<span class='danger'>Your flesh burns in the water!</span>")
 		M.confused = max(M.confused, 2)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -122,7 +122,7 @@
 		strength_mod = 0
 
 	M.add_chemical_effect(CE_ALCOHOL, 1)
-	var/effective_dose = dose * strength_mod * (1 + volume/60) //drinking a LOT will make you go down faster
+	var/effective_dose = M.chem_doses[type] * strength_mod * (1 + volume/60) //drinking a LOT will make you go down faster
 
 	if(effective_dose >= strength) // Early warning
 		M.make_dizzy(6) // It is decreased at the speed of 3 per tick
@@ -400,12 +400,12 @@
 	M.nutrition += removed * 3
 
 	if(alien == IS_UNATHI)
-		if(dose < 2)
-			if(dose == metabolism * 2 || prob(5))
+		if(M.chem_doses[type] < 2)
+			if(M.chem_doses[type] == metabolism * 2 || prob(5))
 				M.emote("yawn")
-		else if(dose < 5)
+		else if(M.chem_doses[type] < 5)
 			M.eye_blurry = max(M.eye_blurry, 10)
-		else if(dose < 20)
+		else if(M.chem_doses[type] < 20)
 			if(prob(50))
 				M.Weaken(2)
 			M.drowsyness = max(M.drowsyness, 20)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -94,12 +94,12 @@
 	..()
 
 	if(alien == IS_UNATHI)
-		if(dose < 2)
-			if(dose == metabolism * 2 || prob(5))
+		if(M.chem_doses[type] < 2)
+			if(M.chem_doses[type] == metabolism * 2 || prob(5))
 				M.emote("yawn")
-		else if(dose < 5)
+		else if(M.chem_doses[type] < 5)
 			M.eye_blurry = max(M.eye_blurry, 10)
-		else if(dose < 20)
+		else if(M.chem_doses[type] < 20)
 			if(prob(50))
 				M.Weaken(2)
 			M.drowsyness = max(M.drowsyness, 20)
@@ -301,8 +301,8 @@
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())
 			return
-	if(dose < agony_dose)
-		if(prob(5) || dose == metabolism) //dose == metabolism is a very hacky way of forcing the message the first time this procs
+	if(M.chem_doses[type] < agony_dose)
+		if(prob(5) || M.chem_doses[type] == metabolism) //dose == metabolism is a very hacky way of forcing the message the first time this procs
 			to_chat(M, discomfort_message)
 	else
 		M.apply_effect(agony_amount, PAIN, 0)
@@ -384,7 +384,7 @@
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())
 			return
-	if(dose == metabolism)
+	if(M.chem_doses[type] == metabolism)
 		to_chat(M, "<span class='danger'>You feel like your insides are burning!</span>")
 	else
 		M.apply_effect(4, PAIN, 0)
@@ -425,7 +425,7 @@
 /datum/reagent/drink/juice/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.immunity = min(M.immunity + 0.25, M.immunity_norm*1.5)
-	var/effective_dose = dose/2
+	var/effective_dose = M.chem_doses[type]/2
 	if(alien == IS_UNATHI)
 		if(effective_dose < 2)
 			if(effective_dose == metabolism * 2 || prob(5))
@@ -825,7 +825,7 @@
 /datum/reagent/milkshake/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 
-	var/effective_dose = dose/2
+	var/effective_dose = M.chem_doses[type]/2
 	if(alien == IS_UNATHI)
 		if(effective_dose < 2)
 			if(effective_dose == metabolism * 2 || prob(5))
@@ -1754,13 +1754,13 @@
 
 /datum/reagent/ethanol/pwine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
-	if(dose > 30)
+	if(M.chem_doses[type] > 30)
 		M.adjustToxLoss(2 * removed)
-	if(dose > 60 && ishuman(M) && prob(5))
+	if(M.chem_doses[type] > 60 && ishuman(M) && prob(5))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/L = H.internal_organs_by_name[BP_HEART]
 		if (L && istype(L))
-			if(dose < 120)
+			if(M.chem_doses[type] < 120)
 				L.take_damage(10 * removed, 0)
 			else
 				L.take_damage(100, 0)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -208,20 +208,20 @@
 
 /datum/reagent/tramadol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/effectiveness = 1
-	if(dose < effective_dose) //some ease-in ease-out for the effect
-		effectiveness = dose/effective_dose
+	if(M.chem_doses[type] < effective_dose) //some ease-in ease-out for the effect
+		effectiveness = M.chem_doses[type]/effective_dose
 	else if(volume < effective_dose)
 		effectiveness = volume/effective_dose
 	M.add_chemical_effect(CE_PAINKILLER, pain_power * effectiveness)
-	if(dose > 0.5 * overdose)
+	if(M.chem_doses[type] > 0.5 * overdose)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
 		if(prob(1))
 			M.slurring = max(M.slurring, 10)
-	if(dose > 0.75 * overdose)
+	if(M.chem_doses[type] > 0.75 * overdose)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
 		if(prob(5))
 			M.slurring = max(M.slurring, 20)
-	if(dose > overdose)
+	if(M.chem_doses[type] > overdose)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
 		M.slurring = max(M.slurring, 30)
 		if(prob(1))
@@ -244,7 +244,7 @@
 	. = 0
 	var/list/pool = M.reagents.reagent_list | M.ingested.reagent_list
 	for(var/datum/reagent/ethanol/booze in pool)
-		if(booze.dose < 2) //let them experience false security at first
+		if(M.chem_doses[booze.type] < 2) //let them experience false security at first
 			continue
 		. = 1
 		if(booze.strength < 40) //liquor stuff hits harder
@@ -407,7 +407,7 @@
 	if(M.ingested)
 		for(var/datum/reagent/R in M.ingested.reagent_list)
 			if(istype(R, /datum/reagent/ethanol))
-				R.dose = max(R.dose - removed * 5, 0)
+				M.chem_doses[R.type] = max(M.chem_doses[R.type] - removed * 5, 0)
 
 /datum/reagent/hyronalin
 	name = "Hyronalin"
@@ -455,7 +455,7 @@
 	if(volume > 10)
 		M.immunity = max(M.immunity - 0.3, 0)
 		M.add_chemical_effect(CE_ANTIVIRAL, VIRUS_ENGINEERED)
-	if(dose > 15)
+	if(M.chem_doses[type] > 15)
 		M.immunity = max(M.immunity - 0.25, 0)
 
 /datum/reagent/spaceacillin/overdose(var/mob/living/carbon/M, var/alien)
@@ -521,7 +521,7 @@
 /datum/reagent/methylphenidate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(volume <= 0.1 && dose >= 0.5 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
+	if(volume <= 0.1 && M.chem_doses[type] >= 0.5 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
 		data = world.time
 		to_chat(M, "<span class='warning'>You lose focus...</span>")
 	else
@@ -541,7 +541,7 @@
 /datum/reagent/citalopram/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(volume <= 0.1 && dose >= 0.5 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
+	if(volume <= 0.1 && M.chem_doses[type] >= 0.5 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
 		data = world.time
 		to_chat(M, "<span class='warning'>Your mind feels a little less stable...</span>")
 	else
@@ -560,7 +560,7 @@
 /datum/reagent/paroxetine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(volume <= 0.1 && dose >= 0.5 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
+	if(volume <= 0.1 && M.chem_doses[type] >= 0.5 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
 		data = world.time
 		to_chat(M, "<span class='warning'>Your mind feels much less stable...</span>")
 	else
@@ -588,7 +588,7 @@
 		return
 	if(prob(volume*20))
 		M.add_chemical_effect(CE_PULSE, 1)
-	if(volume <= 0.02 && dose >= 0.05 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY * 0.3)
+	if(volume <= 0.02 && M.chem_doses[type] >= 0.05 && world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY * 0.3)
 		data = world.time
 		to_chat(M, "<span class='warning'>You feel antsy, your concentration wavers...</span>")
 	else
@@ -633,11 +633,11 @@
 	M.adjustOxyLoss(-2 * removed)
 	M.heal_organ_damage(20 * removed, 20 * removed)
 	M.adjustToxLoss(-20 * removed)
-	if(dose > 3 && ishuman(M))
+	if(M.chem_doses[type] > 3 && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/external/E in H.organs)
 			E.disfigured = 1 //currently only matters for the head, but might as well disfigure them all.
-	if(dose > 10)
+	if(M.chem_doses[type] > 10)
 		M.make_dizzy(5)
 		M.make_jittery(5)
 
@@ -692,13 +692,13 @@
 	if(alien == IS_DIONA)
 		return
 
-	if(dose < 0.2)	//not that effective after initial rush
+	if(M.chem_doses[type] < 0.2)	//not that effective after initial rush
 		M.add_chemical_effect(CE_PAINKILLER, min(30*volume, 80))
 		M.add_chemical_effect(CE_PULSE, 1)
-	else if(dose < 1)
+	else if(M.chem_doses[type] < 1)
 		M.add_chemical_effect(CE_PAINKILLER, min(10*volume, 20))
 	M.add_chemical_effect(CE_PULSE, 2)
-	if(dose > 5)
+	if(M.chem_doses[type] > 5)
 		M.make_jittery(5)
 	if(volume >= 5 && M.is_asystole())
 		remove_self(5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -173,7 +173,7 @@
 	M.adjustOxyLoss(3 * removed)
 	M.Weaken(10)
 	M.silent = max(M.silent, 10)
-	if(dose <= removed) //half-assed attempt to make timeofdeath update only at the onset
+	if(M.chem_doses[type] <= removed) //half-assed attempt to make timeofdeath update only at the onset
 		M.timeofdeath = world.time
 	M.add_chemical_effect(CE_NOPULSE, 1)
 
@@ -330,12 +330,12 @@
 	if(alien == IS_SKRELL)
 		threshold = 1.2
 
-	if(dose < 1 * threshold)
-		if(dose == metabolism * 2 || prob(5))
+	if(M.chem_doses[type] < 1 * threshold)
+		if(M.chem_doses[type] == metabolism * 2 || prob(5))
 			M.emote("yawn")
-	else if(dose < 1.5 * threshold)
+	else if(M.chem_doses[type] < 1.5 * threshold)
 		M.eye_blurry = max(M.eye_blurry, 10)
-	else if(dose < 5 * threshold)
+	else if(M.chem_doses[type] < 5 * threshold)
 		if(prob(50))
 			M.Weaken(2)
 		M.drowsyness = max(M.drowsyness, 20)
@@ -361,16 +361,16 @@
 	if(alien == IS_SKRELL)
 		threshold = 1.2
 
-	if(dose == metabolism * threshold)
+	if(M.chem_doses[type] == metabolism * threshold)
 		M.confused += 2
 		M.drowsyness += 2
-	else if(dose < 2 * threshold)
+	else if(M.chem_doses[type] < 2 * threshold)
 		M.Weaken(30)
 		M.eye_blurry = max(M.eye_blurry, 10)
 	else
 		M.sleeping = max(M.sleeping, 30)
 
-	if(dose > 1 * threshold)
+	if(M.chem_doses[type] > 1 * threshold)
 		M.adjustToxLoss(removed)
 
 /datum/reagent/chloralhydrate/beer2 //disguised as normal beer for use by emagged brobots
@@ -497,12 +497,12 @@
 
 	M.druggy = max(M.druggy, 30)
 
-	if(dose < 1 * threshold)
+	if(M.chem_doses[type] < 1 * threshold)
 		M.apply_effect(3, STUTTER)
 		M.make_dizzy(5)
 		if(prob(5))
 			M.emote(pick("twitch", "giggle"))
-	else if(dose < 2 * threshold)
+	else if(M.chem_doses[type] < 2 * threshold)
 		M.apply_effect(3, STUTTER)
 		M.make_jittery(5)
 		M.make_dizzy(5)
@@ -533,9 +533,9 @@
 	if(H.species.name == SPECIES_PROMETHEAN)
 		return
 	H.adjustToxLoss(40 * removed)
-	if(dose < 1 || prob(30))
+	if(H.chem_doses[type] < 1 || prob(30))
 		return
-	dose = 0
+	H.chem_doses[type] = 0
 	var/list/meatchunks = list()
 	for(var/limb_tag in list(BP_R_ARM, BP_L_ARM, BP_R_LEG,BP_L_LEG))
 		var/obj/item/organ/external/E = H.get_organ(limb_tag)
@@ -647,7 +647,7 @@
 /datum/reagent/toxin/corrupting/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(prob(5))
-		if(dose < 15)
+		if(M.chem_doses[type] < 15)
 			to_chat(M, "<span class='warning'>You feel funny...</span>")
 		else
 			to_chat(M, "<span class='danger'>You feel like you could die at any moment!</span>")


### PR DESCRIPTION
Decoupling consumed dose from reagent into mob  …
It will no longer immediately reset once chemical in bloodstream is done processing.
It will tickle down at double metabolism rate.

In effect currently this buffs alcohol, since wait times between sips are now longer for non-drinking drinking.
It also buffs SUGAR and HONEY againt unathi, as it goes off the dose too.
Technically consequitive doses of soporific will KO you too faster, but what's stopping people from just dosing you high in the first place

System consumed dosages can be detected by handheld scanners for scannable chems, adv masspectromers for others.

Slight handle_chemicals_in_body refactor  …
Moved everything not related to actual chemicals into vaarious placees, species procs, organs processing, regular status updates. Merges trace chem handling into it.

Axed thing for pre-brainmed defibs, no need to proces chems in dead now.
