### PR TITLE
adds cameras to the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -41,6 +41,10 @@
 /datum/gear/utility/paicard
 	display_name = "personal AI device"
 	path = /obj/item/device/paicard
+	
+/datum/gear/utility/camera
+	display_name = "camera"
+	path = /obj/item/device/camera
 
 /****************
 modular computers


### PR DESCRIPTION
🆑TheGreyWolf
rscadd: Cameras can now be found in the loadout.
/🆑
https://baystation12.net/forums/threads/make-cameras-accessible.6008/
can't harm that much, right?