### PR TITLE
Fixes railgun detonation bug

### DIFF
--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -16,6 +16,7 @@
 	var/initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv // 6-8 shots
 	var/slowdown_held = 2
 	var/slowdown_worn = 1
+	gun_unreliable = 0
 
 /obj/item/weapon/gun/magnetic/railgun/Initialize()
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

:cl:
bugfix: Uplink-bought railguns no longer explode
/:cl:

These weren't meant to explode. Looks like we missed a var - Whoops. Note that the original PR assumed they didn't explode, and that was even a review topic, so this is a bug, not a slipped-in buff.