### PR TITLE
Balance grabs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1571,6 +1571,7 @@
 #include "code\modules\mob\grab\normal\norm_kill.dm"
 #include "code\modules\mob\grab\normal\norm_neck.dm"
 #include "code\modules\mob\grab\normal\norm_passive.dm"
+#include "code\modules\mob\grab\normal\norm_struggle.dm"
 #include "code\modules\mob\language\generic.dm"
 #include "code\modules\mob\language\language.dm"
 #include "code\modules\mob\language\monkey.dm"

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -22,6 +22,7 @@
 
 // Grab levels.
 #define NORM_PASSIVE    "normal passive"
+#define NORM_STRUGGLE   "normal struggle"
 #define NORM_AGGRESSIVE "normal aggressive"
 #define NORM_NECK       "normal neck"
 #define NORM_KILL       "normal kill"
@@ -271,8 +272,8 @@
 #define STASIS_COLD "cold"
 
 #define AURA_CANCEL 1
-#define AURA_FALSE  2 
-#define AURA_TYPE_BULLET "Bullet" 
-#define AURA_TYPE_WEAPON "Weapon" 
-#define AURA_TYPE_THROWN "Thrown" 
+#define AURA_FALSE  2
+#define AURA_TYPE_BULLET "Bullet"
+#define AURA_TYPE_WEAPON "Weapon"
+#define AURA_TYPE_THROWN "Thrown"
 #define AURA_TYPE_LIFE   "Life"

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -249,6 +249,9 @@
 /datum/grab/proc/resolve_openhand_attack(var/obj/item/grab/G)
 	return 0
 
+// Used when you want an effect to happen when the grab enters this state as an upgrade
+/datum/grab/proc/enter_as_up(var/obj/item/grab/G)
+
 /datum/grab/proc/item_attack(var/obj/item/grab/G, var/obj/item)
 
 /datum/grab/proc/resolve_item_attack(var/obj/item/grab/G, var/mob/living/carbon/human/user, var/obj/item/I, var/target_zone)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -150,8 +150,8 @@
 /obj/item/grab/proc/check_upgrade_cooldown()
 	return (world.time >= last_upgrade + current_grab.upgrade_cooldown)
 
-/obj/item/grab/proc/upgrade()
-	if(!check_upgrade_cooldown())
+/obj/item/grab/proc/upgrade(var/bypass_cooldown = FALSE)
+	if(!check_upgrade_cooldown() && !bypass_cooldown)
 		to_chat(assailant, "<span class='danger'>It's too soon to upgrade.</span>")
 		return
 
@@ -161,6 +161,7 @@
 		last_upgrade = world.time
 		adjust_position()
 		update_icons()
+		current_grab.enter_as_up(src)
 
 /obj/item/grab/proc/downgrade()
 	var/datum/grab/downgrab = current_grab.downgrade(src)

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -16,6 +16,9 @@
 	visible_message("<span class='warning'>[assailant] has grabbed [affecting]'s [O.name]!</span>")
 	affecting.grabbed_by += src
 
+	if(!(affecting.a_intent == I_HELP))
+		upgrade(TRUE)
+
 /datum/grab/normal
 	type_name = GRAB_NORMAL
 

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -22,8 +22,10 @@
 /datum/grab/normal/aggressive/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 
-	affecting.drop_l_hand()
-	affecting.drop_r_hand()
+	if(G.target_zone in list(BP_L_HAND, BP_R_HAND))
+		affecting.drop_l_hand()
+		affecting.drop_r_hand()
+		affecting.Stun(3)
 
 	// Keeps those who are on the ground down
 	if(affecting.lying)

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -22,7 +22,7 @@
 
 	break_chance_table = list(3, 18, 45, 100)
 
-/datum/grab/normal/aggressive/process_effect(var/obj/item/grab/G)
+/datum/grab/normal/neck/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 
 	affecting.drop_l_hand()

--- a/code/modules/mob/grab/normal/norm_passive.dm
+++ b/code/modules/mob/grab/normal/norm_passive.dm
@@ -2,7 +2,7 @@
 	state_name = NORM_PASSIVE
 	fancy_desc = "holding"
 
-	upgrab_name = NORM_AGGRESSIVE
+	upgrab_name = NORM_STRUGGLE
 
 	shift = 8
 
@@ -16,8 +16,6 @@
 	icon_state = "reinforce"
 
 	break_chance_table = list(15, 60, 100)
-
-/datum/grab/normal/passive/upgrade_effect(var/obj/item/grab/normal/G)
 
 /datum/grab/normal/passive/on_hit_disarm(var/obj/item/grab/normal/G)
 	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to pin.</span>")

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -1,0 +1,69 @@
+/datum/grab/normal/struggle
+	state_name = NORM_STRUGGLE
+	fancy_desc = "holding"
+
+	upgrab_name = NORM_AGGRESSIVE
+	downgrab_name = NORM_PASSIVE
+
+	shift = 8
+
+	stop_move = 1
+	reverse_facing = 0
+	can_absorb = 0
+	shield_assailant = 0
+	point_blank_mult = 1
+	same_tile = 0
+
+	downgrade_on_action = 1
+	downgrade_on_move = 1
+	can_downgrade_on_resist = 0
+
+	icon_state = "reinforce"
+
+	var/done_struggle = FALSE
+
+	break_chance_table = list(15, 30, 70)
+
+/datum/grab/normal/struggle/enter_as_up(var/obj/item/grab/G)
+	var/mob/living/carbon/human/affecting = G.affecting
+	var/mob/living/carbon/human/assailant = G.assailant
+
+	if(affecting.stat || affecting.a_intent == I_HELP || affecting.lying)
+		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
+		done_struggle = TRUE
+		G.upgrade(TRUE)
+	else
+		affecting.Stun(1)
+		affecting.visible_message("<span class='warning'>[affecting] struggles against [assailant]!</span>")
+		spawn(10)
+			handle_resist(G)
+		if(do_mob(assailant, affecting, upgrade_cooldown, G.target_zone))
+			done_struggle = TRUE
+			G.upgrade(TRUE)
+		else
+			let_go(G)
+
+/datum/grab/normal/struggle/let_go_effect(var/obj/item/grab/G)
+	var/mob/living/carbon/human/affecting = G.affecting
+	var/mob/living/carbon/human/assailant = G.assailant
+	affecting.Stun(1)
+	assailant.Stun(1)
+
+/datum/grab/normal/struggle/can_upgrade(var/obj/item/grab/G)
+	return done_struggle
+
+
+/datum/grab/normal/struggle/on_hit_disarm(var/obj/item/grab/normal/G)
+	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to pin.</span>")
+	return 0
+
+/datum/grab/normal/struggle/on_hit_grab(var/obj/item/grab/normal/G)
+	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to jointlock.</span>")
+	return 0
+
+/datum/grab/normal/struggle/on_hit_harm(var/obj/item/grab/normal/G)
+	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to dislocate.</span>")
+	return 0
+
+/datum/grab/normal/struggle/resolve_openhand_attack(var/obj/item/grab/G)
+	return 0


### PR DESCRIPTION
- resolves #20464
- make affecting resist automatically when not on help intent
- add struggle stage between passive and aggressive
- struggle bypassed when affecting on help intent

🆑 FTangSteve
rscadd: "Upgrading to aggressive or initiating normal grab now enters struggle if victim isn't on help intent."
/🆑

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
