### PR TITLE
Adds powernet debug tool

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -201,7 +201,9 @@ var/list/admin_verbs_debug = list(
 	/datum/admins/proc/capture_map,
 	/datum/admins/proc/view_runtimes,
 	/client/proc/cmd_analyse_health_context,
-	/client/proc/cmd_analyse_health_panel
+	/client/proc/cmd_analyse_health_panel,
+	/client/proc/visualpower,
+	/client/proc/visualpower_remove
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -537,3 +537,37 @@
 	if(!ishuman(H))	return
 	cmd_analyse_health(H)
 	feedback_add_details("admin_verb","ANLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/obj/effect/debugmarker
+	icon = 'icons/effects/lighting_overlay.dmi'
+	icon_state = "transparent"
+	plane = ABOVE_TURF_PLANE
+	layer = HOLOMAP_LAYER
+	alpha = 127
+
+/client/var/list/image/powernet_markers = list()
+/client/proc/visualpower()
+	set category = "Debug"
+	set name = "Visualize Powernets"
+
+	if(!check_rights(R_DEBUG)) return
+	visualpower_remove()
+	powernet_markers = list()
+
+	for(var/datum/powernet/PN in SSmachines.powernets)
+		var/netcolor = rgb(rand(100,255),rand(100,255),rand(100,255))
+		for(var/obj/structure/cable/C in PN.cables)
+			var/image/I = image('icons/effects/lighting_overlay.dmi', get_turf(C), "transparent")
+			I.plane = ABOVE_TURF_PLANE
+			I.alpha = 127
+			I.color = netcolor
+			I.maptext = "\ref[PN]"
+			powernet_markers += I
+	images += powernet_markers
+
+/client/proc/visualpower_remove()
+	set category = "Debug"
+	set name = "Remove Powernets Visuals"
+
+	images -= powernet_markers
+	QDEL_NULL_LIST(powernet_markers)


### PR DESCRIPTION
Draws colored stuff over powernets, different colors / names of objects for different powernets.
Handy for spotting non-connecting ones.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
