### PR TITLE
Lets you use combat oxyloss with highpressure oxy

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -145,12 +145,13 @@
 	var/toxins_pp = (poison/breath.total_moles)*breath_pressure
 	var/exhaled_pp = (exhaling/breath.total_moles)*breath_pressure
 
+	var/inhale_efficiency = max(round(inhale_pp/safe_pressure_min, 0.001), 3)
 	// Not enough to breathe
-	if(inhale_pp < safe_pressure_min)
+	if(inhale_efficiency < 1)
 		if(prob(20) && active_breathing)
 			owner.emote("gasp")
 
-		breath_fail_ratio = round(1 - inhale_pp/safe_pressure_min, 0.001)
+		breath_fail_ratio = 1 - inhale_efficiency
 		failed_inhale = 1
 	else
 		breath_fail_ratio = 0
@@ -224,7 +225,7 @@
 			last_failed_breath = world.time
 	else
 		last_failed_breath = null
-		owner.adjustOxyLoss(-5)
+		owner.adjustOxyLoss(-5 * inhale_efficiency)
 		if(robotic < ORGAN_ROBOT && species.breathing_sound && is_below_sound_pressure(get_turf(owner)))
 			if(breathing || owner.shock_stage >= 10)
 				sound_to(owner, sound(species.breathing_sound,0,0,0,5))


### PR DESCRIPTION
If you got more oxygen than you need on a successful breath, you heal more than usual oxyloss, up to 3x the amoutn (15 oxyloss)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
