### PR TITLE
Fix for patches of unassailable darkness on asteroids

### DIFF
--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -89,7 +89,7 @@
 			continue
 
 		num_applied += 1
-		new new_path(T)
+		T.ChangeTurf(new_path)
 
 		CHECK_TICK
 


### PR DESCRIPTION
Those lighting overlay things are pretty good to have after all!

Performance impact on generation seems to be negligible.