### PR TITLE
Lazy refluffs supply pod as storage elevator

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -56,6 +56,7 @@
 
 		if(3)// Shuttle monitoring and control
 			var/datum/shuttle/autodock/ferry/supply/shuttle = supply_controller.shuttle
+			data["shuttle_name"] = shuttle.name
 			if(istype(shuttle))
 				data["shuttle_location"] = shuttle.at_station() ? GLOB.using_map.name : "Remote location"
 			else

--- a/html/changelogs/chinsky - loweffort.yml
+++ b/html/changelogs/chinsky - loweffort.yml
@@ -1,0 +1,8 @@
+author: Chinsky
+
+delete-after: True
+
+changes: 
+  - tweak: "Removes supply drone. There was no supply drone. It can't go that far."
+  - tweak: "Adds elevator going to deep storage. It's not a lazy redraw of supply drone, that'd be silly."
+  - tweak: "Renames 'credits' to 'points' in supply program for less monetary implications."

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -15895,18 +15895,6 @@
 "Em" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
-"En" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"Eo" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "Ep" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/cyan{
@@ -17225,7 +17213,7 @@
 /area/quartermaster/storage)
 "Hc" = (
 /obj/effect/shuttle_landmark/supply/station,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/quartermaster/hangar)
 "Hd" = (
 /obj/machinery/light{
@@ -18180,18 +18168,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
-"IY" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"IZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "Ja" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light{
@@ -19333,6 +19309,9 @@
 "XJ" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/unused)
+"XM" = (
+/turf/simulated/floor/reinforced,
+/area/quartermaster/hangar)
 "XQ" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -39907,15 +39886,15 @@ bi
 bi
 bi
 bi
-bb
-pd
-pd
-pd
-pd
-pd
-pd
-pd
-eJ
+bi
+bi
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 bi
 JL
 JZ
@@ -40109,15 +40088,15 @@ fO
 fO
 Cu
 bi
-bd
 bi
-bi
-bi
-bi
-bi
-bi
-bi
-IY
+bb
+pd
+pd
+pd
+pd
+pd
+pd
+eJ
 bi
 bi
 bi
@@ -40310,17 +40289,17 @@ bi
 bi
 bi
 Cv
-bb
-En
 bi
 bi
-bi
-bi
-bi
-bi
-bi
-bi
+bd
+XM
+XM
+XM
+XM
+XM
+XM
 we
+bi
 bi
 bi
 Qd
@@ -40512,17 +40491,17 @@ bi
 bi
 bi
 Cv
+bi
+bi
 bd
-bi
-bi
-bi
-bi
-bi
-bi
-bi
-bi
-bi
+XM
+XM
+XM
+XM
+XM
+XM
 we
+bi
 bi
 bi
 Qd
@@ -40714,17 +40693,17 @@ yH
 Ab
 bi
 Cv
+bi
+bi
 bd
-bi
-bi
-bi
-bi
+XM
+XM
 Hc
-bi
-bi
-bi
-bi
+XM
+XM
+XM
 we
+bi
 JM
 Ka
 Qd
@@ -40916,17 +40895,17 @@ bi
 bi
 bi
 Cv
+bi
+bi
 bd
-bi
-bi
-bi
-bi
-bi
-bi
-bi
-bi
-bi
+XM
+XM
+XM
+XM
+XM
+XM
 we
+bi
 bi
 Kb
 Qd
@@ -41118,17 +41097,17 @@ bi
 bi
 bi
 Cv
-bh
-Eo
 bi
 bi
-bi
-bi
-bi
-bi
-bi
-bi
+bd
+XM
+XM
+XM
+XM
+XM
+XM
 we
+bi
 bi
 Kc
 Qd
@@ -41321,16 +41300,16 @@ gK
 bi
 Cv
 bi
-bd
 bi
-bi
-bi
-bi
-bi
-bi
-bi
-IZ
+bh
+bH
+bH
+bH
+bH
+bH
+bH
 tg
+bi
 bi
 Kb
 Qd
@@ -41523,15 +41502,15 @@ aJ
 Bn
 Cv
 bi
-bh
-bH
-bH
-bH
-bH
-bH
-bH
-bH
-tg
+bi
+bi
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 bi
 bi
 Kd

--- a/maps/torch/torch-6.dmm
+++ b/maps/torch/torch-6.dmm
@@ -8848,14 +8848,6 @@
 	name = "plating"
 	},
 /area/centcom/living)
-"auc" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/supply/dock)
 "aud" = (
 /turf/space,
 /area/shuttle/alien/base)
@@ -8936,32 +8928,19 @@
 	name = "plating"
 	},
 /area/centcom/living)
-"auo" = (
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
-/area/supply/dock)
 "aup" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
 	},
-/area/supply/dock)
-"auq" = (
-/obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (WEST)";
+	icon_state = "railing0";
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/supply/dock)
-"aur" = (
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "aus" = (
 /obj/effect/decal/cleanable/blood,
@@ -8991,39 +8970,67 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/administration/centcom)
-"auw" = (
-/obj/machinery/button/remote/blast_door{
-	id = "supply_shuttle";
-	name = "Supply Drone Shutter Control";
-	pixel_x = 0;
-	pixel_y = 0;
-	req_access = list(31)
-	},
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/supply/dock)
 "aux" = (
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
 	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (NORTH)";
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (WEST)";
+	icon_state = "railing0";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "auy" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (NORTH)";
+	icon_state = "railing0";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
+"auz" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (NORTH)";
+	icon_state = "railing0";
+	dir = 1
+	},
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/supply/dock)
-"auz" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "auA" = (
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	icon_state = "diagonalWall3"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
 	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (NORTH)";
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (EAST)";
+	icon_state = "railing0";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "auB" = (
 /turf/simulated/mineral,
@@ -9125,15 +9132,6 @@
 	dir = 2
 	},
 /area/centcom/living)
-"auQ" = (
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "supply_shuttle";
-	name = "Supply Drone Shutters"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/supply/dock)
 "auR" = (
 /obj/machinery/light{
 	dir = 8
@@ -9177,7 +9175,7 @@
 /area/centcom/living)
 "auX" = (
 /obj/effect/shuttle_landmark/supply/centcom,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "auY" = (
 /obj/machinery/body_scanconsole{
@@ -9383,39 +9381,16 @@
 	},
 /area/centcom/living)
 "avA" = (
-/turf/simulated/floor/plating,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "avB" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/showcase{
-	desc = "A self-contained autopilot that controls supply drones.";
-	icon_state = "comm_server";
-	name = "Supply Drone Virtual Intelligence"
-	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing/mapped,
 /obj/machinery/light/spot,
-/turf/simulated/floor/plating,
-/area/supply/dock)
-"avC" = (
-/turf/simulated/floor/plating,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "avD" = (
 /obj/structure/lattice,
@@ -23062,6 +23037,18 @@
 	dir = 2
 	},
 /area/syndicate_mothership/raider_base)
+"cfx" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (WEST)";
+	icon_state = "railing0";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
 "exk" = (
 /obj/machinery/computer/pod{
 	dir = 1;
@@ -23072,6 +23059,52 @@
 	icon_state = "lino"
 	},
 /area/tdome/tdomeadmin)
+"jGP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (EAST)";
+	icon_state = "railing0";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
+"mDM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
+"oIk" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	tag = "icon-railing0 (EAST)";
+	icon_state = "railing0";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
+"tji" = (
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
+"vAH" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
+"wkc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/supply/dock)
 
 (1,1,1) = {"
 aaa
@@ -37488,13 +37521,13 @@ aab
 atx
 atR
 atR
-auo
-auw
-auQ
-auQ
-auQ
-auw
-auA
+atR
+atR
+atR
+atR
+atR
+atR
+atR
 atR
 atR
 atR
@@ -37690,14 +37723,14 @@ aab
 atx
 atR
 atR
-aup
+atR
 aux
-auz
-auz
-auz
-aur
+cfx
+wkc
+wkc
+cfx
 aup
-auA
+atR
 atR
 atR
 atR
@@ -37891,15 +37924,15 @@ aab
 aab
 atx
 atR
-auc
-auq
+atR
+atR
 auy
-auz
-auz
-auz
-auz
+vAH
+tji
+tji
+vAH
 avA
-aup
+atR
 atR
 atR
 atR
@@ -38093,15 +38126,15 @@ aab
 aab
 atx
 atR
-auc
-auq
+atR
+atR
 auz
-auz
+tji
 auX
-auz
-auz
+tji
+tji
 avB
-aup
+atR
 atR
 atR
 atR
@@ -38295,15 +38328,15 @@ aab
 aab
 atx
 atR
-auc
-auq
+atR
+atR
 auy
-auz
-auz
-auz
-auz
-avC
-aup
+vAH
+tji
+tji
+vAH
+avA
+atR
 atR
 atR
 atR
@@ -38498,14 +38531,14 @@ aab
 atx
 atR
 atR
-aup
+atR
 auA
-auz
-auz
-auz
-auo
-aup
-aux
+oIk
+mDM
+mDM
+oIk
+jGP
+atR
 atR
 atR
 atR
@@ -38700,13 +38733,13 @@ aab
 atx
 atR
 atR
-aur
-auw
-auQ
-auQ
-auQ
-auw
-aux
+atR
+atR
+atR
+atR
+atR
+atR
+atR
 atR
 atR
 atR

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -540,25 +540,27 @@
 	landmark_tag = "nav_specops_out"
 	docking_controller = "specops_dock_airlock"
 
-//Cargo drone
+//Cargo elevator
 
 /datum/shuttle/autodock/ferry/supply/drone
-	name = "Supply Drone"
+	name = "elevator"
 	location = 1
 	warmup_time = 10
 	shuttle_area = /area/supply/dock
 	waypoint_offsite = "nav_cargo_start"
 	waypoint_station = "nav_cargo_station"
+	sound_takeoff = 'sound/effects/lift_heavy_start.ogg'
+	sound_landing = 'sound/effects/lift_heavy_stop.ogg'
 
 /obj/effect/shuttle_landmark/supply/centcom
-	name = "Centcom"
+	name = "Deep Storage"
 	landmark_tag = "nav_cargo_start"
 
 /obj/effect/shuttle_landmark/supply/station
 	name = "Hangar"
 	landmark_tag = "nav_cargo_station"
 	base_area = /area/quartermaster/hangar
-	base_turf = /turf/simulated/floor/plating
+	base_turf = /turf/simulated/floor/reinforced
 
 /datum/shuttle/autodock/overmap/exploration_shuttle
 	name = "Charon"

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -8,11 +8,11 @@
 <div class="item">
 	{{:helper.link('Browse Goods', 'cart', {'set_screen' : 1}, data.screen == 1 ? 'selected' : null)}}
 	{{:helper.link('View Statistics', 'calculator', {'set_screen' : 2}, data.screen == 2 ? 'selected' : null)}}
-	{{:helper.link('Shuttle Control', 'bullet', {'set_screen' : 3}, data.screen == 3 ? 'selected' : null)}}
+	{{:helper.link('Controls', 'bullet', {'set_screen' : 3}, data.screen == 3 ? 'selected' : null)}}
 	{{:helper.link('Browse Orders', 'check', {'set_screen' : 4}, data.screen == 4 ? 'selected' : null)}}
 </div>
 <hr>
-<span>Current balance: {{:data.credits}} Credits</span>
+<span>Current balance: {{:data.credits}} Points</span>
 <hr>
 {{if data.screen == 1}}
 	{{for data.categories}}
@@ -24,7 +24,7 @@
 			{{for data.possible_purchases}}
 				<tr>
 				<td>{{:value.name}}
-				<td>{{:value.cost}} Credits
+				<td>{{:value.cost}} Points
 				<td>{{:helper.link('Order', null, {'order' : value.ref})}}
 			{{/for}}
 		</table>
@@ -32,7 +32,7 @@
 {{else data.screen == 2}}
 	<div class="item">
 		<div class="itemLabel">
-			Total credits generated today:
+			Total points generated today:
 		</div>
 		<div class="itemContent">
 			{{:data.total_credits}} Cr.
@@ -48,7 +48,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Credits from recycled crates:
+			Points from recycled crates:
 		</div>
 		<div class="itemContent">
 			{{:data.credits_crates}} Cr.
@@ -56,7 +56,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Credits from phoron exports:
+			Points from phoron exports:
 		</div>
 		<div class="itemContent">
 			{{:data.credits_phoron}} Cr.
@@ -64,7 +64,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Credits from platinum exports:
+			Points from platinum exports:
 		</div>
 		<div class="itemContent">
 			{{:data.credits_platinum}} Cr.
@@ -72,7 +72,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Credits from uploaded antibody data:
+			Points from uploaded antibody data:
 		</div>
 		<div class="itemContent">
 			{{:data.credits_virology}} Cr.
@@ -80,7 +80,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Credits from uploaded good explorer points:
+			Points from uploaded good explorer points:
 		</div>
 		<div class="itemContent">
 			{{:data.credits_gep}} Cr.
@@ -88,7 +88,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Credit bonus for paperwork handling:
+			Point bonus for paperwork handling:
 		</div>
 		<div class="itemContent">
 			{{:data.credits_paperwork}} Cr.
@@ -105,7 +105,7 @@
 {{else data.screen == 3}}
 	<div class="item">
 		<div class="itemLabel">
-			Current shuttle location:
+			Current {{:data.shuttle_name}} location:
 		</div>
 		<div class="itemContent">
 			{{:data.shuttle_location}}
@@ -113,7 +113,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Current shuttle status:
+			Current {{:data.shuttle_name}} status:
 		</div>
 		<div class="itemContent">
 			{{:data.shuttle_status}}


### PR DESCRIPTION


![](https://i.imgur.com/KVZrnwB.png)
Adjusts supply program to not rub the fact it was made for shuttles too much in your face.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
