### PR TITLE
Sundry Bugfixes - April

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -128,7 +128,7 @@
 	. = ..()
 
 /obj/item/weapon/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
-	if(user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/weapon/handcuffs/cable)))
+	if(istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/weapon/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\
 		"You hear cable being cut.")

--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -79,7 +79,7 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 		mode = href_list["mode"]
 	else
 		var/build_type = text2path(href_list["build"])
-		if(!build_type || !ispath(build_type))
+		if(!build_type || !ispath(build_type) || !(build_type in recipe_list[mode]))
 			return 1
 		var/cost = 1
 		if(ispath(build_type, /obj/item/device/electronic_assembly))

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -24,7 +24,7 @@
 	if(response == "Analyze")
 		if(loaded_item)
 			var/confirm = alert(user, "This will destroy the item inside forever.  Are you sure?","Confirm Analyze","Yes","No")
-			if(confirm == "Yes") //This is pretty copypasta-y
+			if(confirm == "Yes" && !QDELETED(loaded_item)) //This is pretty copypasta-y
 				to_chat(user, "You activate the analyzer's microlaser, analyzing \the [loaded_item] and breaking it down.")
 				flick("portable_analyzer_scan", src)
 				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)


### PR DESCRIPTION
Port of relevant portions of PolarisSS13/Polaris#5047 and VOREStation/VOREStation#3561
- Fixes Runtime in tools.dm: undefined variable var/handcuffed
Must confirm expected type before referencing var declared on /mob/living/carbon
- Fixes Runtime in robot_items.dm: Cannot read null.origin_tech
Must re-check that item hasn't been deleted after the blocking call to confirm()
- Fixes an exploit with circuit printers
Topic hacking could use it to spawn arbitrary types.
