### PR TITLE
Heads are no longer marked as "irreparable."

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -348,9 +348,9 @@
 		else
 			table += "<td>"
 			if(E.brute_dam)
-				table += "[capitalize(get_wound_severity(E.brute_ratio, E.vital))] physical trauma"
+				table += "[capitalize(get_wound_severity(E.brute_ratio, E.can_heal_overkill))] physical trauma"
 			if(E.burn_dam)
-				table += " [capitalize(get_wound_severity(E.burn_ratio, E.vital))] burns"
+				table += " [capitalize(get_wound_severity(E.burn_ratio, E.can_heal_overkill))] burns"
 			if(E.brute_dam + E.burn_dam == 0)
 				table += "None"
 			table += "</td><td>[english_list(E.get_scan_results(), nothing_text = "", and_text = ", ")]</td></tr>"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -189,9 +189,9 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 			for(var/obj/item/organ/external/org in damaged)
 				var/limb_result = "[capitalize(org.name)][(org.robotic >= ORGAN_ROBOT) ? " (Cybernetic)" : ""]:"
 				if(org.brute_dam > 0)
-					limb_result = "[limb_result] \[<font color = 'red'><b>[get_wound_severity(org.brute_ratio, org.vital)] physical trauma</b></font>\]"
+					limb_result = "[limb_result] \[<font color = 'red'><b>[get_wound_severity(org.brute_ratio, org.can_heal_overkill)] physical trauma</b></font>\]"
 				if(org.burn_dam > 0)
-					limb_result = "[limb_result] \[<font color = '#ffa500'><b>[get_wound_severity(org.burn_ratio, org.vital)] burns</b></font>\]"
+					limb_result = "[limb_result] \[<font color = '#ffa500'><b>[get_wound_severity(org.burn_ratio, org.can_heal_overkill)] burns</b></font>\]"
 				if(org.status & ORGAN_BLEEDING)
 					limb_result = "[limb_result] \[<span class='danger'>bleeding</span>\]"
 				. += limb_result
@@ -254,7 +254,7 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 	. = jointext(.,"<br>")
 
 // Calculates severity based on the ratios defined external limbs.
-proc/get_wound_severity(var/damage_ratio, var/vital = 0)
+proc/get_wound_severity(var/damage_ratio, var/can_heal_overkill = 0)
 	var/degree
 
 	switch(damage_ratio)
@@ -269,7 +269,7 @@ proc/get_wound_severity(var/damage_ratio, var/vital = 0)
 		if(0.75 to 1)
 			degree = "extreme"
 		else
-			if(vital)
+			if(can_heal_overkill)
 				degree = "critical"
 			else
 				degree = "irreparable"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -19,6 +19,7 @@
 	var/brute_ratio = 0                // Ratio of current brute damage to max damage.
 	var/burn_dam = 0                   // Actual current burn damage.
 	var/burn_ratio = 0                 // Ratio of current burn damage to max damage.
+	var/can_heal_overkill = 0          // Whether organ can be still healed once past max_damage in brute/burn.
 	var/last_dam = -1                  // used in healing/processing calculations.
 	var/pain = 0                       // How much the limb hurts.
 	var/pain_disability_threshold      // Point at which a limb becomes unusable due to pain.

--- a/code/modules/organs/external/diona.dm
+++ b/code/modules/organs/external/diona.dm
@@ -33,6 +33,7 @@
 	w_class = ITEM_SIZE_HUGE
 	body_part = UPPER_TORSO
 	vital = 1
+	can_heal_overkill = 1
 	cannot_amputate = 1
 	parent_organ = null
 	gendered_icon = 1

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -8,6 +8,7 @@
 	min_broken_damage = 35
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
+	can_heal_overkill = 1
 	parent_organ = BP_CHEST
 	joint = "jaw"
 	amputation_point = "neck"

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -13,6 +13,7 @@
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	body_part = UPPER_TORSO
 	vital = 1
+	can_heal_overkill = 1
 	amputation_point = "spine"
 	joint = "neck"
 	dislocated = -1
@@ -45,6 +46,7 @@
 	w_class = ITEM_SIZE_LARGE
 	body_part = LOWER_TORSO
 	vital = 1
+	can_heal_overkill = 1
 	parent_organ = BP_CHEST
 	amputation_point = "lumbar"
 	joint = "hip"

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -143,9 +143,9 @@
 	if(embedded_objects.len)
 		return amount // heal nothing
 	if(parent_organ)
-		if(damage_type == BURN && !(parent_organ.burn_ratio < 1 || parent_organ.vital))
+		if(damage_type == BURN && !(parent_organ.burn_ratio < 1 || parent_organ.can_heal_overkill))
 			return amount	//We don't want to heal wounds on irreparable organs.
-		else if(!(parent_organ.brute_ratio < 1 || parent_organ.vital))
+		else if(!(parent_organ.brute_ratio < 1 || parent_organ.can_heal_overkill))
 			return amount
 
 	var/healed_damage = min(src.damage, amount)

--- a/code/modules/organs/subtypes/nabber_organ.dm
+++ b/code/modules/organs/subtypes/nabber_organ.dm
@@ -209,4 +209,5 @@
 /obj/item/organ/external/head/nabber
 	name = "head"
 	vital = 0
+	can_heal_overkill = 0
 	has_lips = 0


### PR DESCRIPTION
:cl:
tweak: Very damaged heads will be marked as "critical" rather than "irreparable" on scanners, and can be healed even past max_damage threshold.
/:cl:

The actual change here is that the `vital` variable is split in two: `vital` now means "if you cut this off/destroy it, you die." `can_heal_overkill` means that the organ can be healed even once past `max_damage` and shows up as "critical" rather than "irreparable" on scanners. See also the discussion in #21297; if this is merged the change there will make the lower body not vital (no more instakill), but it will still have can_heal_overkill, so it will not become irreparable.