### PR TITLE
Fixes Clamp Step and Multi-Organ Bug

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -927,6 +927,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(W.clamped)
 			return 1
 
+obj/item/organ/external/proc/remove_clamps()
+	var/rval = 0
+	for(var/datum/wound/W in wounds)
+		rval |= W.clamped
+		W.clamped = 0
+	return rval
+
 // open incisions and expose implants
 // this is the retract step of surgery
 /obj/item/organ/external/proc/open_incision()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -283,6 +283,8 @@
 		W.close()
 	if(affected.is_stump())
 		affected.status &= ~ORGAN_ARTERY_CUT
+	if(affected.clamped())
+		affected.remove_clamps()
 
 /datum/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -373,6 +373,13 @@
 		to_chat(user, "<span class='warning'>You can't find anywhere to attach [organ_to_replace] to!</span>")
 		return SURGERY_FAILURE
 
+	var/o_a =  (organ_to_replace.gender == PLURAL) ? "" : "a "
+
+	var/obj/item/organ/internal/I = target.internal_organs_by_name[organ_to_replace.organ_tag]
+	if(I && (I.parent_organ == affected.organ_tag || istype(organ_to_replace, /obj/item/organ/internal/stack)))
+		to_chat(user, "<span class='warning'>\The [target] already has [o_a][organ_to_replace.name].</span>")
+		return SURGERY_FAILURE
+
 	target.op_stage.current_organ = organ_to_replace
 	return ..()
 


### PR DESCRIPTION
Makes it so cauterizing a wound removes the "clamped" flag, and allows you to clamp bleeders again in subsequent surgeries.

Also makes it so you can't attach multiple organs of the same type.

Backported from these downstream PRs:
https://github.com/Persistent-SS13/Persistent-Bay/pull/242
https://github.com/Persistent-SS13/Persistent-Bay/pull/250

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
