### PR TITLE
Add a nullspace test

### DIFF
--- a/code/modules/mob/living/silicon/posi_brainmob.dm
+++ b/code/modules/mob/living/silicon/posi_brainmob.dm
@@ -24,7 +24,7 @@
 		if(stat!=DEAD)	//If not dead.
 			death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
 		ghostize()		//Ghostize checks for key so nothing else is necessary.
-	..()
+	return ..()
 
 /mob/living/silicon/sil_brainmob/update_canmove()
 	if(in_contents_of(/obj/mecha))

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -46,9 +46,8 @@
 		brainmob.add_language("Encoded Audio Language")
 
 /obj/item/organ/internal/posibrain/Destroy()
-	if(brainmob)
-		QDEL_NULL(brainmob)
-	..()
+	QDEL_NULL(brainmob)
+	return ..()
 
 /obj/item/organ/internal/posibrain/attack_self(mob/user as mob)
 	if(brainmob && !brainmob.key && searching == 0)

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -584,3 +584,27 @@ datum/unit_test/species_base_skin/start_test()
 
 	return 1	// return 1 to show we're done and don't want to recheck the result.
 
+
+/datum/unit_test/mob_nullspace
+	name = "MOB: Mob in nullspace shall not cause runtimes"
+	var/list/test_subjects = list()
+	async = 1
+
+/datum/unit_test/mob_nullspace/start_test()
+	// Simply create one of each species type in nullspace
+	for(var/species_name in all_species)
+		var/test_subject = new/mob/living/carbon/human(null, species_name)
+		test_subjects += test_subject
+	return TRUE
+
+/datum/unit_test/mob_nullspace/check_result()
+	for(var/ts in test_subjects)
+		var/mob/living/carbon/human/H = ts
+		if(H.life_tick < 10)
+			return FALSE
+
+	QDEL_NULL_LIST(test_subjects)
+
+	// No failure state, we just rely on the general runtime check to fail the entire build for us
+	pass("Mob nullspace test concluded.")
+	return TRUE


### PR DESCRIPTION
Dumps one mob of each species into nullspace and awaits the result.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
