### PR TITLE
Makes athletics skill affect pulling stuff.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -43,10 +43,8 @@
 				item_slowdown += I.slowdown_accessory
 
 				if(item_slowdown >= 0)
-					var/size_mod = 0
-					if(!(mob_size == MOB_MEDIUM))
-						size_mod = log(2, mob_size / MOB_MEDIUM)
-					if(species.strength + size_mod + 1 > 0)
+					var/size_mod = size_strength_mod()
+					if(size_mod + 1 > 0)
 						item_slowdown = item_slowdown / (species.strength + size_mod + 1)
 					else
 						item_slowdown = item_slowdown - species.strength - size_mod
@@ -79,6 +77,10 @@
 		tally = 0
 
 	return (tally+config.human_delay)
+
+/mob/living/carbon/human/size_strength_mod()
+	. = ..()
+	. += species.strength
 
 /mob/living/carbon/human/Allow_Spacemove(var/check_drift = 0)
 	//Can we act?
@@ -122,3 +124,20 @@
 	if(shoes && (shoes.item_flags & ITEM_FLAG_NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))  //magboots + dense_object = no floating
 		return 1
 	return 0
+
+/mob/living/carbon/human/Move()
+	. = ..()
+	if(.) //We moved
+		handle_exertion()
+
+/mob/living/carbon/human/proc/handle_exertion()
+	if(isSynthetic())
+		return
+	var/encumbrance = encumbrance()
+	if(encumbrance && prob(skill_fail_chance(SKILL_HAULING, 4 * encumbrance)))
+		make_adrenaline(1)
+		switch(rand(1,8))
+			if(1)
+				visible_message("<span class='notice'>\The [src] is sweating heavily!</span>", "<span class='notice'>You are sweating heavily!</span>")
+			if(2)
+				visible_message("<span class='notice'>\The [src] looks out of breath!</span>", "<span class='notice'>You are out of breath!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -147,6 +147,11 @@
 	if(istype(loc, /turf))
 		var/turf/T = loc
 		. += T.movement_delay
+	. += encumbrance() * (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN)) //Varies between 0.5 and 2, depending on skill
+
+//How much the stuff the mob is pulling contributes to its movement delay.
+/mob/proc/encumbrance()
+	. = 0
 	if(pulling)
 		if(istype(pulling, /obj))
 			var/obj/O = pulling
@@ -156,6 +161,11 @@
 			. += max(0, M.mob_size) / MOB_MEDIUM
 		else
 			. += 1
+	. *= (0.8 ** size_strength_mod())
+
+//Determines mob size/strength effects for slowdown purposes. Standard is 0; can be pos/neg.
+/mob/proc/size_strength_mod()
+	return log(2, mob_size / MOB_MEDIUM)
 
 /mob/proc/Life()
 //	if(organStructure)


### PR DESCRIPTION
:cl:
rscadd: The slowdown for pulling (i.e. ctl-click) stuff is now affected by the "Athletics" skill.
tweak: Bigger/stronger species pull things faster.
rscadd: Pulling stuff generates adrenaline, depending on "Athletics" skill. This may raise your heart rate. Pulling for a long time without breaks with low skill may give you the jitter effect and minor heart damage (won't kill you).
/:cl:

Figured it's best to keep this stuff in smaller PRs.