### PR TITLE
Adds legalese, ability to partially understand other langauges

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -49,6 +49,7 @@
 #define LANGUAGE_NABBER "Serpentid"
 #define LANGUAGE_SPACER "Spacer"
 #define LANGUAGE_BOGANI "Bogani"
+#define LANGUAGE_LEGALESE "Legalese"
 
 // Language flags.
 #define WHITELISTED  1   // Language is available if the speaker is whitelisted.

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -37,7 +37,7 @@
 				message = pick(S.speak)
 			else
 				if(language)
-					message = language.scramble(message)
+					message = language.scramble(message, languages)
 				else
 					message = stars(message)
 
@@ -108,7 +108,7 @@
 					return
 			else
 				if(language)
-					message = language.scramble(message)
+					message = language.scramble(message, languages)
 				else
 					message = stars(message)
 

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -73,3 +73,14 @@
 	colour = "say_quote"
 	key = "s"
 	flags = SIGNLANG | NO_STUTTER | NONVERBAL
+
+/datum/language/legal
+	name = LANGUAGE_LEGALESE
+	desc = "A cryptic language used by interstellar bureaucrats and lawyers."
+	speech_verb = "states"
+	exclaim_verb = "objects"
+	ask_verb = "inquiries"
+	space_chance = 100
+	key = "u"
+	syllables = list("hitherto","whereof","hereunto","deed","hereinbefore","whereas","consensus","nonwithstanding","exonerated","effecuate","accord","caveat", "stipulation", "pledgee", "covenant", "rights", "lawful", "suit of law", "sequestrator", "et al", "et", "ex", "quid", "bono","quo","pro","ad")
+	partial_understanding = list(LANGUAGE_GALCOM = 20, LANGUAGE_SKRELLIAN = 10)

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -27,6 +27,7 @@
 	key = "0"
 	flags = RESTRICTED
 	syllables = list("blah","blah","blah","bleh","meh","neh","nah","wah")
+	partial_understanding = list(LANGUAGE_SKRELLIAN = 30, LANGUAGE_SOL_COMMON = 30)
 
 //TODO flag certain languages to use the mob-type specific say_quote and then get rid of these.
 /datum/language/common/get_spoken_verb(var/msg_end)
@@ -53,6 +54,7 @@
 					 "voluptate", "velit", "esse", "cillum", "dolore", "eu", "fugiat", "nulla",
 					 "pariatur", "excepteur", "sint", "occaecat", "cupidatat", "non", "proident", "sunt",
 					 "in", "culpa", "qui", "officia", "deserunt", "mollit", "anim", "id", "est", "laborum")
+	partial_understanding = list(LANGUAGE_SOL_COMMON = 10)
 
 // Criminal language.
 /datum/language/gutter
@@ -62,6 +64,7 @@
 	colour = "rough"
 	key = "3"
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
+	partial_understanding = list(LANGUAGE_GALCOM = 10, LANGUAGE_INDEPENDENT = 20, LANGUAGE_SOL_COMMON = 20)
 
 /datum/language/sign
 	name = LANGUAGE_SIGN

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -5,18 +5,22 @@
 	ask_verb = "chimpers"
 	exclaim_verb = "screeches"
 	key = "m"
+	syllables = list("ook","eek")
 
 /datum/language/unathi/monkey
 	name = "Stok"
 	desc = "Hiss hiss hiss."
 	key = "7"
+	syllables = list("hiss","gronk")
 
 /datum/language/skrell/monkey
 	name = "Neaera"
 	desc = "Squik squik squik."
 	key = "8"
+	syllables = list("squick","croak")
 
 /datum/language/tajaran/monkey
 	name = "Farwa"
 	desc = "Meow meow meow."
 	key = "9"
+	syllables = list("meow","mew")

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -223,3 +223,4 @@
 	syllables = list ("die", "en", "skei", "van", "son", "der", "aar", "ch", "op", "ruk", "aa", "be", "ne", "het",
  	"ek", "ras", "ver", "zan", "das", "waa", "geb", "vol", "lu", "min", "breh", "rus", "stv", "ee", "goe", "sk",
  	"la", "ver", "we", "ge", "luk", "an", "ar", "at", "es", "et", "bel", "du", "jaa", "ch", "kk", "gh", "ll", "uu", "wat")
+	partial_understanding = list(LANGUAGE_GALCOM = 15, LANGUAGE_SKRELLIAN = 10, LANGUAGE_INDEPENDENT = 15, LANGUAGE_SOL_COMMON = 15, LANGUAGE_LUNAR = 20, LANGUAGE_GUTTER = 10)


### PR DESCRIPTION
Can now understand random words from other languages even if you don't know them, chance depending on what languages do you know, and what languages are 'related' to target one (decided by a list)

:cl: Chinsky
rcadd: "Adds Legalese language to char setup."
rcadd: "Adds partial understanding. Even if you don't know the language, you can now understand some words, depending on what languages you DO know. This mostly applies to pidgins like Gutter/Spacer etc."
/:cl:

Adds silly language because that's what I was originally adding before it kinda spiraled out.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
