### PR TITLE
Fix #19293

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -205,7 +205,7 @@
 	return ckey ? "[..()] ([ckey])" : ..()
 
 /proc/log_info_line(var/datum/d)
-	if(!d)
+	if(isnull(d))
 		return "*null*"
 	if(islist(d))
 		var/list/L = list()

--- a/code/_helpers/storage.dm
+++ b/code/_helpers/storage.dm
@@ -23,8 +23,10 @@
 	var/prob_method = /proc/prob_call
 
 /datum/atom_creator/simple/New(var/path, var/probability)
+	if(args.len != 2)
+		CRASH("Invalid number of arguments. Expected 2, was [args.len]")
 	if(!isnum(probability) || probability < 1 || probability > 99)
-		CRASH("The given probability must be between 1 and 99") // A probability of 0 or 100 is pretty meaningless.
+		CRASH("Invalid probability. Expected a number between 1 and 99, was [log_info_line(probability)]") // A probability of 0 or 100 is pretty meaningless.
 	src.probability = probability
 	src.path = path
 
@@ -36,7 +38,15 @@
 	var/list/paths
 	var/selection_method = /proc/pickweight
 
-/datum/atom_creator/weighted/New(var/paths)
+/datum/atom_creator/weighted/New(var/list/paths)
+	if(args.len != 1)
+		CRASH("Invalid number of arguments. Expected 1, was [args.len]")
+	if(!istype(paths))
+		CRASH("Invalid argument type. Expected /list, was [log_info_line(paths)]")
+	for(var/path in paths)
+		var/probability = paths[path]
+		if(!(isnull(probability) || (isnum(probability) && probability > 0)))
+			CRASH("Invalid probability. Expected null or a number greater than 0, was [log_info_line(probability)]")
 	src.paths = paths
 
 /datum/atom_creator/weighted/create(var/loc)

--- a/code/unit_tests/override_tests.dm
+++ b/code/unit_tests/override_tests.dm
@@ -42,7 +42,7 @@
 	name = "OVERRIDE - /datum/atom_creator/weighted shall spawn heaviest"
 
 /datum/unit_test/override/atom_creator_weighted_shall_spawn_heaviest/start_test()
-	var/datum/atom_creator/weighted/W = new/datum/atom_creator/weighted(list(/obj/unit_test_light = 100, /obj/unit_test_heavy = 0))
+	var/datum/atom_creator/weighted/W = new/datum/atom_creator/weighted(list(/obj/unit_test_light = 9001, /obj/unit_test_heavy = 1))
 
 	var/safe_turf = get_safe_turf()
 	W.create(safe_turf)
@@ -61,7 +61,7 @@
 /datum/unit_test/override/atom_creator_weighted_shall_spawn_heaviest_recursive/start_test()
 	var/datum/atom_creator/weighted/W = new/datum/atom_creator/weighted(
 		list(
-			new/datum/atom_creator/weighted(list(/obj/unit_test_light = 100, /obj/unit_test_heavy = 0)),
+			new/datum/atom_creator/weighted(list(/obj/unit_test_light = 9001, /obj/unit_test_heavy = 1)),
 			new/datum/atom_creator/simple(/obj/unit_test_medium, 50)
 		)
 	)

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -57,13 +57,13 @@
 		/obj/random/cash,
 		/obj/random/cash,
 		/obj/random/smokes,
-		new /datum/atom_creator/weighted( /obj/item/weapon/reagent_containers/syringe, 50),
-		new /datum/atom_creator/weighted( /obj/item/weapon/reagent_containers/syringe/steroid, 10),
-		new /datum/atom_creator/weighted( /obj/item/weapon/reagent_containers/syringe/steroid, 10),
-		new /datum/atom_creator/weighted( list(/obj/item/weapon/reagent_containers/food/drinks/cans/cola, /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle, /obj/item/weapon/reagent_containers/food/drinks/cans/dr_gibb)),
-		new /datum/atom_creator/weighted( /obj/item/clothing/glasses/eyepatch, 30),
-		new /datum/atom_creator/weighted( /obj/item/clothing/gloves/duty, 80),
-		new /datum/atom_creator/weighted( /obj/item/clothing/mask/balaclava/tactical, 30))
+		new /datum/atom_creator/simple(/obj/item/weapon/reagent_containers/syringe, 50),
+		new /datum/atom_creator/simple(/obj/item/weapon/reagent_containers/syringe/steroid, 10),
+		new /datum/atom_creator/simple(/obj/item/weapon/reagent_containers/syringe/steroid, 10),
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/reagent_containers/food/drinks/cans/cola, /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle, /obj/item/weapon/reagent_containers/food/drinks/cans/dr_gibb)),
+		new /datum/atom_creator/simple(/obj/item/clothing/glasses/eyepatch, 30),
+		new /datum/atom_creator/simple(/obj/item/clothing/gloves/duty, 80),
+		new /datum/atom_creator/simple(/obj/item/clothing/mask/balaclava/tactical, 30))
 
 /obj/random/ore
 	name = "random ore"


### PR DESCRIPTION
Now uses /datum/atom_creator/simple instead of /datum/atom_creator/weighted were appropriate.
Adds some sanitation checks to reduce the likelihood of the wrong type being used again.

Fixes #19293

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
