### PR TITLE
Some tweaks to bloospace jump

### DIFF
--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -105,6 +105,9 @@
 	if (evacuation_controller.is_evacuating())
 		to_chat(user, "Jump preparation already in progress.")
 		return
+	if(world.time < config.vote_autotransfer_initial)
+		to_chat(user, "Bluespace drive is stabilizing, estimated time until operational: [round((config.vote_autotransfer_initial - world.time)/600)] minutes.")
+		return
 	if (evacuation_controller.call_evacuation(user, 0))
 		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated bluespace jump preparation.")
 

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -32,7 +32,7 @@
 	//These should probably be moved into the evac controller...
 	shuttle_docked_message = "Attention all hands: Jump preparation complete. The bluespace drive is now spooling up, secure all stations for departure. Time to jump: approximately %ETD%."
 	shuttle_leaving_dock = "Attention all hands: Jump initiated, exiting bluespace in %ETA%."
-	shuttle_called_message = "Attention all hands: Jump sequence initiated. Transit procedures are now in effect. Jump in %ETA%."
+	shuttle_called_message = "Attention all hands: Bluespace storm inbound, immediate jump required to avoid stranding. Jump sequence initiated. Transit procedures are now in effect. Jump in %ETA%."
 	shuttle_recall_message = "Attention all hands: Jump sequence aborted, return to normal operating conditions."
 
 	evac_controller_type = /datum/evacuation_controller/starship


### PR DESCRIPTION
Now unable to call it prematurely. Not sure why you can call it at all, but guess useful in case of red alert at 3 hours mark.

Adds some possible explanation as to why the FUCK do we always jump, no matter what's going on

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
