### PR TITLE
Fixes floors not resetting color

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -12,6 +12,7 @@
 	var/base_desc = "The naked hull."
 	var/base_icon = 'icons/turf/flooring/plating.dmi'
 	var/base_icon_state = "plating"
+	var/base_color = COLOR_WHITE
 
 	// Flooring data.
 	var/flooring_override
@@ -25,7 +26,7 @@
 
 /turf/simulated/floor/is_plating()
 	return !flooring
-	
+
 /turf/simulated/floor/protects_atom(var/atom/A)
 	return (A.level <= 1 && !is_plating()) || ..()
 
@@ -52,6 +53,7 @@
 	desc = base_desc
 	icon = base_icon
 	icon_state = base_icon_state
+	color = base_color
 	plane = PLATING_PLANE
 
 	if(flooring)


### PR DESCRIPTION
:cl:
bugfix: Fixes plating being dark when prying off floor tiles.
/:cl:
Floors did not reset their color when prying off flooring.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
