### PR TITLE
Adjusts uranium shuriken damage for brainmed changes

### DIFF
--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -17,7 +17,8 @@
 	..()
 	if(material.radioactivity>0 && istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
-		M.adjustToxLoss(rand(20,40))
+		var/urgh = material.radioactivity
+		M.adjustToxLoss(rand(urgh/2,urgh))
 
 /obj/item/weapon/material/star/ninja
 	default_material = "uranium"


### PR DESCRIPTION
Also makes the exact amount vary based on material radioactivity.
Effectively lowers damage from 20-40 to 6-12.
:cl: Spider Clan High Command
-tweak: Ninjas' shurikens are now friendlier and healthier, to better enable use in live capture.
/:cl: