### PR TITLE
Standing still makes shooting more accurate

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -308,8 +308,15 @@
 
 	var/acc_mod = burst_accuracy[min(burst, burst_accuracy.len)]
 	var/disp_mod = dispersion[min(burst, dispersion.len)]
+	var/stood_still = round((world.time - user.l_move_time)/15)
+	if(stood_still)
+		acc_mod += 1 * max(2, stood_still)
+		if(stood_still > 5)
+			acc_mod += accuracy
 
 	if(one_hand_penalty)
+		if(!stood_still)
+			acc_mod -= 1
 		if(!held_twohanded)
 			acc_mod += -ceil(one_hand_penalty/2)
 			disp_mod += one_hand_penalty*0.5 //dispersion per point of two-handedness


### PR DESCRIPTION
If you stand still for some time, you get bonus to accuracy. If you stand still for 3 seconds, bit more bonus, If you stay still for like 10 seconds, you get double accuracy bonus of your gun.
Also if you don't stand still and fire twohanded weapon, not only you lose that bonus, you also get a penalty.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
