### PR TITLE
Fixes several RuntimeBot issues incl. un-reinforcing girders, gravity on null monkeys, and grabbing non-human mobs

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -100,8 +100,11 @@
 		if(do_after(user, 40,src))
 			if(!src) return
 			to_chat(user, "<span class='notice'>You removed the support struts!</span>")
-			reinf_material.place_dismantled_product(get_turf(src))
-			reinf_material = null
+
+			if(reinf_material)
+				reinf_material.place_dismantled_product(get_turf(src))
+				reinf_material = null
+
 			reset_girder()
 
 	else if(isCrowbar(W) && state == 0 && anchored)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -88,6 +88,10 @@
 
 /obj/item/grab/proc/can_grab()
 
+	// can't grab non-carbon/human/'s
+	if(!istype(affecting))
+		return 0
+
 	if(assailant.anchored || affecting.anchored)
 		return 0
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -73,7 +73,7 @@
 
 	// Can't fall if nothing pulls you down
 	var/area/area = get_area(src)
-	if (!area.has_gravity())
+	if (!area || !area.has_gravity())
 		return
 
 	var/limb_pain


### PR DESCRIPTION
* Fixes #14757 related to un-reinforcing girders

* Fixes #20681 relating to gravity

* Adds sanity check to grabs: only allowed to grab carbon/human/'s  …

In grab_object.dm, New() is technically defined as taking a human mob object...
The biggest problem being, however, that everything else grab-related seems to access human vars/procs in some way, so the "easy" workaround is to forbid non-human grabs.

This could naturally be reworked in the future (haha) to allow non-humans to be grabbed (eg. slimes, simple_animals, etc.) by adding checks throughout or some kind of split between grabs-on-humans and grabs-on-other...

This last change tentatively fixes several issues...
1. Fixes #20690 relating to w_uniform
2. Fixes #20688 related to adjust_position()
3. Fixes #20689 related to icon and update_icons()
4. Fixes #20691 related to grab_slowdown()
5. Fixes #20692 related to reverse_facing and assailant_reverse_facing()
6. Fixes #20693 related to assailant_moved()

** Note, issues 2-6 seem to be related to the first issue where init() failed because the Vox tried to leap & grab Faithless, a non-human