### PR TITLE
Restructured the preference datums to be more fluid. Kept current per…

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -45,7 +45,7 @@
 
 /proc/to_debug_listeners(text, prefix = "DEBUG")
 	for(var/client/C in GLOB.admins)
-		if(C.is_preference_enabled(/datum/client_preference/debug/show_debug_logs))
+		if(C.is_preference_enabled(/datum/client_preference/staff/show_debug_logs))
 			to_chat(C, "[prefix]: [text]")
 
 /proc/log_game(text)

--- a/code/datums/communication/looc.dm
+++ b/code/datums/communication/looc.dm
@@ -28,7 +28,7 @@
 		receive_communication(C, t, received_message)
 
 	for(var/client/adm in GLOB.admins)	//Now send to all admins that weren't in range.
-		if(!(adm in listening_clients) && adm.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
+		if(!(adm in listening_clients) && adm.is_preference_enabled(/datum/client_preference/staff/show_rlooc))
 			var/received_message = adm.receive_looc(C, key, message, "R")
 			receive_communication(C, adm, received_message)
 

--- a/code/datums/communication/pray.dm
+++ b/code/datums/communication/pray.dm
@@ -11,7 +11,7 @@
 		var/mob/M = m
 		if(!M.client)
 			continue
-		if(M.client.holder && M.client.is_preference_enabled(/datum/client_preference/admin/show_chat_prayers))
+		if(M.client.holder && M.client.is_preference_enabled(/datum/client_preference/staff/show_chat_prayers))
 			receive_communication(communicator, M, "\[<A HREF='?_src_=holder;adminspawncookie=\ref[communicator]'>SC</a>\] \[<A HREF='?_src_=holder;take_ic=\ref[src]'>TAKE</a>\]<span class='notice'>\icon[cross] <b><font color=purple>PRAY: </font>[key_name(communicator, 1)]: </b>[message]</span>")
 		else if(communicator == M) //Give it to ourselves
 			receive_communication(communicator, M, "<span class='notice'>\icon[cross] <b>You send the prayer, \"[message]\" out into the heavens.</b></span>")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -21,7 +21,7 @@ var/global/floorIsLava = 0
 	var/rendered = "<span class=\"log_message\"><span class=\"prefix\">ATTACK:</span> <span class=\"message\">[text]</span></span>"
 	for(var/client/C in GLOB.admins)
 		if(check_rights(R_INVESTIGATE, 0, C))
-			if(C.is_preference_enabled(/datum/client_preference/admin/show_attack_logs))
+			if(C.is_preference_enabled(/datum/client_preference/staff/show_attack_logs))
 				var/msg = rendered
 				to_chat(C, msg)
 /proc/admin_notice(var/message, var/rights)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -115,7 +115,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 		if((R_ADMIN|R_MOD|R_MENTOR) & X.holder.rights)
 			if(X.is_afk())
 				admin_number_afk++
-			if(X.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))
+			if(X.is_preference_enabled(/datum/client_preference/staff/play_adminhelp_ping))
 				sound_to(X, 'sound/effects/adminhelp.ogg')
 			if(X.holder.rights == R_MENTOR)
 				to_chat(X, mentor_msg)// Mentors won't see coloring of names on people with special_roles (Antags, etc.)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -136,7 +136,7 @@
 
 	//play the recieving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
-	if(C.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))
+	if(C.is_preference_enabled(/datum/client_preference/staff/play_adminhelp_ping))
 		sound_to(C, 'sound/effects/adminhelp.ogg')
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -30,6 +30,9 @@
 	for(var/cp in get_client_preferences())
 		var/datum/client_preference/client_pref = cp
 		client_preference_keys += client_pref.key
+		if(!client_pref.may_toggle(preference_mob()))
+			pref.preferences_enabled -= client_pref.key
+			pref.preferences_disabled -= client_pref.key
 		if((client_pref.key in pref.preferences_enabled) || (client_pref.key in pref.preferences_disabled))
 			continue
 
@@ -85,7 +88,7 @@
 		var/datum/client_preference/cp = get_client_preference(preference)
 		return cp && (cp.key in prefs.preferences_enabled)
 	else
-		log_error("Client is lacking preferences: [log_info_line(src)]")	
+		log_error("Client is lacking preferences: [log_info_line(src)]")
 
 /client/proc/is_preference_disabled(var/preference)
 	return !is_preference_enabled(preference)

--- a/code/modules/client/preference_setup/global/preference_datums.dm
+++ b/code/modules/client/preference_setup/global/preference_datums.dm
@@ -163,49 +163,56 @@ var/list/_client_preferences_by_type
 	disabled_description = "Plain"
 
 /********************
-* Admin Preferences *
+* General Staff Preferences *
 ********************/
-/datum/client_preference/admin/may_toggle(var/mob/preference_mob)
-	return check_rights(R_ADMIN, 0, preference_mob)
 
-/datum/client_preference/admin/show_chat_prayers
+/datum/client_preference/staff
+	var/flags
+
+/datum/client_preference/staff/may_toggle(var/mob/preference_mob)
+	if(flags)
+		return check_rights(flags, 0, preference_mob)
+	else
+		return preference_mob && preference_mob.client && preference_mob.client.holder
+
+/datum/client_preference/staff/show_chat_prayers
 	description = "Chat Prayers"
 	key = "CHAT_PRAYER"
 	enabled_description = "Show"
 	disabled_description = "Hide"
 
-/datum/client_preference/holder/may_toggle(var/mob/preference_mob)
-	return preference_mob && preference_mob.client && preference_mob.client.holder
-
-/datum/client_preference/holder/play_adminhelp_ping
+/datum/client_preference/staff/play_adminhelp_ping
 	description = "Adminhelps"
 	key = "SOUND_ADMINHELP"
 	enabled_description = "Hear"
 	disabled_description = "Silent"
 
-/datum/client_preference/admin/show_attack_logs
-	description = "Attack Log Messages"
-	key = "CHAT_ATTACKLOGS"
-	enabled_description = "Show"
-	disabled_description = "Hide"
-	enabled_by_default = FALSE
-
-/datum/client_preference/holder/show_rlooc
+/datum/client_preference/staff/show_rlooc
 	description ="Remote LOOC chat"
 	key = "CHAT_RLOOC"
 	enabled_description = "Show"
 	disabled_description = "Hide"
 
 /********************
+* Admin Preferences *
+********************/
+
+/datum/client_preference/staff/show_attack_logs
+	description = "Attack Log Messages"
+	key = "CHAT_ATTACKLOGS"
+	enabled_description = "Show"
+	disabled_description = "Hide"
+	flags = R_ADMIN
+	enabled_by_default = FALSE
+
+/********************
 * Debug Preferences *
 ********************/
 
-/datum/client_preference/debug/may_toggle(var/mob/preference_mob)
-	return check_rights(R_ADMIN|R_DEBUG, 0, preference_mob)
-
-/datum/client_preference/debug/show_debug_logs
+/datum/client_preference/staff/show_debug_logs
 	description = "Debug Log Messages"
 	key = "CHAT_DEBUGLOGS"
 	enabled_description = "Show"
 	disabled_description = "Hide"
 	enabled_by_default = FALSE
+	flags = R_ADMIN|R_DEBUG

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -49,7 +49,7 @@
 /mob/proc/send_staffwarn(var/client/C, var/action, var/noise = 1)
 	if(check_rights((R_ADMIN|R_MOD),0,C))
 		to_chat(C,"<span class='staffwarn'>StaffWarn: [client.ckey] [action]</span><br><span class='notice'>[client.staffwarn]</span>")
-		if(noise && C.is_preference_enabled(/datum/client_preference/holder/play_adminhelp_ping))
+		if(noise && C.is_preference_enabled(/datum/client_preference/staff/play_adminhelp_ping))
 			sound_to(C, 'sound/effects/adminhelp.ogg')
 
 /mob


### PR DESCRIPTION
…missions identical. Sanitises out preferences to default if you don't have the role to toggle them.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
