### PR TITLE
Adds a bunch of alt-titles

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -459,9 +459,9 @@
 	selection_color = "#68099e"
 	minimal_player_age = 4
 	ideal_character_age = 20
+	alt_titles = list("Geography Technician", "Geology Technician", "Meteorology Technician", "Exobiology Technician", "Xenoarchaelogy Technician")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/explorer
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
-
 	allowed_ranks = list(
 		/datum/mil_rank/ec/e3,
 		/datum/mil_rank/ec/e5
@@ -1092,6 +1092,7 @@
 	alt_titles = list(
 		"Engineer Trainee",
 		"Corpsman Trainee",
+		"Mass Communication Specialist",
 		)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Saw this [thread](https://forums.baystation12.net/threads/add-alternative-explorer-job-titels.6492/), liked the idea, but not the suggestions, so I decided to do it my way. Explorers get alt-titles that imply a specialization in one of the activities explorers are meant to conduct planetside.

New Explorer alt-titles:
- Geography Technician: records the local terrain characteristics, maps things;
- Geology Technician: records the local terrain's composition, notes down mineral deposits;
- Meteorology Technician: records the local atmosphere composition, notes down weather patterns;
- Exobiology Technician: records the local animal and plant life, captures specimens;
- Xenoarchaeology Technician: studies civilization remains, analyzes artifacts.

New Crewman alt-title:
- Mass Communication Specialist: basically an enlisted journalist. Documents the Torch's journey. Creates positive propaganda.

I initially meant to have Mass Communication Specialists spawn with a TV camera, recorder, and a bunch of spare tapes, but I can't do that without screwing up their uniform (since both EC and Fleet can have the Crewman role), so they'll just have to get those from the loadout, I guess.