### PR TITLE
Tweaks to health analyzer output

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -76,8 +76,10 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 						brain_result = "<span class='notice'>minor brain damage</span>"
 					if(3 to 5)
 						brain_result = "<span class='warning'>weak</span>"
-					if(6 to INFINITY)
+					if(6 to 8)
 						brain_result = "<span class='danger'>extremely weak</span>"
+					if(9 to INFINITY)
+						brain_result = "<span class='danger'>fading</span>"
 					else
 						brain_result = "<span class='danger'>ERROR - Hardware fault</span>"
 	else
@@ -131,7 +133,7 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 	if(H.is_asystole())
 		. += "<span class='danger'>Patient is suffering from cardiovascular shock. Administer CPR immediately.</span>"
 	else if(H.shock_stage > 80)
-		. += "<span class='warning'>Patient is at serious risk of entering cardiovascular shock.</span>"
+		. += "<span class='warning'>Patient is at serious risk of going into shock. Pain relief recommended.</span>"
 
 	// Other general warnings.
 	if(H.getOxyLoss() > 50)


### PR DESCRIPTION
Adds another stage to brain activity - 'fading', as I felt that 'extremely weak' was too fucking long - it covered 2x the brain damage steps.
Makes message about shock more clear about what it means - at least this monkey was confused by it thinking it means issues with blood/heart etc.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
