### PR TITLE
Removes snowflake code.

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -157,14 +157,6 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weapon/material/kitchen/utensil/spoon))
-		if(user.a_intent == I_HURT)
-			user.visible_message("<span class='warning'>[user] bashes \the [src] with a spoon, shattering it to pieces! What a rube.</span>")
-			playsound(src, "shatter", 30, 1)
-			if(reagents)
-				user.visible_message("<span class='notice'>The contents of \the [src] splash all over [user]!</span>")
-				reagents.splash(user, reagents.total_volume)
-			qdel(src)
-			return
 		user.visible_message("<span class='notice'>[user] gently strikes \the [src] with a spoon, calling the room to attention.</span>")
 		playsound(src, "sound/items/wineglass.ogg", 65, 1)
 	else return ..()


### PR DESCRIPTION
Don't make specific cases for allowing you to destroy glasses with a specific type of item. If you want to add this, make it a general feature that accepts any item with sufficient force. This is bad code.