### PR TITLE
Changes hull bleaching

### DIFF
--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -16,9 +16,16 @@
 	paint_color = color
 	color = null //color is just for mapping
 	if(prob(40))
-		var/turf/space/S = locate() in trange(2, src)
-		var/bleach_factor = rand(20,80)/get_dist(src, S)
-		paint_color = adjust_brightness(paint_color, bleach_factor)
+		var/spacefacing = FALSE
+		for(var/direction in GLOB.cardinal)
+			var/turf/T = get_step(src, direction)
+			var/area/A = get_area(T)
+			if(A && (A.area_flags & AREA_FLAG_EXTERNAL))
+				spacefacing = TRUE
+				break
+		if(spacefacing)
+			var/bleach_factor = rand(10,50)
+			paint_color = adjust_brightness(paint_color, bleach_factor)
 	update_icon()
 
 


### PR DESCRIPTION
Now only affects tiles directly near space, and in cardinal directions only, so no unreachable corner ones.
Also makes bleaching bit less severe.
Last but not least bases it on area being external instead of turf being space, so hull near outer ceilings can still get hit too.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
