### PR TITLE
Unathi healing tweaks/nerfs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -187,7 +187,7 @@
 	if(prob(2) && H.nutrition > 150)
 		for(var/limb_type in has_limbs)
 			var/obj/item/organ/external/E = H.organs_by_name[limb_type]
-			if(E && !E.is_usable())
+			if(E && !E.vital && !E.is_usable())
 				E.removed()
 				qdel(E)
 				E= null

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -153,16 +153,16 @@
 
 	//Heals normal damage.
 	if(H.getBruteLoss())
-		H.adjustBruteLoss(-4)
-		H.nutrition -= 4
+		H.adjustBruteLoss(-2 * config.organ_regeneration_multiplier)	//Heal brute better than other ouchies.
+		H.nutrition -= 1
 	if(H.getFireLoss())
-		H.adjustFireLoss(-3)
-		H.nutrition -= 4
+		H.adjustFireLoss(-1 * config.organ_regeneration_multiplier)
+		H.nutrition -= 1
 	if(H.getToxLoss())
-		H.adjustToxLoss(-2)
-		H.nutrition -= 4
+		H.adjustToxLoss(-1 * config.organ_regeneration_multiplier)
+		H.nutrition -= 1
 
-	if(prob(10) && H.nutrition > 150 && !H.getBruteLoss() && !H.getFireLoss())
+	if(prob(5) && H.nutrition > 150 && !H.getBruteLoss() && !H.getFireLoss())
 		var/obj/item/organ/external/head/D = H.organs_by_name["head"]
 		if (D.disfigured)
 			D.disfigured = 0
@@ -184,7 +184,7 @@
 				if(prob(5))
 					to_chat(H, "<span class='warning'>You feel a soothing sensation as your [regen_organ] mends...</span>")
 
-	if(prob(5) && H.nutrition > 150)
+	if(prob(2) && H.nutrition > 150)
 		for(var/limb_type in has_limbs)
 			var/obj/item/organ/external/E = H.organs_by_name[limb_type]
 			if(E && !E.is_usable())

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -89,7 +89,7 @@
 	secondary_langs = list(LANGUAGE_UNATHI)
 	name_language = LANGUAGE_UNATHI
 	health_hud_intensity = 2
-	hunger_factor = 0.2
+	hunger_factor = DEFAULT_HUNGER_FACTOR * 3
 
 	min_age = 18
 	max_age = 260
@@ -147,26 +147,26 @@
 		return
 	if(H.nutrition < 50)
 		H.adjustToxLoss(2,0)
-	else if (H.innate_heal)
-		//Heals normal damage.
-		if (H.getBruteLoss())
-			H.adjustBruteLoss(-4)
-			H.nutrition -= 4
-		if(H.getFireLoss())
-			H.adjustFireLoss(-3)
-			H.nutrition -= 4
-		if(H.getOxyLoss())
-			H.adjustOxyLoss(-4)
-			H.nutrition -= 4
-		if(H.getToxLoss())
-			H.adjustToxLoss(-2)
-			H.nutrition -= 4
+		return
+	if(!H.innate_heal)
+		return
 
-		if(prob(10) && H.nutrition > 150 && !H.getBruteLoss() && !H.getFireLoss())
-			var/obj/item/organ/external/head/D = H.organs_by_name["head"]
-			if (D.disfigured)
-				D.disfigured = 0
-				H.nutrition -= 20
+	//Heals normal damage.
+	if(H.getBruteLoss())
+		H.adjustBruteLoss(-4)
+		H.nutrition -= 4
+	if(H.getFireLoss())
+		H.adjustFireLoss(-3)
+		H.nutrition -= 4
+	if(H.getToxLoss())
+		H.adjustToxLoss(-2)
+		H.nutrition -= 4
+
+	if(prob(10) && H.nutrition > 150 && !H.getBruteLoss() && !H.getFireLoss())
+		var/obj/item/organ/external/head/D = H.organs_by_name["head"]
+		if (D.disfigured)
+			D.disfigured = 0
+			H.nutrition -= 20
 
 	if(H.nutrition <= 100)
 		return
@@ -178,7 +178,7 @@
 		if(regen_organ.robotic >= ORGAN_ROBOT)
 			continue
 		if(istype(regen_organ))
-			if(regen_organ.damage > 0)
+			if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
 				regen_organ.damage = max(regen_organ.damage - 5, 0)
 				H.nutrition -= 5
 				if(prob(5))


### PR DESCRIPTION
:cl:
balance: Unathi no longer recover oxyloss, ignore healing toggle, or repair dead internal organs, and generally heal slower as well. They also are noticeably less ravenous in their day-to-day hunger.
/:cl:
Fixes #19902

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
