### PR TITLE
Auto crew transfer vote now works during code red

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -324,7 +324,7 @@ datum/controller/vote
 							choices.Add("Add Antagonist")
 					else
 						var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-						if (security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level))
+						if (security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level) && !automatic)
 							to_chat(initiator_key, "The current alert status is too high to call for a crew transfer!")
 							return 0
 						if(ticker.current_state <= GAME_STATE_SETTING_UP)


### PR DESCRIPTION
https://baystation12.net/forums/threads/auto-crew-transfer-vote-now-works-during-code-red.5839/

Its been abused recently to the point where it cant be coincidence anymore. 

Multiple rounds have had the alert level switched to red minutes before the transfer is meant to start. And why are we giving a handful of players the ability to hold back the crew transfer vote anyways?