### PR TITLE
Cyberprinter no longer demands DNA sample

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -17,7 +17,6 @@
 	var/max_stored_matter = 0
 	var/print_delay = 100
 	var/printing
-	var/loaded_dna //Blood sample for DNA hashing.
 
 	// These should be subtypes of /obj/item/organ
 	var/list/products = list(
@@ -110,25 +109,12 @@
 	if(stored_matter < products[choice][2])
 		visible_message("<span class='notice'>\The [src] displays a warning: 'Not enough matter. [stored_matter] stored and [products[choice][2]] needed.'</span>")
 		return 0
-
-	if(!loaded_dna || !loaded_dna["donor"])
-		visible_message("<span class='info'>\The [src] displays a warning: 'No DNA saved. Insert a blood sample.'</span>")
-		return 0
-
 	return 1
 
 /obj/machinery/organ_printer/proc/print_organ(var/choice)
 	var/new_organ = products[choice][1]
 	var/obj/item/organ/O = new new_organ(get_turf(src))
 	O.status |= ORGAN_CUT_AWAY
-	var/weakref/W = loaded_dna["donor"]
-	var/mob/living/carbon/C = W.resolve()
-	O.set_dna(C.dna)
-
-	if(O.species)
-		// This is a very hacky way of doing of what organ/New() does if it has an owner
-		O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)
-
 	return O
 // END GENERIC PRINTER
 
@@ -176,13 +162,6 @@
 		to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored matter now: [stored_matter]</span>")
 		S.use(sheets_to_take)
 		return
-	else if(istype(W,/obj/item/weapon/reagent_containers/syringe))
-		var/obj/item/weapon/reagent_containers/syringe/S = W
-		var/datum/reagent/blood/injected = locate() in S.reagents.reagent_list //Grab some blood
-		if(injected && injected.data)
-			loaded_dna = injected.data
-			to_chat(user, "<span class='info'>You inject the blood sample into the bioprinter.</span>")
-		return
 	return ..()
 // END ROBOT ORGAN PRINTER
 
@@ -195,6 +174,13 @@
 		/obj/item/weapon/reagent_containers/food/snacks/meat = 50,
 		/obj/item/weapon/reagent_containers/food/snacks/rawcutlet = 15
 		)
+	var/loaded_dna //Blood sample for DNA hashing.
+
+/obj/machinery/organ_printer/flesh/can_print(var/choice)
+	. = ..()
+	if(!loaded_dna || !loaded_dna["donor"])
+		visible_message("<span class='info'>\The [src] displays a warning: 'No DNA saved. Insert a blood sample.'</span>")
+		return 0
 
 /obj/machinery/organ_printer/flesh/mapped/Initialize()
 	. = ..()
@@ -215,6 +201,13 @@
 
 /obj/machinery/organ_printer/flesh/print_organ(var/choice)
 	var/obj/item/organ/O = ..()
+	var/weakref/W = loaded_dna["donor"]
+	var/mob/living/carbon/C = W.resolve()
+	if(C)
+		O.set_dna(C.dna)
+		if(O.species)
+			// This is a very hacky way of doing of what organ/New() does if it has an owner
+			O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)
 
 	visible_message("<span class='info'>\The [src] churns for a moment, injects its stored DNA into the biomass, then spits out \a [O].</span>")
 	return O

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -172,6 +172,8 @@ var/list/organ_cache = list()
 	// immunosuppressant that changes transplant data to make it match.
 	if(owner.virus_immunity() < 10) //for now just having shit immunity will suppress it
 		return
+	if(isrobotic())
+		return
 	if(dna)
 		if(!rejecting)
 			if(blood_incompatible(dna.b_type, owner.dna.b_type, species, owner.species))
@@ -280,7 +282,8 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/replaced(var/mob/living/carbon/human/target, var/obj/item/organ/external/affected)
 	owner = target
 	forceMove(owner) //just in case
-
+	if(isrobotic())
+		set_dna(owner.dna)
 	return 1
 
 /obj/item/organ/attack(var/mob/target, var/mob/user)


### PR DESCRIPTION
Moved DNA stuff to meat printer.
Robotic organs now autosync to owner on implantations to avoid runtimes and stuff.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
