### PR TITLE
Adds apprentice spellbook, other minor tweaks

### DIFF
--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -2,6 +2,8 @@
 #define LOCKED 				2
 #define CAN_MAKE_CONTRACTS	4
 #define INVESTABLE			8
+#define STANDARD			16
+#define STUDENT				32
 //spells/spellbooks have a variable for this but as artefacts are literal items they do not.
 //so we do this instead.
 var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
@@ -46,15 +48,24 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 
 /obj/item/weapon/spellbook/attack_self(mob/user as mob)
 	if(user.mind)
-		if(!wizards.is_antagonist(user.mind))
-			to_chat(user, "You can't make heads or tails of this book.")
-			return
-		if(spellbook.book_flags & LOCKED)
-			if(user.mind.special_role == "apprentice")
-				to_chat(user, "<span class='warning'>Drat! This spellbook's apprentice proof lock is on!.</span>")
+		if(spellbook.book_flags & STUDENT)
+			if(user.mind.special_role != "apprentice")
+				if(!wizards.is_antagonist(user.mind))
+					to_chat(user, "You can't make heads or tails of this book.")
+					return
+				else
+					to_chat(user, "This spellbook is simple and basic, there is nothing you can learn from it.")
+					return
+		if(spellbook.book_flags & STANDARD)
+			if(!wizards.is_antagonist(user.mind))
+				to_chat(user, "You can't make heads or tails of this book.")
 				return
-			else
-				to_chat(user, "You notice the apprentice proof lock is on. Luckily you are beyond such things and can open it anyways.")
+			if(spellbook.book_flags & LOCKED)
+				if(user.mind.special_role == "apprentice")
+					to_chat(user, "<span class='warning'>Drat! This spellbook's apprentice proof lock is on!.</span>")
+					return
+				else
+					to_chat(user, "You notice the apprentice proof lock is on. Luckily you are beyond such things and can open it anyways.")
 
 	interact(user)
 
@@ -293,7 +304,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 	var/desc = "The legendary book of spells of the wizard."
 	var/book_desc = "Holds information on the various tomes available to a wizard"
 	var/feedback = "" //doesn't need one.
-	var/book_flags = NOREVERT
+	var/book_flags = NOREVERT|STANDARD
 	var/max_uses = 1
 	var/title = "Book of Tomes"
 	var/title_desc = "This tome marks down all the available tomes for use. Choose wisely, there are no refunds."

