### PR TITLE
Remove auto-changelog entries in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,11 +11,4 @@ Examples were changelog entries are optional/not typically required:
 * Minor bug fixes.
 
 You find a README and example file in .\html\changelogs\ for further instructions.
-
-You can use changelog autogeneration. To do so, use this structure in your PR opening post:
-
-:cl: Author Name On This Line
-rscadd: Added some stuff
-tweak: Tweaked stuff too
-/:cl:
 -->

--- a/html/changelogs/AutoChangeLog-pr-18973.yml
+++ b/html/changelogs/AutoChangeLog-pr-18973.yml
@@ -1,5 +1,0 @@
-author: Author Name On This Line
-delete-after: True
-changes: 
-  - rscadd: "Added some stuff"
-  - tweak: "Tweaked stuff too"

--- a/html/changelogs/AutoChangeLog-pr-18986.yml
+++ b/html/changelogs/AutoChangeLog-pr-18986.yml
@@ -1,5 +1,0 @@
-author: Author Name On This Line
-delete-after: True
-changes: 
-  - rscadd: "Added some stuff"
-  - tweak: "Tweaked stuff too"


### PR DESCRIPTION
Also removes the errant changelog entries created from it.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.

You can use changelog autogeneration. To do so, use this structure in your PR opening post:

:cl: Author Name On This Line
rscadd: Added some stuff
tweak: Tweaked stuff too
/:cl:
-->
