### PR TITLE
Fix APC construction

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -116,13 +116,10 @@ Class Procs:
 	var/clicksound			// sound played on succesful interface use by a carbon lifeform
 	var/clickvol = 40		// sound played on succesful interface use
 
-/obj/machinery/New(l, d=0)
-	..(l)
+/obj/machinery/Initialize(mapload, d=0)
+	. = ..()
 	if(d)
 		set_dir(d)
-
-/obj/machinery/Initialize()
-	. = ..()
 	START_PROCESSING(SSmachines, src)
 
 /obj/machinery/Destroy()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -171,8 +171,7 @@
 
 	return drained_energy
 
-/obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0)
-	..()
+/obj/machinery/power/apc/Initialize(mapload, var/ndir, var/building=0)
 
 	wires = new(src)
 
@@ -195,8 +194,8 @@
 		stat |= MAINT
 		src.update_icon()
 
-/obj/machinery/power/apc/Initialize()
-	. = ..()
+	. = ..(mapload)
+
 	if(operating)
 		src.update()
 
@@ -250,8 +249,6 @@
 		name = "\improper [area.name] APC"
 	area.apc = src
 	update_icon()
-
-	make_terminal()
 
 /obj/machinery/power/apc/examine(mob/user)
 	if(..(user, 1))


### PR DESCRIPTION
Fixes #19363.

A runtime was occurring while trying to manually assemble an APC in-round. Due to me moving the `..()` call in the APC's `New` from the end of the function to the beginning (to ensure map-template APCs had their values from the .dmm applied in the first instance, mimicking /tg/ and Aurora's initialisation), the entire `Initialize` chain also moved with it. So, `Initialize` tried to access a variable that `New` hadn't gotten around to setting up yet. Awkward.

This PR moves all of APC's `New` work into `Initialize` to sort this out properly. Now the order of initialisation is much more straightforward and far closer to how it was pre-`..()`-move.

It was necessary to move `/obj/machinery`'s `New` work into `Initialize` as well, because its explicit, parameterised `New` was overriding the args passed down from above, so they didn't get into `/atom/New()` correctly, and were therefore not passed into `Initialize`, so things naturally broke.

That change is a little scary, but it has been tested out and works. Engine was startable normally, atmospherics was running correctly, and I was able to disassemble and reassemble APCs and air alarms and gas cooling systems. I'm happy to do any further suggested testing on this since it's a moderately spooky change.