### PR TITLE
Skill defines used in place of paths; readme added.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -52,6 +52,7 @@
 #include "code\__defines\qdel.dm"
 #include "code\__defines\research.dm"
 #include "code\__defines\shields.dm"
+#include "code\__defines\skills.dm"
 #include "code\__defines\species.dm"
 #include "code\__defines\subsystem-priority.dm"
 #include "code\__defines\subsystems.dm"

--- a/code/__defines/skills.dm
+++ b/code/__defines/skills.dm
@@ -1,0 +1,37 @@
+#define SKILL_NONE     1
+#define SKILL_BASIC    2
+#define SKILL_ADEPT    3
+#define SKILL_EXPERT   4
+#define SKILL_PROF     5
+
+#define SKILL_MIN      1 // Min skill value selectable
+#define SKILL_MAX      5 // Max skill value selectable
+#define SKILL_DEFAULT  4 //most mobs will default to this
+
+#define SKILL_EASY     1
+#define SKILL_AVERAGE  2
+#define SKILL_HARD     4
+
+#define SKILL_MANAGEMENT    /decl/hierarchy/skill/organizational/management
+#define SKILL_BUREAUCRACY   /decl/hierarchy/skill/organizational/bureaucracy
+#define SKILL_FINANCE       /decl/hierarchy/skill/organizational/finance
+#define SKILL_EVA           /decl/hierarchy/skill/general/EVA
+#define SKILL_MECH          /decl/hierarchy/skill/general/mech
+#define SKILL_PILOT         /decl/hierarchy/skill/general/pilot
+#define SKILL_HAULING       /decl/hierarchy/skill/general/hauling
+#define SKILL_COMPUTER      /decl/hierarchy/skill/general/computer
+#define SKILL_BOTANY        /decl/hierarchy/skill/service/botany
+#define SKILL_COOKING       /decl/hierarchy/skill/service/cooking
+#define SKILL_COMBAT        /decl/hierarchy/skill/security/combat
+#define SKILL_WEAPONS       /decl/hierarchy/skill/security/weapons
+#define SKILL_FORENSICS     /decl/hierarchy/skill/security/forensics
+#define SKILL_CONSTRUCTION  /decl/hierarchy/skill/engineering/construction
+#define SKILL_ELECTRICAL    /decl/hierarchy/skill/engineering/electrical
+#define SKILL_ATMOS         /decl/hierarchy/skill/engineering/atmos
+#define SKILL_ENGINES       /decl/hierarchy/skill/engineering/engines
+#define SKILL_DEVICES       /decl/hierarchy/skill/research/devices
+#define SKILL_SCIENCE       /decl/hierarchy/skill/research/science
+#define SKILL_MEDICAL       /decl/hierarchy/skill/medical/medical
+#define SKILL_ANATOMY       /decl/hierarchy/skill/medical/anatomy
+#define SKILL_VIROLOGY      /decl/hierarchy/skill/medical/virology
+#define SKILL_CHEMISTRY     /decl/hierarchy/skill/medical/chemistry

