### PR TITLE
Requires harm intent and a small timer before popping a fueltank with a lit flame.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -143,7 +143,7 @@
 			overlays += test
 
 	else if(isflamesource(W))
-		to_chat(user, "<span class='warning'>Are you crazy? Don't go near that with an open flame!")
+		to_chat(user, "<span class='warning'>Are you crazy? Don't go near that with an open flame!</span>")
 		return
 
 	return ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -143,7 +143,16 @@
 			overlays += test
 
 	else if(isflamesource(W))
-		to_chat(user, "<span class='warning'>Are you crazy? Don't go near that with an open flame!</span>")
+		if(user.a_intent != I_HURT)
+			to_chat(user, "<span class='warning'>You almost got [W] too close to [src]! That could have ended very badly for you.</span>")
+			return
+
+		user.visible_message("<span class='warning'>[user] draws closer to the fueltank with [W].</span>", "<span class='warning'>You draw closer to the fueltank with [W].</span>")
+		if(do_after(user, 50, src))
+			log_and_message_admins("triggered a fueltank explosion with [W].")
+			user.visible_message("<span class='danger'>[user] puts [W] to [src]!</span>", "<span class='danger'>You put \the [W] to \the [src] and with a moment of lucidity you realize, this might not have been the smartest thing you've ever done.</span>")
+			src.explode()
+
 		return
 
 	return ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -143,9 +143,7 @@
 			overlays += test
 
 	else if(isflamesource(W))
-		log_and_message_admins("triggered a fueltank explosion with \a [W].")
-		user.visible_message("<span class='danger'>\The [user] puts \the [W] to \the [src]!</span>", "<span class='danger'>You put \the [W] to \the [src] and with a moment of lucidity you realize, this might not have been the smartest thing you've ever done.</span>")
-		src.explode()
+		to_chat(user, "<span class='warning'>Are you crazy? Don't go near that with an open flame!")
 		return
 
 	return ..()


### PR DESCRIPTION
Altered the behavior of fuel tanks. It is now necessary to be on harm intent and wait a few seconds before it will blow up when exposed to a source of flame. Otherwise, you just get a warning message.

🆑 
tweak: Thanks to the tightening of SCG industrial safety guidelines, you now must be on harm intent and wait a few seconds before blowing up a fueltank with a lit welder, lighter, or other handheld source of flame.
/🆑 