### PR TITLE
Rewrites alarm handler for multi z functionality

### DIFF
--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -28,10 +28,10 @@ var/global/list/minor_air_alarms = list()
 	var/major_alarms[0]
 	var/minor_alarms[0]
 
-	for(var/datum/alarm/alarm in atmosphere_alarm.major_alarms())
+	for(var/datum/alarm/alarm in atmosphere_alarm.major_alarms(get_z(src)))
 		major_alarms[++major_alarms.len] = list("name" = sanitize(alarm.alarm_name()), "ref" = "\ref[alarm]")
 
-	for(var/datum/alarm/alarm in atmosphere_alarm.minor_alarms())
+	for(var/datum/alarm/alarm in atmosphere_alarm.minor_alarms(get_z(src)))
 		minor_alarms[++minor_alarms.len] = list("name" = sanitize(alarm.alarm_name()), "ref" = "\ref[alarm]")
 
 	data["priority_alarms"] = major_alarms
@@ -46,15 +46,12 @@ var/global/list/minor_air_alarms = list()
 
 /obj/machinery/computer/atmos_alert/update_icon()
 	if(!(stat & (NOPOWER|BROKEN)))
-		var/list/alarms = atmosphere_alarm.major_alarms()
-		if(alarms.len)
+		if(atmosphere_alarm.has_major_alarms(get_z(src)))
 			icon_screen = "alert:2"
+		else if (atmosphere_alarm.has_minor_alarms(get_z(src)))
+			icon_screen = "alert:1"
 		else
-			alarms = atmosphere_alarm.minor_alarms()
-			if(alarms.len)
-				icon_screen = "alert:1"
-			else
-				icon_screen = initial(icon_screen)
+			icon_screen = initial(icon_screen)
 	..()
 
 /obj/machinery/computer/atmos_alert/OnTopic(user, href_list)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -59,7 +59,6 @@
 	icon_screen = initial(icon_screen)
 	if(!(stat & (BROKEN|NOPOWER)))
 		if(alarm_monitor)
-			var/list/alarms = alarm_monitor.major_alarms()
-			if(alarms.len)
+			if(alarm_monitor.has_major_alarms(get_z(src)))
 				icon_screen = "alert:2"
 	..()

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -5,6 +5,7 @@
 	var/category = ""
 	var/list/datum/alarm/alarms = new		// All alarms, to handle cases when an origin has been deleted with one or more active alarms
 	var/list/datum/alarm/alarms_assoc = new	// Associative list of alarms, to efficiently acquire them based on origin.
+	var/list/datum/alarm/alarms_by_z = new	// Associative list of alarms based on origin z level
 	var/list/listeners = new				// A list of all objects interested in alarm changes.
 
 /datum/alarm_handler/proc/process()
@@ -30,6 +31,7 @@
 
 	alarms |= existing
 	alarms_assoc[origin] = existing
+	LAZYADD(alarms_by_z["[existing.alarm_z()]"], existing)
 	if(new_alarm)
 		alarms = dd_sortedObjectList(alarms)
 		on_alarm_change(existing, ALARM_RAISED)
@@ -47,21 +49,34 @@
 		existing.clear(source)
 		return check_alarm_cleared(existing)
 
-/datum/alarm_handler/proc/major_alarms()
-	return alarms
+// Returns alarms in connected z levels to z_level. If none is given, returns all.
+/datum/alarm_handler/proc/alarms(var/z_level)
+	if(z_level)
+		. = list()
+		for(var/z in GetConnectedZlevels(z_level))
+			. += alarms_by_z["[z]"] || list()
+	else
+		return alarms
 
-/datum/alarm_handler/proc/has_major_alarms()
-	if(alarms && alarms.len)
-		return 1
-	return 0
+// Returns major alarms in connected z levels to z_level. If none is given, returns all.
+/datum/alarm_handler/proc/major_alarms(var/z_level)
+	return alarms(z_level)
 
-/datum/alarm_handler/proc/minor_alarms()
-	return alarms
+/datum/alarm_handler/proc/has_major_alarms(var/z_level)
+	return !!length(major_alarms(z_level))
+
+// Returns minor alarms in connected z levels to z_level. If none is given, returns all.
+/datum/alarm_handler/proc/minor_alarms(var/z_level)
+	return alarms(z_level)
+
+/datum/alarm_handler/proc/has_minor_alarms(var/z_level)
+	return !!length(minor_alarms(z_level))
 
 /datum/alarm_handler/proc/check_alarm_cleared(var/datum/alarm/alarm)
 	if ((alarm.end_time && world.time > alarm.end_time) || !alarm.sources.len)
 		alarms -= alarm
 		alarms_assoc -= alarm.origin
+		alarms_by_z["[alarm.alarm_z()]"] -= alarm
 		on_alarm_change(alarm, ALARM_CLEARED)
 		return 1
 	return 0

--- a/code/modules/alarm/atmosphere_alarm.dm
+++ b/code/modules/alarm/atmosphere_alarm.dm
@@ -4,16 +4,14 @@
 /datum/alarm_handler/atmosphere/triggerAlarm(var/atom/origin, var/atom/source, var/duration = 0, var/severity = 1)
 	..()
 
-/datum/alarm_handler/atmosphere/major_alarms()
-	var/list/major_alarms = new()
-	for(var/datum/alarm/A in alarms)
+/datum/alarm_handler/atmosphere/major_alarms(var/z_level)
+	. = list()
+	for(var/datum/alarm/A in ..())
 		if(A.max_severity() > 1)
-			major_alarms.Add(A)
-	return major_alarms
+			. += A
 
-/datum/alarm_handler/atmosphere/minor_alarms()
-	var/list/minor_alarms = new()
-	for(var/datum/alarm/A in alarms)
+/datum/alarm_handler/atmosphere/minor_alarms(var/z_level)
+	. = list()
+	for(var/datum/alarm/A in ..())
 		if(A.max_severity() == 1)
-			minor_alarms.Add(A)
-	return minor_alarms
+			. += A

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
@@ -27,6 +27,7 @@
 			ui_header = "alarm_green.gif"
 			update_computer_icon()
 			has_alert = 0
+	return 1
 
 /datum/nano_module/alarm_monitor
 	name = "Alarm monitor"
@@ -64,21 +65,21 @@
 /datum/nano_module/alarm_monitor/proc/all_alarms()
 	var/list/all_alarms = new()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
-		all_alarms += AH.alarms
+		all_alarms += AH.alarms(get_host_z())
 
 	return all_alarms
 
 /datum/nano_module/alarm_monitor/proc/major_alarms()
 	var/list/all_alarms = new()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
-		all_alarms += AH.major_alarms()
+		all_alarms += AH.major_alarms(get_host_z())
 
 	return all_alarms
 
 // Modified version of above proc that uses slightly less resources, returns 1 if there is a major alarm, 0 otherwise.
 /datum/nano_module/alarm_monitor/proc/has_major_alarms()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
-		if(AH.has_major_alarms())
+		if(AH.has_major_alarms(get_host_z()))
 			return 1
 
 	return 0
@@ -86,7 +87,7 @@
 /datum/nano_module/alarm_monitor/proc/minor_alarms()
 	var/list/all_alarms = new()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
-		all_alarms += AH.minor_alarms()
+		all_alarms += AH.minor_alarms(get_host_z())
 
 	return all_alarms
 
@@ -107,9 +108,7 @@
 	var/categories[0]
 	for(var/datum/alarm_handler/AH in alarm_handlers)
 		categories[++categories.len] = list("category" = AH.category, "alarms" = list())
-		for(var/datum/alarm/A in AH.major_alarms())
-			if(!AreConnectedZLevels(get_host_z(), A.alarm_z()))
-				continue
+		for(var/datum/alarm/A in AH.major_alarms(get_host_z()))
 
 			var/cameras[0]
 			var/lost_sources[0]


### PR DESCRIPTION
:cl:
bugfix: Fixes alert monitors being red for away mission alerts.
bugfix: Fixes nonmodular atmos/alert consoles showing away mission alerts.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
