### PR TITLE
Xeno-cult considerations.

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -9,7 +9,12 @@ var/list/ventcrawl_machinery = list(
 	/obj/item/device/radio/borg,
 	/obj/item/weapon/holder,
 	/obj/machinery/camera,
-	/mob/living/simple_animal/borer
+	/mob/living/simple_animal/borer,
+	/obj/item/clothing/head/culthood, //Xenophage cults are a FEATURE, not a bug.
+	/obj/item/clothing/suit/cultrobes,
+	/obj/item/weapon/book/tome,
+	/obj/item/weapon/paper/,
+	/obj/item/weapon/melee/cultblade
 	)
 
 /mob/living/var/list/icon/pipes_shown = list()

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -10,7 +10,7 @@ var/list/ventcrawl_machinery = list(
 	/obj/item/weapon/holder,
 	/obj/machinery/camera,
 	/mob/living/simple_animal/borer,
-	/obj/item/clothing/head/culthood, //Xenophage cults are a FEATURE, not a bug.
+	/obj/item/clothing/head/culthood,
 	/obj/item/clothing/suit/cultrobes,
 	/obj/item/weapon/book/tome,
 	/obj/item/weapon/paper/,


### PR DESCRIPTION
:cl: 
rscadd: Xenophage cultists are now a feature-- They are allowed to ventcrawl with tomes, robes, and swords. Also monkies I guess.
/ :cl: 

Please criticize this on the PR, not Discord, for I cannot access it right now.