### PR TITLE
Fix autolathes always failing sanity check

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -264,7 +264,7 @@
 		update_use_power(1)
 
 		//Sanity check.
-		if(!making || !QDELETED(src)) return TOPIC_HANDLED
+		if(!making || QDELETED(src)) return TOPIC_HANDLED
 
 		//Create the desired item.
 		var/obj/item/I = new making.path(loc)


### PR DESCRIPTION
:cl: sabiram
bugfix: Autolathes now function as normal.
/:cl:

Fixes #20199 

Autolathes in normal operation are not qdeleted, so this test always fails.