### PR TITLE
Fixed a runtime on admin logout.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -14,7 +14,7 @@ var/global/floorIsLava = 0
 	msg = "<span class=\"log_message\"><span class=\"prefix\">STAFF LOG:</span> <span class=\"message\">[msg]</span></span>"
 	log_adminwarn(msg)
 	for(var/client/C in GLOB.admins)
-		if(R_INVESTIGATE & C.holder.rights)
+		if(C && C.holder && (R_INVESTIGATE & C.holder.rights))
 			to_chat(C, msg)
 /proc/msg_admin_attack(var/text) //Toggleable Attack Messages
 	log_attack(text)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -205,7 +205,8 @@
 	//////////////
 /client/Del()
 	ticket_panels -= src
-	STOP_PROCESSING(SSprocessing, watched_variables_window)
+	if(src && watched_variables_window)
+		STOP_PROCESSING(SSprocessing, watched_variables_window)
 	if(holder)
 		holder.owner = null
 		GLOB.admins -= src


### PR DESCRIPTION
The src check seems foolish, but client can be nulled at any time during processing. This at least ensures it doesn't runtime all over the place when that happens.