### PR TITLE
Adding basic gauze/ointment supply crate orders

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -19,6 +19,19 @@
 	cost = 20
 	containername = "\improper Medical crate"
 
+
+/decl/hierarchy/supply_pack/medical/medical
+	name = "Medical gauze crate"
+	contains = list(/obj/item/stack/medical/bruise_pack = 5)
+	cost = 15
+	containername = "\improper Medical gauze crate"
+
+/decl/hierarchy/supply_pack/medical/medical
+	name = "Medical ointment crate"
+	contains = list(/obj/item/stack/medical/ointment = 5)
+	cost = 15
+	containername = "\improper Medical ointment crate"
+
 /decl/hierarchy/supply_pack/medical/trauma
 	name = "Trauma pouch crate"
 	contains = list(/obj/item/weapon/storage/firstaid/trauma = 3)


### PR DESCRIPTION
Adds two crates, a gauze crate and an ointment crate for 15 supply points each. Both crates contain 5 gauzes or ointments respectively. Due to earlier buffs to gauze capacity (from 5->10), 15 points for 50 charges seemed reasonable.


:cl: melioa
rscadd: Adds two new medical crates to be ordered from supply for 15 points, containing 5 units of gauze or ointments.
/:cl: