### PR TITLE
Fix Jaunted wizards not moving

### DIFF
--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -20,7 +20,6 @@
 		if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(target))
 			continue
 
-		ADD_TRANSFORMATION_MOVEMENT_HANDLER(target)
 		if(target.buckled)
 			target.buckled.unbuckle_mob()
 		spawn(0)
@@ -53,11 +52,9 @@
 					if(T)
 						if(target.forceMove(T))
 							break
-			DEL_TRANSFORMATION_MOVEMENT_HANDLER(target)
 			target.client.eye = target
 			qdel(animation)
 			qdel(holder)
-
 
 /spell/targeted/ethereal_jaunt/empower_spell()
 	if(!..())
@@ -95,21 +92,24 @@
 /obj/effect/dummy/spell_jaunt/Destroy()
 	// Eject contents if deleted somehow
 	for(var/atom/movable/AM in src)
-		AM.loc = get_turf(src)
+		AM.dropInto(loc)
 	return ..()
 
 /obj/effect/dummy/spell_jaunt/relaymove(var/mob/user, direction)
-	if (!src.canmove || reappearing) return
-	var/turf/newLoc = get_step(src,direction)
+	if (!canmove || reappearing) return
+	var/turf/newLoc = get_step(src, direction)
 	if(!(newLoc.turf_flags & TURF_FLAG_NOJAUNT))
-		loc = newLoc
+		forceMove(newLoc)
 		var/turf/T = get_turf(loc)
 		if(!T.contains_dense_objects())
 			last_valid_turf = T
 	else
 		to_chat(user, "<span class='warning'>Some strange aura is blocking the way!</span>")
-	src.canmove = 0
-	spawn(2) src.canmove = 1
+	canmove = 0
+	addtimer(CALLBACK(src, .proc/allow_move), 2)
+
+/obj/effect/dummy/spell_jaunt/proc/allow_move()
+	canmove = TRUE
 
 /obj/effect/dummy/spell_jaunt/ex_act(blah)
 	return


### PR DESCRIPTION
And also cleans up the code a bit.
Observers following wizards should now be able to keep track of them even during jaunts.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
