### PR TITLE
Fixed fuel check issue in shuttle fuel consumption

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -21,7 +21,7 @@
 			fuel_ports += fuel_port_in_area
 
 /datum/shuttle/autodock/overmap/fuel_check()
-	if(src.try_consume_fuel()) //insufficient fuel
+	if(!src.try_consume_fuel()) //insufficient fuel
 		for(var/area/A in shuttle_area)
 			for(var/mob/living/M in A)
 				M.show_message("<spawn class='warning'>You hear the shuttle engines sputter... perhaps it doesn't have enough fuel?", AUDIBLE_MESSAGE,

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -72,8 +72,10 @@
 			return FALSE	//someone cancelled the launch
 
 		if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
+			var/datum/shuttle/autodock/S = src
+			if(istype(S))
+				S.cancel_launch(null)
 			return
-			moving_status = SHUTTLE_IDLE
 
 		moving_status = SHUTTLE_INTRANSIT //shouldn't matter but just to be safe
 		attempt_move(destination)
@@ -92,8 +94,10 @@
 			return	//someone cancelled the launch
 
 		if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
+			var/datum/shuttle/autodock/S = src
+			if(istype(S))
+				S.cancel_launch(null)
 			return
-			moving_status = SHUTTLE_IDLE
 
 		arrive_time = world.time + travel_time*10
 		moving_status = SHUTTLE_INTRANSIT


### PR DESCRIPTION
Turns out one of the if-statements had an incorrect condition. The shuttles should actually work now.

I'm trying to figure out what the actual problem is (because it worked, somehow, when tested locally), but it may take a while.

EDIT: Okay, tested it with this quickfix, and it still seems to work fine. Behaves just as expected, both with fuel-consuming and non-fuel-consuming shuttles. No idea how it worked before TBH. I'll make a few more small changes before pushing again