### PR TITLE
fixes #13069

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -221,10 +221,11 @@
 			if (!transfer)
 				to_chat(user, "<span class='warning'>You must weld or remove \the [repairing] from \the [src] before you can add anything else.</span>")
 		else
-			repairing = stack.split(amount_needed)
+			repairing = stack.split(amount_needed, force=TRUE)
 			if (repairing)
 				repairing.loc = src
 				transfer = repairing.amount
+				repairing.uses_charge = FALSE //for clean robot door repair - stacks hint immortal if true
 
 		if (transfer)
 			to_chat(user, "<span class='notice'>You fit [transfer] [stack.singular_name]\s to damaged and broken parts on \the [src].</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -239,10 +239,10 @@
 	return 0
 
 //creates a new stack with the specified amount
-/obj/item/stack/proc/split(var/tamount)
+/obj/item/stack/proc/split(var/tamount, var/force=FALSE)
 	if (!amount)
 		return null
-	if(uses_charge)
+	if(uses_charge && !force)
 		return null
 
 	var/transfer = max(min(tamount, src.amount, initial(max_amount)), 0)

--- a/html/changelogs/spookerton-fix_13069.yml
+++ b/html/changelogs/spookerton-fix_13069.yml
@@ -1,0 +1,4 @@
+author: Spookerton
+delete-after: True
+changes:
+  - bugfix: "Fixes cyborgs being unable to repair doors."


### PR DESCRIPTION
Adds var/force=FALSE to stack/proc/split  -  causes split to skip the uses_charge check, which previously caused cyborg door repair to silently fail by returning null where a new stack was expected. Defaults false to retain normal behavior elsewhere.

Changelog because being #13069 is a long-standing issue and fixing it represents an interaction change to a common object.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
