### PR TITLE
Allow easily adding more character setup backpacks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -268,6 +268,7 @@
 #include "code\datums\outfits\spec_op.dm"
 #include "code\datums\outfits\tournament.dm"
 #include "code\datums\outfits\wizardry.dm"
+#include "code\datums\outfits\equipment\backpacks.dm"
 #include "code\datums\outfits\jobs\_defines.dm"
 #include "code\datums\outfits\jobs\cargo.dm"
 #include "code\datums\outfits\jobs\civilian.dm"

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -213,8 +213,6 @@
 			return global.autolathe_categories;
 		if("autolathe_recipes")
 			return global.autolathe_recipes;
-		if("backbaglist")
-			return global.backbaglist;
 		if("base_miss_chance")
 			return global.base_miss_chance;
 		if("basic_robolimb")
@@ -1274,8 +1272,6 @@
 			global.autolathe_categories=newval;
 		if("autolathe_recipes")
 			global.autolathe_recipes=newval;
-		if("backbaglist")
-			global.backbaglist=newval;
 		if("base_miss_chance")
 			global.base_miss_chance=newval;
 		if("basic_robolimb")
@@ -2228,7 +2224,6 @@
 	"attack_log_repository",
 	"autolathe_categories",
 	"autolathe_recipes",
-	"backbaglist",
 	"base_miss_chance",
 	"basic_robolimb",
 	"blackbox",

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -44,7 +44,6 @@ GLOBAL_LIST_INIT(body_marking_styles_list, list())		//stores /datum/sprite_acces
 
 GLOBAL_DATUM_INIT(underwear, /datum/category_collection/underwear, new())
 
-var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Messenger Bag", "Brown Satchel", "Black Satchel", "Pocketbook")
 var/global/list/exclude_jobs = list(/datum/job/ai,/datum/job/cyborg)
 
 // Visual nets

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -637,6 +637,15 @@ proc/dd_sortedTextList(list/incoming)
 		group_list[key] = values
 
 	values += value
+	
+/proc/duplicates(var/list/L)
+	. = list()
+	var/list/checked = list()
+	for(var/value in L)
+		if(value in checked)
+			. |= value
+		else
+			checked += value
 
 /proc/assoc_by_proc(var/list/plain_list, var/get_initial_value)
 	. = list()

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -222,12 +222,15 @@
 /proc/isLeap(y)
 	return ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
 
-/proc/atomtype2nameassoclist(var/atom_type)
+/proc/atomtypes2nameassoclist(var/list/atom_types)
 	. = list()
-	for(var/sub_atom_type in typesof(atom_type))
-		var/atom/A = sub_atom_type
-		.[initial(A.name)] = sub_atom_type
+	for(var/atom_type in atom_types)
+		var/atom/A = atom_type
+		.[initial(A.name)] = atom_type
 	. = sortAssoc(.)
+
+/proc/atomtype2nameassoclist(var/atom_type)
+	return atomtypes2nameassoclist(typesof(atom_type))
 
 //Splits the text of a file at seperator and returns them in a list.
 /world/proc/file2list(filename, seperator="\n")

--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -1,0 +1,170 @@
+#define BACKPACK_HAS_TYPE_SELECTION 1
+#define BACKPACK_HAS_SUBTYPE_SELECTION 2
+
+/*******************
+* Outfit Backpacks *
+*******************/
+
+/* Setup new backpacks here */
+/decl/backpack_outfit/nothing
+	name = "Nothing"
+
+/decl/backpack_outfit/nothing/spawn_backpack(var/location, var/metadata, var/desired_type)
+	return
+
+/decl/backpack_outfit/backpack
+	name = "Backpack"
+	path = /obj/item/weapon/storage/backpack
+	is_default = TRUE
+
+/decl/backpack_outfit/satchel
+	name = "Satchel"
+	path = /obj/item/weapon/storage/backpack/satchel
+
+/decl/backpack_outfit/satchel/New()
+	..()
+	tweaks += new /datum/backpack_tweak/selection/specified_types(/obj/item/weapon/storage/backpack/satchel/grey, /obj/item/weapon/storage/backpack/satchel/brown, /obj/item/weapon/storage/backpack/satchel/black)
+
+/decl/backpack_outfit/messenger_bag
+	name = "Messenger bag"
+	path = /obj/item/weapon/storage/backpack/messenger
+
+/decl/backpack_outfit/pocketbook
+	name = "Pocketbook"
+	path = /obj/item/weapon/storage/backpack/satchel/pocketbook
+
+/* Code */
+/decl/backpack_outfit
+	var/flags
+	var/name
+	var/path
+	var/is_default = FALSE
+	var/list/tweaks
+
+/decl/backpack_outfit/New()
+	tweaks = tweaks || list()
+
+	if(flags&(BACKPACK_HAS_TYPE_SELECTION|BACKPACK_HAS_SUBTYPE_SELECTION)==(BACKPACK_HAS_TYPE_SELECTION|BACKPACK_HAS_SUBTYPE_SELECTION))
+		CRASH("May not have both type and subtype selection tweaks")
+
+	if(flags & BACKPACK_HAS_TYPE_SELECTION)
+		tweaks += new/datum/backpack_tweak/selection/types(path)
+	if(flags & BACKPACK_HAS_SUBTYPE_SELECTION)
+		tweaks += new/datum/backpack_tweak/selection/subtypes(path)
+
+/decl/backpack_outfit/proc/spawn_backpack(var/location, var/metadata, var/desired_type)
+	metadata = metadata || list()
+	desired_type = desired_type || path
+	for(var/t in tweaks)
+		var/datum/backpack_tweak/bt = t
+		var/tweak_metadata = metadata["[bt]"] || bt.get_default_metadata()
+		desired_type = bt.get_backpack_type(desired_type, tweak_metadata)
+
+	. = new desired_type(location)
+
+	for(var/t in tweaks)
+		var/datum/backpack_tweak/bt = t
+		var/tweak_metadata = metadata["[bt]"]
+		bt.tweak_backpack(., tweak_metadata)
+
+/******************
+* Backpack Tweaks *
+******************/
+/datum/backpack_tweak/proc/get_ui_content(var/metadata)
+	return ""
+
+/datum/backpack_tweak/proc/get_default_metadata()
+	return
+
+/datum/backpack_tweak/proc/get_metadata(var/user, var/metadata, var/title = "Character Preference")
+	return
+
+/datum/backpack_tweak/proc/validate_metadata(var/metadata)
+	return get_default_metadata()
+
+/datum/backpack_tweak/proc/get_backpack_type(var/given_backpack_type)
+	return given_backpack_type
+
+/datum/backpack_tweak/proc/tweak_backpack(var/obj/item/weapon/storage/backpack/backpack, var/metadata)
+	return
+
+
+/* Selection Tweak */
+/datum/backpack_tweak/selection
+	var/const/RETURN_GIVEN_BACKPACK = "default"
+	var/const/RETURN_RANDOM_BACKPACK = "random"
+	var/list/selections
+
+/datum/backpack_tweak/selection/New(var/list/selections)
+	if(!selections.len)
+		CRASH("No selections offered")
+	if(RETURN_GIVEN_BACKPACK in selections)
+		CRASH("May not use the keyword '[RETURN_GIVEN_BACKPACK]'")
+	var/list/duplicate_keys = duplicates(selections)
+	if(duplicate_keys.len)
+		CRASH("Duplicate names found: [english_list(duplicate_keys)]")
+	var/list/duplicate_values = duplicates(list_values(selections))
+	if(duplicate_values.len)
+		CRASH("Duplicate types found: [english_list(duplicate_values)]")
+	for(var/selection_key in selections)
+		if(!istext(selection_key))
+			CRASH("Expected a valid selection key, was [log_info_line(selection_key)]")
+		var/selection_type = selections[selection_key]
+		if(!ispath(selection_type, /obj/item/weapon/storage/backpack))
+			CRASH("Expected a valid selection value, was [log_info_line(selection_type)]")
+
+	src.selections = selections
+	selections += RETURN_GIVEN_BACKPACK
+	selections += RETURN_RANDOM_BACKPACK
+
+/datum/backpack_tweak/selection/get_ui_content(var/metadata)
+	return "Type: [metadata]"
+
+/datum/backpack_tweak/selection/get_default_metadata()
+	return RETURN_GIVEN_BACKPACK
+
+/datum/backpack_tweak/selection/validate_metadata(var/metadata)
+	return (metadata in selections) ? metadata : ..()
+
+/datum/backpack_tweak/selection/get_metadata(var/user, var/metadata, var/title = "Character Preference")
+	return input(user, "Choose a type.", title, metadata) as null|anything in selections
+
+/datum/backpack_tweak/selection/get_backpack_type(var/given_backpack_type, var/metadata)
+	switch(metadata)
+		if(RETURN_GIVEN_BACKPACK)
+			return given_backpack_type
+		if(RETURN_RANDOM_BACKPACK)
+			var/random_choice = pick(selections - RETURN_RANDOM_BACKPACK)
+			return get_backpack_type(given_backpack_type, random_choice)
+		else
+			return selections[metadata]
+
+/datum/backpack_tweak/selection/types/New(var/selection_type)
+	..(atomtype2nameassoclist(selection_type))
+
+/datum/backpack_tweak/selection/subtypes/New(var/selection_type)
+	..(atomtypes2nameassoclist(subtypesof(selection_type)))
+
+/datum/backpack_tweak/selection/specified_types/New()
+	..(atomtypes2nameassoclist(args))
+
+/******************
+* Character setup *
+*******************/
+/datum/backpack_setup
+	var/decl/backpack_outfit/backpack
+	var/metadata
+
+/datum/backpack_setup/New(var/backpack, var/metadata)
+	src.backpack = backpack
+	src.metadata = metadata
+
+/**********
+* Helpers *
+**********/
+/proc/get_default_outfit_backpack()
+	var backpacks = decls_repository.get_decls_of_subtype(/decl/backpack_outfit)
+	for(var/backpack in backpacks)
+		var/decl/backpack_outfit/bo = backpacks[backpack]
+		if(bo.is_default)
+			return bo

--- a/code/datums/outfits/jobs/_defines.dm
+++ b/code/datums/outfits/jobs/_defines.dm
@@ -1,1 +1,31 @@
 #define OUTFIT_JOB_NAME(job_name) ("Job - " + job_name)
+
+#define BACKPACK_OVERRIDE_CHEMISTRY \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/chemistry; \
+backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_chem; \
+backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/chem;
+
+#define BACKPACK_OVERRIDE_ENGINEERING \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/industrial; \
+backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_eng; \
+backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/engi;
+
+#define BACKPACK_OVERRIDE_MEDICAL \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/medic; \
+backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_med; \
+backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/med;
+
+#define BACKPACK_OVERRIDE_RESEARCH \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/toxins; \
+backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_tox; \
+backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/viro;
+
+#define BACKPACK_OVERRIDE_SECURITY \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/security; \
+backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_sec; \
+backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/sec;
+
+#define BACKPACK_OVERRIDE_VIROLOGY \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/virology; \
+backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_vir; \
+backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/viro;

--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -20,9 +20,11 @@
 /decl/hierarchy/outfit/job/cargo/mining
 	name = OUTFIT_JOB_NAME("Shaft miner")
 	uniform = /obj/item/clothing/under/rank/miner
