### PR TITLE
Update pain handling and autoheal threshold

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -229,6 +229,15 @@
 				I.take_damage(amount, silent=TRUE)
 				amount = 0
 
+/mob/living/carbon/human/proc/can_autoheal(var/dam_type)
+	if(!species || !dam_type) return FALSE
+
+	if(dam_type == BRUTE)
+		return(getBruteLoss() < species.total_health / 2)
+	else if(dam_type == BURN)
+		return(getFireLoss() < species.total_health / 2)
+	return FALSE
+
 ////////////////////////////////////////////
 
 //Returns a list of damaged organs
@@ -408,7 +417,6 @@ This function restores all organs.
 
 	if(stat == UNCONSCIOUS)
 		traumatic_shock *= 0.6
-
 	return max(0,traumatic_shock)
 
 /mob/living/carbon/human/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -592,7 +592,7 @@
 			for(var/atom/a in hallucinations)
 				qdel(a)
 
-		if(get_shock() >= (species.total_health - 100))
+		if(get_shock() >= species.total_health)
 			if(!stat)
 				to_chat(src, "<span class='warning'>[species.halloss_message_self]</span>")
 				src.visible_message("<B>[src]</B> [species.halloss_message].")

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -636,7 +636,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		// slow healing
 		var/heal_amt = 0
 		// if damage >= 50 AFTER treatment then it's probably too severe to heal within the timeframe of a round.
-		if (!owner.chem_effects[CE_TOXIN] && W.can_autoheal() && W.wound_damage() < 50)
+		if (!owner.chem_effects[CE_TOXIN] && W.can_autoheal() && W.wound_damage() && brute_ratio < 0.5 && burn_ratio < 0.5)
 			heal_amt += 0.5
 
 		//we only update wounds once in [wound_update_accuracy] ticks so have to emulate realtime
@@ -647,7 +647,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		heal_amt = heal_amt / (wounds.len + 1)
 		// making it look prettier on scanners
 		heal_amt = round(heal_amt,0.1)
-		W.heal_damage(heal_amt)
+		if(owner.can_autoheal(W.damage_type))
+			W.heal_damage(heal_amt)
 
 		// Salving also helps against infection
 		if(W.germ_level > 0 && W.salved && prob(2))
@@ -1034,7 +1035,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 0
 
 /obj/item/organ/external/is_usable()
-	return ..() && !(status & ORGAN_TENDON_CUT) && (!can_feel_pain() || pain < pain_disability_threshold)
+	return ..() && !(status & ORGAN_TENDON_CUT) && (!can_feel_pain() || get_pain() < pain_disability_threshold) && brute_ratio < 1 && burn_ratio < 1
 
 /obj/item/organ/external/proc/is_malfunctioning()
 	return ((robotic >= ORGAN_ROBOT) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))


### PR DESCRIPTION
🆑 FTangSteve
tweak: Make paralysing pain cap higher so normal injuries are less debilitating
tweak: Generalise the autoheal threshold so wounds don't autoheal when a limb has taken either too much overall damage or the mob as a whole has
bugfix: Make wound pain properly checked when seeing if a limb can be used
/🆑 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
