### PR TITLE
Fixes #21043

### DIFF
--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -97,6 +97,10 @@
 
 	if(!beaker)
 		return
+	
+	//SSObj fires twice as fast as SSMobs, so gotta slow down to not OD our victims.
+	if(SSobj.times_fired % 2)
+		return
 
 	if(mode) // Give blood
 		if(beaker.volume > 0)


### PR DESCRIPTION
Turns out it was putting in chems twice a (mob) tick since objs tick faster

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
