### PR TITLE
Adds a bunch of research designs to RnD

### DIFF
--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -136,6 +136,7 @@
 	desc = "A magnetic clamp which can halt the flow of gas in a pipe, via a localised stasis field."
 	icon = 'icons/atmos/clamp.dmi'
 	icon_state = "pclamp0"
+	origin_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 4)
 
 /obj/item/clamp/afterattack(var/atom/A, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -195,5 +195,6 @@
 	name = "advanced flash"
 	desc = "A device that produces a very bright flash of light. This is an advanced and expensive version often issued to VIPs."
 	icon_state = "advflash"
+	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	str_min = 3
 	str_max = 8

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -451,6 +451,7 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 	name = "price scanner"
 	desc = "Using an up-to-date database of various costs and prices, this device estimates the market price of an item up to 0.001% accuracy."
 	icon_state = "price_scanner"
+	origin_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 4)
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
@@ -473,7 +474,7 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 	item_state = "analyzer"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL
-	origin_tech = list(TECH_BIO = 1)
+	origin_tech = list(TECH_MAGNET = 1, TECH_BIO = 1)
 	flags = CONDUCT
 	matter = list(DEFAULT_WALL_MATERIAL = 30,"glass" = 20)
 

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -14,9 +14,17 @@
 /obj/item/weapon/implantcase/New()
 	if(ispath(imp))
 		imp = new imp(src)
-		desc = "A case containing \a [imp]."
+		update_description()
 	..()
 	update_icon()
+
+/obj/item/weapon/implantcase/proc/update_description()
+	if (imp)
+		desc = "A case containing \a [imp]."
+		origin_tech = imp.origin_tech
+	else
+		desc = "A case for implants."
+		origin_tech.Cut()
 
 /obj/item/weapon/implantcase/update_icon()
 	if (imp)
@@ -52,12 +60,14 @@
 			imp.forceMove(M)
 			M.imp = src.imp
 			imp = null
+		update_description()
 		update_icon()
 		M.update_icon()
 	else if (istype(I, /obj/item/weapon/implant))
 		to_chat(usr, "<span class='notice'>You slide \the [I] into \the [src].</span>")
 		user.drop_from_inventory(I,src)
 		imp = I
+		update_description()
 		update_icon()
 	else
 		return ..()

--- a/code/game/objects/items/weapons/implants/implants/adrenaline.dm
+++ b/code/game/objects/items/weapons/implants/implants/adrenaline.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/adrenalin
 	name = "adrenalin"
 	desc = "Removes all stuns and knockdowns."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 2)
 	var/uses
 
 /obj/item/weapon/implant/adrenalin/get_data()

--- a/code/game/objects/items/weapons/implants/implants/chem.dm
+++ b/code/game/objects/items/weapons/implants/implants/chem.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/chem
 	name = "chemical implant"
 	desc = "Injects things."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2)
 	known = 1
 
 /obj/item/weapon/implant/chem/get_data()

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -2,6 +2,7 @@
 	name = "compressed matter implant"
 	desc = "Based on compressed matter technology, can store a single item."
 	icon_state = "implant_evil"
+	origin_tech = list(TECH_MATERIAL = 4, TECH_BIO = 2, TECH_ILLEGAL = 2)
 	var/activation_emote
 	var/obj/item/scanned
 

--- a/code/game/objects/items/weapons/implants/implants/death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implants/death_alarm.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/death_alarm
 	name = "death alarm implant"
 	desc = "An alarm which monitors host vital signs and transmits a radio message upon death."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_DATA = 1)
 	known = 1
 	var/mobname = "Will Robinson"
 

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -3,6 +3,7 @@
 	name = "explosive implant"
 	desc = "A military grade micro bio-explosive. Highly dangerous."
 	icon_state = "implant_evil"
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
 	var/elevel
 	var/phrase
 	var/code = 13

--- a/code/game/objects/items/weapons/implants/implants/freedom.dm
+++ b/code/game/objects/items/weapons/implants/implants/freedom.dm
@@ -3,6 +3,7 @@
 /obj/item/weapon/implant/freedom
 	name = "freedom implant"
 	desc = "Use this to escape from those evil Red Shirts."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 2)
 	implant_color = "r"
 	var/activation_emote
 	var/uses

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/imprinting
 	name = "imprinting implant"
 	desc = "Latest word in training your peons."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_DATA = 3)
 	var/list/instructions = list("Do your job.", "Respect your superiours.", "Wash you hands after using the toilet.")
 	var/brainwashing = 0
 	var/last_reminder
@@ -59,7 +60,7 @@
 	return TRUE
 
 /obj/item/weapon/implant/imprinting/Process()
-	if(world.time < last_reminder + 5 MINUTES) 
+	if(world.time < last_reminder + 5 MINUTES)
 		return
 	last_reminder = world.time
 	var/instruction = pick(instructions)

--- a/code/game/objects/items/weapons/implants/implants/loyalty.dm
+++ b/code/game/objects/items/weapons/implants/implants/loyalty.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/loyalty
 	name = "loyalty implant"
 	desc = "Makes you loyal or such."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
 	known = 1
 
 /obj/item/weapon/implant/loyalty/get_data()

--- a/code/game/objects/items/weapons/implants/implants/tracking.dm
+++ b/code/game/objects/items/weapons/implants/implants/tracking.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/tracking
 	name = "tracking implant"
 	desc = "Track with this."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_BLUESPACE = 2)
 	known = 1
 	var/id = 1
 

--- a/code/game/objects/items/weapons/implants/implants/uplink.dm
+++ b/code/game/objects/items/weapons/implants/implants/uplink.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/implant/uplink
 	name = "uplink"
 	desc = "Summon things."
+	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
 	var/activation_emote
 
 /obj/item/weapon/implant/uplink/New()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -122,7 +122,7 @@
 	name = "tactical goggles"
 	desc = "Self-polarizing goggles with light amplification for dark environments. Made from durable synthetic."
 	icon_state = "swatgoggles"
-	origin_tech = list(TECH_MAGNET = 2)
+	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 4)
 	darkness_view = 5
 	action_button_name = "Toggle Goggles"
 	toggleable = 1

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -12,6 +12,7 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "smes_coil"			// Just few icons patched together. If someone wants to make better icon, feel free to do so!
 	w_class = ITEM_SIZE_LARGE							// It's LARGE (backpack size)
+	origin_tech = list(TECH_MATERIAL = 7, TECH_POWER = 7, TECH_ENGINEERING = 5)
 	var/ChargeCapacity = 50 KILOWATTS
 	var/IOCapacity = 250 KILOWATTS
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -113,6 +113,7 @@ obj/item/weapon/gun/energy/retro
 	icon_state = "oldxray"
 	item_state = "oldxray"
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ILLEGAL = 2)
 	projectile_type = /obj/item/projectile/beam/xray
 	one_hand_penalty = 1
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -117,6 +117,7 @@
 	name = "mind flayer"
 	desc = "A custom-built weapon of some kind."
 	icon_state = "xray"
+	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 4)
 	projectile_type = /obj/item/projectile/beam/mindflayer
 
 /obj/item/weapon/gun/energy/toxgun

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -3,6 +3,7 @@
 	desc = "A bulky pump-action grenade launcher. Holds up to 6 grenades in a revolving magazine."
 	icon_state = "riotgun"
 	item_state = "riotgun"
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 	w_class = ITEM_SIZE_HUGE
 	force = 10
 

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -3,6 +3,7 @@
 	desc = "A large gas-powered cannon."
 	icon_state = "pneumatic"
 	item_state = "pneumatic"
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_HUGE
 	flags =  CONDUCT

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "hypo"
 	icon_state = "hypo"
+	origin_tech = list(TECH_MATERIAL = 4, TECH_BIO = 5)
 	amount_per_transfer_from_this = 5
 	unacidable = 1
 	volume = 30
@@ -114,6 +115,7 @@
 	item_state = "autoinjector"
 	amount_per_transfer_from_this = 5
 	volume = 5
