### PR TITLE
Broad xenomorph rebalance.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2019,6 +2019,7 @@
 #include "code\modules\organs\internal\lungs.dm"
 #include "code\modules\organs\internal\posibrain.dm"
 #include "code\modules\organs\internal\stack.dm"
+#include "code\modules\organs\subtypes\general.dm"
 #include "code\modules\organs\subtypes\nabber_organ.dm"
 #include "code\modules\overmap\_defines.dm"
 #include "code\modules\overmap\overmap_shuttle.dm"

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -86,6 +86,8 @@
 			if(!H.eyecheck() <= 0)
 				continue
 			flash_time = round(H.species.flash_mod * flash_time)
+			if(flash_time <= 0)
+				return
 			var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]
 			if(!E)
 				return

--- a/code/game/objects/structures/alien/resin.dm
+++ b/code/game/objects/structures/alien/resin.dm
@@ -38,7 +38,7 @@
 		// Aliens can get straight through these.
 		if(istype(user,/mob/living/carbon))
 			var/mob/living/carbon/M = user
-			if(locate(/obj/item/organ/internal/xenos/hivenode) in M.internal_organs)
+			if(locate(/obj/item/organ/internal/xeno/hivenode) in M.internal_organs)
 				visible_message("<span class='alium'>\The [user] strokes \the [name] and it melts away!</span>")
 				health = 0
 				healthcheck()

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -45,10 +45,10 @@
 	var/mob/living/carbon/xenos = user
 	var/mob/living/carbon/victim = M
 
-	if(istype(victim) && locate(/obj/item/organ/internal/xenos/hivenode) in victim.internal_organs)
+	if(istype(victim) && locate(/obj/item/organ/internal/xeno/hivenode) in victim.internal_organs)
 		return
 
-	if(istype(xenos) && !(locate(/obj/item/organ/internal/xenos/hivenode) in xenos.internal_organs))
+	if(istype(xenos) && !(locate(/obj/item/organ/internal/xeno/hivenode) in xenos.internal_organs))
 		return
 
 	if(M == usr)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -753,7 +753,7 @@ var/list/name_to_material
 
 /material/resin/can_open_material_door(var/mob/living/user)
 	var/mob/living/carbon/M = user
-	if(istype(M) && locate(/obj/item/organ/internal/xenos/hivenode) in M.internal_organs)
+	if(istype(M) && locate(/obj/item/organ/internal/xeno/hivenode) in M.internal_organs)
 		return 1
 	return 0
 

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -104,7 +104,7 @@
 		if(88)
 			new/obj/item/xenos_claw(src)
 		if(89)
-			new/obj/item/organ/internal/xenos/plasmavessel(src)
+			new/obj/item/organ/internal/xeno/plasmavessel(src)
 		if(90)
 			new/obj/item/organ/internal/heart(src)
 		if(91)

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -27,7 +27,7 @@
 	var/mob/living/carbon/M = other
 	if(!istype(M))
 		return 1
-	if(locate(/obj/item/organ/internal/xenos/hivenode) in M.internal_organs)
+	if(locate(/obj/item/organ/internal/xeno/hivenode) in M.internal_organs)
 		return 1
 
 	return 0

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -11,5 +11,5 @@
 /mob/living/carbon/alien/larva/New()
 	..()
 	add_language("Xenophage") //Bonus language.
-	internal_organs |= new /obj/item/organ/internal/xenos/hivenode(src)
+	internal_organs |= new /obj/item/organ/internal/xeno/hivenode(src)
 	create_reagents(100)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -74,7 +74,7 @@
 				stat("Tank Pressure", internal.air_contents.return_pressure())
 				stat("Distribution Pressure", internal.distribute_pressure)
 
-		var/obj/item/organ/internal/xenos/plasmavessel/P = internal_organs_by_name[BP_PLASMA]
+		var/obj/item/organ/internal/xeno/plasmavessel/P = internal_organs_by_name[BP_PLASMA]
 		if(P)
 			stat(null, "Phoron Stored: [P.stored_plasma]/[P.max_plasma]")
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -99,19 +99,22 @@
 	BITSET(hud_updateflag, HEALTH_HUD)
 
 /mob/living/carbon/human/Stun(amount)
-	if(HULK in mutations)	return
+	amount *= species.stun_mod
+	if(amount <= 0 || (HULK in mutations)) return
 	..()
 
 /mob/living/carbon/human/Weaken(amount)
-	if(HULK in mutations)	return
-	..()
+	amount *= species.weaken_mod
+	if(amount <= 0 || (HULK in mutations)) return
+	..(amount)
 
 /mob/living/carbon/human/Paralyse(amount)
-	if(HULK in mutations)	return
+	amount *= species.paralysis_mod
+	if(amount <= 0 || (HULK in mutations)) return
 	// Notify our AI if they can now control the suit.
 	if(wearing_rig && !stat && paralysis < amount) //We are passing out right this second.
 		wearing_rig.notify_ai("<span class='danger'>Warning: user consciousness failure. Mobility control passed to integrated intelligence system.</span>")
-	..()
+	..(amount)
 
 /mob/living/carbon/human/getCloneLoss()
 	var/amount = 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -97,7 +97,7 @@ meteor_act
 		def_zone = get_organ(check_zone(def_zone))
 	if(!def_zone)
 		return 0
-	var/protection = 0
+	var/protection = def_zone.species.natural_armour_values ? def_zone.species.natural_armour_values[type] : 0
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	for(var/obj/item/clothing/gear in protective_gear)
 		if(gear.body_parts_covered & def_zone.body_part)
@@ -106,7 +106,7 @@ meteor_act
 			for(var/obj/item/clothing/accessory/bling in gear.accessories)
 				if(bling.body_parts_covered & def_zone.body_part)
 					protection = add_armor(protection, bling.armor[type])
-	return protection
+	return Clamp(protection,0,100)
 
 /mob/living/carbon/human/proc/check_head_coverage()
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -257,8 +257,8 @@
 			damage = 8
 			radiation -= 4 * RADIATION_SPEED_COEFFICIENT
 
+		damage = Floor(damage * (isSynthetic() ? 0.5 : species.radiation_mod))
 		if(damage)
-			damage *= isSynthetic() ? 0.5 : species.radiation_mod
 			adjustToxLoss(damage * RADIATION_SPEED_COEFFICIENT)
 			updatehealth()
 			if(!isSynthetic() && organs.len)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -78,6 +78,8 @@
 		/datum/unarmed_attack/bite
 		)
 	var/list/unarmed_attacks = null           // For empty hand harm-intent attack
+
+	var/list/natural_armour_values            // Armour values used if naked.
 	var/brute_mod =      1                    // Physical damage multiplier.
 	var/burn_mod =       1                    // Burn damage multiplier.
 	var/oxy_mod =        1                    // Oxyloss modifier
@@ -85,6 +87,10 @@
 	var/radiation_mod =  1                    // Radiation modifier
 	var/flash_mod =      1                    // Stun from blindness modifier.
 	var/metabolism_mod = 1                    // Reagent metabolism modifier
+	var/stun_mod =       1                    // Stun period modifier.
+	var/paralysis_mod =  1                    // Paralysis period modifier.
+	var/weaken_mod =     1                    // Weaken period modifier.
+
 	var/vision_flags = SEE_SELF               // Same flags as glasses.
 
 	// Death vars.

--- a/code/modules/mob/living/carbon/human/species/station/nabber.dm
+++ b/code/modules/mob/living/carbon/human/species/station/nabber.dm
@@ -80,7 +80,7 @@
 		BP_BRAIN =    /obj/item/organ/internal/brain/nabber,
 		BP_EYES =     /obj/item/organ/internal/eyes/nabber,
 		BP_TRACH =    /obj/item/organ/internal/lungs/nabber,
-		BP_HEART =    /obj/item/organ/internal/heart/nabber,
+		BP_HEART =    /obj/item/organ/internal/heart/open,
 		BP_LIVER =    /obj/item/organ/internal/liver/nabber,
 		BP_PHORON =   /obj/item/organ/internal/phoron,
 		BP_VOICE =    /obj/item/organ/internal/voicebox/nabber

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -11,7 +11,7 @@
 
 /mob/living/carbon/human/proc/gain_plasma(var/amount)
 
-	var/obj/item/organ/internal/xenos/plasmavessel/I = internal_organs_by_name[BP_PLASMA]
+	var/obj/item/organ/internal/xeno/plasmavessel/I = internal_organs_by_name[BP_PLASMA]
 	if(!istype(I)) return
 
 	if(amount)
@@ -20,7 +20,7 @@
 
 /mob/living/carbon/human/proc/check_alien_ability(var/cost,var/needs_foundation,var/needs_organ)
 
-	var/obj/item/organ/internal/xenos/plasmavessel/P = internal_organs_by_name[BP_PLASMA]
+	var/obj/item/organ/internal/xeno/plasmavessel/P = internal_organs_by_name[BP_PLASMA]
 	if(!istype(P))
 		to_chat(src, "<span class='danger'>Your plasma vessel has been removed!</span>")
 		return
@@ -62,7 +62,7 @@
 		to_chat(src, "<span class='alium'>You need to be closer.</span>")
 		return
 
-	var/obj/item/organ/internal/xenos/plasmavessel/I = M.internal_organs_by_name[BP_PLASMA]
+	var/obj/item/organ/internal/xeno/plasmavessel/I = M.internal_organs_by_name[BP_PLASMA]
 	if(!istype(I))
 		to_chat(src, "<span class='alium'>Their plasma vessel is missing.</span>")
 		return
@@ -239,7 +239,7 @@ mob/living/carbon/human/proc/xeno_infest(mob/living/carbon/human/M as mob in ovi
 
 	src.visible_message("<span class='danger'>\The [src] regurgitates something into \the [M]'s torso!</span>")
 	to_chat(M, "<span class='danger'>A hideous lump of alien mass strains your ribcage as it settles within!</span>")
-	var/obj/item/organ/internal/xenos/hivenode/node = new(affecting)
+	var/obj/item/organ/internal/xeno/hivenode/node = new(affecting)
 	node.replaced(M,affecting)
 
 /mob/living/carbon/human/proc/pry_open(obj/machinery/door/A in filter_list(oview(1), /obj/machinery/door))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -15,8 +15,6 @@
 	var/damage_state = "00"            // Modifier used for generating the on-mob damage overlay for this limb.
 
 	// Damage vars.
-	var/brute_mod = 1                  // Multiplier for incoming brute damage.
-	var/burn_mod = 1                   // As above for burn.
 	var/brute_dam = 0                  // Actual current brute damage.
 	var/brute_ratio = 0                // Ratio of current brute damage to max damage.
 	var/burn_dam = 0                   // Actual current burn damage.
@@ -141,7 +139,7 @@
 			burn_damage = 7
 		if (3)
 			burn_damage = 3
-	burn_damage *= robotic/burn_mod //ignore burn mod for EMP damage
+	burn_damage *= robotic/species.burn_mod //ignore burn mod for EMP damage
 
 	var/power = 4 - severity //stupid reverse severity
 	for(var/obj/item/I in implants)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -7,8 +7,8 @@
 	return ((robotic >= ORGAN_ROBOT) || brute_dam + burn_dam + additional_damage < max_damage * 4)
 
 /obj/item/organ/external/take_damage(brute, burn, damage_flags, used_weapon = null)
-	brute = round(brute * brute_mod, 0.1)
-	burn = round(burn * burn_mod, 0.1)
+	brute = round(brute * species.brute_mod, 0.1)
+	burn = round(burn * species.burn_mod, 0.1)
 	if((brute <= 0) && (burn <= 0))
 		return 0
 

--- a/code/modules/organs/external/unbreakable.dm
+++ b/code/modules/organs/external/unbreakable.dm
@@ -2,46 +2,65 @@
 /obj/item/organ/external/chest/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/groin/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/arm/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/arm/right/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/leg/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/leg/right/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/foot/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/foot/right/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/hand/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/hand/right/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	has_tendon = FALSE
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/head/unbreakable
 	cannot_break = 1
 	dislocated = -1
+	arterial_bleed_severity = 0
 
 // Slime limbs.
 /obj/item/organ/external/chest/unbreakable/slime

--- a/code/modules/organs/external/xenos.dm
+++ b/code/modules/organs/external/xenos.dm
@@ -1,28 +1,28 @@
 //XENOMORPH ORGANS
-/obj/item/organ/internal/xenos
+/obj/item/organ/internal/xeno
 	name = "xeno organ"
 	icon = 'icons/effects/blood.dmi'
 	desc = "It smells like an accident in a chemical factory."
 	var/associated_power = /mob/living/carbon/human/proc/resin
 
-/obj/item/organ/internal/xenos/replaced(var/mob/living/carbon/human/target,var/obj/item/organ/external/affected)
+/obj/item/organ/internal/xeno/replaced(var/mob/living/carbon/human/target,var/obj/item/organ/external/affected)
 	. = ..()
 	if(ishuman(owner) && associated_power)
 		owner.verbs |= associated_power
 
-/obj/item/organ/internal/xenos/removed(var/mob/living/user)
+/obj/item/organ/internal/xeno/removed(var/mob/living/user)
 	. = ..()
 	if(ishuman(owner) && associated_power && !(associated_power in owner.species.inherent_verbs))
 		owner.verbs -= associated_power
 
-/obj/item/organ/internal/xenos/eggsac
+/obj/item/organ/internal/xeno/eggsac
 	name = "egg sac"
 	parent_organ = BP_GROIN
 	icon_state = "xgibmid1"
 	organ_tag = BP_EGG
 	associated_power = /mob/living/carbon/human/proc/lay_egg
 
-/obj/item/organ/internal/xenos/plasmavessel
+/obj/item/organ/internal/xeno/plasmavessel
 	name = "plasma vessel"
 	parent_organ = BP_CHEST
 	icon_state = "xgibdown1"
@@ -30,42 +30,42 @@
 	var/stored_plasma = 0
 	var/max_plasma = 500
 
-/obj/item/organ/internal/xenos/plasmavessel/queen
+/obj/item/organ/internal/xeno/plasmavessel/queen
 	name = "bloated plasma vessel"
 	stored_plasma = 200
 	max_plasma = 500
 	associated_power = /mob/living/carbon/human/proc/neurotoxin
 
-/obj/item/organ/internal/xenos/plasmavessel/sentinel
+/obj/item/organ/internal/xeno/plasmavessel/sentinel
 	stored_plasma = 100
 	max_plasma = 250
 
-/obj/item/organ/internal/xenos/plasmavessel/hunter
+/obj/item/organ/internal/xeno/plasmavessel/hunter
 	name = "tiny plasma vessel"
 	stored_plasma = 100
 	max_plasma = 150
 
-/obj/item/organ/internal/xenos/acidgland
+/obj/item/organ/internal/xeno/acidgland
 	name = "acid gland"
 	parent_organ = BP_HEAD
 	icon_state = "xgibtorso"
 	organ_tag = BP_ACID
 	associated_power = /mob/living/carbon/human/proc/corrosive_acid
 
-/obj/item/organ/internal/xenos/hivenode
+/obj/item/organ/internal/xeno/hivenode
 	name = "hive node"
 	parent_organ = BP_CHEST
 	icon_state = "xgibmid2"
 	organ_tag = BP_HIVE
 
-/obj/item/organ/internal/xenos/resinspinner
+/obj/item/organ/internal/xeno/resinspinner
 	name = "resin spinner"
 	parent_organ = BP_HEAD
 	icon_state = "xgibmid2"
 	organ_tag = BP_RESIN
 	associated_power = /mob/living/carbon/human/proc/resin
 
-/obj/item/organ/internal/eyes/xenos/update_colour()
+/obj/item/organ/internal/eyes/xeno/update_colour()
 	if(!owner)
 		return
 	owner.r_eyes = 153
@@ -73,7 +73,7 @@
 	owner.b_eyes = 153
 	..()
 
-/obj/item/organ/internal/xenos/hivenode/removed(var/mob/living/user)
+/obj/item/organ/internal/xeno/hivenode/removed(var/mob/living/user)
 	if(owner && ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		to_chat(H, "<span class='alium'>You feel your connection to the hivemind fray and fade away...</span>")
@@ -82,7 +82,7 @@
 			GLOB.xenomorphs.remove_antagonist(H.mind)
 	..(user)
 
-/obj/item/organ/internal/xenos/hivenode/replaced(var/mob/living/carbon/human/target,var/obj/item/organ/external/affected)
+/obj/item/organ/internal/xeno/hivenode/replaced(var/mob/living/carbon/human/target,var/obj/item/organ/external/affected)
 	if(!..()) return 0
 
 	if(owner && ishuman(owner))
@@ -94,6 +94,38 @@
 
 	return 1
 
+// Xenomorph limbs.
 /obj/item/organ/external/head/unbreakable/xeno
 	eye_icon = "eyes"
 	eye_icon_location = 'icons/mob/human_races/xenos/r_xenos_drone.dmi'
+	encased = "carapace"
+
+/obj/item/organ/external/chest/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/groin/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/arm/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/arm/right/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/leg/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/leg/right/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/foot/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/foot/right/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/hand/unbreakable/xeno
+	encased = "carapace"
+
+/obj/item/organ/external/hand/right/unbreakable/xeno
+	encased = "carapace"

--- a/code/modules/organs/subtypes/general.dm
+++ b/code/modules/organs/subtypes/general.dm
@@ -1,0 +1,2 @@
+/obj/item/organ/internal/heart/open
+	open = 1

--- a/code/modules/organs/subtypes/nabber_organ.dm
+++ b/code/modules/organs/subtypes/nabber_organ.dm
@@ -124,10 +124,6 @@
 		else
 			H.oxygen_alert = 2
 
-
-/obj/item/organ/internal/heart/nabber
-	open = 1
-
 /obj/item/organ/internal/brain/nabber
 	var lowblood_tally = 0
 	var lowblood_mult = 2

--- a/html/changelogs/zuhayr-xenophage.yml
+++ b/html/changelogs/zuhayr-xenophage.yml
@@ -1,0 +1,4 @@
+author: Zuhayr
+delete-after: True
+changes:
+  - tweak: "Xenomorph brute resistance, movement speed and and armour have all been significantly adjusted. Be on the lookout for xenos being nerf OP and report issues to the tracker."


### PR DESCRIPTION
- Xenophage who rest on weeds for ten seconds now receive accelerated heal ticks.
- Weed healing in general has been buffed and now prioritizes internal organs (like the brain).
- Species can now have natural armour. Xenophage have pretty high natural armour. It might be worth replacing brute and burn mods with this system in the future.
- Removes xenophage weakness to fire, replaces it with equivalent value to brute resist. Original fire weakness was a reference to Alien and resulted in insanely fast TTK with lasers (reportedly).
- Increases brute/burn resistance and makes it variable across castes. Faster xenophage generally have less resistance.
- Removed tendons and arterial bleeding from the `unbreakable` limb type.
- Made xenophage hearts `open = TRUE`. Generalized nabber heart path to do so.
- Made all xenophage limbs use `encased` like skulls/ribcages. Mostly fluff for dissections.
- Decreased xenophage movement slowdowns across the board.
- Added stun, paralysis and weakness modifiers to species datums.
- Made xenophages immune to radiation and weakness, and resistant to stun and paralysis.
- Prevented unarmed attacks from showing 'X has been weakened' when the weaken call fails.
- Removed diona organ previously used for rad immunity.
- Minor repathing of some xeno organs for consistency.