### PR TITLE
Turns conference room into a briefing room

### DIFF
--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -4585,21 +4585,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/firstdeck)
-"akT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/vault/bolted{
-	id_tag = "meetingsafedoor";
-	name = "Operations Safe Room"
-	},
-/obj/machinery/button/remote/airlock{
-	id = "meetingsafedoor";
-	name = "safe room door-control";
-	pixel_x = -32;
-	req_access = list(19);
-	specialfunctions = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/safe_room/firstdeck)
 "akU" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
@@ -4927,11 +4912,17 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/aquatic,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "alY" = (
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/structure/sign/double/icarus/solgovflag/left{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
@@ -5424,8 +5415,11 @@
 	pixel_x = -32
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Conference Room - Fore";
+	c_tag = "Briefing Room";
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
@@ -5603,6 +5597,9 @@
 /area/command/conference)
 "ape" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "apf" = (
@@ -5751,6 +5748,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
@@ -6378,12 +6378,18 @@
 /obj/item/stack/package_wrap/twenty_five,
 /obj/item/weapon/hand_labeler,
 /obj/item/device/destTagger,
-/turf/simulated/floor/tiled/dark,
-/area/command/conference)
-"aso" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
+"aso" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6393,15 +6399,12 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "asq" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
@@ -6422,6 +6425,10 @@
 	id = "conference_windows";
 	pixel_x = 6;
 	pixel_y = -24
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
@@ -6844,11 +6851,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftstarboard)
-"auu" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc/full,
-/turf/simulated/floor/tiled/dark,
-/area/command/captainmess)
 "auv" = (
 /obj/machinery/vending/boozeomat{
 	req_access = newlist();
@@ -6858,9 +6860,17 @@
 /area/command/captainmess)
 "auw" = (
 /obj/structure/table/marble,
-/obj/machinery/reagentgrinder,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/machinery/button/remote/blast_door{
+	dir = 2;
+	id = "capmess_shutter";
+	name = "Kitchen Shutter Control";
+	pixel_x = 0;
+	pixel_y = 25;
+	req_access = list(82)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
@@ -7243,11 +7253,6 @@
 /area/command/captainmess)
 "avL" = (
 /obj/structure/table/marble,
-/obj/item/weapon/material/kitchen/rollingpin,
-/obj/item/weapon/reagent_containers/food/condiment/enzyme,
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
@@ -7255,6 +7260,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/chemical_dispenser/bar_soft/full,
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "avP" = (
@@ -7601,6 +7607,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/random/soap,
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "awT" = (
@@ -7618,9 +7625,10 @@
 /area/command/captainmess)
 "awV" = (
 /obj/structure/table/marble,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/item/weapon/material/kitchen/rollingpin,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
@@ -7844,7 +7852,7 @@
 /area/hallway/primary/firstdeck/aft)
 "axK" = (
 /obj/structure/table/marble,
-/obj/random/soap,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "axL" = (
@@ -8441,6 +8449,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"ayM" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "ayP" = (
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8852,6 +8870,12 @@
 "aAD" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/checkpoint)
+"aAI" = (
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "aAJ" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -9052,6 +9076,11 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
@@ -9773,12 +9802,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
-"aDH" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aDI" = (
@@ -16510,6 +16533,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"bxz" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "byb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/structure/window/phoronreinforced,
@@ -18653,6 +18682,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"eRH" = (
+/obj/machinery/door/airlock/vault/bolted{
+	id_tag = "meetingsafedoor";
+	name = "Operations Safe Room"
+	},
+/obj/machinery/button/remote/airlock{
+	id = "meetingsafedoor";
+	name = "safe room door-control";
+	pixel_x = -32;
+	req_access = list(19);
+	specialfunctions = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/safe_room/firstdeck)
 "eRU" = (
 /turf/simulated/wall/r_wall/hull,
 /area/command/armoury)
@@ -20090,6 +20134,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
+"gZT" = (
+/obj/effect/floor_decal/scglogo{
+	icon_state = "0,1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "hab" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -20429,6 +20480,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/development)
+"hyj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/fore)
 "hzb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21180,11 +21246,19 @@
 /turf/simulated/floor/plating,
 /area/command/captainmess)
 "iEb" = (
-/turf/simulated/floor/carpet/blue,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "iFb" = (
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/carpet/blue,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "iGb" = (
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -22522,6 +22596,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
+"kSj" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/scglogo{
+	icon_state = "1,0";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "kTb" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -22814,6 +22898,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lrH" = (
+/obj/effect/floor_decal/scglogo{
+	icon_state = "2,1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "lsb" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -23048,33 +23139,34 @@
 /turf/simulated/floor/carpet,
 /area/medical/mentalhealth)
 "lIb" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/blue,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "lJb" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder/blue{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/command/conference)
-"lKb" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/item/weapon/folder/blue{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/command/conference)
-"lLb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/effect/floor_decal/scglogo{
+	icon_state = "0,0";
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
+"lKb" = (
+/obj/effect/floor_decal/scglogo{
+	icon_state = "0,2";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
+"lLb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "lMb" = (
 /obj/structure/cable/green{
@@ -23144,17 +23236,21 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
 "lVb" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/blue,
+/obj/effect/floor_decal/scglogo{
+	dir = 8;
+	icon_state = "1,1"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "lWb" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/weapon/folder/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/blue,
+/obj/effect/floor_decal/scglogo{
+	icon_state = "1,2";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "lXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23170,24 +23266,29 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
 "lYb" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/weapon/folder/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/blue,
-/area/command/conference)
-"lZb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/effect/floor_decal/scglogo{
+	icon_state = "2,0";
 	dir = 8
 	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
+"lZb" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "mab" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -23212,48 +23313,48 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "mdb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "meb" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "mfb" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue,
-/area/command/conference)
-"mgb" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
+"mgb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "mhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23415,9 +23516,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
@@ -23507,6 +23607,12 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
+"mCe" = (
+/obj/structure/sign/double/icarus/solgovflag/right{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "mDb" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 8;
@@ -24783,9 +24889,12 @@
 /area/command/captainmess)
 "oIb" = (
 /obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_soft/full,
 /obj/item/device/radio/intercom{
 	pixel_y = 22
+	},
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
@@ -25739,6 +25848,10 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qtX" = (
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "qvb" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -25759,6 +25872,21 @@
 /obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/diplomat)
+"qya" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/scglogo{
+	icon_state = "2,2";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "qyb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26736,6 +26864,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"smp" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/tableflag{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "snb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27057,6 +27192,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"sOd" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "sPb" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "xeno_airlock_control";
@@ -27504,6 +27643,26 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/shuttle/escape_pod16/station)
+"vIi" = (
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 2;
+	icon_state = "shutter1";
+	id = "capmess_shutter";
+	name = "Captain's Mess Kitchen Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/captainmess)
+"wZQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	layer = 2.4;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/conference)
 "xPU" = (
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
@@ -36686,11 +36845,11 @@ afF
 ajN
 adK
 alX
-alZ
+bxz
 anU
-alZ
-alZ
-alZ
+bxz
+bxz
+bxz
 alZ
 atr
 mub
@@ -36889,11 +37048,11 @@ ajO
 adK
 alY
 iEb
-lIb
-lIb
-lIb
 iEb
-alZ
+lIb
+lIb
+lIb
+qtX
 ats
 mub
 mDb
@@ -37089,13 +37248,13 @@ adK
 aiO
 ajN
 adK
-alZ
+mCe
 iFb
 lJb
-lJb
+kSj
 lYb
 mdb
-alZ
+wZQ
 att
 mvb
 mEb
@@ -37290,12 +37449,12 @@ adM
 adK
 aiP
 ajP
-akT
-alZ
-iFb
-lJb
+adK
+ama
+sOd
+gZT
 lVb
-lJb
+lrH
 meb
 aso
 atq
@@ -37493,15 +37652,15 @@ adK
 aiQ
 ajQ
 adK
-ama
-iFb
+alZ
+smp
 lKb
 lWb
-lWb
+qya
 mfb
 asp
 atq
-auu
+auv
 avJ
 awT
 axL
@@ -37694,16 +37853,16 @@ adM
 adK
 aiR
 ajR
-adK
-alZ
-iEb
+eRH
+aAI
+bxz
 lLb
-lLb
+ayM
 lZb
 mgb
 asq
-atq
-auv
+vIi
+axL
 avK
 awU
 axM
@@ -37898,8 +38057,8 @@ aiS
 ajS
 adK
 amb
-alZ
-alZ
+iEb
+iEb
 ape
 apW
 mtb
@@ -37913,7 +38072,7 @@ ayR
 aAe
 aBf
 aux
-aDH
+atE
 aEL
 aFT
 asA
@@ -38924,7 +39083,7 @@ axR
 axR
 axR
 axR
-aEQ
+hyj
 aFX
 aGQ
 aIe

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -541,7 +541,7 @@
 
 // Command
 /area/command/conference
-	name = "Conference Room"
+	name = "Briefing Room"
 	icon_state = "head_quarters"
 	sound_env = MEDIUM_SOFTFLOOR
 


### PR DESCRIPTION
🆑Cakey
maptweak: Replaces the conference room on deck one with a briefing room.
maptweak: Added a table/shutter combo intbetween the captain's mess and briefing room for the chef's use.
/🆑

![Preview](https://i.imgur.com/JZmkvUn.png)