### PR TITLE
Fixes 2 runtimes

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -265,7 +265,10 @@ SUBSYSTEM_DEF(garbage)
 // Should be treated as a replacement for the 'del' keyword.
 // Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
 /proc/qdel(datum/D, force=FALSE)
+	if(!D)
+		return
 	if(!istype(D))
+		crash_with("qdel() can only handle /datum (sub)types, was passed: [log_info_line(D)]")
 		del(D)
 		return
 	var/datum/qdel_item/I = SSgarbage.items[D.type]

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -30,7 +30,7 @@
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Stok crate"
 
-/decl/hierarchy/supply_pack/hydroponics/lisa
+/decl/hierarchy/supply_pack/hydroponics/corgi
 	name = "Corgi crate"
 	contains = list()
 	cost = 50

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -56,8 +56,9 @@
 
 /obj/structure/largecrate/animal/New()
 	..()
-	for(var/i = 1;i<=held_count;i++)
-		new held_type(src)
+	if(held_type)
+		for(var/i = 1;i<=held_count;i++)
+			new held_type(src)
 
 /obj/structure/largecrate/animal/mulebot
 	name = "Mulebot crate"


### PR DESCRIPTION
Restore garbage collection qdel checks. Fixes #18885.
Fixes runtime on /obj/structure/largecrate/animal-base spawn. Fixes #18884.