### PR TITLE
Leadership gives some verbs.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1908,6 +1908,8 @@
 #include "code\modules\mob\observer\virtual\helpers.dm"
 #include "code\modules\mob\observer\virtual\mob.dm"
 #include "code\modules\mob\skills\skill.dm"
+#include "code\modules\mob\skills\skill_buffs.dm"
+#include "code\modules\mob\skills\skill_verbs.dm"
 #include "code\modules\mob\skills\skillset.dm"
 #include "code\modules\mob\skills\skillset_silicon.dm"
 #include "code\modules\modular_computers\laptop_vendor.dm"

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -10,7 +10,7 @@
  */
 
 //Returns a list in plain english as a string
-/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
+/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "," )
 	switch(input.len)
 		if(0) return nothing_text
 		if(1) return "[input[1]]"

--- a/code/modules/mob/skills/skill_buffs.dm
+++ b/code/modules/mob/skills/skill_buffs.dm
@@ -1,0 +1,67 @@
+//The base type is suitable for generic buffs not needing special treatment.
+/datum/skill_buff
+	var/list/buffs              //Format: list(skill_path = amount)
+	var/limit                   //How many buffs of this type a skillset can have. null = no limit
+	var/datum/skillset/skillset //The skillset to which this buff belongs.
+
+/datum/skill_buff/New(buff)
+	buffs = buff
+	..()
+
+/datum/skill_buff/Destroy()
+	if(skillset)
+		LAZYREMOVE(skillset.skill_buffs, src)
+		skillset.update_verbs()
+		skillset = null
+	. = ..()
+
+//Clamps the buff amounts so that the target stays between SKILL_MIN and SKILL_MAX in all skills.
+/datum/skill_buff/proc/tailor_buff(mob/target)
+	if(!buffs)
+		return
+	var/list/temp_buffs = buffs.Copy()
+	for(var/skill_type in temp_buffs)
+		var/has_now = target.get_skill_value(skill_type)
+		var/current_buff = buffs[skill_type]
+		var/new_buff = Clamp(has_now + current_buff, SKILL_MIN, SKILL_MAX) - has_now
+		new_buff ? (buffs[skill_type] = new_buff) : (buffs -= skill_type)
+	return length(buffs)
+
+/datum/skill_buff/proc/can_buff(mob/target)
+	if(!length(buffs) || !istype(target))
+		return //what are we even buffing?
+	if(too_many_buffs(target))
+		return
+	return 1
+
+/datum/skill_buff/proc/too_many_buffs(mob/target)
+	if(limit && (length(target.fetch_buffs_of_type(type, 0)) >= limit))
+		return 1
+
+/datum/skill_buff/proc/remove()
+	var/datum/skillset/my_skillset = skillset
+	qdel(src)
+	if(my_skillset)
+		my_skillset.update_verbs()
+
+//returns a list of buffs of the given type.
+/mob/proc/fetch_buffs_of_type(buff_type, subtypes = 1)
+	. = list()
+	for(var/datum/skill_buff/buff in skillset.skill_buffs)
+		if(subtypes && istype(buff, buff_type))
+			. += buff
+		else if(!subtypes && (buff.type == buff_type))
+			. += buff
+
+/mob/proc/buff_skill(to_buff, duration, buff_type = /datum/skill_buff)
+	var/datum/skill_buff/buff = new buff_type(to_buff)
+	if(!buff.can_buff(src))
+		return
+	if(!buff.tailor_buff(src))
+		return //Turns out there's nothing to buff.
+	LAZYADD(skillset.skill_buffs, buff)
+	buff.skillset = skillset
+	skillset.update_verbs()
+	if(duration)
+		addtimer(CALLBACK(buff, /datum/skill_buff/proc/remove), duration)
+	return 1

