### PR TITLE
Malfunction tweaks

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -62,11 +62,10 @@
 	else
 		return
 
-	if(!ability_prechecks(user, price) || !ability_pay(user, price))
+	if(!ability_prechecks(user, price, TRUE) || !ability_pay(user, price))
 		return
 
 	log_ability_use(user, "basic encryption hack", A, 0)	// Does not notify admins, but it's still logged for reference.
-	user.hacking = 1
 	to_chat(user, "Beginning APC system override...")
 	sleep(300)
 	to_chat(user, "APC hack completed. Uploading modified operation software..")
@@ -76,12 +75,11 @@
 	if(A)
 		A.ai_hack(user)
 		if(A.hacker == user)
-			to_chat(user, "Hack successful. You now have full control over the APC.")
+			to_chat(user, "Hack successful. You now have full control over \the [A].")
 		else
 			to_chat(user, "<span class='notice'>Hack failed. Connection to APC has been lost. Please verify wire connection and try again.</span>")
 	else
 		to_chat(user, "<span class='notice'>Hack failed. Unable to locate APC. Please verify the APC still exists.</span>")
-	user.hacking = 0
 
 
 /datum/game_mode/malfunction/verb/advanced_encryption_hack()
@@ -94,12 +92,17 @@
 	if(!ability_prechecks(user, price))
 		return
 
-	var/title = input("Select message title: ")
-	var/text = input("Select message text: ")
+	if(user.last_failed_malf_title || user.last_failed_malf_message)
+		if (alert(user, "Your last hack attempt with title '[user.last_failed_malf_title]' has failed. Try again?", "Retransmission", "Yes", "No") != "Yes")
+			user.last_failed_malf_title = null
+			user.last_failed_malf_message = null
+
+	var/title = user.last_failed_malf_title ? user.last_failed_malf_title : sanitize(input("Select message title: "))
+	var/text = user.last_failed_malf_message ? user.last_failed_malf_message : sanitize(input("Select message text: "))
+
 	if(!title || !text || !ability_pay(user, price))
 		to_chat(user, "Hack Aborted")
 		return
-
 	log_ability_use(user, "advanced encryption hack")
 
 	if(prob(60) && user.hack_can_fail)
@@ -108,8 +111,10 @@
 			user.hack_fails ++
 			announce_hack_failure(user, "quantum message relay")
 			log_ability_use(user, "elite encryption hack (CRITFAIL - title: [title])")
-			return
-		log_ability_use(user, "elite encryption hack (FAIL - title: [title])")
+		else
+			log_ability_use(user, "elite encryption hack (FAIL - title: [title])")
+		user.last_failed_malf_message = text
+		user.last_failed_malf_title = title
 		return
 	log_ability_use(user, "elite encryption hack (SUCCESS - title: [title])")
 	command_announcement.Announce(text, title)
@@ -185,7 +190,6 @@
 
 	to_chat(user, "## BEGINNING SYSTEM OVERRIDE.")
 	to_chat(user, "## ESTIMATED DURATION: [round((duration+300)/600)] MINUTES")
-	user.hacking = 1
 	user.system_override = 1
 	// Now actually begin the hack. Each APC takes 10 seconds.
 	for(var/obj/machinery/power/apc/A in shuffle(remaining_apcs))
@@ -211,6 +215,5 @@
 	if(user.hack_can_fail)
 		command_announcement.Announce("Our system administrators just reported that we've been locked out from your control network. Whoever did this now has full access to [GLOB.using_map.station_name]'s systems.", "Network Administration Center")
 	user.hack_can_fail = 0
-	user.hacking = 0
 	user.system_override = 2
 	user.verbs += new/datum/game_mode/malfunction/verb/ai_destroy_station()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -95,6 +95,8 @@ var/list/ai_verbs_default = list(
 	var/uncardable = 0							// Whether the AI can be carded when malfunctioning.
 	var/hacked_apcs_hidden = 0					// Whether the hacked APCs belonging to this AI are hidden, reduces CPU generation from APCs.
 	var/intercepts_communication = 0			// Whether the AI intercepts fax and emergency transmission communications.
+	var/last_failed_malf_message = null
+	var/last_failed_malf_title = null
 
 	var/datum/ai_icon/selected_sprite			// The selected icon set
 	var/carded


### PR DESCRIPTION
- Generally people seem to dislike (from what i hear) that malf AI's progression is quite slow due to research and tedious APC hacking. This should speed up the research in mid and late game phases considerably. A bonus tweak that allows you to repeat a fake announcement hack if it fails is included.
:cl:
tweak: AI can now hack multiple APCs at once, assuming it has enough CPU power to begin the hack. AI can use abilities while hacking an APC (the hacking task has been completely isolated)
tweak: AI can now use its abilities during system override. On torch the override takes quite a long time due to larger amount of APCs, and during this period the AI is otherwise very vulnerable.
tweak: Failed advanced encryption hack now offers you to retry the hack without having to copy-paste/write the message again. This should make the ability a bit more comfortable to use.
/:cl: