### PR TITLE
Various bug fixes to runtimes caused by explosions.

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -277,7 +277,7 @@ SUBSYSTEM_DEF(garbage)
 
 #ifdef TESTING
 /proc/qdel_and_find_ref_if_fail(datum/D, force = FALSE)
-	SSgarbage.reference_find_on_fail[REF(D)] = TRUE
+	SSgarbage.reference_find_on_fail["\ref[D]"] = TRUE
 	qdel(D, force)
 #endif
 
@@ -342,7 +342,7 @@ SUBSYSTEM_DEF(garbage)
 			if (QDEL_HINT_IFFAIL_FINDREFERENCE)
 				SSgarbage.PreQueue(D)
 				#ifdef TESTING
-				SSgarbage.reference_find_on_fail[REF(D)] = TRUE
+				SSgarbage.reference_find_on_fail["\ref[D]"] = TRUE
 				#endif
 			else
 				#ifdef TESTING
@@ -423,6 +423,13 @@ SUBSYSTEM_DEF(garbage)
 	set src in world
 
 	qdel_and_find_ref_if_fail(src, TRUE)
+
+//Byond type ids
+#define TYPEID_NULL "0"
+#define TYPEID_NORMAL_LIST "f"
+//helper macros
+#define GET_TYPEID(ref) ( ( (lentext(ref) <= 10) ? "TYPEID_NULL" : copytext(ref, 4, lentext(ref)-6) ) )
+#define IS_NORMAL_LIST(L) (GET_TYPEID("\ref[L]") == TYPEID_NORMAL_LIST)
 
 /datum/proc/DoSearchVar(X, Xname, recursive_limit = 64)
 	if(usr && usr.client && !usr.client.running_find_references)

--- a/code/controllers/subsystems/processing/airflow.dm
+++ b/code/controllers/subsystems/processing/airflow.dm
@@ -25,6 +25,15 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 		var/atom/movable/target = curr[curr.len]
 		curr.len--
 
+		if(QDELETED(target))
+			if (target)
+				CLEAR_OBJECT(target)
+			else
+				processing -= target
+			if (MC_TICK_CHECK)
+				return
+			continue
+
 		if (target.airflow_speed <= 0)
 			CLEAR_OBJECT(target)
 			if (MC_TICK_CHECK)

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -75,7 +75,7 @@
 obj/machinery/air_sensor/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src,frequency)
-	..()
+	. = ..()
 
 /obj/machinery/computer/general_air_control
 	icon = 'icons/obj/computer.dmi'

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -120,7 +120,7 @@
 	if(connected_port)
 		update_flag |= 2
 
-	var/tank_pressure = air_contents.return_pressure()
+	var/tank_pressure = return_pressure()
 	if(tank_pressure < 10)
 		update_flag |= 4
 	else if(tank_pressure < ONE_ATMOSPHERE)

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -3,7 +3,7 @@
 	desc = "A gas flow meter."
 	icon = 'icons/obj/meter.dmi'
 	icon_state = "meterX"
-	var/obj/machinery/atmospherics/pipe/target = null
+	var/atom/target = null //A pipe for the base type
 	anchored = 1.0
 	power_channel = ENVIRON
 	var/frequency = 0
@@ -14,7 +14,21 @@
 /obj/machinery/meter/Initialize()
 	. = ..()
 	if (!target)
-		src.target = locate(/obj/machinery/atmospherics/pipe) in loc
+		set_target(locate(/obj/machinery/atmospherics/pipe) in loc)
+
+/obj/machinery/meter/proc/set_target(atom/new_target)
+	clear_target()
+	target = new_target
+	GLOB.destroyed_event.register(target, src, .proc/clear_target)
+
+/obj/machinery/meter/proc/clear_target()
+	if(target)
+		GLOB.destroyed_event.unregister(target, src)
+		target = null	
+
+/obj/machinery/meter/Destroy()
+	clear_target()
+	. = ..()
 
 /obj/machinery/meter/Process()
 	if(!target)
@@ -103,16 +117,9 @@
 
 // TURF METER - REPORTS A TILE'S AIR CONTENTS
 
-/obj/machinery/meter/turf/New()
-	..()
-	src.target = loc
-	return 1
-
-
 /obj/machinery/meter/turf/Initialize()
-	. = ..()
 	if (!target)
-		src.target = loc
+		set_target(loc)
+	. = ..()
 
 /obj/machinery/meter/turf/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	return

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -92,7 +92,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 			req_console_supplies -= department
 		if (departmentType & RC_INFO)
 			req_console_information -= department
-	..()
+	. = ..()
 
 /obj/machinery/requests_console/attack_hand(user as mob)
 	if(..(user))

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -186,7 +186,7 @@ steam.start() -- spawns the effect
 		affect(M)
 
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
-	if (istype(M))
+	if (!istype(M))
 		return 0
 	if (M.internal != null)
 		if(M.wear_mask && (M.wear_mask.item_flags & ITEM_FLAG_AIRTIGHT))
