### PR TITLE
Rework radio channel names

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -257,6 +257,8 @@
 			return global.cargo_supply_packs;
 		if("changelog_hash")
 			return global.changelog_hash;
+		if("channel_color_presets")
+			return global.channel_color_presets;
 		if("channel_to_radio_key")
 			return global.channel_to_radio_key;
 		if("chargen_robolimbs")
@@ -1298,6 +1300,8 @@
 			global.cargo_supply_packs=newval;
 		if("changelog_hash")
 			global.changelog_hash=newval;
+		if("channel_color_presets")
+			global.channel_color_presets=newval;
 		if("channel_to_radio_key")
 			global.channel_to_radio_key=newval;
 		if("chargen_robolimbs")
@@ -2210,6 +2214,7 @@
 	"cargo_supply_pack_root",
 	"cargo_supply_packs",
 	"changelog_hash",
+	"channel_color_presets",
 	"channel_to_radio_key",
 	"chargen_robolimbs",
 	"checked_for_inactives",

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -145,6 +145,20 @@ var/list/radiochannels = list(
 	"Security(I)"	= SEC_I_FREQ
 )
 
+var/list/channel_color_presets = list(
+	"Global Green" = "#008000",
+	"Phenomenal Purple" = "#993399",
+	"Bitchin' Blue" = "#395A9A",
+	"Menacing Maroon" = "#6D3F40",
+	"Pretty Periwinkle" = "#5C5C8A",
+	"Painful Pink" = "#FF00FF",
+	"Raging Red" = "#A30000",
+	"Operational Orange" = "#A66300",
+	"Tantalizing Turquoise" = "#008160",
+	"Bemoaning Brown" = "#7F6539",
+	"Gastric Green" = "#6EAA2C"
+)
+
 // central command channels, i.e deathsquid & response teams
 var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -335,7 +335,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			freq_text = tag
 
 		// Make span consistent with the channel name, not the frequency
-		var/span_class = frequency_span_class(display_freq)
+		var/span_class = "radio"
 		if(tag && radiochannels[tag])
 			span_class = frequency_span_class(radiochannels[tag])
 
@@ -528,7 +528,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(tag)
 			freq_text = tag
 
-		var/span_class = frequency_span_class(display_freq)
+		var/span_class = "radio"
 		if(tag && radiochannels[tag])
 			span_class = frequency_span_class(radiochannels[tag])
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -61,7 +61,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"],,
-							  signal.data["compression"], signal.data["level"], signal.frequency,
+							  signal.data["compression"], signal.data["level"], signal.frequency, signal.data["tag"],
 							  signal.data["verb"], signal.data["language"]	)
 
 
@@ -70,7 +70,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(signal.data["type"] == 1)
 
 			/* ###### Broadcast a message using signal.data ###### */
-			Broadcast_SimpleMessage(signal.data["name"], signal.frequency,
+			Broadcast_SimpleMessage(signal.data["name"], signal.frequency, signal.data["tag"],
 								  signal.data["message"],null, null,
 								  signal.data["compression"], listening_levels)
 
@@ -87,7 +87,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency,
+							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency, signal.data["tag"],
 							  signal.data["verb"], signal.data["language"])
 
 		if(!message_delay)
@@ -219,12 +219,15 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	@param freq
 		The frequency of the signal
 
+	@param tag
+		The "name" of the frequency. Displayed in brackets before the message
+
 **/
 
 /proc/Broadcast_Message(var/datum/radio_frequency/connection, var/mob/M,
 						var/vmask, var/vmessage, var/obj/item/device/radio/radio,
 						var/message, var/name, var/job, var/realname, var/vname,
-						var/data, var/compression, var/list/level, var/freq, var/verbage = "says", var/datum/language/speaking = null)
+						var/data, var/compression, var/list/level, var/freq, var/tag, var/verbage = "says", var/datum/language/speaking = null)
 
 
   /* ###### Prepare the radio connection ###### */
@@ -327,12 +330,19 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	if (length(heard_masked) || length(heard_normal) || length(heard_voice) || length(heard_garbled) || length(heard_gibberish))
 
 	  /* --- Some miscellaneous variables to format the string output --- */
-		var/freq_text = get_frequency_name(display_freq)
+		var/freq_text = format_frequency(display_freq)
+		if(tag)
+			freq_text = tag
+
+		// Make span consistent with the channel name, not the frequency
+		var/span_class = frequency_span_class(display_freq)
+		if(tag && radiochannels[tag])
+			span_class = frequency_span_class(radiochannels[tag])
 
 		var/part_b_extra = ""
 		if(data == 3) // intercepted radio message
 			part_b_extra = " <i>(Intercepted)</i>"
-		var/part_a = "<span class='[frequency_span_class(display_freq)]'>\icon[radio]<b>\[[freq_text]\][part_b_extra]</b> <span class='name'>" // goes in the actual output
+		var/part_a = "<span class='[span_class]'>\icon[radio]<b>\[[freq_text]\][part_b_extra]</b> <span class='name'>" // goes in the actual output
 
 		// --- Some more pre-message formatting ---
 		var/part_b = "</span> <span class='message'>" // Tweaked for security headsets -- TLE
