### PR TITLE
Redoes #19845. Brings Taj back to the 3 language maximum.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -80,16 +80,15 @@
 	tail = "tajtail"
 	tail_animation = 'icons/mob/species/tajaran/tail.dmi'
 	default_h_style = "Tajaran Ears"
+	language = LANGUAGE_SIIK_MAAS
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
 	slowdown = -0.5
 	brute_mod = 1.15
 	burn_mod =  1.15
 	gluttonous = GLUT_TINY
-	num_alternate_languages = 2
+	num_alternate_languages = 1
 	secondary_langs = list(LANGUAGE_SIIK_TAJR)
-	additional_langs = list(LANGUAGE_SIIK_MAAS)
-	name_language = LANGUAGE_SIIK_MAAS
 	health_hud_intensity = 1.75
 
 	min_age = 19


### PR DESCRIPTION
Redoes PR #19845 to be more in line with precedent of species-enforced languages. (I.E. like IPC's EAL)
Consequently reinforces the 3 "Speakable" Language max as with other playable species. Sorry guys.