### PR TITLE
Fixes "3" when placed on surgery table

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -80,7 +80,7 @@
 	if (C == user)
 		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
 	else
-		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>", 3)
+		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>")
 	if (C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src


### PR DESCRIPTION
🆑 
bugfix: Fixed "3" being printed when placed on a surgery table.
/🆑 

I have no way of actually testing if this works locally, but from what I understand this should remove that random "3" you see when you're placed on a surgery table while unconscious.
