### PR TITLE
Scanner fixes/improvements.

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -206,11 +206,13 @@
 		update_verbs()
 		to_chat(user, "<span class='notice'>You insert [W] into [src].</span>")
 		return
-	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/paper_bundle))
+	if(istype(W, /obj/item/weapon/paper))
 		var/obj/item/weapon/paper/paper = W
 		if(scanner && paper.info)
 			scanner.do_on_attackby(user, W)
-		else if(nano_printer)
+			return
+	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/paper_bundle))
+		if(nano_printer)
 			nano_printer.attackby(W, user)
 	if(istype(W, /obj/item/weapon/aicard))
 		if(!ai_slot)

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -26,7 +26,7 @@
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/medical(src)
 
-/obj/item/modular_computer/pda/reagent/install_default_hardware()
+/obj/item/modular_computer/pda/chemistry/install_default_hardware()
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/reagent(src)
 
@@ -42,7 +42,23 @@
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/reagent(src)
 
-/obj/item/modular_computer/pda/heads/install_default_hardware()
+/obj/item/modular_computer/pda/heads/hop/install_default_hardware()
+	..()
+	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)
+
+/obj/item/modular_computer/pda/heads/hos/install_default_hardware()
+	..()
+	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)
+
+/obj/item/modular_computer/pda/heads/ce/install_default_hardware()
+	..()
+	scanner = new /obj/item/weapon/computer_hardware/scanner/atmos(src)
+
+/obj/item/modular_computer/pda/heads/cmo/install_default_hardware()
+	..()
+	scanner = new /obj/item/weapon/computer_hardware/scanner/medical(src)
+
+/obj/item/modular_computer/pda/heads/rd/install_default_hardware()
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1229,6 +1229,43 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/computer_hardware/tesla_link
 	sort_string = "VBADD"
 
+//Scanners
+/datum/design/item/modularcomponent/accessory/reagent_scanner
+	name = "reagent scanner module"
+	id = "scan_reagent"
+	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_BIO = 2, TECH_MAGNET = 2)
+	build_type = PROTOLATHE
+	materials = list(DEFAULT_WALL_MATERIAL = 600, "glass" = 200)
+	build_path = /obj/item/weapon/computer_hardware/scanner/reagent
+	sort_string = "VBADE"
+
+/datum/design/item/modularcomponent/accessory/paper_scanner
+	name = "paper scanner module"
+	id = "scan_paper"
+	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
+	build_type = PROTOLATHE
+	materials = list(DEFAULT_WALL_MATERIAL = 600, "glass" = 200)
+	build_path = /obj/item/weapon/computer_hardware/scanner/paper
+	sort_string = "VBADF"
+
+/datum/design/item/modularcomponent/accessory/atmos_scanner
+	name = "atmospheric scanner module"
+	id = "scan_atmos"
+	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_MAGNET = 2)
+	build_type = PROTOLATHE
+	materials = list(DEFAULT_WALL_MATERIAL = 600, "glass" = 200)
+	build_path = /obj/item/weapon/computer_hardware/scanner/atmos
+	sort_string = "VBADG"
+
+/datum/design/item/modularcomponent/accessory/medical_scanner
+	name = "medical scanner module"
+	id = "scan_medical"
+	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_MAGNET = 2, TECH_BIO = 2)
+	build_type = PROTOLATHE
+	materials = list(DEFAULT_WALL_MATERIAL = 600, "glass" = 200)
+	build_path = /obj/item/weapon/computer_hardware/scanner/medical
+	sort_string = "VBADH"
+
 // Batteries
 /datum/design/item/modularcomponent/battery/AssembleDesignName()
 	..()


### PR DESCRIPTION
:cl:
tweak: CE and CMO get job-appropriate scanners on their PDAs now.
tweak: Modular computer scanners can now be printed via protolathe.
tweak: Hitting a modular computer with a paper bundle puts it in the printer. To scan, separate the bundle.
bugfix: The chemist's pda scanner is fixed.
/:cl:

Fixes  #21420.