### PR TITLE
Manually reverts "Defaults antag prefs to never"

### DIFF
--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -1,6 +1,5 @@
 /datum/preferences
 	var/list/never_be_special_role
-	var/list/sometimes_be_special_role
 	var/list/be_special_role
 
 /datum/category_item/player_setup_item/antagonism/candidacy
@@ -9,19 +8,15 @@
 
 /datum/category_item/player_setup_item/antagonism/candidacy/load_character(var/savefile/S)
 	from_file(S["be_special"],           pref.be_special_role)
-	from_file(S["sometimes_be_special"], pref.sometimes_be_special_role)
 	from_file(S["never_be_special"],     pref.never_be_special_role)
 
 /datum/category_item/player_setup_item/antagonism/candidacy/save_character(var/savefile/S)
 	to_file(S["be_special"],             pref.be_special_role)
-	to_file(S["sometimes_be_special"],   pref.sometimes_be_special_role)
 	to_file(S["never_be_special"],       pref.never_be_special_role)
 
 /datum/category_item/player_setup_item/antagonism/candidacy/sanitize_character()
 	if(!istype(pref.be_special_role))
 		pref.be_special_role = list()
-	if(!istype(pref.sometimes_be_special_role))
-		pref.sometimes_be_special_role = list()
 	if(!istype(pref.never_be_special_role))
 		pref.never_be_special_role = list()
 
@@ -29,9 +24,6 @@
 	for(var/role in pref.be_special_role)
 		if(!(role in special_roles))
 			pref.be_special_role -= role
-	for(var/role in pref.sometimes_be_special_role)
-		if(!(role in special_roles))
-			pref.sometimes_be_special_role -= role
 	for(var/role in pref.never_be_special_role)
 		if(!(role in special_roles))
 			pref.never_be_special_role -= role
@@ -48,10 +40,10 @@
 			. += "<span class='danger'>\[BANNED\]</span><br>"
 		else if(antag.role_type in pref.be_special_role)
 			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];del_special=[antag.role_type]'>Low</a> <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
-		else if(antag.role_type in pref.sometimes_be_special_role)
-			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
-		else
+		else if(antag.role_type in pref.never_be_special_role)
 			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> <a href='?src=\ref[src];del_special=[antag.role_type]'>Low</a> <span class='linkOn'>Never</span></br>"
+		else
+			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
 		. += "</td></tr>"
 
 	var/list/ghost_traps = get_ghost_traps()
@@ -65,10 +57,10 @@
 			. += "<span class='danger'>\[BANNED\]</span><br>"
 		else if(ghost_trap.pref_check in pref.be_special_role)
 			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Low</a> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
-		else if(ghost_trap.pref_check in pref.sometimes_be_special_role)
-			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
-		else
+		else if(ghost_trap.pref_check in pref.never_be_special_role)
 			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Low</a> <span class='linkOn'>Never</span></br>"
+		else
+			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
 		. += "</td></tr>"
 	. += "</table>"
 	. = jointext(.,null)
@@ -84,7 +76,6 @@
 		if(!(href_list["add_special"] in valid_special_roles()))
 			return TOPIC_HANDLED
 		pref.be_special_role |= href_list["add_special"]
-		pref.sometimes_be_special_role -= href_list["add_special"]
 		pref.never_be_special_role -= href_list["add_special"]
 		return TOPIC_REFRESH
 
@@ -92,13 +83,11 @@
 		if(!(href_list["del_special"] in valid_special_roles()))
 			return TOPIC_HANDLED
 		pref.be_special_role -= href_list["del_special"]
-		pref.sometimes_be_special_role |= href_list["del_special"]
 		pref.never_be_special_role -= href_list["del_special"]
 		return TOPIC_REFRESH
 
 	if(href_list["add_never"])
 		pref.be_special_role -= href_list["add_never"]
-		pref.sometimes_be_special_role -= href_list["add_never"]
 		pref.never_be_special_role |= href_list["add_never"]
 		return TOPIC_REFRESH
 
@@ -126,5 +115,6 @@
 		return FALSE
 	if(role in prefs.be_special_role)
 		return 2
-	if(role in prefs.sometimes_be_special_role)
-		return 1
+	if(role in prefs.never_be_special_role)
+		return FALSE
+	return 1	//Default to "sometimes" if they don't opt-out.


### PR DESCRIPTION
Partial (tweaked) revert of #16301.
Fixes #18673

:cl: Techhead
bugfix: Antag preferences default to Low again instead of Never. Relatedly, your preferences will now longer display Never when they haven't actually been set as such, fixing a bug causing unwilling players to be drafted for antag status.
/:cl: