### PR TITLE
Chemistry machines require skills.

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -20,7 +20,6 @@
 #define T100C 373.15 //  100.0 degrees celsius
 #define TCMB  2.7    // -270.3 degrees celcius
 
-#define CLAMP01(x) max(0, min(1, x))
 #define ATMOS_PRECISION 0.0001
 #define QUANTIZE(variable) (round(variable, ATMOS_PRECISION))
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -115,6 +115,7 @@ Class Procs:
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
 	var/clicksound			// sound played on succesful interface use by a carbon lifeform
 	var/clickvol = 40		// sound played on succesful interface use
+	var/core_skill = SKILL_DEVICES //The skill used for skill checks for this machine (mostly so subtypes can use different skills).
 
 /obj/machinery/Initialize(mapload, d=0)
 	. = ..()

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -65,15 +65,15 @@ note dizziness decrements automatically in the mob's Life() proc.
 	is_jittery = 1
 	while(jitteriness > 100)
 		var/amplitude = min(4, jitteriness / 100)
-		pixel_x = default_pixel_x + rand(-amplitude, amplitude)
-		pixel_y = default_pixel_y + rand(-amplitude/3, amplitude/3)
-
+		do_jitter(amplitude)
 		sleep(1)
 	//endwhile - reset the pixel offsets to zero
 	is_jittery = 0
-	pixel_x = default_pixel_x
-	pixel_y = default_pixel_y
+	do_jitter(0)
 
+/mob/proc/do_jitter(amplitude)
+	pixel_x = default_pixel_x + rand(-amplitude, amplitude)
+	pixel_y = default_pixel_y + rand(-amplitude/3, amplitude/3)
 
 //handles up-down floaty effect in space and zero-gravity
 /mob/var/is_floating = 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -786,16 +786,19 @@
 	if(status_flags & CANSTUN)
 		facing_dir = null
 		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
+		update_canmove()
 	return
 
 /mob/proc/SetStunned(amount) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
 	if(status_flags & CANSTUN)
 		stunned = max(amount,0)
+		update_canmove()
 	return
 
 /mob/proc/AdjustStunned(amount)
 	if(status_flags & CANSTUN)
 		stunned = max(stunned + amount,0)
+		update_canmove()
 	return
 
 /mob/proc/Weaken(amount)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -293,7 +293,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 
 	trans_to(target, amount, multiplier, copy)
 
-/datum/reagents/proc/trans_type_to(var/atom/target, var/type, var/amount = 1)
+/datum/reagents/proc/trans_type_to(var/atom/target, var/type, var/amount = 1, var/multiplier = 1)
 	if (!target || !target.reagents || !target.simulated)
 		return
 
@@ -307,7 +307,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 	F.add_reagent(type, amount, tmpdata)
 	remove_reagent(type, amount)
 
-	. = F.trans_to(target, amount) // Let this proc check the atom's type
+	. = F.trans_to(target, amount, multiplier) // Let this proc check the atom's type
 
 	qdel(F)
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /obj/machinery/chem_master
-	name = "ChemMaster 3000"
+	name = "\improper ChemMaster 3000"
 	density = 1
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'
@@ -17,10 +17,9 @@
 	idle_power_usage = 20
 	clicksound = "button"
 	clickvol = 20
-	var/beaker = null
+	var/obj/item/weapon/reagent_containers/beaker = null
 	var/obj/item/weapon/storage/pill_bottle/loaded_pill_bottle = null
 	var/mode = 0
-	var/condi = 0
 	var/useramount = 30 // Last used amount
 	var/pillamount = 10
 	var/bottlesprite = "bottle-1" //yes, strings
@@ -28,6 +27,8 @@
 	var/client/has_sprites = list()
 	var/max_pill_count = 20
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	core_skill = SKILL_CHEMISTRY
+	var/sloppy = 1 //Whether reagents will not be fully purified (sloppy = 1) or there will be reagent loss (sloppy = 0) on reagent add.
 
 /obj/machinery/chem_master/New()
 	create_reagents(120)
@@ -68,49 +69,45 @@
 		B.loc = src
 		to_chat(user, "You add the pill bottle into the dispenser slot!")
 		src.updateUsrDialog()
-	return
 
 /obj/machinery/chem_master/Topic(href, href_list, state)
 	if(..())
 		return 1
+	var/mob/user = usr
 
 	if (href_list["ejectp"])
 		if(loaded_pill_bottle)
-			loaded_pill_bottle.loc = src.loc
+			loaded_pill_bottle.loc = loc
 			loaded_pill_bottle = null
 	else if(href_list["close"])
-		usr << browse(null, "window=chemmaster")
-		usr.unset_machine()
+		show_browser(user, null, "window=chemmaster")
+		user.unset_machine()
 		return
 
 	if(beaker)
-		var/datum/reagents/R = beaker:reagents
+		var/datum/reagents/R = beaker.reagents
 		if (href_list["analyze"])
-			var/dat = ""
-			if(!condi)
-				if(href_list["name"] == "Blood")
-					var/datum/reagent/blood/G
-					for(var/datum/reagent/F in R.reagent_list)
-						if(F.name == href_list["name"])
-							G = F
-							break
-					var/A = G.name
-					var/B = G.data["blood_type"]
-					var/C = G.data["blood_DNA"]
-					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[A]<BR><BR>Description:<BR>Blood Type: [B]<br>DNA: [C]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
-				else
-					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
-			else
-				dat += "<TITLE>Condimaster 3000</TITLE>Condiment infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
-			usr << browse(dat, "window=chem_master;size=575x400")
+			var/datum/reagent/reagent = locate(href_list["analyze"]) in R.reagent_list
+			var/dat = get_chem_info(reagent)
+			if(dat)
+				show_browser(user, dat, "window=chem_master;size=575x400")
 			return
 
 		else if (href_list["add"])
 			if(href_list["amount"])
 				var/datum/reagent/their_reagent = locate(href_list["add"]) in R.reagent_list
 				if(their_reagent)
+					var/mult = 1
 					var/amount = Clamp((text2num(href_list["amount"])), 0, 200)
-					R.trans_type_to(src, their_reagent.type, amount)
+					if(sloppy)
+						var/contaminants = fetch_contaminants(user, R, their_reagent)
+						for(var/datum/reagent/reagent in contaminants)
+							R.trans_type_to(src, reagent.type, round(rand()*amount/5, 0.1))
+					else
+						mult -= 0.4 * (SKILL_MAX - user.get_skill_value(core_skill))/(SKILL_MAX-SKILL_MIN) //10% loss per skill level down from max
+					R.trans_type_to(src, their_reagent.type, amount, mult)
+
+
 
 		else if (href_list["addcustom"])
 			var/datum/reagent/their_reagent = locate(href_list["addcustom"]) in R.reagent_list
@@ -125,11 +122,15 @@
 				var/datum/reagent/my_reagents = locate(href_list["remove"]) in reagents.reagent_list
 				if(my_reagents)
 					var/amount = Clamp((text2num(href_list["amount"])), 0, 200)
+					var/contaminants = fetch_contaminants(user, reagents, my_reagents)
 					if(mode)
 						reagents.trans_type_to(beaker, my_reagents.type, amount)
+						for(var/datum/reagent/reagent in contaminants)
+							reagents.trans_type_to(beaker, reagent.type, round(rand()*amount, 0.1))
 					else
 						reagents.remove_reagent(my_reagents.type, amount)
-
+						for(var/datum/reagent/reagent in contaminants)
+							reagents.remove_reagent(reagent.type, round(rand()*amount, 0.1))
 
 		else if (href_list["removecustom"])
 			var/datum/reagent/my_reagents = locate(href_list["removecustom"]) in reagents.reagent_list
@@ -141,16 +142,17 @@
 
 		else if (href_list["toggle"])
 			mode = !mode
+		else if (href_list["toggle_sloppy"])
+			sloppy = !sloppy
 
 		else if (href_list["main"])
-			attack_hand(usr)
+			attack_hand(user)
 			return
 		else if (href_list["eject"])
-			if(beaker)
-				beaker:loc = src.loc
-				beaker = null
-				reagents.clear_reagents()
-				icon_state = "mixer0"
+			beaker.forceMove(loc)
+			beaker = null
+			reagents.clear_reagents()
+			icon_state = "mixer0"
 		else if (href_list["createpill"] || href_list["createpill_multiple"])
 			var/count = 1
 
@@ -172,57 +174,78 @@
 			if(reagents.total_volume/count < 1) //Sanity checking.
 				return
 			while (count-- && count >= 0)
-				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
+				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(loc)
 				if(!name) name = reagents.get_master_reagent_name()
 				P.SetName("[name] pill")
 				P.icon_state = "pill"+pillsprite
 				if(P.icon_state in list("pill1", "pill2", "pill3", "pill4", "pill5")) // if using greyscale, take colour from reagent
 					P.color = reagents.get_color()
 				reagents.trans_to_obj(P,amount_per_pill)
-				if(src.loaded_pill_bottle)
+				if(loaded_pill_bottle)
 					if(loaded_pill_bottle.contents.len < loaded_pill_bottle.max_storage_space)
 						P.loc = loaded_pill_bottle
-						src.updateUsrDialog()
 
 		else if (href_list["createbottle"])
-			if(!condi)
-				var/name = sanitizeSafe(input(usr,"Name:","Name your bottle!",reagents.get_master_reagent_name()), MAX_NAME_LEN)
-				var/obj/item/weapon/reagent_containers/glass/bottle/P = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
-				if(!name) name = reagents.get_master_reagent_name()
-				P.SetName("[name] bottle")
-				P.icon_state = bottlesprite
-				reagents.trans_to_obj(P,60)
-				P.update_icon()
-			else
-				var/obj/item/weapon/reagent_containers/food/condiment/P = new/obj/item/weapon/reagent_containers/food/condiment(src.loc)
-				reagents.trans_to_obj(P,50)
+			create_bottle(user)
 		else if(href_list["change_pill"])
 			#define MAX_PILL_SPRITE 25 //max icon state of the pill sprites
 			var/dat = "<table>"
 			for(var/i = 1 to MAX_PILL_SPRITE)
 				dat += "<tr><td><a href=\"?src=\ref[src]&pill_sprite=[i]\"><img src=\"pill[i].png\" /></a></td></tr>"
 			dat += "</table>"
-			usr << browse(dat, "window=chem_master")
+			show_browser(user, dat, "window=chem_master")
 			return
 		else if(href_list["change_bottle"])
 			var/dat = "<table>"
 			for(var/sprite in BOTTLE_SPRITES)
 				dat += "<tr><td><a href=\"?src=\ref[src]&bottle_sprite=[sprite]\"><img src=\"[sprite].png\" /></a></td></tr>"
 			dat += "</table>"
-			usr << browse(dat, "window=chem_master")
+			show_browser(user, dat, "window=chem_master")
 			return
 		else if(href_list["pill_sprite"])
 			pillsprite = href_list["pill_sprite"]
 		else if(href_list["bottle_sprite"])
 			bottlesprite = href_list["bottle_sprite"]
 
-	src.updateUsrDialog()
-	return
+	updateUsrDialog()
 
-/obj/machinery/chem_master/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
+/obj/machinery/chem_master/proc/fetch_contaminants(mob/user, datum/reagents/reagents, datum/reagent/main_reagent)
+	. = list()
+	for(var/datum/reagent/reagent in reagents.reagent_list)
+		if(reagent == main_reagent)
+			continue
+		if(prob(user.skill_fail_chance(core_skill, 100)))
+			. += reagent
 
-/obj/machinery/chem_master/attack_hand(mob/user as mob)
+/obj/machinery/chem_master/proc/get_chem_info(datum/reagent/reagent, heading = "Chemical infos", detailed_blood = 1)
+	if(!beaker || !reagent)
+		return
+	. = list()
+	. += "<TITLE>[name]</TITLE>"
+	. += "[heading]:<BR><BR>Name:<BR>[reagent.name]"
+	. += "<BR><BR>Description:<BR>"
+	if(detailed_blood && istype(reagent, /datum/reagent/blood))
+		var/datum/reagent/blood/B = reagent
+		. += "Blood Type: [B.data["blood_type"]]<br>DNA: [B.data["blood.DNA"]]"
+	else
+		. += "[reagent.description]"
+	. += "<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
+	. = JOINTEXT(.)
+
+/obj/machinery/chem_master/proc/create_bottle(mob/user)
+	var/name = sanitizeSafe(input(usr,"Name:","Name your bottle!",reagents.get_master_reagent_name()), MAX_NAME_LEN)
+	var/obj/item/weapon/reagent_containers/glass/bottle/P = new/obj/item/weapon/reagent_containers/glass/bottle(loc)
+	if(!name)
+		name = reagents.get_master_reagent_name()
+	P.SetName("[name] bottle")
+	P.icon_state = bottlesprite
+	reagents.trans_to_obj(P,60)
+	P.update_icon()
+
+/obj/machinery/chem_master/attack_ai(mob/user)
+	return attack_hand(user)
+
+/obj/machinery/chem_master/attack_hand(mob/user)
 	if(inoperable())
 		return
 	user.set_machine(src)
@@ -233,18 +256,21 @@
 				usr << browse_rsc(icon('icons/obj/chemical.dmi', "pill" + num2text(i)), "pill[i].png")
 			for(var/sprite in BOTTLE_SPRITES)
 				usr << browse_rsc(icon('icons/obj/chemical.dmi', sprite), "[sprite].png")
-	var/dat = ""
+	var/dat = list()
+	dat += "<TITLE>[name]</TITLE>"
+	dat += "[name] Menu:"
 	if(!beaker)
-		dat = "Please insert beaker.<BR>"
-		if(src.loaded_pill_bottle)
+		dat += "Please insert beaker.<BR>"
+		if(loaded_pill_bottle)
 			dat += "<A href='?src=\ref[src];ejectp=1'>Eject Pill Bottle \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
 		else
 			dat += "No pill bottle inserted.<BR><BR>"
 		dat += "<A href='?src=\ref[src];close=1'>Close</A>"
 	else
-		var/datum/reagents/R = beaker:reagents
+		var/datum/reagents/R = beaker.reagents
 		dat += "<A href='?src=\ref[src];eject=1'>Eject beaker and Clear Buffer</A><BR>"
-		if(src.loaded_pill_bottle)
+		dat += "Toggle purification mode: <A href='?src=\ref[src];toggle_sloppy=1'>[sloppy ? "Quick" : "Thorough"]</A><BR>"
+		if(loaded_pill_bottle)
 			dat += "<A href='?src=\ref[src];ejectp=1'>Eject Pill Bottle \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
 		else
 			dat += "No pill bottle inserted.<BR><BR>"
@@ -253,8 +279,8 @@
 		else
 			dat += "Add to buffer:<BR>"
 			for(var/datum/reagent/G in R.reagent_list)
-				dat += "[G.name] , [G.volume] Units - "
-				dat += "<A href='?src=\ref[src];analyze=1;desc=[G.description];name=[G.name]'>(Analyze)</A> "
+				dat += "[G.name], [G.volume] Units - "
+				dat += "<A href='?src=\ref[src];analyze=\ref[G]'>(Analyze)</A> "
 				dat += "<A href='?src=\ref[src];add=\ref[G];amount=1'>(1)</A> "
 				dat += "<A href='?src=\ref[src];add=\ref[G];amount=5'>(5)</A> "
 				dat += "<A href='?src=\ref[src];add=\ref[G];amount=10'>(10)</A> "
@@ -264,8 +290,8 @@
 		dat += "<HR>Transfer to <A href='?src=\ref[src];toggle=1'>[(!mode ? "disposal" : "beaker")]:</A><BR>"
 		if(reagents.total_volume)
 			for(var/datum/reagent/N in reagents.reagent_list)
-				dat += "[N.name] , [N.volume] Units - "
-				dat += "<A href='?src=\ref[src];analyze=1;desc=[N.description];name=[N.name]'>(Analyze)</A> "
+				dat += "[N.name], [N.volume] Units - "
+				dat += "<A href='?src=\ref[src];analyze=\ref[N]'>(Analyze)</A> "
 				dat += "<A href='?src=\ref[src];remove=\ref[N];amount=1'>(1)</A> "
 				dat += "<A href='?src=\ref[src];remove=\ref[N];amount=5'>(5)</A> "
 				dat += "<A href='?src=\ref[src];remove=\ref[N];amount=10'>(10)</A> "
@@ -273,28 +299,36 @@
 				dat += "<A href='?src=\ref[src];removecustom=\ref[N]'>(Custom)</A><BR>"
 		else
 			dat += "Empty<BR>"
-		if(!condi)
-			dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (60 units max)</A><a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill[pillsprite].png\" /></a><BR>"
-			dat += "<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills</A><BR>"
-			dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (60 units max)<a href=\"?src=\ref[src]&change_bottle=1\"><img src=\"[bottlesprite].png\" /></A>"
-		else
-			dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (50 units max)</A>"
-	if(!condi)
-		user << browse("<TITLE>Chemmaster 3000</TITLE>Chemmaster menu:<BR><BR>[dat]", "window=chem_master;size=575x400")
-	else
-		user << browse("<TITLE>Condimaster 3000</TITLE>Condimaster menu:<BR><BR>[dat]", "window=chem_master;size=575x400")
+		dat += extra_options()
+	show_browser(user, strip_improper(JOINTEXT(dat)), "window=chem_master;size=575x400")
 	onclose(user, "chem_master")
-	return
+
+//Use to add extra stuff to the end of the menu.
+/obj/machinery/chem_master/proc/extra_options()
+	. = list()
+	. += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (60 units max)</A><a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill[pillsprite].png\" /></a><BR>"
+	. += "<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills</A><BR>"
+	. += "<A href='?src=\ref[src];createbottle=1'>Create bottle (60 units max)<a href=\"?src=\ref[src]&change_bottle=1\"><img src=\"[bottlesprite].png\" /></A>"
+	return JOINTEXT(.)
 
 /obj/machinery/chem_master/condimaster
-	name = "CondiMaster 3000"
-	condi = 1
+	name = "\improper CondiMaster 3000"
+	core_skill = SKILL_COOKING
 
+/obj/machinery/chem_master/condimaster/get_chem_info(datum/reagent/reagent)
+	return ..(reagent, "Condiment infos", 0)
+
+/obj/machinery/chem_master/condimaster/create_bottle(mob/user)
+	var/obj/item/weapon/reagent_containers/food/condiment/P = new/obj/item/weapon/reagent_containers/food/condiment(src.loc)
+	reagents.trans_to_obj(P,50)
+
+/obj/machinery/chem_master/condimaster/extra_options()
+	return "<A href='?src=\ref[src];createbottle=1'>Create bottle (50 units max)</A>"
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 /obj/machinery/reagentgrinder
 
-	name = "All-In-One Grinder"
+	name = "\improper All-In-One Grinder"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "juicer1"
 	layer = BELOW_OBJ_LAYER
@@ -311,11 +345,9 @@
 /obj/machinery/reagentgrinder/New()
 	..()
 	beaker = new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
-	return
 
 /obj/machinery/reagentgrinder/update_icon()
 	icon_state = "juicer"+num2text(!isnull(beaker))
-	return
 
 /obj/machinery/reagentgrinder/attackby(var/obj/item/O as obj, var/mob/user as mob)
 
@@ -371,7 +403,7 @@
 			to_chat(user, "\The [material.name] is unable to produce any usable reagents.")
 			return 1
 
-	if(!O.reagents || !O.reagents.total_volume)
+	else if(!O.reagents || !O.reagents.total_volume)
 		to_chat(user, "\The [O] is not suitable for blending.")
 		return 1
 
@@ -402,7 +434,7 @@
 	var/is_beaker_ready = 0
 	var/processing_chamber = ""
 	var/beaker_contents = ""
-	var/dat = ""
+	var/dat = list()
 
 	if(!inuse)
 		for (var/obj/item/O in holdingitems)
@@ -424,7 +456,7 @@
 				beaker_contents += "Nothing<br>"
 
 
-		dat = {"
+		dat += {"
 	<b>Processing chamber contains:</b><br>
 	[processing_chamber]<br>
 	[beaker_contents]<hr>
@@ -437,16 +469,15 @@
 			dat += "<A href='?src=\ref[src];action=detach'>Detach the beaker</a><BR>"
 	else
 		dat += "Please wait..."
-	user << browse("<HEAD><TITLE>All-In-One Grinder</TITLE></HEAD><TT>[dat]</TT>", "window=reagentgrinder")
+	dat = "<HEAD><TITLE>[name]</TITLE></HEAD><TT>[JOINTEXT(dat)]</TT>"
+	show_browser(user, strip_improper(dat), "window=reagentgrinder")
 	onclose(user, "reagentgrinder")
-	return
-
 
 /obj/machinery/reagentgrinder/OnTopic(user, href_list)
 	if(href_list["action"])
 		switch(href_list["action"])
 			if ("grind")
-				grind()
+				grind(user)
 			if("eject")
 				eject()
 			if ("detach")
@@ -470,7 +501,7 @@
 		holdingitems -= O
 	holdingitems.Cut()
 
-/obj/machinery/reagentgrinder/proc/grind()
+/obj/machinery/reagentgrinder/proc/grind(mob/user)
 
 	power_change()
 	if(stat & (NOPOWER|BROKEN))
@@ -480,14 +511,16 @@
 	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
 		return
 
+	hurt_hand(user)
 	playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
 	inuse = 1
 
 	// Reset the machine.
 	spawn(60)
 		inuse = 0
-		interact(usr)
+		interact(user)
 
+	var/skill_factor = CLAMP01(1 + 0.3*(user.get_skill_value(SKILL_CHEMISTRY) - SKILL_EXPERT)/(SKILL_EXPERT - SKILL_MIN))
 	// Process.
 	for (var/obj/item/O in holdingitems)
 
@@ -512,13 +545,43 @@
 				if(QDELETED(stack))
 					holdingitems -= stack
 				for(var/chem in chem_products)
-					beaker.reagents.add_reagent(chem, (amount_to_take*chem_products[chem]))
+					beaker.reagents.add_reagent(chem, (amount_to_take*chem_products[chem]*skill_factor))
 				continue
 
 		if(O.reagents)
-			O.reagents.trans_to(beaker, min(O.reagents.total_volume, remaining_volume))
+			O.reagents.trans_to(beaker, O.reagents.total_volume, skill_factor)
 			if(O.reagents.total_volume == 0)
 				holdingitems -= O
 				qdel(O)
 			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 				break
+
+/obj/machinery/reagentgrinder/proc/hurt_hand(mob/living/carbon/human/user)
+	if(!istype(user) || !prob(user.skill_fail_chance(SKILL_CHEMISTRY, 50, SKILL_BASIC)))
+		return
+	var/hand = pick(BP_L_HAND, BP_R_HAND)
+	var/obj/item/organ/external/hand_organ = user.get_organ(hand)
+	if(!hand_organ)
+		return
+
+	var/dam = rand(10, 15)
+	user.visible_message("<span class='danger'>\The [user]'s hand gets caught in \the [src]!</span>", "<span class='danger'>Your hand gets caught in \the [src]!</span>")
+	user.apply_damage(dam, BRUTE, hand, damage_flags = DAM_SHARP, used_weapon = "grinder")
+	if(hand_organ.robotic >= ORGAN_ROBOT)
+		beaker.reagents.add_reagent(/datum/reagent/iron, dam)
+	else
+		user.take_blood(beaker, dam)
+	user.Stun(2)
+	addtimer(CALLBACK(src, .proc/shake, user, 40), 0)
+
+/obj/machinery/reagentgrinder/proc/shake(mob/user, duration)
+	for(var/i = 1, i<=duration, i++)
+		sleep(1)
+		if(!user || !Adjacent(user))
+			break
+		if(user.is_jittery)
+			continue
+		user.do_jitter(4)
+
+	if(user && !user.is_jittery)
+		user.do_jitter(0) //resets the icon.

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -20,6 +20,7 @@
 	density = 1
 	anchored = 1
 	obj_flags = OBJ_FLAG_ANCHORABLE
+	core_skill = SKILL_CHEMISTRY
 
 /obj/machinery/chemical_dispenser/New()
 	..()
@@ -137,7 +138,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/obj/machinery/chemical_dispenser/OnTopic(user, href_list)
+/obj/machinery/chemical_dispenser/OnTopic(mob/user, href_list)
 	if(href_list["amount"])
 		amount = round(text2num(href_list["amount"]), 1) // round to nearest 1
 		amount = max(0, min(120, amount)) // Since the user can actually type the commands himself, some sanity checking
@@ -147,7 +148,17 @@
 		var/label = href_list["dispense"]
 		if(cartridges[label] && container && container.is_open_container())
 			var/obj/item/weapon/reagent_containers/chem_disp_cartridge/C = cartridges[label]
-			C.reagents.trans_to(container, amount)
+			var/mult = 1 + (-0.5 + round(rand(), 0.1))*(user.skill_fail_chance(core_skill, 0.3, SKILL_ADEPT))
+			C.reagents.trans_to(container, amount*mult)
+			var/contaminants_left = rand(0, max(SKILL_ADEPT - user.get_skill_value(core_skill), 0))
+			var/choices = cartridges.Copy()
+			while(length(choices) && contaminants_left)
+				var/chosen_label = pick_n_take(choices)
+				var/obj/item/weapon/reagent_containers/chem_disp_cartridge/choice = cartridges[chosen_label]
+				if(choice == C)
+					continue
+				choice.reagents.trans_to(container, round(rand()*amount/5, 0.1))
+				contaminants_left--
 			return TOPIC_REFRESH
 		return TOPIC_HANDLED
 

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -62,6 +62,7 @@
 	icon_state = "soda_dispenser"
 	ui_title = "Soda Dispenser"
 	accept_drinking = 1
+	core_skill = SKILL_COOKING
 
 /obj/machinery/chemical_dispenser/bar_soft/full
 	spawn_cartridges = list(
@@ -90,6 +91,7 @@
 	icon_state = "booze_dispenser"
 	ui_title = "Booze Dispenser"
 	accept_drinking = 1
+	core_skill = SKILL_COOKING
 
 /obj/machinery/chemical_dispenser/bar_alc/full
 	spawn_cartridges = list(
@@ -119,6 +121,7 @@
 	icon_state = "coffee_dispenser"
 	ui_title = "Coffee Dispenser"
 	accept_drinking = 1
+	core_skill = SKILL_COOKING
 
 /obj/machinery/chemical_dispenser/bar_coffee/full
 	spawn_cartridges = list(

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 12 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 46 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 653 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 646 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
:cl:
rscadd: The chem grinder is dangerous to use at "Unskilled" in Chemistry and will lose some ingredients depending on skill level.
rscadd: The chem dispenser will give inaccurate amounts of ingredients or add extra contaminating ingredients when below skill "Trained" (in Chemistry or Cooking, depending on dispenser)  Can be slightly dangerous.
rscadd: The chem master now has two modes. "Quick" will move the correct amount of ingredients from beaker to buffer, but also add contaminants (depending on skill). "Thorough" will only move the desired ingredient, but incur losses (depending on skill). Skill checked is Chemistry for chem master, Cooking for Condimaster.
rscadd: Moving ingredients from buffer to waste or beaker acts like on "Quick" mode.
/:cl:

Fixes #21783 while I'm down there.