### PR TITLE
Makes cult walls less edgy

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -228,7 +228,6 @@
 	cover = 70
 
 /obj/structure/girder/cult/dismantle()
-	new /obj/item/remains/human(get_turf(src))
 	qdel(src)
 
 /obj/structure/girder/cult/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -729,15 +729,9 @@ var/list/name_to_material
 /material/cult/place_dismantled_girder(var/turf/target)
 	new /obj/structure/girder/cult(target)
 
-/material/cult/place_dismantled_product(var/turf/target)
-	new /obj/effect/decal/cleanable/blood(target)
-
 /material/cult/reinf
 	name = "cult2"
-	display_name = "human remains"
-
-/material/cult/reinf/place_dismantled_product(var/turf/target)
-	new /obj/item/remains/human(target)
+	display_name = "runic inscriptions"
 
 /material/resin
 	name = "resin"


### PR DESCRIPTION
Now they're just creepy bricks instead of super edgy bone and blood walls made out of children and eldritch horror. I've never once seen the super edgy walls lead to anything meaningful aside from forcing someone to call a janitor to clean the blood.

:cl:ZeroBits
tweak: Cult walls are just normal creepy now instead of super edgy.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
