### PR TITLE
Adds NANOBLOOD

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -192,6 +192,16 @@
 		//AB is a universal receiver.
 	return 0
 
+/mob/living/carbon/human/proc/regenerate_blood(amount)
+	var/blood_volume_raw = vessel.get_reagent_amount(/datum/reagent/blood)
+	amount = max(0,min(amount, species.blood_volume - blood_volume_raw))
+	if(amount)
+		var/datum/reagent/blood/B = get_blood(vessel)
+		if(istype(B))
+			B.volume += amount
+			vessel.update_total()
+	return amount
+
 proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spray_dir)
 
 	var/obj/effect/decal/cleanable/blood/B

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -58,11 +58,7 @@
 			heal_damage(0.3)
 
 	//Blood regeneration if there is some space
-	var/blood_volume_raw = owner.vessel.get_reagent_amount(/datum/reagent/blood)
-	if(blood_volume_raw < species.blood_volume)
-		var/datum/reagent/blood/B = owner.get_blood(owner.vessel)
-		if(istype(B))
-			B.volume += 0.1 + owner.chem_effects[CE_BLOODRESTORE] // regenerate blood VERY slowly
+	owner.regenerate_blood(0.1 + owner.chem_effects[CE_BLOODRESTORE])
 
 	// Blood loss or liver damage make you lose nutriments
 	var/blood_volume = owner.get_blood_volume()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -732,3 +732,21 @@
 	if(volume >= 5 && M.is_asystole())
 		remove_self(5)
 		M.resuscitate()
+
+/datum/reagent/nanoblood
+	name = "Nanoblood"
+	description = "A stable hemoglobin-based nanoparticle oxygen carrier, used to rapidly replace lost blood. Toxic unless injected in small doses. Does not contain white blood cells."
+	taste_description = "blood with bubbles"
+	reagent_state = LIQUID
+	color = "#c10158"
+	scannable = 1
+	overdose = 5
+	metabolism = 1
+
+/datum/reagent/nanoblood/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
+	if(!M.should_have_organ(BP_HEART)) //We want the var for safety but we can do without the actual blood.
+		return
+	M.regenerate_blood(4 * removed)
+	M.immunity = max(M.immunity - 1, 0)
+	if(M.chem_doses[type] > M.species.blood_volume/8) //half of blood was replaced with us, rip white bodies
+		M.immunity = max(M.immunity - 4, 0)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1935,3 +1935,9 @@
 	result = /datum/reagent/antidexafen
 	required_reagents = list(/datum/reagent/paracetamol = 1, /datum/reagent/carbon = 1)
 	result_amount = 2
+
+/datum/chemical_reaction/nanoblood
+	name = "Nanoblood"
+	result = /datum/reagent/nanoblood
+	required_reagents = list(/datum/reagent/dexalinp = 1, /datum/reagent/iron = 1, /datum/reagent/blood = 1)
+	result_amount = 3


### PR DESCRIPTION
When injected, regenerates blood /rapidly/, regardless of state of liver unlike normal chems with bloodrestore. Processed fast, 1u per tick, generating 4u of blood.
Catch is low OD, so you have to inject it slowish. Also tanks immunity if a lot was used.
Made with blood+iron+dexplus

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
