### PR TITLE
Mech buffs.

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -4,7 +4,7 @@
 	icon_state = "durand"
 	initial_icon = "durand"
 	step_in = 4
-	health = 400
+	health = 600
 	deflect_chance = 20
 	damage_absorption = list("brute"=0.5,"fire"=1.1,"bullet"=0.65,"laser"=0.85,"energy"=0.9,"bomb"=0.8)
 	max_temperature = 30000

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1,7 +1,7 @@
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	name = "hydraulic clamp"
 	icon_state = "mecha_clamp"
-	equip_cooldown = 15
+	equip_cooldown = 5
 	energy_drain = 1 KILOWATTS
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
@@ -74,7 +74,7 @@
 	name = "drill"
 	desc = "This is the drill that'll pierce the heavens! (Can be attached to: Combat and Engineering Exosuits)"
 	icon_state = "mecha_drill"
-	equip_cooldown = 30
+	equip_cooldown = 15
 	energy_drain = 10
 	force = 15
 	required_type = list(/obj/mecha/working/ripley, /obj/mecha/combat)
@@ -131,7 +131,7 @@
 	desc = "This is an upgraded version of the drill that'll pierce the heavens! (Can be attached to: Combat and Engineering Exosuits)"
 	icon_state = "mecha_diamond_drill"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	equip_cooldown = 20
+	equip_cooldown = 5
 	force = 15
 
 	action(atom/target)
@@ -185,9 +185,9 @@
 	energy_drain = 0
 	range = MELEE|RANGED
 	required_type = /obj/mecha/working
-	var/spray_particles = 5
-	var/spray_amount = 5	//units of liquid per particle. 5 is enough to wet the floor - it's a big fire extinguisher, so should be fine
-	var/max_water = 1000
+	var/spray_particles = 6
+	var/spray_amount = 50	//units of liquid per particle. 5 is enough to wet the floor - it's a big fire extinguisher, so should be fine
+	var/max_water = 30000
 
 	New()
 		create_reagents(max_water)
@@ -1148,7 +1148,7 @@
 	var/turf/old_turf
 	var/obj/structure/cable/last_piece
 	var/obj/item/stack/cable_coil/cable
-	var/max_cable = 1000
+	var/max_cable = 10000
 	required_type = /obj/mecha/working
 
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer/New()

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -3,7 +3,7 @@
 	name = "Odysseus"
 	icon_state = "odysseus"
 	initial_icon = "odysseus"
-	step_in = 2
+	step_in = 1
 	max_temperature = 15000
 	health = 120
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -3,7 +3,7 @@
 	name = "Odysseus"
 	icon_state = "odysseus"
 	initial_icon = "odysseus"
-	step_in = 1
+	step_in = 2
 	max_temperature = 15000
 	health = 120
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -4,14 +4,14 @@
 	icon_state = "engineering_pod"
 	initial_icon = "engineering_pod"
 	internal_damage_threshold = 80
-	step_in = 4
+	step_in = 1
 	step_energy_drain = 400
 	max_temperature = 20000
 	health = 150
 	infra_luminosity = 6
 	wreckage = /obj/effect/decal/mecha_wreckage/hoverpod
-	cargo_capacity = 5
-	max_equip = 3
+	cargo_capacity = 7
+	max_equip = 4
 	var/datum/effect/effect/system/trail/ion_trail
 	var/stabilization_enabled = 1
 

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -4,7 +4,7 @@
 	icon_state = "engineering_pod"
 	initial_icon = "engineering_pod"
 	internal_damage_threshold = 80
-	step_in = 1
+	step_in = 2
 	step_energy_drain = 400
 	max_temperature = 20000
 	health = 150

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -3,7 +3,8 @@
 	name = "APLU \"Ripley\""
 	icon_state = "ripley"
 	initial_icon = "ripley"
-	step_in = 6
+	step_in = 4
+	lights_power = 15
 	max_temperature = 20000
 	health = 200
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
@@ -27,6 +28,7 @@
 	max_temperature = 65000
 	health = 250
 	lights_power = 8
+	step_in = 3
 	damage_absorption = list("fire"=0.5,"bullet"=0.8,"bomb"=0.5)
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/firefighter
 


### PR DESCRIPTION
🆑 
tweak: Increased the Durand's base health by 50%
tweak: tripled the hydraulic clamp's usage speed.
tweak: Doubled the basic mech drill's mining speed.
tweak: Increased the diamond mining drill's mining speed by 75%
tweak: The Mech-mounted fire extinguisher now holds 30x as much water, sprays 10x as much water per use, and dispenses one more
tweak: Mech cable layer carries 10x as much cable.
tweak: Doubled the movement speed of the odysseus to account for difficulties navigating the torch.
tweak: Made the hoverpod move 50% faster, carry two more cargo at maximum. Can now equip 4 pieces of equipment, up from 3.
tweak: APLU "Ripley" moves 33% faster.
/ 🆑 