### PR TITLE
Cosmic space buff to toolboxes

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -8,7 +8,8 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	force = 5
+	force = 20
+	attack_cooldown = 21
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 7
@@ -54,9 +55,9 @@
 
 /obj/item/weapon/storage/toolbox/syndicate
 	name = "black and red toolbox"
-	desc = "A toolbox in black, with stylish red trim. This one feels particularly heavy."
+	desc = "A toolbox in black, with stylish red trim. This one feels particularly heavy, yet balanced."
 	icon_state = "syndicate"
 	item_state = "toolbox_syndi"
 	origin_tech = list(TECH_COMBAT = 1, TECH_ILLEGAL = 1)
-	force = 7.0
+	attack_cooldown = 10
 	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/weapon/screwdriver, /obj/item/weapon/wrench, /obj/item/weapon/weldingtool, /obj/item/weapon/crowbar, /obj/item/weapon/wirecutters, /obj/item/device/multitool)


### PR DESCRIPTION
Raises their damage from 5 to 20
On the other hand raises their attack cooldown from 9 ds to 25.
Syndicate boxes are combat rated robusting implements so they get 14 (around same as heavy bats).
Remember, total cooldown is attack_cooldown+w_class

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
