### PR TITLE
Fixes magic missile not doing anything on impact.

### DIFF
--- a/code/modules/spells/targeted/projectile/magic_missile.dm
+++ b/code/modules/spells/targeted/projectile/magic_missile.dm
@@ -23,7 +23,6 @@
 	amt_stunned = 3
 
 	amt_dam_fire = 10
-	cast_prox_range = 0
 
 /spell/targeted/projectile/magic_missile/prox_cast(var/list/targets, atom/spell_holder)
 	spell_holder.visible_message("<span class='danger'>\The [spell_holder] pops with a flash!</span>")


### PR DESCRIPTION
:cl:
bugfix: The magic missile wizard spell now works. It inflicts small burn damage and a substantial disable.
/:cl:

Fixes #13186.