### PR TITLE
Cryo tube tweaks

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -159,7 +159,7 @@
 	taste_description = "sludge"
 	reagent_state = LIQUID
 	color = "#8080ff"
-	metabolism = REM * 0.05
+	metabolism = REM * 0.5
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 
@@ -168,7 +168,7 @@
 	if(M.bodytemperature < 170)
 		M.adjustCloneLoss(-100 * removed)
 		M.add_chemical_effect(CE_OXYGENATED, 1)
-		M.heal_organ_damage(100 * removed, 100 * removed)
+		M.heal_organ_damage(10 * removed, 10 * removed)
 		M.add_chemical_effect(CE_PULSE, -2)
 
 /datum/reagent/clonexadone
@@ -177,7 +177,7 @@
 	taste_description = "slime"
 	reagent_state = LIQUID
 	color = "#80bfff"
-	metabolism = REM * 0.05
+	metabolism = REM * 0.5
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 
@@ -186,7 +186,7 @@
 	if(M.bodytemperature < 170)
 		M.adjustCloneLoss(-300 * removed)
 		M.add_chemical_effect(CE_OXYGENATED, 2)
-		M.heal_organ_damage(300 * removed, 300 * removed)
+		M.heal_organ_damage(30 * removed, 30 * removed)
 		M.add_chemical_effect(CE_PULSE, -2)
 
 /* Painkillers */


### PR DESCRIPTION
:cl:
tweak: Cryo tubes use up chemicals ten times faster. Effective healing rate remains unchanged.
tweak: Genetic damage is healed ten times faster in cryo tubes.
/:cl:

Now, if you look at the change, you'll ask: 10x faster? Really? But note that with the new numbers the starting beakers still last 20 minutes or so of continual use (currently they last over three hours each).

Organ damage healing is not affected.

Cloneloss will heal 10x faster than currently. It should now take 100 seconds or so to fully remove max cloneloss from one organ using cryo/clone mix (so sum up 100 seconds * cloneloss/100 for all organs affected; not exact due to rounding/discretization issues). Cloneloss takes forever to heal right now when caused by slimes, and is horribly non-interactive to players.