### PR TITLE
Access codes no longer random but choosable in decrypter

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -14,6 +14,7 @@
 	var/running = FALSE
 	var/progress = 0
 	var/target_progress = 300
+	var/datum/access/target_access = null
 
 /datum/computer_file/program/access_decrypter/kill_program(var/forced)
 	reset()
@@ -40,12 +41,12 @@
 	progress += CPU.max_idle_programs
 	if(progress >= target_progress)
 		reset()
-		var/datum/access/A = get_access_by_id(pick(get_all_station_access()))
-		RFID.stored_card.access |= A.id
+		RFID.stored_card.access |= target_access.id
 		if(ntnet_global.intrusion_detection_enabled)
-			ntnet_global.add_log("IDS WARNING - Unauthorised access to primary keycode database from device: [computer.network_card.get_network_tag()]  - downloaded access codes for: [A.desc].")
+			ntnet_global.add_log("IDS WARNING - Unauthorised access to primary keycode database from device: [computer.network_card.get_network_tag()]  - downloaded access codes for: [target_access.desc].")
 			ntnet_global.intrusion_detection_alarm = 1
-		message = "Successfully decrypted and saved operational key codes. Downloaded access codes for: [A.desc]"
+		message = "Successfully decrypted and saved operational key codes. Downloaded access codes for: [target_access.desc]"
+		target_access = null
 
 /datum/computer_file/program/access_decrypter/Topic(href, href_list)
 	if(..())
@@ -56,6 +57,8 @@
 	if(href_list["PRG_execute"])
 		if(running)
 			return 1
+		if(text2num(href_list["allowed"]))
+			return 1
 		var/obj/item/weapon/computer_hardware/processor_unit/CPU = computer.processor_unit
 		var/obj/item/weapon/computer_hardware/card_slot/RFID = computer.card_slot
 		if(!istype(CPU) || !CPU.check_functionality() || !istype(RFID) || !RFID.check_functionality())
@@ -65,6 +68,7 @@
 			message = "RFID card is not present in the device. Operation aborted."
 			return
 		running = TRUE
+		target_access = get_access_by_id(text2num(href_list["PRG_execute"]))
 		if(ntnet_global.intrusion_detection_enabled)
 			ntnet_global.add_log("IDS WARNING - Unauthorised access attempt to primary keycode database from device: [computer.network_card.get_network_tag()]")
 			ntnet_global.intrusion_detection_alarm = 1
@@ -72,6 +76,7 @@
 
 /datum/nano_module/program/access_decrypter
 	name = "NTNet Access Decrypter"
+	var/list/restricted_access_codes = list(access_change_ids, access_network) // access codes that are not hackable due to balance reasons
 
 /datum/nano_module/program/access_decrypter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	if(!ntnet_global)
@@ -97,6 +102,23 @@
 				string = "[string][prob(percentage)]"
 			strings.Add(string)
 		data["dos_strings"] = strings
+	else if(program.computer.card_slot && program.computer.card_slot.stored_card)
+		var/obj/item/weapon/card/id/id_card = program.computer.card_slot.stored_card
+		var/list/regions = list()
+		for(var/i = 1; i <= 7; i++)
+			var/list/accesses = list()
+			for(var/access in get_region_accesses(i))
+				if (get_access_desc(access))
+					accesses.Add(list(list(
+						"desc" = replacetext(get_access_desc(access), " ", "&nbsp"),
+						"ref" = access,
+						"allowed" = (access in id_card.access) ? 1 : 0,
+						"blocked" = (access in restricted_access_codes) ? 1 : 0)))
+
+			regions.Add(list(list(
+				"name" = get_region_accesses_name(i),
+				"accesses" = accesses)))
+		data["regions"] = regions
 
 	ui = GLOB.nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/nano/templates/access_decrypter.tmpl
+++ b/nano/templates/access_decrypter.tmpl
@@ -8,5 +8,17 @@
 	{{/for}}
 	{{:helper.link('ABORT', null, { 'PRG_reset' : 1 })}}
 {{else}}
-	##System ready<br><br>{{:helper.link('EXECUTE', null, { 'PRG_execute' : 1 })}}
+	##System ready. Select an access code to decrypt.
+	<div class='item' style='width: 100%'>
+		{{for data.regions}}
+			<div style='float: left; width: 175px; min-height: 250px'>
+				<div class='average'><b>{{:value.name}}</b></div>
+				{{for value.accesses :accessValue:accessKey}}
+					<div class='itemContentWide'>
+						{{:helper.link(accessValue.desc, '', {'PRG_execute' : accessValue.ref, 'allowed' : accessValue.allowed}, accessValue.blocked ? 'disabled' : null, accessValue.allowed ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+		{{/for}}
+	</div>
 {{/if}}


### PR DESCRIPTION
:cl:
rscadd: The access decrypter now allows the user to choose an access code instead of picking one by random.
/:cl:

As promised in the thread about removing the Captain's spare ID.

![Image](https://cdn.discordapp.com/attachments/256853479698464768/413115586202304513/unknown.png)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
