### PR TITLE
Replaces Unathi damage regeneration with inapro/synaptizine generation

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -29,6 +29,9 @@
 	h_style = "Tajaran Ears"
 	..(new_loc, SPECIES_TAJARA)
 
+/mob/living/carbon/human/unathi
+	var/growing_limbs = FALSE
+
 /mob/living/carbon/human/unathi/New(var/new_loc)
 	h_style = "Unathi Horns"
 	..(new_loc, SPECIES_UNATHI)

--- a/code/modules/mob/living/carbon/human/species/station/lizard.dm
+++ b/code/modules/mob/living/carbon/human/species/station/lizard.dm
@@ -24,7 +24,7 @@
 	secondary_langs = list(LANGUAGE_UNATHI)
 	name_language = LANGUAGE_UNATHI
 	health_hud_intensity = 2
-	hunger_factor = DEFAULT_HUNGER_FACTOR * 3
+	hunger_factor = DEFAULT_HUNGER_FACTOR
 
 	min_age = 18
 	max_age = 260
@@ -89,61 +89,9 @@
 	if(!H.innate_heal)
 		return
 
-	//Heals normal damage.
-	if(H.getBruteLoss())
-		H.adjustBruteLoss(-2 * config.organ_regeneration_multiplier)	//Heal brute better than other ouchies.
-		H.nutrition -= 1
-	if(H.getFireLoss())
-		H.adjustFireLoss(-1 * config.organ_regeneration_multiplier)
-		H.nutrition -= 1
-	if(H.getToxLoss())
-		H.adjustToxLoss(-1 * config.organ_regeneration_multiplier)
-		H.nutrition -= 1
+	if(H.reagents.get_reagent_amount(/datum/reagent/inaprovaline) < 1)
+		H.reagents.add_reagent(/datum/reagent/inaprovaline, 0.1)
 
-	if(prob(5) && H.nutrition > 150 && !H.getBruteLoss() && !H.getFireLoss())
-		var/obj/item/organ/external/head/D = H.organs_by_name["head"]
-		if (D.disfigured)
-			D.disfigured = 0
-			H.nutrition -= 20
-
-	if(H.nutrition <= 100)
-		return
-
-	for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
-
-		var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
-
-		if(regen_organ.robotic >= ORGAN_ROBOT)
-			continue
-		if(istype(regen_organ))
-			if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
-				regen_organ.damage = max(regen_organ.damage - 5, 0)
-				H.nutrition -= 5
-				if(prob(5))
-					to_chat(H, "<span class='warning'>You feel a soothing sensation as your [regen_organ] mends...</span>")
-
-	if(prob(2) && H.nutrition > 150)
-		for(var/limb_type in has_limbs)
-			var/obj/item/organ/external/E = H.organs_by_name[limb_type]
-			if(E && E.organ_tag != BP_HEAD && !E.vital && !E.is_usable())	//Skips heads and vital bits...
-				E.removed()			//...because no one wants their head to explode to make way for a new one.
-				qdel(E)
-				E= null
-			if(!E)
-				var/list/organ_data = has_limbs[limb_type]
-				var/limb_path = organ_data["path"]
-				var/obj/item/organ/external/O = new limb_path(H)
-				organ_data["descriptor"] = O.name
-				to_chat(H, "<span class='danger'>With a shower of fresh blood, a new [O.name] forms.</span>")
-				H.visible_message("<span class='danger'>With a shower of fresh blood, a length of biomass shoots from [H]'s [O.amputation_point], forming a new [O.name]!</span>")
-				H.nutrition -= 50
-				var/datum/reagent/blood/B = locate(/datum/reagent/blood) in H.vessel.reagent_list
-				blood_splatter(H,B,1)
-				O.set_dna(H.dna)
-				H.update_body()
-				return
-			else
-				for(var/datum/wound/W in E.wounds)
-					if(W.wound_damage() == 0 && prob(50))
-						E.wounds -= W
+	if(H.reagents.get_reagent_amount(/datum/reagent/synaptizine) < 0.1)
+		H.reagents.add_reagent(/datum/reagent/synaptizine, 0.01)
 


### PR DESCRIPTION
For your consideration. Inaprov to keep them alive, synap to keep them kicking. By compromise, delayed limb regrowth that weakens the player for some time. Nothing else needed.
:cl:mkalash
tweak:Unathi now steadily produce inaprovaline and synaptizine rather than artificially repair damage. This should keep them alive and kicking long enough to receive treatment under reasonable circumstances. As a result, their hunger has been cut by 1/3 down to default.
tweak:Unathi limb regrowth now takes much longer and stuns the player.
/:cl: