### PR TITLE
Camera alarms get cleared upon repair

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,6 +194,7 @@
 				if(stat & BROKEN)
 					assembly.state = 2
 					to_chat(user, "<span class='notice'>You repaired \the [src] frame.</span>")
+					cancelCameraAlarm()
 				else
 					assembly.state = 1
 					to_chat(user, "<span class='notice'>You cut \the [src] free from the wall.</span>")

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -31,7 +31,7 @@
 
 	alarms |= existing
 	alarms_assoc[origin] = existing
-	LAZYADD(alarms_by_z["[existing.alarm_z()]"], existing)
+	LAZYDISTINCTADD(alarms_by_z["[existing.alarm_z()]"], existing)
 	if(new_alarm)
 		alarms = dd_sortedObjectList(alarms)
 		on_alarm_change(existing, ALARM_RAISED)


### PR DESCRIPTION
:cl:
bugfix: Camera alarms get cleared upon repair.
/:cl:
Clears the camera alarm after the welding repair step. It's the last chance to clear the alarm before the camera gets deleted.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