@@ -422,7 +432,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	return 1
 
-/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/text, var/data, var/mob/M, var/compression, var/level)
+/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/tag, var/text, var/data, var/mob/M, var/compression, var/level)
 
   /* ###### Prepare the radio connection ###### */
 
@@ -514,8 +524,15 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	if (length(heard_normal) || length(heard_garbled) || length(heard_gibberish))
 
 	  /* --- Some miscellaneous variables to format the string output --- */
-		var/part_a = "<span class='[frequency_span_class(display_freq)]'><span class='name'>" // goes in the actual output
-		var/freq_text = get_frequency_name(display_freq)
+		var/freq_text = format_frequency(display_freq)
+		if(tag)
+			freq_text = tag
+
+		var/span_class = frequency_span_class(display_freq)
+		if(tag && radiochannels[tag])
+			span_class = frequency_span_class(radiochannels[tag])
+
+		var/part_a = "<span class='[span_class]'><span class='name'>" // goes in the actual output
 
 		// --- Some more pre-message formatting ---
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -61,7 +61,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"],,
-							  signal.data["compression"], signal.data["level"], signal.frequency, signal.data["tag"],
+							  signal.data["compression"], signal.data["level"], signal.frequency, signal.data["channel_tag"],
 							  signal.data["verb"], signal.data["language"]	)
 
 
@@ -70,7 +70,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(signal.data["type"] == 1)
 
 			/* ###### Broadcast a message using signal.data ###### */
-			Broadcast_SimpleMessage(signal.data["name"], signal.frequency, signal.data["tag"],
+			Broadcast_SimpleMessage(signal.data["name"], signal.frequency, signal.data["channel_tag"],
 								  signal.data["message"],null, null,
 								  signal.data["compression"], listening_levels)
 
@@ -87,7 +87,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency, signal.data["tag"],
+							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency, signal.data["channel_tag"],
 							  signal.data["verb"], signal.data["language"])
 
 		if(!message_delay)
@@ -151,7 +151,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency, signal.data["tag"],
+							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency, signal.data["channel_tag"],
 							  signal.data["verb"], signal.data["language"])
 		else
 			if(intercept)
@@ -159,7 +159,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency, signal.data["tag"],
+							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency, signal.data["channel_tag"],
 							  signal.data["verb"], signal.data["language"])
 
 
@@ -227,7 +227,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 /proc/Broadcast_Message(var/datum/radio_frequency/connection, var/mob/M,
 						var/vmask, var/vmessage, var/obj/item/device/radio/radio,
 						var/message, var/name, var/job, var/realname, var/vname,
-						var/data, var/compression, var/list/level, var/freq, var/tag, var/verbage = "says", var/datum/language/speaking = null)
+						var/data, var/compression, var/list/level, var/freq, var/channel_tag, var/verbage = "says", var/datum/language/speaking = null)
 
 
   /* ###### Prepare the radio connection ###### */
@@ -331,13 +331,13 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	  /* --- Some miscellaneous variables to format the string output --- */
 		var/freq_text = format_frequency(display_freq)
-		if(tag)
-			freq_text = tag
+		if(channel_tag)
+			freq_text = channel_tag
 
 		// Make span consistent with the channel name, not the frequency
 		var/span_class = "radio"
-		if(tag && radiochannels[tag])
-			span_class = frequency_span_class(radiochannels[tag])
+		if(channel_tag && radiochannels[channel_tag])
+			span_class = frequency_span_class(radiochannels[channel_tag])
 
 		var/part_b_extra = ""
 		if(data == 3) // intercepted radio message
@@ -432,7 +432,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	return 1
 
-/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/tag, var/text, var/data, var/mob/M, var/compression, var/level)
+/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/channel_tag, var/text, var/data, var/mob/M, var/compression, var/level)
 
   /* ###### Prepare the radio connection ###### */
 
@@ -525,12 +525,12 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	  /* --- Some miscellaneous variables to format the string output --- */
 		var/freq_text = format_frequency(display_freq)
-		if(tag)
-			freq_text = tag
+		if(channel_tag)
+			freq_text = channel_tag
 
 		var/span_class = "radio"
-		if(tag && radiochannels[tag])
-			span_class = frequency_span_class(radiochannels[tag])
+		if(channel_tag && radiochannels[channel_tag])
+			span_class = frequency_span_class(radiochannels[channel_tag])
 
 		var/part_a = "<span class='[span_class]'><span class='name'>" // goes in the actual output
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -62,7 +62,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"],,
 							  signal.data["compression"], signal.data["level"], signal.frequency,
-							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"], signal.data["channel_color"])
 
 
 	   /** #### - Simple Broadcast - #### **/
@@ -72,7 +72,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			/* ###### Broadcast a message using signal.data ###### */
 			Broadcast_SimpleMessage(signal.data["name"], signal.frequency,
 								  signal.data["message"],null, null,
-								  signal.data["compression"], listening_levels, signal.data["channel_tag"])
+								  signal.data["compression"], listening_levels, signal.data["channel_tag"], signal.data["channel_color"])
 
 
 	   /** #### - Artificial Broadcast - #### **/
@@ -87,8 +87,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency, signal.data["channel_tag"],
-							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
+							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency,
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"], signal.data["channel_color"])
 
 		if(!message_delay)
 			message_delay = 1
@@ -152,7 +152,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency,
-							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"], signal.data["channel_color"])
 		else
 			if(intercept)
 				Broadcast_Message(signal.data["connection"], signal.data["mob"],
@@ -160,7 +160,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency,
-							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"], signal.data["channel_color"])
 
 
 
@@ -219,15 +219,19 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	@param freq
 		The frequency of the signal
 
-	@param tag
+	@param channel_tag
 		The "name" of the frequency. Displayed in brackets before the message
+
+	@param channel_color
+		Color of the radio message
 
 **/
 
 /proc/Broadcast_Message(var/datum/radio_frequency/connection, var/mob/M,
 						var/vmask, var/vmessage, var/obj/item/device/radio/radio,
 						var/message, var/name, var/job, var/realname, var/vname,
-						var/data, var/compression, var/list/level, var/freq, var/verbage = "says", var/datum/language/speaking = null, var/channel_tag)
+						var/data, var/compression, var/list/level, var/freq, var/verbage = "says", var/datum/language/speaking = null,
+						var/channel_tag, var/channel_color)
 
 
   /* ###### Prepare the radio connection ###### */
@@ -334,15 +338,14 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(channel_tag)
 			freq_text = channel_tag
 
-		// Make span consistent with the channel name, not the frequency
-		var/span_class = "radio"
-		if(channel_tag && radiochannels[channel_tag])
-			span_class = frequency_span_class(radiochannels[channel_tag])
+		// Default to commons channel green
+		if(!channel_color)
+			channel_color = channel_color_presets["Global Green"] 
 
 		var/part_b_extra = ""
 		if(data == 3) // intercepted radio message
 			part_b_extra = " <i>(Intercepted)</i>"
-		var/part_a = "<span class='[span_class]'>\icon[radio]<b>\[[freq_text]\][part_b_extra]</b> <span class='name'>" // goes in the actual output
+		var/part_a = "<span style='color: [channel_color]'>\icon[radio]<b>\[[freq_text]\][part_b_extra]</b> <span class='name'>" // goes in the actual output
 
 		// --- Some more pre-message formatting ---
 		var/part_b = "</span> <span class='message'>" // Tweaked for security headsets -- TLE
@@ -432,7 +435,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	return 1
 
-/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/text, var/data, var/mob/M, var/compression, var/level, var/channel_tag)
+/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/text, var/data, var/mob/M, var/compression, var/level, var/channel_tag, var/channel_color)
 
   /* ###### Prepare the radio connection ###### */
 
@@ -528,11 +531,10 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(channel_tag)
 			freq_text = channel_tag
 
-		var/span_class = "radio"
-		if(channel_tag && radiochannels[channel_tag])
-			span_class = frequency_span_class(radiochannels[channel_tag])
+		if(!channel_color)
+			channel_color = channel_color_presets["Global Green"] 
 
-		var/part_a = "<span class='[span_class]'><span class='name'>" // goes in the actual output
+		var/part_a = "<span style='color: [channel_color]'><span class='name'>" // goes in the actual output
 
 		// --- Some more pre-message formatting ---
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -151,7 +151,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency,
+							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency, signal.data["tag"],
 							  signal.data["verb"], signal.data["language"])
 		else
 			if(intercept)
@@ -159,7 +159,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency,
+							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency, signal.data["tag"],
 							  signal.data["verb"], signal.data["language"])
 
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -61,8 +61,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"],,
-							  signal.data["compression"], signal.data["level"], signal.frequency, signal.data["channel_tag"],
-							  signal.data["verb"], signal.data["language"]	)
+							  signal.data["compression"], signal.data["level"], signal.frequency,
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
 
 
 	   /** #### - Simple Broadcast - #### **/
@@ -70,9 +70,9 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(signal.data["type"] == 1)
 
 			/* ###### Broadcast a message using signal.data ###### */
-			Broadcast_SimpleMessage(signal.data["name"], signal.frequency, signal.data["channel_tag"],
+			Broadcast_SimpleMessage(signal.data["name"], signal.frequency,
 								  signal.data["message"],null, null,
-								  signal.data["compression"], listening_levels)
+								  signal.data["compression"], listening_levels, signal.data["channel_tag"])
 
 
 	   /** #### - Artificial Broadcast - #### **/
@@ -88,7 +88,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
 							  signal.data["realname"], signal.data["vname"], 4, signal.data["compression"], signal.data["level"], signal.frequency, signal.data["channel_tag"],
-							  signal.data["verb"], signal.data["language"])
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
 
 		if(!message_delay)
 			message_delay = 1
@@ -151,16 +151,16 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency, signal.data["channel_tag"],
-							  signal.data["verb"], signal.data["language"])
+							  signal.data["realname"], signal.data["vname"],, signal.data["compression"], list(0), connection.frequency,
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
 		else
 			if(intercept)
 				Broadcast_Message(signal.data["connection"], signal.data["mob"],
 							  signal.data["vmask"], signal.data["vmessage"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency, signal.data["channel_tag"],
-							  signal.data["verb"], signal.data["language"])
+							  signal.data["realname"], signal.data["vname"], 3, signal.data["compression"], list(0), connection.frequency,
+							  signal.data["verb"], signal.data["language"], signal.data["channel_tag"])
 
 
 
@@ -227,7 +227,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 /proc/Broadcast_Message(var/datum/radio_frequency/connection, var/mob/M,
 						var/vmask, var/vmessage, var/obj/item/device/radio/radio,
 						var/message, var/name, var/job, var/realname, var/vname,
-						var/data, var/compression, var/list/level, var/freq, var/channel_tag, var/verbage = "says", var/datum/language/speaking = null)
+						var/data, var/compression, var/list/level, var/freq, var/verbage = "says", var/datum/language/speaking = null, var/channel_tag)
 
 
   /* ###### Prepare the radio connection ###### */
@@ -432,7 +432,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	return 1
 
-/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/channel_tag, var/text, var/data, var/mob/M, var/compression, var/level)
+/proc/Broadcast_SimpleMessage(var/source, var/frequency, var/text, var/data, var/mob/M, var/compression, var/level, var/channel_tag)
 
   /* ###### Prepare the radio connection ###### */
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -367,12 +367,14 @@
 
 					if(!(freq in freq_listening))
 						temp = "<font color = #660000>-% Not filtering specified frequency %-</font>"
-						return 1
+						updateUsrDialog()
+						return
 
 					for(var/list/rule in freq_tags)
 						if(rule[1] == freq)
 							temp = "<font color = #660000>-% Tagging rule already defined %-</font>"
-							return 1
+							updateUsrDialog()
+							return
 
 					if(freq < 10000)
 						freq_tags.Add(list(list(freq, tag)))

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -166,7 +166,7 @@
 
 		if(length(channel_tags))
 			for(var/list/rule in channel_tags)
-				dat +="<li>[format_frequency(rule[1])] - [rule[2]] <a href='?src=\ref[src];deletetagrule=[rule[1]]'>\[X\]</a></li>"
+				dat +="<li>[format_frequency(rule[1])] -> [rule[2]] ([rule[3]]) <a href='?src=\ref[src];deletetagrule=[rule[1]]'>\[X\]</a></li>"
 
 		dat += "</ol>"
 		dat += "<a href='?src=\ref[src];input=tagrule'>\[Add Rule\]</a>"
@@ -360,8 +360,7 @@
 
 			if("tagrule")
 				var/freq = input(usr, "Specify frequency to tag (GHz). Decimals assigned automatically.", src, network) as null|num
-				var/tag = input(usr, "Specify tag.", src, "") as null|text
-				if(freq && tag && canAccess(usr))
+				if(freq && canAccess(usr))
 					if(findtext(num2text(freq), "."))
 						freq *= 10
 
@@ -376,9 +375,17 @@
 							updateUsrDialog()
 							return
 
+					var/tag = input(usr, "Specify tag.", src, "") as null|text
+					var/color = input(usr, "Select color.", src, "") as null|anything in (channel_color_presets + "Custom color")
+
+					if(color == "Custom color")
+						color = input("Select color.", src, rgb(0, 128, 0)) as null|color
+					else
+						color = channel_color_presets[color]
+
 					if(freq < 10000)
-						channel_tags.Add(list(list(freq, tag)))
-						temp = "<font color = #666633>-% New tagging rule assigned:[freq] GHz -> \"[tag]\" %-</font>"
+						channel_tags.Add(list(list(freq, tag, color)))
+						temp = "<font color = #666633>-% New tagging rule assigned:[freq] GHz -> \"[tag]\" ([color]) %-</font>"
 
 	if(href_list["delete"])
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -162,10 +162,10 @@
 
 		dat += "<br>  <a href='?src=\ref[src];input=freq'>\[Add Filter\]</a>"
 
-		dat += "<br><br>Tagging rules: <ol>"
+		dat += "<br><br>Channel Tagging Rules: <ol>"
 
-		if(length(freq_tags))
-			for(var/list/rule in freq_tags)
+		if(length(channel_tags))
+			for(var/list/rule in channel_tags)
 				dat +="<li>[format_frequency(rule[1])] - [rule[2]] <a href='?src=\ref[src];deletetagrule=[rule[1]]'>\[X\]</a></li>"
 
 		dat += "</ol>"
@@ -370,14 +370,14 @@
 						updateUsrDialog()
 						return
 
-					for(var/list/rule in freq_tags)
+					for(var/list/rule in channel_tags)
 						if(rule[1] == freq)
 							temp = "<font color = #660000>-% Tagging rule already defined %-</font>"
 							updateUsrDialog()
 							return
 
 					if(freq < 10000)
-						freq_tags.Add(list(list(freq, tag)))
+						channel_tags.Add(list(list(freq, tag)))
 						temp = "<font color = #666633>-% New tagging rule assigned:[freq] GHz -> \"[tag]\" %-</font>"
 
 	if(href_list["delete"])
@@ -392,11 +392,11 @@
 
 		var/freq = text2num(href_list["deletetagrule"])
 		var/rule_delete
-		for(var/list/rule in freq_tags)
+		for(var/list/rule in channel_tags)
 			if(rule[1] == freq)
 				rule_delete = rule
 		temp = "<font color = #666633>-% Removed tagging rule: [rule_delete[1]] -> [rule_delete[2]] %-</font>"
-		freq_tags.Remove(list(rule_delete))
+		channel_tags.Remove(list(rule_delete))
 
 	if(href_list["unlink"])
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -161,6 +161,16 @@
 			dat += "NONE"
 
 		dat += "<br>  <a href='?src=\ref[src];input=freq'>\[Add Filter\]</a>"
+
+		dat += "<br><br>Tagging rules: <ol>"
+
+		if(length(freq_tags))
+			for(var/list/rule in freq_tags)
+				dat +="<li>[format_frequency(rule[1])] - [rule[2]] <a href='?src=\ref[src];deletetagrule=[rule[1]]'>\[X\]</a></li>"
+
+		dat += "</ol>"
+		dat += "<a href='?src=\ref[src];input=tagrule'>\[Add Rule\]</a>"
+
 		dat += "<hr>"
 
 		if(P)
@@ -348,6 +358,26 @@
 						freq_listening.Add(newfreq)
 						temp = "<font color = #666633>-% New frequency filter assigned: \"[newfreq] GHz\" %-</font>"
 
+			if("tagrule")
+				var/freq = input(usr, "Specify frequency to tag (GHz). Decimals assigned automatically.", src, network) as null|num
+				var/tag = input(usr, "Specify tag.", src, "") as null|text
+				if(freq && tag && canAccess(usr))
+					if(findtext(num2text(freq), "."))
+						freq *= 10
+
+					if(!(freq in freq_listening))
+						temp = "<font color = #660000>-% Not filtering specified frequency %-</font>"
+						return 1
+
+					for(var/list/rule in freq_tags)
+						if(rule[1] == freq)
+							temp = "<font color = #660000>-% Tagging rule already defined %-</font>"
+							return 1
+
+					if(freq < 10000)
+						freq_tags.Add(list(list(freq, tag)))
+						temp = "<font color = #666633>-% New tagging rule assigned:[freq] GHz -> \"[tag]\" %-</font>"
+
 	if(href_list["delete"])
 
 		// changed the layout about to workaround a pesky runtime -- Doohl
@@ -355,6 +385,16 @@
 		var/x = text2num(href_list["delete"])
 		temp = "<font color = #666633>-% Removed frequency filter [x] %-</font>"
 		freq_listening.Remove(x)
+
+	if(href_list["deletetagrule"])
+
+		var/freq = text2num(href_list["deletetagrule"])
+		var/rule_delete
+		for(var/list/rule in freq_tags)
+			if(rule[1] == freq)
+				rule_delete = rule
+		temp = "<font color = #666633>-% Removed tagging rule: [rule_delete[1]] -> [rule_delete[2]] %-</font>"
+		freq_tags.Remove(list(rule_delete))
 
 	if(href_list["unlink"])
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -176,26 +176,31 @@
 /obj/machinery/telecomms/server/presets/science
 	id = "Science Server"
 	freq_listening = list(SCI_FREQ)
+	freq_tags = list(list(SCI_FREQ, "Science"))
 	autolinkers = list("science")
 
 /obj/machinery/telecomms/server/presets/medical
 	id = "Medical Server"
 	freq_listening = list(MED_FREQ)
+	freq_tags = list(list(MED_FREQ, "Medical"))
 	autolinkers = list("medical")
 
 /obj/machinery/telecomms/server/presets/supply
 	id = "Supply Server"
 	freq_listening = list(SUP_FREQ)
+	freq_tags = list(list(SUP_FREQ, "Supply"))
 	autolinkers = list("supply")
 
 /obj/machinery/telecomms/server/presets/service
 	id = "Service Server"
 	freq_listening = list(SRV_FREQ)
+	freq_tags = list(list(SRV_FREQ, "Service"))
 	autolinkers = list("service")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
 	freq_listening = list(PUB_FREQ, AI_FREQ, ENT_FREQ) // AI Private and Common
+	freq_tags = list(list(PUB_FREQ, "Common"), list(AI_FREQ, "AI Private"), list(ENT_FREQ, "Entertainment"))
 	autolinkers = list("common")
 
 // "Unused" channels, AKA all others.
@@ -214,21 +219,25 @@
 /obj/machinery/telecomms/server/presets/command
 	id = "Command Server"
 	freq_listening = list(COMM_FREQ)
+	freq_tags = list(list(COMM_FREQ, "Command"))
 	autolinkers = list("command")
 
 /obj/machinery/telecomms/server/presets/engineering
 	id = "Engineering Server"
 	freq_listening = list(ENG_FREQ)
+	freq_tags = list(list(ENG_FREQ, "Engineering"))
 	autolinkers = list("engineering")
 
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	freq_listening = list(SEC_FREQ)
+	freq_tags = list(list(SEC_FREQ, "Security"))
 	autolinkers = list("security")
 
 /obj/machinery/telecomms/server/presets/centcomm
 	id = "CentComm Server"
 	freq_listening = list(ERT_FREQ, DTH_FREQ)
+	freq_tags = list(list(ERT_FREQ, "ERT"), list(DTH_FREQ, "#unkn"))
 	produces_heat = 0
 	autolinkers = list("centcomm")
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -237,7 +237,7 @@
 /obj/machinery/telecomms/server/presets/centcomm
 	id = "CentComm Server"
 	freq_listening = list(ERT_FREQ, DTH_FREQ)
-	freq_tags = list(list(ERT_FREQ, "ERT"), list(DTH_FREQ, "#unkn"))
+	freq_tags = list(list(ERT_FREQ, "Response Team"), list(DTH_FREQ, "Special Ops"))
 	produces_heat = 0
 	autolinkers = list("centcomm")
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -176,31 +176,31 @@
 /obj/machinery/telecomms/server/presets/science
 	id = "Science Server"
 	freq_listening = list(SCI_FREQ)
-	freq_tags = list(list(SCI_FREQ, "Science"))
+	channel_tags = list(list(SCI_FREQ, "Science"))
 	autolinkers = list("science")
 
 /obj/machinery/telecomms/server/presets/medical
 	id = "Medical Server"
 	freq_listening = list(MED_FREQ)
-	freq_tags = list(list(MED_FREQ, "Medical"))
+	channel_tags = list(list(MED_FREQ, "Medical"))
 	autolinkers = list("medical")
 
 /obj/machinery/telecomms/server/presets/supply
 	id = "Supply Server"
 	freq_listening = list(SUP_FREQ)
-	freq_tags = list(list(SUP_FREQ, "Supply"))
+	channel_tags = list(list(SUP_FREQ, "Supply"))
 	autolinkers = list("supply")
 
 /obj/machinery/telecomms/server/presets/service
 	id = "Service Server"
 	freq_listening = list(SRV_FREQ)
-	freq_tags = list(list(SRV_FREQ, "Service"))
+	channel_tags = list(list(SRV_FREQ, "Service"))
 	autolinkers = list("service")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
 	freq_listening = list(PUB_FREQ, AI_FREQ, ENT_FREQ) // AI Private and Common
-	freq_tags = list(list(PUB_FREQ, "Common"), list(AI_FREQ, "AI Private"), list(ENT_FREQ, "Entertainment"))
+	channel_tags = list(list(PUB_FREQ, "Common"), list(AI_FREQ, "AI Private"), list(ENT_FREQ, "Entertainment"))
 	autolinkers = list("common")
 
 // "Unused" channels, AKA all others.
@@ -219,25 +219,25 @@
 /obj/machinery/telecomms/server/presets/command
 	id = "Command Server"
 	freq_listening = list(COMM_FREQ)
-	freq_tags = list(list(COMM_FREQ, "Command"))
+	channel_tags = list(list(COMM_FREQ, "Command"))
 	autolinkers = list("command")
 
 /obj/machinery/telecomms/server/presets/engineering
 	id = "Engineering Server"
 	freq_listening = list(ENG_FREQ)
-	freq_tags = list(list(ENG_FREQ, "Engineering"))
+	channel_tags = list(list(ENG_FREQ, "Engineering"))
 	autolinkers = list("engineering")
 
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	freq_listening = list(SEC_FREQ)
-	freq_tags = list(list(SEC_FREQ, "Security"))
+	channel_tags = list(list(SEC_FREQ, "Security"))
 	autolinkers = list("security")
 
 /obj/machinery/telecomms/server/presets/centcomm
 	id = "CentComm Server"
 	freq_listening = list(ERT_FREQ, DTH_FREQ)
-	freq_tags = list(list(ERT_FREQ, "Response Team"), list(DTH_FREQ, "Special Ops"))
+	channel_tags = list(list(ERT_FREQ, "Response Team"), list(DTH_FREQ, "Special Ops"))
 	produces_heat = 0
 	autolinkers = list("centcomm")
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -176,31 +176,35 @@
 /obj/machinery/telecomms/server/presets/science
 	id = "Science Server"
 	freq_listening = list(SCI_FREQ)
-	channel_tags = list(list(SCI_FREQ, "Science"))
+	channel_tags = list(list(SCI_FREQ, "Science", "#993399"))
 	autolinkers = list("science")
 
 /obj/machinery/telecomms/server/presets/medical
 	id = "Medical Server"
 	freq_listening = list(MED_FREQ)
-	channel_tags = list(list(MED_FREQ, "Medical"))
+	channel_tags = list(list(MED_FREQ, "Medical", "#008160"))
 	autolinkers = list("medical")
 
 /obj/machinery/telecomms/server/presets/supply
 	id = "Supply Server"
 	freq_listening = list(SUP_FREQ)
-	channel_tags = list(list(SUP_FREQ, "Supply"))
+	channel_tags = list(list(SUP_FREQ, "Supply", "#7F6539"))
 	autolinkers = list("supply")
 
 /obj/machinery/telecomms/server/presets/service
 	id = "Service Server"
 	freq_listening = list(SRV_FREQ)
-	channel_tags = list(list(SRV_FREQ, "Service"))
+	channel_tags = list(list(SRV_FREQ, "Service", "#6EAA2C"))
 	autolinkers = list("service")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
 	freq_listening = list(PUB_FREQ, AI_FREQ, ENT_FREQ) // AI Private and Common
-	channel_tags = list(list(PUB_FREQ, "Common"), list(AI_FREQ, "AI Private"), list(ENT_FREQ, "Entertainment"))
+	channel_tags = list(
+		list(PUB_FREQ, "Common", "#008000"),
+		list(AI_FREQ, "AI Private", "#FF00FF"),
+		list(ENT_FREQ, "Entertainment", "#6EAA2C")
+	)
 	autolinkers = list("common")
 
 // "Unused" channels, AKA all others.
@@ -219,25 +223,25 @@
 /obj/machinery/telecomms/server/presets/command
 	id = "Command Server"
 	freq_listening = list(COMM_FREQ)
-	channel_tags = list(list(COMM_FREQ, "Command"))
+	channel_tags = list(list(COMM_FREQ, "Command", "#395A9A"))
 	autolinkers = list("command")
 
 /obj/machinery/telecomms/server/presets/engineering
 	id = "Engineering Server"
 	freq_listening = list(ENG_FREQ)
-	channel_tags = list(list(ENG_FREQ, "Engineering"))
+	channel_tags = list(list(ENG_FREQ, "Engineering", "#A66300"))
 	autolinkers = list("engineering")
 
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	freq_listening = list(SEC_FREQ)
-	channel_tags = list(list(SEC_FREQ, "Security"))
+	channel_tags = list(list(SEC_FREQ, "Security", "#A30000"))
 	autolinkers = list("security")
 
 /obj/machinery/telecomms/server/presets/centcomm
 	id = "CentComm Server"
 	freq_listening = list(ERT_FREQ, DTH_FREQ)
-	channel_tags = list(list(ERT_FREQ, "Response Team"), list(DTH_FREQ, "Special Ops"))
+	channel_tags = list(list(ERT_FREQ, "Response Team", "#395A9A"), list(DTH_FREQ, "Special Ops", "#6D3F40"))
 	produces_heat = 0
 	autolinkers = list("centcomm")
 

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -24,7 +24,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/network = "NULL" // the network of the machinery
 
 	var/list/freq_listening = list() // list of frequencies to tune into: if none, will listen to all
-	var/list/freq_tags = list() // a list specifying what to tag packets on different frequencies
+	var/list/channel_tags = list() // a list specifying what to tag packets on different frequencies
 
 	var/machinetype = 0 // just a hacky way of preventing alike machines from pairing
 	var/toggled = 1 	// Is it toggled on
@@ -539,7 +539,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				totaltraffic += traffic // add current traffic to total traffic
 
 			// tag the signal
-			signal.data["tag"] = get_tag(signal.frequency)
+			signal.data["channel_tag"] = get_channel_tag(signal.frequency)
 
 			//Is this a test signal? Bypass logging
 			if(signal.data["type"] != 4)
@@ -639,8 +639,8 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	log_entries.Add(log)
 	update_logs()
 
-/obj/machinery/telecomms/server/proc/get_tag(var/freq)
-	for(var/list/rule in freq_tags)
+/obj/machinery/telecomms/server/proc/get_channel_tag(var/freq)
+	for(var/list/rule in channel_tags)
 		if(rule[1] == freq)
 			return rule[2]
 	return format_frequency(freq)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -538,8 +538,10 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			if(traffic > 0)
 				totaltraffic += traffic // add current traffic to total traffic
 
-			// tag the signal
-			signal.data["channel_tag"] = get_channel_tag(signal.frequency)
+			// channel tag the signal
+			var/list/data = get_channel_info(signal.frequency)
+			signal.data["channel_tag"] = data[1]
+			signal.data["channel_color"] = data[2]
 
 			//Is this a test signal? Bypass logging
 			if(signal.data["type"] != 4)
@@ -639,11 +641,11 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	log_entries.Add(log)
 	update_logs()
 
-/obj/machinery/telecomms/server/proc/get_channel_tag(var/freq)
+/obj/machinery/telecomms/server/proc/get_channel_info(var/freq)
 	for(var/list/rule in channel_tags)
 		if(rule[1] == freq)
-			return rule[2]
-	return format_frequency(freq)
+			return list(rule[2], rule[3])
+	return list(format_frequency(freq), channel_color_presets["Global Green"])
 
 
 // Simple log entry datum

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -24,6 +24,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/network = "NULL" // the network of the machinery
 
 	var/list/freq_listening = list() // list of frequencies to tune into: if none, will listen to all
+	var/list/freq_tags = list() // a list specifying what to tag packets on different frequencies
 
 	var/machinetype = 0 // just a hacky way of preventing alike machines from pairing
 	var/toggled = 1 	// Is it toggled on
@@ -537,6 +538,9 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			if(traffic > 0)
 				totaltraffic += traffic // add current traffic to total traffic
 
+			// tag the signal
+			signal.data["tag"] = get_tag(signal.frequency)
+
 			//Is this a test signal? Bypass logging
 			if(signal.data["type"] != 4)
 
