### PR TITLE
Set the guaranteed mining map to the standard asteroid

### DIFF
--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -15,6 +15,8 @@
 		"nav_cluster_7"
 	)
 	known = 0
+	start_x = 4
+	start_y = 5
 
 /datum/map_template/ruin/away_site/mining_asteroid
 	name = "Mining - Asteroid"
@@ -23,6 +25,7 @@
 	suffixes = list("mining/mining-asteroid.dmm")
 	cost = 1
 	accessibility_weight = 10
+	spawn_guaranteed = TRUE
 
 /obj/effect/shuttle_landmark/cluster/nav1
 	name = "Asteroid Navpoint #1"
@@ -124,8 +127,6 @@
 		"nav_orb_7"
 	)
 	known = 0
-	start_x = 4
-	start_y = 5
 
 /datum/map_template/ruin/away_site/orb
 	name = "Mining - Orb"
@@ -134,7 +135,6 @@
 	suffixes = list("mining/mining-orb.dmm")
 	cost = 1
 	accessibility_weight = 10
-	spawn_guaranteed = TRUE
 	base_turf_for_zs = /turf/simulated/floor/asteroid
 
 /obj/effect/shuttle_landmark/orb/nav1


### PR DESCRIPTION
ORB is a bit too special to always be there, what with the bird temple and all. Returns it to its proper place, replaces it with the standard cluster.