### PR TITLE
Quick and dirty fix for bad exploit

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -161,6 +161,7 @@
 
 			if (href_list["createpill_multiple"])
 				count = input("Select the number of pills to make.", "Max [max_pill_count]", pillamount) as num
+				count = round(count)
 				count = Clamp(count, 1, max_pill_count)
 
 			if(reagents.total_volume/count < 1) //Sanity checking.


### PR DESCRIPTION
If there is a decimal place in the number of how many pills you'd like to create, all of dream daemon dies.