### PR TITLE
Fixes ducttape not being able to be picked up

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -82,9 +82,12 @@
 	icon_state = "tape"
 	w_class = ITEM_SIZE_TINY
 	layer = ABOVE_OBJ_LAYER
-	anchored = 1 //it's sticky, no you cant move it
 
 	var/obj/item/weapon/stuck = null
+
+/obj/item/solar_assembly/attack_hand(var/mob/user)
+	anchored = FALSE // Unattach it from whereever it's on, if anything.
+	return ..()
 
 /obj/item/weapon/ducttape/Initialize()
 	. = ..()
@@ -95,6 +98,7 @@
 
 /obj/item/weapon/ducttape/proc/attach(var/obj/item/weapon/W)
 	stuck = W
+	anchored = TRUE
 	W.forceMove(src)
 	icon_state = W.icon_state + "_taped"
 	name = W.name + " (taped)"


### PR DESCRIPTION
:cl:
bugfix: Fixes ducttape not being able to be picked up.
/:cl:

Fixes #20599

Perhaps someone has a better idea than overwriting `proc/Move` though.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
