### PR TITLE
Deck management fixes, round 2

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -39,6 +39,14 @@
 		return 0
 	return 1
 
+//Checks if the access (constant or list) is contained in one of the entries of access_patterns, a list of lists.
+/proc/has_access_pattern(list/access_patterns, access)
+	if(!islist(access))
+		access = list(access)
+	for(var/access_pattern in access_patterns)
+		if(has_access(access_pattern, list(), access))
+			return 1
+
 /proc/get_centcom_access(job)
 	switch(job)
 		if("VIP Guest")

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -20,15 +20,15 @@
 	var/datum/shuttle_mission/selected_mission       //Which mission is selected.
 	var/datum/computer_file/report/selected_report   //A report being viewed/edited.
 	var/list/report_prototypes = list()              //Stores report prototypes to use for UI purposes.
-	var/default_access = access_cargo                //The default access needed to properly use. Should be set in map files.
+	var/datum/shuttle/prototype_shuttle              //The shuttle for which the prototypes were built (to avoid excessive prototype rebuilding)
+	//The default access needed to properly use. Should be set in map files.
+	var/default_access = list(access_cargo, access_heads)  //The format is (needs one of list(these access constants or lists of access constants))
 
 /datum/nano_module/deck_management/New()
 	..()
 	for(var/shuttle in shuttle_controller.shuttle_logs) //Registering to get shuttle updates.
 		var/datum/shuttle_log/my_log = shuttle_controller.shuttle_logs[shuttle]
 		my_log.register(src)
-	for(var/report_type in subtypesof(/datum/computer_file/report/recipient/shuttle))
-		report_prototypes += new report_type
 
 /datum/nano_module/deck_management/Destroy()
 	for(var/shuttle in shuttle_controller.shuttle_logs) //Unregistering; important for garbage collection.
@@ -41,8 +41,7 @@
 	var/logs = shuttle_controller.shuttle_logs
 
 	data["prog_state"] = prog_state
-	data["default_access"] = check_access(user, default_access)
-	data["access_cargo"] = check_access(user, access_cargo)
+	data["default_access"] = get_default_access(user)
 
 	switch(prog_state)
 		if(DECK_HOME)
@@ -97,11 +96,12 @@
 			if(!(selected_mission.stage in list(SHUTTLE_MISSION_PLANNED, SHUTTLE_MISSION_QUEUED)))
 				var/other_reports = list()
 				for(var/i = 1, i <= length(report_prototypes), i++)
-					var/datum/computer_file/report/report = report_prototypes[i]
+					var/datum/computer_file/report/recipient/shuttle/report = report_prototypes[i]
 					var/L = list()
 					L["name"] = report.display_name()
 					L["index"] = i
 					L["exists"] = locate(report) in selected_mission.other_reports
+					L["access_edit"] = report.verify_access_edit(get_access(user))
 					other_reports += list(L)
 				data["other_reports"] = other_reports
 
@@ -167,8 +167,13 @@
 			mission_data["queued"] = 1
 	return mission_data
 
+/datum/nano_module/deck_management/proc/get_default_access(mob/user)
+	for(var/access_pattern in default_access)
+		if(check_access(user, access_pattern))
+			return 1
+
 /datum/nano_module/deck_management/proc/get_shuttle_access(mob/user, datum/shuttle/shuttle)
-	return shuttle.logging_access ? check_access(user, shuttle.logging_access) : 0
+	return shuttle.logging_access ? (check_access(user, shuttle.logging_access) || check_access(user, access_heads)) : 0
 
 /datum/nano_module/deck_management/proc/set_shuttle(mob/user, shuttle_name, need_access = 1)
 	var/datum/shuttle/shuttle
@@ -177,7 +182,17 @@
 	if(need_access && !get_shuttle_access(user, shuttle))
 		return 0
 	selected_shuttle = shuttle
-	return ensure_valid_shuttle()
+	if(!ensure_valid_shuttle())
+		return 0
+	if(selected_shuttle != prototype_shuttle)
+		prototype_shuttle = selected_shuttle
+		report_prototypes = list()
+		for(var/report_type in subtypesof(/datum/computer_file/report/recipient/shuttle))
+			var/datum/computer_file/report/recipient/shuttle/new_report = new report_type
+			if(new_report.access_shuttle)
+				new_report.set_access(null, selected_shuttle.logging_access, override = 0)
+			report_prototypes += new_report
+	return 1
 
 /datum/nano_module/deck_management/proc/set_mission(mission_ID)
 	var/datum/shuttle_log/my_log = shuttle_controller.shuttle_logs[selected_shuttle]
@@ -192,7 +207,7 @@
 	if(..())
 		return 1
 
-	if(!check_access(user, default_access))
+	if(!get_default_access(user))
 		return 1 //No program access if you don't have the right access.
 	if(text2num(href_list["warning"])) //Gives the user a chance to avoid losing unsaved reports.
 		if(alert(user, "Are you sure you want to do this? Data may be lost.",, "Yes.", "No.") == "No.")
@@ -239,7 +254,7 @@
 	if(href_list["report"])
 		var/shuttle_name = href_list["shuttle"]
 		var/mission_ID = text2num(href_list["mission"])
-		if(set_shuttle(user, shuttle_name, 1) && set_mission(mission_ID))
+		if(set_shuttle(user, shuttle_name, 0) && set_mission(mission_ID))
 			can_view_only = (href_list["view"] ? 1 : 0)
 			if(href_list["flight_plan"])
 				prog_state = DECK_REPORT_EDIT
@@ -247,7 +262,7 @@
 					selected_report = selected_mission.flight_plan.clone()//We always make a new one to buffer changes until submitted.
 				else
 					selected_report = new /datum/computer_file/report/flight_plan
-					selected_report.set_access(null, selected_shuttle.logging_access)
+					selected_report.set_access(null, selected_shuttle.logging_access, override = 0)
 			else
 				if(selected_mission.stage in list(SHUTTLE_MISSION_PLANNED, SHUTTLE_MISSION_QUEUED))
 					return 1 //Hold your horses until the mission is started on these reports.
@@ -262,8 +277,6 @@
 					var/datum/computer_file/report/recipient/shuttle/new_report = prototype.clone()
 					new_report.shuttle.set_value(selected_shuttle.name)
 					new_report.mission.set_value(selected_mission.name)
-					if(new_report.access_shuttle)
-						new_report.set_access(null, selected_shuttle.logging_access)
 					selected_report = new_report
 		return 1
 	if(href_list["home"])

--- a/code/modules/modular_computers/file_system/reports/deck_reports.dm
+++ b/code/modules/modular_computers/file_system/reports/deck_reports.dm
@@ -7,6 +7,10 @@
 	var/datum/report_field/people/manifest
 	var/datum/report_field/planned_depart
 
+/datum/computer_file/report/flight_plan/New()
+	..()
+	set_access(null, access_heads)
+
 /datum/computer_file/report/flight_plan/generate_fields()
 	add_field(/datum/report_field/instruction, "These fields are required:")
 	leader = add_field(/datum/report_field/people/from_manifest, "Leader", required = 1)
@@ -21,7 +25,11 @@
 /datum/computer_file/report/recipient/shuttle
 	var/datum/report_field/shuttle
 	var/datum/report_field/mission
-	var/access_shuttle = 0 //Set to 1 to have the report's access_edit set to be the shuttle's logging access.
+	var/access_shuttle = 0 //Set to 1 to give the shuttle's logging access as an access_edit pattern.
+
+/datum/computer_file/report/recipient/shuttle/New()
+	..()
+	set_access(null, access_heads)
 
 /datum/computer_file/report/recipient/shuttle/generate_fields()
 	..()
@@ -34,6 +42,10 @@
 	form_name = "DC243"
 	title = "Post-flight Damage Assessment"
 
+/datum/computer_file/report/recipient/shuttle/damage/New()
+	..()
+	set_access(null, access_cargo, override = 0)
+
 /datum/computer_file/report/recipient/shuttle/damage/generate_fields()
 	..()
 	add_field(/datum/report_field/instruction, "Assess the damage sustained by the shuttle and its flight readiness.")
@@ -41,11 +53,14 @@
 	add_field(/datum/report_field/simple_text, "Flight readiness")
 	add_field(/datum/report_field/pencode_text, "Repairs required")
 	add_field(/datum/report_field/time, "Estimated completion time")
-	set_access(null, access_cargo)
 
 /datum/computer_file/report/recipient/shuttle/fuel
 	form_name = "DC12"
 	title = "Post-flight Refueling Report"
+
+/datum/computer_file/report/recipient/shuttle/fuel/New()
+	..()
+	set_access(null, access_cargo, override = 0)
 
 /datum/computer_file/report/recipient/shuttle/fuel/generate_fields()
 	..()
@@ -53,11 +68,14 @@
 	add_field(/datum/report_field/simple_text, "Current fuel level")
 	add_field(/datum/report_field/time, "Time of refueling")
 	add_field(/datum/report_field/pencode_text, "Additional notes")
-	set_access(null, access_cargo)
 	
 /datum/computer_file/report/recipient/shuttle/atmos
 	form_name = "DC245"
 	title = "Post-flight Atmospherics Assessment"
+
+/datum/computer_file/report/recipient/shuttle/atmos/New()
+	..()
+	set_access(null, access_cargo, override = 0)
 
 /datum/computer_file/report/recipient/shuttle/atmos/generate_fields()
 	..()
@@ -65,11 +83,14 @@
 	add_field(/datum/report_field/pencode_text, "State of atmospherics supplies")
 	add_field(/datum/report_field/time, "Estimated time of exhaustion")
 	add_field(/datum/report_field/simple_text, "Supplies required")
-	set_access(null, access_cargo)
 
 /datum/computer_file/report/recipient/shuttle/gear
 	form_name = "DC248b"
 	title = "Post-flight Emergency Supply Inventory; Summary Version"
+
+/datum/computer_file/report/recipient/shuttle/gear/New()
+	..()
+	set_access(null, access_cargo, override = 0)
 
 /datum/computer_file/report/recipient/shuttle/gear/generate_fields()
 	..()
@@ -79,7 +100,6 @@
 	add_field(/datum/report_field/time, "Time of restocking")
 	add_field(/datum/report_field/simple_text, "Flight readiness")
 	add_field(/datum/report_field/pencode_text, "Additional Notes")
-	set_access(null, access_cargo)
 
 /datum/computer_file/report/recipient/shuttle/post_flight
 	form_name = "DC102"

--- a/code/modules/modular_computers/file_system/reports/report.dm
+++ b/code/modules/modular_computers/file_system/reports/report.dm
@@ -5,8 +5,8 @@
 	var/form_name = "AB1"                                  //Form code, for maximum bureaucracy.
 	var/creator                                            //The name of the mob that made the report.
 	var/file_time                                          //Time submitted.
-	var/list/access_edit = list()                          //The access required to submit the report.
-	var/list/access = list()                               //The access required to view the report.
+	var/list/access_edit = list(list())                    //The access required to submit the report. See documentation below.
+	var/list/access = list(list())                         //The access required to view the report.
 	var/list/datum/report_field/fields = list()            //A list of fields the report comes with, in order that they should be displayed.
 	var/ID_ticker = 1                                      //Used to name fields, for internal use only.
 
@@ -21,29 +21,38 @@
 /*
 Access stuff. The report's access/access_edit should control whether it can be opened/submitted.
 For field editing or viewing, use the field's access/access_edit permission instead.
-Recursive will add the access to all fields as well.
+The access system is based on "access patterns", lists of access values. 
+A user needs all access values in a pattern to be granted access.
+A user needs to only match one of the potentially several stored access patterns to be granted access.
+You must have access to have edit access.
+
+This proc resets the access to the report, resulting in just one access pattern for access/edit.
+Arguments can be access values (numbers) or lists of access values.
+If null is passed to one of the arguments, that access type is left alone. Pass list() to reset to no access needed instead.
+The recursive option resets access to all fields in the report as well.
+If the override option is set to 0, the access supplied will instead be added as another access pattern, rather than resetting the access.
 */
-/datum/computer_file/report/proc/set_access(access = list(), access_edit = list(), recursive = 1)
+/datum/computer_file/report/proc/set_access(access, access_edit, recursive = 1, override = 1)
 	if(access)
-		src.access = list()
-		src.access += access //works whether access is a list or not.
+		if(!islist(access))
+			access = list(access)
+		override ? (src.access = list(access)) : (src.access += list(access))  //Note that this is a list of lists.
 	if(access_edit)
-		src.access = list()
-		src.access_edit += access_edit
-	src.access_edit |= src.access
+		if(!islist(access_edit))
+			access_edit = list(access_edit)
+		override ? (src.access_edit = list(access_edit)) : (src.access_edit += list(access_edit))
 	if(recursive)
 		for(var/datum/report_field/field in fields)
-			field.set_access(src.access, src.access_edit)
+			field.set_access(access, access_edit, override)
 
+//Strongly recommended to use these procs to check for access. They can take access values (numbers) or lists of values.
 /datum/computer_file/report/proc/verify_access(given_access)
-	if(!islist(given_access))
-		given_access = list(given_access)
-	return  has_access(access, list(), given_access)
+	return has_access_pattern(access, given_access)
 
 /datum/computer_file/report/proc/verify_access_edit(given_access)
-	if(!islist(given_access))
-		given_access = list(given_access)
-	return  has_access(access_edit, list(), given_access)
+	if(!verify_access(given_access))
+		return //Need access for access_edit
+	return has_access_pattern(access_edit, given_access)
 
 //Looking up fields. Names might not be unique unless you ensure otherwise.
 /datum/computer_file/report/proc/field_from_ID(ID)

--- a/code/modules/modular_computers/file_system/reports/report_field.dm
+++ b/code/modules/modular_computers/file_system/reports/report_field.dm
@@ -7,8 +7,8 @@
 	var/ID                         //A unique (per report) id; don't set manually.
 	var/needs_big_box = 0          //Suggests that the output won't look good in-line. Useful in nanoui logic.
 	var/ignore_value = 0           //Suggests that the value should not be displayed.
-	var/list/access_edit = list()  //The access required to edit the field.
-	var/list/access = list()       //The access required to view the field.
+	var/list/access_edit = list(list())  //The access required to edit the field.
+	var/list/access = list(list())       //The access required to view the field.
 
 /datum/report_field/New(datum/computer_file/report/report)
 	owner = report
@@ -18,21 +18,24 @@
 	owner = null
 	. = ..()
 
-//Access stuff. Can be given access constants or lists.
-/datum/report_field/proc/set_access(given_access = list(), given_access_edit = list())
-	access |= given_access
-	access_edit |= given_access
-	access_edit |= given_access_edit
+//Access stuff. Can be given access constants or lists. See report access procs for documentation.
+/datum/report_field/proc/set_access(access, access_edit, override = 1)
+	if(access)
+		if(!islist(access))
+			access = list(access)
+		override ? (src.access = list(access)) : (src.access += list(access))
+	if(access_edit)
+		if(!islist(access_edit))
+			access_edit = list(access_edit)
+		override ? (src.access_edit = list(access_edit)) : (src.access_edit += list(access_edit))
 
 /datum/report_field/proc/verify_access(given_access)
-	if(!islist(given_access))
-		given_access = list(given_access)
-	return  has_access(access, list(), given_access)
+	return has_access_pattern(access, given_access)
 
 /datum/report_field/proc/verify_access_edit(given_access)
-	if(!islist(given_access))
-		given_access = list(given_access)
-	return  has_access(access_edit, list(), given_access)
+	if(!verify_access(given_access))
+		return
+	return has_access_pattern(access_edit, given_access)
 
 //Assumes the old and new fields are of the same type. Override if the field stores information differently.
 /datum/report_field/proc/copy_value(datum/report_field/old_field)

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -689,4 +689,4 @@
 
 //Makes the deck management program use hangar access
 /datum/nano_module/deck_management
-	default_access = access_hangar
+	default_access = list(access_hangar, access_cargo, access_heads)

--- a/nano/templates/deck_management.tmpl
+++ b/nano/templates/deck_management.tmpl
@@ -3,7 +3,7 @@
 	{{if !data.default_access}}
 		do not 
 	{{/if}}
-	have hangar access.
+	have program access.
 </div>
 {{if data.default_access}}<!--Suppressed indentation.-->
 {{if data.prog_state == 1}}<!--DECK_HOME-->
@@ -226,8 +226,8 @@
 			</div>
 			<div class='itemContent'>
 				{{:helper.link('View Report', null, {'report' : 1, 'view' : 1, 'index' : value.index, 'shuttle' : data.shuttle_name, 'mission' : data.mission_data.ID}, value.exists ? null : 'disabled')}}
-				{{:helper.link('Create Report', null, {'report' : 1, 'index' : value.index, 'shuttle' : data.shuttle_name, 'mission' : data.mission_data.ID}, (data.access_cargo && !value.exists) ? null : 'disabled')}}
-				{{:helper.link('Edit Report', null, {'report' : 1, 'index' : value.index, 'shuttle' : data.shuttle_name, 'mission' : data.mission_data.ID}, (data.access_cargo && value.exists) ? null : 'disabled')}}
+				{{:helper.link('Create Report', null, {'report' : 1, 'index' : value.index, 'shuttle' : data.shuttle_name, 'mission' : data.mission_data.ID}, (value.access_edit && !value.exists) ? null : 'disabled')}}
+				{{:helper.link('Edit Report', null, {'report' : 1, 'index' : value.index, 'shuttle' : data.shuttle_name, 'mission' : data.mission_data.ID}, (value.access_edit && value.exists) ? null : 'disabled')}}
 			</div>
 		</div>
 		{{/for}}


### PR DESCRIPTION
:cl:
tweak: Those with heads access now have more access to Deck Management.
bugfix: Access issues with supplementary Deck Management reports should be resolved.
/:cl:

Fixes an access bug with the tmpl that affects the post-mission report.
