### PR TITLE
Fixes recursive explosions

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -51,11 +51,9 @@
 	. = ..()
 	if(density)
 		layer = closed_layer
-		explosion_resistance = initial(explosion_resistance)
 		update_heat_protection(get_turf(src))
 	else
 		layer = open_layer
-		explosion_resistance = 0
 
 
 	if(width > 1)
@@ -387,7 +385,6 @@
 	update_nearby_tiles()
 	sleep(7)
 	src.layer = open_layer
-	explosion_resistance = 0
 	update_icon()
 	set_opacity(0)
 	operating = 0
@@ -409,7 +406,6 @@
 	do_animate("closing")
 	sleep(3)
 	src.set_density(1)
-	explosion_resistance = initial(explosion_resistance)
 	src.layer = closed_layer
 	update_nearby_tiles()
 	sleep(7)

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -72,20 +72,18 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 	if(explosion_turfs[src] >= power)
 		return //The turf already sustained and spread a power greated than what we are dealing with. No point spreading again.
 	explosion_turfs[src] = power
-
-/*	sleep(2)
+/*
+	sleep(2)
 	var/obj/effect/debugging/M = locate() in src
 	if (!M)
 		M = new(src, power, direction)
-	M.maptext = "[power]"
+	M.maptext = "[power] vs [src.get_explosion_resistance()]"
 	if(power > 10)
 		M.color = "#cccc00"
 	if(power > 20)
 		M.color = "#ffcc00"
 */
 	var/spread_power = power - src.get_explosion_resistance() //This is the amount of power that will be spread to the tile in the direction of the blast
-	for(var/obj/O in src)
-		spread_power -= O.get_explosion_resistance()
 
 	var/turf/T = get_step(src, direction)
 	if(T)
@@ -102,11 +100,21 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 
 /atom/var/explosion_resistance
 /atom/proc/get_explosion_resistance()
-	if(simulated && density)
+	if(simulated)
 		return explosion_resistance
+
+/turf/get_explosion_resistance()
+	. = ..()
+	for(var/obj/O in src)
+		. += O.get_explosion_resistance()
 
 /turf/space
 	explosion_resistance = 3
+
+/turf/simulated/floor/get_explosion_resistance()
+	. = ..()
+	if(is_below_sound_pressure(src))
+		. *= 3
 
 /turf/simulated/floor
 	explosion_resistance = 1
@@ -119,3 +127,9 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 
 /turf/simulated/wall
 	explosion_resistance = 10
+
+/obj/machinery/door/get_explosion_resistance()
+	if(!density)
+		return 0
+	else
+		return ..()


### PR DESCRIPTION
Turned out power never dropped off when travelling over floors, going forever.
Fixed explosion resistance calculations for those things.
Cleaned up some doors explosion resistance handling, no need to update it all the time when opening/closing.
Made air pressure matter, now blast propogates worse if air pressure is below 10 kPa

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
