### PR TITLE
Fix water bottles opening incorrectly

### DIFF
--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -16,7 +16,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle
 	name = "bottled water"
-	desc = "Introduced to the vending machines by Skrellian request, this water comes straight from the Martian poles."
+	desc = "Pure drinking water, imported from the Martian poles."
 	icon_state = "waterbottle"
 	center_of_mass = "x=15;y=8"
 	New()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -26,6 +26,11 @@
 	to_chat(user, "<span class='notice'>You open \the [src] with an audible pop!</span>")
 	flags |= OPENCONTAINER
 
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle/open(mob/user)
+	playsound(loc,'sound/effects/bonebreak1.ogg', rand(10,50), 1)
+	to_chat(user, "<span class='notice'>You twist open \the [src], destroying the safety seal!</span>")
+	flags |= OPENCONTAINER
+
 /obj/item/weapon/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob, def_zone)
 	if(force && !(flags & NOBLUDGEON) && user.a_intent == I_HURT)
 		return ..()


### PR DESCRIPTION
This fixes water bottles not opening correctly. Previously they popped open as if they were carbonated. Now they twist open correctly.

Fixes #18868