### PR TITLE
Fixes IC ranges

### DIFF
--- a/code/modules/integrated_electronics/converters.dm
+++ b/code/modules/integrated_electronics/converters.dm
@@ -63,6 +63,8 @@
 	desc = "This circuit can convert a reference to something else to a string, specifically the name of that reference."
 	icon_state = "ref-string"
 
+	dist_check = /decl/dist_check/in_view
+
 /obj/item/integrated_circuit/converter/ref2text/do_work()
 	var/datum/integrated_io/incoming = inputs[1]
 	var/atom/A = incoming.data_as_type(/atom)

--- a/code/modules/integrated_electronics/input_output.dm
+++ b/code/modules/integrated_electronics/input_output.dm
@@ -97,6 +97,8 @@
 	outputs = list("total health %", "total missing health")
 	activators = list("scan")
 
+	dist_check = /decl/dist_check/in_view
+
 /obj/item/integrated_circuit/input/med_scanner/do_work()
 	var/mob/living/carbon/human/H = get_pin_data_as_type(IC_INPUT, 1, /mob/living/carbon/human)
 	if(!istype(H)) //Invalid input
@@ -126,6 +128,8 @@
 		"clone damage"
 	)
 	activators = list("scan")
+
+	dist_check = /decl/dist_check/in_view
 
 /obj/item/integrated_circuit/input/adv_med_scanner/do_work()
 	var/datum/integrated_io/I = inputs[1]

--- a/code/modules/integrated_electronics/manipulation.dm
+++ b/code/modules/integrated_electronics/manipulation.dm
@@ -288,6 +288,8 @@
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
 	matter = list(DEFAULT_WALL_MATERIAL = 10000)
 
+	dist_check = /decl/dist_check/omni
+
 /obj/item/integrated_circuit/manipulation/bluespace_rift/do_work()
 	var/obj/machinery/computer/teleporter/tporter = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/computer/teleporter)
 	var/step_dir = get_pin_data(IC_INPUT, 2)


### PR DESCRIPTION
:cl:
bugfix: Fixes the handheld teleporter only working as expected when adjacent to teleporter hub.
bugfix: Fixes the ref2name converter only working when adjacent to target.
tweak: Medical scanner integrated circuits now work in vision range.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
