### PR TITLE
FORS office changes

### DIFF
--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -125,7 +125,6 @@
 	return list(
 		/obj/item/clothing/gloves/forensic,
 		/obj/item/device/radio/headset/headset_sec,
-		/obj/item/clothing/suit/armor/vest/detective,
 		/obj/item/clothing/head/helmet/solgov/security,
 		/obj/item/clothing/suit/armor/pcarrier/medium/security,
 		/obj/item/weapon/gun/energy/secure/gun/small,
@@ -142,10 +141,6 @@
 		/obj/item/weapon/folder/red,
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape/random = 3,
-		/obj/item/weapon/forensics/sample_kit/powder,
-		/obj/item/weapon/forensics/sample_kit,
-		/obj/item/device/uv_light,
-		/obj/item/weapon/reagent_containers/spray/luminol,
 		/obj/item/weapon/reagent_containers/syringe,
 		/obj/item/clothing/glasses/sunglasses/sechud/toggle,
 		/obj/item/device/holowarrant,

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -11230,8 +11230,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/forensics,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "vj" = (
@@ -12302,6 +12301,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/processing)
+"xu" = (
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white,
+/area/security/detectives_office)
 "xv" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -13136,10 +13139,6 @@
 /obj/machinery/microscope,
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
-"zo" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/white,
-/area/security/detectives_office)
 "zp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13720,8 +13719,6 @@
 /area/security/detectives_office)
 "AQ" = (
 /obj/structure/table/glass,
-/obj/item/weapon/forensics/sample_kit,
-/obj/item/device/uv_light,
 /obj/item/weapon/reagent_containers/spray/sterilizine,
 /obj/item/weapon/reagent_containers/spray/luminol,
 /obj/structure/noticeboard{
@@ -17965,10 +17962,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/gym)
-"Lg" = (
-/obj/item/modular_computer/console/preset/medical,
-/turf/simulated/floor/tiled/white,
-/area/security/detectives_office)
 "Lh" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -18584,7 +18577,6 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "Og" = (
-/obj/item/modular_computer/console/preset/security,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -18592,6 +18584,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/closet/secure_closet/forensics,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "Oh" = (
@@ -42995,7 +42989,7 @@ rp
 sD
 tX
 vf
-Lg
+xp
 Og
 yq
 zn
@@ -43400,9 +43394,9 @@ sF
 tW
 vh
 wp
-xp
+xu
 ys
-zo
+yr
 yr
 AR
 vh


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
![image](https://user-images.githubusercontent.com/5092934/38754880-427ec7a0-3f6c-11e8-961d-10c76838d862.png)

Basically removed two rudimentary consoles and gave some free space for walking.
Also, removed excessive tools from the locker and the room itself.

Actually there was enough equipment for 2-3 forstechs.

(please tell me i didn't fuck up the merge)

:cl: Sbotkin
maptweak: Removed excess stuff (extra tools, consoles) from the forensic technician's laboratory.
rscdel: Removed excess tools from the forensic technician's locker.
/:cl: