### PR TITLE
Moves comms colours into colors.dm.

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -60,6 +60,21 @@
 #define	PIPE_COLOR_BLACK       "#444444"
 #define	PIPE_COLOR_ORANGE      "#b95a00"
 
+#define	COMMS_COLOR_DEFAULT    "#ff00ff"
+#define	COMMS_COLOR_ENTERTAIN  "#666666"
+#define	COMMS_COLOR_AI         "#ff00ff"
+#define	COMMS_COLOR_COMMON     "#408010"
+#define	COMMS_COLOR_SERVICE    "#709b00"
+#define	COMMS_COLOR_SUPPLY     "#7f6539"
+#define	COMMS_COLOR_SCIENCE    "#993399"
+#define	COMMS_COLOR_MEDICAL    "#009190"
+#define	COMMS_COLOR_EXPLORER   "#929820"
+#define	COMMS_COLOR_ENGINEER   "#a68300"
+#define	COMMS_COLOR_SECURITY   "#930000"
+#define	COMMS_COLOR_COMMAND    "#204090"
+#define	COMMS_COLOR_CENTCOMM   "#5c5c7c"
+#define	COMMS_COLOR_SYNDICATE  "#6d3f40"
+
 #define COLOR_BLOOD_HUMAN "#a10808"
 
 #define RANDOM_RGB rgb(rand(0,255), rand(0,255), rand(0,255))

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -146,18 +146,18 @@ var/list/radiochannels = list(
 )
 
 var/list/channel_color_presets = list(
-	"Global Green" = "#008000",
-	"Phenomenal Purple" = "#993399",
-	"Bitchin' Blue" = "#395a9a",
-	"Menacing Maroon" = "#6d3f40",
-	"Pretty Periwinkle" = "#5c5c8a",
-	"Painful Pink" = "#ff00ff",
-	"Raging Red" = "#a30000",
-	"Operational Orange" = "#a66300",
-	"Tantalizing Turquoise" = "#008160",
-	"Bemoaning Brown" = "#7f6539",
-	"Gastric Green" = "#6eaa2c",
-	"Bold Brass" = "#a3a332"
+	"Global Green" = COMMS_COLOR_COMMON,
+	"Phenomenal Purple" = COMMS_COLOR_SCIENCE,
+	"Bitchin' Blue" = COMMS_COLOR_COMMAND,
+	"Menacing Maroon" = COMMS_COLOR_SYNDICATE,
+	"Pretty Periwinkle" = COMMS_COLOR_CENTCOMM,
+	"Painful Pink" = COMMS_COLOR_AI,
+	"Raging Red" = COMMS_COLOR_SECURITY,
+	"Operational Orange" = COMMS_COLOR_ENGINEER,
+	"Tantalizing Turquoise" = COMMS_COLOR_MEDICAL,
+	"Bemoaning Brown" = COMMS_COLOR_SUPPLY,
+	"Gastric Green" = COMMS_COLOR_SERVICE,
+	"Bold Brass" = COMMS_COLOR_EXPLORER
 )
 
 // central command channels, i.e deathsquid & response teams

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -176,34 +176,34 @@
 /obj/machinery/telecomms/server/presets/science
 	id = "Science Server"
 	freq_listening = list(SCI_FREQ)
-	channel_tags = list(list(SCI_FREQ, "Science", "#993399"))
+	channel_tags = list(list(SCI_FREQ, "Science", COMMS_COLOR_SCIENCE))
 	autolinkers = list("science")
 
 /obj/machinery/telecomms/server/presets/medical
 	id = "Medical Server"
 	freq_listening = list(MED_FREQ)
-	channel_tags = list(list(MED_FREQ, "Medical", "#008160"))
+	channel_tags = list(list(MED_FREQ, "Medical", COMMS_COLOR_MEDICAL))
 	autolinkers = list("medical")
 
 /obj/machinery/telecomms/server/presets/supply
 	id = "Supply Server"
 	freq_listening = list(SUP_FREQ)
-	channel_tags = list(list(SUP_FREQ, "Supply", "#7f6539"))
+	channel_tags = list(list(SUP_FREQ, "Supply", COMMS_COLOR_SUPPLY))
 	autolinkers = list("supply")
 
 /obj/machinery/telecomms/server/presets/service
 	id = "Service Server"
 	freq_listening = list(SRV_FREQ)
-	channel_tags = list(list(SRV_FREQ, "Service", "#6eaa2c"))
+	channel_tags = list(list(SRV_FREQ, "Service", COMMS_COLOR_SERVICE))
 	autolinkers = list("service")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
 	freq_listening = list(PUB_FREQ, AI_FREQ, ENT_FREQ) // AI Private and Common
 	channel_tags = list(
-		list(PUB_FREQ, "Common", "#008000"),
-		list(AI_FREQ, "AI Private", "#ff00ff"),
-		list(ENT_FREQ, "Entertainment", "#6eaa2c")
+		list(PUB_FREQ, "Common", COMMS_COLOR_COMMON),
+		list(AI_FREQ, "AI Private", COMMS_COLOR_AI),
+		list(ENT_FREQ, "Entertainment", COMMS_COLOR_ENTERTAIN)
 	)
 	autolinkers = list("common")
 
@@ -223,25 +223,25 @@
 /obj/machinery/telecomms/server/presets/command
 	id = "Command Server"
 	freq_listening = list(COMM_FREQ)
-	channel_tags = list(list(COMM_FREQ, "Command", "#395a9a"))
+	channel_tags = list(list(COMM_FREQ, "Command", COMMS_COLOR_COMMAND))
 	autolinkers = list("command")
 
 /obj/machinery/telecomms/server/presets/engineering
 	id = "Engineering Server"
 	freq_listening = list(ENG_FREQ)
-	channel_tags = list(list(ENG_FREQ, "Engineering", "#a66300"))
+	channel_tags = list(list(ENG_FREQ, "Engineering", COMMS_COLOR_ENGINEER))
 	autolinkers = list("engineering")
 
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	freq_listening = list(SEC_FREQ)
-	channel_tags = list(list(SEC_FREQ, "Security", "#a30000"))
+	channel_tags = list(list(SEC_FREQ, "Security", COMMS_COLOR_SECURITY))
 	autolinkers = list("security")
 
 /obj/machinery/telecomms/server/presets/centcomm
 	id = "CentComm Server"
 	freq_listening = list(ERT_FREQ, DTH_FREQ)
-	channel_tags = list(list(ERT_FREQ, "Response Team", "#395a9a"), list(DTH_FREQ, "Special Ops", "#6d3f40"))
+	channel_tags = list(list(ERT_FREQ, "Response Team", COMMS_COLOR_CENTCOMM), list(DTH_FREQ, "Special Ops", COMMS_COLOR_SYNDICATE))
 	produces_heat = 0
 	autolinkers = list("centcomm")
 

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -40,24 +40,24 @@ em						{font-style: normal;font-weight: bold;}
 
 /* Radio: Misc */
 .deadsay				{color: #530fad;}
-.radio					{color: #008000;}
+.radio					{color: #408010;}
 .deptradio				{color: #ff00ff;}	/* when all other department colors fail */
 .newscaster				{color: #750000;}
 
 /* Radio Channels */
-.comradio				{color: #193a7a;}
+.comradio				{color: #204090;}
 .syndradio				{color: #6d3f40;}
-.centradio				{color: #5c5c8a;}
+.centradio				{color: #5c5c7c;}
 .airadio				{color: #ff00ff;}
-.entradio				{color: #339966;}
+.entradio				{color: #666666;}
 
-.secradio				{color: #a30000;}
-.engradio				{color: #a66300;}
-.medradio				{color: #008160;}
+.secradio				{color: #930000;}
+.engradio				{color: #a68300;}
+.medradio				{color: #009190;}
 .sciradio				{color: #993399;}
-.supradio				{color: #5f4519;}
-.srvradio				{color: #6eaa2c;}
-.expradio				{color: #a3a332;}
+.supradio				{color: #7f6539;}
+.srvradio				{color: #709b00;}
+.expradio				{color: #929820;}
 
 /* Miscellaneous */
 .name					{font-weight: bold;}

--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -31,15 +31,15 @@
 	id = "Service and Exploration Server"
 	freq_listening = list(SRV_FREQ, EXP_FREQ)
 	channel_tags = list(
-		list(SRV_FREQ, "Service", "#6eaa2c"),
-		list(EXP_FREQ, "Exploration", "#a3a332")
+		list(SRV_FREQ, "Service", COMMS_COLOR_SERVICE),
+		list(EXP_FREQ, "Exploration", COMMS_COLOR_EXPLORER)
 	)
 	autolinkers = list("service", "exploration")
 
 /obj/machinery/telecomms/server/presets/exploration
 	id = "Utility Server"
 	freq_listening = list(EXP_FREQ)
-	channel_tags = list(list(EXP_FREQ, "Exploration", "#a3a332"))
+	channel_tags = list(list(EXP_FREQ, "Exploration", COMMS_COLOR_EXPLORER))
 	autolinkers = list("Exploration")
 
 // Suit cyclers and storage


### PR DESCRIPTION
Basically, changing colors.dm should directly affect all comms colours. Also, changed colours to be a bit nicer on the eyes as a whole.

Note, however, that the colours that are displayed in the radio interfaces are still dependent on stylesheet.dm

Before: https://puu.sh/AiBZ7/89ec218e74.png

After: https://puu.sh/AiKnW/fd23b58f0f.png