### PR TITLE
Makes armor penetration not stupid.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,7 +24,7 @@ meteor_act
 
 	var/obj/item/organ/external/organ = get_organ(def_zone)
 	var/armor = getarmor_organ(organ, P.check_armour)
-	var/penetrating_damage = ((P.damage + P.armor_penetration) * P.penetration_modifier) - armor
+	var/penetrating_damage = (P.damage * P.penetration_modifier) - (armor -P.armor_penetration)
 
 	//Embed or sever artery
 	if(P.can_embed() && !(species.species_flags & SPECIES_FLAG_NO_EMBED) && prob(22.5 + max(penetrating_damage, -10)) && !(prob(50) && (organ.sever_artery())))


### PR DESCRIPTION
🆑 
balance: Armor penetration now only subtracts from an armor's defense (Piercing damage), rather than simply adding damage. 
/ 🆑 

[why]: An Xray rifle can one-shot dust limbs, because of the ridiculous AP not being handled by unarmored targets, thus just dumping extra burn on there.

God this is gonna have big, sweeping consequences to most balance prospects.