### PR TITLE
Fixes toggle-hub-visibility

### DIFF
--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -28,3 +28,5 @@ var/DBConnection/dbcon_old = new() // /tg/station database (Old database) -- see
 // However it'd be ok to use for accessing attack logs and such too, which are even laggier.
 var/fileaccess_timer = 0
 var/custom_event_msg = null
+
+GLOBAL_VAR_INIT(visibility_pref, FALSE)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -720,6 +720,8 @@ var/list/gamemode_cache = list()
 					radiation_lower_limit = text2num(value)
 				if("player_limit")
 					player_limit = text2num(value)
+				if("hub")
+					world.update_hub_visibility()
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/hub.dm
+++ b/code/hub.dm
@@ -1,12 +1,13 @@
 /world
-/* This is for any host that would like their server to appear on the main SS13 hub.
- * uncomment the define below to enable the HUB entry for your server
+/* This page contains info for the hub. To allow your server to be visible on the hub, update the entry in the config.
+ * You can also toggle visibility from in-game with toggle-hub-visibility; be aware that it takes a few minutes for the hub go
  */
-//#define HUB_ENABLED 1
 	hub = "Exadv1.spacestation13"
 	name = "Space Station 13 - Baystation 12"
-#ifdef HUB_ENABLED
-	hub_password = "kMZy3U5jJHSiBQjr"
-#else
-	hub_password = "SORRYNOPASSWORD"
-#endif
+
+/world/proc/update_hub_visibility()
+	GLOB.visibility_pref = !(GLOB.visibility_pref)
+	if(GLOB.visibility_pref)
+		hub_password = "kMZy3U5jJHSiBQjr"
+	else
+		hub_password = "SORRYNOPASSWORD"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -784,13 +784,11 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	world.visibility = !(world.visibility)
-	var/long_message = " toggled hub visibility.  The server is now [world.visibility ? "visible" : "invisible"] ([world.visibility])."
-	
-	if(world.visibility)
-		world.hub_password = "kMZy3U5jJHSiBQjr"
-	else
-		world.hub_password = "SORRYNOPASSWORD"
+	//BYOND hates actually changing world.visibility at runtime, so let's just change if we give it the hub password.
+	world.update_hub_visibility() //proc defined in hub.dm
+	var/long_message = "toggled hub visibility. The server is now [GLOB.visibility_pref ? "visible" : "invisible"] ([GLOB.visibility_pref])."
+	if (GLOB.visibility_pref && !world.reachable)
+		message_admins("WARNING: The server will not show up on the hub because byond is detecting that a firewall is blocking incoming connections.")
 
 	send2adminirc("[key_name(src)]" + long_message)
 	log_and_message_admins(long_message)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -16,6 +16,6 @@
 		message_staff("[holder.rank] logout: [key_name(src)]")
 		if(!GLOB.admins.len) //Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
 			send2adminirc("[key_name(src)] logged out - no more admins online.")
-			if(config.delist_when_no_admins && world.visibility)
-				world.visibility = FALSE
-				send2adminirc("Toggled hub visibility. The server is now invisible ([world.visibility]).")
+			if(config.delist_when_no_admins && GLOB.visibility_pref)
+				world.update_hub_visibility()
+				send2adminirc("Toggled hub visibility. The server is now invisible ([GLOB.visibility_pref]).")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -1,6 +1,9 @@
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME spacestation13
 
+## Hub visibility: If you want to be visible on the hub, uncomment the below line and be sure that Dream Daemon is set to "Visible." This can be changed in-round as well with toggle-hub-visibility if Dream Daemon is set correctly.
+# HUB
+
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

:cl: 
bugfix: For the very first time, toggle-hub-visibility works.
/ :cl:

So, the issue with toggle-hub-visibility is that it never quite worked. This isn't the fault of the person who coded it, but the fault of BYOND — for the past three years, changing world.visibility at runtime has been a mixed bag of breaking and not doing what you want when you want it. And there's no sign of it being fixed in sight.

The workaround found by MrStonedOne is to, rather than change visibility, change the hub_password we give to BYOND, since BYOND doesn't mind at all rejecting or accepting changes to you on the Hub at runtime if you have the right or wrong password.

**NOTE: For this to work, Dream Daemon _must_ be set to Visible, or else the workaround won't work.** A config option for appearing on the hub has been added to compensate for your urge to be hidden and secret despite this. By default, servers won't show the hub the correct password to be visible.

TO-DO:

- [x] Confirm standard behavior for config works, that is, that it will be on or off the hub correctly.
- [x] Confirm that the verb will remove and add the server from the hub, regardless of initial state, even if done multiple times in the same round.
- [x] Squash the mess of commits.

Fixes #12237

Misc: Turnaround time for visibility changes is about one minute.