### PR TITLE
Restore locker welding functionality

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -24,7 +24,7 @@
 	var/close_sound = 'sound/effects/locker_close.ogg'
 
 	var/storage_types = CLOSET_STORAGE_ALL
-	var/setup
+	var/setup = CLOSET_CAN_BE_WELDED
 
 	// TODO: Turn these into flags. Skipped it for now because it requires updating 100+ locations...
 	var/broken = FALSE
@@ -308,7 +308,7 @@
 		src.welded = !src.welded
 		src.update_icon()
 		user.visible_message("<span class='warning'>\The [src] has been [welded?"welded shut":"unwelded"] by \the [user].</span>", blind_message = "You hear welding.", range = 3)
-	if(setup & CLOSET_HAS_LOCK)
+	else if(setup & CLOSET_HAS_LOCK)
 		src.togglelock(user, W)
 	else
 		src.attack_hand(user)
@@ -509,7 +509,7 @@
 		update_icon()
 		return TRUE
 	else
-		to_chat(user, "<span class='warning'>Access Denied</span>")
+		to_chat(user, "<span class='warning'>Access denied!</span>")
 		return FALSE
 
 /obj/structure/closet/proc/CanToggleLock(var/mob/user, var/obj/item/weapon/card/id/id_card)

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -4,6 +4,7 @@
 	icon_state = "coffin"
 	icon_closed = "coffin"
 	icon_opened = "coffin_open"
+	setup = 0
 
 /obj/structure/closet/coffin/update_icon()
 	if(!opened)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -2,7 +2,7 @@
 	name = "secure locker"
 	desc = "It's a card-locked storage unit."
 
-	setup = CLOSET_HAS_LOCK
+	setup = CLOSET_HAS_LOCK | CLOSET_CAN_BE_WELDED
 	locked = TRUE
 
 	icon_state = "secure1"

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -1,10 +1,11 @@
-/obj/structure/closet/statue
+/obj/structure/closet/statue //what
 	name = "statue"
 	desc = "An incredibly lifelike marble carving."
 	icon = 'icons/obj/statue.dmi'
 	icon_state = "human_male"
 	density = 1
 	anchored = 1
+	setup = 0
 	health = 0 //destroying the statue kills the mob within
 	var/intialTox = 0 	//these are here to keep the mob from taking damage from things that logically wouldn't affect a rock
 	var/intialFire = 0	//it's a little sloppy I know but it was this or the GODMODE flag. Lesser of two evils.

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -209,6 +209,7 @@
 	density = 0
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
+	setup = 0
 
 /obj/structure/closet/hydrant/New()
 	..()
@@ -234,6 +235,7 @@
 	density = 0
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
+	setup = 0
 
 /obj/structure/closet/medical_wall/update_icon()
 	if(!opened)
@@ -258,6 +260,7 @@
 	density = 0
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
+	setup = 0
 
 /obj/structure/closet/shipping_wall/update_icon()
 	if(!opened)

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -11,6 +11,7 @@
 	icon_closed = "wall-locker"
 	icon_opened = "wall-lockeropen"
 	storage_types = CLOSET_STORAGE_ITEMS
+	setup = 0
 
 //spawns endless (3 sets) amounts of breathmask, emergency oxy tank and crowbar
 


### PR DESCRIPTION
:cl: sabiram
bugfix: Lockers can once again be welded shut.
/:cl:

Will need help thinking of other lockers that should not be able to be welded shut. I'm basing this entirely on which icon files have a 'welded' icon in them.
Fixes #19848