### PR TITLE
adjusts deity zombies to be slightly less round-ending

### DIFF
--- a/code/game/gamemodes/godmode/form_items/narsie_items.dm
+++ b/code/game/gamemodes/godmode/form_items/narsie_items.dm
@@ -71,9 +71,9 @@
 	desc = "Said to bring those who drink it back to life, no matter the price."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "urn"
-	volume = 120
-	amount_per_transfer_from_this = 30
+	volume = 10
+	amount_per_transfer_from_this = 10
 
 /obj/item/weapon/reagent_containers/food/drinks/zombiedrink/New()
 	..()
-	reagents.add_reagent(/datum/reagent/toxin/corrupting,120)
+	reagents.add_reagent(/datum/reagent/toxin/zombie, 10)

--- a/code/modules/mob/living/deity/items/narsie/minions.dm
+++ b/code/modules/mob/living/deity/items/narsie/minions.dm
@@ -17,7 +17,7 @@
 	desc = "Give a vessel to a follower filled with infection so vile, it turns all sapient creatures into mindless husks."
 	category = DEITY_TREE_DARK_MINION
 	requirements = list(DEITY_TREE_DARK_MINION = 1)
-	base_cost = 200 //End game shit.
+	base_cost = 200
 	boon_path = /obj/item/weapon/reagent_containers/food/drinks/zombiedrink
 
 /datum/deity_item/boon/tear_veil

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -18,40 +18,53 @@
 
 /mob/living/proc/breath_death()
 	set name = "Breath Death"
-	set desc = "Infect others with your very breathe."
+	set desc = "Infect others with your very breath."
 	set category = "Abilities"
 
-	if(last_special > world.time)
+	if (last_special > world.time)
+		to_chat(src, "You aren't ready to do that! Wait [round(last_special - world.time) / 10] seconds.")
+		return
+	
+	if (incapacitated())
+		to_chat(src, "You can't do that while you're incapacitated!")
 		return
 
-	last_special = world.time + 1 SECOND
+	last_special = world.time + 60 SECONDS
 
 	var/turf/T = get_turf(src)
 	var/obj/effect/effect/water/chempuff/chem = new(T)
 	chem.create_reagents(10)
-	chem.reagents.add_reagent(/datum/reagent/toxin/corrupting,5)
+	chem.reagents.add_reagent(/datum/reagent/toxin/corrupting, 5)
 	chem.set_up(get_step(T, dir), 2, 10)
-	playsound(T, 'sound/hallucinations/wail.ogg',20,1)
+	playsound(T, 'sound/hallucinations/wail.ogg', 20, 1)
 
 /mob/living/proc/consume()
 	set name = "Consume"
 	set desc = "Regain life by consuming it from others."
 	set category = "Abilities"
 
-	if(last_special > world.time)
+	if (last_special > world.time)
+		to_chat(src, "You aren't ready to do that! Wait [round(last_special - world.time) / 10] seconds.")
 		return
-	var/mob/living/target
-	for(var/mob/living/L in get_turf(src))
-		if(L.lying || L.stat == DEAD)
-			target = L
-			break
-	if(!target)
+	
+	if (incapacitated())
+		to_chat(src, "You can't do that while you're incapacitated!")
 		return
 
-	last_special = world.time + 50
+	var/mob/living/target
+	for (var/mob/living/L in get_turf(src))
+		if (L.lying || L.stat == DEAD)
+			if (target != src)
+				target = L
+				break
+	if (!target)
+		to_chat(src, "You aren't on top of a victim!")
+		return
+
+	last_special = world.time + 5 SECONDS
 
 	src.visible_message("<span class='danger'>\The [src] hunkers down over \the [target], tearing into their flesh.</span>")
-	if(do_mob(src,target,100))
+	if(do_mob(src, target, 5 SECONDS))
 		to_chat(target,"<span class='danger'>\The [src] scrapes your flesh from your bones!</span>")
 		to_chat(src,"<span class='danger'>You feed hungrily off \the [target]'s flesh.</span>")
 		target.adjustBruteLoss(25)

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -34,7 +34,7 @@
 	var/turf/T = get_turf(src)
 	var/obj/effect/effect/water/chempuff/chem = new(T)
 	chem.create_reagents(10)
-	chem.reagents.add_reagent(/datum/reagent/toxin/corrupting, 5)
+	chem.reagents.add_reagent(/datum/reagent/toxin/zombie, 2)
 	chem.set_up(get_step(T, dir), 2, 10)
 	playsound(T, 'sound/hallucinations/wail.ogg', 20, 1)
 

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -22,11 +22,11 @@
 	set category = "Abilities"
 
 	if (last_special > world.time)
-		to_chat(src, "You aren't ready to do that! Wait [round(last_special - world.time) / 10] seconds.")
+		to_chat(src, "<span class='warning'>You aren't ready to do that! Wait [round(last_special - world.time) / 10] seconds.</span>")
 		return
 	
 	if (incapacitated())
-		to_chat(src, "You can't do that while you're incapacitated!")
+		to_chat(src, "<span class='warning'>You can't do that while you're incapacitated!</span>")
 		return
 
 	last_special = world.time + 60 SECONDS
@@ -44,21 +44,20 @@
 	set category = "Abilities"
 
 	if (last_special > world.time)
-		to_chat(src, "You aren't ready to do that! Wait [round(last_special - world.time) / 10] seconds.")
+		to_chat(src, "<span class='warning'>You aren't ready to do that! Wait [round(last_special - world.time) / 10] seconds.</span>")
 		return
 	
 	if (incapacitated())
-		to_chat(src, "You can't do that while you're incapacitated!")
+		to_chat(src, "<span class='warning'>You can't do that while you're incapacitated!</span>")
 		return
 
 	var/mob/living/target
 	for (var/mob/living/L in get_turf(src))
-		if (L.lying || L.stat == DEAD)
-			if (target != src)
-				target = L
-				break
+		if (L != src && (L.lying || L.stat == DEAD))
+			target = L
+			break
 	if (!target)
-		to_chat(src, "You aren't on top of a victim!")
+		to_chat(src, "<span class='warning'>You aren't on top of a victim!</span>")
 		return
 
 	last_special = world.time + 5 SECONDS

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -307,22 +307,24 @@
 	return 0
 
 
-//This is barely a transformation but probably best file for it.
-/mob/living/carbon/human/proc/zombieze()
+/mob/living/carbon/human/proc/zombify()
 	ChangeToHusk()
-	mutations |= CLUMSY //cause zombie
-	src.visible_message("<span class='danger'>\The [src]'s flesh decays before your very eyes!</span>", "<span class='danger'>Your entire body is ripe with pain as it is consumed down to flesh and bones. You... hunger. Not only for flesh, but to spread your disease.</span>")
+	mutations |= CLUMSY
+	src.visible_message("<span class='danger'>\The [src]'s skin decays before your very eyes!</span>", "<span class='danger'>Your entire body is ripe with pain as it is consumed down to flesh and bones. You ... hunger. Not only for flesh, but to spread this gift.</span>")
 	if(src.mind)
 		src.mind.special_role = "Zombie"
 	log_admin("[key_name(src)] has transformed into a zombie!")
 	Weaken(5)
 	if(should_have_organ(BP_HEART))
-		vessel.add_reagent(/datum/reagent/blood,species.blood_volume-vessel.total_volume)
+		vessel.add_reagent(/datum/reagent/blood, species.blood_volume - vessel.total_volume)
 	for(var/o in organs)
 		var/obj/item/organ/organ = o
 		organ.vital = 0
-		organ.rejuvenate(1)
-		organ.max_damage *= 5
-		organ.min_broken_damage *= 5
+		if (!organ.isrobotic())
+			organ.rejuvenate(1)
+			organ.max_damage *= 3
+			organ.min_broken_damage = Floor(organ.max_damage * 0.75)
 	verbs += /mob/living/proc/breath_death
 	verbs += /mob/living/proc/consume
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/hallucinations/wail.ogg', 20, 1)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -311,13 +311,15 @@
 	ChangeToHusk()
 	mutations |= CLUMSY
 	src.visible_message("<span class='danger'>\The [src]'s skin decays before your very eyes!</span>", "<span class='danger'>Your entire body is ripe with pain as it is consumed down to flesh and bones. You ... hunger. Not only for flesh, but to spread this gift.</span>")
-	if(src.mind)
+	if (src.mind)
+		if (src.mind.special_role == "Zombie")
+			return
 		src.mind.special_role = "Zombie"
 	log_admin("[key_name(src)] has transformed into a zombie!")
 	Weaken(5)
-	if(should_have_organ(BP_HEART))
+	if (should_have_organ(BP_HEART))
 		vessel.add_reagent(/datum/reagent/blood, species.blood_volume - vessel.total_volume)
-	for(var/o in organs)
+	for (var/o in organs)
 		var/obj/item/organ/organ = o
 		organ.vital = 0
 		if (!organ.isrobotic())
@@ -326,5 +328,4 @@
 			organ.min_broken_damage = Floor(organ.max_damage * 0.75)
 	verbs += /mob/living/proc/breath_death
 	verbs += /mob/living/proc/consume
-	var/turf/T = get_turf(src)
-	playsound(T, 'sound/hallucinations/wail.ogg', 20, 1)
+	playsound(get_turf(src), 'sound/hallucinations/wail.ogg', 20, 1)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -658,14 +658,14 @@
 	..()
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/doses = H.chem_doses[type]
-		if (doses >= 5)
+		var/current_dose = H.chem_doses[type]
+		var/true_dose = current_dose + volume
+		if (true_dose >= 5)
 			H.zombify()
-		else if (doses > 1)
-			if (prob(doses * 10))
-				H.zombify()
+		else if (true_dose > 1 && prob(20))
+			H.zombify()
 		else if (prob(10))
-			to_chat(M, "<span class='warning'>You feel terribly ill!</span>")
+			to_chat(H, "<span class='warning'>You feel terribly ill!</span>")
 
 /datum/reagent/toxin/bromide
 	name = "Bromide"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -658,7 +658,7 @@
 	..()
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/doses = M.chem_doses[type]
+		var/doses = H.chem_doses[type]
 		if (doses >= 5)
 			H.zombify()
 		else if (doses > 1)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -641,34 +641,31 @@
 	to_chat(M, "<span class='warning'>Your feel a chill, your skin feels lighter..</span>")
 	remove_self(volume)
 
-/datum/reagent/toxin/corrupting
-	name = "Corruption"
-	description = "A loyalty changing liquid."
-	taste_description = "blood"
-	color = "#ffffff"
+/datum/reagent/toxin/zombie
+	name = "Liquid Corruption"
+	description = "A filthy, oily substance which slowly churns of its own accord."
+	taste_description = "decaying blood"
+	color = "#800000"
 	taste_mult = 5
 	strength = 10
 	metabolism = REM * 5
 	overdose = 30
 
-/datum/reagent/toxin/corrupting/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	affect_blood(M,alien,removed*0.5)
+/datum/reagent/toxin/zombie/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
+	affect_blood(M, alien, removed * 0.5)
 
-/datum/reagent/toxin/corrupting/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/toxin/zombie/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
-	if(prob(M.chem_doses[type]*10))
-		if(istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			H.zombieze()
-		else
-			to_chat(M, "<span class='danger'>Your insides are melting!!!</span>")
-			M.adjustToxLoss(100)
-		remove_self(volume)
-	else if(prob(5))
-		if(M.chem_doses[type] < 5)
-			to_chat(M, "<span class='warning'>You feel funny...</span>")
-		else
-			to_chat(M, "<span class='danger'>You feel like you could die at any moment!</span>")
+	if (istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		var/doses = M.chem_doses[type]
+		if (doses >= 5)
+			H.zombify()
+		else if (doses > 1)
+			if (prob(doses * 10))
+				H.zombify()
+		else if (prob(10))
+			to_chat(M, "<span class='warning'>You feel terribly ill!</span>")
 
 /datum/reagent/toxin/bromide
 	name = "Bromide"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -658,8 +658,7 @@
 	..()
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/current_dose = H.chem_doses[type]
-		var/true_dose = current_dose + volume
+		var/true_dose = H.chem_doses[type] + volume
 		if (true_dose >= 5)
 			H.zombify()
 		else if (true_dose > 1 && prob(20))


### PR DESCRIPTION
:cl:
tweak: Zombie abilities now tell you when they can't be used, why, and how long is left on their cooldown, instead of failing silently.
bugfix: Zombies can no longer consume or death_breath while incapacitated.
balance: Zombies can only death_breath once per minute instead of once per second(!).
tweak: Zombie consume now completes at the same rate as its cooldown, preventing multiple consume actions being active at once.
bugfix: Zombie consume no longer allows the user to be the target.
balance: Zombification doesn't magically replace robot parts
balance: Zombification organ health bonus is x3 instead of x5, but organ break threshold is 75% instead of 50%
balance: Zombie toxin urn reduced from 120u(!) to 10u.
tweak: Zombie toxin now guarantees conversion for a 5u or greater dose.
balance: Zombie toxin has a flat per process 20% chance to convert so long as the current + historic amount of reagent in the victim (ie, the total dose at one time) is more than 1u.
balance: Zombie death_breath now only creates 2u instead of 5u. This means a victim should usually take about 15 tox and have two 20% chances to be zombified if a single zombie breathes on them. Zombies can work together to push a victim over the 5u mark and instantly zombify them.
balance: Zombies cannot re-zombify themselves for a free rejuv.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
