### PR TITLE
Removes the MP brassard from the loadout

### DIFF
--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -59,11 +59,6 @@
 	flags = GEAR_HAS_TYPE_SELECTION
 	allowed_roles = MILITARY_ROLES
 
-/datum/gear/accessory/armband_mp
-	display_name = "military police brassard"
-	path = /obj/item/clothing/accessory/armband/solgov/mp
-	allowed_roles = SECURITY_ROLES
-
 /datum/gear/accessory/armband_ma
 	display_name = "master at arms brassard"
 	path = /obj/item/clothing/accessory/armband/solgov/ma


### PR DESCRIPTION
Reasons:
1. Military Police was a Master-at-Arms alt-title, meant for use by marines;
2. Marines no longer exist;
3. The Military Police alt-title no longer exists;
4. The brassard should no longer be available.