### PR TITLE
START_PROCESSING* now checks processing instances

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -19,7 +19,17 @@
 
 #define NEW_SS_GLOBAL(varname) if(varname != src){if(istype(varname)){Recover();qdel(varname);}varname = src;}
 
-#define START_PROCESSING(Processor, Datum) if (!Datum.is_processing) {Datum.is_processing = #Processor;Processor.processing += Datum}
+#define START_PROCESSING(Processor, Datum) \
+if (Datum.is_processing) {\
+	if(Datum.is_processing != #Processor)\
+	{\
+		crash_with("Failed to start processing. [log_info_line(Datum)] is already being processed by [Datum.is_processing] but queue attempt occured on [#Processor]."); \
+	}\
+} else {\
+	Datum.is_processing = #Processor;\
+	Processor.processing += Datum;\
+}
+
 #define STOP_PROCESSING(Processor, Datum) \
 if(Datum.is_processing) {\
 	if(Processor.processing.Remove(Datum)) {\

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -3,7 +3,17 @@
 #define SSMACHINES_POWERNETS     3
 #define SSMACHINES_POWER_OBJECTS 4
 
-#define START_PROCESSING_IN_LIST(Datum, List) if (!Datum.is_processing) {Datum.is_processing = "SSmachines.[#List]"; SSmachines.List += Datum}
+#define START_PROCESSING_IN_LIST(Datum, List) \
+if (Datum.is_processing) {\
+	if(Datum.is_processing != #Processor)\
+	{\
+		crash_with("Failed to start processing. [log_info_line(Datum)] is already being processed by [Datum.is_processing] but queue attempt occured on [#Processor]."); \
+	}\
+} else {\
+	Datum.is_processing = "SSmachines.[#List]";\
+	SSmachines.List += Datum;\
+}
+
 #define STOP_PROCESSING_IN_LIST(Datum, List) \
 if(Datum.is_processing) {\
 	if(SSmachines.List.Remove(Datum)) {\


### PR DESCRIPTION
The START_PROCESSING* macros check which subsystem an already processed
 instance is being processed by.
If it is not the same as the given subsystem an error is raised.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
