### PR TITLE
Adds onjob training/brainwashing implants

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -859,6 +859,7 @@
 #include "code\game\objects\items\weapons\implants\implants\death_alarm.dm"
 #include "code\game\objects\items\weapons\implants\implants\explosive.dm"
 #include "code\game\objects\items\weapons\implants\implants\freedom.dm"
+#include "code\game\objects\items\weapons\implants\implants\imprinting.dm"
 #include "code\game\objects\items\weapons\implants\implants\loyalty.dm"
 #include "code\game\objects\items\weapons\implants\implants\tracking.dm"
 #include "code\game\objects\items\weapons\implants\implants\uplink.dm"

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -27,3 +27,9 @@
 	..()
 	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
 	desc = "Contains [round((DEFAULT_TELECRYSTAL_AMOUNT / 2) * 0.8)] Telecrystal\s"
+
+/datum/uplink_item/item/implants/imp_imprinting
+	name = "Neural Imprinting Implant"
+	desc = "Use on someone who is under influence of Mindbreaker to give them laws-like set of instructions. Kit comes with a dose of mindbreaker."
+	item_cost = 20
+	path = /obj/item/weapon/storage/box/syndie_kit/imp_imprinting

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -1,0 +1,88 @@
+/obj/item/weapon/implant/imprinting
+	name = "imprinting implant"
+	desc = "Latest word in training your peons."
+	var/list/instructions = list("Do your job.", "Respect your superiours.", "Wash you hands after using the toilet.")
+	var/brainwashing = 0
+	var/last_reminder
+
+/obj/item/weapon/implant/imprinting/get_data()
+	. = {"
+	<b>Implant Specifications:</b><BR>
+	<b>Name:</b> NanoTrasen BB-56 "Educator" Employee Assistance Implant<BR>
+	<b>Life:</b> 1 year.<BR>
+	<HR>
+	<b>Function:</b> Adjusts itself to host's brainwaves, and presents supplied instructions as their 'inner voice' for less intrusive reminding. It will transmit them every 5 minutes in non-obtrusive manner.<BR>
+	<b>Special Features:</b> Do NOT implant if subject is under effect of any mind-altering drugs.
+	It carries risk of over-tuning, making subject unable to question the suggestions received, treating them as beliefs they feel strongly about.<BR>
+	It is HIGLY ILLEGAL and NanoTrasen does NOT endorse use of this device in such way.
+	Any amount of Nanotrasen brand "Mind-Breaker"(TM) present in bloodstream will trigger this side-effect.<BR>"}
+	. += "<HR><B>Instructions:</B><BR>"
+	for(var/i = 1 to instructions.len)
+		. += "- [instructions[i]] <A href='byond://?src=\ref[src];edit=[i]'>Edit</A> <A href='byond://?src=\ref[src];del=[i]'>Remove</A><br>"
+	. += "<A href='byond://?src=\ref[src];add=1'>Add</A>"
+
+/obj/item/weapon/implant/imprinting/Topic(href, href_list)
+	..()
+	if (href_list["add"])
+		var/mod = sanitize(input("Add an instruction", "Instructions") as text|null)
+		if(mod)
+			instructions += mod
+		interact(usr)
+	if (href_list["edit"])
+		var/idx = text2num(href_list["edit"])
+		var/mod = sanitize(input("Edit the instruction", "Instruction Editing", instructions[idx]) as text|null)
+		if(mod)
+			instructions[idx] = mod
+			interact(usr)
+	if (href_list["del"])
+		instructions -= instructions[text2num(href_list["del"])]
+		interact(usr)
+
+/obj/item/weapon/implant/imprinting/implanted(mob/M)
+	var/mob/living/carbon/human/H = M
+	if(!istype(H))
+		return FALSE
+	if(H.reagents.has_reagent(/datum/reagent/mindbreaker))
+		brainwashing = 1
+	var/msg
+	if(brainwashing)
+		msg += "<span class='danger'>The fog in your head clears, and you remember some important things. You hold following things as deep convictions, almost like synthetics' laws:</span><br>"
+	else
+		msg += "<span class='notice'>You hear an annoying voice in the back of your head. The things it keeps reminding you of:</span><br>"
+	for(var/thing in instructions)
+		msg += "- [thing]<br>"
+	to_chat(M, msg)
+	if(M.mind)
+		M.mind.store_memory("<hr>[msg]")
+
+	START_PROCESSING(SSobj, src)
+	return TRUE
+
+/obj/item/weapon/implant/imprinting/Process()
+	if(world.time < last_reminder + 5 MINUTES) 
+		return
+	last_reminder = world.time
+	var/instruction = pick(instructions)
+	if(brainwashing)
+		instruction = "<span class='warning'>You recall one of your beliefs: \"[instruction]\"</span>"
+	else
+		instruction = "<span class='notice'>You remember suddenly: \"[instruction]\"</span>"
+	to_chat(imp_in, instruction)
+
+/obj/item/weapon/implant/imprinting/removed()
+	if(brainwashing)
+		to_chat(imp_in,"<span class='notice'>You are no longer so sure of those beliefs you've had...</span>")
+	..()
+	STOP_PROCESSING(SSobj, src)
+
+/obj/item/weapon/implant/imprinting/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/item/weapon/implanter/imprinting
+	name = "imprinting implanter"
+	imp = /obj/item/weapon/implant/imprinting
+
+/obj/item/weapon/implantcase/imprinting
+	name = "glass case - 'imprinting'"
+	imp = /obj/item/weapon/implant/imprinting

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -475,3 +475,12 @@
 	name = "box of spare medical armbands"
 	desc = "A box full of medical armbands. For use in emergencies when provisional medical personnel are needed."
 	startswith = list(/obj/item/clothing/accessory/armband/med = 5)
+
+/obj/item/weapon/storage/box/imprinting
+	name = "box of education implants"
+	desc = "A box full of neural implants for on-job training."
+	startswith = list(
+		/obj/item/weapon/implanter,
+		/obj/item/weapon/implantpad,
+		/obj/item/weapon/implantcase/imprinting = 3
+		)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -34,6 +34,14 @@
 		/obj/item/weapon/implantpad
 		)
 
