### PR TITLE
Removes Deity's Animation Spell

### DIFF
--- a/code/datums/uplink/deity/form_specific/wizard/wizard_transmutation.dm
+++ b/code/datums/uplink/deity/form_specific/wizard/wizard_transmutation.dm
@@ -27,12 +27,6 @@
 	item_cost = 10
 	path = /spell/aoe_turf/smoke
 
-/datum/uplink_item/deity/feat/phenomena/transmutation/animation
-	name = "Phenomena: Animation"
-	desc = "Gain the ability to transform objects into mimics."
-	item_cost = 75
-	path = /datum/phenomena/animate
-
 //Level 2
 /datum/uplink_item/deity/boon/single_charge/transmutation/knock
 	name = "Knock"

--- a/code/modules/mob/living/deity/phenomena/transmutation.dm
+++ b/code/modules/mob/living/deity/phenomena/transmutation.dm
@@ -1,20 +1,3 @@
-/datum/phenomena/animate
-	name = "Animate"
-	cost = 15
-	flags = PHENOMENA_NEAR_STRUCTURE
-	expected_type = /obj
-
-/datum/phenomena/animate/can_activate(var/atom/a)
-	if(!..())
-		return 0
-	return istype(a, /obj/structure) || istype(a, /obj/item)
-
-/datum/phenomena/animate/activate(var/atom/a)
-	..()
-	a.visible_message("\The [a] begins to shift and twist...")
-	var/mob/living/simple_animal/hostile/mimic/mimic = new(get_turf(a), a)
-	mimic.faction = linked.form.faction
-
 /datum/phenomena/warp
 	name = "Warp Body"
 	cost = 25


### PR DESCRIPTION
Putting this up by request. This removes the spell that animates objects into living mobs.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
