### PR TITLE
Targeted grabs

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -204,9 +204,8 @@ var/global/list/string_slot_flags = list(
 
 	paths = typesof(/obj/item/grab) - /obj/item/grab
 	for(var/T in paths)
-		var/obj/item/grab/G = new T
-		if(G.type_name)
-			all_grabobjects[G.type_name] = T
+		var/obj/item/grab/G = T
+		all_grabobjects[initial(G.type_name)] = T
 
 	for(var/grabstate_name in all_grabstates)
 		var/datum/grab/G = all_grabstates[grabstate_name]

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -77,7 +77,7 @@
 	if(!upgrab)
 		return
 
-	if (can_upgrade())
+	if (can_upgrade(G))
 		upgrade_effect(G)
 		admin_attack_log(G.assailant, G.affecting, "tightens their grip on their victim to [upgrab.state_name]", "was grabbed more tightly to [upgrab.state_name]", "tightens grip to [upgrab.state_name] on")
 		return upgrab

--- a/code/modules/mob/grab/nab/grab_nab.dm
+++ b/code/modules/mob/grab/nab/grab_nab.dm
@@ -3,21 +3,6 @@
 	type_name = GRAB_NAB
 	start_grab_name = NAB_PASSIVE
 
-/obj/item/grab/nab/can_grab()
-
-	if(assailant.anchored || affecting.anchored)
-		return 0
-
-	if(!assailant.Adjacent(affecting))
-		return 0
-
-	for(var/obj/item/grab/G in affecting.grabbed_by)
-		if(G.assailant == assailant)
-			to_chat(assailant, "<span class='notice'>You already grabbed [src].</span>")
-			return 0
-
-	return 1
-
 /obj/item/grab/nab/init()
 	..()
 
@@ -90,36 +75,32 @@
 // This causes the assailant to crush the affecting mob. There is a chance that the crush will cause the
 // forelimb spikes to dig into the affecting mob, doing extra damage and likely causing them to bleed.
 /datum/grab/nab/proc/crush(var/obj/item/grab/G, var/attack_damage)
-	var/mob/living/carbon/human/affecting = G.affecting
-	var/mob/living/carbon/human/assailant = G.assailant
 	var/obj/item/organ/external/damaging = G.get_targeted_organ()
-	var/hit_zone = G.assailant.zone_sel.selecting
+	var/hit_zone = G.target_zone
 
-	var/armor = affecting.run_armor_check(hit_zone, "melee")
+	var/armor = G.affecting.run_armor_check(hit_zone, "melee")
 
-	affecting.visible_message("<span class='danger'>[assailant] crushes [affecting]'s [damaging.name]!</span>")
+	G.affecting.visible_message("<span class='danger'>[G.assailant] crushes [G.affecting]'s [damaging.name]!</span>")
 
 	if(prob(30))
-		affecting.apply_damage(max(attack_damage + 10, 15), BRUTE, hit_zone, armor, DAM_SHARP, "organic punctures")
-		affecting.apply_effect(attack_damage, PAIN, armor)
-		affecting.visible_message("<span class='danger'>[assailant]'s spikes dig in painfully!</span>")
+		G.affecting.apply_damage(max(attack_damage + 10, 15), BRUTE, hit_zone, armor, DAM_SHARP, "organic punctures")
+		G.affecting.apply_effect(attack_damage, PAIN, armor)
+		G.affecting.visible_message("<span class='danger'>[G.assailant]'s spikes dig in painfully!</span>")
 	else
-		affecting.apply_damage(attack_damage, BRUTE, hit_zone, armor,, "crushing")
-	playsound(assailant.loc, 'sound/weapons/bite.ogg', 25, 1, -1)
+		G.affecting.apply_damage(attack_damage, BRUTE, hit_zone, armor,, "crushing")
+	playsound(get_turf(G.assailant), 'sound/weapons/bite.ogg', 25, 1, -1)
 
-	admin_attack_log(assailant, affecting, "Crushed their victim.", "Was crushed.", "crushed")
+	admin_attack_log(G.assailant, G.affecting, "Crushed their victim.", "Was crushed.", "crushed")
 
 // This causes the assailant to chew on the affecting mob.
 /datum/grab/nab/proc/masticate(var/obj/item/grab/G, var/attack_damage)
-	var/mob/living/carbon/human/affecting = G.affecting
-	var/mob/living/carbon/human/assailant = G.assailant
-	var/obj/item/organ/external/damaging = G.get_targeted_organ()
 	var/hit_zone = G.assailant.zone_sel.selecting
+	var/obj/item/organ/external/damaging = G.affecting.get_organ(hit_zone)
 
-	var/armor = affecting.run_armor_check(hit_zone, "melee")
+	var/armor = G.affecting.run_armor_check(hit_zone, "melee")
 
-	affecting.apply_damage(attack_damage, BRUTE, hit_zone, armor, DAM_SHARP|DAM_EDGE, "mandibles")
-	affecting.visible_message("<span class='danger'>[assailant] chews on [affecting]'s [damaging.name]!</span>")
-	playsound(assailant.loc, 'sound/weapons/bite.ogg', 25, 1, -1)
+	G.affecting.apply_damage(attack_damage, BRUTE, hit_zone, armor, DAM_SHARP|DAM_EDGE, "mandibles")
+	G.affecting.visible_message("<span class='danger'>[G.assailant] chews on [G.affecting]'s [damaging.name]!</span>")
+	playsound(get_turf(G.assailant), 'sound/weapons/bite.ogg', 25, 1, -1)
 
-	admin_attack_log(assailant, affecting, "Chews their victim.", "Was chewed.", "chewed")
+	admin_attack_log(G.assailant, G.affecting, "Chews their victim.", "Was chewed.", "chewed")

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -28,3 +28,14 @@
 	// Keeps those who are on the ground down
 	if(affecting.lying)
 		affecting.Weaken(4)
+
+/datum/grab/normal/aggressive/can_upgrade(var/obj/item/grab/G)
+	if(!(G.target_zone in list(BP_CHEST, BP_HEAD)))
+		to_chat(G.assailant, "<span class='warning'>You need to be grabbing their torso or head for this!</span>")
+		return FALSE
+	var/obj/item/clothing/C = G.affecting.head
+	if(istype(C)) //hardsuit helmets etc
+		if((C.item_flags & STOPPRESSUREDAMAGE) && C.armor["melee"] > 20)
+			to_chat(G.assailant, "<span class='warning'>\The [C] is in the way!</span>")
+			return FALSE
+	return TRUE


### PR DESCRIPTION
:cl: Chinsky
rscadd: Grabs changed. They are now targeting bodyparts rather than guy in general. This mostly affects jointlocks/dislocations - you will affect bodypart you were targeting when you made the grab.
rscadd: Neckgrab needs grab on chest or head. Also now voidsuit helmets and the like (pressure-protective helmets with 20+ melee armor) prevent neckgrabs.
rscadd: You can now use both hands to grab same guy, as long as it's different bodyparts. Doesn't affect resistance time etc.
/:cl:

Makes grabs 'target' the bodypart - one you were aiming at during initial grab.
Dislocations, jointlocks etc now target that bodypart istead of the one you're aiming at right now.
To get neckgrab, you must have a grab either on torso or head.
You can now have grabs on same guy in both hands, as long as they target different zones.

Small things:
Fixed some weirdness in messages (you already grabbed the grab!, neck being dislocated)
Made voidsuit helmets prevent strangling (any pressure-resistant helmets with melee armor of 20+ qualifies).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
