### PR TITLE
Bioprinter QOL improvement

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -222,10 +222,10 @@
 	// Load with matter for printing.
 	for(var/path in amount_list)
 		if(istype(W, path))
-			if((max_stored_matter - stored_matter) < amount_list[path])
+			if(max_stored_matter == stored_matter)
 				to_chat(user, "<span class='warning'>\The [src] is too full.</span>")
 				return
-			stored_matter += amount_list[path]
+			stored_matter += min(amount_list[path], max_stored_matter - stored_matter)
 			user.drop_item()
 			to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]</span>")
 			qdel(W)


### PR DESCRIPTION
Now filling it with meat when there's not enough space tops it off and wastes the remaining meat, as opposed to blocking filling.
