### PR TITLE
cloaked mobs (ninjas and whatnot/Mehren and other simple mobs.) can now be spotted via T-ray.

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -29,6 +29,10 @@
 /obj/item/device/t_scanner/update_icon()
 	icon_state = "t-ray[on]"
 
+/obj/item/device/t_scanner/emp_act()
+	audible_message(src, "<span class = 'notice'> \The [src] buzzes oddly.</span>")
+	set_active(FALSE)
+
 /obj/item/device/t_scanner/attack_self(mob/user)
 	set_active(!on)
 
@@ -82,7 +86,7 @@
 	flicker = !flicker
 
 //creates a new overlay for a scanned object
-/obj/item/device/t_scanner/proc/get_overlay(obj/scanned)
+/obj/item/device/t_scanner/proc/get_overlay(var/atom/movable/scanned)
 	//Use a cache so we don't create a whole bunch of new images just because someone's walking back and forth in a room.
 	//Also means that images are reused if multiple people are using t-rays to look at the same objects.
 	if(scanned in overlay_cache)
@@ -98,6 +102,16 @@
 			I.color = P.pipe_color
 			I.overlays += P.overlays
 			I.underlays += P.underlays
+
+		if(ismob(scanned))
+			if(ishuman(scanned))
+				var/mob/living/carbon/human/H = scanned
+				if(H.species.appearance_flags & HAS_SKIN_COLOR)
+					I.color = rgb(H.r_skin, H.g_skin, H.b_skin)
+			var/mob/M = scanned
+			I.color = M.color
+			I.overlays += M.overlays
+			I.underlays += M.underlays
 
 		I.alpha = 128
 		I.mouse_opacity = 0
@@ -115,6 +129,16 @@
 	if(!center) return
 
 	for(var/turf/T in range(scan_range, center))
+		for(var/mob/M in T.contents)
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(H.is_cloaked())
+					. += M
+			else if(M.alpha < 255)
+				. += M
+			else if(round_is_spooky() && isobserver(M))
+				. += M
+
 		if(!!T.is_plating())
 			continue
 
@@ -124,6 +148,8 @@
 			if(!O.invisibility)
 				continue //if it's already visible don't need an overlay for it
 			. += O
+
+
 
 /obj/item/device/t_scanner/proc/set_user_client(var/client/new_client)
 	if(new_client == user_client)


### PR DESCRIPTION
WHOOPWHOOPWHOOPWHOOPWHOOPWHOOPWHOOP
:cl:
rscadd: cloaked mobs (ninjas and whatnot/Mehren) can now be spotted via T-ray.
/ :cl:
[why]: T-ray sees metal. Ninja is metal. Therefore, T-ray should be able to see ninja. Also Mehren because why not? It covers other mobs too.
  
  