### PR TITLE
Allows borgs to interact with storage items.

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -80,8 +80,8 @@
 	if(!isturf(loc))
 		return
 
-	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
-	if(isturf(A) || isturf(A.loc))
+	var/sdepth = A.storage_depth_turf()
+	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src)) // see adjacent.dm
 
 			var/resolved = W.resolve_attackby(A, src, params)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -160,6 +160,8 @@ var/obj/screen/robot_inventory
 	var/mob/living/silicon/robot/r = mymob
 
 	if(r.shown_robot_modules)
+		if(r.s_active)
+			r.s_active.close(r) //Closes the inventory ui.
 		//Modules display is shown
 		//r.client.screen += robot_inventory	//"store" icon
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -35,7 +35,7 @@
 	if(!canremove)
 		return
 
-	if ((ishuman(usr) || issmall(usr)) && !usr.incapacitated())
+	if ((ishuman(usr) || isrobot(usr) || issmall(usr)) && !usr.incapacitated())
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
 			src.open(usr)
 			return TRUE
@@ -81,6 +81,10 @@
 /obj/item/weapon/storage/proc/open(mob/user as mob)
 	if (src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 0, -5)
+	if (isrobot(user) && user.hud_used)
+		var/mob/living/silicon/robot/robot = user
+		if(robot.shown_robot_modules) //The robot's inventory is open, need to close it first.
+			robot.hud_used.toggle_show_robot_modules()
 
 	prepare_ui()
 	storage_ui.on_open(user)
@@ -236,8 +240,8 @@
 /obj/item/weapon/storage/attackby(obj/item/W as obj, mob/user as mob)
 	..()
 
-	if(isrobot(user))
-		return //Robots can't interact with storage items.
+	if(isrobot(user) && (W == user.get_active_hand()))
+		return //Robots can't store their modules.
 
 	if(istype(W, /obj/item/device/lightreplacer))
 		var/obj/item/device/lightreplacer/LP = W

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -194,11 +194,6 @@
 		addtimer(CALLBACK(src, .proc/finish_using, target, user, params, force_holder, resolved), 0)
 
 	else if(istype(target,/obj/item)) //Check that we're not pocketing a mob.
-
-		//...and that the item is not in a container.
-		if(!isturf(target.loc))
-			return
-
 		var/obj/item/I = target
 
 		//Check if the item is blacklisted.
@@ -210,8 +205,16 @@
 
 		//We can grab the item, finally.
 		if(grab)
+			if(I == user.s_active)
+				var/obj/item/weapon/storage/storage = I
+				storage.close(user) //Closes the ui.
+			if(istype(I.loc, /obj/item/weapon/storage))
+				var/obj/item/weapon/storage/storage = I.loc
+				if(!storage.remove_from_storage(I, src))
+					return
+			else
+				I.forceMove(src)
 			to_chat(user, "<span class='notice'>You collect \the [I].</span>")
-			I.loc = src
 			wrapped = I
 			return
 		else


### PR DESCRIPTION
:cl:
rscadd: Robots can now interact with storage items like boxes and bags.
/:cl:

Note that they are still limited by their grippers/modules, so I don't see a major balance issue here. Should help make borg code more maintainable as items locked behind inventory interaction are added (e.g. eggs).

May require further revision, but brief testing suggests that in principle it works OK.

Should add that certain modules, like the destructive analyzer, don't work on things in storage (can easily be changed later if people want). This is mostly useful with grippers. Checked the more obvious exploits; most are circumvented by disallowing use of the module on the storage item directly (grippers bypass this).

~~To Do: prevent robots from storing modules inside containers.~~