### PR TITLE
Magnetic gripper - trit+deut ingots gripper

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -24,7 +24,9 @@
 		/obj/item/weapon/circuitboard,
 		/obj/item/weapon/smes_coil,
 		/obj/item/weapon/computer_hardware,
-		/obj/item/weapon/fuel_assembly
+		/obj/item/weapon/fuel_assembly,
+		/obj/item/stack/material/deuterium,
+		/obj/item/stack/material/tritium
 		)
 
 	var/obj/item/wrapped = null // Item currently being held.


### PR DESCRIPTION
Adds a capability for maint drones as well as engiborgs to grab a deuterium and tritium ingots, which are used as R-Ust Tokamak fuel supply.

:cl:
tweak: Magnetic grippers are now capable of grabbing deuterium and tritium ingots as well.
/:cl:
