### PR TITLE
Catwalks on plating

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -100,10 +100,10 @@ What is the naming convention for planes or layers?
 	#define EXPOSED_PIPE_LAYER          5
 	#define EXPOSED_WIRE_LAYER          6
 	#define EXPOSED_WIRE_TERMINAL_LAYER 7
-	#define CATWALK_LAYER               7.5
-	#define BLOOD_LAYER                 8
-	#define MOUSETRAP_LAYER             9
-	#define PLANT_LAYER                 10
+	#define CATWALK_LAYER               8
+	#define BLOOD_LAYER                 9
+	#define MOUSETRAP_LAYER             10
+	#define PLANT_LAYER                 11
 
 #define HIDING_MOB_PLANE              -16 // for hiding mobs like MoMMIs or spiders or whatever, under most objects but over pipes & such.
 

--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -100,6 +100,7 @@ What is the naming convention for planes or layers?
 	#define EXPOSED_PIPE_LAYER          5
 	#define EXPOSED_WIRE_LAYER          6
 	#define EXPOSED_WIRE_TERMINAL_LAYER 7
+	#define CATWALK_LAYER               7.5
 	#define BLOOD_LAYER                 8
 	#define MOUSETRAP_LAYER             9
 	#define PLANT_LAYER                 10

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -64,5 +64,7 @@
 			to_chat(user, "<span class='notice'>Slicing catwalk joints ...</span>")
 			new /obj/item/stack/rods(src.loc)
 			new /obj/item/stack/rods(src.loc)
-			new /obj/structure/lattice/(src.loc)
+			//Lattice would delete itself, but let's save ourselves a new obj
+			if(istype(src.loc, /turf/space) || istype(src.loc, /turf/simulated/open))
+				new /obj/structure/lattice/(src.loc)
 			qdel(src)

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -5,8 +5,8 @@
 	icon_state = "catwalk"
 	density = 0
 	anchored = 1.0
-	plane = ABOVE_PLATING_PLANE
-	layer = LATTICE_LAYER
+	plane = ABOVE_TURF_PLANE
+	layer = CATWALK_LAYER
 
 /obj/structure/catwalk/Initialize()
 	. = ..()

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -142,12 +142,12 @@ var/list/flooring_types
 
 /decl/flooring/reinforced
 	name = "reinforced floor"
-	desc = "Heavily reinforced with steel rods."
+	desc = "Heavily reinforced with steel plating."
 	icon = 'icons/turf/flooring/tiles.dmi'
 	icon_base = "reinforced"
 	flags = TURF_REMOVE_WRENCH | TURF_ACID_IMMUNE
-	build_type = /obj/item/stack/rods
-	build_cost = 2
+	build_type = /obj/item/stack/material/steel
+	build_cost = 1
 	build_time = 30
 	apply_thermal_conductivity = 0.025
 	apply_heat_capacity = 325000

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -47,6 +47,16 @@
 			if(broken || burnt)
 				to_chat(user, "<span class='warning'>This section is too damaged to support anything. Use a welder to fix the damage.</span>")
 				return
+			//first check, catwalk? Else let flooring do its thing
+			if(locate(/obj/structure/catwalk, src))
+				return
+			if (istype(C, /obj/item/stack/rods))
+				var/obj/item/stack/rods/R = C
+				if (R.use(1))
+					to_chat(user, "<span class='notice'>You lay down the support lattice.</span>")
+					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+					new /obj/structure/catwalk(locate(src.x, src.y, src.z))
+				return
 			var/obj/item/stack/S = C
 			var/decl/flooring/use_flooring
 			for(var/flooring_type in flooring_types)
@@ -115,6 +125,7 @@
 					else
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
+
 
 	return ..()
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -52,8 +52,8 @@
 				return
 			if (istype(C, /obj/item/stack/rods))
 				var/obj/item/stack/rods/R = C
-				if (R.use(1))
-					to_chat(user, "<span class='notice'>You lay down the support lattice.</span>")
+				if (R.use(2))
+					to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					new /obj/structure/catwalk(locate(src.x, src.y, src.z))
 				return

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -55,7 +55,7 @@
 				if (R.use(2))
 					to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-					new /obj/structure/catwalk(locate(src.x, src.y, src.z))
+					new /obj/structure/catwalk(src)
 				return
 			var/obj/item/stack/S = C
 			var/decl/flooring/use_flooring

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -41,12 +41,6 @@ var/list/possible_cable_coil_colours
 	color = COLOR_RED
 	var/obj/machinery/power/breakerbox/breaker_box
 
-/obj/structure/cable/hide(var/do_hide)
-	if(do_hide && level == 1)
-		plane = ABOVE_PLATING_PLANE
-		layer = WIRE_LAYER
-	else
-		reset_plane_and_layer()
 
 /obj/structure/cable/drain_power(var/drain_check, var/surge, var/amount = 0)
 

--- a/html/changelogs/CrimsonsShrike - IseePipes.yml
+++ b/html/changelogs/CrimsonsShrike - IseePipes.yml
@@ -1,0 +1,6 @@
+author: CrimsonShrike
+delete-after: True
+changes: 
+  - rscadd: "Now catwalks can be built above plating."
+  - tweak: "Reinforced floor now requires 1 steel sheet instead of 2 rods."
+


### PR DESCRIPTION
Changed reinforced floors to use steel sheets, removed apparently useless proc for wire, added ability to build catwalks over plating.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
