### PR TITLE
Lowers the ideal character age of stowaways and makes them 1.5x as commonly opened

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -1112,10 +1112,10 @@
 
 	total_positions = 1
 	spawn_positions = 1
-	availablity_chance = 20
+	availablity_chance = 30
 	supervisors = "yourself"
 	selection_color = "#515151"
-	ideal_character_age = 30
+	ideal_character_age = 18
 	minimal_player_age = 7
 	create_record = 0
 	account_allowed = 0


### PR DESCRIPTION
🆑 
tweak: Young characters (<30 years) will no longer lose their chance at the stowaway position 100% of the time to older characters.
tweak: Stowaways are slightly more common.
🆑 

Stowaway is a single slot, limited access job. Don't go around fucking people out of a fun role because they're not applying a character to your 100% arbitrary restriction. Vat grown characters exist, they can be young and quite smart regardless of this. Illegally stowing away on a space ship is not something that is age gated, Christ above, you do not need a COLLEGE DEGREE to be a damn criminal.