### PR TITLE
Tweaks to exotic seeds generation

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -442,7 +442,7 @@
 			/datum/reagent/chloralhydrate/beer2
 			)
 		banned_chems += subtypesof(/datum/reagent/ethanol)
-		banned_chems += typesof(/datum/reagent/nicotine/solid)
+		banned_chems += subtypesof(/datum/reagent/tobacco)
 		banned_chems += typesof(/datum/reagent/drink)
 		banned_chems += typesof(/datum/reagent/nutriment)
 		banned_chems += typesof(/datum/reagent/toxin/fertilizer)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -436,10 +436,18 @@
 		var/list/banned_chems = list(
 			/datum/reagent/adminordrazine,
 			/datum/reagent/nutriment,
-			/datum/reagent/nanites
+			/datum/reagent/nanites,
+			/datum/reagent/water/holywater,
+			/datum/reagent/toxin/plantbgone,
+			/datum/reagent/chloralhydrate/beer2
 			)
+		banned_chems += subtypesof(/datum/reagent/ethanol)
+		banned_chems += typesof(/datum/reagent/nicotine/solid)
+		banned_chems += typesof(/datum/reagent/drink)
+		banned_chems += typesof(/datum/reagent/nutriment)
+		banned_chems += typesof(/datum/reagent/toxin/fertilizer)
+		banned_chems += typesof(/datum/reagent/crayon_dust)
 
-		if(prob(30))	banned_chems |= typesof(/datum/reagent/ethanol)
 		if(prob(30))	banned_chems |= typesof(/datum/reagent/toxin)
 
 		for(var/x=1;x<=additional_chems;x++)
@@ -500,7 +508,7 @@
 	set_trait(TRAIT_ENDURANCE,rand(60,100))
 	set_trait(TRAIT_YIELD,rand(3,15))
 	set_trait(TRAIT_MATURATION,rand(5,15))
-	set_trait(TRAIT_PRODUCTION,get_trait(TRAIT_MATURATION)+rand(2,5))
+	set_trait(TRAIT_PRODUCTION,rand(1,10))
 
 	generate_name()
 


### PR DESCRIPTION
Blacklists a few undesirable reagents from spawning in exotic seeds (mostly alcoholic drinks and foods), shortens production time of exotic plants (the former numbers were written, I think, with the misconception that production time had to be longer than maturation time).

🆑
tweak: "Exotic seeds do not contain certain reagents, such as alcoholic drinks, anymore."
tweak: "Exotic seeds' production time is now generally shorter than before."
/🆑

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
