### PR TITLE
Add SetName() and relevant event, make hand labeler utilize it

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -220,6 +220,7 @@
 #include "code\datums\extensions\_defines.dm"
 #include "code\datums\extensions\extensions.dm"
 #include "code\datums\extensions\interactive.dm"
+#include "code\datums\extensions\label.dm"
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\base_icon_state.dm"
 #include "code\datums\extensions\appearance\cardborg.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -251,6 +251,7 @@
 #include "code\datums\observation\logged_in.dm"
 #include "code\datums\observation\logged_out.dm"
 #include "code\datums\observation\moved.dm"
+#include "code\datums\observation\name_set.dm"
 #include "code\datums\observation\observation.dm"
 #include "code\datums\observation\opacity_set.dm"
 #include "code\datums\observation\see_in_dark_set.dm"

--- a/code/_helpers/functional.dm
+++ b/code/_helpers/functional.dm
@@ -34,6 +34,11 @@
 	if(!. && feedback_receiver)
 		to_chat(feedback_receiver, "<span class='warning'>Value must be a numeral.</span>")
 
+/proc/is_text_predicate(var/value, var/feedback_receiver)
+	. = !value || istext(value)
+	if(!. && feedback_receiver)
+		to_chat(feedback_receiver, "<span class='warning'>Value must be a text.</span>")
+
 /proc/is_dir_predicate(var/value, var/feedback_receiver)
 	. = (value in GLOB.alldirs)
 	if(!. && feedback_receiver)

--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -105,7 +105,7 @@
 	if(!name) return
 	var/obj/screen/ability/new_button = new /obj/screen/ability
 	new_button.ability_master = src
-	new_button.name = name_given
+	new_button.SetName(name_given)
 	new_button.ability_icon_state = name_given
 	new_button.update_icon(1)
 	ability_objects.Add(new_button)
@@ -249,7 +249,7 @@
 	A.object_used = object_given
 	A.verb_to_call = verb_given
 	A.ability_icon_state = ability_icon_given
-	A.name = name_given
+	A.SetName(name_given)
 	if(arguments)
 		A.arguments_to_use = arguments
 	ability_objects.Add(A)
@@ -273,7 +273,7 @@
 	A.object_used = object_given
 	A.verb_to_call = verb_given
 	A.ability_icon_state = ability_icon_given
-	A.name = name_given
+	A.SetName(name_given)
 	if(arguments)
 		A.arguments_to_use = arguments
 	ability_objects.Add(A)
@@ -306,7 +306,7 @@
 	A.ability_master = src
 	A.object = object_given
 	A.ability_icon_state = ability_icon_given
-	A.name = object_given.name
+	A.SetName(object_given.name)
 	ability_objects.Add(A)
 	if(my_mob.client)
 		toggle_open(2) //forces the icons to refresh on screen
@@ -336,7 +336,7 @@
 	var/obj/screen/ability/spell/A = new()
 	A.ability_master = src
 	A.spell = spell
-	A.name = spell.name
+	A.SetName(spell.name)
 
 	if(!spell.override_base) //if it's not set, we do basic checks
 		if(spell.spell_flags & CONSTRUCT_CHECK)

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -9,7 +9,7 @@
 	var/obj/screen/using
 
 	using = new /obj/screen()
-	using.name = "mov_intent"
+	using.SetName("mov_intent")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_alien.dmi'
 	using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
@@ -20,13 +20,13 @@
 	mymob.healths = new /obj/screen()
 	mymob.healths.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.healths.icon_state = "health0"
-	mymob.healths.name = "health"
+	mymob.healths.SetName("health")
 	mymob.healths.screen_loc = ui_alien_health
 
 	mymob.fire = new /obj/screen()
 	mymob.fire.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.fire.icon_state = "fire0"
-	mymob.fire.name = "fire"
+	mymob.fire.SetName("fire")
 	mymob.fire.screen_loc = ui_fire
 
 	mymob.client.screen = list()

--- a/code/_onclick/hud/deity.dm
+++ b/code/_onclick/hud/deity.dm
@@ -27,7 +27,7 @@
 	var/mob/living/deity/D = mob
 	for(var/i in 1 to D.control_types.len)
 		var/obj/screen/S = new()
-		S.name = null //Don't want them to be able to actually right click it.
+		S.SetName(null) //Don't want them to be able to actually right click it.
 		S.mouse_opacity = 0
 		S.icon_state = "blank"
 		desc_screens[D.control_types[i]] = S

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -30,7 +30,7 @@
 		inv_box.alpha = ui_alpha
 
 		var/list/slot_data =  hud_data.gear[gear_slot]
-		inv_box.name =        gear_slot
+		inv_box.SetName(gear_slot)
 		inv_box.screen_loc =  slot_data["loc"]
 		inv_box.slot_id =     slot_data["slot"]
 		inv_box.icon_state =  slot_data["state"]
@@ -46,7 +46,7 @@
 
 	if(has_hidden_gear)
 		using = new /obj/screen()
-		using.name = "toggle"
+		using.SetName("toggle")
 		using.icon = ui_style
 		using.icon_state = "other"
 		using.screen_loc = ui_inventory
@@ -65,7 +65,7 @@
 
 	if(hud_data.has_m_intent)
 		using = new /obj/screen()
-		using.name = "mov_intent"
+		using.SetName("mov_intent")
 		using.icon = ui_style
 		using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
 		using.screen_loc = ui_movi
@@ -76,7 +76,7 @@
 
 	if(hud_data.has_drop)
 		using = new /obj/screen()
-		using.name = "drop"
+		using.SetName("drop")
 		using.icon = ui_style
 		using.icon_state = "act_drop"
 		using.screen_loc = ui_drop_throw
@@ -87,7 +87,7 @@
 	if(hud_data.has_hands)
 
 		using = new /obj/screen()
-		using.name = "equip"
+		using.SetName("equip")
 		using.icon = ui_style
 		using.icon_state = "act_equip"
 		using.screen_loc = ui_equip
@@ -96,7 +96,7 @@
 		src.adding += using
 
 		inv_box = new /obj/screen/inventory()
-		inv_box.name = "r_hand"
+		inv_box.SetName("r_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
 		if(mymob && !mymob.hand)	//This being 0 or null means the right hand is in use
@@ -110,7 +110,7 @@
 		src.adding += inv_box
 
 		inv_box = new /obj/screen/inventory()
-		inv_box.name = "l_hand"
+		inv_box.SetName("l_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
 		if(mymob && mymob.hand)	//This being 1 means the left hand is in use
@@ -123,7 +123,7 @@
 		src.adding += inv_box
 
 		using = new /obj/screen/inventory()
-		using.name = "hand"
+		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand1"
 		using.screen_loc = ui_swaphand1
@@ -132,7 +132,7 @@
 		src.adding += using
 
 		using = new /obj/screen/inventory()
-		using.name = "hand"
+		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand2"
 		using.screen_loc = ui_swaphand2
@@ -142,7 +142,7 @@
 
 	if(hud_data.has_resist)
 		using = new /obj/screen()
-		using.name = "resist"
+		using.SetName("resist")
 		using.icon = ui_style
 		using.icon_state = "act_resist"
 		using.screen_loc = ui_pull_resist
@@ -154,7 +154,7 @@
 		mymob.throw_icon = new /obj/screen()
 		mymob.throw_icon.icon = ui_style
 		mymob.throw_icon.icon_state = "act_throw_off"
-		mymob.throw_icon.name = "throw"
+		mymob.throw_icon.SetName("throw")
 		mymob.throw_icon.screen_loc = ui_drop_throw
 		mymob.throw_icon.color = ui_color
 		mymob.throw_icon.alpha = ui_alpha
@@ -164,7 +164,7 @@
 		mymob.pullin = new /obj/screen()
 		mymob.pullin.icon = ui_style
 		mymob.pullin.icon_state = "pull0"
-		mymob.pullin.name = "pull"
+		mymob.pullin.SetName("pull")
 		mymob.pullin.screen_loc = ui_pull_resist
 		src.hotkeybuttons += mymob.pullin
 		hud_elements |= mymob.pullin
@@ -173,7 +173,7 @@
 		mymob.internals = new /obj/screen()
 		mymob.internals.icon = ui_style
 		mymob.internals.icon_state = "internal0"
-		mymob.internals.name = "internal"
+		mymob.internals.SetName("internal")
 		mymob.internals.screen_loc = ui_internal
 		hud_elements |= mymob.internals
 
@@ -181,28 +181,28 @@
 		mymob.oxygen = new /obj/screen()
 		mymob.oxygen.icon = ui_style
 		mymob.oxygen.icon_state = "oxy0"
-		mymob.oxygen.name = "oxygen"
+		mymob.oxygen.SetName("oxygen")
 		mymob.oxygen.screen_loc = ui_oxygen
 		hud_elements |= mymob.oxygen
 
 		mymob.toxin = new /obj/screen()
 		mymob.toxin.icon = ui_style
 		mymob.toxin.icon_state = "tox0"
-		mymob.toxin.name = "toxin"
+		mymob.toxin.SetName("toxin")
 		mymob.toxin.screen_loc = ui_toxin
 		hud_elements |= mymob.toxin
 
 		mymob.fire = new /obj/screen()
 		mymob.fire.icon = ui_style
 		mymob.fire.icon_state = "fire0"
-		mymob.fire.name = "fire"
+		mymob.fire.SetName("fire")
 		mymob.fire.screen_loc = ui_fire
 		hud_elements |= mymob.fire
 
 		mymob.healths = new /obj/screen()
 		mymob.healths.icon = ui_style
 		mymob.healths.icon_state = "health0"
-		mymob.healths.name = "health"
+		mymob.healths.SetName("health")
 		mymob.healths.screen_loc = ui_health
 		hud_elements |= mymob.healths
 
@@ -210,7 +210,7 @@
 		mymob.pressure = new /obj/screen()
 		mymob.pressure.icon = ui_style
 		mymob.pressure.icon_state = "pressure0"
-		mymob.pressure.name = "pressure"
+		mymob.pressure.SetName("pressure")
 		mymob.pressure.screen_loc = ui_pressure
 		hud_elements |= mymob.pressure
 
@@ -218,7 +218,7 @@
 		mymob.bodytemp = new /obj/screen()
 		mymob.bodytemp.icon = ui_style
 		mymob.bodytemp.icon_state = "temp1"
-		mymob.bodytemp.name = "body temperature"
+		mymob.bodytemp.SetName("body temperature")
 		mymob.bodytemp.screen_loc = ui_temp
 		hud_elements |= mymob.bodytemp
 
@@ -226,7 +226,7 @@
 		target.cells = new /obj/screen()
 		target.cells.icon = 'icons/mob/screen1_robot.dmi'
 		target.cells.icon_state = "charge-empty"
-		target.cells.name = "cell"
+		target.cells.SetName("cell")
 		target.cells.screen_loc = ui_nutrition
 		hud_elements |= target.cells
 
@@ -234,7 +234,7 @@
 		mymob.nutrition_icon = new /obj/screen()
 		mymob.nutrition_icon.icon = ui_style
 		mymob.nutrition_icon.icon_state = "nutrition0"
-		mymob.nutrition_icon.name = "nutrition"
+		mymob.nutrition_icon.SetName("nutrition")
 		mymob.nutrition_icon.screen_loc = ui_nutrition
 		hud_elements |= mymob.nutrition_icon
 

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -99,7 +99,7 @@
 	set name = "Spawn Movable UI Object"
 
 	var/obj/screen/movable/M = new()
-	M.name = "Movable UI Object"
+	M.SetName("Movable UI Object")
 	M.icon_state = "block"
 	M.maptext = "Movable"
 	M.maptext_width = 64
@@ -118,7 +118,7 @@
 	set name = "Spawn Snap UI Object"
 
 	var/obj/screen/movable/snap/S = new()
-	S.name = "Snap UI Object"
+	S.SetName("Snap UI Object")
 	S.icon_state = "block"
 	S.maptext = "Snap"
 	S.maptext_width = 64

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -32,19 +32,19 @@
 		mymob.fire = new /obj/screen()
 		mymob.fire.icon = 'icons/mob/screen1_construct.dmi'
 		mymob.fire.icon_state = "fire0"
-		mymob.fire.name = "fire"
+		mymob.fire.SetName("fire")
 		mymob.fire.screen_loc = ui_construct_fire
 
 		mymob.healths = new /obj/screen()
 		mymob.healths.icon = 'icons/mob/screen1_construct.dmi'
 		mymob.healths.icon_state = "[constructtype]_health0"
-		mymob.healths.name = "health"
+		mymob.healths.SetName("health")
 		mymob.healths.screen_loc = ui_construct_health
 
 		mymob.pullin = new /obj/screen()
 		mymob.pullin.icon = 'icons/mob/screen1_construct.dmi'
 		mymob.pullin.icon_state = "pull0"
-		mymob.pullin.name = "pull"
+		mymob.pullin.SetName("pull")
 		mymob.pullin.screen_loc = ui_construct_pull
 
 		mymob.zone_sel = new /obj/screen/zone_sel()
@@ -55,7 +55,7 @@
 		mymob.purged = new /obj/screen()
 		mymob.purged.icon = 'icons/mob/screen1_construct.dmi'
 		mymob.purged.icon_state = "purge0"
-		mymob.purged.name = "purged"
+		mymob.purged.SetName("purged")
 		mymob.purged.screen_loc = ui_construct_purge
 
 	mymob.client.screen = list()

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -12,7 +12,7 @@ var/obj/screen/robot_inventory
 
 //Radio
 	using = new /obj/screen()
-	using.name = "radio"
+	using.SetName("radio")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "radio"
@@ -22,7 +22,7 @@ var/obj/screen/robot_inventory
 //Module select
 
 	using = new /obj/screen()
-	using.name = "module1"
+	using.SetName("module1")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "inv1"
@@ -31,7 +31,7 @@ var/obj/screen/robot_inventory
 	mymob:inv1 = using
 
 	using = new /obj/screen()
-	using.name = "module2"
+	using.SetName("module2")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "inv2"
@@ -40,7 +40,7 @@ var/obj/screen/robot_inventory
 	mymob:inv2 = using
 
 	using = new /obj/screen()
-	using.name = "module3"
+	using.SetName("module3")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "inv3"
@@ -52,7 +52,7 @@ var/obj/screen/robot_inventory
 
 //Intent
 	using = new /obj/screen()
-	using.name = "act_intent"
+	using.SetName("act_intent")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = mymob.a_intent
@@ -64,26 +64,26 @@ var/obj/screen/robot_inventory
 	mymob:cells = new /obj/screen()
 	mymob:cells.icon = 'icons/mob/screen1_robot.dmi'
 	mymob:cells.icon_state = "charge-empty"
-	mymob:cells.name = "cell"
+	mymob:cells.SetName("cell")
 	mymob:cells.screen_loc = ui_toxin
 
 //Health
 	mymob.healths = new /obj/screen()
 	mymob.healths.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.healths.icon_state = "health0"
-	mymob.healths.name = "health"
+	mymob.healths.SetName("health")
 	mymob.healths.screen_loc = ui_borg_health
 
 //Installed Module
 	mymob.hands = new /obj/screen()
 	mymob.hands.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.hands.icon_state = "nomod"
-	mymob.hands.name = "module"
+	mymob.hands.SetName("module")
 	mymob.hands.screen_loc = ui_borg_module
 
 //Module Panel
 	using = new /obj/screen()
-	using.name = "panel"
+	using.SetName("panel")
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "panel"
 	using.screen_loc = ui_borg_panel
@@ -93,12 +93,12 @@ var/obj/screen/robot_inventory
 	mymob.throw_icon = new /obj/screen()
 	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.throw_icon.icon_state = "store"
-	mymob.throw_icon.name = "store"
+	mymob.throw_icon.SetName("store")
 	mymob.throw_icon.screen_loc = ui_borg_store
 
 //Inventory
 	robot_inventory = new /obj/screen()
-	robot_inventory.name = "inventory"
+	robot_inventory.SetName("inventory")
 	robot_inventory.icon = 'icons/mob/screen1_robot.dmi'
 	robot_inventory.icon_state = "inventory"
 	robot_inventory.screen_loc = ui_borg_inventory
@@ -106,26 +106,26 @@ var/obj/screen/robot_inventory
 //Temp
 	mymob.bodytemp = new /obj/screen()
 	mymob.bodytemp.icon_state = "temp0"
-	mymob.bodytemp.name = "body temperature"
+	mymob.bodytemp.SetName("body temperature")
 	mymob.bodytemp.screen_loc = ui_temp
 
 
 	mymob.oxygen = new /obj/screen()
 	mymob.oxygen.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.oxygen.icon_state = "oxy0"
-	mymob.oxygen.name = "oxygen"
+	mymob.oxygen.SetName("oxygen")
 	mymob.oxygen.screen_loc = ui_oxygen
 
 	mymob.fire = new /obj/screen()
 	mymob.fire.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.fire.icon_state = "fire0"
-	mymob.fire.name = "fire"
+	mymob.fire.SetName("fire")
 	mymob.fire.screen_loc = ui_fire
 
 	mymob.pullin = new /obj/screen()
 	mymob.pullin.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.pullin.icon_state = "pull0"
-	mymob.pullin.name = "pull"
+	mymob.pullin.SetName("pull")
 	mymob.pullin.screen_loc = ui_borg_pull
 
 	mymob.zone_sel = new /obj/screen/zone_sel()

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -152,7 +152,7 @@ var/const/tk_maxrange = 15
 /obj/item/tk_grab/proc/apply_focus_overlay()
 	if(!focus)	return
 	var/obj/effect/overlay/O = new /obj/effect/overlay(locate(focus.x,focus.y,focus.z))
-	O.name = "sparkles"
+	O.SetName("sparkles")
 	O.anchored = 1
 	O.set_density(0)
 	O.layer = FLY_LAYER

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -43,6 +43,11 @@
 			extension_data += args.Copy(4)
 		source.extensions[base_type] = extension_data
 
+/proc/get_or_create_extension(var/datum/source, var/base_type, var/extension_type)
+	if(!has_extension(source, base_type))
+		set_extension(arglist(args))
+	return get_extension(source, base_type)
+
 /proc/get_extension(var/datum/source, var/base_type)
 	if(!source.extensions)
 		return

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -1,0 +1,92 @@
+/datum/extension/labels
+	var/atom/atom_holder
+	var/list/labels
+
+/datum/extension/labels/New()
+	..()
+	atom_holder = holder
+
+/datum/extension/labels/Destroy()
+	atom_holder = null
+	return ..()
+
+/datum/extension/labels/proc/AttachLabel(var/mob/user, var/label)
+	if(!CanAttachLabel(user, label))
+		return
+
+	if(!LAZYLEN(labels))
+		atom_holder.verbs += /atom/proc/RemoveLabel
+	LAZYADD(labels, label)
+
+	user.visible_message("<span class='notice'>\The [user] attaches a label to \the [atom_holder].</span>", \
+						 "<span class='notice'>You attach a label, '[label]', to \the [atom_holder].</span>")
+
+	var/old_name = atom_holder.name
+	atom_holder.name = "[atom_holder.name] ([label])"
+	GLOB.name_set_event.raise_event(src, old_name, atom_holder.name)
+
+/datum/extension/labels/proc/RemoveLabel(var/mob/user, var/label)
+	if(!(label in labels))
+		return
+
+	LAZYREMOVE(labels, label)
+	if(!LAZYLEN(labels))
+		atom_holder.verbs -= /atom/proc/RemoveLabel
+
+	var/full_label = " ([label])"
+	var/index = findtextEx(atom_holder.name, full_label)
+	if(!index) // Playing it safe, something might not have set the name properly
+		return
+
+	user.visible_message("<span class='notice'>\The [user] removes a label from \the [atom_holder].</span>", \
+						 "<span class='notice'>You remove a label, '[label]', from \the [atom_holder].</span>")
+
+	var/old_name = atom_holder.name
+	// We find and replace the first instance, since that's the one we removed from the list
+	atom_holder.name = replacetext(atom_holder.name, full_label, "", index, index + length(full_label))
+	GLOB.name_set_event.raise_event(src, old_name, atom_holder.name)
+
+// We may have to do something more complex here
+// in case something appends strings to something that's labelled rather than replace the name outright
+// Non-printable characters should be of help if this comes up
+/datum/extension/labels/proc/AppendLabelsToName(var/name)
+	if(!LAZYLEN(labels))
+		return name
+	. = list(name)
+	for(var/entry in labels)
+		. += " ([entry])"
+	. = jointext(., null)
+
+/datum/extension/labels/proc/CanAttachLabel(var/user, var/label)
+	if(!length(label))
+		return FALSE
+	if(ExcessLabelLength(label, user))
+		return FALSE
+	return TRUE
+
+/datum/extension/labels/proc/ExcessLabelLength(var/label, var/user)
+	. = length(label) + 3 // Each label also adds a space and two brackets when applied to a name
+	if(LAZYLEN(labels))
+		for(var/entry in labels)
+			. += length(entry) + 3
+	. = . > 64 ? TRUE : FALSE
+	if(. && user)
+		to_chat(user, "<span class='warning'>The label won't fit.</span>")
+
+/proc/get_attached_labels(var/atom/source)
+	if(has_extension(source, /datum/extension/labels))
+		var/datum/extension/labels/L = get_extension(source, /datum/extension/labels)
+		if(LAZYLEN(L.labels))
+			return L.labels.Copy()
+		return list()
+
+/atom/proc/RemoveLabel(var/label in get_attached_labels(src))
+	set name = "Remove Label"
+	set desc = "Used to remove labels"
+	set category = "Object"
+	set src in view(1)
+
+	if(CanPhysicallyInteract(usr))
+		if(has_extension(src, /datum/extension/labels))
+			var/datum/extension/labels/L = get_extension(src, /datum/extension/labels)
+			L.RemoveLabel(usr, label)

--- a/code/datums/observation/name_set.dm
+++ b/code/datums/observation/name_set.dm
@@ -1,0 +1,25 @@
+//	Observer Pattern Implementation: Name Set
+//		Registration type: /atom
+//
+//		Raised when: An atom's name changes.
+//
+//		Arguments that the called proc should expect:
+//			/atom/namee:  The atom that had its name set
+//			/old_name: name before the change
+//			/new_name: name after the change
+
+GLOBAL_DATUM_INIT(name_set_event, /decl/observ/name_set, new)
+
+/decl/observ/name_set
+	name = "Name Set"
+	expected_type = /atom
+
+/*********************
+* Name Set Handling *
+*********************/
+
+/atom/proc/SetName(var/new_name)
+	var/old_name = name
+	if(old_name != new_name)
+		name = new_name
+		GLOB.name_set_event.raise_event(src, old_name, new_name)

--- a/code/datums/observation/name_set.dm
+++ b/code/datums/observation/name_set.dm
@@ -22,4 +22,7 @@ GLOBAL_DATUM_INIT(name_set_event, /decl/observ/name_set, new)
 	var/old_name = name
 	if(old_name != new_name)
 		name = new_name
+		if(has_extension(src, /datum/extension/labels))
+			var/datum/extension/labels/L = get_extension(src, /datum/extension/labels)
+			name = L.AppendLabelsToName(name)
 		GLOB.name_set_event.raise_event(src, old_name, new_name)

--- a/code/datums/trading/food.dm
+++ b/code/datums/trading/food.dm
@@ -86,7 +86,7 @@
 		var/obj/item/weapon/reagent_containers/food/snacks/fortunecookie/cookie = new(location)
 		var/obj/item/weapon/paper/paper = new(cookie)
 		cookie.trash = paper
-		paper.name = "Fortune"
+		paper.SetName("Fortune")
 		paper.info = pick(fortunes)
 
 /datum/trader/grocery

--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -65,7 +65,7 @@ datum/category_group/underwear/dd_SortValue()
 		return
 
 	var/obj/item/underwear/UW = new underwear_type()
-	UW.name = underwear_name
+	UW.SetName(underwear_name)
 	UW.gender = underwear_gender
 	UW.icon = icon
 	UW.icon_state = icon_state

--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -49,7 +49,7 @@ var/datum/antagonist/xenos/borer/borers
 				borer.forceMove(head)
 				if(!borer.host_brain)
 					borer.host_brain = new(borer)
-				borer.host_brain.name = host.name
+				borer.host_brain.SetName(host.name)
 				borer.host_brain.real_name = host.real_name
 				return
 	..() // Place them at a vent if they can't get a host.

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -76,7 +76,7 @@
 			// Create and pass on the bomb code paper.
 			var/obj/item/weapon/paper/P = new(paper_spawn_loc)
 			P.info = "The nuclear authorization code is: <b>[code]</b>"
-			P.name = "nuclear bomb code"
+			P.SetName("nuclear bomb code")
 			if(leader && leader.current)
 				if(get_turf(P) == get_turf(leader.current) && !(leader.current.l_hand && leader.current.r_hand))
 					leader.current.put_in_hands(P)
@@ -115,7 +115,7 @@
 	var/newname = sanitize(input(player, "You are a [role_text]. Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
 	if (newname)
 		player.real_name = newname
-		player.name = player.real_name
+		player.SetName(player.real_name)
 		if(player.dna)
 			player.dna.real_name = newname
 	if(player.mind) player.mind.name = player.name

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -73,8 +73,8 @@ var/datum/antagonist/deathsquad/deathsquad
 	A.randomize_appearance_and_body_for(player.current)
 
 	player.name = "[syndicate_commando_rank] [syndicate_commando_name]"
-	player.current.name = player.name
-	player.current.real_name = player.current.name
+	player.current.real_name = player.name
+	player.current.SetName(player.current.name)
 
 	var/mob/living/carbon/human/H = player.current
 	if(istype(H))

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -92,7 +92,7 @@ var/datum/antagonist/ninja/ninjas
 	var/mob/living/carbon/human/H = player.current
 	if(istype(H))
 		H.real_name = "[ninja_title] [ninja_name]"
-		H.name = H.real_name
+		H.SetName(H.real_name)
 	player.name = H.name
 
 /datum/antagonist/ninja/equip(var/mob/living/carbon/human/player)

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -108,9 +108,9 @@ var/datum/antagonist/raider/raiders
 /datum/antagonist/raider/update_access(var/mob/living/player)
 	for(var/obj/item/weapon/storage/wallet/W in player.contents)
 		for(var/obj/item/weapon/card/id/id in W.contents)
-			id.name = "[player.real_name]'s Passport"
+			id.SetName("[player.real_name]'s Passport")
 			id.registered_name = player.real_name
-			W.name = "[initial(W.name)] ([id.name])"
+			W.SetName("[initial(W.name)] ([id.name])")
 
 /datum/antagonist/raider/create_global_objectives()
 
@@ -223,7 +223,7 @@ var/datum/antagonist/raider/raiders
 		equip_weapons(player)
 
 	var/obj/item/weapon/card/id/id = create_id("Visitor", player, equip = 0)
-	id.name = "[player.real_name]'s Passport"
+	id.SetName("[player.real_name]'s Passport")
 	id.assignment = "Visitor"
 	var/obj/item/weapon/storage/wallet/W = new(player)
 	W.handle_item_insertion(id)

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -69,7 +69,7 @@ var/datum/antagonist/wizard/wizards
 	..()
 	wizard.store_memory("<B>Remember:</B> do not forget to prepare your spells.")
 	wizard.current.real_name = "[pick(GLOB.wizard_first)] [pick(GLOB.wizard_second)]"
-	wizard.current.name = wizard.current.real_name
+	wizard.current.SetName(wizard.current.real_name)
 
 /datum/antagonist/wizard/equip(var/mob/living/carbon/human/wizard_mob)
 

--- a/code/game/gamemodes/events/PortalStorm.dm
+++ b/code/game/gamemodes/events/PortalStorm.dm
@@ -21,6 +21,6 @@
 					P.icon = 'icons/obj/objects.dmi'
 					P.failchance = 0
 					P.icon_state = "anom"
-					P.name = "wormhole"
+					P.SetName("wormhole")
 					spawn(rand(100,150))
 						qdel(P)

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -30,7 +30,7 @@
 	if( !cracked && istype(target,/mob/living/carbon/human) && (target.stat == CONSCIOUS) && !target.get_active_hand() )
 		target.visible_message("<span class='notice'>[user] and [target] pop \an [src]! *pop*</span>", "<span class='notice'>You pull \an [src] with [target]! *pop*</span>", "<span class='notice'>You hear a *pop*.</span>")
 		var/obj/item/weapon/paper/Joke = new /obj/item/weapon/paper(user.loc)
-		Joke.name = "[pick("awful","terrible","unfunny")] joke"
+		Joke.SetName("[pick("awful","terrible","unfunny")] joke")
 		Joke.info = pick("What did one snowman say to the other?\n\n<i>'Is it me or can you smell carrots?'</i>",
 			"Why couldn't the snowman get laid?\n\n<i>He was frigid!</i>",
 			"Where are santa's helpers educated?\n\n<i>Nowhere, they're ELF-taught.</i>",

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -60,6 +60,6 @@
 	P.icon = 'icons/obj/objects.dmi'
 	P.failchance = 0
 	P.icon_state = "anom"
-	P.name = "wormhole"
+	P.SetName("wormhole")
 	spawn(rand(300,600))
 		qdel(P)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -32,27 +32,27 @@
 				new_religion = religion_name
 			switch(lowertext(new_religion))
 				if("christianity")
-					B.name = pick("The Holy Bible","The Dead Sea Scrolls")
+					B.SetName(pick("The Holy Bible","The Dead Sea Scrolls"))
 				if("satanism")
-					B.name = "The Unholy Bible"
+					B.SetName("The Unholy Bible")
 				if("cthulu")
-					B.name = "The Necronomicon"
+					B.SetName("The Necronomicon")
 				if("islam")
-					B.name = "Quran"
+					B.SetName("Quran")
 				if("scientology")
-					B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
+					B.SetName(pick("The Biography of L. Ron Hubbard","Dianetics"))
 				if("chaos")
-					B.name = "The Book of Lorgar"
+					B.SetName("The Book of Lorgar")
 				if("imperium")
-					B.name = "Uplifting Primer"
+					B.SetName("Uplifting Primer")
 				if("toolboxia")
-					B.name = "Toolbox Manifesto"
+					B.SetName("Toolbox Manifesto")
 				if("homosexuality")
-					B.name = "Guys Gone Wild"
+					B.SetName("Guys Gone Wild")
 				if("science")
-					B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
+					B.SetName(pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition"))
 				else
-					B.name = "The Holy Book of [new_religion]"
+					B.SetName("The Holy Book of [new_religion]")
 			feedback_set_details("religion_name","[new_religion]")
 
 		spawn(1)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -130,7 +130,7 @@
 	alarm_area = get_area(src)
 	area_uid = alarm_area.uid
 	if (name == "alarm")
-		name = "[alarm_area.name] Air Alarm"
+		SetName("[alarm_area.name] Air Alarm")
 
 	if(!wires)
 		wires = new(src)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -357,7 +357,7 @@ update_flag
 		if (label && CanUseTopic(user, state))
 			canister_color = colors[label]
 			icon_state = colors[label]
-			name = "\improper Canister: [label]"
+			SetName("\improper Canister: [label]")
 		update_icon()
 		. = TOPIC_REFRESH
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -107,7 +107,7 @@
 	name_part2 = pick("Melonoid", "Murdertron", "Sorcerer", "Ruin", "Jeff", "Ectoplasm", "Crushulon", "Uhangoid", "Vhakoid", "Peteoid", "slime", "Griefer", "ERPer", "Lizard Man", "Unicorn", "Bloopers")
 
 	src.enemy_name = replacetext((name_part1 + name_part2), "the ", "")
-	src.name = (name_action + name_part1 + name_part2)
+	src.SetName((name_action + name_part1 + name_part2))
 
 
 /obj/machinery/computer/arcade/battle/attack_hand(mob/user as mob)

--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -69,7 +69,7 @@
 	var/view = 0
 
 /obj/machinery/computer/arcade/orion_trail/proc/newgame(var/emag = 0)
-	name = "orion trail[emag ? ": Realism Edition" : ""]"
+	SetName("orion trail[emag ? ": Realism Edition" : ""]")
 	supplies = list("1" = 1, "2" = 1, "3" = 1, "4" = 60, "5" = 20, "6" = 5000)
 	emagged = emag
 	distance = 0

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -158,7 +158,7 @@
 //				to_chat(user, "Printing the log, standby...")
 				//sleep(50)
 				var/obj/item/weapon/paper/P = new/obj/item/weapon/paper( loc )
-				P.name = "activity log"
+				P.SetName("activity log")
 				P.info = dat
 				. = TOPIC_REFRESH
 
@@ -179,7 +179,7 @@
 					pass.registered_name = giv_name
 					pass.expiration_time = world.time + duration MINUTES
 					pass.reason = reason
-					pass.name = "guest pass #[number]"
+					pass.SetName("guest pass #[number]")
 					pass.assignment = "Guest"
 					playsound(src.loc, 'sound/machines/ping.ogg', 25, 0)
 					. = TOPIC_REFRESH

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -489,7 +489,7 @@
 	src.go_out()
 	add_fingerprint(usr)
 
-	name = initial(name)
+	SetName(initial(name))
 	return
 
 /obj/machinery/cryopod/verb/move_inside()
@@ -545,7 +545,7 @@
 /obj/machinery/cryopod/proc/set_occupant(var/mob/living/carbon/occupant)
 	src.occupant = occupant
 	if(!occupant)
-		name = initial(name)
+		SetName(initial(name))
 		return
 
 	occupant.stop_pulling()
@@ -557,7 +557,5 @@
 	occupant.forceMove(src)
 	time_entered = world.time
 
-	name = "[name] ([occupant])"
+	SetName("[name] ([occupant])")
 	icon_state = occupied_icon_state
-
-

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1191,9 +1191,9 @@ About the new airlock wires panel:
 
 		//get the name from the assembly
 		if(assembly.created_name)
-			name = assembly.created_name
+			SetName(assembly.created_name)
 		else
-			name = "[istext(assembly.glass) ? "[assembly.glass] airlock" : assembly.base_name]"
+			SetName("[istext(assembly.glass) ? "[assembly.glass] airlock" : assembly.base_name]")
 
 		//get the dir from the assembly
 		set_dir(assembly.dir)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -209,9 +209,9 @@
 			var/obj/structure/windoor_assembly/wa = new/obj/structure/windoor_assembly(src.loc)
 			if (istype(src, /obj/machinery/door/window/brigdoor))
 				wa.secure = "secure_"
-				wa.name = "Secure Wired Windoor Assembly"
+				wa.SetName("Secure Wired Windoor Assembly")
 			else
-				wa.name = "Wired Windoor Assembly"
+				wa.SetName("Wired Windoor Assembly")
 			if (src.base_state == "right" || src.base_state == "rightsecure")
 				wa.facing = "r"
 			wa.set_dir(src.dir)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -256,11 +256,11 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	hologram.layer = ABOVE_HUMAN_LAYER //Above all the other objects/mobs. Or the vast majority of them.
 	hologram.anchored = 1//So space wind cannot drag it.
 	if(caller_id)
-		hologram.name = "[caller_id.name] (Hologram)"
+		hologram.SetName("[caller_id.name] (Hologram)")
 		hologram.loc = get_step(src,1)
 		masters[caller_id] = hologram
 	else
-		hologram.name = "[A.name] (Hologram)"//If someone decides to right click.
+		hologram.SetName("[A.name] (Hologram)") //If someone decides to right click.
 		A.holo = src
 		masters[A] = hologram
 	hologram.set_light(2)	//hologram lighting

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -208,10 +208,10 @@
 
 /obj/machinery/cooker/proc/change_product_strings(var/obj/item/weapon/reagent_containers/food/snacks/product)
 	if(product.type == /obj/item/weapon/reagent_containers/food/snacks/variable) // Base type, generic.
-		product.name = "[cook_type] [cooking_obj.name]"
+		product.SetName("[cook_type] [cooking_obj.name]")
 		product.desc = "[cooking_obj.desc] It has been [cook_type]."
 	else
-		product.name = "[cooking_obj.name] [product.name]"
+		product.SetName("[cooking_obj.name] [product.name]")
 
 /obj/machinery/cooker/proc/change_product_appearance(var/obj/item/weapon/reagent_containers/food/snacks/product)
 	if(product.type == /obj/item/weapon/reagent_containers/food/snacks/variable) // Base type, generic.

--- a/code/game/machinery/kitchen/cooking_machines/cereal.dm
+++ b/code/game/machinery/kitchen/cooking_machines/cereal.dm
@@ -9,7 +9,7 @@
 
 /obj/machinery/cooker/cereal/change_product_strings(var/obj/item/weapon/reagent_containers/food/snacks/product)
 	. = ..()
-	product.name = "box of [cooking_obj.name] cereal"
+	product.SetName("box of [cooking_obj.name] cereal")
 
 /obj/machinery/cooker/cereal/change_product_appearance(var/obj/item/weapon/reagent_containers/food/snacks/product)
 	product.icon = 'icons/obj/food.dmi'

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -206,7 +206,7 @@
 	for(var/i=1 to slab_count)
 		var/obj/item/weapon/reagent_containers/food/snacks/meat/new_meat = new slab_type(src, rand(3,8))
 		if(istype(new_meat))
-			new_meat.name = "[slab_name] [new_meat.name]"
+			new_meat.SetName("[slab_name] [new_meat.name]")
 			new_meat.reagents.add_reagent(/datum/reagent/nutriment,slab_nutrition)
 			if(src.occupant.reagents)
 				src.occupant.reagents.trans_to_obj(new_meat, round(occupant.reagents.total_volume/slab_count,1))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -163,7 +163,7 @@
 			if(S.dry || !I.get_specific_product(get_turf(src), S)) continue
 			if(S.dried_type == S.type)
 				S.dry = 1
-				S.name = "dried [S.name]"
+				S.SetName("dried [S.name]")
 				S.color = "#a38463"
 				stock_item(S)
 			else

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -23,7 +23,7 @@
 		src.connected_area = get_area(src)
 
 	if(name == initial(name))
-		name = "light switch ([connected_area.name])"
+		SetName("light switch ([connected_area.name])")
 
 	connected_area.set_lightswitch(on)
 	update_icon()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -143,7 +143,7 @@ Class Procs:
 		var/obj/effect/overlay/pulse2 = new /obj/effect/overlay(loc)
 		pulse2.icon = 'icons/effects/effects.dmi'
 		pulse2.icon_state = "empdisable"
-		pulse2.name = "emp sparks"
+		pulse2.SetName("emp sparks")
 		pulse2.anchored = 1
 		pulse2.set_dir(pick(GLOB.cardinal))
 

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -237,7 +237,7 @@ Buildable meters
 		"fuel down",\
 		"fuel pipe cap",\
 	)
-	name = nlist[pipe_type+1] + " fitting"
+	SetName(nlist[pipe_type+1] + " fitting")
 	var/list/islist = list( \
 		"simple", \
 		"simple", \
@@ -565,7 +565,7 @@ Buildable meters
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
 			if (pipename)
-				C.name = pipename
+				C.SetName(pipename)
 			var/turf/T = C.loc
 			C.level = !T.is_plating() ? 2 : 1
 			C.atmos_init()
@@ -797,7 +797,7 @@ Buildable meters
 			V.set_dir(dir)
 			V.initialize_directions = pipe_dir
 			if (pipename)
-				V.name = pipename
+				V.SetName(pipename)
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
 			V.atmos_init()
@@ -812,7 +812,7 @@ Buildable meters
 			V.set_dir(dir)
 			V.initialize_directions = pipe_dir
 			if (pipename)
-				V.name = pipename
+				V.SetName(pipename)
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
 			V.atmos_init()
@@ -831,7 +831,7 @@ Buildable meters
 			D.set_dir(dir)
 			D.initialize_directions = pipe_dir
 			if (pipename)
-				D.name = pipename
+				D.SetName(pipename)
 			var/turf/T = D.loc
 			D.level = !T.is_plating() ? 2 : 1
 			D.atmos_init()
@@ -848,7 +848,7 @@ Buildable meters
 			S.set_dir(dir)
 			S.initialize_directions = pipe_dir
 			if (pipename)
-				S.name = pipename
+				S.SetName(pipename)
 			var/turf/T = S.loc
 			S.level = !T.is_plating() ? 2 : 1
 			S.atmos_init()
@@ -866,7 +866,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -883,7 +883,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -903,7 +903,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -923,7 +923,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -943,7 +943,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -963,7 +963,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -983,7 +983,7 @@ Buildable meters
 			S.set_dir(dir)
 			S.initialize_directions = pipe_dir
 			if (pipename)
-				S.name = pipename
+				S.SetName(pipename)
 			var/turf/T = S.loc
 			S.level = !T.is_plating() ? 2 : 1
 			S.atmos_init()
@@ -997,7 +997,7 @@ Buildable meters
 			V.set_dir(dir)
 			V.initialize_directions = pipe_dir
 			if (pipename)
-				V.name = pipename
+				V.SetName(pipename)
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
 			V.atmos_init()
@@ -1017,7 +1017,7 @@ Buildable meters
 			V.set_dir(dir)
 			V.initialize_directions = pipe_dir
 			if (pipename)
-				V.name = pipename
+				V.SetName(pipename)
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
 			V.atmos_init()
@@ -1077,7 +1077,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1094,7 +1094,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1111,7 +1111,7 @@ Buildable meters
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
 			if (pipename)
-				C.name = pipename
+				C.SetName(pipename)
 			var/turf/T = C.loc
 			C.level = !T.is_plating() ? 2 : 1
 			C.atmos_init()
@@ -1125,7 +1125,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1141,7 +1141,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1157,7 +1157,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1173,7 +1173,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1189,7 +1189,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1205,7 +1205,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1222,7 +1222,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()
@@ -1238,7 +1238,7 @@ Buildable meters
 			P.set_dir(dir)
 			P.initialize_directions = pipe_dir
 			if (pipename)
-				P.name = pipename
+				P.SetName(pipename)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
 			P.atmos_init()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -822,7 +822,7 @@ var/list/turret_icons
 
 					//The final step: create a full turret
 					var/obj/machinery/porta_turret/Turret = new target_type(loc)
-					Turret.name = finish_name
+					Turret.SetName(finish_name)
 					Turret.installation = installation
 					Turret.gun_charge = gun_charge
 					Turret.enabled = 0

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -1092,11 +1092,11 @@
 	switch(target_department)
 		if("Engineering")
 			if(helmet)
-				helmet.name = "engineering voidsuit helmet"
+				helmet.SetName("engineering voidsuit helmet")
 				helmet.icon_state = "rig0-engineering"
 				helmet.item_state = "eng_helm"
 			if(suit)
-				suit.name = "engineering voidsuit"
+				suit.SetName("engineering voidsuit")
 				suit.icon_state = "rig-engineering"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "eng_voidsuit",
@@ -1104,11 +1104,11 @@
 				)
 		if("Mining")
 			if(helmet)
-				helmet.name = "mining voidsuit helmet"
+				helmet.SetName("mining voidsuit helmet")
 				helmet.icon_state = "rig0-mining"
 				helmet.item_state = "mining_helm"
 			if(suit)
-				suit.name = "mining voidsuit"
+				suit.SetName("mining voidsuit")
 				suit.icon_state = "rig-mining"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "mining_voidsuit",
@@ -1116,11 +1116,11 @@
 				)
 		if("Science")
 			if(helmet)
-				helmet.name = "excavation voidsuit helmet"
+				helmet.SetName("excavation voidsuit helmet")
 				helmet.icon_state = "rig0-excavation"
 				helmet.item_state = "excavation_helm"
 			if(suit)
-				suit.name = "excavation voidsuit"
+				suit.SetName("excavation voidsuit")
 				suit.icon_state = "rig-excavation"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "excavation_voidsuit",
@@ -1128,11 +1128,11 @@
 				)
 		if("Medical")
 			if(helmet)
-				helmet.name = "medical voidsuit helmet"
+				helmet.SetName("medical voidsuit helmet")
 				helmet.icon_state = "rig0-medical"
 				helmet.item_state = "medical_helm"
 			if(suit)
-				suit.name = "medical voidsuit"
+				suit.SetName("medical voidsuit")
 				suit.icon_state = "rig-medical"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "medical_voidsuit",
@@ -1140,11 +1140,11 @@
 				)
 		if("Security")
 			if(helmet)
-				helmet.name = "security voidsuit helmet"
+				helmet.SetName("security voidsuit helmet")
 				helmet.icon_state = "rig0-sec"
 				helmet.item_state = "sec_helm"
 			if(suit)
-				suit.name = "security voidsuit"
+				suit.SetName("security voidsuit")
 				suit.icon_state = "rig-sec"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "sec_voidsuit",
@@ -1152,11 +1152,11 @@
 				)
 		if("Atmos")
 			if(helmet)
-				helmet.name = "atmospherics voidsuit helmet"
+				helmet.SetName("atmospherics voidsuit helmet")
 				helmet.icon_state = "rig0-atmos"
 				helmet.item_state = "atmos_helm"
 			if(suit)
-				suit.name = "atmospherics voidsuit"
+				suit.SetName("atmospherics voidsuit")
 				suit.icon_state = "rig-atmos"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "atmos_voidsuit",
@@ -1164,20 +1164,20 @@
 				)
 		if("Explorer")
 			if(helmet)
-				helmet.name = "exploration voidsuit helmet"
+				helmet.SetName("exploration voidsuit helmet")
 				helmet.icon_state = "helm_explorer"
 				helmet.item_state = "helm_explorer"
 			if(suit)
-				suit.name = "exploration voidsuit"
+				suit.SetName("exploration voidsuit")
 				suit.icon_state = "void_explorer"
 
 		if("^%###^%$" || "Mercenary")
 			if(helmet)
-				helmet.name = "blood-red voidsuit helmet"
+				helmet.SetName("blood-red voidsuit helmet")
 				helmet.icon_state = "rig0-syndie"
 				helmet.item_state = "syndie_helm"
 			if(suit)
-				suit.name = "blood-red voidsuit"
+				suit.SetName("blood-red voidsuit")
 				suit.icon_state = "rig-syndie"
 				suit.item_state_slots = list(
 					slot_l_hand_str = "syndie_voidsuit",
@@ -1185,12 +1185,12 @@
 				)
 		if("Pilot")
 			if(helmet)
-				helmet.name = "pilot voidsuit helmet"
+				helmet.SetName("pilot voidsuit helmet")
 				helmet.icon_state = "rig0_pilot"
 				helmet.item_state = "pilot_helm"
 			if(suit)
-				suit.name = "pilot voidsuit"
+				suit.SetName("pilot voidsuit")
 				suit.icon_state = "rig-pilot"
 
-	if(helmet) helmet.name = "refitted [helmet.name]"
-	if(suit) suit.name = "refitted [suit.name]"
+	if(helmet) helmet.SetName("refitted [helmet.name]")
+	if(suit) suit.SetName("refitted [suit.name]")

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -414,7 +414,7 @@
 		P.icon = 'icons/obj/objects.dmi'
 		P.failchance = 0
 		P.icon_state = "anom"
-		P.name = "wormhole"
+		P.SetName("wormhole")
 		do_after_cooldown()
 		src = null
 		spawn(rand(150,300))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -184,7 +184,7 @@
 
 /obj/mecha/proc/add_radio()
 	radio = new(src)
-	radio.name = "[src] radio"
+	radio.SetName("[src] radio")
 	radio.icon = icon
 	radio.icon_state = icon_state
 	radio.subspace_transmission = 1
@@ -1499,7 +1499,7 @@
 		if(usr != src.occupant)	return
 		var/newname = sanitizeSafe(input(occupant,"Choose new exosuit name","Rename exosuit",initial(name)) as text, MAX_NAME_LEN)
 		if(newname)
-			name = newname
+			SetName(newname)
 		else
 			alert(occupant, "nope.avi")
 		return
@@ -1630,7 +1630,7 @@
 		var/cur_occupant = src.occupant
 		O.invisibility = 0
 		O.canmove = 1
-		O.name = AI.name
+		O.SetName(AI.name)
 		O.real_name = AI.real_name
 		O.anchored = 1
 		O.aiRestorePowerRoutine = 0
@@ -1645,11 +1645,11 @@
 		src.occupant = O
 		if(AI.mind)
 			AI.mind.transfer_to(O)
-		AI.name = "Inactive AI"
+		AI.SetName("Inactive AI")
 		AI.real_name = "Inactive AI"
 		AI.icon_state = "ai-empty"
 		spawn(duration)
-			AI.name = O.name
+			AI.SetName(O.name)
 			AI.real_name = O.real_name
 			if(O.mind)
 				O.mind.transfer_to(AI)

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -237,7 +237,7 @@
 
 /datum/effect/effect/system/smoke_spread/chem/spores/spawnSmoke(var/turf/T, var/icon/I, var/smoke_duration, var/dist = 1)
 	var/obj/effect/effect/smoke/chem/spores = new /obj/effect/effect/smoke/chem(location)
-	spores.name = "cloud of [seed.seed_name] [seed.seed_noun]"
+	spores.SetName("cloud of [seed.seed_name] [seed.seed_noun]")
 	..(T, I, smoke_duration, dist, passed_smoke=spores)
 
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -65,10 +65,10 @@ var/global/list/image/splatter_cache=list()
 	if(basecolor == "rainbow") basecolor = get_random_colour(1)
 	color = basecolor
 	if(basecolor == SYNTH_BLOOD_COLOUR)
-		name = "oil"
+		SetName("oil")
 		desc = "It's black and greasy."
 	else
-		name = initial(name)
+		SetName(initial(name))
 		desc = initial(desc)
 
 /obj/effect/decal/cleanable/blood/Crossed(mob/living/carbon/human/perp)

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -118,7 +118,7 @@
 	. = ..()
 
 /obj/structure/sign/poster/proc/set_poster(var/datum/poster/design)
-	name = "[initial(name)] - [design.name]"
+	SetName("[initial(name)] - [design.name]")
 	desc = "[initial(desc)] [design.desc]"
 	icon_state = design.icon_state // poster[serial_number]
 
@@ -148,7 +148,7 @@
 		playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
 		ruined = 1
 		icon_state = "poster_ripped"
-		name = "ripped poster"
+		SetName("ripped poster")
 		desc = "You can't make out anything from the poster's original print. It's ruined."
 		add_fingerprint(user)
 

--- a/code/game/objects/effects/manifest.dm
+++ b/code/game/objects/effects/manifest.dm
@@ -15,7 +15,7 @@
 		dat += text("    <B>[]</B> -  []<BR>", M.name, M.get_assignment())
 	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( src.loc )
 	P.info = dat
-	P.name = "paper- 'Crew Manifest'"
+	P.SetName("paper- 'Crew Manifest'")
 	//SN src = null
 	qdel(src)
 	return

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -18,7 +18,7 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
 		var/obj/effect/overlay/pulse = new/obj/effect/overlay(epicenter)
 		pulse.icon = 'icons/effects/effects.dmi'
 		pulse.icon_state = "emppulse"
-		pulse.name = "emp pulse"
+		pulse.SetName("emp pulse")
 		pulse.anchored = 1
 		spawn(20)
 			qdel(pulse)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -133,7 +133,7 @@ move an amendment</a> to the drawing, or <a href='?src=\ref[src];action=delete_a
 		to_chat(usr, "<span class='warning'>Name too long.</span>")
 		return
 	var/area/A = new
-	A.name = str
+	A.SetName(str)
 	//var/ma
 	//ma = A.master ? "[A.master]" : "(null)"
 //	log_debug(create_area: <br>A.name=[A.name]<br>A.tag=[A.tag]<br>A.master=[ma]")
@@ -172,7 +172,7 @@ move an amendment</a> to the drawing, or <a href='?src=\ref[src];action=delete_a
 		to_chat(usr, "<span class='warning'>Text too long.</span>")
 		return
 	set_area_machinery_title(A,str,prevname)
-	A.name = str
+	A.SetName(str)
 	to_chat(usr, "<span class='notice'>You set the area '[prevname]' title to '[str]'.</span>")
 	interact()
 	return
@@ -195,15 +195,15 @@ move an amendment</a> to the drawing, or <a href='?src=\ref[src];action=delete_a
 		return
 
 	for(var/obj/machinery/alarm/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
+		M.SetName(replacetext(M.name,oldtitle,title))
 	for(var/obj/machinery/power/apc/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
+		M.SetName(replacetext(M.name,oldtitle,title))
 	for(var/obj/machinery/atmospherics/unary/vent_scrubber/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
+		M.SetName(replacetext(M.name,oldtitle,title))
 	for(var/obj/machinery/atmospherics/unary/vent_pump/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
+		M.SetName(replacetext(M.name,oldtitle,title))
 	for(var/obj/machinery/door/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
+		M.SetName(replacetext(M.name,oldtitle,title))
 	//TODO: much much more. Unnamed airlocks, cameras, etc.
 
 /obj/item/blueprints/proc/check_tile_is_border(var/turf/T2,var/dir)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -51,15 +51,15 @@
 			return
 		t = sanitizeSafe(t, MAX_NAME_LEN)
 		if (t)
-			src.name = "body bag - "
+			src.SetName("body bag - ")
 			src.name += t
 			src.overlays += image(src.icon, "bodybag_label")
 		else
-			src.name = "body bag"
+			src.SetName("body bag")
 	//..() //Doesn't need to run the parent. Since when can fucking bodybags be welded shut? -Agouri
 		return
 	else if(isWirecutter(W))
-		src.name = "body bag"
+		src.SetName("body bag")
 		src.overlays.Cut()
 		to_chat(user, "You cut the tag off \the [src].")
 		return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -238,7 +238,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		ownrank = newrank
 	else
 		ownrank = ownjob
-	name = newname + " (" + ownjob + ")"
+	SetName(newname + " (" + ownjob + ")")
 
 
 //AI verb and proc for sending PDA messages.
@@ -1214,7 +1214,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			return
 		if(!owner)
 			set_owner_rank_job(idcard.registered_name, idcard.rank, idcard.assignment)
-			name = "PDA-[owner] ([ownjob])"
+			SetName("PDA-[owner] ([ownjob])")
 			to_chat(user, "<span class='notice'>Card scanned.</span>")
 		else
 			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.
@@ -1395,7 +1395,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		var/name = P.owner
 		if (name in names)
 			namecounts[name]++
-			name = text("[name] ([namecounts[name]])")
+			SetName(text("[name] ([namecounts[name]])"))
 		else
 			names.Add(name)
 			namecounts[name] = 1

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -211,7 +211,7 @@
 				var/obj/item/PDA = loc
 				var/mob/user = PDA.fingerprintslast
 				if(istype(PDA.loc,/mob/living))
-					name = PDA.loc
+					SetName(PDA.loc)
 				log_admin("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2]")
 				message_admins("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2]")
 

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -106,7 +106,7 @@
 
 	ai.carded = 1
 	admin_attack_log(user, ai, "Carded with [src.name]", "Was carded with [src.name]", "used the [src.name] to card")
-	src.name = "[initial(name)] - [ai.name]"
+	src.SetName("[initial(name)] - [ai.name]")
 
 	ai.forceMove(src)
 	ai.destroy_eyeobj(src)
@@ -129,7 +129,7 @@
 	if(carded_ai && istype(carded_ai.loc, /turf))
 		carded_ai.canmove = 0
 		carded_ai.carded = 0
-	name = initial(name)
+	SetName(initial(name))
 	carded_ai.calculate_power_usage()
 	carded_ai = null
 	update_icon()

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -49,7 +49,7 @@
 	var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text
 	if(length(name))
 		L.real_name = name
-		L.name = name
+		L.SetName(name)
 
 	loaded = 0
 	icon_state = "animal_tagger0"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -342,7 +342,7 @@
 		if(!radio_controller)
 			sleep(30) // Waiting for the radio_controller to be created.
 		if(!radio_controller)
-			src.name = "broken radio headset"
+			src.SetName("broken radio headset")
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -637,7 +637,7 @@
 
 	for (var/ch_name in src.channels)
 		if(!radio_controller)
-			src.name = "broken radio"
+			src.SetName("broken radio")
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -328,7 +328,7 @@
 			printedmessage = "\[[time2text(mytape.timestamp[i]*10,"mm:ss")]\] (Unrecognized sound)"
 		t1 += "[printedmessage]<BR>"
 	P.info = t1
-	P.name = "Transcript"
+	P.SetName("Transcript")
 	canprint = 0
 	sleep(300)
 	canprint = 1
@@ -418,10 +418,10 @@
 			if(isnull(new_name)) return
 			new_name = sanitizeSafe(new_name)
 			if(new_name)
-				name = "tape - '[new_name]'"
+				SetName("tape - '[new_name]'")
 				to_chat(user, "<span class='notice'>You label the tape '[new_name]'.</span>")
 			else
-				name = "tape"
+				SetName("tape")
 				to_chat(user, "<span class='notice'>You scratch off the label.</span>")
 		return
 	..()

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -81,10 +81,10 @@
 	overlays.Cut()
 	switch(contains)
 		if(0)
-			name = initial(name)
+			SetName(initial(name))
 			desc = initial(desc)
 		if(1)
-			name = "tip jar"
+			SetName("tip jar")
 			desc = "A small jar with money inside."
 			for(var/obj/item/weapon/spacecash/S in src)
 				var/list/moneyImages = S.getMoneyImages()
@@ -99,12 +99,12 @@
 				var/image/victim = image(M.icon, M.icon_state)
 				victim.pixel_y = 6
 				underlays += victim
-				name = "glass jar with [M]"
+				SetName("glass jar with [M]")
 				desc = "A small jar with [M] inside."
 		if(3)
 			for(var/obj/effect/spider/spiderling/S in src)
 				var/image/victim = image(S.icon, S.icon_state)
 				underlays += victim
-				name = "glass jar with [S]"
+				SetName("glass jar with [S]")
 				desc = "A small jar with [S] inside."
 	return

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -30,7 +30,7 @@
 /obj/item/clothing/head/helmet/space/void/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O,/obj/item/device/kit/suit))
 		var/obj/item/device/kit/suit/kit = O
-		name = "[kit.new_name] suit helmet"
+		SetName("[kit.new_name] suit helmet")
 		desc = kit.new_desc
 		icon_state = "[kit.new_icon]_helmet"
 		item_state = "[kit.new_icon]_helmet"
@@ -51,7 +51,7 @@
 /obj/item/clothing/suit/space/void/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O,/obj/item/device/kit/suit))
 		var/obj/item/device/kit/suit/kit = O
-		name = "[kit.new_name] voidsuit"
+		SetName("[kit.new_name] voidsuit")
 		desc = kit.new_desc
 		icon_state = "[kit.new_icon]_suit"
 		item_state = "[kit.new_icon]_suit"
@@ -99,7 +99,7 @@
 			return
 
 		user.visible_message("[user] opens [P] and spends some quality time customising [src].")
-		src.name = P.new_name
+		src.SetName(P.new_name)
 		src.desc = P.new_desc
 		src.initial_icon = P.new_icon
 		if(P.new_icon_file)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -20,12 +20,12 @@
 		model_info = model
 		var/datum/robolimb/R = all_robolimbs[model]
 		if(R)
-			name = "[R.company] [initial(name)]"
+			SetName("[R.company] [initial(name)]")
 			desc = "[R.desc]"
 			if(icon_state in icon_states(R.icon))
 				icon = R.icon
 	else
-		name = "robot [initial(name)]"
+		SetName("robot [initial(name)]")
 
 /obj/item/robot_parts/proc/can_install(mob/user)
 	return TRUE
@@ -270,7 +270,7 @@
 				return
 			var/name = sanitizeSafe(input(user,"Set a name for the new prosthetic."), MAX_NAME_LEN)
 			if(!name)
-				name = "prosthetic ([random_id("prosthetic_id", 1, 999)])"
+				SetName("prosthetic ([random_id("prosthetic_id", 1, 999)])")
 
 			// Create a new, nonliving human.
 			var/mob/living/carbon/human/H = new /mob/living/carbon/human(get_turf(loc))

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -49,7 +49,7 @@
 /obj/item/borg/upgrade/rename/action(var/mob/living/silicon/robot/R)
 	if(..()) return 0
 	R.notify_ai(ROBOT_NOTIFICATION_NEW_NAME, R.name, heldname)
-	R.name = heldname
+	R.SetName(heldname)
 	R.custom_name = heldname
 	R.real_name = heldname
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -175,7 +175,7 @@
 			var/obj/effect/foam_dart_dummy/D = new/obj/effect/foam_dart_dummy(get_turf(src))
 			bullets--
 			D.icon_state = "foamdart"
-			D.name = "foam dart"
+			D.SetName("foam dart")
 			playsound(user.loc, 'sound/items/syringeproj.ogg', 50, 1)
 
 			for(var/i=0, i<6, i++)

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -151,7 +151,7 @@
 	sleep(10)
 
 	var/obj/item/weapon/paper/P = new(usr.loc)
-	P.name = "Autopsy Data ([target_name])"
+	P.SetName("Autopsy Data ([target_name])")
 	P.info = "<tt>[scan_data]</tt>"
 	P.icon_state = "paper_words"
 

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -49,10 +49,10 @@
 
 /obj/item/weapon/cane/concealed/update_icon()
 	if(concealed_blade)
-		name = initial(name)
+		SetName(initial(name))
 		icon_state = initial(icon_state)
 		item_state = initial(item_state)
 	else
-		name = "cane shaft"
+		SetName("cane shaft")
 		icon_state = "nullrod"
 		item_state = "foldcane"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -36,9 +36,9 @@
 	set src in usr
 
 	if (t)
-		src.name = text("data disk- '[]'", t)
+		src.SetName(text("data disk- '[]'", t))
 	else
-		src.name = "data disk"
+		src.SetName("data disk")
 	src.add_fingerprint(usr)
 	return
 
@@ -149,11 +149,12 @@ var/const/NO_EMAG_ACT = -50
 	return
 
 /obj/item/weapon/card/id/proc/update_name()
-	name = "[registered_name]'s ID Card"
+	var/final_name = "[registered_name]'s ID Card"
 	if(military_rank && military_rank.name_short)
-		name = military_rank.name_short + " " + name
+		final_name = military_rank.name_short + " " + final_name
 	if(assignment)
-		name = name + " ([assignment])"
+		final_name = final_name + " ([assignment])"
+	SetName(final_name)
 
 /obj/item/weapon/card/id/proc/set_id_photo(var/mob/M)
 	front = getFlatIcon(M, SOUTH, always_use_defdir = 1)

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -181,7 +181,7 @@
 					electronic_warfare = initial(electronic_warfare)
 					fingerprint_hash = initial(fingerprint_hash)
 					icon_state = initial(icon_state)
-					name = initial(name)
+					SetName(initial(name))
 					registered_name = initial(registered_name)
 					unset_registered_user()
 					sex = initial(sex)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -511,7 +511,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		new /obj/effect/decal/cleanable/ash(location)
 		smoketime = 0
 		reagents.clear_reagents()
-		name = "empty [initial(name)]"
+		SetName("empty [initial(name)]")
 
 /obj/item/clothing/mask/smokable/pipe/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/melee/energy/sword))
@@ -530,7 +530,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		smoketime = 1000
 		if(G.reagents)
 			G.reagents.trans_to_obj(src, G.reagents.total_volume)
-		name = "[G.name]-packed [initial(name)]"
+		SetName("[G.name]-packed [initial(name)]")
 		qdel(G)
 
 	else if(istype(W, /obj/item/weapon/flame/lighter))

--- a/code/game/objects/items/weapons/circuitboards/computer/air_management.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/air_management.dm
@@ -51,7 +51,7 @@
 /obj/item/weapon/circuitboard/air_management/construct(var/obj/machinery/computer/general_air_control/C)
 	if (..(C))
 		if(console_name)
-			C.name = console_name
+			C.SetName(console_name)
 		C.set_frequency(frequency)
 		C.sensors = sensors.Copy()
 		C.sensor_information = sensor_information.Copy()

--- a/code/game/objects/items/weapons/circuitboards/computer/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/research.dm
@@ -10,11 +10,11 @@
 	if(isScrewdriver(I))
 		user.visible_message("<span class='notice'>\The [user] adjusts the jumper on \the [src]'s access protocol pins.</span>", "<span class='notice'>You adjust the jumper on the access protocol pins.</span>")
 		if(src.build_path == /obj/machinery/computer/rdconsole/core)
-			src.name = T_BOARD("RD Console - Robotics")
+			src.SetName(T_BOARD("RD Console - Robotics"))
 			src.build_path = /obj/machinery/computer/rdconsole/robotics
 			to_chat(user, "<span class='notice'>Access protocols set to robotics.</span>")
 		else
-			src.name = T_BOARD("RD Console")
+			src.SetName(T_BOARD("RD Console"))
 			src.build_path = /obj/machinery/computer/rdconsole/core
 			to_chat(user, "<span class='notice'>Access protocols set to default.</span>")
 	return

--- a/code/game/objects/items/weapons/circuitboards/mecha.dm
+++ b/code/game/objects/items/weapons/circuitboards/mecha.dm
@@ -12,23 +12,23 @@
 
 
 /obj/item/weapon/circuitboard/mecha/ripley
-		origin_tech = list(TECH_DATA = 3)
+	origin_tech = list(TECH_DATA = 3)
 
 /obj/item/weapon/circuitboard/mecha/ripley/peripherals
-		name = T_BOARD_MECHA("Ripley peripherals control")
-		icon_state = "mcontroller"
+	name = T_BOARD_MECHA("Ripley peripherals control")
+	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/ripley/main
-		name = T_BOARD_MECHA("Ripley central control")
-		icon_state = "mainboard"
+	name = T_BOARD_MECHA("Ripley central control")
+	icon_state = "mainboard"
 
 
 /obj/item/weapon/circuitboard/mecha/gygax
-		origin_tech = list(TECH_DATA = 4)
+	origin_tech = list(TECH_DATA = 4)
 
 /obj/item/weapon/circuitboard/mecha/gygax/peripherals
-		name = T_BOARD_MECHA("Gygax peripherals control")
-		icon_state = "mcontroller"
+	name = T_BOARD_MECHA("Gygax peripherals control")
+	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/gygax/targeting
 		name = T_BOARD_MECHA("Gygax weapon control and targeting")
@@ -36,53 +36,53 @@
 		origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 4)
 
 /obj/item/weapon/circuitboard/mecha/gygax/main
-		name = T_BOARD_MECHA("Gygax central control")
-		icon_state = "mainboard"
+	name = T_BOARD_MECHA("Gygax central control")
+	icon_state = "mainboard"
 
 
 /obj/item/weapon/circuitboard/mecha/durand
-		origin_tech = list(TECH_DATA = 4)
+	origin_tech = list(TECH_DATA = 4)
 
 /obj/item/weapon/circuitboard/mecha/durand/peripherals
-		name = T_BOARD_MECHA("Durand peripherals control")
-		icon_state = "mcontroller"
+	name = T_BOARD_MECHA("Durand peripherals control")
+	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/durand/targeting
-		name = T_BOARD_MECHA("Durand weapon control and targeting")
-		icon_state = "mcontroller"
-		origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 4)
+	name = T_BOARD_MECHA("Durand weapon control and targeting")
+	icon_state = "mcontroller"
+	origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 4)
 
 /obj/item/weapon/circuitboard/mecha/durand/main
-		name = T_BOARD_MECHA("Durand central control")
-		icon_state = "mainboard"
+	name = T_BOARD_MECHA("Durand central control")
+	icon_state = "mainboard"
 
 
 /obj/item/weapon/circuitboard/mecha/honker
-		origin_tech = list(TECH_DATA = 4)
+	origin_tech = list(TECH_DATA = 4)
 
 /obj/item/weapon/circuitboard/mecha/honker/peripherals
-		name = T_BOARD_MECHA("H.O.N.K peripherals control")
-		icon_state = "mcontroller"
+	name = T_BOARD_MECHA("H.O.N.K peripherals control")
+	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/honker/targeting
-		name = T_BOARD_MECHA("H.O.N.K weapon control and targeting")
-		icon_state = "mcontroller"
+	name = T_BOARD_MECHA("H.O.N.K weapon control and targeting")
+	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/honker/main
-		name = T_BOARD_MECHA("H.O.N.K central control")
-		icon_state = "mainboard"
+	name = T_BOARD_MECHA("H.O.N.K central control")
+	icon_state = "mainboard"
 
 
 /obj/item/weapon/circuitboard/mecha/odysseus
-		origin_tech = list(TECH_DATA = 3)
+	origin_tech = list(TECH_DATA = 3)
 
 /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
-		name = T_BOARD_MECHA("Odysseus peripherals control")
-		icon_state = "mcontroller"
+	name = T_BOARD_MECHA("Odysseus peripherals control")
+	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/odysseus/main
-		name = T_BOARD_MECHA("Odysseus central control")
-		icon_state = "mainboard"
+	name = T_BOARD_MECHA("Odysseus central control")
+	icon_state = "mainboard"
 
 //Undef the macro, shouldn't be needed anywhere else
 #undef T_BOARD_MECHA

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -228,10 +228,10 @@
 	var/mob/living/M = loc
 	if(istype(M) && is_held_twohanded(M))
 		wielded = 1
-		name = "[initial(name)] (wielded)"
+		SetName("[initial(name)] (wielded)")
 	else
 		wielded = 0
-		name = initial(name)
+		SetName(initial(name))
 	update_icon()
 	..()
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -33,7 +33,7 @@
 					if(istype(B))
 						beakers -= B
 						user.put_in_hands(B)
-			name = "unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]"
+			SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
 		if(stage > 1 && !active && clown_check(user))
 			to_chat(user, "<span class='warning'>You prime \the [name]!</span>")
 
@@ -68,18 +68,18 @@
 				var/obj/item/device/assembly/timer/T = detonator.a_right
 				det_time = 10*T.time
 			icon_state = initial(icon_state) +"_ass"
-			name = "unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]"
+			SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
 			stage = 1
 		else if(isScrewdriver(W) && path != 2)
 			if(stage == 1)
 				path = 1
 				if(beakers.len)
 					to_chat(user, "<span class='notice'>You lock the assembly.</span>")
-					name = "grenade"
+					SetName("grenade")
 				else
 //					to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the assembly.</span>")
 					to_chat(user, "<span class='notice'>You lock the empty assembly.</span>")
-					name = "fake grenade"
+					SetName("fake grenade")
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, -3)
 				icon_state = initial(icon_state) +"_locked"
 				stage = 2
@@ -91,7 +91,7 @@
 				else
 					to_chat(user, "<span class='notice'>You unlock the assembly.</span>")
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, -3)
-					name = "unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]"
+					SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
 					icon_state = initial(icon_state) + (detonator?"_ass":"")
 					stage = 1
 					active = 0
@@ -107,7 +107,7 @@
 					W.loc = src
 					beakers += W
 					stage = 1
-					name = "unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]"
+					SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
 				else
 					to_chat(user, "<span class='warning'>\The [W] is empty.</span>")
 

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -42,10 +42,10 @@
 			return
 		t = sanitizeSafe(t, MAX_NAME_LEN)
 		if(t)
-			name = "glass case - '[t]'"
+			SetName("glass case - '[t]'")
 			desc = "A case containing \a [t] implant."
 		else
-			name = "glass case"
+			SetName(initial(name))
 			desc = "A case containing an implant."
 	else if(istype(I, /obj/item/weapon/reagent_containers/syringe))
 		if(istype(imp,/obj/item/weapon/implant/chem))

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -53,7 +53,7 @@
 	if(!material)
 		qdel(src)
 	else
-		name = "[material.display_name] [initial(name)]"
+		SetName("[material.display_name] [initial(name)]")
 		health = round(material.integrity/10)
 		if(applies_material_colour)
 			color = material.icon_colour

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -26,7 +26,7 @@
 	update_icon()
 
 	if(material.shard_type)
-		name = "[material.display_name] [material.shard_type]"
+		SetName("[material.display_name] [material.shard_type]")
 		desc = "A small piece of [material.display_name]. It looks sharp, you wouldn't want to step on it barefoot. Could probably be used as ... a throwing weapon?"
 		switch(material.shard_type)
 			if(SHARD_SPLINTER, SHARD_SHRAPNEL)

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -19,7 +19,7 @@
 	if(W.sharp && W.edge && !sharp)
 		user.visible_message("<span class='warning'>[user] sharpens [src] with [W].</span>", "<span class='warning'>You sharpen [src] using [W].</span>")
 		sharp = 1 //Sharpen stick
-		name = "sharpened " + name
+		SetName("sharpened " + name)
 		update_force()
 	return ..()
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -290,7 +290,7 @@ var/list/tape_roll_applications = list()
 	if(!crumpled)
 		crumpled = 1
 		update_icon()
-		name = "crumpled [name]"
+		SetName("crumpled [name]")
 
 /obj/item/tape/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(!lifted && ismob(mover))

--- a/code/game/objects/items/weapons/secrets_disk.dm
+++ b/code/game/objects/items/weapons/secrets_disk.dm
@@ -61,7 +61,7 @@
 		var/input = sanitize(input(usr, "What would you like to change the project codename to?", "Classified Project Data Disk"))
 		if(!input || input == "")
 			return
-		name = "'[input]' project data disk"
+		SetName("'[input]' project data disk")
 	else
 		to_chat(usr, "<span class='warning'>The disk's screen flashes 'Access Denied'. It is locked.</span>")
 

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -43,7 +43,7 @@
 
 /obj/item/weapon/storage/laundry_basket/pickup(mob/user)
 	var/obj/item/weapon/storage/laundry_basket/offhand/O = new(user)
-	O.name = "[name] - second hand"
+	O.SetName("[name] - second hand")
 	O.desc = "Your second grip on the [name]."
 	O.linked = src
 	user.put_in_inactive_hand(O)

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -13,26 +13,26 @@
 /datum/storage_ui/default/New(var/storage)
 	..()
 	boxes = new /obj/screen/storage(  )
-	boxes.name = "storage"
+	boxes.SetName("storage")
 	boxes.master = storage
 	boxes.icon_state = "block"
 	boxes.screen_loc = "7,7 to 10,8"
 	boxes.layer = HUD_BASE_LAYER
 
 	storage_start = new /obj/screen/storage(  )
-	storage_start.name = "storage"
+	storage_start.SetName("storage")
 	storage_start.master = storage
 	storage_start.icon_state = "storage_start"
 	storage_start.screen_loc = "7,7 to 10,8"
 	storage_start.layer = HUD_BASE_LAYER
 	storage_continue = new /obj/screen/storage(  )
-	storage_continue.name = "storage"
+	storage_continue.SetName("storage")
 	storage_continue.master = storage
 	storage_continue.icon_state = "storage_continue"
 	storage_continue.screen_loc = "7,7 to 10,8"
 	storage_continue.layer = HUD_BASE_LAYER
 	storage_end = new /obj/screen/storage(  )
-	storage_end.name = "storage"
+	storage_end.SetName("storage")
 	storage_end.master = storage
 	storage_end.icon_state = "storage_end"
 	storage_end.screen_loc = "7,7 to 10,8"

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -56,7 +56,7 @@
 	if(.)
 		if(W == front_id)
 			front_id = null
-			name = initial(name)
+			SetName(initial(name))
 			update_icon()
 
 /obj/item/weapon/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
@@ -64,7 +64,7 @@
 	if(.)
 		if(!front_id && istype(W, /obj/item/weapon/card/id))
 			front_id = W
-			name = "[name] ([front_id])"
+			SetName("[name] ([front_id])")
 			update_icon()
 
 /obj/item/weapon/storage/wallet/update_icon()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -69,5 +69,5 @@
 			src.locked = 1
 			src.icon_state = src.icon_locked
 			src.registered_name = null
-			src.name = initial(name)
+			src.SetName(initial(name))
 			src.desc = initial(desc)

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -81,7 +81,7 @@
 		//Sad trombone
 		if(pickednum == 1)
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
-			P.name = "IOU"
+			P.SetName("IOU")
 			P.info = "Sorry man, we needed the money so we sold your stash. It's ok, we'll double our money for sure this time!"
 
 		//Metal (common ore)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -227,7 +227,7 @@
 			W.loc = src
 			to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
 			src.state = 2
-			src.name = "Near finished Airlock Assembly"
+			src.SetName("Near finished Airlock Assembly")
 			src.electronics = W
 
 	else if(isCrowbar(W) && state == 2 )
@@ -244,7 +244,7 @@
 			if(!src) return
 			to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
 			src.state = 1
-			src.name = "Wired Airlock Assembly"
+			src.SetName("Wired Airlock Assembly")
 			electronics.loc = src.loc
 			electronics = null
 
@@ -296,13 +296,14 @@
 
 /obj/structure/door_assembly/proc/update_state()
 	icon_state = "door_as_[glass == 1 ? "g" : ""][istext(glass) ? glass : base_icon_state][state]"
-	name = ""
+	var/final_name = ""
 	switch (state)
 		if(0)
 			if (anchored)
-				name = "Secured "
+				final_name = "Secured "
 		if(1)
-			name = "Wired "
+			final_name = "Wired "
 		if(2)
-			name = "Near Finished "
-	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+			final_name = "Near Finished "
+	final_name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+	SetName(final_name)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -93,7 +93,7 @@
 						var/datum/language/L = all_languages[vox.species.default_language]
 						newname = L.get_random_name()
 					vox.real_name = newname
-					vox.name = vox.real_name
+					vox.SetName(vox.real_name)
 					raiders.update_access(vox)
 				qdel(user)
 	..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -102,9 +102,9 @@
 			return
 		t = sanitizeSafe(t, MAX_NAME_LEN)
 		if (t)
-			src.name = text("Morgue- '[]'", t)
+			src.SetName(text("Morgue- '[]'", t))
 		else
-			src.name = "Morgue"
+			src.SetName("Morgue")
 	src.add_fingerprint(user)
 	return
 
@@ -286,9 +286,9 @@
 			return
 		t = sanitizeSafe(t, MAX_NAME_LEN)
 		if (t)
-			src.name = text("Crematorium- '[]'", t)
+			src.SetName(text("Crematorium- '[]'", t))
 		else
-			src.name = "Crematorium"
+			src.SetName("Crematorium")
 	src.add_fingerprint(user)
 	return
 

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -24,7 +24,7 @@
 	if(isScrewdriver(tool) && !istype(src, /obj/structure/sign/double))
 		to_chat(user, "You unfasten the sign with your [tool.name].")
 		var/obj/item/sign/S = new(src.loc)
-		S.name = name
+		S.SetName(name)
 		S.desc = desc
 		S.icon_state = icon_state
 		S.sign_state = icon_state
@@ -53,7 +53,7 @@
 			if("West")
 				S.pixel_x = -32
 			else return
-		S.name = name
+		S.SetName(name)
 		S.desc = desc
 		S.icon_state = sign_state
 		to_chat(user, "You fasten \the [S] with your [tool].")

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -43,8 +43,8 @@
 /obj/structure/skele_stand/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W,/obj/item/weapon/pen))
 		var/nuname = sanitize(input(user,"What do you want to name this skeleton as?","Skeleton Christening",name) as text|null)
-		if(nuname)
-			name = nuname
+		if(nuname && CanPhysicallyInteract(user))
+			SetName(nuname)
 			return 1
 	if(istype(W,/obj/item/clothing))
 		var/slot

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -62,7 +62,7 @@
 
 	// Strings.
 	if(material_alteration & MATERIAL_ALTERATION_NAME)
-		name = padding_material ? "[padding_material.adjective_name] [initial(name)]" : "[material.adjective_name] [initial(name)]" //this is not perfect but it will do for now.
+		SetName(padding_material ? "[padding_material.adjective_name] [initial(name)]" : "[material.adjective_name] [initial(name)]") //this is not perfect but it will do for now.
 
 	if(material_alteration & MATERIAL_ALTERATION_DESC)
 		desc = initial(desc)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -68,10 +68,10 @@ var/global/list/stool_cache = list() //haha stool
 	overlays = noverlays
 	// Strings.
 	if(padding_material)
-		name = "[padding_material.display_name] [initial(name)]" //this is not perfect but it will do for now.
+		SetName("[padding_material.display_name] [initial(name)]") //this is not perfect but it will do for now.
 		desc = "A padded stool. Apply butt. It's made of [material.use_name] and covered with [padding_material.use_name]."
 	else
-		name = "[material.display_name] [initial(name)]"
+		SetName("[material.display_name] [initial(name)]")
 		desc = "A stool. Apply butt with care. It's made of [material.use_name]."
 
 /obj/item/weapon/stool/proc/add_padding(var/padding_type)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -95,9 +95,9 @@ obj/structure/windoor_assembly/Destroy()
 					to_chat(user, "<span class='notice'>You've secured the windoor assembly!</span>")
 					src.anchored = 1
 					if(src.secure)
-						src.name = "Secure Anchored Windoor Assembly"
+						src.SetName("Secure Anchored Windoor Assembly")
 					else
-						src.name = "Anchored Windoor Assembly"
+						src.SetName("Anchored Windoor Assembly")
 
 			//Unwrenching an unsecure assembly un-anchors it. Step 4 undone
 			else if(isWrench(W) && anchored)
@@ -109,9 +109,9 @@ obj/structure/windoor_assembly/Destroy()
 					to_chat(user, "<span class='notice'>You've unsecured the windoor assembly!</span>")
 					src.anchored = 0
 					if(src.secure)
-						src.name = "Secure Windoor Assembly"
+						src.SetName("Secure Windoor Assembly")
 					else
-						src.name = "Windoor Assembly"
+						src.SetName("Windoor Assembly")
 
 			//Adding plasteel makes the assembly a secure windoor assembly. Step 2 (optional) complete.
 			else if(istype(W, /obj/item/stack/rods) && !secure)
@@ -126,9 +126,9 @@ obj/structure/windoor_assembly/Destroy()
 						to_chat(user, "<span class='notice'>You reinforce the windoor.</span>")
 						src.secure = "secure_"
 						if(src.anchored)
-							src.name = "Secure Anchored Windoor Assembly"
+							src.SetName("Secure Anchored Windoor Assembly")
 						else
-							src.name = "Secure Windoor Assembly"
+							src.SetName("Secure Windoor Assembly")
 
 			//Adding cable to the assembly. Step 5 complete.
 			else if(istype(W, /obj/item/stack/cable_coil) && anchored)
@@ -140,9 +140,9 @@ obj/structure/windoor_assembly/Destroy()
 						to_chat(user, "<span class='notice'>You wire the windoor!</span>")
 						src.state = "02"
 						if(src.secure)
-							src.name = "Secure Wired Windoor Assembly"
+							src.SetName("Secure Wired Windoor Assembly")
 						else
-							src.name = "Wired Windoor Assembly"
+							src.SetName("Wired Windoor Assembly")
 			else
 				..()
 
@@ -160,9 +160,9 @@ obj/structure/windoor_assembly/Destroy()
 					new/obj/item/stack/cable_coil(get_turf(user), 1)
 					src.state = "01"
 					if(src.secure)
-						src.name = "Secure Anchored Windoor Assembly"
+						src.SetName("Secure Anchored Windoor Assembly")
 					else
-						src.name = "Anchored Windoor Assembly"
+						src.SetName("Anchored Windoor Assembly")
 
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/weapon/airlock_electronics) && W:icon_state != "door_electronics_smoked")
@@ -175,7 +175,7 @@ obj/structure/windoor_assembly/Destroy()
 					user.drop_item()
 					W.loc = src
 					to_chat(user, "<span class='notice'>You've installed the airlock electronics!</span>")
-					src.name = "Near finished Windoor Assembly"
+					src.SetName("Near finished Windoor Assembly")
 					src.electronics = W
 				else
 					W.loc = src.loc
@@ -189,9 +189,9 @@ obj/structure/windoor_assembly/Destroy()
 					if(!src || !src.electronics) return
 					to_chat(user, "<span class='notice'>You've removed the airlock electronics!</span>")
 					if(src.secure)
-						src.name = "Secure Wired Windoor Assembly"
+						src.SetName("Secure Wired Windoor Assembly")
 					else
-						src.name = "Wired Windoor Assembly"
+						src.SetName("Wired Windoor Assembly")
 					var/obj/item/weapon/airlock_electronics/ae = electronics
 					electronics = null
 					ae.loc = src.loc

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -246,7 +246,7 @@ var/list/point_source_descriptions = list(
 			var/decl/hierarchy/supply_pack/SP = SO.object
 
 			var/obj/A = new SP.containertype(pickedloc)
-			A.name = "[SP.containername][SO.comment ? " ([SO.comment])":"" ]"
+			A.SetName("[SP.containername][SO.comment ? " ([SO.comment])":"" ]")
 			//supply manifest generation begin
 
 			var/obj/item/weapon/paper/manifest/slip

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -48,7 +48,7 @@
 
 	overlays.Cut()
 
-	name = base_name
+	SetName(base_name)
 	desc = base_desc
 	icon = base_icon
 	icon_state = base_icon_state

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -7,7 +7,7 @@ var/list/flooring_cache = list()
 
 	if(flooring)
 		// Set initial icon and strings.
-		name = flooring.name
+		SetName(flooring.name)
 		desc = flooring.desc
 		icon = flooring.icon
 		color = flooring.color

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -15,10 +15,10 @@
 		explosion_resistance = reinf_material.explosion_resistance
 
 	if(reinf_material)
-		name = "reinforced [material.display_name] [initial(name)]"
+		SetName("reinforced [material.display_name] [initial(name)]")
 		desc = "It seems to be a section of hull reinforced with [reinf_material.display_name] and plated with [material.display_name]."
 	else
-		name = "[material.display_name] [initial(name)]"
+		SetName("[material.display_name] [initial(name)]")
 		desc = "It seems to be a section of hull plated with [material.display_name]."
 
 	set_opacity(material.opacity >= 0.5)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -224,7 +224,7 @@
 	if(!can_melt())
 		return
 	var/obj/effect/overlay/O = new/obj/effect/overlay( src )
-	O.name = "Thermite"
+	O.SetName("Thermite")
 	O.desc = "Looks hot."
 	O.icon = 'icons/effects/fire.dmi'
 	O.icon_state = "2"

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -31,7 +31,7 @@
 		var/getName = sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
 		if(getName)
 			H.real_name = getName
-			H.name = getName
+			H.SetName(getName)
 			H.dna.real_name = getName
 			if(H.mind)
 				H.mind.name = H.name

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1455,7 +1455,7 @@ datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies
 /datum/admins/proc/faxCallback(var/obj/item/weapon/paper/admin/P, var/obj/machinery/photocopier/faxmachine/destination)
 	var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
 
-	P.name = "[P.origin] - [customname]"
+	P.SetName("[P.origin] - [customname]")
 	P.desc = "This is a paper titled '" + P.name + "'."
 
 	var/shouldStamp = 1

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1673,13 +1673,13 @@
 						var/turf/N = O.ChangeTurf(path)
 						if(N)
 							if(obj_name)
-								N.name = obj_name
+								N.SetName(obj_name)
 					else
 						var/atom/O = new path(target)
 						if(O)
 							O.set_dir(obj_dir)
 							if(obj_name)
-								O.name = obj_name
+								O.SetName(obj_name)
 								if(istype(O,/mob))
 									var/mob/M = O
 									M.real_name = obj_name

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -92,7 +92,7 @@
 			return 0
 	var/obj/item/device/paicard/card = new(T)
 	var/mob/living/silicon/pai/pai = new(card)
-	pai.name = sanitizeSafe(input(choice, "Enter your pAI name:", "pAI Name", "Personal AI") as text)
+	pai.SetName(sanitizeSafe(input(choice, "Enter your pAI name:", "pAI Name", "Personal AI") as text))
 	pai.real_name = pai.name
 	pai.key = choice.key
 	card.setPersonality(pai)
@@ -263,7 +263,7 @@
 			id.access = get_all_accesses()
 			id.registered_name = H.real_name
 			id.assignment = "Captain"
-			id.name = "[id.registered_name]'s ID Card ([id.assignment])"
+			id.SetName("[id.registered_name]'s ID Card ([id.assignment])")
 			H.equip_to_slot_or_del(id, slot_wear_id)
 			H.update_inv_wear_id()
 	else

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -21,7 +21,7 @@
 
 	usr.forceMove(O)
 	usr.real_name = O.name
-	usr.name = O.name
+	usr.SetName(O.name)
 	usr.client.eye = O
 	usr.control_object = O
 	feedback_add_details("admin_verb","PO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -33,10 +33,10 @@
 
 	if(usr.control_object && usr.name_archive) //if you have a name archived and if you are actually relassing an object
 		usr.real_name = usr.name_archive
-		usr.name = usr.real_name
+		usr.SetName(usr.real_name)
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			H.name = H.get_visible_name()
+			H.SetName(H.get_visible_name())
 //		usr.regenerate_icons() //So the name is updated properly
 
 	usr.forceMove(O.loc) // Appear where the object you were controlling is -- TLE

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -450,7 +450,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			new_character.real_name = capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
 		else
 			new_character.real_name = capitalize(pick(GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
-	new_character.name = new_character.real_name
+	new_character.SetName(new_character.real_name)
 
 	if(G_found.mind && !G_found.mind.active)
 		G_found.mind.transfer_to(new_character)	//be careful when doing stuff like this! I've already checked the mind isn't in use

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -110,3 +110,8 @@
 	handled_type = /atom
 	handled_vars = list("invisibility" = /atom/proc/set_invisibility)
 	predicates = list(/proc/is_num_predicate)
+
+/decl/vv_set_handler/name_handler
+	handled_type = /atom
+	handled_vars = list("name" = /atom/proc/SetName)
+	predicates = list(/proc/is_text_predicate)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -45,7 +45,7 @@
 		D2.loc = src
 		a_left = D
 		a_right = D2
-		name = "[D.name]-[D2.name] assembly"
+		SetName("[D.name]-[D2.name] assembly")
 		update_icon()
 		usr.put_in_hands(src)
 
@@ -59,7 +59,7 @@
 /*		if(O:Attach_Holder())
 			special_assembly = O
 			update_icon()
-			src.name = "[a_left.name] [a_right.name] [special_assembly.name] assembly"
+			src.SetName("[a_left.name] [a_right.name] [special_assembly.name] assembly")
 */
 		return
 
@@ -248,7 +248,7 @@
 		a_right = ign
 		secured = 1
 		update_icon()
-		name = initial(name) + " ([tmr.time] secs)"
+		SetName(initial(name) + " ([tmr.time] secs)")
 
 		loc.verbs += /obj/item/device/assembly_holder/timer_igniter/verb/configure
 
@@ -279,7 +279,7 @@
 				var/ntime = input("Enter desired time in seconds", "Time", "5") as num
 				if (ntime>0 && ntime<1000)
 					tmr.time = ntime
-					name = initial(name) + "([tmr.time] secs)"
+					SetName(initial(name) + "([tmr.time] secs)")
 					to_chat(usr, "<span class='notice'>Timer set to [tmr.time] seconds.</span>")
 				else
 					to_chat(usr, "<span class='notice'>Timer can't be [ntime<=0?"negative":"more than 1000 seconds"].</span>")

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -240,7 +240,7 @@
 	if(!initial_loc.air_vent_names[id_tag])
 		var/new_name = "[initial_loc.name] Vent Pump #[initial_loc.air_vent_names.len+1]"
 		initial_loc.air_vent_names[id_tag] = new_name
-		src.name = new_name
+		src.SetName(new_name)
 	initial_loc.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)
@@ -317,7 +317,7 @@
 		external_pressure_bound = between(0,external_pressure_bound + text2num(signal.data["adjust_external_pressure"]),MAX_PUMP_PRESSURE)
 
 	if(signal.data["init"] != null)
-		name = signal.data["init"]
+		SetName(signal.data["init"])
 		return
 
 	if(signal.data["status"] != null)

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -108,7 +108,7 @@
 	if(!initial_loc.air_scrub_names[id_tag])
 		var/new_name = "[initial_loc.name] Air Scrubber #[initial_loc.air_scrub_names.len+1]"
 		initial_loc.air_scrub_names[id_tag] = new_name
-		src.name = new_name
+		src.SetName(new_name)
 	initial_loc.air_scrub_info[id_tag] = signal.data
 	radio_connection.post_signal(src, signal, radio_filter_out)
 
@@ -242,7 +242,7 @@
 	scrubbing_gas ^= toggle
 
 	if(signal.data["init"] != null)
-		name = signal.data["init"]
+		SetName(signal.data["init"])
 		return
 
 	if(signal.data["status"] != null)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -88,7 +88,7 @@
 		else
 			M.randomize_eye_color()
 
-	M.name = (CORPSE_SPAWNER_RANDOM_NAME & spawn_flags) ? M.species.get_random_name(M.gender) : name
+	M.SetName((CORPSE_SPAWNER_RANDOM_NAME & spawn_flags) ? M.species.get_random_name(M.gender) : name)
 	M.real_name = M.name
 
 #undef HEX_COLOR_TO_RGB_ARGS

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -253,7 +253,7 @@ datum/preferences
 				O.robotize()
 		else //normal organ
 			O.force_icon = null
-			O.name = initial(O.name)
+			O.SetName(initial(O.name))
 			O.desc = initial(O.desc)
 	//For species that don't care about your silly prefs
 	character.species.handle_limbs_setup(character)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -93,7 +93,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head, blocked)
 
 /obj/item/clothing/head/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	update_icon()
@@ -129,7 +129,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit, blocked)
 
 /obj/item/clothing/suit/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	update_icon()
@@ -164,7 +164,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes, blocked)
 
 /obj/item/clothing/shoes/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	item_state = initial(item_state)
@@ -200,7 +200,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/weapon/storage/backpack, blocked)
 
 /obj/item/weapon/storage/backpack/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	item_state = initial(item_state)
@@ -242,7 +242,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves, list(src.type))
 
 /obj/item/clothing/gloves/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	item_state = initial(item_state)
@@ -278,7 +278,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask, list(src.type))
 
 /obj/item/clothing/mask/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	item_state = initial(item_state)
@@ -314,7 +314,7 @@
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses, list(src.type))
 
 /obj/item/clothing/glasses/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	item_state = initial(item_state)
@@ -365,7 +365,7 @@
 /obj/item/weapon/gun/energy/chameleon/consume_next_projectile()
 	var/obj/item/projectile/P = ..()
 	if(P && ispath(copy_projectile))
-		P.name = initial(copy_projectile.name)
+		P.SetName(initial(copy_projectile.name))
 		P.icon = initial(copy_projectile.icon)
 		P.icon_state = initial(copy_projectile.icon_state)
 		P.pass_flags = initial(copy_projectile.pass_flags)
@@ -377,7 +377,7 @@
 	return P
 
 /obj/item/weapon/gun/energy/chameleon/emp_act(severity)
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	icon_state = initial(icon_state)
 	update_icon()

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -141,7 +141,7 @@
 	burn_damage = 0
 
 	if(!can_breach || !breaches || !breaches.len)
-		name = initial(name)
+		SetName(initial(name))
 		return 0
 
 	for(var/datum/breach/B in breaches)
@@ -157,13 +157,13 @@
 
 	if(damage >= 3)
 		if(brute_damage >= 3 && brute_damage > burn_damage)
-			name = "punctured [initial(name)]"
+			SetName("punctured [initial(name)]")
 		else if(burn_damage >= 3 && burn_damage > brute_damage)
-			name = "scorched [initial(name)]"
+			SetName("scorched [initial(name)]")
 		else
-			name = "damaged [initial(name)]"
+			SetName("damaged [initial(name)]")
 	else
-		name = initial(name)
+		SetName(initial(name))
 
 	return damage
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -147,7 +147,7 @@
 		if(!istype(piece))
 			continue
 		piece.canremove = 0
-		piece.name = "[suit_type] [initial(piece.name)]"
+		piece.SetName("[suit_type] [initial(piece.name)]")
 		piece.desc = "It seems to be part of a [src.name]."
 		piece.icon_state = "[initial(icon_state)]"
 		piece.min_cold_protection_temperature = min_cold_protection_temperature

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -117,7 +117,7 @@
 	if(src && input && !M.incapacitated() && in_range(M,src))
 		if(!findtext(input, "the", 1, 4))
 			input = "\improper [input]"
-		name = input
+		SetName(input)
 		to_chat(M, "Suit naming succesful!")
 		verbs -= /obj/item/weapon/rig/light/ninja/verb/rename_suit
 		return 1

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -33,7 +33,7 @@
 
 /obj/item/clothing/accessory/holster/proc/clear_holster()
 	holstered = null
-	name = initial(name)
+	SetName(initial(name))
 
 /obj/item/clothing/accessory/holster/proc/unholster(mob/user as mob)
 	if(!holstered)

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -32,7 +32,7 @@
 	var/kit_desc
 	var/kit_icon
 	var/additional_data
