### PR TITLE
Job description window

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -103,6 +103,7 @@
 #define close_browser(target, browser_name)                 target << browse(null, browser_name)
 #define show_image(target, image)                           target << image
 #define send_rsc(target, rsc_content, rsc_name)             target << browse_rsc(rsc_content, rsc_name)
+#define open_link(target, url)             target << link(url)
 
 #define MAP_IMAGE_PATH "nano/images/[GLOB.using_map.path]/"
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -233,5 +233,28 @@
 		var/datum/mil_rank/R = T
 		if(B && !(initial(R.name) in B.ranks))
 			continue
-		res += initial(R.name)
+		res |= initial(R.name)
 	return english_list(res)
+
+/datum/job/proc/get_description_blurb()
+	return ""
+
+/datum/job/proc/get_job_icon()
+	if(!job_master.job_icons[title])
+		var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin("#job_icon")
+		dress_mannequin(mannequin)
+		mannequin.dir = SOUTH
+		var/icon/preview_icon = getFlatIcon(mannequin)
+
+		preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+		job_master.job_icons[title] = preview_icon
+
+	return job_master.job_icons[title]
+
+/datum/job/proc/dress_mannequin(var/mob/living/carbon/human/dummy/mannequin/mannequin)
+	mannequin.delete_inventory(TRUE)
+	equip(mannequin)
+	if(mannequin.back)
+		var/obj/O = mannequin.back
+		mannequin.drop_from_inventory(O)
+		qdel(O)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -15,6 +15,8 @@ var/global/datum/controller/occupations/job_master
 	var/list/unassigned = list()
 		//Debug info
 	var/list/job_debug = list()
+		//Cache of icons for job info window
+	var/list/job_icons = list()
 
 	proc/SetupOccupations(var/setup_titles = 0)
 		occupations = list()

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -294,11 +294,10 @@
 		var/datum/job/job = job_master.GetJob(rank)
 		var/dat = list()
 
-		dat += "<body bgcolor='[job.selection_color]'><font color='white'>"
-		dat += "<h2>[capitalize(rank)]</h2>"
+		dat += "<p style='background-color: [job.selection_color]'><br><br><p>"
 		if(job.alt_titles)
 			dat += "<i><b>Alternative titles:</b> [english_list(job.alt_titles)].</i>"
-		user << browse_rsc(job.get_job_icon(), "job[ckey(rank)].png")
+		send_rsc(user, job.get_job_icon(), "job[ckey(rank)].png")
 		dat += "<img src=job[ckey(rank)].png width=96 height=96 style='float:left;'>"
 		if(job.department)
 			dat += "<b>Department:</b> [job.department]."
@@ -318,12 +317,13 @@
 		var/description = job.get_description_blurb()
 		if(description)
 			dat += html_encode(description)
-		close_browser(user, "window=jobinfo;size=430x450")
-		show_browser(user, jointext(dat,"<br>"), "window=jobinfo;size=430x500")
+		var/datum/browser/popup = new(user, "Job Info", "[capitalize(rank)]", 430, 520, src)
+		popup.set_content(jointext(dat,"<br>"))
+		popup.open()
 
 	else if(href_list["job_wiki"])
 		var/rank = href_list["job_wiki"]
-		user << link("[config.wikiurl][rank]")
+		open_link(user,"[config.wikiurl][rank]")
 
 	return ..()
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -303,7 +303,7 @@
 		if(job.department)
 			dat += "<b>Department:</b> [job.department]."
 			if(job.head_position)
-				dat += "You are in charge of this deparmtent."
+				dat += "You are in charge of this department."
 
 		dat += "You answer to <b>[job.supervisors]</b> normally."
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -121,9 +121,8 @@
 		. += "<tr bgcolor='[job.selection_color]'><td width='40%' align='right'>"
 		var/rank = job.title
 		lastJob = job
-
+		. += "<a href='?src=\ref[src];job_info=[rank]'>\[?\]</a>"
 		. += "<a href='?src=\ref[src];set_skills=[rank]'>"
-
 		if(job.total_positions == 0 && job.spawn_positions == 0)
 			. += "<del>[rank]</del></a></td><td><b> \[UNAVAILABLE]</b></td></tr>"
 			continue
@@ -289,6 +288,42 @@
 			var/level_name = S.levels[i]
 			HTML +=	"<br><b>[level_name]</b>: [S.levels[level_name]]<br>"
 		show_browser(user, jointext(HTML, null), "window=\ref[user]skillinfo")
+
+	else if(href_list["job_info"])
+		var/rank = href_list["job_info"]
+		var/datum/job/job = job_master.GetJob(rank)
+		var/dat = list()
+
+		dat += "<body bgcolor='[job.selection_color]'><font color='white'>"
+		dat += "<h2>[capitalize(rank)]</h2>"
+		if(job.alt_titles)
+			dat += "<i><b>Alternative titles:</b> [english_list(job.alt_titles)].</i>"
+		user << browse_rsc(job.get_job_icon(), "job[ckey(rank)].png")
+		dat += "<img src=job[ckey(rank)].png width=96 height=96 style='float:left;'>"
+		if(job.department)
+			dat += "<b>Department:</b> [job.department]."
+			if(job.head_position)
+				dat += "You are in charge of this deparmtent."
+
+		dat += "You answer to <b>[job.supervisors]</b> normally."
+
+		if(job.allowed_branches)
+			dat += "You can be of following ranks:"
+			for(var/T in job.allowed_branches)
+				var/datum/mil_branch/B = mil_branches.get_branch_by_type(T)
+				dat += "<li>[B.name]: [job.get_ranks(B.name)]"
+		dat += "<hr style='clear:left;'>"
+		if(config.wikiurl)
+			dat += "<a href='?src=\ref[src];job_wiki=[rank]'>Open wiki page in browser</a>"
+		var/description = job.get_description_blurb()
+		if(description)
+			dat += html_encode(description)
+		close_browser(user, "window=jobinfo;size=430x450")
+		show_browser(user, jointext(dat,"<br>"), "window=jobinfo;size=430x500")
+
+	else if(href_list["job_wiki"])
+		var/rank = href_list["job_wiki"]
+		user << link("[config.wikiurl][rank]")
 
 	return ..()
 

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -68,6 +68,9 @@
 							 /datum/computer_file/program/card_mod,
 							 /datum/computer_file/program/camera_monitor)
 
+/datum/job/captain/get_description_blurb()
+	return "You are the Commanding Officer. You are the top dog. You are an experienced professional officer in control of an entire ship, and ultimately responsible for all that happens onboard. Your job is to make sure [GLOB.using_map.full_name] fulfils its space exploration mission. Delegate to your Executive Officer, your department heads, and your Senior Enlisted Advisor to effectively manage the ship, and listen to and trust their expertise."
+
 /datum/job/hop
 	title = "Executive Officer"
 	supervisors = "the Commanding Officer"
@@ -116,7 +119,8 @@
 							 /datum/computer_file/program/card_mod,
 							 /datum/computer_file/program/camera_monitor)
 
-
+/datum/job/hop/get_description_blurb()
+	return "You are the Executive Officer. You are an experienced senior officer, second in command of the ship, and are responsible for the smooth operation of the ship under your Commanding Officer. In his absence, you are expected to take his place. Your primary duty is directly managing department heads and all those outside a department heading. You are also responsible for the contractors and passengers aboard the ship. Consider the Senior Enlisted Advisor and Bridge Officers tools at your disposal."
 
 /datum/job/rd
 	title = "Research Director"
@@ -146,6 +150,9 @@
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/aidiag,
 							 /datum/computer_file/program/camera_monitor)
+
+/datum/job/rd/get_description_blurb()
+	return "You are the Research Director. You are responsible for the research department. You handle both the science part of the mission but are also responsible for ensuring Nanotrasen's interests along with your Nanotrasen Liaison. Make sure science gets done, do some yourself, and get your prospectors and scientists on away missions to find things to benefit NT. Don’t put NT’s position on board in jeopardy.  Advise the CO on science matters."
 
 /datum/job/cmo
 	title = "Chief Medical Officer"
@@ -182,6 +189,9 @@
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
+
+/datum/job/cmo/get_description_blurb()
+	return "You are the Chief Medical Officer. You manage the medical department. You ensure all members of medical are skilled, tasked and handling their duties. Ensure your doctors are staffing your infirmary and your corpsman/paramedics are ready for response. Act as a second surgeon or backup chemist in the absence of either. You are expected to know medical very well, along with general regulations."
 
 /datum/job/chief_engineer
 	title = "Chief Engineer"
@@ -230,6 +240,9 @@
 							 /datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/shields_monitor)
 
+/datum/job/chief_engineer/get_description_blurb()
+	return "You are the Chief Engineer. You manage the Engineering Department. You are responsible for the Senior engineer, who is your right hand and (should be) an experienced, skilled engineer. Delegate to and listen to them. Manage your engineers, ensure vessel power stays on, breaches are patched and problems are fixed. Advise the CO on engineering matters. You are also responsible for the maintenance and control of any vessel synthetics. You are an experienced engineer with a wealth of theoretical knowledge. You should also know vessel regulations to a reasonable degree."
+
 /datum/job/hos
 	title = "Chief of Security"
 	supervisors = "the Commanding Officer and the Executive Officer"
@@ -265,6 +278,9 @@
 							 /datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
 
+/datum/job/hos/get_description_blurb()
+	return "You are the Chief of Security. You manage ship security. The Masters at Arms and the Military Police, as well as the Brig Officer and the Forensic Technician. You keep the vessel safe. You handle both internal and external security matters. You are the law. You are subordinate to the CO and the XO. You are expected to know the SCMJ and Sol law and Alert Procedure to a very high degree along with general regulations."
+
 /datum/job/liaison
 	title = "NanoTrasen Liaison"
 	department = "Support"
@@ -292,6 +308,9 @@
 						access_xenoarch, access_nanotrasen, access_sec_guard,
 						access_hangar, access_petrov, access_petrov_helm)
 
+/datum/job/liaison/get_description_blurb()
+	return "You are the Nanotrasen Liaison. You are a civilian employee of Nanotrasen assigned to the vessel to promote, protect and ensure the interests of the corporation on board. You are not internal affairs. You assume command of the Research Department in the absence of the RD and the Senior Researcher. You advise the RD on NT matters and try to push NT interests on the CO. Maximise profit. Be the rich corporate lawyer you always wanted to be."
+
 /datum/job/representative
 	title = "SolGov Representative"
 	department = "Support"
@@ -316,6 +335,8 @@
 	access = list(access_representative, access_security,access_medical, access_engine,
 			            access_heads, access_cargo, access_solgov_crew, access_hangar)
 
+/datum/job/representative/get_description_blurb()
+	return "You are the Sol Gov Representative. You are a civilian assigned as both a diplomatic liaison for first contact and foreign affair situations on board. You are also responsible for monitoring for any serious missteps of justice, sol law or other ethical or legal issues aboard and informing and advising the Commanding Officer of them. You are a mid-level bureaucrat. You liaise between the crew and Nanotrasen interests on board. Send faxes back to Sol on mission progress and important events."
 
 /datum/job/sea
 	title = "Senior Enlisted Advisor"
@@ -351,6 +372,9 @@
 			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_emergency_armory)
 
 	software_on_spawn = list(/datum/computer_file/program/camera_monitor)
+
+/datum/job/sea/get_description_blurb()
+	return "You are the Senior Enlisted Advisor. You are the highest enlisted person on the ship. You are directly subordinate to the CO. You advise them on enlisted concerns and provide expertise and advice to officers. You are responsible for ensuring discipline and good conduct among enlisted, as well as notifying officers of any issues and “advising” them on mistakes they make. You also handle various duties on behalf of the CO and XO. You are an experienced enlisted person, very likely equal only in experience to the CO and XO. You know the regulations better than anyone."
 
 /datum/job/bridgeofficer
 	title = "Bridge Officer"
@@ -392,6 +416,9 @@
 							 /datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/shields_monitor)
 
+/datum/job/bridgeofficer/get_description_blurb()
+	return "You are a Bridge Officer. You are a very junior officer. You do not give orders of your own. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take the Torch's helm and pilot the Aquila if needed. You monitor bridge computer programs and communications and report relevant information to command."
+
 /datum/job/pathfinder
 	title = "Pathfinder"
 	department = "Exploration"
@@ -419,6 +446,9 @@
 
 	access = list(access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_cent_creed)
 
+/datum/job/pathfinder/get_description_blurb()
+	return "You are the Pathfinder. Your duty is to organize and lead the expeditions to away sites, carrying out the EC’s Primary Mission. You command Explorers. You make sure that expedition has the supplies and personnel it needs. You can pilot Charon if NT doesn’t provide their pilot. Once on the away mission, your duty is to ensure that anything of scientific interest is brought back to the ship and passed to the relevant research lab."
+
 /datum/job/explorer
 	title = "Explorer"
 	department = "Exploration"
@@ -439,6 +469,9 @@
 	min_skill = list(	/decl/hierarchy/skill/general/EVA			= SKILL_BASIC)
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_cent_creed)
+
+/datum/job/explorer/get_description_blurb()
+	return "You are an Explorer. Your duty is to go on expeditions to away sites. The Pathfinder is your team leader. You are to look for anything of economic or scientific interest to the SCG - mineral deposits, alien flora/fauna, artifacts. You will also likely encounter hazardous environments, aggressive wildlife or malfunctioning defense systems, so tread carefully."
 
 /datum/job/senior_engineer
 	title = "Senior Engineer"
@@ -485,6 +518,9 @@
 							 /datum/computer_file/program/rcon_console,
 							 /datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/shields_monitor)
+
+/datum/job/senior_engineer/get_description_blurb()
+	return "You are the Senior Engineer. You are a veteran SNCO. You are subordinate to the Chief Engineer though you may have many years more experience than them and your subordinates are the rest of engineering. You should be an expert in practically every engineering area and familiar and possess leadership skills. Coordinate the team and ensure the smooth running of the department along with the Chief Engineer."
 
 /datum/job/engineer
 	title = "Engineer"
@@ -535,6 +571,9 @@
 							 /datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/shields_monitor)
 
+/datum/job/engineer/get_description_blurb()
+	return "You are an Engineer. You operate under one of many titles and may be highly specialised in a specific area of engineering. You probably have at least a general familiarity with most other areas though this is not expected. You are subordinate to the Senior Engineer and the Chief Engineer and are expected to follow them."
+
 /datum/job/engineer_contractor
 	title = "Engineering Contractor"
 	department = "Engineering"
@@ -575,6 +614,9 @@
 							 /datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/shields_monitor)
 
+/datum/job/engineer_contractor/get_description_blurb()
+	return "You are an Engineering Contractor. Hired for either general maintenance duties or because of your specialist training and knowledge in a specific area of engineering you are either highly skilled or intermediate in your knowledge of engineering tasks related to your profession. You are subordinate to the rest of the engineering team."
+
 /datum/job/roboticist
 	title = "Roboticist"
 	department = "Engineering"
@@ -598,6 +640,8 @@
 	access = list(access_robotics, access_robotics_engineering, access_tech_storage, access_morgue, access_medical, access_robotics_engineering, access_solgov_crew)
 	minimal_access = list()
 
+/datum/job/roboticist/get_description_blurb()
+	return "You are the Roboticist. You are responsible for repairing, upgrading and handling ship synthetics as well as the repair of all synthetic crew on board. You are also responsible for placing brains into MMI’s and giving them bodies and the production of exosuits(mechs) for various departments. You answer to the Chief Engineer."
 
 /datum/job/warden
 	title = "Brig Officer"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 12 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 46 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 643 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 644 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 34 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
Press button it gives popup.
Most info is generated based on job's vars, e.g. department, if oyu're head or not.
Wiki article link is generated using the job's title and config defined wiki address.
Can also set job description blurb to be displayed, only few jobs got them currently.

Looks like this in action

![](https://i.imgur.com/V3Nq3QO.png)
