### PR TITLE
Larger scale deployment of modular armor.

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -13,7 +13,7 @@
 
 /decl/hierarchy/supply_pack/security/lightarmor
 	name = "Armor - Light"
-	contains = list(/obj/item/clothing/suit/armor/vest = 4,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/light = 4,
 					/obj/item/clothing/head/helmet =4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
@@ -22,7 +22,7 @@
 
 /decl/hierarchy/supply_pack/security/armor
 	name = "Armor - Unmarked"
-	contains = list(/obj/item/clothing/suit/storage/vest = 2,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium = 2,
 					/obj/item/clothing/head/helmet =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
@@ -32,7 +32,7 @@
 /decl/hierarchy/supply_pack/security/tacticalarmor
 	name = "Armor - Tactical"
 	contains = list(/obj/item/clothing/under/tactical,
-					/obj/item/clothing/suit/storage/vest/tactical,
+					/obj/item/clothing/suit/armor/pcarrier/tan/tactical,
 					/obj/item/clothing/head/helmet/tactical,
 					/obj/item/clothing/mask/balaclava/tactical,
 					/obj/item/clothing/glasses/tacgoggles,

--- a/html/changelogs/AtomicWorm - gear-up.yml
+++ b/html/changelogs/AtomicWorm - gear-up.yml
@@ -1,0 +1,9 @@
+author: Broseph Stylin
+
+delete-after: True
+
+changes: 
+  - tweak: "All armor-containing lockers now have a 50% chance to contain a modular armor equivalent to the older armor vests."
+  - tweak: "All armor crates from Supply have been altered to contain modular armor rather than the older vests."
+  - rscadd: "Plate carriers and storage pouches for them have been added to the loadout, priced at 1 and 2 points respectively. Only roles already issued armor can obtain them."
+  

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -3,7 +3,7 @@
 
 /decl/hierarchy/supply_pack/security/lightarmorsol
 	name = "Armor - SCG light"
-	contains = list(/obj/item/clothing/suit/armor/vest/solgov = 4,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/light/sol = 4,
 					/obj/item/clothing/head/helmet/solgov =4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
@@ -12,7 +12,7 @@
 
 /decl/hierarchy/supply_pack/security/secarmor
 	name = "Armor - Security"
-	contains = list(/obj/item/clothing/suit/storage/vest/solgov/security = 2,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium/security = 2,
 					/obj/item/clothing/head/helmet/solgov/security =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
@@ -21,16 +21,16 @@
 
 /decl/hierarchy/supply_pack/security/solarmor
 	name = "Armor - Peacekeeper"
-	contains = list(/obj/item/clothing/suit/storage/vest/solgov = 2,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/blue/sol = 2,
 					/obj/item/clothing/head/helmet/solgov =2)
-	cost = 20
+	cost = 30
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Peacekeeper armor crate"
 	access = access_emergency_armory
 
 /decl/hierarchy/supply_pack/security/comarmor
 	name = "Armor - Command"
-	contains = list(/obj/item/clothing/suit/storage/vest/solgov/command = 2,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium/command = 2,
 					/obj/item/clothing/head/helmet/solgov/command =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
@@ -39,7 +39,7 @@
 
 /decl/hierarchy/supply_pack/security/nanoarmor
 	name = "Armor - NanoTrasen"
-	contains = list(/obj/item/clothing/suit/storage/vest/nt = 2,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium/nt = 2,
 					/obj/item/clothing/head/helmet/nt/guard =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
@@ -48,7 +48,7 @@
 
 /decl/hierarchy/supply_pack/security/lightnanoarmor
 	name = "Armor - NanoTrasen light"
-	contains = list(/obj/item/clothing/suit/armor/vest/nt = 2,
+	contains = list(/obj/item/clothing/suit/armor/pcarrier/light/nt = 2,
 					/obj/item/clothing/head/helmet/nt/guard =2)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -65,3 +65,6 @@
 
 //For jobs that spawn with weapons in their lockers
 #define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/guard, /datum/job/merchant)
+
+//For jobs that spawn with armor in their lockers
+#define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/bridgeofficer, /datum/job/solgov_pilot, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/guard, /datum/job/merchant)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -240,6 +240,21 @@
 	path = /obj/item/clothing/accessory/storage/bandolier
 	cost = 3
 
+/datum/gear/accessory/armor_pouches
+	display_name = "armor storage selection"
+	path = /obj/item/clothing/accessory/storage/pouches
+	cost = 2
+	allowed_roles = ARMORED_ROLES
+
+/datum/gear/accessory/armor_pouches/New()
+	..()
+	var/pouches = list()
+	pouches["black pouches"] = /obj/item/clothing/accessory/storage/pouches
+	pouches["blue pouches"] = /obj/item/clothing/accessory/storage/pouches/blue
+	pouches["green pouches"] = /obj/item/clothing/accessory/storage/pouches/green
+	pouches["tan pouches"] = /obj/item/clothing/accessory/storage/pouches/tan
+	gear_tweaks += new/datum/gear_tweak/path(pouches)
+
 /datum/gear/accessory/hawaii
 	display_name = "hawaii shirt"
 	path = /obj/item/clothing/accessory/toggleable/hawaii

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -67,7 +67,7 @@
 	display_name = "suit jackets"
 	path = /obj/item/clothing/suit/storage
 	allowed_roles = FORMAL_ROLES
-	
+
 /datum/gear/suit/suit_jacket/New()
 	..()
 	var/suitjackets = list()
@@ -159,3 +159,16 @@
 	path = /obj/item/clothing/suit/storage/toggle/track
 	allowed_roles = RESTRICTED_ROLES
 	flags = GEAR_HAS_TYPE_SELECTION
+
+/datum/gear/suit/pcarrier
+	display_name = "plate carrier selection"
+	path = /obj/item/clothing/suit/armor/pcarrier
+	cost = 1
+	allowed_roles = ARMORED_ROLES
+
+/datum/gear/suit/pcarrier/New()
+	..()
+	var/armors = list()
+	armors["green plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/green
+	armors["tan plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/tan
+	gear_tweaks += new/datum/gear_tweak/path(armors)

--- a/maps/torch/loadout/~defines.dm
+++ b/maps/torch/loadout/~defines.dm
@@ -43,3 +43,5 @@
 #undef RESEARCH_ROLES
 
 #undef ARMED_ROLES
+
+#undef ARMORED_ROLES

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -15,7 +15,7 @@
 
 /obj/structure/closet/secure_closet/CO/WillContain()
 	return list(
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/weapon/cartridge/captain,
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/radio/headset/heads/torchcaptain,
@@ -47,7 +47,7 @@
 	return list(
 		/obj/item/clothing/glasses/sunglasses,
 		/obj/item/weapon/cartridge/hop,
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/radio/headset/heads/torchxo,
 		/obj/item/weapon/gun/energy/gun,
@@ -81,7 +81,7 @@
 	return list(
 		/obj/item/clothing/glasses/sunglasses,
 		/obj/item/weapon/cartridge/hop,
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/radio/headset/heads/torchxo,
 		/obj/item/weapon/gun/energy/gun,
@@ -111,7 +111,7 @@
 		/obj/item/device/radio,
 		/obj/item/weapon/pen,
 		/obj/item/device/tape/random,
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/device/taperecorder,
 		/obj/item/device/flash,

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -33,7 +33,7 @@
 		/obj/item/clothing/glasses/welding/superior,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/clothing/accessory/holster/thigh,
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/weapon/clipboard,
 		/obj/item/device/flashlight,

--- a/maps/torch/structures/closets/exploration.dm
+++ b/maps/torch/structures/closets/exploration.dm
@@ -18,7 +18,7 @@
 		/obj/item/device/radio,
 		/obj/item/weapon/pen,
 		/obj/item/device/tape/random,
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/device/taperecorder,
 		/obj/item/device/flash,

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -32,7 +32,7 @@
 		/obj/item/clothing/glasses/hud/health,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/clothing/accessory/holster/thigh,
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/weapon/clipboard,
 		/obj/item/weapon/folder/white,

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -40,7 +40,7 @@
 		/obj/item/taperoll/research,
 		/obj/item/clothing/glasses/welding/superior,
 		/obj/item/device/holowarrant,
-		/obj/item/clothing/suit/armor/vest/nt,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/armor/vest/nt, /obj/item/clothing/suit/armor/pcarrier/light)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/toxins, /obj/item/weapon/storage/backpack/satchel_tox)),
 		new /datum/atom_creator/simple(/obj/item/weapon/storage/backpack/messenger/tox, 50)
 	)
@@ -153,8 +153,8 @@
 /obj/structure/closet/secure_closet/guard/WillContain()
 	return list(
 		/obj/item/clothing/under/rank/guard,
-		/obj/item/clothing/suit/armor/vest/nt,
-		/obj/item/clothing/suit/storage/vest/nt,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/armor/vest/nt, /obj/item/clothing/suit/armor/pcarrier/light/nt)),
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/nt, /obj/item/clothing/suit/armor/pcarrier/medium/nt)),
 		/obj/item/clothing/head/helmet/nt/guard,
 		/obj/item/clothing/head/soft/sec/corp/guard,
 		/obj/item/clothing/head/beret/guard,

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -14,7 +14,7 @@
 
 /obj/structure/closet/secure_closet/security_torch/WillContain()
 	return list(
-		/obj/item/clothing/suit/storage/vest/solgov/security,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/security, /obj/item/clothing/suit/armor/pcarrier/medium/security)),
 		/obj/item/clothing/head/helmet/solgov/security,
 		/obj/item/weapon/cartridge/security,
 		/obj/item/device/radio/headset/headset_sec,
@@ -50,7 +50,7 @@
 
 /obj/structure/closet/secure_closet/cos/WillContain()
 	return list(
-		/obj/item/clothing/suit/storage/vest/solgov/command,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/command, /obj/item/clothing/suit/armor/pcarrier/medium/command)),
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/clothing/head/HoS/dermal,
 		/obj/item/weapon/cartridge/hos,
@@ -90,7 +90,7 @@
 
 /obj/structure/closet/secure_closet/brigofficer/WillContain()
 	return list(
-		/obj/item/clothing/suit/storage/vest/solgov/security,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/security, /obj/item/clothing/suit/armor/pcarrier/medium/security)),
 		/obj/item/clothing/head/helmet/solgov/security,
 		/obj/item/weapon/cartridge/hos,
 		/obj/item/device/radio/headset/headset_sec,
@@ -131,7 +131,7 @@
 		/obj/item/device/radio/headset/headset_sec,
 		/obj/item/clothing/suit/armor/vest/detective,
 		/obj/item/clothing/head/helmet/solgov/security,
-		/obj/item/clothing/suit/storage/vest/solgov/security,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/storage/vest/solgov/security, /obj/item/clothing/suit/armor/pcarrier/medium/security)),
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/device/flash,

--- a/maps/torch/structures/closets/supply.dm
+++ b/maps/torch/structures/closets/supply.dm
@@ -57,7 +57,7 @@
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
 		/obj/item/device/holowarrant,
-		/obj/item/clothing/suit/armor/vest/solgov,
+		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/armor/vest/solgov, /obj/item/clothing/suit/armor/pcarrier/light/sol)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack = 75, /obj/item/weapon/storage/backpack/satchel_norm = 25)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/messenger = 75, /obj/item/weapon/storage/backpack/dufflebag = 25))
 	)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
All armor-containing lockers now have a 50/50 chance of spawning either one of the regular vests, or a modular plate carrier configured in the same way as its equivalent vest.

For the rather hefty price of 3 points, you can be a snowflake and customize what your plate carrier will look like, green and tan carriers being available, along with black, blue, green and tan storage pouches. That is, if you're playing a role whose locker provides armor in the first place. You're not getting an actual armor plate from the loadout either, just the carrier (which provides no protection) and pouches (which are pretty much useless without a carrier).

I've also replaced all of the armor vests orderable from Supply with their modular armor equivalents.