### PR TITLE
Reverts #19126

### DIFF
--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -8,7 +8,6 @@
 	name = "\improper Sol Central Government cap"
 	desc = "It's a ballcap in SCG colors."
 	icon_state = "solsoft"
-	flags_inv = BLOCKHEADHAIR
 	icon = 'maps/torch/icons/obj/solgov-head.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/solgov-head.dmi')
 


### PR DESCRIPTION
No more special Sol hats that have some bluespace property the other soft caps lack.

This broke xeno heads, and the original author does not seem to intend to fix it.