### PR TITLE
First Aid and Emergency Oxygen Tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -28,8 +28,8 @@
 
 	startswith = list(
 		/obj/item/device/healthanalyzer,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
-		/obj/item/stack/medical/ointment,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 1,
+		/obj/item/stack/medical/ointment = 3,
 		/obj/item/weapon/storage/pill_bottle/kelotane,
 		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
@@ -45,7 +45,7 @@
 		/obj/item/stack/medical/bruise_pack = 2,
 		/obj/item/stack/medical/ointment = 1,
 		/obj/item/device/healthanalyzer,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector = 2,
 		/obj/item/weapon/storage/pill_bottle/antidexafen,
 		/obj/item/weapon/storage/pill_bottle/paracetamol
 		)
@@ -57,8 +57,9 @@
 	item_state = "firstaid-toxin"
 
 	startswith = list(
-		/obj/item/weapon/reagent_containers/syringe/antitoxin = 3,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/detox = 4,
 		/obj/item/weapon/storage/pill_bottle/antitox,
+		/obj/item/weapon/storage/pill_bottle/hyronalin,
 		/obj/item/device/healthanalyzer,
 		)
 
@@ -74,8 +75,9 @@
 
 	startswith = list(
 		/obj/item/weapon/storage/pill_bottle/dexalin,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
-		/obj/item/weapon/reagent_containers/syringe/inaprovaline,
+		/obj/item/weapon/storage/pill_bottle/inaprovaline,
+		/obj/item/weapon/reagent_containers/pill/sugariron = 2,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector = 4,
 		/obj/item/device/healthanalyzer,
 		)
 
@@ -86,7 +88,7 @@
 	item_state = "firstaid-advanced"
 
 	startswith = list(
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 1,
 		/obj/item/stack/medical/advanced/bruise_pack = 3,
 		/obj/item/stack/medical/advanced/ointment = 2,
 		/obj/item/stack/medical/splint
@@ -252,3 +254,21 @@
 	desc = "Mild painkiller, also known as Tylenol. Won't fix the cause of your headache (unlike cyanide), but might make it bearable."
 
 	startswith = list(/obj/item/weapon/reagent_containers/pill/paracetamol = 21)
+
+/obj/item/weapon/storage/pill_bottle/hyronalin
+	name = "bottle of Hyronalin pills"
+	desc = "Contains pills used to treat radiation poisoning."
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/hyronalin = 7)
+
+/obj/item/weapon/storage/pill_bottle/stox
+	name = "bottle of Soporific pills"
+	desc = "Commonly used to treat insomnia."
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/stox = 14)
+
+/obj/item/weapon/storage/pill_bottle/sugariron
+	name = "bottle of Sugar-Iron pills"
+	desc = "Used to help the body naturally replenish blood."
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/sugariron = 14)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -76,7 +76,6 @@
 	startswith = list(
 		/obj/item/weapon/storage/pill_bottle/dexalin,
 		/obj/item/weapon/storage/pill_bottle/inaprovaline,
-		/obj/item/weapon/reagent_containers/pill/sugariron = 2,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector = 4,
 		/obj/item/device/healthanalyzer,
 		)
@@ -88,7 +87,7 @@
 	item_state = "firstaid-advanced"
 
 	startswith = list(
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 1,
+		/obj/item/weapon/storage/pill_bottle/assorted,
 		/obj/item/stack/medical/advanced/bruise_pack = 3,
 		/obj/item/stack/medical/advanced/ointment = 2,
 		/obj/item/stack/medical/splint
@@ -261,14 +260,16 @@
 
 	startswith = list(/obj/item/weapon/reagent_containers/pill/hyronalin = 7)
 
-/obj/item/weapon/storage/pill_bottle/stox
-	name = "bottle of Soporific pills"
-	desc = "Commonly used to treat insomnia."
+/obj/item/weapon/storage/pill_bottle/assorted
+	name = "bottle of assorted pills"
+	desc = "Commonly found on paramedics, these assorted pill bottles contain all the basics."
 
-	startswith = list(/obj/item/weapon/reagent_containers/pill/stox = 14)
-
-/obj/item/weapon/storage/pill_bottle/sugariron
-	name = "bottle of Sugar-Iron pills"
-	desc = "Used to help the body naturally replenish blood."
-
-	startswith = list(/obj/item/weapon/reagent_containers/pill/sugariron = 14)
+	startswith = list(
+			/obj/item/weapon/reagent_containers/pill/inaprovaline = 6,
+			/obj/item/weapon/reagent_containers/pill/dylovene = 6,
+			/obj/item/weapon/reagent_containers/pill/sugariron = 2,
+			/obj/item/weapon/reagent_containers/pill/tramadol = 2,
+			/obj/item/weapon/reagent_containers/pill/dexalin = 2,
+			/obj/item/weapon/reagent_containers/pill/kelotane = 2,
+			/obj/item/weapon/reagent_containers/pill/hyronalin
+		)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -59,7 +59,7 @@
 	startswith = list(
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/detox = 4,
 		/obj/item/weapon/storage/pill_bottle/antitox,
-		/obj/item/weapon/storage/pill_bottle/hyronalin,
+		/obj/item/weapon/reagent_containers/pill/hyronalin = 3,
 		/obj/item/device/healthanalyzer,
 		)
 
@@ -253,12 +253,6 @@
 	desc = "Mild painkiller, also known as Tylenol. Won't fix the cause of your headache (unlike cyanide), but might make it bearable."
 
 	startswith = list(/obj/item/weapon/reagent_containers/pill/paracetamol = 21)
-
-/obj/item/weapon/storage/pill_bottle/hyronalin
-	name = "bottle of Hyronalin pills"
-	desc = "Contains pills used to treat radiation poisoning."
-
-	startswith = list(/obj/item/weapon/reagent_containers/pill/hyronalin = 7)
 
 /obj/item/weapon/storage/pill_bottle/assorted
 	name = "bottle of assorted pills"

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -99,7 +99,7 @@
 	desc = "Used for emergencies. Contains very little oxygen, so try to conserve it until you actually need it."
 	icon_state = "emergency"
 	gauge_icon = "indicator_emergency"
-	starting_pressure = list("oxygen" = 3*ONE_ATMOSPHERE)
+	starting_pressure = list("oxygen" = 10*ONE_ATMOSPHERE)
 
 /obj/item/weapon/tank/emergency/oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
@@ -117,7 +117,7 @@
 	desc = "An emergency air tank hastily painted red and issued to Vox crewmembers."
 	icon_state = "emergency_nitro"
 	gauge_icon = "indicator_emergency"
-	starting_pressure = list("nitrogen" = 3*ONE_ATMOSPHERE)
+	starting_pressure = list("nitrogen" = 10*ONE_ATMOSPHERE)
 
 /obj/item/weapon/tank/emergency/nitrogen/double
 	name = "double emergency nitrogen tank"
@@ -133,4 +133,4 @@
 	desc = "A tank of nitrogen."
 	icon_state = "oxygen_fr"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	starting_pressure = list("nitrogen" = 3*ONE_ATMOSPHERE)
+	starting_pressure = list("nitrogen" = 6*ONE_ATMOSPHERE)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -306,7 +306,7 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spra
 	if(chem_effects[CE_OXYGENATED] == 1) // Dexalin.
 		oxygenated_mult = 0.60
 	else if(chem_effects[CE_OXYGENATED] >= 2) // Dexplus.
-		oxygenated_mult = 0.85
+		oxygenated_mult = 0.80
 	blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
 	blood_volume = blood_volume * blood_volume_mod
 	return min(blood_volume, 100)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -304,9 +304,9 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spra
 	var/blood_volume_mod = max(0, 1 - getOxyLoss()/(maxHealth/2))
 	var/oxygenated_mult = 0
 	if(chem_effects[CE_OXYGENATED] == 1) // Dexalin.
-		oxygenated_mult = 0.5
+		oxygenated_mult = 0.60
 	else if(chem_effects[CE_OXYGENATED] >= 2) // Dexplus.
-		oxygenated_mult = 0.8
+		oxygenated_mult = 0.85
 	blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
 	blood_volume = blood_volume * blood_volume_mod
 	return min(blood_volume, 100)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -304,9 +304,9 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spra
 	var/blood_volume_mod = max(0, 1 - getOxyLoss()/(maxHealth/2))
 	var/oxygenated_mult = 0
 	if(chem_effects[CE_OXYGENATED] == 1) // Dexalin.
-		oxygenated_mult = 0.60
+		oxygenated_mult = 0.5
 	else if(chem_effects[CE_OXYGENATED] >= 2) // Dexplus.
-		oxygenated_mult = 0.80
+		oxygenated_mult = 0.8
 	blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
 	blood_volume = blood_volume * blood_volume_mod
 	return min(blood_volume, 100)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -187,7 +187,7 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/paracetamol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_PAINKILLER, 25)
+	M.add_chemical_effect(CE_PAINKILLER, 35)
 
 /datum/reagent/paracetamol/overdose(var/mob/living/carbon/M, var/alien)
 	..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -116,6 +116,8 @@
 	amount_per_transfer_from_this = 5
 	volume = 5
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
+	slot_flags = SLOT_BELT | SLOT_EARS
+	w_class = ITEM_SIZE_TINY
 	var/list/starts_with = list(/datum/reagent/inaprovaline = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/New()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -313,3 +313,24 @@ obj/item/weapon/reagent_containers/pill/noexcutite/New()
 	..()
 	reagents.add_reagent(/datum/reagent/paroxetine, 10)
 	color = reagents.get_color()
+
+
+/obj/item/weapon/reagent_containers/pill/hyronalin
+	name = "Hyronalin (7u)"
+	desc = "Used to treat radiation poisoning."
+	icon_state = "pill1"
+/obj/item/weapon/reagent_containers/pill/hyronalin/New()
+	..()
+	reagents.add_reagent(/datum/reagent/hyronalin, 7)
+	color = reagents.get_color()
+
+
+/obj/item/weapon/reagent_containers/pill/sugariron
+	name = "Sugar-Iron (10u)"
+	desc = "Used to help the body naturally replenish blood."
+	icon_state = "pill1"
+/obj/item/weapon/reagent_containers/pill/sugariron/New()
+	..()
+	reagents.add_reagent(/datum/reagent/iron, 5)
+	reagents.add_reagent(/datum/reagent/sugar, 5)
+	color = reagents.get_color()


### PR DESCRIPTION
:cl: Novacat
   tweak: Advanced First Aid Kit: Swaps inaprovaline autoinjector for assorted pill bottle.
   tweak: Burn First Aid Kit: Adds three ointment kits, swaps inaprovaline autoinjector for tramadol autoinjector
   tweak: Oxygen first aid kits now contain inaprovaline pill bottle, dexalin pill bottle, and four inaprovaline autoinjectors
   tweak: Toxin first aid kits now contain a dylovene pill bottle, three hyronalin pills, and four autoinjectors of dylovene
   tweak: Autoinjectors are now the same size as syringes
   tweak: Emergency Oxygen/Nitrogen Tanks now start off full
   tweak: Regular Nitrogen tank starts off at the same level as oxygen tanks
   tweak: Paracemetol's painkiller effect increased from 25 to 35
   /:cl: