### PR TITLE
Fixes some borg gripper issues

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -41,6 +41,7 @@
 		to_chat(usr, "You can see \a [cooking_obj] inside.")
 
 /obj/machinery/cooker/attackby(var/obj/item/I, var/mob/user)
+	set waitfor = 0  //So that any remaining parts of calling proc don't have to wait for the long cooking time ahead.
 
 	if(!cook_type || (stat & (NOPOWER|BROKEN)))
 		to_chat(user, "<span class='warning'>\The [src] is not working.</span>")

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -114,7 +114,9 @@
 					"<span class='notice'>You add one of [O] to \the [src].</span>")
 			return
 		else
-			user.drop_item(src)
+			if (!user.drop_from_inventory(O))
+				return
+			O.forceMove(src)
 			user.visible_message( \
 				"<span class='notice'>\The [user] has added \the [O] to \the [src].</span>", \
 				"<span class='notice'>You add \the [O] to \the [src].</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -571,6 +571,7 @@
 					opened = 1
 					update_icon()
 
+	// If the robot is having something inserted which will remain inside it, self-inserting must be handled before exiting to avoid logic errors. Use the handle_selfinsert proc.
 	else if (istype(W, /obj/item/weapon/stock_parts/matter_bin) && opened) // Installing/swapping a matter bin
 		if(storage)
 			to_chat(user, "You replace \the [storage] with \the [W]")
@@ -581,6 +582,7 @@
 		user.drop_item()
 		storage = W
 		W.forceMove(src)
+		handle_selfinsert(W, user)
 		recalculate_synth_capacities()
 
 	else if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
@@ -595,6 +597,7 @@
 			user.drop_item()
 			W.loc = src
 			cell = W
+			handle_selfinsert(W, user) //Just in case.
 			to_chat(user, "You insert the power cell.")
 			C.installed = 1
 			C.wrapped = W
@@ -650,6 +653,7 @@
 				to_chat(usr, "You apply the upgrade to [src]!")
 				usr.drop_item()
 				U.loc = src
+				handle_selfinsert(W, user)
 			else
 				to_chat(usr, "Upgrade error!")
 
@@ -657,6 +661,14 @@
 		if( !(istype(W, /obj/item/device/robotanalyzer) || istype(W, /obj/item/device/healthanalyzer)) )
 			spark_system.start()
 		return ..()
+
+/mob/living/silicon/robot/proc/handle_selfinsert(obj/item/W, mob/user)
+	if ((user == src) && istype(get_active_hand(),/obj/item/weapon/gripper))
+		var/obj/item/weapon/gripper/H = get_active_hand()
+		if (W.loc == H) //if this triggers something has gone very wrong, and it's safest to abort
+			return
+		else if (H.wrapped == W)
+			H.wrapped = null
 
 /mob/living/silicon/robot/attack_hand(mob/user)
 

--- a/html/changelogs/afterthought2-borggrip.yml
+++ b/html/changelogs/afterthought2-borggrip.yml
@@ -1,0 +1,4 @@
+author: afterthought
+delete-after: True
+changes: 
+  - bugfix: "Various borg gripper fixes, including self-upgrading, cooking, APCs, and mecha"


### PR DESCRIPTION
Essentially three fixes.
Improves handling of borg grippers used on targets which require delays. This should fix #20585, fix #17994, fix #13521, and fix #17182.
Fixes microwave-service borg interaction. When combined with above this should fix #20619 and fix #19346.
Fixes bad logic in borg self-insertion code. This should fix #16078 and related issues with other items.