+	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
 	var/list/starts_with = list(/datum/reagent/inaprovaline = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/New()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -303,13 +303,33 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/clothing/glasses/hud/security
 	sort_string = "GAAAB"
 
-/datum/design/item/mesons
-	name = "Optical meson scanners design"
+/datum/design/item/optical/AssembleDesignName()
+	..()
+	name = "Optical glasses design ([item_name])"
+
+/datum/design/item/optical/mesons
+	name = "mesons"
 	desc = "Using the meson-scanning technology those glasses allow you to see through walls, floor or anything else."
 	id = "mesons"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 	build_path = /obj/item/clothing/glasses/meson
+	sort_string = "GBAAA"
+
+/datum/design/item/optical/material
+	name = "material"
+	id = "mesons_material"
+	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+	build_path = /obj/item/clothing/glasses/material
+	sort_string = "GAAAB"
+
+/datum/design/item/optical/tactical
+	name = "tactical"
+	id = "tactical_goggles"
+	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, "silver" = 50, "gold" = 50)
+	build_path = /obj/item/clothing/glasses/tacgoggles
 	sort_string = "GAAAC"
 
 /datum/design/item/mining/AssembleDesignName()
@@ -366,13 +386,21 @@ other types of metals and chemistry for reagents).
 	..()
 	name = "Biotech device prototype ([item_name])"
 
+/datum/design/item/medical/slime_scanner
+	desc = "Multipurpose organic life scanner."
+	id = "slime_scanner"
+	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 200, "glass" = 100)
+	build_path = /obj/item/device/slime_scanner
+	sort_string = "MACFA"
+
 /datum/design/item/medical/robot_scanner
 	desc = "A hand-held scanner able to diagnose robotic injuries."
 	id = "robot_scanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200)
 	build_path = /obj/item/device/robotanalyzer
-	sort_string = "MACFA"
+	sort_string = "MACFB"
 
 /datum/design/item/medical/mass_spectrometer
 	desc = "A device for analyzing chemicals in blood."
@@ -408,7 +436,15 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000)
 	build_path = /obj/item/stack/nanopaste
-	sort_string = "MBDAA"
+	sort_string = "MADAA"
+
+/datum/design/item/medical/hypospray
+	desc = "A sterile, air-needle autoinjector for rapid administration of drugs"
+	id = "hypospray"
+	req_tech = list(TECH_MATERIAL = 4, TECH_BIO = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, "glass" = 8000, "silver" = 2000)
+	build_path = /obj/item/weapon/reagent_containers/hypospray/vial
+	sort_string = "MAEAA"
 
 /datum/design/item/surgery/AssembleDesignName()
 	..()
@@ -485,12 +521,47 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/implantcase/chem
 	sort_string = "MFAAA"
 
+/datum/design/item/implant/death_alarm
+	name = "death alarm"
+	id = "implant_death"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 2)
+	build_path = /obj/item/weapon/implantcase/death_alarm
+	sort_string = "MFAAB"
+
+/datum/design/item/implant/tracking
+	name = "tracking"
+	id = "implant_tracking"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_BLUESPACE = 3)
+	build_path = /obj/item/weapon/implantcase/tracking
+	sort_string = "MFAAC"
+
+/datum/design/item/implant/imprinting
+	name = "imprinting"
+	id = "implant_imprinting"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 4)
+	build_path = /obj/item/weapon/implantcase/imprinting
+	sort_string = "MFAAD"
+
+/datum/design/item/implant/adrenaline
+	name = "adrenaline"
+	id = "implant_adrenaline"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ILLEGAL = 3)
+	build_path = /obj/item/weapon/implantcase/adrenalin
+	sort_string = "MFAAE"
+
 /datum/design/item/implant/freedom
 	name = "freedom"
 	id = "implant_free"
-	req_tech = list(TECH_ILLEGAL = 2, TECH_BIO = 3)
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ILLEGAL = 3)
 	build_path = /obj/item/weapon/implantcase/freedom
-	sort_string = "MFAAB"
+	sort_string = "MFAAF"
+
+/datum/design/item/implant/explosive
+	name = "explosive"
+	id = "implant_explosive"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ILLEGAL = 4)
+	build_path = /obj/item/weapon/implantcase/explosive
+	sort_string = "MFAAG"
 
 /datum/design/item/weapon/AssembleDesignName()
 	..()
@@ -533,6 +604,13 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/grenade/chem_grenade/large
 	sort_string = "TABAA"
 
+/datum/design/item/weapon/anti_photon
+	id = "anti_photon"
+	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 1000, "diamond" = 1000)
+	build_path = /obj/item/weapon/grenade/anti_photon
+	sort_string = "TABAB"
+
 /datum/design/item/weapon/flora_gun
 	id = "flora_gun"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
@@ -540,12 +618,26 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/gun/energy/floragun
 	sort_string = "TACAA"
 
+/datum/design/item/weapon/advancedflash
+	id = "advancedflash"
+	req_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000, "silver" = 500)
+	build_path = /obj/item/device/flash/advanced
+	sort_string = "TADAA"
+
 /datum/design/item/weapon/stunrevolver
 	id = "stunrevolver"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/weapon/gun/energy/stunrevolver
-	sort_string = "TADAA"
+	sort_string = "TADAB"
+
+/datum/design/item/weapon/stunrifle
+	id = "stun_rifle"
+	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 1000, "silver" = 500)
+	build_path = /obj/item/weapon/gun/energy/stunrevolver/rifle
+	sort_string = "TADAC"
 
 /datum/design/item/weapon/nuclear_gun
 	id = "nuclear_gun"
@@ -562,26 +654,89 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	sort_string = "TAEAB"
 
+/datum/design/item/weapon/xraypistol
+	id = "xraypistol"
+	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ILLEGAL = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 500, "uranium" = 500)
+	build_path = /obj/item/weapon/gun/energy/xray/pistol
+	sort_string = "TAFAA"
+
+/datum/design/item/weapon/xraypistol
+	id = "xrayrifle"
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ILLEGAL = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 1000)
+	build_path = /obj/item/weapon/gun/energy/xray
+	sort_string = "TAFAB"
+
+/datum/design/item/weapon/grenadelauncher
+	id = "grenadelauncher"
+	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
+	build_path = /obj/item/weapon/gun/launcher/grenade
+	sort_string = "TAGAA"
+
+/datum/design/item/weapon/pneumatic
+	id = "pneumatic"
+	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 2000, "silver" = 500)
+	build_path = /obj/item/weapon/gun/launcher/pneumatic
+	sort_string = "TAGAB"
+
+/datum/design/item/weapon/railgun
+	id = "railgun"
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, "gold" = 2000, "silver" = 2000)
+	build_path = /obj/item/weapon/gun/magnetic/railgun
+	sort_string = "TAHAA"
+
+/datum/design/item/weapon/flechette
+	id = "flechette"
+	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 4, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, "gold" = 4000, "silver" = 4000, "diamond" = 2000)
+	build_path = /obj/item/weapon/gun/magnetic/railgun/flechette
+	sort_string = "TAHAB"
+
 /datum/design/item/weapon/phoronpistol
 	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "phoron" = 3000)
 	build_path = /obj/item/weapon/gun/energy/toxgun
-	sort_string = "TAEAC"
+	sort_string = "TAJAA"
+
+/datum/design/item/weapon/mindflayer
+	id = "mindflayer"
+	req_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 1000)
+	build_path = /obj/item/weapon/gun/energy/mindflayer
+	sort_string = "TAJAB"
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
 	materials = list("gold" = 5000,"uranium" = 10000, "mutagen" = 40)
 	build_path = /obj/item/weapon/gun/energy/decloner
-	sort_string = "TAEAD"
+	sort_string = "TAJAC"
 
 /datum/design/item/weapon/smg
 	id = "smg"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 8000, "silver" = 2000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/projectile/automatic
-	sort_string = "TAFAA"
+	sort_string = "TAPAA"
+
+/datum/design/item/weapon/wt550
+	id = "wt550"
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, "silver" = 3000, "diamond" = 1500)
+	build_path = /obj/item/weapon/gun/projectile/automatic/wt550
+	sort_string = "TAPAB"
+
+/datum/design/item/weapon/bullpup
+	id = "bullpup"
+	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "silver" = 5000, "diamond" = 3000)
+	build_path = /obj/item/weapon/gun/projectile/automatic/z8
+	sort_string = "TAPAC"
 
 /datum/design/item/weapon/ammunition/AssembleDesignName()
 	..()
@@ -592,7 +747,7 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 3750, "silver" = 100)
 	build_path = /obj/item/ammo_magazine/box/c9mm
-	sort_string = "TAGAA"
+	sort_string = "TBAAA"
 
 /datum/design/item/weapon/ammunition/stunshell
 	desc = "A stunning shell for a shotgun."
@@ -600,7 +755,7 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/stunshell
-	sort_string = "TAGAB"
+	sort_string = "TBAAB"
 
 /datum/design/item/weapon/ammunition/ammo_emp_38
 	id = "ammo_emp_38"
@@ -608,7 +763,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 2500, "uranium" = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_magazine/box/emp
-	sort_string = "TAGAC"
+	sort_string = "TBAAC"
 
 /datum/design/item/weapon/ammunition/ammo_emp_45
 	id = "ammo_emp_45"
@@ -616,7 +771,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 2500, "uranium" = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_magazine/box/emp/c45
-	sort_string = "TAGAD"
+	sort_string = "TBAAD"
 
 /datum/design/item/weapon/ammunition/ammo_emp_10
 	id = "ammo_emp_10"
@@ -624,7 +779,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 2500, "uranium" = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_magazine/box/emp/a10mm
-	sort_string = "TAGAE"
+	sort_string = "TBAAE"
 
 /datum/design/item/weapon/ammunition/ammo_emp_slug
 	id = "ammo_emp_slug"
@@ -632,7 +787,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, "uranium" = 1000)
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_casing/shotgun/emp
-	sort_string = "TAGAF"
+	sort_string = "TBAAF"
 
 /datum/design/item/stock_part/subspace_ansible
 	id = "s-ansible"
@@ -776,15 +931,6 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/device/beacon_locator
 	sort_string = "VADAC"
 
-/datum/design/item/bluespace/bag_holding
-	name = "Bag of Holding"
-	desc = "Using localized pockets of bluespace this bag prototype offers incredible storage capacity with the contents weighting nothing. It's a shame the bag itself is pretty heavy."
-	id = "bag_holding"
-	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
-	materials = list("gold" = 3000, "diamond" = 1500, "uranium" = 250)
-	build_path = /obj/item/weapon/storage/backpack/holding
-	sort_string = "VAEAA"
-
 /datum/design/item/bluespace/ano_scanner
 	name = "Alden-Saraspova counter"
 	id = "ano_scanner"
@@ -792,7 +938,16 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000)
 	build_path = /obj/item/device/ano_scanner
-	sort_string = "VAGAA"
+	sort_string = "VAEAA"
+
+/datum/design/item/bluespace/bag_holding
+	name = "Bag of Holding"
+	desc = "Using localized pockets of bluespace this bag prototype offers incredible storage capacity with the contents weighting nothing. It's a shame the bag itself is pretty heavy."
+	id = "bag_holding"
+	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
+	materials = list("gold" = 3000, "diamond" = 1500, "uranium" = 250)
+	build_path = /obj/item/weapon/storage/backpack/holding
+	sort_string = "VAFAA"
 
 // tools
 
@@ -827,6 +982,24 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/crowbar/brace_jack
 	sort_string = "VAGAD"
 
+/datum/design/item/tool/clamp
+	name = "stasis clamp"
+	desc = "A magnetic clamp which can halt the flow of gas in a pipe, via a localised stasis field."
+	id = "stasis_clamp"
+	req_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500)
+	build_path = /obj/item/clamp
+	sort_string = "VAGAE"
+
+/datum/design/item/tool/price_scanner
+	name = "price scanner"
+	desc = "Using an up-to-date database of various costs and prices, this device estimates the market price of an item up to 0.001% accuracy."
+	id = "price_scanner"
+	req_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3000, "silver" = 250)
+	build_path = /obj/item/device/price_scanner
+	sort_string = "VAGAF"
+
 /datum/design/item/tool/experimental_welder
 	name = "experimental welding tool"
 	desc = "This welding tool feels heavier in your possession than is normal. There appears to be no external fuel port."
@@ -834,7 +1007,16 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_ENGINEERING = 5, TECH_PHORON = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 120, "glass" = 50)
 	build_path = /obj/item/weapon/weldingtool/experimental
-	sort_string = "VAGAE"
+	sort_string = "VAGAG"
+
+/datum/design/item/tool/shield_diffuser
+	name = "portable shield diffuser"
+	desc = "A small handheld device designed to disrupt energy barriers."
+	id = "portable_shield_diffuser"
+	req_tech = list(TECH_MAGNET = 5, TECH_POWER = 5, TECH_ILLEGAL = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 5000, "gold" = 2000, "silver" = 2000)
+	build_path = /obj/item/weapon/shield_diffuser
+	sort_string = "VAGAH"
 
 /datum/design/item/encryptionkey/AssembleDesignName()
 	..()
@@ -861,6 +1043,37 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500)
 	build_path = /obj/item/weapon/storage/backpack/chameleon/sydie_kit
 	sort_string = "VASBA"
+
+// Superconductive magnetic coils
+/datum/design/item/smes_coil/AssembleDesignName()
+	..()
+	name = "Superconductive magnetic coil ([item_name])"
+
+/datum/design/item/smes_coil
+	desc = "A superconductive magnetic coil used to store power in magnetic fields."
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000, "gold" = 1000, "silver" = 1000)
+
+/datum/design/item/smes_coil/standard
+	name = "standard"
+	id = "smes_coil_standard"
+	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 7, TECH_ENGINEERING = 5)
+	build_path = /obj/item/weapon/smes_coil
+	sort_string = "VAXAA"
+
+/datum/design/item/smes_coil/super_capacity
+	name = "capacitance"
+	id = "smes_coil_super_capacity"
+	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 8, TECH_ENGINEERING = 6)
+	build_path = /obj/item/weapon/smes_coil/super_capacity
+	sort_string = "VAXAB"
+
+/datum/design/item/smes_coil/super_io
+	name = "transmission"
+	id = "smes_coil_super_io"
+	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 8, TECH_ENGINEERING = 6)
+	build_path = /obj/item/weapon/smes_coil/super_io
+	sort_string = "VAXAC"
+
 
 // Modular computer components
 // Hard drives

--- a/code/modules/shield_generators/handheld_diffuser.dm
+++ b/code/modules/shield_generators/handheld_diffuser.dm
@@ -1,9 +1,10 @@
 /obj/item/weapon/shield_diffuser
 	name = "portable shield diffuser"
-	desc = "A small handheld device designed to disrupt energy barriers"
+	desc = "A small handheld device designed to disrupt energy barriers."
 	description_info = "This device disrupts shields on directly adjacent tiles (in a + shaped pattern), in a similar way the floor mounted variant does. It is, however, portable and run by an internal battery. Can be recharged with a regular recharger."
 	icon = 'icons/obj/machines/shielding.dmi'
 	icon_state = "hdiffuser_off"
+	origin_tech = list(TECH_MAGNET = 5, TECH_POWER = 5, TECH_ILLEGAL = 2)
 	var/obj/item/weapon/cell/device/cell
 	var/enabled = 0
 


### PR DESCRIPTION
Adds a whole bunch of items to RnD that previously were not craftable.

Implants, some more of the exotic weapons, glasses, scanners, smes coils and diverse other things.
Every item that was added to the list of designs does now also have origin tech levels if it previously had none. For the balance of tech levels and required materials I adhered to the already existing designs of similar type.

For the selection of the new designs I tried to exclude items that are already craftable at the autolathe, items that were simply too mundane to add (and perhaps should be added to the autolathe instead), items that would easily annoy a lot of people if research gained access to them almost every round (EMP grenades, explosives, this kind of stuff), and items that would probably do nothing else but bloat up the list because they are too similar to already existing designs.

Implant cases now gain the tech levels of the implants they hold.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
