### PR TITLE
Fixes pain flashing

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -139,3 +139,7 @@
 /obj/screen/fullscreen/fishbed
 	icon_state = "fishbed"
 	allstate = 1
+
+/obj/screen/fullscreen/pain
+	icon_state = "brutedamageoverlay6"
+	alpha = 0

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -239,7 +239,8 @@
 		hud_elements |= mymob.nutrition_icon
 
 
-	mymob.pain = new /obj/screen( null )
+	mymob.pain = new /obj/screen/fullscreen/pain( null )
+	hud_elements |= mymob.pain
 
 	mymob.zone_sel = new /obj/screen/zone_sel( null )
 	mymob.zone_sel.icon = ui_style

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -26,7 +26,7 @@
 			adjustHalLoss(damage * blocked_mult(blocked))
 		if(ELECTROCUTE)
 			electrocute_act(damage, used_weapon, 1.0, def_zone)
-	flash_weak_pain()
+
 	updatehealth()
 	return 1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -849,9 +849,6 @@
 /mob/proc/get_species()
 	return ""
 
-/mob/proc/flash_weak_pain()
-	flick("weak_pain",pain)
-
 /mob/proc/get_visible_implants(var/class = 0)
 	var/list/visible_implants = list()
 	for(var/obj/item/O in embedded)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -1,5 +1,6 @@
-mob/proc/flash_pain()
-	flick("pain",pain)
+mob/proc/flash_pain(var/target)
+	animate(pain, alpha = target, time = 15, easing = ELASTIC_EASING)
+	animate(pain, alpha = 0, time = 20)
 
 mob/var/last_pain_message
 mob/var/next_pain_time = 0
@@ -57,10 +58,10 @@ mob/living/carbon/human/proc/handle_pain()
 			if(1 to 10)
 				msg =  "Your [damaged_organ.name] [burning ? "burns" : "hurts"]."
 			if(11 to 90)
-				flash_weak_pain()
+				flash_pain(127)
 				msg = "<font size=2>Your [damaged_organ.name] [burning ? "burns" : "hurts"] badly!</font>"
 			if(91 to 10000)
-				flash_pain()
+				flash_pain(255)
 				msg = "<font size=3>OH GOD! Your [damaged_organ.name] is [burning ? "on fire" : "hurting terribly"]!</font>"
 		custom_pain(msg, 0, prob(10), affecting = damaged_organ)
 


### PR DESCRIPTION
The overlay was missing for longest of times.
It's actually hella ugly, so I instead reused the max brute damage overlay, using animate() to flick it.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
