### PR TITLE
Fix pAI radios and config program

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -20,7 +20,6 @@
 	var/list/software = list()
 	var/userDNA		// The DNA string of our assigned user
 	var/obj/item/device/paicard/card	// The card we inhabit
-	var/obj/item/device/radio/radio		// Our primary radio
 
 	var/chassis = "repairbot"   // A record of your chosen chassis.
 	var/global/list/possible_chassis = list(

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -90,16 +90,16 @@
 	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui = null, force_open = 1)
 		var/data[0]
 
-		data["listening"] = user.radio.broadcasting
-		data["frequency"] = format_frequency(user.radio.frequency)
+		data["listening"] = user.silicon_radio.broadcasting
+		data["frequency"] = format_frequency(user.silicon_radio.frequency)
 
 		var/channels[0]
-		for(var/ch_name in user.radio.channels)
-			var/ch_stat = user.radio.channels[ch_name]
+		for(var/ch_name in user.silicon_radio.channels)
+			var/ch_stat = user.silicon_radio.channels[ch_name]
 			var/ch_dat[0]
 			ch_dat["name"] = ch_name
 			// FREQ_LISTENING is const in /obj/item/device/radio
-			ch_dat["listening"] = !!(ch_stat & user.radio.FREQ_LISTENING)
+			ch_dat["listening"] = !!(ch_stat & user.silicon_radio.FREQ_LISTENING)
 			channels[++channels.len] = ch_dat
 
 		data["channels"] = channels
@@ -114,7 +114,7 @@
 		var/mob/living/silicon/pai/P = usr
 		if(!istype(P)) return
 
-		P.radio.Topic(href, href_list)
+		P.silicon_radio.Topic(href, href_list)
 		return 1
 
 /datum/pai_software/crew_manifest

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -31,7 +31,7 @@
 	if(message_mode)
 		if(message_mode == "general")
 			message_mode = null
-		return radio.talk_into(src,message,message_mode,verb,speaking)
+		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
 
 /mob/living/silicon/say_quote(var/text)
 	var/ending = copytext(text, length(text))

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -17,7 +17,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 	return STATUS_UPDATE									// Ghosts can view updates
 
 /mob/living/silicon/pai/default_can_use_topic(var/src_object)
-	if((src_object == src || src_object == radio) && !stat)
+	if((src_object == src || src_object == silicon_radio) && !stat)
 		return STATUS_INTERACTIVE
 	else
 		return ..()

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -49,7 +49,7 @@
 
 /mob/living/silicon/pai/tg_default_can_use_topic(src_object)
 	// pAIs can only use themselves and the owner's radio.
-	if((src_object == src || src_object == radio) && !stat)
+	if((src_object == src || src_object == silicon_radio) && !stat)
 		return UI_INTERACTIVE
 	else
 		return ..()

--- a/html/changelogs/sabiram - pairadio.yml
+++ b/html/changelogs/sabiram - pairadio.yml
@@ -1,0 +1,4 @@
+author: sabiram
+delete-after: True
+changes: 
+  - bugfix: "Personal AI system radios now work once again."


### PR DESCRIPTION
This fixes pAIs not being able to use their radios, and the configuration module program not opening or working.

Fixes #18819
Fixes #18821