### PR TITLE
Loadout tweaks

### DIFF
--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -64,7 +64,7 @@
 #define RESEARCH_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/assistant, /datum/job/nt_pilot, /datum/job/senior_scientist, /datum/job/roboticist)
 
 //For jobs that spawn with weapons in their lockers
-#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/guard, /datum/job/merchant)
+#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/guard, /datum/job/merchant)
 
 //For jobs that spawn with armor in their lockers
 #define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/bridgeofficer, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/guard, /datum/job/merchant)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -124,7 +124,11 @@
 /datum/gear/accessory/armband_nt
 	display_name = "NanoTrasen armband"
 	path = /obj/item/clothing/accessory/armband/whitered
-	allowed_roles = list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist, /datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/janitor, /datum/job/chef, /datum/job/bartender)
+	allowed_roles = list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,
+						/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant,
+						/datum/job/roboticist, /datum/job/engineer_contractor,
+						/datum/job/psychiatrist, /datum/job/doctor_contractor, /datum/job/chemist,
+						/datum/job/cargo_contractor, /datum/job/janitor, /datum/job/chef, /datum/job/bartender)
 
 /datum/gear/accessory/armband_solgov
 	display_name = "peacekeeper armband"
@@ -408,4 +412,4 @@
 /datum/gear/accessory/pilot_pin
 	display_name = "pilot's qualification pin"
 	path = /obj/item/clothing/accessory/solgov/speciality/pilot
-	allowed_roles = list(/datum/job/bridgeofficer)
+	allowed_roles = list(/datum/job/captain, /datum/job/hop, /datum/job/bridgeofficer, /datum/job/pathfinder)

--- a/maps/torch/loadout/loadout_gloves.dm
+++ b/maps/torch/loadout/loadout_gloves.dm
@@ -66,7 +66,6 @@
 /datum/gear/gloves/dress
 	display_name = "gloves, dress"
 	path = /obj/item/clothing/gloves/color/white
-	allowed_roles = MILITARY_ROLES
 
 /datum/gear/gloves/duty
 	display_name = "gloves, duty"

--- a/maps/torch/loadout/loadout_shoes.dm
+++ b/maps/torch/loadout/loadout_shoes.dm
@@ -8,7 +8,6 @@
 /datum/gear/shoes/whitedress
 	display_name = "dress shoes, white"
 	path = /obj/item/clothing/shoes/dress/white
-	allowed_roles = MILITARY_ROLES
 
 /datum/gear/shoes/athletic
 	display_name = "athletic shoes, colour select"
@@ -56,7 +55,6 @@
 /datum/gear/shoes/dress
 	display_name = "dress shoes"
 	path = /obj/item/clothing/shoes/dress
-	allowed_roles = MILITARY_ROLES
 
 /datum/gear/shoes/flats
 	display_name = "flats, colour select"
@@ -69,7 +67,7 @@
 	path = /obj/item/clothing/shoes/hightops
 	allowed_roles = FORMAL_ROLES
 	flags = GEAR_HAS_TYPE_SELECTION
-	
+
 /datum/gear/shoes/sandal
 	display_name = "wooden sandals"
 	path = /obj/item/clothing/shoes/sandal


### PR DESCRIPTION
Removed CE and CMO from armed roles because of https://github.com/Baystation12/Baystation12/pull/20293.
~Restricted bandolier to armed roles only because it is a military equipment for carrying ammo.~
Allowed pilot qualification pin for CO, XO, Pathfinder ~and explorers~.
Allowed dress gloves for everyone.
Allowed dress shoes for everyone.

:cl: Sbotkin
tweak: Several loadout access tweaks. More things for civilians and pilot's pin for the CO, XO, and Pathfinder.
/:cl: