### PR TITLE
Fixes stale issues: runtime on ATM accounts, runtime on monkey cubes, mode set to null if nobody votes

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -201,14 +201,17 @@
 					if(.[1] == "Restart Round")
 						restart = 1
 				if("gamemode")
-					if(master_mode != .[1])
-						world.save_mode(.[1])
-						if(ticker && ticker.mode)
-							restart = 1
-						else
-							master_mode = .[1]
-					secondary_mode = .[2]
-					tertiary_mode = .[3]
+					// set gamemode
+					// inconclusive vote -> do nothing
+					if(.[1])
+						if(master_mode != .[1])
+							world.save_mode(.[1])
+							if(ticker && ticker.mode)
+								restart = 1
+							else
+								master_mode = .[1]
+						secondary_mode = .[2]
+						tertiary_mode = .[3]
 				if("crew_transfer")
 					if(.[1] == "Initiate Crew Transfer")
 						init_autotransfer()

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -278,7 +278,9 @@
 					//Below is to avoid a runtime
 					if(tried_account_num)
 						D = get_account(tried_account_num)
-						account_security_level = D.security_level
+
+						if(D)
+							account_security_level = D.security_level
 
 					authenticated_account = attempt_account_access(tried_account_num, tried_pin, held_card && login_card.associated_account_number == tried_account_num ? 2 : 1)
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -41,7 +41,7 @@
 	return
 
 /obj/item/weapon/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
-	if(!reagents.total_volume)
+	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='danger'>None of [src] left!</span>")
 		user.drop_from_inventory(src)
 		qdel(src)


### PR DESCRIPTION
Fixes #13963 when a mode vote runs and nobody votes (i.e. vote controller reports "Inconclusive - No votes!")
* Instead of setting mode to null, will just do nothing
* In effect, the mode will be set to whatever was played last round

Fixes #14672, trying to read the volume of non-existent reagents

Fixes #14665, runtime on trying to get sec level of invalid account numbers, etc.