### PR TITLE
Fixes empty deity menu.

### DIFF
--- a/code/modules/mob/living/deity/deity_sources.dm
+++ b/code/modules/mob/living/deity/deity_sources.dm
@@ -67,6 +67,7 @@
 		to_chat(minion.current, "Your master is now known as [new_name]")
 		minion.special_role = "Servant of [new_name]"
 	eyeobj.SetName("[src] ([eyeobj.name_sufix])")
+	nano_data["name"] = new_name
 	return 1
 
 //Whether we are near an important structure.

--- a/code/modules/mob/living/deity/menu/deity_nano.dm
+++ b/code/modules/mob/living/deity/menu/deity_nano.dm
@@ -4,7 +4,7 @@
 	var/datum/phenomena/selected
 
 /mob/living/deity/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/uistate = GLOB.self_state)
-	if(!nano_data.len)
+	if(!nano_data["categories"]) //If we don't have the categories set yet, we should populate our data.
 		var/list/categories = list()
 		for(var/cat in items_by_category)
 			categories += cat


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Twas a stupid error on my part. Now instead of checking the list if its empty, it checks if there are no categories. Which will allow the deity to add the followers before having a form without bugging it.