### PR TITLE
Makes coats job restricted again

### DIFF
--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -108,9 +108,16 @@
 	gear_tweaks += new/datum/gear_tweak/path(hoodies)
 
 /datum/gear/suit/labcoat
+	display_name = "labcoat, colour select"
+	path = /obj/item/clothing/suit/storage/toggle/labcoat
+	flags = GEAR_HAS_COLOR_SELECTION
+	allowed_roles = STERILE_ROLES
+
+/datum/gear/suit/coat
 	display_name = "coat, colour select"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/coat
 	flags = GEAR_HAS_COLOR_SELECTION
+	allowed_roles = FORMAL_ROLES
 
 /datum/gear/suit/leather
 	display_name = "jacket selection"


### PR DESCRIPTION
Adds colored labcoats back to address original complaint.

People just can't be trusted, third day of seeing random officers picking them up because they can.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