--- a/code/modules/spells/spellbook/battlemage.dm
+++ b/code/modules/spells/spellbook/battlemage.dm
@@ -7,7 +7,7 @@
 	book_desc = "Mix physical with the mystical in head to head combat."
 	title = "The Art of Magical Combat"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE|STANDARD
 	max_uses = 6
 
 	spells = list(/spell/targeted/projectile/dumbfire/passage = 	1,

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -9,7 +9,7 @@
 	book_desc = "All about healing. Mobility and offense comes at a higher price but not impossible."
 	title = "Cleric's Tome of Healing"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE|STANDARD
 	max_uses = 7
 
 	spells = list(/spell/targeted/heal_target/major = 				1,
@@ -23,10 +23,10 @@
 				/spell/radiant_aura =								1,
 				/spell/targeted/equip_item/holy_relic = 			1,
 				/spell/aoe_turf/conjure/grove/sanctuary = 			1,
-				/spell/targeted/projectile/dumbfire/fireball = 		2,
 				/spell/area_teleport = 								2,
 				/spell/aoe_turf/conjure/forcewall = 				1,
 				/spell/noclothes = 									1,
+				/obj/item/weapon/gun/energy/staff/focus = 			2,
 				/obj/item/weapon/magic_rock = 						1,
 				/obj/structure/closet/wizard/scrying = 				2,
 				/obj/item/weapon/contract/wizard/telepathy = 		1,

--- a/code/modules/spells/spellbook/druid.dm
+++ b/code/modules/spells/spellbook/druid.dm
@@ -10,17 +10,18 @@
 	book_desc = "Summons, nature, and a bit o' healin."
 	title = "Druidic Guide on how to be smug about nature"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE|STANDARD
 	max_uses = 6
 
 	spells = list(/spell/targeted/heal_target = 					1,
-				/spell/targeted/heal_target/sacrifice = 			1,
+				/spell/targeted/shapeshift/baleful_polymorph = 		1,
 				/spell/aoe_turf/conjure/mirage = 					1,
 				/spell/aoe_turf/conjure/summon/bats = 				1,
 				/spell/aoe_turf/conjure/summon/bear = 				1,
 				/spell/targeted/equip_item/party_hardy = 			1,
 				/spell/targeted/equip_item/seed = 					1,
 				/spell/targeted/shapeshift/avian = 					1,
+				/spell/targeted/heal_target/major = 				2,
 				/spell/aoe_turf/disable_tech = 						1,
 				/spell/hand/charges/entangle = 						1,
 				/spell/aoe_turf/conjure/grove/sanctuary = 			1,

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -10,7 +10,7 @@
 	book_desc = "Movement and teleportation. Run from your problems!"
 	title = "Manual of Spatial Transportation"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
-	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE|STANDARD
 	max_uses = 11
 
 	spells = list(/spell/targeted/ethereal_jaunt = 				1,
@@ -24,7 +24,7 @@
 				/spell/targeted/heal_target = 					1,
 				/spell/aoe_turf/conjure/forcewall = 			1,
 				/spell/aoe_turf/smoke = 						1,
-				/spell/aoe_turf/conjure/summon/bats = 			3,
+				/spell/aoe_turf/conjure/summon/bats = 			1,
 				/spell/noclothes = 								1,
 				/obj/item/weapon/contract/wizard/tk = 			5,
 				/obj/item/weapon/dice/d20/cursed = 				1,

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -9,7 +9,7 @@
 	title = "Book of Spells and Artefacts"
 	title_desc = "Buy spells using your available spell slots. Artefacts may also be bought however their cost is permanent."
 	book_desc = "A general wizard's spellbook. All its spells are easy to use but hard to master."
-	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
+	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE|STANDARD
 	max_uses = 6
 
 	spells = list(/spell/targeted/projectile/magic_missile = 			1,

--- a/code/modules/spells/spellbook/student.dm
+++ b/code/modules/spells/spellbook/student.dm
@@ -10,12 +10,20 @@
 	book_desc = "This spellbook is dedicated to teaching neophytes in the ways of magic."
 	title = "Book of Spells and Education"
 	title_desc = "Hello. Congratulations on becoming a wizard. You may be asking yourself: What? A wizard? Already? Of course! Anybody can become a wizard! Learning to be a good one is the hard part.<br>Without further adue, let us begin by learning the three concepts of wizardry, 'Spell slots', 'Spells', and 'Artifacts'.<br>Firstly lets try to understand the 'spell slot'. A spell slot is the measurable amount of spells and artifacts one tome can give. Most spells will only take up a singular spell slot, however more powerful spells/artifacts can take up more.<br>Spells are spells. They can have requirements, such as wizard garb, and most can be upgraded by purchasing additional spell slots for them. Most upgrades fall into two categories, 'Speed' and 'Power'. Speed upgrades decrease the time you have to spend recharging your spell. Power increases the potency of your spells. Spells are also special in that they can be refunded while inside the Wizard Acadamy, so if you want to test a spell out before moving out into the field, feel free to do that in the comfort of our home.<br>Artifacts, or 'Artefacts' as we call them, are powerful wizard tools or items made specially for wizards everywhere. Extremely potent, they cannot be refunded like spells, and some of them can be used by non-wizards, so be careful!<br>Knowing these three concepts puts you in a league above most wizards, however knowledge of spells is just as important so we've included a list of spells below made specifically for the beginning wizard. Take all of them, or mix and match, remember being creative is half of being a wizard!"
-	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE
-	max_uses = 5
+	book_flags = NOREVERT|INVESTABLE|STUDENT
+	max_uses = 3
 
 	spells = list(/spell/aoe_turf/knock = 						1,
+				/spell/targeted/heal_target = 					1,
+				/spell/targeted/projectile/dumbfire/passage = 	1,
+				/spell/aoe_turf/conjure/summon/bats = 			1,
+				/spell/aoe_turf/smoke = 						1,
+				/spell/targeted/projectile/dumbfire/fireball = 	2,
 				/spell/targeted/ethereal_jaunt = 				1,
 				/spell/targeted/projectile/magic_missile = 		1,
+				/spell/aoe_turf/conjure/forcewall = 			1,
+				/spell/targeted/genetic/blind = 				1,
 				/obj/item/weapon/gun/energy/staff/focus = 		1,
+				/obj/item/weapon/contract/wizard/telepathy = 	1,
 				/obj/item/weapon/contract/wizard/xray = 		1
 					)

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -16,6 +16,7 @@
 
 	amt_dam_brute = -15
 	amt_dam_fire = -5
+	amt_blood  = 14
 
 	message = "You feel a pleasant rush of heat move through your body."
 
@@ -51,9 +52,9 @@
 	amt_blood  = 28
 	amt_organ = 5
 	amt_brain  = -5
-	amt_radiation  = -25
-	amt_dam_tox = -20
-	amt_dam_oxy = -14
+	amt_radiation  = -50
+	amt_dam_tox = -10
+	amt_dam_oxy = -7
 	amt_dam_brute = -35
 	amt_dam_fire  = -35
 
@@ -74,6 +75,7 @@
 
 	amt_dam_brute = -25
 	amt_dam_fire = -25
+	amt_blood  = 14
 
 /spell/targeted/heal_target/area/empower_spell()
 	if(!..())
@@ -110,7 +112,7 @@
 
 	amt_organ = 25
 	amt_brain  = -25
-	amt_radiation  = -100
+	amt_radiation  = -200
 
 
 

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -11,7 +11,7 @@
 	invocation_type = SpI_SHOUT
 	range = 20
 
-	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 0, Sp_POWER = 5)
+	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 0, Sp_POWER = 3)
 
 	spell_flags = 0
 

--- a/code/modules/spells/targeted/swap.dm
+++ b/code/modules/spells/targeted/swap.dm
@@ -1,12 +1,10 @@
 /spell/targeted/swap
-	name = "swap"
-	desc = "This spell swaps the positions of the wizard and a target. Causes brain damage."
+	name = "Swap"
+	desc = "This spell swaps the positions of the wizard and a target."
 	feedback = "SW"
 	school = "conjuration"
 
 	charge_type = Sp_HOLDVAR
-	holder_var_type = "brainloss"
-	holder_var_amount = 10
 
 	invocation = "Joyo!"
 	invocation_type = SpI_WHISPER


### PR DESCRIPTION
:cl: Novacat
   spellcheck: Fixed capitalization issue with Swap
   tweak: Reduced maximum fireball power upgrades to 3 from 5
   rscadd: Added new Student Spellbook that will automatically spawn for apprentices.
   tweak: Staves are now a bit more concealable.
   tweak: Cleric lost fireball and gained focus staff.
   tweak: Druid lost sacrifice and gained baleful polymorph and cure major wounds.
   tweak: Summoning bats is now cheaper for Spatial
   tweak: Swap no longer causes brain damage to the user.
   tweak: Cure Major Wounds is less effective at healing organs
   tweak: Cure minor wounds and Cure area now replenishes a small amount of blood (2.5% per cast)
   tweak: Boosted effects of sacrifice and cure major wounds on radiation
   /:cl: