### PR TITLE
Adds the "Call to Attention" verb.

### DIFF
--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -52,3 +52,43 @@ GLOBAL_LIST_INIT(skill_verbs, init_subtypes(/datum/skill_verb))
 	cooling_down = 1
 	update_verb()
 	addtimer(CALLBACK(src, .proc/remove_cooldown), cooldown)
+
+/*
+The Call to Attention verb
+*/
+/datum/skill_verb/attention
+	the_verb = /mob/living/carbon/human/proc/attention
+	cooldown = 5 MINUTES
+
+/datum/skill_verb/attention/should_have_verb(datum/skillset/given_skillset)
+	if(!ishuman(given_skillset.owner))
+		return
+	return ..()
+
+/datum/skill_verb/attention/should_see_verb()
+	if(!..())
+		return
+	var/mob/owner = skillset.owner
+	if(owner.mind && player_is_antag(owner.mind))
+		return
+	if(!owner.skill_check(SKILL_MANAGEMENT, SKILL_PROF))
+		return
+	return 1
+
+/mob/living/carbon/human/proc/attention()
+	set category = "IC"
+	set name = "Call To Attention"
+	set src = usr
+
+	if(incapacitated())
+		return
+	var/datum/skill_verb/attention/SV = skillset.fetch_verb_datum(/datum/skill_verb/attention)
+	if(!SV)
+		return
+
+	usr.visible_message("<span class='danger'><font size=3>\The [src] calls for attention!</font></span>")
+	for(var/mob/living/carbon/human/H in oview())
+		if(!H.incapacitated())
+			H.set_dir(get_dir(H, src))
+
+	SV.set_cooldown()


### PR DESCRIPTION
:cl:
rscadd: adds the call to attention verb. A character with professional leadership skill can call those around them to attention, giving a large message to chat and making everyone face them.
/:cl:

Note that this is very much pared down relative to the previous version, with no stun or silence. Antags are also made to turn.

While my previous PR implementing this and other leadership skills was disliked, I wasn't entirely clear on _why_ it was disliked, and which parts were objectionable. In the interests of getting more useful feedback, I'm going to open several PRs with different possible active skills. If you have issues with these, I'd appreciate a brief explanation of what about them you really dislike, so I can make better skill effects in the future.
