### PR TITLE
Makes robbit oxygenation show as N/A on crew sensors

### DIFF
--- a/code/datums/repositories/crew/crew.dm
+++ b/code/datums/repositories/crew/crew.dm
@@ -52,17 +52,21 @@ var/global/datum/repository/crew/crew_repository = new()
 				var/mob/living/carbon/human/H = C.loc
 				if(H.w_uniform != C)
 					continue
+			
 				var/pressure = H.get_blood_pressure()
-				var/blood_result = H.get_blood_oxygenation()
-				if(blood_result > 110)
-					blood_result = "increased"
-				else if(blood_result < 90)
-					blood_result = "low"
-				else if(blood_result < 60)
-					blood_result = "extremely low"
+				if(H.isSynthetic() || !H.should_have_organ(BP_HEART))
+					pressure = "N/A"
 				else
-					blood_result = "normal"
-				pressure += " ([blood_result] oxygenation)"
+					var/blood_result = H.get_blood_oxygenation()
+					if(blood_result > 110)
+						blood_result = "increased"
+					else if(blood_result < 90)
+						blood_result = "low"
+					else if(blood_result < 60)
+						blood_result = "extremely low"
+					else
+						blood_result = "normal"
+					pressure += " ([blood_result] oxygenation)"
 
 				var/true_pulse = H.pulse()
 				var/pulse_span = "good"


### PR DESCRIPTION
Slightly less false positives. It seems that synths return some lower than norm oxygenation values so it spooks people, and we don't really HAVE any liquid in FBPs so might as well just put NA there.
Does same thing if guy isn't supposed to have any liquids in him in the first place, like species-wise.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
