### PR TITLE
Minor Matchmaking Modifications

### DIFF
--- a/code/modules/client/preference_setup/matchmaking/relations_types.dm
+++ b/code/modules/client/preference_setup/matchmaking/relations_types.dm
@@ -65,5 +65,18 @@
 	name = "Served Together"
 	desc = "You have crossed paths while in active military service."
 
+/datum/relation/spessnam/get_candidates()
+	var/list/warbuds = ..()
+	var/list/branchmates = list()
+	var/mob/living/carbon/human/holdermob = holder.current
+	if(istype(holdermob) && GLOB.using_map && (GLOB.using_map.flags & MAP_HAS_BRANCH))
+		for(var/datum/relation/buddy in warbuds)
+			var/mob/living/carbon/human/buddymob = buddy.holder.current
+			if(!istype(buddymob))
+				continue
+			if(holdermob.char_branch == buddymob.char_branch)
+				branchmates += buddy
+	return branchmates.len ? branchmates : warbuds
+
 /datum/relation/spessnam/get_desc_string()
 	return "[holder] and [other.holder] served in military together at some point in the past."

--- a/code/modules/client/preference_setup/matchmaking/relations_types.dm
+++ b/code/modules/client/preference_setup/matchmaking/relations_types.dm
@@ -6,6 +6,29 @@
 /datum/relation/friend/get_desc_string()
 	return "[holder] and [other.holder] seem to be on good terms."
 
+/datum/relation/kid_friend
+	name = "Childhood Friend"
+	desc = "You have known them since you were both young."
+
+/datum/relation/kid_friend/get_desc_string()
+	return "[holder] and [other.holder] knew each other when they were both young."
+
+/datum/relation/kid_friend/get_candidates()
+	var/list/creche = ..()
+	var/mob/living/carbon/human/holdermob = holder.current
+	
+	if(istype(holdermob))
+		for(var/datum/relation/kid in creche)
+			var/mob/living/carbon/human/kidmob = kid.holder.current
+			if(!istype(kidmob))
+				continue
+			if(abs(holdermob.age - kidmob.age) > 3)
+				creche -= kid		//No creepers please, it's okay if the pool is small.
+				continue
+			if(holdermob.home_system && kidmob.home_system && (holdermob.home_system != kidmob.home_system))
+				creche -= kid		//No trans-galactic shennanigans either.
+	return creche
+
 /datum/relation/enemy
 	name = "Enemy"
 	desc = "You have known the fellow for a while now, and you really can't stand each other."


### PR DESCRIPTION
:cl: Techhead
rscadd: Adds a new matchmaking relation, Childhood Friend. It'll only pick people from the same home system with the same approximate age.
tweak: Served Together now prefers to match people with others in the same branch.
/:cl: