### PR TITLE
fixes #21648 & revolver icons

### DIFF
--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -11,8 +11,9 @@
 
 /obj/item/weapon/gun/energy/stunrevolver/secure
 	name = "smart stun revolver"
-	desc = "This A&M X6 is fitted with an NT1019 chip, a component that allows remote authorization of weapon functionality, created by NanoTrasen following the Baetiff Incident."
+	desc = "This A&M X6 is fitted with an NT1019 chip which allows remote authorization of weapon functionality. It has an SCG emblem on the grip."
 	icon = 'icons/obj/gun_secure.dmi'
+	icon_state = "revolverstun"
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/onmob/items/lefthand_guns_secure.dmi',
 		slot_r_hand_str = 'icons/mob/onmob/items/righthand_guns_secure.dmi',
@@ -21,7 +22,7 @@
 					list(mode_name="stun", projectile_type=/obj/item/projectile/energy/electrode/green, modifystate="revolverstun"),
 					list(mode_name="shock", projectile_type=/obj/item/projectile/energy/electrode/stunshot, modifystate="revolvershock")
 					)
-	item_state = null	//so the human update icon uses the icon_state instead.
+	item_state = "revolverstun"
 	req_one_access = list(access_brig, access_heads)
 	projectile_type = /obj/item/projectile/energy/electrode/green
 

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -22,7 +22,7 @@
 					list(mode_name="stun", projectile_type=/obj/item/projectile/energy/electrode/green, modifystate="revolverstun"),
 					list(mode_name="shock", projectile_type=/obj/item/projectile/energy/electrode/stunshot, modifystate="revolvershock")
 					)
-	item_state = "revolverstun"
+	item_state = null
 	req_one_access = list(access_brig, access_heads)
 	projectile_type = /obj/item/projectile/energy/electrode/green
 

--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -122,8 +122,10 @@ Weapons
 	fire_anim = "mosley_fire"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
 
-/obj/item/weapon/gun/energy/secure/stunrevolver
-	req_access = list(access_sec_guard)
+/obj/item/weapon/gun/energy/stunrevolver/secure/nanotrasen
+	name = "corporate stun revolver"
+	desc = "This A&M X6 is fitted with an NT1019 chip which allows remote authorization of weapon functionality. It has a NanoTrasen emblem on the grip."
+	req_one_access = list(access_brig, access_heads, access_rd, access_sec_guard)
 
 /obj/item/weapon/gun/projectile/pistol/liaison
 	magazine_type = /obj/item/ammo_magazine/mc9mm/oneway

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -174,7 +174,7 @@
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/clothing/accessory/badge/holo/NT,
 		/obj/item/device/megaphone,
-		/obj/item/weapon/gun/energy/secure/stunrevolver,
+		/obj/item/weapon/gun/energy/stunrevolver/secure/nanotrasen,
 		/obj/item/clothing/shoes/jackboots,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))


### PR DESCRIPTION
fixes #21648
conflicts #21649

- replace bad stunrevolver path in torch items with stunrevolver/secure/nanotrasen
- adds RD, NTL, NTsec to Brig, Heads on new stunrevolver child
- modifies description and names to be clear who can use which kind
-replaces in closets/research

bonus: also fixes incorrect secure stunrevolver icon and item states

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
