### PR TITLE
Small egun edits

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -20,9 +20,10 @@
 	name = "small energy gun"
 	desc = "A smaller model of the versatile LAEP90 Perun, packing considerable utility in a smaller package. Best used in situations where full-sized sidearms are inappropriate."
 	icon_state = "smallgunstun"
-	max_shots = 5
+	max_shots = 6
 	w_class = ITEM_SIZE_SMALL
 	force = 2 //it's the size of a car key, what did you expect?
+	fire_delay = 16 //it's smaller and can't dissipate heat as fast.
 	modifystate = "smallgunstun"
 
 	firemodes = list(

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -26,7 +26,7 @@
 	eyeblur = 2
 
 /obj/item/projectile/beam/smalllaser
-	damage = 25
+	damage = 35
 
 /obj/item/projectile/beam/midlaser
 	damage = 50


### PR DESCRIPTION
Continuation of  #19886

:cl: Orelbon
Tweak: Small eguns now do 35 damage and have 6 shots, but have a longer fire delay to compensate. 
/:cl:

* Small egun now uses the same lethal beam as the regular gun and has 6 shots.
* It also fires more slowly to balance this out. 