### PR TITLE
Waste system organ tweaks

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -697,7 +697,7 @@
 	name = "banana"
 	seed_name = "banana"
 	display_name = "banana tree"
-	chems = list(/datum/reagent/drink/juice/banana = list(10,10))
+	chems = list(/datum/reagent/drink/juice/banana = list(10,10), /datum/reagent/potassium = list(2,3))
 	trash_type = /obj/item/weapon/bananapeel
 	kitchen_tag = "banana"
 

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -28,6 +28,13 @@
 		else if(is_broken())
 			owner.adjustToxLoss(0.3)
 
+	if(is_bruised())
+		if(prob(5) && reagents.get_reagent_amount(/datum/reagent/potassium) < 5)
+			reagents.add_reagent(/datum/reagent/potassium, REM*5)
+	if(is_broken())
+		if(owner.reagents.get_reagent_amount(/datum/reagent/potassium) < 15)
+			owner.reagents.add_reagent(/datum/reagent/potassium, REM*2)
+
 	//If your kidneys aren't working, your body's going to have a hard time cleaning your blood.
 	if(!owner.reagents.has_reagent(/datum/reagent/dylovene))
 		if(prob(33))

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -42,9 +42,12 @@
 		filter_effect += 1
 	else if(owner.chem_effects[CE_ANTITOX])
 		filter_effect += 1
-	// If you're not filtering well, you're going to take damage. Even more if you have alcohol in you.
+	// If you're not filtering well, you're in trouble. Ammonia buildup to toxic levels and damage from alcohol
 	if(filter_effect < 2)
-		owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0) * (1 + owner.chem_effects[CE_ALCOHOL_TOXIC] + 0.5 * owner.chem_effects[CE_ALCOHOL]))
+		if(owner.reagents.get_reagent_amount(/datum/reagent/ammonia) < 6)
+			owner.reagents.add_reagent(/datum/reagent/ammonia, REM)
+		if(owner.chem_effects[CE_ALCOHOL])
+			owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0) * (owner.chem_effects[CE_ALCOHOL_TOXIC] + 0.5 * owner.chem_effects[CE_ALCOHOL]))
 
 	if(owner.chem_effects[CE_ALCOHOL_TOXIC])
 		take_damage(owner.chem_effects[CE_ALCOHOL_TOXIC], prob(90)) // Chance to warn them

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -248,6 +248,12 @@
 	reagent_state = SOLID
 	color = "#a0a0a0"
 
+/datum/reagent/potassium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(volume > 3)
+		M.add_chemical_effect(CE_PULSE, 1)
+	if(volume > 10)
+		M.add_chemical_effect(CE_PULSE, 1)
+
 /datum/reagent/radium
 	name = "Radium"
 	description = "Radium is an alkaline earth metal. It is extremely radioactive."

--- a/html/changelogs/chinsky - oofowmykidneys.yml
+++ b/html/changelogs/chinsky - oofowmykidneys.yml
@@ -1,0 +1,7 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Liver damage change. Now when it's not working right, it doesn't apply staright up damage (only for alcohol), it builds up ammonia in the blood up to toxic levels. Better get those scrubbers going."
+  - tweak: "Kidneys are doing similar thing, but with potassium."
+  - tweak: "Potassium now raises pulse, dangerously so over 10u."
+  - tweak: "Bananas now have bit of potassium in them."


### PR DESCRIPTION
Liver: no more straight up damage at bad filtering levels, creates ammonia up to toxic levels instead.
Can fight it with dialysis now.

Kidneys: added potassium generation when damaged.

Potassium increases pulse, dangerously so in amounts over 10 units.
Added some potassium to banans for monkey chemistry.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