-	backpack = /obj/item/weapon/storage/backpack/industrial
-	satchel_job  = /obj/item/weapon/storage/backpack/satchel_eng
 	id_type = /obj/item/weapon/card/id/cargo/mining
 	pda_type = /obj/item/device/pda/shaftminer
 	backpack_contents = list(/obj/item/weapon/crowbar = 1, /obj/item/weapon/storage/ore = 1)
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
+
+/decl/hierarchy/outfit/job/cargo/mining/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERING

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -25,11 +25,14 @@
 	suit = /obj/item/clothing/suit/apron
 	gloves = /obj/item/clothing/gloves/thick/botany
 	r_pocket = /obj/item/device/analyzer/plant_analyzer
-	backpack = /obj/item/weapon/storage/backpack/hydroponics
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_hyd
 	id_type = /obj/item/weapon/card/id/civilian/botanist
 	pda_type = /obj/item/device/pda/botanist
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/hyd
+
+/decl/hierarchy/outfit/job/service/gardener/New()
+	..()
+	backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/hydroponics
+	backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_hyd
+	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/hyd
 
 /decl/hierarchy/outfit/job/service/janitor
 	name = OUTFIT_JOB_NAME("Janitor")

--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -5,12 +5,15 @@
 	uniform = /obj/item/clothing/under/rank/captain
 	l_ear = /obj/item/device/radio/headset/heads/captain
 	shoes = /obj/item/clothing/shoes/brown
-	backpack = /obj/item/weapon/storage/backpack/captain
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_cap
 	id_type = /obj/item/weapon/card/id/gold
 	pda_type = /obj/item/device/pda/captain
 	backpack_contents = list(/obj/item/weapon/storage/box/ids = 1)
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/com
+
+/decl/hierarchy/outfit/job/captain/New()
+	..()
+	backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/captain
+	backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_cap
+	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/com
 
 /decl/hierarchy/outfit/job/captain/post_equip(var/mob/living/carbon/human/H)
 	..()

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -3,11 +3,12 @@
 	belt = /obj/item/weapon/storage/belt/utility/full
 	l_ear = /obj/item/device/radio/headset/headset_eng
 	shoes = /obj/item/clothing/shoes/workboots
-	backpack = /obj/item/weapon/storage/backpack/industrial
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_eng
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
 	pda_slot = slot_l_store
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
+
+/decl/hierarchy/outfit/job/engineering/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERING
 
 /decl/hierarchy/outfit/job/engineering/chief_engineer
 	name = OUTFIT_JOB_NAME("Chief engineer")

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -4,9 +4,10 @@
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/device/pda/medical
 	pda_slot = slot_l_store
-	backpack = /obj/item/weapon/storage/backpack/medic
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_med
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/med
+
+/decl/hierarchy/outfit/job/medical/New()
+	..()
+	BACKPACK_OVERRIDE_MEDICAL
 
 /decl/hierarchy/outfit/job/medical/cmo
 	name = OUTFIT_JOB_NAME("Chief Medical Officer")
@@ -41,8 +42,9 @@
 	uniform = /obj/item/clothing/under/rank/virologist
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/virologist
 	mask = /obj/item/clothing/mask/surgical
-	backpack = /obj/item/weapon/storage/backpack/virology
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_vir
+/decl/hierarchy/outfit/job/medical/doctor/virologist/New()
+	..()
+	BACKPACK_OVERRIDE_VIROLOGY
 
 /decl/hierarchy/outfit/job/medical/doctor/nurse
 	name = OUTFIT_JOB_NAME("Nurse")
@@ -64,20 +66,25 @@
 	name = OUTFIT_JOB_NAME("Chemist")
 	uniform = /obj/item/clothing/under/rank/chemist
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/chemist
-	backpack = /obj/item/weapon/storage/backpack/chemistry
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_chem
 	id_type = /obj/item/weapon/card/id/medical/chemist
 	pda_type = /obj/item/device/pda/chemist
+
+/decl/hierarchy/outfit/job/medical/chemist/New()
+	..()
+	BACKPACK_OVERRIDE_VIROLOGY
 
 /decl/hierarchy/outfit/job/medical/geneticist
 	name = OUTFIT_JOB_NAME("Geneticist")
 	uniform = /obj/item/clothing/under/rank/geneticist
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/genetics
-	backpack = /obj/item/weapon/storage/backpack/genetics
 	r_pocket = /obj/item/device/flashlight/pen
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_gen
 	id_type = /obj/item/weapon/card/id/medical/geneticist
 	pda_type = /obj/item/device/pda/geneticist
+
+/decl/hierarchy/outfit/job/medical/geneticist/New()
+	..()
+	backpack_overrides[/decl/backpack_outfit/backpack] = /obj/item/weapon/storage/backpack/genetics
+	backpack_overrides[/decl/backpack_outfit/satchel]  = /obj/item/weapon/storage/backpack/satchel_gen
 
 /decl/hierarchy/outfit/job/medical/psychiatrist
 	name = OUTFIT_JOB_NAME("Psychiatrist")

--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -4,9 +4,10 @@
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/device/pda/science
-	backpack = /obj/item/weapon/storage/backpack/toxins
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_tox
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/tox
+
+/decl/hierarchy/outfit/job/science/New()
+	..()
+	BACKPACK_OVERRIDE_RESEARCH
 
 /decl/hierarchy/outfit/job/science/rd
 	name = OUTFIT_JOB_NAME("Research Director")
@@ -37,5 +38,7 @@
 	id_type = /obj/item/weapon/card/id/science/roboticist
 	pda_slot = slot_r_store
 	pda_type = /obj/item/device/pda/roboticist
-	backpack = /obj/item/weapon/storage/backpack
-	satchel_job = /obj/item/weapon/storage/backpack/satchel/grey
+
+/decl/hierarchy/outfit/job/science/roboticist/New()
+	..()
+	backpack_overrides.Cut()

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -4,10 +4,11 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec
 	gloves = /obj/item/clothing/gloves/thick
 	shoes = /obj/item/clothing/shoes/jackboots
-	backpack = /obj/item/weapon/storage/backpack/security
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_sec
 	backpack_contents = list(/obj/item/weapon/handcuffs = 1)
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/sec
+
+/decl/hierarchy/outfit/job/security/New()
+	..()
+	BACKPACK_OVERRIDE_SECURITY
 
 /decl/hierarchy/outfit/job/security/hos
 	name = OUTFIT_JOB_NAME("Head of security")
@@ -34,9 +35,11 @@
 	r_hand = /obj/item/weapon/storage/briefcase/crimekit
 	id_type = /obj/item/weapon/card/id/security/detective
 	pda_type = /obj/item/device/pda/detective
-	backpack = /obj/item/weapon/storage/backpack
-	satchel_job = /obj/item/weapon/storage/backpack/satchel/grey
 	backpack_contents = list(/obj/item/weapon/storage/box/evidence = 1)
+
+/decl/hierarchy/outfit/job/security/detective/New()
+	..()
+	backpack_overrides.Cut()
 
 /decl/hierarchy/outfit/job/security/detective/forensic
 	name = OUTFIT_JOB_NAME("Forensic technician")

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -50,17 +50,12 @@ var/list/outfits_decls_by_type_
 
 	var/id_pda_assignment
 
-	var/backpack = /obj/item/weapon/storage/backpack
-	var/messenger_bag = /obj/item/weapon/storage/backpack/messenger
-	var/satchel_job  = /obj/item/weapon/storage/backpack/satchel/grey
-	var/satchel_brown  = /obj/item/weapon/storage/backpack/satchel/brown
-	var/satchel_black = /obj/item/weapon/storage/backpack/satchel/black
-	var/pocketbook = /obj/item/weapon/storage/backpack/satchel/pocketbook
-
+	var/list/backpack_overrides
 	var/flags // Specific flags
 
 /decl/hierarchy/outfit/New()
 	..()
+	backpack_overrides = backpack_overrides || list()
 
 	if(is_hidden_category())
 		return
@@ -68,15 +63,7 @@ var/list/outfits_decls_by_type_
 	dd_insertObjectList(outfits_decls_, src)
 
 /decl/hierarchy/outfit/proc/pre_equip(mob/living/carbon/human/H)
-	if(flags & OUTFIT_HAS_BACKPACK)
-		switch(H.backbag)
-			if(2) back = backpack
-			if(3) back = messenger_bag
-			if(4) back = satchel_job
-			if(5) back = satchel_brown
-			if(6) back = satchel_black
-			if(7) back = pocketbook
-			else back = null
+	return
 
 /decl/hierarchy/outfit/proc/post_equip(mob/living/carbon/human/H)
 	if(flags & OUTFIT_HAS_JETPACK)
@@ -143,8 +130,23 @@ var/list/outfits_decls_by_type_
 		H.equip_to_slot_or_del(new uniform(H),slot_w_uniform)
 	if(suit)
 		H.equip_to_slot_or_del(new suit(H),slot_wear_suit)
-	if(back)
-		H.equip_to_slot_or_del(new back(H),slot_back)
+
+	if((flags & OUTFIT_HAS_BACKPACK))
+		var/decl/backpack_outfit/bo
+		var/metadata
+
+		if(H.backpack_setup)
+			bo = H.backpack_setup.backpack
+			metadata = H.backpack_setup.metadata
+		else
+			bo = get_default_outfit_backpack()
+
+		var/override_type = backpack_overrides[bo.type]
+		var/backpack = bo.spawn_backpack(H, metadata, override_type)
+
+		if(backpack)
+			H.equip_to_slot_or_del(backpack,slot_back)
+
 	if(belt)
 		H.equip_to_slot_or_del(new belt(H),slot_belt)
 	if(gloves)

--- a/code/datums/outfits/wizardry.dm
+++ b/code/datums/outfits/wizardry.dm
@@ -8,6 +8,7 @@
 	back = /obj/item/weapon/storage/backpack
 	backpack_contents = list(/obj/item/weapon/storage/box = 1)
 	hierarchy_type = /decl/hierarchy/outfit/wizard
+	flags = OUTFIT_HAS_BACKPACK
 
 /decl/hierarchy/outfit/wizard/blue
 	name = "Wizard - Blue"

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -76,19 +76,10 @@ var/datum/antagonist/wizard/wizards
 	if(!..())
 		return 0
 
-	wizard_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(wizard_mob), slot_l_ear)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/under/color/lightpurple(wizard_mob), slot_w_uniform)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(wizard_mob), slot_shoes)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
-	if(wizard_mob.backbag == 2) wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(wizard_mob), slot_back)
-	if(wizard_mob.backbag == 3) wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/grey(wizard_mob), slot_back)
-	if(wizard_mob.backbag == 4) wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(wizard_mob), slot_back)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box(wizard_mob), slot_in_backpack)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/teleportation_scroll(wizard_mob), slot_r_store)
-	var/obj/item/I = new /obj/item/weapon/spellbook(get_turf(wizard_mob))
-	wizard_mob.put_in_hands(I) //makes sure to at least have it on the ground for the wizard, considering how important it is.
-	wizard_mob.update_icons()
+	var/outfit_type = pick(subtypesof(/decl/hierarchy/outfit/wizard))
+	var/decl/hierarchy/outfit/wizard_outfit = outfit_by_type(outfit_type)
+	wizard_outfit.equip(wizard_mob)
+
 	return 1
 
 /datum/antagonist/wizard/check_victory()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -197,14 +197,16 @@
  * Satchel Types
  */
 
-/obj/item/weapon/storage/backpack/satchel/grey
+/obj/item/weapon/storage/backpack/satchel
 	name = "satchel"
 	desc = "A trendy looking satchel."
 	icon_state = "satchel-norm"
 
-/obj/item/weapon/storage/backpack/satchel/grey/withwallet/New()
-	..()
-	new /obj/item/weapon/storage/wallet/random( src )
+/obj/item/weapon/storage/backpack/satchel/grey
+	name = "grey satchel"
+
+/obj/item/weapon/storage/backpack/satchel/grey/withwallet
+	startswith = list(/obj/item/weapon/storage/wallet/random)
 
 /obj/item/weapon/storage/backpack/satchel/brown
 	name = "brown leather satchel"

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -1,21 +1,40 @@
 /datum/preferences
 	var/list/all_underwear
 	var/list/all_underwear_metadata
-	var/backbag = 2						//backpack type
+
+	var/decl/backpack_outfit/backpack
+	var/list/backpack_metadata
 
 /datum/category_item/player_setup_item/general/equipment
 	name = "Clothing"
 	sort_order = 4
 
+	var/static/list/backpacks_by_name
+
+/datum/category_item/player_setup_item/general/equipment/New()
+	..()
+	if(!backpacks_by_name)
+		backpacks_by_name = list()
+		var/bos = decls_repository.get_decls_of_subtype(/decl/backpack_outfit)
+		for(var/bo in bos)
+			var/decl/backpack_outfit/backpack_outfit = bos[bo]
+			backpacks_by_name[backpack_outfit.name] = backpack_outfit
+
 /datum/category_item/player_setup_item/general/equipment/load_character(var/savefile/S)
-	S["all_underwear"]          >> pref.all_underwear
-	S["all_underwear_metadata"] >> pref.all_underwear_metadata
-	S["backbag"]                >> pref.backbag
+	var/load_backbag
+
+	from_file(S["all_underwear"], pref.all_underwear)
+	from_file(S["all_underwear_metadata"], pref.all_underwear_metadata)
+	from_file(S["backpack"], load_backbag)
+	from_file(S["backpack_metadata"], pref.backpack_metadata)
+
+	pref.backpack = backpacks_by_name[load_backbag] || get_default_outfit_backpack()
 
 /datum/category_item/player_setup_item/general/equipment/save_character(var/savefile/S)
-	S["all_underwear"]          << pref.all_underwear
-	S["all_underwear_metadata"] << pref.all_underwear_metadata
-	S["backbag"]                << pref.backbag
+	to_file(S["all_underwear"], pref.all_underwear)
+	to_file(S["all_underwear_metadata"], pref.all_underwear_metadata)
+	to_file(S["backpack"], pref.backpack.name)
+	to_file(S["backpack_metadata"], pref.backpack_metadata)
 
 /datum/category_item/player_setup_item/general/equipment/sanitize_character()
 	if(!istype(pref.all_underwear))
@@ -43,7 +62,25 @@
 		if(!(underwear_metadata in pref.all_underwear))
 			pref.all_underwear_metadata -= underwear_metadata
 
-	pref.backbag = sanitize_integer(pref.backbag, 1, backbaglist.len, initial(pref.backbag))
+	if(!pref.backpack || !(pref.backpack.name in backpacks_by_name))
+		pref.backpack = get_default_outfit_backpack()
+
+	if(!istype(pref.backpack_metadata))
+		pref.backpack_metadata = list()
+
+	for(var/backpack_metadata_name in pref.backpack_metadata)
+		if(!(backpack_metadata_name in backpacks_by_name))
+			pref.backpack_metadata -= backpack_metadata_name
+
+	for(var/backpack_name in backpacks_by_name)
+		var/decl/backpack_outfit/backpack = backpacks_by_name[backpack_name]
+		var/list/tweak_metadata = pref.backpack_metadata["[backpack]"]
+		if(tweak_metadata)
+			for(var/tw in backpack.tweaks)
+				var/datum/backpack_tweak/tweak = tw
+				var/list/metadata = tweak_metadata["[tweak]"]
+				tweak_metadata["[tweak]"] = tweak.validate_metadata(metadata)
+
 
 /datum/category_item/player_setup_item/general/equipment/content()
 	. = list()
@@ -55,14 +92,16 @@
 		var/datum/category_item/underwear/UWI = UWC.items_by_name[item_name]
 		if(UWI)
 			for(var/datum/gear_tweak/gt in UWI.tweaks)
-				. += " <a href='?src=\ref[src];underwear=[UWC.name];tweak=\ref[gt]'>[gt.get_contents(get_metadata(UWC.name, gt))]</a>"
+				. += " <a href='?src=\ref[src];underwear=[UWC.name];tweak=\ref[gt]'>[gt.get_contents(get_underwear_metadata(UWC.name, gt))]</a>"
 
 		. += "<br>"
-	. += "Backpack Type: <a href='?src=\ref[src];change_backpack=1'><b>[backbaglist[pref.backbag]]</b></a><br>"
-
+	. += "Backpack Type: <a href='?src=\ref[src];change_backpack=1'><b>[pref.backpack.name]</b></a>"
+	for(var/datum/backpack_tweak/bt in pref.backpack.tweaks)
+		. += " <a href='?src=\ref[src];backpack=[pref.backpack.name];tweak=\ref[bt]'>[bt.get_ui_content(get_backpack_metadata(pref.backpack, bt))]</a>"
+	. += "<br>"
 	return jointext(.,null)
 
-/datum/category_item/player_setup_item/general/equipment/proc/get_metadata(var/underwear_category, var/datum/gear_tweak/gt)
+/datum/category_item/player_setup_item/general/equipment/proc/get_underwear_metadata(var/underwear_category, var/datum/gear_tweak/gt)
 	var/metadata = pref.all_underwear_metadata[underwear_category]
 	if(!metadata)
 		metadata = list()
@@ -74,17 +113,28 @@
 		metadata["[gt]"] = tweak_data
 	return tweak_data
 
-/datum/category_item/player_setup_item/general/equipment/proc/set_metadata(var/underwear_category, var/datum/gear_tweak/gt, var/new_metadata)
+/datum/category_item/player_setup_item/general/equipment/proc/get_backpack_metadata(var/decl/backpack_outfit/backpack_outfit, var/datum/backpack_tweak/bt)
+	var/metadata = pref.backpack_metadata[backpack_outfit.name]
+	if(!metadata)
+		metadata = list()
+		pref.backpack_metadata[backpack_outfit.name] = metadata
+
+	var/tweak_data = metadata["[bt]"]
+	if(!tweak_data)
+		tweak_data = bt.get_default_metadata()
+		metadata["[bt]"] = tweak_data
+	return tweak_data
+
+/datum/category_item/player_setup_item/general/equipment/proc/set_underwear_metadata(var/underwear_category, var/datum/gear_tweak/gt, var/new_metadata)
 	var/list/metadata = pref.all_underwear_metadata[underwear_category]
 	metadata["[gt]"] = new_metadata
 
+/datum/category_item/player_setup_item/general/equipment/proc/set_backpack_metadata(var/decl/backpack_outfit/backpack_outfit, var/datum/backpack_tweak/bt, var/new_metadata)
+	var/metadata = pref.backpack_metadata[backpack_outfit.name]
+	metadata["[bt]"] = new_metadata
+
 /datum/category_item/player_setup_item/general/equipment/OnTopic(var/href,var/list/href_list, var/mob/user)
-	if(href_list["change_backpack"])
-		var/new_backbag = input(user, "Choose your character's style of bag:", "Character Preference", backbaglist[pref.backbag]) as null|anything in backbaglist
-		if(!isnull(new_backbag) && CanUseTopic(user))
-			pref.backbag = backbaglist.Find(new_backbag)
-			return TOPIC_REFRESH_UPDATE_PREVIEW
-	else if(href_list["change_underwear"])
+	if(href_list["change_underwear"])
 		var/datum/category_group/underwear/UWC = GLOB.underwear.categories_by_name[href_list["change_underwear"]]
 		if(!UWC)
 			return TOPIC_NOACTION
@@ -99,9 +149,49 @@
 		var/datum/gear_tweak/gt = locate(href_list["tweak"])
 		if(!gt)
 			return TOPIC_NOACTION
-		var/new_metadata = gt.get_metadata(usr, get_metadata(underwear, gt))
+		var/new_metadata = gt.get_metadata(user, get_underwear_metadata(underwear, gt))
 		if(new_metadata)
-			set_metadata(underwear, gt, new_metadata)
+			set_underwear_metadata(underwear, gt, new_metadata)
+			return TOPIC_REFRESH_UPDATE_PREVIEW
+	else if(href_list["change_backpack"])
+		var/new_backpack = input(user, "Choose backpack style:", "Character Preference", pref.backpack) as null|anything in backpacks_by_name
+		if(!isnull(new_backpack) && CanUseTopic(user))
+			pref.backpack = backpacks_by_name[new_backpack]
+			return TOPIC_REFRESH_UPDATE_PREVIEW
+	else if(href_list["backpack"] && href_list["tweak"])
+		var/backpack_name = href_list["backpack"]
+		if(!(backpack_name in backpacks_by_name))
+			return TOPIC_NOACTION
+		var/decl/backpack_outfit/bo = backpacks_by_name[backpack_name]
+		var/datum/backpack_tweak/bt = locate(href_list["tweak"]) in bo.tweaks
+		if(!bt)
+			return TOPIC_NOACTION
+		var/new_metadata = bt.get_metadata(user, get_backpack_metadata(bo, bt))
+		if(new_metadata)
+			set_backpack_metadata(bo, bt, new_metadata)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	return ..()
+
+/datum/category_item/player_setup_item/general/equipment/update_setup(var/savefile/preferences, var/savefile/character)
+	if(preferences["version"]  <= 16)
+		var/list/old_index_to_backpack_type = list(
+			/decl/backpack_outfit/nothing,
+			/decl/backpack_outfit/backpack,
+			/decl/backpack_outfit/satchel,
+			/decl/backpack_outfit/messenger_bag,
+			/decl/backpack_outfit/satchel,
+			/decl/backpack_outfit/satchel,
+			/decl/backpack_outfit/pocketbook
+		)
+
+		var/old_index
+		from_file(character["backbag"], old_index)
+
+		if(old_index > 0 && old_index <= old_index_to_backpack_type.len)
+			pref.backpack = decls_repository.get_decl(old_index_to_backpack_type[old_index])
+		else
+			pref.backpack = get_default_outfit_backpack()
+
+		to_file(character["backpack"], pref.backpack.name)
+		return 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -283,9 +283,8 @@ datum/preferences
 				UW.ForceEquipUnderwear(character, FALSE)
 		else
 			all_underwear -= underwear_category_name
-	if(backbag > 7 || backbag < 1)
-		backbag = 1 //Same as above
-	character.backbag = backbag
+
+	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"])
 
 	for(var/N in character.organs_by_name)
 		var/obj/item/organ/external/O = character.organs_by_name[N]

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN	8
-#define SAVEFILE_VERSION_MAX	16
+#define SAVEFILE_VERSION_MAX	17
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)	return

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -36,7 +36,7 @@
 
 	var/list/worn_underwear = list()
 
-	var/backbag = 2		//Which backpack type the player has chosen. Nothing, Satchel or Backpack.
+	var/datum/backpack_setup/backpack_setup
 
 	// General information
 	var/home_system = ""

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -80,14 +80,16 @@
 
 /datum/species/vox/equip_survival_gear(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H), slot_r_hand)
-		H.internal = H.back
-	else
+
+	if(istype(H.get_equipped_item(slot_back), /obj/item/weapon/storage/backpack))
 		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_r_hand)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H.back), slot_in_backpack)
 		H.internal = H.r_hand
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_back)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H), slot_r_hand)
+		H.internal = H.back
+
 	if(H.internals)
 		H.internals.icon_state = "internal1"
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -215,12 +215,12 @@
 	return sanitizeName(name)
 
 /datum/species/proc/equip_survival_gear(var/mob/living/carbon/human/H,var/extendedtank = 1)
