### PR TITLE
Brain damage effects tweaks

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -136,7 +136,6 @@
 	return (get_current_damage_threshold() > threshold)
 
 /obj/item/organ/internal/brain/Process()
-
 	if(owner)
 		if(damage > max_damage / 2 && healed_threshold)
 			spawn()
@@ -146,37 +145,8 @@
 		if(damage < (max_damage / 4))
 			healed_threshold = 1
 
-		if(owner.paralysis < 1) // Skip it if we're already down.
-
-			if((owner.disabilities & EPILEPSY) && prob(1))
-				to_chat(owner, "<span class='warning'>You have a seizure!</span>")
-				owner.visible_message("<span class='danger'>\The [owner] starts having a seizure!</span>")
-				owner.Paralyse(10)
-				owner.make_jittery(1000)
-			else if((owner.disabilities & TOURETTES) && prob(10))
-				owner.Stun(10)
-				switch(rand(1, 3))
-					if(1)
-						owner.emote("twitch")
-					if(2 to 3)
-						owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
-				owner.make_jittery(100)
-			else if((owner.disabilities & NERVOUS) && prob(10))
-				owner.stuttering = max(10, owner.stuttering)
-
-			if(owner.stat == CONSCIOUS)
-				if(damage > 0 && prob(1))
-					owner.custom_pain("Your head feels numb and painful.",10)
-				if(is_bruised() && prob(1) && owner.eye_blurry <= 0)
-					to_chat(owner, "<span class='warning'>It becomes hard to see for some reason.</span>")
-					owner.eye_blurry = 10
-				if(is_broken() && prob(1) && owner.get_active_hand())
-					to_chat(owner, "<span class='danger'>Your hand won't respond properly, and you drop what you are holding!</span>")
-					owner.drop_item()
-				if((damage >= (max_damage * 0.75)))
-					if(!owner.lying)
-						to_chat(owner, "<span class='danger'>You black out!</span>")
-					owner.Paralyse(10)
+		handle_disabilities()
+		handle_damage_effects()
 
 		// Brain damage from low oxygenation or lack of blood.
 		if(owner.should_have_organ(BP_HEART))
@@ -222,3 +192,40 @@
 					if(prob(damprob))
 						take_damage(1)
 	..()
+
+/obj/item/organ/internal/brain/proc/handle_disabilities()
+	if(owner.stat)
+		return
+	if((owner.disabilities & EPILEPSY) && prob(1))
+		to_chat(owner, "<span class='warning'>You have a seizure!</span>")
+		owner.visible_message("<span class='danger'>\The [owner] starts having a seizure!</span>")
+		owner.Paralyse(10)
+		owner.make_jittery(1000)
+	else if((owner.disabilities & TOURETTES) && prob(10))
+		owner.Stun(10)
+		switch(rand(1, 3))
+			if(1)
+				owner.emote("twitch")
+			if(2 to 3)
+				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
+		owner.make_jittery(100)
+	else if((owner.disabilities & NERVOUS) && prob(10))
+		owner.stuttering = max(10, owner.stuttering)
+
+/obj/item/organ/internal/brain/proc/handle_damage_effects()
+	if(owner.stat)
+		return
+	if(damage > 0 && prob(1))
+		owner.custom_pain("Your head feels numb and painful.",10)
+	if(is_bruised() && prob(1) && owner.eye_blurry <= 0)
+		to_chat(owner, "<span class='warning'>It becomes hard to see for some reason.</span>")
+		owner.eye_blurry = 10
+	if(damage >= 0.5*max_damage && prob(1) && owner.get_active_hand())
+		to_chat(owner, "<span class='danger'>Your hand won't respond properly, and you drop what you are holding!</span>")
+		owner.drop_item()
+	if(damage >= 0.6*max_damage)
+		owner.slurring = max(owner.slurring, 2)
+	if(is_broken())
+		if(!owner.lying)
+			to_chat(owner, "<span class='danger'>You black out!</span>")
+		owner.Paralyse(10)


### PR DESCRIPTION
Reshuffled code a bit to break up brain's yuge Process()

Moved hand not responding thing to 50% damage since it never fired at is_broken() (that's where you get KO'd so hand shenanighans didn't matter)

Added slurring at 60% brain damage.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
