### PR TITLE
Prevent wizards from teleporting to non-station Zs

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -98,10 +98,11 @@ GLOBAL_LIST_INIT(is_contact_but_not_space_or_shuttle_area, list(/proc/is_contact
 
 GLOBAL_LIST_INIT(is_player_but_not_space_or_shuttle_area, list(/proc/is_player_area, /proc/is_not_space_area, /proc/is_not_shuttle_area))
 
+GLOBAL_LIST_INIT(is_station_area, list(/proc/is_station_area))
 
 /*
 	Misc Helpers
 */
 #define teleportlocs area_repository.get_areas_by_name_and_coords(GLOB.is_player_but_not_space_or_shuttle_area)
 #define stationlocs area_repository.get_areas_by_name(GLOB.is_player_but_not_space_or_shuttle_area)
-
+#define wizteleportlocs area_repository.get_areas_by_name(GLOB.is_station_area)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -41,8 +41,8 @@
 	return
 
 /obj/item/weapon/teleportation_scroll/proc/teleportscroll(var/mob/user)
-	var/area/thearea = input(user, "Area to jump to", "BOOYEA") as null|anything in teleportlocs
-	thearea = thearea ? teleportlocs[thearea] : thearea
+	var/area/thearea = input(user, "Area to jump to", "BOOYEA") as null|anything in wizteleportlocs
+	thearea = thearea ? wizteleportlocs[thearea] : thearea
 
 	if (!thearea || CanUseTopic(user) != STATUS_INTERACTIVE)
 		return

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -25,11 +25,11 @@
 /spell/area_teleport/choose_targets()
 	var/area/thearea
 	if(!randomise_selection)
-		thearea = input("Area to teleport to", "Teleport") as null|anything in teleportlocs
+		thearea = input("Area to teleport to", "Teleport") as null|anything in wizteleportlocs
 		if(!thearea) return
 	else
-		thearea = pick(teleportlocs)
-	return list(teleportlocs[thearea])
+		thearea = pick(wizteleportlocs)
+	return list(wizteleportlocs[thearea])
 
 /spell/area_teleport/cast(area/thearea, mob/user)
 	playsound(get_turf(user),cast_sound,50,1)


### PR DESCRIPTION
:cl:
balance: Wizards can no longer teleport to non-station Z levels.
/:cl: