### PR TITLE
Adds ability to educate people on EC directives

### DIFF
--- a/maps/torch/structures/signs.dm
+++ b/maps/torch/structures/signs.dm
@@ -35,6 +35,20 @@
 		to_chat(usr, directives)
 		return TOPIC_HANDLED
 
+/obj/structure/sign/ecplaque/attackby(var/obj/I, var/mob/user)
+	if(istype(I, /obj/item/grab))
+		var/obj/item/grab/G = I
+		if(!ishuman(G.affecting))
+			return
+		G.affecting.apply_damage(5, BRUTE, BP_HEAD, used_weapon="Metal Plaque")
+		visible_message("<span class='warning'>[G.assailant] smashes [G.assailant] into \the [src] face-first!</span>")
+		playsound(get_turf(src), 'sound/weapons/tablehit1.ogg', 50)
+		to_chat(G.affecting, "<span class='danger'>[directives]</span>")
+		admin_attack_log(user, G.affecting, "educated victim on \the [src].", "Was educated on \the [src].", "used \a [src] to educate")
+		G.force_drop()
+	else
+		..()
+
 /obj/effect/floor_decal/scglogo
 	alpha = 230
 	icon = 'maps/torch/icons/obj/solgov_floor.dmi'


### PR DESCRIPTION
Use grab on EC plaque to display EC directives to them.
:cl: Chinsky
rscadd: Can now use grab on EC plaques to display Directives to people. Forcefully.
/:cl:

![](https://i.imgur.com/yTHH8Rc.png)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