-	if(H.backbag == 1)
-		if (extendedtank)	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
-		else	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-	else
+	if(istype(H.get_equipped_item(slot_back), /obj/item/weapon/storage/backpack))
 		if (extendedtank)	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
 		else	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
+	else
+		if (extendedtank)	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
+		else	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -353,10 +353,10 @@
 	return 0
 
 /datum/species/diona/equip_survival_gear(var/mob/living/carbon/human/H)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/device/flashlight/flare(H), slot_r_hand)
-	else
+	if(istype(H.get_equipped_item(slot_back), /obj/item/weapon/storage/backpack))
 		H.equip_to_slot_or_del(new /obj/item/device/flashlight/flare(H.back), slot_in_backpack)
+	else
+		H.equip_to_slot_or_del(new /obj/item/device/flashlight/flare(H), slot_r_hand)
 
 /datum/species/diona/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.gender = NEUTER

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -27,7 +27,7 @@ datum/preferences
 				var/datum/category_item/underwear/WRI = pick(WRC.items)
 				all_underwear[WRC.name] = WRI.name
 
-		backbag = rand(1,5)
+		backpack = decls_repository.get_decl(pick(subtypesof(/decl/backpack_outfit)))
 		age = rand(current_species.min_age, current_species.max_age)
 		b_type = RANDOM_BLOOD_TYPE
 		if(H)

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -115,6 +115,25 @@
 		pass("All languages datums have unique keys.")
 	return 1
 
+/datum/unit_test/outfit_backpacks_shall_have_unique_names
+	name = "UNIQUENESS: Outfit Backpacks Shall Have Unique Names"
+
+/datum/unit_test/outfit_backpacks_shall_have_unique_names/start_test()
+	var/list/backpacks_by_name = list()
+
+	var/bos = decls_repository.get_decls_of_subtype(/decl/backpack_outfit)
+	for(var/bo in bos)
+		var/decl/backpack_outfit/backpack_outfit = bos[bo]
+		group_by(backpacks_by_name, backpack_outfit.name, backpack_outfit)
+
+	var/number_of_issues = number_of_issues(backpacks_by_name, "Outfit Backpack Names")
+	if(number_of_issues)
+		fail("[number_of_issues] outfit backpacks\s found.")
+	else
+		pass("All outfit backpacks have unique names.")
+	return 1
+
+
 /datum/unit_test/proc/number_of_issues(var/list/entries, var/type, var/feedback = /decl/noi_feedback)
 	var/issues = 0
 	for(var/key in entries)

--- a/html/changelogs/AutoChangeLog-pr-19590.yml
+++ b/html/changelogs/AutoChangeLog-pr-19590.yml
@@ -1,0 +1,4 @@
+author: "sabiram"
+delete-after: True
+changes: 
+  - rscadd: "Added a black pocketbook to the backpack selection."

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -50,11 +50,14 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	l_ear = /obj/item/device/radio/headset/heads/torchcaptain
 	shoes = /obj/item/clothing/shoes/dutyboots
 	head = /obj/item/clothing/head/soft/solgov/expedition/co
-	backpack = /obj/item/weapon/storage/backpack/captain
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_cap
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/com
 	id_type = /obj/item/weapon/card/id/torch/gold
 	pda_type = /obj/item/device/pda/captain
+
+/decl/hierarchy/outfit/job/torch/crew/command/CO/New()
+	..()
+	backpack_overrides[/decl/backpack_outfit/backpack] = /obj/item/weapon/storage/backpack/captain
+	backpack_overrides[/decl/backpack_outfit/satchel] = /obj/item/weapon/storage/backpack/satchel_cap
+	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/com
 
 /decl/hierarchy/outfit/job/torch/crew/command/XO
 	name = OUTFIT_JOB_NAME("Executive Officer")
@@ -91,9 +94,10 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	id_type = /obj/item/weapon/card/id/torch/silver/medical
 	pda_type = /obj/item/device/pda/heads/cmo
 	pda_slot = slot_l_store
-	backpack = /obj/item/weapon/storage/backpack/medic
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_med
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/med
+
+/decl/hierarchy/outfit/job/torch/crew/command/cmo/New()
+	..()
+	BACKPACK_OVERRIDE_MEDICAL
 
 /decl/hierarchy/outfit/job/torch/crew/command/cmo/fleet
 	name = OUTFIT_JOB_NAME("Chief Medical Officer - Fleet")
@@ -107,11 +111,12 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	l_ear = /obj/item/device/radio/headset/heads/ce
 	id_type = /obj/item/weapon/card/id/torch/silver/engineering
 	pda_type = /obj/item/device/pda/heads/ce
-	backpack = /obj/item/weapon/storage/backpack/industrial
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_eng
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
 	pda_slot = slot_l_store
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
+
+/decl/hierarchy/outfit/job/torch/crew/command/cos/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERING
 
 /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/fleet
 	name = OUTFIT_JOB_NAME("Chief Engineer - Fleet")
@@ -130,9 +135,10 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_type = /obj/item/weapon/card/id/torch/silver/security
 	pda_type = /obj/item/device/pda/heads/hos
-	backpack = /obj/item/weapon/storage/backpack/security
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_sec
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/sec
+
+/decl/hierarchy/outfit/job/torch/crew/command/cos/New()
+	..()
+	BACKPACK_OVERRIDE_SECURITY
 
 /decl/hierarchy/outfit/job/torch/crew/command/cos/fleet
 	name = OUTFIT_JOB_NAME("Chief of Security - Fleet")
@@ -202,11 +208,12 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/engineering
 	hierarchy_type = /decl/hierarchy/outfit/job/torch/crew/engineering
 	l_ear = /obj/item/device/radio/headset/headset_eng
-	backpack = /obj/item/weapon/storage/backpack/industrial
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_eng
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
 	pda_slot = slot_l_store
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
+
+/decl/hierarchy/outfit/job/torch/crew/engineering/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERING
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer
 	name = OUTFIT_JOB_NAME("Senior Engineer")
@@ -261,10 +268,11 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/security
 	hierarchy_type = /decl/hierarchy/outfit/job/torch/crew/security
 	l_ear = /obj/item/device/radio/headset/headset_sec
-	backpack = /obj/item/weapon/storage/backpack/security
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_sec
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/sec
 	pda_slot = slot_l_store
+
+/decl/hierarchy/outfit/job/torch/crew/security/New()
+	..()
+	BACKPACK_OVERRIDE_SECURITY
 
 /decl/hierarchy/outfit/job/torch/crew/security/brig_officer
 	name = OUTFIT_JOB_NAME("Brig Officer")
@@ -324,9 +332,10 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	l_ear = /obj/item/device/radio/headset/headset_med
 	pda_type = /obj/item/device/pda/medical
 	pda_slot = slot_l_store
-	backpack = /obj/item/weapon/storage/backpack/medic
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_med
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/med
+
+/decl/hierarchy/outfit/job/torch/crew/medical/New()
+	..()
+	BACKPACK_OVERRIDE_MEDICAL
 
 /decl/hierarchy/outfit/job/torch/crew/medical/senior
 	name = OUTFIT_JOB_NAME("Physician")
@@ -380,9 +389,10 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist
 	name = OUTFIT_JOB_NAME("Virologist - Torch")
 	uniform = /obj/item/clothing/under/rank/virologist
-	backpack = /obj/item/weapon/storage/backpack/virology
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_vir
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/viro
+
+/decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist/New()
+	..()
+	BACKPACK_OVERRIDE_VIROLOGY
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/paramedic
 	name = OUTFIT_JOB_NAME("Paramedic - Torch")
@@ -397,10 +407,11 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	name = OUTFIT_JOB_NAME("Chemist - Torch")
 	uniform = /obj/item/clothing/under/rank/chemist
 	shoes = /obj/item/clothing/shoes/white
-	backpack = /obj/item/weapon/storage/backpack/chemistry
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_chem
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/chem
 	pda_type = /obj/item/device/pda/chemist
+
+/decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist/New()
+	..()
+	BACKPACK_OVERRIDE_CHEMISTRY
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor
 	name = OUTFIT_JOB_NAME("Counselor")
@@ -431,9 +442,10 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 /decl/hierarchy/outfit/job/torch/crew/supply
 	l_ear = /obj/item/device/radio/headset/headset_cargo
 	hierarchy_type = /decl/hierarchy/outfit/job/torch/crew/supply
-	backpack = /obj/item/weapon/storage/backpack/industrial
-	satchel_job  = /obj/item/weapon/storage/backpack/satchel_eng
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
+
+/decl/hierarchy/outfit/job/torch/crew/supply/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERING
 
 /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer
 	name = OUTFIT_JOB_NAME("Deck Officer")
@@ -599,10 +611,11 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/science
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/device/pda/heads/rd
-	backpack = /obj/item/weapon/storage/backpack/toxins
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_tox
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/viro
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/senior_scientist
+
+/decl/hierarchy/outfit/job/torch/passenger/research/senior_scientist/New()
+	..()
+	BACKPACK_OVERRIDE_RESEARCH
 
 /decl/hierarchy/outfit/job/torch/passenger/research/nt_pilot //pending better uniform
 	name = OUTFIT_JOB_NAME("NanoTrasen Pilot")
@@ -616,10 +629,11 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/rank/scientist
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/device/pda/science
-	backpack = /obj/item/weapon/storage/backpack/toxins
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_tox
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/viro
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/scientist
+
+/decl/hierarchy/outfit/job/torch/passenger/research/scientist/New()
+	..()
+	BACKPACK_OVERRIDE_RESEARCH
 
 /decl/hierarchy/outfit/job/torch/passenger/research/scientist/psych
 	name = OUTFIT_JOB_NAME("Psychologist - Torch")
@@ -629,22 +643,24 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	name = OUTFIT_JOB_NAME("Prospector")
 	uniform = /obj/item/clothing/under/rank/ntwork
 	shoes = /obj/item/clothing/shoes/workboots
-	backpack = /obj/item/weapon/storage/backpack/industrial
-	satchel_job  = /obj/item/weapon/storage/backpack/satchel_eng
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/mining
 	pda_type = /obj/item/device/pda/shaftminer
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
+
+/decl/hierarchy/outfit/job/torch/passenger/research/prospector/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERING
 
 /decl/hierarchy/outfit/job/torch/passenger/research/guard
 	name = OUTFIT_JOB_NAME("Security Guard")
 	uniform = /obj/item/clothing/under/rank/guard
 	shoes = /obj/item/clothing/shoes/jackboots
-	backpack = /obj/item/weapon/storage/backpack/security
-	satchel_job = /obj/item/weapon/storage/backpack/satchel_sec
-	messenger_bag = /obj/item/weapon/storage/backpack/messenger/sec
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/guard
 	pda_type = /obj/item/device/pda/security
+
+/decl/hierarchy/outfit/job/torch/passenger/research/guard/New()
+	..()
+	BACKPACK_OVERRIDE_SECURITY
 
 /decl/hierarchy/outfit/job/torch/passenger/research/assist
 	name = OUTFIT_JOB_NAME("Research Assistant - Torch")

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -30,7 +30,7 @@ exactly 12 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 46 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 712 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 709 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 39 "text2path uses" 'text2path'
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -240,7 +240,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< 'fb76d4c788a0e8752a582bd0f20f2792 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '4bf1d009ebeee0b6745ea532b08df17d *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Simplifies the process of adding additional backpacks to character setup.
Similar to underwear and loadout gear additional tweaks can also be applied.

:cl:
tweak: Character Setup - Some backpacks now have additional setup options.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
