### PR TITLE
Records list / Sensors styling

### DIFF
--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -693,3 +693,11 @@ th.bot {
 .wideTable tr:nth-child(odd) {
     background-color: #272727;
 }
+
+/* Candystriped rows for tables */
+.candystripe {
+	background-color: rgba(148, 148, 148, 0.25);
+}
+.candystripe:nth-child(odd) {
+	background-color: rgba(0, 0, 0, 0.16);
+}

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -19,7 +19,7 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 {{:helper.link('Show Tracker Map', 'pin-s', {'showMap' : 1})}}
 <table class='wideTable'><tbody>
 	{{for data.crewmembers}}
-		<tr>
+		<tr class="candystripe">
 			<td>{{:value.name}} ({{:value.assignment}}): </td>
 
 			{{if value.sensor_type == 1}}

--- a/nano/templates/crew_records.tmpl
+++ b/nano/templates/crew_records.tmpl
@@ -129,16 +129,16 @@
     	</div>
 	{{/if}}
 {{else}}
-	{{:helper.link('New Record', 'new', {'new_record' : 1}, data.has_empl ? null : 'disabled')}}
+	{{:helper.link('New Record', 'document', {'new_record' : 1}, data.has_empl ? null : 'disabled')}}
 	{{:helper.link('Name Search', 'search', {'name_search' : 1})}}
 	{{:helper.link('DNA Search', 'search', {'dna_search' : 1}, data.has_sec ? null : 'disabled')}}
 	{{:helper.link('Fingerprint Search', 'search', {'fingerprint_search' : 1}, data.has_sec ? null : 'disabled')}}
 	<br><br>
 	<h2>Available records:</h2>
 	<table style="width:100%">
-	<tr><th style="width:60%">Name<th style="width:20%">Position<th style="width:20%">Rank
+	<tr><td style="width:40%">Name<th>Position<th>Rank
 	{{for data.all_records}}
-		<tr><td>{{:helper.link(value.name, '', {'set_active' : value.id})}}
+		<tr class="candystripe"><td>{{:helper.link(value.name, '', {'set_active' : value.id})}}
 		<td>{{:value.rank}}
 		<td>{{:value.milrank}}
 	{{/for}}


### PR DESCRIPTION


![](https://vgy.me/BBkQet.png)
Added candystriping to the rows
Made Name column of records less ridiculously wide, 60% created giant gulf and caused most ranks take two lines.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
