### PR TITLE
Makes carp shoals less laggy in a probably very dumb way.

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -7,9 +7,9 @@
 	simulated = 0
 	invisibility = 101
 	var/delete_me = 0
-	var/list/my_mobs = list()
 	var/listening
 	var/datum/proximity_trigger/prox_trigger
+	var/list/my_mobs
 
 /obj/effect/landmark/New()
 	..()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -7,6 +7,9 @@
 	simulated = 0
 	invisibility = 101
 	var/delete_me = 0
+	var/list/my_mobs = list()
+	var/listening
+	var/datum/proximity_trigger/prox_trigger
 
 /obj/effect/landmark/New()
 	..()
@@ -75,8 +78,26 @@
 		return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/Destroy()
+	my_mobs = null
 	landmarks_list -= src
+	QDEL_NULL(prox_trigger)
 	return ..()
+
+/obj/effect/landmark/proc/link_a_mob_spawn(var/mob/M)
+	LAZYINITLIST(my_mobs)
+	my_mobs += M
+	STOP_PROCESSING(SSmobs, M)
+	if(!listening)
+		prox_trigger = new(src, /obj/effect/landmark/proc/on_turf_entered,, world.view * 1.5, PROXIMITY_EXCLUDE_HOLDER_TURF)
+
+		listening = 1
+
+/obj/effect/landmark/proc/on_turf_entered(var/atom/movable/AM)
+	if(!(AM in my_mobs) && isliving(AM))
+		listening = 0
+		for(var/mob/M in my_mobs)
+			START_PROCESSING(SSmobs, M)
+		prox_trigger.unregister_turfs()
 
 /obj/effect/landmark/start
 	name = "start"

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -38,13 +38,18 @@
 		var/group_size = rand(group_size_min, group_size_max)
 		if(prob(96))
 			for (var/j = 1, j <= group_size, j++)
-				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp(spawn_locations[i]))
+				for(var/obj/effect/landmark/CS in spawn_locations)
+					var/mob/living/simple_animal/hostile/carp/C = new(CS.loc)
+					spawned_carp.Add(CS.link_a_mob_spawn(C))
 			i++
 		else
 			group_size = max(1,round(group_size/6))
 			group_size = min(spawn_locations.len-i+1,group_size)
 			for(var/j = 1, j <= group_size, j++)
-				spawned_carp.Add(new /mob/living/simple_animal/hostile/carp/pike(spawn_locations[i+j]))
+				for(spawn_locations)
+					var/obj/effect/landmark/PS = spawn_locations[i]
+					var/mob/living/simple_animal/hostile/carp/pike/P = new(PS.loc)
+					spawned_carp.Add(PS.link_a_mob_spawn(P))
 			i += group_size
 
 /datum/event/carp_migration/end()


### PR DESCRIPTION
🆑 
bugfix: Carp Shoals should be less laggy now. The mobs will be inactive until a player comes within a screen and a half of their spawn location.
/ 🆑 

I have no idea if this will actually work.