### PR TITLE
Restricts humanish robolimbs to humanish species

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -67,7 +67,7 @@ var/datum/robolimb/basic_robolimb
 	icon = 'icons/mob/human_races/cyberlimbs/zenghu/zenghu_main.dmi'
 	can_eat = 1
 	unavailable_at_fab = 1
-	species_cannot_use = list(SPECIES_TAJARA)
+	restricted_to = list(SPECIES_HUMAN, SPECIES_IPC)
 
 /datum/robolimb/xion
 	company = "Xion"
@@ -134,4 +134,4 @@ var/datum/robolimb/basic_robolimb
 	can_eat = 1
 	skintone = 1
 	unavailable_at_fab = 1
-	species_cannot_use = list(SPECIES_TAJARA)
+	restricted_to = list(SPECIES_HUMAN)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
:cl:
tweak: Vey-Med prosthetics are now restricted to humans only. Zheng-Hu is now restricted to humans and IPCs.
/:cl: