### PR TITLE
Removes cyborg self-destruct

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -92,6 +92,19 @@
 		target.emagged = 1
 		to_chat(target, "<span class='notice'>Failsafe protocols overriden. New tools available.</span>")
 
+	else if (href_list["message"])
+		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["message"])
+		if(!target || !istype(target))
+			return
+
+		var/message = sanitize(input("Enter message to transmit to the synthetic.") as null|text)
+		if(!message || !istype(target))
+			return
+
+		log_and_message_admins("[key_name_admin(usr)] sent message '[message]' to [target.name] using robotics control console!")
+		to_chat(target, "<span class='notice'>New remote message received using R-SSH protocol:</span>")
+		to_chat(target, message)
+
 // Proc: get_cyborgs()
 // Parameters: 1 (operator - mob which is operating the console.)
 // Description: Returns NanoUI-friendly list of accessible cyborgs.
@@ -110,10 +123,12 @@
 		robot["name"] = R.name
 		var/turf/T = get_turf(R)
 		var/area/A = get_area(T)
-		if(istype(A))
+
+		if(istype(T) && istype(A) && (T.z in GLOB.using_map.contact_levels))
 			robot["location"] = "[A.name] ([T.x], [T.y])"
 		else
 			robot["location"] = "Unknown"
+
 		if(R.stat)
 			robot["status"] = "Not Responding"
 		else if (!R.canmove)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -1,14 +1,12 @@
 /obj/machinery/computer/robotics
 	name = "robotics control console"
-	desc = "Used to remotely lockdown or detonate linked cyborgs."
+	desc = "Used to remotely lockdown or monitor linked synthetics."
 	icon = 'icons/obj/computer.dmi'
 	icon_keyboard = "tech_key"
 	icon_screen = "robot"
 	light_color = "#a97faa"
 	req_access = list(access_robotics)
 	circuit = /obj/item/weapon/circuitboard/robotics
-
-	var/safety = 1
 
 /obj/machinery/computer/robotics/attack_ai(var/mob/user as mob)
 	ui_interact(user)
@@ -19,10 +17,7 @@
 /obj/machinery/computer/robotics/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 	data["robots"] = get_cyborgs(user)
-	data["safety"] = safety
-	// Also applies for cyborgs. Hides the manual self-destruct button.
 	data["is_ai"] = issilicon(user)
-
 
 	ui = GLOB.nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -38,37 +33,6 @@
 	if(!src.allowed(user))
 		to_chat(user, "Access Denied")
 		return
-
-	// Destroys the cyborg
-	if(href_list["detonate"])
-		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["detonate"])
-		if(!target || !istype(target))
-			return
-		if(isAI(user) && (target.connected_ai != user))
-			to_chat(user, "Access Denied. This robot is not linked to you.")
-			return
-		// Cyborgs may blow up themselves via the console
-		if(isrobot(user) && user != target)
-			to_chat(user, "Access Denied.")
-			return
-		var/choice = input("Really detonate [target.name]?") in list ("Yes", "No")
-		if(choice != "Yes")
-			return
-		if(!target || !istype(target))
-			return
-
-		// Antagonistic cyborgs? Left here for downstream
-		if(target.mind && target.mind.special_role && target.emagged)
-			to_chat(target, "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered.")
-			target.ResetSecurityCodes()
-		else
-			message_admins("<span class='notice'>[key_name_admin(usr)] detonated [target.name]!</span>")
-			log_game("[key_name(usr)] detonated [target.name]!")
-			to_chat(target, "<span class='danger'>Self-destruct command received.</span>")
-			spawn(10)
-				target.self_destruct()
-
-
 
 	// Locks or unlocks the cyborg
 	else if (href_list["lockdown"])
@@ -128,38 +92,6 @@
 		target.emagged = 1
 		to_chat(target, "<span class='notice'>Failsafe protocols overriden. New tools available.</span>")
 
-	// Arms the emergency self-destruct system
-	else if(href_list["arm"])
-		if(istype(user, /mob/living/silicon))
-			to_chat(user, "Access Denied")
-			return
-
-		safety = !safety
-		to_chat(user, "You [safety ? "disarm" : "arm"] the emergency self destruct")
-
-	// Destroys all accessible cyborgs if safety is disabled
-	else if(href_list["nuke"])
-		if(istype(user, /mob/living/silicon))
-			to_chat(user, "Access Denied")
-			return
-		if(safety)
-			to_chat(user, "Self-destruct aborted - safety active")
-			return
-
-		message_admins("<span class='notice'>[key_name_admin(usr)] detonated all cyborgs!</span>")
-		log_game("[key_name(usr)] detonated all cyborgs!")
-
-		for(var/mob/living/silicon/robot/R in GLOB.silicon_mob_list)
-			if(istype(R, /mob/living/silicon/robot/drone))
-				continue
-			// Ignore antagonistic cyborgs
-			if(R.scrambledcodes)
-				continue
-			to_chat(R, "<span class='danger'>Self-destruct command received.</span>")
-			spawn(10)
-				R.self_destruct()
-
-
 // Proc: get_cyborgs()
 // Parameters: 1 (operator - mob which is operating the console.)
 // Description: Returns NanoUI-friendly list of accessible cyborgs.
@@ -176,6 +108,12 @@
 
 		var/list/robot = list()
 		robot["name"] = R.name
+		var/turf/T = get_turf(R)
+		var/area/A = get_area(T)
+		if(istype(A))
+			robot["location"] = "[A.name] ([T.x], [T.y])"
+		else
+			robot["location"] = "Unknown"
 		if(R.stat)
 			robot["status"] = "Not Responding"
 		else if (!R.canmove)

--- a/nano/templates/robot_control.tmpl
+++ b/nano/templates/robot_control.tmpl
@@ -1,20 +1,3 @@
-{{if !data.is_ai}}
-	<div class='notice'>
-		<div class="itemContentSmall" style="width: 180px">
-			Emergency Self-Destruct:
-		</div>
-		<div class="itemContentFull">
-			{{if data.safety}}
-				{{:helper.link('ARM', 'unlocked', {'arm' : 1})}}
-				{{:helper.link('DETONATE', 'radiation', {'nuke' : 1}, 'disabled')}}
-			{{else}}
-				{{:helper.link('DISARM', 'locked', {'arm' : 1})}}
-				{{:helper.link('DETONATE', 'radiation', {'nuke' : 1}, null, 'redButton')}}
-			{{/if}}
-		</div>
-		<div class="clearBoth"></div>
-	</div>
-{{/if}}
 {{for data.robots}}
 	<hr>
 	<div class='item'>
@@ -38,6 +21,12 @@
 		<span class="itemContent">
 			{{:value.module}}
 		</span>		
+		<span class="itemLabel">
+			Position: 
+		</span>
+		<span class="itemContent">
+			{{:value.location}}
+		</span>	
 
 		{{if value.hackable}}
 			<span class="itemLabel">
@@ -75,7 +64,6 @@
 			{{else}}
 				{{:helper.link('Unlock', 'unlocked', {'lockdown' : value.name})}}
 			{{/if}}
-				{{:helper.link('Self-Destruct', 'radiation', {'detonate' : value.name}, null, 'redButton')}}
 			{{if value.hackable}}
 				{{:helper.link('Hack', 'calculator', {'hack' : value.name}, null, 'redButton')}}
 			{{/if}}

--- a/nano/templates/robot_control.tmpl
+++ b/nano/templates/robot_control.tmpl
@@ -59,6 +59,7 @@
 			<b> N/A %</b>
 		{{/if}}
 		<h3>Actions</h3>
+			{{:helper.link('Message', 'mail-closed', {'message' : value.name})}}
 			{{if value.status == "Operational"}}
 				{{:helper.link('Lockdown', 'locked', {'lockdown' : value.name})}}
 			{{else}}


### PR DESCRIPTION
:cl:
rscdel: Cyborgs can no longer be self-destructed through the remote console.
rscadd: Cyborg's precise position is now displayed on the console instead.
rscadd: The console now offers you an option to send direct message to a cyborg. This message is independent on telecommunications and range.
/:cl: