### PR TITLE
Fixes #20821 - the quicksand glitch

### DIFF
--- a/code/modules/overmap/exoplanets/desert.dm
+++ b/code/modules/overmap/exoplanets/desert.dm
@@ -113,6 +113,10 @@
 			else
 				user.visible_message("<span class='notice'>\The [buckled_mob] has been freed from \the [src] by \the [user].</span>")
 			unbuckle_mob()
+		else
+			busy = 0
+			to_chat(user, "<span class='warning'>You slip and fail to get out!</span>")
+			return
 
 /obj/structure/quicksand/unbuckle_mob()
 	..()


### PR DESCRIPTION
When the buckled mob switched item in hands the busy state wasn't changed, making it impossible to escape the quicksand. Added an else statement to the 'if(do_after...' to remedy this. 