### PR TITLE
More IC Fixes

### DIFF
--- a/code/modules/integrated_electronics/input_output.dm
+++ b/code/modules/integrated_electronics/input_output.dm
@@ -282,34 +282,41 @@
 	desc = "Signals from a signaler can be received with this, allowing for remote control.  Additionally, it can send signals as well."
 	extended_desc = "When a signal is received from another signaler with the right id tag, the 'on signal received' activator pin will be pulsed and the command output is updated.  \
 	The two input pins are to configure the integrated signaler's settings.  Note that the frequency should not have a decimal in it.  \
-	Meaning the default frequency is expressed as 1457, not 145.7.  To send a signal, pulse the 'send signal' activator pin. Set the command output to set the message recieved"
+	Meaning the default frequency is expressed as 1457, not 145.7.  To send a signal, pulse the 'send signal' activator pin. Set the command output to set the message received."
 	complexity = 8
-	inputs = list("frequency", "code", "command", "id tag")
-	outputs = list("recieved command")
+	inputs = list("frequency", "id tag", "command")
+	outputs = list("received command")
 
 /obj/item/integrated_circuit/input/signaler/advanced/Initialize()
 	. = ..()
 	var/datum/integrated_io/new_com = inputs[3]
-	var/datum/integrated_io/new_id = inputs[4]
+	var/datum/integrated_io/new_id = inputs[2]
 	var/datum/integrated_io/new_rec = outputs[1]
 	new_com.data = "ACTIVATE"
 	new_id.data = "Integrated_Circuit"
 	new_rec.data = "ACTIVATE"
 
+/obj/item/integrated_circuit/input/signaler/signal_good(var/datum/signal/signal)
+	. = ..()
+	var/datum/integrated_io/id_tag = inputs[2]
+	if(!id_tag.data || id_tag.data != signal.data["tag"])
+		return 0
+
 /obj/item/integrated_circuit/input/signaler/advanced/create_signal()
 	var/datum/signal/signal = ..()
+	var/datum/integrated_io/new_id = inputs[2]
 	var/datum/integrated_io/new_com = inputs[3]
-	var/datum/integrated_io/new_id = inputs[4]
-	signal.data["command"] = new_com.data
 	signal.data["tag"] = new_id.data
+	signal.data["command"] = new_com.data
+	signal.encryption = null
 	return signal
 
 /obj/item/integrated_circuit/input/signaler/advanced/receive_signal(var/datum/signal/signal)
-	if(!..())
+	if(!signal_good(signal))
 		return 0
 	if(signal.data["command"])
 		set_pin_data(IC_OUTPUT, 1, signal.data["command"])
-	return 1
+	return ..()
 
 /obj/item/integrated_circuit/input/teleporter_locator
 	name = "teleporter locator"

--- a/code/modules/integrated_electronics/manipulation.dm
+++ b/code/modules/integrated_electronics/manipulation.dm
@@ -300,7 +300,9 @@
 	if(isnum(step_dir) && (!step_dir || (step_dir in GLOB.cardinal)))
 		rift_location = get_step(rift_location, step_dir) || rift_location
 	else
-		rift_location = get_step(rift_location, dir) || rift_location
+		var/obj/item/device/electronic_assembly/assembly = get_assembly(src)
+		if(assembly)
+			rift_location = get_step(rift_location, assembly.dir) || rift_location
 
 	if(tporter && tporter.locked && !tporter.one_time_use && tporter.operable())
 		new /obj/effect/portal(rift_location, get_turf(tporter.locked))


### PR DESCRIPTION
Fixes the bluespace rift generator not opening the portal in the direction the assembly is facing (when supposed to).
Fixes the advanced signaler using encryption (against the point, as far as I can tell from what its purpose is) and activating the output pin before data is set.

I actually don't know why the advanced signaler is even a thing, its entire design is to interface with machines over radio signals in a way not supposed to. When enough people agree, I'll just axe it and give the simple IC signaler an input pin to set the 'message' of the radio signal, which can then be received by another signaler.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
