### PR TITLE
Tweaks to sensor report contents and away mission names

### DIFF
--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -33,8 +33,6 @@
 			event.icon_state = pick(overmap_event.event_icon_states)
 			event.opacity =  overmap_event.opacity
 
-		points_of_interest += overmap_event.name
-
 /decl/overmap_event_handler/proc/get_event_turfs_by_z_level(var/z_level)
 	var/z_level_text = num2text(z_level)
 	. = event_turfs_by_z_level[z_level_text]

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -1,7 +1,7 @@
 #include "bearcat_areas.dm"
 
 /obj/effect/overmap/ship/bearcat
-	name = "FTV Bearcat"
+	name = "light freighter"
 	color = "#00FFFF"
 	vessel_mass = 60
 	default_delay = 3 MINUTES
@@ -9,7 +9,7 @@
 	burn_delay = 10 SECONDS
 
 /obj/effect/overmap/ship/bearcat/New()
-	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")]"
+	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")], \a [name]"
 	for(var/area/ship/scrap/A)
 		A.name = "\improper [name] - [A.name]"
 		GLOB.using_map.area_purity_test_exempt_areas += A.type

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -1,15 +1,18 @@
 //quality code theft
 #include "blueriver_areas.dm"
 /obj/effect/overmap/sector/arcticplanet
-	name = "Arctic Planet"
+	name = "arctic planetoid"
 	desc = "Sensor array detects an arctic planet with a small vessle on the planet's surface. Scans further indicate strange energy levels below the planet's surface."
-	name = "Arctic Planet"
 	generic_waypoints = list(
 		"nav_blueriv_1",
 		"nav_blueriv_2",
 		"nav_blueriv_3",
 		"nav_blueriv_antag"
 	)
+
+/obj/effect/overmap/sector/marooned/New(nloc, max_x, max_y)
+	name = "[generate_planet_name()], \a [name]"
+	..()
 
 /datum/map_template/ruin/away_site/blueriver
  	name = "Bluespace River"

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -2,7 +2,7 @@
 #include "../mining/mining_areas.dm"
 
 /obj/effect/overmap/ship/casino
-	name = "Passenger liner."
+	name = "passenger liner"
 	desc = "Sensors detect an undamaged vessel without any signs of activity."
 	color = "#bd6100"
 	vessel_mass = 100
@@ -22,6 +22,10 @@
 		"Casino Cutter" = list("nav_casino_hangar"),
 	)
 	)
+
+/obj/effect/overmap/ship/casino/New(nloc, max_x, max_y)
+	name = "IPV [pick("Fortuna","Gold Rush","Ebisu","Lucky Paw","Four Leaves")], \a [name]"
+	..()
 
 /datum/map_template/ruin/away_site/casino
 	name = "Casino"

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -11,6 +11,10 @@
 		"nav_icarus_antag"
 	)
 
+/obj/effect/overmap/sector/icarus/New(nloc, max_x, max_y)
+	name = "[generate_planet_name()], \a [name]"
+	..()
+
 obj/effect/icarus/irradiate
 	var/radiation_power = 20//20 Bq. Dangerous but survivable for 10-15 minutes if crew is too lazy to read away map description
 	var/datum/radiation_source/S

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -2,7 +2,7 @@
 #include "../mining/mining_areas.dm"
 
 /obj/effect/overmap/sector/lost_supply_base
-	name = "Abandoned supply base"
+	name = "supply station"
 	desc = "This looks like abandoned and heavy damaged supply station."
 	icon_state = "object"
 	known = 0

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -1,8 +1,8 @@
 #include "magshield_areas.dm"
 
 /obj/effect/overmap/sector/magshield
-	name = "Orbital Magnetic Shield Station"
-	desc = "Sensors detect an orbital station above the exoplanet. Sporadic magentic impulses are registred. Planet landing is impossible due to lower orbits being cluttered with chaotically moving metal chunks."
+	name = "orbital station"
+	desc = "Sensors detect an orbital station above the exoplanet. Sporadic magentic impulses are registred inside it. Planet landing is impossible due to lower orbits being cluttered with chaotically moving metal chunks."
 	icon_state = "object"
 	known = 0
 
@@ -13,7 +13,6 @@
 		"nav_magshield_4",
 		"nav_magshield_antag"
 	)
-
 
 /datum/map_template/ruin/away_site/magshield
 	name = "Magshield"

--- a/maps/away/marooned/marooned.dm
+++ b/maps/away/marooned/marooned.dm
@@ -10,8 +10,8 @@
 	dynamic_lighting = 0
 
 /obj/effect/overmap/sector/marooned
-	name = "Glacier planet with power signature in polar region"
-	desc = "Moon-sized planet with breathable atmosphere. We detect power signature on a surface."
+	name = "glacial planetoid"
+	desc = "Moon-sized planet with breathable atmosphere. Sensors are picking up a weak radio signal from the surface."
 	icon_state = "object"
 	known = 0
 
@@ -20,6 +20,10 @@
 		"nav_marooned_2",
 		"nav_marooned_antag"
 	)
+
+/obj/effect/overmap/sector/marooned/New(nloc, max_x, max_y)
+	name = "[generate_planet_name()], \a [name]"
+	..()
 
 /datum/map_template/ruin/away_site/marooned
 	name = "Marooned"

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -66,8 +66,8 @@
 
 //MINING-2 // SIGNAL
 /obj/effect/overmap/sector/away
-	name = "faint signal"
-	desc = "Faint signal detected, originating from the site's surface."
+	name = "faint signal from an asteroid"
+	desc = "Faint signal detected, originating from the human-made structures on the site's surface."
 	icon_state = "sector"
 	generic_waypoints = list(
 		"nav_away_1",

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -1,7 +1,7 @@
 #include "mobius_rift_areas.dm"
 
 /obj/effect/overmap/sector/mobius_rift
-	name = "Hollow asteroid."
+	name = "unusual asteroid"
 	desc = "Sensors error: ERROR #E0x003141592: recursive stack overflow for CALCULATE_APPROXIMATE_SIZE()."
 	icon_state = "object"
 	known = 0

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -2,8 +2,8 @@
 #include "../mining/mining_areas.dm"
 
 /obj/effect/overmap/sector/slavers_base
-	name = "Large asteroid"
-	desc = "Sensor array is recieving unusual readings from this location."
+	name = "large asteroid"
+	desc = "Sensor array is reading an artificial structure inside the asteroid."
 	icon_state = "object"
 	known = 0
 

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -2,8 +2,8 @@
 #include "../mining/mining_areas.dm"
 
 /obj/effect/overmap/sector/smugglers
-	name = "Abandoned station on small asteroid"
-	desc = "This looks like a small abandoned asteroid station."
+	name = "asteroid station"
+	desc = "A small station built into an asteroid. No radio traffic detected."
 	icon_state = "object"
 	known = 0
 

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -1,13 +1,12 @@
 #include "yacht_areas.dm"
 
 /obj/effect/overmap/ship/yacht
-	name = "Small ship"
+	name = "private yacht"
 	desc = "Sensor array is detecting a small vessel with unknown lifeforms on board"
-	name = "Yacht"
 	color = "#FFC966"
 	vessel_mass = 30
 	default_delay = 35 SECONDS
-	speed_mod = 5 SECONDS
+	speed_mod = 10 SECONDS
 	triggers_events = 0
 	generic_waypoints = list(
 		"nav_yacht_1",
@@ -15,6 +14,10 @@
 		"nav_yacht_3",
 		"nav_yacht_antag"
 	)
+
+/obj/effect/overmap/ship/yacht/New(nloc, max_x, max_y)
+	name = "IPV [pick("Razorshark", "Aurora", "Lighting", "Pequod", "Anansi")], \a [name]"
+	..()
 
 /datum/map_template/ruin/away_site/yacht
 	name = "Yacht"

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -59,7 +59,7 @@
 	welcome_text += "Next system targeted for jump:<br /><b>[generate_system_name()]</b><br />"
 	welcome_text += "Travel time to Sol:<br /><b>[rand(15,45)] days</b><br />"
 	welcome_text += "Time since last port visit:<br /><b>[rand(60,180)] days</b><br />"
-	welcome_text += "Scan results show following points of interest:<br />"
+	welcome_text += "Scan results show the following points of interest:<br />"
 	var/list/scan_results = list()
 	for(var/poi in points_of_interest)
 		if(poi == "SEV Torch")

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -59,7 +59,7 @@
 	welcome_text += "Next system targeted for jump:<br /><b>[generate_system_name()]</b><br />"
 	welcome_text += "Travel time to Sol:<br /><b>[rand(15,45)] days</b><br />"
 	welcome_text += "Time since last port visit:<br /><b>[rand(60,180)] days</b><br />"
-	welcome_text += "Scan results:<br />"
+	welcome_text += "Scan results show following points of interest:<br />"
 	var/list/scan_results = list()
 	for(var/poi in points_of_interest)
 		if(poi == "SEV Torch")
@@ -74,6 +74,7 @@
 			welcome_text += "\A <b>[result]</b><br />"
 		else
 			welcome_text += "[count] <b>[result]\s</b><br />"
+	welcome_text += "<br>No distress calls logged.<br />"
 
 	post_comm_message("SEV Torch Sensor Readings", welcome_text)
 	minor_announcement.Announce(message = "New [GLOB.using_map.company_name] Update available at all communication consoles.")


### PR DESCRIPTION
Tweaks rounstart sensor report 
Makes it morea clear that all those ships are NOT distress calls, so people don't HAVE to prioritise them.
Also removes ion storms etc from the list, they're hardly points of interest.

Adjusts names of most away missions 
Makes them something more likely to show up on sensor scan, rather tahn listing exactly what it is.
Adds random generated names where it made sense to.
Fixes some away misison names ending with . or having two names defined.
