### PR TITLE
Clicking on an All-In-Grinder with a pill bottle will now empty its contents into the grinder. (WIP)

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -375,6 +375,31 @@
 		src.updateUsrDialog()
 		return 0
 
+	// Clicking on a grinder with a pill bottle will empty the bottle's contents into the grinder
+	if(istype(O,/obj/item/weapon/storage/pill_bottle))
+		var/obj/item/weapon/storage/pill_bottle/bag = O
+		var/failed = 1
+		for(var/obj/item/G in O.contents)
+			if(!G.reagents || !G.reagents.total_volume)
+				continue
+			failed = 0
+			bag.remove_from_storage(G, src)
+			holdingitems += G
+			if(holdingitems && holdingitems.len >= limit)
+				break
+
+		if(failed)
+			to_chat(user, "The pill bottle is empty.")
+			return 1
+
+		if(!O.contents.len)
+			to_chat(user, "You empty \the [O] into \the [src].")
+		else
+			to_chat(user, "You fill \the [src] from \the [O].")
+
+		src.updateUsrDialog()
+		return 0
+		
 	if(!sheet_reagents[O.type] && (!O.reagents || !O.reagents.total_volume))
 		to_chat(user, "\The [O] is not suitable for blending.")
 		return 1


### PR DESCRIPTION
:cl: 
rscadd: Clicking on an All-In-Grinder with a pill bottle will now empty its contents into the grinder (suggested by Technetium).
/ :cl: 

A little PR to fulfill [this request](https://forums.baystation12.net/threads/the-little-things-4-with-a-vengeance.9/page-56#post-94197). It works exactly the same way as the plant bag.

Not as good as [the recent ore satchel optimization](https://github.com/Baystation12/Baystation12/pull/21574) but I couldn't get it work that way. If you have any better solution, it is more than welcomed!