### PR TITLE
Falling tweaks

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -20,6 +20,7 @@
 	layer = ABOVE_WINDOW_LAYER //icon draw layer
 	infra_luminosity = 15 //byond implementation is bugged.
 	anchor_fall = TRUE
+	w_class = ITEM_SIZE_NO_CONTAINER
 	var/initial_icon = null //Mech type for resetting icon. Only used for reskinning kits (see custom items)
 	var/can_move = 1
 	var/mob/living/carbon/occupant = null
@@ -1852,3 +1853,5 @@
 	//src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 	return
 */
+/obj/mecha/fall_damage()
+	return 550

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -1,3 +1,6 @@
 /obj/effect/decal
 	plane = ABOVE_TURF_PLANE
 	layer = DECAL_LAYER
+
+/obj/effect/decal/fall_damage()
+	return 0

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -125,6 +125,9 @@
 
 //For children to override
 /atom/movable/proc/can_fall(var/anchor_bypass = FALSE)
+	if(!simulated)
+		return FALSE
+
 	if(anchored && !anchor_bypass)
 		return FALSE
 
@@ -170,17 +173,26 @@
 		return 1
 	else
 		handle_fall_effect(landing)
-#define CRUSH_DAMAGE 550
+
 /atom/movable/proc/handle_fall_effect(var/turf/landing)
 	if(istype(landing, /turf/simulated/open))
 		visible_message("\The [src] falls from the deck above through \the [landing]!", "You hear a whoosh of displaced air.")
 	else
 		visible_message("\The [src] falls from the deck above and slams into \the [landing]!", "You hear something slam into the deck.")
-		if(anchored)
+		if(fall_damage())
 			for(var/mob/living/M in landing.contents)
-				visible_message("\The [src] crushes \the [M.name]!")
-				M.take_overall_damage(CRUSH_DAMAGE)
-#undef CRUSH_DAMAGE
+				visible_message("\The [src] hits \the [M.name]!")
+				M.take_overall_damage(fall_damage())
+
+/atom/movable/proc/fall_damage()
+	return 0
+
+/obj/fall_damage()
+	if(w_class == ITEM_SIZE_TINY)
+		return 0
+	if(w_class == ITEM_SIZE_NO_CONTAINER)
+		return 100
+	return base_storage_cost(w_class)
 
 /mob/living/carbon/human/handle_fall_effect(var/turf/landing)
 	if(species && species.handle_fall_special(src, landing))


### PR DESCRIPTION
Makes non-simulated things not fall. Makes fall damage a proc of atom (based on w_class by default). Decals now do not deal damage, mecha deal 550. Code no longer assumes everything anchored is a mecha.
Since it's decided now by fall damage rather than anchoring, other falling things can deal damage too now.
Fixes #19004

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
