### PR TITLE
Newscaster/Computer item insert/remove tweak/fix

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -523,6 +523,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				var/image = photo_data ? photo_data.photo : null
 				feedback_inc("newscaster_stories",1)
 				news_network.SubmitArticle(src.msg, src.scanned_user, src.channel_name, image, 0)
+				if(photo_data)
+					photo_data.photo.forceMove(get_turf(src))
 				src.screen=4
 
 			src.updateUsrDialog()
@@ -752,10 +754,12 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 /obj/machinery/newscaster/proc/AttachPhoto(mob/user as mob)
 	if(photo_data)
 		if(!photo_data.is_synth)
-			photo_data.photo.loc = src.loc
+			photo_data.photo.forceMove(get_turf(src))
 			if(!issilicon(user))
-				user.put_in_inactive_hand(photo_data.photo)
+				user.put_in_hands(photo_data.photo)
 		qdel(photo_data)
+		photo_data = null
+		return
 
 	if(istype(user.get_active_hand(), /obj/item/weapon/photo))
 		var/obj/item/photo = user.get_active_hand()

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -98,6 +98,8 @@
 		P.event_idremoved(1)
 
 	card_slot.stored_card.forceMove(get_turf(src))
+	if(!issilicon(user))
+		user.put_in_hands(card_slot.stored_card)
 	card_slot.stored_card = null
 	update_uis()
 	to_chat(user, "You remove the card from \the [src]")

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -164,8 +164,11 @@
 					else
 						computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
 		if("eject")
-			if(computer && computer.card_slot)
-				computer.proc_eject_id(user)
+			if(computer)
+				if(computer.card_slot && computer.card_slot.stored_card)
+					computer.proc_eject_id(user)
+				else
+					computer.attackby(user.get_active_hand(), user)
 		if("terminate")
 			if(computer && can_run(user, 1))
 				id_card.assignment = "Terminated"


### PR DESCRIPTION
 - Newscaster puts photo in active hand (instead of inactive).
 - Newscaster ejects photo upon story submitting.
 - Modular computer puts photo in hands.
 - Inserting ID into computer by clicking NanoUI button.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
