### PR TITLE
Bullet shrapnel nerf bat

### DIFF
--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -90,8 +90,13 @@
 			return
 
 // Preset types - left here for the code that uses them
+/obj/item/weapon/material/shrapnel
+	name = "shrapnel"
+	default_material = DEFAULT_WALL_MATERIAL
+	w_class = ITEM_SIZE_TINY	//it's real small
+
 /obj/item/weapon/material/shard/shrapnel/New(loc)
-	..(loc, "steel")
+	..(loc, DEFAULT_WALL_MATERIAL)
 
 /obj/item/weapon/material/shard/phoron/New(loc)
 	..(loc, "phglass")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1086,7 +1086,7 @@
 		if(organ.splinted)
 			continue
 		for(var/obj/item/O in organ.implants)
-			if(!istype(O,/obj/item/weapon/implant) && prob(5)) //Moving with things stuck in you could be bad.
+			if(!istype(O,/obj/item/weapon/implant) && O.w_class > 1 && prob(5)) //Moving with things stuck in you could be bad.
 				jossle_internal_object(organ, O)
 	var/obj/item/organ/external/groin = src.get_organ(BP_GROIN)
 	if(groin && stomach_contents && stomach_contents.len)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -28,7 +28,8 @@ meteor_act
 		var/armor = getarmor_organ(organ, "bullet")
 		if(prob(20 + max(P.damage - armor, -10)))
 			var/obj/item/weapon/material/shard/shrapnel/SP = new()
-			SP.name = (P.name != "shrapnel")? "[P.name] shrapnel" : "shrapnel"
+			if(P.name != "shrapnel")
+				SP.name = "[P.name] shrapnel"
 			SP.desc = "[SP.desc] It looks like it was fired from [P.shot_from]."
 			SP.loc = organ
 			organ.embed(SP)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -138,8 +138,15 @@
 		if (3)
 			burn_damage = 3
 	burn_damage *= robotic/burn_mod //ignore burn mod for EMP damage
+	
+	var/power = 4 - severity //stupid reverse severity
+	for(var/obj/item/I in implants)
+		if(I.flags & CONDUCT)
+			burn_damage += I.w_class * rand(power, 3*power)
+
 	if(burn_damage)
-		take_damage(0, burn_damage)
+		owner.custom_pain("Something inside your [src] burns a [severity < 2 ? "bit" : "lot"]!", power * 15) //robotic organs won't feel it anyway
+		take_damage(0, burn_damage, 0, used_weapon = "Hot metal")
 
 /obj/item/organ/external/attack_self(var/mob/user)
 	if(!contents.len)

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -60,9 +60,8 @@
 	return src.damage / src.amount
 
 /datum/wound/proc/can_autoheal()
-	for(var/obj/item/thing in embedded_objects)
-		if(thing.w_class > ITEM_SIZE_SMALL)
-			return 0
+	if(embedded_objects.len)
+		return 0
 	return (wound_damage() <= autoheal_cutoff) ? 1 : is_treated()
 
 // checks whether the wound has been appropriately treated

--- a/html/changelogs/chinsky - bitties.yml
+++ b/html/changelogs/chinsky - bitties.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Shrapnel is less deadly now. Tiny items don't jostle around anymore. They still prevent wounds they're embedded in from healing."
+  - rscdel: "Conductive things embedded in body will heat up in EMP, dealing damage depending on their size and EMP severity."


### PR DESCRIPTION
Only w_class 2 objects and bigger are moving around and causing trauma, teensy things are secured.
They still prevent wounds from healing, and embedded shrapnel also burns you if exposed to EMP (up to 9 burn at max emp severity)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
