### PR TITLE
Chemistry Reagents NullPointer exception

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -32,7 +32,8 @@
 	var/list/glass_special = null // null equivalent to list()
 
 /datum/reagent/proc/remove_self(var/amount) // Shortcut
-	holder.remove_reagent(type, amount)
+	if(holder)
+		holder.remove_reagent(type, amount)
 
 // This doesn't apply to skin contact - this is for, e.g. extinguishers and sprays. The difference is that reagent is not directly on the mob's skin - it might just be on their clothing.
 /datum/reagent/proc/touch_mob(var/mob/M, var/amount)


### PR DESCRIPTION
Added simple Nullcheck to solve this.

Sorry for opening another commit. I closed last one - this was because of my sourcetree problems. Should be working now. 

Fixes #18853 