### PR TITLE
Tries to balances some of the guns

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_LARGE
 	force = 10
 	one_hand_penalty = 2
+	accuracy = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/beam/midlaser

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -20,7 +20,8 @@
 	one_hand_penalty = 3
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 8
-	max_shots = 10
+	max_shots = 12
+	accuracy = 1
 	projectile_type = /obj/item/projectile/beam/stun/heavy
 	wielded_item_state = "tasercarbine-wielded"
 
@@ -47,11 +48,11 @@
 	item_state = "stunrevolver"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	projectile_type = /obj/item/projectile/energy/electrode
-	max_shots = 8
+	max_shots = 6
 
 /obj/item/weapon/gun/energy/stunrevolver/rifle
 	name = "stun rifle"
-	desc = "A LAEP38 Thor, a vastly oversized variant of the LAEP20 Zeus. Fires overcharged electrodes."
+	desc = "A LAEP38 Thor, a vastly oversized variant of the LAEP20 Zeus. Fires overcharged electrodes to take down hostile armored targets without harming them too much."
 	icon_state = "stunrifle"
 	item_state = "stunrifle"
 	w_class = ITEM_SIZE_HUGE
@@ -59,7 +60,8 @@
 	one_hand_penalty = 6
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 10
-	max_shots = 12
+	max_shots = 10
+	accuracy = 1
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
 	wielded_item_state = "stunrifle-wielded"
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -29,7 +29,7 @@
 	damage = 25
 
 /obj/item/projectile/beam/midlaser
-	damage = 40
+	damage = 50
 	armor_penetration = 10
 
 /obj/item/projectile/beam/heavylaser
@@ -191,7 +191,6 @@
 /obj/item/projectile/beam/stun/heavy
 	name = "heavy stun beam"
 	agony = 60
-	armor_penetration = 10
 
 /obj/item/projectile/beam/stun/shock
 	name = "shock beam"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -63,15 +63,16 @@
 	fire_sound = 'sound/weapons/Taser.ogg'
 	nodamage = 1
 	taser_effect = 1
-	agony = 60
+	agony = 50
 	damage_type = PAIN
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
 /obj/item/projectile/energy/electrode/stunshot
 	nodamage = 0
-	damage = 10
-	agony = 80
+	damage = 15
+	agony = 70
 	damage_type = BURN
+	armor_penetration = 10
 
 /obj/item/projectile/energy/declone
 	name = "decloner beam"


### PR DESCRIPTION
:cl: Orelbon
tweak: Laser carbine has 10 more damage and +2 accuracy.
tweak: Taser carbine now has 12 shots, +1 accuracy and looses its 10 armor penetration.
tweak: Stun rifle now has 10 shots, +1 accuracy,+10 armor penetration,+5 burn damage and looses 10 agony. 
tweak: Stun revolver now has 6 shots and 50 agony. 
/:cl:

* Laser carbine has 10 more damage and +2 accuracy because it was too similar to the energy gun while lacking the functionality. 
* Taser carbine is more of an upgraded taser now than it was before, best to use for non armored targets. 
* Stun rifle now works more like an upgraded carbine with armor piercing and 5 more burn damage to discourage using it on non armored crew, but 10 less agony. 
* Stun revolver got nerffed cause it was a bit much, it now has 6 shots and 50 agony. Still better than a taser. 

_braces for shit storm_