### PR TITLE
Removes the leadership skill.

### DIFF
--- a/code/__defines/skills.dm
+++ b/code/__defines/skills.dm
@@ -12,7 +12,6 @@
 #define SKILL_AVERAGE  2
 #define SKILL_HARD     4
 
-#define SKILL_MANAGEMENT    /decl/hierarchy/skill/organizational/management
 #define SKILL_BUREAUCRACY   /decl/hierarchy/skill/organizational/bureaucracy
 #define SKILL_FINANCE       /decl/hierarchy/skill/organizational/finance
 #define SKILL_EVA           /decl/hierarchy/skill/general/EVA

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -70,16 +70,6 @@ GLOBAL_LIST_EMPTY(skills)
 // ONLY SKILL DEFINITIONS BELOW THIS LINE
 // Category: Organizational
 
-/decl/hierarchy/skill/organizational/management
-	ID = "management"
-	name = "Leadership"
-	desc = "Your ability to manage and command other crew members."
-	levels = list( "Unskilled"			= "You know a little about management, but you have a lot of flaws and little experience. You are likely to micromanage, lose track of people, or generally muck things up. Handling a major crisis is probably beyond your ability.",
-						"Basic"				= "You have recieved basic leadership training, but have little experience actually managing people. You can come up with good organizational strategies, but won't know what to do when they fall apart in a crisis.",
-						"Trained"			= "You're a good commander. You know how to coordinate the efforts of a large group of people effectively. You'll still be thrown off in a crisis, but you'll probably get through it.",
-						"Experienced"		= "You're a highly experienced commander. In addition to just doing your job, you know how to inspire love, loyalty or fear, and you handle crises smoothly and efficiently.",
-						"Master"		= "You are an excellent commander. You are listened to instinctively, and can navigate your people through anything thrown at you.")
-
 /decl/hierarchy/skill/organizational/bureaucracy
 	ID = "bureaucracy"
 	name = "Bureaucracy"

--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -70,9 +70,9 @@ Robots and antags can instruct.
 /datum/skill_verb/instruct/should_see_verb()
 	if(!..())
 		return
-	if(!skillset.owner.skill_check(SKILL_MANAGEMENT, SKILL_BASIC))
-		return
-	return 1
+	for(var/decl/hierarchy/skill/S in GLOB.skills)
+		if(skillset.owner.skill_check(S.type, SKILL_EXPERT))
+			return 1
 
 /mob/proc/instruct(mob/living/carbon/human/target as mob in oview(2))
 	set category = "IC"
@@ -93,8 +93,6 @@ Robots and antags can instruct.
 
 	var/options = list()
 	for(var/decl/hierarchy/skill/S in GLOB.skills)
-		if(istype(S, SKILL_MANAGEMENT))
-			continue
 		if(!target.skill_check(S.type, SKILL_BASIC) && skill_check(S.type, SKILL_EXPERT))
 			options[S.name] = S
 	var/choice = input(src, "Select skill to instruct \the [target] in:", "Skill select") as null|anything in options
@@ -102,7 +100,7 @@ Robots and antags can instruct.
 		return
 	var/decl/hierarchy/skill/skill = options[choice]
 
-	if(!do_skilled(6 SECONDS, SKILL_MANAGEMENT, target))
+	if(!do_skilled(6 SECONDS, skill.type, target))
 		return
 	if(incapacitated() || target.incapacitated())
 		return

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -58,11 +58,10 @@
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o6
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
-						SKILL_BUREAUCRACY = SKILL_BASIC,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_SCIENCE     = SKILL_ADEPT,
 						SKILL_PILOT       = SKILL_ADEPT)
-	skill_points = 40
+	skill_points = 36
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/card_mod,
@@ -89,11 +88,10 @@
 		/datum/mil_rank/fleet/o5,
 		/datum/mil_rank/fleet/o4
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
-						SKILL_BUREAUCRACY = SKILL_ADEPT,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
 						SKILL_COMPUTER    = SKILL_BASIC,
 						SKILL_PILOT       = SKILL_BASIC)
-	skill_points = 40
+	skill_points = 36
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
 			            access_medical, access_morgue, access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -131,15 +129,14 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/rd
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
-						SKILL_BUREAUCRACY = SKILL_ADEPT,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
 						SKILL_COMPUTER    = SKILL_BASIC,
 						SKILL_FINANCE     = SKILL_ADEPT,
 						SKILL_BOTANY      = SKILL_BASIC,
 						SKILL_ANATOMY     = SKILL_BASIC,
 						SKILL_DEVICES     = SKILL_BASIC,
 						SKILL_SCIENCE     = SKILL_ADEPT)
-	skill_points = 40
+	skill_points = 36
 
 	access = list(access_tox, access_tox_storage, access_emergency_storage, access_teleporter, access_heads, access_rd,
 						access_research, access_mining, access_mining_office, access_mining_station, access_xenobiology,
@@ -171,13 +168,12 @@
 		/datum/mil_rank/ec/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
-						SKILL_BUREAUCRACY = SKILL_BASIC,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_MEDICAL     = SKILL_ADEPT,
 						SKILL_ANATOMY     = SKILL_EXPERT,
 						SKILL_CHEMISTRY   = SKILL_BASIC,
 						SKILL_VIROLOGY    = SKILL_BASIC)
-	skill_points = 40
+	skill_points = 36
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_heads,
@@ -209,15 +205,14 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	SKILL_MANAGEMENT   = SKILL_ADEPT,
-						SKILL_BUREAUCRACY  = SKILL_BASIC,
+	min_skill = list(	SKILL_BUREAUCRACY  = SKILL_BASIC,
 						SKILL_COMPUTER     = SKILL_ADEPT,
 						SKILL_EVA          = SKILL_ADEPT,
 						SKILL_CONSTRUCTION = SKILL_ADEPT,
 						SKILL_ELECTRICAL   = SKILL_ADEPT,
 						SKILL_ATMOS        = SKILL_ADEPT,
 						SKILL_ENGINES      = SKILL_EXPERT)
-	skill_points = 32
+	skill_points = 30
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_ai_upload, access_teleporter, access_eva, access_heads,
@@ -259,13 +254,12 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_ADEPT,
-						SKILL_BUREAUCRACY = SKILL_ADEPT,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
 						SKILL_EVA         = SKILL_BASIC,
 						SKILL_COMBAT      = SKILL_BASIC,
 						SKILL_WEAPONS     = SKILL_ADEPT,
 						SKILL_FORENSICS   = SKILL_BASIC)
-	skill_points = 30
+	skill_points = 28
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
 			            access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -359,8 +353,7 @@
 		/datum/mil_rank/fleet/e9_alt1,
 		/datum/mil_rank/fleet/e8
 	)
-	min_skill = list(	SKILL_MANAGEMENT = SKILL_ADEPT,
-						SKILL_EVA        = SKILL_BASIC,
+	min_skill = list(	SKILL_EVA        = SKILL_BASIC,
 						SKILL_COMBAT     = SKILL_BASIC,
 						SKILL_WEAPONS    = SKILL_ADEPT)
 	skill_points = 24
@@ -397,8 +390,7 @@
 		/datum/mil_rank/ec/o1,
 		/datum/mil_rank/fleet/o1
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
-						SKILL_BUREAUCRACY = SKILL_BASIC,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_PILOT       = SKILL_ADEPT)
 	skill_points = 20
 
@@ -437,12 +429,11 @@
 		/datum/mil_rank/ec/o3,
 		/datum/mil_rank/ec/o1
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
-						SKILL_BUREAUCRACY = SKILL_BASIC,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_EVA         = SKILL_ADEPT,
 						SKILL_SCIENCE     = SKILL_ADEPT,
 						SKILL_PILOT       = SKILL_BASIC)
-	skill_points = 24
+	skill_points = 22
 
 	access = list(access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_cent_creed)
 
@@ -497,8 +488,7 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/ec/e5
 	)
-	min_skill = list(	SKILL_MANAGEMENT   = SKILL_BASIC,
-						SKILL_COMPUTER     = SKILL_BASIC,
+	min_skill = list(	SKILL_COMPUTER     = SKILL_BASIC,
 						SKILL_EVA          = SKILL_ADEPT,
 						SKILL_CONSTRUCTION = SKILL_ADEPT,
 						SKILL_ELECTRICAL   = SKILL_ADEPT,
@@ -663,8 +653,7 @@
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e5
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
-						SKILL_BUREAUCRACY = SKILL_ADEPT,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
 						SKILL_EVA         = SKILL_BASIC,
 						SKILL_COMBAT      = SKILL_BASIC,
 						SKILL_WEAPONS     = SKILL_BASIC,
@@ -936,13 +925,12 @@
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8
 	)
-	min_skill = list(	SKILL_MANAGEMENT  = SKILL_BASIC,
-						SKILL_BUREAUCRACY = SKILL_ADEPT,
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
 						SKILL_FINANCE     = SKILL_BASIC,
 						SKILL_HAULING     = SKILL_BASIC,
 						SKILL_EVA         = SKILL_BASIC,
 						SKILL_PILOT       = SKILL_BASIC)
-	skill_points = 20
+	skill_points = 18
 
 	access = list(access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
 						access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar)


### PR DESCRIPTION
:cl:
rscdel: The leadership skill has been removed. Check your characters' skill allocations.
tweak: The instruct verb works like before, but no longer requires leadership skill to use.
/:cl:

Meant as an alternative to some variation on #21835. I included the leadership skill because I had some ideas for what effects it should have. These ideas have mostly turned out to be not very good ones. The skills in game currently are not sacred; they are largely artifacts of a legacy skill system that had different design considerations.