### PR TITLE
Fix being able to set red alert on consoles

### DIFF
--- a/code/datums/security_state.dm
+++ b/code/datums/security_state.dm
@@ -13,6 +13,7 @@
 	var/decl/security_level/highest_standard_security_level
 
 	var/decl/security_level/current_security_level  // The current security level. Defaults to the first entry in all_security_levels if unset.
+	var/decl/security_level/stored_security_level   // The security level that we are escalating to high security from - we will return to this level once we choose to revert.
 	var/list/all_security_levels                    // List of all available security levels
 	var/list/standard_security_levels               // List of all normally selectable security levels
 	var/list/comm_console_security_levels           // List of all selectable security levels for the command and communication console - basically standard_security_levels - 1

--- a/code/datums/security_state.dm
+++ b/code/datums/security_state.dm
@@ -15,6 +15,7 @@
 	var/decl/security_level/current_security_level  // The current security level. Defaults to the first entry in all_security_levels if unset.
 	var/list/all_security_levels                    // List of all available security levels
 	var/list/standard_security_levels               // List of all normally selectable security levels
+	var/list/comm_console_security_levels           // List of all selectable security levels for the command and communication console - basically standard_security_levels - 1
 
 /decl/security_state/New()
 	// Setup the severe security level
@@ -53,6 +54,13 @@
 		standard_security_levels += security_level
 		if(security_level == highest_standard_security_level)
 			break
+
+	comm_console_security_levels = list()
+	// Setup the list of selectable security levels available in the comm. console
+	for(var/security_level in all_security_levels)
+		if(security_level == highest_standard_security_level)
+			break
+		comm_console_security_levels += security_level
 
 	// Now we ensure the high security level is not above the severe one (but we allow them to be equal)
 	var/severe_index = all_security_levels.Find(severe_security_level)

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -70,6 +70,7 @@
 	data["current_security_level_title"] = security_state.current_security_level.name
 
 	data["cannot_change_security_level"] = !security_state.can_change_security_level()
+	data["current_security_level_is_high_security_level"] = security_state.current_security_level == security_state.high_security_level
 	var/list/security_levels = list()
 	for(var/decl/security_level/security_level in security_state.comm_console_security_levels)
 		var/list/security_setup = list()

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -71,7 +71,7 @@
 
 	data["cannot_change_security_level"] = !security_state.can_change_security_level()
 	var/list/security_levels = list()
-	for(var/decl/security_level/security_level in security_state.standard_security_levels)
+	for(var/decl/security_level/security_level in security_state.comm_console_security_levels)
 		var/list/security_setup = list()
 		security_setup["title"] = security_level.name
 		security_setup["ref"] = any2ref(security_level)
