### PR TITLE
Adds mappable paint object

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -12,3 +12,38 @@
 	icon_state = "empty"
 	name = "Geas"
 	desc = "You can't resist."
+
+//Paints the wall it spawns on, then dies
+/obj/effect/paint
+	name = "coat of paint"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "white"
+	plane = TURF_PLANE
+	layer = TURF_DETAIL_LAYER
+	blend_mode = BLEND_MULTIPLY
+
+/obj/effect/paint/Initialize()
+	..()
+	var/turf/simulated/wall/W = get_turf(src)
+	if(istype(W))
+		W.paint_color = color
+		W.update_icon()
+	var/obj/structure/wall_frame/WF = locate() in loc
+	if(WF)
+		WF.color = color
+	return INITIALIZE_HINT_QDEL
+
+/obj/effect/paint/pink
+	color = COLOR_PINK
+
+/obj/effect/paint/sun
+	color = COLOR_SUN
+
+/obj/effect/paint/red
+	color = COLOR_RED
+
+/obj/effect/paint/silver
+	color = COLOR_SILVER
+
+/obj/effect/paint/black
+	color = COLOR_DARK_GRAY

--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -132,3 +132,9 @@ Weapons
 
 /obj/item/ammo_magazine/mc9mm/oneway
 	initial_ammo = 1
