### PR TITLE
fixes #20383

### DIFF
--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -81,13 +81,15 @@
 
 /obj/item/weapon/contract/wizard/telepathy/contract_effect(mob/user as mob)
 	..()
-	if(!(mRemotetalk in user.mutations))
-		user.mutations.Add(mRemotetalk)
-		user.dna.SetSEState(GLOB.REMOTETALKBLOCK,1)
-		domutcheck(user, null, MUTCHK_FORCED)
-		to_chat(user, "<span class='notice'>You expand your mind outwards.</span>")
-		return 1
-	return 0
+	if (!ishuman(user))
+		return 0
+	var/mob/living/carbon/human/H = user
+	if (mRemotetalk in H.mutations)
+		return 0
+	H.mutations.Add(mRemotetalk)
+	H.verbs += /mob/living/carbon/human/proc/remotesay
+	to_chat(H, "<span class='notice'>You expand your mind outwards.</span>")
+	return 1
 
 /obj/item/weapon/contract/wizard/tk
 	name = "telekinesis contract"


### PR DESCRIPTION
I'm sick of giving wizards remotesay as a verb through VV.

**Duct tape**: Skips DNA and genes, and just replicates the actual result as `ishuman => add mutation => add verb`.

Isn't realistically all that bad as a solution because the only thing missing as an end result is a gene datum in the user's dna, which is largely meaningless in current play anyway and isn't checked by the remotesay proc. Also since wizard telepathy accounts for easily 99+% of all telepathy, screw DNA. DNA is for people without magic.

This issue appears to occur largely because DNA is crusty and old compared to modern medicine.

1. [user.dna.SetSEState](https://github.com/Baystation12/Baystation12/blob/7ef3fa6024d7612305dc16cf6ad611381ef16403/code/modules/spells/contracts.dm#L86) was not actually setting remotetalkblock validly consistently. Removing the mutation.add before the dna.setsestate seems to fix this part although I have no idea why. The mutation.Add was superfluous anyway though, because the gene toggles it on when it activates correctly. *(see [disease2](https://github.com/Baystation12/Baystation12/blob/532dff47a26d754f74b3b409bdfd6e85c9a2e55c/code/modules/virus2/effect.dm#L198) doing it correctly).*

2. domutcheck checks if the mob should have a heart and [silently fails if it should](https://github.com/Baystation12/Baystation12/blob/890ae6e4ffefc0d09b3d4294e64afcd8469e731f/code/game/dna/dna2_domutcheck.dm#L10). Many human descendants (IPCs, FBPs, some aliens) do not have hearts by default. Removing that check is unfeasible though, because most DNA things probably shouldn't apply to things without meat. Perhaps making it check if the user's torso is robotic would be better, but I'm not doing that.



anyway, fixes #20383 - I welcome a better solution that acts on 1 and corrects domutcheck like suggested in 2, but compiling takes me like 12 minutes on this laptop so I'm not doing it myself.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
