### PR TITLE
servants can no longer access spellbooks

### DIFF
--- a/code/__defines/antagonists.dm
+++ b/code/__defines/antagonists.dm
@@ -1,2 +1,3 @@
 #define ANTAG_SERVANT "servant"
 #define ANTAG_APPRENTICE "apprentice"
+#define ANTAG_WIZARD "Space Wizard"

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -2,8 +2,8 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 
 /datum/antagonist/wizard
 	id = MODE_WIZARD
-	role_text = "Space Wizard"
-	role_text_plural = "Space Wizards"
+	role_text = ANTAG_WIZARD
+	role_text_plural = ANTAG_WIZARD + "s"
 	landmark_id = "wizard"
 	welcome_text = "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.<br>In your pockets you will find a teleport scroll. Use it as needed."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -45,17 +45,17 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 	desc = spellbook.desc
 
 /obj/item/weapon/spellbook/attack_self(mob/user as mob)
-	if(user.mind)
-		if(!GLOB.wizards.is_antagonist(user.mind))
+	if(!user.mind)
+		return
+	if (user.mind.special_role != ANTAG_WIZARD)
+		if (user.mind.special_role != ANTAG_APPRENTICE)
 			to_chat(user, "You can't make heads or tails of this book.")
 			return
-		if(spellbook.book_flags & LOCKED)
-			if(user.mind.special_role == ANTAG_APPRENTICE)
-				to_chat(user, "<span class='warning'>Drat! This spellbook's apprentice proof lock is on!.</span>")
-				return
-			else
-				to_chat(user, "You notice the apprentice proof lock is on. Luckily you are beyond such things and can open it anyways.")
-
+		if (spellbook.book_flags & LOCKED)
+			to_chat(user, "<span class='warning'>Drat! This spellbook's apprentice-proof lock is on!</span>")
+			return
+	else if (spellbook.book_flags & LOCKED)
+		to_chat(user, "You notice the apprentice-proof lock is on. Luckily you are beyond such things.")
 	interact(user)
 
 /obj/item/weapon/spellbook/proc/make_sacrifice(obj/item/I as obj, mob/user as mob, var/reagent)


### PR DESCRIPTION
~ Moves wizard special role title to __defines/antagonists as ANTAG_WIZARD because that seems like a good trend to follow for re-usability.

~ Changes the spellbook to only allow specifically wizards and apprentices to access it. Previously servants were counted as full wizards.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
