### PR TITLE
fixes 21714

### DIFF
--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -110,9 +110,9 @@
 		violent = ""
 	admin_attack_log(attacker,
 	                 victim,
-	                 "used \the [weapon] to [violent]inject - [reagents] - [amount_transferred]u transferred",
+	                 "used \the [weapon] - [reagents] - to [violent]inject [amount_transferred]u transferred",
 	                 "was [violent]injected with \the [weapon] - [reagents] - [amount_transferred]u transferred",
-	                 "used \the [weapon] to [violent]inject [reagents] ([amount_transferred]u transferred) into")
+	                 "used \the [weapon] - [reagents] - to [violent]inject [amount_transferred]u into")
 
 /proc/append_admin_tools(var/message, var/mob, var/turf/location)
 	if(location)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -243,12 +243,10 @@
 
 		if(target != trackTarget && target.loc != trackTarget)
 			return
-
+  admin_inject_log(user, target, src, reagents.get_reagents(), amount_per_transfer_from_this)
 	var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
 
 	if(target != user)
-		var/contained = reagentlist()
-		admin_inject_log(user, target, src, contained, trans)
 		user.visible_message("<span class='warning'>\the [user] injects \the [target] with [visible_name]!</span>", "<span class='notice'>You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")
 	else
 		to_chat(user, "<span class='notice'>You inject yourself with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -243,7 +243,7 @@
 
 		if(target != trackTarget && target.loc != trackTarget)
 			return
-  admin_inject_log(user, target, src, reagents.get_reagents(), amount_per_transfer_from_this)
+	admin_inject_log(user, target, src, reagents.get_reagents(), amount_per_transfer_from_this)
 	var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
 
 	if(target != user)


### PR DESCRIPTION
fixes #21714

makes admin inject log less ambiguous and bad as well

ed: prior usage of get_reagents() as a means to show current syringe contents for logging = [syringes.dm#L295](https://github.com/Baystation12/Baystation12/tree/dev/code/modules/reagents/reagent_containers/syringes.dm#L295) just in case that looks scary to anyone.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
