### PR TITLE
Removes overly specific check.

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -157,14 +157,6 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weapon/material/kitchen/utensil/spoon))
-		if(user.a_intent == I_HURT)
-			user.visible_message("<span class='warning'>[user] bashes \the [src] with a spoon, shattering it to pieces! What a rube.</span>")
-			playsound(src, "shatter", 30, 1)
-			if(reagents)
-				user.visible_message("<span class='notice'>The contents of \the [src] splash all over [user]!</span>")
-				reagents.splash(user, reagents.total_volume)
-			qdel(src)
-			return
 		user.visible_message("<span class='notice'>[user] gently strikes \the [src] with a spoon, calling the room to attention.</span>")
 		playsound(src, "sound/items/wineglass.ogg", 65, 1)
 	else return ..()


### PR DESCRIPTION
Can we just remove shitty code without making a huge mess out of it.
:cl:Kelenius
tweak: You no longer need to be extra careful around the glasses when holding the spoons: spoons are no longer the bane of the glasses, being previously the only object in existence capable of ending them, forever, instantly, and without a trace. Perhaps one day the technology will get there, and the damnable glasses will be smashable with any sufficiently heavy item. But that day is not today.
/:cl: