### PR TITLE
Makes latejoin and vote popup boxes bigger

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -41,12 +41,12 @@ datum/controller/vote
 				result()
 				for(var/client/C in voting)
 					if(C)
-						C << browse(null,"window=vote")
+						C << browse(null,"window=vote;size=450x740")
 				reset()
 			else
 				for(var/client/C in voting)
 					if(C)
-						C << browse(vote.interface(C),"window=vote")
+						C << browse(vote.interface(C),"window=vote;size=450x740")
 
 				voting.Cut()
 
@@ -492,7 +492,7 @@ datum/controller/vote
 			switch(href_list["vote"])
 				if("close")
 					voting -= usr.client
-					usr << browse(null, "window=vote")
+					usr << browse(null, "window=vote;size=450x740")
 					return
 				if("cancel")
 					if(usr.client.holder)
@@ -555,4 +555,4 @@ datum/controller/vote/proc/is_addantag_allowed(var/automatic)
 	set name = "Vote"
 
 	if(vote)
-		src << browse(vote.interface(client),"window=vote")
+		src << browse(vote.interface(client),"window=vote;size=450x740")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -427,7 +427,7 @@
 				dat += "<tr><td><a href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title]</a></td><td>[job.current_positions]</td><td>(Active: [active])</td></tr>"
 
 	dat += "</table></center>"
-	src << browse(jointext(dat, null), "window=latechoices;size=300x640;can_close=1")
+	src << browse(jointext(dat, null), "window=latechoices;size=450x640;can_close=1")
 
 /mob/new_player/proc/create_character(var/turf/spawn_turf)
 	spawning = 1


### PR DESCRIPTION
The late join box is apparently too small on large resolution monitors, and the vote popup box is too small on every monitor.

The vote popup box is now tall enough to contain all the options, so you can change your options to the things lower on the list without having to scroll down (The scrolling is reset every time the page refreshes, like when you click on an option) or manually resize the box every time. 

Potentially fixes #18734 (I do not have the size of monitor as in this issue so I cannot confirm)