+/obj/item/weapon/storage/box/syndie_kit/imp_imprinting
+	name = "box (I)"
+	startswith = list(
+		/obj/item/weapon/implanter/imprinting,
+		/obj/item/weapon/implantpad,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/mindbreaker
+		)
+
 // Space suit uplink kit
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/space
 	//name = "\improper EVA gear pack"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -107,3 +107,8 @@
 	name = "autoinjector (oxycodone)"
 	icon_state = "black"
 	starts_with = list(/datum/reagent/tramadol/oxycodone = 5)
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/mindbreaker
+	name = "autoinjector"
+	icon_state = "black"
+	starts_with = list(/datum/reagent/mindbreaker = 5)

--- a/html/changelogs/chinsky - brainwashing.yml
+++ b/html/changelogs/chinsky - brainwashing.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Brainwashing implants! Well, kinda. XO now has a box of 'imprinting' implants, that can be set to a list of instructions, and will remind about those to whoever is implanted with it. Latest word in grimdark on-job training. They're not binding, just reminders."
+  - rscadd: "Now the fun part is their abuse - when victim has mindbreaker in blood and implanted with those, implant wires deep enough to fool host that he actually believes these. Think borg laws. You can get the kit in uplink too, bundled with a dose of mindbreaker"

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -63,7 +63,8 @@
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/folder/blue,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/captain, /obj/item/weapon/storage/backpack/satchel_cap)),
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/captain, /obj/item/weapon/storage/backpack/messenger/com))
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/captain, /obj/item/weapon/storage/backpack/messenger/com)),
+		/obj/item/weapon/storage/box/imprinting
 	)
 
 /obj/structure/closet/secure_closet/sea


### PR DESCRIPTION
Basically loyalty implant 2.0, now general purpose. Has legal use and illegal abuse.
It holds a set of instructions, and displays those to the implantee every so often. Fluff purpose is on-job training, so you don't have to scream those instructions at them yourself.
Funny part starts when yo implant someone with mindbreaker in their blood. The implant's instructions are then treated as implantee's own beliefs, and strong ones at that. Basically think borg laws. Stores instructions in memory too when used this way.
Available in XO locker and in uplink (bundled with mindbreaker)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Example of brainwash mode:

![](https://vgy.me/MeoCMG.png)
