### PR TITLE
Fixes bug with autogenerating landmarks

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -47,8 +47,7 @@
 		generate_atmosphere()
 		generate_map()
 		generate_features()
-		for(var/i = 0 to 3)
-			generate_landing()
+		generate_landing(4)		//try making 4 landmarks
 		update_biome()
 		START_PROCESSING(SSobj, src)
 
@@ -178,11 +177,14 @@
 			A.verbs -= /mob/living/simple_animal/proc/name_species
 	return TRUE
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_landing()
-	var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])
-	if(T)
-		new landmark_type(T)
-	return T
+//Tries to generate num landmarks, but avoids repeats.
+/obj/effect/overmap/sector/exoplanet/proc/generate_landing(num = 1)
+	var/places = list()
+	for(var/i = 1, i <= num, i++)
+		var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])
+		if(T && !(T in places))
+			places += T
+			new landmark_type(T)
 
 /obj/effect/overmap/sector/exoplanet/proc/generate_atmosphere()
 	atmosphere = new

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -75,7 +75,7 @@
 	var/shuttle_restricted //name of the shuttle, null for generic waypoint
 
 /obj/effect/shuttle_landmark/automatic/Initialize()
-	tag = landmark_tag+"-[x]-[y]"
+	tag = landmark_tag+"-[x]-[y]-[z]"
 	. = ..()
 	base_area = get_area(src)
 	if(!GLOB.using_map.use_overmap)


### PR DESCRIPTION
Fixes #20748.

There appear to be two low-probability sources of the issue: (1) autogenerated landmark tags don't include z-level, leading to a crash if two landmarks on two z-levels have the same x-y coordinates, and (2) exoplanets spawn four landmarks randomly without checking for repeats. This leads to runtimes in 0.1%-1% of runs (guesstimate).

The bug can be reproduced consistently locally by dramatically increasing the number of spawned automatic landmarks and the number of exoplanets in the map defines.

This bug makes Travis randomly fail on away mission testing.
