### PR TITLE
Tweak the shield generator

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -269,13 +269,15 @@
 		if((choice != "Yes") || !running)
 			return TOPIC_HANDLED
 
-		var/temp_integrity = field_integrity()
-		// If the shield would take 5 minutes to disperse and shut down using regular methods, it will take x2 (10 minutes) of this time to cool down after emergency shutdown
-		offline_for = round(current_energy / (SHIELD_SHUTDOWN_DISPERSION_RATE / 2))
+		// If the shield would take 5 minutes to disperse and shut down using regular methods, it will take x1.5 (7 minutes and 30 seconds) of this time to cool down after emergency shutdown
+		offline_for = round(current_energy / (SHIELD_SHUTDOWN_DISPERSION_RATE / 1.5))
+		var/old_energy = current_energy
 		shutdown_field()
-		if(prob(temp_integrity - 50) * 1.75)
-			spawn()
-				empulse(src, 7, 14)
+		log_and_message_admins("has triggered \the [src]'s emergency shutdown!", user)
+		spawn()	
+			empulse(src, old_energy / 60000000, old_energy / 32000000, 1) // If shields are charged at 450 MJ, the EMP will be 7.5, 14.0625. 90 MJ, 1.5, 2.8125
+		old_energy = 0
+
 		return TOPIC_REFRESH
 
 	if(mode_changes_locked)

--- a/html/changelogs/HeyBanditoz - shieldtweaks.yml
+++ b/html/changelogs/HeyBanditoz - shieldtweaks.yml
@@ -1,0 +1,6 @@
+author: Banditoz
+delete-after: True
+changes: 
+  - tweak: "The shield generator's emergency shutdown function is now hidden behind a hackable wire."
+  - tweak: "Cut down the shield generator's emergency shutdown time by 50%."
+  - tweak: "The EMP from the emergency shutdown scales with current charge--and is guarenteed to happen."

--- a/nano/templates/shieldgen.tmpl
+++ b/nano/templates/shieldgen.tmpl
@@ -75,9 +75,9 @@
 				<td>{{:helper.link('Turn on', null, {'start_generator' : '1'})}}
 			{{/if}}
 			{{if data.running}}
-				<td>{{:helper.link('EMERGENCY SHUTDOWN', null, {'emergency_shutdown' : '1'}, null, 'redButton')}}
-			{{else}}
-				<td>{{:helper.link('EMERGENCY SHUTDOWN', null, {'emergency_shutdown' : '1'}, null, 'disabled')}}
+				{{if data.hacked}}
+					<td>{{:helper.link('EMERGENCY SHUTDOWN', null, {'emergency_shutdown' : '1'}, null, 'redButton')}}
+				{{/if}}
 			{{/if}}
 			
 			<tr>


### PR DESCRIPTION
- Emergency shutdown is now behind a hackable wire.
- Shorten the time it takes for the emergency shutdown time to end.
- An EMP is now guaranteed if you use emergency shutdown. It scales with its charge. (Balanced around 450 MJ.)