### PR TITLE
cloaked mobs (ninjas and whatnot/Mehren and other simple mobs.) can now be spotted via T-ray.

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -82,7 +82,7 @@
 	flicker = !flicker
 
 //creates a new overlay for a scanned object
-/obj/item/device/t_scanner/proc/get_overlay(obj/scanned)
+/obj/item/device/t_scanner/proc/get_overlay(var/atom/movable/scanned)
 	//Use a cache so we don't create a whole bunch of new images just because someone's walking back and forth in a room.
 	//Also means that images are reused if multiple people are using t-rays to look at the same objects.
 	if(scanned in overlay_cache)
@@ -98,7 +98,22 @@
 			I.color = P.pipe_color
 			I.overlays += P.overlays
 			I.underlays += P.underlays
-
+		if(ismob(scanned))
+			if(ishuman(scanned))
+				var/mob/living/carbon/human/H = scanned
+				if(H.is_cloaked())
+					if(H.species.appearance_flags & HAS_SKIN_COLOR)
+						I.color = RGB(r_skin, g_skin, b_skin)
+					I.overlays += H.overlays
+					I.underlays += H.underlays
+				else return
+			else
+				var/mob/M = scanned
+				if(M.alpha < 255)
+					I.color = M.color
+					I.overlays += M.overlays
+					I.underlays += M.underlays
+				else return
 		I.alpha = 128
 		I.mouse_opacity = 0
 		. = I

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -310,7 +310,7 @@ var/global/list/robot_modules = list(
 
 	if(src.emag)
 		var/obj/item/weapon/reagent_containers/spray/PS = src.emag
-		PS.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
+		PS.reagents.add_reagent(/datum/reagent/acid/polyacid, 4 * amount)
 
 	..()
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -220,5 +220,5 @@
 
 /datum/reagent/fuel/touch_mob(var/mob/living/L, var/amount)
 	if(istype(L))
-		L.adjust_fire_stacks(amount / 10) // Splashing people with welding fuel to make them easy to ignite!
+		L.adjust_fire_stacks(amount / 2) // Splashing people with welding fuel to make them easy to ignite!
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -107,7 +107,7 @@
 
 /datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
 	if(istype(L))
-		L.adjust_fire_stacks(amount / 15)
+		L.adjust_fire_stacks(amount / 7)
 
 /datum/reagent/ethanol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(removed * 2 * toxicity)
@@ -185,7 +185,7 @@
 	M.adjustToxLoss(4 * removed)
 
 /datum/reagent/hydrazine/affect_touch(var/mob/living/carbon/M, var/alien, var/removed) // Hydrazine is both toxic and flammable.
-	M.adjust_fire_stacks(removed / 12)
+	M.adjust_fire_stacks(removed / 7)
 	M.adjustToxLoss(0.2 * removed)
 
 /datum/reagent/hydrazine/touch_turf(var/turf/T)
@@ -231,7 +231,7 @@
 			step(M, pick(GLOB.cardinal))
 		if(prob(5))
 			M.emote(pick("twitch", "drool", "moan"))
-		M.adjustBrainLoss(0.1)
+		M.adjustBrainLoss(6 * removed)
 
 /datum/reagent/phosphorus
 	name = "Phosphorus"
@@ -287,10 +287,10 @@
 	metabolism = REM * 2
 	touch_met = 50 // It's acid!
 	var/power = 5
-	var/meltdose = 10 // How much is needed to melt
+	var/meltdose = 120 // How much is needed to melt. One large beaker.
 
 /datum/reagent/acid/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.take_organ_damage(0, removed * power * 2)
+	M.take_organ_damage(0, removed * power)
 
 /datum/reagent/acid/affect_touch(var/mob/living/carbon/M, var/alien, var/removed) // This is the most interesting
 	if(ishuman(M))
@@ -369,7 +369,7 @@
 	reagent_state = LIQUID
 	color = "#808080"
 	power = 3
-	meltdose = 8
+	meltdose = 60
 
 /datum/reagent/silicon
 	name = "Silicon"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -298,7 +298,7 @@
 	if(!istype(T))
 		return
 	if(volume >= 1)
-		T.wet_floor(80)
+		T.wet_floor(320)
 
 /datum/reagent/silicate
 	name = "Silicate"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -246,8 +246,8 @@
 	taste_description = "acid"
 	reagent_state = LIQUID
 	color = "#8e18a9"
-	power = 10
-	meltdose = 4
+	power = 7
+	meltdose = 30 //Half a beaker.
 
 /datum/reagent/lexorin
 	name = "Lexorin"
@@ -318,7 +318,7 @@
 		return
 	if(prob(10))
 		to_chat(M, "<span class='danger'>Your insides are burning!</span>")
-		M.adjustToxLoss(rand(100, 300) * removed)
+		M.adjustToxLoss(rand(50, 150) * removed)
 	else if(prob(40))
 		M.heal_organ_damage(25 * removed, 0)
 


### PR DESCRIPTION
:cl: 
add: cloaked mobs (ninjas and whatnot/Mehren) can now be spotted via T-ray.
\ :cl: 
[why]: T-ray sees metal. Ninja is metal. Therefore, T-ray should be able to see ninja. Also Mehren because why not? It covers other mobs too.