### PR TITLE
Nerfs communication outages

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -23,6 +23,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	produces_heat = 0
 	delay = 7
 	circuitboard = /obj/item/weapon/circuitboard/telecomms/broadcaster
+	outage_probability = 10
 
 /obj/machinery/telecomms/broadcaster/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 	// Don't broadcast rejected signals

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -123,6 +123,8 @@
 	dat = "<font face = \"Courier\"><HEAD><TITLE>[src.name]</TITLE></HEAD><center><H3>[src.name] Access</H3></center>"
 	dat += "<br>[temp]<br>"
 	dat += "<br>Power Status: <a href='?src=\ref[src];input=toggle'>[src.toggled ? "On" : "Off"]</a>"
+	if(overloaded_for)
+		dat += "<br><br>WARNING: Ion interference detected. System will automatically recover in [overloaded_for*2] seconds. <a href='?src=\ref[src];input=resetoverload'>Reset manually</a><br>"
 	if(on && toggled)
 		if(id != "" && id)
 			dat += "<br>Identification String: <a href='?src=\ref[src];input=id'>[id]</a>"
@@ -297,6 +299,10 @@
 
 	if(href_list["input"])
 		switch(href_list["input"])
+
+			if("resetoverload")
+				overloaded_for = 0
+				temp = "<font color = #666633>-% Manual override accepted. \The [src] has been reset.</font>"
 
 			if("toggle")
 

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -11,10 +11,11 @@
 		to_chat(A, "<span class='warning'><b>[alert]</b></span>")
 		to_chat(A, "<br>")
 
-	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
+	if(prob(80))	//Announce most of the time, just not always to give some wiggle room for possible sabotages.
 		command_announcement.Announce(alert, new_sound = sound('sound/misc/interference.ogg', volume=25))
 
 
 /datum/event/communications_blackout/start()
 	for(var/obj/machinery/telecomms/T in telecomms_list)
-		T.emp_act(1)
+		if(prob(T.outage_probability))
+			T.overloaded_for = max(severity * rand(90, 120), T.overloaded_for)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -151,7 +151,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1230),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			100, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(ASSIGNMENT_AI = 150, ASSIGNMENT_SECURITY = 120)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	100,	list(ASSIGNMENT_AI = 100, ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			10,		list(ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_JANITOR = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				200,	list(ASSIGNMENT_ENGINEER = 10)),


### PR DESCRIPTION
- Comms outage overall is very frequent, and after facing it /four times/ in a single round i just feel it's way too much, especially given there is nothing you can do to protect against the event or mitigate its impact. This PR allows the chief engineer, senior engineer, AI, or anyone else with access and skills to the telecommunications chamber to reset the malfunctioning machinery to restore the system. Ion anomalies also affect only some of the machines (RNG based), possibly resulting in situations where at least some frequencies remain functional, just with network lag/garbled reception.

:cl:
tweak: Communication outages are overall less common.
tweak: Communication outage has only 75% chance to affect each particular machine, therefore with some luck, enough machines may remain functional to get at least some working frequencies. The hub, broadcaster and receiver have 10% chance to be affected, as they are critical for the whole telecommunications system.
tweak: Increased chance of ion anomaly being announced. There is still a small probability of the anomaly occuring silently.
rscadd: It is now possible to reset EMP/ion/random event affected telecommunications machinery with a multitool through the UI. The UI also shows a timer until automated reset.
/:cl: