### PR TITLE
Slightly optimizes 'no observers' check

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -28,9 +28,10 @@
 
 /proc/living_observers_present(var/list/zlevels)
 	if(LAZYLEN(zlevels))
-		for(var/client/C in GLOB.clients) //if a tree ticks on the empty zlevel does it really tick
-			if(isliving(C.mob)) //(no it doesn't)
-				var/turf/T = get_turf(C.mob)
+		for(var/A in GLOB.player_list) //if a tree ticks on the empty zlevel does it really tick
+			var/mob/M = A
+			if(M.stat != DEAD) //(no it doesn't)
+				var/turf/T = get_turf(M)
 				if(T && (T.z in zlevels))
 					return TRUE
 	return FALSE


### PR DESCRIPTION
Instead of looping over clients and then istyping, now looping over player mobs and checking if they're not dead.
Replacing istype with a var check should help a miniscule amount, which might matter in a proc that is called hundreds of thousands times according to profiler.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
