### PR TITLE
Add player count limit configuration variable

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -158,6 +158,7 @@ var/list/gamemode_cache = list()
 	var/login_export_addr = null
 
 	var/enter_allowed = 1
+	var/player_limit = 0
 
 	var/use_irc_bot = 0
 	var/irc_bot_host = ""
@@ -724,6 +725,8 @@ var/list/gamemode_cache = list()
 					radiation_material_resistance_divisor = text2num(value)
 				if("radiation_lower_limit")
 					radiation_lower_limit = text2num(value)
+				if("player_limit")
+					player_limit = text2num(value)
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -123,6 +123,13 @@
 		qdel(src)
 		return
 
+	if(config.player_limit != 0)
+		if((GLOB.clients.len >= config.player_limit) && !(ckey in admin_datums))
+			alert(src,"This server is currently full and not accepting new connections.","Server Full","OK")
+			log_admin("[ckey] tried to join and was turned away due to the server being full (player_limit=[config.player_limit])")
+			qdel(src)
+			return
+
 	// Change the way they should download resources.
 	if(config.resource_urls && config.resource_urls.len)
 		src.preload_rsc = pick(config.resource_urls)


### PR DESCRIPTION
There's room to improve handling (not counting staff rather than just allowing staff to bypass) if desired, but this is a feature being implemented specifically to use on a second Baystation test server. Requested by @headswe.

Hi @Crushtoe.