### PR TITLE
Forensics tweaks

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -44,6 +44,7 @@
 #define PHORONGUARD        0x20  // Does not get contaminated by phoron.
 #define	NOREACT            0x40  // Reagents don't react inside this container.
 #define PROXMOVE           0x80  // Does this object require proximity checking in Enter()?
+#define NOPRINT            0x100 // Does not leave user's fingerprints/fibers when used on things?
 
 //Flags for items (equipment)
 #define THICKMATERIAL          0x1  // Prevents syringes, reagent pens, and hyposprays if equiped to slot_suit or slot_head.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -25,7 +25,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
 /obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
-	add_fingerprint(user)
+	if(!(flags & NOPRINT))
+		add_fingerprint(user)
 	return A.attackby(src, user, click_params)
 
 // No comment

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -98,8 +98,6 @@
 		to_chat(usr, "<span class='warning'>You can't reach the controls from the inside.</span>")
 		return
 
-	add_fingerprint(usr)
-
 	if(href_list["eject"])
 		go_out()
 	if(href_list["beaker"])
@@ -121,8 +119,8 @@
 	return attack_hand(user)
 
 /obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
-	add_fingerprint(user)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))
+		add_fingerprint(user)
 		if(!beaker)
 			beaker = I
 			user.drop_item()
@@ -131,6 +129,8 @@
 		else
 			to_chat(user, "<span class='warning'>\The [src] has a beaker already.</span>")
 		return
+	else
+		..()
 
 /obj/machinery/sleeper/MouseDrop_T(var/mob/target, var/mob/user)
 	if(!CanMouseDrop(target, user))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -74,6 +74,8 @@
 	return
 
 /obj/machinery/bodyscanner/attackby(obj/item/grab/normal/G, user as mob)
+	if(!istype(G))
+		return ..()
 	if (!ismob(G.affecting))
 		return
 	if (src.occupant)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -760,8 +760,6 @@
 			return 1
 
 /obj/machinery/alarm/attackby(obj/item/W as obj, mob/user as mob)
-	src.add_fingerprint(user)
-
 	switch(buildstage)
 		if(2)
 			if(isScrewdriver(W))  // Opening that Air Alarm up.
@@ -925,8 +923,6 @@ FIRE ALARM
 	..()
 
 /obj/machinery/firealarm/attackby(obj/item/W as obj, mob/user as mob)
-	src.add_fingerprint(user)
-
 	if(isScrewdriver(W) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		update_icon()
@@ -1070,8 +1066,6 @@ FIRE ALARM
 			src.time = min(max(round(src.time), 0), 120)
 
 		src.updateUsrDialog()
-
-		src.add_fingerprint(usr)
 	else
 		usr << browse(null, "window=firealarm")
 		return
@@ -1219,8 +1213,6 @@ Just a object used in constructing fire alarms
 						time += tp
 						time = min(max(round(time), 0), 120)
 		updateUsrDialog()
-
-		add_fingerprint(usr)
 	else
 		usr << browse(null, "window=partyalarm")
 		return

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -26,7 +26,6 @@
 	attack_hand(var/mob/user as mob)
 		if(..(user))
 			return
-		src.add_fingerprint(usr)
 		var/dat = {"
 		<html>
 			<head>
@@ -97,7 +96,6 @@
 		if(..())
 			return
 		usr.set_machine(src)
-		src.add_fingerprint(usr)
 
 
 		if(href_list["scan"])

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -255,7 +255,6 @@ update_flag
 	if(!isWrench(W) && !istype(W, /obj/item/weapon/tank) && !istype(W, /obj/item/device/analyzer) && !istype(W, /obj/item/device/pda))
 		visible_message("<span class='warning'>\The [user] hits \the [src] with \a [W]!</span>")
 		src.health -= W.force
-		src.add_fingerprint(user)
 		healthcheck()
 
 	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/weapon/tank/jetpack))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -218,7 +218,6 @@
 		return
 
 	usr.set_machine(src)
-	add_fingerprint(usr)
 
 	if(busy)
 		to_chat(usr, "<span class='notice'>The autolathe is busy. Please wait for completion of previous operation.</span>")

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -19,14 +19,13 @@
 			break
 
 /obj/machinery/computer/operating/attack_ai(mob/user)
-	add_fingerprint(user)
 	if(stat & (BROKEN|NOPOWER))
 		return
 	interact(user)
 
 
 /obj/machinery/computer/operating/attack_hand(mob/user)
