### PR TITLE
Vox now spawn with the vox breath mask

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -79,7 +79,7 @@
 	return species_language.get_random_name(gender)
 
 /datum/species/vox/equip_survival_gear(var/mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vox(H), slot_wear_mask)
 
 	if(istype(H.get_equipped_item(slot_back), /obj/item/weapon/storage/backpack))
 		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_r_hand)

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -1,9 +1,6 @@
 /datum/gear/suit/lab_xyn_machine
 	allowed_roles = NON_MILITARY_ROLES
 
-/datum/gear/mask/gas/vox
-	allowed_roles = list(/datum/job/merchant) //Since that is the only role vox can be beside stowaway.
-
 /datum/gear/gloves/dress/modified
 	display_name = "modified gloves, dress"
 	path = /obj/item/clothing/gloves/color/white/modified


### PR DESCRIPTION
🆑TheGreyWolf
rscadd: Vox now spawn with their air filter gas mask.
/🆑
@Dukica99 for approval.
THey now spawn with the gas mask that filters oxygen instead of it being loadout. Yes this means all vox regardless of antag status and job gets it.