### PR TITLE
Disables traitor AI. Borgs can stay.

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -3,7 +3,7 @@ var/datum/antagonist/traitor/traitors
 // Inherits most of its vars from the base datum.
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
-	blacklisted_jobs = list(/datum/job/AI) //We have an entire mode for this.
+	blacklisted_jobs = list(/datum/job/ai) //We have an entire mode for this.
 	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -3,6 +3,7 @@ var/datum/antagonist/traitor/traitors
 // Inherits most of its vars from the base datum.
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
+	blacklisted_jobs = list(/datum/job/AI) //We have an entire mode for this.
 	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 


### PR DESCRIPTION
🆑 
rscdel: AIs are now ineligable for traitor. We have a roundtype for this.
/ 🆑 

I'll defend my point in the morning, but to start: Some people have Malf disabled and.  . . Can still get traitor AI. Which, as some people may not know, is basically just a subverted AI. Not Malf. It's just an AI Badman without any of the fun gubbins of Malfunctioning AI. They also steal the round from other traitors.