+
+/obj/effect/paint/hull
+	color = COLOR_HULL
+	
+/obj/effect/paint/expeditionary
+	color = "#68099e"

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -571,9 +571,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "bB" = (
-/obj/machinery/light/spot{
-	pixel_y = 32
-	},
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cockpit)
 "bC" = (
@@ -586,12 +584,11 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
-"bD" = (
-/turf/simulated/wall/titanium,
-/area/exploration_shuttle/cockpit)
 "bE" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/crew)
 "bF" = (
@@ -604,13 +601,8 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
-/area/exploration_shuttle/crew)
-"bG" = (
-/obj/machinery/light/spot{
-	pixel_y = 32
-	},
-/turf/simulated/wall/titanium,
 /area/exploration_shuttle/crew)
 "bH" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -820,6 +812,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
 "ch" = (
@@ -844,10 +837,6 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/exploration_shuttle/cockpit)
-"ck" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
 "cl" = (
 /obj/structure/bed/chair,
@@ -1231,6 +1220,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/crew)
 "da" = (
@@ -1729,10 +1719,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
-"ec" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/plating,
-/area/exploration_shuttle/crew)
 "ed" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -2077,6 +2063,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/airlock)
 "eM" = (
@@ -2139,7 +2126,16 @@
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/airlock)
 "eP" = (
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "calypso_shutters";
+	name = "Protective Shutters";
+	opacity = 0
+	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/airlock)
 "eQ" = (
@@ -2204,6 +2200,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/airlock)
 "eV" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/airlock)
 "eW" = (
@@ -3575,6 +3572,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/airlock)
 "hA" = (
@@ -3582,6 +3580,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/airlock)
 "hB" = (
@@ -4005,6 +4004,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
 "iu" = (
@@ -4105,6 +4105,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
 "iC" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
 "iD" = (
@@ -4461,6 +4462,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
 "jw" = (
@@ -4511,6 +4513,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
 "jB" = (
@@ -6208,6 +6211,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
 "mM" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/atmos)
 "mN" = (
@@ -6240,6 +6244,7 @@
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cargo)
 "mP" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/power)
 "mQ" = (
@@ -7668,6 +7673,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "pr" = (
@@ -9706,6 +9712,7 @@
 /area/exploration_shuttle/power)
 "te" = (
 /obj/structure/fuel_port,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/power)
 "tf" = (
@@ -15381,6 +15388,7 @@
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
 "Ds" = (
+/obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
 "Dt" = (
@@ -15391,6 +15399,7 @@
 /area/guppy_hangar/start)
 "Du" = (
 /obj/structure/fuel_port,
+/obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
 "Dv" = (
@@ -18304,6 +18313,7 @@
 "Jv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "Jw" = (
@@ -19286,6 +19296,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/unused)
+"TT" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/guppy_hangar/start)
 "Uq" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -19320,6 +19334,11 @@
 "Vr" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/aft)
+"Vt" = (
+/obj/effect/paint/black,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/atmos)
 "VO" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
@@ -19429,6 +19448,16 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/quartermaster/office)
+"Yc" = (
+/obj/effect/paint/black,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/power)
+"Ye" = (
+/obj/effect/paint/black,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/cargo)
 "Yp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
@@ -40342,7 +40371,7 @@ bB
 cg
 cg
 cg
-bD
+bB
 eK
 fD
 gB
@@ -40357,7 +40386,7 @@ pe
 qq
 mM
 mM
-mM
+Vt
 we
 ti
 bi
@@ -40544,7 +40573,7 @@ bC
 ch
 cP
 dw
-bD
+bB
 eL
 fE
 eL
@@ -40746,7 +40775,7 @@ bC
 ci
 cQ
 dx
-bD
+bB
 eM
 fF
 gC
@@ -40948,7 +40977,7 @@ bC
 cj
 cR
 dy
-bD
+bB
 eN
 fG
 gD
@@ -40963,7 +40992,7 @@ ph
 qt
 mM
 mM
-mM
+Vt
 we
 ti
 bi
@@ -41146,11 +41175,11 @@ Qd
 Qd
 aE
 bd
-bD
-ck
+bB
+cg
 cS
-ck
-bD
+cg
+bB
 eO
 fH
 gE
@@ -41353,9 +41382,9 @@ cl
 cT
 dz
 bE
-eP
+eL
 fI
-eP
+eL
 eV
 ix
 iA
@@ -41958,7 +41987,7 @@ bF
 co
 cW
 dC
-ec
+bF
 eS
 fL
 gH
@@ -41973,7 +42002,7 @@ pm
 iC
 iC
 iC
-iC
+Ye
 we
 ti
 bi
@@ -42183,16 +42212,16 @@ bi
 bi
 bd
 Ds
-Ds
+TT
 Fe
 FN
-Ds
-Ds
-Ds
-Ds
-Ds
-Ds
-Ds
+TT
+TT
+TT
+TT
+TT
+TT
+TT
 we
 Kb
 Qd
@@ -42388,13 +42417,13 @@ Dt
 Er
 Ff
 FO
-Ds
+TT
 Hd
 HG
 Ih
 Iw
 Ja
-Ds
+TT
 JN
 Ke
 Qd
@@ -42560,7 +42589,7 @@ Qd
 Qd
 aF
 bg
-bG
+bE
 bE
 cZ
 bE
@@ -42579,7 +42608,7 @@ pp
 qz
 mP
 te
-mP
+Yc
 we
 ti
 bi
@@ -42792,13 +42821,13 @@ Dt
 Er
 Fh
 FQ
-Ds
+TT
 Hf
 HI
 Ij
 Iy
 Jc
-Ds
+TT
 we
 Kf
 Qd
@@ -42991,16 +43020,16 @@ bi
 bi
 bd
 Du
-Ds
+TT
 Fi
-Ds
-Ds
-Ds
-Ds
-Ds
-Ds
-Ds
-Ds
+TT
+TT
+TT
+TT
+TT
+TT
+TT
+TT
 we
 Kf
 Qd

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -1331,6 +1331,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"dl" = (
+/obj/effect/paint/silver,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "dm" = (
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_foyer)
@@ -1606,6 +1611,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ec" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/cockpit)
 "ed" = (
@@ -2678,6 +2684,7 @@
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_outer_chamber)
 "gw" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
 "gz" = (
@@ -6350,6 +6357,11 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cos)
+"nT" = (
+/obj/effect/paint/silver,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/storage)
 "nU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6740,6 +6752,7 @@
 /area/maintenance/bridge/aftport)
 "oU" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/medical)
 "oW" = (
@@ -11749,6 +11762,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"zm" = (
+/obj/effect/paint/hull,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
+"zP" = (
+/obj/effect/paint/hull,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "Ab" = (
 /obj/effect/shuttle_landmark/merc/deck5,
 /turf/space,
@@ -11812,6 +11835,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/passenger)
 "Ah" = (
@@ -11995,8 +12019,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "BO" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"BX" = (
+/obj/effect/paint/silver,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/passenger)
 "Cb" = (
 /obj/effect/shuttle_landmark/torch/deck5/aquila,
 /turf/space,
@@ -12113,6 +12143,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/airlock)
 "CN" = (
@@ -12132,6 +12163,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/maintenance/bridge/aftport)
+"CW" = (
+/obj/effect/paint/silver,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/head)
 "Db" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Head";
@@ -12260,6 +12296,7 @@
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/bridge/aft)
 "DR" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/head)
 "Eb" = (
@@ -12504,8 +12541,14 @@
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
 "FK" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
+"FX" = (
+/obj/effect/paint/hull,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "Gb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12531,6 +12574,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/head)
 "Gd" = (
@@ -13076,6 +13120,7 @@
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
 "Ic" = (
@@ -13524,6 +13569,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"Jt" = (
+/obj/effect/paint/silver,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "JA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13570,6 +13620,7 @@
 /area/aquila/passenger)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
 "Kd" = (
@@ -13661,6 +13712,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"KR" = (
+/obj/effect/paint/hull,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "Lb" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Research Director - Office";
@@ -14208,6 +14264,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
 "Ov" = (
@@ -14488,9 +14545,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
 "QF" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/passenger)
 "QL" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/storage)
 "Rb" = (
@@ -14785,6 +14844,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
 "SE" = (
@@ -15402,6 +15462,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Ww" = (
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
 "Xb" = (
@@ -15513,6 +15574,7 @@
 /area/security/bridgecheck)
 "Xp" = (
 /obj/structure/sign/solgov,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
 "Xz" = (
@@ -15520,6 +15582,7 @@
 /area/crew_quarters/heads/cobed)
 "XI" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/airlock)
 "Yb" = (
@@ -33024,14 +33087,14 @@ Ug
 DN
 QL
 QL
+nT
 QL
 QL
-QL
 BO
 BO
+dl
 BO
-BO
-BO
+KR
 vL
 cP
 ah
@@ -33219,7 +33282,7 @@ ad
 gY
 DR
 DR
-DR
+CW
 Gc
 Xp
 Vg
@@ -33835,11 +33898,11 @@ QL
 Sb
 QL
 QL
+zm
 BO
 BO
 BO
-BO
-BO
+KR
 vL
 cP
 ah
@@ -34242,7 +34305,7 @@ ry
 so
 sY
 Ww
-Ww
+zP
 vL
 ad
 cP
@@ -35050,7 +35113,7 @@ Yb
 zc
 Dc
 Ww
-Ww
+zP
 vL
 ad
 cP
@@ -35455,7 +35518,7 @@ gw
 gw
 gw
 gw
-gw
+FX
 vL
 cP
 ah
@@ -36047,7 +36110,7 @@ ad
 gY
 QF
 QF
-QF
+BX
 Ag
 Ag
 QF
@@ -36256,14 +36319,14 @@ eg
 nr
 gw
 gw
+Jt
 gw
 gw
 gw
 gw
+Jt
 gw
-gw
-gw
-gw
+FX
 vL
 cP
 ah


### PR DESCRIPTION


![](https://i.imgur.com/Cx5kUs4.png)
It automagically paints walls/wallframes and poofs.
Used it to paint shuttles on torch, in same boring hull color as Torch + red bits where engines are

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
