### PR TITLE
Makes borg reagent containers not be inserted into various machines.

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -138,8 +138,8 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 				// Attach
 				else
 					if(istype(I, /obj/item/device/assembly/signaler))
-						L.drop_item()
-						Attach(colour, I)
+						if(L.unEquip(I))
+							Attach(colour, I)
 					else
 						to_chat(L, "<span class='error'>You need a remote signaller!</span>")
 

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -6,9 +6,7 @@
 	// This could use work.
 	if(flags & ANTAG_CLEAR_EQUIPMENT)
 		for(var/obj/item/thing in player.contents)
-			player.drop_from_inventory(thing)
-			if(thing.loc != player)
-				qdel(thing)
+			qdel(thing)
 		//mainly for vox antag compatibility. Should not effect item spawning.
 		player.species.equip_survival_gear(player)
 	return 1

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -31,8 +31,8 @@
 	user.apply_damage(rand(force/2, force), BRUTE, zone, 0, (DAM_SHARP|DAM_EDGE))
 	user.Weaken(5)
 
-	user.drop_from_inventory(src)
-	throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), throw_speed)
+	if(user.unEquip(src))
+		throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), throw_speed)
 
 	var/spooky = pick('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/wail.ogg')
 	playsound(loc, spooky, 50, 1)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -148,10 +148,9 @@
 				qdel(Robot.mmi)
 		else
 			for(var/obj/item/W in M)
+				M.drop_from_inventory(W)
 				if(istype(W, /obj/item/weapon/implant))
 					qdel(W)
-					continue
-				M.drop_from_inventory(W)
 
 		var/mob/living/new_mob = new /mob/living/simple_animal/corgi(A.loc)
 		new_mob.a_intent = I_HURT

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -372,22 +372,17 @@
 	visible_message("<span class='warning'>\The [src] disappears with a flash of red light, and a set of armor appears on \the [user].</span>", "<span class='warning'>You are blinded by the flash of red light. After you're able to see again, you see that you are now wearing a set of armor.</span>")
 
 	var/obj/O = user.get_equipped_item(slot_head) // This will most likely kill you if you are wearing a spacesuit, and it's 100% intended
-	if(O && !istype(O, /obj/item/clothing/head/culthood))
-		user.unEquip(O)
+	if(O && !istype(O, /obj/item/clothing/head/culthood) && user.unEquip(O))
+		user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
 	O = user.get_equipped_item(slot_wear_suit)
-	if(O && !istype(O, /obj/item/clothing/suit/cultrobes))
-		user.unEquip(O)
+	if(O && !istype(O, /obj/item/clothing/suit/cultrobes) && user.unEquip(O))
+		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)	
 	O = user.get_equipped_item(slot_shoes)
-	if(O && !istype(O, /obj/item/clothing/shoes/cult))
-		user.unEquip(O)
-
-	user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
-	user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
-	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
+	if(O && !istype(O, /obj/item/clothing/shoes/cult) && user.unEquip(O))
+		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)	
 
 	O = user.get_equipped_item(slot_back)
-	if(istype(O, /obj/item/weapon/storage) && !istype(O, /obj/item/weapon/storage/backpack/cultpack)) // We don't want to make the vox drop their nitrogen tank, though
-		user.unEquip(O)
+	if(istype(O, /obj/item/weapon/storage) && !istype(O, /obj/item/weapon/storage/backpack/cultpack) && user.unEquip(O)) // We don't want to make the vox drop their nitrogen tank, though
 		var/obj/item/weapon/storage/backpack/cultpack/C = new /obj/item/weapon/storage/backpack/cultpack(user)
 		user.equip_to_slot_or_del(C, slot_back)
 		if(C)

--- a/code/game/gamemodes/godmode/form_items/starlight_items.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_items.dm
@@ -26,9 +26,6 @@
 			if(prob(5))
 				to_chat(loc, "<span class='warning'>\The [src] begins to fade, its power dimming this far away from a shrine.</span>")
 		else if(last_near_structure + 1800 < world.time)
-			if(istype(loc, /mob/living))
-				var/mob/living/L = loc
-				L.drop_from_inventory(src)
 			visible_message("<span class='warning'>\The [src] disintegrates into a pile of ash!</span>")
 			new /obj/effect/decal/cleanable/ash(get_turf(src))
 			qdel(src)

--- a/code/game/gamemodes/godmode/god_altar.dm
+++ b/code/game/gamemodes/godmode/god_altar.dm
@@ -19,11 +19,10 @@
 /obj/structure/deity/altar/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/grab))
 		var/obj/item/grab/G = I
-		if(G.force_danger())
+		if(G.force_danger() && user.unEquip(G))
 			G.affecting.forceMove(get_turf(src))
 			G.affecting.Weaken(1)
 			user.visible_message("<span class='warning'>\The [user] throws \the [G.affecting] onto \the [src]!</span>")
-			user.drop_from_inventory(G)
 	else ..()
 
 /obj/structure/deity/altar/Process()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -82,10 +82,10 @@
 
 	if ((!( istype(O, /obj/item/weapon) ) || user.get_active_hand() != O))
 		return
-	user.drop_item()
+	if(!user.unequip_item())
+		return
 	if (O.loc != src.loc)
 		step(O, get_dir(O, src))
-	return
 
 /obj/machinery/optable/proc/check_victim()
 	if(!victim || !victim.lying || victim.loc != loc)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -136,9 +136,9 @@
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))
 		add_fingerprint(user)
 		if(!beaker)
+			if(!user.unEquip(I, src))
+				return
 			beaker = I
-			user.drop_item()
-			I.forceMove(src)
 			user.visible_message("<span class='notice'>\The [user] adds \a [I] to \the [src].</span>", "<span class='notice'>You add \a [I] to \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>\The [src] has a beaker already.</span>")

--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -145,8 +145,8 @@
 	if (istype(A, /obj/machinery/atmospherics/pipe/simple))
 		to_chat(user, "<span class='notice'>You begin to attach \the [src] to \the [A]...</span>")
 		if (do_after(user, 30, src))
+			if(!user.unEquip(src))
+				return
 			to_chat(user, "<span class='notice'>You have attached \the [src] to \the [A].</span>")
 			new/obj/machinery/clamp(A.loc, A)
-			user.drop_from_inventory(src)
 			qdel(src)
-

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -103,10 +103,9 @@
 	if ((istype(W, /obj/item/weapon/tank) && !( src.destroyed )))
 		if (src.holding)
 			return
-		var/obj/item/weapon/tank/T = W
-		user.drop_item()
-		T.forceMove(src)
-		src.holding = T
+		if(!user.unEquip(W, src))
+			return
+		src.holding = W
 		update_icon()
 		return
 
@@ -156,14 +155,10 @@
 		if(cell)
 			to_chat(user, "There is already a power cell installed.")
 			return
-
-		var/obj/item/weapon/cell/C = I
-
-		user.drop_item()
-		C.add_fingerprint(user)
-		cell = C
-		C.forceMove(src)
-		user.visible_message("<span class='notice'>[user] opens the panel on [src] and inserts [C].</span>", "<span class='notice'>You open the panel on [src] and insert [C].</span>")
+		if(!user.unEquip(I, src))
+			return
+		cell = I
+		user.visible_message("<span class='notice'>[user] opens the panel on \the [src] and inserts \the [I].</span>", "<span class='notice'>You open the panel on \the [src] and insert \the [I].</span>")
 		power_change()
 		return
 
@@ -172,7 +167,7 @@
 			to_chat(user, "<span class='warning'>There is no power cell installed.</span>")
 			return
 
-		user.visible_message("<span class='notice'>[user] opens the panel on [src] and removes [cell].</span>", "<span class='notice'>You open the panel on [src] and remove [cell].</span>")
+		user.visible_message("<span class='notice'>[user] opens the panel on \the [src] and removes \the [cell].</span>", "<span class='notice'>You open the panel on \the [src] and remove \the [cell].</span>")
 		cell.add_fingerprint(user)
 		cell.dropInto(loc)
 		cell = null

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -201,12 +201,10 @@
 	if(istype(eating,/obj/item/stack))
 		var/obj/item/stack/stack = eating
 		stack.use(max(1, round(total_used/mass_per_sheet))) // Always use at least 1 to prevent infinite materials.
-	else
-		user.remove_from_mob(O)
+	else if(user.unEquip(O))
 		qdel(O)
 
 	updateUsrDialog()
-	return
 
 /obj/machinery/autolathe/attack_hand(mob/user as mob)
 	user.set_machine(src)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -79,9 +79,7 @@
 	if(istype(O, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
 			to_chat(user, "<span class='notice'>]The [src] is already loaded.</span>")
-		else
-			user.remove_from_mob(O)
-			O.forceMove(src)
+		else if(user.unEquip(O, src))
 			beaker = O
 			state = BG_READY
 			updateUsrDialog()
@@ -108,9 +106,7 @@
 
 	else if(!istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown))
 		to_chat(user, "<span class='notice'>You cannot put this in \the [src].</span>")
-	else
-		user.remove_from_mob(O)
-		O.forceMove(src)
+	else if(user.unEquip(O, src))
 		ingredients++
 		to_chat(user, "<span class='notice'>You put \the [O] in \the [src]</span>")
 	update_icon()

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -238,11 +238,11 @@
 			if(max_stored_matter == stored_matter)
 				to_chat(user, "<span class='warning'>\The [src] is too full.</span>")
 				return
+			if(!user.unEquip(W))
+				return
 			stored_matter += min(amount_list[path], max_stored_matter - stored_matter)
-			user.drop_item()
 			to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]</span>")
 			qdel(W)
-			return
 
 	// DNA sample from syringe.
 	if(istype(W,/obj/item/weapon/reagent_containers/syringe))

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -124,11 +124,9 @@
 				return
 
 	// Upgrades!
-	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
+	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades) && user.unEquip(W, src)) // Is a possible upgrade and isn't in the camera already.
 		to_chat(user, "You attach \the [W] into the assembly inner circuits.")
 		upgrades += W
-		user.remove_from_mob(W)
-		W.forceMove(src)
 		return
 
 	// Taking out upgrades

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -46,15 +46,12 @@
 			to_chat(user, "<span class='warning'>There is already a cell in the charger.</span>")
 			return
 		else
-			var/area/a = loc.loc // Gets our locations location, like a dream within a dream
-			if(!isarea(a))
-				return
+			var/area/a = get_area(loc)
 			if(a.power_equip == 0) // There's no APC in this area, don't try to cheat power!
 				to_chat(user, "<span class='warning'>The [name] blinks red as you try to insert the cell!</span>")
 				return
-
-			user.drop_item()
-			W.loc = src
+			if(!user.unEquip(W, src))
+				return
 			charging = W
 			user.visible_message("[user] inserts a cell into the charger.", "You insert a cell into the charger.")
 			chargelevel = -1

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -49,13 +49,11 @@
 					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
 					anchored = 0
 					state = 0
-			if(istype(P, /obj/item/weapon/circuitboard/aicore) && !circuit)
+			if(istype(P, /obj/item/weapon/circuitboard/aicore) && !circuit && user.unEquip(P, src))
 				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You place the circuit board inside the frame.</span>")
 				icon_state = "1"
 				circuit = P
-				user.drop_item()
-				P.loc = src
 			if(isScrewdriver(P) && circuit)
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
@@ -152,12 +150,11 @@
 				if(jobban_isbanned(B, "AI"))
 					to_chat(user, "<span class='warning'>This [P] does not seem to fit.</span>")
 					return
-
+				if(!user.unEquip(P, src))
+					return
 				if(B.mind)
 					clear_antag_roles(B.mind, 1)
 
-				user.drop_item()
-				P.loc = src
 				brain = P
 				to_chat(usr, "Added [P].")
 				icon_state = "3b"

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -41,12 +41,12 @@
 			if(istype(P, /obj/item/weapon/circuitboard) && !circuit)
 				var/obj/item/weapon/circuitboard/B = P
 				if(B.board_type == "computer")
+					if(!user.unEquip(P, src))
+						return
 					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You place the circuit board inside the frame.</span>")
 					src.icon_state = "1"
 					src.circuit = P
-					user.drop_item()
-					P.loc = src
 				else
 					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 			if(isScrewdriver(P) && circuit)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -52,11 +52,11 @@
 				if(istype(P, /obj/item/weapon/circuitboard))
 					var/obj/item/weapon/circuitboard/B = P
 					if(B.board_type == "machine")
+						if(!user.unEquip(P, src))
+							return
 						playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 						to_chat(user, "<span class='notice'>You add the circuit board to the frame.</span>")
 						circuit = P
-						user.drop_item()
-						P.loc = src
 						icon_state = "box_2"
 						state = 3
 						components = list()
@@ -132,7 +132,6 @@
 						if(istype(P, /obj/item))
 							for(var/I in req_components)
 								if(istype(P, I) && (req_components[I] > 0))
-									playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 									if(isCoil(P))
 										var/obj/item/stack/cable_coil/CP = P
 										if(CP.get_amount() > 1)
@@ -145,12 +144,13 @@
 											req_components[I] -= camt
 											update_desc()
 											break
-									user.drop_item()
-									P.loc = src
+									if(!user.unEquip(P, src))
+										return
 									components += P
 									req_components[I]--
 									update_desc()
 									break
+							playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 							to_chat(user, desc)
 							if(P && P.loc != src && !istype(P, /obj/item/stack/cable_coil))
 								to_chat(user, "<span class='warning'>You cannot add that component to the machine!</span>")

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -177,10 +177,9 @@
 		if(beaker)
 			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
 			return
-
+		if(!user.unEquip(G, src))
+			return
 		beaker =  G
-		user.drop_item()
-		G.forceMove(src)
 		user.visible_message("[user] adds \a [G] to \the [src]!", "You add \a [G] to \the [src]!")
 	else if(istype(G, /obj/item/grab))
 		if(!ismob(G:affecting))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1023,12 +1023,10 @@ About the new airlock wires panel:
 		if((!A.req_access.len && !A.req_one_access) && (alert("\the [A]'s 'Access Not Set' light is flashing. Install it anyway?", "Access not set", "Yes", "No") == "No"))
 			return
 
-		if(do_after(user, 50, src) && density)
+		if(do_after(user, 50, src) && density && user.unEquip(brace, src))
 			to_chat(user, "You successfully install \the [A]. \The [src] has been locked.")
 			brace = A
 			brace.airlock = src
-			user.drop_from_inventory(brace)
-			brace.forceMove(src)
 			update_icon()
 		return
 

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -131,8 +131,8 @@
 			if(cell)
 				to_chat(user, "There is a power cell already installed.")
 			else
-				user.drop_item()
-				W.loc = src
+				if(!user.unEquip(W, src))
+					return
 				cell = W
 				to_chat(user, "You insert the power cell.")
 	update_icon()

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -44,8 +44,9 @@
 		return
 
 	if(istype(W, /obj/item/stack/tile))
+		if(!user.unEquip(W, T))
+			return
 		to_chat(user, "<span class='notice'>\The [W] successfully loaded.</span>")
-		user.drop_item(T)
 		TakeTile(T)
 		return
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -94,10 +94,12 @@
 		if(!G.force_danger())
 			to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
 			return
+		if(!user.unEquip(W))
+			return
 		move_into_gibber(user,G.affecting)
-		user.drop_from_inventory(G)
 	else if(istype(W, /obj/item/organ))
-		user.drop_from_inventory(W)
+		if(!user.unEquip(W))
+			return
 		qdel(W)
 		user.visible_message("<span class='danger'>\The [user] feeds \the [W] into \the [src], obliterating it.</span>")
 	else

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -114,9 +114,8 @@
 					"<span class='notice'>You add one of [O] to \the [src].</span>")
 			return
 		else
-			if (!user.drop_from_inventory(O))
+			if (!user.unEquip(O, src))
 				return
-			O.forceMove(src)
 			user.visible_message( \
 				"<span class='notice'>\The [user] has added \the [O] to \the [src].</span>", \
 				"<span class='notice'>You add \the [O] to \the [src].</span>")

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -221,7 +221,7 @@
 		return
 
 	if(accept_check(O))
-		if(!user.remove_from_mob(O))
+		if(!user.unEquip(O))
 			return
 		stock_item(O)
 		user.visible_message("<span class='notice'>\The [user] has added \the [O] to \the [src].</span>", "<span class='notice'>You add \the [O] to \the [src].</span>")

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -745,9 +745,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		return
 
 	if(istype(user.get_active_hand(), /obj/item/weapon/photo))
+		if(!user.unequip_item(src))
+			return
 		var/obj/item/photo = user.get_active_hand()
-		user.drop_item()
-		photo.loc = src
 		photo_data = new(photo, 0)
 	else if(istype(user,/mob/living/silicon))
 		var/mob/living/silicon/tempAI = user

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -75,8 +75,8 @@ var/bomb_set
 
 	if(src.extended)
 		if(istype(O, /obj/item/weapon/disk/nuclear))
-			usr.drop_item()
-			O.forceMove(src)
+			if(!user.unEquip(O, src))
+				return
 			src.auth = O
 			src.add_fingerprint(user)
 			return attack_hand(user)
@@ -235,8 +235,8 @@ var/bomb_set
 		else
 			var/obj/item/I = usr.get_active_hand()
 			if(istype(I, /obj/item/weapon/disk/nuclear))
-				usr.drop_item()
-				I.forceMove(src)
+				if(!usr.unEquip(I, src))
+					return 1
 				auth = I
 	if(is_auth(usr))
 		if(href_list["type"])

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -35,7 +35,7 @@
 	if(tank)
 		qdel(tank)
 	if(breather)
-		breather.remove_from_mob(contained)
+		breather.drop_from_inventory(contained)
 		src.visible_message("<span class='notice'>The mask rapidly retracts just before /the [src] is destroyed!</span>")
 	qdel(contained)
 	contained = null
@@ -96,8 +96,7 @@
 /obj/machinery/oxygen_pump/proc/detach_mask(mob/user)
 	if(tank)
 		tank.forceMove(src)
-	breather.remove_from_mob(contained)
-	contained.forceMove(src)
+	breather.drop_from_inventory(contained, src)
 	if(user)
 		visible_message("<span class='notice'>\The [user] detaches \the [contained] and it rapidly retracts back into \the [src]!</span>")
 	else
@@ -155,8 +154,8 @@
 		if(tank)
 			to_chat(user, "<span class='warning'>\The [src] already has a tank installed!</span>")
 		else
-			user.drop_item()
-			W.forceMove(src)
+			if(!user.unEquip(W, src))
+				return
 			tank = W
 			user.visible_message("<span class='notice'>\The [user] installs \the [tank] into \the [src].</span>", "<span class='notice'>You install \the [tank] into \the [src].</span>")
 			src.add_fingerprint(user)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -302,7 +302,7 @@ Buildable meters
 /obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity)
 	if(!proximity) return
 	if(istype(target))
-		user.drop_from_inventory(src, target)
+		user.unEquip(src, target)
 	else
 		return ..()
 

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -102,8 +102,9 @@
 
 /obj/machinery/pipedispenser/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	if (istype(W, /obj/item/pipe) || istype(W, /obj/item/pipe_meter))
+		if(!user.unEquip(W))
+			return
 		to_chat(usr, "<span class='notice'>You put \the [W] back into \the [src].</span>")
-		user.drop_item()
 		add_fingerprint(usr)
 		qdel(W)
 		return

--- a/code/game/machinery/resleever.dm
+++ b/code/game/machinery/resleever.dm
@@ -167,11 +167,9 @@ obj/machinery/resleever/Process()
 			to_chat(user, "<span class='warning'>You need to remove the occupant first!</span>")
 			return
 	if(istype(W, /obj/item/organ/internal/stack))
-		if(isnull(lace))
+		if(isnull(lace) && user.unEquip(W, src))
 			to_chat(user, "<span class='notice'>You insert \the [W] into [src].</span>")
-			user.drop_from_inventory(W)
 			lace = W
-			W.forceMove(src)
 			if(lace.backup)
 				lace_name = lace.backup.name
 		else

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -13,8 +13,8 @@ obj/machinery/seed_extractor/attackby(var/obj/item/O as obj, var/mob/user as mob
 
 	// Fruits and vegetables.
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown) || istype(O, /obj/item/weapon/grown))
-
-		user.remove_from_mob(O)
+		if(!user.unEquip(O))
+			return
 
 		var/datum/seed/new_seed_type
 		if(istype(O, /obj/item/weapon/grown))

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -9,31 +9,30 @@
 	var/armed = 0
 	var/damaged = 0
 
-/obj/machinery/self_destruct/attackby(obj/item/W as obj, mob/usr as mob)
+/obj/machinery/self_destruct/attackby(obj/item/W as obj, mob/user as mob)
 	if(isWelder(W))
 		if(damaged)
-			usr.visible_message("[usr] begins to repair [src].", "You begin repairing [src].")
+			user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
 			if(do_after(usr, 100, src))
 				var/obj/item/weapon/weldingtool/w
 				if(w.burn_fuel(10))
 					damaged = 0
-					usr.visible_message("[usr] repairs [src].", "You repair [src].")
+					user.visible_message("[user] repairs [src].", "You repair [src].")
 				else
-					to_chat(usr, "<span class='warning'>There is not enough fuel to repair [src].</span>")
+					to_chat(user, "<span class='warning'>There is not enough fuel to repair [src].</span>")
 				return
 	if(istype(W, /obj/item/weapon/nuclear_cylinder))
 		if(damaged)
-			to_chat(usr, "<span class='warning'>[src] is damaged, you cannot place the cylinder.</span>")
+			to_chat(user, "<span class='warning'>[src] is damaged, you cannot place the cylinder.</span>")
 			return
 		if(cylinder)
-			to_chat(usr, "There is already a cylinder here.")
+			to_chat(user, "There is already a cylinder here.")
 			return
-		usr.visible_message("[usr] begins to carefully place [W] onto the Inserter.", "You begin to carefully place [W] onto the Inserter.")
-		if(do_after(usr, 80, src))
-			usr.drop_from_inventory(W, src)
+		user.visible_message("[user] begins to carefully place [W] onto the Inserter.", "You begin to carefully place [W] onto the Inserter.")
+		if(do_after(user, 80, src) && user.unEquip(W, src))
 			cylinder = W
 			density = 1
-			usr.visible_message("[usr] places [W] onto the Inserter.", "You place [W] onto the Inserter.")
+			user.visible_message("[user] places [W] onto the Inserter.", "You place [W] onto the Inserter.")
 			update_icon()
 			return
 	..()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -61,15 +61,11 @@
 				return
 			else
 				// insert cell
-				var/obj/item/weapon/cell/C = usr.get_active_hand()
-				if(istype(C))
-					user.drop_item()
-					cell = C
-					C.forceMove(src)
-					C.add_fingerprint(usr)
-
-					user.visible_message("<span class='notice'>[user] inserts a power cell into [src].</span>", "<span class='notice'>You insert the power cell into [src].</span>")
-					power_change()
+				if(!user.unEquip(I, src))
+					return
+				cell = I
+				user.visible_message("<span class='notice'>[user] inserts a power cell into [src].</span>", "<span class='notice'>You insert the power cell into [src].</span>")
+				power_change()
 		else
 			to_chat(user, "The hatch must be open to insert a power cell.")
 			return
@@ -146,9 +142,9 @@
 			if(panel_open && !cell)
 				var/obj/item/weapon/cell/C = usr.get_active_hand()
 				if(istype(C))
-					usr.drop_item()
+					if(!usr.unEquip(C, src))
+						return
 					cell = C
-					C.forceMove(src)
 					C.add_fingerprint(usr)
 					power_change()
 					usr.visible_message("<span class='notice'>[usr] inserts \the [C] into \the [src].</span>", "<span class='notice'>You insert \the [C] into \the [src].</span>")

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -586,80 +586,30 @@
 			update_icon()
 			return
 		return
