### PR TITLE
Split up med contractor access amongst their alt-titles

### DIFF
--- a/html/changelogs/sicktrigger-medcontraccess.yml
+++ b/html/changelogs/sicktrigger-medcontraccess.yml
@@ -1,0 +1,6 @@
+author: sick trigger
+
+delete-after: True
+
+changes: 
+  - tweak: "'Medical Contractor' job now has less access. Pick a specialised alt-title if you want into chemistry/virology/etc."

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -193,3 +193,29 @@
 	dna_hash = md5(fingerprint_hash)
 	blood_type = RANDOM_BLOOD_TYPE
 	update_name()
+
+
+/*
+*	Snowflake shit to give different access to alt-titles.
+*	Unique ID card should be added to their outfit.
+*/
+
+/obj/item/weapon/card/id/torch/contractor/medical/chemist/New()
+	..()
+	access &= list(access_medical, access_medical_equip, access_solgov_crew)
+	access |= list(access_chemistry)
+
+/obj/item/weapon/card/id/torch/contractor/medical/virologist/New()
+	..()
+	access &= list(access_medical, access_medical_equip, access_solgov_crew, access_morgue)
+	access |= list(access_virology, access_crematorium)
+
+/obj/item/weapon/card/id/torch/contractor/medical/mortus/New()
+	..()
+	access &= list(access_medical, access_medical_equip, access_solgov_crew, access_morgue)
+	access |= list(access_crematorium)
+
+/obj/item/weapon/card/id/torch/contractor/medical/paramedic/New()
+	..()
+	access &= list(access_medical, access_medical_equip, access_solgov_crew)
+	access |= list(access_eva, access_emergency_storage, access_external_airlocks)

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -743,8 +743,7 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 
-	access = list(access_medical, access_morgue, access_crematorium, access_virology, access_surgery, access_medical_equip, access_solgov_crew,
-		            access_eva, access_maint_tunnels, access_emergency_storage, access_external_airlocks, access_chemistry)
+	access = list(access_medical, access_medical_equip, access_solgov_crew, access_morgue, access_surgery, access_maint_tunnels)
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -385,10 +385,12 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/mortus
 	name = OUTFIT_JOB_NAME("Mortician")
 	uniform = /obj/item/clothing/under/rank/medical/scrubs/black
+	id_type = /obj/item/weapon/card/id/torch/contractor/medical/mortus
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist
 	name = OUTFIT_JOB_NAME("Virologist - Torch")
 	uniform = /obj/item/clothing/under/rank/virologist
+	id_type = /obj/item/weapon/card/id/torch/contractor/medical/virologist
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist/New()
 	..()
@@ -402,11 +404,13 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	l_hand = /obj/item/weapon/storage/firstaid/adv
 	belt = /obj/item/weapon/storage/belt/medical/emt
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
+	id_type = /obj/item/weapon/card/id/torch/contractor/medical/paramedic
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
 	name = OUTFIT_JOB_NAME("Chemist - Torch")
 	uniform = /obj/item/clothing/under/rank/chemist
 	shoes = /obj/item/clothing/shoes/white
+	id_type = /obj/item/weapon/card/id/torch/contractor/medical/chemist
 	pda_type = /obj/item/device/pda/chemist
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist/New()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
per discussion at https://baystation12.net/forums/threads/medical-contractors.5448/
nerfs contractor access substantially and give it to their alts

job | steals
------------ | -------------
chemist | chemistry
virologist | virology (really only gives access to a locker)
paramedic | maint + EVA + airlocks + emergency storage
mortician | crematorium

open to any suggestions/complaints about this

change is a little hacky but it works fine. alt-titles should really be turned into subtypes or something.