### PR TITLE
QoL changes for Wizard, buffs to lesser used spellbooks

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -143,8 +143,8 @@
 	item_state = "staffofchange"
 	fire_sound = 'sound/weapons/emitter.ogg'
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
-	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
+	slot_flags = SLOT_BELT|SLOT_BACK
+	w_class = ITEM_SIZE_LARGE
 	max_shots = 5
 	projectile_type = /obj/item/projectile/change
 	origin_tech = null
@@ -177,7 +177,8 @@ obj/item/weapon/gun/energy/staff/focus
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "focus"
 	item_state = "focus"
-	slot_flags = SLOT_BACK
+	slot_flags = SLOT_BELT|SLOT_BACK
+	w_class = ITEM_SIZE_LARGE
 	projectile_type = /obj/item/projectile/forcebolt
 	/*
 	attack_self(mob/living/user as mob)

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -71,6 +71,21 @@
 		return 1
 	return 0
 
+/obj/item/weapon/contract/wizard/telepathy
+	name = "telepathy contract"
+	desc = "The edges of the contract grow blurry when you look away from them. To be fair, actually reading it gives you a headache."
+	color = "#fcc605"
+
+/obj/item/weapon/contract/wizard/telepathy/contract_effect(mob/user as mob)
+	..()
+	if(!(mRemotetalk in user.mutations))
+		user.mutations.Add(mRemotetalk)
+		user.dna.SetSEState(GLOB.REMOTETALKBLOCK,1)
+		domutcheck(user, null, MUTCHK_FORCED)
+		to_chat(user, "<span class='notice'>You expand your mind outwards.</span>")
+		return 1
+	return 0
+
 /obj/item/weapon/contract/wizard/tk
 	name = "telekinesis contract"
 	desc = "This contract makes your mind buzz. It promises to give you the ability to move things with your mind. At a price."

--- a/code/modules/spells/general/radiant_aura.dm
+++ b/code/modules/spells/general/radiant_aura.dm
@@ -1,5 +1,5 @@
 /spell/radiant_aura
-	name = "radiant aura"
+	name = "Radiant aura"
 	desc = "Form a protective layer of light around you, making you immune to laser fire."
 	school = "transmutation"
 	feedback = "ra"

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -301,8 +301,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 				/datum/spellbook/cleric = 1,
 				/datum/spellbook/battlemage = 1,
 				/datum/spellbook/spatial = 1,
-				/datum/spellbook/druid = 1,
-				/datum/spellbook/student = 1
+				/datum/spellbook/druid = 1
 				) //spell's path = cost of spell
 
 	var/list/sacrifice_reagents

--- a/code/modules/spells/spellbook/battlemage.dm
+++ b/code/modules/spells/spellbook/battlemage.dm
@@ -8,7 +8,7 @@
 	title = "The Art of Magical Combat"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
-	max_uses = 5
+	max_uses = 6
 
 	spells = list(/spell/targeted/projectile/dumbfire/passage = 	1,
 				/spell/targeted/equip_item/dyrnwyn = 				1,
@@ -26,6 +26,8 @@
 				/obj/item/weapon/dice/d20/cursed = 					1,
 				/obj/item/weapon/monster_manual = 					2,
 				/obj/item/weapon/magic_rock = 						1,
+				/obj/item/weapon/contract/wizard/xray = 			1,
+				/obj/item/weapon/contract/wizard/telepathy = 		1,
 				/obj/item/weapon/contract/apprentice = 				1
 					)
 

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -10,10 +10,9 @@
 	title = "Cleric's Tome of Healing"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
-	max_uses = 6
+	max_uses = 7
 
-	spells = list(/spell/targeted/heal_target = 					1,
-				/spell/targeted/heal_target/major = 				1,
+	spells = list(/spell/targeted/heal_target/major = 				1,
 				/spell/targeted/heal_target/area = 					1,
 				/spell/targeted/heal_target/sacrifice = 			1,
 				/spell/targeted/genetic/blind = 					1,
@@ -25,9 +24,12 @@
 				/spell/targeted/equip_item/holy_relic = 			1,
 				/spell/aoe_turf/conjure/grove/sanctuary = 			1,
 				/spell/targeted/projectile/dumbfire/fireball = 		2,
+				/spell/area_teleport = 								2,
 				/spell/aoe_turf/conjure/forcewall = 				1,
+				/spell/noclothes = 									1,
 				/obj/item/weapon/magic_rock = 						1,
-				/obj/item/weapon/gun/energy/staff/focus = 			2,
+				/obj/structure/closet/wizard/scrying = 				2,
+				/obj/item/weapon/contract/wizard/telepathy = 		1,
 				/obj/item/weapon/contract/apprentice = 				1
 				)
 

--- a/code/modules/spells/spellbook/druid.dm
+++ b/code/modules/spells/spellbook/druid.dm
@@ -11,7 +11,7 @@
 	title = "Druidic Guide on how to be smug about nature"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
-	max_uses = 5
+	max_uses = 6
 
 	spells = list(/spell/targeted/heal_target = 					1,
 				/spell/targeted/heal_target/sacrifice = 			1,
@@ -20,13 +20,17 @@
 				/spell/aoe_turf/conjure/summon/bear = 				1,
 				/spell/targeted/equip_item/party_hardy = 			1,
 				/spell/targeted/equip_item/seed = 					1,
+				/spell/targeted/shapeshift/avian = 					1,
 				/spell/aoe_turf/disable_tech = 						1,
 				/spell/hand/charges/entangle = 						1,
 				/spell/aoe_turf/conjure/grove/sanctuary = 			1,
 				/spell/aoe_turf/knock = 							1,
+				/spell/area_teleport = 								2,
+				/spell/noclothes = 									1,
 				/obj/structure/closet/wizard/souls = 				1,
 				/obj/item/weapon/magic_rock = 						1,
 				/obj/item/weapon/monster_manual = 					1,
+				/obj/item/weapon/contract/wizard/telepathy = 		1,
 				/obj/item/weapon/contract/apprentice = 				1
 				)
 	sacrifice_objects = list(/obj/item/seeds/ambrosiavulgarisseed,

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -11,7 +11,7 @@
 	title = "Manual of Spatial Transportation"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
-	max_uses = 10
+	max_uses = 11
 
 	spells = list(/spell/targeted/ethereal_jaunt = 				1,
 				/spell/aoe_turf/blink = 						1,
@@ -20,15 +20,18 @@
 				/spell/mark_recall = 							1,
 				/spell/targeted/swap = 							1,
 				/spell/targeted/shapeshift/avian = 				1,
-				/spell/targeted/projectile/magic_missile = 		2,
+				/spell/targeted/projectile/magic_missile = 		1,
+				/spell/targeted/heal_target = 					1,
 				/spell/aoe_turf/conjure/forcewall = 			1,
 				/spell/aoe_turf/smoke = 						1,
 				/spell/aoe_turf/conjure/summon/bats = 			3,
+				/spell/noclothes = 								1,
 				/obj/item/weapon/contract/wizard/tk = 			5,
 				/obj/item/weapon/dice/d20/cursed = 				1,
 				/obj/structure/closet/wizard/scrying = 			2,
 				/obj/item/weapon/teleportation_scroll = 		1,
 				/obj/item/weapon/magic_rock = 					1,
+				/obj/item/weapon/contract/wizard/telepathy = 	1,
 				/obj/item/weapon/contract/apprentice = 			1
 				)
 

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -10,7 +10,7 @@
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_desc = "A general wizard's spellbook. All its spells are easy to use but hard to master."
 	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
-	max_uses = 5
+	max_uses = 6
 
 	spells = list(/spell/targeted/projectile/magic_missile = 			1,
 							/spell/targeted/projectile/dumbfire/fireball = 		1,
@@ -23,15 +23,16 @@
 							/spell/area_teleport = 								1,
 							/spell/targeted/genetic/mutate = 					1,
 							/spell/targeted/ethereal_jaunt = 					1,
+							/spell/targeted/heal_target = 						1,
 							/spell/aoe_turf/knock = 							1,
 							/spell/noclothes = 									2,
 							/obj/item/weapon/gun/energy/staff/focus = 			1,
 							/obj/structure/closet/wizard/souls = 				1,
-							/obj/structure/closet/wizard/armor = 				1,
 							/obj/item/weapon/gun/energy/staff/animate = 		1,
 							/obj/structure/closet/wizard/scrying = 				1,
 							/obj/item/weapon/monster_manual = 					2,
 							/obj/item/weapon/magic_rock = 						1,
+							/obj/item/weapon/contract/wizard/telepathy = 		1,
 							/obj/item/weapon/contract/apprentice = 				1
 							)
 

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -14,16 +14,16 @@
 	cooldown_reduc = 50
 	hud_state = "heal_minor"
 
-	amt_dam_brute = -15 //-3
-	amt_dam_fire = -5 //-1
+	amt_dam_brute = -15
+	amt_dam_fire = -5
 
 	message = "You feel a pleasant rush of heat move through your body."
 
 /spell/targeted/heal_target/empower_spell()
 	if(!..())
 		return 0
-	amt_dam_brute -= 15 //3
-	amt_dam_fire -= 15 //3
+	amt_dam_brute -= 15
+	amt_dam_fire -= 15
 
 	return "[src] will now heal more."
 
@@ -39,8 +39,8 @@
 	cooldown_reduc = 100
 	hud_state = "heal_major"
 
-	amt_dam_brute = -75 //-15
-	amt_dam_fire  = -50 //-5
+	amt_dam_brute = -75
+	amt_dam_fire  = -50
 	amt_blood  = 28
 
 	message = "Your body feels like a furnace."
@@ -52,8 +52,8 @@
 	amt_organ = 5
 	amt_brain  = -5
 	amt_radiation  = 5
-	amt_dam_tox = -20 //-10
-	amt_dam_oxy = -14 //-7
+	amt_dam_tox = -20
+	amt_dam_oxy = -14
 	amt_dam_brute = -35
 	amt_dam_fire  = -35
 
@@ -72,14 +72,14 @@
 	cooldown_reduc = 300
 	hud_state = "heal_area"
 
-	amt_dam_brute = -25 //-5
-	amt_dam_fire = -25 //-5
+	amt_dam_brute = -25
+	amt_dam_fire = -25
 
 /spell/targeted/heal_target/area/empower_spell()
 	if(!..())
 		return 0
-	amt_dam_brute -= 15 //3
-	amt_dam_fire -= 15 //3
+	amt_dam_brute -= 15
+	amt_dam_fire -= 15
 	range += 2
 
 	return "[src] now heals more in a wider area."
@@ -96,10 +96,10 @@
 	holder_var_amount = 100
 	level_max = list(Sp_TOTAL = 1, Sp_SPEED = 0, Sp_POWER = 1)
 
-	amt_dam_brute = -1000 //-50
-	amt_dam_fire = -1000 //-50
-	amt_dam_oxy = -100 //-50
-	amt_dam_tox = -100 //-50
+	amt_dam_brute = -1000
+	amt_dam_fire = -1000
+	amt_dam_oxy = -100
+	amt_dam_tox = -100
 	amt_blood  = 280
 
 	hud_state = "gen_dissolve"
@@ -111,13 +111,6 @@
 	amt_organ = 25
 	amt_brain  = -25
 	amt_radiation  = 25
-
-	//holder_var_amount *= 2
-
-	//amt_dam_brute *= 2
-	//amt_dam_fire *= 2
-	//amt_dam_oxy *= 2
-	//amt_dam_tox *= 2
 
 
 

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -51,7 +51,7 @@
 	amt_blood  = 28
 	amt_organ = 5
 	amt_brain  = -5
-	amt_radiation  = 5
+	amt_radiation  = -5
 	amt_dam_tox = -20
 	amt_dam_oxy = -14
 	amt_dam_brute = -35
@@ -110,7 +110,7 @@
 
 	amt_organ = 25
 	amt_brain  = -25
-	amt_radiation  = 25
+	amt_radiation  = -25
 
 
 

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -14,16 +14,16 @@
 	cooldown_reduc = 50
 	hud_state = "heal_minor"
 
-	amt_dam_brute = -3
-	amt_dam_fire = -1
+	amt_dam_brute = -15 //-3
+	amt_dam_fire = -5 //-1
 
 	message = "You feel a pleasant rush of heat move through your body."
 
 /spell/targeted/heal_target/empower_spell()
 	if(!..())
 		return 0
-	amt_dam_brute -= 3
-	amt_dam_fire -= 3
+	amt_dam_brute -= 15 //3
+	amt_dam_fire -= 15 //3
 
 	return "[src] will now heal more."
 
@@ -32,25 +32,32 @@
 	desc = "A spell used to fix others that cannot be fixed with regular medicine."
 	feedback = "CM"
 	charge_max = 300
-	spell_flags = SELECTABLE | NEEDSCLOTHES
+	spell_flags = INCLUDEUSER | SELECTABLE | NEEDSCLOTHES
 	invocation = "Borv Di'Nath!"
 	range = 1
 	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 1, Sp_POWER = 1)
 	cooldown_reduc = 100
 	hud_state = "heal_major"
 
-	amt_dam_brute = -15
-	amt_dam_fire  = -5
+	amt_dam_brute = -75 //-15
+	amt_dam_fire  = -50 //-5
+	amt_blood  = 28
 
 	message = "Your body feels like a furnace."
 
 /spell/targeted/heal_target/major/empower_spell()
 	if(!..())
 		return 0
-	amt_dam_tox = -10
-	amt_dam_oxy = -7
+	amt_blood  = 28
+	amt_organ = 5
+	amt_brain  = -5
+	amt_radiation  = 5
+	amt_dam_tox = -20 //-10
+	amt_dam_oxy = -14 //-7
+	amt_dam_brute = -35
+	amt_dam_fire  = -35
 
-	return "[src] now heals oxygen loss and toxic damage."
+	return "[src] heals more, and heals organ damage and radiation."
 
 /spell/targeted/heal_target/area
 	name = "Cure Area"
@@ -65,14 +72,14 @@
 	cooldown_reduc = 300
 	hud_state = "heal_area"
 
-	amt_dam_brute = -5
-	amt_dam_fire = -5
+	amt_dam_brute = -25 //-5
+	amt_dam_fire = -25 //-5
 
 /spell/targeted/heal_target/area/empower_spell()
 	if(!..())
 		return 0
-	amt_dam_brute -= 3
-	amt_dam_fire -= 3
+	amt_dam_brute -= 15 //3
+	amt_dam_fire -= 15 //3
 	range += 2
 
 	return "[src] now heals more in a wider area."
@@ -85,14 +92,15 @@
 	spell_flags = SELECTABLE
 	invocation = "Ei'Nath Borv Di'Nath!"
 	charge_type = Sp_HOLDVAR
-	holder_var_type = "bruteloss"
-	holder_var_amount = 75
+	holder_var_type = "FireLoss"
+	holder_var_amount = 100
 	level_max = list(Sp_TOTAL = 1, Sp_SPEED = 0, Sp_POWER = 1)
 
-	amt_dam_brute = -50
-	amt_dam_fire = -50
-	amt_dam_oxy = -50
-	amt_dam_tox = -50
+	amt_dam_brute = -1000 //-50
+	amt_dam_fire = -1000 //-50
+	amt_dam_oxy = -100 //-50
+	amt_dam_tox = -100 //-50
+	amt_blood  = 280
 
 	hud_state = "gen_dissolve"
 
@@ -100,13 +108,17 @@
 	if(!..())
 		return 0
 
-	holder_var_amount *= 2
+	amt_organ = 25
+	amt_brain  = -25
+	amt_radiation  = 25
 
-	amt_dam_brute *= 2
-	amt_dam_fire *= 2
-	amt_dam_oxy *= 2
-	amt_dam_tox *= 2
+	//holder_var_amount *= 2
+
+	//amt_dam_brute *= 2
+	//amt_dam_fire *= 2
+	//amt_dam_oxy *= 2
+	//amt_dam_tox *= 2
 
 
 
-	return "You will now heal twice as much, but take twice as much damage. It will probably kill you."
+	return "You will now heal organ and brain damage, as well as virtually purge all radiation."

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -22,6 +22,12 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	var/amt_dam_brute = 0
 	var/amt_dam_oxy = 0
 	var/amt_dam_tox = 0
+	
+		//used for advanced healing
+	var/amt_blood = 0 //Positive numbers to add blood
+	var/amt_brain = 0 //Negative numbers to reduce brain damage
+	var/amt_radiation = 0 //Positive numbers to reduce radiation
+	var/amt_organ = 0 //Positive numbers to reduce organ damage
 
 	var/amt_eye_blind = 0
 	var/amt_eye_blurry = 0
@@ -131,6 +137,16 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.adjustFireLoss(amt_dam_fire)
 	target.adjustToxLoss(amt_dam_tox)
 	target.adjustOxyLoss(amt_dam_oxy)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		for(var/obj/item/organ/external/affecting in H.organs)
+			if(affecting && istype(affecting))
+				affecting.heal_damage(amt_organ, amt_organ)
+		H.vessel.add_reagent(/datum/reagent/blood,amt_blood)
+		H.adjustBrainLoss(amt_brain)
+		H.radiation -= min(H.radiation, amt_radiation)
+		H.fixblood()
+	target.regenerate_icons()
 	//disabling
 	target.Weaken(amt_weakened)
 	target.Paralyse(amt_paralysis)

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -17,17 +17,15 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	var/amt_confused = 0
 	var/amt_stuttering = 0
 
-		//set to negatives for healing
+		//set to negatives for healing unless commented otherwise
 	var/amt_dam_fire = 0
 	var/amt_dam_brute = 0
 	var/amt_dam_oxy = 0
 	var/amt_dam_tox = 0
-	
-		//used for advanced healing
+	var/amt_brain = 0
+	var/amt_radiation = 0
 	var/amt_blood = 0 //Positive numbers to add blood
-	var/amt_brain = 0 //Negative numbers to reduce brain damage
-	var/amt_radiation = 0 //Positive numbers to reduce radiation
-	var/amt_organ = 0 //Positive numbers to reduce organ damage
+	var/amt_organ = 0 //Positive numbers for healing
 
 	var/amt_eye_blind = 0
 	var/amt_eye_blurry = 0
@@ -144,7 +142,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 				affecting.heal_damage(amt_organ, amt_organ)
 		H.vessel.add_reagent(/datum/reagent/blood,amt_blood)
 		H.adjustBrainLoss(amt_brain)
-		H.radiation -= min(H.radiation, amt_radiation)
+		H.radiation += min(H.radiation, amt_radiation)
 		H.fixblood()
 	target.regenerate_icons()
 	//disabling


### PR DESCRIPTION
   :cl: Novacat
   spellcheck: Fixed capitalization issue with Radiant Aura
   rscadd: Added telepath (mRemoteSay) contract to all spellbooks
   tweak: Added 1 point to all spellbooks
   rscadd: Added Teleport, Cure Light Wounds, and Noclothes to all spellbooks that lacked them
   rscdel: Removed Mage Armor from Standard spellbook, and Cure Light Wounds from Cleric spellbook
   tweak: Swapped Focus staff for Scrying orb in Cleric book
   rscadd: Added X-ray contract to Battlemage book, parrot transformation to Druid book
   rscdel: Removed Student spellbook
   tweak: Made staves slightly smaller, so that they are more portable
   rscadd: Overhauled cure spells to be more effective
   tweak: Reduced cost of Spatial's magic missile to 1
   /:cl: