### PR TITLE
Add a new armour carrier for CoS with a police tag

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -232,6 +232,11 @@ armour attachments
 	desc = "An armor tag with the words SOL CENTRAL GOVERNMENT printed in gold lettering on it."
 	icon_state = "comtag"
 
+/obj/item/clothing/accessory/armor/tag/solgov/com/sec
+	name = "\improper POLICE tag"
+	desc = "An armor tag with the words POLICE printed in gold lettering on it."
+	icon_state = "comsectag"
+
 /**************
 department tags
 **************/

--- a/maps/torch/items/clothing/solgov-armor.dm
+++ b/maps/torch/items/clothing/solgov-armor.dm
@@ -38,3 +38,6 @@
 
 /obj/item/clothing/suit/armor/pcarrier/medium/command
 	starting_accessories = list(/obj/item/clothing/accessory/armorplate/medium, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/solgov/com)
+
+/obj/item/clothing/suit/armor/pcarrier/medium/command/security
+	starting_accessories = list(/obj/item/clothing/accessory/armorplate/tactical, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/solgov/com/sec)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -50,7 +50,9 @@
 
 /obj/structure/closet/secure_closet/cos/WillContain()
 	return list(
-		/obj/item/clothing/suit/armor/pcarrier/medium/command,
+		/obj/item/clothing/suit/armor/pcarrier/medium/command/security,
+		/obj/item/clothing/accessory/armguards,
+		/obj/item/clothing/accessory/legguards,
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/clothing/head/HoS/dermal,
 		/obj/item/weapon/cartridge/hos,


### PR DESCRIPTION
Add a new armour carrier for CoS with a police tag
- Upgrade plate to tactical for extra defence
- Add arm/leg guards to CoS locker

🆑 FTangSteve
tweak: Add SCG Police tag to CoS carrier
tweak: upgrade CoS armour plate
/🆑 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
