### PR TITLE
Changed flags so that they can be placed on any terrain/turf

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -237,19 +237,22 @@
 /obj/item/stack/flag/attack_self(var/mob/user)
 	var/turf/T = get_turf(src)
 
-	if(!istype(T, /turf/simulated/floor/asteroid) && !istype(T, /turf/simulated/floor/exoplanet))
-		to_chat(user, "The flag won't stand up in this terrain.")
+	if(istype(T, /turf/space) || istype(T, /turf/simulated/open))
+		to_chat(user, "<span class='warning'>There's no solid surface to plant the flag on.</span>")
 		return
 
 	for(var/obj/item/stack/flag/F in T)
 		if(F.upright)
-			to_chat(user, "\The [F] is already planted here.")
+			to_chat(user, "<span class='warning'>\The [F] is already planted here.</span>")
 			return
 
 	if(use(1)) // Don't skip use() checks even if you only need one! Stacks with the amount of 0 are possible, e.g. on synthetics!
 		var/obj/item/stack/flag/newflag = new src.type(T, 1)
 		newflag.set_up()
-		user.visible_message("\The [user] plants \the [newflag.singular_name] firmly in the ground.")
+		if(istype(T, /turf/simulated/floor/asteroid) || istype(T, /turf/simulated/floor/exoplanet))
+			user.visible_message("\The [user] plants \the [newflag.singular_name] firmly in the ground.")
+		else
+			user.visible_message("\The [user] attaches \the [newflag.singular_name] firmly to the ground.")
 
 /obj/item/stack/flag/proc/set_up()
 	pixel_x = 0


### PR DESCRIPTION
🆑 dryerlint
tweak: Flags can now be placed on any terrain/turf, except for space
/🆑

Right now, flags can only be planted on exoplanets (which are disabled) and asteroids. This makes them rather useless for most away missions, like the derelict station, the Bearcat, the marooned officer, the casino ship, etc.

Yeah, I guess it doesn't really make much sense that you can attach a flag to metal flooring, but let's just assume it's got a magnetic or adhesive surface on the bottom.