### PR TITLE
Adjusts exoplanet species renaming.

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -64,7 +64,7 @@
 	return sanitize(replace_characters(input, list(">"=" ","<"=" ", "\""="'")), max_length, encode, trim, extra)
 
 //Filters out undesirable characters from names
-/proc/sanitizeName(var/input, var/max_length = MAX_NAME_LEN, var/allow_numbers = 0)
+/proc/sanitizeName(var/input, var/max_length = MAX_NAME_LEN, var/allow_numbers = 0, var/force_first_letter_uppercase = TRUE)
 	if(!input || length(input) > max_length)
 		return //Rejects the input if it is null or if it is longer then the max length allowed
 
@@ -83,8 +83,10 @@
 
 			// a  .. z
 			if(97 to 122)			//Lowercase Letters
-				if(last_char_group<2)		output += ascii2text(ascii_char-32)	//Force uppercase first character
-				else						output += ascii2text(ascii_char)
+				if(last_char_group<2 && force_first_letter_uppercase)
+					output += ascii2text(ascii_char-32)	//Force uppercase first character
+				else
+					output += ascii2text(ascii_char)
 				number_of_alphanumeric++
 				last_char_group = 4
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -45,13 +45,19 @@
 
 	if(!GLOB.using_map.use_overmap)
 		return
-	
+	if(!CanInteract(usr, GLOB.conscious_state))
+		return
+
 	for(var/obj/effect/overmap/sector/exoplanet/E)
 		if(src in E.animals)
-			var/newname = sanitize(input("What do you want to name this species?", "Species naming", E.get_random_species_name()) as text|null)
-			if(newname)
-				E.rename_species(type, newname)
-				to_chat(usr,"<span class='notice'>This species will be known from now on as '[newname]'.</span>")
+			var/newname = input("What do you want to name this species?", "Species naming", E.get_random_species_name()) as text|null
+			newname = sanitizeName(newname, allow_numbers = TRUE, force_first_letter_uppercase = FALSE)
+			if(newname && CanInteract(usr, GLOB.conscious_state))
+				if(E.rename_species(type, newname))
+					to_chat(usr,"<span class='notice'>This species will be known from now on as '[newname]'.</span>")
+				else
+					to_chat(usr,"<span class='warning'>This species has already been named!</span>")
+			return
 
 /mob/living/simple_animal/hostile/retaliate/beast/samak
 	name = "samak"

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -140,8 +140,10 @@
 /obj/effect/overmap/sector/exoplanet/proc/adapt_animal(var/mob/living/simple_animal/A)
 	if(species[A.type])
 		A.name = species[A.type]
-	else 
+		A.real_name = species[A.type]
+	else
 		A.name = "alien creature"
+		A.real_name = "alien creature"
 		A.verbs |= /mob/living/simple_animal/proc/name_species
 	A.minbodytemp = atmosphere.temperature - 20
 	A.maxbodytemp = atmosphere.temperature + 30
@@ -155,12 +157,18 @@
 /obj/effect/overmap/sector/exoplanet/proc/get_random_species_name()
 	return pick("nol","shan","can","fel","xor")+pick("a","e","o","t","ar")+pick("ian","oid","ac","ese","inian","rd")
 
-/obj/effect/overmap/sector/exoplanet/proc/rename_species(type, newname)
-	species[type] = newname
+/obj/effect/overmap/sector/exoplanet/proc/rename_species(var/species_type, var/newname, var/force = FALSE)
+	if(species[species_type] && !force)
+		return FALSE
+
+	species[species_type] = newname
+	log_and_message_admins("renamed [species_type] to [newname]")
 	for(var/mob/living/simple_animal/A in animals)
-		if(istype(A,type))
+		if(istype(A,species_type))
 			A.name = newname
+			A.real_name = newname
 			A.verbs -= /mob/living/simple_animal/proc/name_species
+	return TRUE
 
 /obj/effect/overmap/sector/exoplanet/proc/generate_landing()
 	var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])


### PR DESCRIPTION
Renaming is logged.
Renaming is now more strictly sanitized.
Must now be conscious to rename species.
Can now only rename a given species once.

Fixes #18855

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
