### PR TITLE
Make adv scans need do_after

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -4,6 +4,8 @@
 /obj/machinery/bodyscanner
 	var/mob/living/carbon/human/occupant
 	var/locked
+	var/scanned = FALSE
+
 	name = "Body Scanner"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scanner_0"
@@ -29,6 +31,7 @@
 		return
 	src.go_out()
 	add_fingerprint(usr)
+	scanned = FALSE
 	return
 
 /obj/machinery/bodyscanner/verb/move_inside()
@@ -178,12 +181,12 @@
 	var/obj/machinery/bodyscanner/connected
 	var/delete
 	var/temphtml
+	var/scanning = FALSE
 	name = "Body Scanner Console"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scannerconsole"
 	density = 0
 	anchored = 1
-
 
 /obj/machinery/body_scanconsole/Initialize()
 	for(var/D in GLOB.cardinal)
@@ -229,6 +232,21 @@
 	if(!ishuman(connected.occupant))
 		to_chat(user, "<span class='warning'>This device can only scan compatible lifeforms.</span>")
 		return
+
+	if(scanning)
+		to_chat(user, "<span class='notice'>There is already someone performing a scan.</span>")
+		return
+
+	if(!connected.scanned)
+		scanning = TRUE
+		visible_message("<span class='notice'>\The [user] begins pressing buttons on the console as \he scans \the [connected.occupant].</span>")
+		playsound(src, 'sound/machines/buttonbeep.ogg', 30, 0)
+		if(!do_after(user, 5 SECONDS, src))
+			scanning = FALSE
+			return
+		connected.scanned = TRUE
+		playsound(src, 'sound/machines/chime.ogg', 30, 0)
+	scanning = FALSE
 
 	var/dat
 	if (src.delete && src.temphtml) //Window in buffer but its just simple message, so nothing


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
After a scan is done, anyone can then click the console to view the results. If the person leaves and reenters the chamber, they must be rescanned.

🆑 FTangSteve
tweak: adv medical scanners now need a short scanning period before the results are viewed
/🆑 