### PR TITLE
resolves #21672

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -117,11 +117,17 @@
 
 	return 1
 
+/obj/item/organ/internal/brain/can_recover()
+	return ~status & ORGAN_DEAD
+
 /obj/item/organ/internal/brain/slime
 	name = "slime core"
 	desc = "A complex, organic knot of jelly and crystalline particles."
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "green slime extract"
+
+/obj/item/organ/internal/brain/slime/can_recover()
+	return 0
 
 /obj/item/organ/internal/brain/golem
 	name = "chem"
@@ -129,6 +135,8 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll"
 
+/obj/item/organ/internal/brain/golem/can_recover()
+	return 0
 
 /obj/item/organ/internal/brain/proc/get_current_damage_threshold()
 	return round(damage / damage_threshold_value)


### PR DESCRIPTION
fixes #21672 (for closing if it's merged, I don't believe this is necessarily an oversight and so it's not really a *fix* per say)

`Brains die when they are killed`

Also slime brains and golem brains can't be repaired with hello kitty bandaids anymore because they are literally a puddle of goo and a bundle of hebrew runes respectively

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
