### PR TITLE
Adds computer damage event

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1434,6 +1434,7 @@
 #include "code\modules\events\camera_damage.dm"
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\communications_blackout.dm"
+#include "code\modules\events\computer_damage.dm"
 #include "code\modules\events\dust.dm"
 #include "code\modules\events\electrical_storm.dm"
 #include "code\modules\events\event.dm"

--- a/code/modules/events/computer_damage.dm
+++ b/code/modules/events/computer_damage.dm
@@ -1,0 +1,25 @@
+/datum/event/computer_damage/start()
+	var/number_of_victims = 0
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
+			number_of_victims = 4
+		if(EVENT_LEVEL_MODERATE)
+			number_of_victims = 8
+		if(EVENT_LEVEL_MAJOR)
+			number_of_victims = 16
+	var/list/victims = list()
+	for(var/obj/item/modular_computer/console/C in SSobj.processing) //yep they're in obj, yep gross
+		if((C.z in GLOB.using_map.station_levels) && C.enabled && C.hard_drive)
+			victims += C
+	while(number_of_victims && victims.len)
+		number_of_victims--
+		var/obj/item/modular_computer/console/victim = pick_n_take(victims)
+		if(prob(50))
+			victim.bsod = 1
+			victim.update_icon()
+		else
+			victim.visible_message("<span class='warning'>[victim] emits some omnious clicks.</span>")
+			if(prob(60))
+				victim.hard_drive.damage = victim.hard_drive.damage_failure
+			else
+				victim.hard_drive.damage = victim.hard_drive.damage_malfunction

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -128,6 +128,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		// Severity level, event name, even type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and non-zero
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",			/datum/event/nothing,			100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "APC Damage",		/datum/event/apc_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Computer Damage",		/datum/event/computer_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",/datum/event/brand_intelligence,10, 	list(ASSIGNMENT_JANITOR = 10),	1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",		/datum/event/camera_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),

--- a/code/modules/modular_computers/computers/modular_computer/ui.dm
+++ b/code/modules/modular_computers/computers/modular_computer/ui.dm
@@ -1,6 +1,6 @@
 // Operates NanoUI
 /obj/item/modular_computer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	if(!screen_on || !enabled)
+	if(!screen_on || !enabled || bsod)
 		if(ui)
 			ui.close()
 		return 0


### PR DESCRIPTION
Mundane event weighted higher if engies are around.
Chance of just a BSOD that goes away on force reset, or HDD damage/failure.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
