### PR TITLE
Wrecks constant brainfixing meta

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -71,7 +71,7 @@
 
 //Blood levels. These are percentages based on the species blood_volume far.
 #define BLOOD_VOLUME_SAFE    85
-#define BLOOD_VOLUME_OKAY    75
+#define BLOOD_VOLUME_OKAY    70
 #define BLOOD_VOLUME_BAD     60
-#define BLOOD_VOLUME_SURVIVE 40
+#define BLOOD_VOLUME_SURVIVE 30
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -120,6 +120,11 @@
 /obj/item/organ/internal/proc/is_bruised()
 	return damage >= min_bruised_damage
 
+/obj/item/organ/internal/proc/set_max_damage(var/ndamage)
+	max_damage = Floor(ndamage)
+	min_broken_damage = Floor(0.75 * max_damage)
+	min_bruised_damage = Floor(0.25 * max_damage)
+
 /obj/item/organ/internal/take_damage(amount, var/silent=0)
 	if(isrobotic())
 		damage = between(0, src.damage + (amount * 0.8), max_damage)
@@ -162,3 +167,22 @@
 		return
 	if(damage < 0.1*max_damage)
 		heal_damage(0.1)
+
+/obj/item/organ/internal/proc/surgical_fix(mob/user)
+	if(damage > min_broken_damage)
+		var/scarring = damage/max_damage
+		scarring = 1 - max(0.2, scarring*scarring)
+		var/new_max_dam = Floor(scarring * max_damage)
+		if(new_max_dam < max_damage)
+			to_chat(user, "<span class='warning'>Not every part of [src] could be saved, some dead tissue had to be removed, making it more suspectable to damage in the future.</span>")
+			set_max_damage(new_max_dam)
+	heal_damage(damage)
+
+/obj/item/organ/internal/proc/get_scarring_level()
+	. = (initial(max_damage) - max_damage)/initial(max_damage)
+
+/obj/item/organ/internal/get_scan_results()
+	. = ..()
+	var/scar_level = get_scarring_level()
+	if(scar_level > 0.01)
+		. += "[get_wound_severity(get_scarring_level())] scarring"

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -49,16 +49,18 @@
 
 /obj/item/organ/internal/brain/New(var/mob/living/carbon/holder)
 	..()
-	max_damage = 200
 	if(species)
-		max_damage = species.total_health
-	min_bruised_damage = max_damage*0.25
-	min_broken_damage = max_damage*0.75
+		set_max_damage(species.total_health)
+	else
+		set_max_damage(200)
 
-	damage_threshold_value = round(max_damage / damage_threshold_count)
 	spawn(5)
 		if(brainmob && brainmob.client)
 			brainmob.client.screen.len = null //clear the hud
+
+/obj/item/organ/internal/brain/set_max_damage(var/ndamage)
+	..()
+	damage_threshold_value = round(max_damage / damage_threshold_count)
 
 /obj/item/organ/internal/brain/Destroy()
 	QDEL_NULL(brainmob)
@@ -215,6 +217,8 @@
 					damprob = owner.chem_effects[CE_STABLE] ? 80 : 100
 					if(prob(damprob))
 						take_damage(1)
+					if(prob(damprob))
+						take_damage(1)
 	..()
 
 /obj/item/organ/internal/brain/take_damage(var/damage)
@@ -270,3 +274,13 @@
 		if(!owner.lying)
 			to_chat(owner, "<span class='danger'>You black out!</span>")
 		owner.Paralyse(10)
+
+/obj/item/organ/internal/brain/surgical_fix(mob/user)
+	var/blood_volume = owner.get_blood_oxygenation()
+	if(blood_volume < BLOOD_VOLUME_SURVIVE)
+		to_chat(user, "<span class='danger'>Parts of [src] didn't survive the procedure due to lack of air supply!</span>")
+		set_max_damage(Floor(max_damage - 0.25*damage))
+	heal_damage(damage)
+
+/obj/item/organ/internal/brain/get_scarring_level()
+	. = (species.total_health - max_damage)/species.total_health

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -92,7 +92,7 @@
 			else
 				user.visible_message("<span class='notice'>[user] treats damage to [target]'s [I.name] with [tool_name].</span>", \
 				"<span class='notice'>You treat damage to [target]'s [I.name] with [tool_name].</span>" )
-			I.damage = 0
+			I.surgical_fix(user)
 
 /datum/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 

--- a/html/changelogs/chinsky - killmed.yml
+++ b/html/changelogs/chinsky - killmed.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - experiment: "Constantly fixing brain is no longer the pro strat anymore."
+  - rscadd: "When fixing very damaged (broken level or more) organs in surgery, their max health is lowered."
+  - rscadd: "Brains get their health lowered /always/ if oxygenation is below survival level (30%). Better fix cause of damage first, if you don't want to do permanent damage."


### PR DESCRIPTION
Adds downsides to repedeately fixing brain of a dying guy. Now if you don't restore oxygenation first, you'll be dealing permanent damage (lowering brain's max damage) every time, by 25% of damage you heal.

Similar thing on lower scale happens to all internal organs now, if they're past 'broken' level, oxygenation isn't considered.

Also rejiggered some numbers with blood levels and braindeath speed. Now OH FUCK WE ARE DYING level is 30% of blood rather than 40%, but on other hand when you go below that level, braindamage is accumulated faster. Should address common complaints about people dying for too long, now if you're out of blood or your heart is stopped, you're on fast track to promotion to other world.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
