### PR TITLE
Enforces reagents holders.

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -3,7 +3,6 @@
 
 var/global/list/cable_list = list()					//Index for all cables, so that powernets don't have to look through the entire world all the time
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions
-GLOBAL_LIST_INIT(chemical_reagents_list, do_initialize_chemical_reagents())
 var/global/list/landmarks_list = list()				//list of all landmarks created
 var/global/list/surgery_steps = list()				//list of all surgery steps  |BS12
 var/global/list/side_effects = list()				//list of all medical sideeffects types by thier names |BS12

--- a/code/controllers/Processes/chemistry.dm
+++ b/code/controllers/Processes/chemistry.dm
@@ -1,9 +1,10 @@
+GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
+
 var/datum/controller/process/chemistry/chemistryProcess
 
 /datum/controller/process/chemistry
 	var/list/active_holders
 	var/list/chemical_reactions
-	var/list/chemical_reagents
 
 /datum/controller/process/chemistry/setup()
 	name = "chemistry"
@@ -11,7 +12,6 @@ var/datum/controller/process/chemistry/chemistryProcess
 	chemistryProcess = src
 	active_holders = list()
 	chemical_reactions = chemical_reactions_list
-	chemical_reagents = GLOB.chemical_reagents_list
 
 /datum/controller/process/chemistry/statProcess()
 	..()

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -17,9 +17,7 @@
 
 /obj/machinery/biogenerator/New()
 	..()
-	var/datum/reagents/R = new/datum/reagents(1000)
-	reagents = R
-	R.my_atom = src
+	create_reagents(1000)
 	beaker = new /obj/item/weapon/reagent_containers/glass/bottle(src)
 
 	component_parts = list()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -190,11 +190,9 @@
 	var/max_water = 1000
 
 	New()
-		reagents = new/datum/reagents(max_water)
-		reagents.my_atom = src
+		create_reagents(max_water)
 		reagents.add_reagent(/datum/reagent/water, max_water)
 		..()
-		return
 
 	action(atom/target) //copypasted from extinguisher. TODO: Rewrite from scratch.
 		if(!action_checks(target) || get_dist(chassis, target)>3) return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -234,9 +234,9 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 	if(H.chem_doses.len)
 		var/list/chemtraces = list()
 		for(var/T in H.chem_doses)
-			var/datum/reagent/R = GLOB.chemical_reagents_list[T]
-			if(R.scannable)
-				chemtraces += "[R.name] ([H.chem_doses[T]])"
+			var/datum/reagent/R = T
+			if(initial(R.scannable))
+				chemtraces += "[initial(R.name)] ([H.chem_doses[T]])"
 		if(chemtraces.len)
 			. += "<span class='notice'>Metabolism products of [english_list(chemtraces)] found in subject's system.</span>"
 
@@ -379,16 +379,16 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 				break
 		var/dat = "Trace Chemicals Found: "
 		for(var/T in blood_traces)
-			var/datum/reagent/R = GLOB.chemical_reagents_list[T]
+			var/datum/reagent/R = T
 			if(details)
-				dat += "[R.name] ([blood_traces[T]] units) "
+				dat += "[initial(R.name)] ([blood_traces[T]] units) "
 			else
-				dat += "[R.name] "
+				dat += "[initial(R.name)] "
 		if(details)
 			dat += "\nMetabolism Products of Chemicals Found:"
 			for(var/T in blood_doses)
-				var/datum/reagent/R = GLOB.chemical_reagents_list[T]
-				dat += "[R.name] ([blood_doses[T]] units) "
+				var/datum/reagent/R = T
+				dat += "[initial(R.name)] ([blood_doses[T]] units) "
 		to_chat(user, "[dat]")
 		reagents.clear_reagents()
 	return

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -39,10 +39,8 @@
 	item_state = "balloon-empty"
 
 /obj/item/toy/water_balloon/New()
+	create_reagents(10)
 	..()
-	var/datum/reagents/R = new/datum/reagents(10)
-	reagents = R
-	R.my_atom = src
 
 /obj/item/toy/water_balloon/attack(mob/living/carbon/human/M as mob, mob/user as mob)
 	return

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -183,7 +183,7 @@
 
 	src.add_data(S)
 	for(var/T in M.chem_doses)
-		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
-		chemtraces += R.name
+		var/datum/reagent/R = T
+		chemtraces += initial(R.name)
 
 	return 1

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -171,10 +171,8 @@
 
 /obj/item/weapon/weldingtool/New()
 //	var/random_fuel = min(rand(10,20),max_fuel)
-	var/datum/reagents/R = new/datum/reagents(max_fuel)
-	reagents = R
-	R.my_atom = src
-	R.add_reagent(/datum/reagent/fuel, max_fuel)
+	create_reagents(max_fuel)
+	reagents.add_reagent(/datum/reagent/fuel, max_fuel)
 	..()
 
 /obj/item/weapon/weldingtool/Destroy()

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -11,10 +11,8 @@
 	var/max_fuel = 350
 
 /obj/item/weapon/weldpack/New()
-	var/datum/reagents/R = new/datum/reagents(max_fuel) //Lotsa refills
-	reagents = R
-	R.my_atom = src
-	R.add_reagent(/datum/reagent/fuel, max_fuel)
+	create_reagents(max_fuel)
+	reagents.add_reagent(/datum/reagent/fuel, max_fuel)
 
 /obj/item/weapon/weldpack/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/weldingtool))

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -86,7 +86,7 @@
 	if(!T)
 		return
 
-	var/datum/reagents/R = new/datum/reagents(100)
+	var/datum/reagents/R = new/datum/reagents(100, GLOB.temp_reagents_holder)
 	if(chems.len)
 		for(var/rid in chems)
 			var/injecting = min(5,max(1,get_trait(TRAIT_POTENCY)/3))
@@ -96,6 +96,7 @@
 	S.attach(T)
 	S.set_up(R, round(get_trait(TRAIT_POTENCY)/4), 0, T)
 	S.start()
+	qdel(R)
 
 // Does brute damage to a target.
 /datum/seed/proc/do_thorns(var/mob/living/carbon/human/target, var/obj/item/fruit, var/target_limb)
@@ -440,7 +441,7 @@
 		if(prob(30))	banned_chems |= typesof(/datum/reagent/toxin)
 
 		for(var/x=1;x<=additional_chems;x++)
-			var/new_chem = pick(GLOB.chemical_reagents_list)
+			var/new_chem = pick(subtypesof(/datum/reagent))
 			if(new_chem in banned_chems)
 				x--
 				continue

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -10,9 +10,7 @@
 	icon_state = "brain1"
 
 /mob/living/carbon/brain/New()
-	var/datum/reagents/R = new/datum/reagents(1000)
-	reagents = R
-	R.my_atom = src
+	create_reagents(1000)
 	..()
 
 /mob/living/carbon/brain/Destroy()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -518,7 +518,7 @@
 
 	chem_effects.Cut()
 
-	if(status_flags & GODMODE)	
+	if(status_flags & GODMODE)
 		return 0
 
 	if(in_stasis)
@@ -536,8 +536,8 @@
 	for(var/T in chem_doses)
 		if(bloodstr.has_reagent(T) || ingested.has_reagent(T) || touching.has_reagent(T))
 			continue
-		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
-		chem_doses[T] -= R.metabolism*2
+		var/datum/reagent/R = T
+		chem_doses[T] -= initial(R.metabolism)*2
 		if(chem_doses[T] <= 0)
 			chem_doses -= T
 
@@ -651,7 +651,7 @@
 		if(gloves && germ_level > gloves.germ_level && prob(10))
 			gloves.germ_level += 1
 
-		if(vsc.plc.CONTAMINATION_LOSS) 
+		if(vsc.plc.CONTAMINATION_LOSS)
 			var/total_phoronloss = 0
 			for(var/obj/item/I in src)
 				if(I.contaminated)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -527,9 +527,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/service(src)
 	src.emag = new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer(src)
 
-	var/datum/reagents/R = new/datum/reagents(50)
-	src.emag.reagents = R
-	R.my_atom = src.emag
+	var/datum/reagents/R = src.emag.create_reagents(50)
 	R.add_reagent(/datum/reagent/chloralhydrate/beer2, 50)
 	src.emag.name = "Mickey Finn's Special Brew"
 	..()

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -3,8 +3,8 @@ GLOBAL_LIST_INIT(borer_reagent_types_by_name, setup_borer_reagents())
 /proc/setup_borer_reagents()
 	. = list()
 	for(var/reagent_type in list(/datum/reagent/alkysine, /datum/reagent/bicaridine, /datum/reagent/hyperzine, /datum/reagent/tramadol))
-		var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_type]
-		.[R.name] = reagent_type
+		var/datum/reagent/R = reagent_type
+		.[initial(R.name)] = reagent_type
 
 /mob/living/simple_animal/borer/verb/release_host()
 	set category = "Abilities"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -25,9 +25,12 @@
 	var/datum/reagents/udder = null
 
 /mob/living/simple_animal/hostile/retaliate/goat/New()
-	udder = new(50)
-	udder.my_atom = src
+	udder = new(50, src)
 	..()
+
+/mob/living/simple_animal/hostile/retaliate/goat/Destroy()
+	QDEL_NULL(udder)
+	. = ..()
 
 /mob/living/simple_animal/hostile/retaliate/goat/Life()
 	. = ..()

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -11,8 +11,7 @@
 	if(vessel)
 		return
 
-	vessel = new/datum/reagents(species.blood_volume)
-	vessel.my_atom = src
+	vessel = new/datum/reagents(species.blood_volume, src)
 
 	if(!should_have_organ(BP_HEART)) //We want the var for safety but we can do without the actual blood.
 		return

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -11,8 +11,8 @@
 	muzzle_type = null
 
 /obj/item/projectile/bullet/chemdart/New()
-	reagents = new/datum/reagents(reagent_amount)
-	reagents.my_atom = src
+	create_reagents(reagent_amount)
+	..()
 
 /obj/item/projectile/bullet/chemdart/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
 	if(blocked < 100 && isliving(target))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -32,10 +32,8 @@
 	flags = OPENCONTAINER
 
 /obj/machinery/chem_master/New()
+	create_reagents(120)
 	..()
-	var/datum/reagents/R = new/datum/reagents(120)
-	reagents = R
-	R.my_atom = src
 
 /obj/machinery/chem_master/ex_act(severity)
 	switch(severity)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1,13 +1,3 @@
-
-//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent type
-/proc/do_initialize_chemical_reagents()
-	. = list()
-	for(var/path in subtypesof(/datum/reagent))
-		var/datum/reagent/D = new path()
-		if(!D.name)
-			continue
-		.[D.type] = D
-
 /datum/reagent
 	var/name = "Reagent"
 	var/description = "A non-descript chemical."
@@ -31,9 +21,14 @@
 	var/glass_desc = "It's a glass of... what, exactly?"
 	var/list/glass_special = null // null equivalent to list()
 
+/datum/reagent/New(var/datum/reagents/holder)
+	if(!istype(holder))
+		CRASH("Invalid reagents holder: [log_info_line(holder)]")
+	src.holder = holder
+	..()
+
 /datum/reagent/proc/remove_self(var/amount) // Shortcut
-	if(holder)
-		holder.remove_reagent(type, amount)
+	holder.remove_reagent(type, amount)
 
 // This doesn't apply to skin contact - this is for, e.g. extinguishers and sprays. The difference is that reagent is not directly on the mob's skin - it might just be on their clothing.
 /datum/reagent/proc/touch_mob(var/mob/M, var/amount)

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -18,8 +18,8 @@
 	. = ..()
 	if(spawn_reagent)
 		reagents.add_reagent(spawn_reagent, volume)
-		var/datum/reagent/R = GLOB.chemical_reagents_list[spawn_reagent]
-		setLabel(R.name)
+		var/datum/reagent/R = spawn_reagent
+		setLabel(initial(R.name))
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,4 +1,4 @@
-/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in GLOB.chemical_reagents_list)
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in subtypesof(/datum/reagent))
 	set name = "Spawn Chemical Dispenser Cartridge"
 	set category = "Admin"
 
@@ -8,6 +8,6 @@
 		if("medium") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge/medium(usr.loc)
 		if("large") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge(usr.loc)
 	C.reagents.add_reagent(reagent, C.volume)
-	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent]
-	C.setLabel(R.name)
-	log_admin("[key_name(usr)] spawned a [size] reagent container containing [reagent] at ([usr.x],[usr.y],[usr.z])")
+	var/datum/reagent/R = reagent
+	C.setLabel(initial(R.name))
+	log_and_message_admins("spawned a [size] reagent container containing [reagent]")

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -28,8 +28,8 @@
 
 	for(var/T in reagent_ids)
 		reagent_volumes[T] = volume
-		var/datum/reagent/R = GLOB.chemical_reagents_list[T]
-		reagent_names += R.name
+		var/datum/reagent/R = T
+		reagent_names += initial(R.name)
 
 /obj/item/weapon/reagent_containers/borghypo/Initialize()
 	. = ..()
@@ -105,17 +105,17 @@
 		if(index > 0 && index <= reagent_ids.len)
 			playsound(loc, 'sound/effects/pop.ogg', 50, 0)
 			mode = index
-			var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_ids[mode]]
-			to_chat(usr, "<span class='notice'>Synthesizer is now producing '[R.name]'.</span>")
+			var/datum/reagent/R = reagent_ids[mode]
+			to_chat(usr, "<span class='notice'>Synthesizer is now producing '[initial(R.name)]'.</span>")
 		return 1
 
 /obj/item/weapon/reagent_containers/borghypo/examine(mob/user)
 	if(!..(user, 2))
 		return
 
-	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_ids[mode]]
+	var/datum/reagent/R = reagent_ids[mode]
 
-	to_chat(user, "<span class='notice'>It is currently producing [R.name] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.</span>")
+	to_chat(user, "<span class='notice'>It is currently producing [initial(R.name)] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.</span>")
 
 /obj/item/weapon/reagent_containers/borghypo/service
 	name = "cyborg drink synthesizer"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -16,9 +16,7 @@
 		return
 
 /obj/structure/reagent_dispensers/New()
