### PR TITLE
fire and fuel fixes

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -8,10 +8,10 @@
 	var/amount = 1
 
 	New(turf/newLoc,amt=1,nologs=0)
-		..()
 		if(!nologs)
 			log_and_message_admins(" - Liquid fuel has been spilled")
 		src.amount = amt
+		..()
 
 	proc/Spread(exclude=list())
 		//Allows liquid fuels to sometimes flow into other tiles.

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -56,7 +56,6 @@
 	return
 
 /obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, proximity)
-	if(!proximity) return
 	// Make sure our user is still holding us
 	if(user && user.get_active_hand() == src)
 		var/turf/target_turf = get_turf(target)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -291,12 +291,14 @@
 	if(!amount)
 		return
 
-	var/datum/reagents/F = new /datum/reagents(amount)
+	var/datum/reagents/F = new /datum/reagents(amount, GLOB.temp_reagents_holder)
 	var/tmpdata = get_data(type)
 	F.add_reagent(type, amount, tmpdata)
 	remove_reagent(type, amount)
 
-	return F.trans_to(target, amount) // Let this proc check the atom's type
+	. = F.trans_to(target, amount) // Let this proc check the atom's type
+
+	qdel(F)
 
 // When applying reagents to an atom externally, touch() is called to trigger any on-touch effects of the reagent.
 // This does not handle transferring reagents to things.
@@ -363,17 +365,19 @@
 			var/datum/reagents/R = C.touching
 			return trans_to_holder(R, amount, multiplier, copy)
 	else
-		var/datum/reagents/R = new /datum/reagents(amount)
+		var/datum/reagents/R = new /datum/reagents(amount, GLOB.temp_reagents_holder)
 		. = trans_to_holder(R, amount, multiplier, copy)
 		R.touch_mob(target)
+		qdel(R)
 
 /datum/reagents/proc/trans_to_turf(var/turf/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Turfs don't have any reagents (at least, for now). Just touch it.
 	if(!target || !target.simulated)
 		return
 
-	var/datum/reagents/R = new /datum/reagents(amount * multiplier)
+	var/datum/reagents/R = new /datum/reagents(amount * multiplier, GLOB.temp_reagents_holder)
 	. = trans_to_holder(R, amount, multiplier, copy)
 	R.touch_turf(target)
+	qdel(R)
 	return
 
 /datum/reagents/proc/trans_to_obj(var/obj/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Objects may or may not; if they do, it's probably a beaker or something and we need to transfer properly; otherwise, just touch.

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -265,15 +265,15 @@
 
 //Removes moles from the gas mixture, limited by a given flag.  Returns a gax_mixture containing the removed air.
 /datum/gas_mixture/proc/remove_by_flag(flag, amount)
+	var/datum/gas_mixture/removed = new
+
 	if(!flag || amount <= 0)
-		return
+		return removed
 
 	var/sum = 0
 	for(var/g in gas)
 		if(gas_data.flags[g] & flag)
 			sum += gas[g]
-
-	var/datum/gas_mixture/removed = new
 
 	for(var/g in gas)
 		if(gas_data.flags[g] & flag)


### PR DESCRIPTION
fixes #18908 in the end I guess, bunch of different fixes

fix fires burning purely liquid fuel

fix various reagent trans_to procs runtiming
fixes #18923 (sorry psi)

fix welding fuel spreading

fix flamethrowers (I'm very sorry)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
