### PR TITLE
Report Editor impovements.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2559,6 +2559,7 @@
 #include "code\unit_tests\extension_tests.dm"
 #include "code\unit_tests\food_tests.dm"
 #include "code\unit_tests\foundation_tests.dm"
+#include "code\unit_tests\garbage_tests.dm"
 #include "code\unit_tests\icon_tests.dm"
 #include "code\unit_tests\integrated_circuits.dm"
 #include "code\unit_tests\job_tests.dm"

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -208,7 +208,7 @@
 
 #define RADIATION_THRESHOLD_CUTOFF 0.1	// Radiation will not affect a tile when below this value.
 
-#define LEGACY_RECORD_STRUCTURE(X, Y) GLOBAL_LIST_EMPTY(##X);/datum/computer_file/data/##Y/var/list/fields[0];/datum/computer_file/data/##Y/New(){..();GLOB.##X.Add(src);}/datum/computer_file/data/##Y/Destroy(){..();GLOB.##X.Remove(src);}
+#define LEGACY_RECORD_STRUCTURE(X, Y) GLOBAL_LIST_EMPTY(##X);/datum/computer_file/data/##Y/var/list/fields[0];/datum/computer_file/data/##Y/New(){..();GLOB.##X.Add(src);}/datum/computer_file/data/##Y/Destroy(){. = ..();GLOB.##X.Remove(src);}
 
 #define SUPPLY_SECURITY_ELEVATED 1
 #define SUPPLY_SECURITY_HIGH 2

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -11,6 +11,7 @@ var/global/datum/ntnet/ntnet_global = new()
 	var/list/chat_channels = list()
 	var/list/fileservers = list()
 	var/list/email_accounts = list()				// I guess we won't have more than 999 email accounts active at once in single round, so this will do until Servers are implemented someday.
+	var/list/available_reports = list()             // A list containing one of each available report datums, used for the report editor program.
 	var/list/banned_nids = list()
 	// Amount of logs the system tries to keep in memory. Keep below 999 to prevent byond from acting weirdly.
 	// High values make displaying logs much laggier.
@@ -37,6 +38,7 @@ var/global/datum/ntnet/ntnet_global = new()
 	build_software_lists()
 	build_news_list()
 	build_emails_list()
+	build_reports_list()
 	add_log("NTNet logging system activated.")
 
 /datum/ntnet/proc/add_log_with_ids_check(var/log_string, var/obj/item/weapon/computer_hardware/network_card/source = null)
@@ -124,6 +126,22 @@ var/global/datum/ntnet/ntnet_global = new()
 /datum/ntnet/proc/build_emails_list()
 	for(var/F in subtypesof(/datum/computer_file/data/email_account/service))
 		new F()
+
+// Builds report list.
+/datum/ntnet/proc/build_reports_list()
+	available_reports = list()
+	for(var/F in typesof(/datum/computer_file/report))
+		var/datum/computer_file/report/type = F
+		if(initial(type.available_on_ntnet))
+			available_reports += new type
+
+/datum/ntnet/proc/fetch_reports(access)
+	if(!access)
+		return available_reports
+	. = list()
+	for(var/datum/computer_file/report/report in available_reports)
+		if(report.verify_access_edit(access))
+			. += report
 
 // Attempts to find a downloadable file according to filename var
 /datum/ntnet/proc/find_ntnet_file_by_name(var/filename)

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -15,15 +15,15 @@ var/global/file_uid = 0
 	file_uid++
 
 /datum/computer_file/Destroy()
+	. = ..()
 	if(!holder)
-		return ..()
+		return
 
 	holder.remove_file(src)
 	// holder.holder is the computer that has drive installed. If we are Destroy()ing program that's currently running kill it.
 	if(holder.holder2 && holder.holder2.active_program == src)
 		holder.holder2.kill_program(1)
 	holder = null
-	..()
 
 // Returns independent copy of this file.
 /datum/computer_file/proc/clone(var/rename = 0)

--- a/code/modules/modular_computers/file_system/programs/generic/reports.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/reports.dm
@@ -1,3 +1,6 @@
+#define REPORTS_VIEW      1
+#define REPORTS_DOWNLOAD  2
+
 /datum/computer_file/program/reports
 	filename = "repview"
 	filedesc = "Report Editor"
@@ -5,19 +8,32 @@
 	extended_desc = "A general paperwork viewing and editing utility."
 	size = 6
 	available_on_ntnet = 1
-	requires_ntnet = 1
+	requires_ntnet = 0
 
 /datum/nano_module/program/reports
 	name = "Report Editor"
 	var/can_view_only = 0                              //Whether we are in view-only mode.
 	var/datum/computer_file/report/selected_report     //A report being viewed/edited. This is a temporary copy.
 	var/datum/computer_file/report/saved_report        //The computer file open.
+	var/prog_state = REPORTS_VIEW
 
 /datum/nano_module/program/reports/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
 	var/list/data = host.initial_data()
-	if(selected_report)
-		data["report_data"] = selected_report.generate_nano_data(get_access(user))
-	data["view_only"] = can_view_only
+	data["prog_state"] = prog_state
+	switch(prog_state)
+		if(REPORTS_VIEW)
+			if(selected_report)
+				data["report_data"] = selected_report.generate_nano_data(get_access(user))
+			data["view_only"] = can_view_only
+			data["printer"] = program.computer.nano_printer
+		if(REPORTS_DOWNLOAD)
+			var/list/L = list()
+			for(var/datum/computer_file/report/report in ntnet_global.fetch_reports(get_access(user)))
+				var/M = list()
+				M["name"] = report.display_name()
+				M["uid"] = report.uid
+				L += list(M)
+			data["reports"] = L
 
 	ui = GLOB.nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -26,22 +42,41 @@
 		ui.set_initial_data(data)
 		ui.open()
 
+/datum/nano_module/program/reports/proc/switch_state(new_state)
+	if(prog_state == new_state)
+		return
+	switch(new_state)
+		if(REPORTS_VIEW)
+			program.requires_ntnet_feature = null
+			program.requires_ntnet = 0
+			prog_state = REPORTS_VIEW
+		if(REPORTS_DOWNLOAD)
+			close_report()
+			program.requires_ntnet_feature = NTNET_SOFTWAREDOWNLOAD
+			program.requires_ntnet = 1
+			prog_state = REPORTS_DOWNLOAD
+
 /datum/nano_module/program/reports/proc/close_report()
-	qdel(selected_report)
+	QDEL_NULL(selected_report)
 	saved_report = null
 
-/datum/nano_module/program/reports/proc/save_report(mob/user)
+/datum/nano_module/program/reports/proc/save_report(mob/user, save_as)
 	if(!program.computer || !program.computer.hard_drive)
 		to_chat(user, "Unable to find hard drive.")
 		return
-	program.computer.hard_drive.remove_file(saved_report)
-	if(!program.computer.hard_drive.store_file(selected_report))
-		to_chat(user, "Error storing file. Please check your hard drive.")		
-		program.computer.hard_drive.store_file(saved_report)
+	selected_report.rename_file()
+	if(!save_as)
+		program.computer.hard_drive.remove_file(saved_report)
+	if(!program.computer.hard_drive.try_store_file(selected_report))
+		to_chat(user, "Error storing file. Please check your hard drive.")
+		program.computer.hard_drive.store_file(saved_report) //Does nothing if already saved.
 		return
-	qdel(saved_report)
+	program.computer.hard_drive.store_file(selected_report)
+	if(!save_as)
+		qdel(saved_report)
 	saved_report = selected_report
 	selected_report = saved_report.clone()
+	to_chat(user, "The report has been saved as [saved_report.filename].[saved_report.filetype]")
 
 /datum/nano_module/program/reports/proc/load_report(mob/user)
 	if(!program.computer || !program.computer.hard_drive)
@@ -69,9 +104,9 @@
 		return 1
 
 /datum/nano_module/program/reports/Topic(href, href_list)
-	var/mob/user = usr
 	if(..())
 		return 1
+	var/mob/user = usr
 
 	if(text2num(href_list["warning"])) //Gives the user a chance to avoid losing unsaved reports.
 		if(alert(user, "Are you sure you want to leave this page? Unsubmitted data will be lost.",, "Yes.", "No.") == "No.")
@@ -87,7 +122,8 @@
 			return 1
 		if(!selected_report.verify_access(get_access(user)))
 			return 1
-		save_report(user)
+		var/save_as = text2num(href_list["save_as"])
+		save_report(user, save_as)
 	if(href_list["submit"])
 		if(!selected_report)
 			return 1
@@ -112,3 +148,44 @@
 			return 1
 		field.ask_value(user) //Handles the remaining IO.
 		return 1
+	if(href_list["print"])
+		if(!selected_report || !program.computer || !program.computer.nano_printer)
+			return 1
+		if(!selected_report.verify_access(get_access(user)))
+			return 1
+		var/with_fields = text2num(href_list["print_mode"])
+		var/text = selected_report.generate_pencode(get_access(user), with_fields)
+		if(!program.computer.nano_printer.print_text(text, selected_report.display_name()))
+			to_chat(user, "Hardware error: Printer was unable to print the file. It may be out of paper.")
+		return 1
+	if(href_list["export"])
+		if(!selected_report || !program.computer || !program.computer.hard_drive)
+			return 1
+		if(!selected_report.verify_access(get_access(user)))
+			return 1
+		var/datum/computer_file/data/text/file = new
+		selected_report.rename_file()
+		file.stored_data = selected_report.generate_pencode(get_access(user), no_html = 1) //TXT files can't have html; they use pencode only.
+		file.filename = selected_report.filename
+		to_chat(user, (program.computer.hard_drive.store_file(file) ? "The report has been exported as [file.filename].[file.filetype]" : "Error storing file. Please check your hard drive."))
+		return 1
+
+	if(href_list["download"])
+		switch_state(REPORTS_DOWNLOAD)
+		return 1
+	if(href_list["get_report"])
+		var/uid = text2num(href_list["report"])
+		for(var/datum/computer_file/report/report in ntnet_global.fetch_reports(get_access(user)))
+			if(report.uid == uid)
+				selected_report = report.clone()
+				can_view_only = 0
+				switch_state(REPORTS_VIEW)
+				return 1
+		to_chat(user, "Network error: Selected report could not be downloaded. Check network functionality and credentials.")
+		return 1
+	if(href_list["home"])
+		switch_state(REPORTS_VIEW)
+		return 1
+
+#undef REPORTS_VIEW
+#undef REPORTS_DOWNLOAD

--- a/code/modules/modular_computers/file_system/reports/deck_reports.dm
+++ b/code/modules/modular_computers/file_system/reports/deck_reports.dm
@@ -11,6 +11,12 @@
 	..()
 	set_access(null, access_heads)
 
+/datum/computer_file/report/flight_plan/Destroy()
+	leader = null
+	manifest = null
+	planned_depart = null
+	return ..()
+
 /datum/computer_file/report/flight_plan/generate_fields()
 	add_field(/datum/report_field/instruction, "These fields are required:")
 	leader = add_field(/datum/report_field/people/from_manifest, "Leader", required = 1)
@@ -30,6 +36,11 @@
 /datum/computer_file/report/recipient/shuttle/New()
 	..()
 	set_access(null, access_heads)
+
+/datum/computer_file/report/recipient/shuttle/Destroy()
+	shuttle = null
+	mission = null
+	return ..()
 
 /datum/computer_file/report/recipient/shuttle/generate_fields()
 	..()

--- a/code/modules/modular_computers/file_system/reports/report_field.dm
+++ b/code/modules/modular_computers/file_system/reports/report_field.dm
@@ -99,11 +99,21 @@ Basic field subtypes.
 	value = "00:00"
 
 /datum/report_field/time/set_value(given_value)
-	if(istext(given_value))
-		value = sanitize_time(given_value)
+	value = sanitize_time(given_value, value, "hh:mm")
 
 /datum/report_field/time/ask_value(mob/user)
 	set_value(input(user, "[display_name()] (time as hh:mm):", "Form Input", get_value()) as null|text)
+
+//Uses YYYY-MM-DD format for dates.
+/datum/report_field/date/New()
+	..()
+	value = stationdate2text()
+
+/datum/report_field/date/set_value(given_value)
+	value = sanitize_time(given_value, value, "YEAR-MM-DD")
+
+/datum/report_field/date/ask_value(mob/user)
+	set_value(input(user, "[display_name()] (date as YYYY-MM-DD):", "Form Input", get_value()) as null|text)
 
 //Will prompt for numbers.
 /datum/report_field/number
@@ -125,3 +135,17 @@ Basic field subtypes.
 
 /datum/report_field/options/ask_value(mob/user)
 	set_value(input(user, "[display_name()] (select one):", "Form Input", get_value()) as null|anything in get_options())
+
+//Yes or no field.
+/datum/report_field/options/yes_no
+	value = "No"
+
+/datum/report_field/options/yes_no/get_options()
+	return list("Yes", "No")
+
+//Signature field; ask_value will obtain the user's signature.
+/datum/report_field/signature/get_value()
+	return "<font face=\"Times New Roman\"><i>[value]</i></font>"
+
+/datum/report_field/signature/ask_value(mob/user)
+	set_value((user && user.real_name) ? user.real_name : "Anonymous")

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -63,27 +63,8 @@
 
 // Use this proc to add file to the drive. Returns 1 on success and 0 on failure. Contains necessary sanity checks.
 /obj/item/weapon/computer_hardware/hard_drive/proc/store_file(var/datum/computer_file/F)
-	if(!F || !istype(F))
+	if(!try_store_file(F))
 		return 0
-
-	if(!can_store_file(F.size))
-		return 0
-
-	if(!check_functionality())
-		return 0
-
-	if(!stored_files)
-		return 0
-
-	var/list/badchars = list("/","\\",":","*","?","\"","<",">","|","#", ".")
-	for(var/char in badchars)
-		if(findtext(F.filename, char))
-			return 0
-
-	// This file is already stored. Don't store it again.
-	if(F in stored_files)
-		return 0
-
 	F.holder = src
 	stored_files.Add(F)
 	recalculate_size()
@@ -137,13 +118,27 @@
 /obj/item/weapon/computer_hardware/hard_drive/proc/try_store_file(var/datum/computer_file/F)
 	if(!F || !istype(F))
 		return 0
+	if(!can_store_file(F.size))
+		return 0
+	if(!check_functionality())
+		return 0
+	if(!stored_files)
+		return 0
+
+	var/list/badchars = list("/","\\",":","*","?","\"","<",">","|","#", ".")
+	for(var/char in badchars)
+		if(findtext(F.filename, char))
+			return 0
+
+	// This file is already stored. Don't store it again.
+	if(F in stored_files)
+		return 0
+
 	var/name = F.filename + "." + F.filetype
 	for(var/datum/computer_file/file in stored_files)
 		if((file.filename + "." + file.filetype) == name)
 			return 0
-	return can_store_file(F.size)
-
-
+	return 1
 
 // Tries to find the file by filename. Returns null on failure
 /obj/item/weapon/computer_hardware/hard_drive/proc/find_file_by_name(var/filename)

--- a/code/unit_tests/garbage_tests.dm
+++ b/code/unit_tests/garbage_tests.dm
@@ -1,0 +1,26 @@
+#define GC_TEST_TIME 140 SECONDS
+
+datum/unit_test/computer_files_must_gc
+	name = "GC: All computer files must garbage collect"
+	async = 1
+	var/start_time
+
+datum/unit_test/computer_files_must_gc/start_test()
+	var/obj/item/modular_computer/computer = new //Spawn a computer in nullspace for better testing.
+	computer.hard_drive = new /obj/item/weapon/computer_hardware/hard_drive/cluster
+	for(var/type in typesof(/datum/computer_file))
+		qdel(new type) //nullspace test first
+		var/file = new type
+		computer.hard_drive.store_file(file)
+		qdel(file) //Then from a hard drive, provided they can be stored in the first place.
+	qdel(computer) //This also tests for whether preloaded programs can be gc'd
+	start_time = world.time
+	return 1
+
+/datum/unit_test/computer_files_must_gc/check_result()
+	if(world.time < GC_TEST_TIME)
+		return 0
+	pass("All computer files have garbage collected.") //Failure condition is to throw runtimes.
+	return 1
+
+#undef GC_TEST_TIME

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -25,7 +25,7 @@
  */
 
 
-#define MAX_UNIT_TEST_RUN_TIME 2 MINUTES
+#define MAX_UNIT_TEST_RUN_TIME 3 MINUTES
 
 var/all_unit_tests_passed = 1
 var/failed_unit_tests = 0

--- a/maps/torch/datums/reports.dm
+++ b/maps/torch/datums/reports.dm
@@ -1,0 +1,140 @@
+//Report datums for use with the report editor and other programs.
+
+/datum/computer_file/report/recipient/crew_transfer
+	form_name = "CTA-SGF-01"
+	title = "Crew Transfer Application"
+	logo = "\[solcrest\]\[logo\]"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/crew_transfer/generate_fields()
+	..()
+	var/list/xo_fields = list()
+	add_field(/datum/report_field/instruction, "SEV Torch - Office of the Executive Officer")
+	add_field(/datum/report_field/people/from_manifest, "Name (XO)")
+	add_field(/datum/report_field/people/from_manifest, "Name (applicant)", required = 1)
+	add_field(/datum/report_field/date, "Date filed")	
+	add_field(/datum/report_field/time, "Time filed")
+	add_field(/datum/report_field/simple_text, "Present position")
+	add_field(/datum/report_field/simple_text, "Requested position")
+	add_field(/datum/report_field/pencode_text, "Reason stated")
+	add_field(/datum/report_field/instruction, "The following fields render the document invalid if not signed clearly.")
+	add_field(/datum/report_field/signature, "Applicant signature")
+	xo_fields += add_field(/datum/report_field/signature, "Executive Officer's signature")
+	xo_fields += add_field(/datum/report_field/number, "Number of personnel in present/previous position")
+	xo_fields += add_field(/datum/report_field/number, "Number of personnel in requested position")
+	xo_fields += add_field(/datum/report_field/options/yes_no, "Approved")
+	for(var/datum/report_field/field in xo_fields)
+		field.set_access(access_edit = access_hop)
+
+/datum/computer_file/report/recipient/access_modification
+	form_name = "AMA-SGF-02"
+	title = "Crew Access Modification Application"
+	logo = "\[solcrest\]\[logo\]"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/access_modification/generate_fields()
+	..()
+	var/list/xo_fields = list()
+	add_field(/datum/report_field/instruction, "SEV Torch - Office of the Executive Officer")
+	add_field(/datum/report_field/people/from_manifest, "Name (XO)")
+	add_field(/datum/report_field/people/from_manifest, "Name (applicant)", required = 1)
+	add_field(/datum/report_field/date, "Date filed")	
+	add_field(/datum/report_field/time, "Time filed")
+	add_field(/datum/report_field/simple_text, "Present position")
+	add_field(/datum/report_field/simple_text, "Requested access")
+	add_field(/datum/report_field/pencode_text, "Reason stated")
+	add_field(/datum/report_field/simple_text, "Duration of expanded access")
+	add_field(/datum/report_field/instruction, "The following fields render the document invalid if not signed clearly.")
+	add_field(/datum/report_field/signature, "Applicant signature")
+	xo_fields += add_field(/datum/report_field/signature, "Executive Officer's signature")
+	xo_fields += add_field(/datum/report_field/number, "Number of personnel in relevant position")
+	xo_fields += add_field(/datum/report_field/options/yes_no, "Approved")
+	for(var/datum/report_field/field in xo_fields)
+		field.set_access(access_edit = access_hop)
+
+/datum/computer_file/report/recipient/borging
+	form_name = "CC-SGF-09"
+	title = "Cyborgification Contract"
+	logo = "\[solcrest\]"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/borging/generate_fields()
+	..()
+	var/list/xo_fields = list()
+	add_field(/datum/report_field/instruction, "SEV Torch - Office of the Executive Officer")
+	add_field(/datum/report_field/people/from_manifest, "Name (XO)")
+	add_field(/datum/report_field/people/from_manifest, "Name (subject)", required = 1)
+	add_field(/datum/report_field/date, "Date filed")	
+	add_field(/datum/report_field/time, "Time filed")
+	add_field(/datum/report_field/instruction, "I, undersigned, hereby agree to willingly undergo a Regulation Lobotimization with intention of cyborgification or AI assimilation, and I am aware of all the consequences of such act. I also understand that this operation may be irreversible, and that my employment contract will be terminated.")
+	add_field(/datum/report_field/signature, "Subject's signature")
+	xo_fields += add_field(/datum/report_field/signature, "Executive Officer's signature")
+	xo_fields += add_field(/datum/report_field/options/yes_no, "Approved")
+	for(var/datum/report_field/field in xo_fields)
+		field.set_access(access_edit = access_hop)
+
+/datum/computer_file/report/recipient/sec
+	logo = "\[solcrest\]"
+
+/datum/computer_file/report/recipient/sec/New()
+	..()
+	set_access(access_security)
+	set_access(access_heads, override = 0)
+
+/datum/computer_file/report/recipient/sec/investigation
+	form_name = "SCG-SEC-43"
+	title = "Investigation Report"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/sec/investigation/generate_fields()
+	..()
+	add_field(/datum/report_field/instruction, "SEV Torch Security Department.")
+	add_field(/datum/report_field/instruction, "For internal use only.")
+	add_field(/datum/report_field/people/from_manifest, "Name")
+	add_field(/datum/report_field/date, "Date")	
+	add_field(/datum/report_field/time, "Time")
+	add_field(/datum/report_field/simple_text, "Case name")
+	add_field(/datum/report_field/pencode_text, "Summary")
+	add_field(/datum/report_field/pencode_text, "Observations")
+	add_field(/datum/report_field/signature, "Signature")
+	set_access(access_edit = access_security)
+
+/datum/computer_file/report/recipient/sec/incident
+	form_name = "SCG-SEC-12"
+	title = "Security Incident Report"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/sec/incident/generate_fields()
+	..()
+	add_field(/datum/report_field/instruction, "SEV Torch Security Department.")
+	add_field(/datum/report_field/instruction, "To be filled out by Officer on duty responding to the Incident. Report must be signed and submitted before the end of the shift!")
+	add_field(/datum/report_field/people/from_manifest, "Reporting Officer")
+	add_field(/datum/report_field/simple_text, "Offense/Incident Type")
+	add_field(/datum/report_field/date, "Date")	
+	add_field(/datum/report_field/time, "Time of incident")
+	add_field(/datum/report_field/people/list_from_manifest, "Assisting Officer(s)")
+	add_field(/datum/report_field/simple_text, "Location")
+	add_field(/datum/report_field/pencode_text, "Personnel involved in Incident", "\[small\]\[i\](V-Victim, S-Suspect, W-Witness, M-Missing, A-Arrested, RP-Reporting Person, D-Deceased)\[/i\]\[/small\]")
+	add_field(/datum/report_field/pencode_text, "Description of Items/Property", "\[small\]\[i\](D-Damaged, E-Evidence, L-Lost, R-Recovered, S-Stolen)\[/i\]\[/small\]")
+	add_field(/datum/report_field/pencode_text, "Narrative")
+	add_field(/datum/report_field/signature, "Reporting Officer's signature")
+	set_access(access_edit = access_security)
+
+/datum/computer_file/report/recipient/sec/evidence
+	form_name = "SCG-SEC-02b"
+	title = "Evidence and Property Form"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/sec/evidence/generate_fields()
+	..()
+	var/datum/report_field/temp_field
+	add_field(/datum/report_field/instruction, "SEV Torch Security Department.")
+	add_field(/datum/report_field/date, "Date")	
+	add_field(/datum/report_field/time, "Time")
+	add_field(/datum/report_field/people/from_manifest, "Confiscated from")
+	add_field(/datum/report_field/pencode_text, "List of items in custody/evidence lockup")
+	set_access(access_edit = access_security)
+	temp_field = add_field(/datum/report_field/signature, "Brig Officer's signature")
+	temp_field.set_access(access_edit = list(access_security, access_armory))
+	temp_field = add_field(/datum/report_field/signature, "Forensic Technician's signature")
+	temp_field.set_access(access_edit = list(access_security, access_forensics_lockers))

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -17,6 +17,7 @@
 	#include "datums/uniforms.dm"
 	#include "datums/uniforms_expedition.dm"
 	#include "datums/uniforms_fleet.dm"
