### PR TITLE
Adds a box of exploration encryption keys to Pathfinder's locker

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -39,6 +39,11 @@
 	icon_state = "srv_cypherkey"
 	channels = list("Exploration" = 1)
 
+/obj/item/weapon/storage/box/encryptionkey/exploration
+	name = "box of spare exploration radio keys"
+	desc = "A box full of exploration department radio keys."
+	startswith = list(/obj/item/weapon/screwdriver, /obj/item/device/encryptionkey/exploration = 5)
+
 /obj/item/device/encryptionkey/pathfinder
 	name = "pathfinder's encryption key"
 	icon_state = "com_cypherkey"

--- a/maps/torch/structures/closets/exploration.dm
+++ b/maps/torch/structures/closets/exploration.dm
@@ -65,6 +65,7 @@
 		/obj/item/weapon/clipboard,
 		/obj/item/weapon/folder/blue,
 		/obj/item/device/radio/headset/pathfinder,
+		/obj/item/weapon/storage/box/encryptionkey/exploration,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel_norm)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/glowstick/random))


### PR DESCRIPTION
🆑 sabiram
rscadd: The Pathfinder now has a box of Exploration department encryption keys to distribute if they choose.
/🆑
(or are ordered to)