### PR TITLE
Fixes sticks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -871,6 +871,7 @@
 #include "code\game\objects\items\weapons\material\material_weapons.dm"
 #include "code\game\objects\items\weapons\material\misc.dm"
 #include "code\game\objects\items\weapons\material\shards.dm"
+#include "code\game\objects\items\weapons\material\stick.dm"
 #include "code\game\objects\items\weapons\material\swords.dm"
 #include "code\game\objects\items\weapons\material\thrown.dm"
 #include "code\game\objects\items\weapons\material\twohanded.dm"

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -77,13 +77,4 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 2)
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
 
-/obj/item/weapon/material/stick
-	name = "stick"
-	desc = "You feel the urge of poking something with this."
-	icon_state = "stick"
-	item_state = "stickmat"
-	force_divisor = 0.05
-	thrown_force_divisor = 0.05
-	w_class = ITEM_SIZE_NORMAL
-	default_material = "wood"
-	attack_verb = list("poked", "jabbed")
+

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/material/stick
 	name = "stick"
-	desc = "You feel the urge of poking something with this."
+	desc = "You feel the urge to poke someone with this."
 	icon_state = "stick"
 	item_state = "stickmat"
 	force_divisor = 0.1
@@ -16,8 +16,8 @@
 
 
 /obj/item/weapon/material/stick/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.sharp && W.edge)
-		user.visible_message("<span class='warning'>\[user] sharpens [src] with [W].</span>", "<span class='warning'>You sharpen [src] using [W].</span>")
+	if(W.sharp && W.edge && !sharp)
+		user.visible_message("<span class='warning'>[user] sharpens [src] with [W].</span>", "<span class='warning'>You sharpen [src] using [W].</span>")
 		sharp = 1 //Sharpen stick
 		name = "sharpened " + name
 		update_force()
@@ -27,7 +27,7 @@
 /obj/item/weapon/material/stick/attack(mob/M, mob/user)
 	if(user != M && user.a_intent == I_HELP)
 		//Playful poking is its own thing
-		user.visible_message("[user] pokes [M] with [src].", "You poke [M] with [src].")
+		user.visible_message("<span class='notice'>[user] pokes [M] with [src].</span>", "<span class='notice'>You poke [M] with [src].</span>")
 		//Consider adding a check to see if target is dead
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(M)

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -1,0 +1,35 @@
+/obj/item/weapon/material/stick
+	name = "stick"
+	desc = "You feel the urge of poking something with this."
+	icon_state = "stick"
+	item_state = "stickmat"
+	force_divisor = 0.1
+	thrown_force_divisor = 0.1
+	w_class = ITEM_SIZE_NORMAL
+	default_material = "wood"
+	attack_verb = list("poked", "jabbed")
+
+
+/obj/item/weapon/material/stick/attack_self(mob/user as mob)
+	user.visible_message("<span class='warning'>\The [user] snaps [src].</span>", "<span class='warning'>You snap [src].</span>")
+	shatter(0)
+
+
+/obj/item/weapon/material/stick/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(W.sharp && W.edge)
+		user.visible_message("<span class='warning'>\[user] sharpens [src] with [W].</span>", "<span class='warning'>You sharpen [src] using [W].</span>")
+		sharp = 1 //Sharpen stick
+		name = "sharpened " + name
+		update_force()
+	return ..()
+
+
+/obj/item/weapon/material/stick/attack(mob/M, mob/user)
+	if(user != M && user.a_intent == I_HELP)
+		//Playful poking is its own thing
+		user.visible_message("[user] pokes [M] with [src].", "You poke [M] with [src].")
+		//Consider adding a check to see if target is dead
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(M)
+		return
+	return ..()

--- a/html/changelogs/CrimsonShrike - fixStick.yml
+++ b/html/changelogs/CrimsonShrike - fixStick.yml
@@ -1,0 +1,6 @@
+author: CrimsonShrike
+delete-after: True
+changes: 
+  - bugfix: "Fixed stick messages not showing."
+  - rscadd: "Sticks can now be sharpened using edged sharp tools."
+


### PR DESCRIPTION
Fixes stick messages not showing and adds sharpening and messages.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
