### PR TITLE
Adds the instruct verb.

### DIFF
--- a/code/modules/mob/skills/skill_buffs.dm
+++ b/code/modules/mob/skills/skill_buffs.dm
@@ -30,13 +30,9 @@
 /datum/skill_buff/proc/can_buff(mob/target)
 	if(!length(buffs) || !istype(target))
 		return //what are we even buffing?
-	if(too_many_buffs(target))
+	if(target.too_many_buffs(type))
 		return
 	return 1
-
-/datum/skill_buff/proc/too_many_buffs(mob/target)
-	if(limit && (length(target.fetch_buffs_of_type(type, 0)) >= limit))
-		return 1
 
 /datum/skill_buff/proc/remove()
 	var/datum/skillset/my_skillset = skillset
@@ -65,3 +61,9 @@
 	if(duration)
 		addtimer(CALLBACK(buff, /datum/skill_buff/proc/remove), duration)
 	return 1
+
+//Takes a buff type or datum; typing is false here.
+/mob/proc/too_many_buffs(datum/skill_buff/buff_type)
+	var/limit = initial(buff_type.limit)
+	if(limit && (length(fetch_buffs_of_type(buff_type, 0)) >= limit))
+		return 1


### PR DESCRIPTION
:cl:
rscadd: adds the instruct verb. A character with basic leadership and experienced skill X can instruct a character in X from Untrained to Basic. Has a 15 minute cooldown to use; buff lasts all round; max of three buffs on any person. The target has to be close and there's a short timer during which neither party should move.
/:cl:

While my previous PR implementing this and other leadership skills was disliked, I wasn't entirely clear on _why_ it was disliked, and which parts were objectionable. In the interests of getting more useful feedback, I'm going to open several PRs with different possible active skills. If you have issues with these, I'd appreciate a brief explanation of what about them you really dislike, so I can make better skill effects in the future.