### PR TITLE
Add the ability to put subsystems into debug mode

### DIFF
--- a/code/controllers/subsystems/processing/processing.dm
+++ b/code/controllers/subsystems/processing/processing.dm
@@ -10,6 +10,9 @@ SUBSYSTEM_DEF(processing)
 	var/list/current_run = list()
 	var/process_proc = /datum/proc/Process
 
+	var/debug_last_thing
+	var/debug_original_process_proc // initial() does not work with procs
+
 /datum/controller/subsystem/processing/stat_entry()
 	..(processing.len)
 
@@ -24,9 +27,38 @@ SUBSYSTEM_DEF(processing)
 	while(current_run.len)
 		var/datum/thing = current_run[current_run.len]
 		current_run.len--
-		if(QDELETED(thing) || (call(thing, process_proc)(wait, times_fired) == PROCESS_KILL))
+		if(QDELETED(thing) || (call(thing, process_proc)(wait, times_fired, src) == PROCESS_KILL))
 			if(thing)
 				thing.is_processing = null
 			processing -= thing
 		if (MC_TICK_CHECK)
 			return
+
+/datum/controller/subsystem/processing/proc/toggle_debug()
+	if(!check_rights(R_DEBUG))
+		return
+
+	if(debug_original_process_proc)
+		process_proc = debug_original_process_proc
+		debug_original_process_proc = null
+	else
+		debug_original_process_proc	= process_proc
+		process_proc = /datum/proc/DebugSubsystemProcess
+
+	to_chat(usr, "[name] - Debug mode [debug_original_process_proc ? "en" : "dis"]abled")
+
+/datum/controller/subsystem/processing/VV_static()
+	return ..() + list("processing", "current_run", "process_proc", "debug_last_thing", "debug_original_process_proc")
+
+/datum/proc/DebugSubsystemProcess(var/wait, var/times_fired, var/datum/controller/subsystem/processing/subsystem)
+	subsystem.debug_last_thing = src
+	var/start_tick = world.time
+	var/start_tick_usage = world.tick_usage
+	. = call(src, subsystem.debug_original_process_proc)(wait, times_fired)
+
+	var/tick_time = world.time - start_tick
+	var/tick_use_limit = world.tick_usage - start_tick_usage - 100 // Current tick use - starting tick use - 100% (a full tick excess)
+	if(tick_time > 0)
+		CRASH("[log_info_line(subsystem.debug_last_thing)] slept during processing. Spent [tick_time] tick\s.")
+	if(tick_use_limit > 0)
+		CRASH("[log_info_line(subsystem.debug_last_thing)] took longer than a tick to process. Exceeded with [tick_use_limit]%")


### PR DESCRIPTION
To enable debugging:
* Click subsystem in the MC tab, this opens the VV window
* In the drop-down menu in the upper right select "Call Proc"
* Enter "toggle_debug", press OK, finish argument input
* Excess running times should now result in runtimes.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
