### PR TITLE
Hackfix for planet dynamic lighting

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -8,7 +8,7 @@
 	var/list/breathgas = list()	//list of gases animals/plants require to survive
 	var/badgas					//id of gas that is toxic to life here
 
-	var/lightlevel
+	var/lightlevel    //natural lighting power, currently broken and unused
 	in_space = 0
 	var/maxx
 	var/maxy
@@ -46,6 +46,7 @@
 	spawn()
 		generate_atmosphere()
 		generate_map()
+		create_lighting_overlays_zlevel(z)
 		generate_features()
 		generate_landing(4)		//try making 4 landmarks
 		update_biome()
@@ -412,9 +413,8 @@
 			if(E.atmosphere)
 				initial_gas = E.atmosphere.gas.Copy()
 				temperature = E.atmosphere.temperature
-			if(E.lightlevel)
-				light_max_bright = E.lightlevel
-				light_outer_range = 2
+	//For some reason without this call dynamic lighitng breaks
+	set_light(0)
 	..()
 
 /turf/simulated/floor/exoplanet/attackby(obj/item/C, mob/user)


### PR DESCRIPTION
Makes dynamic lighting work there, but planets aren't lit anymore.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
