### PR TITLE
Fixes NT holobadges

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -75,7 +75,7 @@
 			var/obj/item/device/pda/pda = O
 			id_card = pda.id
 
-		if(access_security in id_card.access || emagged)
+		if(access_sec_guard in id_card.access || emagged)
 			to_chat(user, "You imprint your ID details onto the badge.")
 			set_name(user.real_name)
 		else

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -75,7 +75,7 @@
 			var/obj/item/device/pda/pda = O
 			id_card = pda.id
 
-		if(access_sec_guard in id_card.access || emagged)
+		if(access_research in id_card.access || emagged)
 			to_chat(user, "You imprint your ID details onto the badge.")
 			set_name(user.real_name)
 		else


### PR DESCRIPTION
🆑TheGreyWolf
bugfix: NT guards can now use their holobadges.
/🆑
If this doesn't work, i'm making it use normal science access.
fixes https://github.com/Baystation12/Baystation12/issues/19987