### PR TITLE
Adjust some QDEL hints

### DIFF
--- a/code/game/images.dm
+++ b/code/game/images.dm
@@ -1,3 +1,3 @@
 /image/Destroy()
 	..()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -18,7 +18,7 @@
 		spellremove(src)
 	ghostize()
 	..()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL
 
 /mob/proc/remove_screen_obj_references()
 	hands = null


### PR DESCRIPTION
Some QDEL_HINT_HARDDEL_NOW are now merely QDEL_HINT_HARDDEL
We'll see if this breaks things horrifically.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