-	add_fingerprint(user)
+	..()
 	if(stat & (BROKEN|NOPOWER))
 		return
 	interact(user)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -192,7 +192,6 @@
 			src.New()
 			emagged = 0
 
-	src.add_fingerprint(usr)
 	src.updateUsrDialog()
 	return
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -23,7 +23,7 @@
 	ui_interact(user)
 
 /obj/machinery/computer/crew/attack_hand(mob/user)
-	add_fingerprint(user)
+	..()
 	if(stat & (BROKEN|NOPOWER))
 		return
 	ui_interact(user)

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -138,7 +138,6 @@
 		dat += "<BR>\n<A href = '?src=\ref[src];door=1'>Toggle Outer Door</A><BR>"
 	dat += "<BR><BR><A href='?src=\ref[user];mach_close=computer'>Close</A></TT></BODY></HTML>"
 	user << browse(dat, "window=computer;size=400x500")
-	add_fingerprint(usr)
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -99,6 +99,5 @@
 					var/mob/living/carbon/R = I.imp_in
 					to_chat(R, "<span class='notice'>You hear a voice in your head saying: '[warning]'</span>")
 
-			src.add_fingerprint(usr)
 		src.updateUsrDialog()
 		return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -167,7 +167,6 @@
 			return 0 // don't update UIs attached to this object
 		go_out()
 
-	add_fingerprint(usr)
 	return 1 // update UIs attached to this object
 
 /obj/machinery/atmospherics/unary/cryo_cell/attackby(var/obj/G, var/mob/user as mob)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -45,9 +45,9 @@
 /obj/machinery/computer/cryopod/attack_hand(mob/user = usr)
 	if(stat & (NOPOWER|BROKEN))
 		return
+	..()
 
 	user.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/dat
 
@@ -70,8 +70,6 @@
 		return
 
 	var/mob/user = usr
-
-	src.add_fingerprint(user)
 
 	if(href_list["log"])
 

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -37,7 +37,6 @@
 	if(..())
 		return
 
-	src.add_fingerprint(user)
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -930,8 +930,6 @@ About the new airlock wires panel:
 	if(istype(C, /obj/item/taperoll))
 		return
 
-	src.add_fingerprint(user)
-
 	if (!repairing && (stat & BROKEN) && src.locked) //bolted and broken
 		if (!cut_bolts(C,user))
 			..()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -268,7 +268,7 @@ obj/machinery/access_button/attackby(obj/item/I as obj, mob/user as mob)
 	..()
 
 obj/machinery/access_button/attack_hand(mob/user)
-	add_fingerprint(usr)
+	..()
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access Denied</span>")
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -121,7 +121,7 @@
 // Description: If we are clicked with crowbar or wielded fire axe, try to manually open the door.
 // This only works on broken doors or doors without power. Also allows repair with Plasteel.
 /obj/machinery/door/blast/attackby(obj/item/weapon/C as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	src.add_fingerprint(user, 0, C)
 	if(isCrowbar(C) || (istype(C, /obj/item/weapon/material/twohanded/fireaxe) && C:wielded == 1))
 		if(((stat & NOPOWER) || (stat & BROKEN)) && !( src.operating ))
 			force_toggle()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -197,7 +197,7 @@
 	..()
 
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	src.add_fingerprint(user, 0, I)
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == src.get_material_name())
 		if(stat & BROKEN)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -180,7 +180,7 @@
 				close()
 
 /obj/machinery/door/firedoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
-	add_fingerprint(user)
+	add_fingerprint(user, 0, C)
 	if(operating)
 		return//Already doing something.
 	if(isWelder(C) && !repairing)

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -118,7 +118,7 @@
 
 
 /obj/machinery/door/unpowered/simple/attackby(obj/item/I as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	src.add_fingerprint(user, 0, I)
 	if(istype(I, /obj/item/weapon/key) && lock)
 		var/obj/item/weapon/key/K = I
 		if(!lock.toggle(I))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -249,7 +249,7 @@
 		return
 
 
-	src.add_fingerprint(user)
+	src.add_fingerprint(user, 0, I)
 
 	if (src.allowed(user))
 		if (src.density)

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -63,7 +63,6 @@
 		return
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/clean = 0
 	switch(href_list["command"])	//anti-HTML-hacking checks
@@ -119,7 +118,6 @@
 		return
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/clean = 0
 	switch(href_list["command"])	//anti-HTML-hacking checks
@@ -183,7 +181,6 @@
 		return
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/clean = 0
 	switch(href_list["command"])	//anti-HTML-hacking checks

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -37,7 +37,6 @@
 		return
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/clean = 0
 	switch(href_list["command"])	//anti-HTML-hacking checks

--- a/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
@@ -86,7 +86,6 @@
 		return
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/clean = 0
 	switch(href_list["command"])	//anti-HTML-hacking checks

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -33,7 +33,6 @@
 		return 1
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	var/clean = 0
 	switch(href_list["command"])	//anti-HTML-hacking checks

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -48,12 +48,14 @@
 //Don't want to render prison breaks impossible
 /obj/machinery/flasher/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isWirecutter(W))
-		add_fingerprint(user)
+		add_fingerprint(user, 0, W)
 		src.disable = !src.disable
 		if (src.disable)
 			user.visible_message("<span class='warning'>[user] has disconnected the [src]'s flashbulb!</span>", "<span class='warning'>You disconnect the [src]'s flashbulb!</span>")
 		if (!src.disable)
 			user.visible_message("<span class='warning'>[user] has connected the [src]'s flashbulb!</span>", "<span class='warning'>You connect the [src]'s flashbulb!</span>")
+	else
+		..()
 
 //Let the AI trigger them directly.
 /obj/machinery/flasher/attack_ai()

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -54,7 +54,6 @@
 /obj/machinery/button/holosign/attack_hand(mob/user as mob)
 	if(..())
 		return
-	add_fingerprint(user)
 
 	use_power(5)
 

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -37,9 +37,7 @@
 /obj/machinery/igniter/attack_hand(mob/user as mob)
 	if(..())
 		return
-	add_fingerprint(user)
 	ignite()
-	return
 
 /obj/machinery/igniter/Process()	//ugh why is this even in process()?
 	if (on && powered() )
@@ -102,6 +100,8 @@
 		else if(!disable)
 			user.visible_message("<span class='warning'>[user] has reconnected the [src]!</span>", "<span class='warning'>You fix the connection to the [src].</span>")
 		update_icon()
+	else
+		..()
 
 /obj/machinery/sparker/attack_ai()
 	if (anchored)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -173,9 +173,8 @@ datum/track/New(var/title_name, var/audio)
 	qdel(src)
 
 /obj/machinery/media/jukebox/attackby(obj/item/W as obj, mob/user as mob)
-	src.add_fingerprint(user)
-
 	if(isWrench(W))
+		add_fingerprint(user)
 		wrench_floor_bolts(user, 0)
 		power_change()
 		return

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -298,8 +298,6 @@
 	var/mob/user = usr
 	var/datum/nanoui/ui = GLOB.nanomanager.get_open_ui(user, src, "main")
 
-	src.add_fingerprint(user)
-
 	if(href_list["close"])
 		user.unset_machine()
 		ui.close()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -239,8 +239,6 @@ Class Procs:
 			to_chat(user, "<span class='warning'>You momentarily forget how to use \the [src].</span>")
 			return 1
 
-	src.add_fingerprint(user)
-
 	return ..()
 
 /obj/machinery/proc/RefreshParts() //Placeholder proc for machines that are built using frames.

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -278,10 +278,11 @@
 		onclose(user, "magnet")
 
 	Topic(href, href_list)
+		if(..())
+			return 1
 		if(stat & (BROKEN|NOPOWER))
 			return
 		usr.set_machine(src)
-		src.add_fingerprint(usr)
 
 		if(href_list["radio-op"])
 

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -86,14 +86,12 @@
 		usr << browse(null, "window=pipedispenser")
 		return
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 	if(href_list["make"])
 		if(!wait)
 			var/p_type = text2num(href_list["make"])
 			var/p_dir = text2num(href_list["dir"])
 			var/obj/item/pipe/P = new (/*usr.loc*/ src.loc, pipe_type=p_type, dir=p_dir)
 			P.update()
-			P.add_fingerprint(usr)
 			wait = 1
 			spawn(10)
 				wait = 0
@@ -106,13 +104,14 @@
 	return
 
 /obj/machinery/pipedispenser/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	src.add_fingerprint(usr)
 	if (istype(W, /obj/item/pipe) || istype(W, /obj/item/pipe_meter))
 		to_chat(usr, "<span class='notice'>You put \the [W] back into \the [src].</span>")
 		user.drop_item()
