### PR TITLE
Causes bioprinter to print species specific organs

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -200,11 +200,17 @@
 	component_parts += new /obj/item/weapon/circuitboard/bioprinter
 
 /obj/machinery/organ_printer/flesh/print_organ(var/choice)
-	var/obj/item/organ/O = ..()
+	var/obj/item/organ/O
 	var/weakref/W = loaded_dna["donor"]
-	var/mob/living/carbon/C = W.resolve()
-	if(C)
-		O.set_dna(C.dna)
+	var/mob/living/carbon/human/H = W.resolve()
+	if(H && istype(H))
+		if(H.species && H.species.has_organ[choice])
+			var/new_organ = H.species.has_organ[choice]
+			O = new new_organ(get_turf(src))
+			O.status |= ORGAN_CUT_AWAY
+		else
+			O = ..()
+		O.set_dna(H.dna)
 		if(O.species)
 			// This is a very hacky way of doing of what organ/New() does if it has an owner
 			O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
The bioprinter will now print a species-specific version of an internal organ if it is available.

🆑 FTangSteve
tweak: Bioprinter will now print species-specific internal organs if they are available
/🆑