### PR TITLE
Adds a Fancy-Dancy timestamp to PDA messages.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1012,8 +1012,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			tempmessage[P] = t
 			return
 
-		tnote.Add(list(list("sent" = 1, "owner" = "[P.owner]", "job" = "[P.ownjob]", "message" = "[t]", "target" = "\ref[P]")))
-		P.tnote.Add(list(list("sent" = 0, "owner" = "[owner]", "job" = "[ownjob]", "message" = "[t]", "target" = "\ref[src]")))
+		tnote.Add(list(list("sent" = 1, "owner" = "[P.owner]", "job" = "[P.ownjob]", "message" = "[t]", "timestamp" = stationtime2text(), "target" = "\ref[P]")))
+		P.tnote.Add(list(list("sent" = 0, "owner" = "[owner]", "job" = "[ownjob]", "message" = "[t]", "timestamp" = stationtime2text(), "target" = "\ref[src]")))
 		for(var/mob/M in GLOB.player_list)
 			if(M.stat == DEAD && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH) // src.client is so that ghosts don't have to listen to mice
 				if(istype(M, /mob/new_player))

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -257,9 +257,9 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                     {{for data.messages}}
                         {{if data.active_conversation == value.target}}
                             {{if value.sent==0}}
-                                <span class="average"><B>Them</B>: {{:value.message}}</span><br>
+                                <span class="average">{{:value.timestamp}}- <B>Them</B>: {{:value.message}}</span><br>
                             {{else}}
-                                <span class="good"><B>You</B>: {{:value.message}}</span><br>
+                                <span class="good">{{:value.timestamp}}- <B>You</B>: {{:value.message}}</span><br>
                             {{/if}}
                         {{/if}}
                     {{/for}}


### PR DESCRIPTION
:cl:LorenLuke
rscadd: Adds timestamp to PDA messages.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
