### PR TITLE
lowered hacking time

### DIFF
--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -53,8 +53,8 @@
 
 	to_chat(user, "<span class='notice'>You begin hacking \the [target]...</span>")
 	is_hacking = 1
-	// On average hackin takes ~30 seconds. Fairly small random span to avoid people simply aborting and trying again
-	var/hack_result = do_after(user, (20 SECONDS + rand(0, 10 SECONDS) + rand(0, 10 SECONDS)), progress = 0)
+	// Hackin takes roughly 15-25 seconds. Fairly small random span to avoid people simply aborting and trying again.
+	var/hack_result = do_after(user, (15 SECONDS + rand(0, 5 SECONDS) + rand(0, 5 SECONDS)), progress = 0)
 	is_hacking = 0
 
 	if(hack_result && in_hack_mode)


### PR DESCRIPTION
🆑TheGreyWolf
tweak: Lowered the hacking time for the hacktool to 15-25 seconds.
/🆑
on request of @Loneguyfly 
https://i.imgur.com/yYwtVe4.png
Time is up for debate of course if any dev wishes it to be different.