### PR TITLE
Make bullet penetration utilize extensions

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -225,6 +225,7 @@
 #include "code\datums\extensions\extensions.dm"
 #include "code\datums\extensions\interactive.dm"
 #include "code\datums\extensions\label.dm"
+#include "code\datums\extensions\penetration.dm"
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\base_icon_state.dm"
 #include "code\datums\extensions\appearance\cardborg.dm"

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -1,4 +1,5 @@
 /datum/extension/labels
+	expected_type = /atom
 	var/atom/atom_holder
 	var/list/labels
 

--- a/code/datums/extensions/penetration.dm
+++ b/code/datums/extensions/penetration.dm
@@ -1,0 +1,28 @@
+/datum/extension/penetration
+	expected_type = /atom
+
+// Returns a value between 0 and 100
+/datum/extension/penetration/proc/PenetrationProbability(var/base_probability, var/damage, var/damage_type)
+	return 100
+
+
+/datum/extension/penetration/simple
+	var/static_probability
+
+/datum/extension/penetration/simple/New(host, static_probability)
+	..()
+	src.static_probability = static_probability
+
+/datum/extension/penetration/simple/PenetrationProbability()
+	return static_probability
+
+
+/datum/extension/penetration/proc_call
+	var/proc_call
+
+/datum/extension/penetration/proc_call/New(host, proc_call)
+	..()
+	src.proc_call = proc_call
+
+/datum/extension/penetration/proc_call/PenetrationProbability(var/base_probability, var/damage, var/damage_type)
+	return call(holder, proc_call)(base_probability, damage, damage_type)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -68,7 +68,10 @@
 	update_icon()
 
 	update_nearby_tiles(need_rebuild=1)
-	return
+
+/obj/machinery/door/Initialize()
+	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
+	. = ..()
 
 /obj/machinery/door/Destroy()
 	set_density(0)
@@ -458,6 +461,11 @@
 	if(.)
 		deconstruct(null, TRUE)
 
+/obj/machinery/door/proc/CheckPenetration(var/base_chance, var/damage)
+	. = damage/maxhealth*180
+	if(glass)
+		. *= 2
+	. = round(.)
 
 /obj/machinery/door/proc/deconstruct(mob/user, var/moved = FALSE)
 	return null

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -11,6 +11,10 @@
 	var/material/reinf_material
 	var/reinforcing = 0
 
+/obj/structure/girder/Initialize()
+	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/simple, 100)
+	. = ..()
+
 /obj/structure/girder/displaced
 	icon_state = "displaced"
 	anchored = 0

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -35,6 +35,10 @@
 	hitsound = material.hitsound
 	processing_turfs |= src
 
+/turf/simulated/wall/Initialize()
+	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
+	. = ..()
+
 /turf/simulated/wall/Destroy()
 	processing_turfs -= src
 	dismantle_wall(null,null,1)
@@ -268,3 +272,6 @@
 
 /turf/simulated/wall/get_color()
 	return paint_color
+
+/turf/simulated/wall/proc/CheckPenetration(var/base_chance, var/damage)
+	return round(damage/material.integrity*180)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -35,7 +35,7 @@
 	return ..()
 
 /obj/item/projectile/bullet/check_penetrate(var/atom/A)
-	if(!A || !A.density) return 1 //if whatever it was got destroyed when we hit it, then I guess we can just keep going
+	if(QDELETED(A) || !A.density) return 1 //if whatever it was got destroyed when we hit it, then I guess we can just keep going
 
 	if(istype(A, /obj/mecha))
 		return 1 //mecha have their own penetration handling
@@ -46,15 +46,9 @@
 		return 1
 
 	var/chance = damage
-	if(istype(A, /turf/simulated/wall))
-		var/turf/simulated/wall/W = A
-		chance = round(damage/W.material.integrity*180)
-	else if(istype(A, /obj/machinery/door))
-		var/obj/machinery/door/D = A
-		chance = round(damage/D.maxhealth*180)
-		if(D.glass) chance *= 2
-	else if(istype(A, /obj/structure/girder))
-		chance = 100
+	if(has_extension(A, /datum/extension/penetration))
+		var/datum/extension/penetration/P = get_extension(A, /datum/extension/penetration)
+		chance = P.PenetrationProbability(chance, damage, damage_type)
 
 	if(prob(chance))
 		if(A.opacity)


### PR DESCRIPTION
Any atom can customize penetration probability without istype() checks.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
