### PR TITLE
Fire extinguishers accept more reagents, and may spray water to cool below 100c. Misc. related changes.

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -15,9 +15,10 @@
 #define RADIATOR_EXPOSED_SURFACE_AREA_RATIO 0.04 // (3 cm + 100 cm * sin(3deg))/(2*(3+100 cm)). Unitless ratio.
 #define HUMAN_EXPOSED_SURFACE_AREA          5.2 //m^2, surface area of 1.7m (H) x 0.46m (D) cylinder
 
-#define T0C  273.15 //    0.0 degrees celcius
-#define T20C 293.15 //   20.0 degrees celcius
-#define TCMB 2.7    // -270.3 degrees celcius
+#define T0C   273.15 //    0.0 degrees celcius
+#define T20C  293.15 //   20.0 degrees celcius
+#define T100C 373.15 //  100.0 degrees celsius
+#define TCMB  2.7    // -270.3 degrees celcius
 
 #define CLAMP01(x) max(0, min(1, x))
 #define ATMOS_PRECISION 0.0001

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -189,63 +189,64 @@
 	var/spray_amount = 5	//units of liquid per particle. 5 is enough to wet the floor - it's a big fire extinguisher, so should be fine
 	var/max_water = 1000
 
-	New()
-		create_reagents(max_water)
-		reagents.add_reagent(/datum/reagent/water, max_water)
-		..()
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/New()
+	create_reagents(max_water)
+	reagents.add_reagent(/datum/reagent/water, max_water)
+	..()
 
-	action(atom/target) //copypasted from extinguisher. TODO: Rewrite from scratch.
-		if(!action_checks(target) || get_dist(chassis, target)>3) return
-		if(get_dist(chassis, target)>2) return
-		set_ready_state(0)
-		if(do_after_cooldown(target))
-			if( istype(target, /obj/structure/reagent_dispensers/watertank) && get_dist(chassis,target) <= 1)
-				var/obj/o = target
-				var/amount = o.reagents.trans_to_obj(src, 200)
-				occupant_message("<span class='notice'>[amount] units transferred into internal tank.</span>")
-				playsound(chassis, 'sound/effects/refill.ogg', 50, 1, -6)
-				return
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/action(atom/target) //copypasted from extinguisher. TODO: Rewrite from scratch.
+	if(!action_checks(target) || get_dist(chassis, target)>3) return
+	if(get_dist(chassis, target)>2) return
+	set_ready_state(0)
+	if(do_after_cooldown(target))
+		if( istype(target, /obj/structure/reagent_dispensers) && get_dist(chassis,target) <= 1)
+			var/obj/o = target
+			var/amount = o.reagents.trans_to_obj(src, 200)
+			occupant_message("<span class='notice'>[amount] units transferred into internal tank.</span>")
+			playsound(chassis, 'sound/effects/refill.ogg', 50, 1, -6)
+			return
 
-			if (src.reagents.total_volume < 1)
-				occupant_message("<span class='warning'>\The [src] is empty.</span>")
-				return
+		if (src.reagents.total_volume < 1)
+			occupant_message("<span class='warning'>\The [src] is empty.</span>")
+			return
 
-			playsound(chassis, 'sound/effects/extinguish.ogg', 75, 1, -3)
+		playsound(chassis, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
-			var/direction = get_dir(chassis,target)
+		addtimer(CALLBACK(src, .proc/do_spray, target), 0)
+		return 1
 
-			var/turf/T = get_turf(target)
-			var/turf/T1 = get_step(T,turn(direction, 90))
-			var/turf/T2 = get_step(T,turn(direction, -90))
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/get_equip_info()
+	return "[..()] \[[src.reagents.total_volume]\]"
 
-			var/list/the_targets = list(T,T1,T2)
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/on_reagent_change()
+	return
 
-			for(var/a = 1 to 5)
-				spawn(0)
-					var/obj/effect/effect/water/W = new /obj/effect/effect/water(get_turf(chassis))
-					var/turf/my_target
-					if(a == 1)
-						my_target = T
-					else if(a == 2)
-						my_target = T1
-					else if(a == 3)
-						my_target = T2
-					else
-						my_target = pick(the_targets)
-					W.create_reagents(5)
-					if(!W || !src)
-						return
-					reagents.trans_to_obj(W, spray_amount)
-					W.set_color()
-					W.set_up(my_target)
-			return 1
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/proc/do_spray(var/atom/Target)
+	var/direction = get_dir(chassis,Target)
 
-	get_equip_info()
-		return "[..()] \[[src.reagents.total_volume]\]"
+	var/turf/T = get_turf(Target)
+	var/turf/T1 = get_step(T,turn(direction, 90))
+	var/turf/T2 = get_step(T,turn(direction, -90))
 
-	on_reagent_change()
-		return
+	var/list/the_targets = list(T,T1,T2)
 
+	for(var/a = 1 to 5)
+		var/obj/effect/effect/water/W = new /obj/effect/effect/water(get_turf(chassis))
+		var/turf/my_target
+		if(a == 1)
+			my_target = T
+		else if(a == 2)
+			my_target = T1
+		else if(a == 3)
+			my_target = T2
+		else
+			my_target = pick(the_targets)
+		W.create_reagents(5)
+		if(!W || !src)
+			return
+		reagents.trans_to_obj(W, spray_amount)
+		W.set_color()
+		W.set_up(my_target)
 
 /obj/item/mecha_parts/mecha_equipment/tool/rcd
 	name = "mounted RCD"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -121,7 +121,7 @@
 		M.antibodies |= src.data["antibodies"]
 	..()
 
-#define WATER_LATENT_HEAT 19000 // How much heat is removed when applied to a hot turf, in J/unit (19000 makes 120 u of water roughly equivalent to 4L)
+#define WATER_LATENT_HEAT 9500 // How much heat is removed when applied to a hot turf, in J/unit (9500 makes 120 u of water roughly equivalent to 2L
 /datum/reagent/water
 	name = "Water"
 	description = "A ubiquitous chemical substance that is composed of hydrogen and oxygen."
@@ -147,7 +147,7 @@
 		return
 
 	var/datum/gas_mixture/environment = T.return_air()
-	var/min_temperature = T0C + 100 // 100C, the boiling point of water
+	var/min_temperature = T20C + rand(0, 20) // Room temperature + some variance. An actual diminishing return would be better, but this is *like* that. In a way. . This has the potential for weird behavior, but I says fuck it. Water grenades for everyone.
 
 	var/hotspot = (locate(/obj/fire) in T)
 	if(hotspot && !istype(T, /turf/space))
@@ -160,7 +160,7 @@
 	if (environment && environment.temperature > min_temperature) // Abstracted as steam or something
 		var/removed_heat = between(0, volume * WATER_LATENT_HEAT, -environment.get_thermal_energy_change(min_temperature))
 		environment.add_thermal_energy(-removed_heat)
-		if (prob(5))
+		if (prob(5) && environment && environment.temperature > T100C)
 			T.visible_message("<span class='warning'>The water sizzles as it lands on \the [T]!</span>")
 
 	else if(volume >= 10)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -332,6 +332,7 @@
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
+#define COOLANT_LATENT_HEAT 19000 //Twice as good at cooling than water is, but may cool below 20c. It'll cause freezing that atmos will have to deal with..
 /datum/reagent/coolant
 	name = "Coolant"
 	description = "Industrial cooling substance."
@@ -339,6 +340,29 @@
 	taste_mult = 1.1
 	reagent_state = LIQUID
 	color = "#c8a5dc"
+
+/datum/reagent/coolant/touch_turf(var/turf/simulated/T)
+	if(!istype(T))
+		return
+
+	var/datum/gas_mixture/environment = T.return_air()
+	var/min_temperature = 0 // Room temperature + some variance. An actual diminishing return would be better, but this is *like* that. In a way. . This has the potential for weird behavior, but I says fuck it. Water grenades for everyone.
+
+	var/hotspot = (locate(/obj/fire) in T)
+	if(hotspot && !istype(T, /turf/space))
+		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles)
+		lowertemp.temperature = max(min(lowertemp.temperature-2000, lowertemp.temperature / 2), 0)
+		lowertemp.react()
+		T.assume_air(lowertemp)
+		qdel(hotspot)
+
+	if (environment && environment.temperature > min_temperature) // Abstracted as steam or something
+		var/removed_heat = between(0, volume * COOLANT_LATENT_HEAT, -environment.get_thermal_energy_change(min_temperature))
+		environment.add_thermal_energy(-removed_heat)
+		if (prob(5) && environment && environment.temperature > T100C)
+			T.visible_message("<span class='warning'>The water sizzles as it lands on \the [T]!</span>")
+
+
 
 /datum/reagent/ultraglue
 	name = "Ultra Glue"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑 
rscadd: Fire extinguisher may now accept fluids from all forms of reagent containers (HCL dispensers, capsaicin dispensers, coolant tanks, fuel tanks etc.) and spray them at EXTREMELY low levels of efficiency (100 units a spray, wasteful for most things.) Firefighter extinguishers may also accept in the same way. BEWARE.
tweak: Water may now cool down to 20c when sprayed (Includes grenades, for example.), with a diminishing return below 60c.
rscadd: Like the above, coolant may be used to cool areas, best saved for phoron fires or traitoring, because it's extremely efficient and may dip an area to just a little over 0 kelvin if you're not careful.
tweak: Extinguishers will fire multiple puffs of reagents instead of three sprays at the exact same time. More or less consequence of a performance change.
/ 🆑 
https://streamable.com/9iowy