### PR TITLE
Restricts RCON and alarm monitoring programs to connected z levels

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -35,6 +35,10 @@
 					return TRUE
 	return FALSE
 
+/proc/get_z(O)
+	var/turf/loc = get_turf(O)
+	return loc ? loc.z : 0
+
 /proc/get_area(O)
 	var/turf/loc = get_turf(O)
 	if(loc)

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -22,6 +22,7 @@
 	var/area/last_area				//The last acquired area, used should origin be lost (for example a destroyed borg containing an alarming camera).
 	var/area/last_name				//The last acquired name, used should origin be lost
 	var/area/last_camera_area		//The last area in which cameras where fetched, used to see if the camera list should be updated.
+	var/last_z_level				//The last acquired z-level, used should origin be lost
 	var/end_time					//Used to set when this alarm should clear, in case the origin is lost.
 
 /datum/alarm/New(var/atom/origin, var/atom/source, var/duration, var/severity)
@@ -59,6 +60,11 @@
 	var/datum/alarm_source/AS = sources_assoc[source]
 	sources -= AS
 	sources_assoc -= source
+
+/datum/alarm/proc/alarm_z()
+	if(origin)
+		last_z_level = origin.get_alarm_z(origin)
+	return last_z_level
 
 /datum/alarm/proc/alarm_area()
 	if(!origin)
@@ -100,6 +106,12 @@
 /******************
 * Assisting procs *
 ******************/
+/atom/proc/get_alarm_z()
+	return get_z(src)
+
+area/get_alarm_z()
+	return contents.len ? get_z(contents[1]) : 0
+
 /atom/proc/get_alarm_area()
 	return get_area(src)
 

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
@@ -108,6 +108,9 @@
 	for(var/datum/alarm_handler/AH in alarm_handlers)
 		categories[++categories.len] = list("category" = AH.category, "alarms" = list())
 		for(var/datum/alarm/A in AH.major_alarms())
+			if(!AreConnectedZLevels(get_host_z(), A.alarm_z()))
+				continue
+
 			var/cameras[0]
 			var/lost_sources[0]
 

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -123,10 +123,10 @@
 /datum/nano_module/rcon/proc/FindDevices()
 	known_SMESs = new /list()
 	for(var/obj/machinery/power/smes/buildable/SMES in SSmachines.machinery)
-		if(SMES.RCon_tag && (SMES.RCon_tag != "NO_TAG") && SMES.RCon)
+		if(AreConnectedZLevels(get_host_z(), get_z(SMES)) && SMES.RCon_tag && (SMES.RCon_tag != "NO_TAG") && SMES.RCon)
 			known_SMESs.Add(SMES)
 
 	known_breakers = new /list()
 	for(var/obj/machinery/power/breakerbox/breaker in SSmachines.machinery)
-		if(breaker.RCon_tag != "NO_TAG")
+		if(AreConnectedZLevels(get_host_z(), get_z(breaker)) && breaker.RCon_tag != "NO_TAG")
 			known_breakers.Add(breaker)

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -39,6 +39,10 @@
 		return TRUE
 	. = ..()
 
+/datum/nano_module/proc/get_host_z()
+	var/atom/host = nano_host()
+	return istype(host) ? get_z(host) : 0
+
 /datum/nano_module/proc/print_text(var/text, var/mob/user)
 	var/obj/item/modular_computer/MC = nano_host()
 	if(istype(MC))


### PR DESCRIPTION
:cl:
tweak: RCON program no longer shows SMES units and breakers offsite the Torch.
tweak: Alarm monitoring program no longer shows alerts offsite the Torch.
/:cl:

So SMES units, breakers and alarms from away mission sites or similar will no longer show on the console.

Fixes #18763
Fixes #19901
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
