### PR TITLE
Add Ctrl+Alt+click shortcuts

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -27,6 +27,9 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["ctrl"] && modifiers["alt"])
+		CtrlAltClickOn(A)
+		return
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
@@ -89,6 +92,11 @@
 	for AI shift, ctrl, and alt clicking.
 */
 
+/mob/living/silicon/ai/CtrlAltClickOn(var/atom/A)
+	if(!control_disabled && A.AICtrlAltClick(src))
+		return
+	..()
+
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
 	if(!control_disabled && A.AIShiftClick(src))
 		return
@@ -113,6 +121,17 @@
 	The following criminally helpful code is just the previous code cleaned up;
 	I have no idea why it was in atoms.dm instead of respective files.
 */
+
+/atom/proc/AICtrlAltClick()
+
+/obj/machinery/door/airlock/AICtrlAltClick() // Electrifies doors.
+	if(!electrified_until)
+		// permanent shock
+		Topic(src, list("command"="electrify_permanently", "activate" = "1"))
+	else
+		// disable/6 is not in Topic; disable/5 disables both temporary and permanent shock
+		Topic(src, list("command"="electrify_permanently", "activate" = "0"))
+	return 1
 
 /atom/proc/AICtrlShiftClick()
 	return
@@ -147,15 +166,6 @@
 
 /atom/proc/AIAltClick(var/atom/A)
 	return AltClick(A)
-
-/obj/machinery/door/airlock/AIAltClick() // Electrifies doors.
-	if(!electrified_until)
-		// permanent shock
-		Topic(src, list("command"="electrify_permanently", "activate" = "1"))
-	else
-		// disable/6 is not in Topic; disable/5 disables both temporary and permanent shock
-		Topic(src, list("command"="electrify_permanently", "activate" = "0"))
-	return 1
 
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -48,6 +48,9 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return 1
+	if(modifiers["ctrl"] && modifiers["alt"])
+		CtrlAltClickOn(A)
+		return 1
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return 1
@@ -278,6 +281,16 @@
 	return
 
 /atom/proc/CtrlShiftClick(var/mob/user)
+	return
+
+/*
+	Control+Alt click
+*/
+/mob/proc/CtrlAltClickOn(var/atom/A)
+	A.CtrlAltClick(src)
+	return
+
+/atom/proc/CtrlAltClick(var/mob/user)
 	return
 
 /*

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -142,7 +142,7 @@
 	return
 
 /obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
-	AIAltClick()
+	AICtrlAltClick()
 
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -337,6 +337,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		return 0
 
+/obj/item/device/pda/proc/toggle_light()
+	if(can_use())
+		if(fon)
+			fon = 0
+			set_light(0)
+		else
+			fon = 1
+			set_light(f_lum)
+
 /obj/item/device/pda/GetAccess()
 	if(id)
 		return id.GetAccess()
@@ -639,12 +648,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 //MAIN FUNCTIONS===================================
 
 		if("Light")
-			if(fon)
-				fon = 0
-				set_light(0)
-			else
-				fon = 1
-				set_light(f_lum)
+			toggle_light()
 		if("Medical Scan")
 			if(scanmode == 1)
 				scanmode = 0
@@ -957,6 +961,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/AltClick()
 	if(Adjacent(usr))
 		verb_remove_id()
+
+/obj/item/device/pda/CtrlAltClick()
+	toggle_light()
 
 /obj/item/device/pda/proc/create_message(var/mob/living/U = usr, var/obj/item/device/pda/P, var/tap = 1)
 	if(!istype(P))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -521,6 +521,9 @@
 	else
 		return ..()
 
+/obj/structure/closet/CtrlAltClick(var/mob/user)
+	verb_toggleopen()
+
 /obj/structure/closet/emp_act(severity)
 	for(var/obj/O in src)
 		O.emp_act(severity)


### PR DESCRIPTION
:cl: sabiram
rscadd: Control+Alt clicking a PDA will now toggle the flashlight.
rscadd: Control+Alt clicking closets and lockers is now a shortcut to the toggle open verb.
tweak: AI door electrification shortcut moved from Alt-click to Control-Alt-click to remove conflict with Alt-click inspecting the turf.
/:cl: