### PR TITLE
E-cigarettes update and overhaul

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -10,7 +10,7 @@ obj/machinery/recharger
 	idle_power_usage = 4
 	active_power_usage = 30 KILOWATTS
 	var/obj/item/charging = null
-	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/gun/magnetic/railgun, /obj/item/weapon/melee/baton, /obj/item/weapon/cell, /obj/item/modular_computer/, /obj/item/device/suit_sensor_jammer, /obj/item/weapon/computer_hardware/battery_module, /obj/item/weapon/shield_diffuser)
+	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/gun/magnetic/railgun, /obj/item/weapon/melee/baton, /obj/item/weapon/cell, /obj/item/modular_computer/, /obj/item/device/suit_sensor_jammer, /obj/item/weapon/computer_hardware/battery_module, /obj/item/weapon/shield_diffuser, /obj/item/clothing/mask/smokable/ecig)
 	var/icon_state_charged = "recharger2"
 	var/icon_state_charging = "recharger1"
 	var/icon_state_idle = "recharger0" //also when unpowered
@@ -109,6 +109,9 @@ obj/machinery/recharger/Process()
 		else if(istype(charging, /obj/item/weapon/gun/magnetic/railgun))
 			var/obj/item/weapon/gun/magnetic/railgun/RG = charging
 			cell = RG.cell
+		else if(istype(charging, /obj/item/clothing/mask/smokable/ecig))
+			var/obj/item/clothing/mask/smokable/ecig/CIG = charging
+			cell = CIG.cigcell
 
 		if(istype(cell, /obj/item/weapon/cell))
 			var/obj/item/weapon/cell/C = cell

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -79,11 +79,7 @@ obj/item/clothing/mask/smokable/ecig/deluxe/examine(mob/user)
 /obj/item/clothing/mask/smokable/ecig/Process()
 	if(idle >= idle_treshold) //idle too long -> automatic shut down
 		idle = 0
-		if(ishuman(loc))
-			var/mob/living/carbon/human/D = loc
-			to_chat(D,"<span class='notice'>\The [src] powered down automatically.</span>")
-		else
-			src.visible_message("<span class='notice'>\The [src] powered down automatically.</span>", null, 2)
+		src.visible_message("<span class='notice'>\The [src] powered down automatically.</span>", null, 2)
 		active=0//autodisable the cigarette
 		STOP_PROCESSING(SSobj, src)
 		update_icon()

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -36,6 +36,7 @@
 	icon_on = "ccigon"
 
 /obj/item/clothing/mask/smokable/ecig/simple/examine(mob/user)
+	..()
 	if(src.ec_cartridge)
 		to_chat(user,"<span class='notice'>There is roughly [round(ec_cartridge.reagents.total_volume / ec_cartridge.volume, 25)]% of liquid remaining.</span>")
 	else
@@ -55,6 +56,7 @@
 	color = pick(ecig_colors)
 
 obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
+	..()
 	if(src.ec_cartridge)
 		to_chat(user,"<span class='notice'>There are [round(ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.</span>")
 	else
@@ -71,6 +73,7 @@ obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
 	cell_type = /obj/item/weapon/cell/device/high //enough for four catridges
 
 obj/item/clothing/mask/smokable/ecig/deluxe/examine(mob/user)
+	..()
 	if(src.ec_cartridge)
 		to_chat(user,"<span class='notice'>There are [round(ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.</span>")
 	else

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -28,7 +28,7 @@
 	ec_cartridge = new cartridge_type(src)
 
 /obj/item/clothing/mask/smokable/ecig/simple
-	name = "\improper Lucky 1337 e-cig"
+	name = "cheap electronic cigarette"
 	desc = "A cheap Lucky 1337 electronic cigarette, styled like a traditional cigarette."
 	icon_state = "ccigoff"
 	icon_off = "ccigoff"
@@ -43,7 +43,7 @@
 		to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
 
 /obj/item/clothing/mask/smokable/ecig/util
-	name = "\improper ONI-55 e-cig"
+	name = "electronic cigarette"
 	desc = "A popular utilitarian model electronic cigarette, the ONI-55. Comes in a variety of colors."
 	icon_state = "ecigoff1"
 	icon_off = "ecigoff1"
@@ -64,7 +64,7 @@ obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
 	to_chat(user,"<span class='notice'>Gauge shows about [round(cigcell.percent(), 25)]% energy remaining</span>")
 
 /obj/item/clothing/mask/smokable/ecig/deluxe
-	name = "\improper eGavana MK3 e-cig"
+	name = "deluxe electronic cigarette"
 	desc = "A premium model eGavana MK3 electronic cigarette, shaped like a cigar."
 	icon_state = "pcigoff1"
 	icon_off = "pcigoff1"

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -26,38 +26,22 @@
 		cigcell = new cigcell(src)
 	ec_cartridge = new cartridge_type(src)
 
-/obj/item/clothing/mask/smokable/ecig/examine(mob/user)
-	. = ..()
-	if(istype(src, /obj/item/clothing/mask/smokable/ecig/simple))
-		if(ec_cartridge)
-			to_chat(user,"<span class='notice'>There are roughly [round(src.ec_cartridge.reagents.total_volume / src.ec_cartridge.volume, 25)]% of liquid remaining.</span>")
-		else
-			to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
-
-	else if(istype(src, /obj/item/clothing/mask/smokable/ecig/util))
-		if(ec_cartridge)
-			to_chat(user,"<span class='notice'>There are [round(src.ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.</span>")
-		else
-			to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
-		to_chat(user,"<span class='notice'>Gauge shows about [round(src.cigcell.percent(), 25)]% energy remaining</span>")
-
-	else if(istype(src, /obj/item/clothing/mask/smokable/ecig/deluxe))
-		if(ec_cartridge)
-			to_chat(user,"<span class='notice'>There are [round(src.ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.</span>")
-		else
-			to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
-		to_chat(user,"<span class='notice'>Gauge shows [round(src.cigcell.percent(), 1)]% energy remaining</span>")
-
 /obj/item/clothing/mask/smokable/ecig/simple
-	name = "Lucky 1337"
+	name = "\improper Lucky 1337 e-cig"
 	desc = "A cheap Lucky 1337 electronic cigarette, styled like a traditional cigarette."
 	icon_state = "ccigoff"
 	icon_off = "ccigoff"
 	icon_empty = "ccigoff"
 	icon_on = "ccigon"
 
+/obj/item/clothing/mask/smokable/ecig/simple/examine(mob/user)
+	if(src.ec_cartridge)
+		to_chat(user,"<span class='notice'>There is roughly [round(src.ec_cartridge.reagents.total_volume / src.ec_cartridge.volume, 25)]% of liquid remaining.</span>")
+	else
+		to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
+
 /obj/item/clothing/mask/smokable/ecig/util
-	name = "ONI-55"
+	name = "\improper ONI-55 e-cig"
 	desc = "A popular utilitarian model electronic cigarette, the ONI-55. Comes in a variety of colors."
 	icon_state = "ecigoff1"
 	icon_off = "ecigoff1"
@@ -69,8 +53,15 @@
 	..()
 	color = pick(ecig_colors)
 
+obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
+	if(src.ec_cartridge)
+		to_chat(user,"<span class='notice'>There are [round(src.ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.</span>")
+	else
+		to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
+	to_chat(user,"<span class='notice'>Gauge shows about [round(src.cigcell.percent(), 25)]% energy remaining</span>")
+
 /obj/item/clothing/mask/smokable/ecig/deluxe
-	name = "eGavana MK3"
+	name = "\improper eGavana MK3 e-cig"
 	desc = "A premium model eGavana MK3 electronic cigarette, shaped like a cigar."
 	icon_state = "pcigoff1"
 	icon_off = "pcigoff1"
@@ -78,15 +69,21 @@
 	icon_on = "pcigon"
 	power_usage = 0.25 //enough for four catridges
 
-/obj/item/clothing/mask/smokable/ecig/deluxe/New()
-	..()
+obj/item/clothing/mask/smokable/ecig/deluxe/examine(mob/user)
+	if(src.ec_cartridge)
+		to_chat(user,"<span class='notice'>There are [round(src.ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.</span>")
+	else
+		to_chat(user,"<span class='notice'>There is no cartridge connected.</span>")
+	to_chat(user,"<span class='notice'>Gauge shows [round(src.cigcell.percent(), 1)]% energy remaining</span>")
 
 /obj/item/clothing/mask/smokable/ecig/Process()
 	if(idle >= idle_treshold) //idle too long -> automatic shut down
 		idle = 0
 		if(ishuman(loc))
 			var/mob/living/carbon/human/D = loc
-			to_chat(D, "<span class='notice'>\The [src] powered down automatically.</span>")
+			to_chat(D,"<span class='notice'>\The [src] powered down automatically.</span>")
+		else
+			src.visible_message("<span class='notice'>\The [src] powered down automatically.</span>", null, 2)
 		active=0//autodisable the cigarette
 		STOP_PROCESSING(SSobj, src)
 		update_icon()


### PR DESCRIPTION
E-cigarettes now use battery. They need to be reacharged, and amount of power consumed is dependent on cigarette type. When examined, they show amount of liquid and battery left. Those readings get more accuarte with better cigarette type. They also shut-down while idle. Battery charge is consumed only when smoking (not just being powered ON, just like real e-cig). Also, they've been renamed to their original names.