### PR TITLE
Adds the "Say Loudly" verb.

### DIFF
--- a/code/__defines/languages.dm
+++ b/code/__defines/languages.dm
@@ -29,3 +29,7 @@
 #define NO_TALK_MSG  128 // Do not show the "\The [speaker] talks into \the [radio]" message
 #define NO_STUTTER   256 // No stuttering, slurring, or other speech problems
 #define ALT_TRANSMIT 512 // Language is not based on vision or sound (Todo: add this into the say code and use it for the rootspeak languages)
+
+#define SAY_STYLE_ITALIC "<style>.SayStyle{font-style: italic;}</style>"
+#define SAY_STYLE_BIG "<style>.SayStyle{font-size: 3;}</style>"
+#define SAY_STYLE_BOLD "<style>.SayStyle{font-weight: bold;}</style>"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -1,6 +1,6 @@
 // At minimum every mob has a hear_say proc.
 
-/mob/proc/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/proc/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/style, var/mob/speaker, var/sound/speech_sound, var/sound_vol)
 	if(!client)
 		return
 
@@ -18,7 +18,7 @@
 			return
 
 		if (pressure < ONE_ATMOSPHERE*0.4) //sound distortion pressure, to help clue people in that the air is thin, even if it isn't a vacuum yet
-			italics = 1
+			style = SAY_STYLE_ITALIC
 			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
 	if(sleeping || stat == UNCONSCIOUS)
@@ -49,16 +49,13 @@
 		var/mob/living/carbon/human/H = speaker
 		speaker_name = H.GetVoice()
 
-	if(italics)
-		message = "<i>[message]</i>"
-
 	var/track = null
 	if(isghost(src))
 		if(speaker_name != speaker.real_name && speaker.real_name)
 			speaker_name = "[speaker.real_name] ([speaker_name])"
 		track = "([ghost_follow_link(speaker, src)]) "
 		if(get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH && (speaker in view(src)))
-			message = "<b>[message]</b>"
+			style = SAY_STYLE_BOLD
 
 	if(is_deaf())
 		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
@@ -70,7 +67,7 @@
 		if(language)
 			var/nverb = null
 			if(!say_understands(speaker,language) || language.name == LANGUAGE_GALCOM) //Check to see if we can understand what the speaker is saying. If so, add the name of the language after the verb. Don't do this for Galactic Common.
-				on_hear_say("<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, verb)]</span>")
+				on_hear_say("[style]<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, verb)]</span>")
 			else //Check if the client WANTS to see language names.
 				switch(src.get_preference_value(/datum/client_preference/language_display))
 					if(GLOB.PREF_FULL) // Full language name
@@ -79,10 +76,10 @@
 						nverb = "[verb] ([language.shorthand])"
 					if(GLOB.PREF_OFF)//Regular output
 						nverb = verb
-				on_hear_say("<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, nverb)]</span>")
+				on_hear_say("[style]<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, nverb)]</span>")
 
 		else
-			on_hear_say("<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
+			on_hear_say("[style]<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][verb], <span class='message body SayStyle'>\"[capitalize(message)]\"</span></span>")
 		if (speech_sound && (get_dist(speaker, src) <= world.view && src.z == speaker.z))
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)
 			src.playsound_local(source, speech_sound, sound_vol, 1)

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -6,7 +6,7 @@
 	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
 
 /datum/language/noise/format_message(message, verb)
-	return "<span class='message'><span class='[colour]'>[message]</span></span>"
+	return "<span class='message [colour] SayStyle'>[message]</span>"
 
 /datum/language/noise/format_message_plain(message, verb)
 	return message

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -87,7 +87,7 @@
 	return scrambled_text
 
 /datum/language/proc/format_message(message, verb)
-	return "[verb], <span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
+	return "[verb], <span class='message [colour] SayStyle'>\"[capitalize(message)]\"</span>"
 
 /datum/language/proc/format_message_plain(message, verb)
 	return "[verb], \"[capitalize(message)]\""

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -206,6 +206,8 @@
 		if("whisper") //It's going to get sanitized again immediately, so decode.
 			whisper_say(html_decode(message), speaking, alt_name)
 			return 1
+		if("big") //Doesn't work over radio.
+			return
 		else
 			if(message_mode)
 				if(l_ear && istype(l_ear,/obj/item/device/radio))

--- a/code/modules/mob/living/carbon/xenobiological/say.dm
+++ b/code/modules/mob/living/carbon/xenobiological/say.dm
@@ -24,7 +24,7 @@
 		return 1
 	return ..()
 
-/mob/living/carbon/slime/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/carbon/slime/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/style, var/mob/speaker, var/sound/speech_sound, var/sound_vol)
 	if (speaker in Friends)
 		speech_buffer = list()
 		speech_buffer.Add(speaker)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -10,6 +10,7 @@ var/list/department_radio_keys = list(
 	  ":e" = "Engineering", ".e" = "Engineering",
 	  ":s" = "Security",	".s" = "Security",
 	  ":w" = "whisper",		".w" = "whisper",
+	  ":b" = "big",         ".b" = "big",
 	  ":t" = "Mercenary",	".t" = "Mercenary",
 	  ":x" = "Raider",		".x" = "Raider",
 	  ":u" = "Supply",		".u" = "Supply",
@@ -28,6 +29,7 @@ var/list/department_radio_keys = list(
 	  ":E" = "Engineering",	".E" = "Engineering",
 	  ":S" = "Security",	".S" = "Security",
 	  ":W" = "whisper",		".W" = "whisper",
+	  ":B" = "big",         ".B" = "big",
 	  ":T" = "Mercenary",	".T" = "Mercenary",
 	  ":X" = "Raider",		".X" = "Raider",
 	  ":U" = "Supply",		".U" = "Supply",
@@ -212,16 +214,19 @@ proc/get_radio_key_from_channel(var/channel)
 	var/sound/speech_sound = handle_v[1]
 	var/sound_vol = handle_v[2]
 
-	var/italics = 0
+	var/style
 	var/message_range = world.view
 
+	if((message_mode == "big") && skill_check(SKILL_MANAGEMENT, SKILL_EXPERT))
+		style = SAY_STYLE_BIG
+
 	if(whispering)
-		italics = 1
+		style = SAY_STYLE_ITALIC
 		message_range = 1
 
 	//speaking into radios
 	if(used_radios.len)
-		italics = 1
+		style = SAY_STYLE_ITALIC
 		message_range = 1
 		if(speaking)
 			message_range = speaking.get_talkinto_msg_range(message)
@@ -256,7 +261,7 @@ proc/get_radio_key_from_channel(var/channel)
 			message_range = 1
 
 		if (pressure < ONE_ATMOSPHERE*0.4) //sound distortion pressure, to help clue people in that the air is thin, even if it isn't a vacuum yet
-			italics = 1
+			style = SAY_STYLE_ITALIC
 			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
 		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj, /datum/client_preference/ghost_ears)
@@ -281,7 +286,7 @@ proc/get_radio_key_from_channel(var/channel)
 	var/list/speech_bubble_recipients = list()
 	for(var/mob/M in listening)
 		if(M)
-			M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+			M.hear_say(message, verb, speaking, alt_name, style, src, speech_sound, sound_vol)
 			if(M.client)
 				speech_bubble_recipients += M.client
 
@@ -302,7 +307,7 @@ proc/get_radio_key_from_channel(var/channel)
 		for(var/mob/M in eavesdroping)
 			if(M)
 				show_image(M, speech_bubble)
-				M.hear_say(stars(message), verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+				M.hear_say(stars(message), verb, speaking, alt_name, style, src, speech_sound, sound_vol)
 
 		for(var/obj/O in eavesdroping)
 			spawn(0)

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -10,7 +10,7 @@
 	var/list/allowed_targets = list() //WHO CAN I KILL D:
 	var/retribution = 1 //whether or not they will attack us if we attack them like some kinda dick.
 
-/mob/living/simple_animal/hostile/commanded/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/simple_animal/hostile/commanded/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/style, var/mob/speaker, var/sound/speech_sound, var/sound_vol)
 	if((weakref(speaker) in friends) || speaker == master)
 		command_buffer.Add(speaker)
 		command_buffer.Add(lowertext(html_decode(message)))

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -62,7 +62,7 @@
 			if(3)
 				src.visible_message("<span class='danger'>\The [src] snaps at the air!</span>")
 
-/mob/living/simple_animal/faithful_hound/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/simple_animal/faithful_hound/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/style, var/mob/speaker, var/sound/speech_sound, var/sound_vol)
 	if(password && findtext(message,password))
 		allowed_mobs |= speaker
 		spawn(10)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -717,7 +717,7 @@
 	..(message)
 
 
-/mob/living/simple_animal/parrot/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null)
+/mob/living/simple_animal/parrot/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/style, var/mob/speaker)
 	if(prob(50))
 		parrot_hear(message)
 	..()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -553,7 +553,7 @@
 /mob/new_player/is_ready()
 	return ready && ..()
 
-/mob/new_player/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null)
+/mob/new_player/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/syle, var/mob/speaker)
 	return
 
 /mob/new_player/hear_radio(var/message, var/verb="says", var/datum/language/language=null, var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0)

--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -52,3 +52,31 @@ GLOBAL_LIST_INIT(skill_verbs, init_subtypes(/datum/skill_verb))
 	cooling_down = 1
 	update_verb()
 	addtimer(CALLBACK(src, .proc/remove_cooldown), cooldown)
+
+/*
+The Say Loudly verb. Same effect as using :b.
+*/
+
+/datum/skill_verb/say_loudly
+	the_verb = /mob/living/proc/say_loudly
+
+/datum/skill_verb/say_loudly/should_have_verb(datum/skillset/given_skillset)
+	if(!isliving(given_skillset.owner))
+		return
+	return ..()
+
+/datum/skill_verb/say_loudly/should_see_verb()
+	if(!..())
+		return
+	if(!skillset.owner.skill_check(SKILL_MANAGEMENT, SKILL_EXPERT))
+		return
+	return 1
+
+/mob/living/proc/say_loudly()
+	set category = "IC"
+	set name = "Say Loudly"
+	set src = usr
+
+	var/message = input(src, null, "Say Loudly \"text\"") as null|text
+	if(message)
+		say(":b[message]")

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -42,12 +42,12 @@
 	return owner.examine(user, distance, infix, suffix)
 
 // Relay some stuff they hear
-/mob/zshadow/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/zshadow/hear_say(var/message, var/verb = "says", var/datum/language/language, var/alt_name = "", var/style, var/mob/speaker, var/sound/speech_sound, var/sound_vol)
 	if(speaker && speaker.z != src.z)
 		return // Only relay speech on our actual z, otherwise we might relay sounds that were themselves relayed up!
 	if(isliving(owner))
 		verb += " from above"
-	return owner.hear_say(message, verb, language, alt_name, italics, speaker, speech_sound, sound_vol)
+	return owner.hear_say(message, verb, language, alt_name, style, speaker, speech_sound, sound_vol)
 
 /mob/zshadow/proc/sync_icon(var/mob/M)
 	var/lay = src.layer


### PR DESCRIPTION
:cl:
rscadd: Adds the "Say Loudly" verb. A character with leadership of at least Experienced will be able to say messages in a larger font, either using Say Loudly from the IC tab or by using the ":b" code at the front of the message. Text is displayed in a larger font.
/:cl:

Does not work over radio.

Yes, I know the implementation is crap, but I couldn't figure out a clean way of doing it with how say code works.

Fixes lack of auto-capitalization in whispering as well.