### PR TITLE
Make jukebox tracks (more) admin proof

### DIFF
--- a/code/_global_vars/lists/flavor.dm
+++ b/code/_global_vars/lists/flavor.dm
@@ -79,3 +79,34 @@ GLOBAL_LIST_INIT(numbers_as_words, list("One", "Two", "Three", "Four",
 	"Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven", "Twelve",
 	"Thirteen", "Fourteen", "Fifteen", "Sixteen", "Seventeen",
 	"Eighteen", "Nineteen"))
+
+GLOBAL_LIST_INIT(music_tracks, list(
+	"Beyond" = /music_track/ambispace,
+	"Clouds of Fire" = /music_track/clouds_of_fire,
+	"Stage Three" = /music_track/dilbert,
+	"Asteroids" = /music_track/df_theme,
+	"Floating" = /music_track/floating,
+	"Endless Space" = /music_track/endless_space,
+	"Fleet Party Theme" = /music_track/one_loop,
+	"Scratch" = /music_track/level3_mod,
+	"Absconditus" = /music_track/absconditus,
+	"lasers rip apart the bulkhead" = /music_track/lasers,
+	"Maschine Klash" = /music_track/digit_one,
+	"Comet Halley" = /music_track/comet_haley,
+	"Please Come Back Any Time" = /music_track/elevator,
+	"Human" = /music_track/human,
+	"Memories of Lysendraa" = /music_track/lysendraa,
+	"Marhaba" = /music_track/marhaba,
+	"Space Oddity" = /music_track/space_oddity,
+	"THUNDERDOME" = /music_track/thunderdome,
+	"Torch: A Light in the Darkness" = /music_track/torch,
+	"Treacherous Voyage" = /music_track/treacherous_voyage,
+	"Wake" = /music_track/wake
+))
+
+/proc/setup_music_tracks(var/list/tracks)
+	. = list()
+	var/track_list = LAZYLEN(tracks) ? tracks : GLOB.music_tracks
+	for(var/track_name in track_list)
+		var/track_path = track_list[track_name]
+		. += new/datum/track(track_name, track_path)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -8,30 +8,6 @@
 	src.title = title
 	src.track = track
 
-GLOBAL_LIST_INIT(music_tracks, list(
-		new/datum/track("Beyond", /music_track/ambispace),
-		new/datum/track("Clouds of Fire", /music_track/clouds_of_fire),
-		new/datum/track("Stage Three", /music_track/dilbert),
-		new/datum/track("Asteroids", /music_track/df_theme),
-		new/datum/track("Floating", /music_track/floating),
-		new/datum/track("Endless Space", /music_track/endless_space),
-		new/datum/track("Fleet Party Theme", /music_track/one_loop),
-		new/datum/track("Scratch", /music_track/level3_mod),
-		new/datum/track("Absconditus", /music_track/absconditus),
-		new/datum/track("lasers rip apart the bulkhead", /music_track/lasers),
-		new/datum/track("Maschine Klash", /music_track/digit_one),
-		new/datum/track("Comet Halley", /music_track/comet_haley),
-		new/datum/track("Please Come Back Any Time", /music_track/elevator),
-		new/datum/track("Human", /music_track/human),
-		new/datum/track("Memories of Lysendraa", /music_track/lysendraa),
-		new/datum/track("Marhaba", /music_track/marhaba),
-		new/datum/track("Space Oddity", /music_track/space_oddity),
-		new/datum/track("THUNDERDOME", /music_track/thunderdome),
-		new/datum/track("Torch: A Light in the Darkness", /music_track/torch),
-		new/datum/track("Treacherous Voyage", /music_track/treacherous_voyage),
-		new/datum/track("Wake", /music_track/wake)
-))
-
 datum/track/proc/GetTrack()
 	if(ispath(track, /music_track))
 		var/music_track/music_track = decls_repository.get_decl(track)
@@ -82,7 +58,7 @@ datum/track/proc/GetTrack()
 
 /obj/machinery/media/jukebox/Initialize()
 	. = ..()
-	tracks = tracks || GLOB.music_tracks.Copy()
+	tracks = setup_music_tracks(tracks)
 
 /obj/machinery/media/jukebox/Destroy()
 	StopPlaying()

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -23,7 +23,7 @@
 
 /obj/item/device/boombox/Initialize()
 	. = ..()
-	tracks = tracks || GLOB.music_tracks.Copy()
+	tracks = setup_music_tracks(tracks)
 
 /obj/item/device/boombox/Destroy()
 	stop()


### PR DESCRIPTION
If one edits the track of a jukebox/boombox those edits only affect that instance.
For global edits one have to edit the GLOB music list, tho this only updates new instances.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
