### PR TITLE
Removes teleport test firing.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -161,9 +161,6 @@
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))
 	return 1
 
-/obj/machinery/teleport/station/AIAltClick()
-	testfire()
-
 /atom/proc/AIMiddleClick(var/mob/living/silicon/user)
 	return 0
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -147,9 +147,6 @@
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()
 
-/obj/machinery/teleport/station/BorgAltClick()
-	testfire()
-
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -38,10 +38,6 @@
 	if(locked)
 		var/turf/T = get_turf(locked)
 		to_chat(user, "<span class='notice'>The console is locked on to \[[T.loc.name]\].</span>")
-		if(hub.accurate)
-			to_chat(user, "<span class='notice'>Test fire completed.</span>")
-		else
-			to_chat(user, "<span class='warning'>Destination untested. Test firing recommended.</span>")
 
 
 /obj/machinery/computer/teleporter/attackby(I as obj, mob/living/user as mob)
@@ -140,7 +136,6 @@
 		return
 
 	src.locked = L[desc]
-	hub.accurate = 0
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='notice'>Locked In</span>", 2)
 	src.add_fingerprint(usr)
@@ -179,7 +174,6 @@
 	desc = "It's the hub of a teleporting machine."
 	icon_state = "tele0"
 	dir = 4
-	var/accurate = 0
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
@@ -205,24 +199,10 @@
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return
-	if (istype(M, /atom/movable))
-		if(prob(5) && !accurate) //oh dear a problem
-			var/turf/T = get_turf(M)
-			var/destination_z = T ? GetConnectedZlevels(T.z) : GetConnectedZlevels(z)
-			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), destination_z), 2)
-		else
-			do_teleport(M, com.locked) //dead-on precision
-
-		if(com.one_time_use) //Make one-time-use cards only usable one time!
-			com.one_time_use = 0
-			com.locked = null
-	else
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-		accurate = 1
-		for(var/mob/B in hearers(src, null))
-			B.show_message("<span class='notice'>Test fire completed.</span>")
+	do_teleport(M, com.locked)
+	if(com.one_time_use) //Make one-time-use cards only usable one time!
+		com.one_time_use = 0
+		com.locked = null
 	return
 /*
 /proc/do_teleport(atom/movable/M as mob|obj, atom/destination, precision)
@@ -361,39 +341,12 @@
 
 	if (com)
 		com.icon_state = "tele0"
-		com.accurate = 0
 		com.update_use_power(1)
 		update_use_power(1)
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='notice'>Teleporter disengaged!</span>", 2)
 	src.add_fingerprint(usr)
 	src.engaged = 0
-	return
-
-/obj/machinery/teleport/station/AltClick()
-	if(!usr.incapacitated() && Adjacent(usr))
-		testfire()
-
-
-/obj/machinery/teleport/station/verb/testfire()
-	set name = "Test Fire Teleporter"
-	set category = "Object"
-	set src in oview(1)
-
-	if(stat & (BROKEN|NOPOWER) || !istype(usr,/mob/living))
-		return
-
-	if (com && !active)
-		active = 1
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='notice'>Test firing!</span>", 2)
-		com.teleport()
-		use_power(5000)
-
-		spawn(30)
-			active=0
-
-	src.add_fingerprint(usr)
 	return
 
 /obj/machinery/teleport/station/update_icon()

--- a/html/changelogs/Kelenius - BanTeleportTesting.yml
+++ b/html/changelogs/Kelenius - BanTeleportTesting.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Teleporters don't need to be test-fired anymore."


### PR DESCRIPTION
Take two. Removes test firing, as it's pointless tedium and only serves to punish the players who don't know about this somewhat obscure feature.