### PR TITLE
Changes press tag restriction to allow passenger role.

### DIFF
--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -145,6 +145,10 @@
 /datum/gear/tactical/armor_deco
 	allowed_roles = ARMORED_ROLES
 
+/datum/gear/tactical/press_tag
+	display_name = "Press tag"
+	path = /obj/item/clothing/accessory/armor/tag/press
+
 /datum/gear/tactical/helm_covers
 	allowed_roles = ARMORED_ROLES
 

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -148,6 +148,7 @@
 /datum/gear/tactical/press_tag
 	display_name = "Press tag"
 	path = /obj/item/clothing/accessory/armor/tag/press
+	allowed_roles = list(/datum/job/assistant)
 
 /datum/gear/tactical/helm_covers
 	allowed_roles = ARMORED_ROLES


### PR DESCRIPTION
🆑 TheGreyWolf
bugfix: Press tags can now actually be taken by the press.
/🆑
I saw the request, thought I would just do the quick fix. This should allow the press tag to be selected for passenger (role).