### PR TITLE
Sign language can be used while being muzzled.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -178,8 +178,9 @@ proc/get_radio_key_from_channel(var/channel)
 		return 1
 
 	if(is_muzzled())
-		to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
-		return
+		if(!(speaking && (speaking.flags & SIGNLANG)))
+			to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
+			return
 
 	if (speaking)
 		if(whispering)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -177,10 +177,9 @@ proc/get_radio_key_from_channel(var/channel)
 		speaking.broadcast(src,trim(message))
 		return 1
 
-	if(is_muzzled())
-		if(!(speaking && (speaking.flags & SIGNLANG)))
-			to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
-			return
+	if((is_muzzled()) && !(speaking && (speaking.flags & SIGNLANG)))
+		to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
+		return
 
 	if (speaking)
 		if(whispering)


### PR DESCRIPTION
:cl: 
bugfix: You can now use sign language even if you are muzzled.
/:cl: 

Attempts to fix #21416.

This is my first PR attempt so do tell me if I messed up the changelog/the code part! I hope it'll be helpful.