### PR TITLE
Adds additional L O R E to detergent pod bags.

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -497,6 +497,6 @@
 
 /obj/item/weapon/storage/box/detergent
 	name = "detergent pods bag"
-	desc = "A bag full of juicy, yummy detergent pods. This bag has been labeled: Tod Pods a Waffle Co. product."
+	desc = "A bag full of juicy, yummy detergent pods. This bag has been labeled: Tod Pods, a Waffle Co. product."
 	icon_state = "detergent"
 	startswith = list(/obj/item/weapon/reagent_containers/pill/detergent = 10)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -497,6 +497,6 @@
 
 /obj/item/weapon/storage/box/detergent
 	name = "detergent pods bag"
-	desc = "A bag full of juicy yummy detergent pods."
+	desc = "A bag full of juicy, yummy detergent pods. This bag has been labeled: Tod Pods a Waffle Co. product."
 	icon_state = "detergent"
 	startswith = list(/obj/item/weapon/reagent_containers/pill/detergent = 10)


### PR DESCRIPTION
Detergent bags now have a brand instead of relying on inferior generic brands. Introducing Tod Pods, the galaxy's first choice in detergent pods.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
