### PR TITLE
Emergency borg gripper fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -251,7 +251,7 @@
 	if(QDELETED(wrapped))
 		wrapped.loc = null
 		wrapped = null
-	return
+		return
 
 	if(!resolved && wrapped && target)
 		wrapped.afterattack(target, user, 1, params)


### PR DESCRIPTION
Fixes #20986, caused by #20914. Borg grippers work again.