### PR TITLE
Adds in the old Sleepy Pen - Now with 300% less instant murder

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -28,6 +28,11 @@
 	name = "Detomatix PDA Cartridge"
 	item_cost = 16
 	path = /obj/item/weapon/cartridge/syndicate
+	
+/datum/uplink_item/item/stealthy_weapons/sleepy
+	name = "Sleepy Pen"
+	item_cost = 20
+	path = /obj/item/weapon/pen/reagent/sleepy
 
 /datum/uplink_item/item/stealthy_weapons/syringegun
 	name = "Disguised Syringe Gun"

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -55,6 +55,7 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealthy_weapons/soap, 5, 100)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealthy_weapons/concealed_cane, 50, 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealthy_weapons/detomatix, 20, 10)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealthy_weapons/sleepy)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealthy_weapons/cigarette_kit)
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealth_items/id)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -101,7 +101,7 @@
 
 /obj/item/weapon/pen/reagent/sleepy/New()
 	..()
-	reagents.add_reagent(/datum/reagent/chloralhydrate, 22)	//Used to be 100 sleep toxin//30 Chloral seems to be fatal, reducing it to 22./N
+	reagents.add_reagent(/datum/reagent/chloralhydrate, 15)	//Used to be 100 sleep toxin//30 Chloral seems to be fatal, reducing it to 22, reducing it further to 15 because fuck you OD code./N
 
 
 /*


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
:cl:SparklySheep
rscadd: Added in the sleepy pen. The sleepy pen is available for purchase for 20 telecrystals on any uplink. Sleepy pen is not an immediate knockout and allows for person to call for help if not gagged or silenced.
/:cl:


Adds in the sleepy pen for traitors to use. This is NOT the parapen, as there are a few key differences:

1. When stabbed with the pen, player will be dizzy for around 20-30 seconds and fall over, in this time they can still call for help.
2. No damage is caused to the person unless they already have chloral in them. It's (mostly) safe to use.
3. Knockout lasts for around 5-6 minutes. Long enough to drag away the person to your traitor lair.

Pen can only be identified if the person looks at it closely, otherwise it's just a normal pen.