### PR TITLE
Nerfs gun tracking a bit

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
+++ b/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
@@ -18,9 +18,16 @@
 	data["is_silicon_usr"] = issilicon(user)
 
 	data["guns"] = list()
+	var/atom/movable/AM = nano_host()
+	if(!istype(AM))
+		return
+	var/list/zlevels = GetConnectedZlevels(AM.z)
 	for(var/obj/item/weapon/gun/energy/secure/G in GLOB.registered_weapons)
+		if(G.standby || G.emagged)
+			continue
+
 		var/turf/T = get_turf(G)
-		if(!T || !(T.z in GLOB.using_map.station_levels))
+		if(!T || !(T.z in zlevels))
 			continue
 
 		var/list/modes = list()
@@ -31,6 +38,9 @@
 			modes += list(list("index" = i, "mode_name" = firemode.name, "authorized" = G.authorized_modes[i]))
 
 		data["guns"] += list(list("name" = "[G]", "ref" = "\ref[G]", "owner" = G.registered_owner, "modes" = modes, "loc" = list("x" = T.x, "y" = T.y, "z" = T.z)))
+	var/list/guns = data["guns"]
+	if(!guns.len)
+		data["message"] = "No weapons registered"
 
 	if(!data["is_silicon_usr"]) // don't send data even though they won't be able to see it
 		data["cyborg_guns"] = list()

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -10,6 +10,7 @@
 	var/list/authorized_modes = list(ALWAYS_AUTHORIZED) // index of this list should line up with firemodes, unincluded firemodes at the end will default to unauthorized
 	var/registered_owner
 	var/emagged = 0
+	var/standby = 0
 
 /obj/item/weapon/gun/energy/secure/Initialize()
 	if(!authorized_modes)
@@ -32,6 +33,14 @@
 				to_chat(user, "This weapon is already registered, you must reset it first.")
 		else
 			to_chat(user, "You swipe your ID, but nothing happens.")
+	else if(istype(W, /obj/item/device/multitool))
+		visible_message("<span class='warning'>[user] starts fiddling with the [src]'s security chip!</span>")
+		if(do_after(user, 20, src))
+			standby = !standby
+			if(standby)
+				to_chat(user,"<span class='notice'>You put \the [src] in the standby mode.</span>")
+			else
+				to_chat(user,"<span class='notice'>You reactivate \the [src].</span>")
 	else
 		..()
 
@@ -69,7 +78,7 @@
 	return 1
 
 /obj/item/weapon/gun/energy/secure/special_check()
-	if(!emagged && !fire_free() && (!authorized_modes[sel_mode] || !registered_owner))
+	if(!emagged && !fire_free() && (!authorized_modes[sel_mode] || !registered_owner || standby))
 		audible_message("<span class='warning'>\The [src] buzzes, refusing to fire.</span>")
 		playsound(loc, 'sound/machines/buzz-sigh.ogg', 30, 0)
 		return 0
@@ -97,6 +106,8 @@
 
 	if(registered_owner)
 		to_chat(user, "A small screen on the side of the weapon indicates that it is registered to [registered_owner].")
+	if(standby)
+		to_chat(user, "It's in a standby mode.")
 
 /obj/item/weapon/gun/energy/secure/proc/get_next_authorized_mode()
 	. = sel_mode

--- a/html/changelogs/chinsky - nerfsec.yml
+++ b/html/changelogs/chinsky - nerfsec.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Can now use multitool on secure guns to disable tracker. Prevents gun from firing, but won't report its coordinates to the force auth program."
+  - rscadd: "Makes emagged secure guns not show up too."

--- a/nano/templates/forceauthorization.tmpl
+++ b/nano/templates/forceauthorization.tmpl
@@ -1,3 +1,6 @@
+{{if data.message}}
+    {{:data.message}}
+{{/if}}
 <h1>Non-Cyborg Weapons</h1>
 {{for data.guns :value:index}}
     <div>


### PR DESCRIPTION
First, makes program pick up things on connected zlevels instead of always station, so no gun control across the stars.
Second, allows you to use multitool to 'disable' the gun, which prevents it from firing but also prevents it from showing up on the gun tracker.
Also adds some message to gun tracker program so it's obvious it's not broken just no guns registered

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
