### PR TITLE
Adds subystem processing sanity checking

### DIFF
--- a/code/controllers/subsystems/processing/processing.dm
+++ b/code/controllers/subsystems/processing/processing.dm
@@ -25,7 +25,8 @@ SUBSYSTEM_DEF(processing)
 		var/datum/thing = current_run[current_run.len]
 		current_run.len--
 		if(QDELETED(thing) || (call(thing, process_proc)(wait, times_fired) == PROCESS_KILL))
-			thing.is_processing = null
+			if(thing)
+				thing.is_processing = null
 			processing -= thing
 		if (MC_TICK_CHECK)
 			return


### PR DESCRIPTION
The processing system now checks if an entry is null before attempting to unmark it for processing.
null-entires occur when an instance has been qdel-ed without first stopping its processing.

Fixes #18788.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
