### PR TITLE
Nerf nabling, strength and species slow

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -116,6 +116,13 @@
 #define MOB_TINY 		5
 #define MOB_MINISCULE	1
 
+// Defines how strong the species is compared to humans. Think like strength in D&D
+#define STR_VHIGH       2
+#define STR_HIGH        1
+#define STR_MEDIUM      0
+#define STR_LOW        -1
+#define STR_VLOW       -2
+
 // Gluttony levels.
 #define GLUT_TINY 1       // Eat anything tiny and smaller
 #define GLUT_SMALLER 2    // Eat anything smaller than we are

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -272,6 +272,19 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	changeling.chem_charges -= 5
 	changeling.geneticdamage = 30
 
+	var/S_name = chosen_dna.speciesName
+	var/datum/species/S_dat = all_species[S_name]
+	var/changeTime = 2 SECONDS
+	if(mob_size != S_dat.mob_size)
+		src.visible_message("<span class='warning'>[src]'s body begins to twist, their mass changing rapidly!</span>")
+		changeTime = 8 SECONDS
+	else
+		src.visible_message("<span class='warning'>[src]'s body begins to twist, changing rapidly!</span>")
+
+	src.visible_message("<span class='warning'>[src]'s body begins to twist, their mass changing rapidly!</span>")
+	if(!do_after(src, changeTime))
+		to_chat(src, "<span class='notice'>You fail to change shape.</span>")
+		return
 	handle_changeling_transform(chosen_dna)
 
 	src.verbs -= /mob/proc/changeling_transform

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -281,7 +281,6 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	else
 		src.visible_message("<span class='warning'>[src]'s body begins to twist, changing rapidly!</span>")
 
-	src.visible_message("<span class='warning'>[src]'s body begins to twist, their mass changing rapidly!</span>")
 	if(!do_after(src, changeTime))
 		to_chat(src, "<span class='notice'>You fail to change shape.</span>")
 		return

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -151,6 +151,8 @@
 /obj/item/weapon/storage/backpack/dufflebag/New()
 	..()
 	slowdown_per_slot[slot_back] = 3
+	slowdown_per_slot[slot_r_hand] = 1
+	slowdown_per_slot[slot_l_hand] = 1
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie
 	name = "black dufflebag"

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -33,11 +33,24 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 	else
+		var/total_item_slowdown = 0
 		for(var/slot = slot_first to slot_last)
 			var/obj/item/I = get_equipped_item(slot)
 			if(I)
-				tally += I.slowdown_general
-				tally += I.slowdown_per_slot[slot]
+				var/item_slowdown = 0
+				item_slowdown += I.slowdown_general
+				item_slowdown += I.slowdown_per_slot[slot]
+
+				if(item_slowdown >= 0)
+					var/size_mod = 0
+					if(!(mob_size == MOB_MEDIUM))
+						size_mod = log(2, mob_size / MOB_MEDIUM)
+					if(species.strength + size_mod + 1 > 0)
+						item_slowdown = item_slowdown / (species.strength + size_mod + 1)
+					else
+						item_slowdown = item_slowdown - species.strength - size_mod
+				total_item_slowdown += max(item_slowdown, 0)
+		tally += round(total_item_slowdown)
 
 		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/E = get_organ(organ_name)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -38,6 +38,7 @@
 	var/pixel_offset_y = 0                    // Used for offsetting large icons.
 
 	var/mob_size	= MOB_MEDIUM
+	var/strength    = STR_MEDIUM
 	var/show_ssd = "fast asleep"
 	var/virus_immune
 	var/short_sighted                         // Permanent weldervision.

--- a/code/modules/mob/living/carbon/human/species/station/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine.dm
@@ -15,6 +15,7 @@
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2
 	num_alternate_languages = 2
+	strength = STR_HIGH
 	name_language = LANGUAGE_EAL
 
 	min_age = 1

--- a/code/modules/mob/living/carbon/human/species/station/nabber.dm
+++ b/code/modules/mob/living/carbon/human/species/station/nabber.dm
@@ -47,6 +47,7 @@
 	burn_mod =  1.35
 	gluttonous = GLUT_SMALLER
 	mob_size = MOB_LARGE
+	strength = STR_HIGH
 	breath_pressure = 25
 	blood_volume = 840
 	spawns_with_stack = 0

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -81,6 +81,7 @@
 	primitive_form = "Stok"
 	darksight = 3
 	gluttonous = GLUT_TINY
+	strength = STR_HIGH
 	slowdown = 0.5
 	brute_mod = 0.8
 	num_alternate_languages = 2
@@ -264,6 +265,7 @@
 	siemens_coefficient = 0.3
 	show_ssd = "completely quiescent"
 	num_alternate_languages = 2
+	strength = STR_VHIGH
 	secondary_langs = list(LANGUAGE_ROOTGLOBAL)
 	name_language = LANGUAGE_ROOTLOCAL
 	spawns_with_stack = 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑 FTangSteve
rscadd: makes item slowdown impacted by species strength
tweak: changeling transform now takes time with a progress bar based on mob_size difference
/🆑

All species stuff is approved by the respective maintainers.

Nabling is nerfed to make it so they can't quickly change to eliminate their weaknesses.

Addresses issues brought up as a result of #19465 such as nabling being too strong. Tajara are no longer impacted by the changes.