### PR TITLE
Removes the time restriction on the following jobs: Explorer, Corpsman, Deck Technician, and Scientist.

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -457,7 +457,6 @@
 	spawn_positions = 3
 	supervisors = "the Commanding Officer, Executive Officer, and Pathfinder"
 	selection_color = "#68099e"
-	minimal_player_age = 4
 	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/explorer
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
@@ -797,7 +796,6 @@
 
 /datum/job/doctor
 	title = "Corpsman"
-	minimal_player_age = 7
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Chief Medical Officer"
@@ -959,7 +957,6 @@
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Deck Officer and Executive Officer"
-	minimal_player_age = 3
 	ideal_character_age = 24
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
 	allowed_branches = list(
@@ -1167,7 +1164,6 @@
 	spawn_positions = 6
 	supervisors = "the Research Director"
 	economic_modifier = 10
-	minimal_player_age = 7
 	ideal_character_age = 45
 	alt_titles = list(
 		"Xenoarcheologist",


### PR DESCRIPTION
:cl:
rscdel: Removed the time restriction on the following jobs: Explorer, Corpsman, Deck Technician, and Scientist.
/:cl:

The result of [this topic](https://forums.baystation12.net/threads/ease-up-on-player-age-times.6581/), though it's the bare minimum on what everyone (seemed to) agreed.

I believe it's more or less safe to remove the time restriction on these jobs as

1) Most people who come to Bay are not new to SS13 (we are not listed)
2) They cannot easily grief that would end the round for everyone or some people (i.e. engineers, pathfinders marooning an entire away mission or just security in general)
3) At least who I talked with, they tried out Bay because of the away missions or milRP

And if they fail at milRP, we have a heck ton of roles and officers to correct them in-game.

I don't mind entirely green corpsmen and I don't think a first-time DT could do too much harm either (unless it is intentional). Scientists are more or less the same as on any other servers and I'd encourage people joining away missions from the get-go.

For further explanation, read the topic.