@@ -214,9 +214,9 @@
 			. = 1
 			if(is_autenthicated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
 				var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-				var/decl/security_level/target_level = locate(href_list["target"]) in security_state.standard_security_levels
+				var/decl/security_level/target_level = locate(href_list["target"]) in security_state.comm_console_security_levels
 				if(target_level && security_state.can_switch_to(target_level))
-					var/confirm = alert("Are you sure you want to change alert level to [target_level.name]?", name, "No", "Yes")
+					var/confirm = alert("Are you sure you want to change the alert level to [target_level.name]?", name, "No", "Yes")
 					if(confirm == "Yes" && can_still_topic())
 						if(security_state.set_security_level(target_level))
 							feedback_inc(target_level.type,1)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -68,7 +68,14 @@
 		dat += "Select an event to trigger:<ul>"
 
 		var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-		dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Engage [security_state.high_security_level.name]</A></li>"
+		if(security_state.current_security_level == security_state.severe_security_level)
+			dat += "<li>Cannot modify the alert level at this time: [security_state.severe_security_level.name] engaged.</li>"
+		else
+			if(security_state.current_security_level == security_state.high_security_level)
+				dat += "<li><A href='?src=\ref[src];triggerevent=Revert alert'>Disengage [security_state.high_security_level.name]</A></li>"
+			else
+				dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Engage [security_state.high_security_level.name]</A></li>"
+
 		if(!config.ert_admin_call_only)
 			dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>"
 
@@ -149,8 +156,13 @@
 	switch(event)
 		if("Red alert")
 			var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
+			security_state.stored_security_level = security_state.current_security_level
 			security_state.set_security_level(security_state.high_security_level)
 			feedback_inc("alert_keycard_auth_red",1)
+		if("Revert alert")
+			var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
+			security_state.set_security_level(security_state.stored_security_level)
+			feedback_inc("alert_keycard_revert_red",1)
 		if("Grant Emergency Maintenance Access")
 			make_maint_all_access()
 			feedback_inc("alert_keycard_auth_maintGrant",1)

--- a/maps/torch/torch_security_state.dm
+++ b/maps/torch/torch_security_state.dm
@@ -4,7 +4,6 @@
 //Torch map alert levels. Refer to security_state.dm.
 /decl/security_state/default/torchdept
 	all_security_levels = list(/decl/security_level/default/torchdept/code_green, /decl/security_level/default/torchdept/code_violet, /decl/security_level/default/torchdept/code_orange, /decl/security_level/default/torchdept/code_blue, /decl/security_level/default/torchdept/code_red, /decl/security_level/default/code_delta)
-	standard_security_levels = list(/decl/security_level/default/torchdept/code_green, /decl/security_level/default/torchdept/code_violet, /decl/security_level/default/torchdept/code_orange, /decl/security_level/default/torchdept/code_blue)
 
 /decl/security_level/default/torchdept
 	icon = 'maps/torch/icons/security_state.dmi'

--- a/nano/templates/communication.tmpl
+++ b/nano/templates/communication.tmpl
@@ -91,18 +91,22 @@
 	{{else data.state === 5}}
 		Security Level: {{:data.current_security_level_title}}
 		{{if data.cannot_change_security_level}}
-			<div class=item><font color='red'><b>The self-destruct mechanism is active. Find a way to deactivate the mechanism to lower the alert level or evacuate.</b></font></div>
+			<div class=item><font color='red'><b>The self-destruct mechanism is active! Find a way to deactivate the mechanism, or evacuate.</b></font></div>
 		{{else}}
-			<div class=item>Set Security Level: </div>
-			<div class=itemGroup>
-			{{for data.security_levels}}
-				<div class="item">
-					<div class=item>{{:helper.link(value.title, null, {'action' : 'setalert', 'target' : value.ref}, data.current_security_level_ref === value.ref || data.isAI ? 'disabled' : null)}} </div>
-				</div>
-			{{/for}}
+			{{if data.current_security_level_is_high_security_level}}
+				<div class=item><font color='red'><b>This emergency may not be resolved from this system! Utilise the authentication devices.</b></font></div>
+			{{else}}
+				<div class=item>Set Security Level: </div>
+				<div class=itemGroup>
+				{{for data.security_levels}}
+					<div class="item">
+						<div class=item>{{:helper.link(value.title, null, {'action' : 'setalert', 'target' : value.ref}, data.current_security_level_ref === value.ref || data.isAI ? 'disabled' : null)}} </div>
+					</div>
+				{{/for}}
+			{{/if}}
+			</br>
+			<div class=item>{{:helper.link('Back', null, {'action' : 'sw_menu', 'target' : 1})}} </div>
 		{{/if}}
-		</br>
-		<div class=item>{{:helper.link('Back', null, {'action' : 'sw_menu', 'target' : 1})}} </div>
 	{{else}}
 		Something went wrong. Please reset your console.
 		<div class=item>{{:helper.link('Back', null, {'action' : 'sw_menu', 'target' : 1})}}</div>


### PR DESCRIPTION
:cl:
bugfix: Fixes red alert being available in the command and communications program. 
bugfix: Red alert once again may only be set through the keycard authentication devices (small white and black panels on walls) found in officers' offices and on the bridge.
rscadd: Red alert now only be cancelled using the keycard authentication devices.
/:cl: