### PR TITLE
Bandaid fix for subsystems access runtime

### DIFF
--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -102,4 +102,7 @@
 	. = ..()
 
 /stat_silicon_subsystem/Click(var/mob/given = usr)
-	subsystem.ui_interact(given, state = ui_state)
+	if (istype(given))
+		subsystem.ui_interact(given, state = ui_state)
+	else
+		subsystem.ui_interact(usr, state = ui_state)


### PR DESCRIPTION
Fixes #19288.

(Sort of.)

I'm not wholly sure why `Click` is being passed the string 'Subsystems' instead of just null (which would then default sensibly to `usr` via the default parameter value), but that's how it is.

If somebody knows why that's happening, you can probably make a more pleasant fix than this.