### PR TITLE
Overseers are made clumsy while invisible.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -780,6 +780,8 @@ default behaviour is:
 		. += 15
 	if(confused)
 		. += 30
+	if(CLUMSY in mutations)
+		. += 40
 
 /mob/living/proc/ranged_accuracy_mods()
 	. = 0
@@ -791,3 +793,5 @@ default behaviour is:
 		. -= 5
 	if(eye_blurry)
 		. -= 1
+	if(CLUMSY in mutations)
+		. -= 3

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -124,6 +124,9 @@
 
 /obj/item/weapon/contract/boon/contract_effect(mob/user as mob)
 	..()
+	if(user.mind.special_role == ANTAG_SERVANT)
+		to_chat(user, "<span class='warning'>As a servant you find yourself unable to use this contract.</span>")
+		return 0
 	if(ispath(path,/spell))
 		user.add_spell(new path)
 		return 1

--- a/code/modules/spells/general/invisibility.dm
+++ b/code/modules/spells/general/invisibility.dm
@@ -18,5 +18,7 @@
 	if(on)
 		if(H.add_cloaking_source(src))
 			playsound(get_turf(H), 'sound/effects/teleport.ogg', 90, 1)
+			H.mutations |= CLUMSY
 	else if(H.remove_cloaking_source(src))
 		playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 90, 1)
+		H.mutations -= CLUMSY


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

This stops them from being invisible invincible powerhouses.
