### PR TITLE
Nerf cult summon damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -6,10 +6,10 @@
 	icon_state = "otherthing"
 	icon_living = "otherthing"
 	icon_dead = "otherthing-dead"
-	health = 80
-	maxHealth = 80
-	melee_damage_lower = 25
-	melee_damage_upper = 50
+	health = 100
+	maxHealth = 100
+	melee_damage_lower = 15
+	melee_damage_upper = 25
 	attacktext = "chomped"
 	attack_sound = 'sound/weapons/bite.ogg'
 	faction = "creature"


### PR DESCRIPTION
These values are much too high for something that can be spawned en masse by players. Ups health a little to compensate. This is still the most powerful of the three summons.