### PR TITLE
Continues Grab Balances and Bug Fixes

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -190,7 +190,7 @@ proc/age2agedescription(age)
 	if (progbar)
 		qdel(progbar)
 
-/proc/do_after(mob/user, delay, atom/target = null, needhand = 1, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT, var/same_direction = 0)
+/proc/do_after(mob/user, delay, atom/target = null, needhand = 1, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT, var/same_direction = 0, var/can_move = 0)
 	if(!user)
 		return 0
 	var/atom/target_loc = null
@@ -218,7 +218,7 @@ proc/age2agedescription(age)
 		if (progress)
 			progbar.update(world.time - starttime)
 
-		if(!user || user.incapacitated(incapacitation_flags) || user.loc != original_loc || (same_direction && user.dir != original_dir))
+		if(!user || user.incapacitated(incapacitation_flags) || (user.loc != original_loc && !can_move) || (same_direction && user.dir != original_dir))
 			. = 0
 			break
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -91,6 +91,9 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		return
 	if(isanimal(user) && O != user)
 		return
+	for (var/obj/item/grab/G in user.grabbed_by)
+		if(G.stop_move())
+			return
 	if (do_after(user, 25 + (5 * user.weakened), incapacitation_flags = ~INCAPACITATION_FORCELYING))
 		step_towards(O, src)
 

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -21,6 +21,7 @@
 	var/downgrade_on_action = 0					// If the grab needs to be downgraded when the grabber does stuff.
 	var/downgrade_on_move = 0					// If the grab needs to be downgraded when the grabber moves.
 	var/force_danger = 0						// If the grab is strong enough to be able to force someone to do something harmful to them.
+	var/restrains = 0							// If the grab acts like cuffs and prevents action from the victim.
 
 	var/grab_slowdown = 7
 
@@ -261,9 +262,14 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
 
+	if(affecting.incapacitated(INCAPACITATION_KNOCKOUT | INCAPACITATION_STUNNED))
+		to_chat(G.assailant, "<span class='warning'>You can't resist in your current state!</span>")
+
 	var/break_strength = breakability + size_difference(affecting, assailant)
 
-	if(affecting.lying)
+	if(affecting.incapacitated(INCAPACITATION_ALL))
+		break_strength--
+	if(affecting.confused)
 		break_strength--
 
 	if(break_strength < 1)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -239,6 +239,9 @@
 /obj/item/grab/proc/assailant_moved()
 	current_grab.assailant_moved(src)
 
+/obj/item/grab/proc/restrains()
+	return current_grab.restrains
+
 /obj/item/grab/proc/resolve_openhand_attack()
 		return current_grab.resolve_openhand_attack(src)
 

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -15,17 +15,17 @@
 	same_tile = 0
 	can_throw = 1
 	force_danger = 1
+	breakability = 3
 
 	icon_state = "reinforce1"
 
-	break_chance_table = list(15, 60, 100)
+	break_chance_table = list(5, 20, 40, 80, 100)
 /datum/grab/normal/aggressive/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 
 	if(G.target_zone in list(BP_L_HAND, BP_R_HAND))
 		affecting.drop_l_hand()
 		affecting.drop_r_hand()
-		affecting.Stun(3)
 
 	// Keeps those who are on the ground down
 	if(affecting.lying)

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -12,6 +12,7 @@
 	point_blank_mult = 1
 	same_tile = 1
 	force_danger = 1
+	restrains = 1
 
 	downgrade_on_action = 1
 	downgrade_on_move = 1
@@ -29,7 +30,6 @@
 	if(affecting.lying)
 		affecting.Weaken(4)
 
-	affecting.Stun(3)
 	affecting.adjustOxyLoss(1)
 
 	affecting.apply_effect(STUTTER, 5) //It will hamper your voice, being choked and all.

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -17,6 +17,7 @@
 	same_tile = 1
 	can_throw = 1
 	force_danger = 1
+	restrains = 1
 
 	icon_state = "kill"
 
@@ -31,5 +32,4 @@
 	if(affecting.lying)
 		affecting.Weaken(4)
 
-	affecting.Stun(3)
 	affecting.adjustOxyLoss(1)

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -10,7 +10,6 @@
 	stop_move = 1
 	reverse_facing = 0
 	can_absorb = 0