--- a/code/modules/mob/skills/README_skills.txt
+++ b/code/modules/mob/skills/README_skills.txt
@@ -1,0 +1,54 @@
+User's Guide to Skills
+
+1. How does the skill system work, and what are the relevant objects?
+	Every skill is defined via a /decl/hierarchy/skill/skill_category/skill_name in skill.dm.
+	These are initialized once and /decl/hierarchy/skill is stored in decls_repository. The actual skill instances are stored in GLOB.skills (this is a list).
+	Every mob has a variable mob.skillset of type datum/skillset (or a subtype of that).
+	The skillset contains all of the skill information for that mob, along with various procs for obtaining or manipulating it.
+	Using those procs, you will be able to extract skill values from the mob. These should be positive integers between SKILL_MIN and SKILL_MAX.
+	These values each have define corresponidng to them, starting with SKILL_. Use that define, not the number.
+
+2. Where do skills come from?
+	Most mobs (i.e. not player-controlled ones) will respond SKILL_DEFAULT when checked for skills.
+	Players set up their skill preferences on a per-job basis in the player setup screen, under occupations. See below for more.
+	At round start, these preferences are transferred over to the relevant mob. This is handled in the skillset.obtain_from_client proc.
+	If a player is an antag, this is bypassed. Modify the skillset.set_antag_skills proc to change the antag behavior.
+	When minds are transferred between mobs, the skillset is generally copied over to the new mob.
+	Silicon mobs do not inherit skills in this way.
+
+3. What do you do with skills?
+	The correct way of obtaining the value of a mob's skill is to use the get_skill_value proc on the mob. It takes a skill path, which should be called via a corresponding SKILL_ define.
+	Do not try to get the datum instance out of decls_repository; use the type path getter instead or else find it in GLOB.skills.
+	The values can be used directly to make skill checks.
+	Additional helper procs may be given to mobs to convert skill values into times, probabilities, or whatever in a reusable way.
+	Currently implemented examples:
+		skill_check(SKILL_PATH, SKILL_VALUE) returns 1 if the mob's skill is >= value.
+		skill_delay_mult(SKILL_PATH, factor) gives a generic way to modify times via skills.
+		do_skilled(base_delay, SKILL_PATH, atom/target, factor) is like do_after, but modifies the time by skill_delay_mult
+		skill_fail_chance(SKILL_PATH, fail_chance, no_more_fail, factor) modifies fail probabilities according to skill.
+
+4. What determines what skill options are available in player setup? How can you change them?
+	Skill setup works largely on a per-job basis, with some per-species and branch modifiers.
+	For each job, a minimum value can be assigned to any skill. To do this, add an entry of /decl/hierarchy/skill/skill_category/skill_name = min_value to that job datums's min_skill variable (this is a list).
+	This minimum value is given for free to the player, and does not use up allocation points.
+	For each job, a maximum value can also be assigned. Add a similar entry to the max_skills list.
+	For each job, a base number of free points can be assigned. This is given in the job datum's skill_points variable (should be a number).
+	Free point bonuses/penalties can be specified, for each species, as a function of a player's selected age. 
+	This can be done by overwriting species datum's skills_from_age proc, which takes in the age and returns an integer (positive or negative) which will be added to all jobs' available skill points.
+	Free point bonuses/penalties can be specified, for each species, as a function of the job.
+	To do this, add the entry /datum/job/my_job = points_to_add to the species datum's job_skill_buffs variable (this is a list). Then points_to_add (positive or negative) will be added to that job's available skill points.
+	Generally, if the free point allocations or min/max values turn out to be negative or otherwise contradictory, this will not result in runtime errors, so make sure to test whether your changes work as intended.
+
+5. You want to make skill-related changes but are worried about whether they will break savefiles.
+	Savefiles are on a per-job basis. Only affected jobs will have their savefiles reset.
+	If a savefile represents a plausable skill point allocation, it will be imported; if not, a default skill allocation is used.
+	In particular, changes which increase the number of free skill points, decrease minimum allocations, or increase maximum allocations, will not break savefiles.
+	Changes which increase minimum allocations or decrease maximum allocations will not reset the entire allocation, but may leave extra unassigned points if the skill cap is reached.
+	Changes which decrease the number of free points (including from species/age buffs) may reset the entire job's allocation.
+	The size of the savefile roughly corresponds to the number of skills with nondefault allocations; this is only significant if many jobs have nondefault skill selections.
+
+6. You are an admin and need to bus skill stuff.
+	If you are antaging/unantaging someone via the traitor panel, this will usually change their skills.
+	To make sure they have the correct skills (as in their prefs), you should check that the role (top item) is correct, in addition to their antag status.
+	If you need to change their skill values directly, you can use VV on mob/skillset, in particular changing the values of the entries in skill_list.
+	There is a show skills admin verb, that displays skill values of any human mob (pick from list) in a similar way to the player Show Own Skills verb.

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -1,44 +1,4 @@
-// Skill-related constants
-
 GLOBAL_LIST_EMPTY(skills)
-
-var/const/SKILL_NONE = 1
-var/const/SKILL_BASIC = 2
-var/const/SKILL_ADEPT = 3
-var/const/SKILL_EXPERT = 4
-var/const/SKILL_PROF = 5
-
-var/const/SKILL_MIN = 1 // Min skill value selectable
-var/const/SKILL_MAX = 5 // Max skill value selectable
-var/const/SKILL_DEFAULT = 4 //most mobs will default to this
-
-var/const/SKILL_EASY = 1
-var/const/SKILL_AVERAGE = 2
-var/const/SKILL_HARD = 4
-
-var/const/SKILL_MANAGEMENT = /decl/hierarchy/skill/organizational/management
-var/const/SKILL_BUREAUCRACY =/decl/hierarchy/skill/organizational/bureaucracy
-var/const/SKILL_FINANCE = /decl/hierarchy/skill/organizational/finance
-var/const/SKILL_EVA = /decl/hierarchy/skill/general/EVA
-var/const/SKILL_MECH = /decl/hierarchy/skill/general/mech
-var/const/SKILL_PILOT = /decl/hierarchy/skill/general/pilot
-var/const/SKILL_HAULING = /decl/hierarchy/skill/general/hauling
-var/const/SKILL_COMPUTER = /decl/hierarchy/skill/general/computer
-var/const/SKILL_BOTANY = /decl/hierarchy/skill/service/botany
-var/const/SKILL_COOKING = /decl/hierarchy/skill/service/cooking
-var/const/SKILL_COMBAT = /decl/hierarchy/skill/security/combat
-var/const/SKILL_WEAPONS = /decl/hierarchy/skill/security/weapons
-var/const/SKILL_FORENSICS = /decl/hierarchy/skill/security/forensics
-var/const/SKILL_CONSTRUCTION = /decl/hierarchy/skill/engineering/construction
-var/const/SKILL_ELECTRICAL = /decl/hierarchy/skill/engineering/electrical
-var/const/SKILL_ATMOS = /decl/hierarchy/skill/engineering/atmos
-var/const/SKILL_ENGINES = /decl/hierarchy/skill/engineering/engines
-var/const/SKILL_DEVICES = /decl/hierarchy/skill/research/devices
-var/const/SKILL_SCIENCE = /decl/hierarchy/skill/research/science
-var/const/SKILL_MEDICAL = /decl/hierarchy/skill/medical/medical
-var/const/SKILL_ANATOMY = /decl/hierarchy/skill/medical/anatomy
-var/const/SKILL_VIROLOGY = /decl/hierarchy/skill/medical/virology
-var/const/SKILL_CHEMISTRY = /decl/hierarchy/skill/medical/chemistry
 
 /decl/hierarchy/skill
 	var/ID = "none"					// ID of this skill. Needs to be unique.

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -58,10 +58,10 @@
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o6
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/research/science				= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/pilot					= SKILL_ADEPT)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
+						SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_SCIENCE     = SKILL_ADEPT,
+						SKILL_PILOT       = SKILL_ADEPT)
 	skill_points = 40
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -89,10 +89,10 @@
 		/datum/mil_rank/fleet/o5,
 		/datum/mil_rank/fleet/o4
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/computer				= SKILL_BASIC,
-						/decl/hierarchy/skill/general/pilot					= SKILL_BASIC)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
+						SKILL_BUREAUCRACY = SKILL_ADEPT,
+						SKILL_COMPUTER    = SKILL_BASIC,
+						SKILL_PILOT       = SKILL_BASIC)
 	skill_points = 40
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -131,14 +131,14 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/rd
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management		= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/computer				= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_ADEPT,
-						/decl/hierarchy/skill/service/botany				= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/anatomy				= SKILL_BASIC,
-						/decl/hierarchy/skill/research/devices				= SKILL_BASIC,
-						/decl/hierarchy/skill/research/science				= SKILL_ADEPT)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
+						SKILL_BUREAUCRACY = SKILL_ADEPT,
+						SKILL_COMPUTER    = SKILL_BASIC,
+						SKILL_FINANCE     = SKILL_ADEPT,
+						SKILL_BOTANY      = SKILL_BASIC,
+						SKILL_ANATOMY     = SKILL_BASIC,
+						SKILL_DEVICES     = SKILL_BASIC,
+						SKILL_SCIENCE     = SKILL_ADEPT)
 	skill_points = 40
 
 	access = list(access_tox, access_tox_storage, access_emergency_storage, access_teleporter, access_heads, access_rd,
@@ -171,12 +171,12 @@
 		/datum/mil_rank/ec/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/medical				= SKILL_ADEPT,
-						/decl/hierarchy/skill/medical/anatomy				= SKILL_EXPERT,
-						/decl/hierarchy/skill/medical/chemistry				= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/virology				= SKILL_BASIC)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
+						SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_MEDICAL     = SKILL_ADEPT,
+						SKILL_ANATOMY     = SKILL_EXPERT,
+						SKILL_CHEMISTRY   = SKILL_BASIC,
+						SKILL_VIROLOGY    = SKILL_BASIC)
 	skill_points = 40
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -209,14 +209,14 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/computer				= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/EVA					= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/construction		= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/electrical		= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/atmos				= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/engines			= SKILL_EXPERT)
+	min_skill = list(	SKILL_MANAGEMENT   = SKILL_ADEPT,
+						SKILL_BUREAUCRACY  = SKILL_BASIC,
+						SKILL_COMPUTER     = SKILL_ADEPT,
+						SKILL_EVA          = SKILL_ADEPT,
+						SKILL_CONSTRUCTION = SKILL_ADEPT,
+						SKILL_ELECTRICAL   = SKILL_ADEPT,
+						SKILL_ATMOS        = SKILL_ADEPT,
+						SKILL_ENGINES      = SKILL_EXPERT)
 	skill_points = 32
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -259,12 +259,12 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC,
-						/decl/hierarchy/skill/security/combat				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons				= SKILL_ADEPT,
-						/decl/hierarchy/skill/security/forensics			= SKILL_BASIC)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
+						SKILL_BUREAUCRACY = SKILL_ADEPT,
+						SKILL_EVA         = SKILL_BASIC,
+						SKILL_COMBAT      = SKILL_BASIC,
+						SKILL_WEAPONS     = SKILL_ADEPT,
+						SKILL_FORENSICS   = SKILL_BASIC)
 	skill_points = 30
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -299,8 +299,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/cl
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_EXPERT,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY	= SKILL_EXPERT,
+						SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_liaison, access_tox, access_tox_storage, access_heads, access_research,
@@ -328,8 +328,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/representative
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/civ)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_EXPERT,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_EXPERT,
+						SKILL_FINANCE     = SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_representative, access_security,access_medical, access_engine,
@@ -359,10 +359,10 @@
 		/datum/mil_rank/fleet/e9_alt1,
 		/datum/mil_rank/fleet/e8
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management	= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/EVA			= SKILL_BASIC,
-						/decl/hierarchy/skill/security/combat		= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons		= SKILL_ADEPT)
+	min_skill = list(	SKILL_MANAGEMENT = SKILL_ADEPT,
+						SKILL_EVA        = SKILL_BASIC,
+						SKILL_COMBAT     = SKILL_BASIC,
+						SKILL_WEAPONS    = SKILL_ADEPT)
 	skill_points = 24
 
 
@@ -397,9 +397,9 @@
 		/datum/mil_rank/ec/o1,
 		/datum/mil_rank/fleet/o1
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/pilot					= SKILL_ADEPT)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
+						SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_PILOT       = SKILL_ADEPT)
 	skill_points = 20
 
 
@@ -437,11 +437,11 @@
 		/datum/mil_rank/ec/o3,
 		/datum/mil_rank/ec/o1
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management	= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/bureaucracy = SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA			= SKILL_ADEPT,
-						/decl/hierarchy/skill/research/science		= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/pilot			= SKILL_BASIC)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
+						SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_EVA         = SKILL_ADEPT,
+						SKILL_SCIENCE     = SKILL_ADEPT,
+						SKILL_PILOT       = SKILL_BASIC)
 	skill_points = 24
 
 	access = list(access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_cent_creed)
@@ -466,7 +466,7 @@
 		/datum/mil_rank/ec/e3,
 		/datum/mil_rank/ec/e5
 	)
-	min_skill = list(	/decl/hierarchy/skill/general/EVA			= SKILL_BASIC)
+	min_skill = list(	SKILL_EVA = SKILL_BASIC)
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_cent_creed)
 
@@ -498,13 +498,13 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/ec/e5
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/computer			= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA				= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/construction	= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/electrical	= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/atmos			= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/engines		= SKILL_ADEPT)
+	min_skill = list(	SKILL_MANAGEMENT   = SKILL_BASIC,
+						SKILL_COMPUTER     = SKILL_BASIC,
+						SKILL_EVA          = SKILL_ADEPT,
+						SKILL_CONSTRUCTION = SKILL_ADEPT,
+						SKILL_ELECTRICAL   = SKILL_ADEPT,
+						SKILL_ATMOS        = SKILL_BASIC,
+						SKILL_ENGINES      = SKILL_ADEPT)
 	skill_points = 24
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -551,12 +551,12 @@
 		/datum/mil_rank/ec/e3,
 		/datum/mil_rank/fleet/e2
 	)
-	min_skill = list(	/decl/hierarchy/skill/general/computer			= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA				= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/construction	= SKILL_ADEPT,
-						/decl/hierarchy/skill/engineering/electrical	= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/atmos			= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/engines		= SKILL_BASIC)
+	min_skill = list(	SKILL_COMPUTER     = SKILL_BASIC,
+						SKILL_EVA          = SKILL_BASIC,
+						SKILL_CONSTRUCTION = SKILL_ADEPT,
+						SKILL_ELECTRICAL   = SKILL_BASIC,
+						SKILL_ATMOS        = SKILL_BASIC,
+						SKILL_ENGINES      = SKILL_BASIC)
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
@@ -594,12 +594,12 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	/decl/hierarchy/skill/general/computer			= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA				= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/construction	= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/electrical	= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/atmos			= SKILL_BASIC,
-						/decl/hierarchy/skill/engineering/engines		= SKILL_BASIC)
+	min_skill = list(	SKILL_COMPUTER      = SKILL_BASIC,
+						SKILL_EVA           = SKILL_BASIC,
+						SKILL_CONSTRUCTION	= SKILL_BASIC,
+						SKILL_ELECTRICAL    = SKILL_BASIC,
+						SKILL_ATMOS         = SKILL_BASIC,
+						SKILL_ENGINES       = SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -633,9 +633,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	/decl/hierarchy/skill/general/computer		= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/mech			= SKILL_ADEPT,
-						/decl/hierarchy/skill/research/devices		= SKILL_ADEPT)
+	min_skill = list(	SKILL_COMPUTER		= SKILL_ADEPT,
+						SKILL_MECH = SKILL_ADEPT,
+						SKILL_DEVICES		= SKILL_ADEPT)
 
 	access = list(access_robotics, access_robotics_engineering, access_tech_storage, access_morgue, access_medical, access_robotics_engineering, access_solgov_crew)
 	minimal_access = list()
@@ -664,12 +664,12 @@
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e5
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management 	= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC,
-						/decl/hierarchy/skill/security/combat				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/forensics			= SKILL_BASIC)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
+						SKILL_BUREAUCRACY = SKILL_ADEPT,
+						SKILL_EVA         = SKILL_BASIC,
+						SKILL_COMBAT      = SKILL_BASIC,
+						SKILL_WEAPONS     = SKILL_BASIC,
+						SKILL_FORENSICS   = SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -706,12 +706,12 @@
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor,
 		/datum/mil_rank/civ/marshal = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/marshal
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/computer				= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC,
-						/decl/hierarchy/skill/security/combat				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/forensics			= SKILL_ADEPT)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_COMPUTER    = SKILL_BASIC,
+						SKILL_EVA         = SKILL_BASIC,
+						SKILL_COMBAT      = SKILL_BASIC,
+						SKILL_WEAPONS     = SKILL_BASIC,
+						SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 	access = list(access_security, access_brig, access_forensics_lockers,
@@ -742,11 +742,11 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC,
-						/decl/hierarchy/skill/security/combat				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/forensics			= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_EVA         = SKILL_BASIC,
+						SKILL_COMBAT      = SKILL_BASIC,
+						SKILL_WEAPONS     = SKILL_BASIC,
+						SKILL_FORENSICS   = SKILL_BASIC)
 
 	access = list(access_security, access_brig, access_maint_tunnels,
 						access_external_airlocks, access_emergency_storage,
@@ -781,11 +781,11 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o1
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/medical				= SKILL_ADEPT,
-						/decl/hierarchy/skill/medical/anatomy				= SKILL_EXPERT,
-						/decl/hierarchy/skill/medical/chemistry				= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/virology				= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_MEDICAL     = SKILL_ADEPT,
+						SKILL_ANATOMY     = SKILL_EXPERT,
+						SKILL_CHEMISTRY   = SKILL_BASIC,
+						SKILL_VIROLOGY    = SKILL_BASIC)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
@@ -820,9 +820,9 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6
 	)
-	min_skill = list(	/decl/hierarchy/skill/general/EVA			= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/medical		= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/anatomy		= SKILL_BASIC)
+	min_skill = list(	SKILL_EVA     = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_ANATOMY = SKILL_BASIC)
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_eva, access_surgery, access_medical_equip, access_solgov_crew, access_hangar)
 	minimal_access = list()
@@ -850,9 +850,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	/decl/hierarchy/skill/general/EVA			= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/medical		= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/anatomy		= SKILL_BASIC)
+	min_skill = list(	SKILL_EVA     = SKILL_BASIC,
+						SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_ANATOMY = SKILL_BASIC)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_crematorium, access_virology, access_surgery, access_medical_equip, access_solgov_crew,
@@ -875,8 +875,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	/decl/hierarchy/skill/medical/medical		= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/chemistry		= SKILL_ADEPT)
+	min_skill = list(	SKILL_MEDICAL   = SKILL_BASIC,
+						SKILL_CHEMISTRY = SKILL_ADEPT)
 	skill_points = 26
 
 	access = list(access_medical, access_maint_tunnels, access_emergency_storage, access_medical_equip, access_solgov_crew, access_chemistry)
@@ -903,8 +903,8 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/ec/o1)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/medical				= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_MEDICAL     = SKILL_BASIC)
 
 	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_psychiatrist, access_solgov_crew)
 	minimal_access = list()
@@ -938,12 +938,12 @@
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/management		= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_ADEPT,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_BASIC,
-						/decl/hierarchy/skill/general/hauling				= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC,
-						/decl/hierarchy/skill/general/pilot					= SKILL_BASIC)
+	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
+						SKILL_BUREAUCRACY = SKILL_ADEPT,
+						SKILL_FINANCE     = SKILL_BASIC,
+						SKILL_HAULING     = SKILL_BASIC,
+						SKILL_EVA         = SKILL_BASIC,
+						SKILL_PILOT       = SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
@@ -972,9 +972,9 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_BASIC,
-						/decl/hierarchy/skill/general/hauling				= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_FINANCE     = SKILL_BASIC,
+						SKILL_HAULING     = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
 						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar)
@@ -995,9 +995,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_BASIC,
-						/decl/hierarchy/skill/general/hauling				= SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_FINANCE     = SKILL_BASIC,
+						SKILL_HAULING     = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting, access_hangar, access_guppy, access_guppy_helm, access_solgov_crew)
 
@@ -1027,7 +1027,7 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	/decl/hierarchy/skill/general/hauling		= SKILL_BASIC)
+	min_skill = list(	SKILL_HAULING = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew)
 	minimal_access = list()
@@ -1056,9 +1056,9 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	/decl/hierarchy/skill/service/cooking	 	= SKILL_ADEPT,
-						/decl/hierarchy/skill/service/botany		= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/chemistry		= SKILL_BASIC)
+	min_skill = list(	SKILL_COOKING   = SKILL_ADEPT,
+						SKILL_BOTANY    = SKILL_BASIC,
+						SKILL_CHEMISTRY = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_hydroponics, access_kitchen, access_solgov_crew, access_bar)
 	minimal_access = list()
@@ -1075,9 +1075,9 @@
 
 	access = list(access_hydroponics, access_bar, access_solgov_crew, access_kitchen)
 	minimal_access = list()
-	min_skill = list(	/decl/hierarchy/skill/service/cooking	 	= SKILL_BASIC,
-						/decl/hierarchy/skill/service/botany		= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/chemistry		= SKILL_BASIC)
+	min_skill = list(	SKILL_COOKING   = SKILL_BASIC,
+						SKILL_BOTANY    = SKILL_BASIC,
+						SKILL_CHEMISTRY = SKILL_BASIC)
 
 /datum/job/crew
 	title = "Crewman"
@@ -1129,13 +1129,13 @@
 	access = list(access_tox, access_tox_storage, access_research, access_mining, access_mining_office,
 						access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen,
 						access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/computer				= SKILL_BASIC,
-						/decl/hierarchy/skill/organizational/finance		= SKILL_BASIC,
-						/decl/hierarchy/skill/service/botany				= SKILL_BASIC,
-						/decl/hierarchy/skill/medical/anatomy				= SKILL_BASIC,
-						/decl/hierarchy/skill/research/devices				= SKILL_ADEPT,
-						/decl/hierarchy/skill/research/science				= SKILL_ADEPT)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_COMPUTER    = SKILL_BASIC,
+						SKILL_FINANCE     = SKILL_BASIC,
+						SKILL_BOTANY      = SKILL_BASIC,
+						SKILL_ANATOMY     = SKILL_BASIC,
+						SKILL_DEVICES     = SKILL_ADEPT,
+						SKILL_SCIENCE     = SKILL_ADEPT)
 	skill_points = 20
 
 /datum/job/nt_pilot
@@ -1158,8 +1158,8 @@
 	access = list(access_research, access_mining_office,
 						access_mining_station, access_nanotrasen, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy,
 						access_hangar, access_petrov, access_petrov_helm, access_guppy_helm, access_mining)
-	min_skill = list(	/decl/hierarchy/skill/general/EVA			= SKILL_BASIC,
-						/decl/hierarchy/skill/general/pilot			= SKILL_ADEPT)
+	min_skill = list(	SKILL_EVA   = SKILL_BASIC,
+						SKILL_PILOT = SKILL_ADEPT)
 
 /datum/job/scientist
 	title = "Scientist"
@@ -1176,10 +1176,10 @@
 		"Xenobiologist",
 		"Xenobotanist",
 		"Psychologist" = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/psych)
-	min_skill = list(	/decl/hierarchy/skill/organizational/bureaucracy	= SKILL_BASIC,
-						/decl/hierarchy/skill/general/computer				= SKILL_BASIC,
-						/decl/hierarchy/skill/research/devices				= SKILL_BASIC,
-						/decl/hierarchy/skill/research/science				= SKILL_ADEPT)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_COMPUTER    = SKILL_BASIC,
+						SKILL_DEVICES     = SKILL_BASIC,
+						SKILL_SCIENCE     = SKILL_ADEPT)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/scientist
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -1206,9 +1206,9 @@
 		"Drill Technician",
 		"Shaft Miner",
 		"Salvage Technician")
-	min_skill = list(	/decl/hierarchy/skill/general/mech			= SKILL_BASIC,
-						/decl/hierarchy/skill/general/hauling		= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/EVA			= SKILL_BASIC)
+	min_skill = list(	SKILL_MECH    = SKILL_BASIC,
+						SKILL_HAULING = SKILL_ADEPT,
+						SKILL_EVA     = SKILL_BASIC)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -1234,8 +1234,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/guard
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt, /datum/mil_rank/civ/contractor)
-	min_skill = list(	/decl/hierarchy/skill/security/combat		= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons		= SKILL_BASIC)
+	min_skill = list(	SKILL_COMBAT  = SKILL_BASIC,
+						SKILL_WEAPONS = SKILL_BASIC)
 
 	access = list(access_tox, access_tox_storage,access_research, access_mining, access_mining_office, access_mining_station, access_xenobiology,
 						access_xenoarch, access_nanotrasen, access_sec_guard, access_hangar, access_petrov, access_expedition_shuttle, access_guppy)
@@ -1320,8 +1320,8 @@
 	latejoin_at_spawnpoints = 1
 	access = list(access_merchant)
 	announced = FALSE
-	min_skill = list(	/decl/hierarchy/skill/organizational/finance		= SKILL_ADEPT,
-						/decl/hierarchy/skill/general/pilot					= SKILL_BASIC)
+	min_skill = list(	SKILL_FINANCE = SKILL_ADEPT,
+						SKILL_PILOT	  = SKILL_BASIC)
 	skill_points = 24
 
 /datum/job/stowaway

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -85,8 +85,8 @@
 
 	assistant_job = "Crewman"
 
-	min_skill = list(	/decl/hierarchy/skill/research/science				= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC)
+	min_skill = list(	SKILL_SCIENCE = SKILL_BASIC,
+						SKILL_EVA     = SKILL_BASIC)
 
 /datum/mil_branch/fleet
 	name = "Fleet"
@@ -143,9 +143,9 @@
 	)
 
 	assistant_job = "Crewman"
-	min_skill = list(	/decl/hierarchy/skill/general/hauling				= SKILL_BASIC,
-						/decl/hierarchy/skill/security/weapons				= SKILL_BASIC,
-						/decl/hierarchy/skill/general/EVA					= SKILL_BASIC)
+	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
+						SKILL_WEAPONS = SKILL_BASIC,
+						SKILL_EVA     = SKILL_BASIC)
 
 /datum/mil_branch/civilian
 	name = "Civilian"


### PR DESCRIPTION
This adds a readme about skills, turns constants into defines, and changes the (torch) jobs.dm to use the skill path defines for better overall code consistency.

So, no balance changes, no code changes, just some cleanup.

Ready for review.