+		add_fingerprint(usr)
 		qdel(W)
 		return
 	else if(isWrench(W))
+		add_fingerprint(usr)
 		if (unwrenched==0)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>You begin to unfasten \the [src] from the floor...</span>")
@@ -206,7 +205,6 @@ Nah
 	if(..())
 		return
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 	if(href_list["dmake"])
 		if(unwrenched || !usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
 			usr << browse(null, "window=pipedispenser")
@@ -258,7 +256,6 @@ Nah
 					if(22)
 						C.ptype = 12
 ///// Z-Level stuff
-				C.add_fingerprint(usr)
 				C.update()
 			wait = 1
 			spawn(15)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -69,7 +69,7 @@ obj/machinery/recharger/attack_hand(mob/user as mob)
 	if(istype(user,/mob/living/silicon))
 		return
 
-	add_fingerprint(user)
+	..()
 
 	if(charging)
 		charging.update_icon()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -129,7 +129,6 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 /obj/machinery/requests_console/Topic(href, href_list)
 	if(..())	return
 	usr.set_machine(src)
-	add_fingerprint(usr)
 
 	if(reject_bad_text(href_list["write"]))
 		recipient = href_list["write"] //write contains the string of the receiving department's name

--- a/code/game/machinery/robot_fabricator.dm
+++ b/code/game/machinery/robot_fabricator.dm
@@ -65,7 +65,6 @@ Please wait until completion...</TT><BR>
 		return
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	if (href_list["make"])
 		if (!src.operating)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -85,7 +85,7 @@
 	return
 
 /obj/machinery/space_heater/attack_hand(mob/user as mob)
-	src.add_fingerprint(user)
+	..()
 	interact(user)
 
 /obj/machinery/space_heater/interact(mob/user as mob)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -318,9 +318,6 @@
 			src.eject_occupant(usr)
 			src.updateUsrDialog()
 			src.update_icon()
-	/*if (href_list["refresh"])
-		src.updateUsrDialog()*/
-	src.add_fingerprint(usr)
 	return
 
 
@@ -932,9 +929,6 @@
 	return 1
 
 /obj/machinery/suit_cycler/attack_hand(mob/user as mob)
-
-	add_fingerprint(user)
-
 	if(..() || stat & (BROKEN|NOPOWER))
 		return
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -115,8 +115,6 @@
 		if(..())
 			return
 
-
-		add_fingerprint(usr)
 		usr.set_machine(src)
 
 		if(href_list["viewserver"])

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -287,7 +287,8 @@
 
 
 /obj/machinery/telecomms/Topic(href, href_list)
-
+	if(..())
+		return 1
 	if(!issilicon(usr))
 		if(!istype(usr.get_active_hand(), /obj/item/device/multitool))
 			return
@@ -398,7 +399,6 @@
 	src.Options_Topic(href, href_list)
 
 	usr.set_machine(src)
-	src.add_fingerprint(usr)
 
 	updateUsrDialog()
 

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -69,8 +69,6 @@
 		if(..())
 			return
 
-
-		add_fingerprint(usr)
 		usr.set_machine(src)
 
 		if(href_list["viewmachine"])

--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -121,8 +121,6 @@
 		if(..())
 			return
 
-
-		add_fingerprint(usr)
 		usr.set_machine(src)
 		if(!src.allowed(usr) && !emagged)
 			to_chat(usr, "<span class='warning'>ACCESS DENIED.</span>")

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -140,7 +140,6 @@
 	src.locked = L[desc]
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='notice'>Locked In</span>", 2)
-	src.add_fingerprint(usr)
 	return
 
 /obj/machinery/computer/teleporter/verb/set_id(t as text)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -437,7 +437,6 @@
 		else if ((href_list["togglevoice"]) && (src.panel_open))
 			src.shut_up = !src.shut_up
 
-		src.add_fingerprint(usr)
 		GLOB.nanomanager.update_uis(src)
 
 /obj/machinery/vending/proc/vend(var/datum/stored_items/vending_products/R, mob/user)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -122,7 +122,6 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/blood/attack_hand(mob/living/carbon/human/user)
 	..()
 	if (amount && istype(user))
-		add_fingerprint(user)
 		if (user.gloves)
 			return
 		var/taken = rand(1,amount)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -594,7 +594,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			ui.close()
 		return 0
 
-	add_fingerprint(U)
 	U.set_machine(src)
 
 	switch(href_list["choice"])

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -38,7 +38,6 @@
 		A.part2 = src
 
 		user.put_in_hands(A)
-		A.add_fingerprint(user)
 
 /obj/item/device/radio/electropack/Topic(href, href_list)
 	//..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -516,10 +516,7 @@
 		else
 			user.show_message("<span class='notice'>\The [src] can no longer be modified or attached!</span>")
 		updateDialog()
-			//Foreach goto(83)
-		add_fingerprint(user)
 		return
-	else return
 
 /obj/item/device/radio/emp_act(severity)
 	broadcasting = 0

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -122,7 +122,6 @@
 			update_icon()
 		if(href_list["device"])
 			attached_device.attack_self(usr)
-	src.add_fingerprint(usr)
 	return 1 // Returning 1 sends an update to attached UIs
 
 /obj/item/device/transfer_valve/process_activation(var/obj/item/device/D)

--- a/code/game/objects/items/devices/violin.dm
+++ b/code/game/objects/items/devices/violin.dm
@@ -293,7 +293,8 @@
 	onclose(user, "violin")
 
 /obj/item/device/violin/Topic(href, href_list)
-
+	if(..())
+		return 1
 	if(!in_range(src, usr) || issilicon(usr) || !isliving(usr) || !usr.canmove || usr.restrained())
 		usr << browse(null, "window=violin;size=700x300")
 		onclose(usr, "violin")
@@ -391,7 +392,6 @@
 				song.lines = lines
 				song.tempo = tempo
 
-	add_fingerprint(usr)
 	for(var/mob/M in viewers(1, loc))
 		if((M.client && M.machine == src))
 			attack_self(M)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -42,7 +42,6 @@
 				return
 
 			var/obj/item/stack/material/glass/reinforced/RG = new (user.loc)
-			RG.add_fingerprint(user)
 			RG.add_to_stacks(user)
 			var/obj/item/stack/material/glass/G = src
 			src = null

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -172,7 +172,6 @@
 					var/obj/item/weapon/gift/G = new /obj/item/weapon/gift( src.loc, W )
 					G.add_fingerprint(user)
 					W.add_fingerprint(user)
-					src.add_fingerprint(user)
 					src.amount -= a_used
 
 			if (src.amount <= 0)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -119,7 +119,6 @@
 					src.code += text("[]", href_list["type"])
 					if (length(src.code) > 5)
 						src.code = "ERROR"
-			src.add_fingerprint(usr)
 			for(var/mob/M in viewers(1, src.loc))
 				if ((M.client && M.machine == src))
 					src.attack_self(M)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -199,3 +199,8 @@
 		to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured \the [src]!</span>")
 		anchored = !anchored
 	return 1
+
+/obj/attack_hand(mob/living/user)
+	if(Adjacent(user))
+		add_fingerprint(user)
+	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -49,6 +49,15 @@
 	. = ..()
 	gunshot_residue = null
 
+/obj/item/clothing/proc/get_fibers()
+	. = "material from \a [name]"
+	var/list/acc = list()
+	for(var/obj/item/clothing/accessory/A in accessories)
+		if(prob(40) && A.get_fibers())
+			acc += A.get_fibers()
+	if(acc.len)
+		. += " with traces of [english_list(acc)]"
+
 /obj/item/clothing/New()
 	..()
 	if(starting_accessories)
@@ -258,6 +267,9 @@ BLIND     // can't see anything
 		if (cell.charge < 0)
 			cell.charge = 0
 	..()
+
+/obj/item/clothing/gloves/get_fibers()
+	return "material from a pair of [name]."
 
 // Called just before an attack_hand(), in mob/UnarmedAttack()
 /obj/item/clothing/gloves/proc/Touch(var/atom/A, var/proximity)

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -58,6 +58,9 @@
 	armor = list(melee = 25, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
 	slot = ACCESSORY_SLOT_ARMOR_C
 
+/obj/item/clothing/accessory/armorplate/get_fibers()
+	return null	//plates do not shed
+
 /obj/item/clothing/accessory/armorplate/medium
 	name = "medium armor plate"
 	desc = "A plasteel-reinforced synthetic armor plate, providing good protection. Attaches to a plate carrier."

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -30,10 +30,12 @@ atom/var/var/fingerprintslast = null
 	src.fingerprintshidden += "\[[time_stamp()]\] Real name: [M.real_name], Key: [M.key]"
 	return 1
 
-/atom/proc/add_fingerprint(mob/M, ignoregloves)
+/atom/proc/add_fingerprint(mob/M, ignoregloves, obj/item/tool)
 	if(isnull(M)) return
 	if(isAI(M)) return
 	if(!M || !M.key)
+		return
+	if(istype(tool) && (tool.flags & NOPRINT))
 		return
 
 	add_hiddenprint(M)
@@ -127,21 +129,24 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 	var/fibertext
 	var/item_multiplier = istype(src,/obj/item)?1.2:1
 	var/suit_coverage = 0
-	if(M.wear_suit)
-		fibertext = "Material from \a [M.wear_suit]."
-		if(prob(10*item_multiplier) && !(fibertext in suit_fibers))
-			suit_fibers += fibertext
-		suit_coverage = M.wear_suit.body_parts_covered
+	if(istype(M.wear_suit, /obj/item/clothing))
+		var/obj/item/clothing/C = M.wear_suit
+		fibertext = C.get_fibers()
+		if(fibertext && prob(10*item_multiplier))
+			suit_fibers |= fibertext
+		suit_coverage = C.body_parts_covered
 
-	if(M.w_uniform && (M.w_uniform.body_parts_covered & ~suit_coverage))
-		fibertext = "Fibers from \a [M.w_uniform]."
-		if(prob(15*item_multiplier) && !(fibertext in suit_fibers))
-			suit_fibers += fibertext
+	if(istype(M.w_uniform, /obj/item/clothing) && (M.w_uniform.body_parts_covered & ~suit_coverage))
+		var/obj/item/clothing/C = M.w_uniform
+		fibertext = C.get_fibers()
+		if(fibertext && prob(15*item_multiplier))
+			suit_fibers |= fibertext
 
-	if(M.gloves && (M.gloves.body_parts_covered & ~suit_coverage))
-		fibertext = "Material from a pair of [M.gloves.name]."
-		if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
-			suit_fibers += fibertext
+	if(istype(M.gloves, /obj/item/clothing) && (M.gloves.body_parts_covered & ~suit_coverage))
+		var/obj/item/clothing/C = M.gloves
+		fibertext = C.get_fibers()
+		if(fibertext && prob(20*item_multiplier))
+			suit_fibers |= fibertext
 
 /mob/proc/get_full_print()
 	return FALSE

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/sample
 	name = "forensic sample"
 	icon = 'icons/obj/forensics.dmi'
+	flags = NOPRINT
 	w_class = ITEM_SIZE_TINY
 	var/list/evidence = list()
 
@@ -124,6 +125,9 @@
 		for(var/print in supplied.fingerprints)
 			evidence[print] = supplied.fingerprints[print]
 		supplied.fingerprints.Cut()
+
+/obj/item/weapon/forensics
+	flags = NOPRINT
 
 /obj/item/weapon/forensics/sample_kit
 	name = "fiber collection kit"

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -208,7 +208,7 @@
 /obj/structure/disposalconstruct/attackby(var/obj/item/I, var/mob/user)
 	var/nicetype = "pipe"
 	var/ispipe = 0 // Indicates if we should change the level of this pipe
-	src.add_fingerprint(user)
+	add_fingerprint(user, 0, I)
 	switch(ptype)
 		if(6)
 			nicetype = "disposal bin"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -55,7 +55,7 @@
 	if(stat & BROKEN || !I || !user)
 		return
 
-	src.add_fingerprint(user)
+	add_fingerprint(user, 0, I)
 	if(mode<=0) // It's off
 		if(isScrewdriver(I))
 			if(contents.len > 0)
@@ -878,7 +878,7 @@
 		var/turf/T = src.loc
 		if(!T.is_plating())
 			return		// prevent interaction with T-scanner revealed pipes
-		src.add_fingerprint(user)
+		src.add_fingerprint(user, 0, I)
 		if(istype(I, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/W = I
 
@@ -1518,7 +1518,7 @@
 	var/turf/T = src.loc
 	if(!T.is_plating())
 		return		// prevent interaction with T-scanner revealed pipes
-	src.add_fingerprint(user)
+	src.add_fingerprint(user, 0, I)
 	if(istype(I, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/W = I
 
@@ -1637,7 +1637,7 @@
 	attackby(var/obj/item/I, var/mob/user)
 		if(!I || !user)
 			return
-		src.add_fingerprint(user)
+		src.add_fingerprint(user, 0, I)
 		if(isScrewdriver(I))
 			if(mode==0)
 				mode=1

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -364,7 +364,8 @@
 	return
 
 /obj/item/device/destTagger/Topic(href, href_list)
-	src.add_fingerprint(usr)
+	if(..())
+		return 1
 	if(href_list["nextTag"] && href_list["nextTag"] in GLOB.tagger_locations)
 		src.currTag = href_list["nextTag"]
 	if(href_list["nextTag"] == "CUSTOM")

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -164,7 +164,6 @@
 	if(..())
 		return 1
 
-	add_fingerprint(usr)
 	usr.set_machine(src)
 	if(!allowed(usr) && !emagged)
 		to_chat(usr, "<span class='warning'>You do not have the required access level</span>")

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -99,7 +99,6 @@
 		reset()
 
 	updateUsrDialog()
-	add_fingerprint(usr)
 	return
 
 /obj/machinery/keycard_auth/proc/reset()

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -14,7 +14,6 @@
 /obj/machinery/computer/shuttle_control/attack_hand(user as mob)
 	if(..(user))
 		return
-	//src.add_fingerprint(user)	//shouldn't need fingerprints just for looking at it.
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access Denied.</span>")
 		return 1

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -97,8 +97,6 @@
 	var/mob/user = usr
 	var/datum/nanoui/ui = GLOB.nanomanager.get_open_ui(user, src, "main")
 
-	src.add_fingerprint(user)
-
 	if (href_list["close"])
 		user.unset_machine()
 		ui.close()

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -90,7 +90,6 @@
 		container.loc = src.loc
 		container = null
 
-	src.add_fingerprint(usr)
 	src.updateUsrDialog()
 
 

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -129,8 +129,6 @@
 	var/mob/user = usr
 	var/datum/nanoui/ui = GLOB.nanomanager.get_open_ui(user, src, "main")
 
-	src.add_fingerprint(user)
-
 	if (href_list["close"])
 		user.unset_machine()
 		ui.close()

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -151,8 +151,6 @@
 	var/mob/user = usr
 	var/datum/nanoui/ui = GLOB.nanomanager.get_open_ui(user, src, "main")
 
-	src.add_fingerprint(user)
-
 	if (href_list["close"])
 		user.unset_machine()
 		ui.close()

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -126,8 +126,6 @@
 	var/mob/user = usr
 	var/datum/nanoui/ui = GLOB.nanomanager.get_open_ui(user, src, "main")
 
-	src.add_fingerprint(user)
-
 	if (href_list["close"])
 		user.unset_machine()
 		ui.close()

--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -34,7 +34,7 @@
 		return..()
 
 /obj/machinery/artifact_harvester/attack_hand(var/mob/user as mob)
-	src.add_fingerprint(user)
+	..()
 	interact(user)
 
 /obj/machinery/artifact_harvester/interact(var/mob/user as mob)

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -358,6 +358,4 @@
 		if(scanned_item)
 			scanned_item.loc = src.loc
 			scanned_item = null
-
-	add_fingerprint(usr)
 	return 1 // update UIs attached to this object

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -113,6 +113,9 @@ specialty pins
 	icon_state = "marinerank_command"
 	slot = ACCESSORY_SLOT_INSIGNIA
 
+/obj/item/clothing/accessory/solgov/specialty/get_fibers()
+	return null
+
 /obj/item/clothing/accessory/solgov/specialty/janitor
 	name = "custodial blazes"
 	desc = "Purple blazes denoting a custodial technician."
@@ -373,6 +376,9 @@ ranks - ec
 	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_RANK
 	gender = PLURAL
+
+/obj/item/clothing/accessory/solgov/rank/get_fibers()
+	return null
 
 /obj/item/clothing/accessory/solgov/rank/ec
 	name = "explorer ranks"


### PR DESCRIPTION
When using forensic collection tools they get sample first, do the detective's fibers leaving after. Makes it less torturing to just keep finding your own fibers fucking everywhere.
Most accessories now show up as part of fiber string.
Most of diff is me hunting down duplicate fingerprint adding calls, base Topic and attackby handle those
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

  