### PR TITLE
Adds watch variable functionality

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -7,6 +7,7 @@ var/list/admin_verbs_default = list(
 	/client/proc/hide_verbs,			//hides all our adminverbs,
 	/client/proc/hide_most_verbs,		//hides all our hideable adminverbs,
 	/client/proc/debug_variables,		//allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify,
+	/client/proc/watched_variables,
 	/client/proc/debug_global_variables,//as above but for global variables,
 //	/client/proc/check_antagonists,		//shows all antags,
 	/client/proc/cmd_mentor_check_new_players
@@ -300,6 +301,7 @@ var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	// right-click adminPM interface,
 	/client/proc/cmd_admin_pm_panel,	// admin-pm list,
 	/client/proc/debug_variables,		// allows us to -see- the variables of any instance in the game.,
+	/client/proc/watched_variables,
 	/client/proc/debug_global_variables,// as above but for global variables,
 	/datum/admins/proc/PlayerNotes,
 	/client/proc/admin_ghost,			// allows us to ghost/reenter body at will,

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -110,18 +110,20 @@
 /datum/proc/get_initial_variable_value(varname)
 	return initial(vars[varname])
 
-/datum/proc/make_view_variables_variable_entry(varname, value)
+/datum/proc/make_view_variables_variable_entry(var/varname, var/value, var/hide_watch = 0)
 	return {"
 			(<a href='?_src_=vars;datumedit=\ref[src];varnameedit=[varname]'>E</a>)
 			(<a href='?_src_=vars;datumchange=\ref[src];varnamechange=[varname]'>C</a>)
 			(<a href='?_src_=vars;datummass=\ref[src];varnamemass=[varname]'>M</a>)
+			[hide_watch ? "" : "(<a href='?_src_=vars;datumwatch=\ref[src];varnamewatch=[varname]'>W</a>)"]
 			"}
 
 // No mass editing of clients
-/client/make_view_variables_variable_entry(varname, value)
+/client/make_view_variables_variable_entry(var/varname, var/value, var/hide_watch = 0)
 	return {"
 			(<a href='?_src_=vars;datumedit=\ref[src];varnameedit=[varname]'>E</a>)
 			(<a href='?_src_=vars;datumchange=\ref[src];varnamechange=[varname]'>C</a>)
+			[hide_watch ? "" : "(<a href='?_src_=vars;datumwatch=\ref[src];varnamewatch=[varname]'>W</a>)"]
 			"}
 
 // These methods are all procs and don't use stored lists to avoid VV exploits

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -65,6 +65,27 @@
 
 		cmd_mass_modify_object_variables(A, href_list["varnamemass"])
 
+	else if(href_list["datumwatch"] && href_list["varnamewatch"])
+		var/datum/D = locate(href_list["datumwatch"])
+		if(D)
+			if(!watched_variables[D])
+				watched_variables[D] = list()
+			watched_variables[D] |= href_list["varnamewatch"]
+			watched_variables()
+
+			if(!watched_variables_window.is_processing)
+				START_PROCESSING(SSprocessing, watched_variables_window)
+
+	else if(href_list["datumunwatch"] && href_list["varnameunwatch"])
+		var/datum/D = locate(href_list["datumunwatch"])
+		if(D && watched_variables[D])
+			watched_variables[D] -= href_list["varnameunwatch"]
+			var/list/datums_watched_vars = watched_variables[D]
+			if(!datums_watched_vars.len)
+				watched_variables -= D
+		if(!watched_variables.len && watched_variables_window.is_processing)
+			STOP_PROCESSING(SSprocessing, watched_variables_window)
+
 	else if(href_list["mob_player_panel"])
 		if(!check_rights(0))	return
 

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -98,6 +98,47 @@
 
 	usr << browse(html, "window=variables\ref[D];size=475x650")
 
+/client
+	var/list/watched_variables = list()
+	var/datum/browser/watched_variables/watched_variables_window
+
+/client/proc/watched_variables()
+	set category = "Debug"
+	set name = "View Watched Variables"
+
+	watched_variables_window = new(usr, "watchedvariables", "Watched Variables", 640, 640, src)
+
+	watched_variables_window.set_content()
+	watched_variables_window.open()
+
+/datum/browser/watched_variables/set_content()
+	var/list/dat = list()
+
+	if(!user.client)
+		return
+
+	dat += "<style>div.var { padding: 5px; } div.var:nth-child(even) { background-color: #555; }</style>"
+	for(var/datum/D in user.client.watched_variables)
+		dat += "<h1>[make_view_variables_value(D)]</h1>"
+		for(var/v in user.client.watched_variables[D])
+			dat += "<div class='var'>"
+			dat += "(<a href='?_src_=vars;datumunwatch=\ref[D];varnameunwatch=[v]'>X</a>) "
+			dat += "[D.make_view_variables_variable_entry(v, D.get_variable_value(v), 1)] [v] = [make_view_variables_value(D.get_variable_value(v), v)]"
+			dat += "</div>"
+
+	..(jointext(dat, null))
+
+/datum/browser/watched_variables/update()
+	set_content()
+	..()
+
+/datum/browser/watched_variables/Process()
+	update()
+
+/datum/browser/watched_variables/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+
+	. = ..()
 
 /proc/make_view_variables_var_list(datum/D)
 	. = list()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -205,6 +205,7 @@
 	//////////////
 /client/Del()
 	ticket_panels -= src
+	STOP_PROCESSING(SSprocessing, watched_variables_window)
 	if(holder)
 		holder.owner = null
 		GLOB.admins -= src


### PR DESCRIPTION
:cl:mkalash
rscadd: Staff now have the ability to mark variables to easily view them in an auto-updating panel.
/:cl:

![image](https://user-images.githubusercontent.com/313146/36646223-e06f6e78-1a42-11e8-9e57-0f15d61567ec.png)
