### PR TITLE
Expands emote formatting, including automatic punctuation and prepended text.

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -60,6 +60,55 @@
 		if (I.implanted)
 			I.trigger(act, src)
 
+/datum/proc/format_emote(var/source = null, var/message = null)
+	var/pretext
+	var/subtext
+	var/nametext
+	var/end_char
+	var/start_char
+	var/name_anchor
+
+	if(!message || !source)
+		return
+
+	// Store the player's name in a nice bold, naturalement
+	nametext = "<B>[source]</B>"
+
+	name_anchor = findtext(message, "^")
+	if(name_anchor > 0) // User supplied emote with a carat
+		pretext = copytext(message, 1, name_anchor)
+		subtext = copytext(message, name_anchor + 1, lentext(message) + 1)
+	else
+		// No carat. Just the emote as usual.
+		subtext = message
+
+	// Oh shit, we got this far! Let's see... did the user attempt to use more than one carat?
+	if(findtext(subtext, "^"))
+		// abort abort!
+		return 0
+
+	// Auto-capitalize our pretext if there is any.
+	if(pretext)
+		pretext = uppertext(copytext(pretext, 1, 2)) + copytext(pretext, 2, lentext(pretext) + 1)
+		// Add a space at the end if we didn't already supply one.
+		end_char = copytext(pretext, lentext(pretext), lentext(pretext) + 1)
+		if(end_char != " ")
+			pretext += " "
+
+	// Grab the last character of the emote message.
+	end_char = copytext(subtext, lentext(subtext), lentext(subtext) + 1)
+	if(end_char != "." && end_char != "?" && end_char != "!" && end_char != "\"")
+		// No punctuation supplied. Tack a period on the end.
+		subtext += "."
+
+	// Add a space to the subtext, unless it begins with an apostrophe or comma... or a space.
+	if(subtext != ".")
+		start_char = copytext(subtext, 1, 2)
+		if(start_char != "," && start_char != " " && start_char != "&") // Apostrophes are parsed as "&#039;", so uhh, yeah.
+			subtext = " " + subtext
+
+	return pretext + nametext + subtext
+
 /mob/proc/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message = null)
 
 	if((usr && stat) || (!use_me && usr == src))
@@ -71,8 +120,10 @@
 		input = sanitize(input(src,"Choose an emote to display.") as text|null)
 	else
 		input = message
+
 	if(input)
-		message = "<B>[src]</B> [input]"
+		//message = "<B>[src]</B> [input]"
+		message = format_emote(src, message)
 	else
 		return
 

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -60,7 +60,7 @@
 		if (I.implanted)
 			I.trigger(act, src)
 
-/datum/proc/format_emote(var/source = null, var/message = null)
+/mob/proc/format_emote(var/source = null, var/message = null)
 	var/pretext
 	var/subtext
 	var/nametext
@@ -122,7 +122,6 @@
 		input = message
 
 	if(input)
-		//message = "<B>[src]</B> [input]"
 		message = format_emote(src, message)
 	else
 		return

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -89,7 +89,7 @@
 
 	// Auto-capitalize our pretext if there is any.
 	if(pretext)
-		pretext = uppertext(copytext(pretext, 1, 2)) + copytext(pretext, 2, lentext(pretext) + 1)
+		pretext = capitalize(pretext)
 		// Add a space at the end if we didn't already supply one.
 		end_char = copytext(pretext, lentext(pretext), lentext(pretext) + 1)
 		if(end_char != " ")


### PR DESCRIPTION
🆑 
tweak: You can now insert a caret (^) into an emote to adjust where your name appears (ex: "me Angrily, ^ draws a gun").
tweak: Emotes are automatically capitalized and will correct your punctuation if needed.
\ 🆑 

This PR changes how the "me" verb works in a number of ways.

- Emotes no longer have to begin with your character's name. Throw in a caret (^) to really play around with the writing format!
```
me Panting heavily, ^ comes running down the stairs
-->
Panting heavily, Miki Aji comes running down the stairs.
```
```
me "I'm the Pathfinder," says ^.
-->
"I'm the Pathfinder," says Miki Aji.
```
- Prepended text will capitalize automatically. Emotes will now add a period on the end if you didn't already use appropriate punctuation. **Bonus:** The leading space is omitted if you begin your emote with a comma or apostrophe!
```
me angrily, ^ draws a gun
-->
Angrily, Miki Aji draws a gun.
```
```
me , just in the nick of time, cuts the wire
-->
Miki Aji, just in the nick of time, cuts the wire.
```
```
me 's hair stands on end
-->
Miki Aji's hair stands on end.
```