### PR TITLE
Buffs Meteor Mode

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -21,8 +21,8 @@
 
 	// Moved these from defines to variables, to allow for in-round tweaking via varedit:
 	var/time_between_waves_minutes = 2
-	var/escalation_probability = 50
-	var/maximal_severity = 40
+	var/escalation_probability = 90
+	var/maximal_severity = 80
 	var/send_admin_broadcasts = FALSE	// Enables debugging/information mode, sending admin messages when waves occur and when severity escalates.
 
 	event_delay_mod_moderate = 0.5		// As a bonus, more frequent events.


### PR DESCRIPTION
Upped escalation chance and maximum number of possible meteors in waves.
Now you have possibility of tunguska (non zero but tiny) at 40+ minutes, with total hell mode starting at ~1 hour mark.
Max number of meteors will be reached at ~3 hours mark, if you somehow hold out until that.

The current meteor is meaningless, as it is survivable. It's just a no-EVA extended, with some busier engineering prep in beginning.
I believe it gotta be a short, brutal, PvE palate cleaner. If you survive meteor it should be after mad dash to last evac pod, not sipping coco in your chair.

:cl: Chinsky
tweak: Meteor mode now progresses a bit faster on difficulty scale, and can produce bigger waves in the end.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
