### PR TITLE
Allow dmitool.py to handle more icon states

### DIFF
--- a/tools/dmitool/dmitool.py
+++ b/tools/dmitool/dmitool.py
@@ -58,10 +58,10 @@ def info(filepath):
             continue
 
         stateinfo = {}
-        item = item.split(",", 3)
-        _safe_parse(stateinfo, "name", lambda: item[0].split()[1].strip(" \""))
-        _safe_parse(stateinfo, "dirs", lambda: int(item[1].split()[0].strip()))
-        _safe_parse(stateinfo, "frames", lambda: int(item[2].split()[0].strip()))
+        item = [x.strip() for x in item.split(",")]
+        _safe_parse(stateinfo, "name", lambda: ''.join(item[0:(len(item)-2)]).split()[1].strip(" \""))
+        _safe_parse(stateinfo, "dirs", lambda: int(item[len(item)-2].split()[0].strip()))
+        _safe_parse(stateinfo, "frames", lambda: (item[len(item)-1] if item[len(item)-1] == 'loop(infinite)' else int(item[len(item)-1].split()[0].strip())))
         if len(item) > 3:
             stateinfo["misc"] = item[3]
 


### PR DESCRIPTION
dmitool.py can now handle icon states with names containing ,
dmitool.py can now handle icon states which loop

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