-	if( istype(I,/obj/item/clothing/suit/space) )
-		if(!isopen)
-			return
-		var/obj/item/clothing/suit/space/S = I
-		if(suit)
-			to_chat(user, "<span class='notice'>The unit already contains a suit.</span>")
-			return
-		to_chat(user, "You load the [S.name] into the storage compartment.")
-		user.drop_item()
-		S.forceMove(src)
-		suit = S
-		update_icon()
-		updateUsrDialog()
-		return
-	if( istype(I,/obj/item/clothing/head/helmet/space) )
-		if(!isopen)
-			return
-		var/obj/item/clothing/head/helmet/H = I
-		if(helmet )
-			to_chat(user, "<span class='notice'>The unit already contains a helmet.</span>")
-			return
-		to_chat(user, "You load the [H.name] into the storage compartment.")
-		user.drop_item()
-		H.forceMove(src)
-		helmet  = H
-		update_icon()
-		updateUsrDialog()
-		return
-	if( istype(I,/obj/item/clothing/shoes/magboots) )
-		if(!isopen)
-			return
-		var/obj/item/clothing/shoes/magboots/B = I
-		if(boots)
-			to_chat(user, "<span class='notice'>The unit already contains a pair of magboots.</span>")
-			return
-		to_chat(user, "You load the [B.name] into the storage compartment.")
-		user.drop_item()
-		B.forceMove(src)
-		boots = B
-		update_icon()
-		updateUsrDialog()
-		return
-	if( istype(I,/obj/item/weapon/tank) )
-		if(!isopen)
-			return
-		var/obj/item/weapon/tank/T = I
-		if(tank)
-			to_chat(user, "<span class='notice'>The unit already contains an air tank.</span>")
-			return
-		to_chat(user, "You load the [T.name] into the storage compartment.")
-		user.drop_item()
-		T.forceMove(src)
-		tank = T
-		update_icon()
-		updateUsrDialog()
-		return
-	if( istype(I,/obj/item/clothing/mask) )
-		if(!isopen)
-			return
-		var/obj/item/clothing/mask/M = I
-		if(mask)
-			to_chat(user, "<span class='notice'>The unit already contains a mask.</span>")
-			return
-		to_chat(user, "You load the [M.name] into the storage compartment.")
-		user.drop_item()
-		M.forceMove(src)
-		mask = M
-		update_icon()
-		updateUsrDialog()
-		return
+
+#define TRY_INSERT_SUIT_PIECE(slot, path)\
+	if(istype(I, /obj/item/##path)){\
+		if(!isopen) return;\
+		if(##slot){\
+			to_chat(user, "<span class='notice'>The unit already contains \a [slot].</span>");\
+			return\
+		};\
+		if(!user.unEquip(I, src)) return;\
+		to_chat(user, "You load the [I.name] into the storage compartment.");\
+		##slot = I;\
+		update_icon();\
+		updateUsrDialog();\
+		return\
+	}
+
+	TRY_INSERT_SUIT_PIECE(suit, clothing/suit/space)
+	TRY_INSERT_SUIT_PIECE(helmet, clothing/head/helmet/space)
+	TRY_INSERT_SUIT_PIECE(boots, clothing/shoes/magboots)
+	TRY_INSERT_SUIT_PIECE(tank, weapon/tank)
+	TRY_INSERT_SUIT_PIECE(mask, clothing/mask)
 	update_icon()
 	updateUsrDialog()
-	return
-
+#undef TRY_INSERT_SUIT_PIECE
 
 /obj/machinery/suit_storage_unit/attack_ai(mob/user as mob)
 	return attack_hand(user)
@@ -833,10 +783,9 @@
 		if(I.icon_override == CUSTOM_ITEM_MOB)
 			to_chat(user, "You cannot refit a customised voidsuit.")
 			return
-
+		if(!user.unEquip(I, src))
+			return
 		to_chat(user, "You fit \the [I] into the suit cycler.")
-		user.drop_item()
-		I.loc = src
 		helmet = I
 
 		update_icon()
@@ -856,10 +805,9 @@
 		if(I.icon_override == CUSTOM_ITEM_MOB)
 			to_chat(user, "You cannot refit a customised voidsuit.")
 			return
-
+		if(!user.unEquip(I, src))
+			return
 		to_chat(user, "You fit \the [I] into the suit cycler.")
-		user.drop_item()
-		I.loc = src
 		suit = I
 
 		update_icon()

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -15,9 +15,10 @@
 	user.visible_message("<span class='notice'>\The [user] begins setting up \the [src].</span>")
 	if(!do_after(user, deploy_time, src))
 		return
+	if(!user.unEquip(src))
+		return
 	var/obj/S = new deploy_path(get_turf(user))
 	user.visible_message("<span class='notice'>\The [user] deploys \the [S].</span>")
-	user.unEquip(src)
 	qdel(src)
 
 /obj/machinery/power/supply_beacon

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -65,9 +65,10 @@
 
 
 		if(istype(L, /obj/effect/landmark/) && istype(L.loc, /turf))
+			if(!user.unEquip(I))
+				return
 			to_chat(usr, "You insert the coordinates into the machine.")
 			to_chat(usr, "A message flashes across the screen reminding the traveller that the nuclear authentication disk is to remain on the [station_name()] at all times.")
-			user.drop_item()
 			qdel(I)
 
 			if(C.data == "Clown Land")

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -199,8 +199,8 @@
 		power_change()
 		return
 	else if(istype(W, /obj/item/weapon/coin) && premium.len > 0)
-		user.drop_item()
-		W.forceMove(src)
+		if(!user.unEquip(W, src))
+			return
 		coin = W
 		categories |= CAT_COIN
 		to_chat(user, "<span class='notice'>You insert \the [W] into \the [src].</span>")
@@ -236,7 +236,6 @@
 	cashmoney.worth -= currently_vending.price
 
 	if(cashmoney.worth <= 0)
-		usr.drop_from_inventory(cashmoney)
 		qdel(cashmoney)
 	else
 		cashmoney.update_icon()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -87,9 +87,9 @@
 	if(istype(W,/obj/item/weapon/pen/crayon) || istype(W,/obj/item/weapon/stamp))
 		if( state in list(	1, 3, 6 ) )
 			if(!crayon)
-				user.drop_item()
+				if(!user.unEquip(W, src))
+					return
 				crayon = W
-				crayon.forceMove(src)
 			else
 				..()
 		else
@@ -147,8 +147,8 @@
 
 		if(contents.len < 5)
 			if ( state in list(1, 3) )
-				user.drop_item()
-				W.loc = src
+				if(!user.unEquip(W, src))
+					return
 				state = 3
 			else
 				to_chat(user, "<span class='notice'>You can't put the item in right now.</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -718,7 +718,8 @@
 		var/obj/item/mecha_parts/mecha_equipment/E = W
 		spawn()
 			if(E.can_attach(src))
-				user.drop_item()
+				if(!user.unEquip(E))
+					return
 				E.attach(src)
 				user.visible_message("[user] attaches [W] to [src]", "You attach [W] to [src]")
 			else
@@ -790,9 +791,9 @@
 	else if(istype(W, /obj/item/weapon/cell))
 		if(state==4)
 			if(!src.cell)
+				if(!user.unEquip(W, src))
+					return
 				to_chat(user, "You install the powercell")
-				user.drop_item()
-				W.forceMove(src)
 				src.cell = W
 				src.log_message("Powercell installed")
 			else
@@ -816,9 +817,7 @@
 			to_chat(user, "The [src.name] is at full integrity")
 		return
 
-	else if(istype(W, /obj/item/mecha_parts/mecha_tracking))
-		user.drop_from_inventory(W)
-		W.forceMove(src)
+	else if(istype(W, /obj/item/mecha_parts/mecha_tracking) && user.unEquip(W, src))
 		user.visible_message("[user] attaches [W] to [src].", "You attach [W] to [src]")
 		return
 

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -569,7 +569,6 @@
 	custom_action(step, atom/used_atom, mob/user)
 		user.visible_message("[user] has connected [used_atom] to [holder].", "You connect [used_atom] to [holder]")
 		holder.overlays += used_atom.icon_state+"+o"
-		user.drop_item()
 		qdel(used_atom)
 		return 1
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -228,7 +228,7 @@ steam.start() -- spawns the effect
 /obj/effect/effect/smoke/bad/affect(var/mob/living/carbon/M)
 	if (!..())
 		return 0
-	M.drop_item()
+	M.unequip_item()
 	M.adjustOxyLoss(1)
 	if (M.coughedtime != 1)
 		M.coughedtime = 1
@@ -257,7 +257,7 @@ steam.start() -- spawns the effect
 	if (!..())
 		return 0
 
-	M.drop_item()
+	M.unequip_item()
 	M:sleeping += 1
 	if (M.coughedtime != 1)
 		M.coughedtime = 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -554,7 +554,7 @@ var/list/global/slot_flags_enumeration = list(
 			if(prob(50))
 				if(M.stat != 2)
 					to_chat(M, "<span class='warning'>You drop what you're holding and clutch at your eyes!</span>")
-					M.drop_item()
+					M.unequip_item()
 				M.eye_blurry += 10
 				M.Paralyse(1)
 				M.Weaken(4)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -19,7 +19,7 @@
 /obj/item/device/flash/proc/clown_check(var/mob/user)
 	if(user && (CLUMSY in user.mutations) && prob(50))
 		to_chat(user, "<span class='warning'>\The [src] slips out of your hand.</span>")
-		user.drop_item()
+		user.unequip_item()
 		return 0
 	return 1
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -108,9 +108,10 @@
 		var/obj/item/weapon/light/L = W
 		if(L.status == 0) // LIGHT OKAY
 			if(uses < max_uses)
+				if(!user.unEquip(L))
+					return
 				AddUses(1)
 				to_chat(user, "You insert \the [L.name] into \the [src.name]. You have [uses] light\s remaining.")
-				user.drop_item()
 				qdel(L)
 				return
 		else

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -23,7 +23,6 @@
 
 	if(!parts)
 		to_chat(user, "<span class='warning'>This kit has no parts for this modification left.</span>")
-		user.drop_from_inventory(src)
 		qdel(src)
 		return
 
@@ -59,7 +58,6 @@
 		parts &= ~MODKIT_SUIT
 
 	if(!parts)
-		user.drop_from_inventory(src)
 		qdel(src)
 
 /obj/item/device/modkit/examine(mob/user)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -24,16 +24,16 @@
 		if(!b_stat)
 			to_chat(user, "<span class='notice'>[src] is not ready to be attached!</span>")
 			return
+		if(!user.unEquip(W) || !user.unEquip(src))
+			return
 		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit( user )
 		A.icon = 'icons/obj/assemblies.dmi'
 
-		user.drop_from_inventory(W)
-		W.loc = A
+		W.forceMove(A)
 		W.master = A
 		A.part1 = W
 
-		user.drop_from_inventory(src)
-		loc = A
+		forceMove(A)
 		master = A
 		A.part2 = src
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -653,8 +653,8 @@
 			return
 
 		if(!keyslot)
-			user.drop_item()
-			W.loc = src
+			if(!user.unEquip(W, src))
+				return
 			keyslot = W
 
 		recalculateChannels()

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -130,8 +130,8 @@
 			if(cell)
 				to_chat(user, "There is a [cell] already installed here.")
 			else
-				user.drop_item()
-				W.forceMove(src)
+				if(!user.unEquip(W, src))
+					return
 				cell = W
 				to_chat(user, "You insert the [cell].")
 		update_icon()

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -28,8 +28,8 @@
 			to_chat(user, "<span class='warning'>There are already two tanks attached, remove one first.</span>")
 			return
 
-		user.drop_item()
-		item.forceMove(src)
+		if(!user.unEquip(item, src))
+			return
 		if(!tank_one)
 			tank_one = item
 		else
@@ -56,9 +56,9 @@
 		if(attached_device)
 			to_chat(user, "<span class='warning'>There is already an device attached to the valve, remove it first.</span>")
 			return
-		user.remove_from_mob(item)
+		if(!user.unEquip(item, src))
+			return
 		attached_device = A
-		A.forceMove(src)
 		to_chat(user, "<span class='notice'>You attach the [item] to the valve controls and secure it.</span>")
 		A.holder = src
 		A.toggle_secure()	//this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -93,7 +93,6 @@
 	qdel(S)
 	user.put_in_hands(A)
 	to_chat(user, "<span class='notice'>You add the infrared sensor to the robot head.</span>")
-	user.drop_from_inventory(src)
 	qdel(src)
 
 /* Using camcorder icon as I can't sprite.
@@ -111,17 +110,13 @@ Using robohead because of restricting to roboticist */
 	switch(buildstep)
 		if(0)
 			if(istype(W, /obj/item/robot_parts/robot_component/camera))
-				var/obj/item/robot_parts/robot_component/camera/CA = W
 				to_chat(user, "<span class='notice'>You add the camera module to [src]</span>")
-				user.drop_item()
-				qdel(CA)
+				qdel(W)
 				desc = "This TV camera assembly has a camera module."
 				buildstep++
 		if(1)
 			if(istype(W, /obj/item/device/taperecorder))
-				var/obj/item/device/taperecorder/T = W
-				user.drop_item()
-				qdel(T)
+				qdel(W)
 				buildstep++
 				to_chat(user, "<span class='notice'>You add the tape recorder to [src]</span>")
 				desc = "This TV camera assembly has a camera and audio module."
@@ -152,7 +147,6 @@ Using robohead because of restricting to roboticist */
 				to_chat(user, "<span class='notice'>You encase the assembly.</span>")
 				var/turf/T = get_turf(src)
 				new /obj/item/device/tvcamera(T)
-				user.drop_from_inventory(src)
 				qdel(src)
 				return
 

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -70,10 +70,10 @@
 			contains = 1
 		if(contains != 1)
 			return
+		if(!user.unEquip(W, src))
+			return
 		var/obj/item/weapon/spacecash/S = W
 		user.visible_message("<span class='notice'>[user] puts [S.worth] [S.worth > 1 ? "thalers" : "thaler"] into \the [src].</span>")
-		user.drop_from_inventory(S)
-		S.forceMove(src)
 		update_icon()
 
 /obj/item/glass_jar/update_icon() // Also updates name and desc

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -15,7 +15,6 @@
 	uses -= amt
 	playsound(get_turf(user), 'sound/items/Screwdriver.ogg', 50, 1)
 	if(uses<1)
-		user.drop_item()
 		qdel(src)
 
 // Root hardsuit kit defines.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -136,11 +136,10 @@
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == DEFAULT_WALL_MATERIAL && !parts[BP_L_ARM] && !parts[BP_R_ARM] && !parts[BP_L_LEG] && !parts[BP_R_LEG] && !parts[BP_CHEST] && !parts[BP_HEAD])
 		var/obj/item/stack/material/M = W
 		if (M.use(1))
-			var/obj/item/weapon/secbot_assembly/ed209_assembly/B = new /obj/item/weapon/secbot_assembly/ed209_assembly
-			B.loc = get_turf(src)
+			var/obj/item/weapon/secbot_assembly/ed209_assembly/B = new /obj/item/weapon/secbot_assembly/ed209_assembly(get_turf(src))
 			to_chat(user, "<span class='notice'>You armed the robot frame.</span>")
 			if (user.get_inactive_hand()==src)
-				user.remove_from_mob(src)
+				user.drop_from_inventory(src) //clears inactive hand; item will be deleted anyway.
 				user.put_in_inactive_hand(B)
 			qdel(src)
 		else
@@ -150,8 +149,8 @@
 		var/obj/item/robot_parts/part = W
 		if(src.parts[part.bp_tag])	return
 		if(part.can_install(user))
-			user.drop_item()
-			part.loc = src
+			if(!user.unEquip(W, src))
+				return
 			src.parts[part.bp_tag] = part
 			src.update_icon()
 
@@ -188,11 +187,10 @@
 			if(jobban_isbanned(B, "Robot"))
 				to_chat(user, "<span class='warning'>This [W] does not seem to fit.</span>")
 				return
-
+			if(!user.unEquip(W))
+				return
 			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1)
 			if(!O)	return
-
-			user.drop_item()
 
 			O.mmi = W
 			O.set_invisibility(0)
@@ -208,8 +206,8 @@
 
 			var/obj/item/robot_parts/chest/chest = parts[BP_CHEST]
 			O.cell = chest.cell
-			O.cell.loc = O
-			W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
+			O.cell.forceMove(O)
+			W.forceMove(O) //Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 
 			// Since we "magically" installed a cell, we also have to update the correct component.
 			if(O.cell)
@@ -243,8 +241,8 @@
 			to_chat(user, "<span class='warning'>You have already inserted a cell!</span>")
 			return
 		else
-			user.drop_item()
-			W.loc = src
+			if(!user.unEquip(W, src))
+				return
 			src.cell = W
 			to_chat(user, "<span class='notice'>You insert the cell!</span>")
 	if(isCoil(W))
@@ -332,7 +330,6 @@
 	else if(istype(W, /obj/item/weapon/stock_parts/manipulator))
 		to_chat(user, "<span class='notice'>You install some manipulators and modify the head, creating a functional spider-bot!</span>")
 		new /mob/living/simple_animal/spiderbot(get_turf(loc))
-		user.drop_item()
 		qdel(W)
 		qdel(src)
 		return
@@ -343,13 +340,13 @@
 		to_chat(user, "<span class='notice'>You have already inserted the eyes!</span>")
 		return
 	else if(src.flash1)
-		user.drop_item()
-		W.loc = src
+		if(!user.unEquip(W, src))
+			return
 		src.flash2 = W
 		to_chat(user, "<span class='notice'>You insert the flash into the eye socket!</span>")
 	else
-		user.drop_item()
-		W.loc = src
+		if(!user.unEquip(W, src))
+			return
 		src.flash1 = W
 		to_chat(user, "<span class='notice'>You insert the flash into the eye socket!</span>")
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -184,8 +184,6 @@
 	if(!uses_charge)
 		amount -= used
 		if (amount <= 0)
-			if(usr)
-				usr.remove_from_mob(src)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		return 1
 	else

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -159,7 +159,8 @@
 	attackby(obj/item/I as obj, mob/user as mob)
 		if(istype(I, /obj/item/toy/ammo/crossbow))
 			if(bullets <= 4)
-				user.drop_item()
+				if(!user.unEquip(I))
+					return
 				qdel(I)
 				bullets++
 				to_chat(user, "<span class='notice'>You load the foam dart into the crossbow.</span>")

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -70,7 +70,6 @@
 			to_chat(user, "<span class='notice'>The RCD can't hold that many additional matter-units.</span>")
 			return
 		stored_matter += cartridge.remaining
-		user.drop_from_inventory(W)
 		qdel(W)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>The RCD now holds [stored_matter]/[max_stored_matter] matter-units.</span>")

--- a/code/game/objects/items/weapons/beachball.dm
+++ b/code/game/objects/items/weapons/beachball.dm
@@ -12,6 +12,6 @@
 	throw_range = 20
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
-		user.drop_item()
+/obj/item/weapon/beach_ball/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+	if(user.unequip_item())
 		src.throw_at(target, throw_range, throw_speed, user)

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -36,10 +36,8 @@
 		..()
 
 /obj/item/weapon/cane/concealed/attackby(var/obj/item/weapon/material/butterfly/W, var/mob/user)
-	if(!src.concealed_blade && istype(W))
+	if(!src.concealed_blade && istype(W) && user.unEquip(W, src))
 		user.visible_message("<span class='warning'>[user] has sheathed \a [W] into [src]!</span>", "You sheathe \the [W] into [src].")
-		user.drop_from_inventory(W)
-		W.loc = src
 		src.concealed_blade = W
 		update_icon()
 		user.update_inv_l_hand()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -84,7 +84,6 @@ var/const/NO_EMAG_ACT = -50
 
 	if(uses<1)
 		user.visible_message("<span class='warning'>\The [src] fizzles and sparks - it seems it's been used once too often, and is now spent.</span>")
-		user.drop_item()
 		var/obj/item/weapon/card/emag_broken/junk = new(user.loc)
 		junk.add_fingerprint(user)
 		qdel(src)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -246,7 +246,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/mob/living/M = loc
 			if (!nomessage)
 				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
-			M.remove_from_mob(src) //un-equip it so the overlays can update
 		qdel(src)
 
 /obj/item/clothing/mask/smokable/cigarette/menthol
@@ -875,7 +874,6 @@ obj/item/clothing/mask/chewable/Destroy()
 			var/mob/living/M = loc
 			if (!nomessage)
 				to_chat(M, "<span class='notice'>You spit out the [name].</span>")
-			M.remove_from_mob(src) //un-equip it so the overlays can update
 		qdel(src)
 
 /obj/item/clothing/mask/chewable/tobacco/lenni

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -152,9 +152,7 @@ obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
 	if(istype(I, /obj/item/weapon/reagent_containers/ecig_cartridge))
 		if (ec_cartridge)//can't add second one
 			to_chat(user, "<span class='notice'>A cartridge has already been installed.</span> ")
-		else//fits in new one
-			user.remove_from_mob(I)
-			I.forceMove(src)//I.loc=src
+		else if(user.unEquip(I, src))//fits in new one
 			ec_cartridge = I
 			update_icon()
 			to_chat(user, "<span class='notice'>You insert \the [I] into \the [src].</span> ")

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -49,7 +49,8 @@
 	user.do_attack_animation(target)
 
 	if(do_after(user, 50, target) && in_range(user, target))
-		user.drop_item()
+		if(!user.unequip_item())
+			return
 		src.target = target
 		forceMove(null)
 

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -93,8 +93,8 @@
 		var/obj/item/device/assembly/igniter/I = W
 		if(I.secured)	return
 		if(igniter)		return
-		user.drop_item()
-		I.loc = src
+		if(!user.unEquip(I, src))
+			return
 		igniter = I
 		update_icon()
 		return
@@ -103,9 +103,9 @@
 		if(ptank)
 			to_chat(user, "<span class='notice'>There appears to already be a hydrogen tank loaded in [src]!</span>")
 			return
-		user.drop_item()
+		if(!user.unEquip(W, src))
+			return
 		ptank = W
-		W.loc = src
 		update_icon()
 		return
 

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -97,11 +97,9 @@
 	if(!ispath(gift_type,/obj/item))	return
 
 	var/obj/item/I = new gift_type(M)
-	M.remove_from_mob(src)
 	M.put_in_hands(I)
 	I.add_fingerprint(M)
 	qdel(src)
-	return
 
 /*
  * Wrapping Paper and Gifts
@@ -168,7 +166,7 @@
 				if(istype(W, /obj/item/smallDelivery) || istype(W, /obj/item/weapon/gift)) //No gift wrapping gifts!
 					return
 
-				if(user.drop_from_inventory(W))
+				if(user.unEquip(W))
 					var/obj/item/weapon/gift/G = new /obj/item/weapon/gift( src.loc, W )
 					G.add_fingerprint(user)
 					W.add_fingerprint(user)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -55,11 +55,11 @@
 			if(!det.secured)
 				to_chat(user, "<span class='warning'>Assembly must be secured with screwdriver.</span>")
 				return
+			if(!user.unEquip(det, src))
+				return
 			path = 1
 			to_chat(user, "<span class='notice'>You add [W] to the metal casing.</span>")
 			playsound(src.loc, 'sound/items/Screwdriver2.ogg', 25, -3)
-			user.remove_from_mob(det)
-			det.loc = src
 			detonator = det
 			if(istimer(detonator.a_left))
 				var/obj/item/device/assembly/timer/T = detonator.a_left
@@ -102,9 +102,9 @@
 				return
 			else
 				if(W.reagents.total_volume)
+					if(!user.unEquip(W, src))
+						return
 					to_chat(user, "<span class='notice'>You add \the [W] to the assembly.</span>")
-					user.drop_item()
-					W.loc = src
 					beakers += W
 					stage = 1
 					SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -86,6 +86,12 @@
 	if(!can_place(target, user)) // victim may have resisted out of the grab in the meantime
 		return 0
 
+	var/obj/item/weapon/handcuffs/cuffs = src
+	if(dispenser)
+		cuffs = new(get_turf(user))
+	else if(!user.unEquip(cuffs))
+		return 0
+
 	admin_attack_log(user, H, "Attempted to handcuff the victim", "Was target of an attempted handcuff", "attempted to handcuff")
 	feedback_add_details("handcuffs","H")
 
@@ -95,11 +101,6 @@
 	user.visible_message("<span class='danger'>\The [user] has put [cuff_type] on \the [H]!</span>")
 
 	// Apply cuffs.
-	var/obj/item/weapon/handcuffs/cuffs = src
-	if(dispenser)
-		cuffs = new(get_turf(user))
-	else
-		user.drop_from_inventory(cuffs)
 	target.equip_to_slot(cuffs,slot_handcuffed)
 	return 1
 

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -63,9 +63,8 @@
 		update_description()
 		update_icon()
 		M.update_icon()
-	else if (istype(I, /obj/item/weapon/implant))
+	else if (istype(I, /obj/item/weapon/implant) && user.unEquip(I, src))
 		to_chat(usr, "<span class='notice'>You slide \the [I] into \the [src].</span>")
-		user.drop_from_inventory(I,src)
 		imp = I
 		update_description()
 		update_icon()

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -57,9 +57,8 @@
 	return 0
 
 /obj/item/weapon/implanter/attackby(obj/item/weapon/I, mob/user)
-	if(!imp && istype(I, /obj/item/weapon/implant))
+	if(!imp && istype(I, /obj/item/weapon/implant) && user.unEquip(I,src))
 		to_chat(usr, "<span class='notice'>You slide \the [I] into \the [src].</span>")
-		user.drop_from_inventory(I,src)
 		imp = I
 		update_icon()
 	else

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -50,9 +50,8 @@
 			C.imp = imp
 			imp = null
 		C.update_icon()
-	else if(istype(I, /obj/item/weapon/implant))
+	else if(istype(I, /obj/item/weapon/implant) && user.unEquip(I, src))
 		imp = I
-		user.drop_from_inventory(I,src)
 	update_icon()
 
 /obj/item/weapon/implantpad/attack_self(mob/user)

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -68,10 +68,10 @@
 		return
 	..()
 
-/obj/item/weapon/implanter/compressed/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/weapon/implanter/compressed/afterattack(obj/item/A, mob/user as mob, proximity)
 	if(!proximity)
 		return
-	if(istype(A,/obj/item) && imp)
+	if(istype(A) && imp)
 		var/obj/item/weapon/implant/compressed/c = imp
 		if (c.scanned)
 			if (!istype(A,/obj/item/weapon/storage))
@@ -81,14 +81,15 @@
 			if (!istype(A,/obj/item/weapon/storage))
 				to_chat(user, "<span class='warning'>The matter compressor safeties prevent you from doing that.</span>")
 			return
-		c.scanned = A
 		if(istype(A.loc,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = A.loc
-			H.remove_from_mob(A)
+			if(!H.unEquip(A))
+				return
 		else if(istype(A.loc,/obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = A.loc
 			S.remove_from_storage(A)
-		A.loc.contents.Remove(A)
+		c.scanned = A
+		A.forceMove(src)  //Store it inside
 		safe = 2
 		desc = "It currently contains some matter."
 		update_icon()

--- a/code/game/objects/items/weapons/improvised_components.dm
+++ b/code/game/objects/items/weapons/improvised_components.dm
@@ -64,8 +64,6 @@
 		finished = new /obj/item/weapon/melee/baton/cattleprod(get_turf(user))
 		to_chat(user, "<span class='notice'>You fasten the wirecutters to the top of the rod with the cable, prongs outward.</span>")
 	if(finished)
-		user.drop_from_inventory(src)
-		user.drop_from_inventory(I)
 		qdel(I)
 		qdel(src)
 		user.put_in_hands(finished)

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -40,13 +40,9 @@
 			else if (cig.lit == 0)
 				to_chat(user, "You place [cig] in [src] without even smoking it. Why would you do that?")
 
-		user.remove_from_mob(W, src)
-
-		visible_message("[user] places [W] in [src].")
-		user.update_inv_l_hand()
-		user.update_inv_r_hand()
-		add_fingerprint(user)
-		update_icon()
+		if(user.unEquip(W, src))
+			visible_message("[user] places [W] in [src].")
+			update_icon()
 	else
 		..()
 		health = max(0,health - W.force)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -129,9 +129,8 @@
 	thrown_force_divisor = 1 // as above
 
 /obj/item/weapon/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob)
-	if ((CLUMSY in user.mutations) && prob(50))
+	if ((CLUMSY in user.mutations) && prob(50) && user.unEquip(src))
 		to_chat(user, "<span class='warning'>\The [src] slips out of your hand and hits your head.</span>")
-		user.drop_from_inventory(src)
 		user.take_organ_damage(10)
 		user.Paralyse(2)
 		return

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -88,11 +88,9 @@
 /obj/item/weapon/material/proc/shatter(var/consumed)
 	var/turf/T = get_turf(src)
 	T.visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")
-	if(istype(loc, /mob/living))
-		var/mob/living/M = loc
-		M.drop_from_inventory(src)
 	playsound(src, "shatter", 70, 1)
-	if(!consumed && drops_debris) material.place_shard(T)
+	if(!consumed && drops_debris)
+		material.place_shard(T)
 	qdel(src)
 /*
 Commenting this out pending rebalancing of radiation based on small objects.

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -203,7 +203,6 @@
 
 /obj/item/weapon/melee/energy/blade/attack_self(mob/user as mob)
 	user.drop_from_inventory(src)
-	spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/dropped()
 	..()

--- a/code/game/objects/items/weapons/paiwire.dm
+++ b/code/game/objects/items/weapons/paiwire.dm
@@ -1,8 +1,8 @@
 /obj/item/weapon/pai_cable/proc/plugin(obj/machinery/M as obj, mob/user as mob)
 	if(istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
 		user.visible_message("[user] inserts [src] into a data port on [M].", "You insert [src] into a data port on [M].", "You hear the satisfying click of a wire jack fastening into place.")
-		user.drop_item()
-		src.loc = M
+		if(!user.unEquip(src, M))
+			return
 		src.machine = M
 	else
 		user.visible_message("[user] dumbly fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -110,7 +110,6 @@
 			usr.drop_from_inventory(S, src)
 			if(!S.amount)
 				qdel(S)
-			usr.update_icons()	//update our overlays
 
 		prepare_ui(usr)
 		update_icon()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -176,7 +176,8 @@
 		return 0
 	if(istype(W.loc, /mob))
 		var/mob/M = W.loc
-		M.remove_from_mob(W)
+		if(!M.unEquip(W))
+			return
 	W.forceMove(src)
 	W.on_enter_storage(src)
 	if(usr)

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -76,12 +76,10 @@
 	..()
 	if (istype(W, /obj/item/weapon/flamethrower))
 		var/obj/item/weapon/flamethrower/F = W
-		if (!F.status||F.ptank)	return
+		if (!F.status || F.ptank || user.unEquip(src, F))
+			return
 		master = F
 		F.ptank = src
-		user.remove_from_mob(src)
-		forceMove(F)
-
 /*
  * Emergency Oxygen
  */

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -539,9 +539,11 @@ var/list/global/tank_gauge_cache = list()
 	if(isigniter(S.a_left) == isigniter(S.a_right))		//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
 		return
 
-	M.drop_item()			//Remove the assembly from your hands
-	M.remove_from_mob(src)	//Remove the tank from your character,in case you were holding it
-	M.put_in_hands(src)		//Equips the bomb if possible, or puts it on the floor.
+	if(!M.unequip_item())
+		return					//Remove the assembly from your hands
+	if(!M.unEquip(src))
+		return					//Remove the tank from your character,in case you were holding it
+	M.put_in_hands(src)			//Equips the bomb if possible, or puts it on the floor.
 
 	proxyassembly.assembly = S	//Tell the bomb about its assembly part
 	S.master = proxyassembly	//Tell the assembly about its new owner

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -64,7 +64,6 @@
 			playsound(src, 'sound/effects/tape.ogg',25)
 			var/obj/item/weapon/handcuffs/cable/tape/T = new(user)
 			if(!T.place_handcuffs(H, user))
-				user.unEquip(T)
 				qdel(T)
 
 		else if(user.zone_sel.selecting == BP_CHEST)
@@ -80,9 +79,8 @@
 		return 1
 
 /obj/item/weapon/tape_roll/proc/stick(var/obj/item/weapon/W, mob/user)
-	if(!istype(W, /obj/item/weapon/paper))
+	if(!istype(W, /obj/item/weapon/paper) || !user.unEquip(W))
 		return
-	user.drop_from_inventory(W)
 	var/obj/item/weapon/ducttape/tape = new(get_turf(src))
 	tape.attach(W)
 	user.put_in_hands(tape)
@@ -121,7 +119,6 @@
 		return
 
 	to_chat(user, "You remove \the [initial(name)] from [stuck].")
-	user.drop_from_inventory(src)
 	stuck.forceMove(get_turf(src))
 	user.put_in_hands(stuck)
 	stuck = null
@@ -143,9 +140,9 @@
 			to_chat(user, "You cannot reach that from here.")// can only place stuck papers in cardinal directions, to
 			return											// reduce papers around corners issue.
 
-	user.drop_from_inventory(src)
+	if(!user.unEquip(src, source_turf))
+		return
 	playsound(src, 'sound/effects/tape.ogg',25)
-	forceMove(source_turf)
 
 	if(params)
 		var/list/mouse_control = params2list(params)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -207,8 +207,7 @@
 		var/obj/item/weapon/weldpack/wp = over
 		if(wp.welder)
 			to_chat(usr, "\The [wp] already has \a [wp.welder] attached.")
-		else
-			usr.drop_from_inventory(src, wp)
+		else if(usr.unEquip(src, wp))
 			wp.welder = src
 			usr.visible_message("[usr] attaches \the [src] to \the [wp].", "You attach \the [src] to \the [wp].")
 			wp.update_icon()
@@ -234,21 +233,10 @@
 		var/obj/item/stack/rods/R = W
 		R.use(1)
 		var/obj/item/weapon/flamethrower/F = new/obj/item/weapon/flamethrower(user.loc)
-		src.loc = F
+		user.drop_from_inventory(src, F)
 		F.weldtool = src
-		if (user.client)
-			user.client.screen -= src
-		if (user.r_hand == src)
-			user.remove_from_mob(src)
-		else
-			user.remove_from_mob(src)
-		src.master = F
-		src.reset_plane_and_layer()
-		user.remove_from_mob(src)
-		if (user.client)
-			user.client.screen -= src
-		src.loc = F
-		src.add_fingerprint(user)
+		master = F
+		add_fingerprint(user)
 		return
 
 	if(istype(W, /obj/item/weapon/welder_tank))
@@ -260,7 +248,8 @@
 			to_chat(user, "\The [W] is too large to fit in \the [src].")
 			return
 
-		user.drop_from_inventory(W, src)
+		if(!user.unEquip(W, src))
+			return
 		tank = W
 		user.visible_message("[user] slots \a [W] into \the [src].", "You slot \a [W] into \the [src].")
 		update_icon()

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -38,7 +38,7 @@
 			"You hear the slow creaking of a spring."
 			)
 
-		if (do_after(user, 60, src))
+		if (do_after(user, 60, src) && user.unEquip(src))
 			user.visible_message(
 				"<span class='danger'>\The [user] has deployed \the [src].</span>",
 				"<span class='danger'>You have deployed \the [src]!</span>",
@@ -46,7 +46,6 @@
 				)
 
 			deployed = 1
-			user.drop_from_inventory(src)
 			update_icon()
 			anchored = 1
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -127,14 +127,14 @@ LINEN BINS
 
 /obj/structure/bedsheetbin/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/bedsheet))
-		user.drop_item()
-		I.loc = src
+		if(!user.unEquip(I, src))
+			return
 		sheets.Add(I)
 		amount++
 		to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 	else if(amount && !hidden && I.w_class < ITEM_SIZE_HUGE)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
-		user.drop_item()
-		I.loc = src
+		if(!user.unEquip(I, src))
+			return
 		hidden = I
 		to_chat(user, "<span class='notice'>You hide [I] among the sheets.</span>")
 

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -18,10 +18,9 @@
 	for (var/T in allowed)
 		if(istype(W,T))
 			can_hang = 1
-	if (can_hang && !coat)
+	if (can_hang && !coat && user.unEquip(coat, src))
 		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
 		coat = W
-		user.drop_from_inventory(coat, src)
 		update_icon()
 	else
 		to_chat(user, "<span class='notice'>You cannot hang [W] on [src]</span>")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -280,8 +280,7 @@
 								 "<span class='notice'>You hear rustling of clothes.</span>")
 			return
 
-		if(usr.drop_item())
-			W.forceMove(loc)
+		if(user.unEquip(W, loc))
 			W.pixel_x = 0
 			W.pixel_y = 0
 			W.pixel_z = 0

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -51,9 +51,9 @@ obj/structure/closet/crate
 			return
 	else if(istype(W, /obj/item/device/assembly_holder) || istype(W, /obj/item/device/assembly))
 		if(rigged)
+			if(!user.unEquip(W, src))
+				return
 			to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
-			user.drop_item()
-			W.forceMove(src)
 			return
 	else if(isWirecutter(W))
 		if(rigged)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -149,8 +149,8 @@
 
 		if(do_after(user, 40,src))
 			if(!src) return
-			user.drop_item()
-			W.loc = src
+			if(!user.unEquip(W, src))
+				return
 			to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
 			src.state = 2
 			src.SetName("Near finished Airlock Assembly")

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -16,9 +16,7 @@
 	if(isrobot(user))
 		return
 	if(istype(O, /obj/item/weapon/extinguisher))
-		if(!has_extinguisher && opened)
-			user.remove_from_mob(O)
-			contents += O
+		if(!has_extinguisher && opened && user.unEquip(O, src))
 			has_extinguisher = O
 			to_chat(user, "<span class='notice'>You place [O] in [src].</span>")
 			playsound(src.loc, 'sound/effects/extin.ogg', 50, 0)

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -73,18 +73,16 @@
 			to_chat(user, "<span class='notice'>[buckled_mob] is already on the ironing table!</span>")
 			return
 
-		if(user.drop_item())
+		if(user.unEquip(I, src))
 			cloth = I
-			I.forceMove(src)
 			GLOB.destroyed_event.register(I, src, /obj/structure/bed/roller/ironingboard/proc/remove_item)
 			update_icon()
 		return
 	else if(istype(I,/obj/item/weapon/ironingiron))
 		var/obj/item/weapon/ironingiron/R = I
 
-		if(!holding && !R.enabled && user.drop_item())
+		if(!holding && !R.enabled && user.unEquip(I, src))
 			holding = R
-			I.forceMove(src)
 			GLOB.destroyed_event.register(I, src, /obj/structure/bed/roller/ironingboard/proc/remove_item)
 			update_icon()
 			return

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -63,8 +63,8 @@
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
 			return
-		user.drop_item()
-		W.forceMove(src)
+		if(!user.unEquip(W, src))
+			return
 		beaker = W
 		to_chat(user, "You attach \the [W] to \the [src].")
 		queue_icon_update()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -27,9 +27,9 @@
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/storage/bag/trash) && !mybag)
-		user.drop_item()
+		if(!user.unEquip(I, src))
+			return
 		mybag = I
-		I.loc = src
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
@@ -44,33 +44,33 @@
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 				return
 		if(!mymop)
-			user.drop_item()
+			if(!user.unEquip(I, src))
+				return
 			mymop = I
-			I.loc = src
 			update_icon()
 			updateUsrDialog()
 			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 
 	else if(istype(I, /obj/item/weapon/reagent_containers/spray) && !myspray)
-		user.drop_item()
+		if(!user.unEquip(I, src))
+			return
 		myspray = I
-		I.loc = src
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 
 	else if(istype(I, /obj/item/device/lightreplacer) && !myreplacer)
-		user.drop_item()
+		if(!user.unEquip(I, src))
+			return
 		myreplacer = I
-		I.loc = src
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 
 	else if(istype(I, /obj/item/weapon/caution))
 		if(signs < 4)
-			user.drop_item()
-			I.loc = src
+			if(!user.unEquip(I, src))
+				return
 			signs++
 			update_icon()
 			updateUsrDialog()
@@ -200,9 +200,9 @@
 	else if(istype(I, /obj/item/key))
 		to_chat(user, "Hold [I] in one of your hands while you drive this [callme].")
 	else if(istype(I, /obj/item/weapon/storage/bag/trash))
+		if(!user.unEquip(I, src))
+			return
 		to_chat(user, "<span class='notice'>You hook the trashbag onto the [callme].</span>")
-		user.drop_item()
-		I.loc = src
 		mybag = I
 
 

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -19,10 +19,8 @@
 //attaching papers!!
 /obj/structure/noticeboard/attackby(var/obj/item/weapon/O as obj, var/mob/user as mob)
 	if(istype(O, /obj/item/weapon/paper) || istype(O, /obj/item/weapon/photo))
-		if(notices < 5)
-			O.add_fingerprint(user)
+		if((notices < 5) && user.unEquip(O, src))
 			add_fingerprint(user)
-			user.drop_from_inventory(O,src)
 			notices++
 			icon_state = "nboard0[notices]"	//update sprite
 			to_chat(user, "<span class='notice'>You pin the paper to the noticeboard.</span>")

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -145,9 +145,9 @@ FLOOR SAFES
 /obj/structure/safe/attackby(obj/item/I as obj, mob/user as mob)
 	if(open)
 		if(I.w_class + space <= maxspace)
+			if(!user.unEquip(I, src))
+				return
 			space += I.w_class
-			user.drop_item()
-			I.loc = src
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 			updateUsrDialog()
 			return

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -65,9 +65,8 @@
 		if(slot)
 			if(swag[slot])
 				to_chat(user,"<span class='notice'>There is already that kind of clothing on \the [src].</span>")
-			else
+			else if(user.unEquip(W, src))
 				swag[slot] = W
-				user.drop_from_inventory(W,src)
 				update_icon()
 				return 1
 	else

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -99,7 +99,6 @@
 			return
 		var/obj/item/stack/C = W
 		if(C.get_amount() < 1) // How??
-			user.drop_from_inventory(C)
 			qdel(C)
 			return
 		var/padding_type //This is awful but it needs to be like this until tiles are given a material var.
@@ -114,8 +113,7 @@
 			return
 		C.use(1)
 		if(!istype(src.loc, /turf))
-			user.drop_from_inventory(src)
-			src.loc = get_turf(src)
+			src.forceMove(get_turf(src))
 		to_chat(user, "You add padding to \the [src].")
 		add_padding(padding_type)
 		return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -15,7 +15,8 @@
 		if(!SK.status)
 			to_chat(user, "<span class='notice'>\The [SK] is not ready to be attached!</span>")
 			return
-		user.drop_item()
+		if(!user.unEquip(SK))
+			return
 		var/obj/structure/bed/chair/e_chair/E = new (src.loc, material.name)
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		E.set_dir(dir)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -89,9 +89,7 @@ var/global/list/stool_cache = list() //haha stool
 		user.visible_message("<span class='danger'>[user] breaks [src] over [target]'s back!</span>")
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(target)
-		user.remove_from_mob(src)
-		dismantle()
-		qdel(src)
+		dismantle() //This deletes self.
 
 		var/blocked = target.run_armor_check(hit_zone, "melee")
 		target.Weaken(10 * blocked_mult(blocked))
@@ -132,7 +130,6 @@ var/global/list/stool_cache = list() //haha stool
 			return
 		var/obj/item/stack/C = W
 		if(C.get_amount() < 1) // How??
-			user.drop_from_inventory(C)
 			qdel(C)
 			return
 		var/padding_type //This is awful but it needs to be like this until tiles are given a material var.

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -50,8 +50,8 @@
 /obj/structure/dispenser/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/tank/oxygen) || istype(I, /obj/item/weapon/tank/air) || istype(I, /obj/item/weapon/tank/anesthetic))
 		if(oxygentanks < 10)
-			user.drop_item()
-			I.loc = src
+			if(!user.unEquip(I, src))
+				return
 			oxytanks.Add(I)
 			oxygentanks++
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
@@ -63,8 +63,8 @@
 		return
 	if(istype(I, /obj/item/weapon/tank/phoron))
 		if(phorontanks < 10)
-			user.drop_item()
-			I.loc = src
+			if(!user.unEquip(I, src))
+				return
 			platanks.Add(I)
 			phorontanks++
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -24,11 +24,9 @@
 		if(pinned_target)
 			return // get rid of that pinned target first!
 
-		if(istype(W, /obj/item/target))
+		if(istype(W, /obj/item/target) && user.unEquip(W, loc))
 			set_density(0)
 			W.set_density(1)
-			user.remove_from_mob(W)
-			W.forceMove(loc)
 			W.layer = ABOVE_OBJ_LAYER
 			pinned_target = W
 			to_chat(user, "You slide the target into the stake.")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -59,8 +59,8 @@
 		if(w_items + I.w_class > 5)
 			to_chat(user, "<span class='notice'>The cistern is full.</span>")
 			return
-		user.drop_item()
-		I.loc = src
+		if(!user.unEquip(I, src))
+			return
 		w_items += I.w_class
 		to_chat(user, "You carefully place \the [I] into the cistern.")
 		return

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -171,9 +171,8 @@ obj/structure/windoor_assembly/Destroy()
 
 				if(do_after(user, 40,src))
 					if(!src) return
-
-					user.drop_item()
-					W.loc = src
+					if(!user.unEquip(W, src))
+						return
 					to_chat(user, "<span class='notice'>You've installed the airlock electronics!</span>")
 					src.SetName("Near finished Windoor Assembly")
 					src.electronics = W

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -32,17 +32,20 @@
 		return 1
 
 
-	attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
-		if((!D)||(!D2))	return 0
-		if((!isassembly(D))||(!isassembly(D2)))	return 0
-		if((D:secured)||(D2:secured))	return 0
+	attach(var/obj/item/device/assembly/D, var/obj/item/device/assembly/D2, var/mob/user)
+		if((!D)||(!D2))
+			return 0
+		if((!istype(D))||(!istype(D2)))
+			return 0
+		if((D.secured)||(D2.secured))
+			return 0
 		if(user)
-			user.remove_from_mob(D)
-			user.remove_from_mob(D2)
-		D:holder = src
-		D2:holder = src
-		D.loc = src
-		D2.loc = src
+			user.drop_from_inventory(D)
+			user.drop_from_inventory(D2)
+		D.holder = src
+		D2.holder = src
+		D.forceMove(src)
+		D2.forceMove(src)
 		a_left = D
 		a_right = D2
 		SetName("[D.name]-[D2.name] assembly")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -331,8 +331,9 @@ BLIND     // can't see anything
 			to_chat(user, "You are unable to wear \the [src] as \the [H.gloves] are in the way.")
 			ring = null
 			return 0
-		H.drop_from_inventory(ring)	//Remove the ring (or other under-glove item in the hand slot?) so you can put on the gloves.
-		ring.forceMove(src)
+		if(!H.unEquip(ring, src))//Remove the ring (or other under-glove item in the hand slot?) so you can put on the gloves.
+			ring = null
+			return 0
 
 	if(!..())
 		if(ring) //Put the ring back on if the check fails.
@@ -610,8 +611,8 @@ BLIND     // can't see anything
 		if(holding)
 			to_chat(user, "<span class='warning'>\The [src] is already holding \a [holding].</span>")
 			return
-		user.unEquip(I)
-		I.forceMove(src)
+		if(!user.unEquip(I, src))
+			return
 		holding = I
 		user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>", range = 1)
 		verbs |= /obj/item/clothing/shoes/proc/draw_knife

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -17,7 +17,8 @@
 
 		var/obj/item/clothing/accessory/A = I
 		if(can_attach_accessory(A))
-			user.drop_item()
+			if(!user.unEquip(A))
+				return
 			attach_accessory(user, A)
 			return
 		else

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -64,7 +64,8 @@
 /obj/item/clothing/shoes/orange/proc/attach_cuffs(var/obj/item/weapon/handcuffs/cuffs, mob/user as mob)
 	if (src.chained) return
 
-	user.drop_item()
+	if(!user.unequip_item())
+		return
 	cuffs.loc = src
 	src.chained = cuffs
 	src.slowdown_per_slot[slot_shoes] += 15

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -49,8 +49,9 @@
 			to_chat(user, "You are unable to wear \the [src] as \the [H.shoes] are in the way.")
 			shoes = null
 			return 0
-		H.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
-		shoes.forceMove(src)
+		if(!H.unEquip(shoes, src))//Remove the old shoes so you can put on the magboots.
+			shoes = null
+			return 0
 
 	if(!..())
 		if(shoes) 	//Put the old shoes back on if the check fails.

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -65,7 +65,6 @@
 		return 0
 
 	to_chat(user, "<font color='blue'><b>You slot \the [input_device] into the suit module.</b></font>")
-	user.drop_from_inventory(input_device)
 	qdel(input_device)
 	accepted_item.charges++
 	return 1
@@ -263,7 +262,6 @@
 		return
 
 	for(var/obj/item/weapon/melee/energy/blade/blade in M.contents)
-		M.drop_from_inventory(blade)
 		qdel(blade)
 
 /obj/item/rig_module/fabricator

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -208,9 +208,7 @@
 						return 0
 				else
 					return 0
-			else
-				user.drop_from_inventory(ai)
-				ai.forceMove(src)
+			else if(user.unEquip(ai, src))
 				ai_card = ai
 				to_chat(ai_mob, "<span class='notice'>You have been transferred to \the [holder]'s [src.name].</span>")
 				to_chat(user, "<span class='notice'>You load \the [ai_mob] into \the [holder]'s [src.name].</span>")

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -164,9 +164,6 @@
 
 /obj/item/weapon/rig/Destroy()
 	for(var/obj/item/piece in list(gloves,boots,helmet,chest))
-		var/mob/living/M = piece.loc
-		if(istype(M))
-			M.drop_from_inventory(piece)
 		qdel(piece)
 	STOP_PROCESSING(SSobj, src)
 	qdel(wires)
@@ -707,25 +704,21 @@
 	if(sealed)
 		if(H.head)
 			var/obj/item/garbage = H.head
-			H.drop_from_inventory(garbage)
 			H.head = null
 			qdel(garbage)
 
 		if(H.gloves)
 			var/obj/item/garbage = H.gloves
-			H.drop_from_inventory(garbage)
 			H.gloves = null
 			qdel(garbage)
 
 		if(H.shoes)
 			var/obj/item/garbage = H.shoes
-			H.drop_from_inventory(garbage)
 			H.shoes = null
 			qdel(garbage)
 
 		if(H.wear_suit)
 			var/obj/item/garbage = H.wear_suit
