### PR TITLE
CoS once again gets the same armor protection level as everybody else.

### DIFF
--- a/maps/torch/items/clothing/solgov-armor.dm
+++ b/maps/torch/items/clothing/solgov-armor.dm
@@ -40,4 +40,4 @@
 	starting_accessories = list(/obj/item/clothing/accessory/armorplate/medium, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/solgov/com)
 
 /obj/item/clothing/suit/armor/pcarrier/medium/command/security
-	starting_accessories = list(/obj/item/clothing/accessory/armorplate/tactical, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/solgov/com/sec)
+	starting_accessories = list(/obj/item/clothing/accessory/armorplate/medium, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/solgov/com/sec)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -51,8 +51,6 @@
 /obj/structure/closet/secure_closet/cos/WillContain()
 	return list(
 		/obj/item/clothing/suit/armor/pcarrier/medium/command/security,
-		/obj/item/clothing/accessory/armguards,
-		/obj/item/clothing/accessory/legguards,
 		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/clothing/head/HoS/dermal,
 		/obj/item/weapon/cartridge/hos,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
There is absolutely no reason why the Chief of Security should be going around wearing full combat armor all the time. They're meant to order and coordinate, not be a frontline combatant.

This reverts their armor plate back to the standard security and officer medium grade, and removes the arm and leg guards from the CoS' locker. If they're necessary, they can be easily ordered from Supply.

Gold POLICE tag is maintained.