### PR TITLE
Replace 'Interfere' with 'Interact' in drone laws

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -95,7 +95,7 @@
 /datum/ai_laws/drone/New()
 	add_inherent_law("Preserve, repair and improve your assigned vessel to the best of your abilities.")
 	add_inherent_law("Cause no harm to your assigned vessel or anything on it.")
-	add_inherent_law("Interfere with no sentient being that is not a fellow maintenance drone.")
+	add_inherent_law("Interact with no sentient being that is not a fellow maintenance drone.")
 	..()
 
 /datum/ai_laws/construction_drone

--- a/html/changelogs/SierraKomodo - makeDroneLawsMatchStaffPolicy.yml
+++ b/html/changelogs/SierraKomodo - makeDroneLawsMatchStaffPolicy.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changed wording of maintenance drone laws from 'do not interfere' to 'do not interact' to better fit the spirit of the law and staff policy."


### PR DESCRIPTION
Changes the wording of maintenance drone's fourth law from

`Interfere with no sentient being that is not a fellow maintenance drone.`

to

`Interact with no sentient being that is not a fellow maintenance drone.`

This better fits the intent of the law and how it's enforced by staff, since 'Interfere' is technically defined as 'Preventing or hindering action' and has caused some confusion/disconnect in terms of how the law is interpreted by players vs staff.