### PR TITLE
Makes ointment actually disinfect wounds

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -137,6 +137,7 @@
 			                         "<span class='notice'>You salved wounds on [M]'s [affecting.name].</span>" )
 			use(1)
 			affecting.salve()
+			affecting.disinfect()
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -195,7 +196,7 @@
 	singular_name = "advanced burn kit"
 	desc = "An advanced treatment kit for severe burns."
 	icon_state = "burnkit"
-	heal_burn = 0
+	heal_burn = 5
 	origin_tech = list(TECH_BIO = 1)
 	animal_heal = 7
 
@@ -222,6 +223,7 @@
 			affecting.heal_damage(0,heal_burn)
 			use(1)
 			affecting.salve()
+			affecting.disinfect()
 
 /obj/item/stack/medical/splint
 	name = "medical splints"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -663,11 +663,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(owner.can_autoheal(dam_type))
 			W.heal_damage(heal_amt)
 
-		// Salving also helps against infection
-		if(W.germ_level > 0 && W.salved && prob(2))
-			W.disinfected = 1
-			W.germ_level = 0
-
 	// sync the organ's damage with its wounds
 	src.update_damages()
 	if (update_damstate())


### PR DESCRIPTION
For longest time I believed it did, wiki claims so too, but only way to actually disinfect wounds was advanced TRAUMA kit.
Gives advanced burn kit some burn healy capability so it's any different from plain ointment (and plain actually heals whooping 1 dmage too so it was /worse/)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
