### PR TITLE
Change mounted flasher and flash rounds effects

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -83,7 +83,7 @@
 			var/mob/living/carbon/human/H = O
 			if(!H.eyecheck() <= 0)
 				continue
-			flash_time *= H.species.flash_mod
+			flash_time = round(H.species.flash_mod * flash_time)
 			var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]
 			if(!E)
 				return
@@ -94,7 +94,10 @@
 			if(!O.blinded && isliving(O))
 				var/mob/living/L = O
 				L.flash_eyes()
-		O.Weaken(flash_time)
+		O.flash_eyes()
+		O.confused += (flash_time + 2)
+		O.Stun(flash_time / 2)
+		O.Weaken(3)
 
 /obj/machinery/flasher/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -12,10 +12,10 @@
 	icon_state = "bullet"
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	damage = 5
-	agony = 10
+	agony = 20
 	kill_count = 15 //if the shell hasn't hit anything after travelling this far it just explodes.
 	muzzle_type = /obj/effect/projectile/bullet/muzzle
-	var/flash_range = 0
+	var/flash_range = 1
 	var/brightness = 7
 	var/light_colour = "#ffffff"
 
@@ -23,10 +23,12 @@
 	var/turf/T = flash_range? src.loc : get_turf(A)
 	if(!istype(T)) return
 
-	//blind adjacent people
+	//blind and confuse adjacent people
 	for (var/mob/living/carbon/M in viewers(T, flash_range))
 		if(M.eyecheck() < FLASH_PROTECTION_MODERATE)
 			M.flash_eyes()
+			M.eye_blurry += (brightness / 2)
+			M.confused += (brightness / 2)
 
 	//snap pop
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)
@@ -39,9 +41,10 @@
 	new /obj/effect/decal/cleanable/ash(src.loc) //always use src.loc so that ash doesn't end up inside windows
 	new /obj/effect/effect/smoke/illumination(T, 5, brightness, brightness, light_colour)
 
-//blinds people like the flash round, but in a small area and can also be used for temporary illumination
+//blinds people like the flash round, but in a larger area and can also be used for temporary illumination
 /obj/item/projectile/energy/flash/flare
 	damage = 10
+	agony = 25
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
 	flash_range = 2
 	brightness = 15


### PR DESCRIPTION
:cl: sabiram
tweak: Mounted flash effect changed from 20 seconds of knock down to 6 seconds of knock down followed by a further 10 seconds of stun - a total of 16 seconds of useful disable - followed by a further 8 seconds of confusion.
tweak: Flash and flare cartridges now inflict more agony damage.
rscadd: Flash and flare cartridges now blur the vision and disorient those within their flash ranges - tiles adjacent to the explosion for flashes, and two tiles adjacent for flares.
/:cl: