### PR TITLE
Prevents crimes against fashion

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -84,7 +84,8 @@
 /obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
 	accessories += A
 	A.on_attached(src, user)
-	src.verbs |= /obj/item/clothing/proc/removetie_verb
+	if(A.removable)
+		src.verbs |= /obj/item/clothing/proc/removetie_verb
 	update_accessory_slowdown()
 	update_clothing_icon()
 
@@ -105,12 +106,17 @@
 	if(usr.stat) return
 	if(!accessories.len) return
 	var/obj/item/clothing/accessory/A
+	var/list/removables = list()
+	for(var/obj/item/clothing/accessory/ass in accessories)
+		if(ass.removable)
+			removables |= ass
 	if(accessories.len > 1)
-		A = input("Select an accessory to remove from [src]") as null|anything in accessories
+		A = input("Select an accessory to remove from [src]") as null|anything in removables
 	else
 		A = accessories[1]
 	src.remove_accessory(usr,A)
-	if(!accessories.len)
+	removables -= A
+	if(!removables.len)
 		src.verbs -= /obj/item/clothing/proc/removetie_verb
 
 /obj/item/clothing/emp_act(severity)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -19,6 +19,7 @@
 	var/list/on_rolled = list()	//used when jumpsuit sleevels are rolled ("rolled" entry) or it's rolled down ("down"). Set to "none" to hide in those states.
 	var/high_visibility	//if it should appear on examine without detailed view
 	var/slowdown //used when an accessory is meant to slow the wearer down when attached to clothing
+	var/removable = TRUE
 
 /obj/item/clothing/accessory/Destroy()
 	on_removed()

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -297,6 +297,7 @@ department tags
 	icon_state = "dept_exped"
 	on_rolled = list("down" = "none", "rolled" = "dept_exped_sleeves")
 	slot = ACCESSORY_SLOT_DEPT
+	removable = FALSE
 
 /obj/item/clothing/accessory/solgov/department/command
 	name = "command insignia"


### PR DESCRIPTION
Makes department insignia non-detachable.
It's purely a code thing to avoid making 9000 sprites, but it seems some people remove them to put on other clothes.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
