### PR TITLE
Nerfs spoons

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -156,15 +156,15 @@
 		side = "right"
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/weapon/material/kitchen/utensil/spoon))
-		if(user.a_intent == I_HURT)
-			user.visible_message("<span class='warning'>[user] bashes \the [src] with a spoon, shattering it to pieces! What a rube.</span>")
-			playsound(src, "shatter", 30, 1)
-			if(reagents)
-				user.visible_message("<span class='notice'>The contents of \the [src] splash all over [user]!</span>")
-				reagents.splash(user, reagents.total_volume)
-			qdel(src)
-			return
+	if(W.force > 3 && user.a_intent == I_HURT)
+		user.visible_message("<span class='warning'>[user] bashes \the [src] with \a [W], shattering it to pieces! What a rube.</span>")
+		playsound(src, "shatter", 30, 1)
+		if(reagents.total_volume)
+			user.visible_message("<span class='notice'>The contents of \the [src] splash all over [user]!</span>")
+			reagents.splash(user, reagents.total_volume)
+		qdel(src)
+		return
+	else if(istype(W, /obj/item/weapon/material/kitchen/utensil/spoon))
 		user.visible_message("<span class='notice'>[user] gently strikes \the [src] with a spoon, calling the room to attention.</span>")
 		playsound(src, "sound/items/wineglass.ogg", 65, 1)
 	else return ..()


### PR DESCRIPTION
Removes unique mechanic that made spoons main meta for fast glass breaking.
To soothe certain player's burning pain at such injustice, all items with sufficient force at harm intent will now shatter drinking glasses.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
