### PR TITLE
Removes cumulative burn and brute mods being applied.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -85,7 +85,6 @@
 	return amount
 
 /mob/living/carbon/human/adjustBruteLoss(var/amount)
-	amount = amount*species.brute_mod
 	if(amount > 0)
 		take_overall_damage(amount, 0)
 	else
@@ -93,7 +92,6 @@
 	BITSET(hud_updateflag, HEALTH_HUD)
 
 /mob/living/carbon/human/adjustFireLoss(var/amount)
-	amount = amount*species.burn_mod
 	if(amount > 0)
 		take_overall_damage(0, amount)
 	else


### PR DESCRIPTION
Burn and brute mod are both applied by `take_overall_damage` meaning two things:
1. Brute and burn were being modified twice, cumulatively. This was resulting in 50 incoming damage to a 0.25 brute mod xenophage coming out at 2 damage.
2. Brute and burn were being reduced by brute mod even when being used for healing, causing some unexpected weirdness with regen.