### PR TITLE
Randomly tweaks some projectile damage values

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,6 +10,7 @@
 	eyeblur = 4
 	hitscan = 1
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
+	penetration_modifier = 0.3
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer
@@ -22,10 +23,11 @@
 
 /obj/item/projectile/beam/smalllaser
 	damage = 25
+	armor_penetration = 10
 
 /obj/item/projectile/beam/midlaser
 	damage = 50
-	armor_penetration = 10
+	armor_penetration = 20
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -124,16 +124,14 @@
 /obj/item/projectile/bullet/pistol
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	damage = 25 //9mm, .38, etc
-	armor_penetration = 13.5
 
 /obj/item/projectile/bullet/pistol/medium
 	damage = 26.5 //.45
-	armor_penetration = 14.5
 
 /obj/item/projectile/bullet/pistol/medium/smg
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	damage = 28 //10mm
-	armor_penetration = 18
+	penetration_modifier = 0.8
 
 /obj/item/projectile/bullet/pistol/medium/revolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
@@ -155,7 +153,6 @@
 	agony = 30
 	embed = 0
 	sharp = 0
-	armor_penetration = 2.5
 
 /* shotgun projectiles */
 
@@ -172,6 +169,7 @@
 	agony = 60
 	embed = 0
 	sharp = 0
+	armor_penetration = 0
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding


### PR DESCRIPTION
It was chosen by a fair dice throw.
Lasers now deal bit more damage to internal organs (0.3x damage instead of 0.2x), and have more armor penetration - 10 on smoll lasers, 20 on carbine ones.

Peestol bullets (and SMG) lost armor penetration, and SMG boolets are not bit shittier at organ damage.

I gathered enough sec tears, might as well do this to tweak them ever so slightly towards not being steamrolled. Just a bit.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
