### PR TITLE
Catwalk Fixes and Tweaks

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -64,15 +64,14 @@
 		qdel(src)
 	if (istype(C, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = C
-		if(R.amount <= 2)
+		if(R.use(2))
+			src.alpha = 0
+			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+			new /obj/structure/catwalk(src.loc)
+			qdel(src)
 			return
 		else
-			R.use(2)
-			to_chat(user, "<span class='notice'>You start connecting [R.name] to [src.name] ...</span>")
-			if(do_after(user,50))
-				src.alpha = 0
-				new /obj/structure/catwalk(src.loc)
-				qdel(src)
+			to_chat(user, "<span class='notice'>You require at least two rods to complete the catwalk.</span>")
 			return
 	return
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -53,7 +53,6 @@
 			if (istype(C, /obj/item/stack/rods))
 				var/obj/item/stack/rods/R = C
 				if (R.use(2))
-					to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					new /obj/structure/catwalk(src)
 				return

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -56,7 +56,7 @@
 	if (istype(C, /obj/item/stack/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			return
+			return L.attackby(C, user)
 		var/obj/item/stack/rods/R = C
 		if (R.use(1))
 			to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -144,7 +144,7 @@
 	if (istype(C, /obj/item/stack/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			return
+			return L.attackby(C, user)
 		var/obj/item/stack/rods/R = C
 		if (R.use(1))
 			to_chat(user, "<span class='notice'>You lay down the support lattice.</span>")


### PR DESCRIPTION
- Fixes requiring three rods when only two are used.
- Gets rid of wait time when placing catwalk on lattices, as placing floors on lattices or placing catwalk on floors does not have a wait time either. 
- Message when having too few rods.
- Sound for placing catwalk on lattice.
- Does no longer have to click directly on the lattice to place the catwalk.
- Gets rid of the message for placing catwalk on floor. We don't have that for normal flooring either and it's unnecessary spam.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
