### PR TITLE
Muzzle fix

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -151,6 +151,8 @@
 	if(silent || (sdisabilities & MUTE))
 		message_data[1] = ""
 		. = 1
+	else if(istype(wear_mask, /obj/item/clothing/mask/muzzle) && isSynthetic())
+		. = (message_data)
 
 	else if(istype(wear_mask, /obj/item/clothing/mask))
 		var/obj/item/clothing/mask/M = wear_mask

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -177,7 +177,7 @@ proc/get_radio_key_from_channel(var/channel)
 		speaking.broadcast(src,trim(message))
 		return 1
 
-	if(is_muzzled())
+	if(is_muzzled() && !isSynthetic())
 		to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
 		return
 

--- a/html/changelogs/AMahinko - muzzle-fix.yml
+++ b/html/changelogs/AMahinko - muzzle-fix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Shotgun_Gospel
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed muzzles / duct tape working on synthetics"


### PR DESCRIPTION
Basic bugfix ([issue #20735](https://github.com/Baystation12/Baystation12/issues/20735)) to check if a muzzled character is a synthetic and allowing them to speak regardless in such a case.
