### PR TITLE
Replace taser rifle with secure gun on secborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -429,7 +429,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/borg/sight/hud/sec(src)
 	src.modules += new /obj/item/weapon/handcuffs/cyborg(src)
 	src.modules += new /obj/item/weapon/melee/baton/robot(src)
-	src.modules += new /obj/item/weapon/gun/energy/taser/mounted/cyborg(src)
+	src.modules += new /obj/item/weapon/gun/energy/secure/gun/mounted(src)
 	src.modules += new /obj/item/taperoll/police(src)
 	src.modules += new /obj/item/device/megaphone(src)
 	src.modules += new /obj/item/device/holowarrant(src)
@@ -438,7 +438,7 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/security/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
-	var/obj/item/weapon/gun/energy/taser/mounted/cyborg/T = locate() in src.modules
+	var/obj/item/weapon/gun/energy/secure/gun/mounted/T = locate() in src.modules
 	if(T && T.power_supply)
 		if(T.power_supply.charge < T.power_supply.maxcharge)
 			T.power_supply.give(T.charge_cost * amount)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_INIT(registered_weapons, list())
+GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 
 /obj/item/weapon/gun/energy
 	name = "energy gun"

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -154,6 +154,21 @@
 		list(mode_name="kill", projectile_type=/obj/item/projectile/beam, modifystate="energykill"),
 		)
 
+/obj/item/weapon/gun/energy/secure/gun/mounted
+	name = "robot energy gun"
+	desc = "A robot-mounted equivalnet of the LAEP90-S, which is always registered to its owner."
+	self_recharge = 1
+	use_external_power = 1
+	one_hand_penalty = 0
+
+/obj/item/weapon/gun/energy/secure/gun/mounted/New()
+	var/mob/borg = get_holder_of_type(src, /mob/living/silicon/robot)
+	if(!borg)
+		CRASH("Invalid spawn location.")
+	registered_owner = borg.name
+	GLOB.registered_cyborg_weapons += src
+	..()
+
 /obj/item/weapon/gun/energy/secure/gun/small
 	name = "small energy gun"
 	desc = "Combining the two LAEP90 variants, the secure and compact LAEP90-CS is the next best thing to keeping your security forces on a literal leash."

--- a/html/changelogs/HeyBanditoz - borg_secure_gun.yml
+++ b/html/changelogs/HeyBanditoz - borg_secure_gun.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes: 
+  - rscadd: "Cyborgs get a secure energy gun (replaced taser rifle) which can be granted lethal mode by a console, or red alert. Silicons cannot set it for eachother, or themselves."

--- a/nano/templates/forceauthorization.tmpl
+++ b/nano/templates/forceauthorization.tmpl
@@ -1,3 +1,4 @@
+<h1>Non-Cyborg Weapons</h1>
 {{for data.guns :value:index}}
     <div>
         {{:value.name}} registered to {{:value.owner}} at ({{:value.loc.x}}, {{:value.loc.y}}, {{:value.loc.z}})<br />
@@ -11,3 +12,19 @@
     </div>
     <br><br>
 {{/for}}
+{{if data.is_silicon_usr == 0}}
+	<h1>Cyborg Weapons</h1>
+	{{for data.cyborg_guns :value:index}}
+		<div>
+			{{:value.name}} registered to {{:value.owner}}<br />
+			{{for value.modes :inner_value:inner_index}}
+				{{if inner_value.authorized == "1"}}
+					{{:helper.link("Unauthorize " + inner_value.mode_name, null, {"cyborg_gun" : value.ref, "mode" : inner_value.index, "authorize" : 0})}}
+				{{else}}
+					{{:helper.link("Authorize " + inner_value.mode_name, null, {"cyborg_gun" : value.ref, "mode" : inner_value.index, "authorize" : 1})}}
+				{{/if}}
+			{{/for}}
+		</div>
+		<br><br>
+	{{/for}}
+{{/if}}


### PR DESCRIPTION
Finally, secborgs are useful again! This PR is not meant to replace #21310 (fat chance I know)

Some notes:
- Borgs cannot set gun status on themselves, or other synthetics (including the AI)
- They will automatically be granted lethal mode on red (like other secure guns)

![Use of Force Program Example](https://banditoz.org/u/FiUVT.png)