### PR TITLE
EVA skill effects

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -312,22 +312,23 @@ var/list/mob/living/forced_ambiance_list = new
 			thunk(M)
 		M.update_floating()
 
-/area/proc/thunk(mob)
+/area/proc/thunk(mob/mob)
 	if(istype(get_turf(mob), /turf/space)) // Can't fall onto nothing.
+		return
+
+	if(mob.Check_Shoegrip())
 		return
 
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
-		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & ITEM_FLAG_NOSLIP))
-			return
-
-		if(H.m_intent == M_RUN)
-			H.AdjustStunned(6)
-			H.AdjustWeakened(6)
-		else
-			H.AdjustStunned(3)
-			H.AdjustWeakened(3)
-		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
+		if(prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_PROF)))
+			if(H.m_intent == M_RUN)
+				H.AdjustStunned(6)
+				H.AdjustWeakened(6)
+			else
+				H.AdjustStunned(3)
+				H.AdjustWeakened(3)
+			to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
 
 /area/proc/prison_break()
 	var/obj/machinery/power/apc/theAPC = get_apc()

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -53,7 +53,7 @@
 
 	to_chat(usr, "You toggle the thrusters [on? "on":"off"].")
 
-/obj/item/weapon/tank/jetpack/proc/allow_thrust(num, mob/living/user as mob)
+/obj/item/weapon/tank/jetpack/proc/allow_thrust(num, mob/living/user)
 	if(!(src.on))
 		return 0
 	if((num < 0.005 || src.air_contents.total_moles < num))
@@ -62,12 +62,10 @@
 
 	var/datum/gas_mixture/G = src.air_contents.remove(num)
 
-	var/allgases = G.gas["carbon_dioxide"] + G.gas["nitrogen"] + G.gas["oxygen"] + G.gas["phoron"]
-	if(allgases >= 0.005)
+	if(G.total_moles >= 0.005)
 		return 1
 
 	qdel(G)
-	return
 
 /obj/item/weapon/tank/jetpack/ui_action_click()
 	toggle()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -6,7 +6,10 @@
 
 	tally += species.handle_movement_delay_special(src)
 
-	if (istype(loc, /turf/space)) return -1 // It's hard to be slowed down in space by... anything
+	if (istype(loc, /turf/space)) // It's hard to be slowed down in space by... anything
+		if(skill_check(SKILL_EVA, SKILL_PROF))
+			return -2
+		return -1 
 
 	if(embedded_flag || (stomach_contents && stomach_contents.len))
 		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
@@ -83,9 +86,9 @@
 	. += species.strength
 
 /mob/living/carbon/human/Allow_Spacemove(var/check_drift = 0)
-	//Can we act?
-	if(restrained())	return 0
-
+	. = ..()
+	if(.)
+		return
 	//Do we have a working jetpack?
 	var/obj/item/weapon/tank/jetpack/thrust
 	if(back)
@@ -98,13 +101,14 @@
 				break
 
 	if(thrust)
+		if(prob(skill_fail_chance(SKILL_EVA, 10, SKILL_ADEPT)))
+			to_chat(src, "<span class='warning'>You fumble with [thrust] controls!</span>")
+			inertia_dir = pick(GLOB.cardinal)
+			return 0
+
 		if(((!check_drift) || (check_drift && thrust.stabilization_on)) && (!lying) && (thrust.allow_thrust(0.01, src)))
 			inertia_dir = 0
 			return 1
-
-	//If no working jetpack then use the other checks
-	. = ..()
-
 
 /mob/living/carbon/human/slip_chance(var/prob_slip = 5)
 	if(!..())

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -376,18 +376,22 @@
 
 //return 1 if slipped, 0 otherwise
 /mob/proc/handle_spaceslipping()
-	if(prob(slip_chance(5)) && !buckled)
+	if(prob(skill_fail_chance(SKILL_EVA, slip_chance(10), SKILL_EXPERT)))
 		to_chat(src, "<span class='warning'>You slipped!</span>")
 		src.inertia_dir = src.last_move
 		step(src, src.inertia_dir)
 		return 1
 	return 0
 
-/mob/proc/slip_chance(var/prob_slip = 5)
+/mob/proc/slip_chance(var/prob_slip = 10)
 	if(stat)
+		return 0
+	if(buckled)
 		return 0
 	if(Check_Shoegrip())
 		return 0
+	if(m_intent == M_WALK)
+		prob_slip *= 0.5
 	return prob_slip
 
 #define DO_MOVE(this_dir) var/final_dir = turn(this_dir, -dir2angle(dir)); Move(get_step(mob, final_dir), final_dir);

--- a/html/changelogs/chinsky - spaceasshole.yml
+++ b/html/changelogs/chinsky - spaceasshole.yml
@@ -1,0 +1,8 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "EVA skill now has mechanical effects."
+  - rscadd: "Space slipping chance is affected by EVA skill. Bit higher at unskilled, lesser with skill, no slipping at experienced."
+  - rscadd: "Flooring when entering gravity from space is now not guaranteed at Basic skill or more. Doesn't happen at Professional skill."
+  - rscadd: "At Unskilled and Basic skill, jetpack can sometimes go wrong way. Not that bad if you notice in time and have fuel to turn back."
+  - rscadd: "At Professional skill you go faster when in space with a jetpack. Zooom."


### PR DESCRIPTION
Slipping chance is now tied to skill.
Currently ingame it's 5%. With these changes it goes like.
* Higher at Unskilled (9%)
* Same at Basic
* Half at Trained
* None at Experienced and above
Additionaly setting to walk halves slip chance.

YOu know how you get floored when you enter gravity area from space? That's a chance now too.
*  100% on Unskilled
*  Halving at each level above that
*  No chance at Professional

Jetpacks now require some skills to use. At Unskilled and Basic level there's a chance you fuck up controls a bit, and start flying wrong way. Easy to fix as long as you have fuel left and notice it in time.
On other hand, having Professional skill lets you zooom faster in space using jetpack.
Adjusts how jetpack is checked in spacemove so you don't use it when you have a wall to go by etc. Also cleaned up jetpack code a bit, hardcoded gas values eugh.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