-	shield_assailant = 1
 	point_blank_mult = 1
 	same_tile = 0
 	breakability = 3
@@ -31,7 +30,7 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
 
-	if(affecting.incapacitated(INCAPACITATION_ALL) || affecting.a_intent == I_HELP)
+	if(affecting.incapacitated() || affecting.a_intent == I_HELP)
 		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
 		done_struggle = TRUE
 		G.upgrade(TRUE)
@@ -40,7 +39,7 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
 
-	if(affecting.incapacitated(INCAPACITATION_ALL) || affecting.a_intent == I_HELP)
+	if(affecting.incapacitated() || affecting.a_intent == I_HELP)
 		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
 		done_struggle = TRUE
 		G.upgrade(TRUE)

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -10,48 +10,52 @@
 	stop_move = 1
 	reverse_facing = 0
 	can_absorb = 0
-	shield_assailant = 0
+	shield_assailant = 1
 	point_blank_mult = 1
 	same_tile = 0
+	breakability = 3
 
-	downgrade_on_action = 1
-	downgrade_on_move = 1
+	grab_slowdown = 10
+	upgrade_cooldown = 20
+
 	can_downgrade_on_resist = 0
 
 	icon_state = "reinforce"
 
 	var/done_struggle = FALSE
 
-	break_chance_table = list(15, 30, 70)
+	break_chance_table = list(5, 20, 30, 80, 100)
+
+
+/datum/grab/normal/struggle/process_effect(var/obj/item/grab/G)
+	var/mob/living/carbon/human/affecting = G.affecting
+	var/mob/living/carbon/human/assailant = G.assailant
+
+	if(affecting.incapacitated(INCAPACITATION_ALL) || affecting.a_intent == I_HELP)
+		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
+		done_struggle = TRUE
+		G.upgrade(TRUE)
 
 /datum/grab/normal/struggle/enter_as_up(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
 
-	if(affecting.stat || affecting.a_intent == I_HELP || affecting.lying)
+	if(affecting.incapacitated(INCAPACITATION_ALL) || affecting.a_intent == I_HELP)
 		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
 		done_struggle = TRUE
 		G.upgrade(TRUE)
 	else
-		affecting.Stun(1)
 		affecting.visible_message("<span class='warning'>[affecting] struggles against [assailant]!</span>")
 		spawn(10)
 			handle_resist(G)
-		if(do_mob(assailant, affecting, upgrade_cooldown, G.target_zone))
+		if(do_after(assailant, upgrade_cooldown, G, can_move = 1))
 			done_struggle = TRUE
 			G.upgrade(TRUE)
 		else
-			let_go(G)
-
-/datum/grab/normal/struggle/let_go_effect(var/obj/item/grab/G)
-	var/mob/living/carbon/human/affecting = G.affecting
-	var/mob/living/carbon/human/assailant = G.assailant
-	affecting.Stun(1)
-	assailant.Stun(1)
+			G.downgrade()
 
 /datum/grab/normal/struggle/can_upgrade(var/obj/item/grab/G)
 	return done_struggle
-
 
 /datum/grab/normal/struggle/on_hit_disarm(var/obj/item/grab/normal/G)
 	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to pin.</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -177,9 +177,16 @@
 /mob/living/carbon/human/restrained()
 	if (handcuffed)
 		return 1
+	if(grab_restrained())
+		return 1
 	if (istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
 		return 1
 	return 0
+
+/mob/living/carbon/human/proc/grab_restrained()
+	for (var/obj/item/grab/G in grabbed_by)
+		if(G.restrains())
+			return TRUE
 
 /mob/living/carbon/human/var/co2overloadtime = null
 /mob/living/carbon/human/var/temperature_resistance = T0C+75


### PR DESCRIPTION
- Fixes #20500
- Fixes #20495
- Fixes #20475
- Change time of struggle to 2 seconds
- Allow movement during struggle
- Make stunned and unconscious unable to struggle
- Make confuse reduce resist chance
- Make other incap reduce resist chance

🆑 author: FTangSteve
tweak: Makes struggle grab state shorter and causes confusion to make resisting grabs more difficult
/ 🆑
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
