### PR TITLE
Makes Ion weapons not terrible

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -28,7 +28,7 @@
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	one_hand_penalty = 0
 	charge_cost = 20
-	max_shots = 8
+	max_shots = 6
 	projectile_type = /obj/item/projectile/ion/small
 
 /obj/item/weapon/gun/energy/decloner

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -6,15 +6,17 @@
 	damage_type = BURN
 	nodamage = 1
 	check_armour = "energy"
-	var/pulse_range = 1
+	var/heavy_effect_range = 1
+	var/light_effect_range = 2
 
-	on_hit(var/atom/target, var/blocked = 0)
-		empulse(target, pulse_range, pulse_range)
+	on_impact(var/atom/A)
+		empulse(A, heavy_effect_range, light_effect_range)
 		return 1
 
 /obj/item/projectile/ion/small
 	name = "ion pulse"
-	pulse_range = 0
+	heavy_effect_range = 0
+	light_effect_range = 1
 
 /obj/item/projectile/bullet/gyro
 	name ="explosive bolt"


### PR DESCRIPTION
:cl: Orelbon
Tweak: Ion weapons shouldn't be horrible anymore, they now activate their emp no matter what they hit. 
Tweak: The rifle now has a max range of 2, and the pistol a max range of 1. 
Tweak: Ion pistol max shots lowered to 6.
/:cl:

Fixes #17150

They now call the on_impact proc so the emp effect can occur no matter what they hit, and their ranges have been made a bit better, also lowers the max shots of the pistol by 2. 