### PR TITLE
Remap toxins on the Petrov

### DIFF
--- a/html/changelogs/HeyBanditoz - toxins.yml
+++ b/html/changelogs/HeyBanditoz - toxins.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes: 
+  - maptweak: "Remaps the Petrov toxins lab to be more intuitive to use."

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -347,14 +347,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/powered/pump,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "aV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/portable_atmospherics/powered/pump,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "aW" = (
@@ -3249,16 +3249,21 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/ship)
 "gS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 10
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
 	},
-/turf/simulated/wall/titanium,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "gT" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
 	},
 /turf/simulated/wall/ocp_wall,
 /area/shuttle/petrov/ship)
@@ -3616,25 +3621,28 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/ship)
 "hI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	icon_state = "map";
-	dir = 8
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/wall/titanium,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "hJ" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Exhaust pump"
-	},
 /obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
 	dir = 4
+	},
+/obj/machinery/atmospherics/tvalve/mirrored/digital{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "hK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
 /turf/simulated/wall/ocp_wall,
 /area/shuttle/petrov/ship)
 "hL" = (
@@ -3655,7 +3663,7 @@
 	pressure_checks = 2;
 	pressure_checks_default = 2;
 	pump_direction = 0;
-	use_power = 1
+	use_power = 0
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/ship)
@@ -4187,18 +4195,15 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "iR" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	name = "Heating valve"
-	},
 /obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "iS" = (
@@ -4222,6 +4227,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/ship)
 "iU" = (
@@ -4232,6 +4238,7 @@
 	icon_state = "phoronrwindow";
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/ship)
 "iV" = (
@@ -4247,13 +4254,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/ship)
 "iW" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -4417,6 +4422,18 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
+"jr" = (
+/obj/machinery/atmospherics/omni/mixer{
+	tag_east = 2;
+	tag_north = 1;
+	tag_north_con = 0.33;
+	tag_south = 1;
+	tag_south_con = 0.33;
+	tag_west = 1;
+	tag_west_con = 0.34
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "js" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4674,8 +4691,7 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "jS" = (
-/obj/machinery/atmospherics/tvalve/mirrored{
-	icon_state = "map_tvalvem0";
+/obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -4704,14 +4720,18 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "jV" = (
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
-	dir = 5
+	dir = 9
 	},
-/obj/machinery/meter,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -4733,24 +4753,24 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "jX" = (
-/obj/machinery/atmospherics/tvalve,
 /obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "jY" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32;
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "jZ" = (
@@ -5118,36 +5138,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
-"kR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"kS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Exhaust pump"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
 "kT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5155,14 +5148,10 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "kU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -5174,23 +5163,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"kW" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"kX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "kY" = (
@@ -5198,9 +5170,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
+/obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
@@ -5668,42 +5638,15 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "lW" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"lX" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"lY" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"lZ" = (
-/obj/machinery/atmospherics/tvalve/mirrored{
-	icon_state = "map_tvalvem0";
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "ma" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/unary/heater{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "mb" = (
@@ -6366,32 +6309,18 @@
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
-/obj/machinery/computer/area_atmos/area,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
-	dir = 5
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"nd" = (
-/obj/machinery/atmospherics/omni/mixer{
-	tag_east = 1;
-	tag_north = 2;
-	tag_south = 1;
-	tag_west = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"ne" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "nf" = (
@@ -6821,6 +6750,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"nO" = (
+/obj/structure/sign/warning/hot_exhaust,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/ship)
 "nP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7038,10 +6975,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
-"ok" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
 "ol" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7052,14 +6985,8 @@
 	c_tag = "Petrov - Laboratory";
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"on" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "oo" = (
@@ -7806,13 +7733,6 @@
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/ship)
-"pC" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
 "pD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7845,7 +7765,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/ship)
 "pI" = (
-/obj/structure/closet/crate/internals/fuel,
+/obj/machinery/computer/area_atmos/area,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/ship)
 "pJ" = (
@@ -8063,6 +7983,10 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/laundry)
+"qh" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "qi" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -8379,6 +8303,11 @@
 /area/shuttle/petrov/ship)
 "qO" = (
 /obj/structure/table/standard,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/ship)
 "qP" = (
@@ -9030,20 +8959,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/ship)
 "sd" = (
-/obj/structure/dispenser/oxygen,
+/obj/structure/dispenser,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "se" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/ship)
-"sf" = (
-/obj/structure/table/standard,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "sg" = (
@@ -13606,6 +13526,10 @@
 	dir = 8
 	},
 /obj/machinery/washing_machine,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "zC" = (
@@ -18839,6 +18763,17 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/checkpoint2)
+"KP" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "KS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -18853,6 +18788,26 @@
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/center)
+"Le" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/ship)
+"Li" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/ship)
+"Mj" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/ship)
 "MA" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
@@ -18987,6 +18942,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"Pw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "Py" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
@@ -19044,6 +19005,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
+"Rc" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/ship)
 "Rl" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/brigdoor/northleft{
@@ -19117,6 +19085,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"RO" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "RQ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/storage/auxillary/starboard)
@@ -19128,6 +19103,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"Sl" = (
+/obj/machinery/atmospherics/tvalve/digital{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "Sm" = (
 /obj/machinery/mining/brace{
 	dir = 8
@@ -19234,6 +19219,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/unused)
+"TX" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "Uq" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -19359,6 +19354,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
+"Zr" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/ship)
 "ZG" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/center)
@@ -48339,7 +48341,7 @@ aa
 aa
 aa
 aa
-aa
+gR
 fV
 iP
 jQ
@@ -48540,8 +48542,8 @@ aa
 aa
 aa
 aa
-aa
-gR
+Mj
+Rc
 fV
 fV
 fV
@@ -48742,15 +48744,15 @@ aa
 aa
 aa
 aa
-aa
+Le
 gS
 hI
+RO
 iQ
-iQ
-kR
+kP
 lT
 nb
-ok
+iQ
 py
 qJ
 sb
@@ -48944,15 +48946,15 @@ aa
 aa
 aa
 aa
-fV
-fV
+Li
+KP
 hJ
 iR
-jR
-kS
-lU
-lQ
-ol
+Sl
+rY
+lV
+jr
+Zr
 py
 qK
 sc
@@ -49146,13 +49148,13 @@ aa
 aa
 aa
 aa
-fW
+nO
 gT
 hK
 iS
 jS
 kT
-lV
+Pw
 nc
 om
 pB
@@ -49355,9 +49357,9 @@ iT
 jT
 kU
 lW
-nd
-on
-pC
+lU
+lQ
+ol
 qL
 sd
 fV
@@ -49555,9 +49557,9 @@ gV
 hM
 iU
 jU
-kU
-lU
-jR
+TX
+qh
+Zr
 lQ
 pD
 lQ
@@ -49758,8 +49760,8 @@ hN
 iV
 jV
 kV
-lX
-ne
+qM
+oo
 oo
 pE
 qM
@@ -49959,13 +49961,13 @@ gX
 gX
 gX
 jW
-kW
-lY
+lQ
+lQ
 nf
 lQ
 pF
 lQ
-sf
+ol
 lS
 vg
 ws
@@ -50161,8 +50163,8 @@ fV
 fV
 iW
 jX
-kX
-lZ
+lQ
+lQ
 fV
 op
 pG


### PR DESCRIPTION
![The remap, in-editor](https://banditoz.org/u/evKAy.png)
![How it looks in-game](https://banditoz.org/u/QMcWs.png)
Toxins has been remapped so it's actually usable now.
This PR also fills the air pumps in D4 emergency storage. Forgot to mention that.
Fixes #21473