### PR TITLE
Fixes species rig sprites

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -112,6 +112,7 @@
 	camera = /obj/machinery/camera/network/engineering
 	species_restricted = list(SPECIES_HUMAN)
 	sprite_sheets = list(
+		SPECIES_SKRELL = 'icons/mob/species/skrell/helmet.dmi',
 		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/head.dmi'
 		)
 
@@ -255,29 +256,27 @@
 	camera = /obj/machinery/camera/network/medbay
 	species_restricted = list(SPECIES_HUMAN, SPECIES_TAJARA, SPECIES_UNATHI)
 	sprite_sheets = list(
-		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/head.dmi',
-		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi'
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/helmet.dmi',
+		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/head.dmi'
 		)
 
 /obj/item/clothing/suit/space/rig/medical
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_TAJARA, SPECIES_UNATHI)
 	sprite_sheets = list(
-		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/head.dmi',
-		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi'
+		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi',
+		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/suit.dmi'
 		)
 
 /obj/item/clothing/shoes/magboots/rig/medical
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_TAJARA, SPECIES_UNATHI)
 	sprite_sheets = list(
-		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/head.dmi',
-		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi'
+		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/feet.dmi'
 		)
 
 /obj/item/clothing/gloves/rig/medical
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_TAJARA, SPECIES_UNATHI)
 	sprite_sheets = list(
-		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/head.dmi',
-		SPECIES_TAJARA = 'icons/mob/species/tajaran/suit.dmi'
+		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/hands.dmi'
 		)
 
 /obj/item/weapon/rig/medical/equipped


### PR DESCRIPTION
Properly fixes missing sprites caused by #20386.

![image](https://user-images.githubusercontent.com/313146/37559632-ac3ffc18-29ff-11e8-8942-1e35cead1b86.png)
