### PR TITLE
Fixes chemical grenades not activating properly

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -242,7 +242,7 @@
 		tmr.time=5
 		tmr.secured = 1
 		tmr.holder = src
-		STOP_PROCESSING(SSobj, tmr)
+		START_PROCESSING(SSobj, tmr)
 		a_left = tmr
 		a_right = ign
 		secured = 1


### PR DESCRIPTION
🆑 sabiram
bugfix: Chemical grenades (cleaner, metal foam, etc) now work properly again.
/🆑

This fixes chemical grenades' timers not working properly.
Credit to @mustafakalash 

Fixes #18830
Resolves #18959  (which I could not reproduce; timers worked, and timers attached to igniters generated sparks after their time ran out)
