### PR TITLE
Replaces message server world loops

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -158,13 +158,10 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 
 	if( href_list["department"] && message )
 		var/log_msg = message
-		var/pass = 0
 		screen = RCS_SENTFAIL
-		for (var/obj/machinery/message_server/MS in world)
-			if(!MS.active) continue
+		var/obj/machinery/message_server/MS = get_message_server(get_z(src))
+		if(MS)
 			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority)
-			pass = 1
-		if(pass)
 			screen = RCS_SENTPASS
 			message_log += "<B>Message sent to [recipient]</B><BR>[message]"
 		else

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -15,12 +15,15 @@
 		kill()
 
 /datum/event/money_hacker/announce()
-	// Hide the account number for now since it's all you need to access a standard-security account. Change when that's no longer the case.
-	var/accnr_hidden = "***[copytext("[affected_account.account_number]", -3)]"
-	var/message = "A brute force hack has been detected (in progress since [stationtime2text()]). The target of the attack is: Financial account #[accnr_hidden], \
-	without intervention this attack will succeed in approximately 10 minutes. Required intervention: temporary suspension of affected accounts until the attack has ceased. \
-	Notifications will be sent as updates occur."
-	command_announcement.Announce(message, "[location_name()] Firewall Subroutines")
+	var/obj/machinery/message_server/MS = get_message_server()
+	if(MS)
+		// Hide the account number for now since it's all you need to access a standard-security account. Change when that's no longer the case.
+		var/accnr_hidden = "***[copytext("[affected_account.account_number]", -3)]"
+		var/message = "A brute force hack has been detected (in progress since [stationtime2text()]). The target of the attack is: Financial account #[accnr_hidden], \
+		without intervention this attack will succeed in approximately 10 minutes. Required intervention: temporary suspension of affected accounts until the attack has ceased. \
+		Notifications will be sent as updates occur."
+		var/my_department = "[location_name()] Firewall Subroutines"
+		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)
 
 
 /datum/event/money_hacker/tick()
@@ -30,7 +33,7 @@
 		endWhen = activeFor + 10
 
 /datum/event/money_hacker/end()
-	var/message
+	var/message = "The attack has ceased, the affected accounts can now be brought online."
 	if(affected_account && !affected_account.suspended)
 		//hacker wins
 		message = "The hack attempt has succeeded."
@@ -52,8 +55,7 @@
 		T.source_terminal = pick("","[pick("Biesel","New Gibson")] GalaxyNet Terminal #[rand(111,999)]","your mums place","nantrasen high CommanD")
 
 		affected_account.do_transaction(T)
-
-	else
-		//crew wins
-		message = "The attack has ceased, the affected accounts can now be brought online."
-	command_announcement.Announce(message, "[location_name()] Firewall Subroutines")
+	var/obj/machinery/message_server/MS = get_message_server()
+	if(MS)
+		var/my_department = "[location_name()] Firewall Subroutines"
+		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -46,9 +46,10 @@
 			areas += A
 
 	if(areas && areas.len > 0)
-		var/my_department = "[location_name()] firewall subroutines"
+		var/my_department = "[location_name()] Firewall Subroutines"
 		var/rc_message = "An unknown malicious program has been detected in the [english_list(areaName)] lighting and airlock control systems at [stationtime2text()]. Systems will be fully compromised within approximately three minutes. Direct intervention is required immediately.<br>"
-		for(var/obj/machinery/message_server/MS in world)
+		var/obj/machinery/message_server/MS = get_message_server()
+		if(MS)
 			MS.send_rc_message("Engineering", my_department, rc_message, "", "", 2)
 		for(var/mob/living/silicon/ai/A in GLOB.player_list)
 			to_chat(A, "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and airlock control systems by [my_department].</span>")


### PR DESCRIPTION
Also partly reverts #20581, the money hacker announcement will once again only show on the HoP's request console.
And yes, I don't like having to use magic strings either, the request consoles use mapped values right now. If anyone has a simple solution that could make it into the scope of this PR, feel free to share.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
