### PR TITLE
Removes the anaesthetics closet, rearranges the contents of a few containers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -4,9 +4,9 @@
 
 /obj/structure/closet/secure_closet/freezer/kitchen/WillContain()
 	return list(
+		/obj/item/weapon/reagent_containers/food/condiment/salt = 1,
 		/obj/item/weapon/reagent_containers/food/condiment/flour = 7,
-		/obj/item/weapon/reagent_containers/food/condiment/sugar = 2,
-		/obj/item/weapon/reagent_containers/food/condiment/salt = 1
+		/obj/item/weapon/reagent_containers/food/condiment/sugar = 2
 	)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining

--- a/code/game/objects/structures/crates_lockers/med_crate.dm
+++ b/code/game/objects/structures/crates_lockers/med_crate.dm
@@ -8,9 +8,9 @@
 /obj/structure/closet/crate/med_crate/trauma/WillContain()
 	return list(
 		/obj/item/stack/medical/splint = 2,
+		/obj/item/stack/medical/advanced/bruise_pack = 10,
 		/obj/item/weapon/reagent_containers/pill/sugariron = 6,
 		/obj/item/weapon/storage/pill_bottle/paracetamol = 2,
-		/obj/item/stack/medical/advanced/bruise_pack = 10,
 		/obj/item/weapon/storage/pill_bottle/inaprovaline
 		)
 
@@ -23,11 +23,11 @@
 
 /obj/structure/closet/crate/med_crate/burn/WillContain()
 	return list(
+		/obj/item/weapon/defibrillator/loaded,
+		/obj/item/stack/medical/advanced/ointment = 10,
 		/obj/item/weapon/storage/pill_bottle/kelotane,
 		/obj/item/weapon/storage/pill_bottle/tramadol = 2,
-		/obj/item/weapon/storage/pill_bottle/spaceacillin,
-		/obj/item/stack/medical/advanced/ointment = 10,
-		/obj/item/weapon/defibrillator/loaded
+		/obj/item/weapon/storage/pill_bottle/spaceacillin
 	)
 
 /obj/structure/closet/crate/med_crate/oxyloss
@@ -39,9 +39,9 @@
 
 /obj/structure/closet/crate/med_crate/oxyloss/WillContain()
 	return list(
+		/obj/item/device/healthanalyzer = 2,
 		/obj/item/weapon/storage/pill_bottle/dexalin = 2,
-		/obj/item/weapon/storage/pill_bottle/inaprovaline,
-		/obj/item/device/healthanalyzer = 2
+		/obj/item/weapon/storage/pill_bottle/inaprovaline
 	)
 /obj/structure/closet/crate/med_crate/toxin
 	name = "\improper Toxin crate"

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -195,14 +195,6 @@
 "as" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/disposal)
-"at" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/weapon/storage/box/autoinjectors,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/box/bodybags,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/storage/medical)
 "au" = (
 /obj/structure/sign/warning/vent_port,
 /turf/simulated/wall/r_wall/hull,
@@ -37283,7 +37275,7 @@ aa
 aB
 bn
 bq
-at
+bq
 db
 ee
 Ge


### PR DESCRIPTION
:cl:
maptweak: Reorganized the kitchen cabinet and the crates in the Medical Storage (the big bag of salt and the defibrillator are no longer blocking everything else).
maptweak: Removed the anaesthetics closet from the Medical Storage.
/ :cl:

* The contents are rearranged because the sprites of the bag of salt and the defibrillator were blocking everything below them (a few people were complaining about it, guess it didn't hurt anyone if I changed it).
* I think the anaesthetics locker is redundant now due to #21690 and #21702. The additional body bags and syringes in it were never moved or used as far as I noticed so they got deleted as well - but do tell me if I should place them back.

The second change is also an attempt to see if I set up map merger correctly because if I did, I could finally help with fixing trivial mapping issues (such as lights over APCs and whatnot). It worked well on locally but do tell me if I messed up somewhere.