-	var/datum/reagents/R = new/datum/reagents(initial_capacity)
-	reagents = R
-	R.my_atom = src
+	create_reagents(initial_capacity)
 
 	if (!possible_transfer_amounts)
 		src.verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -67,8 +67,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return return_name
 
 /obj/machinery/computer/rdconsole/proc/CallReagentName(var/reagent_type)
-	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_type]
-	return R ? R.name : "Unknown"
+	var/datum/reagent/R = reagent_type
+	return ispath(reagent_type, /datum/reagent) ? initial(R.name) : "Unknown"
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).
 	for(var/obj/machinery/r_n_d/D in range(3, src))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -140,7 +140,7 @@
 
 	if(!affected)
 		return 0
-	
+
 	if(affected.robotic >= ORGAN_ROBOT)
 		return 0
 
@@ -462,20 +462,21 @@
 	var/obj/item/weapon/reagent_containers/container = tool
 
 	var/amount = container.amount_per_transfer_from_this
-	var/datum/reagents/temp = new(amount)
-	container.reagents.trans_to_holder(temp, amount)
+	var/datum/reagents/temp_reagents = new(amount, GLOB.temp_reagents_holder)
+	container.reagents.trans_to_holder(temp_reagents, amount)
 
-	var/rejuvenate = temp.has_reagent(/datum/reagent/peridaxon)
+	var/rejuvenate = temp_reagents.has_reagent(/datum/reagent/peridaxon)
 
-	var/trans = temp.trans_to_mob(target, temp.total_volume, CHEM_BLOOD) //technically it's contact, but the reagents are being applied to internal tissue
+	var/trans = temp_reagents.trans_to_mob(target, temp_reagents.total_volume, CHEM_BLOOD) //technically it's contact, but the reagents are being applied to internal tissue
 	if (trans > 0)
 
 		if(rejuvenate)
 			affected.status &= ~ORGAN_DEAD
 			affected.owner.update_body(1)
 
-		user.visible_message("<span class='notice'>[user] applies [trans] units of the solution to affected tissue in [target]'s [affected.name]</span>.", \
-			"<span class='notice'>You apply [trans] units of the solution to affected tissue in [target]'s [affected.name] with \the [tool].</span>")
+		user.visible_message("<span class='notice'>[user] applies [trans] unit\s of the solution to affected tissue in [target]'s [affected.name]</span>.", \
+			"<span class='notice'>You apply [trans] unit\s of the solution to affected tissue in [target]'s [affected.name] with \the [tool].</span>")
+	qdel(temp_reagents)
 
 /datum/surgery_step/internal/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -196,13 +196,16 @@
 	var/obj/item/weapon/reagent_containers/container = tool
 
 	var/amount = container.amount_per_transfer_from_this
-	var/datum/reagents/temp = new(amount)
-	container.reagents.trans_to_holder(temp, amount)
+	var/temp_holder = new/obj()
+	var/datum/reagents/temp_reagents = new(amount, temp_holder)
+	container.reagents.trans_to_holder(temp_reagents, amount)
 
-	var/trans = temp.trans_to_mob(target, temp.total_volume, CHEM_BLOOD) //technically it's contact, but the reagents are being applied to internal tissue
+	var/trans = temp_reagents.trans_to_mob(target, temp_reagents.total_volume, CHEM_BLOOD) //technically it's contact, but the reagents are being applied to internal tissue
 	if (trans > 0)
 		user.visible_message("<span class='notice'>[user] rubs [target]'s [affected.name] down with \the [tool]'s contents</span>.", \
 			"<span class='notice'>You rub [target]'s [affected.name] down with \the [tool]'s contents.</span>")
+	qdel(temp_reagents)
+	qdel(temp_holder)
 
 /datum/surgery_step/sterilize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -240,8 +240,8 @@
 			data = pick(/datum/reagent/bicaridine, /datum/reagent/kelotane, /datum/reagent/dylovene, /datum/reagent/inaprovaline, /datum/reagent/space_drugs, /datum/reagent/sugar,
 						/datum/reagent/tramadol, /datum/reagent/dexalin, /datum/reagent/cryptobiolin, /datum/reagent/impedrezene, /datum/reagent/hyperzine, /datum/reagent/ethylredoxrazine,
 						/datum/reagent/mindbreaker, /datum/reagent/nutriment/glucose)
-		var/datum/reagent/R = GLOB.chemical_reagents_list[data]
-		name = "[initial(name)] ([R.name])"
+		var/datum/reagent/R = data
+		name = "[initial(name)] ([initial(R.name)])"
 
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		if (mob.reagents.get_reagent_amount(data) < 5)


### PR DESCRIPTION
The reagents and reagent types must now have valid holders.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
