### PR TITLE
Makes it so the flammenwerfer doesn't werf flammens on help intent

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -58,6 +58,9 @@
 /obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, proximity)
 	// Make sure our user is still holding us
 	if(user && user.get_active_hand() == src)
+		if(user.a_intent == I_HELP) //don't shoot if we're on help intent
+			to_chat(user, "<span class='warning'>You refrain from firing \the [src] as your intent is set to help.</span>")
+			return
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)
 			var/turflist = getline(user, target_turf)


### PR DESCRIPTION
This seems like an oversight, so I fixed it.

EDIT: I tested it, and it works. It doesn't werf on help. Here's a gif of it werfing on harm though:
![werf](https://user-images.githubusercontent.com/7545411/32704208-18ccab4c-c7c7-11e7-8d25-e7f309a324f3.gif)


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
