### PR TITLE
Some tweaks to things on overmap map

### DIFF
--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -9,10 +9,11 @@
 	burn_delay = 10 SECONDS
 
 /obj/effect/overmap/ship/bearcat/New()
-	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")], \a [name]"
+	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")]"
 	for(var/area/ship/scrap/A)
 		A.name = "\improper [name] - [A.name]"
 		GLOB.using_map.area_purity_test_exempt_areas += A.type
+	name = "[name], \a [initial(name)]"
 	..()
 
 /datum/map_template/ruin/away_site/bearcat_wreck

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -4,6 +4,7 @@
 	name = "arctic planetoid"
 	desc = "Sensor array detects an arctic planet with a small vessle on the planet's surface. Scans further indicate strange energy levels below the planet's surface."
 	in_space = 0
+	icon_state = "globe"
 	generic_waypoints = list(
 		"nav_blueriv_1",
 		"nav_blueriv_2",
@@ -11,7 +12,7 @@
 		"nav_blueriv_antag"
 	)
 
-/obj/effect/overmap/sector/marooned/New(nloc, max_x, max_y)
+/obj/effect/overmap/sector/arcticplanet/New(nloc, max_x, max_y)
 	name = "[generate_planet_name()], \a [name]"
 	..()
 

--- a/maps/away/marooned/marooned.dm
+++ b/maps/away/marooned/marooned.dm
@@ -12,7 +12,7 @@
 /obj/effect/overmap/sector/marooned
 	name = "glacial planetoid"
 	desc = "Moon-sized planet with breathable atmosphere. Sensors are picking up a weak radio signal from the surface."
-	icon_state = "object"
+	icon_state = "globe"
 	known = 0
 	in_space = 0
 


### PR DESCRIPTION
Makes planetary missions use planet icons
Fixes a copypaste derp, blueriver mission never got name, marooned got it twice.
Made bearcat use shorter name for areas prefix.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
