### PR TITLE
Revert "Automatic changelog generation for PR #19348 [ci skip]"

### DIFF
--- a/html/changelogs/AutoChangeLog-pr-19348.yml
+++ b/html/changelogs/AutoChangeLog-pr-19348.yml
@@ -1,4 +1,0 @@
-author: "Hubblenaut"
-delete-after: True
-changes: 
-  - tweak: "Field medics do once again spawn with marine utilities."


### PR DESCRIPTION
This reverts commit 90deb59cb9620d8c9cac1085569b0a31e20886c1.
Change log is erroneous and was created when a PR's branch was overriden by a different change in a different PR.