### PR TITLE
Hotfix for being unable to move up and down on EVA

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -46,7 +46,7 @@
 			to_chat(src, "<span class='warning'>\The [A] blocks you.</span>")
 			return 0
 
-	if(direction == UP && can_fall(FALSE, destination))
+	if(direction == UP && area.has_gravity() && can_fall(FALSE, destination))
 		to_chat(src, "<span class='warning'>You see nothing to hold on to.</span>")
 		return 0
 


### PR DESCRIPTION
Apparently can_fall doesn't check for gravity