### PR TITLE
Changes how known sectors look on map

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -91,7 +91,8 @@ var/list/points_of_interest = list()
 /obj/effect/overmap/sector/Initialize()
 	. = ..()
 	if(known)
-		set_light(2, 5)
+		layer = ABOVE_LIGHTING_LAYER
+		plane = EFFECTS_ABOVE_LIGHTING_PLANE
 		for(var/obj/machinery/computer/helm/H in SSmachines.machinery)
 			H.get_known_sectors()
 


### PR DESCRIPTION
Instead of glowing like sensor emitting things they just layer over darkness. Won't be visible from further than intended, or spoiling asteroid fields on approach.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
