### PR TITLE
Fixes, Removals, Changes

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -877,7 +877,7 @@ arguments tx, ty, tz are target coordinates (requred), range defines render dist
 cap_mode is capturing mode (optional), user is capturing mob (requred only wehen cap_mode = CAPTURE_MODE_REGULAR),
 lighting determines lighting capturing (optional), suppress_errors suppreses errors and continues to capture (optional).
 */
-proc/generate_image(var/tx as num, var/ty as num, var/tz as num, var/range as num, var/cap_mode = CAPTURE_MODE_PARTIAL, var/mob/living/user, var/lighting = 1, var/suppress_errors = 1)
+proc/generate_image(var/tx as num, var/ty as num, var/tz as num, var/range as num, var/cap_mode = CAPTURE_MODE_PARTIAL, var/mob/living/user, var/lighting = 0, var/suppress_errors = 1)
 	var/list/turfstocapture = list()
 	//Lines below determine what tiles will be rendered
 	for(var/xoff = 0 to range)

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -90,11 +90,6 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	path = /obj/item/weapon/crowbar
 	category = "Tools"
 
-/datum/autolathe/recipe/prybar
-	name = "pry bar"
-	path = /obj/item/weapon/crowbar/prybar
-	category = "Tools"
-
 /datum/autolathe/recipe/int_wirer
 	name = "integrated circuit wirer"
 	path = /obj/item/device/integrated_electronics/wirer

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -471,17 +471,6 @@
 	icon_state = "red_crowbar"
 	item_state = "crowbar_red"
 
-/obj/item/weapon/crowbar/prybar
-	name = "pry bar"
-	desc = "A steel bar with a wedge at one end and a hard rubber pommel handle at the other."
-	icon_state = "prybar"
-	item_state = "crowbar"
-	force = 4.0
-	throwforce = 6.0
-	throw_range = 5
-	w_class = ITEM_SIZE_SMALL
-	matter = list(DEFAULT_WALL_MATERIAL = 80)
-
 /*
  * Combitool
  */

--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -4,6 +4,7 @@
 	tesla_link = new/obj/item/weapon/computer_hardware/tesla_link(src)
 	hard_drive = new/obj/item/weapon/computer_hardware/hard_drive/super(src)
 	network_card = new/obj/item/weapon/computer_hardware/network_card/wired(src)
+	nano_printer = new/obj/item/weapon/computer_hardware/nano_printer(src)
 
 // Engineering
 /obj/item/modular_computer/console/preset/engineering/install_default_programs()
@@ -59,7 +60,6 @@
 // Command
 /obj/item/modular_computer/console/preset/command/install_default_hardware()
 	..()
-	nano_printer = new/obj/item/weapon/computer_hardware/nano_printer(src)
 	card_slot = new/obj/item/weapon/computer_hardware/card_slot(src)
 
 /obj/item/modular_computer/console/preset/command/install_default_programs()
@@ -95,12 +95,10 @@
 // Offices
 /obj/item/modular_computer/console/preset/civilian/professional/install_default_hardware()
 	..()
-	nano_printer = new/obj/item/weapon/computer_hardware/nano_printer(src)
 
 // Crew-facing supply ordering computer
 /obj/item/modular_computer/console/preset/supply/install_default_hardware()
 	..()
-	nano_printer = new/obj/item/weapon/computer_hardware/nano_printer(src)
 
 /obj/item/modular_computer/console/preset/supply/install_default_programs()
 	..()
@@ -111,7 +109,6 @@
 /obj/item/modular_computer/console/preset/ert/install_default_hardware()
 	..()
 	ai_slot = new/obj/item/weapon/computer_hardware/ai_slot(src)
-	nano_printer = new/obj/item/weapon/computer_hardware/nano_printer(src)
 	card_slot = new/obj/item/weapon/computer_hardware/card_slot(src)
 
 /obj/item/modular_computer/console/preset/ert/install_default_programs()

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -45,9 +45,9 @@
 				"id" = R.uid
 			)))
 		data["all_records"] = all_records
-		data["creation"] = check_access(user, access_heads) 
-		data["dnasearch"] = check_access(user, access_medical) 
-		data["fingersearch"] = check_access(user, access_security) 
+		data["creation"] = check_access(user, access_heads)
+		data["dnasearch"] = check_access(user, access_medical) || check_access(user, access_security)
+		data["fingersearch"] = check_access(user, access_security)
 
 	ui = GLOB.nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)


### PR DESCRIPTION
Fixes #17320 cameras with a simple solution that also prevents runtimes that currently occur with the blend proc, removes prybars as the only function discernible from a crowbar is size, adds a printer to all computers.
:cl: Aetsuki
tweak: You can now print from pretty much any default modular computer. Everyone rejoice. 
bugfix: Cameras now work! You're welcome Forensics Techs. Add those pretty crime scene photos to folders now.
/:cl: 