### PR TITLE
Prevent ID computers from modifying off-duty IDs

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -118,6 +118,7 @@ var/const/NO_EMAG_ACT = -50
 
 	var/datum/mil_branch/military_branch = null //Vars for tracking branches and ranks on multi-crewtype maps
 	var/datum/mil_rank/military_rank = null
+	var/offduty = FALSE
 
 /obj/item/weapon/card/id/New()
 	..()

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -118,6 +118,10 @@
 	var/obj/item/weapon/card/id/id_card
 	if (computer.card_slot)
 		id_card = computer.card_slot.stored_card
+	if (id_card.offduty)
+		computer.visible_message("<span class='warning'>\The [computer] flashes an error and ejects the ID: 'Error XX107: The modification and issuance of identification cards for off-duty personnel is prohibited.'</span>")
+		computer.proc_eject_id(user)
+		return
 
 	var/datum/nano_module/program/card_mod/module = NM
 	switch(href_list["action"])

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -141,9 +141,10 @@
 	job_access_type = /datum/job/assistant
 
 /obj/item/weapon/card/id/torch/offduty
-	desc = "A card issued to off-duty personnel aboard the SEV Torch."
-	icon_state = "id"
+	desc = "A cheaply laminated card issued to off-duty personnel aboard the SEV Torch. Tiny print warns against attempting to modify this ID card."
+	icon_state = "mime"
 	job_access_type = /datum/job/offduty
+	offduty = TRUE
 
 /obj/item/weapon/card/id/torch/passenger/research
 	desc = "A card issued to NanoTrasen personnel aboard the SEV Torch."


### PR DESCRIPTION
:cl:
tweak: Off-duty ID cards are now visually distinct and can no longer be modified.
/:cl: