### PR TITLE
Ruin loader fixes and tweaks

### DIFF
--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -10,6 +10,7 @@
 	var/base_turf_for_zs = null
 	var/accessibility_weight = 0
 	var/spawn_guaranteed = FALSE
+	var/clear_contents = FALSE  //if it should destroy objects it spawns on top of
 
 /datum/map_template/New(var/list/paths = null, var/rename = null)
 	if(paths && !islist(paths))
@@ -25,7 +26,7 @@
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
 	var/z_offset = 1 // needed to calculate z-bounds correctly
 	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), 1, 1, z_offset, cropMap=FALSE, measureOnly=TRUE, no_changeturf=TRUE)
+		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), 1, 1, z_offset, cropMap=FALSE, measureOnly=TRUE, no_changeturf=TRUE, clear_contents=clear_contents)
 		if(M)
 			bounds = extend_bounds_if_needed(bounds, M.bounds)
 			z_offset++

--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -65,7 +65,7 @@
 				for(var/m in ruins)
 					var/datum/map_template/ruin/ruin_to_remove = ruins[m]
 					if(ruin_to_remove.id == ruin.id) //remove all ruins with the same ID, to make sure that ruins with multiple variants work properly
-						ruins -= ruin_to_remove.name
+						ruins -= ruin_to_remove.id
 						last_checked_ruin_index--
 			break
 


### PR DESCRIPTION
Fixes ruin loader not giving a fuck about 'no duplicates allowed' flag.
Adds a flag to templates if they should wipe stuff where they spawn.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
