### PR TITLE
Adds the ability to write on foreheads.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -3,36 +3,42 @@
 	colour = "#da0000"
 	shadeColour = "#810c0c"
 	colourName = "red"
+	color_description = "red crayon"
 
 /obj/item/weapon/pen/crayon/orange
 	icon_state = "crayonorange"
 	colour = "#ff9300"
 	shadeColour = "#a55403"
 	colourName = "orange"
+	color_description = "orange crayon"
 
 /obj/item/weapon/pen/crayon/yellow
 	icon_state = "crayonyellow"
 	colour = "#fff200"
 	shadeColour = "#886422"
 	colourName = "yellow"
+	color_description = "yellow crayon"
 
 /obj/item/weapon/pen/crayon/green
 	icon_state = "crayongreen"
 	colour = "#a8e61d"
 	shadeColour = "#61840f"
 	colourName = "green"
+	color_description = "green crayon"
 
 /obj/item/weapon/pen/crayon/blue
 	icon_state = "crayonblue"
 	colour = "#00b7ef"
 	shadeColour = "#0082a8"
 	colourName = "blue"
+	color_description = "blue crayon"
 
 /obj/item/weapon/pen/crayon/purple
 	icon_state = "crayonpurple"
 	colour = "#da00ff"
 	shadeColour = "#810cff"
 	colourName = "purple"
+	color_description = "purple crayon"
 
 /obj/item/weapon/pen/crayon/random/Initialize()
 	..()
@@ -46,6 +52,7 @@
 	colour = "#ffffff"
 	shadeColour = "#000000"
 	colourName = "mime"
+	color_description = "white crayon"
 	uses = 0
 
 /obj/item/weapon/pen/crayon/mime/attack_self(mob/living/user as mob) //inversion
@@ -64,6 +71,7 @@
 	colour = "#fff000"
 	shadeColour = "#000fff"
 	colourName = "rainbow"
+	color_description = "rainbow crayon"
 	uses = 0
 
 /obj/item/weapon/pen/crayon/rainbow/attack_self(mob/living/user as mob)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -39,31 +39,38 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/weapon/lipstick/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/lipstick/attack(atom/A, mob/user as mob, target_zone)
 	if(!open)	return
 
-	if(!istype(M, /mob))	return
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.lip_style)	//if they already have lipstick on
-			to_chat(user, "<span class='notice'>You need to wipe off the old lipstick first!</span>")
+		if(!istype(head))
 			return
-		if(H == user)
-			user.visible_message("<span class='notice'>[user] does their lips with \the [src].</span>", \
-								 "<span class='notice'>You take a moment to apply \the [src]. Perfect!</span>")
-			H.lip_style = colour
-			H.update_body()
-		else
-			user.visible_message("<span class='warning'>[user] begins to do [H]'s lips with \the [src].</span>", \
-								 "<span class='notice'>You begin to apply \the [src].</span>")
-			if(do_after(user, 20, H) && do_after(H, 20, needhand = 0, progress = 0, incapacitation_flags = INCAPACITATION_NONE))	//user needs to keep their active hand, H does not.
-				user.visible_message("<span class='notice'>[user] does [H]'s lips with \the [src].</span>", \
-									 "<span class='notice'>You apply \the [src].</span>")
+
+		if(user.a_intent == I_HELP && target_zone == BP_HEAD)
+			head.write_on(user, src.name)
+		else if(head.has_lips)
+			if(H.lip_style)	//if they already have lipstick on
+				to_chat(user, "<span class='notice'>You need to wipe off the old lipstick first!</span>")
+				return
+			if(H == user)
+				user.visible_message("<span class='notice'>[user] does their lips with \the [src].</span>", \
+									 "<span class='notice'>You take a moment to apply \the [src]. Perfect!</span>")
 				H.lip_style = colour
 				H.update_body()
-	else
-		to_chat(user, "<span class='notice'>Where are the lips on that?</span>")
+			else
+				user.visible_message("<span class='warning'>[user] begins to do [H]'s lips with \the [src].</span>", \
+									 "<span class='notice'>You begin to apply \the [src].</span>")
+				if(do_after(user, 20, H) && do_after(H, 20, needhand = 0, progress = 0, incapacitation_flags = INCAPACITATION_NONE))	//user needs to keep their active hand, H does not.
+					user.visible_message("<span class='notice'>[user] does [H]'s lips with \the [src].</span>", \
+										 "<span class='notice'>You apply \the [src].</span>")
+					H.lip_style = colour
+					H.update_body()
+	else if(istype(A, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = A
+		head.write_on(user, src)
 
 //you can wipe off lipstick with paper! see code/modules/paperwork/paper.dm, paper/attack()
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -232,6 +232,11 @@
 				if(H.belt.clean_blood())
 					H.update_inv_belt(0)
 			H.clean_blood(washshoes)
+
+			var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
+			if(istype(head))
+				head.forehead_graffiti = null
+				head.graffiti_style = null
 		else
 			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 				if(M.wear_mask.clean_blood())
@@ -402,6 +407,12 @@
 	if(user.get_active_hand() != I) return		//Person has switched hands or the item in their hands
 
 	O.clean_blood()
+
+	if(istype(O, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = O
+		head.forehead_graffiti = null
+		head.graffiti_style = null
+
 	user.visible_message( \
 		"<span class='notice'>[user] washes \a [I] using \the [src].</span>", \
 		"<span class='notice'>You wash \a [I] using \the [src].</span>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -187,6 +187,10 @@
 		else if(!client)
 			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>\n"
 
+	var/obj/item/organ/external/head/H = organs_by_name[BP_HEAD]
+	if(istype(H) && H.forehead_graffiti && H.graffiti_style)
+		msg += "<span class='notice'>[T.He] [T.has] \"[H.forehead_graffiti]\" written on [T.his] [H.name] in [H.graffiti_style]!</span>\n"
+
 	var/list/wound_flavor_text = list()
 	var/applying_pressure = ""
 	var/list/shown_objects = list()

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -20,7 +20,48 @@
 	var/eye_icon = "eyes_s"
 	var/eye_icon_location = 'icons/mob/human_face.dmi'
 
-	var/has_lips
+	var/has_lips = 1
+
+	var/forehead_graffiti
+	var/graffiti_style
+
+/obj/item/organ/external/head/examine(mob/user)
+	. = ..()
+
+	if(forehead_graffiti && graffiti_style)
+		to_chat(user, "<span class='notice'>It has \"[forehead_graffiti]\" written on it in [graffiti_style]!</span>")
+
+/obj/item/organ/external/head/proc/write_on(var/mob/penman, var/style)
+	var/head_name = name
+	var/atom/target = src
+	if(owner)
+		head_name = "[owner]'s [name]"
+		target = owner
+
+	if(forehead_graffiti)
+		to_chat(penman, "<span class='notice'>There is no room left to write on [head_name]!</span>")
+		return
+
+	var/graffiti = sanitizeSafe(input(penman, "Enter a message to write on [head_name]:") as text|null, MAX_NAME_LEN)
+	if(graffiti)
+		if(!target.Adjacent(penman))
+			to_chat(penman, "<span class='notice'>[head_name] is too far away.</span>")
+			return
+
+		if(owner && owner.check_head_coverage())
+			to_chat(penman, "<span class='notice'>[head_name] is covered up.</span>")
+			return
+
+		penman.visible_message("<span class='warning'>[penman] begins writing something on [head_name]!</span>", "You begin writing something on [head_name].")
+
+		if(do_after(penman, 3 SECONDS, target))
+			if(owner && owner.check_head_coverage())
+				to_chat(penman, "<span class='notice'>[head_name] is covered up.</span>")
+				return
+
+			penman.visible_message("<span class='warning'>[penman] writes something on [head_name]!</span>", "You write something on [head_name].")
+			forehead_graffiti = graffiti
+			graffiti_style = style
 
 /obj/item/organ/external/head/set_dna(var/datum/dna/new_dna)
 	..()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -24,28 +24,33 @@
 	throw_range = 15
 	matter = list(DEFAULT_WALL_MATERIAL = 10)
 	var/colour = "black"	//what colour the ink is!
+	var/color_description = "black ink"
 
 
 /obj/item/weapon/pen/blue
 	desc = "It's a normal blue ink pen."
 	icon_state = "pen_blue"
 	colour = "blue"
+	color_description = "blue ink"
 
 /obj/item/weapon/pen/red
 	desc = "It's a normal red ink pen."
 	icon_state = "pen_red"
 	colour = "red"
+	color_description = "red ink"
 
 /obj/item/weapon/pen/multi
 	desc = "It's a pen with multiple colors of ink!"
 	var/selectedColor = 1
 	var/colors = list("black","blue","red")
+	var/color_descriptions = list("black ink", "blue ink", "red ink")
 
 /obj/item/weapon/pen/multi/attack_self(mob/user)
 	if(++selectedColor > 3)
 		selectedColor = 1
 
 	colour = colors[selectedColor]
+	color_description = color_descriptions[selectedColor]
 
 	if(colour == "black")
 		icon_state = "pen"
@@ -58,15 +63,24 @@
 	desc = "It's an invisble pen marker."
 	icon_state = "pen"
 	colour = "white"
+	color_description = "transluscent ink"
 
 
-/obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob)
-	if(!ismob(M))
-		return
-	to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
-	admin_attack_log(user, M, "Stabbed using \a [src]", "Was stabbed with \a [src]", "used \a [src] to stab")
+/obj/item/weapon/pen/attack(atom/A, mob/user as mob, target_zone)
+	if(ismob(A))
+		var/mob/M = A
+		if(ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
+			var/mob/living/carbon/human/H = M
+			var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
+			if(istype(head))
+				head.write_on(user, src.color_description)
+		else
+			to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
+			admin_attack_log(user, M, "Stabbed using \a [src]", "Was stabbed with \a [src]", "used \a [src] to stab")
+	else if(istype(A, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = A
+		head.write_on(user, src.color_description)
 
-	return
 
 /*
  * Reagent pens
@@ -143,22 +157,31 @@
 		switch(selected_type)
 			if("Yellow")
 				colour = COLOR_YELLOW
+				color_description = "yellow ink"
 			if("Green")
 				colour = COLOR_LIME
+				color_description = "green ink"
 			if("Pink")
 				colour = COLOR_PINK
+				color_description = "pink ink"
 			if("Blue")
 				colour = COLOR_BLUE
+				color_description = "blue ink"
 			if("Orange")
 				colour = COLOR_ORANGE
+				color_description = "orange ink"
 			if("Cyan")
 				colour = COLOR_CYAN
+				color_description = "cyan ink"
 			if("Red")
 				colour = COLOR_RED
+				color_description = "red ink"
 			if("Invisible")
 				colour = COLOR_WHITE
+				color_description = "transluscent ink"
 			else
 				colour = COLOR_BLACK
+				color_description = "black ink"
 		to_chat(usr, "<span class='info'>You select the [lowertext(selected_type)] ink container.</span>")
 
 
@@ -178,6 +201,7 @@
 	var/uses = 30 //0 for unlimited uses
 	var/instant = 0
 	var/colourName = "red" //for updateIcon purposes
+	color_description = "red crayon"
 
 /obj/item/weapon/pen/crayon/Initialize()
 	name = "[colourName] crayon"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/313146/37011189-fdb26cf8-20bc-11e8-85a2-0f37fa4dd90f.png)
:cl:mkalash
rscadd: You can now deface people's heads by targeting it with help intent and using a pen, crayon, or lipstick -- even if it's no longer attached. Heads with shoulders below them can be gentrified using a shower, or in a sink otherwise.
bugfix: You can no longer apply lipstick to things without lips.
/:cl: