### PR TITLE
Changes way lung bursting is triggered

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -111,7 +111,8 @@
 	var/breath_type = "oxygen"                        // Non-oxygen gas breathed, if any.
 	var/poison_type = "phoron"                        // Poisonous air.
 	var/exhale_type = "carbon_dioxide"                // Exhaled gas type.
-	var/cold_level_1 = 243                           // Cold damage level 1 below this point. -30 Celsium degrees
+	var/max_pressure_diff = 60						  // Maximum pressure difference that is safe for lungs
+	var/cold_level_1 = 243                            // Cold damage level 1 below this point. -30 Celsium degrees
 	var/cold_level_2 = 200                            // Cold damage level 2 below this point.
 	var/cold_level_3 = 120                            // Cold damage level 3 below this point.
 	var/heat_level_1 = 360                            // Heat damage level 1 above this point.

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -17,6 +17,9 @@
 	var/exhale_type
 
 	var/min_breath_pressure
+	var/last_int_pressure
+	var/last_ext_pressure
+	var/max_pressure_diff = 60
 
 	var/oxygen_deprivation = 0
 	var/safe_exhaled_max = 6
@@ -50,6 +53,7 @@
 /obj/item/organ/internal/lungs/set_dna(var/datum/dna/new_dna)
 	..()
 	sync_breath_types()
+	max_pressure_diff = species.max_pressure_diff
 
 /obj/item/organ/internal/lungs/replaced()
 	..()
@@ -106,6 +110,19 @@
 		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50, affecting = parent)
 	bruise()
 
+//exposure to extreme pressures can rupture lungs
+/obj/item/organ/internal/lungs/proc/check_rupturing(breath_pressure)
+	if(isnull(last_int_pressure))
+		last_int_pressure = breath_pressure
+		return
+	var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
+	var/int_pressure_diff = abs(last_int_pressure - breath_pressure)
+	var/ext_pressure_diff = abs(last_ext_pressure - environment.return_pressure()) * owner.get_pressure_weakness()
+	if(int_pressure_diff > max_pressure_diff && ext_pressure_diff > max_pressure_diff)
+		var/lung_rupture_prob = isrobotic() ? prob(30) : prob(60) //Robotic lungs are less likely to rupture.
+		if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
+			rupture()
+
 /obj/item/organ/internal/lungs/proc/handle_breath(datum/gas_mixture/breath, var/forced)
 	if(!owner)
 		return 1
@@ -113,16 +130,11 @@
 		breath_fail_ratio = 1
 		handle_failed_breath()
 		return 1
-
 	var/breath_pressure = breath.return_pressure()
-	//exposure to extreme pressures can rupture lungs
-	if(breath_pressure < species.hazard_low_pressure || breath_pressure > species.hazard_high_pressure)
-		var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
-		var/env_pressure = environment.return_pressure()
-		var/lung_rupture_prob =  robotic >= ORGAN_ROBOT ? prob(2.5) : prob(5) //Robotic lungs are less likely to rupture.
-		if(env_pressure < species.hazard_low_pressure || env_pressure > species.hazard_high_pressure)
-			if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
-				rupture()
+	check_rupturing(breath_pressure)
+	var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
+	last_ext_pressure = environment.return_pressure()
+	last_int_pressure = breath_pressure
 	if(breath.total_moles == 0)
 		breath_fail_ratio = 1
 		handle_failed_breath()
@@ -258,6 +270,7 @@
 		owner.adjustOxyLoss(HUMAN_MAX_OXYLOSS*breath_fail_ratio)
 
 	owner.oxygen_alert = max(owner.oxygen_alert, 2)
+	last_int_pressure = 0
 
 /obj/item/organ/internal/lungs/proc/handle_temperature_effects(datum/gas_mixture/breath)
 	// Hot air hurts :(

--- a/html/changelogs/chinsky - popteamepic.yml
+++ b/html/changelogs/chinsky - popteamepic.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Lung popping condition changed. Now it only happens when pressure changes (both internal and external), not constantly when you're in vacuum. Pressurized suits prevent popping by reducing external pressure difference impact."


### PR DESCRIPTION
It now only happens on pressure change, not constantly when you're in bad pressure.
Lungs remembers internal and external pressure, and if both changed too much (60 kpa right now), it tries to pop.
Pressurized suits prevent external pressure difference from triggering that.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
