### PR TITLE
Makes the amputation text larger (for the surgeon)

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -318,7 +318,7 @@
 /datum/surgery_step/generic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to amputate [target]'s [affected.name] with \the [tool]." , \
-	"You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool].")
+	"<FONT size=3>You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool].</FONT>")
 	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",100,affecting = affected)
 	..()
 


### PR DESCRIPTION
🆑 
tweak: Amputation text is now larger for the surgeon performing the amputation
/🆑 

The text box can get really spammy, I figure it's a good idea to avoid accidental amputations.

In reality, sometimes surgery bugs out and shit happens, if surgery bugs out and you miss a step, hopefully this prevents you from amputating someones head/lower body(?) when you shouldn't.