### PR TITLE
Close Combat skill effects

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -272,8 +272,8 @@
 
 	if(affecting.incapacitated(INCAPACITATION_KNOCKOUT | INCAPACITATION_STUNNED))
 		to_chat(G.assailant, "<span class='warning'>You can't resist in your current state!</span>")
-
-	var/break_strength = breakability + size_difference(affecting, assailant)
+	var/skill_mod = Clamp(-1, affecting.get_skill_difference(SKILL_COMBAT, assailant), 1)
+	var/break_strength = breakability + size_difference(affecting, assailant) + skill_mod
 
 	if(affecting.incapacitated(INCAPACITATION_ALL))
 		break_strength--

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -65,6 +65,9 @@
 	var/mob/living/carbon/human/assailant = G.assailant
 	var/mob/living/carbon/human/affecting = G.affecting
 
+	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		return
+
 	if(!O)
 		to_chat(assailant, "<span class='warning'>[affecting] is missing that body part!</span>")
 		return 0
@@ -92,6 +95,9 @@
 	var/obj/item/organ/external/O = G.get_targeted_organ()
 	var/mob/living/carbon/human/assailant = G.assailant
 	var/mob/living/carbon/human/affecting = G.affecting
+
+	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		return
 
 	if(!O)
 		to_chat(assailant, "<span class='warning'>[affecting] is missing that body part!</span>")
@@ -161,6 +167,9 @@
 /datum/grab/normal/proc/headbutt(var/obj/item/grab/G)
 	var/mob/living/carbon/human/attacker = G.assailant
 	var/mob/living/carbon/human/target = G.affecting
+
+	if(!attacker.skill_check(SKILL_COMBAT, SKILL_BASIC))
+		return
 
 	if(target.lying)
 		return
@@ -244,7 +253,7 @@
 	user.visible_message("<span class='danger'>\The [user] begins to slit [affecting]'s throat with \the [W]!</span>")
 
 	user.next_move = world.time + 20 //also should prevent user from triggering this repeatedly
-	if(!do_after(user, 20, progress = 0))
+	if(!do_after(user, 20*user.skill_delay_mult(SKILL_COMBAT) , progress = 0))
 		return 0
 	if(!(G && G.affecting == affecting)) //check that we still have a grab
 		return 0
@@ -277,6 +286,9 @@
 
 /datum/grab/normal/proc/attack_tendons(var/obj/item/grab/G, var/obj/item/W, var/mob/living/carbon/human/user, var/target_zone)
 	var/mob/living/carbon/human/affecting = G.affecting
+
+	if(!user.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		return
 
 	if(user.a_intent != I_HURT)
 		return 0 // Not trying to hurt them.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -144,6 +144,7 @@ meteor_act
 		return target_zone
 
 	var/accuracy_penalty = user.melee_accuracy_mods()
+	accuracy_penalty += 10*get_skill_difference(SKILL_COMBAT, user)
 
 	var/hit_zone = get_zone_with_miss_chance(target_zone, src, accuracy_penalty)
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -544,7 +544,10 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				target.visible_message("<span class='danger'>[target]'s [W] goes off during the struggle!</span>")
 				return W.afterattack(shoot_to,target)
 
-	var/randn = rand(1, 100)
+	var/skill_mod = 10 * attacker.get_skill_difference(SKILL_COMBAT, target)
+	var/state_mod = attacker.melee_accuracy_mods() - target.melee_accuracy_mods()
+
+	var/randn = rand(1, 100) - skill_mod + state_mod
 	if(!(species_flags & SPECIES_FLAG_NO_SLIP) && randn <= 25)
 		var/armor_check = target.run_armor_check(affecting, "melee")
 		target.apply_effect(3, WEAKEN, armor_check)

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -56,6 +56,9 @@
 	var/points = get_skill_value(skill_path)
 	return points >= needed
 
+/mob/proc/get_skill_difference(skill_path, mob/opponent)
+	return get_skill_value(skill_path) - opponent.get_skill_value(skill_path)
+
 // A generic way of modifying times via skill values	
 /mob/proc/skill_delay_mult(skill_path, factor = 0.3) 
 	var/points = get_skill_value(skill_path)

--- a/html/changelogs/chinsky - kungfu.yml
+++ b/html/changelogs/chinsky - kungfu.yml
@@ -1,0 +1,7 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Close Combat now has ingame effects. Mostly chances to hit in melee."
+  - rscadd: "Disarm chances now both affected by skills and anything tha affects melee accuracy (being blind, being confused, blurry eyes, being in pain etc)."
+  - rscadd: "Most fancy grab moves (jointlocks, dislocations, tendons cutting) were locked away behind Trained skill in CQC."
+  


### PR DESCRIPTION
Oof ow my nerfs.

Adds helper to get difference of skills between mob and opponent, as most checks are opposed here.

First - disarm.
Disarm chances are now affected by both everything that affects melee accuracy (confusion, blindness etc) and the skill difference. In unskilled vs professional combat, unskilled dude would be lucky to disarm pro, and won't be able to push him down unless pro has status effects (like being flashed). Pro would pretty much always disarm him, and get a good chance to push him down too.

Next, melee combat.
Simple change, accuracy penalty affected by difference in skill, again, pro will hit noob easier, noob will have harder time hitting pro, especially in remote locations.

Last but not least: grabs.
Difference in skill now affects breakout chance (not drastically since not a lot of space there, only up to 1 level of skill difference matter.
A lot of grab maneuvers were locked behind a skillwall. As a rule of a thumb, you need Trained to do fancy kung fu shit in grab.
Also throat slitting speed is affected by skill now.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
