### PR TITLE
[WIP] Load a random mining map each round

### DIFF
--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -9,7 +9,7 @@
 	var/list/shuttles_to_initialise = list()
 	var/base_turf_for_zs = null
 	var/accessibility_weight = 0
-	var/spawn_guaranteed = FALSE
+	var/mining = FALSE
 
 /datum/map_template/New(var/list/paths = null, var/rename = null)
 	if(paths && !islist(paths))

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -25,7 +25,7 @@
 	suffixes = list("mining/mining-asteroid.dmm")
 	cost = 1
 	accessibility_weight = 10
-	spawn_guaranteed = TRUE
+	mining = TRUE
 
 /obj/effect/shuttle_landmark/cluster/nav1
 	name = "Asteroid Navpoint #1"
@@ -72,6 +72,8 @@
 		"nav_away_7"
 	)
 	known = 0
+	start_x = 4
+	start_y = 5
 
 /datum/map_template/ruin/away_site/mining_signal
 	name = "Mining - Planetoid"
@@ -80,6 +82,7 @@
 	suffixes = list("mining/mining-signal.dmm")
 	cost = 1
 	base_turf_for_zs = /turf/simulated/floor/asteroid
+	mining = TRUE
 
 /obj/effect/shuttle_landmark/away
 	base_area = /area/mine/explored
@@ -127,6 +130,8 @@
 		"nav_orb_7"
 	)
 	known = 0
+	start_x = 4
+	start_y = 5
 
 /datum/map_template/ruin/away_site/orb
 	name = "Mining - Orb"
@@ -136,6 +141,7 @@
 	cost = 1
 	accessibility_weight = 10
 	base_turf_for_zs = /turf/simulated/floor/asteroid
+	mining = TRUE
 
 /obj/effect/shuttle_landmark/orb/nav1
 	name = "Anchor point A"

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -84,6 +84,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/overmap_size = 20		//Dimensions of overmap zlevel if overmap is used.
 	var/overmap_z = 0		//If 0 will generate overmap zlevel on init. Otherwise will populate the zlevel provided.
 	var/overmap_event_areas = 0 //How many event "clouds" will be generated
+	var/mining_spawned = FALSE //To prevent the loader from spawning two mining areas
 
 	var/lobby_icon									// The icon which contains the lobby image(s)
 	var/list/lobby_screens = list()                 // The list of lobby screen to pick() from. If left unset the first icon state is always selected.
@@ -188,10 +189,16 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for (var/site_name in SSmapping.away_sites_templates)
 		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 
-		if(site.spawn_guaranteed && site.load_new_z()) // no check for budget, but guaranteed means guaranteed
-			report_progress("Loaded guaranteed away site [site]!")
-			away_site_budget -= site.cost
-			continue
+		if(site.mining)
+			if(!mining_spawned) //only do this once
+				if(site.load_new_z()) // no check for budget, but guaranteed means guaranteed
+					report_progress("Loaded mining away site [site]!")
+					away_site_budget -= site.cost
+					mining_spawned = TRUE
+					continue
+			else
+				world << "attempted to load [site.name], but a mining site was already spawned"
+				continue
 
 		sites_by_spawn_weight[site] = site.spawn_weight
 	while (away_site_budget > 0 && sites_by_spawn_weight.len)


### PR DESCRIPTION
Select from the list of sites with `mining` var set instead of relying on one spawn_guaranteed. Mostly works except for the things below.

Kinks I didn't work out tonight:
The Orb is always selected. Need a way to randomise the list of mining maps
Still have to set the x and y manually (and matching the torch's manually set coords)
Make the check cleaner if possible