### PR TITLE
Adds binoculars to explorer, pathfinder and DO locker

### DIFF
--- a/maps/torch/structures/closets/exploration.dm
+++ b/maps/torch/structures/closets/exploration.dm
@@ -65,6 +65,7 @@
 		/obj/item/weapon/folder/blue,
 		/obj/item/device/radio/headset/pathfinder,
 		/obj/item/weapon/storage/box/encryptionkey/exploration,
+		/obj/item/device/binoculars,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel_norm)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/glowstick/random))
@@ -98,6 +99,7 @@
 		/obj/item/device/analyzer,
 		/obj/item/device/slime_scanner,
 		/obj/item/device/radio/headset/exploration,
+		/obj/item/device/binoculars,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel_norm)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/glowstick/random))

--- a/maps/torch/structures/closets/supply.dm
+++ b/maps/torch/structures/closets/supply.dm
@@ -58,6 +58,7 @@
 		/obj/item/device/megaphone,
 		/obj/item/device/holowarrant,
 		/obj/item/clothing/suit/armor/pcarrier/light/sol,
+		/obj/item/device/binoculars,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack = 75, /obj/item/weapon/storage/backpack/satchel_norm = 25)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/messenger = 75, /obj/item/weapon/storage/backpack/dufflebag = 25))
 	)


### PR DESCRIPTION
🆑TheGreyWolf
rscadd: Deck officer, pathfinder and explorers now got binoculars in their lockers.
/🆑
On the request of Maveriknight.
I will be keeping neutral on this and just do the coding and potential changes requested by devs.