### PR TITLE
Makes the handtele worth attempting to use ever.

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -58,7 +58,7 @@
 		qdel(src)
 		return
 	if (istype(M, /atom/movable))
-		if(dangerous) //oh dear a problem, put em in deep space
+		if(dangerous && prob(failchance)) //oh dear a problem, put em in deep space
 			var/destination_z = GLOB.using_map.get_transit_zlevel(z)
 			do_teleport(M, locate(rand(TRANSITIONEDGE, world.maxx - TRANSITIONEDGE), rand(TRANSITIONEDGE, world.maxy -TRANSITIONEDGE), destination_z), 0)
 		else

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -5,7 +5,6 @@
 	icon_state = "portal"
 	density = 1
 	unacidable = 1//Can't destroy energy portals.
-	var/failchance = 5
 	var/obj/item/target = null
 	var/creator = null
 	anchored = 1.0

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -8,6 +8,8 @@
 	var/obj/item/target = null
 	var/creator = null
 	anchored = 1.0
+	var/dangerous = 0
+	var/failchance = 0
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
 	spawn(0)
@@ -27,10 +29,16 @@
 		return
 	return
 
-/obj/effect/portal/New(var/start, var/end, var/delete_after = 300)
+/obj/effect/portal/New(var/start, var/end, var/delete_after = 300, var/failure_rate)
 	..()
+	if(failure_rate)
+		failchance = failure_rate
+		if(prob(failchance))
+			icon_state = "portal1"
+			dangerous = 1
 	playsound(src, 'sound/effects/phasein.ogg', 25, 1)
 	target = end
+
 	if(delete_after)
 		spawn(delete_after)
 			qdel(src)
@@ -50,8 +58,7 @@
 		qdel(src)
 		return
 	if (istype(M, /atom/movable))
-		if(prob(failchance)) //oh dear a problem, put em in deep space
-			src.icon_state = "portal1"
+		if(dangerous) //oh dear a problem, put em in deep space
 			var/destination_z = GLOB.using_map.get_transit_zlevel(z)
 			do_teleport(M, locate(rand(TRANSITIONEDGE, world.maxx - TRANSITIONEDGE), rand(TRANSITIONEDGE, world.maxy -TRANSITIONEDGE), destination_z), 0)
 		else

--- a/code/modules/integrated_electronics/manipulation.dm
+++ b/code/modules/integrated_electronics/manipulation.dm
@@ -306,7 +306,7 @@
 	else
 		var/turf/destination = get_random_turf_in_range(src, 10)
 		if(destination)
-			new /obj/effect/portal(rift_location, destination)
+			new /obj/effect/portal(rift_location, destination, 30 SECONDS, 33)
 		else
 			playsound(src, 'sound/effects/sparks2.ogg', 50, 1)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
:cl: 
rscdel: hand teleporter will no longer randomly teleport you into space.
rscadd: Hand teleporter's dangerous portals are now orange BEFORE you go into them, forcing the player to make a calculated risk, rather than a complete gamble.
\ :cl: 