### PR TITLE
Radiation resistance adjustments

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -205,8 +205,9 @@ var/list/gamemode_cache = list()
 	var/wait_for_sigusr1_reboot = 0 // Don't allow reboot unless it was caused by SIGUSR1
 
 	var/radiation_decay_rate = 1 //How much radiation is reduced by each tick
-	var/radiation_resistance_multiplier = 6.5
-	var/radiation_lower_limit = 0.35 //If the radiation level for a turf would be below this, ignore it.
+	var/radiation_resistance_multiplier = 1.25
+	var/radiation_material_resistance_divisor = 2 //A turf's possible radiation resistance is divided by this number, to get the real value.
+	var/radiation_lower_limit = 0.15 //If the radiation level for a turf would be below this, ignore it.
 
 	var/autostealth = 0 // Staff get automatic stealth after this many minutes
 
@@ -715,6 +716,14 @@ var/list/gamemode_cache = list()
 					max_gear_cost = text2num(value)
 					if(max_gear_cost < 0)
 						max_gear_cost = INFINITY
+				if("radiation_decay_rate")
+					radiation_decay_rate = text2num(value)
+				if("radiation_resistance_multiplier")
+					radiation_resistance_multiplier = text2num(value)
+				if("radiation_material_resistance_divisor")
+					radiation_material_resistance_divisor = text2num(value)
+				if("radiation_lower_limit")
+					radiation_lower_limit = text2num(value)
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/datums/repositories/radiation.dm
+++ b/code/datums/repositories/radiation.dm
@@ -119,13 +119,13 @@ var/global/repository/radiation/radiation_repository = new()
 		else if(O.density) //So open doors don't get counted
 			var/material/M = O.get_material()
 			if(!M)	continue
-			cached_rad_resistance += M.weight
+			cached_rad_resistance += M.weight / config.radiation_material_resistance_divisor
 	// Looks like storing the contents length is meant to be a basic check if the cache is stale due to items enter/exiting.  Better than nothing so I'm leaving it as is. ~Leshana
 	radiation_repository.resistance_cache[src] = (length(contents) + 1)
 
 /turf/simulated/wall/calc_rad_resistance()
 	radiation_repository.resistance_cache[src] = (length(contents) + 1)
-	cached_rad_resistance = (density ? material.weight : 0)
+	cached_rad_resistance = (density ? material.weight / config.radiation_material_resistance_divisor : 0)
 
 /obj
 	var/rad_resistance = 0  // Allow overriding rad resistance

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -385,3 +385,15 @@ STARLIGHT 0
 
 ## How many loadout points are available. Use 0 to disable loadout, and any negative number to indicate infinite points.
 MAX_GEAR_COST 10
+
+## How much radiation levels self-reduce by each tick.
+RADIATION_DECAY_RATE 1
+
+## The amount of radiation resistance on a turf is multiplied by this value
+RADIATION_RESISTANCE_MULTIPLIER 1.25
+
+## General material radiation resistance is divided by this value
+RADIATION_MATERIAL_RESISTANCE_DIVISOR 2
+
+## Below this point, radiation is ignored
+RADIATION_LOWER_LIMIT 0.15


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
It's almost as if I, long ago, implemented a handy little variable for easily balancing this stuff (that everyone forgot about.)

We originally voted to revert the change that made radiation basically a non-factor, back in https://baystation12.net/forums/threads/vote-revert-the-radiation-rebalance.5320/ . I was then told, in the PR, to adjust material resistance instead. So here it is. 

Radiation is currently irrelevant. This changes that. With reactor blast doors closed and observation doors open, radiation levels in the observation room should be about 0.4. With both doors open, it's around 2.0. Should be 0 with both sets of doors closed (Both tested on the setup-supermatter phoron setup.) Shouldn't leak into maint. The new radiation calculation *system* is intact.

:cl: Cirra
tweak: Radiation is now relevant again, due to material radiation resistance being lowered.
/:cl: