### PR TITLE
Adds sandals to the loadout selection.

### DIFF
--- a/html/changelogs/tlc2013-roughandcoarseandgetseverywhere.yml
+++ b/html/changelogs/tlc2013-roughandcoarseandgetseverywhere.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: tlc2013
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added sandals to the loadout selection. Because those weren't there before, apparently."

--- a/maps/torch/loadout/loadout_shoes.dm
+++ b/maps/torch/loadout/loadout_shoes.dm
@@ -69,3 +69,8 @@
 	path = /obj/item/clothing/shoes/hightops
 	allowed_roles = FORMAL_ROLES
 	flags = GEAR_HAS_TYPE_SELECTION
+	
+/datum/gear/shoes/sandal
+	display_name = "wooden sandals"
+	path = /obj/item/clothing/shoes/sandal
+	allowed_roles = NON_MILITARY_ROLES


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
I'm not quite sure why they weren't there before, so I decided to add them in. That's about it.

Yes, they do have the 'wizard-garb' tag, but so do (to the best of my knowledge) the ones that can just be built with wooden planks.