### PR TITLE
Drastically cuts blood cough volume

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -87,7 +87,7 @@
 					"blood drips from <B>\the [owner]'s</B> [parent.name]!",
 				)
 
-			owner.drip(10)
+			owner.drip(1)
 		if(prob(4))
 			if(active_breathing)
 				owner.visible_message(


### PR DESCRIPTION
It was supposed to be a cosmetic effect, but it drips 10u per cough, while mobs regenerate at like 0.1, resulting in people actually bleeding out given enough time from /coughing/.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
