### PR TITLE
Adds support for away mission jobs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -695,6 +695,7 @@
 #include "code\game\objects\auras\radiant_aura.dm"
 #include "code\game\objects\auras\personal_shields\personal_shield.dm"
 #include "code\game\objects\effects\aliens.dm"
+#include "code\game\objects\effects\awayjob.dm"
 #include "code\game\objects\effects\bump_teleporter.dm"
 #include "code\game\objects\effects\effect_system.dm"
 #include "code\game\objects\effects\explosion_particles.dm"

--- a/code/_global_vars/lists/locations.dm
+++ b/code/_global_vars/lists/locations.dm
@@ -17,3 +17,4 @@ GLOBAL_LIST_EMPTY(prisonsecuritywarp) // Prison security goes to these.
 GLOBAL_LIST_EMPTY(prisonwarped) // List of players already warped.
 
 GLOBAL_LIST_EMPTY(awaydestinations) // Away missions. A list of landmarks that the warpgate can take you to.
+GLOBAL_LIST_EMPTY(awayjobs) //away mission jobs

--- a/code/game/objects/effects/awayjob.dm
+++ b/code/game/objects/effects/awayjob.dm
@@ -1,0 +1,48 @@
+/obj/effect/awayjob
+	anchored = 1
+	desc = "Clicking on this will turn you into a controllable human"
+	name = "away job"
+	icon = 'icons/obj/rune.dmi'
+	icon_state = "golem"
+	invisibility = INVISIBILITY_OBSERVER
+	unacidable = 1
+	plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	layer = ABOVE_LIGHTING_LAYER
+	var/inuse = FALSE
+
+/obj/effect/awayjob/Initialize()
+	. = ..()
+	GLOB.awayjobs.Add(src)
+
+
+/obj/effect/awayjob/attack_ghost(var/mob/observer/ghost/user)
+	if(inuse)
+		to_chat(user, "<span class='notice'> Another observer is currently using this.</span>")
+		return
+	inuse = TRUE
+	var/response = alert(user, "Are you sure you wish to become [src]? Contact with other players is not guaranteed", "Take control [src]", "Yes", "No")
+	if(response == "Yes")
+		var/mob/living/carbon/human/G = new(src.loc)
+		G.ckey = user.ckey
+		prepare(G)
+		qdel(src)
+	else
+		inuse = FALSE
+	return
+
+// Up to mappers to decide how to overload this function with their own stuff.
+/obj/effect/awayjob/proc/prepare(var/mob/living/carbon/human/H)
+	var/list/valid_species = list(SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_HUMAN,SPECIES_VOX)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/syndicate(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/silenced(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/swat(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(H), slot_glasses)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/syndicate(H), slot_wear_mask)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box(H), slot_in_backpack)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/box/c45(H), slot_in_backpack)
+	H.equip_to_slot_or_del(new /obj/item/weapon/rig/merc(H), slot_back)
+	H.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse_rifle(H), slot_r_hand)
+	H.equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(H), slot_l_hand)
+	H.change_appearance(APPEARANCE_ALL, H.loc, H, valid_species, state = GLOB.z_state)
+	to_chat(H, "<b> You are playing an off-station role. Use your surroundings to your advantage, and create good roleplay. REMEMBER: Server rules still apply.")
+

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -96,6 +96,17 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 			if(istype(target))
 				ManualFollow(target)
 
+	else if(href_list["playercoordteleport"])
+		var/x = text2num(href_list["X"])
+		var/y = text2num(href_list["Y"])
+		var/z = text2num(href_list["Z"])
+		sleep(2)
+		var/turf/T = locate(x, y, z)
+		if(T)
+			ghost_to_turf(T)
+		else
+			to_chat(src, "<span class='warning'>Invalid coordinates.</span>")
+
 /*
 Transfer_mind is there to check if mob is being deleted/not going to have a body.
 Works together with spawning an observer, noted above.
@@ -208,6 +219,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	mind.current.reload_fullscreen()
 	if(!admin_ghosted)
 		announce_ghost_joinleave(mind, 0, "They now occupy their body again.")
+	return 1
+
+/mob/observer/ghost/verb/check_awayjobs()
+	set category = "Ghost"
+	set name = "Find away-site jobs"
+	if(!client)
+		return
+	to_chat(src, "<span class='notice'> Located [GLOB.awayjobs.len] away jobs.")
+	for(var/obj/effect/awayjob/T in GLOB.awayjobs)
+		to_chat(src, "<span class='notice'>Off-station job located at [T.loc.loc] <a href='byond://?src=\ref[src];playercoordteleport=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JUMP)</a></span>")
 	return 1
 
 /mob/observer/ghost/verb/toggle_medHUD()

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -40,3 +40,18 @@
 /obj/effect/shuttle_landmark/nav_yacht/nav4
 	name = "Small Yacht Navpoint #4"
 	landmark_tag = "nav_yacht_antag"
+
+/obj/effect/awayjob/yacht
+	desc = "Clicking on this will turn you into this ship's captain."
+	name = "yacht captain"
+
+/obj/effect/awayjob/yacht/prepare(var/mob/living/carbon/human/H)
+	var/list/valid_species = list(SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_HUMAN,SPECIES_VOX)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/tan(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box(H), slot_in_backpack)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/leather(H), slot_back)
+	H.change_appearance(APPEARANCE_ALL, H.loc, H, valid_species, state = GLOB.z_state)
+	to_chat(H, "<i>You wake up at the controls of a small vessle. Who knows what kind of incompetence led you to fall asleep at the wheel. In fact you don't quite remember how you got here in the first place.")
+	to_chat(H, "<b> You are playing an off-station role. Use your surroundings to your advantage, and create good roleplay. You may shred the papers scattered about, in order to create your own version of the events. REMEMBER: Server rules still apply.")
+	to_chat(H, "<span class='warning'>You hear creepy skittering around the hull of your ship.</span>")

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -10,11 +10,7 @@
 "aj" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/computer/sensors,/turf/simulated/floor/wood,/area/yacht/bridge)
 "ak" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/bed/chair/comfy/captain,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
 "al" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/computer/engines,/turf/simulated/floor/wood,/area/yacht/bridge)
-"am" = (/obj/item/weapon/folder/blue,/obj/item/weapon/form_printer,/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/coffeecup,/obj/item/weapon/newspaper,/obj/effect/spider/stickyweb,/obj/effect/decal/cleanable/dirt,/obj/random/energy,/obj/item/weapon/paper{info = "I used up all of my energy. I am hopelessly lost. This ship has become my grave. They did it. The intelligence agency that no one ever talks about. Sol Gov wanted their revenge, and they got it. They easily could have killed me on my ship, or tortured me, but they knew that floating here through space would be the worst possible torture. "},/turf/simulated/floor/wood,/area/yacht/bridge)
-"an" = (/obj/machinery/atmospherics/unary/vent_pump/on,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/decal/cleanable/dirt,/mob/living/simple_animal/hostile/giant_spider/hunter,/turf/simulated/floor/wood,/area/yacht/bridge)
 "ao" = (/obj/effect/decal/cleanable/dirt,/obj/random/maintenance/clean,/turf/simulated/floor/wood,/area/yacht/bridge)
-"ap" = (/obj/structure/filingcabinet/chestdrawer,/obj/effect/decal/cleanable/cobweb2,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
-"aq" = (/obj/machinery/light{dir = 8},/obj/structure/safe,/obj/item/weapon/reagent_containers/pill/cyanide,/obj/item/weapon/rig/medical/equipped,/obj/item/weapon/gun/energy/captain,/obj/effect/spider/stickyweb,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
 "ar" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
 "as" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
 "at" = (/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 2; name = "Yacht bridge"; pixel_x = 0; pixel_y = -24},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
@@ -113,10 +109,6 @@
 "cm" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/light/small{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
 "cn" = (/obj/machinery/atmospherics/pipe/simple/hidden/universal{icon_state = "map_universal"; dir = 4},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
 "co" = (/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{dir = 4},/obj/effect/decal/cleanable/dirt,/obj/machinery/portable_atmospherics/powered/pump,/turf/simulated/floor/plating,/area/yacht/engine)
-"cp" = (/obj/structure/cable{icon_state = "0-2"; dir = 4; pixel_y = 0; d1 = 16; d2 = 0},/obj/effect/decal/cleanable/ash,/obj/effect/decal/cleanable/blood/oil/streak,/obj/effect/decal/cleanable/generic,/obj/effect/decal/cleanable/molten_item,/turf/simulated/floor/airless{icon_state = "dmg2"},/area/yacht/engine)
-"cq" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/item/weapon/circuitboard/broken,/turf/simulated/floor/airless{icon_state = "dmg2"},/area/yacht/engine)
-"cr" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/item/weapon/storage/toolbox/syndicate,/turf/simulated/floor/airless{icon_state = "dmg2"},/area/yacht/engine)
-"cs" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/item/weapon/plastique,/turf/simulated/floor/airless,/area/yacht/engine)
 "ct" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless,/area/yacht/engine)
 "cu" = (/obj/effect/decal/cleanable/dirt,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless,/area/yacht/engine)
 "cC" = (/obj/structure/cable,/obj/machinery/power/apc{dir = 8; name = "Yacht living"; pixel_x = -24},/obj/machinery/portable_atmospherics/hydroponics,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/living)
@@ -159,7 +151,6 @@
 "ds" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/obj/structure/closet/crate/medical,/obj/effect/decal/cleanable/dirt,/obj/machinery/meter,/turf/simulated/floor/plating,/area/yacht/engine)
 "dt" = (/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 10},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
 "du" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; layer = 2.4; level = 2},/obj/structure/closet/secure_closet/freezer/meat,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
-"dv" = (/obj/machinery/atmospherics/pipe/simple/visible/black,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
 "dw" = (/obj/machinery/atmospherics/unary/heater{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
 "dx" = (/turf/simulated/floor/reinforced/carbon_dioxide,/area/yacht/engine)
 "dy" = (/obj/machinery/light/small{dir = 4; pixel_y = 8},/obj/structure/closet/secure_closet/freezer/meat,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/yacht/engine)
@@ -189,6 +180,13 @@
 "tb" = (/obj/structure/closet/firecloset,/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/plating,/area/yacht/engine)
 "ub" = (/obj/effect/decal/cleanable/dirt,/obj/random/closet,/turf/simulated/floor/plating,/area/yacht/engine)
 "vb" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/item/weapon/storage/firstaid,/obj/effect/decal/cleanable/dirt,/obj/random/closet,/turf/simulated/floor/plating,/area/yacht/engine)
+"wb" = (/obj/item/weapon/folder/blue,/obj/item/weapon/form_printer,/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/coffeecup,/obj/item/weapon/newspaper,/obj/effect/spider/stickyweb,/obj/effect/decal/cleanable/dirt,/obj/random/energy,/obj/item/weapon/paper{info = "I used up all of my energy. I am hopelessly lost. This ship has become my grave. They did it. The intelligence agency that no one ever talks about. Sol Gov wanted their revenge, and they got it. They easily could have killed me on my ship, or tortured me, but they knew that floating here through space would be the worst possible torture. "},/obj/item/weapon/gun/energy/captain,/turf/simulated/floor/wood,/area/yacht/bridge)
+"xb" = (/obj/machinery/atmospherics/unary/vent_pump/on,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/decal/cleanable/dirt,/obj/effect/awayjob/yacht,/turf/simulated/floor/wood,/area/yacht/bridge)
+"yb" = (/obj/effect/decal/cleanable/cobweb2,/obj/effect/decal/cleanable/dirt,/obj/machinery/papershredder,/turf/simulated/floor/wood,/area/yacht/bridge)
+"zb" = (/obj/machinery/light{dir = 8},/obj/structure/safe,/obj/item/weapon/reagent_containers/pill/cyanide,/obj/item/weapon/rig/medical/equipped,/obj/effect/spider/stickyweb,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/yacht/bridge)
+"Ab" = (/obj/structure/cable{icon_state = "0-2"; dir = 4; pixel_y = 0; d1 = 16; d2 = 0},/obj/effect/decal/cleanable/ash,/obj/effect/decal/cleanable/blood/oil/streak,/obj/effect/decal/cleanable/generic,/obj/effect/decal/cleanable/molten_item,/obj/machinery/power/tracker,/turf/simulated/floor/airless{icon_state = "dmg2"},/area/yacht/engine)
+"Bb" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless{icon_state = "dmg2"},/area/yacht/engine)
+"Cb" = (/obj/machinery/atmospherics/binary/pump,/turf/simulated/floor/plating,/area/yacht/engine)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -218,8 +216,8 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadacaeacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagaaaaaaaaaaaaaaaaaaaaaaaaaaaaahacaiacahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahahajakalahahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahamaeanaoapahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahahaqarasatauahahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahwbaexbaoybahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahahzbarasatauahahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahavavavawaxaxayazaAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaBaCaDavaEaFaGaHaBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaBaBaIaJavaKaLaMaNaOaBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -234,13 +232,13 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNbNbNbNbNbNavbOaBavbPbQbNbRbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNbSbTbUbVbNbWaEbXbYbPbZcacbbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaccccccccccccccccccccccccccccccccccccccccfbbNbNbNgbcehbibchcicjckclbPcmcncobNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacpcqcrcsctctctctctctctctctctctctctctctctctcujbkblbmbnbobpbbNcCcDcEcFbPcGcHqbcJcKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAbBbBbctctctctctctctctctctctctctctctctctctcujbkblbmbnbobpbbNcCcDcEcFbPcGcHqbcJcKaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacLcLcLcLcLcLcLcLcLcLcLcLcLcLcLcLcLcLcLcLaabNbNbNrbcNsbtbbNcQcRcEcSbPcTubvbbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNbNbNcObNbNcWcXbNbNbNcYbNbNbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNbNcZdadbbNdcddbNdedfcTdgbNbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNbNdhdibNdjdjbNdkdldmbNbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNbNdndodpdqdrdpdsdtdubNbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNdvdwbNdxdxbNdwdvdybNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNCbdwbNdxdxbNdwCbdybNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNdzdAbNdxdxbNdBdCdDbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNdEdEbNbNbNbNbNdEdEbNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Adds a decently dynamic support for away mission jobs. This commit includes an away mission job for the Yacht. Away mission jobs can be used by any ghost by using the "Find away-site jobs" verb. This will allow you to jump to any active away site jobs and join. The position is deleted as soon as someone joins, so this won't cause everyone to have a party at the Yacht while the Torch has 3 players. So far this only has support for the Yacht, but more can be added by mappers at will. 


Thank you to all of coder discord for this PR. I couldn't have done this without all of the help/support. 
Thank you to gentlefood for inspiration for Yacht wake up message. 
:cl: 
rscadd: Away mission playable character support has been added to the codebase. Ghosts/observers can find said playable characters by clicking on the newly added ghost verb, clicking jump, and clicking on the rune. 
rscadd: So far, only one away mission exists at the yacht captain. This will of course only be available while the yacht is one of the away missions that was generated. More to be added later(tm). 
/:cl: