### PR TITLE
Fixes antag preferences being reset.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -14,8 +14,7 @@
 	var/loss_feedback_tag                   // Used by the database for end of round loss.
 
 	// Role data.
-	var/id = "traitor"                      // Unique datum identifier.
-	var/role_type                           // Preferences option for this role. Defaults to the id if unset
+	var/id = "traitor"                      // Unique datum identifier. Also preferences option for this role.
 	var/role_text = "Traitor"               // special_role text.
 	var/role_text_plural = "Traitors"       // As above but plural.
 
@@ -86,10 +85,6 @@
 	..()
 
 /datum/antagonist/proc/Initialize()
-
-	if(!role_type)
-		role_type = id
-
 	cur_max = hard_cap
 	get_starting_locations()
 	if(!role_text_plural)
@@ -111,7 +106,7 @@
 
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
-	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
+	for(var/datum/mind/player in ticker.mode.get_players_for_role(id))
 		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
 		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
@@ -134,7 +129,7 @@
 	var/candidates = list()
 
 	// Keeping broken up for readability
-	for(var/datum/mind/player in mode.get_players_for_role(role_type, id))
+	for(var/datum/mind/player in mode.get_players_for_role(id))
 		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
 		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
 		else if(player.special_role)

--- a/code/game/antagonist/mutiny/mutineer.dm
+++ b/code/game/antagonist/mutiny/mutineer.dm
@@ -1,7 +1,6 @@
 var/datum/antagonist/mutineer/mutineers
 
 /datum/antagonist/mutineer
-	role_type = BE_MUTINEER
 	role_text = "Mutineer"
 	role_text_plural = "Mutineers"
 	id = MODE_MUTINEER

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -367,7 +367,7 @@ var/global/list/additional_antag_types = list()
 /datum/game_mode/proc/check_win() //universal trigger to be called at mob death, nuke explosion, etc. To be called from everywhere.
 	return 0
 
-/datum/game_mode/proc/get_players_for_role(var/role, var/antag_id)
+/datum/game_mode/proc/get_players_for_role(var/antag_id)
 	var/list/players = list()
 	var/list/candidates = list()
 
@@ -383,7 +383,7 @@ var/global/list/additional_antag_types = list()
 				continue
 			if(istype(player, /mob/new_player))
 				continue
-			if(!role || (role in player.client.prefs.be_special_role))
+			if(!antag_id || (antag_id in player.client.prefs.be_special_role))
 				log_debug("[player.key] had [antag_id] enabled, so we are drafting them.")
 				candidates += player.mind
 	else
@@ -394,7 +394,7 @@ var/global/list/additional_antag_types = list()
 
 		// Get a list of all the people who want to be the antagonist for this round
 		for(var/mob/new_player/player in players)
-			if(!role || (role in player.client.prefs.be_special_role))
+			if(!antag_id || (antag_id in player.client.prefs.be_special_role))
 				log_debug("[player.key] had [antag_id] enabled, so we are drafting them.")
 				candidates += player.mind
 				players -= player
@@ -402,7 +402,7 @@ var/global/list/additional_antag_types = list()
 		// If we don't have enough antags, draft people who voted for the round.
 		if(candidates.len < required_enemies)
 			for(var/mob/new_player/player in players)
-				if(!role || !(role in player.client.prefs.never_be_special_role))
+				if(!antag_id || !(antag_id in player.client.prefs.never_be_special_role))
 					log_debug("[player.key] has not selected never for this role, so we are drafting them.")
 					candidates += player.mind
 					players -= player

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -21,10 +21,12 @@
 		pref.never_be_special_role = list()
 
 	var/special_roles = valid_special_roles()
-	for(var/role in pref.be_special_role)
+	var/old_be_special_role = pref.be_special_role.Copy()
+	var/old_never_be_special_role = pref.never_be_special_role.Copy()
+	for(var/role in old_be_special_role)
 		if(!(role in special_roles))
 			pref.be_special_role -= role
-	for(var/role in pref.never_be_special_role)
+	for(var/role in old_never_be_special_role)
 		if(!(role in special_roles))
 			pref.never_be_special_role -= role
 
@@ -38,12 +40,12 @@
 		. += "<tr><td>[antag.role_text]: </td><td>"
 		if(jobban_isbanned(preference_mob(), antag.id) || (antag.id == MODE_MALFUNCTION && jobban_isbanned(preference_mob(), "AI")))
 			. += "<span class='danger'>\[BANNED\]</span><br>"
-		else if(antag.role_type in pref.be_special_role)
-			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];del_special=[antag.role_type]'>Low</a> <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
-		else if(antag.role_type in pref.never_be_special_role)
-			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> <a href='?src=\ref[src];del_special=[antag.role_type]'>Low</a> <span class='linkOn'>Never</span></br>"
+		else if(antag.id in pref.be_special_role)
+			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];del_special=[antag.id]'>Low</a> <a href='?src=\ref[src];add_never=[antag.id]'>Never</a></br>"
+		else if(antag.id in pref.never_be_special_role)
+			. += "<a href='?src=\ref[src];add_special=[antag.id]'>High</a> <a href='?src=\ref[src];del_special=[antag.id]'>Low</a> <span class='linkOn'>Never</span></br>"
 		else
-			. += "<a href='?src=\ref[src];add_special=[antag.role_type]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[antag.role_type]'>Never</a></br>"
+			. += "<a href='?src=\ref[src];add_special=[antag.id]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[antag.id]'>Never</a></br>"
 		. += "</td></tr>"
 
 	var/list/ghost_traps = get_ghost_traps()
@@ -96,10 +98,8 @@
 /datum/category_item/player_setup_item/antagonism/candidacy/proc/valid_special_roles()
 	var/list/private_valid_special_roles = list()
 
-	var/list/all_antag_types = GLOB.all_antag_types_
-	for(var/antag_type in all_antag_types)
-		var/datum/antagonist/antag = all_antag_types[antag_type]
-		private_valid_special_roles += antag.role_type
+	for(var/antag_type in GLOB.all_antag_types_)
+		private_valid_special_roles += antag_type
 
 	var/list/ghost_traps = get_ghost_traps()
 	for(var/ghost_trap_key in ghost_traps)


### PR DESCRIPTION
:cl:
bugfix: Antag preferences being reset to low should be fixed. If you continue experiencing this issue, please submit a new bug report.
/:cl:

Fixes #21504

The issue appears to be caused by two separate problems that compound each other: (1) antag player setup is using an antiquated variable on antag datums for IO purposes which is not populated until Initialize(), which runs after player preferences are loaded, and (2) a faulty checking mechanism only removes some portion of bad antag preferences on sanitization.

Warning: any server using the "mutineer" antag class (?) will have mutineer preferences reset to low for everyone.