### PR TITLE
Fixes #14645 and related runtime issues with force-feeding

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -457,3 +457,13 @@
 
 /mob/living/carbon/proc/need_breathe()
 	return
+
+/mob/living/carbon/check_has_mouth()
+	// carbon mobs have mouths by default
+	// behavior of this proc for humans is overridden in human.dm
+	return 1
+
+/mob/living/carbon/proc/check_mouth_coverage()
+	// carbon mobs do not have blocked mouths by default
+	// overridden in human_defense.dm
+	return null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -627,7 +627,8 @@
 	return
 
 /mob/living/proc/check_has_mouth()
-	return 1
+	// mobs do not have mouths by default
+	return 0
 
 /mob/living/carbon/human/check_has_mouth()
 	// Todo, check stomach organ when implemented.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -135,7 +135,7 @@ meteor_act
 	return 0
 
 //Used to check if they can be fed food/drinks/pills
-/mob/living/carbon/human/proc/check_mouth_coverage()
+/mob/living/carbon/human/check_mouth_coverage()
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform)
 	for(var/obj/item/gear in protective_gear)
 		if(istype(gear) && (gear.body_parts_covered & FACE) && !(gear.item_flags & FLEXIBLEMATERIAL))

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -301,6 +301,9 @@
 /mob/living/carbon/slime/has_eyes()
 	return 0
 
+/mob/living/carbon/slime/check_has_mouth()
+	return 0
+
 /mob/living/carbon/slime/proc/gain_nutrition(var/amount)
 	nutrition += amount
 	if(prob(amount * 2)) // Gain around one level per 50 nutrition

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -111,25 +111,28 @@
 		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
 		return 1
 
-	if(target == user)
-		if(istype(user, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = user
-			if(!H.check_has_mouth())
-				to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
-				return
-			var/obj/item/blocked = H.check_mouth_coverage()
-			if(blocked)
-				to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
-				return
+	// only carbons can eat
+	if(istype(target, /mob/living/carbon))
+		if(target == user)
+			if(istype(user, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = user
+				if(!H.check_has_mouth())
+					to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
+					return
+				var/obj/item/blocked = H.check_mouth_coverage()
+				if(blocked)
+					to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
+					return
 
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //puts a limit on how fast people can eat/drink things
-		self_feed_message(user)
-		reagents.trans_to_mob(user, issmall(user) ? ceil(amount_per_transfer_from_this/2) : amount_per_transfer_from_this, CHEM_INGEST)
-		feed_sound(user)
-		return 1
-	else
-		if(istype(user, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = target
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //puts a limit on how fast people can eat/drink things
+			self_feed_message(user)
+			reagents.trans_to_mob(user, issmall(user) ? ceil(amount_per_transfer_from_this/2) : amount_per_transfer_from_this, CHEM_INGEST)
+			feed_sound(user)
+			return 1
+
+
+		else
+			var/mob/living/carbon/H = target
 			if(!H.check_has_mouth())
 				to_chat(user, "Where do you intend to put \the [src]? \The [H] doesn't have a mouth!")
 				return
@@ -138,20 +141,22 @@
 				to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
 				return
 
-		other_feed_message_start(user, target)
+			other_feed_message_start(user, target)
 
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if(!do_mob(user, target))
-			return
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			if(!do_mob(user, target))
+				return
 
-		other_feed_message_finish(user, target)
+			other_feed_message_finish(user, target)
 
-		var/contained = reagentlist()
-		admin_attack_log(user, target, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
+			var/contained = reagentlist()
+			admin_attack_log(user, target, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
 
-		reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INGEST)
-		feed_sound(user)
-		return 1
+			reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INGEST)
+			feed_sound(user)
+			return 1
+
+	return 0
 
 /obj/item/weapon/reagent_containers/proc/standard_pour_into(var/mob/user, var/atom/target) // This goes into afterattack and yes, it's atom-level
 	if(!target.reagents)


### PR DESCRIPTION
I've only changed the procedures for reagent_containers as food (snacks.dm) has a different proc entirely.
* check_has_mouth() defined for carbons and defaults to 1
* check_mouth_coverage() moved from humans to carbons and defaults to null
* standard_feed_mob() changed to only allow feeding mobs (incl. yourself) of type living/carbon

Affected runtime issues, all related:
* Fixes #14645
* Fixes #15279
* Fixes #15652
* Fixes #18237
