### PR TITLE
Hotfix for lasers not appearing / Hopefully fixes lasers running forever

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1,3 +1,6 @@
+//Amount of time in deciseconds to wait before deleting all drawn segments of a projectile.
+#define SEGMENT_DELETION_DELAY 2
+
 /obj/item/projectile
 	name = "projectile"
 	icon = 'icons/obj/projectiles.dmi'
@@ -70,8 +73,6 @@
 	. = ..()
 
 /obj/item/projectile/Destroy()
-	spawn(step_delay)
-		QDEL_NULL_LIST(segments)
 	return ..()
 
 /obj/item/projectile/forceMove()
@@ -91,6 +92,7 @@
 	L.stun_effect_act(stun, agony, def_zone, src)
 	//radiation protection is handled separately from other armour types.
 	L.apply_effect(irradiate, IRRADIATE, L.getarmor(null, "rad"))
+
 
 	return 1
 
@@ -151,6 +153,8 @@
 	spawn()
 		setup_trajectory(curloc, targloc, x_offset, y_offset, angle_offset) //plot the initial trajectory
 		Process()
+		spawn(SEGMENT_DELETION_DELAY)
+			QDEL_NULL_LIST(segments)
 
 	return 0
 


### PR DESCRIPTION
We probably shouldn't make a changelog for this until I can squash the bug for sure.

Why add debug vars to live? Simple:  
![image](https://user-images.githubusercontent.com/4706052/34979574-8ea3e1d4-fa56-11e7-997b-dd36cf9c1ec3.png)
I CANNOT REPRODUCE THIS LOCALLY BUT I SEE IT ALL THE TIME ON LIVE.