### PR TITLE
Ship sensor overheating

### DIFF
--- a/html/changelogs/sicktrigger-sensorsheat.yml
+++ b/html/changelogs/sicktrigger-sensorsheat.yml
@@ -1,0 +1,6 @@
+author: sicktrigger
+
+delete-after: True
+
+changes: 
+  - rscadd: "Ship sensors will now heat up and eventually take damage at higher settings (they can be repaired with a welder). Their power usage has also been significantly reduced."

--- a/nano/templates/shipsensors.tmpl
+++ b/nano/templates/shipsensors.tmpl
@@ -18,6 +18,48 @@
 		</div>
 	</div>
 </div>
+<div class='block'>
+	<div class='item'>
+		<div class="itemLabel">
+			Integrity:
+		</div>
+		<div class="itemContent">
+			{{if data.health < (data.max_health * 0.25)}}
+				{{:helper.displayBar(data.health, 0, data.max_health, 'bad')}}
+				<br><span class="bad">{{:data.health}}/{{:data.max_health}}</span>
+			{{else data.health < data.max_health *.75}}
+				{{:helper.displayBar(data.health, 0, data.max_health, 'average')}}
+				<br><span class="average">{{:data.health}}/{{:data.max_health}}</span>
+			{{else}}
+				{{:helper.displayBar(data.health, 0, data.max_health, 'good')}}
+				<br><span class="good">{{:data.health}}/{{:data.max_health}}</span>
+			{{/if}}
+		</div>
+	</div>
+	<div class='item'>
+		<div class="itemLabel">
+			Temperature:
+		</div>
+		<div class="itemContent">
+			{{if data.heat < (data.critical_heat * 0.5)}}
+				{{:helper.displayBar(data.heat, 0, data.critical_heat, 'good')}}
+			{{else data.heat < (data.critical_heat * 0.75)}}
+				{{:helper.displayBar(data.heat, 0, data.critical_heat, 'average')}}
+			{{else}}
+				{{:helper.displayBar(data.heat, 0, data.critical_heat, 'bad')}}
+			{{/if}}
+		</div>
+		<div class="itemContent">
+			{{if data.heat < (data.critical_heat * 0.5)}}
+				<span class="good">Temperature low.</span>
+			{{else data.heat < (data.critical_heat * 0.75)}}
+				<span class="average">Sensor temperature high!</span>
+			{{else}}
+				<span class="bad">TEMPERATURE CRITICAL: Disable or reduce power immediately!</span>
+			{{/if}}
+		</div>
+	</div>
+</div>
 <div class='item'>
 	<div class="itemContent">
 		<div class='item'>


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
It's based on how much energy they're using. Currently it'll slowly tick up at range 4, and is pretty quick at 7. Takes damage and shuts down if they get too hot. Their power draw has also been reduced to about a tenth, making managing sensors more of a bridge responsibility and less of an engineering one.

(conflicts with #18757 )

![](https://i.gyazo.com/63333cd378b7505ed0920d62c77673d5.png)