+	#include "datums/reports.dm"
 	#include "datums/shackle_law_sets.dm"
 	#include "datums/supplypacks/security.dm"
 	#include "datums/supplypacks/science.dm"

--- a/nano/templates/reports.tmpl
+++ b/nano/templates/reports.tmpl
@@ -1,47 +1,74 @@
-<div class='item'>
-	{{:helper.link('Load Report', null, {'load' : 1, 'warning' : data.report_data && data.report_data.access_edit}, null)}}
-	{{:helper.link('Save Report', null, {'save' : 1}, data.report_data ? null : 'disabled')}}
-</div>
-<center><h2>Report Editor</h2></center>
-{{if data.report_data}}
-	<h3>{{:data.report_data.name}}</h3>
-	{{for data.report_data.fields}}
-		<div class='item'>
-			{{if value.ignore_value}}
-				<h3>{{:value.name}}</h3>
-			{{else}}
-				<div class='itemLabel'>
-					{{if (value.can_edit && value.access_edit && !data.view_only)}}
-						{{:helper.link('','pencil' , {'edit' : 1, 'ID' : value.ID}, null)}}
-					{{/if}}
-					{{:value.name}}: 
-				</div>
-				{{if value.access}}
-					<div class="itemContent">
-						{{if value.needs_big_box}}
-						<div class='block'>
-							{{:value.value}}
-						</div>
-						{{else}}
-						<div class='statusDisplayComm'>
-							{{:value.value}}
-						</div>
-						{{/if}}
-					</div>
+{{if data.prog_state == 1}} <!--REPORT_VIEW-->
+	<div class='item'>
+		{{:helper.link('Load Report', null, {'load' : 1, 'warning' : (data.report_data && !data.view_only) ? 1 : 0}, null)}}
+		{{:helper.link('Save Report', null, {'save' : 1, 'save_as' : 0}, (data.report_data && !data.view_only) ? null : 'disabled')}}
+		{{:helper.link('Save Copy', null, {'save' : 1, 'save_as' : 1}, (data.report_data && !data.view_only) ? null : 'disabled')}}		
+		{{:helper.link('New Report', null, {'download' : 1, 'warning' : (data.report_data && !data.view_only) ? 1 : 0}, null)}}
+	</div>
+	<center><h2>Report Editor</h2></center>
+	{{if data.report_data}}
+		<h3>{{:data.report_data.name}}</h3>
+		{{for data.report_data.fields}}
+			<div class='item'>
+				{{if value.ignore_value}}
+					<h3>{{:value.name}}</h3>
 				{{else}}
-					<div class="itemContent">Access Denied.</div>
+					<div class='itemLabel'>
+						{{if (value.can_edit && value.access_edit && !data.view_only)}}
+							{{:helper.link('','pencil' , {'edit' : 1, 'ID' : value.ID}, null)}}
+						{{/if}}
+						{{:value.name}}: 
+					</div>
+					{{if value.access}}
+						<div class="itemContent">
+							{{if value.needs_big_box}}
+							<div class='block'>
+								{{:value.value}}
+							</div>
+							{{else}}
+							<div class='statusDisplayComm'>
+								{{:value.value}}
+							</div>
+							{{/if}}
+						</div>
+					{{else}}
+						<div class="itemContent">Access Denied.</div>
+					{{/if}}
 				{{/if}}
-			{{/if}}
-		</div>
-	{{/for}}
-	{{if !data.view_only}}
+			</div>
+		{{/for}}
+			<div class='item'>
+				<div class='itemContent'>
+					{{:helper.link('Print Copy', null, {'print' : 1, 'print_mode' : 0}, data.printer ? null : 'disabled')}}
+					{{:helper.link('Print With Fields', null, {'print' : 1, 'print_mode' : 1}, data.printer ? null : 'disabled')}}
+					{{:helper.link('Export to Text', null, {'export' : 1}, null)}}
+				</div>
+			</div>
+		{{if !data.view_only}}
+			<div class='item'>
+				<div class='itemContent'>
+					{{:helper.link('Submit Report', null, {'submit' : 1}, data.report_data.access_edit ? null : 'disabled')}}
+					{{:helper.link('Discard Changes', null, {'discard' : 1, 'warning' : 1}, data.report_data.access_edit ? null : 'disabled')}}
+				</div>
+			</div>
+		{{else}}
+			<div class='item'>
+				<div class='itemContent'>
+					{{:helper.link('Close Report', null, {'discard' : 1}, null)}}
+				</div>
+			</div>
+		{{/if}}
+	{{/if}}
+{{else data.prog_state == 2}} <!--REPORT_DOWNLOAD-->
+	{{:helper.link('Back', null, {'home' : 1}, null)}}
+	<center><h2>Report Download</h2></center>
+	{{for data.reports}}
 		<div class='item'>
-			<div class='itemContent'>
-				{{:helper.link('Submit Report', null, {'submit' : 1}, data.report_data.access_edit ? null : 'disabled')}}
-				{{:helper.link('Discard Changes', null, {'discard' : 1, 'warning' : 1}, data.report_data.access_edit ? null : 'disabled')}}
+			<div class='itemLabel'>
+				{{:helper.link(value.name, null, {'get_report' : 1, 'report' : value.uid}, null)}}
 			</div>
 		</div>
-	{{else}}
-		{{:helper.link('Close Report', null, {'discard' : 1}, null)}}
-	{{/if}}
+	{{empty}}
+		There are no reports available for downloading.
+	{{/for}}
 {{/if}}


### PR DESCRIPTION
:cl:
rscadd: the report editor can now print reports and export them to text files.
rscadd: the report editor can download new (blank) reports from NTnet. A few of the forms from the wiki can now be chosen in this way.
/:cl:

The reports in the torch folder are slight modifications of those on the wiki: credit to sabiram and CrimsonShrike for them. Hopefully either I or someone else will add more in the future.

Other changes include small bugfixes to the program and a more sophisticated time sanitization proc.
Includes fixes for the following legacy issues:

- Hard drives did not run the full suite of checks when storing new files, potentially resulting in storing files that later could not be accessed properly. Now they do.
- Certain computer files, including all that were stored in a hard drive (!), would fail to return a QDEL hint. Fixed, and also added a unit test so that such GC issues are easier to spot in the future.