### PR TITLE
Added queuing functionality to modular-computer software downloading

### DIFF
--- a/html/changelogs/dryerlint-softwaredownloads.yml
+++ b/html/changelogs/dryerlint-softwaredownloads.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: dryerlint
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added queuing functionality to modular computer software downloader."

--- a/nano/templates/ntnet_downloader.tmpl
+++ b/nano/templates/ntnet_downloader.tmpl
@@ -1,4 +1,4 @@
-<i>Welcome to software download utility. Please select which software you wish to download.</i><hr>
+<i>Welcome to the software download utility. Please select which software you wish to download.</i><hr>
 {{if data.error}}
 	<h2>Download Error</h2>
 	<div class="itemLabel">
@@ -13,7 +13,10 @@
 	<div class="itemContent">
 		{{:helper.link("RESET", null, {'PRG_reseterror' : 1})}}
 	</div>	
-{{else data.downloadname}}
+	<hr>
+{{/if}}
+
+{{if data.downloadname}}
 	<h2>Download Running</h2>
 	<i>Please wait...</i>
 	<div class="item">
@@ -49,6 +52,60 @@
 		</div>
 	</div>
 {{else}}
+	<h2>No Downloads In Progress</h2>
+	<i>Standing by...</i>
+	<div class="item">
+		<div class="itemLabel">
+			File name: 
+		</div>
+		<div class="itemContent">
+			N/A
+		</div>
+		<div class="itemLabel">
+			File description: 
+		</div>
+		<div class="itemContent">
+			N/A
+		</div>
+		<div class="itemLabel">
+			File size: 
+		</div>
+		<div class="itemContent">
+			N/A
+		</div>
+		<div class="itemLabel">
+			Transfer Rate: 
+		</div>
+		<div class="itemContent">
+			0 GQ/s
+		</div>
+		<div class="itemLabel">
+			Download progress: 
+		</div>
+		<div class="itemContent">
+			{{:helper.displayBar(0, 0, 1, 'good')}}
+		</div>
+	</div>
+{{/if}}
+
+	<br><hr>
+	
+	<h2>Downloads Queue</h2>
+	<div class="item">
+	{{for data.downloads_queue}}
+		<div class="itemLabel">
+			{{:index + 1}}:
+		</div>
+		<div class="itemContent">
+			{{:value}}
+			{{:helper.link('', 'close', {'PRG_removequeued' : value})}}
+		</div>
+	{{empty}}
+		<i>The queue is currently empty.</i>
+	{{/for}}
+	</div>
+	<br><hr>
+	
 	<h2>Primary software repository</h2>
 	<div class="itemLabel">
 		Hard drive: 
@@ -77,5 +134,4 @@
 		{{/for}}
 	{{/if}}
 
-{{/if}}
 <br><br><hr><i>NTOS v2.0.4b Copyright NanoTrasen 2557 - 2559</i>

--- a/nano/templates/ntnet_downloader.tmpl
+++ b/nano/templates/ntnet_downloader.tmpl
@@ -16,77 +16,40 @@
 	<hr>
 {{/if}}
 
-{{if data.downloadname}}
-	<h2>Download Running</h2>
-	<i>Please wait...</i>
+	<h2>{{:data.downloadname ? 'Download Running' : 'No Downloads In Progress'}}</h2>
+	<i>{{:data.downloadname ? 'Please wait...' : 'Standing by...'}}</i>
 	<div class="item">
 		<div class="itemLabel">
 			File name: 
 		</div>
 		<div class="itemContent">
-			{{:data.downloadname}}
+			{{:data.downloadname ? data.downloadname : 'N/A'}}
 		</div>
 		<div class="itemLabel">
 			File description: 
 		</div>
 		<div class="itemContent">
-			{{:data.downloaddesc}}
+			{{:data.downloadname ? data.downloaddesc : 'N/A'}}
 		</div>
 		<div class="itemLabel">
 			File size: 
 		</div>
 		<div class="itemContent">
-			{{:data.downloadcompletion}}GQ / {{:data.downloadsize}}GQ
+			{{:data.downloadname ? (data.downloadcompletion + 'GQ / ' + data.downloadsize + 'GQ') : 'N/A'}}
 		</div>
 		<div class="itemLabel">
 			Transfer Rate: 
 		</div>
 		<div class="itemContent">
-			{{:data.downloadspeed}} GQ/s
+			{{:data.downloadname ? data.downloadspeed : '0'}} GQ/s
 		</div>
 		<div class="itemLabel">
 			Download progress: 
 		</div>
 		<div class="itemContent">
-			{{:helper.displayBar(data.downloadcompletion, 0, data.downloadsize, 'good')}}
+			{{:helper.displayBar(data.downloadcompletion, 0, data.downloadname ? data.downloadsize : 0, 'good')}}
 		</div>
 	</div>
-{{else}}
-	<h2>No Downloads In Progress</h2>
-	<i>Standing by...</i>
-	<div class="item">
-		<div class="itemLabel">
-			File name: 
-		</div>
-		<div class="itemContent">
-			N/A
-		</div>
-		<div class="itemLabel">
-			File description: 
-		</div>
-		<div class="itemContent">
-			N/A
-		</div>
-		<div class="itemLabel">
-			File size: 
-		</div>
-		<div class="itemContent">
-			N/A
-		</div>
-		<div class="itemLabel">
-			Transfer Rate: 
-		</div>
-		<div class="itemContent">
-			0 GQ/s
-		</div>
-		<div class="itemLabel">
-			Download progress: 
-		</div>
-		<div class="itemContent">
-			{{:helper.displayBar(0, 0, 1, 'good')}}
-		</div>
-	</div>
-{{/if}}
 
 	<br><hr>
 	


### PR DESCRIPTION
While downloading stuff:
![image](https://user-images.githubusercontent.com/30705790/31529442-52920ef4-afa7-11e7-8789-a9aa0e17f866.png)

While idle:
![image](https://user-images.githubusercontent.com/30705790/31529445-55708178-afa7-11e7-94db-0cd9a20702ea.png)

~~This PR is a work in progress, and has **not** been thoroughly tested yet, though I haven't seen any bugs so far.~~ It seems to work fine, as far as I can tell.

Right now, to download a bunch of software (Engineering, for example, needs the supermatter monitor, power monitor, RCON, alarm monitor, etc.) you have to repeatedly take out your computer, click the button, wait for the download, then do it again... it gets boring.
This feature allows you to add all the desired programs at once, then go do something else while they download automatically.

Arguably, this makes networking speed kind of pointless, but I still feel like it is better this way. Thoughts?