### PR TITLE
Fixes camera damage event

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -37,6 +37,11 @@
 
 	var/affected_by_emp_until = 0
 
+/obj/machinery/camera/examine(mob/user)
+	. = ..()
+	if(stat & BROKEN)
+		to_chat(user, "<span class='warning'>It is completely demolished.</span>")
+
 /obj/machinery/camera/malf_upgrade(var/mob/living/silicon/ai/user)
 	..()
 	malf_upgraded = 1

--- a/code/modules/events/camera_damage.dm
+++ b/code/modules/events/camera_damage.dm
@@ -17,9 +17,10 @@
 			if(prob(2*severity))
 				cam.destroy()
 			else
-				cam.wires.UpdateCut(CAMERA_WIRE_POWER, 0)
-				if(prob(5*severity))
-					cam.wires.UpdateCut(CAMERA_WIRE_ALARM, 0)
+				if(!cam.wires.IsIndexCut(CAMERA_WIRE_POWER))
+					cam.wires.CutWireIndex(CAMERA_WIRE_POWER)
+				if(!cam.wires.IsIndexCut(CAMERA_WIRE_ALARM) && prob(5*severity))
+					cam.wires.CutWireIndex(CAMERA_WIRE_ALARM)
 
 /datum/event/camera_damage/proc/acquire_random_camera(var/remaining_attempts = 5)
 	if(!cameranet.cameras.len)


### PR DESCRIPTION
Also examining a camera can now reveal if it was broken completely.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
