### PR TITLE
Raises minimum of players for cult and deity

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "There has been an infiltration by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 5
+	required_players = 10
 	required_enemies = 3
 	end_on_antag_death = 0
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/godmode/godmode.dm
+++ b/code/game/gamemodes/godmode/godmode.dm
@@ -3,7 +3,7 @@
 	round_description = "An otherworldly beast has turned its attention to you and your fellow cremembers."
 	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "god"
-	required_players = 5
+	required_players = 10
 	required_enemies = 3
 	end_on_antag_death = 0
 	antag_tags = list(MODE_DEITY, MODE_GODCULTIST)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Almost every lowpop round is a cult or deity one. And it takes like 15-20 minute to turn the whole crew into cultists. Personally I'd delete both gamemodes but some people may like them I guess.

:cl: Sbotkin
tweak: Changed required players for cult and deity from 5 to 10.
/:cl: