### PR TITLE
Removes pain heartstop, buffs burns

### DIFF
--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -113,7 +113,7 @@
 		if (BRUISE)
 			return prob(dam_coef*5)
 		if (BURN)
-			return prob(dam_coef*10)
+			return prob(dam_coef*30)
 		if (CUT)
 			return prob(dam_coef*20)
 

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -42,6 +42,8 @@
 
 	if(owner.shock_stage > 30)
 		pulse_mod++
+	if(owner.shock_stage > 80)
+		pulse_mod++
 
 	var/oxy = owner.get_blood_oxygenation()
 	if(oxy < BLOOD_VOLUME_OKAY) //brain wants us to get MOAR OXY
@@ -59,8 +61,7 @@
 	else //and if it's beating, let's see if it should
 		var/should_stop = prob(80) && owner.get_blood_circulation() < BLOOD_VOLUME_SURVIVE //cardiovascular shock, not enough liquid to pump
 		should_stop = should_stop || prob(max(0, owner.getBrainLoss() - owner.maxHealth * 0.75)) //brain failing to work heart properly
-		should_stop = should_stop || (prob(10) && owner.shock_stage >= 120) //traumatic shock
-		should_stop = should_stop || (prob(10) && pulse == PULSE_THREADY) //erratic heart patterns, usually caused by oxyloss
+		should_stop = should_stop || (prob(5) && pulse == PULSE_THREADY) //erratic heart patterns, usually caused by oxyloss
 		if(should_stop) // The heart has stopped due to going into traumatic or cardiovascular shock.
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE


### PR DESCRIPTION
As its main raison d'etre was preventing people living with silly amounts of burn damage, burn damage was tweaked too.

1.Burns now increase brute damage taken by that limb, up to 20% more damage.
2.When taking more brute damage, burns can become unsalved.
3.Burns are now a lot more likely to become infected.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