-	
+
 /datum/custom_item/proc/is_valid(var/checker)
 	if(!item_path)
 		to_chat(checker, "<span class='warning'>The given item path, [item_path_as_string], is invalid and does not exist.</span>")
@@ -51,7 +51,7 @@
 	if(!item)
 		return
 	if(name)
-		item.name = name
+		item.SetName(name)
 	if(item_desc)
 		item.desc = item_desc
 	if(item_icon)
@@ -206,7 +206,7 @@
 		// Check for requisite ckey and character name.
 		if((lowertext(citem.assoc_key) != lowertext(M.ckey)) || (lowertext(citem.character_name) != lowertext(M.real_name)))
 			continue
-			
+
 		// Once we've decided that the custom item belongs to this player, validate it
 		if(!citem.is_valid(M))
 			return

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -103,7 +103,7 @@
 	update_icon()
 	if(bloodsamp)
 		var/obj/item/weapon/paper/P = new(src)
-		P.name = "[src] report #[++report_num]: [bloodsamp.name]"
+		P.SetName("[src] report #[++report_num]: [bloodsamp.name]")
 		P.stamped = list(/obj/item/weapon/stamp)
 		P.overlays = list("paper_stamped")
 		//dna data itself

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -45,7 +45,7 @@
 	if(istype(sample, /obj/item/weapon/forensics/swab))
 		var/obj/item/weapon/forensics/swab/swab = sample
 
-		report.name = "GSR report #[++report_num]: [swab.name]"
+		report.SetName("GSR report #[++report_num]: [swab.name]")
 		report.info = "<b>Scanned item:</b><br>[swab.name]<br><br>"
 
 		if(swab.gsr)
@@ -55,7 +55,7 @@
 
 	else if(istype(sample, /obj/item/weapon/sample/fibers))
 		var/obj/item/weapon/sample/fibers/fibers = sample
-		report.name = "Fiber report #[++report_num]: [fibers.name]"
+		report.SetName("Fiber report #[++report_num]: [fibers.name]")
 		report.info = "<b>Scanned item:</b><br>[fibers.name]<br><br>"
 		if(fibers.evidence)
 			report.info = "Molecular analysis on provided sample has determined the presence of unique fiber strings.<br><br>"
@@ -64,7 +64,7 @@
 		else
 			report.info += "No fibers found."
 	else if(istype(sample, /obj/item/weapon/sample/print))
-		report.name = "Fingerprint report #[report_num]: [sample.name]"
+		report.SetName("Fingerprint report #[report_num]: [sample.name]")
 		report.info = "<b>Fingerprint analysis report #[report_num]</b>: [sample.name]<br>"
 		var/obj/item/weapon/sample/print/card = sample
 		if(card.evidence && card.evidence.len)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -61,11 +61,11 @@
 
 /obj/item/weapon/reagent_containers/glass/rag/proc/update_name()
 	if(on_fire)
-		name = "burning [initial(name)]"
+		SetName("burning [initial(name)]")
 	else if(reagents.total_volume)
-		name = "damp [initial(name)]"
+		SetName("damp [initial(name)]")
 	else
-		name = "dry [initial(name)]"
+		SetName("dry [initial(name)]")
 
 /obj/item/weapon/reagent_containers/glass/rag/update_icon()
 	if(on_fire)

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -25,7 +25,7 @@
 	if(!supplied.evidence || !supplied.evidence.len)
 		return 0
 	evidence |= supplied.evidence
-	name = "[initial(name)] (combined)"
+	SetName("[initial(name)] (combined)")
 	to_chat(user, "<span class='notice'>You transfer the contents of \the [supplied] into \the [src].</span>")
 	return 1
 
@@ -37,7 +37,7 @@
 			evidence[print] = stringmerge(evidence[print],supplied.evidence[print])
 		else
 			evidence[print] = supplied.evidence[print]
-	name = "[initial(name)] (combined)"
+	SetName("[initial(name)] (combined)")
 	to_chat(user, "<span class='notice'>You overlay \the [src] and \the [supplied], combining the print records.</span>")
 	return 1
 
@@ -78,7 +78,7 @@
 	to_chat(user, "<span class='notice'>You firmly press your fingertips onto the card.</span>")
 	var/fullprint = H.get_full_print()
 	evidence[fullprint] = fullprint
-	name = "[initial(name)] (\the [H])"
+	SetName("[initial(name)] (\the [H])")
 	icon_state = "fingerprint1"
 
 /obj/item/weapon/sample/print/attack(var/mob/living/M, var/mob/user)
@@ -115,7 +115,7 @@
 		var/fullprint = H.get_full_print()
 		evidence[fullprint] = fullprint
 		copy_evidence(src)
-		name = "[initial(name)] (\the [H])"
+		SetName("[initial(name)] (\the [H])")
 		icon_state = "fingerprint1"
 		return 1
 	return 0

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -114,7 +114,7 @@
 		set_used(sample_type, A)
 
 /obj/item/weapon/forensics/swab/proc/set_used(var/sample_str, var/atom/source)
-	name = "[initial(name)] ([sample_str] - [source])"
+	SetName("[initial(name)] ([sample_str] - [source])")
 	desc = "[initial(desc)] The label on the vial reads 'Sample of [sample_str] from [source].'."
 	icon_state = "swab_used"
 	used = 1

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -345,7 +345,7 @@
 			if("balance_statement")
 				if(authenticated_account)
 					var/obj/item/weapon/paper/R = new(src.loc)
-					R.name = "Account balance: [authenticated_account.owner_name]"
+					R.SetName("Account balance: [authenticated_account.owner_name]")
 					R.info = "<b>NT Automated Teller Account Statement</b><br><br>"
 					R.info += "<i>Account holder:</i> [authenticated_account.owner_name]<br>"
 					R.info += "<i>Account number:</i> [authenticated_account.account_number]<br>"
@@ -369,7 +369,7 @@
 			if ("print_transaction")
 				if(authenticated_account)
 					var/obj/item/weapon/paper/R = new(src.loc)
-					R.name = "Transaction logs: [authenticated_account.owner_name]"
+					R.SetName("Transaction logs: [authenticated_account.owner_name]")
 					R.info = "<b>Transaction logs</b><br>"
 					R.info += "<i>Account holder:</i> [authenticated_account.owner_name]<br>"
 					R.info += "<i>Account number:</i> [authenticated_account.account_number]<br>"

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -84,7 +84,7 @@
 
 		var/obj/item/weapon/paper/R = new /obj/item/weapon/paper(P)
 		P.wrapped = R
-		R.name = "Account information: [M.owner_name]"
+		R.SetName("Account information: [M.owner_name]")
 		R.info = "<b>Account details (confidential)</b><br><hr><br>"
 		R.info += "<i>Account holder:</i> [M.owner_name]<br>"
 		R.info += "<i>Account number:</i> [M.account_number]<br>"

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -200,7 +200,7 @@
 				var/text
 				var/obj/item/weapon/paper/P = new(loc)
 				if (detailed_account_view)
