### PR TITLE
Adds the "Motivate" verb.

### DIFF
--- a/code/modules/mob/skills/skill_buffs.dm
+++ b/code/modules/mob/skills/skill_buffs.dm
@@ -30,13 +30,9 @@
 /datum/skill_buff/proc/can_buff(mob/target)
 	if(!length(buffs) || !istype(target))
 		return //what are we even buffing?
-	if(too_many_buffs(target))
+	if(target.too_many_buffs(type))
 		return
 	return 1
-
-/datum/skill_buff/proc/too_many_buffs(mob/target)
-	if(limit && (length(target.fetch_buffs_of_type(type, 0)) >= limit))
-		return 1
 
 /datum/skill_buff/proc/remove()
 	var/datum/skillset/my_skillset = skillset
@@ -65,3 +61,9 @@
 	if(duration)
 		addtimer(CALLBACK(buff, /datum/skill_buff/proc/remove), duration)
 	return 1
+
+//Takes a buff type or datum; typing is false here.
+/mob/proc/too_many_buffs(datum/skill_buff/buff_type)
+	var/limit = initial(buff_type.limit)
+	if(limit && (length(fetch_buffs_of_type(buff_type, 0)) >= limit))
+		return 1

--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -52,3 +52,126 @@ GLOBAL_LIST_INIT(skill_verbs, init_subtypes(/datum/skill_verb))
 	cooling_down = 1
 	update_verb()
 	addtimer(CALLBACK(src, .proc/remove_cooldown), cooldown)
+
+/*
+The Motivate verb.
+*/
+/datum/skill_verb/motivate
+	the_verb = /mob/living/carbon/human/proc/motivate
+	cooldown = 10 MINUTES
+
+/datum/skill_verb/motivate/should_have_verb(datum/skillset/given_skillset)
+	if(!ishuman(given_skillset.owner))
+		return
+	return ..()
+
+/datum/skill_verb/motivate/should_see_verb()
+	if(!..())
+		return
+	var/mob/owner = skillset.owner
+	if(owner.mind && player_is_antag(owner.mind))
+		return
+	if(!owner.skill_check(SKILL_MANAGEMENT, SKILL_ADEPT))
+		return
+	return 1
+
+/mob/living/carbon/human/proc/motivate(mob/living/carbon/human/target as mob in oview())
+	set category = "IC"
+	set name = "Motivate"
+	set src = usr
+
+	var/datum/skill_verb/motivate/SV = skillset.fetch_verb_datum(/datum/skill_verb/motivate)
+	if(!SV || !istype(target))
+		return
+	if(src == target)
+		return
+	if(src.incapacitated() || target.incapacitated())
+		return
+
+	if(target.too_many_buffs(/datum/skill_buff/motivate))
+		to_chat(src, "<span class='notice'>\The [target] appears to be highly motivated already.</span>")
+		return
+
+	var/options = list()
+	var/own_leadership = get_skill_value(SKILL_MANAGEMENT)
+	for(var/decl/hierarchy/skill/S in GLOB.skills)
+		if(istype(S, SKILL_MANAGEMENT))
+			continue //No buffing leadership to avoid exploits.
+		if(!target.skill_check(S.type, own_leadership)) //only buff skills below our leadership value.
+			options[S.name] = S
+	var/choice = input(src, "Select skill to motivate \the [target] in:", "Skill select") as null|anything in options
+
+	if(!(choice in options) || !(target in view())) //Check again, might have moved.
+		return
+	if(src.incapacitated() || target.incapacitated())
+		return
+	if(target.too_many_buffs(/datum/skill_buff/motivate))
+		to_chat(src, "<span class='notice'>\The [target] appears to be highly motivated already.</span>")
+		return
+	var/decl/hierarchy/skill/skill = options[choice]
+	if(target.skill_check(skill.type, own_leadership))
+		return //Maybe they got buffed while we waited for input.
+
+	var/duration = 30 MINUTES * (1 + (get_skill_value(SKILL_MANAGEMENT)-SKILL_ADEPT)/(SKILL_MAX-SKILL_ADEPT))
+	target.buff_skill(list(skill.type = 1), duration, /datum/skill_buff/motivate)
+	visible_message(motivate_message(target, skill))
+	SV.set_cooldown()
+
+/mob/living/carbon/human/proc/motivate_message(mob/living/carbon/human/target, decl/hierarchy/skill/skill)
+	. = list()
+	. += "\The [src] gives \the [target] a"
+	. += pick("n inspiring", " riveting", " stirring", " moving")
+	. += " speech, urging them to focus on [skill.name]. The speech features appeals to "
+	var/list/dat = list()
+	if(religion == target.religion)
+		if(religion != "None")
+			dat += "their common religion ([religion])"
+		else
+			dat += "their common lack of spirituality"
+	if(home_system == target.home_system)
+		dat += "their shared home system of [home_system]"
+	if(personal_faction == target.personal_faction)
+		dat += "their commitment to [personal_faction]"
+	if(citizenship == target.citizenship)
+		dat += "their [citizenship] citizenship"
+	if(species == target.species)
+		if(species != all_species[SPECIES_HUMAN])
+			dat += "their [species] heritage"
+		else
+			dat += "their humanity"
+	if(char_branch == target.char_branch)
+		dat += "their experiences in \the [char_branch.name]"
+	switch(target.age)
+		if(0 to 20)
+			dat += "\the [target]'s youth and sense of adventure"
+		if(21 to 35)
+			dat += "\the [target]'s competence and ambition"
+		else
+			dat += "\the [target]'s age and experience"
+	dat += "\the [target]'s sense of duty"
+	dat += "\the [target]'s commitment to the mission"
+	dat = shuffle(dat)
+	dat.Cut(4)
+	. += english_list(dat)
+	. += ". \The [src]'s tone is "
+	. += pick("warm", "steely", "no-bullshit", "caring", "nostalgic", "angry")
+	. += ", and \the [target] appears "
+	. += pick("captivated", "moved", "indifferent", "stoic", "encouraged", "heartened")
+	. += "."
+	. = "<span class='notice'>[JOINTEXT(.)]</span>"
+
+/datum/skill_buff/motivate/
+	limit = 2
+
+/datum/skill_buff/motivate/can_buff(mob/target)
+	if(!..())
+		return
+	if(!ishuman(target))
+		return
+	if(target.mind && player_is_antag(target.mind))
+		return //No motivating antags.
+	return 1
+
+/datum/skill_buff/motivate/remove()
+	to_chat(skillset.owner, "<span class='notice'>You feel some of your motivation wearing off.</span>")
+	..()


### PR DESCRIPTION
:cl:
rscadd: adds the motivate verb. A character with (X, at least trained) leadership can motivate a character in a skill other than leadership, buffing it by one level to a max of X. Has a 10 minute cooldown to use; buff lasts 30-60 minutes; max of two buffs on any person. The target needs to be in view. A message will describe the motivational speech given. Antags and borgs can't be inspired.
/:cl:

While my previous PR implementing this and other leadership skills was disliked, I wasn't entirely clear on _why_ it was disliked, and which parts were objectionable. In the interests of getting more useful feedback, I'm going to open several PRs with different possible active skills. If you have issues with these, I'd appreciate a brief explanation of what about them you really dislike, so I can make better skill effects in the future.