### PR TITLE
Deck 2 decal implementation

### DIFF
--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -17,7 +17,7 @@
 /obj/machinery/camera/network/engine{
 	c_tag = "Tech Storage - Main"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "ac" = (
 /obj/machinery/cryopod{
@@ -280,7 +280,7 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/circuitboard/helm,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aI" = (
 /obj/item/weapon/circuitboard/shield_diffuser,
@@ -293,14 +293,14 @@
 /obj/item/weapon/circuitboard/shield_generator,
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aJ" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/circuitboard/borgupload,
 /obj/item/weapon/circuitboard/aiupload,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aK" = (
 /turf/simulated/wall/r_wall/hull,
@@ -414,7 +414,17 @@
 /obj/machinery/camera/network/engine{
 	c_tag = "Tech Storage - Secure"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aS" = (
 /obj/structure/table/rack,
@@ -428,7 +438,7 @@
 /obj/item/device/t_scanner,
 /obj/item/device/multitool,
 /obj/item/clothing/glasses/meson,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aT" = (
 /obj/structure/table/rack,
@@ -446,7 +456,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aU" = (
 /obj/structure/table/rack,
@@ -458,7 +468,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aV" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -466,7 +476,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/central)
 "aW" = (
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aX" = (
 /obj/machinery/light/small{
@@ -477,7 +493,13 @@
 	pixel_x = -23;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aY" = (
 /obj/structure/table/rack,
@@ -490,11 +512,31 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "ba" = (
 /obj/structure/table/standard{
@@ -506,7 +548,7 @@
 /obj/random/powercell,
 /obj/item/weapon/cell/high,
 /obj/item/weapon/cell/high,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bb" = (
 /obj/structure/sign/warning/docking_area,
@@ -589,7 +631,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "bm" = (
 /obj/structure/table/rack,
@@ -670,13 +712,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	tag = "icon-corner_techfloor_grid_full (NORTH)";
+	icon_state = "corner_techfloor_grid_full";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "bw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bx" = (
 /turf/simulated/wall,
@@ -686,7 +745,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bz" = (
 /obj/item/weapon/circuitboard/telecomms/processor,
@@ -696,7 +755,7 @@
 /obj/item/weapon/circuitboard/telecomms/broadcaster,
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bA" = (
 /obj/item/weapon/stock_parts/subspace/treatment,
@@ -708,14 +767,14 @@
 /obj/item/weapon/stock_parts/subspace/transmitter,
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bB" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/circuitboard/mecha_control,
 /obj/item/weapon/circuitboard/robotics,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bC" = (
 /obj/random/closet,
@@ -913,7 +972,17 @@
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bX" = (
 /obj/structure/table/standard{
@@ -925,11 +994,16 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "bY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "bZ" = (
 /obj/machinery/light/small{
@@ -944,7 +1018,7 @@
 /obj/item/weapon/circuitboard/atmos_alert,
 /obj/item/weapon/circuitboard/powermonitor,
 /obj/item/weapon/circuitboard/stationalert,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "cb" = (
 /turf/simulated/floor/plating,
@@ -1166,16 +1240,31 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "cA" = (
 /obj/machinery/vending/assist,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "cB" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "cC" = (
 /obj/structure/table/rack,
@@ -1185,7 +1274,7 @@
 /obj/item/weapon/circuitboard/protolathe,
 /obj/item/weapon/circuitboard/destructive_analyzer,
 /obj/item/weapon/circuitboard/rdconsole,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "cD" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1468,7 +1557,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1477,7 +1571,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1486,7 +1585,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 5
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dn" = (
 /obj/structure/bed/roller,
@@ -1591,7 +1705,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dF" = (
 /obj/structure/table/rack,
@@ -1599,7 +1718,7 @@
 /obj/item/weapon/circuitboard/holodeckcontrol,
 /obj/item/weapon/circuitboard/mech_recharger,
 /obj/item/weapon/circuitboard/solar_control,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "dG" = (
 /obj/structure/cable/green{
@@ -1618,7 +1737,8 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dI" = (
 /obj/structure/table/standard{
@@ -1628,7 +1748,12 @@
 /obj/random/technology_scanner,
 /obj/random/bomb_supply,
 /obj/random/bomb_supply,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dJ" = (
 /obj/structure/table/standard{
@@ -1636,7 +1761,8 @@
 	},
 /obj/item/weapon/aicard,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dK" = (
 /obj/machinery/requests_console{
@@ -1644,7 +1770,8 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dL" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -1769,7 +1896,8 @@
 	},
 /obj/item/device/flash,
 /obj/item/device/flash,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "dW" = (
 /obj/structure/cable{
@@ -1912,7 +2040,8 @@
 	},
 /obj/item/weapon/storage/box/lights/bulbs,
 /obj/item/weapon/storage/box/lights/tubes,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "ee" = (
 /turf/simulated/wall,
@@ -1924,7 +2053,8 @@
 /area/storage/expedition)
 "eg" = (
 /obj/structure/closet/secure_closet/guncabinet/sidearm/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "eh" = (
 /obj/machinery/power/fusion_core/mapped{
@@ -1946,15 +2076,31 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	tag = "icon-corner_techfloor_grid_full (EAST)";
+	icon_state = "corner_techfloor_grid_full";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "ej" = (
 /obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/weapon/circuitboard/arcade/battle,
 /obj/item/weapon/circuitboard/arcade/orion_trail,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "ek" = (
 /obj/structure/disposalpipe/segment{
@@ -2000,7 +2146,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "eq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2011,7 +2167,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "er" = (
 /obj/machinery/power/apc{
@@ -2023,7 +2185,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "es" = (
 /obj/structure/cable{
@@ -2283,7 +2445,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/aiModule/reset,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "eQ" = (
 /obj/structure/table/rack,
@@ -2294,7 +2456,7 @@
 /obj/item/weapon/airlock_brace,
 /obj/item/weapon/airlock_brace,
 /obj/item/weapon/airlock_brace,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "eR" = (
 /obj/structure/cable{
@@ -2314,7 +2476,7 @@
 /obj/item/weapon/airlock_electronics,
 /obj/item/weapon/airlock_electronics,
 /obj/item/weapon/airlock_electronics,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "eT" = (
 /obj/structure/cable/green{
@@ -2889,7 +3051,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "gj" = (
 /obj/structure/cable/green{
@@ -3773,7 +3945,7 @@
 /area/engineering/hardstorage)
 "hT" = (
 /obj/machinery/computer/atmos_alert,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_monitoring)
 "hU" = (
 /obj/structure/lattice,
@@ -3900,7 +4072,7 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/folder/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_monitoring)
 "ic" = (
 /obj/structure/disposalpipe/segment{
@@ -4147,7 +4319,12 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "iF" = (
 /obj/structure/cable/green{
@@ -4178,7 +4355,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "iH" = (
 /obj/item/device/floor_painter,
@@ -4190,7 +4367,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "iI" = (
 /obj/item/device/radio/off{
@@ -4223,7 +4400,7 @@
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "iJ" = (
 /obj/structure/cable{
@@ -4295,11 +4472,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/item/device/radio/beacon,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
 /area/engineering/foyer)
 "iP" = (
 /obj/machinery/door/firedoor/border_only,
@@ -4653,17 +4830,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/hologram/holopad,
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals_central6,
+/turf/simulated/floor/tiled/monotile,
 /area/engineering/foyer)
 "jG" = (
 /obj/structure/cable{
@@ -4757,8 +4930,27 @@
 	pixel_y = -22
 	},
 /obj/machinery/light/small,
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (SOUTHWEST)";
+	icon_state = "borderfloor";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	tag = "icon-bordercolor (SOUTHWEST)";
+	icon_state = "bordercolor";
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	tag = "icon-borderfloorcorner2 (NORTHWEST)";
+	icon_state = "borderfloorcorner2";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	tag = "icon-bordercolorcorner2 (NORTHWEST)";
+	icon_state = "bordercolorcorner2";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "jQ" = (
 /obj/machinery/door/airlock/external{
@@ -4780,8 +4972,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	tag = "icon-steel_decals10 (SOUTHEAST)";
+	icon_state = "steel_decals10";
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	tag = "icon-steel_decals10 (NORTHEAST)";
+	icon_state = "steel_decals10";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -4796,10 +4995,19 @@
 	pixel_y = -24
 	},
 /obj/machinery/light/small,
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (SOUTHEAST)";
+	icon_state = "borderfloor";
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/paleblue/border{
+	tag = "icon-bordercolor (SOUTHEAST)";
+	icon_state = "bordercolor";
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/blue/bordercorner2,
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "jT" = (
 /obj/machinery/door/firedoor/border_only,
@@ -4814,7 +5022,7 @@
 	name = "Second Deck Teleporter";
 	req_access = list(17)
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "jU" = (
 /obj/machinery/vending/assist,
@@ -4845,6 +5053,26 @@
 /obj/structure/closet/secure_closet/crew,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
+/obj/effect/floor_decal/borderfloorblack{
+	tag = "icon-borderfloor_black (NORTHWEST)";
+	icon_state = "borderfloor_black";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	tag = "icon-bordercolor (NORTHWEST)";
+	icon_state = "bordercolor";
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	tag = "icon-borderfloorcorner2 (SOUTHWEST)";
+	icon_state = "borderfloorcorner2";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	tag = "icon-bordercolorcorner2 (SOUTHWEST)";
+	icon_state = "bordercolorcorner2";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "jY" = (
@@ -4860,11 +5088,31 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_monitoring)
 "jZ" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
+/obj/effect/floor_decal/borderfloorblack{
+	tag = "icon-borderfloor_black (NORTH)";
+	icon_state = "borderfloor_black";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	tag = "icon-borderfloorcorner2_black (NORTH)";
+	icon_state = "borderfloorcorner2_black";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	tag = "icon-bordercolorcorner2 (NORTH)";
+	icon_state = "bordercolorcorner2";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "ka" = (
@@ -4876,6 +5124,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/bluespace_beacon,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	tag = "icon-steel_decals10 (NORTHWEST)";
+	icon_state = "steel_decals10";
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	tag = "icon-steel_decals10 (SOUTHWEST)";
+	icon_state = "steel_decals10";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kb" = (
@@ -4927,6 +5185,26 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	tag = "icon-borderfloor_black (NORTH)";
+	icon_state = "borderfloor_black";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	tag = "icon-borderfloorcorner2_black (EAST)";
+	icon_state = "borderfloorcorner2_black";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	tag = "icon-bordercolorcorner2 (EAST)";
+	icon_state = "bordercolorcorner2";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kg" = (
@@ -4948,6 +5226,16 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	tag = "icon-borderfloor_black (NORTH)";
+	icon_state = "borderfloor_black";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "ki" = (
@@ -4967,6 +5255,16 @@
 /turf/simulated/floor/plating,
 /area/teleporter/seconddeck)
 "kk" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	tag = "icon-steel_decals10 (WEST)";
+	icon_state = "steel_decals10";
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	tag = "icon-steel_decals10 (NORTH)";
+	icon_state = "steel_decals10";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kl" = (
@@ -4994,8 +5292,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "kn" = (
 /obj/structure/cable{
@@ -5010,7 +5309,7 @@
 "ko" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "kp" = (
 /obj/structure/cable/cyan{
@@ -5100,8 +5399,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "ky" = (
 /obj/machinery/shield_diffuser,
@@ -5111,8 +5411,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "kA" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5135,8 +5436,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "kB" = (
+/obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "kC" = (
 /obj/machinery/door/airlock/maintenance{
@@ -5152,6 +5454,26 @@
 "kE" = (
 /obj/prefab/hand_teleporter,
 /obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack{
+	tag = "icon-borderfloor_black (WEST)";
+	icon_state = "borderfloor_black";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	tag = "icon-bordercolor (WEST)";
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	tag = "icon-borderfloorcorner2 (WEST)";
+	icon_state = "borderfloorcorner2";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	tag = "icon-bordercolorcorner2 (WEST)";
+	icon_state = "bordercolorcorner2";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kF" = (
@@ -5160,16 +5482,21 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
+/obj/structure/table/standard,
+/obj/random/tank,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/random/tank,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "kG" = (
 /obj/machinery/teleport/hub,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter/seconddeck)
 "kH" = (
 /obj/structure/table/steel,
@@ -5182,7 +5509,17 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	tag = "icon-techfloororange_edges (WEST)";
+	icon_state = "techfloororange_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "kI" = (
 /turf/simulated/open,
@@ -5195,7 +5532,12 @@
 	},
 /area/space)
 "kJ" = (
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "kK" = (
 /obj/structure/cable/green{
@@ -5206,11 +5548,16 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "kL" = (
 /obj/machinery/computer/teleporter,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter/seconddeck)
 "kM" = (
 /obj/machinery/alarm{
@@ -5218,7 +5565,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/teleport/station,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter/seconddeck)
 "kN" = (
 /obj/structure/disposalpipe/segment,
@@ -5258,7 +5605,7 @@
 "kQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/firstaid/toxin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "kR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5334,7 +5681,22 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	tag = "icon-corner_techfloor_grid_full (WEST)";
+	icon_state = "corner_techfloor_grid_full";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_monitoring)
 "kX" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -5524,7 +5886,7 @@
 /area/maintenance/exterior)
 "lm" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "ln" = (
 /obj/structure/cable/green{
@@ -5568,6 +5930,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
+"lw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTH)";
+	icon_state = "corner_techfloor_grid";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/storage/tech)
 "ly" = (
 /obj/structure/table/steel,
 /obj/item/weapon/hand_labeler,
@@ -5582,21 +5963,26 @@
 	pixel_x = -32
 	},
 /obj/item/device/destTagger,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/orange{
+	tag = "icon-techfloororange_edges (WEST)";
+	icon_state = "techfloororange_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "lA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "lB" = (
 /obj/structure/cable/green{
@@ -5615,7 +6001,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "lD" = (
 /turf/simulated/floor/plating,
@@ -5673,7 +6059,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid/full,
+/obj/effect/floor_decal/techfloor/corner,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_monitoring)
 "lN" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -5812,7 +6210,7 @@
 	id_tag = "fusion_injector";
 	req_access = list(11)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "mg" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5887,18 +6285,27 @@
 "mm" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/brown,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "mn" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "mo" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
+"mq" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/seconddeck)
 "ms" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5908,11 +6315,16 @@
 "mt" = (
 /obj/item/modular_computer/console/preset/engineering,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/orange/corner{
+	tag = "icon-techfloororange_corners (WEST)";
+	icon_state = "techfloororange_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "mu" = (
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "mv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5924,7 +6336,8 @@
 	icon_state = "1-2"
 	},
 /obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/orange/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "mw" = (
 /obj/machinery/light/small{
@@ -5982,11 +6395,16 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_monitoring)
 "mE" = (
 /obj/structure/cable/green{
@@ -6050,7 +6468,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "mJ" = (
 /obj/structure/sign/warning/radioactive,
@@ -6282,6 +6710,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
+"no" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
 "nq" = (
 /obj/structure/noticeboard,
 /turf/simulated/wall,
@@ -6323,11 +6759,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_monitoring)
 "nx" = (
 /obj/structure/sign/warning/internals_required{
@@ -6353,7 +6790,22 @@
 	c_tag = "Engine - Control";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	tag = "icon-corner_techfloor_grid_full (WEST)";
+	icon_state = "corner_techfloor_grid_full";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "nz" = (
 /obj/item/device/radio/intercom{
@@ -6361,12 +6813,14 @@
 	pixel_x = -22
 	},
 /obj/machinery/computer/robotics,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/orange{
+	tag = "icon-techfloororange_edges (SOUTHWEST)";
+	icon_state = "techfloororange_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "nA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -6380,7 +6834,12 @@
 	pixel_x = 30;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/orange{
+	tag = "icon-techfloororange_edges (SOUTHEAST)";
+	icon_state = "techfloororange_edges";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "nC" = (
 /obj/machinery/door/blast/regular{
@@ -6485,6 +6944,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/seconddeck/forestarboard)
+"nS" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/storage/tech)
 "nT" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 1;
@@ -6537,10 +7004,17 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "ob" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (NORTH)";
+	icon_state = "borderfloor";
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/yellow/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "oc" = (
 /turf/simulated/floor/tiled,
@@ -6559,13 +7033,20 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "of" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "oh" = (
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "oi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6610,13 +7091,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/engineering/storage)
 "on" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6624,30 +7101,58 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
-"oo" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 5
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/hallway)
+"oo" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "oq" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway)
 "or" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway)
 "os" = (
 /obj/structure/sign/warning/nosmoking_2,
@@ -6664,21 +7169,31 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "ou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "ov" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "ow" = (
 /obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "oz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -6816,10 +7331,10 @@
 	req_access = list(19);
 	specialfunctions = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "pk" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "pl" = (
 /obj/structure/disposalpipe/segment,
@@ -6852,7 +7367,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "po" = (
 /obj/machinery/door/airlock/engineering{
@@ -6878,7 +7393,12 @@
 	dir = 8
 	},
 /obj/item/weapon/book/manual/supermatter_engine,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "pq" = (
 /obj/structure/closet/radiation,
@@ -6893,7 +7413,12 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "pr" = (
 /obj/machinery/door/firedoor/border_only,
@@ -6923,11 +7448,27 @@
 /area/crew_quarters/safe_room/seconddeck)
 "pu" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (NORTH)";
+	icon_state = "borderfloor";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	tag = "icon-borderfloorcorner2 (EAST)";
+	icon_state = "borderfloorcorner2";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	tag = "icon-bordercolorcorner2 (EAST)";
+	icon_state = "bordercolorcorner2";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "pv" = (
 /obj/structure/cable/green{
@@ -6941,6 +7482,16 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	tag = "icon-steel_decals6 (WEST)";
+	icon_state = "steel_decals6";
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	tag = "icon-steel_decals6 (NORTH)";
+	icon_state = "steel_decals6";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -6960,7 +7511,7 @@
 	icon_state = "pipe-j2";
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
+/obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "py" = (
@@ -6985,20 +7536,37 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "pA" = (
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (NORTH)";
+	icon_state = "borderfloor";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/yellow/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	tag = "icon-borderfloorcorner2 (NORTH)";
+	icon_state = "borderfloorcorner2";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	tag = "icon-bordercolorcorner2 (NORTH)";
+	icon_state = "bordercolorcorner2";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "pB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -7011,7 +7579,26 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	tag = "icon-corner_techfloor_grid_full (WEST)";
+	icon_state = "corner_techfloor_grid_full";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "pC" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -7035,7 +7622,12 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "pE" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -7054,32 +7646,46 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "pG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "pH" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
-"pI" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
 	dir = 1
 	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/hallway)
+"pI" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7091,7 +7697,12 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "pL" = (
 /obj/structure/closet/emcloset,
@@ -7099,7 +7710,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7115,7 +7726,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "pN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
@@ -7130,7 +7741,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "pO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -7142,16 +7753,24 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "pP" = (
 /obj/machinery/door/firedoor/border_only,
@@ -7170,7 +7789,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "pR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7178,7 +7798,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "pS" = (
 /obj/structure/table/steel_reinforced,
@@ -7212,7 +7832,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "pT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7229,7 +7854,7 @@
 	pressure_setting = 100;
 	sensors = list("engine_sensor" = "Engine Core")
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "pU" = (
 /obj/machinery/door/blast/regular{
@@ -7281,10 +7906,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
 	dir = 4
 	},
+/obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "pZ" = (
@@ -7359,7 +7991,13 @@
 	name = "Engineering Bay";
 	req_one_access = list(10)
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "qf" = (
 /obj/structure/sink{
@@ -7411,7 +8049,6 @@
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
 "qk" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/engineering{
 	name = "Fusion Testing Facility";
 	req_access = list(11);
@@ -7430,7 +8067,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "ql" = (
 /obj/structure/bed/chair{
@@ -7490,11 +8127,31 @@
 "qz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "qA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "qB" = (
 /obj/structure/disposalpipe/segment{
@@ -7516,7 +8173,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "qC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7533,7 +8190,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "qE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7549,6 +8206,19 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"qF" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/storage/tech)
 "qG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7564,7 +8234,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "qH" = (
 /obj/structure/disposalpipe/segment{
@@ -7582,7 +8252,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "qI" = (
 /obj/machinery/door/airlock/glass_engineering{
@@ -7604,7 +8274,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "qJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7623,7 +8299,18 @@
 	name = "Engineering Bay";
 	sortType = "Engineering Bay"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "qK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7651,7 +8338,18 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7672,7 +8370,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -7682,7 +8391,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qN" = (
 /obj/structure/sign/atmosplaque,
@@ -7701,7 +8411,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -7717,7 +8428,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
@@ -7726,34 +8437,41 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1;
 	icon_state = "map"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	icon_state = "intact";
 	dir = 10
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qV" = (
 /turf/simulated/wall/r_wall,
@@ -7786,11 +8504,22 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (WEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "qX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "qY" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -7913,7 +8642,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "rj" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -7937,8 +8677,12 @@
 "rl" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "rm" = (
 /obj/structure/cable/green{
@@ -8058,7 +8802,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "rN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -8067,20 +8817,35 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "rO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "rP" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 2;
 	target_pressure = 200
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "rQ" = (
 /turf/simulated/wall/r_wall,
@@ -8101,15 +8866,40 @@
 /area/engineering/foyer)
 "rS" = (
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/borderfloor/corner{
+	tag = "icon-borderfloorcorner (WEST)";
+	icon_state = "borderfloorcorner";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	tag = "icon-bordercolorcorner (WEST)";
+	icon_state = "bordercolorcorner";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "rV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTH)";
+	icon_state = "corner_techfloor_grid";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "rX" = (
 /obj/machinery/power/apc{
@@ -8123,9 +8913,9 @@
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -8137,32 +8927,41 @@
 "sa" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_storage_unit/engineering/alt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "sb" = (
 /obj/structure/window/reinforced,
-/obj/effect/floor_decal/corner/yellow,
 /obj/machinery/autolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "sc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "sd" = (
 /obj/structure/window/reinforced,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
 /obj/structure/table/steel,
 /obj/item/weapon/book/manual/engineering_hacking,
 /obj/item/weapon/book/manual/engineering_construction,
 /obj/item/weapon/book/manual/engineering_guide,
 /obj/item/weapon/book/manual/atmospipes,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "se" = (
 /obj/structure/window/reinforced,
@@ -8178,7 +8977,7 @@
 	c_tag = "Engineering - Equipment";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "sf" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -8186,7 +8985,12 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway)
 "sg" = (
 /obj/machinery/door/airlock/glass_engineering{
@@ -8203,7 +9007,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "sh" = (
 /obj/machinery/button/remote/driver{
@@ -8220,7 +9034,7 @@
 	name = "emergency core eject";
 	req_access = list(11)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_monitoring)
 "si" = (
 /obj/machinery/button/remote/blast_door{
@@ -8244,7 +9058,12 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "sk" = (
 /obj/structure/table/steel_reinforced,
@@ -8252,7 +9071,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_monitoring)
 "sl" = (
 /obj/machinery/light,
@@ -8363,16 +9182,16 @@
 "sI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "sJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "sK" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "sL" = (
 /obj/item/bodybag/cryobag,
@@ -8389,7 +9208,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloorblack{
+	tag = "icon-borderfloor_black (EAST)";
+	icon_state = "borderfloor_black";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -8397,28 +9226,30 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "sN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1;
 	icon_state = "map"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "sP" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
 /obj/structure/ladder,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "sQ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /obj/structure/ladder/up,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "sR" = (
 /obj/structure/table/rack{
@@ -8440,28 +9271,21 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "sS" = (
 /obj/structure/closet/secure_closet/engineering_senior,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "sT" = (
 /obj/structure/closet/secure_closet/engineering_torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "sU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8472,7 +9296,17 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "sV" = (
 /obj/machinery/alarm{
@@ -8497,7 +9331,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "sW" = (
 /obj/machinery/status_display,
@@ -8515,14 +9349,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "sY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "sZ" = (
 /turf/simulated/wall/r_wall,
@@ -8615,7 +9457,7 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "tp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -8626,7 +9468,8 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "tq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8637,13 +9480,15 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "tr" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "ts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
@@ -8652,11 +9497,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/sign/warning/fire{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid/full,
+/obj/effect/floor_decal/techfloor/corner,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway)
 "tt" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -8664,29 +9515,40 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "tv" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
 /obj/structure/ladder,
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "tw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ty" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (WEST)";
+	icon_state = "borderfloor";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/lime/border{
+	tag = "icon-bordercolor (WEST)";
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer)
+"ty" = (
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (EAST)";
+	icon_state = "borderfloor";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	tag = "icon-bordercolor (EAST)";
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
 "tz" = (
 /obj/structure/table/steel_reinforced,
@@ -8698,13 +9560,24 @@
 	pixel_y = -32
 	},
 /obj/item/device/geiger,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "tA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "tB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8716,20 +9589,20 @@
 	pixel_y = -24
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "tE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_storage_unit/atmos/alt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "tF" = (
 /obj/machinery/vending/engivend,
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "tG" = (
 /obj/structure/table/rack{
@@ -8753,11 +9626,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "tH" = (
 /turf/simulated/wall,
@@ -8768,7 +9638,12 @@
 	dir = 5
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "tK" = (
 /obj/structure/closet/secure_closet/engineering_torch{
@@ -8777,12 +9652,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "tL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -8798,7 +9669,12 @@
 /obj/item/weapon/tank/oxygen/yellow,
 /obj/item/weapon/tank/oxygen/yellow,
 /obj/item/weapon/tank/emergency/oxygen/double,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "tM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -8807,17 +9683,22 @@
 /obj/structure/table/steel,
 /obj/item/weapon/book/manual/atmospipes,
 /obj/item/weapon/tank/jetpack,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "tO" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "tP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/pipedispenser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "tQ" = (
 /obj/machinery/camera/network/engineering{
@@ -8825,7 +9706,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/pipedispenser/disposal,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "tR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8833,7 +9714,17 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "tV" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -8852,7 +9743,7 @@
 	dir = 8
 	},
 /obj/structure/dispenser/oxygen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "tY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -8920,28 +9811,32 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "ui" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
 /obj/structure/ladder,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "uj" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
 /obj/structure/ladder/up,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -8961,11 +9856,12 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "um" = (
 /obj/machinery/vending/engineering,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "un" = (
 /obj/structure/table/rack{
@@ -8998,22 +9894,29 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "uo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "up" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "uq" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -9024,12 +9927,22 @@
 	pixel_y = -24
 	},
 /obj/machinery/suit_storage_unit/atmos/alt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "ur" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "us" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -9042,7 +9955,12 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "ut" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -9063,37 +9981,52 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "uu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "uv" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 4;
 	name = "Scrubber to Waste"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "uw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	icon_state = "map";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "uy" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "uA" = (
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "uD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -9258,7 +10191,8 @@
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "uV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -9268,7 +10202,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "uW" = (
 /obj/structure/closet/crate,
@@ -9281,7 +10225,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "uX" = (
 /obj/structure/sign/warning/secure_area,
@@ -9299,7 +10244,7 @@
 	icon_state = "0-2"
 	},
 /obj/item/weapon/tape_roll,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_monitoring)
 "vc" = (
 /turf/simulated/wall,
@@ -9312,7 +10257,17 @@
 	req_one_access = newlist()
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_eva)
 "ve" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
@@ -9327,21 +10282,26 @@
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vg" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
 	name = "Air to Supply"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -9349,7 +10309,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vi" = (
 /obj/structure/cable{
@@ -9373,7 +10333,7 @@
 	pixel_x = 22;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "vj" = (
 /obj/structure/cable/yellow{
@@ -9398,13 +10358,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "vm" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vn" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -9426,7 +10401,7 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "vo" = (
 /obj/structure/sign/warning/compressed_gas,
@@ -9557,14 +10532,25 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "vG" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "vH" = (
 /obj/machinery/light/small{
@@ -9578,7 +10564,8 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "vI" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -9614,11 +10601,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "vP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9694,7 +10678,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -9702,7 +10701,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -9710,20 +10709,20 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "vX" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "vZ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "wb" = (
 /obj/structure/sign/solgov{
@@ -9737,7 +10736,16 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "wd" = (
 /obj/machinery/alarm{
@@ -9938,22 +10946,30 @@
 /obj/structure/closet/crate/freezer/rations,
 /obj/random/snack,
 /obj/random/snack,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "wz" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "wA" = (
 /obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "wB" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -9982,7 +10998,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "wL" = (
 /obj/random/junk,
@@ -10007,18 +11023,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "wO" = (
 /obj/machinery/atmospherics/valve/digital/open{
 	dir = 4;
 	icon_state = "map_valve1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "wP" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "wQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -10026,7 +11047,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (EAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "wU" = (
 /turf/simulated/wall/r_wall/hull,
@@ -10101,7 +11132,12 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "xd" = (
 /obj/structure/table/standard{
@@ -10230,21 +11266,19 @@
 /area/engineering/atmos)
 "xG" = (
 /obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "xH" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "xK" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -10258,8 +11292,47 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTH)";
+	icon_state = "corner_techfloor_grid";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
+"xN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (EAST)";
+	icon_state = "borderfloor";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	tag = "icon-bordercolor (EAST)";
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer)
+"xO" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/storage/tech)
 "xT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plating,
@@ -10472,13 +11545,22 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "yB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "yC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -10488,7 +11570,7 @@
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "yE" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -10503,27 +11585,27 @@
 	tag_west_con = 0.79;
 	use_power = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "yF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "yG" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "yJ" = (
 /obj/machinery/atmospherics/valve/digital/open,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "yK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "yN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -10676,7 +11758,8 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "zk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -10694,14 +11777,18 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zm" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zn" = (
 /obj/structure/disposalpipe/segment{
@@ -10721,28 +11808,30 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
 /obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zs" = (
 /obj/machinery/atmospherics/unary/freezer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zt" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zu" = (
 /obj/machinery/atmospherics/unary/heater,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zv" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -10751,7 +11840,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zx" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -11006,7 +12099,7 @@
 	icon_state = "intact";
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ad" = (
 /obj/machinery/alarm{
@@ -11038,7 +12131,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ag" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -11055,7 +12148,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ah" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11067,14 +12160,14 @@
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	target_pressure = 15000
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ai" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Aj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11083,7 +12176,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11092,7 +12185,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Al" = (
 /obj/structure/cable/green{
@@ -11162,7 +12255,7 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Aq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -11324,6 +12417,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
+"AJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer)
 "AN" = (
 /turf/simulated/wall,
 /area/storage/cargo)
@@ -11388,7 +12487,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "AY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -11401,7 +12500,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "AZ" = (
 /obj/structure/window/reinforced{
@@ -11409,12 +12508,12 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ba" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Bb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11429,7 +12528,12 @@
 /obj/machinery/camera/network/engine{
 	c_tag = "Tech Storage - Main - Center"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "Bc" = (
 /turf/simulated/wall/r_wall,
@@ -11667,7 +12771,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "BG" = (
 /obj/structure/table/rack,
@@ -12357,7 +13461,7 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Dp" = (
 /obj/structure/sign/warning/fire,
@@ -12525,7 +13629,7 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "DJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -12537,14 +13641,14 @@
 /area/engineering/atmos)
 "DK" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "DL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	icon_state = "intact";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "DM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -12783,7 +13887,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/aftport)
 "Eq" = (
 /obj/structure/cable/green{
@@ -12801,7 +13913,16 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/aftport)
 "Es" = (
 /obj/structure/cable/yellow{
@@ -12845,7 +13966,17 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/seconddeck/aftport)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -13030,14 +14161,11 @@
 /turf/simulated/floor/airless,
 /area/solar/port)
 "EO" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
 /obj/structure/ladder,
 /obj/structure/sign/deck/second{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "EP" = (
 /obj/structure/cable/green{
@@ -13072,13 +14200,17 @@
 	icon_state = "intact"
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "ET" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "EU" = (
 /turf/simulated/wall/ocp_wall,
@@ -13134,9 +14266,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "Fc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -13152,7 +14281,16 @@
 	pixel_x = 24;
 	pixel_y = 22
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/orange/corner,
+/obj/effect/floor_decal/techfloor/orange/corner{
+	tag = "icon-techfloororange_corners (EAST)";
+	icon_state = "techfloororange_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "Fd" = (
 /obj/effect/floor_decal/corner/blue,
@@ -13166,7 +14304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Fe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -13176,7 +14314,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Fg" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -13204,7 +14342,7 @@
 	charge = 0;
 	RCon_tag = "Prototype - Distribution"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Fj" = (
 /obj/machinery/atmospherics/valve/shutoff,
@@ -13248,7 +14386,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "Fo" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/engineering{
 	name = "Fuel Bay";
 	req_access = list(32)
@@ -13258,10 +14395,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/fuelbay)
 "Fp" = (
 /turf/simulated/wall/r_wall,
@@ -13275,7 +14421,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/fuelbay)
 "Fr" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -13291,7 +14442,12 @@
 	c_tag = "Engineering - Fuel Bay";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/fuelbay)
 "Fs" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
@@ -13303,7 +14459,16 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
 "Fx" = (
 /obj/machinery/power/apc{
@@ -13315,7 +14480,16 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
 "Fy" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
@@ -13326,17 +14500,22 @@
 /turf/simulated/floor/plating,
 /area/engineering/fuelbay)
 "Fz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
 "FD" = (
 /obj/machinery/computer/engines,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/fuelbay)
 "FE" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -13346,7 +14525,7 @@
 	output_tag = "fuel_out";
 	sensors = list("fuel_sensor" = "Tank")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/fuelbay)
 "FF" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13355,7 +14534,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
 "FP" = (
 /obj/effect/shuttle_landmark/merc/deck2,
@@ -13381,7 +14560,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Gd" = (
 /obj/structure/cable/cyan{
@@ -13404,7 +14591,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Gg" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -13440,7 +14632,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Gj" = (
 /obj/structure/cable/green{
@@ -13511,7 +14708,7 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "GQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -13525,6 +14722,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"GV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	tag = "icon-borderfloor (WEST)";
+	icon_state = "borderfloor";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	tag = "icon-bordercolor (WEST)";
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/foyer)
 "GW" = (
 /turf/simulated/wall/r_wall/hull,
 /area/storage/tech)
@@ -13537,7 +14750,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Hd" = (
 /obj/machinery/access_button{
@@ -13605,7 +14818,12 @@
 	icon_state = "0-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Hg" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -13643,7 +14861,22 @@
 	pixel_x = -24;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
 "Hj" = (
 /obj/machinery/shower{
@@ -13656,7 +14889,6 @@
 /area/vacant/prototype/control)
 "Hk" = (
 /obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -13673,7 +14905,7 @@
 	name = "Desk Shutter Control";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_monitoring)
 "Hl" = (
 /obj/structure/cable/green{
@@ -13743,7 +14975,32 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
+"Hr" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/seconddeck)
+"Hv" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/engine_monitoring)
+"HC" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Ib" = (
 /obj/effect/wingrille_spawn/reinforced/full,
@@ -13756,7 +15013,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Id" = (
 /obj/effect/engine_setup/smes,
@@ -13833,7 +15098,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Ik" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -13861,7 +15136,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Im" = (
 /obj/structure/cable/green{
@@ -13884,7 +15162,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarport)
 "It" = (
-/obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/computer/engines,
 /obj/machinery/button/toggle/valve{
 	frequency = 1447;
@@ -13900,11 +15177,29 @@
 	pixel_x = 24;
 	pixel_y = -4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	tag = "icon-techfloororange_edges (EAST)";
+	icon_state = "techfloororange_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "IE" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/seconddeck/aftstarboard)
+"IL" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -13953,7 +15248,7 @@
 /area/vacant/prototype/engine)
 "Jh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Ji" = (
 /obj/effect/landmark{
@@ -14017,7 +15312,7 @@
 	name = "Engineering Desk Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engineering_monitoring)
 "Jl" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -14026,7 +15321,15 @@
 	tag_south = 1;
 	tag_west = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Jm" = (
 /obj/structure/catwalk,
@@ -14053,14 +15356,35 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "JF" = (
 /turf/simulated/wall/r_wall/hull,
 /area/engineering/fuelbay)
+"JO" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/storage/tech)
 "JX" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/seconddeck/forestarboard)
+"JZ" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/hallway)
 "Kb" = (
 /obj/effect/shuttle_landmark/ert/deck2,
 /turf/space,
@@ -14191,7 +15515,7 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Lb" = (
 /obj/effect/shuttle_landmark/ninja/deck2,
@@ -14278,7 +15602,7 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/circuitboard/message_monitor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "Ll" = (
 /obj/random/obstruction,
@@ -14316,13 +15640,35 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
+"LP" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (EAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
+"LW" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "Mb" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "Mc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -14332,7 +15678,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Md" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -14399,7 +15748,12 @@
 	pixel_y = 29;
 	req_access = list(11)
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Mj" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -14451,7 +15805,8 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "Mm" = (
 /obj/structure/cable/green{
@@ -14485,6 +15840,22 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
+"Mr" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	tag = "icon-techfloor_hole_left (NORTH)";
+	icon_state = "techfloor_hole_left";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "Nb" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -14507,7 +15878,9 @@
 	icon_state = "intact";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Nd" = (
 /obj/machinery/power/terminal{
@@ -14627,7 +16000,7 @@
 	pixel_y = 0;
 	req_one_access = list(24,11)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Nm" = (
 /obj/structure/cable/green{
@@ -14649,7 +16022,7 @@
 /obj/item/weapon/circuitboard/unary_atmos/engine,
 /obj/item/weapon/circuitboard/unary_atmos/engine,
 /obj/item/weapon/circuitboard/oxyregenerator,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "No" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -14657,16 +16030,29 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
+"Nw" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/seconddeck)
 "Ob" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	icon_state = "intact";
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Oc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Od" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14757,7 +16143,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/book/manual/rust_engine,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Oj" = (
 /obj/structure/cable/green{
@@ -14829,7 +16215,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/fuelbay)
 "Pa" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -14852,7 +16248,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Pd" = (
 /obj/machinery/power/terminal{
@@ -14908,7 +16306,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Ph" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14960,7 +16358,22 @@
 	pixel_x = -20;
 	pixel_y = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	tag = "icon-corner_techfloor_grid_full (WEST)";
+	icon_state = "corner_techfloor_grid_full";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Pm" = (
 /obj/structure/cable{
@@ -15011,7 +16424,17 @@
 	req_access = list(24)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Qb" = (
 /obj/machinery/door/firedoor/border_only,
@@ -15042,7 +16465,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Qd" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -15077,7 +16500,12 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Qh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -15133,7 +16561,7 @@
 	icon_state = "intact"
 	},
 /obj/item/device/radio/beacon,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Qn" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -15171,7 +16599,17 @@
 	icon_state = "intact";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	tag = "icon-techfloor_hole_left (NORTH)";
+	icon_state = "techfloor_hole_left";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Rc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15184,7 +16622,7 @@
 	icon_state = "intact";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Rd" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -15217,7 +16655,7 @@
 	id_tag = "fusion_core";
 	req_access = list(11)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Rg" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -15266,7 +16704,22 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Rk" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
@@ -15301,7 +16754,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 26
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Rm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15311,7 +16764,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Rn" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
@@ -15328,6 +16781,29 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/fuelbay)
+"RA" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
+"RJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/foyer)
 "RT" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/cargo)
@@ -15340,7 +16816,10 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15353,7 +16832,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Sd" = (
 /obj/structure/cable/cyan{
@@ -15374,7 +16853,12 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Sg" = (
 /obj/structure/closet/crate/radiation,
@@ -15420,7 +16904,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Sk" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -15446,7 +16930,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Sn" = (
 /obj/machinery/meter,
@@ -15469,9 +16953,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"SL" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTHEAST)";
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/seconddeck)
 "Tb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Tc" = (
 /obj/machinery/door/firedoor/border_only,
@@ -15574,7 +17068,7 @@
 	pixel_x = -6;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Tm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15584,7 +17078,18 @@
 	dir = 1;
 	icon_state = "map"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (SOUTHEAST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (EAST)";
+	icon_state = "techfloor_corners";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Tn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -15605,17 +17110,39 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
+"TJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
 "Ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Uc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ud" = (
 /obj/machinery/camera/network/engine{
@@ -15669,7 +17196,7 @@
 	c_tag = "Engine - Prototype Chamber 01"
 	},
 /obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Uh" = (
 /obj/structure/cable/yellow{
@@ -15701,7 +17228,17 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/locker_room)
 "Ul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15715,7 +17252,17 @@
 	pixel_x = -24;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "Um" = (
 /obj/structure/cable/green{
@@ -15750,7 +17297,12 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Vc" = (
 /obj/machinery/meter,
@@ -15758,7 +17310,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Vd" = (
 /obj/structure/cable/cyan{
@@ -15800,7 +17352,7 @@
 /area/vacant/prototype/engine)
 "Vf" = (
 /obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Vg" = (
 /obj/machinery/door/airlock/hatch{
@@ -15818,7 +17370,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Vi" = (
 /obj/structure/cable/green{
@@ -15880,7 +17437,12 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Vn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -15892,6 +17454,23 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/greengrid/airless,
 /area/engineering/engine_room)
+"VB" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (WEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "Wa" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/landmark/start{
@@ -15914,7 +17493,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Wd" = (
 /obj/structure/cable/cyan{
@@ -15994,7 +17573,17 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/vacant/prototype/control)
 "Wk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -16014,13 +17603,15 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod10/station)
 "Wm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Wn" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -16046,12 +17637,28 @@
 "Wp" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/seconddeck/foreport)
+"Wv" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos)
 "Xb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTH)";
+	icon_state = "corner_techfloor_grid";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Xc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -16059,7 +17666,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Xd" = (
 /obj/structure/lattice,
@@ -16107,7 +17714,7 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
 "Xj" = (
 /obj/machinery/fusion_fuel_injector/mapped{
@@ -16164,6 +17771,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
+"XH" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (NORTH)";
+	icon_state = "techfloor_edges";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/storage/tech)
 "Yb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -16172,14 +17787,17 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Yc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Yd" = (
 /obj/structure/lattice,
@@ -16256,7 +17874,22 @@
 	pixel_x = -20;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTHWEST)";
+	icon_state = "corner_techfloor_grid";
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "Yj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -16298,7 +17931,12 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (SOUTHWEST)";
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/seconddeck)
 "Yn" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -16312,7 +17950,14 @@
 	icon_state = "intact";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
+"YL" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "YT" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -16326,13 +17971,23 @@
 "YU" = (
 /obj/structure/closet/secure_closet/atmos_torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "YV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	tag = "icon-corner_techfloor_grid (NORTH)";
+	icon_state = "corner_techfloor_grid";
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (NORTH)";
+	icon_state = "techfloor_corners";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "YZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -16346,7 +18001,7 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Za" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
@@ -16356,24 +18011,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Zb" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Zc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/techfloor/corner{
+	tag = "icon-techfloor_corners (WEST)";
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Zd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Ze" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -16382,7 +18042,7 @@
 	c_tag = "Atmospherics - South";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Zf" = (
 /obj/machinery/power/apc/super/critical{
@@ -16483,7 +18143,11 @@
 /obj/structure/closet/hydrant{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/seconddeck)
 "Zn" = (
 /obj/machinery/camera/network/engine{
@@ -16512,6 +18176,25 @@
 "Zs" = (
 /turf/simulated/wall/r_wall/hull,
 /area/engineering/engine_room)
+"ZG" = (
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (WEST)";
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	tag = "icon-techfloor_edges (EAST)";
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/locker_room)
+"ZY" = (
+/obj/machinery/atmospherics/valve/digital/open,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
 
 (1,1,1) = {"
 aa
@@ -32772,8 +34455,8 @@ jV
 jV
 lm
 pk
-pk
-pk
+Nw
+mq
 Vm
 Ym
 jV
@@ -32974,7 +34657,7 @@ jV
 jV
 jV
 jV
-pk
+Hr
 Qm
 sI
 tp
@@ -33176,7 +34859,7 @@ jV
 jV
 mm
 mn
-pk
+Hr
 Rm
 sJ
 tq
@@ -33378,7 +35061,7 @@ jV
 jV
 jV
 jV
-pk
+Hr
 Sm
 sK
 tr
@@ -33580,7 +35263,7 @@ jV
 jV
 mm
 mn
-pk
+SL
 Tm
 sL
 qz
@@ -35804,9 +37487,9 @@ pu
 pw
 oc
 rS
-oc
+GV
 tw
-oc
+tw
 jP
 qu
 jZ
@@ -36006,9 +37689,9 @@ ob
 iO
 iQ
 iU
-iQ
+TJ
 jF
-iQ
+RJ
 jR
 jT
 ka
@@ -36207,10 +37890,10 @@ Kk
 pA
 py
 oc
-rS
-oc
+AJ
+xN
 ty
-oc
+ty
 jS
 qu
 kf
@@ -37015,10 +38698,10 @@ od
 of
 qC
 tA
-oh
-oh
-oh
-oh
+ZG
+ZG
+ZG
+ZG
 xH
 vc
 zV
@@ -37416,7 +39099,7 @@ lF
 Ii
 od
 iG
-oh
+of
 qH
 sd
 sS
@@ -37618,12 +39301,12 @@ ms
 kU
 od
 iH
-oh
+of
 qG
 sc
-oh
-oh
-oh
+ZG
+ZG
+ZG
 Uk
 vc
 vP
@@ -39219,7 +40902,7 @@ aH
 aW
 bz
 cx
-aW
+XH
 dH
 bx
 fJ
@@ -39446,7 +41129,7 @@ uv
 vg
 uv
 wO
-wc
+YL
 yF
 ET
 Ah
@@ -39641,14 +41324,14 @@ jA
 or
 pO
 qU
-sf
+JZ
 sZ
 tL
 uw
 vh
 vV
 wP
-wc
+YL
 yG
 ES
 DI
@@ -39849,10 +41532,10 @@ tM
 wQ
 DK
 vW
-wQ
+IL
 Wc
 DL
-yF
+no
 Ai
 AX
 BE
@@ -40049,12 +41732,12 @@ sh
 sZ
 YU
 uy
-uy
+HC
 vX
 vX
-wc
+YL
 zo
-yJ
+ZY
 Fe
 AY
 Zd
@@ -40226,10 +41909,10 @@ GW
 GW
 GW
 aT
-aW
-aW
+JO
+nS
 cB
-dl
+lw
 ej
 bx
 bx
@@ -40253,7 +41936,7 @@ YU
 Rb
 Tb
 Vb
-Tb
+LP
 Xc
 yJ
 Nc
@@ -40448,15 +42131,15 @@ dp
 pp
 ov
 pS
-ov
+Hv
 tz
 sZ
 tP
 uA
-uy
+LW
 vZ
-vX
-wc
+Mr
+YL
 zs
 Oc
 Ak
@@ -40655,12 +42338,12 @@ sk
 sZ
 tQ
 uA
-Rb
-Vb
+VB
+RA
 Xb
-wc
+YL
 zt
-Oc
+Wv
 Ak
 ko
 mo
@@ -40832,10 +42515,10 @@ GW
 GW
 GW
 aU
-aW
-aW
-aW
-aW
+qF
+xO
+xO
+xO
 ep
 eP
 bx


### PR DESCRIPTION
🆑 Cakey
maptweak: Deck two now has new decals and flooring.
/ 🆑

Implements new decals to deck 2

Preview:

![preview](https://i.imgur.com/nADba1U.png)