### PR TITLE
fixes MAA alt title

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -730,7 +730,7 @@
 	economic_modifier = 4
 	minimal_player_age = 10
 	ideal_character_age = 25
-	alt_titles = null
+	alt_titles = list()
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/maa
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,


### PR DESCRIPTION
🆑 TheGreyWolf
bugfix: The MAA alt title is now fixed to not exist.
/🆑

Not the best fix but it at least works last time I tested it compared to what we have currently.