### PR TITLE
Bumps chance of fun monolith reaction

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -47,7 +47,7 @@
 			if(!H.isSynthetic())
 				active = 1
 				update_icon()
-				if(prob(99))
+				if(prob(70))
 					to_chat(H, "<span class='notice'>As you touch \the [src], you suddenly get a vivid image - [E.get_engravings()]</span>")
 				else
 					to_chat(H, "<span class='warning'>An overwhelming stream of information invades your mind!</span>")


### PR DESCRIPTION
Most people only touch it once or twice, so people never ran into it.
After rubbing my face on monoliths a lot ingame, even with unholy spam 1% just doesn't come up.
I didn't intend it to be THIS hidden.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
