### PR TITLE
Removes Ensigns (and Marine 2nd LTs) from Command positions

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -178,9 +178,6 @@
 		/datum/mil_rank/marine/o3,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/marine/o2,
-		/datum/mil_rank/ec/o1,
-		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/marine/o1
 	)
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -221,9 +218,6 @@
 		/datum/mil_rank/marine/o3,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/marine/o2,
-		/datum/mil_rank/ec/o1,
-		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/marine/o1
 	)
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,


### PR DESCRIPTION
:cl:Techhead
tweak: Removes Ensign and 2nd Lieutenant from the positions of Chief Engineer and Head of Security. To any O-1 who had previously held these positions: Congratulations on your promotion, Lieutenant.
/:cl:

Basically done to simplify the rank structure for EC, with fleet/marines as a side effect. This way, EC has:
- Captain: CO
- Commander: XO
- Head of staff: LT
- Lesser officers: ENS