### PR TITLE
Reverts Off-Duty rework.

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -118,7 +118,6 @@ var/const/NO_EMAG_ACT = -50
 
 	var/datum/mil_branch/military_branch = null //Vars for tracking branches and ranks on multi-crewtype maps
 	var/datum/mil_rank/military_rank = null
-	var/offduty = FALSE
 
 /obj/item/weapon/card/id/New()
 	..()

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -118,10 +118,6 @@
 	var/obj/item/weapon/card/id/id_card
 	if (computer.card_slot)
 		id_card = computer.card_slot.stored_card
-	if (id_card.offduty)
-		computer.visible_message("<span class='warning'>\The [computer] flashes an error and ejects the ID: 'Error XX107: The modification and issuance of identification cards for off-duty personnel is prohibited.'</span>")
-		computer.proc_eject_id(user)
-		return
 
 	var/datum/nano_module/program/card_mod/module = NM
 	switch(href_list["action"])

--- a/maps/torch/datums/uniforms_expedition.dm
+++ b/maps/torch/datums/uniforms_expedition.dm
@@ -207,27 +207,3 @@
 	dress_skirt = /obj/item/clothing/under/solgov/service/expeditionary/command/skirt
 	dress_over = /obj/item/clothing/suit/dress/solgov/expedition/command
 	dress_hat = /obj/item/clothing/head/solgov/service/expedition/command
-
-/decl/hierarchy/mil_uniform/ec/offduty
-	name = "EC off-duty"
-	departments = CIV
-
-	utility_under = null
-	utility_shoes = null
-	utility_hat = null
-	utility_extra = null
-
-/decl/hierarchy/mil_uniform/ec/offduty/officer
-	name = "EC off-duty CO"
-	departments = CIV
-	min_rank = 11
-
-	service_under = /obj/item/clothing/under/solgov/service/expeditionary/command
-	service_skirt = /obj/item/clothing/under/solgov/service/expeditionary/command/skirt
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
-	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
-
-	dress_under = /obj/item/clothing/under/solgov/service/expeditionary/command
-	dress_skirt = /obj/item/clothing/under/solgov/service/expeditionary/command/skirt
-	dress_over = /obj/item/clothing/suit/dress/solgov/expedition/command
-	dress_hat = /obj/item/clothing/head/solgov/service/expedition/command

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -136,15 +136,9 @@
 //NanoTrasen and Passengers
 
 /obj/item/weapon/card/id/torch/passenger
-	desc = "A card issued to passengers aboard the SEV Torch."
+	desc = "A card issued to passengers and off-duty personnel aboard the SEV Torch."
 	icon_state = "id"
 	job_access_type = /datum/job/assistant
-
-/obj/item/weapon/card/id/torch/offduty
-	desc = "A cheaply laminated card issued to off-duty personnel aboard the SEV Torch. Tiny print warns against attempting to modify this ID card."
-	icon_state = "mime"
-	job_access_type = /datum/job/offduty
-	offduty = TRUE
 
 /obj/item/weapon/card/id/torch/passenger/research
 	desc = "A card issued to NanoTrasen personnel aboard the SEV Torch."

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -26,7 +26,7 @@
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
 						/datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist, /datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant,
 						/datum/job/ai, /datum/job/cyborg,
-						/datum/job/crew, /datum/job/assistant, /datum/job/offduty,
+						/datum/job/crew, /datum/job/assistant,
 						/datum/job/merchant, /datum/job/stowaway
 						)
 
@@ -1285,45 +1285,14 @@
 		"Entertainer",
 		"Independent Observer",
 		"Sociologist",
+		"Off-Duty",
 		"Trainer")
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/passenger
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/civ,
+		/datum/mil_rank/civ/offduty,
 		/datum/mil_rank/civ/nt
-	)
-
-/datum/job/offduty
-	title = "Off-Duty"
-	department_flag = CIV
-	announced = FALSE
-	total_positions = 6
-	spawn_positions = 6
-	supervisors = "the Executive Officer and Commanding Officer"
-	selection_color = "#515151"
-	outfit_type = /decl/hierarchy/outfit/job/torch/offduty
-	allowed_branches = list(
-		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/offduty/fleet
-	)
-	allowed_ranks = list(
-		/datum/mil_rank/ec/e3,
-		/datum/mil_rank/ec/e5,
-		/datum/mil_rank/ec/e7,
-		/datum/mil_rank/ec/o1 = /decl/hierarchy/outfit/job/torch/offduty/officer,
-		/datum/mil_rank/ec/o3 = /decl/hierarchy/outfit/job/torch/offduty/officer,
-		/datum/mil_rank/fleet/e1,
-		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/fleet/e4,
-		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/fleet/e6,
-		/datum/mil_rank/fleet/e7,
-		/datum/mil_rank/fleet/e8,
-		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/fleet/o4
 	)
 
 /datum/job/cyborg

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -627,23 +627,6 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	var/obj/item/weapon/storage/secure/briefcase/money/case = new(H.loc)
 	H.put_in_hands(case)
 
-/decl/hierarchy/outfit/job/torch/offduty
-	name = OUTFIT_JOB_NAME("Off-Duty - Torch")
-	uniform = /obj/item/clothing/under/solgov/service/expeditionary
-	l_ear = /obj/item/device/radio/headset
-	shoes = /obj/item/clothing/shoes/dress
-	pda_type = /obj/item/modular_computer/pda
-	id_type = /obj/item/weapon/card/id/torch/offduty
-
-/decl/hierarchy/outfit/job/torch/offduty/officer
-	name = OUTFIT_JOB_NAME("Off-Duty - Officer")
-	uniform = /obj/item/clothing/under/solgov/service/expeditionary/command
-
-/decl/hierarchy/outfit/job/torch/offduty/fleet
-	name = OUTFIT_JOB_NAME("Off-Duty - Fleet")
-	uniform = /obj/item/clothing/under/solgov/service/fleet
-	shoes = /obj/item/clothing/shoes/dress/white
-
 /decl/hierarchy/outfit/job/torch/merchant
 	name = OUTFIT_JOB_NAME("Merchant - Torch")
 	uniform = /obj/item/clothing/under/color/black

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -1,28 +1,28 @@
 //The following is a list of defs to be used for the Torch loadout.
 
 //For all SolGov personnel, representative included
-#define SOLGOV_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/representative, /datum/job/pathfinder, /datum/job/explorer, /datum/job/offduty)
+#define SOLGOV_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/representative, /datum/job/pathfinder, /datum/job/explorer)
 
 //For EC/Fleet/Marines
-#define MILITARY_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/pathfinder, /datum/job/explorer, /datum/job/offduty)
+#define MILITARY_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/pathfinder, /datum/job/explorer)
 
 //For EC/Fleet/Marine Officers
-#define MILITARY_OFFICER_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/senior_doctor, /datum/job/qm, /datum/job/pathfinder, /datum/job/offduty)
+#define MILITARY_OFFICER_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/senior_doctor, /datum/job/qm, /datum/job/pathfinder)
 
 //For EC/Fleet/Marine Enlisted
 #define MILITARY_ENLISTED_ROLES list(/datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/explorer, /datum/job/officer)
 
 //For all civilians or off-duty personnel, regardless of formality of dress or job.
-#define NON_MILITARY_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway, /datum/job/offduty)
+#define NON_MILITARY_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway)
 
 //For jobs that allow for decorative or ceremonial clothing
-#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/guard, /datum/job/detective, /datum/job/offduty)
+#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/guard, /datum/job/detective)
 
 //For civilian jobs that may have a uniform, but not a strict one
-#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/stowaway, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/detective, /datum/job/offduty)
+#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/stowaway, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/detective)
 
 //For civilian jobs that may have a strict uniform.
-#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway, /datum/job/detective, /datum/job/offduty)
+#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway, /datum/job/detective)
 
 //For NanoTrasen employees
 #define NANOTRASEN_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant)
@@ -34,7 +34,7 @@
 #define REPRESENTATIVE_ROLES list(/datum/job/representative, /datum/job/liaison)
 
 //For roles with no uniform or formal clothing requirements
-#define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/offduty)
+#define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway)
 
 //For members of the command department
 #define COMMAND_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea)

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -156,6 +156,7 @@
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/civ/nt,
 		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/civ/offduty,
 		/datum/mil_rank/civ/marshal,
 		/datum/mil_rank/civ/synthetic
 	)
@@ -164,6 +165,7 @@
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/civ/nt,
 		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/civ/offduty,
 		/datum/mil_rank/civ/marshal,
 		/datum/mil_rank/civ/synthetic
 	)


### PR DESCRIPTION
:cl:
tweak: Off-Duty is no longer a separate job, but an alt-title of Passenger. You no longer spawn with ranks in uniform if selecting off-duty.
/:cl:

This reverts #20742. There have been some OOC and IC issues with Off-Duty, requiring a whole new rule, and that change didn't even seem that popular to begin with. Will close if the community is against this, but floating the PR to see what people think.