### PR TITLE
Adds potted plant crates, orderable by cargo.

### DIFF
--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -144,3 +144,38 @@
 	containertype = /obj/structure/closet/crate/large/hydroponics
 	containername = "\improper Hydroponics tray crate"
 	access = access_hydroponics
+
+/decl/hierarchy/supply_pack/hydroponics/pottedplant
+	name = "Potted plant crate"
+	num_contained = 1
+	contains = list(/obj/structure/flora/pottedplant,
+					/obj/structure/flora/pottedplant/large,
+					/obj/structure/flora/pottedplant/fern,
+					/obj/structure/flora/pottedplant/overgrown,
+					/obj/structure/flora/pottedplant/bamboo,
+					/obj/structure/flora/pottedplant/largebush,
+					/obj/structure/flora/pottedplant/thinbush,
+					/obj/structure/flora/pottedplant/mysterious,
+					/obj/structure/flora/pottedplant/smalltree,
+					/obj/structure/flora/pottedplant/unusual,
+					/obj/structure/flora/pottedplant/orientaltree,
+					/obj/structure/flora/pottedplant/smallcactus,
+					/obj/structure/flora/pottedplant/tall,
+					/obj/structure/flora/pottedplant/sticky,
+					/obj/structure/flora/pottedplant/smelly,
+					/obj/structure/flora/pottedplant/small,
+					/obj/structure/flora/pottedplant/aquatic,
+					/obj/structure/flora/pottedplant/shoot,
+					/obj/structure/flora/pottedplant/flower,
+					/obj/structure/flora/pottedplant/crystal,
+					/obj/structure/flora/pottedplant/subterranean,
+					/obj/structure/flora/pottedplant/minitree,
+					/obj/structure/flora/pottedplant/stoutbush,
+					/obj/structure/flora/pottedplant/drooping,
+					/obj/structure/flora/pottedplant/tropical,
+					/obj/structure/flora/pottedplant/dead,
+					/obj/structure/flora/pottedplant/decorative)
+	cost = 3
+	containertype = /obj/structure/closet/crate/large/hydroponics
+	containername = "\improper Potted plant crate"
+	supply_method = /decl/supply_method/randomized

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -252,7 +252,7 @@
 	name = "unusual potted plant"
 	desc = "This is an unusual plant. It's bulbous ends emit a soft blue light."
 	icon_state = "plant-09"
-	set_light(l_range = 1, l_power = 0.5, l_color = "#0000ff")
+	set_light(l_range = 2, l_power = 2, l_color = "#007fff")
 
 /obj/structure/flora/pottedplant/orientaltree
 	name = "potted oriental tree"
@@ -270,7 +270,7 @@
 	icon_state = "plant-12"
 
 /obj/structure/flora/pottedplant/sticky
-	name = "styicky potted plant"
+	name = "sticky potted plant"
 	desc = "This is an odd plant. Its sticky leaves trap insects."
 	icon_state = "plant-13"
 


### PR DESCRIPTION
🆑 
rscadd: Potted plants can now be ordered by Supply, under the Hydroponics tab.
\ 🆑 

Adds crates that contain a single, randomized potted plant for 3 points each.