### PR TITLE
Allows the deconstruction of Plating

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -71,7 +71,24 @@
 				set_flooring(use_flooring)
 				playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
 				return
-		// Repairs.
+		// Repairs and Deconstruction.
+		else if(istype(C, /obj/item/weapon/crowbar))
+			if(broken || burnt)
+				playsound(src, 'sound/items/Crowbar.ogg', 80, 1)
+				visible_message("<span class='notice'>[user] has begun prying off the damaged plating.</span>")
+				var/turf/T = GetBelow(src)
+				if(T)
+					T.visible_message("<span class='warning'>The ceiling above looks as if it's being pried off.</span>")
+				if(do_after(user, 10 SECONDS))
+					visible_message("<span class='warning'>[user] has pried off the damaged plating.</span>")
+					new /obj/item/stack/tile/floor(src)
+					src.ReplaceWithLattice()
+					playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
+					if(T)
+						T.visible_message("<span class='danger'>The ceiling above has been pried off!</span>")
+			else
+				return
+			return
 		else if(istype(C, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/welder = C
 			if(welder.isOn() && (is_plating()))
@@ -85,6 +102,20 @@
 					else
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
+				else
+					if(welder.remove_fuel(0,user))
+						playsound(src, 'sound/items/Welder.ogg', 80, 1)
+						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
+						if(do_after(user, 5 SECONDS) && welder.isOn() && welder.remove_fuel(0,user))
+							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
+							playsound(src, 'sound/items/Welder.ogg', 80, 1)
+							burnt = 1
+							remove_decals()
+							update_icon()
+					else
+						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+					return
+
 	return ..()
 
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -93,7 +93,7 @@
 			var/obj/item/weapon/weldingtool/welder = C
 			if(welder.isOn() && (is_plating()))
 				if(broken || burnt)
-					if(welder.remove_fuel(0,user))
+					if(welder.isOn())
 						to_chat(user, "<span class='notice'>You fix some dents on the broken plating.</span>")
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						icon_state = "plating"
@@ -103,10 +103,10 @@
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
 				else
-					if(welder.remove_fuel(0,user))
+					if(welder.isOn())
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
-						if(do_after(user, 5 SECONDS) && welder.isOn() && welder.remove_fuel(0,user))
+						if(do_after(user, 5 SECONDS) && welder.isOn())
 							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
 							playsound(src, 'sound/items/Welder.ogg', 80, 1)
 							burnt = 1

--- a/html/changelogs/ZeroBits - platin.yml
+++ b/html/changelogs/ZeroBits - platin.yml
@@ -1,0 +1,4 @@
+author: ZeroBits
+delete-after: True
+changes: 
+  - tweak: "You can now disassemble bare plating by first damaging it with a welder (or bomb) then prying it up with a crowbar."


### PR DESCRIPTION
You can now disassemble damaged plating by prying it up with a crowbar,
as well as being able to damage plating slightly with a welder. It deconstructs to lattice.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
