### PR TITLE
Internationalise some ranks

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -592,8 +592,8 @@ ranks - marines
 	icon_state = "marinerank_officer"
 
 /obj/item/clothing/accessory/solgov/rank/marine/officer/o2
-	name = "ranks (O-2 lieutenant)"
-	desc = "Insignia denoting the rank of Lieutenant."
+	name = "ranks (O-2 first lieutenant)"
+	desc = "Insignia denoting the rank of First Lieutenant."
 
 /obj/item/clothing/accessory/solgov/rank/marine/officer/o3
 	name = "ranks (O-3 captain)"

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -487,8 +487,8 @@ ranks - fleet
 	desc = "Insignia denoting the elusive rank of Warrant Officer. Too bad it's obviously fake."
 
 /obj/item/clothing/accessory/solgov/rank/fleet/officer/o2
-	name = "ranks (O-2 lieutenant junior grade)"
-	desc = "Insignia denoting the rank of Lieutenant Junior Grade."
+	name = "ranks (O-2 sub-lieutenant)"
+	desc = "Insignia denoting the rank of Sub-lieutenant."
 
 /obj/item/clothing/accessory/solgov/rank/fleet/officer/o3
 	name = "ranks (O-3 lieutenant)"
@@ -508,13 +508,13 @@ ranks - fleet
 	icon_state = "fleetrank_command"
 
 /obj/item/clothing/accessory/solgov/rank/fleet/flag
-	name = "ranks (O-7 rear admiral lower half)"
-	desc = "Insignia denoting the rank of Rear Admiral Lower Half."
+	name = "ranks (O-7 commodore)"
+	desc = "Insignia denoting the rank of Commodore."
 	icon_state = "fleetrank_command"
 
 /obj/item/clothing/accessory/solgov/rank/fleet/flag/o8
-	name = "ranks (O-8 rear admiral upper half)"
-	desc = "Insignia denoting the rank of Rear Admiral Upper Half."
+	name = "ranks (O-8 rear admiral)"
+	desc = "Insignia denoting the rank of Rear Admiral."
 
 /obj/item/clothing/accessory/solgov/rank/fleet/flag/o9
 	name = "ranks (O-9 vice admiral)"
@@ -592,8 +592,8 @@ ranks - marines
 	icon_state = "marinerank_officer"
 
 /obj/item/clothing/accessory/solgov/rank/marine/officer/o2
-	name = "ranks (O-2 first lieutenant)"
-	desc = "Insignia denoting the rank of First Lieutenant."
+	name = "ranks (O-2 lieutenant)"
+	desc = "Insignia denoting the rank of Lieutenant."
 
 /obj/item/clothing/accessory/solgov/rank/marine/officer/o3
 	name = "ranks (O-3 captain)"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -569,19 +569,19 @@
 
 /datum/mil_rank/marine/o1
 	name = "Second Lieutenant"
-	name_short = "2ndLt"
+	name_short = "2Lt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine/officer)
 	sort_order = 11
 
 /datum/mil_rank/marine/o2
-	name = "Lieutenant"
-	name_short = "Lt"
+	name = "First Lieutenant"
+	name_short = "1Lt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine/officer/o2)
 	sort_order = 12
 
 /datum/mil_rank/marine/o3
 	name = "Captain"
-	name_short = "Capt"
+	name_short = "Cpt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine/officer/o3)
 	sort_order = 13
 

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -348,8 +348,8 @@
 	sort_order = 11
 
 /datum/mil_rank/fleet/o2
-	name = "Lieutenant (junior grade)"
-	name_short = "LTJG"
+	name = "Sub-lieutenant"
+	name_short = "SLT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 12
 
@@ -378,8 +378,8 @@
 	sort_order = 16
 
 /datum/mil_rank/fleet/o7
-	name = "Rear Admiral (lower half)"
-	name_short = "RDML"
+	name = "Commodore"
+	name_short = "CDRE"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 17
 
@@ -574,8 +574,8 @@
 	sort_order = 11
 
 /datum/mil_rank/marine/o2
-	name = "First Lieutenant"
-	name_short = "1stLt"
+	name = "Lieutenant"
+	name_short = "Lt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine/officer/o2)
 	sort_order = 12
 


### PR DESCRIPTION
Lieutenant (junior grade) (a rank name so bad they had to parenthesise to explain what they meant) to Sub-lieutenant

The rear admiral's lower and upper halves have been combined into their true form, Rear Admiral - and Commodore has been resurrected to occupy the vacancy