### PR TITLE
Fixes records not showing to some HUD eyewear

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -301,9 +301,17 @@
 		var/mob/living/carbon/human/H = M
 		switch(hudtype)
 			if("security")
-				return istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud)
+				if(istype(H.glasses,/obj/item/clothing/glasses))
+					var/obj/item/clothing/glasses/G = H.glasses
+					return istype(G.hud, /obj/item/clothing/glasses/hud/security) || istype(G, /obj/item/clothing/glasses/hud/security)
+				else 
+					return FALSE
 			if("medical")
-				return istype(H.glasses, /obj/item/clothing/glasses/hud/health)
+				if(istype(H.glasses,/obj/item/clothing/glasses))
+					var/obj/item/clothing/glasses/G = H.glasses
+					return istype(G.hud, /obj/item/clothing/glasses/hud/health) || istype(G, /obj/item/clothing/glasses/hud/health)
+				else 
+					return FALSE
 			else
 				return 0
 	else if(istype(M, /mob/living/silicon/robot))


### PR DESCRIPTION
Makes it check glasses' HUD instead of type of glasses themselves.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
