### PR TITLE
Adds department voidsuits to the Supply list

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -81,3 +81,13 @@
 	containername = "\improper CO2 canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
+
+/decl/hierarchy/supply_pack/atmospherics/voidsuit
+	name = "Atmospherics voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/atmos/alt,
+					/obj/item/clothing/head/helmet/space/void/atmos/alt,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Atmospherics voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_atmospherics

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -243,3 +243,13 @@
 	cost = 20
 	containertype = /obj/structure/closet/firecloset
 	containername = "\improper fire-safety closet"
+
+/decl/hierarchy/supply_pack/engineering/voidsuit
+	name = "Engineering voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/engineering/alt,
+					/obj/item/clothing/head/helmet/space/void/engineering/alt,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Engineering voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_engine

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -259,3 +259,13 @@
 	cost = 15
 	containertype = /obj/structure/closet/crate
 	containername = "\improper Sterile equipment crate"
+
+/decl/hierarchy/supply_pack/medical/voidsuit
+	name = "Medical voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/medical/alt,
+					/obj/item/clothing/head/helmet/space/void/medical/alt,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Medical voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_medical_equip

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -116,6 +116,16 @@
 	containername = "\improper Ablative suit crate"
 	access = access_armory
 
+/decl/hierarchy/supply_pack/security/voidsuit
+	name = "Armor - Security voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/security/alt,
+					/obj/item/clothing/head/helmet/space/void/security/alt,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Security voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_brig
+
 /decl/hierarchy/supply_pack/security/weapons
 	name = "Weapons - Security basic"
 	contains = list(/obj/item/device/flash = 4,
@@ -315,6 +325,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Security biohazard gear crate"
 	access = access_security
+
 /*
 /decl/hierarchy/supply_pack/security/flareguns
 	name = "Flare guns crate"

--- a/maps/torch/datums/supplypacks/science.dm
+++ b/maps/torch/datums/supplypacks/science.dm
@@ -1,0 +1,39 @@
+/decl/hierarchy/supply_pack/science/voidsuit
+	name = "Excavation voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/excavation,
+					/obj/item/clothing/head/helmet/space/void/excavation,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Excavation voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_nanotrasen
+
+/decl/hierarchy/supply_pack/science/voidsuit_mining
+	name = "Mining voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/mining/alt,
+					/obj/item/clothing/head/helmet/space/void/mining/alt,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Mining voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_nanotrasen
+
+/decl/hierarchy/supply_pack/science/voidsuit_pilot
+	name = "Pilot voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/pilot,
+					/obj/item/clothing/head/helmet/space/void/pilot,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Pilot voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_nanotrasen
+
+/decl/hierarchy/supply_pack/science/voidsuit_exploration
+	name = "Exploration voidsuit"
+	contains = list(/obj/item/clothing/suit/space/void/exploration,
+					/obj/item/clothing/head/helmet/space/void/exploration,
+					/obj/item/clothing/shoes/magboots)
+	cost = 120
+	containername = "\improper Exploration voidsuit crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_explorer

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -17,6 +17,7 @@
 	#include "datums/uniforms_fleet.dm"
 	#include "datums/uniforms_marine.dm"
 	#include "datums/supplypacks/security.dm"
+	#include "datums/supplypacks/science.dm"
 
 	#include "items/cards_ids.dm"
 	#include "items/clothing.dm"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Voidsuits are currently impossible to replace if any are lost or destroyed. This adds all department voidsuits in the relevant categories, locked with appropriate access levels. All of them cost 120 credits, which is more expensive than anything short of a new supermatter core, a full chemistry dispenser refill, or the collectable crap crates.