### PR TITLE
Makes net guns usable on all mobs

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -108,11 +108,10 @@
 	desc = "An energized net meant to subdue animals."
 
 	anchored = 0
-	health = 1
+	health = 5
 	temporary = 0
-	min_free_time = 0
-	max_free_time = 0
-
+	min_free_time = 5
+	max_free_time = 10
 
 /obj/effect/energy_net/teleport
 	countdown = 60
@@ -161,13 +160,6 @@
 		if(!C.handcuffed)
 			C.handcuffed = src
 	return 1
-
-/obj/effect/energy_net/safari/capture_mob(mob/living/M)
-	if(istype(M, /mob/living/simple_animal))
-		. = ..()
-	else
-		visible_message("\The [src] fails to contain \the [M]!")
-		qdel(src)
 
 /obj/effect/energy_net/post_buckle_mob(mob/living/M)
 	if(buckled_mob)


### PR DESCRIPTION
Were only working on simple animals
Mobs can break out of them in under a second if they resist, so it's mostly for in field accidents and jackassery.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
