### PR TITLE
Fixes several runtime issues: organs, stasis clamps, god constructs, handcuffs

### DIFF
--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -52,7 +52,7 @@
 	. = ..()
 
 /obj/machinery/clamp/proc/open()
-	if(open)
+	if(open || !target)
 		return 0
 
 	target.build_network()

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -51,7 +51,8 @@
 				to_chat(user, "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>")
 		else
 			to_chat(user, "<span class='warning'>\The [C] is already handcuffed!</span>")
-	..()
+	else
+		..()
 
 /obj/item/weapon/handcuffs/proc/can_place(var/mob/target, var/mob/user)
 	if(user == target || istype(user, /mob/living/silicon/robot) || istype(user, /mob/living/bot))

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -37,16 +37,21 @@
 		place_handcuffs(user, user)
 		return
 
-	if(!C.handcuffed)
-		if (C == user)
-			place_handcuffs(user, user)
-			return
+	// only carbons can be handcuffed
+	if(istype(C))
+		if(!C.handcuffed)
+			if (C == user)
+				place_handcuffs(user, user)
+				return
 
-		//check for an aggressive grab (or robutts)
-		if(can_place(C, user))
-			place_handcuffs(C, user)
+			//check for an aggressive grab (or robutts)
+			if(can_place(C, user))
+				place_handcuffs(C, user)
+			else
+				to_chat(user, "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>")
 		else
-			to_chat(user, "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>")
+			to_chat(user, "<span class='warning'>\The [C] is already handcuffed!</span>")
+	..()
 
 /obj/item/weapon/handcuffs/proc/can_place(var/mob/target, var/mob/user)
 	if(user == target || istype(user, /mob/living/silicon/robot) || istype(user, /mob/living/bot))

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -31,3 +31,9 @@
 	//the second is the message in question.
 	var/last_taste_time = 0
 	var/last_taste_text = ""
+
+	// organ-related variables, see organ.dm and human_organs.dm
+	var/list/internal_organs = list()
+	var/list/organs = list()
+	var/list/organs_by_name = list() // map organ names to organs
+	var/list/internal_organs_by_name = list() // so internal organs have less ickiness too

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -4,11 +4,6 @@
 		eyes.update_colour()
 		regenerate_icons()
 
-/mob/living/carbon/var/list/internal_organs = list()
-/mob/living/carbon/var/list/organs = list()
-/mob/living/carbon/var/list/organs_by_name = list() // map organ names to organs
-/mob/living/carbon/var/list/internal_organs_by_name = list() // so internal organs have less ickiness too
-
 /mob/living/carbon/human/proc/get_bodypart_name(var/zone)
 	var/obj/item/organ/external/E = get_organ(zone)
 	if(E) . = E.name

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -5,9 +5,9 @@
 		regenerate_icons()
 
 /mob/living/carbon/var/list/internal_organs = list()
-/mob/living/carbon/human/var/list/organs = list()
-/mob/living/carbon/human/var/list/organs_by_name = list() // map organ names to organs
-/mob/living/carbon/human/var/list/internal_organs_by_name = list() // so internal organs have less ickiness too
+/mob/living/carbon/var/list/organs = list()
+/mob/living/carbon/var/list/organs_by_name = list() // map organ names to organs
+/mob/living/carbon/var/list/internal_organs_by_name = list() // so internal organs have less ickiness too
 
 /mob/living/carbon/human/proc/get_bodypart_name(var/zone)
 	var/obj/item/organ/external/E = get_organ(zone)

--- a/code/modules/spells/general/god_construct.dm
+++ b/code/modules/spells/general/god_construct.dm
@@ -16,7 +16,7 @@
 
 /spell/construction/choose_targets()
 	var/list/possible_targets = list()
-	if(connected_god)
+	if(connected_god && connected_god.form)
 		for(var/type in connected_god.form.buildables)
 			var/cost = 10
 			if(ispath(type, /obj/structure/deity))


### PR DESCRIPTION
Fixes #19965 and fixes #18118 related to Destroy()'ing internal organs
* The runtime in _internal.dm seemed to concern some adminbus and gib()...
* several organ-related variables have been moved from /human to /carbon
* (limited) testing shows this does not seem to affect human organ operation
* it should not affect other carbons (brain, nymph) as they do not have organs

Fixes #19948 related to stasis clamp adminbus
* opening a stasis clamp will no longer be possible if it isn't attached to a pipe of some kind

Tentatively fixes #19934, can't read null.buildables 
* checks for connected_god.form before proceeding
* I'm not sure if there's some underlying issue here, or what happened to have this runtime occur to begin with?

Fixes #19905, attempts to handcuff non-carbon mobs
* only carbons can be handcuffed
* added a check for mobs that're already cuffed
* added a ..() return at the end