@@ -635,7 +639,11 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	log_entries.Add(log)
 	update_logs()
 
-
+/obj/machinery/telecomms/server/proc/get_tag(var/freq)
+	for(var/list/rule in freq_tags)
+		if(rule[1] == freq)
+			return rule[2]
+	return format_frequency(freq)
 
 
 // Simple log entry datum

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -115,7 +115,7 @@
 	var/dat[0]
 	for(var/internal_chan in internal_channels)
 		if(has_channel_access(user, internal_chan))
-			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_name(text2num(internal_chan)), "chan_span" = frequency_span_class(text2num(internal_chan)))))
+			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_default_name(text2num(internal_chan)), "chan_span" = frequency_span_class(text2num(internal_chan)))))
 
 	return dat
 
@@ -432,7 +432,7 @@
 	if(!connection)	return 0	//~Carn
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
-					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency,verb,speaking)
+					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency,,verb,speaking)
 
 
 /obj/item/device/radio/hear_talk(mob/M as mob, msg, var/verb = "says", var/datum/language/speaking = null)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -434,7 +434,7 @@
 	if(!connection)	return 0	//~Carn
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
-					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency, "#unkn", verb, speaking)
+					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency, verb, speaking, "#unkn")
 
 
 /obj/item/device/radio/hear_talk(mob/M as mob, msg, var/verb = "says", var/datum/language/speaking = null)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -355,6 +355,7 @@
 			"server" = null, // the last server to log this signal
 			"reject" = 0,	// if nonzero, the signal will not be accepted by any broadcasting machinery
 			"level" = position.z, // The source's z level
+			"channel_tag" = "#unkn", // channel tag for the message
 			"language" = speaking,
 			"verb" = verb
 		)
@@ -410,6 +411,7 @@
 		"server" = null,
 		"reject" = 0,
 		"level" = position.z,
+		"channel_tag" = "#unkn",
 		"language" = speaking,
 		"verb" = verb
 	)
@@ -432,7 +434,7 @@
 	if(!connection)	return 0	//~Carn
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
-					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency,,verb,speaking)
+					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency, "#unkn", verb, speaking)
 
 
 /obj/item/device/radio/hear_talk(mob/M as mob, msg, var/verb = "says", var/datum/language/speaking = null)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -356,6 +356,7 @@
 			"reject" = 0,	// if nonzero, the signal will not be accepted by any broadcasting machinery
 			"level" = position.z, // The source's z level
 			"channel_tag" = "#unkn", // channel tag for the message
+			"channel_color" = channel_color_presets["Menacing Maroon"], // radio message color
 			"language" = speaking,
 			"verb" = verb
 		)
@@ -412,6 +413,7 @@
 		"reject" = 0,
 		"level" = position.z,
 		"channel_tag" = "#unkn",
+		"channel_color" = channel_color_presets["Menacing Maroon"],
 		"language" = speaking,
 		"verb" = verb
 	)
@@ -434,7 +436,8 @@
 	if(!connection)	return 0	//~Carn
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
-					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency, verb, speaking, "#unkn")
+					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency, verb, speaking,
+					  "#unkn", channel_color_presets["Menacing Maroon"])
 
 
 /obj/item/device/radio/hear_talk(mob/M as mob, msg, var/verb = "says", var/datum/language/speaking = null)

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -41,7 +41,7 @@
 	dat += "Channel name is: <a href='?src=\ref[src];channel=1'>[channel ? channel : "unidentified broadcast"]</a><br>"
 	dat += "Video streaming is: <a href='?src=\ref[src];video=1'>[camera.status ? "Online" : "Offline"]</a><br>"
 	dat += "Microphone is: <a href='?src=\ref[src];sound=1'>[radio.broadcasting ? "Online" : "Offline"]</a><br>"
-	dat += "Sound is being broadcasted on frequency: [format_frequency(radio.frequency)] ([get_frequency_name(radio.frequency)])<br>"
+	dat += "Sound is being broadcasted on frequency: [format_frequency(radio.frequency)] ([get_frequency_default_name(radio.frequency)])<br>"
 	var/datum/browser/popup = new(user, "Press Camera Drone", "EyeBuddy", 300, 390, src)
 	popup.set_content(jointext(dat,null))
 	popup.open()

--- a/code/procs/radio.dm
+++ b/code/procs/radio.dm
@@ -8,7 +8,7 @@
 	if(radio_controller)
 		radio_controller.remove_object(source, frequency)
 
-/proc/get_frequency_name(var/display_freq)
+/proc/get_frequency_default_name(var/display_freq)
 	var/freq_text
 
 	// the name of the channel

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -240,7 +240,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '85c1014b6acc177765709b3b1753dd01 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '04c191714dc5cb8773c998464185407b *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
:cl: Atebite
rscadd: Telecommunication servers now have tagging rules which determine the radio channel name and color for a given frequency
/:cl:

Found it annoying that I couldn't set up a new radio channel with a proper name in-round. Now you can do it with tagging rules on the comms servers. Also lets you extend the frequency "range" for the default channels, or swap them around if you like.

![](https://i.imgur.com/LuBzKjK.png)