### PR TITLE
Enforces taj having Siik'maas

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -151,7 +151,8 @@
 	burn_mod =  1.15
 	gluttonous = GLUT_TINY
 	num_alternate_languages = 2
-	secondary_langs = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR)
+	secondary_langs = list(LANGUAGE_SIIK_TAJR)
+	additional_langs = list(LANGUAGE_SIIK_MAAS)
 	name_language = LANGUAGE_SIIK_MAAS
 	health_hud_intensity = 1.75
 


### PR DESCRIPTION
🆑TheGreyWolf
rscadd: Taj are now forced to have Siik'maas.
/🆑
@IDTia 
they still get their additional two language choices (one of which can easily be used on their OTHER species language).