### PR TITLE
Survellance cam - D3 mess hall kitchen

### DIFF
--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -19517,6 +19517,10 @@
 /obj/structure/closet/shipping_wall/filled{
 	pixel_x = -24
 	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Mess Hall - Galley";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "Ub" = (


### PR DESCRIPTION
A missing survellance cam has been installed at the D3 Mess Hall - Galley. Mapmerge completed. Cam labeled as such.

:cl:
maptweak: A survellance camera had been installed - D3 mess hall - galley.
/:cl:
