### PR TITLE
Add ability to export GEP with supply shuttle

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -117,6 +117,7 @@ var/list/point_source_descriptions = list(
 	"phoron" = "From exported phoron",
 	"platinum" = "From exported platinum",
 	"virology" = "From uploaded antibody data",
+	"gep" = "From uploaded good explorer points",
 	"total" = "Total" // If you're adding additional point sources, add it here in a new line. Don't forget to put a comma after the old last line.
 	)
 
@@ -209,6 +210,13 @@ var/list/point_source_descriptions = list(
 							switch(P.get_material_name())
 								if("phoron") phoron_count += P.get_amount()
 								if("platinum") plat_count += P.get_amount()
+							continue
+
+						// Hahahaha must sell ore detector disks in crates
+						if(istype(A, /obj/item/weapon/disk/survey))
+							var/obj/item/weapon/disk/survey/D = A
+							add_points_from_source(round(D.Value() * 0.005), "gep")
+							
 				qdel(MA)
 
 		if(phoron_count)

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -12,7 +12,7 @@
 
 /obj/item/weapon/mining_scanner/examine(mob/user)
 	..()
-	to_chat(user,"Tiny indicator shows it holds [survey_data] Good Explorer Points worth of data.")
+	to_chat(user,"A tiny indicator on the [src] shows it holds [survey_data] good explorer points.")
 
 /obj/item/weapon/mining_scanner/attack_self(mob/user as mob)
 	to_chat(user, "You begin sweeping \the [src] about, scanning for metal deposits.")
@@ -85,9 +85,9 @@
 	if(M.incapacitated())
 		return
 	if(!survey_data)
-		to_chat(M,"<span class='warning'>There is no survey data stored on [src].</span>")
+		to_chat(M,"<span class='warning'>There is no survey data stored on the [src].</span>")
 		return
-	visible_message("<span class='notice'>[src] records [survey_data] GEP worth of the data on the disk and spits it out.</span>")
+	visible_message("<span class='notice'>The [src] spits out a disk containing [survey_data] GEP.</span>")
 	var/obj/item/weapon/disk/survey/D = new(get_turf(src))
 	D.data = survey_data
 	survey_data = 0
@@ -101,7 +101,7 @@
 
 /obj/item/weapon/disk/survey/examine(mob/user)
 	..()
-	to_chat(user,"Tiny indicator shows it holds [data] Good Explorer Points of data.")
+	to_chat(user,"A tiny indicator on the [src] shows it holds [data] good explorer points.")
 
 /obj/item/weapon/disk/survey/Value()
 	if(data < 10000)

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -51,6 +51,7 @@
 			data["credits_platinum"] = supply_controller.point_sources["platinum"] ? supply_controller.point_sources["platinum"] : 0
 			data["credits_paperwork"] = supply_controller.point_sources["manifest"] ? supply_controller.point_sources["manifest"] : 0
 			data["credits_virology"] = supply_controller.point_sources["virology"] ? supply_controller.point_sources["virology"] : 0
+			data["credits_gep"] = supply_controller.point_sources["gep"] ? supply_controller.point_sources["gep"] : 0
 			data["can_print"] = can_print()
 
 		if(3)// Shuttle monitoring and control

--- a/html/changelogs/HeyBanditoz - gep_export.yml
+++ b/html/changelogs/HeyBanditoz - gep_export.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes: 
+  - rscadd: "You can now export ore scanner disks inside of crates on the supply shuttle for some extra supply points."

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -80,6 +80,14 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
+			Credits from uploaded good explorer points:
+		</div>
+		<div class="itemContent">
+			{{:data.credits_gep}} Cr.
+		</div>
+	</div>
+	<div class="item">
+		<div class="itemLabel">
 			Credit bonus for paperwork handling:
 		</div>
 		<div class="itemContent">


### PR DESCRIPTION
When you right click an ore scanner, you get a disk. Now, you can put that disk on a crate and send it away on a supply shuttle for a few extra points, if you've got a bit of data on it. (10,000 GEP points = 5 supply points.)