### PR TITLE
Lets you disassemble PDAs

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -6,7 +6,6 @@
 	icon_state_unpowered = "pda"
 	hardware_flag = PROGRAM_PDA
 	max_hardware_size = 1
-	modifiable = FALSE
 	w_class = ITEM_SIZE_SMALL
 	light_strength = 5
 	slot_flags = SLOT_ID | SLOT_BELT


### PR DESCRIPTION
They're still restricted in choice of programs, but this way yo ucould at least /repair/ them.
I think at some point they just need to be dropped in lieu of tablets, or vice versa, but for now this.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
