### PR TITLE
HUD code cleanup, part 1

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -115,6 +115,7 @@
 #include "code\_onclick\hud\alien_larva.dm"
 #include "code\_onclick\hud\deity.dm"
 #include "code\_onclick\hud\fullscreen.dm"
+#include "code\_onclick\hud\global_hud.dm"
 #include "code\_onclick\hud\gun_mode.dm"
 #include "code\_onclick\hud\hud.dm"
 #include "code\_onclick\hud\human.dm"

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -1,7 +1,7 @@
-/mob/living/carbon/alien/instantiate_hud(var/datum/hud/HUD)
-	HUD.larva_hud()
+/mob/living/carbon/alien
+	hud_type = /datum/hud/larva
 
-/datum/hud/proc/larva_hud()
+/datum/hud/larva/FinalizeInstantiation()
 
 	src.adding = list()
 	src.other = list()

--- a/code/_onclick/hud/deity.dm
+++ b/code/_onclick/hud/deity.dm
@@ -1,7 +1,7 @@
-/mob/living/deity/instantiate_hud(var/datum/hud/HUD)
-	HUD.deity_hud()
+/mob/living/deity
+	hud_type = /datum/hud/deity
 
-/datum/hud/proc/deity_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
+/datum/hud/deity/FinalizeInstantiation(ui_style = 'icons/mob/screen1_Midnight.dmi')
 	src.adding = list()
 	src.other = list()
 

--- a/code/_onclick/hud/global_hud.dm
+++ b/code/_onclick/hud/global_hud.dm
@@ -1,0 +1,27 @@
+/*
+	The global hud:
+	Uses the same visual objects for all players.
+*/
+
+GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new())
+
+/datum/global_hud
+	var/obj/screen/nvg
+	var/obj/screen/thermal
+	var/obj/screen/meson
+	var/obj/screen/science
+
+/datum/global_hud/proc/setup_overlay(var/icon_state)
+	var/obj/screen/screen = new /obj/screen()
+	screen.screen_loc = "1,1"
+	screen.icon = 'icons/obj/hud_full.dmi'
+	screen.icon_state = icon_state
+	screen.mouse_opacity = 0
+
+	return screen
+
+/datum/global_hud/New()
+	nvg = setup_overlay("nvg_hud")
+	thermal = setup_overlay("thermal_hud")
+	meson = setup_overlay("meson_hud")
+	science = setup_overlay("science_hud")

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -1,36 +1,20 @@
 /*
-	The global hud:
-	Uses the same visual objects for all players.
-*/
-
-GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new())
-
-/datum/global_hud
-	var/obj/screen/nvg
-	var/obj/screen/thermal
-	var/obj/screen/meson
-	var/obj/screen/science
-
-/datum/global_hud/proc/setup_overlay(var/icon_state)
-	var/obj/screen/screen = new /obj/screen()
-	screen.screen_loc = "1,1"
-	screen.icon = 'icons/obj/hud_full.dmi'
-	screen.icon_state = icon_state
-	screen.mouse_opacity = 0
-
-	return screen
-
-/datum/global_hud/New()
-	nvg = setup_overlay("nvg_hud")
-	thermal = setup_overlay("thermal_hud")
-	meson = setup_overlay("meson_hud")
-	science = setup_overlay("science_hud")
-
-/*
 	The hud datum
 	Used to show and hide huds for all the different mob types,
 	including inventories and item quick actions.
 */
+
+/mob
+	var/hud_type = null
+	var/datum/hud/hud_used = null
+
+/mob/proc/InitializeHud()
+	if(hud_used)
+		qdel(hud_used)
+	if(hud_type)
+		hud_used = new hud_type(src)
+	else
+		hud_used = new /datum/hud
 
 /datum/hud
 	var/mob/mymob
@@ -53,7 +37,7 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new())
 	var/obj/screen/movable/action_button/hide_toggle/hide_actions_toggle
 	var/action_buttons_hidden = 0
 
-datum/hud/New(mob/owner)
+/datum/hud/New(mob/owner)
 	mymob = owner
 	instantiate()
 	..()
@@ -68,7 +52,6 @@ datum/hud/New(mob/owner)
 	adding = null
 	other = null
 	hotkeybuttons = null
-//	item_action_list = null // ?
 	mymob = null
 
 /datum/hud/proc/hidden_inventory_update()
@@ -164,9 +147,9 @@ datum/hud/New(mob/owner)
 	var/ui_color = mymob.client.prefs.UI_style_color
 	var/ui_alpha = mymob.client.prefs.UI_style_alpha
 
-	mymob.instantiate_hud(src, ui_style, ui_color, ui_alpha)
+	FinalizeInstantiation(ui_style, ui_color, ui_alpha)
 
-/mob/proc/instantiate_hud(var/datum/hud/HUD, var/ui_style, var/ui_color, var/ui_alpha)
+/datum/hud/proc/FinalizeInstantiation(var/ui_style, var/ui_color, var/ui_alpha)
 	return
 
 //Triggered when F12 is pressed (Unless someone changed something in the DMF)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -1,7 +1,8 @@
-/mob/living/carbon/human/instantiate_hud(var/datum/hud/HUD, var/ui_style, var/ui_color, var/ui_alpha)
-	HUD.human_hud(ui_style, ui_color, ui_alpha, src)
+/mob/living/carbon/human
+	hud_type = /datum/hud/human
 
-/datum/hud/proc/human_hud(var/ui_style='icons/mob/screen1_White.dmi', var/ui_color = "#ffffff", var/ui_alpha = 255, var/mob/living/carbon/human/target)
+/datum/hud/human/FinalizeInstantiation(var/ui_style='icons/mob/screen1_White.dmi', var/ui_color = "#ffffff", var/ui_alpha = 255)
+	var/mob/living/carbon/human/target = mymob
 	var/datum/hud_data/hud_data
 	if(!istype(target))
 		hud_data = new()
@@ -287,10 +288,3 @@
 	else
 		client.screen -= hud_used.hotkeybuttons
 		hud_used.hotkey_ui_hidden = 1
-
-//Used for new human mobs created by cloning/goleming/etc.
-/mob/living/carbon/human/proc/set_cloned_appearance()
-	f_style = "Shaved"
-	if(dna.species == SPECIES_HUMAN) //no more xenos losing ears/tentacles
-		h_style = pick("Bedhead", "Bedhead 2", "Bedhead 3")
-	regenerate_icons()

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -1,27 +1,7 @@
+/mob/living/carbon/slime
+	hud_type = /datum/hud/slime
 
-/datum/hud/proc/unplayer_hud()
-	return
-
-/mob/observer/ghost/instantiate_hud(var/datum/hud/HUD)
-	HUD.ghost_hud()
-
-/datum/hud/proc/ghost_hud()
-	return
-
-/mob/living/carbon/brain/instantiate_hud(var/datum/hud/HUD)
-	return
-
-/mob/living/silicon/ai/instantiate_hud(var/datum/hud/HUD)
-	HUD.ai_hud()
-
-/datum/hud/proc/ai_hud()
-	return
-
-/mob/living/carbon/slime/instantiate_hud(var/datum/hud/HUD)
-	HUD.slime_hud()
-
-/datum/hud/proc/slime_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
-
+/datum/hud/slime/FinalizeInstantiation(ui_style = 'icons/mob/screen1_Midnight.dmi')
 	src.adding = list()
 
 	var/obj/screen/using
@@ -33,10 +13,10 @@
 	mymob.client.screen = list()
 	mymob.client.screen += src.adding
 
-/mob/living/simple_animal/construct/instantiate_hud(var/datum/hud/HUD)
-	HUD.construct_hud()
+/mob/living/simple_animal/construct
+	hud_type = /datum/hud/construct
 
-/datum/hud/proc/construct_hud()
+/datum/hud/construct/FinalizeInstantiation()
 	var/constructtype
 
 	if(istype(mymob,/mob/living/simple_animal/construct/armoured) || istype(mymob,/mob/living/simple_animal/construct/behemoth))

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -1,9 +1,9 @@
 var/obj/screen/robot_inventory
 
-/mob/living/silicon/robot/instantiate_hud(var/datum/hud/HUD)
-	HUD.robot_hud()
+/mob/living/silicon/robot
+	hud_type = /datum/hud/robot
 
-/datum/hud/proc/robot_hud()
+/datum/hud/robot/FinalizeInstantiation()
 
 	src.adding = list()
 	src.other = list()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1083,9 +1083,7 @@
 	// Rebuild the HUD. If they aren't logged in then login() should reinstantiate it for them.
 	if(client && client.screen)
 		client.screen.len = null
-		if(hud_used)
-			qdel(hud_used)
-		hud_used = new /datum/hud(src)
+		InitializeHud()
 
 	if(config && config.use_cortical_stacks && client && client.prefs.has_cortical_stack)
 		create_stack()

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -18,7 +18,7 @@
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(new_name)
 	..("[new_name] (mannequin)", FALSE)
 
-/mob/living/carbon/human/dummy/mannequin/instantiate_hud()
+/mob/living/carbon/human/dummy/mannequin/InitializeHud()
 	return	// Mannequins don't get HUDs
 
 /mob/living/carbon/human/skrell/New(var/new_loc)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -65,8 +65,7 @@
 
 	client.images = null				//remove the images such as AIs being unable to see runes
 	client.screen = list()				//remove hud items just in case
-	if(hud_used)	qdel(hud_used)		//remove the hud objects
-	hud_used = new /datum/hud(src)
+	InitializeHud()
 
 	next_move = 1
 	set_sight(sight|SEE_SELF)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -100,9 +100,6 @@
 	var/obj/item/weapon/storage/s_active = null//Carbon
 	var/obj/item/clothing/mask/wear_mask = null//Carbon
 
-
-	var/datum/hud/hud_used = null
-
 	var/list/grabbed_by = list(  )
 
 	var/in_throw_mode = 0


### PR DESCRIPTION
I understand that you'll probably want me to do a complete cleanup in one PR, but I'll just go insane and nothing ever will get done. So we get this for now. What it does:

1) Removes a wild unused `set_cloned_appearance` proc that's in hud code for some reason
2) Creates subtypes for `/datum/hud`. Currently `/datum/hud` has various procs (`/datum/hud/proc/larva_hud`, etc) that are called depending on the type of the mob that uses the hud. All mobs have the same hud type. I've changed it to be more sane and gave different mobs different hud types, and turned all those procs into one, `/datum/hud/proc/FinalizeInstantiation()`

I'm intending to continue working on the HUD code to bring it up to the standard. It's absolutely disgusting right now.