### PR TITLE
Fix air alarm access & mining site spawning

### DIFF
--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -9,7 +9,7 @@
 	var/list/shuttles_to_initialise = list()
 	var/base_turf_for_zs = null
 	var/accessibility_weight = 0
-	var/spawn_guranteed = FALSE
+	var/spawn_guaranteed = FALSE
 
 /datum/map_template/New(var/list/paths = null, var/rename = null)
 	if(paths && !islist(paths))

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -23,7 +23,6 @@
 	suffixes = list("mining/mining-asteroid.dmm")
 	cost = 1
 	accessibility_weight = 10
-	spawn_guranteed = TRUE
 
 /obj/effect/shuttle_landmark/cluster/nav1
 	name = "Asteroid Navpoint #1"
@@ -125,6 +124,8 @@
 		"nav_orb_7"
 	)
 	known = 0
+	start_x = 4
+	start_y = 5
 
 /datum/map_template/ruin/away_site/mine
 	name = "Mining - Orb"
@@ -133,6 +134,7 @@
 	suffixes = list("mining/mining-orb.dmm")
 	cost = 1
 	accessibility_weight = 10
+	spawn_guaranteed = TRUE
 
 /obj/effect/shuttle_landmark/orb
 	base_area = /area/mine/explored

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -14625,7 +14625,7 @@
 	dir = 8;
 	pixel_x = 25;
 	pixel_y = 0;
-	req_one_access = list(201)
+	req_one_access = list(24,11)
 	},
 /turf/simulated/floor/tiled,
 /area/vacant/prototype/control)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -188,8 +188,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for (var/site_name in SSmapping.away_sites_templates)
 		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 
-		if(site.spawn_guranteed && site.load_new_z()) // no check for budget, but guranteed means guranteed
-			report_progress("Loaded guranteed away site [site]!")
+		if(site.spawn_guaranteed && site.load_new_z()) // no check for budget, but guaranteed means guaranteed
+			report_progress("Loaded guaranteed away site [site]!")
 			away_site_budget -= site.cost
 			continue
 


### PR DESCRIPTION
Fixes #21101
Fixes #21112

Also swaps the designated mining map over to the orb since I guess there can only be 1 of those, and fixes spelling