### PR TITLE
Tweaks to non-magical diagnostics

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -103,7 +103,7 @@
 		var/list/dilating = list(/datum/reagent/space_drugs=5,/datum/reagent/mindbreaker=1,/datum/reagent/adrenaline=1)
 		if(H.reagents.has_any_reagent(pinpoint) || H.ingested.has_any_reagent(pinpoint))
 			to_chat(user, "<span class='notice'>\The [H]'s pupils are already pinpoint and cannot narrow any more.</span>")
-		else if(H.reagents.has_any_reagent(dilating) || H.ingested.has_any_reagent(dilating))
+		else if(H.shock_stage >= 30 || H.reagents.has_any_reagent(dilating) || H.ingested.has_any_reagent(dilating))
 			to_chat(user, "<span class='notice'>\The [H]'s pupils narrow slightly, but are still very dilated.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [H]'s pupils narrow.</span>")

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -6,48 +6,9 @@
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
 	if(ishuman(M) && isliving(user))
 		if(user.a_intent == I_HELP)
-			var/body_part = parse_zone(user.zone_sel.selecting)
-			if(body_part)
-				var/their = "their"
-				switch(M.gender)
-					if(MALE)	their = "his"
-					if(FEMALE)	their = "her"
-
-				var/sound = "heartbeat"
-				var/sound_strength = "cannot hear"
-				var/heartbeat = 0
-				var/obj/item/organ/internal/heart/heart = M.internal_organs_by_name[BP_HEART]
-				if(heart && !(heart.robotic >= ORGAN_ROBOT))
-					heartbeat = 1
-				if(M.stat == DEAD || (M.status_flags&FAKEDEATH))
-					sound_strength = "cannot hear"
-					sound = "anything"
-				else
-					switch(body_part)
-						if(BP_CHEST)
-							sound_strength = "hear"
-							sound = "no heartbeat"
-							if(heartbeat)
-								if(heart.is_bruised() || M.getOxyLoss() > 50)
-									sound = "[pick("odd noises in","weak")] heartbeat"
-								else
-									sound = "healthy heartbeat"
-
-							var/obj/item/organ/internal/lungs/L = M.internal_organs_by_name[M.species.breathing_organ]
-							if(!L || M.losebreath || !L.active_breathing)
-								sound += " and no respiration"
-							else if(M.is_lung_ruptured() || M.getOxyLoss() > 50)
-								sound += " and [pick("wheezing","gurgling")] sounds"
-							else
-								sound += " and healthy respiration"
-						if(BP_EYES,BP_MOUTH)
-							sound_strength = "cannot hear"
-							sound = "anything"
-						else
-							if(heartbeat)
-								sound_strength = "hear a weak"
-								sound = "pulse"
-
-				user.visible_message("[user] places [src] against [M]'s [body_part] and listens attentively.", "You place [src] against [their] [body_part]. You [sound_strength] [sound].")
+			var/obj/item/organ/organ = M.get_organ(user.zone_sel.selecting)
+			if(organ)
+				user.visible_message("[user] places [src] against [M]'s [organ.name] and listens attentively.", 
+									 "You place [src] against [M]'s [organ.name]. You hear [english_list(organ.listen())].")
 				return
 	return ..(M,user)

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -31,7 +31,7 @@
 /datum/grab/normal/on_hit_help(var/obj/item/grab/normal/G)
 	var/obj/item/organ/external/O = G.get_targeted_organ()
 	if(O)
-		return O.inspect(G.affecting, G.assailant)
+		return O.inspect(G.assailant)
 
 /datum/grab/normal/on_hit_disarm(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
@@ -73,7 +73,7 @@
 
 		G.attacking = 0
 		G.action_used()
-		O.jointlock(affecting, assailant)
+		O.jointlock(assailant)
 		assailant.visible_message("<span class='danger'>[affecting]'s [O.name] is twisted!</span>")
 		playsound(assailant.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		return 1

--- a/code/modules/organs/external/machine.dm
+++ b/code/modules/organs/external/machine.dm
@@ -98,6 +98,10 @@
 		owner.set_stat(CONSCIOUS)
 		owner.visible_message("<span class='danger'>\The [owner] twitches visibly!</span>")
 
+/obj/item/organ/internal/cell/listen()
+	if(get_charge())
+		return "faint hum of the power bank"
+
 // Used for an MMI or posibrain being installed into a human.
 /obj/item/organ/internal/mmi_holder
 	name = "brain interface"

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -165,3 +165,29 @@
 		return FALSE
 
 	return pulse > PULSE_NONE || robotic == ORGAN_ROBOT || (owner.status_flags & FAKEDEATH)
+
+/obj/item/organ/internal/heart/listen()
+	if(robotic == ORGAN_ROBOT && is_working())
+		if(is_bruised())
+			return "sputtering pump"
+		else
+			return "steady whirr of the pump"
+
+	if(!pulse || (owner.status_flags & FAKEDEATH))
+		return "no pulse"
+
+	var/pulsesound = "normal"
+	if(is_bruised())
+		pulsesound = "irregular"
+
+	switch(pulse)
+		if(PULSE_SLOW)
+			pulsesound = "slow"
+		if(PULSE_FAST)
+			pulsesound = "fast"
+		if(PULSE_2FAST)
+			pulsesound = "very fast"
+		if(PULSE_THREADY)
+			pulsesound = "extremely fast and faint"
+
+	. = "[pulsesound] pulse"

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -313,3 +313,29 @@
 		species.get_environment_discomfort(owner,"heat")
 	else if(breath.temperature <= species.cold_discomfort_level)
 		species.get_environment_discomfort(owner,"cold")
+
+/obj/item/organ/internal/lungs/listen()
+	if(owner.failed_last_breath || !active_breathing)
+		return "no respiration"
+
+	if(robotic == ORGAN_ROBOT)
+		if(is_bruised())
+			return "malfunctioning fans"
+		else
+			return "air flowing"
+
+	. = list()
+	if(is_bruised())
+		. += "[pick("wheezing", "gurgling")] sounds"
+
+	var/list/breathtype = list()
+	if(get_oxygen_deprivation() > 50)
+		breathtype += pick("straining","labored")
+	if(owner.shock_stage > 50)
+		breathtype += pick("shallow and rapid")
+	if(!breathtype.len)
+		breathtype += "healthy"
+	
+	. += "[english_list(breathtype)] breathing"
+
+	return english_list(.)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -354,3 +354,7 @@ var/list/organ_cache = list()
 
 /obj/item/organ/proc/isrobotic()
 	return robotic >= ORGAN_ROBOT
+
+//used by stethoscope
+/obj/item/organ/proc/listen()
+	return


### PR DESCRIPTION
Added shock pupil dilation to eye penlight check.

Cleaned up and tweaked grab-diagnostic.
It now doesn't need to be passed its own owner, nor does it use temp var to keep src in, wtf? Done same to jointlock proc while in the area.
As for actual changes: added tendons/dislocations diagnostics, added shock symptom (clammy cold skin), circulation, oxygenation (replaces stariht up oxyloss), embedded items.

Stethoscope now uses organ proc to get what can be heard form on. Externa organs just compile what can be heard from internal ones. Added some noise to working FBP battery as proof of concept. Robotic hearts/lungs now make sound too. Lungs now show indication of shock (rapid breathing), heart shows how fast pulse is.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
