### PR TITLE
Fixes alarm duplicates

### DIFF
--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -31,7 +31,7 @@
 
 	alarms |= existing
 	alarms_assoc[origin] = existing
-	LAZYADD(alarms_by_z["[existing.alarm_z()]"], existing)
+	LAZYDISTINCTADD(alarms_by_z["[existing.alarm_z()]"], existing)
 	if(new_alarm)
 		alarms = dd_sortedObjectList(alarms)
 		on_alarm_change(existing, ALARM_RAISED)


### PR DESCRIPTION
Since atmos alarms register two alarms per sensor in the same area.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
