### PR TITLE
Adds mounted cooling units

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -457,3 +457,31 @@
 	interface_desc = "Eats trash like no one's business."
 	origin_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 5)
 	device_type = /obj/item/weapon/matter_decompiler
+
+
+
+/obj/item/rig_module/cooling_unit
+	name = "mounted cooling unit"
+	toggleable = 1
+	origin_tech = list(TECH_MAGNET = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 5)
+	interface_name = "mounted cooling unit"
+	interface_desc = "A heat sink with liquid cooled radiator."
+	module_cooldown = 0 SECONDS //no cd because its critical for a life-support module
+	var/charge_consumption = 0.5 KILOWATTS
+	var/max_cooling = 12
+	var/thermostat = T20C
+
+/obj/item/rig_module/cooling_unit/Process()
+	if(!active)
+		return passive_power_cost
+
+	var/mob/living/carbon/human/H = holder.wearer
+
+	var/temp_adj = min(H.bodytemperature - thermostat, max_cooling) //Actually copies the original CU code
+
+	if (temp_adj < 0.5)
+		return passive_power_cost
+
+	H.bodytemperature -= temp_adj
+	active_power_cost = round((temp_adj/max_cooling)*charge_consumption)
+	return active_power_cost

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -38,7 +38,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/chem_dispenser/combat
+		/obj/item/rig_module/chem_dispenser/combat,
+		/obj/item/rig_module/cooling_unit
 		)
 
 //Extremely OP, hardly standard issue equipment
@@ -83,5 +84,6 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/chem_dispenser/injector
+		/obj/item/rig_module/chem_dispenser/injector,
+		/obj/item/rig_module/cooling_unit
 		)

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -21,6 +21,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/datajack,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/clothing/head/helmet/space/rig/ert
@@ -51,7 +52,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/plasmacutter,
-		/obj/item/rig_module/device/rcd
+		/obj/item/rig_module/device/rcd,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/clothing/gloves/rig/ert/engineer
@@ -69,7 +71,8 @@
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/fabricator/wf_sign,
 		/obj/item/rig_module/grenade_launcher/cleaner,
-		/obj/item/rig_module/device/decompiler
+		/obj/item/rig_module/device/decompiler,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/weapon/rig/ert/medical
@@ -82,7 +85,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
-		/obj/item/rig_module/chem_dispenser/injector
+		/obj/item/rig_module/chem_dispenser/injector,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/weapon/rig/ert/security
@@ -96,6 +100,7 @@
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/mounted/egun,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/weapon/rig/ert/assetprotection
@@ -116,7 +121,8 @@
 		/obj/item/rig_module/chem_dispenser/injector,
 		/obj/item/rig_module/device/plasmacutter,
 		/obj/item/rig_module/device/rcd,
-		/obj/item/rig_module/datajack
+		/obj/item/rig_module/datajack,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/clothing/gloves/rig/ert/assetprotection

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -54,6 +54,7 @@
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/voice,
 		/obj/item/rig_module/vision,
+		/obj/item/rig_module/cooling_unit
 		)
 
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
@@ -99,7 +100,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/datajack,
-		/obj/item/rig_module/self_destruct
+		/obj/item/rig_module/self_destruct,
+		/obj/item/rig_module/cooling_unit
 		)
 
 	..()

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -29,7 +29,8 @@
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/device/paperdispenser,
 		/obj/item/rig_module/device/pen,
-		/obj/item/rig_module/device/stamp
+		/obj/item/rig_module/device/stamp,
+		/obj/item/rig_module/cooling_unit
 		)
 
 	glove_type = null
@@ -79,7 +80,8 @@
 		/obj/item/rig_module/device/drill,
 		/obj/item/rig_module/device/orescanner,
 		/obj/item/rig_module/device/rcd,
-		/obj/item/rig_module/vision/meson
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/weapon/rig/eva
@@ -119,11 +121,14 @@
 
 /obj/item/weapon/rig/eva/equipped
 
+	req_access = list(access_engine_equip)
+
 	initial_modules = list(
 		/obj/item/rig_module/device/plasmacutter,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/rcd,
-		/obj/item/rig_module/vision/meson
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/weapon/rig/ce
@@ -157,6 +162,7 @@
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/vision/meson,
 		/obj/item/rig_module/grenade_launcher/mfoam,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/clothing/head/helmet/space/rig/ce
@@ -206,7 +212,8 @@
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/device/anomaly_scanner
+		/obj/item/rig_module/device/anomaly_scanner,
+		/obj/item/rig_module/cooling_unit,
 		)
 
 /obj/item/weapon/rig/medical
@@ -250,7 +257,8 @@
 		/obj/item/rig_module/chem_dispenser/injector,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
-		/obj/item/rig_module/vision/medhud
+		/obj/item/rig_module/vision/medhud,
+		/obj/item/rig_module/cooling_unit
 		)
 
 /obj/item/weapon/rig/hazard
@@ -293,5 +301,6 @@
 		/obj/item/rig_module/vision/sechud,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/grenade_launcher,
-		/obj/item/rig_module/mounted/taser
+		/obj/item/rig_module/mounted/taser,
+		/obj/item/rig_module/cooling_unit
 		)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1618,6 +1618,15 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/rig_module/stealth_field
 	sort_string = "WCLAA"
 
+/datum/design/item/rig/cooling_unit
+	name = "Cooling Unit"
+	desc = "A suit cooling unit, mountable on a RIG."
+	id = "rig_cooler"
+	req_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 2, TECH_ENGINEERING = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3500, "plastic" = 2000)
+	build_path = /obj/item/rig_module/cooling_unit
+	sort_string = "WCLAB"
+
 
 /datum/design/prefab
 	name = "Device"

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -47,7 +47,9 @@
 
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/device/flash)
+		/obj/item/rig_module/device/flash,
+		/obj/item/rig_module/cooling_unit
+		)
 
 /*
  * EXECUTIVE OFFICER
@@ -79,7 +81,8 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/flash/advanced,
-		/obj/item/rig_module/grenade_launcher/smoke)
+		/obj/item/rig_module/grenade_launcher/smoke,
+		/obj/item/rig_module/cooling_unit)
 
 /*
  * COMMANDING OFFICER
@@ -113,7 +116,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/flash/advanced,
-		/obj/item/rig_module/grenade_launcher/smoke)
+		/obj/item/rig_module/grenade_launcher/smoke,
+		/obj/item/rig_module/cooling_unit)
 
 /*
  * CHIEF MEDICAL OFFICER
@@ -146,7 +150,8 @@
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/chem_dispenser/injector,
-		/obj/item/rig_module/vision/medhud)
+		/obj/item/rig_module/vision/medhud,
+		/obj/item/rig_module/cooling_unit)
 
 /*
 * CHIEF OF SECURITY
@@ -177,4 +182,5 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/flash,
-		/obj/item/rig_module/vision/sechud)
+		/obj/item/rig_module/vision/sechud,
+		/obj/item/rig_module/cooling_unit)


### PR DESCRIPTION
Now you can actually play as IPC/FBP CE/SE/RD.

Two questions:
~~1. Where to put them? Pre-installed? EVA? Researchable only?~~
2. How much power should it eat? Now it's almost the same as mounted mesons (about 0.8-0.9 KW at 20°C).

:cl: Sbotkin
rscadd: Adds mounted cooling units, available in all hardsuits.
/:cl: