### PR TITLE
Admins get notified when wizard teleports off ship

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -83,5 +83,8 @@
 	if(!success)
 		user.forceMove(pick(L))
 
+	if(!is_station_area(get_area(user)))
+		log_and_message_admins("has teleported to [get_area(user)].")
+
 	smoke.start()
 	src.uses -= 1

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -65,7 +65,9 @@
 			break
 
 	if(!success)
-		user.loc = pick(L)
+		user.forceMove(pick(L))
+	if(!is_station_area(get_area(user)))
+		log_and_message_admins("has teleported to [get_area(user)].")
 
 	return
 


### PR DESCRIPTION
Alternative to #20950.
Supersedes #20976.
Personally, I think wizards should maintain their freedom, but this should make it easier to catch the bad ones.