### PR TITLE
Supply packs come with secure guns now

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -141,12 +141,19 @@
 
 /decl/hierarchy/supply_pack/security/egun
 	name = "Weapons - Energy sidearms"
-	contains = list(/obj/item/weapon/gun/energy/gun = 4)
+	contains = list(/obj/item/weapon/gun/energy/secure/gun = 4)
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Energy sidearms crate"
 	access = access_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
+
+/decl/hierarchy/supply_pack/security/egun/shady
+	name = "Weapons - Energy sidearms (For disposal)"
+	contains = list(/obj/item/weapon/gun/energy/gun = 4)
+	cost = 60
+	contraband = 1
+	security_level = null
 
 /decl/hierarchy/supply_pack/security/ion
 	name = "Weapons - Electromagnetic"

--- a/html/changelogs/chinsky - nogun.yml
+++ b/html/changelogs/chinsky - nogun.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Supply crates now have secure variants of guns."
+  - rscadd: "Unsecure guns can be ordered with contraband crates."

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -57,12 +57,19 @@
 
 /decl/hierarchy/supply_pack/security/laser
 	name = "Weapons - Laser carbines"
-	contains = list(/obj/item/weapon/gun/energy/laser = 4)
+	contains = list(/obj/item/weapon/gun/energy/secure/laser = 4)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Laser carbines crate"
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
+
+/decl/hierarchy/supply_pack/security/laser/shady
+	name = "Weapons - Laser carbines (For disposal)"
+	contains = list(/obj/item/weapon/gun/energy/laser = 4)
+	cost = 80
+	contraband = 1
+	security_level = null
 
 /decl/hierarchy/supply_pack/security/advancedlaser
 	name = "Weapons - Advanced Laser Weapons"


### PR DESCRIPTION
Adds non-secure guns as contraband crate. No alert level req, but it still comes in armory-access crate.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
