### PR TITLE
Fixes automatic shutoff valves

### DIFF
--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -3,12 +3,9 @@
 	icon_state = "map_vclamp0"
 
 	name = "automatic shutoff valve"
-	desc = "A pipe valve. There is a reset button on the side."
-	var/threshold = 101.15
-	var/node1_last_pressure = 0
-	var/node2_last_pressure = 0
-	var/safe_counter = 0
-	var/override_counter = 0
+	desc = "An automatic valve with control circuitry and pipe integrity sensor, capable of automatically isolating damaged segments of the pipe network."
+	var/closed_auto = 0
+	var/override_open = FALSE	// If true it will be always open
 	level = 1
 	connect_types = CONNECT_TYPE_SCRUBBER | CONNECT_TYPE_SUPPLY | CONNECT_TYPE_REGULAR
 
@@ -16,14 +13,21 @@
 /obj/machinery/atmospherics/valve/shutoff/update_icon()
 	icon_state = "vclamp[open]"
 
+/obj/machinery/atmospherics/valve/shutoff/examine(var/mob/user)
+	..()
+	to_chat(user, "The automatic shutoff circuit is [override_open ? "disabled" : "enabled"].")
+
 /obj/machinery/atmospherics/valve/shutoff/New()
 	open()
 	hide(1)
 	..()
 
-/obj/machinery/atmospherics/valve/shutoff/attack_hand(mob/user as mob)
-	..()
-	override_counter = 3
+/obj/machinery/atmospherics/valve/shutoff/attack_hand(var/mob/user as mob)
+	override_open = !override_open
+	to_chat(user, "You [override_open ? "disable" : "enable"] the automatic shutoff circuit.")
+
+/obj/machinery/atmospherics/valve/shutoff/attack_ai(var/mob/user as mob)
+	attack_hand(user)
 
 /obj/machinery/atmospherics/valve/shutoff/hide(var/do_hide)
 	if(do_hide)
@@ -38,27 +42,14 @@
 /obj/machinery/atmospherics/valve/shutoff/Process()
 	..()
 
-	if(!node1 || !node2)
-		return
-	var/datum/gas_mixture/node1_air = node1.return_air()
-	var/datum/gas_mixture/node2_air = node2.return_air()
-	var/node1_pressure = node1_air.return_pressure()
-	var/node2_pressure = node2_air.return_pressure()
-	if(node1_last_pressure && node2_last_pressure && !override_counter)
+	if(!network_node1 || !network_node2)
 		if(open)
-			if(((node1_pressure <= threshold) || (node2_pressure <= threshold)) && (!((node1_pressure >= node1_last_pressure) && (node2_pressure >= node2_last_pressure)))) //I'm not proud of this line. /BlueNexus
-				close()
-				safe_counter = 0
-		else
-			if((node1_pressure >= node1_last_pressure) && (node2_pressure >= node2_last_pressure))
-				safe_counter++
-			else
-				safe_counter = 0
-			if(safe_counter >= 6)
-				open()
-				safe_counter = 0
+			close()
+		return
 
-	node1_last_pressure = node1_pressure
-	node2_last_pressure = node2_pressure
-	if(override_counter)
-		override_counter--
+	closed_auto = (network_node1.leaks.len || network_node2.leaks.len || override_open)
+
+	if(closed_auto && open)
+		close()
+	else if(!closed_auto && !open)
+		open()

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -4,7 +4,6 @@
 
 	name = "automatic shutoff valve"
 	desc = "An automatic valve with control circuitry and pipe integrity sensor, capable of automatically isolating damaged segments of the pipe network."
-	var/closed_auto = 0
 	var/override_open = FALSE	// If true it will be always open
 	level = 1
 	connect_types = CONNECT_TYPE_SCRUBBER | CONNECT_TYPE_SUPPLY | CONNECT_TYPE_REGULAR
@@ -47,7 +46,7 @@
 			close()
 		return
 
-	closed_auto = (network_node1.leaks.len || network_node2.leaks.len || override_open)
+	var/closed_auto = (network_node1.leaks.len || network_node2.leaks.len || override_open)
 
 	if(closed_auto && open)
 		close()

--- a/code/modules/atmospherics/datum_pipe_network.dm
+++ b/code/modules/atmospherics/datum_pipe_network.dm
@@ -5,7 +5,7 @@
 	var/list/obj/machinery/atmospherics/normal_members = list()
 	var/list/datum/pipeline/line_members = list()
 		//membership roster to go through for updates and what not
-
+	var/list/leaks = list()
 	var/update = 1
 
 /datum/pipe_network/Destroy()
@@ -15,6 +15,7 @@
 	for(var/obj/machinery/atmospherics/normal_member in normal_members)
 		normal_member.reassign_network(src, null)
 	gases.Cut()  // Do not qdel the gases, we don't own them
+	leaks.Cut()
 	return ..()
 
 /datum/pipe_network/Process()
@@ -50,6 +51,8 @@
 	normal_members |= giver.normal_members
 
 	line_members |= giver.line_members
+
+	leaks |= giver.leaks
 
 	for(var/obj/machinery/atmospherics/normal_member in giver.normal_members)
 		normal_member.reassign_network(giver, src)

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -5,6 +5,8 @@
 	var/list/obj/machinery/atmospherics/pipe/edges //Used for building networks
 
 	var/datum/pipe_network/network
+	// Leaking nodes
+	var/list/leaks = list()
 
 	var/alert_pressure = 0
 
@@ -20,11 +22,10 @@
 		qdel(air)
 	for(var/obj/machinery/atmospherics/pipe/P in members)
 		P.parent = null
-
+	leaks.Cut()
 	. = ..()
 
 /datum/pipeline/Process()//This use to be called called from the pipe networks
-
 	//Check to see if pressure is within acceptable limits
 	var/pressure = air.return_pressure()
 	if(pressure > alert_pressure)
@@ -59,6 +60,9 @@
 	else
 		air = new
 
+	if(base.leaking)
+		leaks |= base
+
 	while(possible_expansions.len>0)
 		for(var/obj/machinery/atmospherics/pipe/borderline in possible_expansions)
 
@@ -81,6 +85,9 @@
 						if(item.air_temporary)
 							air.merge(item.air_temporary)
 
+						if(item.leaking)
+							leaks |= item
+
 					edge_check--
 
 			if(edge_check>0)
@@ -98,6 +105,7 @@
 	new_network.line_members += src
 
 	network = new_network
+	network.leaks |= leaks
 
 	for(var/obj/machinery/atmospherics/pipe/edge in edges)
 		for(var/obj/machinery/atmospherics/result in edge.pipeline_expansion())


### PR DESCRIPTION
- Pipelines and pipenets now track their leaking pipe segments
- Automatic shutoff valves no longer guess whether a leak exists based on dark magic and pressure approximations. Rather, actual leak data is used. This fixes numerous issues with false positives (valves seal even when no breach exists) or false negatives (valves don't seal even when the pipe is leaking) and should be completely bulletproof.
- Fixes manifolds and manifolds4w not leaking at all.
- Fixes #17198
- Fixes #17196
- Probably fixes #16590

:cl:
bugfix: Automatic shutoff valves now correctly detect leaks at all times, and no longer have false positives.
bugfix: Manifolds and 4way manifolds can now leak their contents similarly to how straight pipes do.
/:cl: