### PR TITLE
Un-foolproofs computer programs

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -126,6 +126,7 @@
 	if(can_run(user, 1) || !requires_access_to_run)
 		if(nanomodule_path)
 			NM = new nanomodule_path(src, new /datum/topic_manager/program(src), src)
+			NM.using_access = user.GetAccess()
 		if(requires_ntnet && network_destination)
 			generate_network_log("Connection opened to [network_destination].")
 		program_state = PROGRAM_STATE_ACTIVE

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -58,7 +58,7 @@
 
 
 /datum/nano_module/records/proc/get_record_access(var/mob/user)
-	var/list/user_access = user.GetAccess()
+	var/list/user_access = using_access || user.GetAccess()
 
 	var/obj/item/modular_computer/PC = nano_host()
 	if(istype(PC) && PC.computer_emagged)

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -3,6 +3,7 @@
 	var/datum/host
 	var/available_to_ai = TRUE
 	var/datum/topic_manager/topic_manager
+	var/list/using_access
 
 /datum/nano_module/New(var/datum/host, var/topic_manager)
 	..()
@@ -21,6 +22,12 @@
 /datum/nano_module/proc/check_access(var/mob/user, var/access)
 	if(!access)
 		return 1
+
+	if(using_access)
+		if(access in using_access)
+			return 1
+		else
+			return 0
 
 	if(!istype(user))
 		return 0

--- a/html/changelogs/chinsky - secpatch.yml
+++ b/html/changelogs/chinsky - secpatch.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Modular computer programs were patched to allow more abuse. Now they use the access of user who started them, instead of constantly checking for current user's."
+


### PR DESCRIPTION
Now instead of constantly scanning user to have proper access, they use whatever access they were started with. Don't leave high security stuff open where greyshirts can get to it, folks.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
