### PR TITLE
Admins get notified when wizard teleports off ship

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -75,6 +75,8 @@
 	while(tempL.len)
 		attempt = pick(tempL)
 		success = user.Move(attempt)
+		if (!is_station_area(attempt))
+			log_and_message_admins("has teleported to [get_area(attempt)].")
 		if(!success)
 			tempL.Remove(attempt)
 		else

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -59,6 +59,8 @@
 	while(L.len)
 		attempt = pick(L)
 		success = user.Move(attempt)
+		if (!is_station_area(attempt))
+			log_and_message_admins("has teleported to [get_area(attempt)].")
 		if(!success)
 			L.Remove(attempt)
 		else


### PR DESCRIPTION
Alternative to #20950.
Personally, I think wizards should maintain their freedom, but this should make it easier to catch the bad ones.