### PR TITLE
Fixes bag overhead by removing snowflake istype checks.

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -77,7 +77,7 @@
 				S.remove_from_storage(L, T)
 				qdel(L)
 		if(amt_inserted)
-			to_chat(user, "You insert [amt_inserted] light[uses > 1 ? "s" : ""] into \The [src]. It has [uses] light[uses > 1 ? "s" : ""] remaining.")
+			to_chat(user, "You insert [amt_inserted] light\s into \The [src]. It has [uses] light\s remaining.")
 			add_fingerprint(user)
 			return
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -57,16 +57,37 @@
 	var/max_uses = 32
 	var/uses = 32
 	var/emagged = 0
-	var/failmsg = ""
 	var/charge = 0
-
-/obj/item/device/lightreplacer/New()
-	failmsg = "The [name]'s refill light blinks red."
-	..()
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	if(..(user, 2))
-		to_chat(user, "It has [uses] light\s remaining.")
+		to_chat(user, "It has [uses] light[uses > 1 ? "s" : ""] remaining.")
+
+/obj/item/device/lightreplacer/resolve_attackby(var/atom/A, mob/user)
+
+	//Check for lights in a container, refilling our charges.
+	if(istype(A, /obj/item/weapon/storage/))
+		var/obj/item/weapon/storage/S = A
+		var/amt_inserted = 0
+		var/turf/T = get_turf(user)
+		for(var/obj/item/weapon/light/L in S.contents)
+			if(!user.stat && src.uses < src.max_uses)
+				src.AddUses(1)
+				amt_inserted++
+				S.remove_from_storage(L, T)
+				qdel(L)
+		if(amt_inserted)
+			to_chat(user, "You insert [amt_inserted] light[uses > 1 ? "s" : ""] into \The [src]. It has [uses] light[uses > 1 ? "s" : ""] remaining.")
+			return
+
+	//Actually replace the light.
+	if(istype(A, /obj/machinery/light/))
+		var/obj/machinery/light/L = A
+		if(isliving(user))
+			var/mob/living/U = user
+			ReplaceLight(L, U)
+			return
+	..()
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == "glass")
@@ -130,7 +151,7 @@
 	if(target.get_status() == LIGHT_OK)
 		to_chat(U, "There is a working [target.get_fitting_name()] already inserted.")
 	else if(!CanUse(U))
-		to_chat(U, failmsg)
+		to_chat(U, "\The [src]'s refill light blinks red.")
 	else if(Use(U))
 		to_chat(U, "<span class='notice'>You replace the [target.get_fitting_name()] with the [src].</span>")
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -61,7 +61,7 @@
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	if(..(user, 2))
-		to_chat(user, "It has [uses] light[uses > 1 ? "s" : ""] remaining.")
+		to_chat(user, "It has [uses] light\s remaining.")
 
 /obj/item/device/lightreplacer/resolve_attackby(var/atom/A, mob/user)
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -78,6 +78,7 @@
 				qdel(L)
 		if(amt_inserted)
 			to_chat(user, "You insert [amt_inserted] light[uses > 1 ? "s" : ""] into \The [src]. It has [uses] light[uses > 1 ? "s" : ""] remaining.")
+			add_fingerprint(user)
 			return
 
 	//Actually replace the light.
@@ -86,8 +87,9 @@
 		if(isliving(user))
 			var/mob/living/U = user
 			ReplaceLight(L, U)
+			add_fingerprint(user)
 			return
-	..()
+	. = ..()
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == "glass")

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -182,7 +182,7 @@
 			for(var/mob/M in viewers(usr, null))
 				if (M == usr)
 					to_chat(usr, "<span class='notice'>You put \the [W] into [src].</span>")
-				else if (M in range(1)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
+				else if (M in trange(1, src)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
 				else if (W && W.w_class >= ITEM_SIZE_NORMAL) //Otherwise they can only see large or normal items from a distance...
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
@@ -233,33 +233,9 @@
 	if(isrobot(user))
 		return //Robots can't interact with storage items.
 
-	if(istype(W, /obj/item/device/lightreplacer))
-		var/obj/item/device/lightreplacer/LP = W
-		var/amt_inserted = 0
-		var/turf/T = get_turf(user)
-		for(var/obj/item/weapon/light/L in src.contents)
-			if(L.status == 0)
-				if(LP.uses < LP.max_uses)
-					LP.AddUses(1)
-					amt_inserted++
-					remove_from_storage(L, T)
-					qdel(L)
-		if(amt_inserted)
-			to_chat(user, "You inserted [amt_inserted] light\s into \the [LP.name]. You have [LP.uses] light\s remaining.")
-			return
-
 	if(!can_be_inserted(W, user))
 		return
 
-	if(istype(W, /obj/item/weapon/tray))
-		var/obj/item/weapon/tray/T = W
-		if(T.calc_carry() > 0)
-			if(prob(85))
-				to_chat(user, "<span class='warning'>The tray won't fit in [src].</span>")
-				return
-			else
-				if(user.unEquip(W))
-					to_chat(user, "<span class='warning'>God damnit!</span>")
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -182,7 +182,7 @@
 			for(var/mob/M in viewers(usr, null))
 				if (M == usr)
 					to_chat(usr, "<span class='notice'>You put \the [W] into [src].</span>")
-				else if (M in trange(1, src)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
+				else if (M in range(1, src)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
 				else if (W && W.w_class >= ITEM_SIZE_NORMAL) //Otherwise they can only see large or normal items from a distance...
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -21,7 +21,7 @@
 		to_chat(user, "<span class='warning'>The tray won't fit in [A].</span>")
 		return
 	else
-		..()
+		. = ..()
 
 /obj/item/weapon/tray/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -16,6 +16,13 @@
 	var/list/carrying = list() // List of things on the tray. - Doohl
 	var/max_carry = 2*base_storage_cost(ITEM_SIZE_NORMAL)
 
+/obj/item/weapon/tray/resolve_attackby(var/atom/A, mob/user)
+	if(istype(A, /obj/item/weapon/storage/)) // There used to be here where it would just deny the tray storage if it had contents. It seems wiser, considering just how useful this tray is as a weapon, to deny it backpacks entirely without actually raising its weight class.
+		to_chat(user, "<span class='warning'>The tray won't fit in [A].</span>")
+		return
+	else
+		..()
+
 /obj/item/weapon/tray/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	// Drop all the things. All of them.

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -313,14 +313,6 @@
 
 /obj/machinery/light/attackby(obj/item/W, mob/user)
 
-	//Light replacer code
-	if(istype(W, /obj/item/device/lightreplacer))
-		var/obj/item/device/lightreplacer/LR = W
-		if(isliving(user))
-			var/mob/living/U = user
-			LR.ReplaceLight(src, U)
-			return
-
 	// attempt to insert light
 	if(istype(W, /obj/item/weapon/light))
 		if(lightbulb)


### PR DESCRIPTION
### The resolve_attackby proc exists for a reason. It is called when you hit something with an item. Instead of snowflake istypes, just have the item *take* from another, rather than the other item giving! USE IT!
🆑 
bugfix: Trays will now adequately notify you of not being able to be placed in bags.
/ 🆑 
And thus begins my stupid crusade of easy fixes.
https://streamable.com/j15ut