### PR TITLE
Description update for the fleet cap.

### DIFF
--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -30,7 +30,7 @@
 
 /obj/item/clothing/head/soft/solgov/fleet
 	name = "fleet cap"
-	desc = "It's a navy blue ballcap with the SCG Fleet crest."
+	desc = "It's a navy blue field cap with the SCG Fleet crest in a silver colour."
 	icon_state = "fleetsoft"
 
 /obj/item/clothing/head/solgov/utility


### PR DESCRIPTION
Changes ball cap to field cap, as it should.
I don't have anything else to say, it's the dumbest pull request i've done to date.
It wasn't just properly changed when the sprites did, the current sprites are not a ball cap, the description is just mis-written.