### PR TITLE
Adds missing uniform definition for off-duty EC officers

### DIFF
--- a/maps/torch/datums/uniforms_expedition.dm
+++ b/maps/torch/datums/uniforms_expedition.dm
@@ -211,9 +211,23 @@
 /decl/hierarchy/mil_uniform/ec/offduty
 	name = "EC off-duty"
 	departments = CIV
-	min_rank = 11
 
 	utility_under = null
 	utility_shoes = null
 	utility_hat = null
 	utility_extra = null
+
+/decl/hierarchy/mil_uniform/ec/offduty/officer
+	name = "EC off-duty CO"
+	departments = CIV
+	min_rank = 11
+
+	service_under = /obj/item/clothing/under/solgov/service/expeditionary/command
+	service_skirt = /obj/item/clothing/under/solgov/service/expeditionary/command/skirt
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
+
+	dress_under = /obj/item/clothing/under/solgov/service/expeditionary/command
+	dress_skirt = /obj/item/clothing/under/solgov/service/expeditionary/command/skirt
+	dress_over = /obj/item/clothing/suit/dress/solgov/expedition/command
+	dress_hat = /obj/item/clothing/head/solgov/service/expedition/command


### PR DESCRIPTION
Fixes #21573

Uniform definitions were missing an entry for EC officers

This does not do anything about the underlying bug in the uniform vendor that causes it to runtime error if it attempts to look for an officer uniform in a branch/department for which no such uniform is defined, but I think all departments that can have officers in them have been covered right now.