### PR TITLE
Properly adds a civilian security role in a way that makes sense.

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -379,6 +379,15 @@
 	icon_open = "brown_jacket_nt_open"
 	icon_closed = "brown_jacket_nt"
 
+/obj/item/clothing/suit/storage/toggle/marshal_jacket
+	name = "colonial marshal jacket"
+	desc = "A black leather jacket belonging to an agent of the Colonial Marshal Bureau."
+	icon_state = "marshal_jacket"
+	item_state = "marshal_jacket"
+	icon_open = "marshal_jacket_open"
+	icon_closed = "marshal_jacket"
+	body_parts_covered = UPPER_TORSO|ARMS
+
 /obj/item/clothing/suit/storage/toggle/hoodie
 	name = "hoodie"
 	desc = "A warm sweatshirt."

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -600,7 +600,8 @@
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
 		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/marine
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/marine,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/civ
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e3,
@@ -609,7 +610,8 @@
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/marine/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/marine/e5
+		/datum/mil_rank/marine/e5,
+		/datum/mil_rank/civ/marshal
 	)
 
 	access = list(access_security, access_brig, access_forensics_lockers,

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -308,6 +308,12 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	uniform = /obj/item/clothing/under/solgov/utility/marine/security
 	shoes = /obj/item/clothing/shoes/jungleboots
 
+/decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/civ
+	name = OUTFIT_JOB_NAME("Forensic Technician - Civilian")
+	uniform = /obj/item/clothing/under/det/grey
+	suit = /obj/item/clothing/suit/storage/toggle/marshal_jacket
+	shoes = /obj/item/clothing/shoes/dress
+
 /decl/hierarchy/outfit/job/torch/crew/security/maa
 	name = OUTFIT_JOB_NAME("Master at Arms")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/security

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -16,13 +16,13 @@
 #define NON_MILITARY_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway)
 
 //For jobs that allow for decorative or ceremonial clothing
-#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/guard)
+#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/guard, /datum/job/detective)
 
 //For civilian jobs that may have a uniform, but not a strict one
-#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/stowaway, /datum/job/scientist, /datum/job/senior_scientist)
+#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/stowaway, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/detective)
 
 //For civilian jobs that may have a strict uniform.
-#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway)
+#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway, /datum/job/detective)
 
 //For NanoTrasen employees
 #define NANOTRASEN_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant)

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -213,6 +213,7 @@
 		/datum/mil_rank/civ/nt,
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/civ/offduty,
+		/datum/mil_rank/civ/marshal,
 		/datum/mil_rank/civ/synthetic
 	)
 
@@ -221,6 +222,7 @@
 		/datum/mil_rank/civ/nt,
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/civ/offduty,
+		/datum/mil_rank/civ/marshal,
 		/datum/mil_rank/civ/synthetic
 	)
 
@@ -651,6 +653,11 @@
 
 /datum/mil_rank/civ/offduty
 	name = "Off-Duty Personnel"
+
+/datum/mil_rank/civ/marshal
+	name = "Colonial Marshal"
+	name_short = "CMar"
+	accessory = list(/obj/item/clothing/accessory/badge/marshal)
 
 /datum/mil_rank/civ/synthetic
 	name = "Synthetic"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
# Introducing: The Colonial Marshal Bureau
The Colonial Marshal Bureau is a civilian law enforcement agency of the Sol Central Government whose jurisdiction spans anywhere within SCG space and, in some cases, even out of it. Rather than transcribe their whole fluff here, I'll leave a link to the Baylore wiki's article that explains them: https://baystation12.net/lore/Organizations/SCG/SCG%20Peace#colonial-marshal-bureau

The Colonial Marshals are already present within the Baystation lore, and, as such, I see them as a perfect alternative for those who want civilian roles within the Torch's security department. Furthermore, I have not actually added any new assets with this PR. All the uniforms and stuff were already present, and completely unused.

## Why am I making this PR?
There is currently a push by what appears to be a very vocal minority to have contractors added to security, in the guise of having a civilian role within the department. Well, Torch security is legitimate law enforcement. They are not Ancapistan's McPolice. They are not a private security force hired by a corporation to protect its assets. They are sworn law enforcement agents working for a legitimate government. Contractors are private people whose only allegiance is money. Hell, one could argue that "contractor" is legalese for mercenary, the way it's used these days. Contractors make no sense within the Torch's security force. Enter the Colonial Marshal Bureau. A government law enforcement agency staffed by civilian agents who are sworn law enforcement officers, and have a ridiculously large jurisdiction. Including the Torch. Unless the reason why people want contractors in security is some idiotic real-life bias against the government that they're letting bleed through, this right here is the best of both worlds.

## What the Colonial Marshals **ARE**:
- C I V I L I A N S;
- Proper, legitimate law enforcement;
- Firmly under the authority of the CoS, just like a EC/DF Forensic Technician;
- Agents operating under the SCG's authority;
- An integral and fully legitimate part of the Torch security department.

## What the Colonial Marshals **ARE NOT**:
- Military personnel;
- Subject to the SCMJ;
- Contractors/McPolice;
- Limited on their attire, including hairstyle, provided their role as law enforcement remains clear;
- Above the Torch hierarchy, or operating separately from their department. The CoS still calls the shots.

## The Colonial Marshal "Uniform":
This, sans the sunglasses, is what a player who picked Colonial Marshal spawns with:
![temp2](https://user-images.githubusercontent.com/13301593/34446147-e8f9b77a-ecbf-11e7-8365-f7bb01a437fb.png)

A detective suit, which spawns with a red tie and their Colonial Marshal's badge attached, dress shoes, and their Colonial Marshal's leather jacket. That's it. Beyond this, you can wear whatever the hell you like. Be completely formal, completely informal, somewhere between them. Doesn't matter. Just wear either the badge or the jacket, as those are the things that identify them as their role.

## How do I choose to be a Colonial Marshal?
The Colonial Marshal is treated as a rank. In the same way in which you'd choose a branch and then a rank between E-2 to E-5 for an EC/DF Forensic Technician, you'll choose the Civilian branch, and the Colonial Marshal "rank". Forensic Technician is the **only** job available for this "rank". You can fully use any alt-titles for the job as well. Instead of spawning with rank tabs or pins, you'll be spawning with a badge.
![temp](https://user-images.githubusercontent.com/13301593/34446246-95166774-ecc0-11e7-90f4-870e25baa717.png)

In the crew manifest, your name will be prefixed by "CMar", indicating what you are, and also stating that you are a civilian.

## Final considerations:
This PR, as a side effect for allowing marshals to wear whatever they want, also opens those clothing options for EC/DF FTs. That does not mean they are free to wear them instead of their uniform, and odds are they're gonna get assblasted by their superiors if they do. I sure hope you guys don't do this.
![shiggydiggy](https://user-images.githubusercontent.com/13301593/34446314-294ef6a4-ecc1-11e7-8650-903f5cf89879.jpg)