### PR TITLE
Ports crawling.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -27,6 +27,10 @@
 		return 0
 	if(!istype(M) || (M.loc != loc) || M.buckled || M.pinned.len || (buckle_require_restraints && !M.restrained()))
 		return 0
+	if(ismob(src))
+		var/mob/living/carbon/C = src //Don't wanna forget the xenos.
+		if(M != src && C.incapacitated())
+			return 0
 
 	M.buckled = src
 	M.facing_dir = null
@@ -61,7 +65,7 @@
 	if(!ticker) //why do we need to check this?
 		to_chat(user, "<span class='warning'>You can't buckle anyone in before the game starts.</span>")
 		return 0
-	if(!user.Adjacent(M) || user.restrained() || user.lying || user.stat || istype(user, /mob/living/silicon/pai))
+	if(!user.Adjacent(M) || user.restrained() || user.stat || istype(user, /mob/living/silicon/pai))
 		return 0
 	if(M == buckled_mob)
 		return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -78,6 +78,22 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 			S.gather_all(src, user)
 	return ..()
 
+/turf/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+	var/turf/T = get_turf(user)
+	var/area/A = T.loc
+	if((istype(A) && !(A.has_gravity)) || (istype(T,/turf/space)))
+		return
+	if(istype(O, /obj/screen))
+		return
+	if((!(istype(O, /atom/movable)) || O.anchored || !Adjacent(user) || !Adjacent(O) || !user.Adjacent(O)))
+		return
+	if(!isturf(O.loc) || !isturf(user.loc))
+		return
+	if(isanimal(user) && O != user)
+		return
+	if (do_after(user, 25 + (5 * user.weakened), incapacitation_flags = ~INCAPACITATION_FORCELYING))
+		step_towards(O, src)
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 
 	..()


### PR DESCRIPTION
https://github.com/PolarisSS13/Polaris/pull/4424
🆑 author: PrismaticGynoid
rscadd: Adds the ability to 'crawl' to an adjacent turf by click-dragging yourself to it, after a delay. This can be used to move while unable to stand. You can also do this with other movable objects, if you really wanted to.
tweak: Conscious mobs lying on the ground can now buckle themselves to chairs/beds. This includes people missing legs.
/ 🆑 
https://streamable.com/v9lb8