### PR TITLE
Small set of fixes for away maps.

### DIFF
--- a/maps/away/marooned/marooned.dm
+++ b/maps/away/marooned/marooned.dm
@@ -23,14 +23,17 @@
 /obj/effect/shuttle_landmark/nav_marooned/nav1
 	name = "Planetside Navpoint #1"
 	landmark_tag = "nav_marooned_1"
+	autoset = 1
 
 /obj/effect/shuttle_landmark/nav_marooned/nav2
 	name = "Planetside Navpoint #2"
 	landmark_tag = "nav_marooned_2"
+	autoset = 1
 
 /obj/effect/shuttle_landmark/nav_marooned/nav3
 	name = "Planetside Navpoint #3"
 	landmark_tag = "nav_marooned_antag"
+	autoset = 1
 
 /obj/item/clothing/under/magintka_uniform
 	name = "Magnitka fleet officer uniform"

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -20,7 +20,7 @@
 /obj/effect/shuttle_landmark/nav_asteroid_base/nav2
 	name = "Abandoned Asteroid Base Navpoint #2"
 	landmark_tag = "nav_smugglers_antag"
-
+	autoset = 1
 
 /obj/item/weapon/paper/smug_1
 	name = "suspicios note"

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -5,121 +5,117 @@
 "ae" = (/obj/effect/overmap/sector/smugglers,/turf/space,/area/space)
 "af" = (/turf/simulated/wall/r_wall,/area/smugglers/base)
 "ag" = (/obj/machinery/door/airlock/external{frequency = 1503; icon_state = "door_closed"; locked = 0},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"ah" = (/obj/effect/landmark/corpse,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/asteroid,/area/mine/explored)
-"ai" = (/obj/item/ammo_casing/a50{pixel_x = 5; pixel_y = 5},/obj/item/ammo_casing/a50,/obj/item/weapon/shovel{pixel_x = 10; pixel_y = -5},/obj/effect/decal/cleanable/blood,/turf/simulated/floor/asteroid,/area/mine/explored)
-"aj" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/asteroid,/area/mine/explored)
-"ak" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/turf/simulated/wall/r_wall,/area/smugglers/base)
-"al" = (/obj/machinery/airlock_sensor{frequency = 1503; master_tag = "asteroid_base_dock_airlock"; pixel_x = 25},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 2; frequency = 1503; id_tag = "asteroid_base_dock_pump"},/obj/effect/floor_decal/industrial/warning/full,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"am" = (/obj/machinery/atmospherics/unary/outlet_injector{injecting = 1; use_power = 1},/turf/simulated/floor/airless,/area/space)
-"an" = (/obj/machinery/door/airlock/external{frequency = 1503; icon_state = "door_closed"; locked = 0; name = "Internal Airlock"},/obj/item/pipe{dir = 7},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"ao" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/structure/window/reinforced{dir = 8},/obj/item/pipe{dir = 7},/turf/simulated/floor/airless,/area/smugglers/base)
-"ap" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/turf/simulated/floor/airless,/area/smugglers/base)
-"aq" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/airless,/area/smugglers/base)
-"ar" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/airless,/area/smugglers/base)
-"as" = (/obj/item/device/flashlight/glowstick/yellow{pixel_x = 5; pixel_y = 7},/obj/item/device/flashlight/glowstick/yellow,/turf/simulated/floor/asteroid,/area/mine/explored)
-"at" = (/obj/effect/decal/cleanable/blood/drip,/obj/item/pipe{dir = 5},/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1503; id_tag = "asteroid_base_dock_airlock"; name = "Dock Airlock Controller"; pixel_x = -25; tag_airpump = "asteroid_base_dock_pump"; tag_exterior_door = "asteroid_base_dock_outer"; tag_interior_door = "asteroid_base_dock_inner"},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1503; master_tag = "asteroid_base_dock_airlock"; name = "interior access button"; pixel_x = 28; pixel_y = 24; req_one_access = list(13)},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"au" = (/obj/machinery/portable_atmospherics/canister/air,/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"av" = (/obj/machinery/floodlight,/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aw" = (/obj/item/stack/cable_coil{pixel_x = 5; pixel_y = 5; pixel_z = 0},/obj/item/stack/cable_coil,/obj/item/pipe{dir = 4},/obj/machinery/power/apc{dir = 1; name = "Asteroid base main APC"; pixel_x = 0; pixel_y = 24},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"ax" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"ay" = (/obj/item/stack/material/phoron{pixel_y = 7; pixel_z = -8},/obj/item/stack/material/phoron{pixel_x = -5; pixel_y = 5},/obj/item/stack/material/phoron,/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"az" = (/obj/item/pipe{dir = 4},/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/powered/scrubber,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aA" = (/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aB" = (/obj/machinery/atmospherics/pipe/manifold/visible{dir = 1},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aC" = (/obj/machinery/door/airlock/maintenance,/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aD" = (/obj/effect/decal/cleanable/dirt,/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aE" = (/obj/item/pipe{dir = 4},/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1501; id_tag = "asteroid_base_east_airlock"; pixel_y = 25; tag_airpump = "asteroid_base_east_pump"; tag_exterior_door = "asteroid_base_east_outer"; tag_exterior_sensor = null; tag_interior_door = "asteroid_base_east_inner"; tag_interior_sensor = null},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1501; master_tag = "asteroid_base_east_airlock"; name = "interior access button"; pixel_x = -28; pixel_y = 24; req_one_access = list(13)},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aF" = (/obj/machinery/door/airlock/external{frequency = 1501; icon_state = "door_locked"; id_tag = "asteroid_base_east_inner"; locked = 1; name = "Internal Airlock"},/obj/item/pipe{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aG" = (/obj/item/weapon/beartrap,/obj/machinery/airlock_sensor{frequency = 1501; master_tag = "asteroid_base_east_airlock"; pixel_y = -25},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; frequency = 1501; id_tag = "asteroid_base_east_pump"},/obj/effect/floor_decal/industrial/warning/full,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aH" = (/obj/machinery/door/airlock/external{frequency = 1501; icon_state = "door_locked"; id_tag = "asteroid_base_east_outer"; locked = 1},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aI" = (/obj/machinery/access_button/airlock_exterior{frequency = 1501; master_tag = "asteroid_base_east_airlock"; name = "exterior access button"; pixel_x = -25; pixel_y = 25},/turf/simulated/floor/asteroid,/area/mine/explored)
-"aJ" = (/obj/random/trash,/turf/simulated/floor/asteroid,/area/mine/explored)
-"aK" = (/obj/effect/decal/cleanable/generic,/obj/machinery/light/small{dir = 8},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aL" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aM" = (/obj/effect/decal/cleanable/blood/drip,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/item/weapon/wirecutters,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aN" = (/obj/structure/cable,/obj/structure/cable{d1 = 32; d2 = 4; icon_state = "32-4"},/obj/structure/cable{tag = "icon-0-2 (EAST)"; icon_state = "0-2"; dir = 4; pixel_y = 0; d1 = 16; d2 = 0},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aO" = (/obj/effect/decal/cleanable/blood/drip,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aP" = (/obj/item/pipe,/obj/machinery/light/small{dir = 4; pixel_y = 8},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aQ" = (/turf/simulated/wall,/area/smugglers/base)
-"aR" = (/obj/machinery/light/small/red{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aS" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aT" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/clothing/mask/breath,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aU" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/decal/cleanable/generic,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aV" = (/obj/effect/decal/cleanable/generic,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aW" = (/obj/structure/closet/crate/plastic_smug_ammo,/obj/effect/floor_decal/industrial/warning{dir = 9},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aX" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/decal/cleanable/generic,/obj/item/weapon/paper/smug_1,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aY" = (/obj/random/ore_smug,/obj/effect/floor_decal/industrial/warning{dir = 5},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"aZ" = (/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"ba" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/item/pipe,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bb" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/tank/air{pixel_x = 5},/obj/item/weapon/tank/air,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bc" = (/obj/item/weapon/pickaxe/hand{pixel_x = -15},/turf/simulated/floor/asteroid,/area/mine/explored)
-"bd" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"be" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/effect/decal/cleanable/generic,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bf" = (/obj/structure/closet/crate/plastic_smug_weapons,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bg" = (/obj/structure/closet/crate/plastic,/obj/random/action_figure,/obj/random/loot,/obj/random/loot,/obj/random/smokes,/obj/random/smokes,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bh" = (/obj/machinery/floodlight,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bi" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/machinery/light/small/red,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bj" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/voidsuit,/obj/random/voidhelmet,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bk" = (/obj/structure/boulder,/turf/simulated/floor/asteroid,/area/mine/explored)
-"bl" = (/obj/item/weapon/ore/silver,/obj/item/weapon/ore/silver{pixel_x = 10; pixel_y = -5},/turf/simulated/floor/asteroid,/area/mine/explored)
-"bm" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light/small{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bn" = (/obj/effect/decal/cleanable/generic,/obj/item/weapon/paper/smug_2,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bo" = (/obj/structure/ore_box,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bp" = (/obj/structure/ore_box,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bq" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/effect/decal/cleanable/generic,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"br" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/item/pipe,/obj/machinery/light/small{dir = 4; pixel_y = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bs" = (/turf/simulated/wall,/area/smugglers/office)
-"bt" = (/turf/simulated/wall/r_wall,/area/smugglers/office)
-"bu" = (/obj/item/weapon/ore/slag,/obj/item/weapon/ore/slag{pixel_x = 5; pixel_y = -2},/obj/item/weapon/ore/slag,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bv" = (/obj/structure/ore_box,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bw" = (/obj/random/ore_smug,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bx" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"by" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/item/pipe,/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bz" = (/obj/machinery/door/airlock/maintenance,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/office)
-"bA" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bB" = (/obj/structure/table/woodentable,/obj/item/weapon/paper,/obj/item/weapon/pen,/obj/item/device/flashlight/lamp,/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 1; name = "Asteroid base office APC"; pixel_x = 0; pixel_y = 24},/turf/simulated/floor/tiled,/area/smugglers/office)
-"bC" = (/obj/structure/safe/floor,/obj/random/contraband,/obj/random/contraband,/obj/random/loot,/obj/random/projectile,/obj/random/cash,/obj/random/cash,/obj/random/cash,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bD" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 10},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bE" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bF" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bG" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bH" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bI" = (/obj/structure/table/woodentable,/obj/random/coin{pixel_x = -5; pixel_y = -3},/obj/random/coin,/obj/item/weapon/storage/bible/booze{pixel_x = 10},/obj/item/weapon/paper/smug_4{pixel_x = -5; pixel_y = 4},/obj/item/weapon/paper/smug_5,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bJ" = (/obj/structure/bed/chair/comfy/red{dir = 8},/obj/machinery/light{tag = "icon-tube1 (EAST)"; icon_state = "tube1"; dir = 4},/turf/simulated/floor/tiled,/area/smugglers/office)
-"bK" = (/obj/effect/decal/cleanable/generic,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light/small{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bL" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bM" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/powered/scrubber,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bN" = (/obj/machinery/portable_atmospherics/canister/air,/obj/item/weapon/wrench,/obj/machinery/light/small{dir = 4; pixel_y = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bO" = (/turf/simulated/floor/tiled,/area/smugglers/office)
-"bP" = (/obj/random/trash,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bQ" = (/obj/structure/table/standard,/obj/random/tech_supply,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bR" = (/obj/structure/table/standard,/obj/random/toolbox,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bS" = (/obj/structure/table/standard,/obj/random/firstaid,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bT" = (/obj/structure/closet/crate/trashcart,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bU" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/canister,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bV" = (/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
-"bW" = (/obj/machinery/constructable_frame/machine_frame,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bX" = (/obj/structure/table/rack,/obj/item/clothing/head/cowboy_hat,/obj/item/clothing/suit/armor/hos/jensen,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bY" = (/obj/structure/filingcabinet/chestdrawer,/turf/simulated/floor/tiled,/area/smugglers/office)
-"bZ" = (/turf/simulated/wall/r_wall,/area/smugglers/dorms)
-"ca" = (/obj/machinery/door/airlock/maintenance{name = "Restroom"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
-"cb" = (/turf/simulated/wall,/area/smugglers/dorms)
-"cc" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cd" = (/obj/structure/noticeboard{pixel_y = 30},/obj/effect/decal/cleanable/dirt,/obj/structure/table/standard,/obj/machinery/microwave{pixel_y = 10},/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"ce" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/crate,/obj/random/snack,/obj/random/snack,/obj/random/snack,/obj/random/snack,/obj/random/snack,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cf" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/crate,/obj/random/drinkbottle,/obj/random/drinkbottle,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cg" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/computer/arcade,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"ch" = (/obj/structure/closet/crate/freezer/rations,/obj/effect/decal/cleanable/cobweb2,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"ci" = (/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
-"cj" = (/obj/machinery/light/small{dir = 4},/obj/structure/sink{pixel_y = 15},/obj/structure/mirror{pixel_y = 30},/obj/random/soap,/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
-"ck" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/cable,/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -24},/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cl" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cm" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cn" = (/obj/machinery/door/airlock/maintenance{name = "Toilet"},/turf/simulated/floor,/area/smugglers/dorms)
-"co" = (/obj/effect/decal/cleanable/vomit,/obj/random/medical/lite,/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
-"cp" = (/obj/structure/toilet{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
-"cq" = (/turf/unsimulated/mask,/area/mine/explored)
-"cr" = (/obj/structure/bed/chair{dir = 4},/obj/machinery/light,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"ah" = (/turf/simulated/floor/asteroid,/area/space)
+"ai" = (/turf/space,/area/mine/explored)
+"aj" = (/obj/effect/landmark/corpse,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/asteroid,/area/mine/explored)
+"ak" = (/obj/item/ammo_casing/a50{pixel_x = 5; pixel_y = 5},/obj/item/ammo_casing/a50,/obj/item/weapon/shovel{pixel_x = 10; pixel_y = -5},/obj/effect/decal/cleanable/blood,/turf/simulated/floor/asteroid,/area/mine/explored)
+"al" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/asteroid,/area/mine/explored)
+"am" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/turf/simulated/wall/r_wall,/area/smugglers/base)
+"ao" = (/turf/unsimulated/mask,/area/mine/explored)
+"ap" = (/turf/space,/area/mine/unexplored)
+"aq" = (/obj/machinery/atmospherics/unary/outlet_injector{injecting = 1; use_power = 1},/turf/simulated/floor/airless,/area/space)
+"ar" = (/obj/machinery/door/airlock/external{frequency = 1503; icon_state = "door_closed"; locked = 0; name = "Internal Airlock"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"as" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/blast/regular,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/airless,/area/smugglers/base)
+"at" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/machinery/door/blast/regular,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/airless,/area/smugglers/base)
+"au" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/blast/regular,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/airless,/area/smugglers/base)
+"av" = (/obj/item/device/flashlight/glowstick/yellow{pixel_x = 5; pixel_y = 7},/obj/item/device/flashlight/glowstick/yellow,/turf/simulated/floor/asteroid,/area/mine/explored)
+"aw" = (/obj/effect/decal/cleanable/blood/drip,/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1503; id_tag = "asteroid_base_dock_airlock"; name = "Dock Airlock Controller"; pixel_x = -25; tag_airpump = "asteroid_base_dock_pump"; tag_exterior_door = "asteroid_base_dock_outer"; tag_interior_door = "asteroid_base_dock_inner"},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1503; master_tag = "asteroid_base_dock_airlock"; name = "interior access button"; pixel_x = 28; pixel_y = 24; req_one_access = list(13)},/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 5},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"ax" = (/obj/machinery/portable_atmospherics/canister/air,/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"ay" = (/obj/machinery/floodlight,/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"az" = (/obj/item/stack/cable_coil{pixel_x = 5; pixel_y = 5; pixel_z = 0},/obj/item/stack/cable_coil,/obj/machinery/power/apc{dir = 1; name = "Asteroid base main APC"; pixel_x = 0; pixel_y = 24},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aA" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aB" = (/obj/item/stack/material/phoron{pixel_y = 7; pixel_z = -8},/obj/item/stack/material/phoron{pixel_x = -5; pixel_y = 5},/obj/item/stack/material/phoron,/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aC" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/powered/scrubber,/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aD" = (/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aE" = (/obj/machinery/atmospherics/pipe/manifold/visible/black{icon_state = "map"; dir = 1},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aF" = (/obj/machinery/door/airlock/maintenance,/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aG" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aH" = (/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aI" = (/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1501; id_tag = "asteroid_base_east_airlock"; pixel_y = 25; tag_airpump = "asteroid_base_east_pump"; tag_exterior_door = "asteroid_base_east_outer"; tag_exterior_sensor = null; tag_interior_door = "asteroid_base_east_inner"; tag_interior_sensor = null},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1501; master_tag = "asteroid_base_east_airlock"; name = "interior access button"; pixel_x = -28; pixel_y = 24; req_one_access = list(13)},/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aJ" = (/obj/machinery/door/airlock/external{frequency = 1501; icon_state = "door_locked"; id_tag = "asteroid_base_east_inner"; locked = 1; name = "Internal Airlock"},/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aL" = (/obj/machinery/door/airlock/external{frequency = 1501; icon_state = "door_locked"; id_tag = "asteroid_base_east_outer"; locked = 1},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aM" = (/obj/machinery/access_button/airlock_exterior{frequency = 1501; master_tag = "asteroid_base_east_airlock"; name = "exterior access button"; pixel_x = -25; pixel_y = 25},/turf/simulated/floor/asteroid,/area/mine/explored)
+"aN" = (/obj/random/trash,/turf/simulated/floor/asteroid,/area/mine/explored)
+"aO" = (/obj/machinery/light/small{dir = 8},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aP" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aQ" = (/obj/effect/decal/cleanable/blood/drip,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/item/weapon/wirecutters,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aS" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aT" = (/obj/effect/decal/cleanable/blood/drip,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aU" = (/obj/machinery/light/small{dir = 4; pixel_y = 8},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/visible/black,/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aV" = (/turf/simulated/wall,/area/smugglers/base)
+"aW" = (/obj/machinery/light/small/red{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aX" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aY" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/clothing/mask/breath,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"aZ" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"ba" = (/obj/random/trash,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bb" = (/obj/structure/closet/crate/plastic_smug_ammo,/obj/effect/floor_decal/industrial/warning{dir = 9},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bc" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/item/weapon/paper/smug_1,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bd" = (/obj/random/ore_smug,/obj/effect/floor_decal/industrial/warning{dir = 5},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"be" = (/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bf" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/visible/black,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bg" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/item/weapon/tank/air{pixel_x = 5},/obj/item/weapon/tank/air,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bh" = (/obj/item/weapon/pickaxe/hand{pixel_x = -15},/turf/simulated/floor/asteroid,/area/mine/explored)
+"bi" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bj" = (/obj/structure/closet/crate/plastic_smug_weapons,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bk" = (/obj/structure/closet/crate/plastic,/obj/random/action_figure,/obj/random/loot,/obj/random/loot,/obj/random/smokes,/obj/random/smokes,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bl" = (/obj/machinery/floodlight,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bm" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/machinery/light/small/red,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bn" = (/obj/structure/table/rack{dir = 8; layer = 2.9},/obj/random/voidsuit,/obj/random/voidhelmet,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bo" = (/obj/structure/boulder,/turf/simulated/floor/asteroid,/area/mine/explored)
+"bp" = (/obj/item/weapon/ore/silver,/obj/item/weapon/ore/silver{pixel_x = 10; pixel_y = -5},/turf/simulated/floor/asteroid,/area/mine/explored)
+"bq" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light/small{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"br" = (/obj/item/weapon/paper/smug_2,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bs" = (/obj/structure/ore_box,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bt" = (/obj/structure/ore_box,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bu" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bv" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light/small{dir = 4; pixel_y = 8},/obj/machinery/atmospherics/pipe/simple/visible/black,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bw" = (/turf/simulated/wall,/area/smugglers/office)
+"bx" = (/turf/simulated/wall/r_wall,/area/smugglers/office)
+"by" = (/obj/item/weapon/ore/slag,/obj/item/weapon/ore/slag{pixel_x = 5; pixel_y = -2},/obj/item/weapon/ore/slag,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bz" = (/obj/structure/ore_box,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/random/ore_smug,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bA" = (/obj/random/ore_smug,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bB" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bC" = (/obj/machinery/door/airlock/maintenance,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/office)
+"bD" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/office)
+"bE" = (/obj/structure/table/woodentable,/obj/item/weapon/paper,/obj/item/weapon/pen,/obj/item/device/flashlight/lamp,/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 1; name = "Asteroid base office APC"; pixel_x = 0; pixel_y = 24},/turf/simulated/floor/tiled,/area/smugglers/office)
+"bF" = (/obj/structure/safe/floor,/obj/random/contraband,/obj/random/contraband,/obj/random/loot,/obj/random/projectile,/obj/random/cash,/obj/random/cash,/obj/random/cash,/turf/simulated/floor/tiled,/area/smugglers/office)
+"bG" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 10},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bH" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bI" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bJ" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bK" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/office)
+"bL" = (/obj/structure/table/woodentable,/obj/random/coin{pixel_x = -5; pixel_y = -3},/obj/random/coin,/obj/item/weapon/storage/bible/booze{pixel_x = 10},/obj/item/weapon/paper/smug_4{pixel_x = -5; pixel_y = 4},/obj/item/weapon/paper/smug_5,/turf/simulated/floor/tiled,/area/smugglers/office)
+"bN" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bO" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/powered/scrubber,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bP" = (/obj/machinery/portable_atmospherics/canister/air,/obj/item/weapon/wrench,/obj/machinery/light/small{dir = 4; pixel_y = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bQ" = (/turf/simulated/floor/tiled,/area/smugglers/office)
+"bR" = (/obj/structure/table/standard,/obj/random/tech_supply,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bS" = (/obj/structure/table/standard,/obj/random/toolbox,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bT" = (/obj/structure/table/standard,/obj/random/firstaid,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bU" = (/obj/structure/closet/crate/trashcart,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bV" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/canister,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bW" = (/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"bX" = (/obj/machinery/constructable_frame/machine_frame,/obj/random/trash,/turf/simulated/floor/tiled,/area/smugglers/office)
+"bY" = (/obj/structure/table/rack,/obj/item/clothing/head/cowboy_hat,/obj/item/clothing/suit/armor/hos/jensen,/turf/simulated/floor/tiled,/area/smugglers/office)
+"bZ" = (/obj/structure/filingcabinet/chestdrawer,/turf/simulated/floor/tiled,/area/smugglers/office)
+"ca" = (/turf/simulated/wall/r_wall,/area/smugglers/dorms)
+"cb" = (/obj/machinery/door/airlock/maintenance{name = "Restroom"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
+"cc" = (/turf/simulated/wall,/area/smugglers/dorms)
+"cd" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"ce" = (/obj/structure/noticeboard{pixel_y = 30},/obj/effect/decal/cleanable/dirt,/obj/structure/table/standard,/obj/machinery/microwave{pixel_y = 10},/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cf" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/crate,/obj/random/snack,/obj/random/snack,/obj/random/snack,/obj/random/snack,/obj/random/snack,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cg" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/crate,/obj/random/drinkbottle,/obj/random/drinkbottle,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"ch" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/computer/arcade,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"ci" = (/obj/structure/closet/crate/freezer/rations,/obj/effect/decal/cleanable/cobweb2,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cj" = (/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
+"ck" = (/obj/machinery/light/small{dir = 4},/obj/structure/sink{pixel_y = 15},/obj/structure/mirror{pixel_y = 30},/obj/random/soap,/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
+"cl" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/cable,/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -24},/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cm" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cn" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"co" = (/obj/machinery/door/airlock/maintenance{name = "Toilet"},/turf/simulated/floor,/area/smugglers/dorms)
+"cp" = (/obj/effect/decal/cleanable/vomit,/obj/random/medical/lite,/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
+"cq" = (/obj/structure/toilet{dir = 8},/turf/simulated/floor/airless/ceiling,/area/smugglers/dorms)
+"cr" = (/obj/structure/bed/chair{dir = 4},/obj/machinery/light,/obj/random/trash,/turf/simulated/floor/tiled,/area/smugglers/dorms)
 "cs" = (/obj/structure/table/standard,/obj/effect/decal/cleanable/dirt,/obj/item/weapon/paper/smug_3,/obj/item/weapon/flame/lighter/random,/obj/random/coin,/turf/simulated/floor/tiled,/area/smugglers/dorms)
 "ct" = (/obj/structure/table/standard,/obj/effect/decal/cleanable/dirt,/obj/item/weapon/spacecash/bundle/c10,/obj/random/smokes,/obj/random/snack,/turf/simulated/floor/tiled,/area/smugglers/dorms)
 "cu" = (/obj/structure/bed/chair{dir = 8},/obj/machinery/light,/turf/simulated/floor/tiled,/area/smugglers/dorms)
@@ -127,9 +123,14 @@
 "cw" = (/obj/machinery/door/airlock/maintenance,/turf/simulated/floor/tiled,/area/smugglers/dorms)
 "cx" = (/obj/structure/bed,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
 "cy" = (/obj/structure/closet/smuggler,/obj/random/suit,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cz" = (/obj/machinery/light/small{dir = 2},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
-"cA" = (/obj/effect/shuttle_landmark/nav_asteroid_base/nav1,/turf/simulated/floor/asteroid,/area/mine/explored)
-"cB" = (/obj/effect/shuttle_landmark/nav_asteroid_base/nav2,/turf/space,/area/space)
+"cz" = (/obj/effect/decal/cleanable/dirt,/obj/random/trash,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cA" = (/obj/machinery/light/small{dir = 2},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/smugglers/dorms)
+"cB" = (/obj/effect/shuttle_landmark/nav_asteroid_base/nav1,/turf/simulated/floor/asteroid,/area/mine/explored)
+"cC" = (/obj/effect/shuttle_landmark/nav_asteroid_base/nav2,/turf/space,/area/space)
+"db" = (/obj/machinery/airlock_sensor{frequency = 1503; master_tag = "asteroid_base_dock_airlock"; pixel_x = 25},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 2; frequency = 1503; id_tag = "asteroid_base_dock_pump"},/obj/effect/floor_decal/industrial/warning/full,/obj/item/weapon/beartrap{anchored = 1; deployed = 1; icon_state = "beartrap1"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"eb" = (/obj/item/weapon/beartrap{anchored = 1; deployed = 1; icon_state = "beartrap1"},/obj/machinery/airlock_sensor{frequency = 1501; master_tag = "asteroid_base_east_airlock"; pixel_y = -25},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; frequency = 1501; id_tag = "asteroid_base_east_pump"},/obj/effect/floor_decal/industrial/warning/full,/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"fb" = (/obj/structure/cable,/obj/structure/cable{d1 = 32; d2 = 4; icon_state = "32-4"},/obj/structure/cable{icon_state = "0-2"; dir = 4; pixel_y = 0; d1 = 16; d2 = 0},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/airless/ceiling,/area/smugglers/base)
+"gb" = (/obj/structure/bed/chair/comfy/red{dir = 8},/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/tiled,/area/smugglers/office)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -137,29 +138,29 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaababacaaaaaaaaaaacaaababacaaaaaaacacaaacaaaaaaaaaaaaaaaaaaaa
 aaaaaaabacacaaaaaaaaaaaaaaaaaaaaaaaaabababababacacaaaaaaacacacabacaaadaaacacaaacacaaaaaaaaaaaaaaaaaa
 aaaaaaababacaaaaaaaeaaaaaaaaaaaaaaaaaaabacacababababaaaaaaacacacabaaaaaaaaacacacacaaaaaaaaaaaaaaaaaa
-aaaaaaacababaaaaafagafaaaaaaabaaaaaaaaabacacababaaabaaaaaaacacahaiajajaaaaacacacacacacacaaaaaaaaaaaa
-aaaaaaaaacabababakalafaaaaabacamaaaaaaacacacabababacacacacacacabacacabababababacacababacababaaaaaaaa
-aaaaaaaaacababacafanafafafafafaoapaqafafafafafarafasacacacacabacacacabababababacababacacacabaaaaaaaa
-aaaaaaaaababababafatauavawaxayazaAaBaCaDaAaEaFaGaHaIababacacabacababaJabababababababacacacabaaaaaaaa
-aaaaaaaaababacacafaKaLaMaNaNaLaLaOaPaQaRaSaTafafafacabababababababababacabababababacacacacaaaaaaaaaa
-aaaaaaaaabacacacafaUaVaWaXaYaZaVaVbaaQaZaZbbafacacacacacacacbcababacacababababacacacacacacaaaaaaaaaa
-aaaaaaaaacacacacafbdaZbebfbgaVaVaVbaaQbhbibjafacacacacacacacbkblabacacabacacacabacacacacacabaaaaaaaa
-aaaaaaabacacacacafbmbnbobpbqaZaVaVbrbsbsbsbsbtacacacacacacacacacacacacababababababababaaaaaaaaaaaaaa
-aaaaaaababacacacafbdbubvbwbxaVaZaVbybzbAbBbCbtacacacacacacacacacacacacacacacaJababacabaaaaaaaaaaaaaa
-aaaaaaacabacacacafbdaZbDbEbFaZaZaZbGbsbHbIbJbtabacacacacacacacacacacacacacacacabacababaaaaaaaaaaaaaa
-aaaaaaacababacacafbKaZaZaZaZbLbMaZbNbsbHbObObtacacacacacacacacacacababacacacacabacabacaaaaaaaaaaaaaa
-aaaaaaaaaaacacabafbdbPbQbRbSbTbUaZbVbsbWbXbYbtacabababababacacacacabacacacacacacabababaaaaabaaaaaaaa
-aaaaaaaaaaacacabbZcacbcbcbcbcbcbcbcbbZbtbtbtbtacabababababacacacacababacacacacabacacabaaaaabaaaaaaaa
-aaaaaaaaaaaaacacbZcccdcecfcgchcbcicjbZacacacacacacacabacacacacacacabababacacacaJabababacacacaaaaaaaa
-aaaaaaaaabacacacbZckclclclclcmcncocpbZababababababaccqacacacacacacacabababacacabacacacacacaaaaaaaaaa
-aaaaaaaaababacacbZclcrcsctcucvcbbZbZbZacacacabababacababacacacacabacacacacacacabacacacacacaaaaaaaaaa
-aaaaaaaaaaabacacbZcwcbcbcbcbcbcbbZabacacacacabababababaJabacacababacacacacacababacacababababacaaaaaa
-aaaaaaaaaaabacacbZclcxcycxcycxcybZabacacacacacacababacacababababacacacababababacacacabababacacaaaaaa
-aaaaaaacaaababacbZclczclclclczclbZacacacabababababacacacababacababacacaJacacacacacacabababacacaaaaaa
-aaaaaaababababacbZbZbZbZbZbZbZbZbZacabababababacacacacacabacacacababababacacacaaaaaaaaaaaaaaacaaaaaa
-aaaaaaaaaaaaabacacababacacacacacabababaJacacacabacacacacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaacacacabacacacacacacacacacaJabacabacacacaaaaacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaabacabacacacacababababaJabababababacacacaaaaacacacacabacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaacababaaaaafagafaaaaahaiaaaaaaaaabacacababaaabaaaaaaacacajakalalaaaaacacacacacacacaaaaaaaaaaaa
+aaaaaaaaacabababamdbafaaahaoapaqaaaaaaacacacabababacacacacacacabacacabababababacacababacababaaaaaaaa
+aaaaaaaaacababacafarafafafafafasatauafafafafafafafavacacacacabacacacabababababacababacacacabaaaaaaaa
+aaaaaaaaababababafawaxayazaAaBaCaDaEaFaGaHaIaJebaLaMababacacabacababaNabababababababacacacabaaaaaaaa
+aaaaaaaaababacacafaOaPaQfbfbaPaSaTaUaVaWaXaYafafafacabababababababababacabababababacacacacaaaaaaaaaa
+aaaaaaaaabacacacafaZbabbbcbdbebebabfaVbabebgafacacacacacacacbhababacacababababacacacacacacaaaaaaaaaa
+aaaaaaaaacacacacafaZbebibjbkbebebebfaVblbmbnafacacacacacacacbobpabacacabacacacabacacacacacabaaaaaaaa
+aaaaaaabacacacacafbqbrbsbtbubebabebvbwbwbwbwbxacacacacacacacacacacacacababababababababaaaaaaaaaaaaaa
+aaaaaaababacacacafaZbybzbAbubebebebBbCbDbEbFbxacacacacacacacacacacacacacacacaNababacabaaaaaaaaaaaaaa
+aaaaaaacabacacacafaZbabGbHbIbebebebJbwbKbLgbbxabacacacacacacacacacacacacacacacabacababaaaaaaaaaaaaaa
+aaaaaaacababacacafbqbebebebebNbObebPbwbKbQbQbxacacacacacacacacacacababacacacacabacabacaaaaaaaaaaaaaa
+aaaaaaaaaaacacabafaZbabRbSbTbUbVbebWbwbXbYbZbxacabababababacacacacabacacacacacacabababaaaaabaaaaaaaa
+aaaaaaaaaaacacabcacbcccccccccccccccccabxbxbxbxacabababababacacacacababacacacacabacacabaaaaabaaaaaaaa
+aaaaaaaaaaaaacaccacdcecfcgchcicccjckcaacacacacacacacabacacacacacacabababacacacaNabababacacacaaaaaaaa
+aaaaaaaaabacacaccaclcmcmcmcmcncocpcqcaababababababacaoacacacacacacacabababacacabacacacacacaaaaaaaaaa
+aaaaaaaaababacaccacmcrcsctcucvcccacacaacacacabababacababacacacacabacacacacacacabacacacacacaaaaaaaaaa
+aaaaaaaaaaabacaccacwcccccccccccccaabacacacacabababababaNabacacababacacacacacababacacababababacaaaaaa
+aaaaaaaaaaabacaccacmcxcycxcycxcycaabacacacacacacababacacababababacacacababababacacacabababacacaaaaaa
+aaaaaaacaaababaccaczcAcmcmcmcAcmcaacacacabababababacacacababacababacacaNacacacacacacabababacacaaaaaa
+aaaaaaababababaccacacacacacacacacaacabababababacacacacacabacacacababababacacacaaaaaaaaaaaaaaacaaaaaa
+aaaaaaaaaaaaabacacababacacacacacabababaNacacacabacacacacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaacacacabacacacacacacacacacaNabacabacacacaaaaacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaabacabacacacacababababaNabababababacacacaaaaacacacacabacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaababacabacacababababababababababababababacaaaaacacacacabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaabababacabababababababababababababababacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaabababacababababababababababababababababacacababacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -167,8 +168,8 @@ aaaaaaaaaaaaababacacacabababababababababababababababacacababababaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaababacacababababababababababababababababacacacacabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaababaaaaabababababababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaabababababababababababababababababacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaababababababababcAabababababababababacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababababababababababababababababacacaaaaaaaaaaaaaaaaaaaaaaaacBaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaababababababababcBabababababababababacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababababababababababababababababacacaaaaaaaaaaaaaaaaaaaaaaaacCaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaababababababababababababababababababacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaacacabababababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaacacabababababababababababababababacacabacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
- Makes landing areas avaliable for marooned crashsite.
- Fixed old design mistakes of smugglers' base (name, piping , accessibility etc).