### PR TITLE
Modifies Example Config to Generate Asteroid

### DIFF
--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -354,7 +354,7 @@ STARLIGHT 0
 
 
 ## Enable asteroid tunnel/cave generation. Will behave strangely if turned off with a map that expects it on.
-# GENERATE_ASTEROID
+GENERATE_ASTEROID
 
 
 


### PR DESCRIPTION
A very large chunk of our away maps use the random generator, and people who run their own servers might be confused as to why their away sites are weird if it's left commented out.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
