### PR TITLE
Some stasis-related tweaks n fixes

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -12,7 +12,7 @@
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/filtering = 0
 	var/pump
-	var/list/stasis_settings = list(1, 3, 5)
+	var/list/stasis_settings = list(1, 2, 5)
 	var/stasis = 1
 
 	use_power = 1

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -18,7 +18,7 @@
 	clickvol = 30
 
 	var/temperature_archived
-	var/mob/living/carbon/occupant = null
+	var/mob/living/carbon/human/occupant = null
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 
 	var/current_heat_capacity = 50
@@ -112,7 +112,7 @@
 		scan = replacetext(scan,"'notice'","'white'")
 		scan = replacetext(scan,"'warning'","'average'")
 		scan = replacetext(scan,"'danger'","'bad'")
-		scan += "<br>Cryostasis factor: [occupant.GetStasis()]x"
+		scan += "<br>Cryostasis factor: [occupant.getCryogenicFactor(occupant.bodytemperature)]x"
 		data["occupant"] = scan
 
 	data["cellTemperature"] = round(air_contents.temperature)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -621,7 +621,7 @@
 		if (drowsyness > 0)
 			drowsyness = max(0, drowsyness-1)
 			eye_blurry = max(2, eye_blurry)
-			if ((prob(5) || drowsyness >= 60))
+			if (drowsyness > 10 && (prob(5) || drowsyness >= 60))
 				if(stat == CONSCIOUS)
 					to_chat(src, "<span class='notice'>You are about to fall asleep...</span>")
 				Sleeping(5)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -12,17 +12,17 @@
 	if(machine && !CanMouseDrop(machine, src))
 		machine = null
 
+	//Handle temperature/pressure differences between body and environment
+	var/datum/gas_mixture/environment = loc.return_air()
+	if(environment)
+		handle_environment(environment)
+
 	blinded = 0 // Placing this here just show how out of place it is.
 	// human/handle_regular_status_updates() needs a cleanup, as blindness should be handled in handle_disabilities()
 	handle_regular_status_updates() // Status & health update, are we dead or alive etc.
 
 	if(stat != DEAD)
 		aura_check(AURA_TYPE_LIFE)
-
-	//Handle temperature/pressure differences between body and environment
-	var/datum/gas_mixture/environment = loc.return_air()
-	if(environment)
-		handle_environment(environment)
 
 	//Check if we're on fire
 	handle_fire()


### PR DESCRIPTION
Cryopods now properly display stasis factors, they were cleared by mob before pod could get them.
Can now actually set middle stasis option on sleepers.
Made drowsiness before 10 not knock you out at all.
Cryo makes you sleepy now.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
