### PR TITLE
Fixes the topic for summoning stone to work for non-admins.

### DIFF
--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -188,6 +188,11 @@
 		if(G.assess_candidate(ghost,null,FALSE))
 			to_chat(ghost,"<span class='notice'><b>A wizard is requesting a Spell-Bound Servant!</b></span> (<a href='?src=\ref[src];master=\ref[user]'>Join</a>)")
 
+/obj/effect/cleanable/spellbound/CanUseTopic(var/mob)
+	if(isliving(mob))
+		return STATUS_CLOSE
+	return STATUS_INTERACTIVE
+
 /obj/effect/cleanable/spellbound/OnTopic(var/mob/user, href_list, state)
 	if(href_list["master"])
 		var/mob/master = locate(href_list["master"])


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
My bad. Turned it into a basic check if you are /mob/living or not. 