### PR TITLE
Cleans up and sorts camera nets

### DIFF
--- a/html/changelogs/Kelenius - CameraNetOfLies.yml
+++ b/html/changelogs/Kelenius - CameraNetOfLies.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kelenius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Camera networks have been sorted in an other that makes more sense."
+

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -2,7 +2,6 @@ var/const/NETWORK_AQUILA      = "Aquila"
 var/const/NETWORK_BRIDGE      = "Bridge"
 var/const/NETWORK_CALYPSO     = "Charon"
 var/const/NETWORK_EXPEDITION  = "Expedition"
-var/const/NETWORK_FIFTH_DECK  = "Fifth Deck"
 var/const/NETWORK_FIRST_DECK  = "First Deck"
 var/const/NETWORK_FOURTH_DECK = "Fourth Deck"
 var/const/NETWORK_POD         = "General Utility Pod"
@@ -33,26 +32,25 @@ var/const/NETWORK_THIRD_DECK  = "Third Deck"
 /datum/map/torch
 	// Networks that will show up as options in the camera monitor program
 	station_networks = list(
-		NETWORK_AQUILA,
-		NETWORK_BRIDGE,
-		NETWORK_CALYPSO,
-		NETWORK_ENGINE,
-		NETWORK_EXPEDITION,
-		NETWORK_FIFTH_DECK,
-		NETWORK_FIRST_DECK,
-		NETWORK_FOURTH_DECK,
 		NETWORK_ROBOTS,
-		NETWORK_POD,
+		NETWORK_FIRST_DECK,
 		NETWORK_SECOND_DECK,
 		NETWORK_THIRD_DECK,
-		NETWORK_SUPPLY,
-		NETWORK_HANGAR,
-		NETWORK_EXPLO,
+		NETWORK_FOURTH_DECK,
+		NETWORK_BRIDGE,
 		NETWORK_COMMAND,
 		NETWORK_ENGINEERING,
+		NETWORK_ENGINE,
 		NETWORK_MEDICAL,
 		NETWORK_RESEARCH,
 		NETWORK_SECURITY,
+		NETWORK_SUPPLY,
+		NETWORK_EXPEDITION,
+		NETWORK_EXPLO,
+		NETWORK_HANGAR,
+		NETWORK_AQUILA,
+		NETWORK_CALYPSO,
+		NETWORK_POD,
 		NETWORK_ALARM_ATMOS,
 		NETWORK_ALARM_CAMERA,
 		NETWORK_ALARM_FIRE,
@@ -77,9 +75,6 @@ var/const/NETWORK_THIRD_DECK  = "Third Deck"
 
 /obj/machinery/camera/network/expedition
 	network = list(NETWORK_EXPEDITION)
-
-/obj/machinery/camera/network/fifth_deck
-	network = list(NETWORK_FIFTH_DECK)
 
 /obj/machinery/camera/network/first_deck
 	network = list(NETWORK_FIRST_DECK)


### PR DESCRIPTION
Removes an unused NETWORK_FIFTH_DECK.
Sorts the remaining ones in the following order: robots, decks from 1 to 4, bridge, command, departments, hangar, ships, alarms, thunderdome.