### PR TITLE
Have outfits remove prior equipment by default

### DIFF
--- a/code/datums/outfits/_defines.dm
+++ b/code/datums/outfits/_defines.dm
@@ -1,3 +1,5 @@
-#define OUTFIT_HAS_JETPACK       1
-#define OUTFIT_HAS_BACKPACK      2
-#define OUTFIT_EXTENDED_SURVIVAL 4
+#define OUTFIT_NONE                   0x0000
+#define OUTFIT_HAS_JETPACK            0x0001
+#define OUTFIT_HAS_BACKPACK           0x0002
+#define OUTFIT_EXTENDED_SURVIVAL      0x0004
+#define OUTFIT_RESET_EQUIPMENT        0x0008

--- a/code/datums/outfits/misc.dm
+++ b/code/datums/outfits/misc.dm
@@ -6,7 +6,7 @@
 	uniform = /obj/item/clothing/under/color/grey
 	back = /obj/item/weapon/tank/jetpack/oxygen
 	mask = /obj/item/clothing/mask/breath
-	flags = OUTFIT_HAS_JETPACK
+	flags = OUTFIT_HAS_JETPACK|OUTFIT_RESET_EQUIPMENT
 
 /decl/hierarchy/outfit/soviet_soldier
 	name = "Soviet soldier"

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -51,7 +51,7 @@ var/list/outfits_decls_by_type_
 	var/id_pda_assignment
 
 	var/list/backpack_overrides
-	var/flags // Specific flags
+	var/flags = OUTFIT_RESET_EQUIPMENT
 
 /decl/hierarchy/outfit/New()
 	..()
@@ -63,7 +63,8 @@ var/list/outfits_decls_by_type_
 	dd_insertObjectList(outfits_decls_, src)
 
 /decl/hierarchy/outfit/proc/pre_equip(mob/living/carbon/human/H)
-	return
+	if(flags & OUTFIT_RESET_EQUIPMENT)
+		H.delete_inventory(TRUE)
 
 /decl/hierarchy/outfit/proc/post_equip(mob/living/carbon/human/H)
 	if(flags & OUTFIT_HAS_JETPACK)

--- a/code/datums/outfits/pirates.dm
+++ b/code/datums/outfits/pirates.dm
@@ -14,4 +14,4 @@
 	head = /obj/item/clothing/head/helmet/space
 	suit = /obj/item/clothing/suit/pirate
 	back = /obj/item/weapon/tank/jetpack/oxygen
-	flags = OUTFIT_HAS_JETPACK
+	flags = OUTFIT_HAS_JETPACK|OUTFIT_RESET_EQUIPMENT

--- a/code/datums/outfits/spec_op.dm
+++ b/code/datums/outfits/spec_op.dm
@@ -22,7 +22,7 @@
 	back = /obj/item/weapon/tank/jetpack/oxygen
 	mask = /obj/item/clothing/mask/gas/swat
 
-	flags = OUTFIT_HAS_JETPACK
+	flags = OUTFIT_HAS_JETPACK|OUTFIT_RESET_EQUIPMENT
 
 /decl/hierarchy/outfit/ert
 	name = "Spec ops - Emergency response team"
@@ -66,4 +66,4 @@
 	id_type = /obj/item/weapon/card/id/syndicate
 	id_pda_assignment = "Mercenary"
 
-	flags = OUTFIT_HAS_BACKPACK
+	flags = OUTFIT_HAS_BACKPACK|OUTFIT_RESET_EQUIPMENT

--- a/code/datums/outfits/wizardry.dm
+++ b/code/datums/outfits/wizardry.dm
@@ -8,7 +8,7 @@
 	back = /obj/item/weapon/storage/backpack
 	backpack_contents = list(/obj/item/weapon/storage/box = 1)
 	hierarchy_type = /decl/hierarchy/outfit/wizard
-	flags = OUTFIT_HAS_BACKPACK
+	flags = OUTFIT_HAS_BACKPACK|OUTFIT_RESET_EQUIPMENT
 
 /decl/hierarchy/outfit/wizard/blue
 	name = "Wizard - Blue"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -398,8 +398,12 @@
 	if(!outfit)
 		return
 
+	var/reset_equipment = (outfit.flags&OUTFIT_RESET_EQUIPMENT)
+	if(!reset_equipment)
+		reset_equipment = alert("Do you wish to delete all current equipment first?", "Delete Equipment?","Yes", "No") == "Yes"
+
 	feedback_add_details("admin_verb","SEQ")
-	dressup_human(H, outfit)
+	dressup_human(H, outfit, reset_equipment)
 
 /proc/dressup_human(var/mob/living/carbon/human/H, var/decl/hierarchy/outfit/outfit, var/undress = TRUE)
 	if(!H || !outfit)


### PR DESCRIPTION
Job outfits will still function as before, and not delete any pre-existing gear.
Fixes #19704

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
