### PR TITLE
Borg and AI email bugfix/improvement

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -129,6 +129,32 @@
 
 	return output
 
+//Used to strip text of everything but letters and numbers, make letters lowercase, and turn spaces into .'s.
+//Make sure the text hasn't been encoded if using this.
+/proc/sanitize_for_email(text)
+	if(!text) return ""
+	var/list/dat = list()
+	var/last_was_space = 1
+	for(var/i=1, i<=length(text), i++)
+		var/ascii_char = text2ascii(text,i)
+		switch(ascii_char)
+			if(65 to 90)	//A-Z, make them lowercase
+				dat += ascii2text(ascii_char + 32)
+			if(97 to 122)	//a-z
+				dat += ascii2text(ascii_char)
+				last_was_space = 0
+			if(48 to 57)	//0-9
+				dat += ascii2text(ascii_char)
+				last_was_space = 0
+			if(32)			//space
+				if(last_was_space)
+					continue
+				dat += "."		//We turn these into ., but avoid repeats or . at start.
+				last_was_space = 1
+	if(dat[length(dat)] == ".")	//kill trailing .
+		dat.Cut(length(dat))
+	return jointext(dat, null)
+
 //Returns null if there is any bad text in the string
 /proc/reject_bad_text(var/text, var/max_length=512)
 	if(length(text) > max_length)	return			//message too long

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -312,8 +312,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 		fully_replace_character_name(newname)
 
-
-
 //Picks a string of symbols to display as the law number for hacked or ion laws
 /proc/ionnum()
 	return "[pick("1","2","3","4","5","6","7","8","9","0")][pick("!","@","#","$","%","^","&","*")][pick("!","@","#","$","%","^","&","*")][pick("!","@","#","$","%","^","&","*")]"

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -372,31 +372,15 @@ var/global/datum/controller/occupations/job_master
 			job.setup_account(H)
 
 			// EMAIL GENERATION
-			var/domain
-			if(H.char_branch && H.char_branch.email_domain)
-				domain = H.char_branch.email_domain
-			else
-				domain = "freemail.nt"
-			var/sanitized_name = sanitize(replacetext(replacetext(lowertext(H.real_name), " ", "."), "'", ""))
-			var/complete_login = "[sanitized_name]@[domain]"
-
-			// It is VERY unlikely that we'll have two players, in the same round, with the same name and branch, but still, this is here.
-			// If such conflict is encountered, a random number will be appended to the email address. If this fails too, no email account will be created.
-			if(ntnet_global.does_email_exist(complete_login))
-				complete_login = "[sanitized_name][random_id(/datum/computer_file/data/email_account/, 100, 999)]@[domain]"
-
-			// If even fallback login generation failed, just don't give them an email. The chance of this happening is astronomically low.
-			if(ntnet_global.does_email_exist(complete_login))
-				to_chat(H, "You were not assigned an email address.")
-				H.mind.store_memory("You were not assigned an email address.")
-			else
-				var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account()
-				EA.password = GenerateKey()
-				EA.login = 	complete_login
-				to_chat(H, "Your email account address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
-				H.mind.initial_email_login["login"] = EA.login
-				H.mind.initial_email_login["password"] = EA.password
-				H.mind.store_memory("Your email account address is [EA.login] and the password is [EA.password].")
+			if(rank != "Robot" && rank != "AI")		//These guys get their emails later.
+				var/domain
+				var/desired_name
+				if(H.char_branch && H.char_branch.email_domain)
+					domain = H.char_branch.email_domain
+				else
+					domain = "freemail.nt"
+				desired_name = H.real_name
+				ntnet_global.create_email(H, desired_name, domain)
 			// END EMAIL GENERATION
 
 			job.equip(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -289,6 +289,7 @@
 	else
 		changed_name = "[modtype] [braintype]-[num2text(ident)]"
 
+	create_or_rename_email(changed_name, "root.rt")
 	real_name = changed_name
 	name = real_name
 	if(mind)
@@ -316,7 +317,7 @@
 
 	spawn(0)
 		var/newname
-		newname = sanitizeSafe(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
+		newname = sanitizeName(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN, allow_numbers = 1)
 		if (newname)
 			custom_name = newname
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -54,6 +54,7 @@
 
 /mob/living/silicon/fully_replace_character_name(new_name)
 	..()
+	create_or_rename_email(new_name, "root.rt")
 	if(istype(idcard))
 		idcard.registered_name = new_name
 		idcard.update_name()

--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -2,7 +2,8 @@
 	var/list/silicon_subsystems_by_name = list()
 	var/list/silicon_subsystems = list(
 		/datum/nano_module/alarm_monitor/all,
-		/datum/nano_module/law_manager
+		/datum/nano_module/law_manager,
+		/datum/nano_module/email_client
 	)
 
 /mob/living/silicon/ai/New()
@@ -15,7 +16,8 @@
 
 /mob/living/silicon/robot/syndicate
 	silicon_subsystems = list(
-		/datum/nano_module/law_manager
+		/datum/nano_module/law_manager,
+		/datum/nano_module/email_client
 	)
 
 /mob/living/silicon/Destroy()
@@ -81,6 +83,14 @@
 	for(var/subsystem_type in silicon_subsystems)
 		var/stat_silicon_subsystem/SSS = silicon_subsystems[subsystem_type]
 		stat(SSS)
+
+/mob/living/silicon/proc/get_subsystem_from_path(subsystem_type)
+	var/stat_silicon_subsystem/SSS = silicon_subsystems[subsystem_type]
+	if(!istype(SSS))
+		return 0
+	if(!istype(SSS.subsystem, subsystem_type))
+		return 0
+	return SSS.subsystem
 
 /stat_silicon_subsystem
 	parent_type = /atom/movable

--- a/code/modules/modular_computers/file_system/programs/research/email_administration.dm
+++ b/code/modules/modular_computers/file_system/programs/research/email_administration.dm
@@ -15,7 +15,7 @@
 
 
 /datum/nano_module/email_administration/
-	name = "Email Client"
+	name = "Email Administration"
 	var/datum/computer_file/data/email_account/current_account = null
 	var/datum/computer_file/data/email_message/current_message = null
 	var/error = ""
@@ -133,7 +133,7 @@
 			return 1
 
 		var/complete_login = "[newlogin]@[newdomain]"
-		if(ntnet_global.does_email_exist(complete_login))
+		if(ntnet_global.find_email_by_name(complete_login))
 			error = "Error creating account: An account with same address already exists."
 			return 1
 


### PR DESCRIPTION
:cl:
bugfix: Borgs and AI are given emails after name selection. Emails are updated on name change.
bugfix: Borgs and AI can read emails from the "Email Client" in the Subsystems verb. The email administration program can still be accessed by AI but has been moved to "Email Administration."
/:cl:

Fixes #21351.
Fixes #21352: for AI, was legitimately a bug. Also QOL improvement: login for the subsystem is automatically entered on email spawn/change.