--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -1,0 +1,215 @@
+//Skill-related mob verbs that require skill checks to be satisfied to be added.
+
+GLOBAL_LIST_INIT(skill_verbs, init_subtypes(/datum/skill_verb))
+
+/datum/skillset/proc/fetch_verb_datum(given_type)
+	for(var/datum/skill_verb/SV in skill_verbs)
+		if(SV.type == given_type)
+			return SV
+
+/datum/skillset/proc/update_verbs()
+	for(var/datum/skill_verb/SV in skill_verbs)
+		SV.update_verb()
+
+/datum/skill_verb
+	var/datum/skillset/skillset   //Owner, if any.
+	var/the_verb                  //The verb to keep track of. Should be a mob verb.
+	var/cooldown                  //How long the verb cools down for after use. null = has no cooldown.
+	var/cooling_down = 0          //Whether it's currently cooling down.
+
+/datum/skill_verb/Destroy()
+	skillset = null
+	. = ..()
+
+//Not whether it can be accessed/used; just whether the mob skillset should have this datum and check it when updating skill verbs.
+/datum/skill_verb/proc/should_have_verb(datum/skillset/given_skillset)
+	return 1
+
+/datum/skill_verb/proc/give_to_skillset(datum/skillset/given_skillset)
+	var/datum/skill_verb/new_verb = new type
+	new_verb.skillset = given_skillset
+	LAZYADD(given_skillset.skill_verbs, new_verb)
+
+//Updates whether or not the mob has access to this verb.
+/datum/skill_verb/proc/update_verb()
+	if(!skillset || !skillset.owner)
+		return
+	. = should_see_verb()
+	. ? (skillset.owner.verbs |= the_verb) : (skillset.owner.verbs -= the_verb)
+
+/datum/skill_verb/proc/should_see_verb()
+	if(cooling_down)
+		return
+	return 1
+
+/datum/skill_verb/proc/remove_cooldown()
+	cooling_down = 0
+	update_verb()
+
+/datum/skill_verb/proc/set_cooldown()
+	if(!cooldown)
+		return
+	cooling_down = 1
+	update_verb()
+	addtimer(CALLBACK(src, .proc/remove_cooldown), cooldown)
+
+/*
+The Motivate verb.
+*/
+/datum/skill_verb/motivate
+	the_verb = /mob/living/carbon/human/proc/motivate
+	cooldown = 15 MINUTES
+
+/datum/skill_verb/motivate/should_have_verb(datum/skillset/given_skillset)
+	if(!ishuman(given_skillset.owner))
+		return
+	return ..()
+
+/datum/skill_verb/motivate/should_see_verb()
+	if(!..())
+		return
+	var/mob/owner = skillset.owner
+	if(owner.mind && player_is_antag(owner.mind))
+		return
+	if(!owner.skill_check(SKILL_MANAGEMENT, SKILL_BASIC))
+		return
+	return 1
+
+/mob/living/carbon/human/proc/motivate(mob/living/carbon/human/target as mob in oview())
+	set category = "IC"
+	set name = "Motivate"
+	set src = usr
+
+	var/datum/skill_verb/motivate/SV = skillset.fetch_verb_datum(/datum/skill_verb/motivate)
+	if(!SV || !istype(target))
+		return
+	if(src == target)
+		return
+
+	var/datum/skill_buff/motivate/buff = new //For doing checks with
+	if(buff.too_many_buffs(target))
+		to_chat(src, "<span class='notice'>\The [target] appears to be highly motivated already.</span>")
+		return
+
+	var/options = list()
+	var/own_leadership = get_skill_value(SKILL_MANAGEMENT)
+	for(var/decl/hierarchy/skill/S in GLOB.skills)
+		if(istype(S, SKILL_MANAGEMENT))
+			continue //No buffing leadership to avoid exploits.
+		if(!target.skill_check(S.type, own_leadership)) //only buff skills below our leadership value.
+			options[S.name] = S
+	var/choice = input(src, "Select skill to motivate \the [target] in:", "Skill select") as null|anything in options
+
+	if(!(choice in options) || !(target in view())) //Check again, might have moved.
+		return
+	if(buff.too_many_buffs(target))
+		to_chat(src, "<span class='notice'>\The [target] appears to be highly motivated already.</span>")
+		return
+	var/decl/hierarchy/skill/skill = options[choice]
+	if(target.skill_check(skill.type, own_leadership))
+		return //Maybe they got buffed while we waited for input.
+
+	target.buff_skill(list(skill.type = 1), 45 MINUTES, /datum/skill_buff/motivate)
+	visible_message(motivate_message(target, skill))
+	SV.set_cooldown()
+
+/mob/living/carbon/human/proc/motivate_message(mob/living/carbon/human/target, decl/hierarchy/skill/skill)
+	. = list()
+	. += "\The [src] gives \the [target] a"
+	. += pick("n inspiring", " riveting", " stirring", " moving")
+	. += " speech, urging them to focus on [skill.name]. The speech features appeals to "
+	var/list/dat = list()
+	if(religion == target.religion)
+		if(religion != "None")
+			dat += "their common religion ([religion])"
+		else
+			dat += "their common lack of spirituality"
+	if(home_system == target.home_system)
+		dat += "their shared home system of [home_system]"
+	if(personal_faction == target.personal_faction)
+		dat += "their commitment to [personal_faction]"
+	if(citizenship == target.citizenship)
+		dat += "their [citizenship] citizenship"
+	if(species == target.species)
+		if(species != all_species[SPECIES_HUMAN])
+			dat += "their [species] heritage"
+		else
+			dat += "their humanity"
+	if(char_branch == target.char_branch)
+		dat += "their experiences in \the [char_branch.name]"
+	switch(target.age)
+		if(0 to 20)
+			dat += "\the [target]'s youth and sense of adventure"
+		if(21 to 35)
+			dat += "\the [target]'s competence and ambition"
+		else
+			dat += "\the [target]'s age and experience"
+	dat += "\the [target]'s sense of duty"
+	dat += "\the [target]'s commitment to the mission"
+	dat = shuffle(dat)
+	dat.Cut(4)
+	. += english_list(dat)
+	. += ". \The [src]'s tone is "
+	. += pick("warm", "steely", "no-bullshit", "caring", "nostalgic", "angry")
+	. += ", and \the [target] appears "
+	. += pick("captivated", "moved", "indifferent", "stoic", "encouraged", "heartened")
+	. += "."
+	. = "<span class='notice'>[JOINTEXT(.)]</span>"
+
+/datum/skill_buff/motivate/
+	limit = 2
+
+/datum/skill_buff/motivate/can_buff(mob/target)
+	if(!..())
+		return
+	if(!ishuman(target))
+		return
+	if(target.mind && player_is_antag(target.mind))
+		return //No motivating antags.
+	return 1
+
+/datum/skill_buff/motivate/remove()
+	to_chat(skillset.owner, "<span class='notice'>You feel some of your motivation wearing off.</span>")
+	..()
+/*
+The Call to Attention verb
+*/
+/datum/skill_verb/attention
+	the_verb = /mob/living/carbon/human/proc/attention
+	cooldown = 5 MINUTES
+
+/datum/skill_verb/attention/should_have_verb(datum/skillset/given_skillset)
+	if(!ishuman(given_skillset.owner))
+		return
+	return ..()
+
+/datum/skill_verb/attention/should_see_verb()
+	if(!..())
+		return
+	var/mob/owner = skillset.owner
+	if(owner.mind && player_is_antag(owner.mind))
+		return
+	if(!owner.skill_check(SKILL_MANAGEMENT, SKILL_PROF))
+		return
+	return 1
+
+/mob/living/carbon/human/proc/attention()
+	set category = "IC"
+	set name = "Call To Attention"
+	set src = usr
+
+	var/datum/skill_verb/attention/SV = skillset.fetch_verb_datum(/datum/skill_verb/attention)
+	if(!SV)
+		return
+
+	usr.visible_message("<span class='danger'><font size=3>\The [src] calls for attention!</font></span>")
+	for(var/mob/living/carbon/human/H in oview())
+		if(!H.incapacitated())
+			H.set_dir(get_dir(H, src))
+		if(H.mind && player_is_antag(H.mind))
+			continue //No mass stunning the antags, but they do get distracted.
+		if(!H.skill_check(SKILL_MANAGEMENT, SKILL_PROF))
+			H.Stun(5)
+			H.silent += 10 SECONDS
+
+	SV.set_cooldown()


### PR DESCRIPTION
:cl:
rscadd: Having "Trained" leadership gives access to the Motivate verb. Use this to boost the skill level of a human mob by one point (but not above your current leadership skill) for 30-60 minutes. Has a 10 minute cooldown. Can't be used on borgs, on self, or on the leadership skill. Can be used on antags, but won't actually buff them. A person can only have two motivation buffs active at once.
rscadd: Having "Basic" leadership gives access to the Instruct verb. This boosts a mob's skill from untrained to basic, provided you are at least experienced in it. Has 15 minute cooldown. Unlike Motivate, requires being close to the mob and takes a minute to work; you can't move or do anything else while you wait.
rscadd: Having "Professional" leadership gives access to the Call to Attention verb. Use to stun and silence all human mobs around you for 10 seconds and make them turn towards you. Won't stun/silence antags; this is for leadership, not crowd control. Has 5 minute cooldown.
/:cl:

I have more planned, but that's for another PR.

Also some backend stuff: Skill buffs are datums stored on the skill set and modify skill values. Added a framework for skill verbs to be added/removed on skill change. Some small changes to how the skillset stores data internally to make it more consistent and simpler.