@@ -322,7 +322,6 @@ steam.start() -- spawns the effect
 		addtimer(CALLBACK(src, /datum/effect/effect/system/proc/spread, i), 0)
 
 /datum/effect/effect/system/smoke_spread/spread(var/i)
-	set waitfor = 0
 	if(holder)
 		src.location = get_turf(holder)
 	var/obj/effect/effect/smoke/smoke = new smoke_type(location)
@@ -335,15 +334,12 @@ steam.start() -- spawns the effect
 			direction = pick(GLOB.alldirs)
 	for(i=0, i<pick(0,1,1,1,2,2,2,3), i++)
 		sleep(1 SECOND)
+		if(QDELETED(smoke))
+			total_smoke--
+			return
 		step(smoke,direction)
-		var/obj/effect/effect/smoke/not_us = locate() in get_turf(src)
-		if(not_us && not_us != smoke)
-			step(not_us,direction)
-	addtimer(CALLBACK(src, .proc/spread_callback),0)
-
-/datum/effect/effect/system/smoke_spread/proc/spread_callback(var/obj/effect/effect/smoke/smoke, var/datum/effect/effect/system/smoke_spread/parent, var/time)
-	QDEL_IN(src, smoke.time_to_live*0.75+rand(10,30))
-	parent.total_smoke--
+	QDEL_IN(smoke, smoke.time_to_live*0.75+rand(10,30))
+	total_smoke--
 
 /datum/effect/effect/system/smoke_spread/bad
 	smoke_type = /obj/effect/effect/smoke/bad

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -216,7 +216,7 @@
 	update_underlays()
 
 /obj/machinery/atmospherics/tvalve/build_network()
-	if(!network_node1 && node1)
+	if(!network_node1 && node1)				
 		network_node1 = new /datum/pipe_network()
 		network_node1.normal_members += src
 		network_node1.build_network(node1, src)

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -166,8 +166,6 @@
 				node2 = target
 				break
 
-	build_network()
-
 	update_icon()
 	update_underlays()
 

--- a/code/modules/atmospherics/datum_pipe_network.dm
+++ b/code/modules/atmospherics/datum_pipe_network.dm
@@ -16,6 +16,8 @@
 		normal_member.reassign_network(src, null)
 	gases.Cut()  // Do not qdel the gases, we don't own them
 	leaks.Cut()
+	normal_members.Cut()
+	line_members.Cut()
 	return ..()
 
 /datum/pipe_network/Process()
@@ -35,7 +37,6 @@
 	if(!start_normal)
 		qdel(src)
 		return
-
 	start_normal.network_expand(src, reference)
 
 	update_network_gases()

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -23,6 +23,8 @@
 	for(var/obj/machinery/atmospherics/pipe/P in members)
 		P.parent = null
 	leaks.Cut()
+	members.Cut()
+	edges.Cut()
 	. = ..()
 
 /datum/pipeline/Process()//This use to be called called from the pipe networks

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -269,8 +269,7 @@
 		node1 = null
 	if(node2)
 		node2.disconnect(src)
-		node1 = null
-
+		node2 = null
 	. = ..()
 
 /obj/machinery/atmospherics/pipe/simple/pipeline_expansion()

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -88,7 +88,7 @@ obj/machinery/atmospherics/pipe/zpipe/Destroy()
 		node1.disconnect(src)
 	if(node2)
 		node2.disconnect(src)
-	..()
+	. = ..()
 
 obj/machinery/atmospherics/pipe/zpipe/pipeline_expansion()
 	return list(node1, node2)

--- a/code/modules/overmap/ships/engines/engine.dm
+++ b/code/modules/overmap/ships/engines/engine.dm
@@ -41,7 +41,7 @@ var/list/ship_engines = list()
 	return 1
 
 /datum/ship_engine/Destroy()
-	..()
+	. = ..()
 	ship_engines -= src
 	var/obj/effect/overmap/ship/S = map_sectors["[holder.z]"]
 	if(istype(S))


### PR DESCRIPTION
Fixes #18876. This runtime would happen upwards of 10,000 times per SM delamination.
Fixes GC issues with pipes, pipelines, and pipe_networks, as well as other related issues.
Fixes pipelines and atmos objects belonging to multiple pipe_networks (causes GC issues and possibly other problems, like multiple processing per tick).
Fixes #21910 and related deletion issues (some GC issues involving sound remain).
Fixes TESTING mode failing to compile; QDEL_HINT_FINDREFERENCE and QDEL_HINT_IFFAIL_FINDREFERENCE should work now if you turn TESTING on.

Also:
Fixes #20806


There are some GC issues left with explosions, but the number of runtimes should be decreased by several orders of magnitude (and I don't have it in me to do more at the moment).