### PR TITLE
[Ready for review] Fixes computer damage event + Overmap ion storm tweaks

### DIFF
--- a/code/modules/events/computer_damage.dm
+++ b/code/modules/events/computer_damage.dm
@@ -1,4 +1,7 @@
 /datum/event/computer_damage/start()
+	computer_damage_event(severity)
+
+/proc/computer_damage_event(var/severity)
 	var/number_of_victims = 0
 	switch(severity)
 		if(EVENT_LEVEL_MUNDANE)
@@ -20,6 +23,6 @@
 		else
 			victim.visible_message("<span class='warning'>[victim] emits some omnious clicks.</span>")
 			if(prob(60))
-				victim.hard_drive.damage = victim.hard_drive.damage_failure
+				victim.hard_drive.take_damage(victim.hard_drive.damage_failure)
 			else
-				victim.hard_drive.damage = victim.hard_drive.damage_malfunction
+				victim.hard_drive.take_damage(victim.hard_drive.damage_malfunction)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -143,3 +143,7 @@
 		return L.name
 	else // Highly unlikely but it is a failsafe fallback.
 		return "Gibberish."
+
+/datum/event/ionstorm/overmap/start()
+	..()
+	computer_damage_event(severity)

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -63,10 +63,10 @@
 	if(!enabled)
 		return 0
 	// Too damaged to work at all.
-	if(damage > damage_failure)
+	if(damage >= damage_failure)
 		return 0
 	// Still working. Well, sometimes...
-	if(damage > damage_malfunction)
+	if(damage >= damage_malfunction)
 		if(prob(malfunction_probability))
 			return 0
 	// Good to go.

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -181,11 +181,12 @@
 
 /datum/overmap_event/ion
 	name = "ion cloud"
-	event = /datum/event/ionstorm
+	event = /datum/event/ionstorm/overmap
 	count = 8
 	radius = 3
 	opacity = 0
 	event_icon_states = list("ion1", "ion2", "ion3", "ion4")
+	difficulty = EVENT_LEVEL_MAJOR
 
 /datum/overmap_event/carp
 	name = "carp shoal"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
1. The computer damage event now actually works. >= instead of > @comma 
2. The overmap ion storm event now uses a version of the computer damage event, so it's actually slightly threatening now.