### PR TITLE
No air no chatter

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -7,7 +7,24 @@
 			name = get_id_name("Unknown")
 
 	message = sanitize(message)
-	..(message, alt_name = alt_name, speaking = language)
+	var/obj/item/organ/internal/voicebox/vox = locate() in internal_organs
+	var/snowflake_speak = (language && (language.flags & NONVERBAL|SIGNLANG)) || (vox && vox.is_usable() && (language in vox.assists_languages))
+	if(!isSynthetic() && need_breathe() && failed_last_breath && !snowflake_speak)
+		var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species.breathing_organ]
+		if(L.breath_fail_ratio > 0.9)
+			if(world.time < L.last_failed_breath + 2 MINUTES) //if we're in grace suffocation period, give it up for last words
+				to_chat(src, "<span class='warning'>You use your remaining air to say something!</span>")
+				L.last_failed_breath = world.time - 2 MINUTES
+				..(message, alt_name = alt_name, speaking = language)
+				return
+			to_chat(src, "<span class='warning'>You don't have enough air in [L] to make a sound!</span>")
+			return
+		else if(L.breath_fail_ratio > 0.7)
+			whisper_say(length(message) > 5 ? stars(message) : message, language, alt_name)
+		else if(L.breath_fail_ratio > 0.4 && length(message) > 10)
+			whisper_say(message, language, alt_name)
+	else
+		..(message, alt_name = alt_name, speaking = language)
 
 /mob/living/carbon/human/proc/forcesay(list/append)
 	if(stat == CONSCIOUS)

--- a/html/changelogs/chinsky - wheeze.yml
+++ b/html/changelogs/chinsky - wheeze.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Not having enough air in lungs will prevent you from talking efficiently. If you don't have air at all, you might use remaining air in lungs for one message. If you're just not getting enough, you'll be stuck whispering. Long messages might come out garbled."


### PR DESCRIPTION
Makes failed breaths prevent you from talking. Silencing (bar one last message if you're in grace period) for total failure, whispering for not enough air (e.g. lung damage / underpressure)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
