### PR TITLE
ERT changes

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/rig/ert
-	name = "asset protection command hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has blue highlights. Armoured and space ready."
+	name = "emergency response command hardsuit control module"
+	desc = "A hardsuit used by many corporate and government emergency response forces. Has blue highlights. Armoured and space ready."
 	suit_type = "Asset Protection command"
 	icon_state = "ert_commander_rig"
 
@@ -40,8 +40,8 @@
 
 
 /obj/item/weapon/rig/ert/engineer
-	name = "asset protection engineering hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has orange highlights. Armoured and space ready."
+	name = "emergency response engineering hardsuit control module"
+	desc = "A hardsuit used by many corporate and government emergency response forces. Has orange highlights. Armoured and space ready."
 	suit_type = "Asset Protection engineer"
 	icon_state = "ert_engineer_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 100, rad = 100)
@@ -60,8 +60,8 @@
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/ert/janitor
-	name = "asset protection sanitation hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has purple highlights. Armoured and space ready."
+	name = "emergency response sanitation hardsuit control module"
+	desc = "A hardsuit used by many corporate and government emergency response forces. Has purple highlights. Armoured and space ready."
 	suit_type = "Asset Protection sanitation"
 	icon_state = "ert_janitor_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 40, bomb = 40, bio = 100, rad = 100)
@@ -76,8 +76,8 @@
 		)
 
 /obj/item/weapon/rig/ert/medical
-	name = "asset protection medical hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has white highlights. Armoured and space ready."
+	name = "emergency response medical hardsuit control module"
+	desc = "A hardsuit used by many corporate and government emergency response forces. Has white highlights. Armoured and space ready."
 	suit_type = "Asset Protection medic"
 	icon_state = "ert_medical_rig"
 
@@ -90,8 +90,8 @@
 		)
 
 /obj/item/weapon/rig/ert/security
-	name = "asset protection security hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has red highlights. Armoured and space ready."
+	name = "emergency response security hardsuit control module"
+	desc = "A hardsuit used by many corporate and government emergency response forces. Has red highlights. Armoured and space ready."
 	suit_type = "Asset Protection security"
 	icon_state = "ert_security_rig"
 
@@ -104,8 +104,8 @@
 		)
 
 /obj/item/weapon/rig/ert/assetprotection
-	name = "heavy asset protection suit control module"
-	desc = "A heavy, modified version of a common asset protection hardsuit. Has blood red highlights.  Armoured and space ready."
+	name = "heavy emergency response hardsuit control module"
+	desc = "A heavy, modified version of a common emergency response hardsuit. Has blood red highlights.  Armoured and space ready."
 	suit_type = "heavy asset protection"
 	icon_state = "asset_protection_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 40, bomb = 40, bio = 100, rad = 100)

--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -135,6 +135,14 @@ Weapons
 
 /obj/effect/paint/hull
 	color = COLOR_HULL
-	
+
 /obj/effect/paint/expeditionary
 	color = "#68099e"
+
+
+/obj/item/weapon/storage/box/ertranks
+	name = "box of rank tabs"
+	desc = "A box with various Fleet rank tabs."
+	startswith = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7,
+					  /obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6 = 2,
+					  /obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5 = 2)

--- a/maps/torch/torch-6.dmm
+++ b/maps/torch/torch-6.dmm
@@ -1673,18 +1673,15 @@
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
 "aef" = (
-/obj/item/clothing/under/ert,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/under/rank/centcom_officer,
-/obj/item/clothing/head/beret/centcom/officer,
-/obj/item/clothing/mask/balaclava,
-/obj/item/weapon/coin/silver,
 /obj/structure/closet{
 	icon_closed = "syndicate1";
 	icon_opened = "syndicate1open";
 	icon_state = "syndicate1";
 	name = "emergency response team wardrobe"
 	},
+/obj/item/clothing/head/solgov/utility/fleet,
+/obj/item/clothing/under/solgov/utility/fleet/combat,
+/obj/item/clothing/accessory/solgov/fleet_patch/fifth,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2244,14 +2241,14 @@
 /obj/item/weapon/melee/baton/loaded,
 /obj/item/weapon/reagent_containers/spray/pepper,
 /obj/item/weapon/reagent_containers/spray/pepper,
-/obj/item/weapon/gun/energy/stunrevolver,
-/obj/item/weapon/gun/energy/stunrevolver,
 /obj/item/weapon/melee/telebaton,
 /obj/item/weapon/melee/telebaton,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 32
 	},
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2292,34 +2289,24 @@
 /area/rescue_base/base)
 "afD" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"afE" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	icon_state = "dark"
 	},
 /area/rescue_base/base)
 "afF" = (
 /obj/structure/table/rack,
-/obj/item/weapon/gun/energy/stunrevolver,
-/obj/item/weapon/gun/energy/stunrevolver,
+/obj/item/weapon/gun/energy/gun,
+/obj/item/weapon/gun/energy/gun,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2591,61 +2578,6 @@
 /obj/structure/window/reinforced/holowindow,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_boxingcourt)
-"agf" = (
-/obj/machinery/vending/snack{
-	name = "Getmore Chocolate Corp";
-	prices = list()
-	},
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agg" = (
-/obj/machinery/vending/cola{
-	name = "Robust Softdrinks";
-	prices = list()
-	},
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agh" = (
-/obj/machinery/vending/cigarette{
-	prices = list()
-	},
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agi" = (
-/obj/machinery/lapvend,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agj" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agk" = (
-/obj/structure/table/reinforced,
-/obj/item/device/radio/intercom/specops{
-	dir = 2;
-	pixel_y = 22
-	},
-/obj/item/weapon/storage/box/cups,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
 "agl" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass{
@@ -3040,31 +2972,8 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
 "ahg" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahh" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/stamp/centcomm,
-/obj/item/weapon/pen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahi" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/board,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahj" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
+/obj/structure/bed/chair{
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3240,13 +3149,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
-"ahG" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/fancy/cigar,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
 "ahH" = (
 /obj/structure/table/reinforced,
 /obj/item/device/megaphone,
@@ -3264,9 +3166,20 @@
 	},
 /area/rescue_base/base)
 "ahI" = (
-/obj/structure/table/reinforced,
-/obj/item/taperoll/police,
-/obj/item/taperoll/police,
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "emergency response team wardrobe"
+	},
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/security,
+/obj/item/clothing/head/beret/solgov/fleet/security,
+/obj/item/clothing/head/beret/solgov/fleet/security,
+/obj/item/clothing/head/beret/solgov/fleet/security,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -3489,20 +3402,6 @@
 	icon_state = "asteroid"
 	},
 /area/rescue_base/base)
-"aii" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/material/ashtray/plastic,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"aij" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/box/donut,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
 "aik" = (
 /obj/structure/table/reinforced,
 /obj/item/device/paicard,
@@ -3688,7 +3587,7 @@
 	desc = "A secure airlock. Doesn't look like you can get through easily.";
 	icon = 'icons/obj/doors/centcomm/door.dmi';
 	icon_state = "closed";
-	name = "Delta Barracks"
+	name = "Delta Barracks";
 	dir = 4
 	},
 /area/rescue_base/base)
@@ -3757,17 +3656,30 @@
 	},
 /area/rescue_base/base)
 "aiQ" = (
-/obj/machinery/computer/arcade,
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "armor closet"
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	icon_state = "dark"
 	},
 /area/rescue_base/base)
 "aiR" = (
 /obj/machinery/recharge_station,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	icon_state = "dark"
 	},
 /area/rescue_base/base)
 "aiS" = (
@@ -3784,16 +3696,11 @@
 	},
 /area/rescue_base/base)
 "aiT" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
+/obj/structure/table/reinforced,
+/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6,
+/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	icon_state = "dark"
 	},
 /area/rescue_base/base)
 "aiU" = (
@@ -3804,19 +3711,6 @@
 /obj/item/clothing/accessory/storage/brown_vest,
 /obj/item/clothing/accessory/storage/brown_vest,
 /obj/item/clothing/accessory/storage/brown_vest,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"aiV" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/holster/thigh,
-/obj/item/clothing/accessory/holster/thigh,
-/obj/item/clothing/accessory/holster/thigh,
-/obj/item/clothing/accessory/holster/thigh,
-/obj/item/clothing/accessory/holster/thigh,
-/obj/item/clothing/accessory/holster/thigh,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4223,13 +4117,6 @@
 	icon_state = "dark"
 	},
 /area/rescue_base/base)
-"ajR" = (
-/obj/structure/table/steel,
-/obj/item/weapon/stamp/centcomm,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
 "ajS" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/fancy/cigar,
@@ -4336,6 +4223,7 @@
 /area/ninja_dojo/dojo)
 "ake" = (
 /obj/structure/table/steel,
+/obj/item/weapon/stamp/solgov,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4355,7 +4243,6 @@
 /obj/item/weapon/storage/box/teargas,
 /obj/item/weapon/storage/box/handcuffs,
 /obj/item/weapon/melee/baton/loaded,
-/obj/item/weapon/gun/energy/stunrevolver,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4389,8 +4276,8 @@
 /area/rescue_base/base)
 "akk" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert,
-/obj/item/clothing/head/helmet/ert,
+/obj/item/clothing/head/helmet/solgov/command,
+/obj/item/clothing/suit/armor/pcarrier/medium/command,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4460,7 +4347,7 @@
 	},
 /area/rescue_base/base)
 "akt" = (
-/obj/structure/closet/secure_closet/hos,
+/obj/structure/closet/secure_closet/cos,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4469,7 +4356,6 @@
 "aku" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/secure/briefcase,
-/obj/item/clothing/head/beret/centcom/captain,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4535,17 +4421,6 @@
 /turf/unsimulated/floor{
 	name = "plating";
 	icon_state = "cult"
-	},
-/area/rescue_base/base)
-"akB" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
 	},
 /area/rescue_base/base)
 "akC" = (
@@ -4815,7 +4690,7 @@
 /obj/structure/table/woodentable{
 	dir = 5
 	},
-/obj/item/weapon/storage/fancy/cigar,
+/obj/item/clothing/head/beret/solgov/marcom,
 /turf/unsimulated/floor{
 	name = "plating";
 	icon_state = "cult"
@@ -5416,11 +5291,10 @@
 	},
 /area/rescue_base/base)
 "aml" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 9
-	},
+/turf/simulated/wall/titanium,
 /area/rescue_base/start)
 "amm" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -5428,81 +5302,16 @@
 	name = "Cockpit Blast Shutters";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
-/area/rescue_base/start)
-"amn" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
-"amo" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
-"amp" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 5
-	},
-/area/rescue_base/start)
-"amq" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
 /area/rescue_base/start)
 "amr" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
 	id = "rescuedock";
 	name = "Blast Shutters";
 	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
@@ -5514,7 +5323,7 @@
 	name = "Ship External Access";
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amt" = (
 /obj/machinery/door/unpowered/simple/wood,
@@ -5608,15 +5417,15 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amE" = (
 /obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amF" = (
 /obj/machinery/computer/shuttle_control/multi/rescue,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amG" = (
 /obj/structure/table/steel_reinforced,
@@ -5626,12 +5435,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amH" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1331;
@@ -5646,18 +5452,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amJ" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1331;
@@ -5673,7 +5476,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amK" = (
 /obj/effect/overlay/palmtree_r,
@@ -5769,13 +5572,13 @@
 /area/ninja_dojo/dojo)
 "amV" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amW" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amX" = (
 /obj/structure/table/steel_reinforced,
@@ -5784,22 +5587,20 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amY" = (
-/obj/structure/bed/chair{
+/obj/structure/handrai{
+	icon_state = "handrail";
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "ana" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/button/remote/blast_door{
 	icon_state = "doorctrl0";
 	id = "rescuedock";
@@ -5808,7 +5609,11 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/red,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anb" = (
 /obj/effect/landmark{
@@ -5901,28 +5706,29 @@
 	icon_state = "console";
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anl" = (
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anm" = (
 /obj/item/modular_computer/console/preset/engineering{
 	icon_state = "console";
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "ann" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/item/device/radio/intercom/specops{
 	dir = 8;
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/red,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "ano" = (
 /obj/structure/table/standard,
@@ -6127,19 +5933,16 @@
 	dir = 4;
 	name = "Implant Management"
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anK" = (
 /obj/item/modular_computer/console/preset/security{
 	icon_state = "console";
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anL" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1331;
@@ -6148,21 +5951,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anM" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/meter,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anO" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1331;
@@ -6171,7 +5971,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anP" = (
 /obj/structure/table/standard,
@@ -6282,7 +6082,7 @@
 	},
 /area/ninja_dojo/dojo)
 "aoe" = (
-/obj/effect/wingrille_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aof" = (
@@ -6291,11 +6091,11 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aog" = (
-/obj/effect/wingrille_spawn/reinforced/crescent,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aoh" = (
@@ -6306,7 +6106,7 @@
 	name = "Ship External Access";
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aoi" = (
 /turf/unsimulated/wall/fakeglass,
@@ -6432,35 +6232,16 @@
 	},
 /area/rescue_base/base)
 "aov" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "rescuebridge";
 	name = "Cockpit Blast Shutters";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/rescue_base/start)
-"aow" = (
-/obj/structure/closet,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/turf/simulated/floor/shuttle/black,
 /area/rescue_base/start)
 "aox" = (
 /obj/structure/table/rack,
@@ -6473,7 +6254,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoy" = (
 /obj/machinery/atmospherics/pipe/tank/air{
@@ -6483,12 +6264,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -6501,34 +6282,13 @@
 	pixel_y = 25;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoB" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"aoC" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescueeva";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoD" = (
 /obj/structure/bookcase,
@@ -6592,71 +6352,15 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"aoL" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
 "aoM" = (
 /obj/structure/closet,
 /obj/item/weapon/storage/box/sinpockets,
 /obj/item/weapon/storage/box/sinpockets,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoN" = (
 /obj/structure/closet/bombclosetsecurity,
-/turf/simulated/floor/shuttle/black,
-/area/rescue_base/start)
-"aoO" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"aoP" = (
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"aoQ" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/engineering,
-/obj/item/clothing/head/helmet/space/void/engineering,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"aoR" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescueeva";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoT" = (
 /obj/structure/table/woodentable,
@@ -6741,25 +6445,6 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"apc" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
 "apd" = (
 /obj/structure/closet,
 /obj/item/device/flashlight/flare,
@@ -6774,7 +6459,7 @@
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "ape" = (
 /obj/item/device/radio/intercom/specops{
@@ -6783,32 +6468,7 @@
 	pixel_y = 0
 	},
 /obj/structure/closet/l3closet,
-/turf/simulated/floor/shuttle/black,
-/area/rescue_base/start)
-"apf" = (
-/obj/structure/table/rack,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apg" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescueeva";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aph" = (
 /obj/structure/bed/chair,
@@ -6833,7 +6493,7 @@
 	desc = "A secure airlock. Doesn't look like you can get through easily.";
 	icon = 'icons/obj/doors/centcomm/door.dmi';
 	icon_state = "closed";
-	name = "Outer Gate"
+	name = "Outer Gate";
 	dir = 4
 	},
 /area/ninja_dojo/dojo)
@@ -6888,14 +6548,13 @@
 /area/ninja_dojo/dojo)
 "apr" = (
 /obj/structure/closet,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aps" = (
-/obj/structure/closet/l3closet,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apt" = (
 /obj/structure/bed/chair{
@@ -6904,16 +6563,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apu" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apv" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apw" = (
 /obj/structure/bed/chair{
@@ -6922,18 +6577,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apx" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apy" = (
 /obj/item/device/radio/intercom/specops{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apz" = (
 /obj/structure/table/rack,
@@ -6948,7 +6599,7 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apA" = (
 /obj/item/clothing/head/collectable/paper,
@@ -6971,30 +6622,11 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"apD" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 10
-	},
-/area/rescue_base/start)
-"apE" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Crew Area";
-	opacity = 1;
-	req_access = list(103)
-	},
-/turf/simulated/floor/shuttle/black,
-/area/rescue_base/start)
 "apF" = (
 /obj/structure/sign/poster/bay_9{
 	pixel_x = -32
 	},
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apG" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apH" = (
 /obj/machinery/vending/wallmed1{
@@ -7004,20 +6636,15 @@
 	pixel_y = 0;
 	req_access = newlist()
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apI" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Passageway";
+	name = "Crew Area";
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apJ" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 6
-	},
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apK" = (
 /obj/effect/floor_decal/carpet,
@@ -7136,13 +6763,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apZ" = (
 /turf/unsimulated/beach/water{
@@ -7166,7 +6787,7 @@
 "aqc" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/orange,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqd" = (
 /obj/machinery/flasher{
@@ -7174,13 +6795,13 @@
 	pixel_x = 0;
 	pixel_y = 28
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqe" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqf" = (
 /obj/machinery/door/airlock/centcom{
@@ -7205,19 +6826,19 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqi" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqj" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqk" = (
 /obj/structure/table/glass,
@@ -7225,7 +6846,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aql" = (
 /obj/structure/closet/coffin,
@@ -7287,18 +6908,18 @@
 /area/ninja_dojo/dojo)
 "aqs" = (
 /obj/item/weapon/stool,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqt" = (
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqu" = (
 /obj/structure/table/rack,
 /obj/random/loot,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqv" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -7313,24 +6934,24 @@
 /area/rescue_base/start)
 "aqy" = (
 /obj/structure/closet/secure_closet/chemical,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqz" = (
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqC" = (
 /obj/structure/cult/pylon,
@@ -7413,7 +7034,7 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqK" = (
 /obj/machinery/light{
@@ -7423,7 +7044,7 @@
 /area/rescue_base/start)
 "aqL" = (
 /obj/structure/closet/secure_closet/medical1,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqM" = (
 /obj/structure/closet/medical_wall{
@@ -7442,25 +7063,25 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
 /obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqN" = (
 /obj/machinery/bodyscanner{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqO" = (
 /obj/machinery/body_scanconsole{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqP" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqQ" = (
 /obj/item/remains/human,
@@ -7492,10 +7113,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -25
 	},
-/turf/simulated/floor/shuttle/red,
-/area/rescue_base/start)
-"aqW" = (
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqX" = (
 /obj/machinery/door/airlock/centcom{
@@ -7503,37 +7121,40 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqY" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqZ" = (
 /obj/machinery/recharge_station,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "ara" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/closet/crate/secure{
+	req_access = list(103)
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "arb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/defibrillator/loaded,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arc" = (
 /obj/item/device/radio/intercom/specops{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "ard" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "are" = (
 /obj/item/device/radio/intercom/specops{
@@ -7541,7 +7162,7 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arf" = (
 /mob/living/simple_animal/hostile/creature{
@@ -7617,7 +7238,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aro" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -7641,7 +7262,7 @@
 /obj/item/weapon/reagent_containers/syringe,
 /obj/item/weapon/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arq" = (
 /obj/structure/window/reinforced{
@@ -7656,7 +7277,7 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arr" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -7758,21 +7379,6 @@
 	icon_state = "asteroid"
 	},
 /area/rescue_base/base)
-"arC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
 "arD" = (
 /obj/structure/closet{
 	name = "Prisoner's Locker"
@@ -7784,7 +7390,7 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "arE" = (
 /obj/structure/shuttle/engine/heater,
@@ -7797,33 +7403,11 @@
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/sterilizine,
 /obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arG" = (
 /obj/machinery/optable,
-/turf/simulated/floor/shuttle/white,
-/area/rescue_base/start)
-"arH" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescueinfirm";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arI" = (
 /obj/machinery/door/airlock/centcom{
@@ -7855,7 +7439,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "arM" = (
 /obj/structure/closet{
@@ -7863,7 +7447,7 @@
 	},
 /obj/item/clothing/shoes/orange,
 /obj/item/clothing/under/color/orange,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "arN" = (
 /obj/structure/shuttle/engine/propulsion,
@@ -7874,12 +7458,12 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/stack/medical/advanced/bruise_pack,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arP" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arQ" = (
 /obj/structure/table/glass,
@@ -7888,7 +7472,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arR" = (
 /obj/structure/flora/pottedplant/unusual,
@@ -8310,7 +7894,7 @@
 	},
 /area/ninja_dojo/start)
 "asG" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/structure/bed/chair/shuttle,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "dark"
@@ -11349,7 +10933,9 @@
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
 "azF" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/shuttle{
+	tag = "icon-shuttle_chair_preview (NORTH)";
+	icon_state = "shuttle_chair_preview";
 	dir = 1
 	},
 /turf/simulated/floor/shuttle/darkred,
@@ -17480,6 +17066,7 @@
 	dir = 4;
 	pixel_y = 8
 	},
+/obj/structure/aliumizer,
 /turf/simulated/floor/carpet/blue,
 /area/merchant_station)
 "aNc" = (
@@ -20118,15 +19705,17 @@
 /turf/simulated/floor/carpet/blue,
 /area/shuttle/merchant/home)
 "aTd" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/button/remote/blast_door{
 	id = "merchantshuttle";
 	name = "Merchant Window Shutters";
 	pixel_x = 0;
 	pixel_y = -28;
 	req_access = list(201)
+	},
+/obj/structure/bed/chair/shuttle{
+	tag = "icon-shuttle_chair_preview (WEST)";
+	icon_state = "shuttle_chair_preview";
+	dir = 8
 	},
 /turf/simulated/floor/carpet/blue,
 /area/shuttle/merchant/home)
@@ -21024,7 +20613,9 @@
 /turf/simulated/floor/shuttle/red,
 /area/skipjack_station/start)
 "aVd" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/bed/chair/shuttle{
+	tag = "icon-shuttle_chair_preview (WEST)";
+	icon_state = "shuttle_chair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/shuttle/red,
@@ -22736,6 +22327,12 @@
 	icon_state = "steel"
 	},
 /area/centcom/control)
+"bvA" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 "bwb" = (
 /obj/item/modular_computer/console/preset/security,
 /obj/effect/floor_decal/corner/red{
@@ -22967,6 +22564,25 @@
 	dir = 2
 	},
 /area/syndicate_mothership/raider_base)
+"cWy" = (
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
+"dFV" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/tableflag,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
 "eqZ" = (
 /turf/space,
 /turf/simulated/shuttle/wall/corner/dark,
@@ -22993,6 +22609,25 @@
 /obj/item/clothing/mask/breath/medical,
 /turf/simulated/floor/shuttle/white,
 /area/syndicate_station/start)
+"ePc" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 1
+	},
+/area/rescue_base/base)
 "eYq" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
@@ -23028,6 +22663,38 @@
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
+"gLQ" = (
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "emergency response team wardrobe"
+	},
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 1
+	},
+/area/rescue_base/base)
+"ivR" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "rescueinfirm";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/rescue_base/start)
 "ixw" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l";
@@ -23039,6 +22706,18 @@
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/shuttle/white,
 /area/syndicate_station/start)
+"jjm" = (
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
+"jlt" = (
+/obj/effect/floor_decal/snow,
+/obj/structure/aliumizer,
+/turf/unsimulated/floor{
+	icon = 'icons/turf/snow.dmi';
+	icon_state = "ice"
+	},
+/area/ninja_dojo/dojo)
 "jwM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23105,12 +22784,37 @@
 	},
 /turf/simulated/floor/airless,
 /area/syndicate_station/start)
+"lTk" = (
+/obj/structure/closet/l3closet,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
+"lUI" = (
+/obj/structure/aliumizer,
+/turf/unsimulated/floor{
+	icon_state = "asteroid"
+	},
+/area/syndicate_mothership/raider_base)
+"lWZ" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Passageway";
+	opacity = 1;
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 "mVh" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/syndicate_station/start)
+"mXu" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 "mXz" = (
 /obj/machinery/computer/pod{
 	dir = 1;
@@ -23121,17 +22825,78 @@
 	icon_state = "lino"
 	},
 /area/tdome/tdomeadmin)
+"mZG" = (
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rescue_base/start)
+"nBR" = (
+/obj/structure/aliumizer,
+/turf/simulated/floor/carpet,
+/area/wizard_station)
 "nUi" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/shuttle/black,
 /area/syndicate_station/start)
+"oYr" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
+"oYs" = (
+/obj/structure/aliumizer,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"pbb" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/accessory/solgov/rank/fleet/officer/o3,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
+"pGP" = (
+/obj/structure/table/steel,
+/obj/item/clothing/accessory/solgov/department/command/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/command,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
+"rio" = (
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 "ryl" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/teleport/hub,
 /turf/simulated/floor/plating,
 /area/syndicate_station/start)
+"rPx" = (
+/obj/structure/bed/chair/shuttle,
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
+"sfo" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
 "snr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -23154,6 +22919,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/syndicate_station/start)
+"std" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 "suk" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced/crescent{
@@ -23208,6 +22979,80 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/floor/shuttle/white,
 /area/syndicate_station/start)
+"tFp" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
+"vlI" = (
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "emergency response team wardrobe"
+	},
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
+"vlK" = (
+/obj/structure/table/rack,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
+	},
+/area/rescue_base/base)
+"wlM" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "rescueeva";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/rescue_base/start)
+"wXT" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5,
+/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
+"xhY" = (
+/obj/structure/closet/crate/secure{
+	req_access = list(103)
+	},
+/turf/simulated/floor/plating,
+/area/rescue_base/start)
+"xmT" = (
+/obj/item/device/radio/intercom/specops{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 
 (1,1,1) = {"
 aaa
@@ -24639,12 +24484,12 @@ aaL
 aaL
 aef
 aae
-agf
-aaL
-aaL
-aaL
-aaL
-aaL
+aaO
+aaO
+aaO
+aaO
+aaO
+aaO
 aiQ
 aae
 aad
@@ -24841,12 +24686,12 @@ aey
 aey
 aeg
 aae
-agg
-aaL
+aaO
+sfo
+aaO
 ahg
 ahg
 ahg
-aaL
 aiR
 aae
 aad
@@ -25043,13 +24888,13 @@ aaL
 aaL
 aef
 aae
-agh
-aaL
-ahh
-ahG
-aii
-aaL
-aiS
+aaO
+pbb
+aaO
+ahg
+ahg
+ahg
+cWy
 aae
 aad
 aad
@@ -25245,12 +25090,12 @@ aey
 aey
 aeg
 aae
-agi
-aaL
-ahi
-afh
-aij
-aaL
+aaO
+dFV
+aaO
+ahg
+ahg
+ahg
 aiT
 aae
 aae
@@ -25447,18 +25292,18 @@ aaL
 aaL
 aef
 aae
-agj
-aaL
-ahj
-ahj
-ahj
-aaL
-aiU
+aaO
+aaO
+aaO
+aaO
+aaO
+aaO
+wXT
 acy
 aaO
 aaO
 ajQ
-ake
+pGP
 aks
 aae
 aad
@@ -25649,17 +25494,17 @@ aey
 aey
 aeg
 aae
-agk
-aaL
-aaL
-aaL
-aaL
-aaL
-aiV
+akL
+aaO
+aaO
+aaO
+aaO
+aaO
+aaO
 acy
 aaO
 ajH
-ajR
+ake
 akf
 aaO
 aae
@@ -25884,15 +25729,15 @@ alU
 alU
 alU
 aml
-amq
-amq
-amq
-amq
-amq
-arC
-amq
-amq
-apD
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 alU
 ass
 adB
@@ -26085,13 +25930,13 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqc
 aqs
 aoe
 aqV
 aqV
-amY
+std
 arL
 arE
 arN
@@ -26287,14 +26132,14 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqd
 anl
 aqJ
-aqW
-aqW
-aqW
-aqW
+anl
+anl
+anl
+anl
 arE
 arN
 alU
@@ -26489,11 +26334,11 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqe
 aqt
 aoe
-aqW
+anl
 arn
 arD
 arM
@@ -26662,7 +26507,7 @@ afA
 aaO
 aaO
 aaO
-afh
+ajy
 acy
 aaL
 aaL
@@ -26680,27 +26525,27 @@ adA
 alH
 alU
 aml
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
 aov
-aoL
-apc
-amq
-apD
+aov
+aov
+aml
+aml
 alU
-amp
-amq
-amq
-amq
+aml
+aml
+aml
+aml
 aqX
-amq
-amq
-amq
-amq
-apJ
+aml
+aml
+aml
+aml
+aml
 alU
 ass
 adB
@@ -26887,18 +26732,18 @@ amV
 ank
 anJ
 aoe
-aow
+apr
 aoM
 apd
 apr
-amq
+aml
 alU
 alU
 alU
-amq
-aoP
-aoP
-amq
+aml
+anl
+anl
+aml
 alU
 alU
 alU
@@ -27083,24 +26928,24 @@ adB
 adB
 alH
 alU
-amn
+amm
 amE
-amW
+anl
 anl
 anl
 aof
 anl
 anl
 anl
-anl
-amq
-amq
-amq
-amq
-amq
-aoP
+rio
+aml
+aml
+aml
+aml
+aml
+jjm
 aqY
-amq
+aml
 alU
 alU
 alU
@@ -27266,8 +27111,8 @@ aaO
 aae
 afD
 aaL
-aaL
-aaL
+ePc
+vlK
 aaL
 aim
 aaL
@@ -27285,9 +27130,9 @@ adA
 adB
 alH
 alU
-amn
+amm
 amF
-amW
+rPx
 anl
 anl
 aoe
@@ -27295,14 +27140,14 @@ anl
 anl
 anl
 anl
-apE
-aoP
-apX
 apI
-aoP
-aoP
+anl
+apX
+lWZ
+anl
+anl
 apy
-amq
+aml
 alU
 alU
 alU
@@ -27487,7 +27332,7 @@ adB
 adB
 alH
 alU
-amo
+amm
 amG
 amX
 anm
@@ -27496,15 +27341,15 @@ aoe
 aox
 aoN
 ape
-aps
+lTk
 aoe
-aoP
-aoP
+anl
+anl
 aoe
 aqu
 aqu
 aqZ
-amq
+aml
 alU
 alU
 alU
@@ -27668,7 +27513,7 @@ aae
 aaO
 aaO
 aae
-afE
+aiS
 aaL
 aaL
 aaL
@@ -27682,33 +27527,33 @@ aaL
 aaL
 aaL
 aaL
-akB
+aiU
 aae
 adB
 adB
 aih
 alH
 alU
-amp
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-aoP
-aoP
-amq
-amq
-amq
-amq
-amq
-amq
-apD
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+jjm
+rio
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 alU
 alU
 alU
@@ -27899,12 +27744,12 @@ alU
 alU
 alU
 alU
-amq
+aml
 apt
 apF
-aoP
-aoP
-amq
+anl
+anl
+aml
 aqv
 aqK
 aqw
@@ -28101,11 +27946,11 @@ alU
 alU
 alU
 alU
-amq
+aml
 apu
-apG
-aoP
-aoP
+amW
+anl
+anl
 aqf
 aqw
 aqw
@@ -28303,11 +28148,11 @@ alU
 alU
 alU
 alU
-amq
-apv
-apG
-aoP
-aoP
+aml
+amV
+amW
+anl
+anl
 aqg
 aqw
 aqw
@@ -28478,7 +28323,7 @@ aaL
 acy
 afI
 aaO
-aaO
+vlI
 aaO
 ahK
 aip
@@ -28505,16 +28350,16 @@ alU
 alU
 alU
 alU
-amq
+aml
 apw
 apH
-aoP
-aoP
-amq
+anl
+anl
+aml
 aqx
 aqx
 ara
-aqw
+xhY
 arE
 arN
 alU
@@ -28700,25 +28545,25 @@ adB
 alH
 alU
 aml
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-aoP
-apy
-amq
-amq
-amq
-amq
-amq
-amq
-apJ
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+jjm
+xmT
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 alU
 alU
 alU
@@ -28901,24 +28746,24 @@ adB
 adB
 alH
 alU
-amq
+aml
 amH
 amY
 amY
 anL
-amq
+aml
 aoy
-aoO
-apf
-apx
+oYr
+bvA
+mXu
 aoe
-aoP
-aoP
+anl
+anl
 aoe
 aqy
 aqL
 arb
-amq
+aml
 alU
 alU
 alU
@@ -29110,17 +28955,17 @@ amZ
 anM
 aog
 aoz
-aoP
-aoP
-aoP
-apI
-aoP
-apY
+anl
+anl
+anl
+lWZ
+anl
+aps
 aqh
 aqz
 aqz
 arc
-amq
+aml
 alU
 alU
 alU
@@ -29312,17 +29157,17 @@ amZ
 anN
 aoh
 aoA
-aoP
-aoP
+anl
+anl
 apy
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
 aqM
 ard
-amq
+aml
 alU
 alU
 alU
@@ -29495,7 +29340,7 @@ aaL
 aaL
 aaL
 aae
-ajy
+gLQ
 ajy
 ajW
 ajW
@@ -29507,24 +29352,24 @@ ajX
 adB
 alH
 alU
-amq
+aml
 amJ
 ana
 ann
 anO
-amq
+aml
 aoB
-aoQ
-aoQ
+tFp
+tFp
 apz
-amq
+aml
 alU
 alU
 alU
-amq
+aml
 aqN
-aqz
-amq
+mZG
+aml
 alU
 alU
 alU
@@ -29709,28 +29554,28 @@ ajX
 adB
 alH
 alU
-amp
-amq
-amq
-amq
-amq
-amq
-aoC
-aoR
-apg
-amq
-apJ
+aml
+aml
+aml
+aml
+aml
+aml
+wlM
+wlM
+wlM
+aml
+aml
 alU
 aml
-amq
-amq
+aml
+aml
 aqO
 aqz
-amq
-amq
-amq
-amq
-apD
+aml
+aml
+aml
+aml
+aml
 alU
 ass
 adB
@@ -29923,7 +29768,7 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqi
 aqA
 aqz
@@ -30125,7 +29970,7 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqj
 aqB
 aqz
@@ -30327,7 +30172,7 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqk
 aqz
 aqP
@@ -30529,16 +30374,16 @@ alU
 alU
 alU
 alU
-amp
-amq
-amq
-amq
-amq
-amq
-arH
-amq
-amq
-apJ
+aml
+aml
+aml
+aml
+aml
+aml
+ivR
+aml
+aml
+aml
 alU
 ass
 adB
@@ -50916,7 +50761,7 @@ ajN
 ajN
 ale
 alj
-alv
+nBR
 alM
 alZ
 alb
@@ -56078,7 +55923,7 @@ aLM
 aLM
 aLM
 aLM
-aML
+lUI
 aML
 aOO
 aML
@@ -58604,7 +58449,7 @@ akd
 ajP
 apa
 apo
-apo
+jlt
 aoZ
 ajP
 ajP
@@ -59462,7 +59307,7 @@ ayB
 azK
 aAf
 aAB
-aAS
+oYs
 aAS
 aAS
 aBS


### PR DESCRIPTION
What has been done:
- ERT now has access to Fleet uniforms, including ranks and insignias (including Fifth Fleet patches, optional).
- ERT's leader is a Lieutenant (E-3).
- ERT's 2IC is a CPO (E-7)
- Others are E-6 and E-5, optional.
- The ERT shuttle has been upgraded to match other Sol vessels. Mostly walls and windows, titanuim now.
- Stun revolvers have been replaced with energy guns.
- Everything related to Asset Protection or Nanotrasen has been removed or replaced with SCG analogue. (if I haven't forgot something)
- AP armor has been replaced with plate carriers.
- A bunch of tablets added.
- Security part of the ERT is provided with riot gear.

:cl: Sbotkin
tweak: Emergency Response Team is officially a part of the SCG Fleet now.
/:cl: