### PR TITLE
Lets off-station antags and trader become aliums

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -265,6 +265,7 @@
 #define SPECIES_NABBER      "giant armoured serpentid"
 #define SPECIES_PROMETHEAN  "Promethean"
 #define SPECIES_XENO        "Xenophage"
+#define SPECIES_ALIEN       "Humanoid"
 
 #define SURGERY_CLOSED 0
 #define SURGERY_OPEN 1

--- a/code/modules/mob/living/carbon/human/species/outsider/random.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/random.dm
@@ -1,10 +1,11 @@
 /datum/species/alium
-	name = "Humanoid"
+	name = SPECIES_ALIEN
 	name_plural = "Humanoids"
 	blurb = "Some alien humanoid species, unknown to humanity. How exciting."
 	rarity_value = 5
 
 	species_flags = SPECIES_FLAG_NO_SCAN
+	spawn_flags = SPECIES_IS_RESTRICTED
 
 	icobase = 'icons/mob/human_races/r_humanoid.dmi'
 	deform = 'icons/mob/human_races/r_humanoid.dmi'
@@ -85,6 +86,9 @@
 	..()
 #undef RANDOM_COEF
 
+/datum/species/human/get_bodytype(var/mob/living/carbon/human/H)
+	return SPECIES_HUMAN
+
 /datum/species/alium/proc/adapt_to_atmosphere(var/datum/gas_mixture/atmosphere)
 	var/temp_comfort_shift = atmosphere.temperature - body_temperature
 
@@ -120,3 +124,29 @@
 		poison_types = list(pick_n_take(newgases))
 	if(newgases.len)
 		exhale_type = pick_n_take(newgases)
+
+/obj/structure/aliumizer
+	name = "alien monolith"
+	desc = "Your true form is calling. Use this to become an alien humanoid."
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	icon_state = "ano51"
+	anchored = 1
+
+/obj/structure/aliumizer/attack_hand(mob/living/carbon/human/user)
+	if(!istype(user))
+		to_chat(user, "You got no business touching this.")
+		return
+	if(user.species.name == SPECIES_ALIEN)
+		to_chat(user, "You're already a [SPECIES_ALIEN].")
+		return
+	if(alert("Are you sure you want to be an alien?", "Mom Look I'm An Alien!", "Yes", "No") == "No")
+		to_chat(user, "Okie dokie.")
+		return
+	if(user && user.species.name == SPECIES_ALIEN) //no spamming it to get free implants
+		return
+	to_chat(user, "You're now an alien humanoid of some undiscovered species. Make up what lore you want, no one knows a thing about your species! You can check info about your traits with Check Species Info verb in IC tab.")
+	to_chat(user, "You can't speak GalCom or any other languages by default. You can use translator implant that spawns on top of this monolith - it will give you knowledge of any language if you hear it enough times.")
+	new/obj/item/weapon/implanter/translator(get_turf(src))
+	user.set_species(SPECIES_ALIEN)
+	user.fully_replace_character_name(user.species.get_random_name(user.gender))
+	user.rename_self("Humanoid Alien", 1)

--- a/html/changelogs/chinsky - aliums.yml
+++ b/html/changelogs/chinsky - aliums.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Offstation antags (and traider) can now become ALIUMS!"
+  - rscadd: "Their bases have 'alien monolith' somewhere, which turns you into a humanoid alien of unknown species."
+  - rscadd: "Remember to implant the spawned translator implanter if you're planning on talking to people."

--- a/maps/torch/torch-6.dmm
+++ b/maps/torch/torch-6.dmm
@@ -17480,6 +17480,7 @@
 	dir = 4;
 	pixel_y = 8
 	},
+/obj/structure/aliumizer,
 /turf/simulated/floor/carpet/blue,
 /area/merchant_station)
 "aNc" = (
@@ -22613,6 +22614,12 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
 /area/skipjack_station/start)
+"bfZ" = (
+/obj/structure/aliumizer,
+/turf/unsimulated/floor{
+	icon_state = "asteroid"
+	},
+/area/syndicate_mothership/raider_base)
 "bgb" = (
 /obj/structure/closet{
 	icon_closed = "cabinet_closed";
@@ -23028,6 +23035,14 @@
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
+"isk" = (
+/obj/effect/floor_decal/snow,
+/obj/structure/aliumizer,
+/turf/unsimulated/floor{
+	icon = 'icons/turf/snow.dmi';
+	icon_state = "ice"
+	},
+/area/ninja_dojo/dojo)
 "ixw" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l";
@@ -23127,6 +23142,13 @@
 	},
 /turf/simulated/floor/shuttle/black,
 /area/syndicate_station/start)
+"pMd" = (
+/obj/structure/aliumizer,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
 "ryl" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/teleport/hub,
@@ -23208,6 +23230,10 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/floor/shuttle/white,
 /area/syndicate_station/start)
+"wIu" = (
+/obj/structure/aliumizer,
+/turf/simulated/floor/carpet,
+/area/wizard_station)
 
 (1,1,1) = {"
 aaa
@@ -50916,7 +50942,7 @@ ajN
 ajN
 ale
 alj
-alv
+wIu
 alM
 alZ
 alb
@@ -56078,7 +56104,7 @@ aLM
 aLM
 aLM
 aLM
-aML
+bfZ
 aML
 aOO
 aML
@@ -58604,7 +58630,7 @@ akd
 ajP
 apa
 apo
-apo
+isk
 aoZ
 ajP
 ajP
@@ -59462,7 +59488,7 @@ ayB
 azK
 aAf
 aAB
-aAS
+pMd
 aAS
 aAS
 aBS


### PR DESCRIPTION
Adds structure that lets people turn into aliums to all antag spawns and trader base.


![](https://pbs.twimg.com/profile_images/789549579108835329/d876e4B2.jpg)


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
