### PR TITLE
Add EMP repair step for rig modules

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -163,6 +163,18 @@
 					installed_modules -= removed
 					update_icon()
 
+		else if(istype(W,/obj/item/stack/nanopaste)) //EMP repair
+			var/obj/item/stack/S = W
+			if(malfunctioning || malfunction_delay)
+				if(S.use(1))
+					to_chat(user, "You pour some of \the [S] over \the [src]'s control circuitry and watch as the nanites do their work with impressive speed and precision.")
+					malfunctioning = 0
+					malfunction_delay = 0
+				else
+					to_chat(user, "\The [S] is empty!")
+			else
+				to_chat(user, "You don't see any use for \the [S].")
+
 		return
 
 	// If we've gotten this far, all we have left to do before we pass off to root procs


### PR DESCRIPTION
:cl: sabiram
rscadd: Hardsuit rig modules damaged by EMP can now be repaired with nanopaste.
/:cl:

Process() takes care of this for us when they're wearing the hardsuit, but if the suit is EMP'd while unequipped or they take it off before Process is finished, it bricks the suit.