### PR TITLE
Changes occupation settings from a cycle to a list.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -129,7 +129,7 @@ datum/preferences
 	dat += player_setup.content(user)
 
 	dat += "</html></body>"
-	var/datum/browser/popup = new(user, "Character Setup","Character Setup", 1200, 800, src)
+	var/datum/browser/popup = new(user, "Character Setup","Character Setup", 1366, 800, src)
 	popup.set_content(dat)
 	popup.open()
 


### PR DESCRIPTION
:cl:mkalash
tweak: Changes occupation settings from a cycle to a list.
/:cl:
![image](https://user-images.githubusercontent.com/313146/36957487-b703b5b0-2002-11e8-9a7b-ec4505c011e4.png)

Also cleans up a little bit of the disgusting mess that is occupation preferences. Hot damn, that code made this take way longer than it should have.