-			H.drop_from_inventory(garbage)
 			H.wear_suit = null
 			qdel(garbage)
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -137,16 +137,14 @@ else if(##equipment_var) {\
 		H = helmet.loc
 		if(istype(H))
 			if(helmet && H.head == helmet)
-				H.drop_from_inventory(helmet)
-				helmet.forceMove(src)
+				H.drop_from_inventory(helmet, src)
 
 	if(boots)
 		boots.canremove = 1
 		H = boots.loc
 		if(istype(H))
 			if(boots && H.shoes == boots)
-				H.drop_from_inventory(boots)
-				boots.forceMove(src)
+				H.drop_from_inventory(boots, src)
 
 	if(tank)
 		tank.canremove = 1
@@ -173,8 +171,7 @@ else if(##equipment_var) {\
 	if(H.head == helmet)
 		to_chat(H, "<span class='notice'>You retract your suit helmet.</span>")
 		helmet.canremove = 1
-		H.drop_from_inventory(helmet)
-		helmet.forceMove(src)
+		H.drop_from_inventory(helmet, src)
 	else
 		if(H.head)
 			to_chat(H, "<span class='danger'>You cannot deploy your helmet while wearing \the [H.head].</span>")
@@ -243,18 +240,18 @@ else if(##equipment_var) {\
 		if(helmet)
 			to_chat(user, "\The [src] already has a helmet installed.")
 		else
+			if(!user.unEquip(W, src))
+				return
 			to_chat(user, "You attach \the [W] to \the [src]'s helmet mount.")
-			user.drop_item()
-			W.forceMove(src)
 			src.helmet = W
 		return
 	else if(istype(W,/obj/item/clothing/shoes/magboots))
 		if(boots)
 			to_chat(user, "\The [src] already has magboots installed.")
 		else
+			if(!user.unEquip(W, src))
+				return
 			to_chat(user, "You attach \the [W] to \the [src]'s boot mounts.")
-			user.drop_item()
-			W.forceMove(src)
 			boots = W
 		return
 	else if(istype(W,/obj/item/weapon/tank))
@@ -263,9 +260,9 @@ else if(##equipment_var) {\
 		else if(istype(W,/obj/item/weapon/tank/phoron))
 			to_chat(user, "\The [W] cannot be inserted into \the [src]'s storage compartment.")
 		else
+			if(!user.unEquip(W, src))
+				return
 			to_chat(user, "You insert \the [W] into \the [src]'s storage compartment.")
-			user.drop_item()
-			W.forceMove(src)
 			tank = W
 		return
 

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -32,7 +32,7 @@
 	update_icon()
 	if(ishuman(hood.loc))
 		var/mob/living/carbon/H = hood.loc
-		H.unEquip(hood, 1)
+		H.drop_from_inventory(hood)
 		H.update_inv_wear_suit()
 	hood.forceMove(src)
 

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -27,8 +27,7 @@
 	if(istype(user))
 		user.stop_aiming(no_message=1)
 	holstered = I
-	user.drop_from_inventory(holstered)
-	holstered.loc = src
+	user.drop_from_inventory(holstered, src)
 	holstered.add_fingerprint(user)
 	w_class = max(w_class, holstered.w_class)
 	user.visible_message("<span class='notice'>[user] holsters \the [holstered].</span>", "<span class='notice'>You holster \the [holstered].</span>")

--- a/code/modules/clothing/under/accessories/lockets.dm
+++ b/code/modules/clothing/under/accessories/lockets.dm
@@ -38,9 +38,9 @@
 		if(held)
 			to_chat(usr, "\The [src] already has something inside it.")
 		else
+			if(!user.unEquip(O, src))
+				return
 			to_chat(usr, "You slip [O] into [src].")
-			user.drop_item()
-			O.loc = src
 			src.held = O
 		return
 	..()

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -27,9 +27,9 @@
 
 	var/obj/item/weapon/forensics/swab/swab = W
 	if(istype(swab) && swab.is_used())
-		user.unEquip(W)
+		if(!user.unEquip(W, src))
+			return
 		src.bloodsamp = swab
-		swab.loc = src
 		to_chat(user, "<span class='notice'>You insert \the [W] into \the [src].</span>")
 	else
 		to_chat(user, "<span class='warning'>\The [src] only accepts used swabs.</span>")

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -18,11 +18,10 @@
 
 	if(istype(W, /obj/item/weapon/forensics/swab)|| istype(W, /obj/item/weapon/sample/fibers) || istype(W, /obj/item/weapon/sample/print))
 		to_chat(user, "<span class='notice'>You insert \the [W] into the microscope.</span>")
-		user.unEquip(W)
-		W.forceMove(src)
+		if(!user.unEquip(W, src))
+			return
 		sample = W
 		update_icon()
-		return
 
 /obj/machinery/microscope/attack_hand(mob/user)
 

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -39,9 +39,8 @@
 	. = ..()
 
 /obj/item/weapon/reagent_containers/glass/rag/attack_self(mob/user as mob)
-	if(on_fire)
+	if(on_fire && user.unEquip(src))
 		user.visible_message("<span class='warning'>\The [user] stamps out [src].</span>", "<span class='warning'>You stamp out [src].</span>")
-		user.unEquip(src)
 		extinguish()
 	else
 		remove_contents(user)

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -47,8 +47,7 @@
 
 /obj/item/weapon/sample/attackby(var/obj/O, var/mob/user)
 	if(O.type == src.type)
-		user.unEquip(O)
-		if(merge_evidence(O, user))
+		if(user.unEquip(O) && merge_evidence(O, user))
 			qdel(O)
 		return 1
 	return ..()

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -80,8 +80,8 @@
 
 		var/obj/item/weapon/card/id/idcard = I
 		if(!held_card)
-			usr.drop_item()
-			idcard.loc = src
+			if(!user.unEquip(idcard, src))
+				return
 			held_card = idcard
 			if(authenticated_account && held_card.associated_account_number != authenticated_account.account_number)
 				authenticated_account = null
@@ -422,8 +422,8 @@
 					else
 						var/obj/item/I = usr.get_active_hand()
 						if (istype(I, /obj/item/weapon/card/id))
-							usr.drop_item()
-							I.loc = src
+							if(!usr.unEquip(I, src))
+								return
 							held_card = I
 				else
 					release_held_id(usr)

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -48,8 +48,8 @@
 		return ..()
 
 	if(!held_card)
-		user.drop_item()
-		O.loc = src
+		if(!user.unEquip(O, src))
+			return
 		held_card = O
 
 		GLOB.nanomanager.update_uis(src)
@@ -169,10 +169,9 @@
 				else
 					var/obj/item/I = usr.get_active_hand()
 					if (istype(I, /obj/item/weapon/card/id))
-						var/obj/item/weapon/card/id/C = I
-						usr.drop_item()
-						C.loc = src
-						held_card = C
+						if(!usr.unEquip(I, src))
+							return
+						held_card = I
 
 			if("view_account_detail")
 				var/index = text2num(href_list["account_index"])

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -24,7 +24,6 @@
 		var/obj/item/weapon/spacecash/bundle/bundle
 		if(!istype(W, /obj/item/weapon/spacecash/bundle))
 			var/obj/item/weapon/spacecash/cash = W
-			user.drop_from_inventory(cash)
 			bundle = new (src.loc)
 			bundle.worth += cash.worth
 			qdel(cash)
@@ -34,7 +33,6 @@
 		bundle.update_icon()
 		if(istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/h_user = user
-			h_user.drop_from_inventory(src)
 			h_user.drop_from_inventory(bundle)
 			h_user.put_in_hands(bundle)
 		to_chat(user, "<span class='notice'>You add [src.worth] Thalers worth of money to the bundles.<br>It holds [bundle.worth] Thalers now.</span>")
@@ -98,8 +96,6 @@
 
 	src.worth -= amount
 	src.update_icon()
-	if(!worth)
-		usr.drop_from_inventory(src)
 	if(amount in list(1000,500,200,100,50,20,1))
 		var/cashtype = text2path("/obj/item/weapon/spacecash/bundle/c[amount]")
 		var/obj/cash = new cashtype (usr.loc)

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -35,7 +35,6 @@
 /obj/machinery/food_replicator/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks))
 		var/obj/item/weapon/reagent_containers/food/snacks/S = O
-		user.drop_item(O)
 		for(var/datum/reagent/nutriment/N in S.reagents.reagent_list)
 			biomass = Clamp(biomass + round(N.volume*deconstruct_eff),1,biomass_max)
 		qdel(O)

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -38,9 +38,8 @@ obj/item/weapon/board/attackby(obj/item/I as obj, mob/user as mob)
 		return 0
 	if(!user.Adjacent(src))
 		return 0
-
-	user.drop_from_inventory(I)
-	I.forceMove(src)
+	if(!user.unEquip(I, src))
+		return 0
 	num++
 
 

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -141,7 +141,6 @@
 		for(var/datum/playingcard/P in cards)
 			H.cards += P
 		H.concealed = src.concealed
-		user.drop_from_inventory(src)
 		qdel(src)
 		H.update_icon()
 		return
@@ -180,7 +179,6 @@
 
 	H.cards += cards
 	cards.Cut();
-	user.drop_item()
 	qdel(src)
 
 	H.update_icon()

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -226,12 +226,6 @@
 	if(obj == null)
 		return
 
-	if(isobj(obj))
-		var/mob/M = obj.loc
-		if(ismob(M))
-			M.remove_from_mob(obj)
-			M.update_icons()	//so their overlays update
-
 	if(!silent)
 		var/obj/oldobj = obj
 		visible_message("The [oldobj.name] fades away!")

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -76,7 +76,6 @@
 		++frames
 		user.visible_message("<span class='notice'>\The [user] loads \the [I] into \the [src].</span>", "<span class='notice'>You load \the [I] into \the [src].</span>")
 		update_icon()
-		user.drop_from_inventory(I)
 		qdel(I)
 		return
 	else if(istype(I, /obj/item/bee_pack))
@@ -240,9 +239,7 @@
 	if(do_after(user, 30, src))
 		user.visible_message("<span class='notice'>\The [user] constructs a beehive.</span>", "<span class='notice'>You construct a beehive.</span>")
 		new /obj/machinery/beehive(get_turf(user))
-		user.drop_from_inventory(src)
 		qdel(src)
-	return
 
 /obj/item/stack/wax
 	name = "wax"

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -244,7 +244,6 @@
 		if(prob(35))
 			if(user)
 				to_chat(user, "<span class='danger'>\The [src] has fallen to bits.</span>")
-				user.drop_from_inventory(src)
 			qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/attack_self(mob/user as mob)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -78,9 +78,7 @@
 		var/obj/item/seeds/S =W
 		if(S.seed && S.seed.get_trait(TRAIT_IMMUTABLE) > 0)
 			to_chat(user, "That seed is not compatible with our genetics technology.")
-		else
-			user.drop_from_inventory(W)
-			W.loc = src
+		else if(user.unEquip(W, src))
 			seed = W
 			to_chat(user, "You load [W] into [src].")
 		return
@@ -110,9 +108,8 @@
 				if(disk_needs_genes)
 					to_chat(user, "That disk does not have any gene data loaded.")
 					return
-
-			user.drop_from_inventory(W)
-			W.loc = src
+			if(!user.unEquip(W, src))
+				return
 			loaded_disk = W
 			to_chat(user, "You load [W] into [src].")
 

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -326,7 +326,8 @@
 	if(!bypass_removal)
 		if (istype(O.loc, /mob))
 			var/mob/user = O.loc
-			user.remove_from_mob(O)
+			if(!user.unEquip(O, src))
+				return
 		else if(istype(O.loc,/obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = O.loc
 			S.remove_from_storage(O, src)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -468,9 +468,7 @@
 	else if (istype(O, /obj/item/seeds))
 
 		if(!seed)
-
 			var/obj/item/seeds/S = O
-			user.remove_from_mob(O)
 
 			if(!S.seed)
 				to_chat(user, "The packet seems to be empty. You throw it away.")
@@ -523,7 +521,6 @@
 	else if ( istype(O, /obj/item/weapon/plantspray) )
 
 		var/obj/item/weapon/plantspray/spray = O
-		user.remove_from_mob(O)
 		toxins += spray.toxicity
 		pestlevel -= spray.pest_kill_str
 		weedlevel -= spray.weed_kill_str

--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -52,7 +52,6 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 		return
 	if(istype(O,/obj/item/integrated_circuit))
 		to_chat(user, "<span class='notice'>You insert the circuit into [src]. </span>")
-		user.unEquip(O)
 		qdel(O)
 		metal = min(metal+1,maxMetal)
 		return 1

--- a/code/modules/integrated_electronics/manipulation.dm
+++ b/code/modules/integrated_electronics/manipulation.dm
@@ -229,7 +229,7 @@
 	if(istype(G))
 		if(attached_grenade)
 			to_chat(user, "<span class='warning'>There is already a grenade attached!</span>")
-		else if(user.unEquip(G, target = src))
+		else if(user.unEquip(G, src))
 			user.visible_message("<span class='warning'>\The [user] attaches \a [G] to \the [src]!</span>", "<span class='notice'>You attach \the [G] to \the [src].</span>")
 			attach_grenade(G)
 	else
@@ -354,10 +354,9 @@
 		to_chat(user, "<span class='warning'>There is already a card in there!</span>")
 		return
 	var/mob/living/L = locate(/mob/living) in card.contents
-	if(L && L.key)
+	if(L && L.key && user.unEquip(card))
 		L.forceMove(src)
 		controlling = L
-		user.drop_from_inventory(card)
 		card.dropInto(src)
 		aicard = card
 		user.visible_message("\The [user] loads \the [card] into \the [src]'s device slot")

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -28,8 +28,8 @@
 
 /obj/structure/bookcase/attackby(obj/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/weapon/book))
-		user.drop_item()
-		O.loc = src
+		if(!user.unEquip(O, src))
+			return
 		update_icon()
 	else if(istype(O, /obj/item/weapon/pen))
 		var/newname = sanitizeSafe(input("What would you like to title this bookshelf?"), MAX_NAME_LEN)
@@ -168,8 +168,8 @@
 	if(carved == 1)
 		if(!store)
 			if(W.w_class < ITEM_SIZE_NORMAL)
-				user.drop_item()
-				W.loc = src
+				if(!user.unEquip(W, src))
+					return
 				store = W
 				to_chat(user, "<span class='notice'>You put [W] in [title].</span>")
 				return

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -18,8 +18,8 @@
 
 /obj/machinery/libraryscanner/attackby(var/obj/O as obj, var/mob/user as mob)
 	if(istype(O, /obj/item/weapon/book))
-		user.drop_item()
-		O.loc = src
+		if(!user.unEquip(O, src))
+			return
 
 /obj/machinery/libraryscanner/attack_hand(var/mob/user as mob)
 	usr.set_machine(src)
@@ -68,8 +68,8 @@
 
 /obj/machinery/bookbinder/attackby(var/obj/O as obj, var/mob/user as mob)
 	if(istype(O, /obj/item/weapon/paper))
-		user.drop_item()
-		O.loc = src
+		if(!user.unEquip(O, src))
+			return
 		user.visible_message("[user] loads some paper into [src].", "You load some paper into [src].")
 		src.visible_message("[src] begins to hum as it warms up its printing drums.")
 		sleep(rand(200,400))

--- a/code/modules/locks/key.dm
+++ b/code/modules/locks/key.dm
@@ -24,7 +24,6 @@
 	if(uses == 1)
 		to_chat(user, "<span class='warning'>\The [src] is going to break soon!</span>")
 	else if(uses <= 0)
-		user.drop_item(src)
 		to_chat(user, "<span class='warning'>\The [src] crumbles in your hands.</span>")
 		qdel(src)
 	return ..()

--- a/code/modules/locks/lock_construct.dm
+++ b/code/modules/locks/lock_construct.dm
@@ -30,6 +30,5 @@
 
 /obj/item/weapon/material/lock_construct/proc/create_lock(var/atom/target, var/mob/user)
 	. = new /datum/lock(target,lock_data)
-	user.drop_item(src)
 	user.visible_message("\The [user] attaches \the [src] to \the [target]")
 	qdel(src)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -162,8 +162,8 @@
 		if(cell)
 			to_chat(user, "The drill already has a cell installed.")
 		else
-			user.drop_item()
-			O.loc = src
+			if(!user.unEquip(O, src))
+				return
 			cell = O
 			component_parts += O
 			to_chat(user, "You install \the [O].")

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -12,9 +12,8 @@
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/ore))
-		user.remove_from_mob(W)
-		src.contents += W
-	if (istype(W, /obj/item/weapon/storage))
+		user.unEquip(W, src)
+	else if (istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
 		S.hide_from(usr)
 		for(var/obj/item/weapon/ore/O in S.contents)
@@ -23,8 +22,6 @@
 		to_chat(user, "<span class='notice'>You empty the satchel into the box.</span>")
 
 	update_ore_count()
-
-	return
 
 /obj/structure/ore_box/proc/update_ore_count()
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -221,11 +221,17 @@ var/list/slot_equipment_priority = list( \
 			break
 	return slot
 
-//This differs from remove_from_mob() in that it checks if the item can be unequipped first.
-/mob/proc/unEquip(obj/item/I, force = 0, var/atom/target = null) //Force overrides NODROP for things like wizarditis and admin undress.
-	if(!(force || canUnEquip(I)))
+//This differs from remove_from_mob() in that it checks if the item can be unequipped first. Use drop_from_inventory if you don't want to check.
+/mob/proc/unEquip(obj/item/I, var/atom/target)
+	if(!canUnEquip(I))
 		return
 	drop_from_inventory(I, target)
+	return 1
+
+/mob/proc/unequip_item(atom/target)
+	if(!canUnEquip(get_active_hand()))
+		return
+	drop_item(target)
 	return 1
 
 //Attemps to remove an object on a mob.

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -173,13 +173,11 @@
 /obj/item/weapon/bucket_sensor/attackby(var/obj/item/O, var/mob/user)
 	..()
 	if(istype(O, /obj/item/robot_parts/l_arm) || istype(O, /obj/item/robot_parts/r_arm))
-		user.drop_item()
 		qdel(O)
 		var/turf/T = get_turf(loc)
 		var/mob/living/bot/cleanbot/A = new /mob/living/bot/cleanbot(T)
 		A.SetName(created_name)
 		to_chat(user, "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>")
-		user.drop_from_inventory(src)
 		qdel(src)
 
 	else if(istype(O, /obj/item/weapon/pen))

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -92,7 +92,6 @@
 	switch(build_step)
 		if(0, 1)
 			if(istype(W, /obj/item/robot_parts/l_leg) || istype(W, /obj/item/robot_parts/r_leg))
-				user.drop_item()
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add the robot leg to [src].</span>")
@@ -110,7 +109,6 @@
 					if(!locate(/obj/item/clothing/accessory/armorplate) in W.contents)
 						to_chat(user, "There's no armor plates on this [W].")
 						return
-				user.drop_item()
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
@@ -127,7 +125,6 @@
 					to_chat(user, "<span class='notice'>You welded the vest to [src].</span>")
 		if(4)
 			if(istype(W, /obj/item/clothing/head/helmet))
-				user.drop_item()
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add the helmet to [src].</span>")
@@ -137,7 +134,6 @@
 
 		if(5)
 			if(isprox(W))
-				user.drop_item()
 				qdel(W)
 				build_step++
 				to_chat(user, "<span class='notice'>You add the prox sensor to [src].</span>")
@@ -166,7 +162,6 @@
 				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
 				item_state = "ed209_taser"
 				icon_state = "ed209_taser"
-				user.drop_item()
 				qdel(W)
 
 		if(8)
@@ -186,7 +181,5 @@
 				to_chat(user, "<span class='notice'>You complete the ED-209.</span>")
 				var/turf/T = get_turf(src)
 				new /mob/living/bot/secbot/ed209(T,created_name,lasercolor)
-				user.drop_item()
 				qdel(W)
-				user.drop_from_inventory(src)
 				qdel(src)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -307,7 +307,6 @@
 		return
 
 	to_chat(user, "You add the robot arm to [src].")
-	user.drop_from_inventory(S)
 	qdel(S)
 	new /obj/item/weapon/farmbot_arm_assembly(loc, src)
 
@@ -317,21 +316,18 @@
 		build_step++
 		to_chat(user, "You add the plant analyzer to [src].")
 		SetName("farmbot assembly")
-		user.remove_from_mob(W)
 		qdel(W)
 
 	else if((istype(W, /obj/item/weapon/reagent_containers/glass/bucket)) && (build_step == 1))
 		build_step++
 		to_chat(user, "You add a bucket to [src].")
 		SetName("farmbot assembly with bucket")
-		user.remove_from_mob(W)
 		qdel(W)
 
 	else if((istype(W, /obj/item/weapon/material/minihoe)) && (build_step == 2))
 		build_step++
 		to_chat(user, "You add a minihoe to [src].")
 		SetName("farmbot assembly with bucket and minihoe")
-		user.remove_from_mob(W)
 		qdel(W)
 
 	else if((isprox(W)) && (build_step == 3))
@@ -339,7 +335,6 @@
 		to_chat(user, "You complete the Farmbot! Beep boop.")
 		var/mob/living/bot/farmbot/S = new /mob/living/bot/farmbot(get_turf(src), tank)
 		S.SetName(created_name)
-		user.remove_from_mob(W)
 		qdel(W)
 		qdel(src)
 

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -263,7 +263,6 @@
 		B.boxtype = icon_state
 		user.put_in_hands(B)
 		to_chat(user, "<span class='notice'>You add the tiles into the empty toolbox. They protrude from the top.</span>")
-		user.drop_from_inventory(src)
 		qdel(src)
 	else
 		to_chat(user, "<span class='warning'>You need 10 floor tiles for a floorbot.</span>")
@@ -290,7 +289,6 @@
 		B.created_name = created_name
 		user.put_in_hands(B)
 		to_chat(user, "<span class='notice'>You add the sensor to the toolbox and tiles!</span>")
-		user.drop_from_inventory(src)
 		B.boxtype = src.boxtype
 		qdel(src)
 	else if (istype(W, /obj/item/weapon/pen))
@@ -323,7 +321,6 @@
 		A.SetName(created_name)
 		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly! Boop beep!</span>")
 		A.boxtype = src.boxtype
-		user.drop_from_inventory(src)
 		qdel(src)
 	else if(istype(W, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -103,8 +103,8 @@
 			to_chat(user, "<span class='notice'>There is already a beaker loaded.</span>")
 			return
 
-		user.drop_item()
-		O.loc = src
+		if(!user.unEquip(O, src))
+			return
 		reagent_glass = O
 		to_chat(user, "<span class='notice'>You insert [O].</span>")
 		return
@@ -267,7 +267,6 @@
 	qdel(S)
 	user.put_in_hands(A)
 	to_chat(user, "<span class='notice'>You add the robot arm to the first aid kit.</span>")
-	user.drop_from_inventory(src)
 	qdel(src)
 
 /obj/item/weapon/firstaid_arm_assembly
@@ -298,7 +297,6 @@
 		switch(build_step)
 			if(0)
 				if(istype(W, /obj/item/device/healthanalyzer))
-					user.drop_item()
 					qdel(W)
 					build_step++
 					to_chat(user, "<span class='notice'>You add the health sensor to [src].</span>")
@@ -307,7 +305,6 @@
 
 			if(1)
 				if(isprox(W))
-					user.drop_item()
 					qdel(W)
 					to_chat(user, "<span class='notice'>You complete the Medibot! Beep boop.</span>")
 					var/turf/T = get_turf(src)
@@ -315,5 +312,4 @@
 					S.skin = skin
 					S.SetName(created_name)
 					S.update_icons() // apply the skin
-					user.drop_from_inventory(src)
 					qdel(src)

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -167,5 +167,4 @@
 	var/turf/T = get_turf(src.loc)
 	new /mob/living/bot/remotebot(T)
 	new /obj/item/device/bot_controller(T)
-	user.drop_from_inventory(src)
 	qdel(src)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -265,7 +265,6 @@
 		var/obj/item/weapon/secbot_assembly/A = new /obj/item/weapon/secbot_assembly
 		user.put_in_hands(A)
 		to_chat(user, "You add the signaler to the helmet.")
-		user.drop_from_inventory(src)
 		qdel(src)
 	else
 		return
@@ -289,7 +288,6 @@
 			to_chat(user, "You weld a hole in \the [src].")
 
 	else if(isprox(O) && (build_step == 1))
-		user.drop_item()
 		build_step = 2
 		to_chat(user, "You add \the [O] to [src].")
 		overlays += image('icons/mob/bot/secbot.dmi', "hs_eye")
@@ -297,7 +295,6 @@
 		qdel(O)
 
 	else if((istype(O, /obj/item/robot_parts/l_arm) || istype(O, /obj/item/robot_parts/r_arm)) && build_step == 2)
-		user.drop_item()
 		build_step = 3
 		to_chat(user, "You add \the [O] to [src].")
 		SetName("helmet/signaler/prox sensor/robot arm assembly")
@@ -305,7 +302,6 @@
 		qdel(O)
 
 	else if(istype(O, /obj/item/weapon/melee/baton) && build_step == 3)
-		user.drop_item()
 		to_chat(user, "You complete the Securitron! Beep boop.")
 		var/mob/living/bot/secbot/S = new /mob/living/bot/secbot(get_turf(src))
 		S.SetName(created_name)

--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -76,7 +76,7 @@
 
 /mob/living/carbon/alien/diona/hotkey_drop()
 	if(holding_item || hat)
-		drop_item()
+		unequip_item()
 	else
 		to_chat(usr, "<span class='warning'>You have nothing to drop.</span>")
 

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -55,7 +55,8 @@
 		else if(!B.brainmob || !B.can_use_mmi)
 			to_chat(user, "<span class='notice'>This brain is completely useless to you.</span>")
 			return
-
+		if(!user.unEquip(O, src))
+			return
 		user.visible_message("<span class='notice'>\The [user] sticks \a [O] into \the [src].</span>")
 
 		brainmob = B.brainmob
@@ -65,9 +66,7 @@
 		brainmob.set_stat(CONSCIOUS)
 		brainmob.switch_from_dead_to_living_mob_list() //Update dem lists
 
-		user.drop_item()
 		brainobj = O
-		brainobj.forceMove(src)
 
 		SetName("[initial(name)]: ([brainmob.real_name])")
 		icon_state = "mmi_full"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -299,8 +299,8 @@
 		var/obj/item/I = item
 		itemsize = I.w_class
 
-	src.drop_from_inventory(item)
-	
+	if(!unEquip(item))
+		return	
 	if(!item || !isturf(item.loc))
 		return
 	

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -50,7 +50,7 @@
 			//Moving around with fractured ribs won't do you any good
 				if (prob(10) && !stat && can_feel_pain() && chem_effects[CE_PAINKILLER] < 50 && E.is_broken() && E.internal_organs.len)
 					custom_pain("Pain jolts through your broken [E.encased ? E.encased : E.name], staggering you!", 50, affecting = E)
-					drop_item(loc)
+					unequip_item(loc)
 					Stun(2)
 
 				//Moving makes open wounds get infected much faster
@@ -163,7 +163,8 @@
 	if(!thing)
 		return
 
-	drop_from_inventory(thing)
+	if(!unEquip(thing))
+		return
 
 	if(affected.robotic >= ORGAN_ROBOT)
 		visible_message("<B>\The [src]</B> drops what they were holding, \his [affected.name] malfunctioning!")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -180,7 +180,7 @@
 	..()
 	if(stat != DEAD)
 		if ((disabilities & COUGHING) && prob(5) && paralysis <= 1)
-			drop_item()
+			unequip_item()
 			spawn(0)
 				emote("cough")
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -567,8 +567,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 		//Actually disarm them
 		for(var/obj/item/I in holding)
-			if(I)
-				target.drop_from_inventory(I)
+			if(I && target.unEquip(I))
 				target.visible_message("<span class='danger'>[attacker] has disarmed [target]!</span>")
 				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 				return

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -324,9 +324,8 @@
 	if(istype(H))
 		var/mob/living/M = H.loc
 		if(istype(M))
-			M.drop_from_inventory(H)
-		H.loc = get_turf(src)
-		src.loc = get_turf(H)
+			M.drop_from_inventory(H, get_turf(src))
+		src.forceMove(get_turf(src))
 
 	// Move us into the card and move the card to the ground.
 	src.loc = card

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -8,9 +8,9 @@
 
 /obj/item/weapon/pai_cable/proc/plugin(obj/machinery/M as obj, mob/user as mob)
 	if(istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
+		if(!user.unEquip(src, M))
+			return
 		user.visible_message("[user] inserts [src] into a data port on [M].", "You insert [src] into a data port on [M].", "You hear the satisfying click of a wire jack fastening into place.")
-		user.drop_item()
-		src.loc = M
 		src.machine = M
 	else
 		user.visible_message("[user] dumbly fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -198,10 +198,9 @@ var/list/mob_hat_cache = list()
 	if(user.a_intent == I_HELP && istype(W, /obj/item/clothing/head))
 		if(hat)
 			to_chat(user, "<span class='warning'>\The [src] is already wearing \the [hat].</span>")
-			return
-		user.unEquip(W)
-		wear_hat(W)
-		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
+		else if(user.unEquip(W))
+			wear_hat(W)
+			user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
 		return
 	else if(istype(W, /obj/item/borg/upgrade/))
 		to_chat(user, "<span class='danger'>\The [src] is not compatible with \the [W].</span>")

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -249,3 +249,11 @@
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W) // No hands.
 	W.forceMove(get_turf(src))
 	return 1
+
+//Robots don't use inventory slots, so we need to override this.
+/mob/living/silicon/robot/canUnEquip(obj/item/I)
+	if(!I)
+		return 1
+	if((I in module) || (I in src)) //Includes all modules and installed components.
+		return I.canremove          //Will be 0 for modules, but items held by grippers will also be checked here.
+	return 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -464,10 +464,11 @@
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
 			if(!C.installed && istype(W, C.external_type))
+				if(!user.unEquip(W))
+					return
 				C.installed = 1
 				C.wrapped = W
 				C.install()
-				user.drop_item()
 				W.loc = null
 
 				var/obj/item/robot_parts/robot_component/WC = W
@@ -574,15 +575,15 @@
 
 	// If the robot is having something inserted which will remain inside it, self-inserting must be handled before exiting to avoid logic errors. Use the handle_selfinsert proc.
 	else if (istype(W, /obj/item/weapon/stock_parts/matter_bin) && opened) // Installing/swapping a matter bin
+		if(!user.unEquip(W, src))
+			return
 		if(storage)
 			to_chat(user, "You replace \the [storage] with \the [W]")
 			storage.forceMove(get_turf(src))
 			storage = null
 		else
 			to_chat(user, "You install \the [W]")
-		user.drop_item()
 		storage = W
-		W.forceMove(src)
 		handle_selfinsert(W, user)
 		recalculate_synth_capacities()
 
@@ -594,9 +595,7 @@
 			to_chat(user, "There is a power cell already installed.")
 		else if(W.w_class != ITEM_SIZE_NORMAL)
 			to_chat(user, "\The [W] is too [W.w_class < ITEM_SIZE_NORMAL? "small" : "large"] to fit here.")
-		else
-			user.drop_item()
-			W.loc = src
+		else if(user.unEquip(W, src))
 			cell = W
 			handle_selfinsert(W, user) //Just in case.
 			to_chat(user, "You insert the power cell.")
@@ -651,9 +650,9 @@
 			to_chat(usr, "The upgrade is locked and cannot be used yet!")
 		else
 			if(U.action(src))
+				if(!user.unEquip(U, src))
+					return
 				to_chat(usr, "You apply the upgrade to [src]!")
-				usr.drop_item()
-				U.loc = src
 				handle_selfinsert(W, user)
 			else
 				to_chat(usr, "Upgrade error!")

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -106,8 +106,8 @@
 					access_card = equipping
 				if("back")
 					messenger_bag = equipping
-			usr.drop_from_inventory(equipping)
-			equipping.forceMove(src)
+			if(!usr.unEquip(equipping, src))
+				return 0
 			visible_message("<span class='notice'>\The [usr] places \the [equipping] on to \the [src]'s [href_list["add_inv"]].</span>")
 			update_icon()
 			show_inv(usr)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -234,7 +234,6 @@ var/global/chicken_count = 0
 		if(G.seed && G.seed.kitchen_tag == "wheat")
 			if(!stat && eggsleft < 8)
 				user.visible_message("<span class='notice'>[user] feeds [O] to [name]! It clucks happily.</span>","<span class='notice'>You feed [O] to [name]! It clucks happily.</span>")
-				user.drop_item()
 				qdel(O)
 				eggsleft += rand(1, 4)
 			else

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -81,17 +81,16 @@
 		if(jobban_isbanned(B, "Robot"))
 			to_chat(user, "<span class='warning'>\The [O] does not seem to fit.</span>")
 			return
-
+		if(!user.unEquip(O, src))
+			return
 		to_chat(user, "<span class='notice'>You install \the [O] in \the [src]!</span>")
 		if(istype(O, /obj/item/organ/internal/posibrain))
 			positronic = 1
 			add_language("Robot Talk")
 
-		user.drop_item()
 		src.mmi = O
 		src.transfer_personality(O)
 
-		O.loc = src
 		src.update_icon()
 		return 1
 

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -82,7 +82,6 @@ Small, little HP, poisonous.
 		var/mob/living/carbon/human/H = target
 		if(!do_mob(user, H, 30))
 			return
-		user.drop_from_inventory(src)
 		V.attach(H)
 		qdel(src)
 		return

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -176,11 +176,10 @@
 						if( !istype(item_to_add,  /obj/item/device/radio/headset) )
 							to_chat(usr, "<span class='warning'>This object won't fit.</span>")
 							return
-
+						if(!usr.unEquip(item_to_add, src))
+							return
 						var/obj/item/device/radio/headset/headset_to_add = item_to_add
 
-						usr.drop_item()
-						headset_to_add.loc = src
 						src.ears = headset_to_add
 						to_chat(usr, "You fit the headset onto [src].")
 
@@ -603,10 +602,8 @@
 		if(C.r_hand && C.r_hand.w_class <= ITEM_SIZE_SMALL)
 			stolen_item = C.r_hand
 
-		if(stolen_item)
-			C.remove_from_mob(stolen_item)
+		if(stolen_item && C.unEquip(stolen_item, src))
 			held_item = stolen_item
-			stolen_item.loc = src
 			visible_message("[src] grabs the [held_item] out of [C]'s hand!", "<span class='warning'>You snag the [held_item] out of [C]'s hand!</span>", "You hear the sounds of wings flapping furiously.")
 			return held_item
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -60,7 +60,7 @@
 	if(!get_active_hand())
 		to_chat(usr, "<span class='warning'>You have nothing to drop in your hand.</span>")
 	else
-		drop_item()
+		unequip_item()
 
 //This gets called when you press the delete button.
 /client/verb/delete_key_pressed()
@@ -102,7 +102,7 @@
 /client/verb/drop_item()
 	set hidden = 1
 	if(!isrobot(mob) && mob.stat == CONSCIOUS && isturf(mob.loc))
-		return mob.drop_item()
+		return mob.unequip_item()
 	return
 
 

--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -66,11 +66,9 @@
 		found = 1
 		scanner = H
 		scanner.do_after_install(user, src)
-	if(found)
+	if(found && user.unEquip(H, src))
 		to_chat(user, "You install \the [H] into \the [src]")
 		H.holder2 = src
-		user.drop_from_inventory(H)
-		H.forceMove(src)
 		update_verbs()
 
 // Uninstalls component. Found and Critical vars may be passed by parent types, if they have additional hardware.

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -187,9 +187,9 @@
 			to_chat(user, "You try to insert [I] into [src], but its ID card slot is occupied.")
 			return
 
-		user.drop_from_inventory(I)
+		if(!user.unEquip(I, src))
+			return
 		card_slot.stored_card = I
-		I.forceMove(src)
 		update_uis()
 		update_verbs()
 		to_chat(user, "You insert [I] into [src].")
@@ -199,9 +199,9 @@
 		if(istype(stored_pen))
 			to_chat(user, "<span class='notice'>There is already a pen in [src].</span>")
 			return
-		user.drop_from_inventory(W)
+		if(!user.unEquip(W, src))
+			return
 		stored_pen = W
-		W.forceMove(src)
 		update_verbs()
 		to_chat(user, "<span class='notice'>You insert [W] into [src].</span>")
 		return

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -24,9 +24,9 @@
 		if(stored_card)
 			to_chat(user, "\The [src] is already occupied.")
 			return
-		user.drop_from_inventory(W)
+		if(!user.unEquip(W, src))
+			return
 		stored_card = W
-		W.forceMove(src)
 		update_power_usage()
 	if(isScrewdriver(W))
 		to_chat(user, "You manually remove \the [stored_card] from \the [src].")

--- a/code/modules/organs/external/machine.dm
+++ b/code/modules/organs/external/machine.dm
@@ -86,8 +86,7 @@
 		if(open)
 			if(cell)
 				to_chat(user, "<span class ='warning'>There is a power cell already installed.</span>")
-			else
-				user.drop_from_inventory(W,src)
+			else if(user.unEquip(W, src))
 				cell = W
 				to_chat(user, "<span class = 'notice'>You insert \the [cell].</span>")
 

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -267,7 +267,7 @@
 		owner.eye_blurry = 10
 	if(damage >= 0.5*max_damage && prob(1) && owner.get_active_hand())
 		to_chat(owner, "<span class='danger'>Your hand won't respond properly, and you drop what you are holding!</span>")
-		owner.drop_item()
+		owner.unequip_item()
 	if(damage >= 0.6*max_damage)
 		owner.slurring = max(owner.slurring, 2)
 	if(is_broken())

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -294,8 +294,8 @@ var/list/organ_cache = list()
 	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
 		to_chat(user, "<span class='notice'>You successfully repress your cannibalistic tendencies.</span>")
 		return
-
-	user.drop_from_inventory(src)
+	if(!user.unEquip(src))
+		return
 	var/obj/item/weapon/reagent_containers/food/snacks/organ/O = new(get_turf(src))
 	O.SetName(name)
 	O.appearance = src

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -58,7 +58,7 @@ mob/living/carbon/human/proc/handle_pain()
 		if(maxdam > 10 && paralysis)
 			paralysis = max(0, paralysis - round(maxdam/10))
 		if(maxdam > 50 && prob(maxdam / 5))
-			drop_item()
+			unequip_item()
 		var/burning = damaged_organ.burn_dam > damaged_organ.brute_dam
 		var/msg
 		switch(maxdam)

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -143,6 +143,5 @@
 			to_chat(user, "<spawn class='warning'>\The [src] door is still closed!")
 			return
 		if(contents.len == 0)
-			user.drop_from_inventory(W)
-			W.forceMove(src)
+			user.unEquip(W, src)
 	update_icon()

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -46,8 +46,8 @@
 /obj/item/weapon/clipboard/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
 	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/photo))
-		user.drop_item()
-		W.loc = src
+		if(!user.unEquip(W, src))
+			return
 		if(istype(W, /obj/item/weapon/paper))
 			toppaper = W
 		to_chat(user, "<span class='notice'>You clip the [W] onto \the [src].</span>")
@@ -100,8 +100,8 @@
 			if(!haspen)
 				var/obj/item/weapon/pen/W = usr.get_active_hand()
 				if(istype(W, /obj/item/weapon/pen))
-					usr.drop_item()
-					W.loc = src
+					if(!usr.unEquip(W, src))
+						return
 					haspen = W
 					to_chat(usr, "<span class='notice'>You slot the pen into \the [src].</span>")
 

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -49,10 +49,10 @@
 
 /obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
 	if(is_type_in_list(P, can_hold))
+		if(!user.unEquip(P, src))
+			return
 		add_fingerprint(user)
 		to_chat(user, "<span class='notice'>You put [P] in [src].</span>")
-		user.drop_item()
-		P.loc = src
 		icon_state = "[initial(icon_state)]-open"
 		sleep(5)
 		icon_state = initial(icon_state)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -33,8 +33,8 @@
 
 /obj/item/weapon/folder/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/photo) || istype(W, /obj/item/weapon/paper_bundle))
-		user.drop_item()
-		W.loc = src
+		if(!user.unEquip(W, src))
+			return
 		to_chat(user, "<span class='notice'>You put the [W] into \the [src].</span>")
 		update_icon()
 	else if(istype(W, /obj/item/weapon/pen))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -250,10 +250,7 @@
 				user.visible_message("<span class='[class]'>[user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
 				"<span class='[class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
-				if(user.get_inactive_hand() == src)
-					user.drop_from_inventory(src)
-
-				new /obj/effect/decal/cleanable/ash(src.loc)
+				new /obj/effect/decal/cleanable/ash(get_turf(src))
 				qdel(src)
 
 			else
@@ -351,11 +348,9 @@
 		else if (P.name != "paper" && P.name != "photo")
 			B.SetName(P.name)
 
-		user.drop_from_inventory(P)
-		user.drop_from_inventory(src)
+		if(!user.unEquip(P, B) || !user.unEquip(src, B))
+			return
 		user.put_in_hands(B)
-		src.forceMove(B)
-		P.forceMove(B)
 
 		to_chat(user, "<span class='notice'>You clip the [P.name] to [(src.name == "paper") ? "the paper" : src.name].</span>")
 

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -34,7 +34,6 @@
 
 	// merging bundles
 	else if(istype(W, /obj/item/weapon/paper_bundle))
-		user.drop_from_inventory(W)
 		for(var/obj/O in W)
 			O.loc = src
 			O.add_fingerprint(usr)
@@ -60,10 +59,8 @@
 		to_chat(user, "<span class='notice'>You add [(sheet.name == "paper") ? "the paper" : sheet.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>")
 	else if(istype(sheet, /obj/item/weapon/photo))
 		to_chat(user, "<span class='notice'>You add [(sheet.name == "photo") ? "the photo" : sheet.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>")
-
-	user.drop_from_inventory(sheet)
-	sheet.loc = src
-
+	else if(!user.unEquip(sheet, src))
+		return
 	pages.Insert(index, sheet)
 
 	if(index <= page)
@@ -207,9 +204,7 @@
 		O.dropInto(usr.loc)
 		O.reset_plane_and_layer()
 		O.add_fingerprint(usr)
-	usr.drop_from_inventory(src)
 	qdel(src)
-	return
 
 
 /obj/item/weapon/paper_bundle/update_icon()

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -78,8 +78,8 @@
 
 /obj/item/weapon/paper_bin/attackby(obj/item/weapon/i as obj, mob/user as mob)
 	if(istype(i, /obj/item/weapon/paper))
-		user.drop_item()
-		i.forceMove(src)
+		if(!user.unEquip(i, src))
+			return
 		to_chat(user, "<span class='notice'>You put [i] in [src].</span>")
 		papers.Add(i)
 		update_icon()
@@ -96,11 +96,9 @@
 				was_there_a_photo = 1
 				bundleitem.dropInto(user.loc)
 				bundleitem.reset_plane_and_layer()
-		user.drop_from_inventory(i)
 		qdel(i)
 		if(was_there_a_photo)
 			to_chat(user, "<span class='notice'>The photo cannot go into \the [src].</span>")
-	return
 
 
 /obj/item/weapon/paper_bin/examine(mob/user)

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -33,7 +33,6 @@
 				to_chat(user, "<span class='warning'>\The [src] is full; please empty it before you continue.</span>")
 				return
 			paperamount += paper_result
-			user.drop_from_inventory(W)
 			qdel(W)
 			playsound(src.loc, 'sound/items/pshred.ogg', 75, 1)
 			if(paperamount > max_paper)
@@ -120,9 +119,6 @@
 	FireBurn()
 
 /obj/item/weapon/shreddedp/proc/FireBurn()
-	var/mob/living/M = loc
-	if(istype(M))
-		M.drop_from_inventory(src)
 	new /obj/effect/decal/cleanable/ash(get_turf(src))
 	qdel(src)
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -106,9 +106,9 @@
 /obj/machinery/photocopier/attackby(obj/item/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/weapon/paper) || istype(O, /obj/item/weapon/photo) || istype(O, /obj/item/weapon/paper_bundle))
 		if(!copyitem)
-			user.drop_item()
+			if(!user.unEquip(O, src))
+				return
 			copyitem = O
-			O.loc = src
 			to_chat(user, "<span class='notice'>You insert \the [O] into \the [src].</span>")
 			flick(insert_anim, src)
 			updateUsrDialog()
@@ -116,7 +116,8 @@
 			to_chat(user, "<span class='notice'>There is already something in \the [src].</span>")
 	else if(istype(O, /obj/item/device/toner))
 		if(toner <= 10) //allow replacing when low toner is affecting the print darkness
-			user.drop_item()
+			if(!user.unEquip(O, src))
+				return
 			to_chat(user, "<span class='notice'>You insert the toner cartridge into \the [src].</span>")
 			var/obj/item/device/toner/T = O
 			toner += T.toner_amount

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -185,7 +185,6 @@ var/global/photo_count = 0
 			to_chat(user, "<span class='notice'>[src] still has some film in it!</span>")
 			return
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-		user.drop_item()
 		qdel(I)
 		pictures_left = pictures_max
 		return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -481,8 +481,8 @@
 			to_chat(user, "\The [W] is too [W.w_class < ITEM_SIZE_NORMAL? "small" : "large"] to fit here.")
 			return
 
-		user.drop_item()
-		W.forceMove(src)
+		if(!user.unEquip(W, src))
+			return
 		cell = W
 		user.visible_message(\
 			"<span class='warning'>[user.name] has inserted the power cell to [src.name]!</span>",\

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -161,10 +161,9 @@
 
 	if(internal_cells.len >= max_cells)
 		return 0
-
+	if(user && !user.unEquip(C))
+		return 0
 	internal_cells.Add(C)
-	if(user)
-		user.drop_from_inventory(C)
 	C.forceMove(src)
 	RefreshParts()
 	update_maxcharge()

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -51,15 +51,12 @@ var/list/fuel_injectors = list()
 		if(injecting)
 			to_chat(user, "<span class='warning'>Shut \the [src] off before playing with the fuel rod!</span>")
 			return
-
+		if(!user.unEquip(W, src))
+			return
 		if(cur_assembly)
-			cur_assembly.forceMove(get_turf(src))
 			visible_message("<span class='notice'>\The [user] swaps \the [src]'s [cur_assembly] for \a [W].</span>")
 		else
 			visible_message("<span class='notice'>\The [user] inserts \a [W] into \the [src].</span>")
-
-		user.drop_from_inventory(W)
-		W.forceMove(src)
 		if(cur_assembly)
 			cur_assembly.forceMove(get_turf(src))
 			user.put_in_hands(cur_assembly)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -339,9 +339,9 @@
 		if(!istype(W, light_type))
 			to_chat(user, "This type of light requires a [get_fitting_name()].")
 			return
-
+		if(!user.unEquip(W, src))
+			return
 		to_chat(user, "You insert [W].")
-		user.drop_item()
 		insert_bulb(W)
 		src.add_fingerprint(user)
 

--- a/code/modules/power/pacman2.dm
+++ b/code/modules/power/pacman2.dm
@@ -71,9 +71,9 @@
 			if(P)
 				to_chat(user, "<span class='warning'>The generator already has a phoron tank loaded!</span>")
 				return
+			if(!user.unEquip(O, src))
+				return
 			P = O
-			user.drop_item()
-			O.loc = src
 			to_chat(user, "<span class='notice'>You add the phoron tank to the generator.</span>")
 		else if(!active)
 			if(isWrench(O))

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -65,9 +65,9 @@ var/global/list/rad_collectors = list()
 		if(src.P)
 			to_chat(user, "<span class='warning'>There's already a phoron tank loaded.</span>")
 			return 1
-		user.drop_item()
+		if(!user.unEquip(W, src))
+			return
 		src.P = W
-		W.loc = src
 		update_icons()
 		return 1
 	else if(isCrowbar(W))

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -390,11 +390,10 @@
 				if (failure_probability && prob(failure_probability))
 					total_system_failure(failure_probability, user)
 					return
-
+				if(!user.unEquip(W, src))
+					return
 				to_chat(usr, "You install the coil into the SMES unit!")
-				user.drop_item()
 				component_parts += W
-				W.forceMove(src)
 				recalc_coils()
 			else
 				to_chat(usr, "<span class='warning'>You can't insert more coils to this SMES unit!</span>")

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -259,7 +259,6 @@ var/list/solars_list = list()
 	if(!tracker)
 		if(istype(W, /obj/item/weapon/tracker_electronics))
 			tracker = 1
-			user.drop_item()
 			qdel(W)
 			user.visible_message("<span class='notice'>[user] inserts the electronics into the solar assembly.</span>")
 			return 1

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -135,8 +135,8 @@
 		if(stored_ammo.len >= max_ammo)
 			to_chat(user, "<span class='warning'>[src] is full!</span>")
 			return
-		user.remove_from_mob(C)
-		C.forceMove(src)
+		if(!user.unEquip(C, src))
+			return
 		stored_ammo.Add(C)
 		update_icon()
 	else ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -139,7 +139,7 @@
 					"<span class='danger'>\The [user] shoots \himself in the foot with \the [src]!</span>",
 					"<span class='danger'>You shoot yourself in the foot with \the [src]!</span>"
 					)
-				M.drop_item()
+				M.unequip_item()
 		else
 			handle_click_empty(user)
 		return 0

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -140,8 +140,7 @@
 
 /obj/item/weapon/gun/launcher/crossbow/attackby(obj/item/W as obj, mob/user as mob)
 	if(!bolt)
-		if (istype(W,/obj/item/weapon/arrow))
-			user.drop_from_inventory(W, src)
+		if (istype(W,/obj/item/weapon/arrow) && user.unEquip(W, src))
 			bolt = W
 			user.visible_message("[user] slides [bolt] into [src].","You slide [bolt] into [src].")
 			update_icon()
@@ -159,9 +158,9 @@
 
 	if(istype(W, /obj/item/weapon/cell))
 		if(!cell)
-			user.drop_item()
+			if(!user.unEquip(W, src))
+				return
 			cell = W
-			cell.loc = src
 			to_chat(user, "<span class='notice'>You jam [cell] into [src] and wire it to the firing coil.</span>")
 			superheat_rod(user)
 		else

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -58,7 +58,8 @@
 	if(grenades.len >= max_grenades)
 		to_chat(user, "<span class='warning'>\The [src] is full.</span>")
 		return
-	user.drop_from_inventory(G, src)
+	if(!user.unEquip(G, src))
+		return
 	grenades.Insert(1, G) //add to the head of the list, so that it is loaded on the next pump
 	user.visible_message("\The [user] inserts \a [G] into \the [src].", "<span class='notice'>You insert \a [G] into \the [src].</span>")
 
@@ -142,7 +143,8 @@
 	if(chambered)
 		to_chat(user, "<span class='warning'>\The [src] is already loaded.</span>")
 		return
-	user.drop_from_inventory(G, src)
+	if(!user.unEquip(G, src))
+		return
 	chambered = G
 	user.visible_message("\The [user] load \a [G] into \the [src].", "<span class='notice'>You load \a [G] into \the [src].</span>")
 

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -78,7 +78,6 @@
 
 	src.receptacle_value += bling.worth
 	to_chat(user, "<span class='notice'>You load [bling] into [src].</span>")
-	user.drop_from_inventory(bling)
 	qdel(bling)
 
 /obj/item/weapon/gun/launcher/money/consume_next_projectile(mob/user=null)

--- a/code/modules/projectiles/guns/launcher/net.dm
+++ b/code/modules/projectiles/guns/launcher/net.dm
@@ -23,8 +23,8 @@
 	if(chambered)
 		to_chat(user, "<span class='warning'>\The [src] already has a shell loaded.</span>")
 		return
-
-	user.drop_from_inventory(S, src)
+	if(!user.unEquip(S, src))
+		return
 	chambered = S
 	user.visible_message("\The [user] inserts \a [S] into \the [src].", "<span class='notice'>You insert \a [S] into \the [src].</span>")
 

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -65,8 +65,7 @@
 		return ..()
 
 /obj/item/weapon/gun/launcher/pneumatic/attackby(obj/item/W as obj, mob/user as mob)
-	if(!tank && istype(W,/obj/item/weapon/tank))
-		user.drop_from_inventory(W, src)
+	if(!tank && istype(W,/obj/item/weapon/tank) && user.unEquip(W, src))
 		tank = W
 		user.visible_message("[user] jams [W] into [src]'s valve and twists it closed.","You jam [W] into [src]'s valve and twist it closed.")
 		update_icon()
@@ -159,7 +158,6 @@
 /obj/item/weapon/cannonframe/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/pipe))
 		if(buildstate == 0)
-			user.drop_from_inventory(W)
 			qdel(W)
 			to_chat(user, "<span class='notice'>You secure the piping inside the frame.</span>")
 			buildstate++
@@ -177,7 +175,6 @@
 			return
 	else if(istype(W,/obj/item/device/transfer_valve))
 		if(buildstate == 4)
-			user.drop_from_inventory(W)
 			qdel(W)
 			to_chat(user, "<span class='notice'>You install the transfer valve and connect it to the piping.</span>")
 			buildstate++

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -26,8 +26,8 @@
 /obj/item/weapon/gun/launcher/rocket/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/ammo_casing/rocket))
 		if(rockets.len < max_rockets)
-			user.drop_item()
-			I.loc = src
+			if(!user.unEquip(I, src))
+				return
 			rockets += I
 			to_chat(user, "<span class='notice'>You put the rocket in [src].</span>")
 			to_chat(user, "<span class='notice'>[rockets.len] / [max_rockets] rockets.</span>")

--- a/code/modules/projectiles/guns/launcher/slugsling.dm
+++ b/code/modules/projectiles/guns/launcher/slugsling.dm
@@ -15,7 +15,6 @@
 	return ..()
 
 /obj/item/weapon/slugegg/attack_self(var/mob/living/user)
-	user.drop_from_inventory(src)
 	squish()
 
 /obj/item/weapon/slugegg/HasProximity(var/atom/movable/AM)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -19,11 +19,9 @@
 		underlays += syringe.filling
 
 /obj/item/weapon/syringe_cartridge/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/reagent_containers/syringe))
+	if(istype(I, /obj/item/weapon/reagent_containers/syringe) && user.unEquip(I, src))
 		syringe = I
 		to_chat(user, "<span class='notice'>You carefully insert [syringe] into [src].</span>")
-		user.remove_from_mob(syringe)
-		syringe.loc = src
 		sharp = 1
 		name = "syringe dart"
 		update_icon()
@@ -123,8 +121,8 @@
 		if(darts.len >= max_darts)
 			to_chat(user, "<span class='warning'>[src] is full!</span>")
 			return
-		user.remove_from_mob(C)
-		C.loc = src
+		if(!user.unEquip(C, src))
+			return
 		darts += C //add to the end
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
 	else

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -98,9 +98,9 @@
 			if(cell)
 				to_chat(user, "<span class='warning'>\The [src] already has \a [cell] installed.</span>")
 				return
+			if(!user.unEquip(cell, src))
+				return
 			cell = thing
-			user.drop_from_inventory(cell)
-			cell.forceMove(src)
 			playsound(loc, 'sound/machines/click.ogg', 10, 1)
 			user.visible_message("<span class='notice'>\The [user] slots \the [cell] into \the [src].</span>")
 			update_icon()
@@ -122,9 +122,9 @@
 			if(capacitor)
 				to_chat(user, "<span class='warning'>\The [src] already has \a [capacitor] installed.</span>")
 				return
+			if(!user.unEquip(capacitor, src))
+				return
 			capacitor = thing
-			user.drop_from_inventory(capacitor)
-			capacitor.forceMove(src)
 			playsound(loc, 'sound/machines/click.ogg', 10, 1)
 			power_per_tick = (power_cost*0.15) * capacitor.rating
 			user.visible_message("<span class='notice'>\The [user] slots \the [capacitor] into \the [src].</span>")
@@ -140,9 +140,9 @@
 			if(loaded)
 				to_chat(user, "<span class='warning'>\The [src] already has \a [loaded] loaded.</span>")
 				return
+			if(!user.unEquip(thing, src))
+				return
 			loaded = thing
-			user.drop_from_inventory(thing)
-			thing.forceMove(src)
 		else if(load_sheet_max > 1)
 			var ammo_count = 0
 			var/obj/item/stack/loaded_ammo = loaded

--- a/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
@@ -27,7 +27,6 @@
 		return
 
 	if(istype(thing, /obj/item/pipe) && construction_stage == 3)
-		user.drop_from_inventory(thing)
 		qdel(thing)
 		user.visible_message("<span class='notice'>\The [user] jams \the [thing] into \the [src].</span>")
 		increment_construction_stage()
@@ -61,7 +60,6 @@
 
 	if(istype(thing, /obj/item/weapon/smes_coil) && construction_stage >= 6 && construction_stage <= 8)
 		user.visible_message("<span class='notice'>\The [user] installs \a [thing] into \the [src].</span>")
-		user.drop_from_inventory(thing)
 		qdel(thing)
 		increment_construction_stage()
 		return

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -125,8 +125,8 @@
 					to_chat(user, "<span class='warning'>[src] already has a magazine loaded.</span>")//already a magazine here
 
 					return
-				user.remove_from_mob(AM)
-				AM.forceMove(src)
+				if(!user.unEquip(AM, src))
+					return
 				ammo_magazine = AM
 				user.visible_message("[user] inserts [AM] into [src].", "<span class='notice'>You insert [AM] into [src].</span>")
 				playsound(loc, mag_insert_sound, 50, 1)
@@ -154,9 +154,8 @@
 		if(loaded.len >= max_shells)
 			to_chat(user, "<span class='warning'>[src] is full.</span>")
 			return
-
-		user.remove_from_mob(C)
-		C.forceMove(src)
+		if(!user.unEquip(C, src))
+			return
 		loaded.Insert(1, C) //add to the head of the list
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
 		playsound(loc, load_sound, 50, 1)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -117,7 +117,8 @@
 	if(beakers.len >= max_beakers)
 		to_chat(user, "<span class='warning'>[src] already has [max_beakers] beakers in it - another one isn't going to fit!</span>")
 		return
-	user.drop_from_inventory(B, src)
+	if(!user.unEquip(B, src))
+		return
 	beakers |= B
 	user.visible_message("\The [user] inserts \a [B] into [src].", "<span class='notice'>You slot [B] into [src].</span>")
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -174,11 +174,11 @@
 		if(user.l_hand != src && user.r_hand != src)	//if we're not in his hands
 			to_chat(user, "<span class='notice'>You'll need [src] in your hands to do that.</span>")
 			return
-		user.drop_item()
+		if(!user.unEquip(I, src))
+			return//put the silencer into the gun
 		to_chat(user, "<span class='notice'>You screw [I] onto [src].</span>")
 		silenced = I	//dodgy?
-		w_class = ITEM_SIZE_NORMAL
-		I.forceMove(src)		//put the silencer into the gun
+		w_class = ITEM_SIZE_NORMAL		
 		update_icon()
 		return
 	..()
@@ -255,7 +255,6 @@
 
 /obj/item/weapon/zipgunframe/attackby(var/obj/item/thing, var/mob/user)
 	if(istype(thing,/obj/item/pipe) && buildstate == 0)
-		user.drop_from_inventory(thing)
 		qdel(thing)
 		user.visible_message("<span class='notice'>\The [user] fits \the [thing] to \the [src] as a crude barrel.</span>")
 		add_fingerprint(user)
@@ -269,7 +268,6 @@
 		update_icon()
 		return
 	else if(istype(thing,/obj/item/device/assembly/mousetrap) && buildstate == 2)
-		user.drop_from_inventory(thing)
 		qdel(thing)
 		user.visible_message("<span class='notice'>\The [user] takes apart \the [thing] and uses the parts to construct a crude trigger and firing mechanism inside the assembly.</span>")
 		add_fingerprint(user)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -51,9 +51,9 @@
 		if(src.beaker)
 			to_chat(user, "A beaker is already loaded into the machine.")
 			return
+		if(!user.unEquip(B, src))
+			return
 		src.beaker = B
-		user.drop_item()
-		B.loc = src
 		to_chat(user, "You add the beaker to the machine!")
 		src.updateUsrDialog()
 		icon_state = "mixer1"
@@ -63,10 +63,9 @@
 		if(src.loaded_pill_bottle)
 			to_chat(user, "A pill bottle is already loaded into the machine.")
 			return
-
+		if(!user.unEquip(B, src))
+			return
 		src.loaded_pill_bottle = B
-		user.drop_item()
-		B.loc = src
 		to_chat(user, "You add the pill bottle into the dispenser slot!")
 		src.updateUsrDialog()
 
@@ -358,9 +357,9 @@
 		if (beaker)
 			return 1
 		else
+			if(!user.unEquip(O, src))
+				return
 			src.beaker =  O
-			user.drop_item()
-			O.loc = src
 			update_icon()
 			src.updateUsrDialog()
 			return 0
@@ -407,8 +406,8 @@
 		to_chat(user, "\The [O] is not suitable for blending.")
 		return 1
 
-	user.remove_from_mob(O)
-	O.loc = src
+	if(!user.unEquip(O, src))
+		return
 	holdingitems += O
 	src.updateUsrDialog()
 	return 0

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -106,9 +106,7 @@
 	else if(istype(thing, /obj/item/weapon/reagent_containers))
 		if(container)
 			to_chat(user, "<span class='warning'>\The [src] is already loaded with \the [container].</span>")
-		else
-			user.drop_from_inventory(thing)
-			thing.forceMove(src)
+		else if(user.unEquip(thing, src))
 			container = thing
 			user.visible_message("<span class='notice'>\The [user] loads \the [thing] into \the [src].</span>")
 			verbs |= /obj/machinery/portable_atmospherics/reagent_sublimator/proc/remove_container

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -56,10 +56,12 @@
 		return
 
 	if(user)
-		user.drop_from_inventory(C)
-		to_chat(user, "<span class='notice'>You add \the [C] to \the [src].</span>")
+		if(user.unEquip(C))
+			to_chat(user, "<span class='notice'>You add \the [C] to \the [src].</span>")
+		else
+			return
 
-	C.loc = src
+	C.forceMove(src)
 	cartridges[C.label] = C
 	cartridges = sortAssoc(cartridges)
 	GLOB.nanomanager.update_uis(src)

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -5,8 +5,8 @@
 		var/obj/item/weapon/glass_extra/GE = I
 		if(can_add_extra(GE))
 			extras += GE
-			user.remove_from_mob(GE)
-			GE.loc = src
+			if(!user.unEquip(GE, src))
+				return
 			to_chat(user, "<span class=notice>You add \the [GE] to \the [src].</span>")
 			update_icon()
 		else
@@ -17,10 +17,10 @@
 			return
 		var/obj/item/weapon/reagent_containers/food/snacks/fruit_slice/FS = I
 		extras += FS
-		user.remove_from_mob(FS)
+		if(!user.unEquip(FS, src))
+			return
 		FS.pixel_x = 0 // Reset its pixel offsets so the icons work!
 		FS.pixel_y = 0
-		FS.loc = src
 		to_chat(user, "<span class=notice>You add \the [FS] to \the [src].</span>")
 		update_icon()
 	else

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -47,10 +47,6 @@
 	return prob(chance_table[idx])
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/proc/smash(var/newloc, atom/against = null)
-	if(ismob(loc))
-		var/mob/M = loc
-		M.drop_from_inventory(src)
-
 	//Creates a shattering noise and replaces the bottle with a broken_bottle
 	var/obj/item/weapon/broken_bottle/B = new /obj/item/weapon/broken_bottle(newloc)
 	if(prob(33))

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -26,17 +26,17 @@
 		to_chat(user, "<span class='wwarning'>If you put anything else on \the [src] it's going to collapse.</span>")
 		return
 	else if(istype(W,/obj/item/weapon/material/shard))
+		if(!user.unEquip(W, src))
+			return
 		to_chat(user, "<span class='warning'>You hide [W] in \the [src].</span>")
-		user.drop_item()
-		W.loc = src
 		update()
 		return
 	else if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		if(!user.unEquip(W, src))
+			return
 		to_chat(user, "<span class='warning'>You layer [W] over \the [src].</span>")
 		var/obj/item/weapon/reagent_containers/F = W
 		F.reagents.trans_to_obj(src, F.reagents.total_volume)
-		user.drop_item()
-		W.loc = src
 		ingredients += W
 		update()
 		return

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -43,7 +43,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='danger'>None of [src] left!</span>")
-		user.drop_from_inventory(src)
 		qdel(src)
 		return 0
 
@@ -158,9 +157,10 @@
 		if (hide_item)
 			if (W.w_class >= src.w_class || is_robot_module(W))
 				return
+			if(!user.unEquip(W, src))
+				return
 
 			to_chat(user, "<span class='warning'>You slip \the [W] inside \the [src].</span>")
-			user.drop_from_inventory(W, src)
 			add_fingerprint(user)
 			contents += W
 			return
@@ -274,7 +274,6 @@
 		return
 	to_chat(user, "You crack \the [src] into \the [O].")
 	reagents.trans_to(O, reagents.total_volume)
-	user.drop_from_inventory(src)
 	qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/throw_impact(atom/hit_atom)
@@ -2808,9 +2807,8 @@
 				boxestoadd += i
 
 			if( (boxes.len+1) + boxestoadd.len <= 5 )
-				user.drop_item()
-
-				box.loc = src
+				if(!user.unEquip(box, src))
+					return
 				box.boxes = list()// clear the box boxes so we don't have boxes inside boxes. - Xzibit
 				src.boxes.Add( boxestoadd )
 
@@ -2825,11 +2823,11 @@
 
 		return
 
-	if( istype(I, /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/) )// Long ass fucking object name
+	if( istype(I, /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/) )
 
 		if( src.open )
-			user.drop_item()
-			I.loc = src
+			if(!user.unEquip(I, src))
+				return
 			src.pizza = I
 
 			update_icon()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -244,7 +244,6 @@
 		to_chat(user, "You add [D] to [src].")
 		qdel(D)
 		user.put_in_hands(new /obj/item/weapon/bucket_sensor)
-		user.drop_from_inventory(src)
 		qdel(src)
 		return
 	else if(istype(D, /obj/item/weapon/mop))

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -93,11 +93,11 @@
 		if(!loaded_vial)
 			if(!do_after(user,10) || loaded_vial || !(W in user))
 				return 0
+			if(!user.unEquip(W, src))
+				return
 			if(W.is_open_container())
 				W.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
 				W.update_icon()
-			user.drop_item()
-			W.forceMove(src)
 			loaded_vial = W
 			reagents.maximum_volume = loaded_vial.reagents.maximum_volume
 			loaded_vial.reagents.trans_to_holder(reagents,volume)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -26,7 +26,6 @@
 			return
 
 		to_chat(M, "<span class='notice'>You swallow \the [src].</span>")
-		M.drop_from_inventory(src) //icon update
 		if(reagents.total_volume)
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		qdel(src)
@@ -40,7 +39,6 @@
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(!do_mob(user, M))
 			return
-		user.drop_from_inventory(src) //icon update
 		user.visible_message("<span class='warning'>[user] forces [M] to swallow \the [src].</span>")
 		var/contained = reagentlist()
 		admin_attack_log(user, M, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -277,7 +277,6 @@
 		if (target != user && H.getarmor(target_zone, "melee") > 5 && prob(50))
 			for(var/mob/O in viewers(world.view, user))
 				O.show_message(text("<span class='danger'>[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!</span>"), 1)
-			user.remove_from_mob(src)
 			qdel(src)
 
 			admin_attack_log(user, target, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -126,6 +126,8 @@
 			return ..()
 		user.visible_message("\The [user] begins rigging [W] to \the [src].", "You begin rigging [W] to \the [src]")
 		if(do_after(user, 20, src))
+			if(!user.unEquip(W, src))
+				return
 			user.visible_message("<span class='notice'>The [user] rigs [W] to \the [src].</span>", "<span class='notice'>You rig [W] to \the [src].</span>")
 
 			var/obj/item/device/assembly_holder/H = W
@@ -134,9 +136,6 @@
 				log_game("[key_name(user)] rigged fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]) for explosion.")
 
 			rig = W
-			user.drop_item()
-			W.loc = src
-
 			var/icon/test = getFlatIcon(W)
 			test.Shift(NORTH,1)
 			test.Shift(EAST,6)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -88,11 +88,7 @@
 		to_chat(user, "<span class='notice'>You remove the conveyor belt.</span>")
 		qdel(src)
 		return
-	if(isrobot(user))	return //Carn: fix for borgs dropping their modules on conveyor belts
-	if(I.loc != user)	return // This should stop mounted modules ending up outside the module.
-
-	user.drop_item(get_turf(src))
-	return
+	user.unequip_item(get_turf(src))
 
 // attack with hand, move pulled object onto conveyor
 /obj/machinery/conveyor/attack_hand(mob/user as mob)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -130,9 +130,8 @@
 	if(!I)
 		return
 
-	user.drop_item()
-	if(I)
-		I.forceMove(src)
+	if(!user.unEquip(I, src))
+		return
 
 	to_chat(user, "You place \the [I] into the [src].")
 	for(var/mob/M in viewers(src))

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -75,11 +75,10 @@ Note: Must be placed within 3 tiles of the R&D Console
 			if(O.origin_tech.len == 0 || O.holographic)
 				to_chat(user, "<span class='notice'>You cannot deconstruct this item.</span>")
 				return
-
+		if(!user.unEquip(O, src))
+			return
 		busy = 1
 		loaded_item = O
-		user.drop_item()
-		O.loc = src
 		to_chat(user, "<span class='notice'>You add \the [O] to \the [src].</span>")
 		flick("d_analyzer_la", src)
 		spawn(10)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -130,7 +130,6 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	if (active && !(stat & (BROKEN|NOPOWER)) && (spamfilter_limit < MESSAGE_SERVER_DEFAULT_SPAM_LIMIT*2) && \
 		istype(O,/obj/item/weapon/circuitboard/message_monitor))
 		spamfilter_limit += round(MESSAGE_SERVER_DEFAULT_SPAM_LIMIT / 2)
-		user.drop_item()
 		qdel(O)
 		to_chat(user, "You install additional memory and processors into message server. Its filtering capabilities been enhanced.")
 	else

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -118,7 +118,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(t_disk || d_disk)
 			to_chat(user, "A disk is already loaded into the machine.")
 			return
-
+		if(!user.canUnEquip(D))
+			return
 		if(istype(D, /obj/item/weapon/disk/tech_disk))
 			t_disk = D
 		else if (istype(D, /obj/item/weapon/disk/design_disk))
@@ -126,8 +127,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		else
 			to_chat(user, "<span class='notice'>Machine cannot accept disks in that format.</span>")
 			return
-		user.drop_item()
-		D.loc = src
+		user.drop_from_inventory(D, src)
 		to_chat(user, "<span class='notice'>You add \the [D] to the machine.</span>")
 	else
 		//The construction/deconstruction of the console code.

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -121,14 +121,16 @@
 /obj/item/device/spaceflare/proc/activate()
 	if(active)
 		return
-	active = 1
 	var/turf/T = get_turf(src)
+	var/mob/M = loc
+	if(istype(M) && !M.unEquip(src, T))
+		return
+
+	active = 1
+	anchored = 1
+
 	var/obj/effect/shuttle_landmark/automatic/mark = new(T)
 	mark.SetName("Beacon signal ([T.x],[T.y])")
-	if(ismob(loc))
-		var/mob/M = loc
-		M.drop_from_inventory(src,T)
-	anchored = 1
 	T.hotspot_expose(1500, 5)
 	update_icon()
 

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -48,7 +48,7 @@
 	spells = list(/spell/noclothes)
 
 /datum/spellbound_type/apprentice/set_antag(var/datum/mind/M, var/mob/master)
-	GLOB.wizards.add_antagonist_mind(M,1,ANTAG_APPRENTICE,"<b>You are an apprentice-type Servant! You’re just an ordinary Wizard-To-Be, with no special abilities, but do not need robes to cast spells. Follow your teacher’s orders!</b>")
+	GLOB.wizards.add_antagonist_mind(M,1,ANTAG_APPRENTICE,"<b>You are an apprentice-type Servant! Youï¿½re just an ordinary Wizard-To-Be, with no special abilities, but do not need robes to cast spells. Follow your teacherï¿½s orders!</b>")
 
 /datum/spellbound_type/servant
 	var/spiel = "You don't do anything in particular."
@@ -82,7 +82,7 @@
 /datum/spellbound_type/servant/familiar
 	name = "Familiar"
 	desc = "A friend! Or are they a pet? They can transform into animals, and take some particular traits from said creatures."
-	spiel = "This form of yours is weak in comparison to your transformed form, but that certainly won’t pose a problem, considering the fact that you have an alternative. Whatever it is you can turn into, use its powers wisely and serve your Master as well as possible!"
+	spiel = "This form of yours is weak in comparison to your transformed form, but that certainly wonï¿½t pose a problem, considering the fact that you have an alternative. Whatever it is you can turn into, use its powers wisely and serve your Master as well as possible!"
 	equipment = list(/obj/item/clothing/head/bandana/familiarband = slot_head,
 					/obj/item/clothing/under/familiargarb = slot_w_uniform)
 
@@ -112,7 +112,7 @@
 /datum/spellbound_type/servant/fiend
 	name = "Fiend"
 	desc = "A practitioner of dark and evil magics, almost certainly a demon, and possibly a lawyer."
-	spiel = "The Summoning Ritual has bound you to this world with limited access to your infernal powers; you’ll have to be strategic in how you use them. Follow your Master’s orders as well as you can!"
+	spiel = "The Summoning Ritual has bound you to this world with limited access to your infernal powers; youï¿½ll have to be strategic in how you use them. Follow your Masterï¿½s orders as well as you can!"
 	spells = list(/spell/targeted/projectile/dumbfire/fireball/firebolt,
 				/spell/targeted/ethereal_jaunt,
 				/spell/targeted/torment,
@@ -153,7 +153,7 @@
 /datum/spellbound_type/servant/overseer
 	name = "Overseer"
 	desc = "A ghost, or an imaginary friend; the Overseer is immune to space and can turn invisible at a whim, but has little offensive capabilities."
-	spiel = "Physicality is not something you are familiar with. Indeed, injuries cannot slow you down, but you can’t fight back, either! In addition to this, you can reach into the void and return the soul of a single departed crewmember via the revoke death verb, if so desired; this can even revive your Master, should they fall in combat before you do. Serve them well."
+	spiel = "Physicality is not something you are familiar with. Indeed, injuries cannot slow you down, but you canï¿½t fight back, either! In addition to this, you can reach into the void and return the soul of a single departed crewmember via the revoke death verb, if so desired; this can even revive your Master, should they fall in combat before you do. Serve them well."
 	equipment = list(/obj/item/clothing/under/grimhoodie = slot_w_uniform,
 					/obj/item/clothing/shoes/sandals/grimboots = slot_shoes,
 					/obj/item/weapon/contract/wizard/xray = slot_l_hand,
@@ -233,8 +233,6 @@
 	onclose(user,"summoning")
 
 /obj/item/weapon/summoning_stone/proc/use_type(var/type, var/mob/user)
-	user.drop_from_inventory(src)
-
 	new /obj/effect/cleanable/spellbound(get_turf(src),type)
 	if(prob(20))
 		var/list/base_areas = maintlocs //Have to do it this way as its a macro

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -30,7 +30,6 @@
 			for(var/spell_type in contract_spells)
 				M.add_spell(new spell_type(user), "const_spell_ready")
 		log_and_message_admins("signed their soul over to \the [contract_master] using \the [src].", user)
-		user.drop_from_inventory(src)
 		qdel(src)
 
 /obj/item/weapon/contract/proc/contract_effect(mob/user as mob)

--- a/code/modules/spells/hand/hand.dm
+++ b/code/modules/spells/hand/hand.dm
@@ -33,9 +33,6 @@
 
 /spell/hand/proc/cancel_hand()
 	if(current_hand)
-		if(istype(current_hand.loc, /mob/living))
-			var/mob/living/L = current_hand.loc
-			L.drop_from_inventory(current_hand)
 		QDEL_NULL(current_hand)
 
 /spell/hand/Destroy()

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -31,7 +31,6 @@
 		if(istype(S,reward))
 			to_chat(user, "\The [src] can do no more for you.")
 			return
-	user.drop_from_inventory(src)
 	var/a = new reward()
 	if(ispath(reward,/spell))
 		H.add_spell(a)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -70,7 +70,6 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 			if(S.amount < S.max_amount)
 				to_chat(usr, "<span class='warning'>You must sacrifice [S.max_amount] stacks of [S]!</span>")
 				return
-		user.remove_from_mob(I)
 		qdel(I)
 	to_chat(user, "<span class='notice'>Your sacrifice was accepted!</span>")
 	has_sacrificed = 1

--- a/code/modules/spells/targeted/equip/equip.dm
+++ b/code/modules/spells/targeted/equip/equip.dm
@@ -22,14 +22,12 @@
 				slot_id = text2num(slot_id) //because the index is text, we access this instead
 			var/obj/item/new_item = summon_item(to_create)
 			var/obj/item/old_item = L.get_equipped_item(slot_id)
-			L.equip_to_slot(new_item, slot_id)
-			new_item.pickup(L)
 			if(old_item)
-				L.remove_from_mob(old_item)
+				L.drop_from_inventory(old_item)
 				if(delete_old)
 					qdel(old_item)
-				else
-					old_item.loc = L.loc
+			L.equip_to_slot(new_item, slot_id)
+			new_item.pickup(L)
 
 			if(duration)
 				summoned_items += new_item //we store it in a list to remove later
@@ -37,9 +35,6 @@
 	if(duration)
 		spawn(duration)
 			for(var/obj/item/to_remove in summoned_items)
-				if(istype(to_remove.loc, /mob))
-					var/mob/M = to_remove.loc
-					M.remove_from_mob(to_remove)
 				qdel(to_remove)
 
 /spell/targeted/equip_item/proc/summon_item(var/newtype)

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -45,8 +45,6 @@
 		trans.SetName("[trans.name] ([M])")
 		if(istype(M,/mob/living/carbon/human) && drop_items)
 			for(var/obj/item/I in M.contents)
-				if(istype(I,/obj/item/organ))
-					continue
 				M.drop_from_inventory(I)
 		if(M.mind)
 			M.mind.transfer_to(trans)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -130,15 +130,14 @@
 
 /datum/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
-
+	if(!user.unEquip(tool, affected))
+		return
 	user.visible_message("<span class='notice'>[user] puts \the [tool] inside [target]'s [affected.cavity_name] cavity.</span>", \
 	"<span class='notice'>You put \the [tool] inside [target]'s [affected.cavity_name] cavity.</span>" )
 	if (tool.w_class > affected.cavity_max_w_class/2 && prob(50) && !(affected.robotic >= ORGAN_ROBOT) && affected.sever_artery())
 		to_chat(user, "<span class='warning'>You tear some blood vessels trying to fit such a big object in this cavity.</span>")
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1,affecting = affected)
-	user.drop_item()
 	affected.implants += tool
-	tool.loc = affected
 	affected.cavity = 0
 
 //////////////////////////////////////////////////////////////////

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -46,10 +46,11 @@
 	"You start attaching [E.name] to [target]'s [E.amputation_point].")
 
 /datum/surgery_step/limb/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(!user.unEquip(tool))
+		return
 	var/obj/item/organ/external/E = tool
 	user.visible_message("<span class='notice'>[user] has attached [target]'s [E.name] to the [E.amputation_point].</span>",	\
 	"<span class='notice'>You have attached [target]'s [E.name] to the [E.amputation_point].</span>")
-	user.drop_from_inventory(E)
 	E.replaced(target)
 	target.update_body()
 	target.updatehealth()

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -319,9 +319,7 @@
 	user.visible_message("<span class='notice'>[user] has transplanted \the [tool] into [target]'s [affected.name].</span>", \
 	"<span class='notice'>You have transplanted \the [tool] into [target]'s [affected.name].</span>")
 	var/obj/item/organ/O = tool
-	if(istype(O))
-		user.remove_from_mob(O)
-		O.forceMove(target)
+	if(istype(O) && user.unEquip(O, target))
 		affected.implants |= O //move the organ into the patient. The organ is properly reattached in the next step
 		if(!(O.status & ORGAN_CUT_AWAY))
 			log_debug("[user] ([user.ckey]) replaced organ [O], which didn't have ORGAN_CUT_AWAY set, in [target] ([target.ckey])")

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -506,6 +506,8 @@
 	..()
 
 /datum/surgery_step/robotics/install_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(!user.unEquip(tool))
+		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has installed \the [tool] into [target]'s [affected.name].</span>", \
 	"<span class='notice'>You have installed \the [tool] into [target]'s [affected.name].</span>")
@@ -513,7 +515,6 @@
 	var/obj/item/device/mmi/M = tool
 	var/obj/item/organ/internal/mmi_holder/holder = new(target, 1)
 	target.internal_organs_by_name[BP_BRAIN] = holder
-	user.drop_from_inventory(tool)
 	tool.forceMove(holder)
 	holder.stored_mmi = tool
 	holder.update_from_mmi()

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -70,7 +70,7 @@
 		return ..()
 	if(isrobot(user))
 		return
-	user.drop_item()
+	user.unequip_item()
 	if (O.loc != src.loc)
 		step(O, get_dir(O, src))
 	return
@@ -119,11 +119,9 @@
 		return
 
 	// Placing stuff on tables
-	if(user.drop_from_inventory(W, src.loc))
+	if(user.unEquip(W, src.loc))
 		auto_align(W, click_params)
 		return 1
-
-	return
 
 /*
 Automatic alignment of items to an invisible grid, defined by CELLS and CELLSIZE, defined in code/__defines/misc.dm.

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -71,8 +71,8 @@
 /obj/vehicle/bike/proc/load_engine(var/obj/item/weapon/engine/E, var/mob/user)
 	if(engine)
 		return
-	if(user)
-		user.drop_from_inventory(E)
+	if(user && !user.unEquip(E))
+		return
 	engine = E
 	engine.forceMove(src)
 	if(trail)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -75,8 +75,8 @@
 /obj/vehicle/train/cargo/engine/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/key/cargo_train))
 		if(!key)
-			user.drop_item()
-			W.forceMove(src)
+			if(!user.unEquip(W, src))
+				return
 			key = W
 			verbs += /obj/vehicle/train/cargo/engine/verb/remove_key
 		return

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -239,9 +239,8 @@
 		return
 	if(!istype(C))
 		return
-
-	H.drop_from_inventory(C)
-	C.forceMove(src)
+	if(!H.unEquip(C, src))
+		return
 	cell = C
 	powercheck()
 	to_chat(usr, "<span class='notice'>You install [C] in [src].</span>")

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -16,10 +16,9 @@
 	if(dish)
 		to_chat(user, "\The [src] is already loaded.")
 		return
-
+	if(!user.unEquip(O, src))
+		return
 	dish = O
-	user.drop_item()
-	O.forceMove(src)
 	operator_skill = user.get_skill_value(core_skill)
 
 	user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")

--- a/code/modules/virus2/biohazard destroyer.dm
+++ b/code/modules/virus2/biohazard destroyer.dm
@@ -9,12 +9,11 @@
 /obj/machinery/disease2/biodestroyer/attackby(var/obj/I as obj, var/mob/user as mob)
 	for(var/path in accepts)
 		if(I.type in typesof(path))
-			user.drop_item()
 			qdel(I)
 			overlays += image('icons/obj/pipes/disposal.dmi', "dispover-handle")
 			return
-	user.drop_item()
-	I.loc = src.loc
+	if(!user.unEquip(I, get_turf(src)))
+		return
 
 	for(var/mob/O in hearers(src, null))
 		O.show_message("\icon[src] <span class='notice'>\The [src] beeps</span>", 2)

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -18,10 +18,9 @@
 		if(sample)
 			to_chat(user, "\The [src] is already loaded.")
 			return
-
+		if(!user.unEquip(O, src))
+			return
 		sample = O
-		user.drop_item()
-		O.forceMove(src)
 
 		user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")
 		GLOB.nanomanager.update_uis(src)

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -11,11 +11,10 @@
 
 /obj/machinery/computer/curer/attackby(var/obj/I as obj, var/mob/user as mob)
 	if(istype(I,/obj/item/weapon/reagent_containers))
-		var/mob/living/carbon/C = user
 		if(!container)
+			if(!user.unEquip(I, src))
+				return
 			container = I
-			C.drop_item()
-			I.loc = src
 		return
 	if(istype(I,/obj/item/weapon/virusdish))
 		if(virusing)

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -17,14 +17,12 @@
 		return ..(I,user)
 
 	if(istype(I,/obj/item/weapon/virusdish))
-		var/mob/living/carbon/c = user
 		if (dish)
 			to_chat(user, "\The [src] is already loaded.")
 			return
-
+		if(!user.unEquip(I, src))
+			return
 		dish = I
-		c.drop_item()
-		I.forceMove(src)
 
 	if(istype(I,/obj/item/weapon/diseasedisk))
 		to_chat(user, "You upload the contents of the disk onto the buffer.")

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -20,10 +20,9 @@
 		if(beaker)
 			to_chat(user, "\The [src] is already loaded.")
 			return
-
+		if(!user.unEquip(O, src))
+			return
 		beaker = O
-		user.drop_item()
-		O.forceMove(src)
 
 		user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")
 		GLOB.nanomanager.update_uis(src)
@@ -36,10 +35,9 @@
 		if(dish)
 			to_chat(user, "The dish tray is aleady full!")
 			return
-
+		if(!user.unEquip(O, src))
+			return
 		dish = O
-		user.drop_item()
-		O.forceMove(src)
 
 		user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")
 		GLOB.nanomanager.update_uis(src)

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -29,15 +29,12 @@
 
 /obj/machinery/disease2/isolator/attackby(var/obj/O as obj, var/mob/user)
 	if(!istype(O,/obj/item/weapon/reagent_containers/syringe)) return
-	var/obj/item/weapon/reagent_containers/syringe/S = O
-
 	if(sample)
 		to_chat(user, "\The [src] is already loaded.")
 		return
-
-	sample = S
-	user.drop_item()
-	S.forceMove(src)
+	if(!user.unEquip(O, src))
+		return
+	sample = O
 
 	user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")
 	GLOB.nanomanager.update_uis(src)

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -125,8 +125,8 @@
 	user << browse(dat, "window=alien_replicator")
 
 /obj/machinery/replicator/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
-	user.drop_item()
-	W.forceMove(src)
+	if(!user.unEquip(W, src))
+		return
 	stored_materials.Add(W)
 	src.visible_message("<span class='notice'>\The [user] inserts \the [W] into \the [src].</span>")
 

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -39,9 +39,9 @@
 /obj/item/weapon/anodevice/attackby(var/obj/I as obj, var/mob/user as mob)
 	if(istype(I, /obj/item/weapon/anobattery))
 		if(!inserted_battery)
+			if(!user.unEquip(I, src))
+				return
 			to_chat(user, "<span class='notice'>You insert the battery.</span>")
-			user.drop_item()
-			I.loc = src
 			inserted_battery = I
 			UpdateSprite()
 	else

--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -23,9 +23,9 @@
 /obj/machinery/artifact_harvester/attackby(var/obj/I as obj, var/mob/user as mob)
 	if(istype(I,/obj/item/weapon/anobattery))
 		if(!inserted_battery)
+			if(!user.unEquip(I, src))
+				return
 			to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-			user.drop_item()
-			I.loc = src
 			src.inserted_battery = I
 			updateDialog()
 		else

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -94,8 +94,8 @@
 		if(scanned_item)
 			to_chat(user, "<span class=warning>\The [src] already has \a [scanned_item] inside!</span>")
 			return
-		user.drop_item()
-		I.loc = src
+		if(!user.unEquip(I, src))
+			return
 		scanned_item = I
 		to_chat(user, "<span class=notice>You put \the [I] into \the [src].</span>")
 

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -87,8 +87,8 @@
 	else if(href_list["insertcard"])
 		var/obj/item/I = user.get_active_hand()
 		if (istype(I, /obj/item/weapon/card))
-			user.drop_item()
-			I.forceMove(src)
+			if(!user.unEquip(I, src))
+				return
 			auth_card = I
 			if(attempt_unlock(I, user))
 				to_chat(user, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</i>\'</span>")
@@ -148,9 +148,7 @@
 		if(panel_open)
 			if(cell)
 				to_chat(user, "<span class='warning'>There is a power cell already installed.</span>")
-			else
-				user.drop_item()
-				W.forceMove(src)
+			else if(user.unEquip(W, src))
 				cell = W
 				to_chat(user, "<span class='info'>You insert the power cell.</span>")
 				icon_state = "suspension1"

--- a/maps/torch/items/uniform_vendor.dm
+++ b/maps/torch/items/uniform_vendor.dm
@@ -64,7 +64,7 @@
 			selected_outfit.Cut()
 		else
 			var/obj/item/weapon/card/id/I = user.get_active_hand()
-			if(I && user.unEquip(I, FALSE, src))
+			if(I && user.unEquip(I, src))
 				ID = I
 		. = TOPIC_REFRESH
 	if(href_list["get_all"])
@@ -99,10 +99,9 @@
 			return
 		to_chat(user, "<span class='notice'>You put \the [W] into \the [src]'s recycling slot.</span>")
 		qdel(W)
-	else if(istype(W, /obj/item/weapon/card/id) && !ID && user.unEquip(W, FALSE, src))
+	else if(istype(W, /obj/item/weapon/card/id) && !ID && user.unEquip(W, src))
 		to_chat(user, "<span class='notice'>You slide \the [W] into \the [src]!</span>")
 		ID = W
-		user.drop_from_inventory(W, src)
 		attack_hand(user)
 	else
 		..()


### PR DESCRIPTION
Fixes #21869.
Fixes #19347.
Fixes numerous other issues of the same type. 

Basically, code which takes reagent containers typically does not check for borgness, taking the container. The borg can then summon the container back by dropping it and re-selecting it from the inventory, resulting in possible runtimes, exploits, and who knows what.