### PR TITLE
Added classified project data disk, a fluff item with "secret blueprints and designs" contained inside

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -808,6 +808,7 @@
 #include "code\game\objects\items\weapons\RCD.dm"
 #include "code\game\objects\items\weapons\RSF.dm"
 #include "code\game\objects\items\weapons\scrolls.dm"
+#include "code\game\objects\items\weapons\secrets_disk.dm"
 #include "code\game\objects\items\weapons\shields.dm"
 #include "code\game\objects\items\weapons\soap.dm"
 #include "code\game\objects\items\weapons\staff.dm"

--- a/code/game/objects/items/weapons/secrets_disk.dm
+++ b/code/game/objects/items/weapons/secrets_disk.dm
@@ -1,0 +1,74 @@
+/obj/item/weapon/disk/secret_project
+	name = "'classified' project data disk"
+	desc = "A special disk for storing massive amounts of data. It is marked as classified, and has an ID card slot on top."
+	icon = 'icons/obj/cloning.dmi'
+	icon_state = "datadisk0"
+	item_state = "card-id"
+	w_class = ITEM_SIZE_SMALL
+	req_access = access_ce
+	var/subject = "some strange, incomprehensible design"
+	var/locked = 1
+
+/obj/item/weapon/disk/secret_project/science
+	desc = "A special disk for storing massive amounts of data. It is marked as classified, and has an ID card slot on top. \
+	This one has a NanoTrasen label on it."
+	req_access = access_rd
+
+/obj/item/weapon/disk/secret_project/Initialize()
+	. = ..()
+	var/codename = pick("gamma", "delta", "epsilon", "zeta", "theta", "lambda", "omicron", "sigma", "tau",\
+	"upsilon", "omega", "echelon", "prism", "calypso", "bernoulli", "harmony", "nyx", "fresnel")
+	name = "'[codename]' project data disk"
+	subject = pick("an experimental design for", "a blueprint to build",\
+	"a long set of theoretical formulas detailing the functioning of")
+	subject += " " + pick("a bluespace artillery cannon", "a supermatter engine", "a fusion engine", "an atmospheric scrubber",\
+	"a human cloning pod", "a microwave oven", "a bluespace drive", "a laser carbine", "an energy pistol",\
+	"a bluespace gateway", "a teleporter", "a huge mining drill", "a strange spacecraft", "a space station",\
+	"a sleek-looking fighter spacecraft", "a ballistic rifle", "an energy sword", "an inanimate carbon rod")
+	subject += " " + pick("that is extremely powerful", "which is highly efficient", "which is incredibly compact",\
+	"that runs off of phoron", "that runs off of hydrogen gas", "created by the Skrell", "that just looks really cool")
+
+/obj/item/weapon/disk/secret_project/examine(var/user)
+	..()
+	if(!locked)
+		to_chat(user, "With the disk's classified contents unlocked, \
+		you peer into its preview screen and see <span class='notice'>[subject]</span>.")
+	else
+		to_chat(user, "The disk is locked, you cannot see its contents.")
+
+/obj/item/weapon/disk/secret_project/emag_act(var/remaining_charges, var/mob/user)
+	to_chat(user, "<span class='warning'>The cryptographic lock on this disk is far too complex. \
+	Your sequencer can't break the code.</span>")
+	return 0
+
+/obj/item/weapon/disk/secret_project/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W,/obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/ID = W
+		if(check_access(ID))
+			locked = !locked
+			to_chat(user, "<span class='notice'>You swipe your card and [locked ? "lock":"unlock"] the disk.</span>")
+		else
+			to_chat(user, "<span class='warning'>The disk's screen flashes 'Access Denied'.</span>")
+		return
+	. = ..()
+
+/obj/item/weapon/disk/secret_project/verb/change_codename()
+	set name = "Change project codename"
+	set category = "Object"
+	set src in view(0)
+
+	if(!locked)
+		var/input = sanitize(input(usr, "What would you like to change the project codename to?", "Classified Project Data Disk"))
+		if(!input || input == "")
+			return
+		name = "'[input]' project data disk"
+	else
+		to_chat(usr, "<span class='warning'>The disk's screen flashes 'Access Denied'. It is locked.</span>")
+
+/obj/item/weapon/storage/box/secret_project_disks
+	name = "box of classified data disks"
+	desc = "A box full of disks. Marked with a red 'Top Secret' label. Looks rather ominous."
+	startswith = list(/obj/item/weapon/disk/secret_project = 5)
+
+/obj/item/weapon/storage/box/secret_project_disks/science
+	startswith = list(/obj/item/weapon/disk/secret_project/science = 5)

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -42,6 +42,7 @@
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/folder/yellow,
 		/obj/item/weapon/storage/box/armband/engine,
+		/obj/item/weapon/storage/box/secret_project_disks,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel_eng)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))
 	)

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -41,6 +41,7 @@
 		/obj/item/clothing/glasses/welding/superior,
 		/obj/item/device/holowarrant,
 		/obj/item/clothing/suit/armor/pcarrier/light,
+		/obj/item/weapon/storage/box/secret_project_disks/science,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/toxins, /obj/item/weapon/storage/backpack/satchel_tox)),
 		new /datum/atom_creator/simple(/obj/item/weapon/storage/backpack/messenger/tox, 50)
 	)


### PR DESCRIPTION
_"Many ~~Bothans~~ greytiders died to bring us this information..."_
(Because we all know SolGov is probably building a death star somewhere.)

Similarly to Chinsky's PR which adds some secret documents to the CO locker, this adds five Project Data Disks to the CE's locker. They spawn with a randomly generated spooky codename, along with a "subject" that describes the stuff inside.

🆑 dryerlint
rcadd: "Added classified project data disks, a useless fluff item which gives antags something to steal. They spawn in the CE and RD lockers, five disks each."
/🆑

![image](https://user-images.githubusercontent.com/30705790/34191426-ec78e2a2-e514-11e7-9b73-0b82bdeab538.png)