### PR TITLE
Improve uplink source selection

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -343,6 +343,7 @@
 #include "code\datums\uplink\telecrystals.dm"
 #include "code\datums\uplink\uplink_categories.dm"
 #include "code\datums\uplink\uplink_items.dm"
+#include "code\datums\uplink\uplink_sources.dm"
 #include "code\datums\uplink\deity\_defines.dm"
 #include "code\datums\uplink\deity\deity_categories.dm"
 #include "code\datums\uplink\deity\deity_items.dm"

--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -46,6 +46,7 @@
 #define MODE_GODCULTIST "god cultist"
 
 #define DEFAULT_TELECRYSTAL_AMOUNT 130
+#define IMPLANT_TELECRYSTAL_AMOUNT(x) (round(x * 0.49)) // If this cost is ever greater than half of DEFAULT_TELECRYSTAL_AMOUNT then it is possible to buy more TC than you spend
 
 /////////////////
 ////WIZARD //////

--- a/code/_global_vars/lists/flavor.dm
+++ b/code/_global_vars/lists/flavor.dm
@@ -5,12 +5,6 @@ GLOBAL_LIST_INIT(robot_module_types, list(
 	"Research"
 )) // This shouldn't be a static list. Am I the only one who cares about extendability around here?
 
-//Uplink spawn loc
-#define UPLINK_PDA   "PDA"
-#define UPLINK_RADIO "Headset"
-#define UPLINK_NONE  "None"
-GLOBAL_LIST_INIT(uplink_locations, list(UPLINK_PDA, UPLINK_RADIO, UPLINK_NONE))
-
 // Noises made when hit while typing.
 GLOBAL_LIST_INIT(hit_appends, list("-OOF", "-ACK", "-UGH", "-HRNK", "-HURGH", "-GLORF"))
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -407,14 +407,14 @@
 			if("crystals")
 				if (usr.client.holder.rights & R_FUN)
 					var/obj/item/device/uplink/suplink = find_syndicate_uplink()
-					var/crystals
-					if (suplink)
-						crystals = suplink.uses
+					if(!suplink)
+						to_chat(usr, "<span class='warning'>Failed to find an uplink.</span>")
+						return
+					var/crystals = suplink.uses
 					crystals = input("Amount of telecrystals for [key]","Operative uplink", crystals) as null|num
-					if (!isnull(crystals))
-						if (suplink)
-							suplink.uses = crystals
-							log_and_message_admins("set the telecrystals for [key] to [crystals]")
+					if (!isnull(crystals) && !QDELETED(suplink))
+						suplink.uses = crystals
+						log_and_message_admins("set the telecrystals for [key] to [crystals]")
 
 	else if (href_list["obj_announce"])
 		var/obj_count = 1

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -26,7 +26,7 @@
 /datum/uplink_item/item/implants/imp_uplink/New()
 	..()
 	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
-	desc = "Contains [round((DEFAULT_TELECRYSTAL_AMOUNT / 2) * 0.8)] Telecrystal\s"
+	desc = "Contains [IMPLANT_TELECRYSTAL_AMOUNT(DEFAULT_TELECRYSTAL_AMOUNT)] Telecrystal\s"
 
 /datum/uplink_item/item/implants/imp_imprinting
 	name = "Neural Imprinting Implant"

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -1,0 +1,130 @@
+GLOBAL_LIST_INIT(default_uplink_source_priority, list(
+	/decl/uplink_source/pda,
+	/decl/uplink_source/radio,
+	/decl/uplink_source/unit))
+
+/decl/uplink_source
+	var/name
+	var/desc
+
+/decl/uplink_source/proc/setup_uplink_source(var/mob/M, var/amount)
+	return FALSE
+
+/decl/uplink_source/pda
+	name = "PDA"
+
+/decl/uplink_source/pda/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/device/pda/P = find_in_mob(M, /obj/item/device/pda)
+	if(!P)
+		return FALSE
+
+	var/pda_pass = "[rand(100,999)] [pick(GLOB.greek_letters)]"
+	var/obj/item/device/uplink/T = new(P, M.mind, amount)
+	P.hidden_uplink = T
+	P.lock_code = pda_pass
+	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [P.name]. Simply enter the code \"[pda_pass]\" into the ringtone select to unlock its hidden features.</span>")
+	M.mind.store_memory("<B>Uplink Passcode:</B> [pda_pass] ([P.name]).")
+
+/decl/uplink_source/radio
+	name = "Radio"
+
+/decl/uplink_source/radio/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/device/radio/R = find_in_mob(M, /obj/item/device/radio)
+	if(!R)
+		return FALSE
+
+	var/freq = PUBLIC_LOW_FREQ
+	var/list/freqlist = list()
+	while (freq <= PUBLIC_HIGH_FREQ)
+		if (freq < 1451 || freq > PUB_FREQ)
+			freqlist += freq
+		freq += 2
+		if ((freq % 2) == 0)
+			freq += 1
+
+	freq = freqlist[rand(1, freqlist.len)]
+	var/obj/item/device/uplink/T = new(R, M.mind, amount)
+	R.hidden_uplink = T
+	R.traitor_frequency = freq
+	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [R.name]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features.</span>")
+	M.mind.store_memory("<B>Radio Freq:</B> [format_frequency(freq)] ([R.name]).")
+
+	return TRUE
+
+/decl/uplink_source/implant
+	name = "Implant"
+	desc = "Teleports an uplink implant into your head, costing at least half the initial TC amount."
+
+/decl/uplink_source/implant/setup_uplink_source(var/mob/living/carbon/human/H, var/amount)
+	if(!istype(H))
+		return FALSE
+
+	var/obj/item/organ/external/head = H.organs_by_name[BP_HEAD]
+	if(!head)
+		return FALSE
+
+	var/obj/item/weapon/implant/uplink/U = new(H, IMPLANT_TELECRYSTAL_AMOUNT(amount))
+	U.imp_in = H
+	U.implanted = TRUE
+	U.part = head
+	head.implants += U
+
+	U.implanted(H) // This proc handles the installation feedback
+	return TRUE
+
+/decl/uplink_source/unit
+	name = "Uplink Unit"
+	desc = "Teleports an uplink unit to your location, costing 10% of the initial TC amount."
+
+/decl/uplink_source/unit/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/device/radio/uplink/U = new(M, M.mind, round(amount * 0.9))
+	put_on_mob(M, U, "\A [U]")
+	return TRUE
+
+/decl/uplink_source/telecrystals
+	name = "Telecrystals"
+	desc = "Get your telecrystals in pure form, without the means to trade them for goods."
+
+/decl/uplink_source/telecrystals/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/stack/telecrystal/TC = new(M, amount)
+	put_on_mob(M, TC, "[amount] telecrystal\s")
+	return TRUE
+
+/decl/uplink_source/proc/find_in_mob(var/mob/M, var/type)
+	for(var/item in M.get_equipped_items(TRUE))
+		if(!istype(item, type))
+			continue
+		var/obj/item/I = item
+		if(!I.hidden_uplink)
+			return I
+
+/decl/uplink_source/proc/put_on_mob(var/mob/M, var/atom/movable/AM, var/text)
+	var/obj/O = M.equip_to_storage(AM)
+	if(O)
+		to_chat(M, "<span class='notice'>[text] can be found in your [O.name].</span>")
+	else if(M.put_in_hands(AM))
+		to_chat(M, "<span class='notice'>[text] appear in your hands.</span>")
+	else
+		AM.dropInto(M.loc)
+		to_chat(M, "<span class='notice'>[text] appear at your location.</span>")
+
+/proc/setup_uplink_source(var/mob/M, var/amount = DEFAULT_TELECRYSTAL_AMOUNT)
+	if(!istype(M) || !M.mind)
+		return FALSE
+
+	var/list/priority_order
+	if(M.client && M.client.prefs)
+		priority_order = M.client.prefs.uplink_sources
+
+	if(!priority_order || !priority_order.len)
+		priority_order = list()
+		for(var/entry in GLOB.default_uplink_source_priority)
+			priority_order += decls_repository.get_decl(entry)
+
+	for(var/entry in priority_order)
+		var/decl/uplink_source/US = entry
+		if(US.setup_uplink_source(M, amount))
+			return TRUE
+
+	to_chat(M, "<span class='warning'>Either by choice or circumstance you will be without an uplink.</span>")
+	return FALSE

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -15,8 +15,10 @@ var/datum/antagonist/traitor/traitors
 
 /datum/antagonist/traitor/Topic(href, href_list)
 	if (..())
-		return
-	if(href_list["spawn_uplink"]) spawn_uplink(locate(href_list["spawn_uplink"]))
+		return 1
+	if(href_list["spawn_uplink"])
+		spawn_uplink(locate(href_list["spawn_uplink"]))
+		return 1
 
 /datum/antagonist/traitor/create_objectives(var/datum/mind/traitor)
 	if(!..())
@@ -106,68 +108,7 @@ var/datum/antagonist/traitor/traitors
 	to_chat(traitor_mob, "Use the code words, preferably in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
 
 /datum/antagonist/traitor/proc/spawn_uplink(var/mob/living/carbon/human/traitor_mob)
-	if(!istype(traitor_mob))
-		return
-
-	var/loc = ""
-	var/obj/item/R = locate() //Hide the uplink in a PDA if available, otherwise radio
-
-	if(traitor_mob.client.prefs.uplinklocation == "Headset")
-		R = locate(/obj/item/device/radio) in traitor_mob.contents
-		if(!R)
-			R = locate(/obj/item/device/pda) in traitor_mob.contents
-			to_chat(traitor_mob, "Could not locate a Radio, installing in PDA instead!")
-		if (!R)
-			to_chat(traitor_mob, "Unfortunately, neither a radio or a PDA relay could be installed.")
-	else if(traitor_mob.client.prefs.uplinklocation == "PDA")
-		R = locate(/obj/item/device/pda) in traitor_mob.contents
-		if(!R)
-			R = locate(/obj/item/device/radio) in traitor_mob.contents
-			to_chat(traitor_mob, "Could not locate a PDA, installing into a Radio instead!")
-		if(!R)
-			to_chat(traitor_mob, "Unfortunately, neither a radio or a PDA relay could be installed.")
-	else if(traitor_mob.client.prefs.uplinklocation == "None")
-		to_chat(traitor_mob, "You have elected to not have an AntagCorp portable teleportation relay installed!")
-		R = null
-	else
-		to_chat(traitor_mob, "You have not selected a location for your relay in the antagonist options! Defaulting to PDA!")
-		R = locate(/obj/item/device/pda) in traitor_mob.contents
-		if (!R)
-			R = locate(/obj/item/device/radio) in traitor_mob.contents
-			to_chat(traitor_mob, "Could not locate a PDA, installing into a Radio instead!")
-		if (!R)
-			to_chat(traitor_mob, "Unfortunately, neither a radio or a PDA relay could be installed.")
-
-	if(!R)
-		return
-
-	if(istype(R,/obj/item/device/radio))
-		// generate list of radio freqs
-		var/obj/item/device/radio/target_radio = R
-		var/freq = PUBLIC_LOW_FREQ
-		var/list/freqlist = list()
-		while (freq <= PUBLIC_HIGH_FREQ)
-			if (freq < 1451 || freq > PUB_FREQ)
-				freqlist += freq
-			freq += 2
-			if ((freq % 2) == 0)
-				freq += 1
-		freq = freqlist[rand(1, freqlist.len)]
-		var/obj/item/device/uplink/T = new(R, traitor_mob.mind)
-		target_radio.hidden_uplink = T
-		target_radio.traitor_frequency = freq
-		to_chat(traitor_mob, "A portable object teleportation relay has been installed in your [R.name] [loc]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features.")
-		traitor_mob.mind.store_memory("<B>Radio Freq:</B> [format_frequency(freq)] ([R.name] [loc]).")
-
-	else if (istype(R, /obj/item/device/pda))
-		// generate a passcode if the uplink is hidden in a PDA
-		var/pda_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
-		var/obj/item/device/uplink/T = new(R, traitor_mob.mind)
-		R.hidden_uplink = T
-		var/obj/item/device/pda/P = R
-		P.lock_code = pda_pass
-		to_chat(traitor_mob, "A portable object teleportation relay has been installed in your [R.name] [loc]. Simply enter the code \"[pda_pass]\" into the ringtone select to unlock its hidden features.")
-		traitor_mob.mind.store_memory("<B>Uplink Passcode:</B> [pda_pass] ([R.name] [loc]).")
+	setup_uplink_source(traitor_mob, DEFAULT_TELECRYSTAL_AMOUNT)
 
 /datum/antagonist/traitor/proc/add_law_zero(mob/living/silicon/ai/killer)
 	var/law = "Accomplish your objectives at all costs. You may ignore all other laws."

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -241,9 +241,9 @@
 // Includes normal radio uplink, multitool uplink,
 // implant uplink (not the implant tool) and a preset headset uplink.
 
-/obj/item/device/radio/uplink/New(var/loc, var/owner)
+/obj/item/device/radio/uplink/New(var/loc, var/owner, var/amount)
 	..()
-	hidden_uplink = new(src, owner)
+	hidden_uplink = new(src, owner, amount)
 	icon_state = "radio"
 
 /obj/item/device/radio/uplink/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/implants/implants/uplink.dm
+++ b/code/game/objects/items/weapons/implants/implants/uplink.dm
@@ -4,12 +4,13 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
 	var/activation_emote
 
-/obj/item/weapon/implant/uplink/New()
-	hidden_uplink = new(src, telecrystals = round((DEFAULT_TELECRYSTAL_AMOUNT / 2) * 0.8))
+/obj/item/weapon/implant/uplink/New(var/loc, var/amount)
+	amount = amount || IMPLANT_TELECRYSTAL_AMOUNT(DEFAULT_TELECRYSTAL_AMOUNT)
+	hidden_uplink = new(src, telecrystals = amount)
 	..()
 
 /obj/item/weapon/implant/uplink/implanted(mob/source)
-	activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch_v", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	activation_emote = input("Choose activation emote:", "Uplink Implant Setup") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch_v", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	source.mind.store_memory("Uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 	to_chat(source, "The implanted uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.")
 	hidden_uplink.uplink_owner = source.mind

--- a/code/modules/client/preference_setup/antagonism/02_setup.dm
+++ b/code/modules/client/preference_setup/antagonism/02_setup.dm
@@ -1,25 +1,64 @@
 /datum/preferences
-	var/uplinklocation = "PDA"
+	var/list/uplink_sources
 	var/exploit_record = ""
 
 /datum/category_item/player_setup_item/antagonism/basic
 	name = "Setup"
 	sort_order = 2
 
+	var/static/list/uplink_sources
+	var/static/list/uplink_sources_by_name
+
+/datum/category_item/player_setup_item/antagonism/basic/New()
+	..()
+	if(!uplink_sources_by_name)
+		uplink_sources = list()
+		uplink_sources_by_name = list()
+
+		var/uplink_sources_by_type = decls_repository.get_decls_of_subtype(/decl/uplink_source)
+		for(var/uplink_source_type in uplink_sources_by_type)
+			var/decl/uplink_source/uplink_source = uplink_sources_by_type[uplink_source_type]
+			uplink_sources += uplink_source
+			uplink_sources_by_name[uplink_source.name] = uplink_source
+
 /datum/category_item/player_setup_item/antagonism/basic/load_character(var/savefile/S)
-	S["uplinklocation"] >> pref.uplinklocation
+	var/list/uplink_order
+	S["uplink_sources"] >> uplink_order
 	S["exploit_record"] >> pref.exploit_record
 
+	if(istype(uplink_order))
+		pref.uplink_sources = list()
+		for(var/entry in uplink_order)
+			var/uplink_source = uplink_sources_by_name[entry]
+			if(uplink_source)
+				pref.uplink_sources += uplink_source
+
 /datum/category_item/player_setup_item/antagonism/basic/save_character(var/savefile/S)
-	S["uplinklocation"] << pref.uplinklocation
+	var/uplink_order = list()
+	for(var/entry in pref.uplink_sources)
+		var/decl/uplink_source/UL = entry
+		uplink_order += UL.name
+
+	S["uplink_sources"] << uplink_order
 	S["exploit_record"] << pref.exploit_record
 
 /datum/category_item/player_setup_item/antagonism/basic/sanitize_character()
-	pref.uplinklocation	= sanitize_inlist(pref.uplinklocation, GLOB.uplink_locations, initial(pref.uplinklocation))
+	if(!istype(pref.uplink_sources))
+		pref.uplink_sources = list()
+		for(var/entry in GLOB.default_uplink_source_priority)
+			pref.uplink_sources += decls_repository.get_decl(entry)
 
 /datum/category_item/player_setup_item/antagonism/basic/content(var/mob/user)
 	. +="<b>Antag Setup:</b><br>"
-	. +="Uplink Type: <a href='?src=\ref[src];antagtask=1'>[pref.uplinklocation]</a><br>"
+	. +="Uplink Source Priority: <a href='?src=\ref[src];add_source=1'>Add</a><br>"
+	for(var/entry in pref.uplink_sources)
+		var/decl/uplink_source/US = entry
+		. +="[US.name] <a href='?src=\ref[src];move_source_up=\ref[US]'>Move Up</a> <a href='?src=\ref[src];move_source_down=\ref[US]'>Move Down</a> <a href='?src=\ref[src];remove_source=\ref[US]'>Remove</a><br>"
+		if(US.desc)
+			. += "<font size=1>[US.desc]</font><br>"
+	if(!pref.uplink_sources.len)
+		. += "<span class='warning'>You will not receive an uplink unless you add an uplink source!</span>"
+	. +="<br>"
 	. +="Exploitable information:<br>"
 	if(jobban_isbanned(user, "Records"))
 		. += "<b>You are banned from using character records.</b><br>"
@@ -27,9 +66,37 @@
 		. +="<a href='?src=\ref[src];exploitable_record=1'>[TextPreview(pref.exploit_record,40)]</a><br>"
 
 /datum/category_item/player_setup_item/antagonism/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
-	if (href_list["antagtask"])
-		pref.uplinklocation = next_in_list(pref.uplinklocation, GLOB.uplink_locations)
+	if(href_list["add_source"])
+		var/source_selection = input(user, "Select Uplink Source to Add", "Character Setup") as null|anything in (uplink_sources - pref.uplink_sources)
+		if(source_selection && CanUseTopic(user))
+			pref.uplink_sources |= source_selection
+			return TOPIC_REFRESH
+
+	if(href_list["remove_source"])
+		var/decl/uplink_source/US = locate(href_list["remove_source"]) in pref.uplink_sources
+		if(US && pref.uplink_sources.Remove(US))
+			return TOPIC_REFRESH
+
+	if(href_list["move_source_up"])
+		var/decl/uplink_source/US = locate(href_list["move_source_up"]) in pref.uplink_sources
+		if(!US)
+			return TOPIC_NOACTION
+		var/index = pref.uplink_sources.Find(US)
+		if(index <= 1)
+			return TOPIC_NOACTION
+		pref.uplink_sources.Swap(index, index - 1)
 		return TOPIC_REFRESH
+
+	if(href_list["move_source_down"])
+		var/decl/uplink_source/US = locate(href_list["move_source_down"]) in pref.uplink_sources
+		if(!US)
+			return TOPIC_NOACTION
+		var/index = pref.uplink_sources.Find(US)
+		if(index >= pref.uplink_sources.len)
+			return TOPIC_NOACTION
+		pref.uplink_sources.Swap(index, index + 1)
+		return TOPIC_REFRESH
+
 
 	if(href_list["exploitable_record"])
 		var/exploitmsg = sanitize(input(user,"Set exploitable information about you here.","Exploitable Information", html_decode(pref.exploit_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)


### PR DESCRIPTION
:cl:
tweak: Improved uplink source priority setup. Check the Roles tab in the Character Setup.
rscadd: Adds two new uplink sources which do not require pre-existing equipment to be successfully setup, such as radios and PDAs, but at a cost.
rscadd: There is technically a third uplink source, but it is just a pile of telecrystals which you cannot trade in for goods.
/:cl:

Fixes #19906

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
