### PR TITLE
Fix whisper encoding when using :w

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -203,8 +203,8 @@
 			if(has_radio)
 				R.talk_into(src,message,null,verb,speaking)
 				used_radios += R
-		if("whisper")
-			whisper_say(message, speaking, alt_name)
+		if("whisper") //It's going to get sanitized again immediately, so decode.
+			whisper_say(html_decode(message), speaking, alt_name)
 			return 1
 		else
 			if(message_mode)


### PR DESCRIPTION
Using :w to whisper runs the code through `say()`, leading to an obvious double-encode issue.

This was not a part of my earlier fix because, embarrassingly, I did not know that you could use :w to whisper.