### PR TITLE
Added neural suppressor to optables.

### DIFF
--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -239,11 +239,3 @@
 			tank.distribute_pressure += cp
 		tank.distribute_pressure = min(max(round(tank.distribute_pressure), 0), TANK_MAX_RELEASE_PRESSURE)
 		return 1
-
-/obj/machinery/oxygen_pump/anesthetic
-	name = "anesthetic pump"
-	spawn_type = /obj/item/weapon/tank/anesthetic
-	icon_state = "anesthetic_tank"
-	icon_state_closed = "anesthetic_tank"
-	icon_state_open = "anesthetic_tank_open"
-	mask_type = /obj/item/clothing/mask/breath/anesthetic

--- a/html/changelogs/zuhayr-optables.yml
+++ b/html/changelogs/zuhayr-optables.yml
@@ -1,0 +1,5 @@
+author: Zuhayr
+delete-after: True
+changes: 
+  - rscadd: "Added an interaction to optables that will automatically put someone lying on top of it to sleep with no need for N2O or painkillers."
+  - rscdel: "Removed N2O pumps as being both redundant and buggy."

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -3068,9 +3068,6 @@
 /obj/machinery/optable,
 /obj/item/weapon/reagent_containers/food/drinks/coffeecup/britcup,
 /obj/item/weapon/reagent_containers/glass/rag,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/white/usedup,
 /area/ship/scrap/crew/medbay)
 "eQ" = (

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -3375,9 +3375,6 @@
 /area/errant_pisces/infirmary)
 "hJ" = (
 /obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_x = -25
-	},
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/infirmary)
 "hK" = (

--- a/maps/away/icarus/icarus-1.dmm
+++ b/maps/away/icarus/icarus-1.dmm
@@ -1143,9 +1143,6 @@
 /area/icarus/vessel)
 "dP" = (
 /obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = 30
-	},
 /turf/simulated/floor/tiled/white,
 /area/icarus/open)
 "dQ" = (

--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -1024,9 +1024,6 @@
 	dir = 4
 	},
 /obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = -25
-	},
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
 "cH" = (
@@ -1044,9 +1041,6 @@
 	},
 /obj/machinery/optable,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = -25
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -22,9 +22,6 @@
 "e" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "f" = (

--- a/maps/overmap_example/bearcat/bearcat-2.dmm
+++ b/maps/overmap_example/bearcat/bearcat-2.dmm
@@ -5118,9 +5118,6 @@
 /obj/machinery/optable,
 /obj/item/weapon/reagent_containers/food/drinks/coffeecup/britcup,
 /obj/item/weapon/reagent_containers/glass/rag,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "oW" = (

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -15961,9 +15961,6 @@
 /area/vacant/infirmary)
 "Ew" = (
 /obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/white,
 /area/vacant/infirmary)
 "Ex" = (

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -17194,9 +17194,6 @@
 /area/medical/surgery)
 "cDb" = (
 /obj/machinery/optable,
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/floordetail/edgedrain{
 	icon_state = "edge";
 	dir = 1
@@ -18653,9 +18650,6 @@
 /obj/effect/floor_decal/floordetail/edgedrain{
 	icon_state = "edge";
 	dir = 1
-	},
-/obj/machinery/oxygen_pump/anesthetic{
-	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics_surgery)


### PR DESCRIPTION
Clicking on an op table with an empty hand (or as an AI) will toggle a neural suppressor, which automatically puts whoever is lying on the table to sleep, no muss no fuss. As this completely obviates anesthetic, N2O pumps have been removed.

This seems pretty out of nowhere but it is prep for #21690 which makes it infeasible to use N2O for anesthesia at all.