### PR TITLE
Duct tape can temporarily reseal spacesuits

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -63,6 +63,14 @@
 			if(!T.place_handcuffs(H, user))
 				user.unEquip(T)
 				qdel(T)
+
+		else if(user.zone_sel.selecting == BP_CHEST)
+			if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/space))
+				if(H == user || do_mob(user, H, 10))	//Skip the time-check if patching your own suit, that's handled in attackby()
+					H.wear_suit.attackby(src, user)
+			else
+				to_chat(user, "<span class='warning'>\The [H] isn't wearing a spacesuit for you to reseal.</span>")
+
 		else
 			return ..()
 		return 1

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -6,6 +6,7 @@
 	var/class = 0                           // Size. Lower is smaller. Uses floating point values!
 	var/descriptor                          // 'gaping hole' etc.
 	var/damtype = BURN                      // Punctured or melted
+	var/patched = FALSE
 	var/obj/item/clothing/suit/space/holder // Suit containing the list of breaches holding this instance.
 	var/global/list/breach_brute_descriptors = list(
 		"tiny puncture",
@@ -29,9 +30,9 @@
 	var/list/breaches = list()              // Breach datum container.
 	var/resilience = 0.2                    // Multiplier that turns damage into breach class. 1 is 100% of damage to breach, 0.1 is 10%. 0.2 -> 50 brute/burn damage to cause 10 breach damage
 	var/breach_threshold = 3                // Min damage before a breach is possible. Damage is subtracted by this amount, it determines the "hardness" of the suit.
-	var/damage = 0                          // Current total damage
-	var/brute_damage = 0                    // Specifically brute damage.
-	var/burn_damage = 0                     // Specifically burn damage.
+	var/damage = 0                          // Current total damage. Does not count patched breaches.
+	var/brute_damage = 0                    // Specifically brute damage. Includes patched punctures.
+	var/burn_damage = 0                     // Specifically burn damage. Includes patched burns.
 
 /datum/breach/proc/update_descriptor()
 
@@ -42,6 +43,8 @@
 		descriptor = breach_burn_descriptors[class]
 	else if(damtype == BRUTE)
 		descriptor = breach_brute_descriptors[class]
+	if(patched)
+		descriptor = "patched [descriptor]"
 
 //Repair a certain amount of brute or burn damage to the suit.
 /obj/item/clothing/suit/space/proc/repair_breaches(var/damtype, var/amount, var/mob/user)
@@ -89,10 +92,6 @@
 
 	if(damage > 25) return //We don't need to keep tracking it when it's at 250% pressure loss, really.
 
-	if(!loc) return
-	var/turf/T = get_turf(src)
-	if(!T) return
-
 	//Increase existing breaches.
 	for(var/datum/breach/existing in breaches)
 
@@ -111,9 +110,11 @@
 				amount -= needs
 
 			if(existing.damtype == BRUTE)
-				T.visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] gapes wider!</span>")
+				visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] gapes wider[existing.patched ? ", tearing the patch" : ""]!</span>")
 			else if(existing.damtype == BURN)
-				T.visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] widens!</span>")
+				visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] widens[existing.patched ? ", ruining the patch" : ""]!</span>")
+
+			existing.patched = FALSE
 
 	if (amount)
 		//Spawn a new breach.
@@ -127,9 +128,9 @@
 		B.holder = src
 
 		if(B.damtype == BRUTE)
-			T.visible_message("<span class = 'warning'>\A [B.descriptor] opens up on [src]!</span>")
+			visible_message("<span class = 'warning'>\A [B.descriptor] opens up on [src]!</span>")
 		else if(B.damtype == BURN)
-			T.visible_message("<span class = 'warning'>\A [B.descriptor] marks the surface of [src]!</span>")
+			visible_message("<span class = 'warning'>\A [B.descriptor] marks the surface of [src]!</span>")
 
 	calc_breach_damage()
 
@@ -139,6 +140,7 @@
 	damage = 0
 	brute_damage = 0
 	burn_damage = 0
+	var/all_patched = TRUE
 
 	if(!can_breach || !breaches || !breaches.len)
 		SetName(initial(name))
@@ -149,7 +151,10 @@
 			src.breaches -= B
 			qdel(B)
 		else
-			damage += B.class
+			if(!B.patched)
+				all_patched = FALSE
+				damage += B.class
+
 			if(B.damtype == BRUTE)
 				brute_damage += B.class
 			else if(B.damtype == BURN)
@@ -162,7 +167,9 @@
 			SetName("scorched [initial(name)]")
 		else
 			SetName("damaged [initial(name)]")
-	else
+	else if(all_patched)
+		SetName("patched [initial(name)]")
+	else 
 		SetName(initial(name))
 
 	return damage
@@ -185,7 +192,7 @@
 			to_chat(user, "<span class='warning'>How do you intend to patch a hardsuit while someone is wearing it?</span>")
 			return
 
-		if(!damage || !burn_damage)
+		if(burn_damage <= 0)
 			to_chat(user, "There is no surface damage on \the [src] to repair.")
 			return
 
@@ -201,7 +208,7 @@
 			to_chat(user, "<span class='warning'>How do you intend to patch a hardsuit while someone is wearing it?</span>")
 			return
 
-		if (!damage || ! brute_damage)
+		if (brute_damage <= 0)
 			to_chat(user, "There is no structural damage on \the [src] to repair.")
 			return
 
@@ -211,6 +218,23 @@
 			return
 
 		repair_breaches(BRUTE, 3, user)
+		return
+
+	else if(istype(W, /obj/item/weapon/tape_roll))
+		var/datum/breach/target_breach		//Target the largest unpatched breach.
+		for(var/datum/breach/B in breaches)
+			if(B.patched)
+				continue
+			if(!target_breach || (B.class > target_breach.class))
+				target_breach = B
+
+		if(!target_breach)
+			to_chat(user, "There are no open breaches to seal with \the [W].")
+		else if(user != loc || do_after(user, 30, src))		//Doing this in your own inventory is awkward.
+			user.visible_message("<b>[user]</b> uses \the [W] to seal \the [target_breach] on \the [src].")
+			target_breach.patched = TRUE
+			target_breach.update_descriptor()
+			calc_breach_damage()
 		return
 
 	..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -452,8 +452,7 @@ meteor_act
 	if(!wear_suit) return
 	if(!istype(wear_suit,/obj/item/clothing/suit/space)) return
 	var/obj/item/clothing/suit/space/SS = wear_suit
-	var/penetrated_dam = max(0,(damage - SS.breach_threshold))
-	if(penetrated_dam) SS.create_breaches(damtype, penetrated_dam)
+	SS.create_breaches(damtype, damage)
 
 /mob/living/carbon/human/reagent_permeability()
 	var/perm = 0


### PR DESCRIPTION
:cl: 
rscadd: You can now temporarily reseal damaged spacesuits with duct tape. Either click on the suit itself, or target the chest and click on a mob wearing a spacesuit. But be warned, further damage will tear off the patch.
/:cl:

Alternative implementation of #20737