### PR TITLE
No more EVA to planetary away missions

### DIFF
--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -3,6 +3,7 @@
 /obj/effect/overmap/sector/arcticplanet
 	name = "arctic planetoid"
 	desc = "Sensor array detects an arctic planet with a small vessle on the planet's surface. Scans further indicate strange energy levels below the planet's surface."
+	in_space = 0
 	generic_waypoints = list(
 		"nav_blueriv_1",
 		"nav_blueriv_2",

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -1,10 +1,11 @@
 #include "icarus_areas.dm"
 
 /obj/effect/overmap/sector/icarus
-	name = "lush expolanet"
+	name = "forest planetoid"
 	desc = "Sensors detect anomalous radiation area with the presence of artificial structures."
 	icon_state = "globe"
 	known = 0
+	in_space = 0
 	generic_waypoints = list(
 		"nav_icarus_1",
 		"nav_icarus_2",

--- a/maps/away/marooned/marooned.dm
+++ b/maps/away/marooned/marooned.dm
@@ -14,6 +14,7 @@
 	desc = "Moon-sized planet with breathable atmosphere. Sensors are picking up a weak radio signal from the surface."
 	icon_state = "object"
 	known = 0
+	in_space = 0
 
 	generic_waypoints = list(
 		"nav_marooned_1",


### PR DESCRIPTION
Sets no-spess var properly so they're not considered valid targets for random space travel. It would lead to oddity when hit in certain parts of edge or frustration when hitting the invisible walls.

Also renames icarus wreck mission a bit to differentiate from 'real' planets

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