-					P.name = "account #[detailed_account_view.account_number] details"
+					P.SetName("account #[detailed_account_view.account_number] details")
 					var/title = "Account #[detailed_account_view.account_number] Details"
 					text = {"
 						[accounting_letterhead(title)]
@@ -238,7 +238,7 @@
 						"}
 
 				else
-					P.name = "financial account list"
+					P.SetName("financial account list")
 					text = {"
 						[accounting_letterhead("Financial Account List")]
 

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -21,7 +21,7 @@
 
 		//create a short manual as well
 		var/obj/item/weapon/paper/R = new(src.loc)
-		R.name = "Steps to success: Correct EFTPOS Usage"
+		R.SetName("Steps to success: Correct EFTPOS Usage")
 		/*
 		R.info += "<b>When first setting up your EFTPOS device:</b>"
 		R.info += "1. Memorise your EFTPOS command code (provided with all EFTPOS devices).<br>"
@@ -64,7 +64,7 @@
 
 /obj/item/device/eftpos/proc/print_reference()
 	var/obj/item/weapon/paper/R = new(src.loc)
-	R.name = "Reference: [eftpos_name]"
+	R.SetName("Reference: [eftpos_name]")
 	R.info = "<b>[eftpos_name] reference</b><br><br>"
 	R.info += "Access code: [access_code]<br><br>"
 	R.info += "<b>Do not lose or misplace this code.</b><br>"
@@ -80,7 +80,7 @@
 	var/obj/item/smallDelivery/D = new(R.loc)
 	R.loc = D
 	D.wrapped = R
-	D.name = "small parcel - 'EFTPOS access code'"
+	D.SetName("small parcel - 'EFTPOS access code'")
 
 /obj/item/device/eftpos/attack_self(mob/user as mob)
 	if(get_dist(src,user) <= 1)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -82,9 +82,9 @@
 
 	src.desc = "They are worth [worth] Thalers."
 	if(worth in denominations)
-		src.name = "[worth] Thaler"
+		src.SetName("[worth] Thaler")
 	else
-		src.name = "pile of [worth] thalers"
+		src.SetName("pile of [worth] thalers")
 
 	if(overlays.len <= 2)
 		w_class = ITEM_SIZE_TINY

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -112,7 +112,7 @@
 	src.audible_message("<b>\The [src]</b> states, \"Your [text] is ready!\"")
 	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 	var/atom/A = new type(src.loc)
-	A.name = text
+	A.SetName(text)
 	A.desc = "Looks... actually pretty good."
 	use_power(75000)
 	return 1

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -112,7 +112,7 @@ var/list/ghost_traps
 	if(!istype(P)) //wat
 		return
 	P.searching = 0
-	P.name = "positronic brain ([P.brainmob.name])"
+	P.SetName("positronic brain ([P.brainmob.name])")
 	P.update_icon()
 
 // Allows people to set their own name. May or may not need to be removed for posibrains if people are dumbasses.
@@ -123,7 +123,7 @@ var/list/ghost_traps
 	var/newname = sanitizeSafe(input(target,"Enter a name, or leave blank for the default name.", "Name change",target.real_name) as text, MAX_NAME_LEN)
 	if (newname && newname != "")
 		target.real_name = newname
-		target.name = target.real_name
+		target.SetName(target.real_name)
 
 /***********************************
 * Diona pods and walking mushrooms *

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -270,7 +270,7 @@ var/global/list/datum/stack_recipe/wax_recipes = list( \
 
 /obj/item/bee_pack/proc/fill()
 	full = initial(full)
-	name = initial(name)
+	SetName(initial(name))
 	desc = initial(desc)
 	overlays.Cut()
 	overlays += "beepack-full"

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -28,7 +28,7 @@
 	if(!seed)
 		return INITIALIZE_HINT_QDEL
 
-	name = "[seed.seed_name]"
+	SetName("[seed.seed_name]")
 	trash = seed.get_trash_type()
 	if(!dried_type)
 		dried_type = type

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -172,7 +172,7 @@
 	if(splat_type && !(locate(/obj/effect/vine) in T))
 		var/obj/effect/vine/splat = new splat_type(T, src)
 		if(!istype(splat)) // Plants handle their own stuff.
-			splat.name = "[thrown.name] [pick("smear","smudge","splatter")]"
+			splat.SetName("[thrown.name] [pick("smear","smudge","splatter")]")
 			if(get_trait(TRAIT_BIOLUM))
 				var/clr
 				if(get_trait(TRAIT_BIOLUM_COLOUR))

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -13,7 +13,7 @@
 		var/choice = alert(user, "Are you sure you want to wipe the disk?", "Xenobotany Data", "No", "Yes")
 		if(src && user && genes && choice && choice == "Yes" && user.Adjacent(get_turf(src)))
 			to_chat(user, "You wipe the disk data.")
-			name = initial(name)
+			SetName(initial(name))
 			desc = initial(name)
 			genes = list()
 			genesource = "unknown"

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -51,10 +51,10 @@ var/global/list/plant_seed_sprites = list()
 	overlays |= seed_overlay
 
 	if(is_seeds)
-		src.name = "packet of [seed.seed_name] [seed.seed_noun]"
+		src.SetName("packet of [seed.seed_name] [seed.seed_noun]")
 		src.desc = "It has a picture of [seed.display_name] on the front."
 	else
-		src.name = "sample of [seed.seed_name] [seed.seed_noun]"
+		src.SetName("sample of [seed.seed_name] [seed.seed_noun]")
 		src.desc = "It's labelled as coming from [seed.display_name]."
 
 /obj/item/seeds/examine(mob/user)
@@ -68,7 +68,7 @@ var/global/list/plant_seed_sprites = list()
 
 /obj/item/seeds/cutting/update_appearance()
 	..()
-	src.name = "packet of [seed.seed_name] cuttings"
+	src.SetName("packet of [seed.seed_name] cuttings")
 
 /obj/item/seeds/random
 	seed_type = null

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -37,7 +37,6 @@
 	var/closed_system          // If set, the tray will attempt to take atmos from a pipe.
 	var/force_update           // Set this to bypass the cycle time check.
 	var/obj/temp_chem_holder   // Something to hold reagents during process_reagents()
-	var/labelled
 
 	// Seed details/line data.
 	var/datum/seed/seed = null // The currently planted seed
@@ -360,23 +359,6 @@
 		seed = seed.diverge()
 	seed.mutate(severity,get_turf(src))
 
-	return
-
-/obj/machinery/portable_atmospherics/hydroponics/verb/remove_label()
-
-	set name = "Remove Label"
-	set category = "Object"
-	set src in view(1)
-
-	if(usr.incapacitated())
-		return
-	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
-		if(labelled)
-			to_chat(usr, "You remove the label.")
-			labelled = null
-			update_icon()
-		else
-			to_chat(usr, "There is no label to remove.")
 	return
 
 /obj/machinery/portable_atmospherics/hydroponics/verb/setlight()

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -15,7 +15,6 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/New()
 	..()
 	verbs -= /obj/machinery/portable_atmospherics/hydroponics/verb/close_lid_verb
-	verbs -= /obj/machinery/portable_atmospherics/hydroponics/verb/remove_label
 	verbs -= /obj/machinery/portable_atmospherics/hydroponics/verb/setlight
 
 // Holder for vine plants.
@@ -25,7 +24,7 @@
 	name = "plant"
 	icon = 'icons/obj/seeds.dmi'
 	icon_state = "blank"
-	var/list/connected_zlevels //cached for checking if we someone is obseving us so we should process 
+	var/list/connected_zlevels //cached for checking if we someone is obseving us so we should process
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/New(var/newloc,var/datum/seed/newseed, var/start_mature)
 	..()

--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -33,7 +33,7 @@
 		to_chat(user, "There is no scan data to print.")
 		return
 	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(get_turf(src))
-	P.name = "paper - [form_title]"
+	P.SetName("paper - [form_title]")
 	P.info = "[last_data]"
 	if(istype(user,/mob/living/carbon/human) && !(user.l_hand && user.r_hand))
 		user.put_in_hands(P)

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -7,7 +7,7 @@
 		else
 			name = "[seed.seed_name]"
 	else
-		name = initial(name)
+		SetName(initial(name))
 
 	if(labelled)
 		name += " ([labelled])"

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -9,9 +9,6 @@
 	else
 		SetName(initial(name))
 
-	if(labelled)
-		name += " ([labelled])"
-
 	overlays.Cut()
 	var/new_overlays = list()
 	// Updates the plant overlay.

--- a/code/modules/integrated_electronics/assemblies.dm
+++ b/code/modules/integrated_electronics/assemblies.dm
@@ -171,7 +171,7 @@
 	var/input = sanitizeSafe(input("What do you want to name this?", "Rename", src.name) as null|text, MAX_NAME_LEN)
 	if(src && input && input != name && CanInteract(M, GLOB.physical_state))
 		to_chat(M, "<span class='notice'>The machine now has a label reading '[input]'.</span>")
-		name = input
+		SetName(input)
 
 /obj/item/device/electronic_assembly/update_icon()
 	if(applied_shell)

--- a/code/modules/integrated_electronics/prefab/prefab.dm
+++ b/code/modules/integrated_electronics/prefab/prefab.dm
@@ -63,7 +63,7 @@
 /decl/prefab/ic_assembly/create(var/atom/location)
 	..()
 	var/obj/item/device/electronic_assembly/assembly = new assembly_type(location)
-	assembly.name = assembly_name || assembly.name
+	assembly.SetName(assembly_name || assembly.name)
 
 	var/list/circuits = list()
 	for(var/ic in integrated_circuits)
@@ -97,7 +97,7 @@
 
 /datum/ic_assembly_integrated_circuits/proc/create_circuit(var/obj/item/device/electronic_assembly/assembly, var/list/circuits)
 	var/obj/circuit = new circuit_type()
-	circuit.name = circuit_name || circuit.name
+	circuit.SetName(circuit_name || circuit.name)
 	circuits += circuit
 
 	assembly.opened = TRUE

--- a/code/modules/integrated_electronics/tools.dm
+++ b/code/modules/integrated_electronics/tools.dm
@@ -248,7 +248,7 @@
 
 /obj/item/weapon/storage/bag/circuits/debug/Initialize()
 	. = ..()
-	name = "[name] - not intended for general use"
+	SetName("[name] - not intended for general use")
 	desc = "[desc] - not intended for general use"
 	for(var/subtype in subtypesof(/obj/item/integrated_circuit))
 		var/obj/item/integrated_circuit/ic = subtype

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -36,7 +36,7 @@
 		if(!newname)
 			return
 		else
-			name = ("bookcase ([newname])")
+			SetName("bookcase ([newname])")
 	else if(isScrewdriver(O))
 		playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 		to_chat(user, "<span class='notice'>You begin dismantling \the [src].</span>")
@@ -191,7 +191,7 @@
 					to_chat(usr, "The title is invalid.")
 					return
 				else
-					src.name = newtitle
+					src.SetName(newtitle)
 					src.title = newtitle
 			if("Contents")
 				var/content = sanitize(input("Write your book's contents (HTML NOT allowed):") as message|null, MAX_BOOK_MESSAGE_LEN)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -76,7 +76,7 @@
 		src.visible_message("[src] whirs as it prints and binds a new book.")
 		var/obj/item/weapon/book/b = new(src.loc)
 		b.dat = O:info
-		b.name = "Print Job #" + "[rand(100, 999)]"
+		b.SetName("Print Job #" + "[rand(100, 999)]")
 		b.icon_state = "book[rand(1,7)]"
 		qdel(O)
 	else

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -46,11 +46,11 @@
 	singular_name = material.sheet_singular_name
 
 	if(amount>1)
-		name = "[material.use_name] [material.sheet_plural_name]"
+		SetName("[material.use_name] [material.sheet_plural_name]")
 		desc = "A stack of [material.use_name] [material.sheet_plural_name]."
 		gender = PLURAL
 	else
-		name = "[material.use_name] [material.sheet_singular_name]"
+		SetName("[material.use_name] [material.sheet_singular_name]")
 		desc = "A [material.sheet_singular_name] of [material.use_name]."
 		gender = NEUTER
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -11,7 +11,7 @@ var/list/mining_floors = list()
 	opacity = 1
 
 /turf/simulated/mineral //wall piece
-	name = "Rock"
+	name = "rock"
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rock"
 	initial_gas = null
@@ -59,10 +59,10 @@ var/list/mining_floors = list()
 
 /turf/simulated/mineral/update_icon(var/update_neighbors)
 	if(!mineral)
-		name = "rock"
+		SetName(initial(name))
 		icon_state = "rock"
 	else
-		name = "[mineral.display_name] deposit"
+		SetName("[mineral.display_name] deposit")
 
 	overlays.Cut()
 

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -17,7 +17,7 @@
 		update_ore()
 
 /obj/item/weapon/ore/proc/update_ore()
-	name = ore.display_name
+	SetName(ore.display_name)
 	icon_state = "ore_[ore.icon_tag]"
 	origin_tech = ore.origin_tech.Copy()
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -29,7 +29,7 @@
 	affecting = victim
 	target_zone = attacker.zone_sel.selecting
 	var/obj/item/O = get_targeted_organ()
-	name = "[name] ([O.name])"
+	SetName("[name] ([O.name])")
 
 	if(start_grab_name)
 		current_grab = all_grabstates[start_grab_name]

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -174,7 +174,7 @@
 		qdel(O)
 		var/turf/T = get_turf(loc)
 		var/mob/living/bot/cleanbot/A = new /mob/living/bot/cleanbot(T)
-		A.name = created_name
+		A.SetName(created_name)
 		to_chat(user, "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>")
 		user.drop_from_inventory(src)
 		qdel(src)

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -94,7 +94,7 @@
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add the robot leg to [src].</span>")
-				name = "legs/frame assembly"
+				SetName("legs/frame assembly")
 				if(build_step == 1)
 					item_state = "ed209_leg"
 					icon_state = "ed209_leg"
@@ -112,7 +112,7 @@
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
-				name = "vest/legs/frame assembly"
+				SetName("vest/legs/frame assembly")
 				item_state = "ed209_shell"
 				icon_state = "ed209_shell"
 
@@ -121,7 +121,7 @@
 				var/obj/item/weapon/weldingtool/WT = W
 				if(WT.remove_fuel(0, user))
 					build_step++
-					name = "shielded frame assembly"
+					SetName("shielded frame assembly")
 					to_chat(user, "<span class='notice'>You welded the vest to [src].</span>")
 		if(4)
 			if(istype(W, /obj/item/clothing/head/helmet))
@@ -129,7 +129,7 @@
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add the helmet to [src].</span>")
-				name = "covered and shielded frame assembly"
+				SetName("covered and shielded frame assembly")
 				item_state = "ed209_hat"
 				icon_state = "ed209_hat"
 
@@ -139,7 +139,7 @@
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add the prox sensor to [src].</span>")
-				name = "covered, shielded and sensored frame assembly"
+				SetName("covered, shielded and sensored frame assembly")
 				item_state = "ed209_prox"
 				icon_state = "ed209_prox"
 
@@ -154,12 +154,12 @@
 					if(C.use(1))
 						build_step++
 						to_chat(user, "<span class='notice'>You wire the ED-209 assembly.</span>")
-						name = "wired ED-209 assembly"
+						SetName("wired ED-209 assembly")
 				return
 
 		if(7)
 			if(istype(W, /obj/item/weapon/gun/energy/taser))
-				name = "taser ED-209 assembly"
+				SetName("taser ED-209 assembly")
 				build_step++
 				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
 				item_state = "ed209_taser"
@@ -175,7 +175,7 @@
 				sleep(40)
 				if(get_turf(user) == T && build_step == 8)
 					build_step++
-					name = "armed [name]"
+					SetName("armed [name]")
 					to_chat(user, "<span class='notice'>Taser gun attached.</span>")
 
 		if(9)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -316,21 +316,21 @@
 	if((istype(W, /obj/item/device/analyzer/plant_analyzer)) && (build_step == 0))
 		build_step++
 		to_chat(user, "You add the plant analyzer to [src].")
-		name = "farmbot assembly"
+		SetName("farmbot assembly")
 		user.remove_from_mob(W)
 		qdel(W)
 
 	else if((istype(W, /obj/item/weapon/reagent_containers/glass/bucket)) && (build_step == 1))
 		build_step++
 		to_chat(user, "You add a bucket to [src].")
-		name = "farmbot assembly with bucket"
+		SetName("farmbot assembly with bucket")
 		user.remove_from_mob(W)
 		qdel(W)
 
 	else if((istype(W, /obj/item/weapon/material/minihoe)) && (build_step == 2))
 		build_step++
 		to_chat(user, "You add a minihoe to [src].")
-		name = "farmbot assembly with bucket and minihoe"
+		SetName("farmbot assembly with bucket and minihoe")
 		user.remove_from_mob(W)
 		qdel(W)
 
@@ -338,7 +338,7 @@
 		build_step++
 		to_chat(user, "You complete the Farmbot! Beep boop.")
 		var/mob/living/bot/farmbot/S = new /mob/living/bot/farmbot(get_turf(src), tank)
-		S.name = created_name
+		S.SetName(created_name)
 		user.remove_from_mob(W)
 		qdel(W)
 		qdel(src)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -284,7 +284,7 @@
 		qdel(W)
 		var/turf/T = get_turf(user.loc)
 		var/mob/living/bot/floorbot/A = new /mob/living/bot/floorbot(T)
-		A.name = created_name
+		A.SetName(created_name)
 		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly! Boop beep!</span>")
 		user.drop_from_inventory(src)
 		qdel(src)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -308,7 +308,7 @@
 					qdel(W)
 					build_step++
 					to_chat(user, "<span class='notice'>You add the health sensor to [src].</span>")
-					name = "First aid/robot arm/health analyzer assembly"
+					SetName("First aid/robot arm/health analyzer assembly")
 					overlays += image('icons/obj/aibots.dmi', "na_scanner")
 
 			if(1)
@@ -319,7 +319,7 @@
 					var/turf/T = get_turf(src)
 					var/mob/living/bot/medbot/S = new /mob/living/bot/medbot(T)
 					S.skin = skin
-					S.name = created_name
+					S.SetName(created_name)
 					S.update_icons() // apply the skin
 					user.drop_from_inventory(src)
 					qdel(src)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -290,14 +290,14 @@
 		build_step = 2
 		to_chat(user, "You add \the [O] to [src].")
 		overlays += image('icons/obj/aibots.dmi', "hs_eye")
-		name = "helmet/signaler/prox sensor assembly"
+		SetName("helmet/signaler/prox sensor assembly")
 		qdel(O)
 
 	else if((istype(O, /obj/item/robot_parts/l_arm) || istype(O, /obj/item/robot_parts/r_arm)) && build_step == 2)
 		user.drop_item()
 		build_step = 3
 		to_chat(user, "You add \the [O] to [src].")
-		name = "helmet/signaler/prox sensor/robot arm assembly"
+		SetName("helmet/signaler/prox sensor/robot arm assembly")
 		overlays += image('icons/obj/aibots.dmi', "hs_arm")
 		qdel(O)
 
@@ -305,7 +305,7 @@
 		user.drop_item()
 		to_chat(user, "You complete the Securitron! Beep boop.")
 		var/mob/living/bot/secbot/S = new /mob/living/bot/secbot(get_turf(src))
-		S.name = created_name
+		S.SetName(created_name)
 		qdel(O)
 		qdel(src)
 

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -53,7 +53,7 @@
 	to_chat(src, "<span class='danger'>You burrow deeply into \the [H]'s [E.name]!</span>")
 	var/obj/item/weapon/holder/holder = new (loc)
 	src.loc = holder
-	holder.name = src.name
+	holder.SetName(src.name)
 	E.embed(holder,0,"\The [src] burrows deeply into \the [H]'s [E.name]!")
 
 /mob/living/carbon/alien/larva/verb/release_host()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -29,7 +29,7 @@
 	return
 
 /obj/item/device/mmi
-	name = "man-machine interface"
+	name = "\improper Man-Machine Interface"
 	desc = "A complex life support shell that interfaces between a brain and electronic devices."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
@@ -67,9 +67,9 @@
 
 		user.drop_item()
 		brainobj = O
-		brainobj.loc = src
+		brainobj.forceMove(src)
 
-		name = "man-machine interface ([brainmob.real_name])"
+		SetName("[initial(name)]: ([brainmob.real_name])")
 		icon_state = "mmi_full"
 
 		locked = 1
@@ -100,7 +100,7 @@
 		to_chat(user, "<span class='notice'>You upend the MMI, spilling the brain onto the floor.</span>")
 		var/obj/item/organ/internal/brain/brain
 		if (brainobj)	//Pull brain organ out of MMI.
-			brainobj.loc = user.loc
+			brainobj.forceMove(user.loc)
 			brain = brainobj
 			brainobj = null
 		else	//Or make a new one if empty.
@@ -112,16 +112,16 @@
 		brainmob = null//Set mmi brainmob var to null
 
 		icon_state = "mmi_empty"
-		name = "man-machine interface"
+		SetName(initial(name))
 
 /obj/item/device/mmi/proc/transfer_identity(var/mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->robot people.
 	brainmob = new(src)
-	brainmob.name = H.real_name
+	brainmob.SetName(H.real_name)
 	brainmob.real_name = H.real_name
 	brainmob.dna = H.dna
 	brainmob.container = src
 
-	name = "Man-Machine Interface: [brainmob.real_name]"
+	SetName("[initial(name)]: [brainmob.real_name]")
 	icon_state = "mmi_full"
 	locked = 1
 	return

--- a/code/modules/mob/living/carbon/brain/robot.dm
+++ b/code/modules/mob/living/carbon/brain/robot.dm
@@ -7,7 +7,7 @@
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3, TECH_DATA = 4)
 
 /obj/item/device/mmi/digital/robot/PickName()
-	src.brainmob.name = "[pick(list("ADA","DOS","GNU","MAC","WIN"))]-[random_id(type,1000,9999)]"
+	src.brainmob.SetName("[pick(list("ADA","DOS","GNU","MAC","WIN"))]-[random_id(type,1000,9999)]")
 	src.brainmob.real_name = src.brainmob.name
 
 /obj/item/device/mmi/digital/robot/transfer_identity(var/mob/living/carbon/H)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,7 +54,7 @@
 		if(B.host_brain.ckey)
 			ckey = B.host_brain.ckey
 			B.host_brain.ckey = null
-			B.host_brain.name = "host brain"
+			B.host_brain.SetName("host brain")
 			B.host_brain.real_name = "host brain"
 
 		verbs -= /mob/living/carbon/proc/release_control

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -23,7 +23,7 @@
 
 	if(species)
 		real_name = species.get_random_name(gender)
-		name = real_name
+		SetName(real_name)
 		if(mind)
 			mind.name = real_name
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -44,7 +44,7 @@ meteor_act
 	//Embed or sever artery
 	if(P.can_embed() && !(species.species_flags & SPECIES_FLAG_NO_EMBED) && prob(22.5 + max(penetrating_damage, -10)) && !(prob(50) && (organ.sever_artery())))
 		var/obj/item/weapon/material/shard/shrapnel/SP = new()
-		SP.name = (P.name != "shrapnel")? "[P.name] shrapnel" : "shrapnel"
+		SP.SetName((P.name != "shrapnel")? "[P.name] shrapnel" : "shrapnel")
 		SP.desc = "[SP.desc] It looks like it was fired from [P.shot_from]."
 		SP.loc = organ
 		organ.embed(SP)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -86,7 +86,7 @@
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 
 	//Update our name based on whether our face is obscured/disfigured
-	name = get_visible_name()
+	SetName(get_visible_name())
 
 /mob/living/carbon/human/set_stat(var/new_stat)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -40,7 +40,7 @@
 	outfit.equip(src)
 	var/obj/item/clothing/head/helmet/facecover/F = locate() in src
 	if(F)
-		F.name = "[F.name] ([number])"
+		F.SetName("[F.name] ([number])")
 
 /mob/living/carbon/human/blank/ssd_check()
 	return FALSE

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -4,7 +4,7 @@
 		if(get_id_name("Unknown") != GetVoice())
 			alt_name = "(as [get_id_name("Unknown")])"
 		else
-			name = get_id_name("Unknown")
+			SetName(get_id_name("Unknown"))
 
 	//parse the language code and consume it
 	if(!speaking)

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -29,5 +29,5 @@
 		H.mind.assigned_role = "Golem"
 		H.mind.special_role = "Golem"
 	H.real_name = "adamantine golem ([rand(1, 1000)])"
-	H.name = H.real_name
+	H.SetName(H.real_name)
 	..()

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -122,7 +122,7 @@
 
 	alien_number++ //Keep track of how many aliens we've had so far.
 	H.real_name = "alien [caste_name] ([alien_number])"
-	H.name = H.real_name
+	H.SetName(H.real_name)
 
 	..()
 
@@ -317,10 +317,10 @@
 	// Make sure only one official queen exists at any point.
 	if(!alien_queen_exists(1,H))
 		H.real_name = "alien queen ([alien_number])"
-		H.name = H.real_name
+		H.SetName(H.real_name)
 	else
 		H.real_name = "alien princess ([alien_number])"
-		H.name = H.real_name
+		H.SetName(H.real_name)
 
 /datum/hud_data/alien
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -18,7 +18,7 @@
 		if(get_id_name("Unknown") != GetVoice())
 			alt_name = "(as [get_id_name("Unknown")])"
 		else
-			name = get_id_name("Unknown")
+			SetName(get_id_name("Unknown"))
 
 	whisper_say(message, alt_name = alt_name)
 

--- a/code/modules/mob/living/carbon/xenobiological/death.dm
+++ b/code/modules/mob/living/carbon/xenobiological/death.dm
@@ -12,7 +12,7 @@
 		revive()
 		if (!client) rabid = 1
 		number = rand(1, 1000)
-		name = "[colour] [is_adult ? "adult" : "baby"] slime ([number])"
+		SetName("[colour] [is_adult ? "adult" : "baby"] slime ([number])")
 		return
 
 	. = ..(gibbed, deathmessage, show_dead_message)

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -151,7 +151,7 @@
 
 		if (!newname)
 			newname = "pet slime"
-		pet.name = newname
+		pet.SetName(newname)
 		pet.real_name = newname
 		qdel(src)
 
@@ -182,7 +182,7 @@
 
 		if (!newname)
 			newname = "pet slime"
-		pet.name = newname
+		pet.SetName(newname)
 		pet.real_name = newname
 		qdel(src)
 

--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -134,7 +134,7 @@
 			maxHealth = 200
 			amount_grown = 0
 			regenerate_icons()
-			name = text("[colour] [is_adult ? "adult" : "baby"] slime ([number])")
+			SetName(text("[colour] [is_adult ? "adult" : "baby"] slime ([number])"))
 		else
 			to_chat(src, "<span class='notice'>I am not ready to evolve yet...</span>")
 	else

--- a/code/modules/mob/living/deity/deity.dm
+++ b/code/modules/mob/living/deity/deity.dm
@@ -102,7 +102,7 @@
 	form = new type(src)
 	to_chat(src, "<span class='notice'>You undergo a transformation into your new form!</span>")
 	spawn(1)
-		name = form.name
+		SetName(form.name)
 		var/newname = sanitize(input(src, "Choose a name for your new form.", "Name change", form.name) as text, MAX_NAME_LEN)
 		if(newname)
 			fully_replace_character_name(newname)

--- a/code/modules/mob/living/deity/deity_sources.dm
+++ b/code/modules/mob/living/deity/deity_sources.dm
@@ -70,7 +70,7 @@
 		var/datum/mind/minion = m
 		to_chat(minion.current, "Your master is now known as [new_name]")
 		minion.special_role = "Servant of [new_name]"
-	eyeobj.name = "[src] ([eyeobj.name_sufix])"
+	eyeobj.SetName("[src] ([eyeobj.name_sufix])")
 	return 1
 
 //Whether we are near an important structure.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -385,7 +385,7 @@
 
 		B.UpdateIcon()
 
-		B.name = A.UpdateName()
+		B.SetName(A.UpdateName())
 
 		client.screen += B
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -280,7 +280,7 @@ var/list/ai_verbs_default = list(
 	..()
 	announcement.announcer = pickedName
 	if(eyeobj)
-		eyeobj.name = "[pickedName] (AI Eye)"
+		eyeobj.SetName("[pickedName] (AI Eye)")
 
 	// Set ai pda name
 	if(aiPDA)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -34,9 +34,9 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		if(istype(card,/obj/item/device/paicard) && istype(candidate,/datum/paiCandidate))
 			var/mob/living/silicon/pai/pai = new(card)
 			if(!candidate.name)
-				pai.name = pick(GLOB.ninja_names)
+				pai.SetName(pick(GLOB.ninja_names))
 			else
-				pai.name = candidate.name
+				pai.SetName(candidate.name)
 			pai.real_name = pai.name
 			pai.key = candidate.key
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -154,14 +154,14 @@ var/list/mob_hat_cache = list()
 /mob/living/silicon/robot/drone/fully_replace_character_name(pickedName as text)
 	// Would prefer to call the grandparent proc but this isn't possible, so..
 	real_name = pickedName
-	name = real_name
+	SetName(real_name)
 
 /mob/living/silicon/robot/drone/updatename()
 	if(controlling_ai)
 		real_name = "remote drone ([controlling_ai.name])"
 	else
 		real_name = "[initial(name)] ([random_id(type,100,999)])"
-	name = real_name
+	SetName(real_name)
 
 /mob/living/silicon/robot/drone/update_icon()
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -251,7 +251,7 @@
 
 	//n_name = copytext(n_name, 1, 32)
 	if(( get_dist(user,paper) <= 1  && user.stat == 0))
-		paper.name = "paper[(n_name ? text("- '[n_name]'") : null)]"
+		paper.SetName("paper[(n_name ? text("- '[n_name]'") : null)]")
 	add_fingerprint(user)
 	return
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -226,7 +226,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	src.emag.name = "Polyacid spray"
+	src.emag.SetName("Polyacid spray")
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
 	synths += medicine
@@ -279,7 +279,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src) // Allows usage of inflatables. Since they are basically robotic alternative to EMTs, they should probably have them.
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	src.emag.name = "Polyacid spray"
+	src.emag.SetName("Polyacid spray")
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
 	synths += medicine
@@ -468,7 +468,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent(/datum/reagent/lube, 250)
-	src.emag.name = "Lube spray"
+	src.emag.SetName("Lube spray")
 	..()
 
 /obj/item/weapon/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
@@ -533,7 +533,7 @@ var/global/list/robot_modules = list(
 
 	var/datum/reagents/R = src.emag.create_reagents(50)
 	R.add_reagent(/datum/reagent/chloralhydrate/beer2, 50)
-	src.emag.name = "Mickey Finn's Special Brew"
+	src.emag.SetName("Mickey Finn's Special Brew")
 	..()
 
 /obj/item/weapon/robot_module/clerical/general
@@ -703,7 +703,7 @@ var/global/list/robot_modules = list(
 	src.modules += robot.internals
 
 	src.emag = new /obj/item/weapon/gun/energy/plasmacutter(src)
-	src.emag.name = "Plasma Cutter"
+	src.emag.SetName("Plasma Cutter")
 
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(25000)
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass(25000)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -315,7 +315,7 @@ GLOBAL_LIST_INIT(borer_reagent_types_by_name, setup_borer_reagents())
 
 			host_brain.ckey = host.ckey
 
-			host_brain.name = host.name
+			host_brain.SetName(host.name)
 
 			if(!host_brain.computer_id)
 				host_brain.computer_id = h2b_id

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -36,7 +36,7 @@
 
 /mob/living/simple_animal/construct/New()
 	..()
-	name = text("[initial(name)] ([rand(1, 1000)])")
+	name = text("[initial(name)] ([random_id(/mob/living/simple_animal/construct, 1000, 9999)])")
 	real_name = name
 	add_language("Cult")
 	add_language("Occult")

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -46,7 +46,7 @@
 		icon_state = "soulstone2" //TODO: A spookier sprite. Also unique sprites.
 	if(full == SOULSTONE_CRACKED)
 		icon_state = "soulstone"//TODO: cracked sprite
-		name = "cracked soulstone"
+		SetName("cracked soulstone")
 
 /obj/item/device/soulstone/attackby(var/obj/item/I, var/mob/user)
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -112,5 +112,5 @@
 /mob/living/simple_animal/mouse/brown/Tom/New()
 	..()
 	// Change my name back, don't want to be named Tom (666)
-	name = initial(name)
+	SetName(initial(name))
 	real_name = name

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -151,7 +151,7 @@
 		src.mind = M.brainmob.mind
 		src.mind.key = M.brainmob.key
 		src.ckey = M.brainmob.ckey
-		src.name = "spider-bot ([M.brainmob.name])"
+		src.SetName("spider-bot ([M.brainmob.name])")
 
 /mob/living/simple_animal/spiderbot/proc/explode() //When emagged.
 	src.visible_message("<span class='danger'>\The [src] makes an odd warbling noise, fizzles, and explodes!</span>")
@@ -179,7 +179,7 @@
 		if(mind)	mind.transfer_to(mmi.brainmob)
 		mmi = null
 		real_name = initial(real_name)
-		name = real_name
+		SetName(real_name)
 		update_icon()
 	remove_language("Robot Talk")
 	positronic = null

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -220,52 +220,52 @@
 
 		if(spawnees & 1)
 			C = new(src.loc)
-			C.name = "Drone CPU motherboard"
+			C.SetName("Drone CPU motherboard")
 			C.origin_tech = list(TECH_DATA = rand(3, 6))
 
 		if(spawnees & 2)
 			C = new(src.loc)
-			C.name = "Drone neural interface"
+			C.SetName("Drone neural interface")
 			C.origin_tech = list(TECH_BIO = rand(3,6))
 
 		if(spawnees & 4)
 			C = new(src.loc)
-			C.name = "Drone suspension processor"
+			C.SetName("Drone suspension processor")
 			C.origin_tech = list(TECH_MAGNET = rand(3,6))
 
 		if(spawnees & 8)
 			C = new(src.loc)
-			C.name = "Drone shielding controller"
+			C.SetName("Drone shielding controller")
 			C.origin_tech = list(TECH_BLUESPACE = rand(3,6))
 
 		if(spawnees & 16)
 			C = new(src.loc)
-			C.name = "Drone power capacitor"
+			C.SetName("Drone power capacitor")
 			C.origin_tech = list(TECH_POWER = rand(3,6))
 
 		if(spawnees & 32)
 			C = new(src.loc)
-			C.name = "Drone hull reinforcer"
+			C.SetName("Drone hull reinforcer")
 			C.origin_tech = list(TECH_MATERIAL = rand(3,6))
 
 		if(spawnees & 64)
 			C = new(src.loc)
-			C.name = "Drone auto-repair system"
+			C.SetName("Drone auto-repair system")
 			C.origin_tech = list(TECH_ENGINEERING = rand(3,6))
 
 		if(spawnees & 128)
 			C = new(src.loc)
-			C.name = "Drone phoron overcharge counter"
+			C.SetName("Drone phoron overcharge counter")
 			C.origin_tech = list(TECH_PHORON = rand(3,6))
 
 		if(spawnees & 256)
 			C = new(src.loc)
-			C.name = "Drone targetting circuitboard"
+			C.SetName("Drone targetting circuitboard")
 			C.origin_tech = list(TECH_COMBAT = rand(3,6))
 
 		if(spawnees & 512)
 			C = new(src.loc)
-			C.name = "Corrupted drone morality core"
+			C.SetName("Corrupted drone morality core")
 			C.origin_tech = list(TECH_ILLEGAL = rand(3,6))
 
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -334,7 +334,7 @@
 	if(meat_type && actual_meat_amount>0 && (stat == DEAD))
 		for(var/i=0;i<actual_meat_amount;i++)
 			var/obj/item/meat = new meat_type(get_turf(src))
-			meat.name = "[src.name] [meat.name]"
+			meat.SetName("[src.name] [meat.name]")
 		if(issmall(src))
 			user.visible_message("<span class='danger'>[user] chops up \the [src]!</span>")
 			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -593,7 +593,7 @@ proc/is_blind(A)
 /mob/proc/fully_replace_character_name(var/new_name, var/in_depth = TRUE)
 	if(!new_name || new_name == real_name)	return 0
 	real_name = new_name
-	name = new_name
+	SetName(new_name)
 	if(mind)
 		mind.name = new_name
 	if(dna)

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -34,10 +34,10 @@
 		return
 
 	if( istext(new_name) )
-		M.name = new_name
+		M.SetName(new_name)
 		M.real_name = new_name
 	else
-		M.name = src.name
+		M.SetName(src.name)
 		M.real_name = src.real_name
 
 	if(src.dna)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -145,7 +145,7 @@
 			if(client.prefs.be_random_name)
 				client.prefs.real_name = random_name(client.prefs.gender)
 			observer.real_name = client.prefs.real_name
-			observer.name = observer.real_name
+			observer.SetName(observer.real_name)
 			if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
 				observer.verbs -= /mob/observer/ghost/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
 			observer.key = key
@@ -487,7 +487,7 @@
 			mind.gen_relations_info = client.prefs.relations_info["general"]
 		mind.transfer_to(new_character)					//won't transfer key since the mind is not active
 
-	new_character.name = real_name
+	new_character.SetName(real_name)
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.sync_organ_dna()

--- a/code/modules/mob/observer/freelook/eye.dm
+++ b/code/modules/mob/observer/freelook/eye.dm
@@ -60,7 +60,7 @@
 		return
 	owner = user
 	owner.eyeobj = src
-	name = "[owner.name] ([name_sufix])" // Update its name
+	SetName("[owner.name] ([name_sufix])") // Update its name
 	if(owner.client)
 		owner.client.eye = src
 	setLoc(owner)
@@ -74,7 +74,7 @@
 	visualnet.remove_eye(src)
 	owner.eyeobj = null
 	owner = null
-	name = initial(name)
+	SetName(initial(name))
 
 // Use this when setting the eye's location.
 // It will also stream the chunk that the new loc is in.

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -222,7 +222,7 @@
 					if(!access_allowed)
 						id_card.access += access_type
 	if(id_card)
-		id_card.name = text("[id_card.registered_name]'s ID Card ([id_card.assignment])")
+		id_card.SetName(text("[id_card.registered_name]'s ID Card ([id_card.assignment])"))
 
 	GLOB.nanomanager.update_uis(NM)
 	return 1

--- a/code/modules/modular_computers/file_system/programs/generic/library.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/library.dm
@@ -94,7 +94,7 @@ The answer was five and a half years -ZeroBits
 			error_message = "Interface Error: Cached book is copy-protected."
 			return 1
 
-		B.name = input(usr, "Enter Book Title", "Title", B.name) as text|null
+		B.SetName(input(usr, "Enter Book Title", "Title", B.name) as text|null)
 		B.author = input(usr, "Enter Author Name", "Author", B.author) as text|null
 
 		if(!B.author)
@@ -144,7 +144,7 @@ The answer was five and a half years -ZeroBits
 			var/obj/machinery/bookbinder/bndr = locate(/obj/machinery/bookbinder, get_step(nano_host(), d))
 			if(bndr && bndr.anchored)
 				var/obj/item/weapon/book/B = new(bndr.loc)
-				B.name = current_book["title"]
+				B.SetName(current_book["title"])
 				B.title = current_book["title"]
 				B.author = current_book["author"]
 				B.dat = current_book["content"]

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -2,26 +2,26 @@
 // parent class for pipes //
 ////////////////////////////
 obj/machinery/atmospherics/pipe/zpipe
-		icon = 'icons/obj/structures.dmi'
-		icon_state = "up"
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "up"
 
-		name = "upwards pipe"
-		desc = "A pipe segment to connect upwards."
+	name = "upwards pipe"
+	desc = "A pipe segment to connect upwards."
 
-		volume = 70
+	volume = 70
 
-		dir = SOUTH
-		initialize_directions = SOUTH
+	dir = SOUTH
+	initialize_directions = SOUTH
 
-		var/minimum_temperature_difference = 300
-		var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
+	var/minimum_temperature_difference = 300
+	var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
 
-		var/maximum_pressure = 70*ONE_ATMOSPHERE
-		var/fatigue_pressure = 55*ONE_ATMOSPHERE
-		alert_pressure = 55*ONE_ATMOSPHERE
+	var/maximum_pressure = 70*ONE_ATMOSPHERE
+	var/fatigue_pressure = 55*ONE_ATMOSPHERE
+	alert_pressure = 55*ONE_ATMOSPHERE
 
 
-		level = 1
+	level = 1
 
 obj/machinery/atmospherics/pipe/zpipe/New()
 	..()
@@ -112,11 +112,11 @@ obj/machinery/atmospherics/pipe/zpipe/disconnect(obj/machinery/atmospherics/refe
 // the elusive up pipe //
 /////////////////////////
 obj/machinery/atmospherics/pipe/zpipe/up
-		icon = 'icons/obj/structures.dmi'
-		icon_state = "up"
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "up"
 
-		name = "upwards pipe"
-		desc = "A pipe segment to connect upwards."
+	name = "upwards pipe"
+	desc = "A pipe segment to connect upwards."
 
 obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 	..()
@@ -151,11 +151,11 @@ obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 ///////////////////////
 
 obj/machinery/atmospherics/pipe/zpipe/down
-		icon = 'icons/obj/structures.dmi'
-		icon_state = "down"
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "down"
 
-		name = "downwards pipe"
-		desc = "A pipe segment to connect downwards."
+	name = "downwards pipe"
+	desc = "A pipe segment to connect downwards."
 
 obj/machinery/atmospherics/pipe/zpipe/down/atmos_init()
 	..()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -791,7 +791,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			parent_organ.update_damages()
 		else
 			var/obj/item/organ/external/stump/stump = new (victim, 0, src)
-			stump.name = "stump of \a [name]"
+			stump.SetName("stump of \a [name]")
 			stump.artery_name = "mangled [artery_name]"
 			stump.arterial_bleed_severity = arterial_bleed_severity
 			stump.add_pain(max_damage)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -41,7 +41,7 @@
 
 /obj/item/organ/external/head/removed()
 	if(owner)
-		name = "[owner.real_name]'s head"
+		SetName("[owner.real_name]'s head")
 		owner.drop_from_inventory(owner.glasses)
 		owner.drop_from_inventory(owner.head)
 		owner.drop_from_inventory(owner.l_ear)

--- a/code/modules/organs/external/machine.dm
+++ b/code/modules/organs/external/machine.dm
@@ -133,8 +133,8 @@
 		stored_mmi.brainobj = new(stored_mmi)
 		stored_mmi.brainmob.container = stored_mmi
 		stored_mmi.brainmob.real_name = owner.real_name
-		stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
-		stored_mmi.name = "[initial(stored_mmi.name)] ([owner.real_name])"
+		stored_mmi.brainmob.SetName(stored_mmi.brainmob.real_name)
+		stored_mmi.SetName("[initial(stored_mmi.name)] ([owner.real_name])")
 
 	if(!owner) return
 

--- a/code/modules/organs/internal/appendix.dm
+++ b/code/modules/organs/internal/appendix.dm
@@ -9,7 +9,7 @@
 	..()
 	if(inflamed)
 		icon_state = "appendixinflamed"
-		name = "inflamed appendix"
+		SetName("inflamed appendix")
 
 /obj/item/organ/internal/appendix/Process()
 	..()

--- a/code/modules/organs/internal/borer.dm
+++ b/code/modules/organs/internal/borer.dm
@@ -26,7 +26,7 @@
 		blood_splatter(H,B,1)
 		var/obj/effect/decal/cleanable/blood/splatter/goo = locate() in get_turf(owner)
 		if(goo)
-			goo.name = "husk ichor"
+			goo.SetName("husk ichor")
 			goo.desc = "It's thick and stinks of decay."
 			goo.basecolor = "#412464"
 			goo.update_icon()

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -67,7 +67,7 @@
 
 	if(!brainmob)
 		brainmob = new(src)
-		brainmob.name = H.real_name
+		brainmob.SetName(H.real_name)
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
 		brainmob.timeofhostdeath = H.timeofdeath

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -40,7 +40,7 @@
 	brainmob = new(src)
 
 	if(istype(H))
-		brainmob.name = H.real_name
+		brainmob.SetName(H.real_name)
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
 		brainmob.add_language("Encoded Audio Language")
@@ -119,7 +119,7 @@
 	..()
 
 /obj/item/organ/internal/posibrain/proc/PickName()
-	src.brainmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[random_id(type,100,999)]"
+	src.brainmob.SetName("[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[random_id(type,100,999)]")
 	src.brainmob.real_name = src.brainmob.name
 
 /obj/item/organ/internal/posibrain/proc/shackle(var/given_lawset)
@@ -149,7 +149,7 @@
 	if(H && H.mind)
 		brainmob.set_stat(CONSCIOUS)
 		H.mind.transfer_to(brainmob)
-		brainmob.name = H.real_name
+		brainmob.SetName(H.real_name)
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
 		brainmob.show_laws(brainmob)
@@ -164,7 +164,7 @@
 		return ..()
 
 	if(name == initial(name))
-		name = "\the [owner.real_name]'s [initial(name)]"
+		SetName("\the [owner.real_name]'s [initial(name)]")
 
 	transfer_identity(owner)
 

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -80,7 +80,7 @@
 		owner.ghostize() // Remove the previous owner to avoid their client getting reset.
 	//owner.dna.real_name = backup.name
 	//owner.real_name = owner.dna.real_name
-	//owner.name = owner.real_name
+	//owner.SetName(owner.real_name)
 	//The above three lines were commented out for
 	backup.active = 1
 	backup.transfer_to(owner)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -297,7 +297,7 @@ var/list/organ_cache = list()
 
 	user.drop_from_inventory(src)
 	var/obj/item/weapon/reagent_containers/food/snacks/organ/O = new(get_turf(src))
-	O.name = name
+	O.SetName(name)
 	O.appearance = src
 	reagents.trans_to(O, reagents.total_volume)
 	if(fingerprints)

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -29,7 +29,7 @@
 			GLOB.exited_event.register(event_turf, src, /decl/overmap_event_handler/proc/on_turf_exited)
 
 			var/obj/effect/overmap_event/event = new(event_turf)
-			event.name = overmap_event.name
+			event.SetName(overmap_event.name)
 			event.icon_state = pick(overmap_event.event_icon_states)
 			event.opacity =  overmap_event.opacity
 

--- a/code/modules/overmap/exoplanets/desert.dm
+++ b/code/modules/overmap/exoplanets/desert.dm
@@ -64,7 +64,7 @@
 
 /turf/simulated/floor/exoplanet/desert/fire_act(datum/gas_mixture/air, temperature, volume)
 	if((temperature > T0C + 1700 && prob(5)) || temperature > T0C + 3000)
-		name = "molten silica"
+		SetName("molten silica")
 		icon_state = "sandglass"
 		diggable = 0
 

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -146,10 +146,10 @@
 
 /obj/effect/overmap/sector/exoplanet/proc/adapt_animal(var/mob/living/simple_animal/A)
 	if(species[A.type])
-		A.name = species[A.type]
+		A.SetName(species[A.type])
 		A.real_name = species[A.type]
 	else
-		A.name = "alien creature"
+		A.SetName("alien creature")
 		A.real_name = "alien creature"
 		A.verbs |= /mob/living/simple_animal/proc/name_species
 	A.minbodytemp = atmosphere.temperature - 20
@@ -172,7 +172,7 @@
 	log_and_message_admins("renamed [species_type] to [newname]")
 	for(var/mob/living/simple_animal/A in animals)
 		if(istype(A,species_type))
-			A.name = newname
+			A.SetName(newname)
 			A.real_name = newname
 			A.verbs -= /mob/living/simple_animal/proc/name_species
 	return TRUE

--- a/code/modules/overmap/exoplanets/grass.dm
+++ b/code/modules/overmap/exoplanets/grass.dm
@@ -84,5 +84,5 @@
 
 /turf/simulated/floor/exoplanet/grass/fire_act(datum/gas_mixture/air, temperature, volume)
 	if((temperature > T0C + 200 && prob(5)) || temperature > T0C + 1000) 
-		name = "scorched ground"
+		SetName("scorched ground")
 		icon_state = "scorched"

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -39,7 +39,7 @@
 		copycontents = replacetext(copycontents, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
 		copy.info += copycontents
 		copy.info += "</font>"
-		copy.name = "Copy - " + c.name
+		copy.SetName("Copy - " + c.name)
 		copy.fields = c.fields
 		copy.updateinfolinks()
 		to_chat(usr, "<span class='notice'>You tear off the carbon-copy!</span>")

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -40,7 +40,7 @@
 	else if(istype(W, /obj/item/weapon/pen))
 		var/n_name = sanitizeSafe(input(usr, "What would you like to label the folder?", "Folder Labelling", null)  as text, MAX_NAME_LEN)
 		if((loc == usr && usr.stat == 0))
-			name = "folder[(n_name ? text("- '[n_name]'") : null)]"
+			SetName("folder[(n_name ? text("- '[n_name]'") : null)]")
 	return
 
 /obj/item/weapon/folder/attack_self(mob/user as mob)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -23,35 +23,32 @@
 		to_chat(user, "<span class='notice'>No labels left.</span>")
 		return
 	if(!label || !length(label))
-		to_chat(user, "<span class='notice'>No text set.</span>")
+		to_chat(user, "<span class='notice'>No label text set.</span>")
 		return
-	if(length(A.name) + length(label) > 64)
-		to_chat(user, "<span class='notice'>Label too big.</span>")
-		return
-	if(ishuman(A))
-		to_chat(user, "<span class='notice'>The label refuses to stick to [A.name].</span>")
-		return
-	if(issilicon(A))
-		to_chat(user, "<span class='notice'>The label refuses to stick to [A.name].</span>")
-		return
-	if(isobserver(A))
-		to_chat(user, "<span class='notice'>[src] passes through [A.name].</span>")
-		return
-	if(istype(A, /obj/item/weapon/reagent_containers/glass))
-		to_chat(user, "<span class='notice'>The label can't stick to the [A.name].  (Try using a pen)</span>")
-		return
-	if(istype(A, /obj/machinery/portable_atmospherics/hydroponics))
-		var/obj/machinery/portable_atmospherics/hydroponics/tray = A
-		if(!tray.mechanical)
-			to_chat(user, "<span class='notice'>How are you going to label that?</span>")
+	if(has_extension(A, /datum/extension/labels))
+		var/datum/extension/labels/L = get_extension(A, /datum/extension/labels)
+		if(!L.CanAttachLabel(user, label))
 			return
-		tray.labelled = label
-		spawn(1)
-			tray.update_icon()
+	A.attach_label(user, src, label)
 
-	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
-						 "<span class='notice'>You label [A] as [label].</span>")
-	A.SetName("[A.name] ([label])")
+/atom/proc/attach_label(var/user, var/atom/labeler, var/label_text)
+	to_chat(user, "<span class='notice'>The label refuses to stick to [name].</span>")
+
+/mob/observer/attach_label(var/user, var/atom/labeler, var/label_text)
+	to_chat(user, "<span class='notice'>\The [labeler] passes through \the [src].</span>")
+
+/obj/machinery/portable_atmospherics/hydroponics/attach_label(var/user)
+	if(!mechanical)
+		to_chat(user, "<span class='notice'>How are you going to label that?</span>")
+		return
+	..()
+	update_icon()
+
+/obj/attach_label(var/user, var/atom/labeler, var/label_text)
+	if(!simulated)
+		return
+	var/datum/extension/labels/L = get_or_create_extension(src, /datum/extension/labels, /datum/extension/labels)
+	L.AttachLabel(user, label_text)
 
 /obj/item/weapon/hand_labeler/attack_self(mob/user as mob)
 	mode = !mode

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -51,7 +51,7 @@
 
 	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
 						 "<span class='notice'>You label [A] as [label].</span>")
-	A.name = "[A.name] ([label])"
+	A.SetName("[A.name] ([label])")
 
 /obj/item/weapon/hand_labeler/attack_self(mob/user as mob)
 	mode = !mode

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -41,7 +41,7 @@
 
 /obj/item/weapon/paper/proc/set_content(text,title)
 	if(title)
-		name = title
+		SetName(title)
 	info = html_encode(text)
 	info = parsepencode(text)
 	update_icon()
@@ -89,7 +89,7 @@
 
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/weapon/photo/rename()
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0 && n_name)
-		name = n_name
+		SetName(n_name)
 		add_fingerprint(usr)
 
 /obj/item/weapon/paper/attack_self(mob/living/user as mob)
@@ -339,9 +339,9 @@
 				return
 		var/obj/item/weapon/paper_bundle/B = new(src.loc)
 		if (name != "paper")
-			B.name = name
+			B.SetName(name)
 		else if (P.name != "paper" && P.name != "photo")
-			B.name = P.name
+			B.SetName(P.name)
 
 		user.drop_from_inventory(P)
 		user.drop_from_inventory(src)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -192,7 +192,7 @@
 
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the bundle?", "Bundle Labelling", null)  as text, MAX_NAME_LEN)
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
-		name = "[(n_name ? text("[n_name]") : "paper")]"
+		SetName("[(n_name ? text("[n_name]") : "paper")]")
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -156,7 +156,7 @@
 	copied = replacetext(copied, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
 	c.info += copied
 	c.info += "</font>"//</font>
-	c.name = copy.name // -- Doohl
+	c.SetName(copy.name) // -- Doohl
 	c.fields = copy.fields
 	c.stamps = copy.stamps
 	c.stamped = copy.stamped
@@ -220,7 +220,7 @@
 	p.loc = src.loc
 	p.update_icon()
 	p.icon_state = "paper_words"
-	p.name = bundle.name
+	p.SetName(bundle.name)
 	return p
 
 /obj/item/device/toner

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -89,7 +89,7 @@ var/global/photo_count = 0
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text, MAX_NAME_LEN)
 	//loc.loc check is for making possible renaming photos in clipboards
 	if(( (loc == usr || (loc.loc && loc.loc == usr)) && usr.stat == 0))
-		name = "[(n_name ? text("[n_name]") : "photo")]"
+		SetName("[(n_name ? text("[n_name]") : "photo")]")
 	add_fingerprint(usr)
 	return
 
@@ -277,7 +277,7 @@ var/global/photo_count = 0
 /obj/item/weapon/photo/proc/copy(var/copy_id = 0)
 	var/obj/item/weapon/photo/p = new/obj/item/weapon/photo()
 
-	p.name = name
+	p.SetName(name)
 	p.icon = icon(icon, icon_state)
 	p.tiny = icon(tiny)
 	p.img = icon(img)

--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -18,7 +18,7 @@
 /obj/item/device/camera/siliconcam/proc/injectaialbum(obj/item/weapon/photo/p, var/sufix = "") //stores image information to a list similar to that of the datacore
 	p.loc = src
 	photos_taken++
-	p.name = "Image [photos_taken][sufix]"
+	p.SetName("Image [photos_taken][sufix]")
 	aipictures += p
 
 /obj/item/device/camera/siliconcam/proc/injectmasteralbum(obj/item/weapon/photo/p) //stores image information to a list similar to that of the datacore

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -83,5 +83,5 @@
 		var/obj/item/weapon/stamp/chosen_stamp = stamps[capitalize(input_stamp)]
 
 		if(chosen_stamp)
-			name = chosen_stamp.name
+			SetName(chosen_stamp.name)
 			icon_state = chosen_stamp.icon_state

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -179,7 +179,7 @@
 		area.apc = src
 		opened = 1
 		operating = 0
-		name = "\improper [area.name] APC"
+		SetName("\improper [area.name] APC")
 		stat |= MAINT
 		src.update_icon()
 
@@ -234,10 +234,10 @@
 	//if area isn't specified use current
 	if(isarea(A) && src.areastring == null)
 		src.area = A
-		name = "\improper [area.name] APC"
+		SetName("\improper [area.name] APC")
 	else
 		src.area = get_area_name(areastring)
-		name = "\improper [area.name] APC"
+		SetName("\improper [area.name] APC")
 	area.apc = src
 	update_icon()
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -532,13 +532,13 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		color = possible_cable_coil_colours[pick(possible_cable_coil_colours)]
 	if(amount == 1)
 		icon_state = "coil1"
-		name = "cable piece"
+		SetName("cable piece")
 	else if(amount == 2)
 		icon_state = "coil2"
-		name = "cable piece"
+		SetName("cable piece")
 	else
-		icon_state = "coil"
-		name = "cable coil"
+		icon_state = initial(icon_state)
+		SetName(initial(name))
 
 /obj/item/stack/cable_coil/proc/set_cable_color(var/selected_color, var/user)
 	if(!selected_color)

--- a/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	var/material/material = get_material_by_name(fuel_type)
 	if(istype(material))
-		name = "[material.use_name] fuel rod assembly"
+		SetName("[material.use_name] fuel rod assembly")
 		desc = "A fuel rod for a fusion reactor. This one is made from [material.use_name]."
 		fuel_colour = material.icon_colour
 		fuel_type = material.use_name
@@ -33,7 +33,7 @@
 		if(material.luminescence)
 			set_light(material.luminescence, material.luminescence, material.icon_colour)
 	else
-		name = "[fuel_type] fuel rod assembly"
+		SetName("[fuel_type] fuel rod assembly")
 		desc = "A fuel rod for a fusion reactor. This one is made from [fuel_type]."
 
 	icon_state = "blank"

--- a/code/modules/power/fusion/fusion_particle_catcher.dm
+++ b/code/modules/power/fusion/fusion_particle_catcher.dm
@@ -27,10 +27,10 @@
 /obj/effect/fusion_particle_catcher/proc/UpdateSize()
 	if(parent.size >= mysize)
 		set_density(1)
-		name = "collector [mysize] ON"
+		SetName("collector [mysize] ON")
 	else
 		set_density(0)
-		name = "collector [mysize] OFF"
+		SetName("collector [mysize] OFF")
 
 /obj/effect/fusion_particle_catcher/bullet_act(var/obj/item/projectile/Proj)
 	parent.AddEnergy(Proj.damage)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -123,7 +123,7 @@
 
 	switch (temp_allowed_size)
 		if (STAGE_ONE)
-			name = "gravitational singularity"
+			SetName("gravitational singularity")
 			desc = "A gravitational singularity."
 			current_size = STAGE_ONE
 			icon = 'icons/obj/singularity.dmi'
@@ -140,7 +140,7 @@
 				overlays = "chain_s1"
 			visible_message("<span class='notice'>The singularity has shrunk to a rather pitiful size.</span>")
 		if (STAGE_TWO) //1 to 3 does not check for the turfs if you put the gens right next to a 1x1 then its going to eat them.
-			name = "gravitational singularity"
+			SetName("gravitational singularity")
 			desc = "A gravitational singularity."
 			current_size = STAGE_TWO
 			icon = 'icons/effects/96x96.dmi'
@@ -161,7 +161,7 @@
 				visible_message("<span class='notice'>The singularity has shrunk to a less powerful size.</span>")
 		if (STAGE_THREE)
 			if ((check_turfs_in(1, 2)) && (check_turfs_in(2, 2)) && (check_turfs_in(4, 2)) && (check_turfs_in(8, 2)))
-				name = "gravitational singularity"
+				SetName("gravitational singularity")
 				desc = "A gravitational singularity."
 				current_size = STAGE_THREE
 				icon = 'icons/effects/160x160.dmi'
@@ -182,7 +182,7 @@
 					visible_message("<span class='notice'>The singularity has returned to a safe size.</span>")
 		if(STAGE_FOUR)
 			if ((check_turfs_in(1, 3)) && (check_turfs_in(2, 3)) && (check_turfs_in(4, 3)) && (check_turfs_in(8, 3)))
-				name = "gravitational singularity"
+				SetName("gravitational singularity")
 				desc = "A gravitational singularity."
 				current_size = STAGE_FOUR
 				icon = 'icons/effects/224x224.dmi'
@@ -202,7 +202,7 @@
 				else
 					visible_message("<span class='notice'>Miraculously, the singularity reduces in size, and can be contained.</span>")
 		if(STAGE_FIVE) //This one also lacks a check for gens because it eats everything.
-			name = "gravitational singularity"
+			SetName("gravitational singularity")
 			desc = "A gravitational singularity."
 			current_size = STAGE_FIVE
 			icon = 'icons/effects/288x288.dmi'
@@ -220,7 +220,7 @@
 			else
 				visible_message("<span class='warning'>The singularity miraculously reduces in size and loses its supermatter properties.</span>")
 		if(STAGE_SUPER)//SUPERSINGULO
-			name = "super gravitational singularity"
+			SetName("super gravitational singularity")
 			desc = "A gravitational singularity with the properties of supermatter. <b>It has the power to destroy worlds.</b>"
 			current_size = STAGE_SUPER
 			icon = 'icons/effects/352x352.dmi'

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -58,10 +58,10 @@
 			to_chat(user, "<span class='warning'>The inscription can be at most 20 characters long.</span>")
 		else if(!label_text)
 			to_chat(user, "<span class='notice'>You scratch the inscription off of [initial(BB)].</span>")
-			BB.name = initial(BB.name)
+			BB.SetName(initial(BB.name))
 		else
 			to_chat(user, "<span class='notice'>You inscribe \"[label_text]\" into \the [initial(BB.name)].</span>")
-			BB.name = "[initial(BB.name)] (\"[label_text]\")"
+			BB.SetName("[initial(BB.name)] (\"[label_text]\")")
 	else ..()
 
 /obj/item/ammo_casing/update_icon()

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -25,7 +25,7 @@
 /obj/item/weapon/gun/launcher/pneumatic/New()
 	..()
 	item_storage = new(src)
-	item_storage.name = "hopper"
+	item_storage.SetName("hopper")
 	item_storage.max_w_class = max_w_class
 	item_storage.max_storage_space = max_storage_space
 	item_storage.use_sound = null

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -34,7 +34,7 @@
 		user.put_in_hands(syringe)
 		syringe = null
 		sharp = initial(sharp)
-		name = initial(name)
+		SetName(initial(name))
 		update_icon()
 
 /obj/item/weapon/syringe_cartridge/proc/prime()

--- a/code/modules/projectiles/guns/projectile/detective.dm
+++ b/code/modules/projectiles/guns/projectile/detective.dm
@@ -57,7 +57,7 @@
 		icon_state = choice.icon_state
 		unique_reskin = choice
 		if(!unique_name)
-			name = choice.name
+			SetName(choice.name)
 		to_chat(M, "Your gun is now skinned as \a [choice]. Say hello to your new friend.")
 		return 1
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -68,7 +68,7 @@
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
 
 	if(src && input && !M.stat && in_range(M,src))
-		name = input
+		SetName(input)
 		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
 		return 1
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -105,7 +105,7 @@
 			one_hand_penalty = 0
 			slot_flags &= ~SLOT_BACK	//you can't sling it on your back
 			slot_flags |= (SLOT_BELT|SLOT_HOLSTER) //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally) - or in a holster, why not.
-			name = "sawn-off shotgun"
+			SetName("sawn-off shotgun")
 			desc = "Omar's coming!"
 			to_chat(user, "<span class='warning'>You shorten the barrel of \the [src]!</span>")
 	else

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -67,13 +67,13 @@
 
 				if(M.gender == MALE)
 					H.gender = MALE
-					H.name = pick(GLOB.first_names_male)
+					H.SetName(pick(GLOB.first_names_male))
 				else if(M.gender == FEMALE)
 					H.gender = FEMALE
-					H.name = pick(GLOB.first_names_female)
+					H.SetName(pick(GLOB.first_names_female))
 				else
 					H.gender = NEUTER
-					H.name = pick(GLOB.first_names_female|GLOB.first_names_male)
+					H.SetName(pick(GLOB.first_names_female|GLOB.first_names_male))
 
 				H.name += " [pick(GLOB.last_names)]"
 				H.real_name = H.name

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -36,26 +36,26 @@
 	if(owner.gun_move_icon)
 		if(!(target_permissions & TARGET_CAN_MOVE))
 			owner.gun_move_icon.icon_state = "no_walk0"
-			owner.gun_move_icon.name = "Allow Movement"
+			owner.gun_move_icon.SetName("Allow Movement")
 		else
 			owner.gun_move_icon.icon_state = "no_walk1"
-			owner.gun_move_icon.name = "Disallow Movement"
+			owner.gun_move_icon.SetName("Disallow Movement")
 
 	if(owner.item_use_icon)
 		if(!(target_permissions & TARGET_CAN_CLICK))
 			owner.item_use_icon.icon_state = "no_item0"
-			owner.item_use_icon.name = "Allow Item Use"
+			owner.item_use_icon.SetName("Allow Item Use")
 		else
 			owner.item_use_icon.icon_state = "no_item1"
-			owner.item_use_icon.name = "Disallow Item Use"
+			owner.item_use_icon.SetName("Disallow Item Use")
 
 	if(owner.radio_use_icon)
 		if(!(target_permissions & TARGET_CAN_RADIO))
 			owner.radio_use_icon.icon_state = "no_radio0"
-			owner.radio_use_icon.name = "Allow Radio Use"
+			owner.radio_use_icon.SetName("Allow Radio Use")
 		else
 			owner.radio_use_icon.icon_state = "no_radio1"
-			owner.radio_use_icon.name = "Disallow Radio Use"
+			owner.radio_use_icon.SetName("Disallow Radio Use")
 
 	var/message = "no longer permitted to "
 	var/use_span = "warning"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -176,7 +176,7 @@
 			while (count-- && count >= 0)
 				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
-				P.name = "[name] pill"
+				P.SetName("[name] pill")
 				P.icon_state = "pill"+pillsprite
 				if(P.icon_state in list("pill1", "pill2", "pill3", "pill4", "pill5")) // if using greyscale, take colour from reagent
 					P.color = reagents.get_color()
@@ -191,7 +191,7 @@
 				var/name = sanitizeSafe(input(usr,"Name:","Name your bottle!",reagents.get_master_reagent_name()), MAX_NAME_LEN)
 				var/obj/item/weapon/reagent_containers/glass/bottle/P = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
-				P.name = "[name] bottle"
+				P.SetName("[name] bottle")
 				P.icon_state = bottlesprite
 				reagents.trans_to_obj(P,60)
 				P.update_icon()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -851,7 +851,7 @@
 	T.Uses--
 	if(T.Uses <= 0)
 		T.visible_message("\icon[T]<span class='notice'>\The [T]'s power is consumed in the reaction.</span>")
-		T.name = "used slime extract"
+		T.SetName("used slime extract")
 		T.desc = "This extract has been used up."
 
 //Grey

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -44,12 +44,12 @@
 			to_chat(user, "<span class='notice'>You set the label on \the [src] to '[L]'.</span>")
 
 		label = L
-		name = "[initial(name)] - '[L]'"
+		SetName("[initial(name)] - '[L]'")
 	else
 		if(user)
 			to_chat(user, "<span class='notice'>You clear the label on \the [src].</span>")
 		label = ""
-		name = initial(name)
+		SetName(initial(name))
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/attack_self()
 	..()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -48,9 +48,9 @@
 
 /obj/item/weapon/reagent_containers/proc/update_name_label()
 	if(label_text == "")
-		name = initial(name)
+		SetName(initial(name))
 	else
-		name = "[initial(name)] ([label_text])"
+		SetName("[initial(name)] ([label_text])")
 
 /obj/item/weapon/reagent_containers/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
 	if(!istype(target))

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -95,7 +95,7 @@
 
 	if (reagents.reagent_list.len > 0)
 		var/datum/reagent/R = reagents.get_master_reagent()
-		name = "[base_name] of [R.glass_name ? R.glass_name : "something"]"
+		SetName("[base_name] of [R.glass_name ? R.glass_name : "something"]")
 		desc = R.glass_desc ? R.glass_desc : initial(desc)
 
 		var/list/under_liquid = list()
@@ -128,7 +128,7 @@
 		for(var/k in over_liquid)
 			underlays += image(DRINK_ICON_FILE, src, k, -1)
 	else
-		name = initial(name)
+		SetName(initial(name))
 		desc = initial(desc)
 
 	var/side = "left"

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -93,14 +93,14 @@
 	if(reagents.reagent_list.len > 0)
 		if(base_name)
 			var/datum/reagent/R = reagents.get_master_reagent()
-			name = "[base_name] of [R.glass_name ? R.glass_name : "something"]"
+			SetName("[base_name] of [R.glass_name ? R.glass_name : "something"]")
 			desc = R.glass_desc ? R.glass_desc : initial(desc)
 		if(filling_states)
 			var/image/filling = image(icon, src, "[base_icon][get_filling_state()]")
 			filling.color = reagents.get_color()
 			overlays += filling
 	else
-		name = initial(name)
+		SetName(initial(name))
 		desc = initial(desc)
 
 

--- a/code/modules/reagents/reagent_containers/food/drinks/jar.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/jar.dm
@@ -13,10 +13,10 @@
 /obj/item/weapon/reagent_containers/food/drinks/jar/on_reagent_change()
 	if (reagents.reagent_list.len > 0)
 		icon_state ="jar_what"
-		name = "jar of something"
+		SetName("jar of something")
 		desc = "You can't really tell what this is."
 	else
-		icon_state = "jar"
-		name = "empty jar"
+		icon_state = initial(icon_state)
+		SetName(initial(name))
 		desc = "A jar. You're not sure what it's supposed to hold."
 		return

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -69,8 +69,8 @@
 	T.pixel_y = (ingredients.len * 2)+1
 	overlays += T
 
-	name = lowertext("[fullname] sandwich")
-	if(length(name) > 80) name = "[pick(list("absurd","colossal","enormous","ridiculous"))] sandwich"
+	SetName(lowertext("[fullname] sandwich"))
+	if(length(name) > 80) SetName("[pick(list("absurd","colossal","enormous","ridiculous"))] sandwich")
 	w_class = n_ceil(Clamp((ingredients.len/2),2,4))
 
 /obj/item/weapon/reagent_containers/food/snacks/csandwich/Destroy()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -380,7 +380,7 @@
 		if(prob(30))
 			src.icon_state = "donut2"
 			src.overlay_state = "box-donut2"
-			src.name = "frosted donut"
+			src.SetName("frosted donut")
 			reagents.add_reagent(/datum/reagent/nutriment/sprinkles, 2)
 			center_of_mass = "x=19;y=16"
 
@@ -419,7 +419,7 @@
 		if(prob(30))
 			src.icon_state = "donut2"
 			src.overlay_state = "box-donut2"
-			src.name = "Frosted Chaos Donut"
+			src.SetName("Frosted Chaos Donut")
 			reagents.add_reagent(/datum/reagent/nutriment/sprinkles, 2)
 
 
@@ -438,7 +438,7 @@
 		if(prob(30))
 			src.icon_state = "jdonut2"
 			src.overlay_state = "box-donut2"
-			src.name = "Frosted Jelly Donut"
+			src.SetName("Frosted Jelly Donut")
 			reagents.add_reagent(/datum/reagent/nutriment/sprinkles, 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/slimejelly
@@ -456,7 +456,7 @@
 		if(prob(30))
 			src.icon_state = "jdonut2"
 			src.overlay_state = "box-donut2"
-			src.name = "Frosted Jelly Donut"
+			src.SetName("Frosted Jelly Donut")
 			reagents.add_reagent(/datum/reagent/nutriment/sprinkles, 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly
@@ -474,7 +474,7 @@
 		if(prob(30))
 			src.icon_state = "jdonut2"
 			src.overlay_state = "box-donut2"
-			src.name = "Frosted Jelly Donut"
+			src.SetName("Frosted Jelly Donut")
 			reagents.add_reagent(/datum/reagent/nutriment/sprinkles, 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/egg
@@ -755,7 +755,7 @@
 		for(var/reagent in heated_reagents)
 			reagents.add_reagent(reagent, heated_reagents[reagent])
 		bitesize = 6
-		name = "Warm " + name
+		SetName("Warm " + name)
 		cooltime()
 
 	proc/cooltime()
@@ -764,7 +764,7 @@
 				src.warm = 0
 				for(var/reagent in heated_reagents)
 					src.reagents.del_reagent(reagent)
-				src.name = initial(name)
+				src.SetName(initial(name))
 		return
 
 /obj/item/weapon/reagent_containers/food/snacks/brainburger

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1142,9 +1142,9 @@
 
 	proc/updatename()
 		if(sort_tag)
-			name = "[initial(name)] ([sort_tag])"
+			SetName("[initial(name)] ([sort_tag])")
 		else
-			name = initial(name)
+			SetName(initial(name))
 
 	New()
 		. = ..()
@@ -1359,9 +1359,9 @@
 
 	proc/updatename()
 		if(sortType)
-			name = "[initial(name)] ([sortType])"
+			SetName("[initial(name)] ([sortType])")
 		else
-			name = initial(name)
+			SetName(initial(name))
 
 	proc/updatedir()
 		posdir = dir

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -51,7 +51,7 @@
 				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
 				"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
 				"You hear someone scribbling a note.")
-				name = "[name] ([str])"
+				SetName("[name] ([str])")
 				if(!examtext && !nameset)
 					nameset = 1
 					update_icon()
@@ -176,7 +176,7 @@
 				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
 				"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
 				"You hear someone scribbling a note.")
-				name = "[name] ([str])"
+				SetName("[name] ([str])")
 				if(!examtext && !nameset)
 					nameset = 1
 					update_icon()
@@ -276,16 +276,16 @@
 			if(i in list(1,2,3,4,5))
 				P.icon_state = "deliverycrate[i]"
 				switch(i)
-					if(1) P.name = "tiny parcel"
-					if(3) P.name = "normal-sized parcel"
-					if(4) P.name = "large parcel"
-					if(5) P.name = "huge parcel"
+					if(1) P.SetName("tiny parcel")
+					if(3) P.SetName("normal-sized parcel")
+					if(4) P.SetName("large parcel")
+					if(5) P.SetName("huge parcel")
 			if(i < 1)
 				P.icon_state = "deliverycrate1"
-				P.name = "tiny parcel"
+				P.SetName("tiny parcel")
 			if(i > 5)
 				P.icon_state = "deliverycrate5"
-				P.name = "huge parcel"
+				P.SetName("huge parcel")
 			P.add_fingerprint(usr)
 			O.add_fingerprint(usr)
 			src.add_fingerprint(usr)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -812,5 +812,5 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	req_access = list(access_robotics)
 
 /obj/machinery/computer/rdconsole/core
-	name = "сore fabricator console"
+	name = "?ore fabricator console"
 	id = 1

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -254,23 +254,23 @@
 
 //////////////Containment Field START
 /obj/machinery/shieldwall
-		name = "Shield"
-		desc = "An energy shield."
-		icon = 'icons/effects/effects.dmi'
-		icon_state = "shieldwall"
-		anchored = 1
-		density = 1
-		unacidable = 1
-		light_range = 3
-		var/needs_power = 0
-		var/active = 1
-		var/delay = 5
-		var/last_active
-		var/mob/U
-		var/obj/machinery/shieldwallgen/gen_primary
-		var/obj/machinery/shieldwallgen/gen_secondary
-		var/power_usage = 800	//how much power it takes to sustain the shield
-		var/generate_power_usage = 5000	//how much power it takes to start up the shield
+	name = "Shield"
+	desc = "An energy shield."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "shieldwall"
+	anchored = 1
+	density = 1
+	unacidable = 1
+	light_range = 3
+	var/needs_power = 0
+	var/active = 1
+	var/delay = 5
+	var/last_active
+	var/mob/U
+	var/obj/machinery/shieldwallgen/gen_primary
+	var/obj/machinery/shieldwallgen/gen_secondary
+	var/power_usage = 800	//how much power it takes to sustain the shield
+	var/generate_power_usage = 5000	//how much power it takes to start up the shield
 
 /obj/machinery/shieldwall/New(var/obj/machinery/shieldwallgen/A, var/obj/machinery/shieldwallgen/B)
 	..()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -85,7 +85,7 @@
 /obj/effect/shuttle_landmark/automatic/proc/add_to_sector(var/obj/effect/overmap/O, var/tag_only)
 	if(!istype(O))
 		return
-	name = "[O.name] - [name]"
+	SetName("[O.name] - [name]")
 	if(shuttle_restricted)
 		if(!O.restricted_waypoints[shuttle_restricted])
 			O.restricted_waypoints[shuttle_restricted] = list()
@@ -125,7 +125,7 @@
 	active = 1
 	var/turf/T = get_turf(src)
 	var/obj/effect/shuttle_landmark/automatic/mark = new(T)
-	mark.name = "Beacon signal ([T.x],[T.y])"
+	mark.SetName("Beacon signal ([T.x],[T.y])")
 	if(ismob(loc))
 		var/mob/M = loc
 		M.drop_from_inventory(src,T)

--- a/code/modules/spells/aoe_turf/conjure/conjure.dm
+++ b/code/modules/spells/aoe_turf/conjure/conjure.dm
@@ -51,7 +51,7 @@ How they spawn stuff is decided by behaviour vars, which are explained below
 		else
 			summoned_object = new summoned_object_type(spawn_place)
 		var/atom/movable/overlay/animation = new /atom/movable/overlay(spawn_place)
-		animation.name = "conjure"
+		animation.SetName("conjure")
 		animation.set_density(0)
 		animation.anchored = 1
 		animation.icon = 'icons/effects/effects.dmi'

--- a/code/modules/spells/targeted/equip/dyrnwyn.dm
+++ b/code/modules/spells/targeted/equip/dyrnwyn.dm
@@ -22,7 +22,7 @@
 
 /spell/targeted/equip_item/dyrnwyn/summon_item(var/new_type)
 	var/obj/item/weapon/W = new new_type(null,material)
-	W.name = "\improper Dyrnwyn"
+	W.SetName("\improper Dyrnwyn")
 	W.damtype = BURN
 	W.hitsound = 'sound/items/welder2.ogg'
 	W.slowdown_per_slot[slot_l_hand] = 1

--- a/code/modules/spells/targeted/equip/shield.dm
+++ b/code/modules/spells/targeted/equip/shield.dm
@@ -27,7 +27,7 @@
 	var/obj/item/weapon/shield/I = new new_type()
 	I.icon_state = "buckler"
 	I.color = item_color
-	I.name = "Wizard's Shield"
+	I.SetName("Wizard's Shield")
 	I.base_block_chance = block_chance
 	return I
 

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -24,7 +24,7 @@
 			var/mobloc = get_turf(target.loc)
 			var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
 			var/atom/movable/overlay/animation = new /atom/movable/overlay( mobloc )
-			animation.name = "water"
+			animation.SetName("water")
 			animation.set_density(0)
 			animation.anchored = 1
 			animation.icon = 'icons/mob/mob.dmi'

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -34,7 +34,7 @@
 			if(varName in trans.vars)
 				trans.vars[varName] = newVars[varName]
 
-		trans.name = "[trans.name] ([M])"
+		trans.SetName("[trans.name] ([M])")
 		if(istype(M,/mob/living/carbon/human) && drop_items)
 			for(var/obj/item/I in M.contents)
 				if(istype(I,/obj/item/organ))

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -142,7 +142,7 @@
 	var/obj/effect/overlay/pulse2 = new /obj/effect/overlay(loc)
 	pulse2.icon = 'icons/effects/effects.dmi'
 	pulse2.icon_state = "empdisable"
-	pulse2.name = "emp sparks"
+	pulse2.SetName("emp sparks")
 	pulse2.anchored = 1
 	pulse2.set_dir(pick(GLOB.cardinal))
 

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -34,7 +34,7 @@
 				ping("\The [src] pings, \"New pathogen added to data bank.\"")
 
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src.loc)
-			P.name = "paper - [dish.virus2.name()]"
+			P.SetName("paper - [dish.virus2.name()]")
 
 			var/r = dish.virus2.get_info()
 			P.info = {"
@@ -45,7 +45,7 @@
 "}
 			dish.basic_info = dish.virus2.get_basic_info()
 			dish.info = r
-			dish.name = "[initial(dish.name)] ([dish.virus2.name()])"
+			dish.SetName("[initial(dish.name)] ([dish.virus2.name()])")
 			dish.analysed = 1
 			dish.loc = src.loc
 			dish = null

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -163,7 +163,7 @@
 
 /obj/machinery/computer/centrifuge/proc/print(var/mob/user)
 	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(loc)
-	P.name = "paper - Pathology Report"
+	P.SetName("paper - Pathology Report")
 	P.info = {"
 		[virology_letterhead("Pathology Report")]
 		<large><u>Sample:</u></large> [sample.name]<br>

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -107,17 +107,17 @@
 			d.analysed = analysed
 			if(analysed)
 				if (memorybank)
-					d.name = "[memorybank.name] GNA disk (Stage: [memorybank.stage])"
+					d.SetName("[memorybank.name] GNA disk (Stage: [memorybank.stage])")
 					d.effect = memorybank
 				else if (species_buffer)
-					d.name = "[jointext(species_buffer, ", ")] GNA disk"
+					d.SetName("[jointext(species_buffer, ", ")] GNA disk")
 					d.species = species_buffer
 			else
 				if (memorybank)
-					d.name = "Unknown GNA disk (Stage: [memorybank.stage])"
+					d.SetName("Unknown GNA disk (Stage: [memorybank.stage])")
 					d.effect = memorybank
 				else if (species_buffer)
-					d.name = "Unknown Species GNA disk"
+					d.SetName("Unknown Species GNA disk")
 					d.species = species_buffer
 
 			ping("\The [src] pings, \"Backup disk saved.\"")

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -166,7 +166,7 @@
 	switch (state)
 		if (HOME)
 			if (!sample) return
-			P.name = "paper - Patient Diagnostic Report"
+			P.SetName("paper - Patient Diagnostic Report")
 			P.info = {"
 				[virology_letterhead("Patient Diagnostic Report")]
 				<center><small><font color='red'><b>CONFIDENTIAL MEDICAL REPORT</b></font></small></center><br>
@@ -198,7 +198,7 @@
 "}
 
 		if (LIST)
-			P.name = "paper - Virus List"
+			P.SetName("paper - Virus List")
 			P.info = {"
 				[virology_letterhead("Virus List")]
 "}
@@ -216,7 +216,7 @@
 "}
 
 		if (ENTRY)
-			P.name = "paper - Viral Profile"
+			P.SetName("paper - Viral Profile")
 			P.info = {"
 				[virology_letterhead("Viral Profile")]
 				[entry.fields["description"]]

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -93,7 +93,7 @@
 			var/obj/spawned_obj = new spawn_type(src.loc)
 			if(source_material)
 				if(lentext(source_material.name) < MAX_MESSAGE_LEN)
-					spawned_obj.name = "[source_material] " +  spawned_obj.name
+					spawned_obj.SetName("[source_material] " +  spawned_obj.name)
 				if(lentext(source_material.desc) < MAX_MESSAGE_LEN * 2)
 					if(spawned_obj.desc)
 						spawned_obj.desc += " It is made of [source_material]."

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -83,7 +83,7 @@
 		desc = "This item is completely [pick("alien","bizarre")]."
 
 	//icon and icon_state should have already been set
-	I.name = name
+	I.SetName(name)
 	I.desc = desc
 
 	if(prob(5))
@@ -157,7 +157,7 @@
 		new_item = new /obj/item/weapon/vampiric(loc)
 	else
 		new_item = new(loc)
-	new_item.name = "statuette"
+	new_item.SetName("statuette")
 	new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 	new_item.icon_state = "statuette"
 
@@ -173,7 +173,7 @@
 
 /obj/item/weapon/archaeological_find/instrument/spawn_item()
 	var/obj/item/new_item = new(loc)
-	new_item.name = "instrument"
+	new_item.SetName("instrument")
 	new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 	new_item.icon_state = "instrument"
 	if(prob(30))

--- a/code/modules/xenoarcheaology/finds/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/fossils.dm
@@ -66,7 +66,7 @@
 				icon_state = "skel"
 				src.bstate = 1
 				src.set_density(1)
-				src.name = "alien skeleton display"
+				src.SetName("alien skeleton display")
 				if(src.contents.Find(/obj/item/weapon/fossil/skull/horned))
 					src.desc = "A creature made of [src.contents.len-1] assorted bones and a horned skull. The plaque reads \'[plaque_contents]\'."
 				else

--- a/code/modules/xenoarcheaology/misc.dm
+++ b/code/modules/xenoarcheaology/misc.dm
@@ -4,35 +4,35 @@
 
 /obj/structure/noticeboard/anomaly/New()
 	var/obj/item/weapon/paper/P = new()
-	P.name = "Memo RE: proper analysis procedure"
+	P.SetName("Memo RE: proper analysis procedure")
 	P.info = "<br>We keep test dummies in pens here for a reason, so standard procedure should be to activate newfound alien artifacts and place the two in close proximity. Promising items I might even approve monkey testing on."
 	P.stamped = list(/obj/item/weapon/stamp/rd)
 	P.overlays = list("paper_stamped_rd")
 	src.contents += P
 
 	P = new()
-	P.name = "Memo RE: materials gathering"
+	P.SetName("Memo RE: materials gathering")
 	P.info = "Corasang,<br>the hands-on approach to gathering our samples may very well be slow at times, but it's safer than allowing the blundering miners to roll willy-nilly over our dig sites in their mechs, destroying everything in the process. And don't forget the escavation tools on your way out there!<br>- R.W"
 	P.stamped = list(/obj/item/weapon/stamp/rd)
 	P.overlays = list("paper_stamped_rd")
 	src.contents += P
 
 	P = new()
-	P.name = "Memo RE: ethical quandaries"
+	P.SetName("Memo RE: ethical quandaries")
 	P.info = "Darion-<br><br>I don't care what his rank is, our business is that of science and knowledge - questions of moral application do not come into this. Sure, so there are those who would employ the energy-wave particles my modified device has managed to abscond for their own personal gain, but I can hardly see the practical benefits of some of these artifacts our benefactors left behind. Ward--"
 	P.stamped = list(/obj/item/weapon/stamp/rd)
 	P.overlays = list("paper_stamped_rd")
 	src.contents += P
 
 	P = new()
-	P.name = "READ ME! Before you people destroy any more samples"
+	P.SetName("READ ME! Before you people destroy any more samples")
 	P.info = "how many times do i have to tell you people, these xeno-arch samples are del-i-cate, and should be handled so! careful application of a focussed, concentrated heat or some corrosive liquids should clear away the extraneous carbon matter, while application of an energy beam will most decidedly destroy it entirely - like someone did to the chemical dispenser! W, <b>the one who signs your paychecks</b>"
 	P.stamped = list(/obj/item/weapon/stamp/rd)
 	P.overlays = list("paper_stamped_rd")
 	src.contents += P
 
 	P = new()
-	P.name = "Reminder regarding the anomalous material suits"
+	P.SetName("Reminder regarding the anomalous material suits")
 	P.info = "Do you people think the anomaly suits are cheap to come by? I'm about a hair trigger away from instituting a log book for the damn things. Only wear them if you're going out for a dig, and for god's sake don't go tramping around in them unless you're field testing something, R"
 	P.stamped = list(/obj/item/weapon/stamp/rd)
 	P.overlays = list("paper_stamped_rd")

--- a/code/modules/xenoarcheaology/sampling.dm
+++ b/code/modules/xenoarcheaology/sampling.dm
@@ -128,7 +128,7 @@
 		else
 			//create a new sample bag which we'll fill with rock samples
 			filled_bag = new /obj/item/weapon/evidencebag(src)
-			filled_bag.name = "sample bag"
+			filled_bag.SetName("sample bag")
 			filled_bag.desc = "a bag for holding research samples."
 
 			icon_state = "sampler1"

--- a/code/modules/xenoarcheaology/tools/artifact_analyser.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_analyser.dm
@@ -71,7 +71,7 @@
 
 		src.visible_message("<b>[name]</b> states, \"Scanning complete.\"")
 		var/obj/item/weapon/paper/P = new(src.loc)
-		P.name = "[src] report #[++report_num]"
+		P.SetName("[src] report #[++report_num]")
 		P.info = "<b>[src] analysis report #[report_num]</b><br>"
 		P.info += "<br>"
 		P.info += "\icon[scanned_object] [results]"

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -266,7 +266,7 @@
 	if(scanned_item)
 		//create report
 		var/obj/item/weapon/paper/P = new(src)
-		P.name = "[src] report #[++report_num]: [scanned_item.name]"
+		P.SetName("[src] report #[++report_num]: [scanned_item.name]")
 		P.stamped = list(/obj/item/weapon/stamp)
 		P.overlays = list("paper_stamped")
 

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -41,7 +41,7 @@
 	..()
 	for(var/i = 1 to 7)
 		var/obj/item/weapon/evidencebag/S = new(src)
-		S.name = "sample bag"
+		S.SetName("sample bag")
 		S.desc = "a bag for holding research samples."
 
 /obj/item/device/ano_scanner

--- a/maps/overmap_example/bearcat/bearcat_jobs.dm
+++ b/maps/overmap_example/bearcat/bearcat_jobs.dm
@@ -25,7 +25,7 @@
 	GLOB.using_map.station_name = "FTV [ship]"
 	var/obj/effect/overmap/ship/bearcat/B = locate() in world
 	if(B)
-		B.name = GLOB.using_map.station_name
+		B.SetName(GLOB.using_map.station_name)
 	command_announcement.Announce("Attention all hands on [GLOB.using_map.station_name]! Thank you for your attention.", "Ship re-christened")
 	verbs -= /client/proc/rename_ship
 


### PR DESCRIPTION
 Add the name-set event

Only applicable to /atom, as /datum does not have the name var by default.
SetName() is not required in constructors, because the name cannot (under normal circumstances) be acquired before completion anyway.
Beyond that SetName() should generally always be used, including in /Initialize().

:cl:PsiOmegaDelta
tweak: Labels that have been attached using a hand labeler will now be remain even if the name changes.
add: Attached labels can now be removed using the "Remove Label" verb in the "Object" category.
/:cl: