### PR TITLE
Fixes organ printer printing invisible organs.

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -199,15 +199,14 @@
 
 /obj/machinery/organ_printer/flesh/print_organ(var/choice)
 	var/obj/item/organ/O
+	var/weakref/R = loaded_dna["donor"]
+	var/mob/living/carbon/human/H = R.resolve()
 	if(loaded_species.has_organ[choice])
 		var/new_organ = loaded_species.has_organ[choice]
-		O = new new_organ(get_turf(src))
+		O = new new_organ(get_turf(src), given_dna = H.dna)
 		O.status |= ORGAN_CUT_AWAY
 	else
 		O = ..()
-	var/weakref/R = loaded_dna["donor"]
-	var/mob/living/carbon/human/H = R.resolve()
-	O.set_dna(H.dna)
 	if(O.species)
 		// This is a very hacky way of doing of what organ/New() does if it has an owner
 		O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -42,8 +42,11 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/is_broken()
 	return (damage >= min_broken_damage || (status & ORGAN_CUT_AWAY) || (status & ORGAN_BROKEN))
 
-/obj/item/organ/New(var/mob/living/carbon/holder)
+//Second argument may be a dna datum; if null will be set to holder's dna.
+/obj/item/organ/New(var/mob/living/carbon/holder, var/datum/dna/given_dna)
 	..(holder)
+	if(!istype(given_dna))
+		given_dna = null
 
 	if(max_damage)
 		min_broken_damage = Floor(max_damage / 2)
@@ -53,18 +56,12 @@ var/list/organ_cache = list()
 	if(istype(holder))
 		owner = holder
 		w_class = max(w_class + mob_size_difference(holder.mob_size, MOB_MEDIUM), 1) //smaller mobs have smaller organs.
-
-		if(holder.dna)
-			dna = holder.dna.Clone()
-			species = all_species[dna.species]
+		if(!given_dna && holder.dna)
+			given_dna = holder.dna
 		else
-			species = all_species[SPECIES_HUMAN]
 			log_debug("[src] spawned in [holder] without a proper DNA.")
 
-	if(dna)
-		if(!blood_DNA)
-			blood_DNA = list()
-		blood_DNA[dna.unique_enzymes] = dna.b_type
+	given_dna ? set_dna(given_dna) : (species = all_species[SPECIES_HUMAN])
 
 	create_reagents(5 * (w_class-1)**2)
 	reagents.add_reagent(/datum/reagent/nutriment/protein, reagents.maximum_volume)


### PR DESCRIPTION
:cl:
bugfix: The organ printer now prints visible organs.
/:cl:

Fixes #20533 (this happens for all organs spawned not in a mob).
Fixes #21505
Fixes #16225

If an organ's species could not be set in New(), it would runtime and fail to get through update_icon(). Now the organ's species is imported at New() through an optional dna argument, and failing that is defaulted to human.