### PR TITLE
Fixes projectile segments never being cleared if sent adrift in blueshift.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -74,6 +74,11 @@
 		QDEL_NULL_LIST(segments)
 	return ..()
 
+/obj/item/projectile/forceMove()
+	..()
+	if(istype(loc, /turf/space/) && istype(loc.loc, /area/space))
+		qdel(src)
+
 //TODO: make it so this is called more reliably, instead of sometimes by bullet_act() and sometimes not
 /obj/item/projectile/proc/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
 	if(blocked >= 100)		return 0//Full block


### PR DESCRIPTION
🆑 
bugfix: Lasers will no longer fail to disappear during bluespace jump.
/ 🆑 