### PR TITLE
Makes PDAs come with embedded cheap tablets.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1877,6 +1877,7 @@
 #include "code\modules\modular_computers\computers\modular_computer\variables.dm"
 #include "code\modules\modular_computers\computers\subtypes\dev_console.dm"
 #include "code\modules\modular_computers\computers\subtypes\dev_laptop.dm"
+#include "code\modules\modular_computers\computers\subtypes\dev_PDA_internal.dm"
 #include "code\modules\modular_computers\computers\subtypes\dev_tablet.dm"
 #include "code\modules\modular_computers\computers\subtypes\dev_telescreen.dm"
 #include "code\modules\modular_computers\computers\subtypes\preset_console.dm"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -17,6 +17,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/default_cartridge = 0 // Access level defined by cartridge
 	var/obj/item/weapon/cartridge/cartridge = null //current cartridge
 	var/mode = 0 //Controls what menu the PDA will display. 0 is hub; the rest are either built in or based on cartridge.
+	var/obj/item/modular_computer/PDA_internal/computer	//the integrated modular computer.
 
 	var/lastmode = 0
 	var/ui_tick = 0
@@ -327,6 +328,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(default_cartridge)
 		cartridge = new default_cartridge(src)
 	new pen(src)
+	computer = new(src)
 
 /obj/item/device/pda/proc/can_use()
 
@@ -650,6 +652,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if("Light")
 			toggle_light()
+		if("apps")
+			computer.enable_computer(user)
 		if("Medical Scan")
 			if(scanmode == 1)
 				scanmode = 0
@@ -1365,6 +1369,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		QDEL_NULL(src.id)
 	QDEL_NULL(src.cartridge)
 	QDEL_NULL(src.pai)
+	QDEL_NULL(computer)
 	return ..()
 
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
@@ -1448,3 +1453,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/proc/update_label()
 	name = "PDA-[owner] ([ownjob])"
+
+/obj/item/device/pda/initial_data()		//This may be called by the attached computer.
+	return computer.initial_data()

--- a/code/modules/modular_computers/computers/subtypes/dev_PDA_internal.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_PDA_internal.dm
@@ -1,0 +1,34 @@
+//An internal modular computer for the PDA.
+
+/obj/item/modular_computer/PDA_internal
+	name = "integrated PDA computer"
+	desc = "A computer integrated into a PDA."
+	hardware_flag = PROGRAM_TABLET
+	max_hardware_size = 1
+	
+	var/obj/item/device/pda/pda = null
+
+/obj/item/modular_computer/PDA_internal/install_default_hardware()
+	..()
+	processor_unit = new/obj/item/weapon/computer_hardware/processor_unit/small(src)
+	tesla_link = new/obj/item/weapon/computer_hardware/tesla_link(src)
+	hard_drive = new/obj/item/weapon/computer_hardware/hard_drive/micro(src)
+	network_card = new/obj/item/weapon/computer_hardware/network_card(src)
+	battery_module = new/obj/item/weapon/computer_hardware/battery_module/nano(src)
+	battery_module.charge_to_full()
+
+/obj/item/modular_computer/PDA_internal/install_default_programs()
+	..()
+	hard_drive.store_file(new/datum/computer_file/program/records())
+
+/obj/item/modular_computer/PDA_internal/New(obj/item/device/pda/parent_pda)
+	pda = parent_pda
+	forceMove(pda)
+	..()
+
+/obj/item/modular_computer/PDA_internal/Destroy()
+	pda = null
+	. = ..()
+
+/obj/item/modular_computer/PDA_internal/nano_host()
+	return pda

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -70,6 +70,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 {{:helper.link('Messenger', data.new_Message ? 'mail-closed' : 'mail-open', {'choice' : "2"}, null, 'fixedLeftWide')}}
                 {{:helper.link('Crew Manifest', 'contact', {'choice' : "41"}, null, 'fixedLeftWide')}}
 				{{:helper.link('News', data.new_News ? 'mail-closed' : 'mail-open', {'choice' : "6"}, null, 'fixedLeftWide')}}
+				{{:helper.link('NT Apps', 'circle-arrow-s', {'choice' : "apps"}, null, 'fixedLeftWide')}}
             </div>
         </div>
         <br>


### PR DESCRIPTION
:cl:
rscadd: PDAs now have an integrated modular computer, comparable to a cheap tablet, found under "NT Apps." It starts with the crew records program loaded.
/:cl:

The cheap tablet has a total of 32 gigabytes of space, of which 16 is usable. So crew records occupies almost all of it. You could uninstall it and replace it with 1-3 other programs, though (depending on size). The motivation was to restore the crew records to the PDA.

I am aware that the implementation is a bit goofy, but it minimizes codebase changes. Might need a lore check, as PDAs are not made by NT.