### PR TITLE
Lowers away mission budget

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -12,8 +12,8 @@
 	admin_levels = list(6,7)
 	empty_levels = list(8)
 	accessible_z_levels = list("1"=1,"2"=1,"3"=1,"4"=1,"5"=1,"8"=30)
-	overmap_size = 40
-	overmap_event_areas = 30
+	overmap_size = 35
+	overmap_event_areas = 22
 	usable_email_tlds = list("torch.ec.scg", "torch.fleet.mil", "torch.marine.mil", "freemail.nt")
 
 	allowed_spawns = list("Cryogenic Storage", "Cyborg Storage")
@@ -42,7 +42,7 @@
 	num_exoplanets = 1
 	planet_size = list(129,129)
 
-	away_site_budget = 4
+	away_site_budget = 3
 
 	id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'
 	lobby_screens = list("title","title2")


### PR DESCRIPTION
Now instead of 4-7 missions, it would spawn 3-6. Shrunk map a bit
accordingly.

1.It's an exceptional event to even visit 2 in one round.
2.Machinery controller could use a break.

:cl:
tweak: Overmap size has been decreased.
tweak: Number of overmap events has been decreased.
tweak: Potential number of away missions has been decreased.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
