### PR TITLE
Adjust the lighting engine

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -25,12 +25,6 @@
 
 #undef NONSENSICAL_VALUE
 
-/atom/movable/New()
-	. = ..()
-	var/turf/simulated/T = loc
-	if(istype(T))
-		T.opaque_counter += opacity
-
 /atom/proc/update_light()
 	set waitfor = FALSE
 
@@ -62,13 +56,22 @@
 		if(istype(T))
 			T.handle_opacity_change(src)
 
-/atom/movable/Move()
-	var/turf/old_loc = loc
-	. = ..()
+#define LIGHT_MOVE_UPDATE \
+var/turf/old_loc = loc;\
+. = ..();\
+if(loc != old_loc) {\
+	for(var/datum/light_source/L in light_sources) {\
+		L.source_atom.update_light();\
+	}\
+}
 
-	if(loc != old_loc)
-		for(var/datum/light_source/L in light_sources)
-			L.source_atom.update_light()
+/atom/movable/Move()
+	LIGHT_MOVE_UPDATE
+
+/atom/movable/forceMove()
+	LIGHT_MOVE_UPDATE
+
+#undef LIGHT_MOVE_UPDATE
 
 /obj/item/equipped()
 	. = ..()


### PR DESCRIPTION
Opaque atoms are no longer counted twice.
Force moved atoms now properly cause lighting updates.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
