### PR TITLE
Improves ruin loader further, changes to exoplanet init.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -77,6 +77,12 @@
 #define AREA_FLAG_RAD_SHIELDED 1 // shielded from radiation, clearly
 #define AREA_FLAG_EXTERNAL     2 // External as in exposed to space, not outside in a nice, green, forest
 
+//Map template flags
+#define TEMPLATE_FLAG_ALLOW_DUPLICATES 1 // Lets multiple copies of the template to be spawned
+#define TEMPLATE_FLAG_SPAWN_GUARANTEED 2 // Makes it ignore away site budget and just spawn (only for away sites)
+#define TEMPLATE_FLAG_CLEAR_CONTENTS   4 // if it should destroy objects it spawns on top of
+#define TEMPLATE_FLAG_NO_RUINS         8 // if it should forbid ruins from spawning on top of it
+
 // Convoluted setup so defines can be supplied by Bay12 main server compile script.
 // Should still work fine for people jamming the icons into their repo.
 #ifndef CUSTOM_ITEM_OBJ

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -52,8 +52,9 @@
 #define SS_INIT_MACHINES         1
 #define SS_INIT_DEFAULT          0
 #define SS_INIT_AIR             -1
-#define SS_INIT_ALARM           -2
-#define SS_INIT_LIGHTING        -3
+#define SS_INIT_MISC_LATE       -2
+#define SS_INIT_ALARM           -3
+#define SS_INIT_LIGHTING        -4
 #define SS_INIT_XENOARCH       -50
 #define SS_INIT_OPEN_SPACE    -150
 #define SS_INIT_BAY_LEGACY    -200

--- a/code/controllers/subsystems/misc_late.dm
+++ b/code/controllers/subsystems/misc_late.dm
@@ -1,0 +1,11 @@
+
+//Initializes relatively late in subsystem init order.
+
+SUBSYSTEM_DEF(misc_late)
+	name = "Late Initialization"
+	init_order = SS_INIT_MISC_LATE
+	flags = SS_NO_FIRE
+
+/datum/controller/subsystem/misc_late/Initialize()
+	GLOB.using_map.build_exoplanets()
+	. = ..()

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -10,6 +10,7 @@
 
 	var/prefix = null
 	var/suffixes = null
+	template_flags = 0 // No duplicates by default
 
 /datum/map_template/ruin/New()
 	if(!name && id)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -109,7 +109,7 @@
 
 	if(config.generate_map)
 		GLOB.using_map.perform_map_generation()
-	GLOB.using_map.build_exoplanets()
+
 
 	// Create robolimbs for chargen.
 	populate_robolimb_list()

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -42,7 +42,7 @@
 
 	var/datum/map_template/template = SSmapping.map_templates[map]
 
-	if (template.loaded && !template.allow_duplicates)
+	if (template.loaded && !(template.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 		var/jesus_take_the_wheel = alert(usr, "That template has already been loaded and doesn't want to be loaded again. \
 			Proceeding may unpredictably break things and cause runtimes.", "Confirm load", "Cancel load", "Do you see any cops around?") == "Do you see any cops around?"
 		if (!jesus_take_the_wheel)

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -5,12 +5,10 @@
 	var/tallness = 0
 	var/list/mappaths = null
 	var/loaded = 0 // Times loaded this round
-	var/allow_duplicates = TRUE
 	var/list/shuttles_to_initialise = list()
 	var/base_turf_for_zs = null
 	var/accessibility_weight = 0
-	var/spawn_guaranteed = FALSE
-	var/clear_contents = FALSE  //if it should destroy objects it spawns on top of
+	var/template_flags = TEMPLATE_FLAG_ALLOW_DUPLICATES
 
 /datum/map_template/New(var/list/paths = null, var/rename = null)
 	if(paths && !islist(paths))
@@ -26,7 +24,7 @@
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
 	var/z_offset = 1 // needed to calculate z-bounds correctly
 	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), 1, 1, z_offset, cropMap=FALSE, measureOnly=TRUE, no_changeturf=TRUE, clear_contents=clear_contents)
+		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), 1, 1, z_offset, cropMap=FALSE, measureOnly=TRUE, no_changeturf=TRUE, clear_contents= template_flags & TEMPLATE_FLAG_CLEAR_CONTENTS)
 		if(M)
 			bounds = extend_bounds_if_needed(bounds, M.bounds)
 			z_offset++
@@ -122,7 +120,7 @@
 	var/list/atoms_to_initialise = list()
 
 	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, clear_contents=clear_contents)
+		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, clear_contents= template_flags & TEMPLATE_FLAG_CLEAR_CONTENTS)
 		if (M)
 			atoms_to_initialise += M.atoms_to_initialise
 		else

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -41,18 +41,16 @@
 	possible_features.Cut()
 	for(var/T in feature_types)
 		var/datum/map_template/ruin/exoplanet/ruin = new T
-		possible_features[ruin.id] = ruin
+		possible_features += ruin
 	..()
 
 /obj/effect/overmap/sector/exoplanet/proc/build_level()
-	spawn()
-		generate_atmosphere()
-		generate_map()
-		create_lighting_overlays_zlevel(z) //Creates overlays, if not created already.
-		generate_features()
-		generate_landing(4)		//try making 4 landmarks
-		update_biome()
-		START_PROCESSING(SSobj, src)
+	generate_atmosphere()
+	generate_map()
+	generate_features()
+	generate_landing(4)		//try making 4 landmarks
+	update_biome()
+	START_PROCESSING(SSobj, src)
 
 //attempt at more consistent history generation for xenoarch finds.
 /obj/effect/overmap/sector/exoplanet/proc/get_engravings()

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -3,4 +3,3 @@
 /datum/map_template/ruin/away_site
 	var/spawn_weight = 1
 	prefix = "maps/away/"
-	allow_duplicates = FALSE // duplicating these will probably screw up shuttles etc!

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -25,7 +25,7 @@
 	suffixes = list("mining/mining-asteroid.dmm")
 	cost = 1
 	accessibility_weight = 10
-	spawn_guaranteed = TRUE
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /obj/effect/shuttle_landmark/cluster/nav1
 	name = "Asteroid Navpoint #1"

--- a/maps/away_sites_testing/away_sites_testing_unit_testing.dm
+++ b/maps/away_sites_testing/away_sites_testing_unit_testing.dm
@@ -38,8 +38,7 @@
 		/area/slavers_base/hangar = NO_SCRUBBER,
 		/area/map_template/hydrobase = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/map_template/hydrobase/station = NO_SCRUBBER,
-		/area/map_template/monolith = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/mobius_rift = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/mobius_rift = NO_SCRUBBER|NO_VENT|NO_APC
 //		/area/icarus/vessel = NO_APC,
 //		/area/icarus/open = NO_SCRUBBER|NO_VENT|NO_APC,
 	)

--- a/maps/overmap_example/overmap_unit_testing.dm
+++ b/maps/overmap_example/overmap_unit_testing.dm
@@ -21,6 +21,5 @@
 		/area/ship/scrap/shuttle/outgoing = NO_SCRUBBER,
 		/area/ship/scrap/maintenance/atmos = NO_SCRUBBER,
 		/area/map_template/hydrobase = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/map_template/hydrobase/station = NO_SCRUBBER,
-		/area/map_template/monolith = NO_SCRUBBER|NO_VENT|NO_APC
+		/area/map_template/hydrobase/station = NO_SCRUBBER
 	)

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -4,8 +4,7 @@
 	description = "hydroponics base with random plants and a lot of enemies"
 	suffixes = list("hydrobase/hydrobase.dmm")
 	cost = 1
-	allow_duplicates = FALSE
-	clear_contents = 1
+	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 
 // Areas //
 /area/map_template/hydrobase

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -2709,14 +2709,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
 "gc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/map_template/hydrobase/station/growA)
-"gd" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
 	dir = 8;
@@ -2727,11 +2719,11 @@
 /obj/item/seeds/towermycelium,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/growB)
-"ge" = (
+"gd" = (
 /obj/item/weapon/cigbutt,
 /turf/simulated/floor/tiled/white,
 /area/map_template/hydrobase/station/growB)
-"gf" = (
+"ge" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2740,7 +2732,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/shipaccess)
-"gg" = (
+"gf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
 	icon_state = "map"
@@ -2758,7 +2750,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/shipaccess)
-"gh" = (
+"gg" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2770,7 +2762,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/shipaccess)
-"gi" = (
+"gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2783,7 +2775,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gj" = (
+"gi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -2794,7 +2786,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gk" = (
+"gj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -2805,7 +2797,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gl" = (
+"gk" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	icon_state = "shower";
@@ -2813,20 +2805,20 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gm" = (
+"gl" = (
 /obj/structure/lattice,
 /turf/simulated/wall/alium,
 /area/map_template/hydrobase/station/shower)
-"gn" = (
+"gm" = (
 /obj/structure/catwalk,
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/chantermycelium,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/growB)
-"go" = (
+"gn" = (
 /turf/simulated/wall/alium,
 /area/map_template/hydrobase/station/dockport)
-"gp" = (
+"go" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
 	frequency = 1391;
@@ -2843,18 +2835,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/dockport)
-"gq" = (
+"gp" = (
 /obj/effect/wingrille_spawn/reinforced_phoron/full,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/map_template/hydrobase/station/dockport)
-"gr" = (
+"gq" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gs" = (
+"gr" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -2867,19 +2859,19 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gt" = (
+"gs" = (
 /obj/structure/catwalk,
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/chantermycelium,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/growB)
-"gu" = (
+"gt" = (
 /obj/machinery/mech_recharger,
 /mob/living/simple_animal/hostile/retaliate/malf_drone/hydro,
 /turf/simulated/floor/tiled/white,
 /area/map_template/hydrobase/station/growB)
-"gv" = (
+"gu" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 1
@@ -2902,7 +2894,7 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/dockport)
-"gw" = (
+"gv" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 1
@@ -2918,7 +2910,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/dockport)
-"gx" = (
+"gw" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 1
@@ -2931,13 +2923,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/dockport)
-"gy" = (
+"gx" = (
 /obj/item/clothing/under/overalls,
 /obj/item/clothing/shoes/desertboots,
 /obj/structure/closet,
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gz" = (
+"gy" = (
 /obj/item/clothing/accessory/toggleable/hawaii/random,
 /obj/item/clothing/under/casual_pants/greyjeans,
 /obj/item/clothing/head/bowlerhat,
@@ -2945,14 +2937,14 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gA" = (
+"gz" = (
 /obj/item/clothing/under/skirt_c/dress/black,
 /obj/item/clothing/head/beret/purple,
 /obj/item/clothing/shoes/dress,
 /obj/structure/closet,
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/hydrobase/station/shower)
-"gB" = (
+"gA" = (
 /obj/machinery/oxygen_pump{
 	pixel_x = -32
 	},
@@ -2964,11 +2956,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/dockport)
-"gC" = (
+"gB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/dockport)
-"gD" = (
+"gC" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1391;
@@ -2989,7 +2981,7 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/dockport)
-"gE" = (
+"gD" = (
 /obj/machinery/power/solar{
 	id = "hydrosolar"
 	},
@@ -3001,7 +2993,7 @@
 	},
 /turf/simulated/floor/fixed/alium/airless,
 /area/map_template/hydrobase/solars)
-"gF" = (
+"gE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -3009,7 +3001,7 @@
 	},
 /turf/simulated/floor/fixed/alium/airless,
 /area/map_template/hydrobase/solars)
-"gG" = (
+"gF" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small{
 	dir = 8
@@ -3022,13 +3014,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/dockport)
-"gH" = (
+"gG" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/dockport)
-"gI" = (
+"gH" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small{
 	dir = 4
@@ -3041,18 +3033,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/dockport)
-"gJ" = (
+"gI" = (
 /obj/machinery/light,
 /obj/structure/catwalk,
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/finetobaccoseed,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/growA)
-"gK" = (
+"gJ" = (
 /obj/structure/sign/warning/smoking,
 /turf/simulated/wall/alium,
 /area/map_template/hydrobase/station/dockport)
-"gL" = (
+"gK" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1391;
 	icon_state = "door_locked";
@@ -3063,7 +3055,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/hydrobase/station/dockport)
-"gM" = (
+"gL" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1391;
@@ -3272,7 +3264,7 @@ fh
 fx
 fJ
 fS
-gd
+gc
 eN
 eN
 aa
@@ -3314,7 +3306,7 @@ fi
 fi
 fi
 fj
-gn
+gm
 eN
 eN
 aa
@@ -3356,7 +3348,7 @@ fx
 fi
 fj
 fj
-gt
+gs
 eN
 aa
 aa
@@ -3438,7 +3430,7 @@ fy
 fi
 fx
 fi
-gn
+gm
 fw
 aa
 aa
@@ -3479,7 +3471,7 @@ fi
 fi
 fx
 fi
-gn
+gm
 fw
 aa
 aa
@@ -3520,7 +3512,7 @@ fy
 fj
 fx
 fj
-gt
+gs
 eN
 aa
 aa
@@ -3559,9 +3551,9 @@ fl
 fz
 fi
 fU
-ge
+gd
 fi
-gu
+gt
 eN
 aa
 aa
@@ -3769,7 +3761,7 @@ ef
 aE
 av
 aq
-gJ
+gI
 al
 al
 "}
@@ -3929,11 +3921,11 @@ fB
 fB
 fB
 fB
-go
-go
-go
-go
-gK
+gn
+gn
+gn
+gn
+gJ
 aa
 aa
 "}
@@ -3969,12 +3961,12 @@ fp
 fC
 fM
 fW
-gf
-go
-gv
-gB
-gG
-gq
+ge
+gn
+gu
+gA
+gF
+gp
 aa
 aa
 "}
@@ -4010,13 +4002,13 @@ fq
 fD
 fN
 fX
-gg
-gp
-gw
-gC
-gH
+gf
+go
+gv
+gB
+gG
+gK
 gL
-gM
 aa
 "}
 (24,1,1) = {"
@@ -4051,12 +4043,12 @@ ep
 fC
 fO
 fY
-gh
-gq
-gx
-gD
-gI
-go
+gg
+gp
+gw
+gC
+gH
+gn
 aa
 aa
 "}
@@ -4092,12 +4084,12 @@ fr
 fE
 fE
 fE
-gi
-go
-go
-go
-go
-go
+gh
+gn
+gn
+gn
+gn
+gn
 aa
 aa
 "}
@@ -4133,9 +4125,9 @@ eX
 fE
 fP
 fZ
-gj
-gr
-gy
+gi
+gq
+gx
 fE
 aa
 aa
@@ -4174,9 +4166,9 @@ fs
 fF
 fQ
 ga
-gk
+gj
 gb
-gz
+gy
 fE
 aa
 aa
@@ -4215,9 +4207,9 @@ ez
 fE
 fR
 gb
-gl
-gs
-gA
+gk
+gr
+gz
 fE
 aa
 aa
@@ -4256,7 +4248,7 @@ ft
 fE
 fE
 fE
-gm
+gl
 fE
 fE
 fE
@@ -4378,7 +4370,7 @@ er
 dJ
 dJ
 dg
-gc
+fH
 dg
 fH
 dg
@@ -4423,7 +4415,7 @@ fG
 dg
 fG
 dg
-gE
+gD
 aa
 aa
 aa
@@ -4505,7 +4497,7 @@ fG
 dg
 fG
 dg
-gE
+gD
 aa
 aa
 aa
@@ -4546,7 +4538,7 @@ fI
 dh
 fI
 dh
-gF
+gE
 aa
 aa
 aa

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -4,12 +4,7 @@
 	description = "Bunch of monoliths surrounding an artifact."
 	suffixes = list("monoliths/monoliths.dmm")
 	cost = 1
-	allow_duplicates = FALSE
-
-/area/map_template/monolith
-	name = "Monolith Ring"
-	icon = 'icons/obj/monolith.dmi'
-	icon_state = "jaggy1"
+	template_flags = TEMPLATE_FLAG_NO_RUINS
 
 /obj/structure/monolith
 	name = "monolith"

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dmm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dmm
@@ -1,14 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/map_template/monolith)
+/area/template_noop)
 "b" = (
 /obj/structure/monolith,
 /turf/template_noop,
-/area/map_template/monolith)
+/area/template_noop)
 "c" = (
 /turf/simulated/floor/fixed/alium/ruin,
-/area/map_template/monolith)
+/area/template_noop)
 "d" = (
 /obj/machinery/artifact,
 /obj/structure/window/phoronreinforced{
@@ -25,7 +25,7 @@
 	},
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/fixed/alium/ruin,
-/area/map_template/monolith)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/maps/random_ruins/space_ruins/space_ruins.dm
+++ b/maps/random_ruins/space_ruins/space_ruins.dm
@@ -3,7 +3,6 @@
 /datum/map_template/ruin/space
 	prefix = "maps/random_ruins/space_ruins/"
 	cost = 1
-	allow_duplicates = FALSE
 
 /datum/map_template/ruin/space/multi_zas_test
 	name = "Multi-ZAS Test"

--- a/maps/torch/torch_unit_testing.dm
+++ b/maps/torch/torch_unit_testing.dm
@@ -70,8 +70,7 @@
 		/area/icarus/vessel = NO_APC,
 		/area/icarus/open = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/map_template/hydrobase = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/map_template/hydrobase/station = NO_SCRUBBER,
-		/area/map_template/monolith = NO_SCRUBBER|NO_VENT|NO_APC
+		/area/map_template/hydrobase/station = NO_SCRUBBER
 	)
 
 	area_coherency_test_exempt_areas = list(
@@ -119,8 +118,7 @@
 		/area/exoplanet/garbage,
 		/area/template_noop,
 		/area/map_template,
-		/area/map_template/little_house,
-		/area/map_template/monolith
+		/area/map_template/little_house
 	)
 
 	// not an away site? you probably want to be using area_usage_test_exempted_areas

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -188,7 +188,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for (var/site_name in SSmapping.away_sites_templates)
 		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 
-		if(site.spawn_guaranteed && site.load_new_z()) // no check for budget, but guaranteed means guaranteed
+		if((site.template_flags & TEMPLATE_FLAG_SPAWN_GUARANTEED) && site.load_new_z()) // no check for budget, but guaranteed means guaranteed
 			report_progress("Loaded guaranteed away site [site]!")
 			away_site_budget -= site.cost
 			continue

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -9,8 +9,7 @@
 		/area/exoplanet/desert      = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/exoplanet/grass       = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/exoplanet/snow        = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/exoplanet/garbage     = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/map_template/monolith = NO_SCRUBBER|NO_VENT|NO_APC
+		/area/exoplanet/garbage     = NO_SCRUBBER|NO_VENT|NO_APC
 	)
 
 	var/list/area_coherency_test_exempt_areas = list(
@@ -65,8 +64,7 @@
 		/area/exoplanet/garbage,
 		/area/template_noop,
 		/area/map_template,
-		/area/map_template/little_house,
-		/area/map_template/monolith
+		/area/map_template/little_house
 	)
 
 	var/list/area_usage_test_exempted_root_areas = list(


### PR DESCRIPTION
- Changes map template bools to flags.
- The ruin loader now has the following behavior with the `id` var on map templates: at most one ruin with a given id will be loaded (globally), provided all ruins with that id do not have `TEMPLATE_FLAG_ALLOW_DUPLICATES`. (If some ruins do have that flag, of the ones that don't, at most one will be loaded, with unpredictable results for the ones that do have it)
- Setting `TEMPLATE_FLAG_NO_RUINS` on a ruin will prevent other ruins from spawning over it.
- Exoplanets are now fully initialized in a subsystem.

The hydrobase map change: there was one rogue turf with the wrong area in the map file. This makes it fail the area coherency unit test whenever hydrobase actually loads on the Travis build. Previously this was not being done, as the tests finished before the load (they didn't wait).