### PR TITLE
Synthetic eyes prevent hallucinating from SM

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -374,7 +374,8 @@
 		env.merge(removed)
 
 	for(var/mob/living/carbon/human/l in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
-		if(!istype(l.glasses, /obj/item/clothing/glasses/meson))
+		var/obj/item/organ/internal/eyes/E = l.internal_organs_by_name[BP_EYES]
+		if(E && !E.isrobotic() && !istype(l.glasses, /obj/item/clothing/glasses/meson)) //Synthetics eyes stop evil hallucination rays
 			var/effect = max(0, min(200, power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)))) )
 			l.adjust_hallucination(effect, 0.25*effect)
 


### PR DESCRIPTION
:cl: Sbotkin
tweak: Supermatter hallucination does not affect people without eyes or with synthetics eyes.
/:cl: