### PR TITLE
Buffs monkey ventcrawl

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -53,6 +53,10 @@ var/list/ventcrawl_machinery = list(
 /mob/living/carbon/human/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if(carried_item in organs)
 		return 1
+	if(carried_item in list(w_uniform, gloves, glasses, wear_mask, l_ear, r_ear, belt, l_store, r_store))
+		return 1
+	if(carried_item in list(l_hand,r_hand))
+		return carried_item.w_class <= ITEM_SIZE_NORMAL
 	return ..()
 
 /mob/living/simple_animal/spiderbot/is_allowed_vent_crawl_item(var/obj/item/carried_item)


### PR DESCRIPTION
🆑 chinsky
tweak: Humanoids able to vent-crawl can now bring select articles of clothing and carry items which are not too big.
/:cl:

Or I guess any species that has ventcrawling. Only monkeys now.
Now you can wear clothes while doing it. No shoes though, you cannot ventcrawl wearing shoes, that is forbidden. Also no suits or helmets cause that's bulky.
You can also carry items in hands, but of normal size or smaller.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
