### PR TITLE
Security/Checkpoint re-map

### DIFF
--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -3458,6 +3458,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"hu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "hangar_hallway_shutters";
+	name = "Hangar Deck Hallway Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/fore)
 "hv" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning{
@@ -5264,9 +5288,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/center)
-"lk" = (
-/turf/simulated/wall/prepainted,
-/area/security/checkpoint2)
 "ll" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -6025,81 +6046,89 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/center)
-"mw" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "dockcheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint2)
 "mx" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"my" = (
-/obj/machinery/papershredder,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"mz" = (
-/obj/machinery/photocopier,
-/obj/machinery/camera/network/security{
-	c_tag = "Fourth Deck - Security Checkpoint"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"mA" = (
-/obj/structure/table/rack,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"mB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
+/obj/structure/bedsheetbin,
+/obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 24
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"my" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/ironingiron{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/item/weapon/ironingiron{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/detergent{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/detergent{
+	pixel_x = -3
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"mA" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"mB" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
 "mC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -6555,6 +6584,15 @@
 	dir = 4;
 	icon_state = "intact"
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "hangar_hallway_shutters";
+	name = "Hangar Deck Hallway Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "nv" = (
@@ -6669,55 +6707,44 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/center)
-"nD" = (
+"nE" = (
+/obj/structure/bed/roller/ironingboard,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"nF" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "dockcheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint2)
-"nE" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/flora/pottedplant/small{
-	pixel_y = 13
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"nF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"nG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
 "nH" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Security Checkpoint Maintenance";
-	req_access = list(1)
+	name = "Laundry Maintenance";
+	req_access = list(14)
 	},
 /turf/simulated/floor/plating,
-/area/security/checkpoint2)
+/area/crew_quarters/laundry)
 "nI" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -7248,61 +7275,95 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/center)
-"oM" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "dockcheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint2)
 "oN" = (
-/obj/item/modular_computer/console/preset/security,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/structure/bed/roller/ironingboard,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
 "oO" = (
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"oP" = (
-/obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"oQ" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"oR" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"oP" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"oQ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
+"oR" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Laundry";
+	dir = 8
+	},
 /obj/machinery/light_switch{
-	pixel_x = 26;
+	pixel_x = -6;
 	pixel_y = -24
 	},
-/obj/machinery/button/windowtint{
-	id = "dockcheck_windows";
-	pixel_x = 38;
-	pixel_y = -24
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
 "oS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7833,17 +7894,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/fourthdeck)
 "pN" = (
-/obj/machinery/button/remote/blast_door{
-	id = "teleport3";
-	name = "Third Deck Teleporter Access Shutter Control";
-	pixel_x = -6;
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
 	},
 /obj/machinery/bluespace_beacon,
+/obj/machinery/button/remote/blast_door{
+	id = "teleport4";
+	name = "Fourth Deck Teleporter Access Shutter Control";
+	pixel_x = -6;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/fourthdeck)
 "pO" = (
@@ -8001,82 +8062,27 @@
 	dir = 1
 	},
 /turf/simulated/wall/prepainted,
-/area/security/checkpoint2)
-"qf" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "dockcheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint2)
-"qg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "Security Checkpoint";
-	req_access = list(63)
-	},
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/southleft{
-	name = "Security Checkpoint"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
-"qh" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "dockcheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint2)
+/area/crew_quarters/laundry)
 "qi" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/prepainted,
-/area/security/checkpoint2)
-"qj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access = list(1);
-	secured_wires = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Laundry Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/security/checkpoint2)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/laundry)
 "qk" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8092,9 +8098,6 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "qm" = (
@@ -8600,44 +8603,22 @@
 /area/hallway/primary/fourthdeck/center)
 "rm" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/corner/red{
+/obj/machinery/door/airlock/glass,
+/obj/effect/floor_decal/corner/brown{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "rn" = (
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/brown{
 	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
-"ro" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "rp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/brown{
 	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
-"rq" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Security Checkpoint";
-	dir = 2
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -8645,27 +8626,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
-"rr" = (
+"rq" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "rs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Security Checkpoint";
+	dir = 2
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
@@ -9277,9 +9262,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "sA" = (
@@ -9354,9 +9336,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -9368,21 +9347,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
-"sE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 8
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8;
+	name = "Security Checkpoint - Deck 4";
+	sortType = "Security Checkpoint - Deck 4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
@@ -9500,11 +9468,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "sL" = (
@@ -9528,16 +9491,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Security Checkpoint";
-	sortType = "Security Checkpoint"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
@@ -9547,16 +9509,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "sO" = (
@@ -10514,14 +10475,11 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "uc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	name = "Primary Tool Storage"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
 /area/storage/primary)
 "ud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10529,9 +10487,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -10549,27 +10504,24 @@
 /area/hallway/primary/fourthdeck/fore)
 "uf" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/corner/yellow{
+/obj/machinery/door/airlock/glass,
+/obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
-/obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "ug" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "uh" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -10577,12 +10529,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "ui" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -10594,22 +10547,21 @@
 	c_tag = "Fourth Deck Hallway - Lift";
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "uj" = (
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "uk" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/effect/floor_decal/corner/red{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
@@ -11250,8 +11202,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/corner/lime{
-	dir = 1
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "hangar_hallway_shutters";
+	name = "Hangar Deck Hallway Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -11265,36 +11223,40 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "hangar_hallway_shutters";
+	name = "Hangar Deck Hallway Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "vC" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/laundry)
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/checkpoint2)
 "vD" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/laundry)
 "vE" = (
-/obj/machinery/door/airlock/glass{
-	name = "Laundry Room"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access = list(1);
+	secured_wires = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/laundry)
-"vF" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/laundry)
+/area/security/checkpoint2)
 "vG" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -11875,6 +11837,10 @@
 	pixel_x = -23;
 	pixel_y = 0
 	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "wH" = (
@@ -11887,93 +11853,80 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white,
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Primary Tool Storage";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "wI" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/firealarm{
-	dir = 1;
+	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/structure/table/steel,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "hangar_checkpoint_shutters";
+	name = "Checkpoint Window Shutters";
+	pixel_x = -3;
+	pixel_y = 7;
+	req_access = list(1)
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "hangar_hallway_shutters";
+	name = "Hallway Checkpoint Shutters";
+	pixel_x = -3;
+	pixel_y = -3;
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "wJ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "wK" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
 /obj/machinery/light_switch{
-	pixel_x = -6;
+	pixel_x = -4;
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
-"wL" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/obj/machinery/camera/network/security{
+	c_tag = "Fourth Deck - Security Checkpoint"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "wM" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/item/modular_computer/console/preset/security,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/bed/roller/ironingboard,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "wN" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/center)
@@ -12760,106 +12713,51 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white,
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Primary Tool Storage";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
-"ye" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
-"yf" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/fore)
+"ye" = (
+/obj/structure/bed/chair/office/dark{
+	icon_state = "officechair_dark";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
+"yf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "yg" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "yh" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "yi" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/structure/table/steel,
+/obj/structure/flora/pottedplant/small{
+	pixel_y = 13
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/bed/roller/ironingboard,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "yj" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
@@ -13711,33 +13609,24 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "zC" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "zD" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/structure/bedsheetbin,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "zE" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -13749,23 +13638,18 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "zF" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/machinery/papershredder,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/washing_machine,
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Laundry";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "zG" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
@@ -14341,70 +14225,44 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
-"AM" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
 "AN" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/random/maintenance/solgov/clean,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Security";
+	departmentType = 5;
+	pixel_y = -32
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/secure_closet{
+	name = "Security Equipment Locker";
+	req_access = list(1)
 	},
-/obj/structure/disposalpipe/segment,
-/obj/item/weapon/ironingiron{
-	pixel_x = 0;
-	pixel_y = 10
-	},
-/obj/item/weapon/ironingiron{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/box/detergent{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/box/detergent{
-	pixel_x = -3
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "AO" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/machinery/washing_machine,
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "AP" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/center)
@@ -15050,20 +14908,6 @@
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"Cb" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
 "Cc" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
@@ -15510,11 +15354,11 @@
 /area/maintenance/fourthdeck/foreport)
 "Db" = (
 /turf/simulated/wall/r_wall/hull,
-/area/crew_quarters/laundry)
+/area/security/checkpoint2)
 "Dc" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/hull,
-/area/crew_quarters/laundry)
+/area/security/checkpoint2)
 "Dd" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/hull,
@@ -18979,6 +18823,22 @@
 /obj/effect/landmark/test/space_turf,
 /turf/space,
 /area/space)
+"KH" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint2)
 "KS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -19009,9 +18869,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
+"MD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "MH" = (
 /turf/simulated/wall/r_wall/hull,
 /area/quartermaster/expedition/storage)
+"Nm" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint2)
 "Nq" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/tiled,
@@ -19045,6 +18930,42 @@
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/mess)
+"NN" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint2)
+"Oj" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint2)
+"OX" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/checkpoint2)
 "OZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19089,27 +19010,25 @@
 "Qd" = (
 /turf/simulated/wall/r_wall/hull,
 /area/quartermaster/hangar)
+"Qo" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/obj/structure/closet/hydrant{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Qp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/storage)
 "Qq" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "QI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19125,6 +19044,54 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
+"Rl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 4;
+	name = "Security Checkpoint";
+	req_access = list(63)
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Security Checkpoint"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
+"Rm" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/checkpoint2)
 "RJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19179,9 +19146,59 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/storage)
+"SD" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint2)
+"Tc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Ty" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/infirmary)
+"TB" = (
+/obj/random/maintenance/solgov/clean,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/secure_closet{
+	name = "Security Equipment Locker";
+	req_access = list(1)
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "TC" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19196,12 +19213,38 @@
 /obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"TE" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -32
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint2)
 "TG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/unused)
+"Uq" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "US" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -19265,6 +19308,41 @@
 "XJ" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/unused)
+"XQ" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint2)
+"XV" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "XZ" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -31703,9 +31781,9 @@ hV
 jf
 kg
 lf
-mo
+hu
 nu
-oB
+wF
 pS
 rc
 sw
@@ -32720,7 +32798,7 @@ pW
 rd
 oB
 uc
-oB
+wF
 wF
 ny
 zy
@@ -33327,11 +33405,11 @@ rg
 sB
 uf
 vC
-vD
-vD
-vD
-vD
-vD
+Nm
+Rl
+XQ
+OX
+OX
 Db
 DT
 DT
@@ -33528,12 +33606,12 @@ pZ
 rh
 sC
 ug
-vD
+OX
 wI
 ye
 Qq
-AM
-zB
+OX
+OX
 Db
 DU
 EN
@@ -33734,8 +33812,8 @@ vE
 wJ
 yf
 zC
-zE
-zE
+TB
+OX
 Db
 DV
 EO
@@ -33930,14 +34008,14 @@ kl
 kl
 qa
 ri
-sE
+sL
 ui
-vF
+OX
 wK
 yg
-zD
+MD
 AN
-Cb
+OX
 Db
 DV
 EO
@@ -34134,12 +34212,12 @@ qa
 rh
 sF
 uj
-vG
-wL
+KH
+Qq
 yh
-zE
-zE
-zE
+zD
+TE
+OX
 Db
 DV
 EO
@@ -34334,14 +34412,14 @@ kl
 kl
 am
 rh
-sC
-uj
-vG
+XV
+Uq
+SD
 wM
 yi
 zF
 AO
-zB
+OX
 Db
 DW
 EN
@@ -34538,12 +34616,12 @@ qb
 rj
 sG
 uk
-vD
-vD
-vD
-vD
-vD
-vD
+Rm
+Oj
+NN
+OX
+OX
+OX
 Dc
 ZG
 an
@@ -35136,10 +35214,10 @@ an
 ZG
 jl
 kn
-lk
-mw
-nD
-oM
+vD
+vD
+vD
+vD
 qe
 rm
 sJ
@@ -35338,11 +35416,11 @@ aP
 if
 aq
 ko
-lk
+vD
 mx
 nE
 oN
-qf
+vG
 rn
 sC
 uo
@@ -35540,12 +35618,12 @@ hk
 ig
 aq
 ko
-lk
+vD
 my
-nF
+zE
 oO
-qg
-ro
+vG
+rn
 sK
 up
 vL
@@ -35742,11 +35820,11 @@ hk
 ig
 aq
 ko
-lk
-mz
-nF
+vD
+zB
+zE
 oP
-qh
+vD
 rp
 sL
 uq
@@ -35944,7 +36022,7 @@ hk
 ig
 aq
 ko
-lk
+vD
 mA
 nF
 oQ
@@ -36146,12 +36224,12 @@ aP
 ih
 aq
 ko
-lk
+vD
 mB
-nG
+zE
 oR
-qj
-rr
+vD
+Qo
 sN
 us
 vO
@@ -36348,14 +36426,14 @@ aq
 aq
 aq
 ko
-lk
-lk
+vD
+vD
 nH
-lk
-lk
+vD
+vD
 rs
 sL
-uq
+Tc
 vK
 vK
 yr

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -5574,6 +5574,7 @@
 /obj/item/weapon/gun/energy/secure/gun,
 /obj/item/weapon/gun/energy/secure/gun,
 /obj/item/weapon/gun/energy/secure/gun,
+/obj/item/weapon/gun/energy/secure/gun,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "lS" = (
@@ -6419,6 +6420,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "ny" = (
@@ -6431,6 +6438,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "nz" = (
@@ -6439,9 +6452,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -6449,6 +6459,12 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
@@ -6474,6 +6490,9 @@
 	name = "Brig Officer";
 	req_access = list(3)
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "nB" = (
@@ -6495,6 +6514,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/item/device/radio/beacon,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "nC" = (
@@ -6998,6 +7021,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "oy" = (
@@ -7500,6 +7524,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "pu" = (
@@ -8018,6 +8043,7 @@
 	req_access = list(2);
 	secured_wires = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "qq" = (
@@ -8561,6 +8587,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "rw" = (
@@ -9671,8 +9698,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Brig Officer";
+	sortType = "Brig Officer"
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
@@ -15036,13 +15065,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 4
 	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "Em" = (
@@ -18240,6 +18271,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
+"MZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bo)
 "Nb" = (
 /obj/effect/shuttle_landmark/merc/deck3,
 /turf/space,
@@ -18509,6 +18546,7 @@
 	dir = 9
 	},
 /obj/machinery/computer/prisoner,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "Om" = (
@@ -19014,6 +19052,10 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "Rm" = (
@@ -19443,16 +19485,10 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Tl" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Warden's Office"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/obj/structure/table/steel,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "Tm" = (
@@ -20059,9 +20095,6 @@
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "Wl" = (
-/obj/item/weapon/stamp/denied{
-	pixel_x = 5
-	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 30;
 	pixel_y = -30
@@ -20070,11 +20103,13 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/item/weapon/stamp/brig,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
 /obj/structure/table/steel,
+/obj/machinery/photocopier/faxmachine{
+	department = "Warden's Office"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "Wn" = (
@@ -20701,6 +20736,10 @@
 /area/tcommsat/chamber)
 "ZR" = (
 /obj/structure/table/steel,
+/obj/item/weapon/stamp/brig,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 
@@ -44432,7 +44471,7 @@ ld
 Fl
 mC
 nx
-mD
+MZ
 PK
 Zl
 lc

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -936,7 +936,7 @@
 	name = "Pathfinder's Office";
 	sortType = "Pathfinder's Office"
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -6513,6 +6513,15 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_hallway_shutters";
+	name = "Operation Deck Hallway Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "asE" = (
@@ -6676,8 +6685,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "atw" = (
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "atA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
@@ -6894,15 +6907,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "auB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
-"auD" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "auE" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -7263,15 +7279,6 @@
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
-"avP" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
 "avS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7283,6 +7290,9 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/deck/first{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "avT" = (
@@ -7297,9 +7307,6 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
-/obj/structure/sign/deck/first{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "avU" = (
@@ -7634,7 +7641,7 @@
 /area/command/captainmess)
 "awX" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/vacant/office)
+/area/security/opscheck)
 "awZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7760,6 +7767,7 @@
 	dir = 1
 	},
 /obj/structure/closet/hydrant{
+	pixel_x = 4;
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -9445,7 +9453,6 @@
 /obj/item/weapon/gun/energy/secure/gun,
 /obj/item/weapon/gun/energy/secure/gun,
 /obj/item/weapon/gun/energy/secure/gun,
-/obj/item/weapon/gun/energy/secure/gun,
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/tactical)
 "aCw" = (
@@ -9479,6 +9486,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/weapon/gun/energy/secure/laser,
 /obj/item/weapon/gun/energy/secure/laser,
 /obj/item/weapon/gun/energy/secure/laser,
 /turf/simulated/floor/tiled/dark,
@@ -9846,9 +9854,17 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/red{
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_hallway_shutters";
+	name = "Operation Deck Hallway Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -9864,6 +9880,15 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_hallway_shutters";
+	name = "Operation Deck Hallway Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -10160,8 +10185,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -10172,12 +10197,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -10188,8 +10214,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/red{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -10201,7 +10232,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/red{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -10607,6 +10638,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aGd" = (
@@ -10643,6 +10679,11 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aGf" = (
@@ -10658,6 +10699,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aGg" = (
@@ -10872,68 +10916,22 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aGQ" = (
-/turf/simulated/wall/prepainted,
-/area/security/opscheck)
-"aGR" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "opscheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/opscheck)
-"aGS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	name = "Security Checkpoint";
-	req_access = list(63)
-	},
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Security Checkpoint"
+/obj/machinery/door/airlock{
+	name = "Unused Office"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aGT" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "opscheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aGU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11219,57 +11217,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"aId" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "opscheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/opscheck)
 "aIe" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/filingcabinet/filingcabinet,
+/obj/item/device/radio/intercom{
+	pixel_y = 22
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aIf" = (
-/obj/item/modular_computer/console/preset/command,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aIg" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aIh" = (
 /obj/item/modular_computer/console/preset/security,
 /turf/simulated/floor/tiled/dark,
@@ -11280,22 +11241,15 @@
 	pixel_y = 24
 	},
 /obj/machinery/button/windowtint{
-	id = "opscheck_windows";
+	id = "vacantoffice_windows";
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/structure/table/rack,
-/obj/item/weapon/hand_labeler,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aIj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11571,62 +11525,42 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"aJu" = (
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "opscheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/opscheck)
 "aJv" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
 "aJw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aJx" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/structure/table/standard,
+/obj/item/weapon/hand_labeler,
+/obj/item/stack/package_wrap/twenty_five,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aJy" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aJz" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Office";
-	req_access = list(1);
-	secured_wires = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aJA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
+"aJz" = (
+/obj/machinery/door/airlock{
+	name = "Unused Office"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
+"aJA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	tag = "icon-pipe-y (NORTH)";
+	icon_state = "pipe-y";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/diplomat)
@@ -11948,40 +11882,39 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Emergency Armory";
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
-"aKI" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Office";
-	req_access = list(1);
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aKJ" = (
+/obj/effect/floor_decal/corner/lime,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/fore)
+"aKJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aKK" = (
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aKL" = (
-/obj/item/modular_computer/console/preset/security,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"aKL" = (
+/obj/machinery/vending/snack,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aKM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -12025,16 +11958,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/diplomat)
-"aKP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/lino,
 /area/crew_quarters/diplomat)
 "aKQ" = (
 /obj/machinery/firealarm{
@@ -12244,53 +12167,40 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
 "aLH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Emergency Armory";
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aLJ" = (
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = -32
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aLK" = (
-/obj/structure/table/steel,
-/obj/machinery/camera/network/security{
-	c_tag = "First Deck - Security Office";
-	dir = 1
-	},
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/structure/bed/chair,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aLL" = (
-/obj/structure/table/steel,
-/obj/item/device/taperecorder{
-	pixel_y = 0
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aLM" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
@@ -12585,48 +12495,40 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aML" = (
-/obj/machinery/papershredder,
-/obj/item/device/radio/intercom/department/security{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/photocopier,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aMM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aMN" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor/lino,
+/area/vacant/office)
+"aMN" = (
+/obj/structure/table/standard,
+/obj/item/weapon/folder{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/item/weapon/folder,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aMO" = (
 /obj/structure/toilet{
 	dir = 4
@@ -12653,7 +12555,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/lino,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
 /area/crew_quarters/diplomat)
 "aMV" = (
 /obj/structure/disposalpipe/up,
@@ -12934,32 +12839,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aNN" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Security";
-	departmentType = 5;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
-"aNO" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/firealarm{
-	dir = 1;
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
 	pixel_y = -24
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "aNP" = (
 /obj/machinery/shower{
 	dir = 1
@@ -12974,15 +12861,6 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/diplomat)
-"aNS" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/lino,
 /area/crew_quarters/diplomat)
 "aNV" = (
 /obj/structure/cable/green{
@@ -16300,6 +16178,32 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
+"bhL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/lino,
+/area/crew_quarters/diplomat)
+"bhO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/security{
+	name = "Security Office";
+	req_access = list(1);
+	secured_wires = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "bib" = (
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "rcheckinner_windows"
@@ -16448,11 +16352,27 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "brb" = (
-/obj/machinery/newscaster{
-	pixel_x = -30
+/obj/structure/ladder/up,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Security Checkpoint Ladder";
+	req_access = list(1)
+	},
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "bsb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/table/steel_reinforced,
@@ -17845,6 +17765,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"dBa" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/opscheck)
 "dBb" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -18158,6 +18094,17 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/aux)
+"edT" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "eeb" = (
 /obj/structure/table/standard,
 /obj/machinery/button/windowtint{
@@ -18798,6 +18745,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
+"eVQ" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "eWb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19295,6 +19248,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
+"fHk" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "fIb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -19863,6 +19820,32 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"gDm" = (
+/obj/structure/table/steel,
+/obj/item/device/taperecorder{
+	pixel_y = 0
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "operation_hallway_shutters";
+	name = "Hallway Checkpoint Shutters";
+	pixel_x = 3;
+	pixel_y = 6;
+	req_access = list(1)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "operation_checkpoint_shutters";
+	name = "Checkpoint Window Shutters";
+	pixel_x = 3;
+	pixel_y = -3;
+	req_access = list(1)
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "gEb" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
@@ -19905,6 +19888,51 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
+"gGG" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Security Checkpoint"
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 8;
+	name = "Security Checkpoint";
+	req_access = list(63)
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "gHb" = (
 /obj/structure/closet/crate,
 /obj/item/stack/material/phoron{
@@ -21165,6 +21193,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
+"isE" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "itb" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -21195,6 +21236,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
+"iui" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/opscheck)
 "ivb" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -21277,6 +21334,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
+"iAZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/fore)
 "iBb" = (
 /obj/effect/wingrille_spawn/reinforced/full,
 /obj/machinery/door/firedoor/border_only,
@@ -21295,6 +21364,15 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/rnd/checkpoint)
+"iCj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/fore)
 "iDb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green,
@@ -23377,6 +23455,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"lYS" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/machinery/photocopier,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "lZb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23525,6 +23615,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"mlw" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "mmb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23953,18 +24049,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "mXb" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/machinery/button/windowtint{
-	id = "vacantoffice_windows";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/item/device/radio/intercom{
+	pixel_y = 32
 	},
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "mZb" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
@@ -24052,21 +24150,39 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "ngb" = (
-/obj/structure/table/standard,
-/obj/item/weapon/hand_labeler,
-/obj/item/stack/package_wrap/twenty_five,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nhb" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/red{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -24124,29 +24240,43 @@
 /turf/simulated/floor/blackgrid,
 /area/security/nuke_storage)
 "npb" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "First Deck - Security Office";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nqb" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
-"nrb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nsb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/lime{
+/obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -24179,35 +24309,47 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "nub" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Security";
+	departmentType = 5;
+	pixel_x = -32;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nvb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nwb" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24215,37 +24357,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nxb" = (
-/obj/machinery/door/airlock{
-	name = "Unused Office"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/security{
+	name = "Security Office";
+	req_access = list(1);
+	secured_wires = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nyb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
@@ -24256,24 +24388,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime{
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
 	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
-"nzb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
@@ -24350,44 +24467,33 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "nEb" = (
-/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled,
-/area/vacant/office)
-"nFb" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
-"nGb" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 20
+	pixel_x = -24
 	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled,
-/area/vacant/office)
-"nHb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/lime{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 18
+	},
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
+"nGb" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/rack,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "nIb" = (
 /obj/structure/closet/secure_closet/guard,
 /obj/effect/floor_decal/corner/red{
@@ -24571,18 +24677,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/rnd/xenobiology)
-"nXb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
 "nYb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24605,14 +24699,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "Command Hallway - Port"
 	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"nZB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark,
+/area/security/opscheck)
 "oab" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -24740,23 +24847,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "ohb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "oib" = (
@@ -24802,6 +24901,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"onA" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/opscheck)
 "oob" = (
 /turf/simulated/floor/carpet/purple,
 /area/chapel/main)
@@ -25137,6 +25256,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"oRK" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/opscheck)
 "oSb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25192,26 +25331,23 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "oVb" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 6
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "oWb" = (
-/obj/machinery/photocopier,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/opscheck)
+/obj/machinery/papershredder,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "oXb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25984,6 +26120,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/diplomat)
 "qxb" = (
@@ -25996,6 +26133,15 @@
 /obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/diplomat)
+"qxQ" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/green,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "qya" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -26113,6 +26259,10 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/rnd/xenobiology/xenoflora)
+"qHx" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/opscheck)
 "qIb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/white,
@@ -26605,6 +26755,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rGU" = (
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "rHb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/structure/table/standard,
@@ -27202,6 +27356,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"sEm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "operation_hallway_shutters";
+	name = "Operation Deck Hallway Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/fore)
 "sFb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27789,12 +27961,25 @@
 "tAS" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/foreport)
-"vwr" = (
-/obj/structure/shuttle/engine/propulsion{
+"uVw" = (
+/obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/wall/r_wall/hull,
-/area/shuttle/escape_pod16/station)
+/turf/simulated/floor/lino,
+/area/vacant/office)
+"uXr" = (
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/opscheck)
 "vIi" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -27807,6 +27992,39 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
+"wAK" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/diplomat)
+"wWc" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "operation_checkpoint_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/opscheck)
+"wXc" = (
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "xuW" = (
 /obj/structure/morgue,
 /obj/item/device/radio/intercom{
@@ -27815,6 +28033,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
+"xJP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/fore)
 "xPU" = (
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
@@ -39035,14 +39266,14 @@ axR
 nOb
 aEP
 aFW
+asx
+asv
+asv
+asx
 aGQ
-aId
-aJu
-aKI
-aGQ
-aGQ
-aGQ
-aGQ
+asx
+asx
+asx
 afI
 afI
 aRt
@@ -39237,14 +39468,14 @@ axR
 axR
 hyj
 aFX
-aGQ
+asx
 aIe
-aJv
-aJv
+qxQ
+wXc
 oVb
 aML
 oWb
-aGQ
+asx
 aFf
 aCN
 aRu
@@ -39439,14 +39670,14 @@ axR
 axR
 nWb
 ogb
-aGR
+asv
 aIf
-aJv
-aJv
-aJv
+fHk
+eVQ
+edT
 aMM
 aNN
-aGQ
+asx
 aPz
 aCN
 aRu
@@ -39639,16 +39870,16 @@ nob
 oyb
 aDN
 axR
-nXb
+aEQ
 ohb
-aGS
+asv
 aIg
 aJw
 aKJ
 aLJ
 aMN
-aNO
-aGQ
+aIg
+asx
 aCN
 aQx
 aRv
@@ -39843,14 +40074,14 @@ axR
 axR
 aEQ
 aGa
-aGT
-aIh
-aJx
-aKK
+asv
+aIg
+aIg
+aIg
 aLK
-aGQ
-aGQ
-aGQ
+fHk
+uVw
+asx
 aCN
 aQy
 aRw
@@ -40045,14 +40276,14 @@ axR
 axR
 nYb
 aGb
-aGQ
+asx
 aIi
 aJy
 aKL
 aLL
-aGQ
-aCN
-aCN
+isE
+rGU
+asx
 aCN
 aDV
 aRx
@@ -40247,14 +40478,14 @@ awX
 awX
 nZb
 aFX
-aGQ
-aGQ
+asx
+asx
 aJz
-aGQ
-aGQ
-aGQ
-aCN
-aCN
+asx
+aGX
+aGX
+aGX
+aGX
 aPA
 aCN
 aPC
@@ -40446,7 +40677,7 @@ ngb
 npb
 nub
 nEb
-asx
+oRK
 aEU
 aGc
 aGU
@@ -40454,9 +40685,9 @@ aIj
 aJA
 aKM
 aGX
-aCN
-aCN
-aCN
+aMO
+aNP
+aGX
 aPB
 aQz
 aRy
@@ -40647,8 +40878,8 @@ mXb
 nhb
 nqb
 auB
-auD
-asv
+mlw
+iui
 aET
 aGd
 aGV
@@ -40656,8 +40887,8 @@ aIk
 aJB
 aKN
 aGX
-aGX
-aGX
+aMP
+aNQ
 aGX
 aPC
 aCN
@@ -40844,13 +41075,13 @@ asA
 atC
 auG
 avU
-awX
+dBa
 atw
-avP
-nrb
+aJv
+gDm
 nvb
-nFb
-asv
+aKK
+bhO
 aEW
 aGe
 aGW
@@ -40858,8 +41089,8 @@ aIl
 aJC
 aKO
 aGX
-aMO
-aNP
+aMQ
+kGb
 aGX
 aPC
 aQA
@@ -41046,22 +41277,22 @@ asy
 atD
 auH
 avU
-awX
-atw
-atw
-atw
+onA
+lYS
+nZB
+aIh
 nwb
 nGb
-asx
-aET
+qHx
+iAZ
 aGf
 aGX
 aGX
 aev
 aGX
 aGX
-aMP
-aNQ
+aMR
+aGX
 aGX
 aPD
 aIr
@@ -41248,22 +41479,22 @@ asB
 atE
 auI
 avV
-awX
-asv
-asv
-asv
+qHx
+wWc
+gGG
+uXr
 nxb
-asx
-asx
+awX
+awX
 aEX
 aGg
 aGX
 aIm
 aJE
-aKP
-aGX
-aMQ
-kGb
+aIn
+wAK
+aIn
+bhL
 aGX
 aPC
 aQB
@@ -41446,26 +41677,26 @@ aCF
 bMb
 aql
 arx
-asC
+sEm
 asC
 auJ
 avW
-asC
+iCj
 abI
 nib
 nsb
 nyb
-nHb
+iCj
 aDO
 aEY
 aGh
 aGY
 aIn
 aJF
+aIn
+aIn
+aIn
 aKQ
-aGX
-aMR
-aGX
 aGX
 aPC
 aQB
@@ -41654,9 +41885,9 @@ auK
 avX
 awZ
 axY
-awZ
+xJP
 aAl
-nzb
+aCH
 aCH
 aDP
 aEZ
@@ -41667,7 +41898,7 @@ aJG
 aKR
 aKR
 aMS
-aNS
+qTb
 aGX
 aPC
 tAS
@@ -44903,7 +45134,7 @@ aJO
 aAr
 aPO
 jjh
-vwr
+aRD
 aSz
 aSz
 aSz

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -1471,6 +1471,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/cobed)
+"dH" = (
+/obj/structure/cable/green,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
 "dI" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -3112,11 +3125,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/ce)
-"hB" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "hC" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
@@ -3150,6 +3158,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -3732,6 +3749,7 @@
 	c_tag = "Bridge - Stairs";
 	dir = 4
 	},
+/obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iU" = (
@@ -3784,10 +3802,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iX" = (
@@ -3807,9 +3821,6 @@
 	icon_state = "warningcorner";
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iY" = (
@@ -3827,10 +3838,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iZ" = (
@@ -4147,37 +4155,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jO" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"jP" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
-/obj/structure/sign/deck/bridge{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"jQ" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jR" = (
-/obj/structure/sign/directions/infirmary{
-	dir = 2;
-	pixel_z = -6
-	},
-/obj/structure/sign/directions/science{
-	dir = 2;
-	pixel_z = 6
-	},
-/turf/simulated/wall/r_wall/prepainted,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jS" = (
 /obj/effect/floor_decal/corner/blue{
@@ -4948,83 +4930,50 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "lw" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/papershredder,
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Medical Officer - Office";
-	network = list("Command","Medical")
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ladder,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"lx" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/goldenplaque/medical{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "ly" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "lz" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/button/windowtint{
-	id = "cmo_windows";
-	pixel_x = 6;
-	pixel_y = 24;
-	range = 11
+/obj/item/modular_computer/console/preset/security,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 1
 	},
-/obj/structure/flora/pottedplant/overgrown,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "lA" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cmo)
 "lB" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Aft";
-	dir = 4
-	},
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "lC" = (
@@ -5045,9 +4994,6 @@
 	dir = 4
 	},
 /obj/item/device/radio/beacon,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "lD" = (
@@ -5064,9 +5010,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "lE" = (
@@ -5081,36 +5024,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
-"lG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5516,6 +5433,15 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"mC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access = list(1);
+	secured_wires = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/bridgecheck)
 "mD" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -5577,117 +5503,100 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "mK" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"mL" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/office/light,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"mM" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov/clean,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "mN" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"mO" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Chief Medical Officer";
-	req_access = list(40);
-	secured_wires = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"mO" = (
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"mP" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 8;
+	name = "Security Checkpoint";
+	req_access = list(63)
+	},
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Security Checkpoint"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"mP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Chief Medical Officer";
-	sortType = "Chief Medical Officer"
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -5702,13 +5611,20 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "mR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass,
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -5718,22 +5634,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
-"mU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5745,8 +5650,11 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/blue{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5758,9 +5666,15 @@
 	c_tag = "Bridge Hallway - Lift";
 	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5768,11 +5682,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5824,14 +5736,6 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "nc" = (
@@ -6222,6 +6126,15 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"nG" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/item/modular_computer/console/preset/command,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "nH" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -6309,22 +6222,37 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
-"nY" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/item/weapon/folder/white{
-	pixel_y = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
 "nZ" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "bridge_checkpoint_shutters";
+	name = "Checkpoint Window Shutters";
+	pixel_x = -3;
+	pixel_y = 6;
+	req_access = list(1)
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "bridge_hallway_shutters";
+	name = "Hallway Checkpoint Shutters";
+	pixel_x = -3;
+	pixel_y = -4;
+	req_access = list(1)
+	},
+/obj/item/weapon/folder/red{
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "oa" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow,
@@ -6332,9 +6260,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ob" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -6354,42 +6279,44 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"od" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/prepainted,
-/area/security/bridgecheck)
 "oe" = (
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "bridgecheck_windows"
-	},
 /obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
-"of" = (
-/turf/simulated/wall/prepainted,
-/area/security/bridgecheck)
-"og" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access = list(1);
-	secured_wires = 1
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "cmo_windows"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
+"of" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
+"og" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
 "oh" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/aftport)
@@ -6573,36 +6500,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
-"oI" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"oJ" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
 "oK" = (
 /obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cmo_windows"
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cmo)
+/area/security/bridgecheck)
 "oL" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "oM" = (
@@ -6611,72 +6534,49 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 4
+/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"oN" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "bridgecheck_windows"
-	},
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
 "oO" = (
-/obj/item/modular_computer/console/preset/security,
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"oP" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/papershredder,
 /obj/machinery/button/windowtint{
-	id = "bridgecheck_windows";
-	pixel_x = 6;
-	pixel_y = 24;
+	id = "cmo_windows";
+	pixel_x = -24;
+	pixel_y = 6;
 	range = 11
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"oQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"oP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "oR" = (
-/obj/machinery/disposal,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 24
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/closet/secure_closet/CMO_torch,
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Medical Officer - Office";
+	network = list("Command","Medical")
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "oS" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
@@ -6946,142 +6846,107 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "pC" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "CMO"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 0;
-	pixel_y = -24
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "pE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/closet/secure_closet/CMO_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"pF" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/newscaster{
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Security";
+	departmentType = 5;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"pG" = (
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cmo_windows"
+/obj/machinery/light,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"pF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cmo)
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/maintenance/solgov/clean,
+/obj/structure/closet/secure_closet{
+	name = "Security Equipment Locker";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"pG" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/bridgecheck)
 "pH" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/paleblue,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "pI" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 4;
-	name = "Security Checkpoint";
-	req_access = list(63)
-	},
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Security Checkpoint"
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "cmo_windows"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
 "pJ" = (
-/obj/structure/bed/chair/office/dark{
-	icon_state = "officechair_dark";
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2;
+	layer = 2.4;
+	level = 2
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "pK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/catwalk,
+/turf/simulated/open,
 /area/security/bridgecheck)
 "pL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "pM" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/flora/pottedplant/overgrown,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "pQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -7387,59 +7252,95 @@
 "qr" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cmo)
-"qs" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cmo)
+/area/security/bridgecheck)
 "qt" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 2;
+	name = "Chief Medical Officer";
+	sortType = "Chief Medical Officer"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "qu" = (
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "bridgecheck_windows"
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/door/airlock/medical{
+	name = "Chief Medical Officer";
+	req_access = list(40);
+	secured_wires = 1
 	},
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "qv" = (
-/obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "qw" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
 "qx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "qy" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/disposal,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "qB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7757,9 +7658,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rg" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7769,18 +7667,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rh" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -7792,22 +7688,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "rj" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rk" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7849,47 +7742,35 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rn" = (
-/obj/machinery/papershredder,
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/red{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair/office/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"ro" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Bridge - Security Checkpoint";
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Security";
-	departmentType = 5;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"rp" = (
-/obj/machinery/photocopier,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"rp" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "rv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/crew,
@@ -8373,6 +8254,11 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -11280,9 +11166,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "ya" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11423,6 +11306,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"yw" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "yz" = (
 /obj/effect/shuttle_landmark/torch/deck5/exploration_shuttle,
 /turf/space,
@@ -11436,16 +11335,12 @@
 /turf/space,
 /area/space)
 "yZ" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/obj/structure/cable/green,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "zb" = (
@@ -11639,6 +11534,42 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Aq" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 4;
+	name = "Security Checkpoint - Bridge Deck";
+	sortType = "Security Checkpoint - Bridge Deck"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"Ay" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
 "Bb" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -11741,6 +11672,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Bn" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/stamp/cmo,
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "medbay emergency radio link"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "Cb" = (
 /obj/effect/shuttle_landmark/torch/deck5/aquila,
 /turf/space,
@@ -11840,12 +11788,26 @@
 "Cj" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Cs" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/bridgecheck)
 "CN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftport)
 "CO" = (
 /turf/simulated/wall/r_wall/hull,
 /area/aux_eva)
+"CU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/maintenance/bridge/aftport)
 "Db" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Head";
@@ -12036,6 +11998,36 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Ey" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -35
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/light,
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/bridge/aftport)
+"EN" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "CMO"
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "Fb" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12133,20 +12125,22 @@
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
 "Gb" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/camera/network/bridge{
 	c_tag = "Command Hallway - Center Port"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -13085,23 +13079,17 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/cobed)
 "Jf" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
+	pixel_x = -23;
 	pixel_y = 0
 	},
-/obj/item/weapon/clipboard,
-/obj/item/weapon/stamp/cmo,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "medbay emergency radio link"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "Jg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -13132,6 +13120,32 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"JD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/titanium,
@@ -13211,6 +13225,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"KP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder/white{
+	pixel_y = 10
+	},
+/obj/item/weapon/pen,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "Lb" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Research Director - Office";
@@ -13269,11 +13297,20 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Lf" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/filingcabinet,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "Lg" = (
 /obj/machinery/light/small,
 /obj/effect/floor_decal/industrial/warning,
@@ -13323,6 +13360,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"Lp" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access = list(1);
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "Mb" = (
 /obj/effect/floor_decal/corner/purple/diagonal{
 	dir = 4
@@ -13433,6 +13487,43 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"Mq" = (
+/obj/structure/sign/directions/science{
+	dir = 2;
+	pixel_z = 6
+	},
+/obj/structure/sign/directions/infirmary{
+	dir = 2;
+	pixel_z = -6
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/hallway/primary/bridge/fore)
+"Mr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Aft";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"MF" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
 "Nb" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -13746,13 +13837,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Ph" = (
-/obj/random/closet,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/aftport)
 "Pi" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/disciplinary_board_room)
@@ -14136,6 +14220,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Sr" = (
+/obj/structure/sign/deck/bridge,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/bridgecheck)
+"Sw" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
+"SE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Tb" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Infirmary";
@@ -14291,6 +14401,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Tz" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "TX" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room)
@@ -14520,23 +14648,13 @@
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
 "Vh" = (
-/obj/structure/table/steel,
-/obj/machinery/newscaster/security_unit{
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/sign/goldenplaque/medical{
 	pixel_x = 32;
-	pixel_y = -32
+	pixel_y = 0
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "Vi" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/effect/floor_decal/corner/blue{
@@ -14565,6 +14683,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Wa" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/maintenance/solgov/clean,
+/obj/structure/closet/secure_closet{
+	name = "Security Equipment Locker";
+	req_access = list(1)
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = -16
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "Wb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -14639,14 +14782,20 @@
 /turf/simulated/floor/plating,
 /area/aquila_hangar/start)
 "Wh" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/item/device/radio/intercom{
+/obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_x = 0;
+	pixel_y = -24
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
+/obj/machinery/camera/network/security{
+	c_tag = "Bridge - Security Checkpoint";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "Wi" = (
 /obj/structure/sign/double/icarus/solgovflag/right{
 	pixel_y = 32
@@ -14761,6 +14910,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Xk" = (
+/obj/item/modular_computer/console/preset/command,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "Xp" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/titanium,
@@ -14969,6 +15125,16 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/aquila_hangar/start)
+"ZQ" = (
+/obj/random/closet,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/aftport)
+"ZX" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 
 (1,1,1) = {"
 aa
@@ -27389,12 +27555,12 @@ gl
 gl
 gl
 gl
-kJ
-kJ
-kJ
-kJ
-kJ
-kJ
+Cs
+Cs
+Cs
+Cs
+Cs
+Cs
 qr
 ya
 yb
@@ -27591,13 +27757,13 @@ gl
 ik
 iT
 jN
-kJ
+Cs
 lw
 mK
 Jf
 Lf
 pC
-kJ
+Lp
 rh
 sc
 sM
@@ -27789,19 +27955,19 @@ Ge
 fB
 gf
 gO
-hB
+gl
 il
 iU
 jO
-kJ
-lx
-mL
-Kf
-oI
+mC
+qw
+pK
+pK
+pK
 Wh
-kJ
+Cs
 Gb
-sd
+Aq
 sN
 ty
 um
@@ -27994,14 +28160,14 @@ gS
 hC
 im
 iV
-jP
-kJ
-ly
-mM
-nY
-oJ
+jO
+Sw
+Xk
+pK
+pK
+pK
 pE
-qs
+Cs
 rj
 se
 sO
@@ -28193,17 +28359,17 @@ Nj
 TX
 Uj
 Wj
-gl
+Mq
 im
 iW
-jQ
-kJ
+jO
+Ay
 lz
 mN
 nZ
-nZ
+Wa
 pF
-kJ
+dH
 rg
 sd
 sP
@@ -28399,13 +28565,13 @@ hD
 in
 iX
 jR
-kJ
-lA
+Sr
+MF
 mO
 oK
-oK
+Cs
 pG
-kJ
+Cs
 rk
 sf
 sQ
@@ -28597,16 +28763,16 @@ Pj
 Tj
 Vj
 Xj
-hE
+Tz
 hE
 iY
 jS
-hE
+Mr
 lB
 mP
 ob
 oL
-oL
+SE
 qt
 rl
 sg
@@ -28809,7 +28975,7 @@ mQ
 oc
 oM
 pH
-oM
+JD
 rm
 sh
 sS
@@ -29008,13 +29174,13 @@ in
 kL
 lD
 mR
-od
-oN
+lA
+kJ
 pI
 qu
-of
-of
-sT
+kJ
+kJ
+kJ
 tD
 up
 up
@@ -29215,8 +29381,8 @@ oO
 pJ
 qv
 rn
-of
-sT
+yw
+kJ
 tE
 ur
 uW
@@ -29414,11 +29580,11 @@ nb
 yZ
 of
 oP
-pK
-qw
-ro
-of
-sT
+ZX
+Bn
+Kf
+KP
+kJ
 sT
 us
 sT
@@ -29612,15 +29778,15 @@ gm
 gm
 jV
 kM
-lG
-mU
+lI
+yZ
 og
-oQ
+ly
 pL
 qx
 rp
-of
-sT
+nG
+kJ
 sT
 sT
 sT
@@ -29816,13 +29982,13 @@ jV
 kN
 lH
 mV
-of
+kJ
 oR
 pM
 qy
 Vh
-of
-oh
+EN
+kJ
 tF
 oS
 oh
@@ -30016,15 +30182,15 @@ gm
 gm
 fI
 kM
-lI
+lE
 mW
-of
-of
-of
-of
-of
-of
-oh
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
 Gi
 oS
 Hi
@@ -30220,9 +30386,9 @@ jW
 kM
 lI
 mX
+Ey
 oh
-Ph
-oS
+ZQ
 oS
 ji
 wi
@@ -30422,8 +30588,8 @@ jX
 kO
 az
 mY
+CU
 oi
-oT
 oT
 oT
 oT


### PR DESCRIPTION
🆑 Cakey
maptweak: Moved alll checkpoints to be positioned in more key areas. B-deck and deck one checkpoints are now connected via ladder. All checkpoints now have the ability to cut-off certain sections of the hallways for flow control.
maptweak: Brig officer now has a disposals bin.
maptweak: Emergency armory has been altered to have 3 carbines and 3 e-guns as opposed to the 2:3 loadout to match the rest of the E-ARM.
maptweak: Brig armory has been altered to have 4 e-guns as opposed to 3 to match the rest of the armory.
/🆑

fixes #20393 
fixes deck 1 escape pod wall issue.
fixes deck 4 teleporter shutter button issue.

Having 6 sets of peacekeeper armor in the e-arm along with 4 pistols and 3 shields makes no sense. Find some other way to nerf ship weapons or do it proper plz.
Same goes for brig armory, there are 4 sets of each armor but only 3 e-guns. Makes 0 sense.

Checkpoints now actually have tactical positions. Previews:

![Bridge Deck](https://i.imgur.com/PBf4XeV.png)

![Operation Deck](https://i.imgur.com/DHRmOvU.png)

![Hangar Deck](https://i.imgur.com/0FSIkUK.png)
