### PR TITLE
Don't show speech bubbles for ages

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -260,7 +260,6 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/speech_bubble_test = say_test(message)
 	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"h[speech_bubble_test]")
-	spawn(30) qdel(speech_bubble)
 
 	// VOREStation Port - Attempt Multi-Z Talking
 	var/mob/above = src.shadow
@@ -275,10 +274,14 @@ proc/get_radio_key_from_channel(var/channel)
 
 	// VOREStation Port End
 
+	var/list/speech_bubble_recipients = list()
 	for(var/mob/M in listening)
 		if(M)
-			show_image(M, speech_bubble)
 			M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+			if(M.client)
+				speech_bubble_recipients += M.client
+
+	flick_overlay(speech_bubble, speech_bubble_recipients, 30)
 
 	for(var/obj/O in listening_obj)
 		spawn(0)


### PR DESCRIPTION
Fixes #20059.

This uses `flick_overlay` to show the speech bubbles for only a limited amount of time.

Caveats:

* Does nothing for that multi-z speech bubble thing right next to it. I don't think that actually works at the moment anyway.
* Other codebases wrap the `flick_overlay` in `INVOKE_ASYNC`. We don't have that, and I don't know if that's a problem. Maybe it is for large numbers of listeners (e.g. many ghosts and people nearby). Untested. Should we steal it?
  