### PR TITLE
Fixes forced ambience constantly restarting

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -262,18 +262,12 @@ var/list/mob/living/forced_ambiance_list = new
 			thunk(L)
 		L.update_floating()
 
-	L.lastarea = newarea
 	play_ambience(L)
-
+	L.lastarea = newarea
+	
 /area/proc/play_ambience(var/mob/living/L)
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
 	if(!(L && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))	return
-
-
-	// If we previously were in an area with force-played ambiance, stop it.
-	if(L in forced_ambiance_list)
-		sound_to(L, sound(null, channel = 1))
-		forced_ambiance_list -= L
 
 	var/turf/T = get_turf(L)
 	var/hum = 0
@@ -282,7 +276,6 @@ var/list/mob/living/forced_ambiance_list = new
 			if(vent.can_pump())
 				hum = 1
 				break
-
 	if(hum)
 		if(!L.client.ambience_playing)
 			L.client.ambience_playing = 1
@@ -291,18 +284,17 @@ var/list/mob/living/forced_ambiance_list = new
 		if(L.client.ambience_playing)
 			L.client.ambience_playing = 0
 			sound_to(L, sound(null, channel = 2))
-
-	if(forced_ambience)
-		if(forced_ambience.len)
+	
+	if(L.lastarea != src)
+		if(LAZYLEN(forced_ambience))
 			forced_ambiance_list |= L
 			L.playsound_local(T,sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = 1))
-		else
+		else	//stop any old area's forced ambience, and try to play our non-forced ones
 			sound_to(L, sound(null, channel = 1))
-	else if(src.ambience.len && prob(35))
-		if((world.time >= L.client.played + 3 MINUTES))
-			var/sound = pick(ambience)
-			L.playsound_local(T, sound(sound, repeat = 0, wait = 0, volume = 15, channel = 1))
-			L.client.played = world.time
+			forced_ambiance_list -= L
+			if(ambience.len && prob(35) && (world.time >= L.client.played + 3 MINUTES))
+				L.playsound_local(T, sound(pick(ambience), repeat = 0, wait = 0, volume = 15, channel = 1))
+				L.client.played = world.time
 
 /area/proc/gravitychange(var/gravitystate = 0)
 	has_gravity = gravitystate


### PR DESCRIPTION
Now only reset forced ambience when we need to

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
