### PR TITLE
Fixes double 'the' in glowsticks

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -291,10 +291,10 @@
 /obj/item/device/flashlight/glowstick/attack_self(mob/user)
 
 	if(!fuel)
-		to_chat(user,"<span class='notice'>The [src] is spent.</span>")
+		to_chat(user,"<span class='notice'>\The [src] is spent.</span>")
 		return
 	if(on)
-		to_chat(user,"<span class='notice'>The [src] is already lit.</span>")
+		to_chat(user,"<span class='notice'>\The [src] is already lit.</span>")
 		return
 
 	. = ..()


### PR DESCRIPTION
Message was saying 'The the green glowstick...'