### PR TITLE
Atmospheric pumps can be toggled by alt clicking

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -161,6 +161,9 @@
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))
 	return 1
 
+/obj/machinery/atmospherics/binary/pump/AIAltClick()
+	return AltClick()
+
 /atom/proc/AIMiddleClick(var/mob/living/silicon/user)
 	return 0
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -147,6 +147,9 @@
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()
 
+/obj/machinery/atmospherics/binary/pump/BorgAltClick()
+	return AltClick()
+
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -39,6 +39,9 @@ Thus, the two variables affect pump operation are set in New():
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP
 
+/obj/machinery/atmospherics/binary/pump/AltClick()
+	Topic(src, list("power" = "1"))
+
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"
 	use_power = 1


### PR DESCRIPTION
:cl: Hubblenaut
rscadd: Atmospheric pumps can be toggled by alt clicking.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
