### PR TITLE
[Wip] Fire for solar storms, makes them affect turfs that are outside, rather than just space.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -7,6 +7,7 @@
 	var/global/global_uid = 0
 	var/uid
 	var/area_flags
+	mouse_opacity = 2
 
 /area/New()
 	icon_state = ""

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_EMPTY(space_turfs)
 /turf/space
 	plane = SPACE_PLANE
 	icon = 'icons/turf/space.dmi'
@@ -21,6 +22,7 @@
 
 /turf/space/Initialize()
 	. = ..()
+	GLOB.space_turfs += src
 	icon_state = "white"
 	update_starlight()
 	if (!dust_cache)
@@ -217,6 +219,7 @@
 	return
 
 /turf/space/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
+	GLOB.space_turfs -= src
 	return ..(N, tell_universe, 1)
 
 //Bluespace turfs for shuttles and possible future transit use

--- a/code/modules/events/solar_storm.dm
+++ b/code/modules/events/solar_storm.dm
@@ -1,3 +1,4 @@
+#define SOLAR_FLARE_STEP 5
 /datum/event/solar_storm
 	startWhen				= 1
 	announceWhen			= 1
@@ -6,6 +7,7 @@
 	var/const/fire_loss     = 40
 	var/base_solar_gen_rate
 	var/list/solar_flames = list()
+	var/list/turfs_to_light = list()
 	var/image/fire
 
 
@@ -25,7 +27,8 @@
 	command_announcement.Announce("The solar storm has reached the [location_name()]. Please refain from EVA and remain inside until it has passed.", "[location_name()] Sensor Array", zlevels = affecting_z)
 	adjust_solar_output(5)
 	fire = image('icons/effects/fire.dmi', src, "2")
-	fire.color = heat2color(5800) //Kelvin. That's our sun's surface temp. A bit too crispy, but I digress.
+	var/fire_color = heat2color(5800) //Kelvin. That's our sun's surface temp. A bit too crispy,though.
+	fire.color =  fire_color
 	fire.plane = EFFECTS_BELOW_LIGHTING_PLANE
 	fire.layer = FIRE_LAYER
 	fire.blend_mode = BLEND_DEFAULT
@@ -36,16 +39,30 @@
 			var/turf/unsimulated/wall/U
 			var/turf/simulated/floor/F
 			var/turf/unsimulated/floor/UN
+			var/turf/T
+			turfs_to_light += get_area_turfs(A)
 
-			if(S in A.contents || U in A.contents) //Imperfect, because somehow you are able to have more than one turf in a coordinate cell, but it shouldn't cause issues.
-				continue //Doesn't work..?
-			if(F in A.contents || UN in A.contents) //ditto. We should really have a UT that prevents this.
-				fire.blend_mode = BLEND_ADD //This doesn't appear to work.
+			for(T in turfs_to_light)
+				if(!(T.x % SOLAR_FLARE_STEP == 0) && !(T.y % SOLAR_FLARE_STEP == 0)) //Would it not be faster to -construct- this list via the step?
+					turfs_to_light -= T
+
+			for(S in turfs_to_light) //Skip walls.
+				turfs_to_light -= S // Doesn't work.
+			for(U in turfs_to_light) //Skip walls.
+				turfs_to_light -= U // Doesn't work.
+			for(var/turf/space/SP in turfs_to_light)//Skip space.
+				turfs_to_light -= SP
+
+			if(F in A.contents || UN in A.contents)
+				fire.blend_mode = BLEND_ADD //This doesn't appear to work
 
 			fire.dir = pick(GLOB.cardinal)
 			A.underlays += fire
 			solar_flames += A
 			CHECK_TICK
+			for(T in turfs_to_light)
+				CHECK_TICK
+				T.set_light(1, round(SOLAR_FLARE_STEP/2, 1), SOLAR_FLARE_STEP, 5 , l_color = fire_color)
 
 
 /datum/event/solar_storm/tick()
@@ -72,8 +89,12 @@
 /datum/event/solar_storm/end()
 	command_announcement.Announce("The solar storm has passed the [location_name()]. It is now safe to resume EVA activities. ", "[location_name()] Sensor Array", zlevels = affecting_z)
 	adjust_solar_output()
-	for(var/area/A in solar_flames)
+	for(var/area/A in solar_flames) //This doesn't work if the controller hangs?
 		A.overlays -= fire
+		solar_flames -= A
+		CHECK_TICK
+	for(var/turf/T in turfs_to_light)
+		T.set_light(0)
 		CHECK_TICK
 	qdel(fire)
 


### PR DESCRIPTION
🆑 
tweak: Solar storms now affect all tiles that are outside the ship. This includes away maps. Be. CAREFUL.
rscadd: Solar storms now light all affected turfs aflame with solar emissions.
/ 🆑 
Not quite done, but nearing finished. I have a few bugs to hammer out, and I want to know if I'm going about this badly.
https://streamable.com/u889v
![image](https://user-images.githubusercontent.com/4706052/38887785-9dc88fe6-422e-11e8-9498-5a7f072299dc.png)

# IT IS NOT REAL FIRE. SOLAR FLARES ALREADY BURNT YOU.

Should I increase the time you have before you DIE IN HOLY FLAME increased for the miners?

