### PR TITLE
Added 3-ft or more clearance to nearly every APC, as well as fixing a couple mapping issues related to the R-UST.

### DIFF
--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -751,6 +751,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/storage)
 "cc" = (
@@ -844,20 +853,12 @@
 /area/exploration_shuttle/cockpit)
 "cl" = (
 /obj/structure/bed/chair,
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(201)
+/obj/structure/sign/ecplaque{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
@@ -871,8 +872,16 @@
 	icon_state = "tube1";
 	dir = 1
 	},
-/obj/structure/sign/ecplaque{
-	pixel_y = 30
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(201)
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
@@ -1037,14 +1046,10 @@
 /obj/machinery/mining/brace{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/storage)
@@ -1148,25 +1153,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
-"cT" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/exploration_shuttle/crew)
 "cU" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -1565,15 +1551,20 @@
 "dH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
 /obj/structure/table/rack,
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
 "dI" = (
@@ -1778,6 +1769,11 @@
 /area/quartermaster/exploration)
 "eg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
 "eh" = (
@@ -2328,6 +2324,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
 "fc" = (
@@ -2795,14 +2796,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
@@ -4685,11 +4686,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "jG" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -5198,11 +5194,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "kG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/border_only,
@@ -5676,19 +5667,23 @@
 "lD" = (
 /obj/machinery/mineral/mint,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal_mint"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "lE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -5698,12 +5693,22 @@
 	dir = 4;
 	icon_state = "intact"
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "lG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
 	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -5713,12 +5718,22 @@
 	dir = 4;
 	icon_state = "intact"
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "lI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
 	icon_state = "map"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -5728,8 +5743,8 @@
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -6263,10 +6278,17 @@
 /area/security/checkpoint2)
 "mA" = (
 /obj/structure/table/rack,
-/obj/machinery/alarm{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
 "mB" = (
@@ -6438,15 +6460,15 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "mS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "mT" = (
@@ -6467,11 +6489,6 @@
 /area/maintenance/fourthdeck/aft)
 "mW" = (
 /obj/random/junk,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "mX" = (
@@ -6895,6 +6912,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
 "nH" = (
@@ -7113,17 +7135,10 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/cell_charger,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
 	},
 /obj/structure/handrai,
 /turf/simulated/floor/plating,
@@ -7147,18 +7162,15 @@
 	name = "mining conveyor"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/quartermaster/hangar)
-"od" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"oe" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
+"od" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "of" = (
@@ -7484,15 +7496,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
 "oR" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
@@ -7503,6 +7506,16 @@
 	id = "dockcheck_windows";
 	pixel_x = 38;
 	pixel_y = -24
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
@@ -7791,9 +7804,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/cyan{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
@@ -7804,10 +7817,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
@@ -7822,6 +7835,10 @@
 /obj/structure/cable/cyan{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
@@ -7872,6 +7889,11 @@
 	dir = 4
 	},
 /obj/machinery/mineral/input,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/hangar)
 "pu" = (
@@ -7895,17 +7917,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"px" = (
-/obj/random/closet,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
 "py" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -8397,12 +8408,9 @@
 /area/exploration_shuttle/cargo)
 "qx" = (
 /obj/machinery/floodlight,
-/obj/structure/cable/cyan,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
@@ -8420,15 +8428,6 @@
 /obj/item/weapon/module/power_control,
 /obj/random/powercell,
 /obj/random/toolbox,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/handrai{
 	icon_state = "handrail";
 	dir = 8
@@ -8437,25 +8436,22 @@
 	icon_state = "camera";
 	dir = 1
 	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "qz" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
-"qA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "qB" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -8464,11 +8460,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "qC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -8477,15 +8468,12 @@
 	req_one_access = list(12,73)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"qD" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall/hull,
+/turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "qE" = (
 /obj/machinery/suit_storage_unit/science,
@@ -8891,11 +8879,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "rx" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(201)
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
@@ -8985,10 +8981,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"rG" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "rH" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -9020,11 +9012,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "rL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -9036,6 +9023,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "rM" = (
@@ -9066,11 +9058,6 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -22
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/oxygen_pump{
 	pixel_y = 32
@@ -10123,30 +10110,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "tl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/valve/shutoff{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"tm" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aft)
+"tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10156,28 +10138,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "tn" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -10197,6 +10179,11 @@
 	dir = 4;
 	icon_state = "intact"
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/fourthdeck/aft)
 "tp" = (
@@ -10209,6 +10196,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
 	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/fourthdeck/aft)
@@ -10233,6 +10225,11 @@
 	tag_exterior_door = "petrov_shuttle_dock_outer";
 	tag_interior_door = "petrov_shuttle_dock_inner"
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/fourthdeck/aft)
 "tr" = (
@@ -10254,6 +10251,11 @@
 	name = "Docking Port Airlock";
 	req_access = list(13)
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "ts" = (
@@ -10266,12 +10268,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "tt" = (
@@ -10674,6 +10676,15 @@
 	c_tag = "Fourth Deck Hallway - Tool Storage";
 	dir = 4
 	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "tZ" = (
@@ -10681,6 +10692,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "ua" = (
@@ -11032,20 +11048,25 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "uO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	icon_state = "bulb1";
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -11383,24 +11404,15 @@
 	pixel_y = 0
 	},
 /obj/item/device/paicard,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -14169,6 +14181,10 @@
 "Af" = (
 /obj/machinery/mineral/input,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
 /turf/simulated/floor,
 /area/quartermaster/hangar)
 "Ag" = (
@@ -14929,6 +14945,10 @@
 "Bp" = (
 /obj/machinery/mineral/processing_unit,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
 /turf/simulated/floor,
 /area/quartermaster/hangar)
 "Bq" = (
@@ -16363,6 +16383,10 @@
 "Eu" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_internal"
+	},
 /turf/simulated/floor,
 /area/quartermaster/hangar)
 "Ev" = (
@@ -18445,6 +18469,16 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"IF" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "IG" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -18774,18 +18808,8 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/shuttlefuel)
 "Jy" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/quartermaster/shuttlefuel)
 "Jz" = (
@@ -18944,34 +18968,29 @@
 /area/quartermaster/shuttlefuel)
 "JQ" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/quartermaster/shuttlefuel)
+"JR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/shuttlefuel)
-"JR" = (
-/obj/machinery/door/airlock/glass_mining{
-	id_tag = null;
-	name = "Shuttle Fuel Bay Interior";
-	req_access = list(31)
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /turf/simulated/floor/tiled,
 /area/quartermaster/shuttlefuel)
 "JS" = (
@@ -19107,8 +19126,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	layer = 2.4;
+	level = 2
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/shuttlefuel)
@@ -19196,25 +19217,62 @@
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/center)
+"LG" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "MA" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/item/device/radio/intercom{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
+"MG" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "MH" = (
 /turf/simulated/wall/r_wall/hull,
 /area/quartermaster/expedition/storage)
+"MY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/exploration)
+"No" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/exploration)
 "Nq" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/tiled,
@@ -19226,6 +19284,14 @@
 "NB" = (
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
+"NE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/exploration)
 "NF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19248,6 +19314,35 @@
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/mess)
+"NX" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/shuttlefuel)
+"Oh" = (
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
 "OZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19286,6 +19381,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
+"Rr" = (
+/obj/machinery/mineral/input,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/conveyor{
+	icon_state = "conveyor0";
+	dir = 5;
+	id = "mining_internal_mint"
+	},
+/turf/simulated/floor,
+/area/quartermaster/hangar)
 "RJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19308,6 +19413,25 @@
 "RQ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/storage/auxillary/starboard)
+"Sd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/exploration_shuttle/crew)
 "Sm" = (
 /obj/machinery/mining/brace{
 	dir = 8
@@ -19322,9 +19446,64 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/storage)
+"SI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "Ty" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/infirmary)
+"TB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"UC" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"UD" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "Vr" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/aft)
@@ -19335,10 +19514,46 @@
 "Wh" = (
 /turf/simulated/wall/r_wall/hull,
 /area/quartermaster/office)
+"Ww" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "WB" = (
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/aft)
+"WC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"WI" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "WT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -19350,6 +19565,39 @@
 "WZ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/fore)
+"XJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
+"XL" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"XT" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/exploration)
 "XZ" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -19357,9 +19605,65 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/quartermaster/office)
+"Yg" = (
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/shuttlefuel)
+"Ym" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
+"YS" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"Zs" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "ZG" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/center)
+"ZP" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 
 (1,1,1) = {"
 aa
@@ -36019,7 +36323,7 @@ aq
 ko
 lk
 mA
-nF
+Yw
 oQ
 qi
 rq
@@ -37235,7 +37539,7 @@ nJ
 oT
 kq
 MA
-RJ
+sR
 uw
 vS
 wY
@@ -37841,7 +38145,7 @@ mG
 oW
 kq
 rx
-sR
+RJ
 uu
 vQ
 xb
@@ -39647,7 +39951,7 @@ cO
 dv
 ea
 by
-by
+UC
 gA
 hx
 ir
@@ -39849,7 +40153,7 @@ bz
 bi
 bi
 bi
-bi
+ZP
 bi
 bi
 bi
@@ -40051,7 +40355,7 @@ bA
 bA
 bA
 bA
-bA
+WC
 bA
 bA
 bA
@@ -41259,7 +41563,7 @@ aE
 bd
 bE
 cl
-cT
+cU
 dz
 bE
 eP
@@ -41461,7 +41765,7 @@ aE
 bd
 bE
 cm
-cU
+Sd
 dA
 bE
 eQ
@@ -42876,10 +43180,10 @@ bi
 bz
 bz
 bz
-bi
-bi
-bi
-bi
+IF
+SI
+SI
+Ww
 bi
 bi
 bi
@@ -43078,10 +43382,10 @@ bi
 bi
 bi
 bi
-bi
+YS
 bi
 aZ
-fO
+MG
 fO
 hC
 iD
@@ -43091,8 +43395,8 @@ iD
 iD
 iD
 ps
-qA
-rG
+eJ
+bi
 th
 uJ
 wg
@@ -43280,22 +43584,22 @@ bj
 bI
 bj
 bj
-bj
+WI
 bj
 eW
-bi
-gK
-bd
-iE
-jD
-kD
-kD
-kD
+UD
+XL
+Zs
+Oh
+Ym
+XJ
+XJ
+XJ
 oc
 pt
-qB
-bi
-ti
+LG
+SI
+TB
 bi
 wh
 xp
@@ -43482,7 +43786,7 @@ bk
 aJ
 cq
 cq
-dF
+No
 dF
 eX
 dF
@@ -43684,7 +43988,7 @@ bl
 bJ
 cq
 da
-dG
+MY
 ed
 eY
 fP
@@ -43886,7 +44190,7 @@ bm
 bl
 cq
 db
-dG
+MY
 ee
 eZ
 dG
@@ -43919,9 +44223,9 @@ HK
 Il
 IC
 Je
-Jx
+NX
 JR
-Jx
+Yg
 Vr
 Vr
 Vr
@@ -44088,7 +44392,7 @@ Vr
 bK
 cq
 dc
-dG
+MY
 ef
 fa
 dG
@@ -44112,7 +44416,7 @@ Af
 Bp
 Cy
 yL
-Af
+Rr
 Fk
 FU
 Gw
@@ -44290,10 +44594,10 @@ Vr
 Vr
 cq
 dd
-dG
+XT
 eg
 fb
-dG
+NE
 gM
 ag
 ag
@@ -45513,9 +45817,9 @@ jK
 kH
 lJ
 mW
-oe
-px
-qD
+bl
+aK
+Vr
 rO
 ts
 uR

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -41,7 +41,16 @@
 /turf/simulated/floor/tiled,
 /area/vacant/brig)
 "af" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/vacant/brig)
 "ag" = (
@@ -66,8 +75,15 @@
 	},
 /obj/structure/closet/secure_closet/hydroponics_torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light_switch{
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
 	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
@@ -171,6 +187,11 @@
 /obj/machinery/door/airlock/security{
 	name = "Secure Brig Interior Airlock"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aF" = (
@@ -199,26 +220,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/vacant/brig)
-"aK" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/vacant/brig)
-"aL" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
 /area/vacant/brig)
 "aM" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -498,14 +499,9 @@
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
@@ -748,12 +744,26 @@
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/storage)
 "bX" = (
 /obj/item/weapon/stock_parts/subspace/transmitter,
 /obj/item/weapon/stock_parts/subspace/transmitter,
 /obj/structure/table/rack,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/storage)
 "bY" = (
@@ -773,15 +783,6 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
 "cc" = (
@@ -796,30 +797,27 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
 "ce" = (
-/obj/machinery/power/apc{
+/obj/machinery/firealarm{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/green{
-	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "cf" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "cg" = (
@@ -1086,11 +1084,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
 "cN" = (
@@ -1125,6 +1118,11 @@
 	},
 /obj/effect/floor_decal/corner/green{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
@@ -1465,18 +1463,6 @@
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/lower)
-"dt" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tcommsat/storage)
 "du" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/plating,
@@ -1529,6 +1515,9 @@
 /obj/machinery/seed_extractor,
 /obj/effect/floor_decal/corner/green{
 	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
@@ -2158,6 +2147,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "fa" = (
@@ -2323,6 +2316,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
+"fz" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/starboard)
 "fA" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -2587,19 +2595,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"fT" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
 "fU" = (
 /obj/item/modular_computer/console/preset/civilian,
 /turf/simulated/floor/tiled,
@@ -2682,16 +2677,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/chamber)
 "ge" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = -22
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/storage)
@@ -2730,6 +2725,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "gh" = (
@@ -2743,6 +2741,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
@@ -3001,11 +3003,6 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "gL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -3398,11 +3395,6 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "hH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -3712,11 +3704,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3745,6 +3732,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
@@ -3924,11 +3916,6 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "iy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/device/radio/beacon,
@@ -4179,11 +4166,9 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/closet/shipping_wall/filled{
+	pixel_x = 0;
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
@@ -4234,6 +4219,16 @@
 /obj/item/weapon/stool/padded,
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Mess Hall - Center"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
@@ -4315,11 +4310,6 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "jo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -4360,6 +4350,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "js" = (
@@ -4828,11 +4821,25 @@
 	},
 /obj/item/device/radio/headset,
 /obj/item/weapon/book/manual/military_law,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "kh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -4846,6 +4853,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "kj" = (
@@ -4855,16 +4867,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "kk" = (
 /obj/machinery/vending/wallmed1{
 	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -4875,6 +4887,11 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "kl" = (
@@ -4975,6 +4992,13 @@
 "ks" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/button/remote/airlock{
+	id = "civsafedoor";
+	name = "safe room door-control";
+	pixel_x = 32;
+	req_access = list(19);
+	specialfunctions = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/thirddeck)
 "kt" = (
@@ -5116,16 +5140,6 @@
 "kL" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/bar)
-"kM" = (
-/obj/machinery/button/remote/airlock{
-	id = "civsafedoor";
-	name = "safe room door-control";
-	pixel_x = 32;
-	req_access = list(19);
-	specialfunctions = 4
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/safe_room/thirddeck)
 "kN" = (
 /obj/machinery/requests_console{
 	announcementConsole = 0;
@@ -5289,6 +5303,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "lh" = (
@@ -5300,10 +5315,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "li" = (
@@ -5540,18 +5552,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "lP" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
@@ -5970,6 +5993,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "mC" = (
@@ -5999,11 +6027,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/item/device/radio/intercom/department/security{
 	dir = 4;
 	pixel_x = -22
@@ -6016,15 +6039,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
@@ -6290,9 +6304,14 @@
 /obj/item/weapon/storage/mirror{
 	pixel_x = 28
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
@@ -6533,16 +6552,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "nE" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -6559,6 +6578,11 @@
 /obj/item/device/flashlight/flare,
 /obj/item/device/flashlight/flare,
 /obj/item/device/flashlight/flare,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "nG" = (
@@ -6574,6 +6598,11 @@
 /obj/item/weapon/airlock_brace,
 /obj/item/weapon/airlock_brace,
 /obj/item/weapon/crowbar/brace_jack,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "nH" = (
@@ -6587,6 +6616,15 @@
 /obj/item/weapon/storage/box/flashbangs{
 	pixel_x = -2;
 	pixel_y = -2
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -6957,6 +6995,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/lower)
+"op" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/detectives_office)
 "or" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -7014,15 +7060,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"oz" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
 "oA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -7981,15 +8018,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "qo" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -9947,36 +9975,6 @@
 	pixel_x = -3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"th" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"ti" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "tj" = (
@@ -10730,6 +10728,16 @@
 "uE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/bed/chair,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'";
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "uF" = (
@@ -11129,6 +11137,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "vA" = (
@@ -11146,6 +11159,11 @@
 	name = "E.V.A. Miscellaneous Suit Storage";
 	req_one_access = list(18)
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "vB" = (
@@ -11157,6 +11175,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
@@ -11171,6 +11194,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
@@ -11234,13 +11262,9 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
@@ -11665,6 +11689,15 @@
 	c_tag = "EVA - Miscellaneous Suit Storage";
 	dir = 8
 	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "wH" = (
@@ -11959,6 +11992,11 @@
 "xk" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
 "xl" = (
@@ -12140,10 +12178,12 @@
 	dir = 10;
 	icon_state = "intact"
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "xG" = (
@@ -12384,18 +12424,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "ye" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -12404,24 +12439,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"yg" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "yh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "yi" = (
@@ -12805,20 +12826,20 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "zd" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
 	},
 /obj/machinery/light/small,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "ze" = (
@@ -13167,11 +13188,6 @@
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "Ae" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13370,6 +13386,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "AD" = (
@@ -13497,6 +13522,15 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "AQ" = (
@@ -13577,8 +13611,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
@@ -13713,13 +13752,9 @@
 /area/maintenance/thirddeck/foreport)
 "Bs" = (
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
@@ -13925,22 +13960,13 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "BO" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "BP" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
@@ -14352,9 +14378,9 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
@@ -14376,6 +14402,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "CK" = (
@@ -14582,14 +14614,9 @@
 /area/vacant/cabin)
 "Do" = (
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
@@ -14619,6 +14646,17 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
+"Dx" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "DA" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -14681,6 +14719,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
+"DH" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/cryolocker)
 "DI" = (
 /obj/structure/table/standard,
 /obj/random/single{
@@ -14866,11 +14917,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/closet/crate/trashcart,
 /obj/random/junk,
 /obj/random/junk,
@@ -14879,15 +14925,14 @@
 "DY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
@@ -15535,10 +15580,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
 "FV" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -15564,6 +15605,19 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
+"Ga" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/missile)
 "Gb" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -15594,8 +15648,15 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/lounge)
 "Gf" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
@@ -15954,6 +16015,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
+"Ha" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "Hb" = (
 /obj/structure/bed/chair/comfy/beige,
 /turf/simulated/floor/carpet,
@@ -16181,8 +16250,8 @@
 "HN" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/vacant/missile)
@@ -16194,10 +16263,6 @@
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/vacant/missile)
@@ -16516,6 +16581,11 @@
 /area/vacant/missile)
 "ID" = (
 /obj/random_multi/single_item/punitelly,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/vacant/brig)
 "IE" = (
@@ -17139,6 +17209,11 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "JP" = (
@@ -17792,25 +17867,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/range)
-"Lk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
 "Ll" = (
 /obj/machinery/atmospherics/valve/digital{
 	frequency = 1447;
@@ -17917,12 +17973,11 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "LE" = (
@@ -17933,6 +17988,18 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
+"LG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
 "LN" = (
 /obj/effect/shuttle_landmark/skipjack/deck3,
 /turf/space,
@@ -18195,6 +18262,14 @@
 /obj/item/weapon/aiModule/solgov,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload)
+"MB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/brig)
 "MC" = (
 /obj/structure/table/marble,
 /obj/machinery/cooker/candy,
@@ -18209,6 +18284,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
+"MK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/lounge)
+"MN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
 "MT" = (
 /obj/machinery/cooker/fryer,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -18397,6 +18494,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
+"NB" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/brig)
 "Ob" = (
 /obj/effect/shuttle_landmark/torch/deck2/aquila,
 /turf/space,
@@ -18498,6 +18603,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Ol" = (
@@ -18542,6 +18652,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d3port)
+"OG" = (
+/obj/structure/door_assembly/door_assembly_sec,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/vacant/brig)
 "OH" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -18561,6 +18680,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
+"OR" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/galley)
 "OS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
@@ -18915,6 +19045,20 @@
 "Qq" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/missile)
+"Qs" = (
+/obj/machinery/door/airlock/highsecurity{
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Missile Pod Interior Airlock";
+	req_access = list(87)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/missile)
 "QX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/cable/green{
@@ -19205,7 +19349,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/recharge_station,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
 "Sk" = (
@@ -19251,6 +19395,14 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"Su" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/brig)
 "Sv" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -19274,6 +19426,16 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
+"SC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tcommsat/storage)
 "SI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19484,6 +19646,14 @@
 /obj/item/weapon/crowbar,
 /turf/simulated/floor/tiled,
 /area/security/equipment)
+"Tu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/vacant/brig)
 "Tx" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -19510,12 +19680,19 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
-/obj/structure/closet/shipping_wall/filled{
-	pixel_x = -24
-	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Mess Hall - Galley";
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'";
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
@@ -19622,18 +19799,11 @@
 	icon_state = "spline_fancy";
 	dir = 10
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 38
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
@@ -19741,6 +19911,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
+"UM" = (
+/obj/random/trash,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/vacant/brig)
 "UR" = (
 /obj/machinery/sparker{
 	id = "engines";
@@ -19890,6 +20069,15 @@
 /obj/structure/table/standard,
 /obj/item/weapon/material/minihoe,
 /obj/item/weapon/material/hatchet,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "Vn" = (
@@ -19923,6 +20111,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
+"VD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
 "VT" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -20270,6 +20473,15 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
+"XG" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/vacant/missile)
 "XS" = (
 /obj/random/closet,
 /obj/effect/landmark/start{
@@ -20437,6 +20649,14 @@
 /obj/machinery/atmospherics/valve/shutoff,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
+"Yq" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/brig)
 "Yx" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder{
@@ -20673,6 +20893,17 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
+"ZG" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/galley)
 "ZH" = (
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/lower)
@@ -30296,9 +30527,9 @@ oH
 pB
 qA
 rN
-th
+qA
 ut
-oH
+MN
 nM
 Mo
 yI
@@ -30498,7 +30729,7 @@ oI
 pC
 qB
 rO
-ti
+qB
 uu
 vC
 wH
@@ -31288,7 +31519,7 @@ EJ
 EJ
 bn
 bW
-bW
+SC
 ge
 eo
 fa
@@ -31491,7 +31722,7 @@ EJ
 bo
 bX
 cC
-dt
+cB
 en
 fb
 gj
@@ -34344,7 +34575,7 @@ xN
 Bm
 Bm
 Bm
-kM
+Bm
 CW
 CW
 lG
@@ -36342,8 +36573,8 @@ cN
 DA
 ey
 Nv
-fp
-fp
+OR
+ZG
 il
 ZB
 Vi
@@ -37182,7 +37413,7 @@ uO
 FW
 Gz
 GZ
-Hp
+DH
 zG
 zG
 zG
@@ -37548,7 +37779,7 @@ aa
 aI
 be
 Tm
-cg
+Ha
 cf
 cR
 dH
@@ -37786,7 +38017,7 @@ Gc
 Gc
 Ew
 Uj
-Lk
+GD
 Hb
 Sk
 HB
@@ -38380,7 +38611,7 @@ tI
 uO
 vV
 vV
-yg
+Gc
 yZ
 vV
 vV
@@ -38583,7 +38814,7 @@ uO
 Cj
 yk
 yh
-za
+LG
 zV
 AE
 Bw
@@ -38769,7 +39000,7 @@ ZK
 Aq
 UB
 Lz
-jc
+Dx
 Tx
 zC
 lB
@@ -39400,7 +39631,7 @@ yp
 CE
 Ex
 Gf
-Oj
+MK
 xk
 Ok
 Hb
@@ -40970,11 +41201,11 @@ aa
 aa
 ad
 af
-ag
-ag
-ae
-ae
-ag
+Su
+Su
+Tu
+Tu
+MB
 ae
 ad
 aa
@@ -41176,7 +41407,7 @@ ae
 ae
 ag
 av
-az
+OG
 av
 ad
 ad
@@ -41378,7 +41609,7 @@ ak
 ap
 au
 ax
-ag
+Yq
 aC
 ad
 aG
@@ -41782,11 +42013,11 @@ ae
 ag
 av
 ag
-ag
-al
+NB
+UM
 aE
-ae
-aK
+Tu
+Tu
 aS
 aZ
 aZ
@@ -41833,10 +42064,10 @@ Hy
 HF
 HK
 HN
-HM
-HS
-HV
-HM
+HN
+Qs
+Ga
+XG
 HH
 Ir
 HH
@@ -41988,7 +42219,7 @@ aA
 ag
 aF
 aH
-aL
+ag
 ad
 ba
 aY
@@ -42403,7 +42634,7 @@ df
 df
 fN
 cl
-ba
+fz
 cS
 aY
 aY
@@ -43433,7 +43664,7 @@ xo
 Xo
 Xo
 wK
-yr
+op
 AQ
 vh
 Ak
@@ -43635,7 +43866,7 @@ xu
 ys
 Xo
 SK
-yr
+op
 Uw
 vh
 CG
@@ -43820,7 +44051,7 @@ gK
 hG
 ix
 jn
-gK
+VD
 la
 Zg
 Nl
@@ -44017,7 +44248,7 @@ cn
 cn
 cn
 cn
-fT
+jm
 gL
 hH
 iy
@@ -45845,7 +46076,7 @@ li
 lR
 mH
 nE
-oz
+mI
 pv
 qr
 rw

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -530,6 +530,7 @@
 /area/maintenance/seconddeck/central)
 "bg" = (
 /obj/machinery/door/blast/regular{
+	dir = 4;
 	id = "prototype_exhaust"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1057,10 +1058,14 @@
 /area/maintenance/seconddeck/central)
 "cm" = (
 /obj/item/weapon/stool,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -1133,10 +1138,20 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "cu" = (
 /obj/item/weapon/stool,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "cv" = (
@@ -1314,18 +1329,19 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarstarboard)
 "cV" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Solar Control - Starboard";
 	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -1422,13 +1438,9 @@
 /area/maintenance/disposal)
 "df" = (
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -3791,14 +3803,6 @@
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/plating,
-/area/engineering/hardstorage)
-"hW" = (
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "south bump";
@@ -3808,7 +3812,20 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/turf/simulated/floor/plating,
+/area/engineering/hardstorage)
+"hW" = (
 /obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage)
 "hX" = (
@@ -4871,14 +4888,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "ka" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/bluespace_beacon,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kb" = (
@@ -4919,19 +4936,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
-"kf" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/teleporter/seconddeck)
 "kg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Expedition Storage Maintenance";
@@ -4998,6 +5002,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kn" = (
@@ -5104,6 +5113,11 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "ky" = (
@@ -5155,19 +5169,26 @@
 "kE" = (
 /obj/prefab/hand_teleporter,
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
-/area/teleporter/seconddeck)
-"kF" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = -24
 	},
+/turf/simulated/floor/tiled/dark,
+/area/teleporter/seconddeck)
+"kF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/structure/table/standard,
 /obj/random/tank,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kG" = (
@@ -7094,6 +7115,11 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/seconddeck)
 "pL" = (
@@ -7101,6 +7127,13 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/machinery/power/apc/super{
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/seconddeck)
@@ -7111,12 +7144,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/power/apc/super{
-	pixel_y = 24
-	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/seconddeck)
@@ -7175,6 +7206,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"pQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "pR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -8009,27 +8048,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "rD" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/engineering/drone_fabrication)
-"rE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
@@ -8116,6 +8139,7 @@
 /area/crew_quarters/safe_room/seconddeck)
 "rX" = (
 /obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems.This one has a red sticker on it that gleefully states 'CODE VIOLATION'.";
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
@@ -8350,6 +8374,11 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "sF" = (
@@ -8478,27 +8507,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "sV" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/structure/table/rack{
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - EVA";
 	dir = 8
 	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/dispenser/oxygen,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
@@ -8850,11 +8865,25 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
 "tW" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - EVA";
+/obj/structure/table/rack{
 	dir = 8
 	},
-/obj/structure/dispenser/oxygen,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "tY" = (
@@ -10568,17 +10597,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/incinerator)
-"yX" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/maintenance/incinerator)
-"yY" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -10588,6 +10606,17 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/incinerator)
+"yX" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/incinerator)
+"yY" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
@@ -10825,6 +10854,11 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
 "zI" = (
@@ -10903,6 +10937,20 @@
 "zO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos/storage)
+"zP" = (
+/obj/structure/table/standard,
+/obj/random/maintenance/solgov,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/drone_fabrication)
 "zS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11540,18 +11588,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/cargo)
-"Bu" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/storage/cargo)
 "Bv" = (
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
@@ -11999,17 +12035,18 @@
 /turf/simulated/floor/plating,
 /area/vacant/cargo)
 "Cx" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Solar Control - Port"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -12064,15 +12101,6 @@
 /turf/simulated/floor/plating,
 /area/storage/research)
 "CF" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/bodybags,
 /turf/simulated/floor/plating,
@@ -12249,11 +12277,12 @@
 /area/vacant/cargo)
 "CZ" = (
 /obj/item/weapon/stool,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "Da" = (
@@ -12309,6 +12338,15 @@
 "Dh" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/beakers,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/storage/research)
 "Di" = (
@@ -13519,6 +13557,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"Gw" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/storage/cargo)
 "GQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13531,6 +13581,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"GU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/incinerator)
 "GW" = (
 /turf/simulated/wall/r_wall/hull,
 /area/storage/tech)
@@ -13698,6 +13756,11 @@
 	pixel_x = 23;
 	pixel_y = 23
 	},
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "prototype_controller";
+	pixel_x = -23;
+	pixel_y = 23
+	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/control)
 "Hm" = (
@@ -13751,6 +13814,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"HG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/storage/expedition)
 "Ib" = (
 /obj/effect/wingrille_spawn/reinforced/full,
 /obj/machinery/door/firedoor/border_only,
@@ -14061,6 +14132,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"Jt" = (
+/turf/space,
+/area/maintenance/seconddeck/aftport)
 "JF" = (
 /turf/simulated/wall/r_wall/hull,
 /area/engineering/fuelbay)
@@ -14663,6 +14737,14 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos)
+"NB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/storage/cargo)
 "Ob" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	icon_state = "intact";
@@ -15019,6 +15101,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"PY" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/storage/research)
 "Qb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced_phoron,
@@ -15272,6 +15362,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "prototype_controller";
+	pixel_x = -23;
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled,
 /area/vacant/prototype/control)
 "Rk" = (
@@ -15389,6 +15484,9 @@
 	},
 /obj/item/stack/material/tritium/ten,
 /obj/item/stack/material/tritium/ten,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/vacant/prototype/engine)
 "Sh" = (
@@ -15475,6 +15573,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"SK" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "Tb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled,
@@ -15751,6 +15861,17 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/greengrid/airless,
 /area/engineering/engine_room)
+"Uw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/drone_fabrication)
 "Vb" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -16020,11 +16141,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod10/station)
 "Wm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/seconddeck)
@@ -16518,6 +16640,15 @@
 "Zs" = (
 /turf/simulated/wall/r_wall/hull,
 /area/engineering/engine_room)
+"Zv" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/drone_fabrication)
 
 (1,1,1) = {"
 aa
@@ -30769,7 +30900,7 @@ qv
 uO
 yg
 yW
-zG
+zI
 Az
 Bi
 zG
@@ -31165,7 +31296,7 @@ Am
 iP
 rD
 sE
-tl
+Zv
 tl
 tl
 vB
@@ -31173,7 +31304,7 @@ qv
 uO
 yg
 yY
-zI
+GU
 Ki
 EU
 EU
@@ -31365,9 +31496,9 @@ bd
 Xl
 Fm
 qv
-rE
 sF
 sF
+Uw
 sF
 sF
 vC
@@ -31569,7 +31700,7 @@ Gm
 qv
 rF
 rF
-tm
+zP
 tm
 rF
 rF
@@ -36200,7 +36331,7 @@ ee
 hd
 He
 iJ
-Ke
+iK
 ee
 ee
 iF
@@ -36219,7 +36350,7 @@ ty
 oc
 jS
 qu
-kf
+kk
 kz
 kM
 qu
@@ -36402,7 +36533,7 @@ ee
 ef
 eR
 Ke
-iK
+HG
 ee
 kO
 kT
@@ -36629,9 +36760,9 @@ qu
 qu
 zU
 AO
+NB
+NB
 Bt
-Ce
-Ce
 Ce
 Ce
 DT
@@ -36831,9 +36962,9 @@ AP
 xC
 DG
 AN
-Bu
-Cf
 Ce
+Cf
+Gw
 De
 Dx
 DU
@@ -37029,7 +37160,7 @@ xH
 vc
 zV
 xC
-xC
+Jt
 xC
 zT
 AN
@@ -37641,8 +37772,8 @@ Ez
 AR
 Bx
 Ch
+PY
 CE
-Dg
 Dg
 DX
 Eh
@@ -38013,7 +38144,7 @@ aN
 aN
 aN
 ct
-bs
+pQ
 dh
 em
 aN
@@ -38213,7 +38344,7 @@ aa
 fb
 aO
 bs
-bs
+SK
 cu
 dg
 dh

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -1041,6 +1041,7 @@
 	dir = 6
 	},
 /obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems.This one has a red sticker on it that gleefully states 'CODE VIOLATION'.";
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
@@ -2061,10 +2062,14 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
 	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
@@ -2282,45 +2287,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/firstdeck)
-"aeC" = (
-/obj/structure/grille,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard)
 "aeD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
 "aeE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard)
-"aeF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
@@ -2332,11 +2307,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
 "aeH" = (
@@ -2347,11 +2317,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
 "aeI" = (
@@ -2360,11 +2325,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -2387,11 +2347,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -3545,6 +3500,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'.";
 	dir = 1;
 	name = "north bump";
 	pixel_x = 0;
@@ -5441,14 +5397,9 @@
 "aoa" = (
 /obj/machinery/light/small,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
@@ -6277,11 +6228,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
 "asa" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -6799,6 +6745,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "aug" = (
@@ -7069,14 +7020,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
-"auS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/assembly/robotics)
 "auW" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
@@ -9761,6 +9704,16 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'";
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/tactical)
 "aDD" = (
@@ -10030,6 +9983,11 @@
 /area/maintenance/firstdeck/aftport)
 "aEF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/tactical)
 "aEG" = (
@@ -10452,6 +10410,11 @@
 /area/maintenance/firstdeck/aftport)
 "aFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/tactical)
 "aFP" = (
@@ -11104,33 +11067,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/tactical)
 "aHW" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/tactical)
 "aHX" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -11881,15 +11839,6 @@
 "aKB" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/item/weapon/pinpointer,
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
@@ -12195,6 +12144,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
 "aLD" = (
@@ -12521,6 +12475,11 @@
 /area/command/armoury)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
 "aME" = (
@@ -13261,6 +13220,16 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/blanks)
 "aOU" = (
@@ -13681,16 +13650,16 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/blanks)
@@ -14830,6 +14799,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "aTd" = (
@@ -15415,6 +15389,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems.This one has a red sticker on it that gleefully states 'CODE VIOLATION'.";
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
@@ -16276,6 +16251,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
+"bfe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/vacant/office)
 "bgb" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -16329,11 +16312,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -17233,6 +17211,16 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "cCb" = (
@@ -17352,6 +17340,14 @@
 /obj/item/weapon/reagent_containers/ivbag/nanoblood,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"cMI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "cNb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/corner/paleblue{
@@ -17424,6 +17420,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -17636,16 +17637,16 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -17688,17 +17689,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/plating,
 /area/engineering/auxpower)
-"dmb" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "dnb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17843,19 +17833,6 @@
 	c_tag = "Infirmary - Operating Theatre";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"dBb" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/floordetail/edgedrain,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "dCb" = (
@@ -18557,17 +18534,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
-"eFb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/subacute)
 "eGb" = (
 /obj/structure/table/standard,
 /obj/item/stack/material/uranium,
@@ -18829,28 +18795,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
-"eYb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/subacute)
 "eZb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
 /obj/effect/floor_decal/corner/pink{
 	dir = 6
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch.";
@@ -18858,6 +18807,11 @@
 	name = "Sub-acute Door Control";
 	pixel_x = 0;
 	pixel_y = -25
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
@@ -18868,6 +18822,16 @@
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	icon_state = "corner_white_three_quarters";
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
@@ -19407,17 +19371,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "fSb" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
@@ -19874,10 +19834,14 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
 	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -22286,6 +22250,28 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"knJ" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/mirror{
+	pixel_x = -32
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/head/aux)
 "kob" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -22391,11 +22377,26 @@
 "kub" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/window/reinforced,
+/obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'";
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "kvb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
@@ -22467,25 +22468,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
-"kEb" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled,
-/area/assembly/robotics)
 "kFb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
@@ -24017,6 +24000,7 @@
 	dir = 6
 	},
 /obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'.";
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
@@ -24119,6 +24103,18 @@
 	},
 /turf/simulated/floor/blackgrid,
 /area/security/nuke_storage)
+"nnV" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/tactical)
 "nob" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/blackgrid,
@@ -24203,12 +24199,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vacant/office)
-"nwb" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+"nvz" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(201)
 	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/vacant/office)
+"nwb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -24217,6 +24222,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/vacant/office)
@@ -24323,6 +24333,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/blanks)
 "nCb" = (
@@ -24366,12 +24381,6 @@
 /turf/simulated/floor/tiled,
 /area/vacant/office)
 "nGb" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 20
@@ -24614,16 +24623,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "oab" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -24634,6 +24633,11 @@
 /obj/machinery/light_switch{
 	pixel_x = -12;
 	pixel_y = 24
+	},
+/obj/machinery/alarm{
+	frequency = 1439;
+	pixel_y = 23;
+	req_one_access = list(201)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -25060,6 +25064,15 @@
 /area/chapel/main)
 "oMb" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
 "oOb" = (
@@ -25138,11 +25151,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
 "oSb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25233,16 +25241,6 @@
 "oYb" = (
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = 6
@@ -26605,6 +26603,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rGY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "rHb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/structure/table/standard,
@@ -36810,7 +36817,7 @@ mBb
 nkb
 aBc
 aCv
-aDD
+nnV
 aEF
 aFO
 aFO
@@ -37021,7 +37028,7 @@ aJn
 aKA
 aLA
 aMD
-aMD
+rGY
 aOI
 aPv
 aQu
@@ -37393,7 +37400,7 @@ hBr
 hBr
 hBr
 adN
-aeC
+afG
 afG
 agC
 adK
@@ -37999,7 +38006,7 @@ hBr
 hBr
 hBr
 adQ
-aeF
+aeE
 afG
 adM
 adK
@@ -39220,7 +39227,7 @@ ajW
 akX
 ame
 kqb
-kqb
+knJ
 ahL
 aqb
 arv
@@ -41047,9 +41054,9 @@ atD
 auH
 avU
 awX
-atw
-atw
-atw
+nvz
+bfe
+bfe
 nwb
 nGb
 asx
@@ -44880,7 +44887,7 @@ amA
 amA
 amA
 amA
-kEb
+apo
 kMb
 kUb
 amA
@@ -45082,7 +45089,7 @@ iyb
 kfb
 kob
 kub
-auS
+apo
 apo
 auW
 awg
@@ -49313,8 +49320,8 @@ adt
 aen
 cCb
 age
-dmb
-dBb
+dnb
+dCb
 amL
 eeb
 eEb
@@ -49519,8 +49526,8 @@ dnb
 dCb
 dOb
 efb
-eFb
-eYb
+eEb
+efb
 fJb
 ffb
 hkb
@@ -51749,7 +51756,7 @@ ktb
 aqQ
 oab
 atf
-atg
+cMI
 avr
 awx
 axC
@@ -51951,7 +51958,7 @@ lUb
 aqT
 mmb
 atg
-atg
+cMI
 avs
 awy
 axs

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -443,6 +443,16 @@
 "aY" = (
 /obj/structure/closet/secure_closet/CO,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/apc{
+	desc = "A control terminal for the area electrical systems. This one has a red sticker on it that gleefully states 'CODE VIOLATION'.";
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cobed)
 "aZ" = (
@@ -1114,11 +1124,6 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1338,25 +1343,33 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/bridge)
 "du" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/bridge)
-"dv" = (
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/bridge)
+"dv" = (
 /obj/machinery/atmospherics/valve/shutoff{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
@@ -5758,10 +5771,13 @@
 	c_tag = "Bridge Hallway - Lift";
 	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "mX" = (
@@ -5826,11 +5842,6 @@
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -6845,6 +6856,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"ps" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
 "pt" = (
 /obj/structure/table/steel,
 /obj/item/weapon/paper_bin{
@@ -7928,7 +7958,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/alarm{
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/hyper{
+	dir = 1;
+	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -8502,6 +8538,11 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
 "st" = (
@@ -8835,6 +8876,11 @@
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
@@ -10744,20 +10790,28 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarbridge)
 "wT" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)
 "wU" = (
 /obj/item/weapon/stool,
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)
@@ -11436,16 +11490,13 @@
 /turf/space,
 /area/space)
 "yZ" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
-/obj/structure/cable/green,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "zb" = (
@@ -11560,9 +11611,9 @@
 	icon_state = "intact"
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
@@ -11668,22 +11719,17 @@
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
 "Bd" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/fern,
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
@@ -11874,13 +11920,11 @@
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
 "Dd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
@@ -11976,11 +12020,18 @@
 /obj/machinery/camera/network/command{
 	c_tag = "Executive Officer - Office"
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
@@ -12260,6 +12311,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cobed)
 "GY" = (
@@ -12329,16 +12385,10 @@
 /area/crew_quarters/heads/cobed)
 "Hd" = (
 /obj/machinery/papershredder,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/cable/green,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cobed)
@@ -12947,13 +12997,6 @@
 	dir = 1;
 	icon_state = "map"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/safe_room/bridge)
-"IA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -13025,6 +13068,12 @@
 	},
 /obj/structure/closet/crate/freezer/rations,
 /obj/random/drinkbottle,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/safe_room/bridge)
 "IH" = (
@@ -13470,11 +13519,6 @@
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
 "Nd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13484,6 +13528,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
@@ -13915,6 +13964,11 @@
 "Rd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "Re" = (
@@ -14046,6 +14100,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
@@ -14333,6 +14392,11 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "Ue" = (
@@ -14438,17 +14502,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/power/apc/hyper{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
@@ -14857,15 +14915,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Zb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/aquila_hangar/start)
 "Zc" = (
 /obj/machinery/light{
 	dir = 1
@@ -23364,7 +23413,7 @@ tT
 uB
 qO
 Iv
-IA
+IC
 IH
 ti
 xb
@@ -30016,7 +30065,7 @@ gm
 gm
 fI
 kM
-lI
+ps
 mW
 of
 of
@@ -33659,7 +33708,7 @@ pe
 pX
 ec
 Vb
-Zb
+tc
 Ac
 tL
 uw

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -556,7 +556,7 @@
 	sound_env = MEDIUM_SOFTFLOOR
 
 /area/command/armoury
-	name = "\improper Emergency Armory"
+	name = "\improper Emergency Supplies Storage"
 	icon_state = "Warden"
 
 /area/command/armoury/access


### PR DESCRIPTION
If at any point this conflicts, I am closing it without a single word.
🆑 
tweak: Nearly every single APC has been remapped to have approximately three feet or more clearance from any door.
tweak: Removed redundant pipelines in d3 cryo.
tweak: Removed a wire-through-wall situation on D4.
bugfix: Put the Charon back on the D3 powernet.
bugfix: R-UST has an air alarm and proper airlock buttons.
/ 🆑 
![image](https://user-images.githubusercontent.com/4706052/39404279-276ab62e-4b45-11e8-822c-a761dc0a5c2c.png)

