### PR TITLE
Issue report #21208 fix attemp

### DIFF
--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -13666,11 +13666,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aPW" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -13681,6 +13676,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/blanks)


### PR DESCRIPTION
Atmospheric fix attemp for the aux custodial being located at RnD hallway. Air alarm pushed under the one and the most common standart, all the items inside re-checked for any differences among each other, under issue report #21208

:cl:
experiment: Atmospheric fix attemp for the RnD aux custodial
/:cl:
