### PR TITLE
Reducing Required Players for Heist

### DIFF
--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/heist
 	name = "Heist"
 	config_tag = "heist"
-	required_players = 15
+	required_players = 12
 	required_enemies = 4
 	round_description = "An unidentified bluespace signature has slipped into close sensor range and is approaching!"
 	extended_round_description = "The Company's majority control of phoron in Nyx has marked the \

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -6,7 +6,7 @@
 	name = "Heist"
 	config_tag = "heist"
 	required_players = 12
-	required_enemies = 4
+	required_enemies = 3
 	round_description = "An unidentified bluespace signature has slipped into close sensor range and is approaching!"
 	extended_round_description = "The Company's majority control of phoron in Nyx has marked the \
 		station to be a highly valuable target for many competing organizations and individuals. Being a \


### PR DESCRIPTION
:cl: Roodledoot
tweak: Reduced amount of required players to start a Heist match from 15 to 12.
tweak: Reduced amount of required enemies down from 4 to 3.
/:cl:

Right as it says on the tin.  As discussed briefly in https://baystation12.net/forums/threads/lower-heist-player-requirement.5907/#post-86607   most of the reasons this is a good idea is listed there.


