### PR TITLE
Hides ID overlays on rolled down jumpsuits.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -758,7 +758,8 @@ BLIND     // can't see anything
 /obj/item/clothing/under/update_clothing_icon()
 	if (ismob(src.loc))
 		var/mob/M = src.loc
-		M.update_inv_w_uniform()
+		M.update_inv_w_uniform(0)
+		M.update_inv_wear_id()
 
 
 /obj/item/clothing/under/examine(mob/user)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -474,13 +474,13 @@ var/global/list/damage_icon_parts = list()
 		update_icons()
 
 /mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)
-	if(wear_id)
-		if(w_uniform && w_uniform:displays_id)
-			overlays_standing[ID_LAYER] = wear_id.get_mob_overlay(src,slot_wear_id_str)
-		else
-			overlays_standing[ID_LAYER]	= null
-	else
-		overlays_standing[ID_LAYER]	= null
+	var/image/id_overlay
+	if(wear_id && istype(w_uniform, /obj/item/clothing/under))
+		var/obj/item/clothing/under/U = w_uniform
+		if(U.displays_id && !U.rolled_down)
+			id_overlay = wear_id.get_mob_overlay(src,slot_wear_id_str)
+
+	overlays_standing[ID_LAYER]	= id_overlay
 
 	BITSET(hud_updateflag, ID_HUD)
 	BITSET(hud_updateflag, WANTED_HUD)


### PR DESCRIPTION
An ID grew arms and robusted me with a toolbox so I'm nerfing it as revenge.
🆑 mkalash
tweak: Spacemen no longer pin their IDs to their skin when they roll down their jumpsuits.
/:cl: