### PR TITLE
Nerfs ID cards

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -128,13 +128,25 @@ var/const/NO_EMAG_ACT = -50
 			assignment = rank
 			access |= j.get_access()
 
+/obj/item/weapon/card/id/get_examine_line()
+	. = ..()
+	. += "  <a href='?src=\ref[src];look_at_id=1'>\[View\]</a>"
+
+/obj/item/weapon/card/id/CanUseTopic(var/user)
+	if(user in view(get_turf(src)))
+		return STATUS_INTERACTIVE
+
+/obj/item/weapon/card/id/OnTopic(var/mob/user, var/list/href_list)
+	if(href_list["look_at_id"])
+		if(istype(user))
+			user.examinate(src)
+			return TOPIC_HANDLED
+
 /obj/item/weapon/card/id/examine(mob/user)
-	set src in oview(1)
-	if(in_range(usr, src))
-		show(usr)
-		to_chat(usr, desc)
-	else
-		to_chat(usr, "<span class='warning'>It is too far away.</span>")
+	..()
+	to_chat(user, "It says '[get_display_name()]'.")
+	if(in_range(user, src))
+		show(user)
 
 /obj/item/weapon/card/id/proc/prevent_tracking()
 	return 0
@@ -149,15 +161,12 @@ var/const/NO_EMAG_ACT = -50
 	popup.open()
 	return
 
-/obj/item/weapon/card/id/proc/update_name()
-	SetName("[get_display_name()]'s ID Card")
-
 /obj/item/weapon/card/id/proc/get_display_name()
 	. = registered_name
 	if(military_rank && military_rank.name_short)
 		. = military_rank.name_short + " " + .
 	if(assignment)
-		. += " ([assignment])"
+		. += ", [assignment]"
 
 /obj/item/weapon/card/id/proc/set_id_photo(var/mob/M)
 	front = getFlatIcon(M, SOUTH, always_use_defdir = 1)
@@ -173,7 +182,6 @@ var/const/NO_EMAG_ACT = -50
 		id_card.blood_type		= dna.b_type
 		id_card.dna_hash		= dna.unique_enzymes
 		id_card.fingerprint_hash= md5(dna.uni_identity)
-	id_card.update_name()
 
 /mob/living/carbon/human/set_id_info(var/obj/item/weapon/card/id/id_card)
 	..()

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -119,7 +119,6 @@
 				if(!isnull(new_job) && CanUseTopic(user, state))
 					src.assignment = new_job
 					to_chat(user, "<span class='notice'>Occupation changed to '[new_job]'.</span>")
-					update_name()
 					. = 1
 			if("Blood Type")
 				var/default = blood_type
@@ -158,7 +157,6 @@
 				var/new_name = sanitizeName(input(user,"What name would you like to put on this card?","Agent Card Name", registered_name) as null|text, allow_numbers=TRUE)
 				if(!isnull(new_name) && CanUseTopic(user, state))
 					src.registered_name = new_name
-					update_name()
 					to_chat(user, "<span class='notice'>Name changed to '[new_name]'.</span>")
 					. = 1
 			if("Photo")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -141,7 +141,7 @@
 	var/list/ties = list()
 	for(var/obj/item/clothing/accessory/accessory in accessories)
 		if(accessory.high_visibility)
-			ties += "\icon[accessory] \a [accessory]"
+			ties += "\a [accessory.get_examine_line()]"
 	if(ties.len)
 		.+= " with [english_list(ties)] attached"
 	if(accessories.len > ties.len)

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -10,14 +10,33 @@
 	icon_state = "detectivebadge"
 	slot_flags = SLOT_BELT | SLOT_TIE
 	slot = ACCESSORY_SLOT_INSIGNIA
+	high_visibility = 1
 	var/badge_string = "Detective"
 	var/stored_name
 
 /obj/item/clothing/accessory/badge/proc/set_name(var/new_name)
 	stored_name = new_name
-	name = "[initial(name)] ([stored_name])"
 
 /obj/item/clothing/accessory/badge/proc/set_desc(var/mob/living/carbon/human/H)
+
+/obj/item/clothing/accessory/badge/CanUseTopic(var/user)
+	if(user in view(get_turf(src)))
+		return STATUS_INTERACTIVE
+
+/obj/item/clothing/accessory/badge/OnTopic(var/mob/user, var/list/href_list)
+	if(href_list["look_at_me"])
+		if(istype(user))
+			user.examinate(src)
+			return TOPIC_HANDLED
+
+/obj/item/clothing/accessory/badge/get_examine_line()
+	. = ..()
+	. += "  <a href='?src=\ref[src];look_at_me=1'>\[View\]</a>"
+
+/obj/item/clothing/accessory/badge/examine(user)
+	..()
+	if(stored_name)
+		to_chat(user,"It reads: [stored_name], [badge_string].")
 
 /obj/item/clothing/accessory/badge/attack_self(mob/user as mob)
 
@@ -36,6 +55,8 @@
 /obj/item/clothing/accessory/badge/attack(mob/living/carbon/human/M, mob/living/user)
 	if(isliving(user))
 		user.visible_message("<span class='danger'>[user] invades [M]'s personal space, thrusting \the [src] into their face insistently.</span>","<span class='danger'>You invade [M]'s personal space, thrusting \the [src] into their face insistently.</span>")
+		if(stored_name)
+			to_chat(M, "<span class='warning'>It reads: [stored_name], [badge_string].</span>")
 
 /obj/item/clothing/accessory/badge/PI
 	name = "private investigator's badge"
@@ -52,6 +73,7 @@
 	item_state = "holobadge"
 	badge_string = "Security"
 	var/badge_access = access_security
+	var/badge_number
 	var/emagged //emag_act removes access requirements
 
 /obj/item/clothing/accessory/badge/holo/NT
@@ -69,6 +91,16 @@
 /obj/item/clothing/accessory/badge/holo/NT/cord
 	icon_state = "holobadge-cord"
 	slot_flags = SLOT_MASK | SLOT_TIE
+
+/obj/item/clothing/accessory/badge/holo/set_name(var/new_name)
+	..()
+	badge_number = random_id(type,1000,9999)
+	name = "[name] ([badge_number])"
+
+/obj/item/clothing/accessory/badge/holo/examine(user)
+	..()
+	if(badge_number)
+		to_chat(user,"The badge number is [badge_number].")
 
 /obj/item/clothing/accessory/badge/holo/attack_self(mob/user as mob)
 	if(!stored_name)
@@ -95,7 +127,8 @@
 
 		if((badge_access in id_card.access) || emagged)
 			to_chat(user, "You imprint your ID details onto the badge.")
-			set_name(user.real_name)
+			set_name(id_card.registered_name)
+			set_desc(user)
 		else
 			to_chat(user, "[src] rejects your ID, and flashes 'Insufficient access!'")
 		return

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -106,7 +106,6 @@
 			var/obj/item/weapon/card/id/ID = A
 			if(ID.registered_name == old_name)
 				ID.registered_name = new_name
-				ID.update_name()
 				search_id = 0
 		else if(search_pda && istype(A,/obj/item/modular_computer/pda))
 			var/obj/item/modular_computer/pda/PDA = A

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -57,7 +57,6 @@
 	create_or_rename_email(new_name, "root.rt")
 	if(istype(idcard))
 		idcard.registered_name = new_name
-		idcard.update_name()
 
 /mob/living/silicon/proc/init_id()
 	if(ispath(idcard))

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -192,7 +192,6 @@
 		I.forceMove(src)
 		update_uis()
 		update_verbs()
-		update_name()
 		to_chat(user, "You insert [I] into [src].")
 
 		return
@@ -286,6 +285,9 @@
 
 	if(enabled && .)
 		to_chat(user, "The time [stationtime2text()] is displayed in the corner of the screen.")
+		
+	if(card_slot && card_slot.stored_card)
+		to_chat(user, "The [card_slot.stored_card] is inserted into it.")
 
 /obj/item/modular_computer/MouseDrop(var/atom/over_object)
 	var/mob/M = usr

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -12,19 +12,6 @@
 	stores_pen = TRUE
 	stored_pen = /obj/item/weapon/pen
 
-/obj/item/modular_computer/pda/update_name()
-	var/obj/item/weapon/card/id/id
-	if(card_slot && istype(card_slot.stored_card))
-		id = card_slot.stored_card
-	else
-		var/mob/living/L = get_holder_of_type(src, /mob/living)
-		if(istype(L) && L.GetIdCard())
-			id = L.GetIdCard()
-		else
-			return
-
-	SetName("[id.get_display_name()]'s PDA")
-
 /obj/item/modular_computer/pda/Initialize()
 	. = ..()
 	enable_computer()
@@ -36,7 +23,12 @@
 		eject_id()
 	else
 		..()
-	
+
+/obj/item/modular_computer/pda/get_examine_line()
+	. = ..()
+	if(card_slot && istype(card_slot.stored_card))
+		. += "  <a href='?src=\ref[card_slot.stored_card];look_at_id=1'>\[Look at ID\]</a>"
+
 // PDA box
 /obj/item/weapon/storage/box/PDAs
 	name = "box of spare PDAs"
@@ -79,6 +71,7 @@
 	icon_state_unpowered = "pda-nt"
 
 /obj/item/modular_computer/pda/heads
+	name = "command PDA"
 	icon_state = "pda-h"
 	icon_state_unpowered = "pda-h"
 

--- a/html/changelogs/chinsky - whois.yml
+++ b/html/changelogs/chinsky - whois.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "PDAs and ID cards no longer have whole name and job in their item name."
+  - tweak: "When examining people, you will see a linkie to see their ID. That will give you name/job if you're nearby, or show you the window with full info if you're adjacent."

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -197,4 +197,3 @@
 	fingerprint_hash = md5(registered_name)
 	dna_hash = md5(fingerprint_hash)
 	blood_type = RANDOM_BLOOD_TYPE
-	update_name()


### PR DESCRIPTION
They no longer show full name and job in their name, moved that to examine bit instead.
PDAs got same treatment.

In exchange, they get a linkie when you examine a guy, letting you see the ID (in full detail with pic and all if you're adjacent)

IMO should make stowaways/impersonations less obvious while still letting legit seeing who is who.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
