### PR TITLE
Fixes oversight with falling checks

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -46,7 +46,7 @@
 			to_chat(src, "<span class='warning'>\The [A] blocks you.</span>")
 			return 0
 
-	if(can_fall(FALSE, destination))
+	if(direction == UP && can_fall(FALSE, destination))
 		to_chat(src, "<span class='warning'>You see nothing to hold on to.</span>")
 		return 0
 


### PR DESCRIPTION
This check would fail moving down onto solid turfs because can_fall is not supposed to be called there.