### PR TITLE
Fixes not being able to land on certain exoplanets.

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -48,7 +48,7 @@
 	generate_atmosphere()
 	generate_map()
 	generate_features()
-	generate_landing(4)		//try making 4 landmarks
+	generate_landing(2)		//try making 4 landmarks
 	update_biome()
 	START_PROCESSING(SSobj, src)
 
@@ -181,11 +181,12 @@
 //Tries to generate num landmarks, but avoids repeats.
 /obj/effect/overmap/sector/exoplanet/proc/generate_landing(num = 1)
 	var/places = list()
-	var/attempts = 5*num
+	var/attempts = 10*num
+	var/new_type = landmark_type
 	while(num)
 		attempts--
 		var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])
-		if(!T || (T in places))
+		if(!T || (T in places)) // Two landmarks on one turf is forbidden as the landmark code doesn't work with it.
 			continue
 		if(attempts >= 0) // While we have the patience, try to find better spawn points. If out of patience, put them down wherever, so long as there are no repeats.
 			var/valid = 1
@@ -194,11 +195,18 @@
 				if(!istype(get_area(check), /area/exoplanet) || check.turf_flags & TURF_FLAG_NORUINS)
 					valid = 0
 					break
+			if(attempts >= 10)
+				if(check_collision(T.loc, block_to_check)) //While we have lots of patience, ensure landability
+					valid = 0
+			else //Running out of patience, but would rather not clear ruins, so switch to clearing landmarks and bypass landability check
+				new_type = /obj/effect/shuttle_landmark/automatic/clearing
+
 			if(!valid)
 				continue
+
 		num--
 		places += T
-		new landmark_type(T)
+		new new_type(T) 
 
 /obj/effect/overmap/sector/exoplanet/proc/generate_atmosphere()
 	atmosphere = new

--- a/code/modules/overmap/exoplanets/mountain.dm
+++ b/code/modules/overmap/exoplanets/mountain.dm
@@ -1,7 +1,6 @@
 /obj/effect/overmap/sector/exoplanet/rocks
 	name = "rocky exoplanet"
 	desc = "A planet with rocky formations on the surface, exposing minerals. Rest of terrain varies."
-	landmark_type = /obj/effect/shuttle_landmark/automatic/clearing
 	color = "#7c7670"
 
 	possible_features = list(/datum/map_template/ruin/exoplanet/monolith,

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -52,16 +52,16 @@
 		return FALSE
 	for(var/area/A in shuttle.shuttle_area)
 		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents)
-		if(check_collision(translation))
+		if(check_collision(base_area, list_values(translation)))
 			return FALSE
 	return TRUE
 
-/obj/effect/shuttle_landmark/proc/check_collision(var/list/turf_translation)
-	for(var/source in turf_translation)
-		var/turf/target = turf_translation[source]
+/proc/check_collision(area/target_area, list/target_turfs)
+	for(var/target_turf in target_turfs)
+		var/turf/target = target_turf
 		if(!target)
 			return TRUE //collides with edge of map
-		if(target.loc != base_area)
+		if(target.loc != target_area)
 			return TRUE //collides with another area
 		if(target.density)
 			return TRUE //dense turf
@@ -102,8 +102,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/shuttle_landmark/automatic/clearing/LateInitialize()
-	var/list/victims = circlerangeturfs(get_turf(src),radius)
-	for(var/turf/T in victims)
+	for(var/turf/T in range(radius, src))
 		if(T.density)
 			T.ChangeTurf(get_base_turf_by_area(T))
 


### PR DESCRIPTION
Fixes #21997. Basically the Charon was too fat, or rather too square-shaped.

This will essentially guarantee two Charon-viable landmark spawns per exoplanet, with progressively crappier handling of the surrounding location (land in the field -> land over some rocks -> land on a ruin) as it runs out of patience with finding a place to land.

It's a tight squeeze, so Aquila probably won't be able to land on some exoplanet types.

Should also
Close #22003
Close #22002 
Close #22001
as these are likely related bus issues.