### PR TITLE
Fix 'the The binoculars' message

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -2,6 +2,7 @@
 
 	name = "binoculars"
 	desc = "A pair of binoculars."
+	zoomdevicename = "eyepieces"
 	icon_state = "binoculars"
 
 	obj_flags = OBJ_FLAG_CONDUCTIBLE


### PR DESCRIPTION
Results in `X peers though the eyepieces of the binoculars`
Instead of `X peers through the The binoculars`
