### PR TITLE
Enables borg combat module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -17,10 +17,11 @@
 	var/sight_mode = 0
 	var/custom_name = ""
 	var/custom_sprite = 0 //Due to all the sprites involved, a var for our custom borgs may be best
-	var/crisis //Admin-settable for combat module use.
-	var/crisis_override = 0
+	var/combat_override = 0 // Admin-settable for combat module use.
 	var/integrated_light_max_bright = 0.75
 	var/datum/wires/robot/wires
+
+	GLOBAL_VAR_INIT(combat_mode, 0) // You can be swiped to use the combat module on a keycard device during red.
 
 //Icon stuff
 
@@ -258,7 +259,7 @@
 	var/list/modules = list()
 	modules.Add(GLOB.robot_module_types)
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-	if((crisis && security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level)) || crisis_override) //Leaving this in until it's balanced appropriately.
+	if((GLOB.combat_mode && security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level)) || combat_override)
 		to_chat(src, "<span class='warning'>Crisis mode active. Combat module available.</span>")
 		modules+="Combat"
 	modtype = input("Please, select a module!", "Robot module", null, null) as null|anything in modules

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -675,7 +675,6 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/security/combat
 	name = "combat robot module"
-	hide_on_manifest = 1
 	sprites = list("Combat Android" = "droid-combat")
 
 /obj/item/weapon/robot_module/security/combat/New()
@@ -685,6 +684,13 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/gun/energy/plasmacutter(src)
 	src.modules += new /obj/item/borg/combat/shield(src)
 	src.modules += new /obj/item/borg/combat/mobility(src)
+	src.modules += new /obj/item/borg/sight/hud/sec(src)
+	src.modules += new /obj/item/weapon/handcuffs/cyborg(src)
+	src.modules += new /obj/item/weapon/melee/baton/robot(src)
+	src.modules += new /obj/item/weapon/gun/energy/taser/mounted/cyborg(src)
+	src.modules += new /obj/item/taperoll/police(src)
+	src.modules += new /obj/item/device/megaphone(src)
+	src.modules += new /obj/item/device/holowarrant(src)
 	src.emag = new /obj/item/weapon/gun/energy/lasercannon/mounted(src)
 	..()
 

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -82,6 +82,9 @@
 		dat += "<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
 		dat += "<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>"
 		dat += "<li><A href='?src=\ref[src];triggerevent=Grant Nuclear Authorization Code'>Grant Nuclear Authorization Code</A></li>"
+		if(security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level))
+			dat += "<li><A href='?src=\ref[src];triggerevent=Grant Robot Combat Module'>Grant Robot Combat Module</A></li>"
+		dat += "<li><A href='?src=\ref[src];triggerevent=Revoke Robot Combat Module'>Revoke Robot Combat Module</A></li>"
 		dat += "</ul>"
 		user << browse(dat, "window=keycard_auth;size=500x250")
 	if(screen == 2)
@@ -183,6 +186,14 @@
 			else
 				to_chat(usr, "No self destruct terminal found.")
 			feedback_inc("alert_keycard_auth_nukecode",1)
+		if("Grant Robot Combat Module")
+			for(var/mob/living/silicon/robot/A in GLOB.silicon_mob_list)
+				to_chat(A, "<span class='warning'>Crisis mode activated. Combat module available.</span>")
+			GLOB.combat_mode = 1
+		if("Revoke Robot Combat Module")
+			for(var/mob/living/silicon/robot/A in GLOB.silicon_mob_list)
+				to_chat(A, "<span class='warning'>Crisis mode deactivated. The combat module is no longer available.</span>")
+			GLOB.combat_mode = 0
 
 /obj/machinery/keycard_auth/proc/is_ert_blocked()
 	if(config.ert_admin_call_only) return 1

--- a/html/changelogs/HeyBanditoz - combat_module.yml
+++ b/html/changelogs/HeyBanditoz - combat_module.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes: 
+  - rscadd: "You can now enable a combat module for borgs via the keycard authentication device during red."


### PR DESCRIPTION
Security borgs are complete garbage. They're effectively useless when everything turns to shit. Re-enabling the combat module aims to be an alternative to secborgs (they get all secborg items, on top of the standard combat module stuff,) only usable during code red via a keycard swipe.