### PR TITLE
ERT Changes: second attempt

### DIFF
--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -14,6 +14,8 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	leader_welcome_text = "You shouldn't see this"
 	landmark_id = "Response Team"
 	id_type = /obj/item/weapon/card/id/centcom/ERT
+	var/outfit_type = /decl/hierarchy/outfit/ert
+	var/leader_outfit_type = /decl/hierarchy/outfit/ert
 
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 	antaghud_indicator = "hudloyalist"
@@ -30,7 +32,7 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 
 /datum/antagonist/ert/Initialize()
 	..()
-	leader_welcome_text = "As leader of the Emergency Response Team, you answer only to [GLOB.using_map.boss_name], and have authority to override the Captain where it is necessary to achieve your mission goals. It is recommended that you attempt to cooperate with the captain where possible, however."
+	leader_welcome_text = "As leader of the Emergency Response Team, you answer only to [GLOB.using_map.company_name], and have authority to override the Captain where it is necessary to achieve your mission goals. It is recommended that you attempt to cooperate with the captain where possible, however."
 
 /datum/antagonist/ert/greet(var/datum/mind/player)
 	if(!..())
@@ -40,12 +42,27 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 
 /datum/antagonist/ert/equip(var/mob/living/carbon/human/player)
 
-	//Special radio setup
-	player.equip_to_slot_or_del(new /obj/item/device/radio/headset/ert(src), slot_l_ear)
-	player.equip_to_slot_or_del(new /obj/item/clothing/under/ert(src), slot_w_uniform)
-	player.equip_to_slot_or_del(new /obj/item/clothing/shoes/swat(src), slot_shoes)
-	player.equip_to_slot_or_del(new /obj/item/clothing/gloves/thick/swat(src), slot_gloves)
-	player.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(src), slot_glasses)
+	if(!..())
+		return 0
+	if(player.mind == leader)
+		var/decl/hierarchy/outfit/ert_outfit = outfit_by_type(leader_outfit_type)
+		ert_outfit.equip(player)
+	else
+		var/decl/hierarchy/outfit/ert_outfit = outfit_by_type(outfit_type)
+		ert_outfit.equip(player)
 
-	create_id(role_text, player)
+	//mostly for Torch's military stuff like rank boards, but can be useful for other maps
+	if(player.char_rank && player.char_rank.accessory)
+		for(var/accessory_path in player.char_rank.accessory)
+			var/list/accessory_data = player.char_rank.accessory[accessory_path]
+			if(islist(accessory_data))
+				var/amt = accessory_data[1]
+				var/list/accessory_args = accessory_data.Copy()
+				accessory_args[1] = src
+				for(var/i in 1 to amt)
+					player.equip_to_slot_or_del(new accessory_path(arglist(accessory_args)), slot_tie)
+			else
+				for(var/i in 1 to (isnull(accessory_data)? 1 : accessory_data))
+					player.equip_to_slot_or_del(new accessory_path(src), slot_tie)
+
 	return 1

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -4,18 +4,16 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	id = MODE_ERT
 	role_text = "Emergency Responder"
 	role_text_plural = "Emergency Responders"
-	welcome_text = "As member of the Emergency Response Team, you answer only to your leader and company officials."
 	antag_text = "You are an <b>anti</b> antagonist! Within the rules, \
 		try to save the installation and its inhabitants from the ongoing crisis. \
 		Try to make sure other players have <i>fun</i>! If you are confused or at a loss, always adminhelp, \
 		and before taking extreme actions, please try to also contact the administration! \
 		Think through your actions and make the roleplay immersive! <b>Please remember all \
 		rules aside from those without explicit exceptions apply to the ERT.</b>"
+	welcome_text = "You shouldn't see this"
 	leader_welcome_text = "You shouldn't see this"
 	landmark_id = "Response Team"
 	id_type = /obj/item/weapon/card/id/centcom/ERT
-	var/outfit_type = /decl/hierarchy/outfit/ert
-	var/leader_outfit_type = /decl/hierarchy/outfit/ert
 
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 	antaghud_indicator = "hudloyalist"
@@ -33,6 +31,7 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 /datum/antagonist/ert/Initialize()
 	..()
 	leader_welcome_text = "As leader of the Emergency Response Team, you answer only to [GLOB.using_map.company_name], and have authority to override the Captain where it is necessary to achieve your mission goals. It is recommended that you attempt to cooperate with the captain where possible, however."
+	welcome_text = "As member of the Emergency Response Team, you answer only to your leader and [GLOB.using_map.company_name] officials."
 
 /datum/antagonist/ert/greet(var/datum/mind/player)
 	if(!..())
@@ -40,29 +39,4 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	to_chat(player.current, "The Emergency Response Team works for Asset Protection; your job is to protect [GLOB.using_map.company_name]'s ass-ets. There is a code red alert on [station_name()], you are tasked to go and fix the problem.")
 	to_chat(player.current, "You should first gear up and discuss a plan with your team. More members may be joining, don't move out before you're ready.")
 
-/datum/antagonist/ert/equip(var/mob/living/carbon/human/player)
-
-	if(!..())
-		return 0
-	if(player.mind == leader)
-		var/decl/hierarchy/outfit/ert_outfit = outfit_by_type(leader_outfit_type)
-		ert_outfit.equip(player)
-	else
-		var/decl/hierarchy/outfit/ert_outfit = outfit_by_type(outfit_type)
-		ert_outfit.equip(player)
-
-	//mostly for Torch's military stuff like rank boards, but can be useful for other maps
-	if(player.char_rank && player.char_rank.accessory)
-		for(var/accessory_path in player.char_rank.accessory)
-			var/list/accessory_data = player.char_rank.accessory[accessory_path]
-			if(islist(accessory_data))
-				var/amt = accessory_data[1]
-				var/list/accessory_args = accessory_data.Copy()
-				accessory_args[1] = src
-				for(var/i in 1 to amt)
-					player.equip_to_slot_or_del(new accessory_path(arglist(accessory_args)), slot_tie)
-			else
-				for(var/i in 1 to (isnull(accessory_data)? 1 : accessory_data))
-					player.equip_to_slot_or_del(new accessory_path(src), slot_tie)
-
-	return 1
+//Equip proc has been moved to the map specific folders.

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/rig/ert
-	name = "asset protection command hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has blue highlights. Armoured and space ready."
+	name = "emergency response command hardsuit control module"
+	desc = "A hardsuit used by many corporate and governmental emergency response forces. Has blue highlights. Armoured and space ready."
 	suit_type = "Asset Protection command"
 	icon_state = "ert_commander_rig"
 
@@ -40,8 +40,8 @@
 
 
 /obj/item/weapon/rig/ert/engineer
-	name = "asset protection engineering hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has orange highlights. Armoured and space ready."
+	name = "emergency response engineering hardsuit control module"
+	desc = "A hardsuit used by many corporate and governmental emergency response forces. Has orange highlights. Armoured and space ready."
 	suit_type = "Asset Protection engineer"
 	icon_state = "ert_engineer_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 100, rad = 100)
@@ -60,8 +60,8 @@
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/ert/janitor
-	name = "asset protection sanitation hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has purple highlights. Armoured and space ready."
+	name = "emergency response sanitation hardsuit control module"
+	desc = "A hardsuit used by many corporate and governmental emergency response forces. Has purple highlights. Armoured and space ready."
 	suit_type = "Asset Protection sanitation"
 	icon_state = "ert_janitor_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 40, bomb = 40, bio = 100, rad = 100)
@@ -76,8 +76,8 @@
 		)
 
 /obj/item/weapon/rig/ert/medical
-	name = "asset protection medical hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has white highlights. Armoured and space ready."
+	name = "emergency response medical hardsuit control module"
+	desc = "A hardsuit used by many corporate and governmental emergency response forces. Has white highlights. Armoured and space ready."
 	suit_type = "Asset Protection medic"
 	icon_state = "ert_medical_rig"
 
@@ -90,8 +90,8 @@
 		)
 
 /obj/item/weapon/rig/ert/security
-	name = "asset protection security hardsuit control module"
-	desc = "A hardsuit used by many corporate and private asset protection forces. Has red highlights. Armoured and space ready."
+	name = "emergency response security hardsuit control module"
+	desc = "A hardsuit used by many corporate and governmental emergency response forces. Has red highlights. Armoured and space ready."
 	suit_type = "Asset Protection security"
 	icon_state = "ert_security_rig"
 
@@ -104,8 +104,8 @@
 		)
 
 /obj/item/weapon/rig/ert/assetprotection
-	name = "heavy asset protection suit control module"
-	desc = "A heavy, modified version of a common asset protection hardsuit. Has blood red highlights.  Armoured and space ready."
+	name = "heavy emergency response suit control module"
+	desc = "A heavy, modified version of a common emergency response hardsuit. Has blood red highlights.  Armoured and space ready."
 	suit_type = "heavy asset protection"
 	icon_state = "asset_protection_rig"
 	armor = list(melee = 60, bullet = 50, laser = 50,energy = 40, bomb = 40, bio = 100, rad = 100)

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -160,6 +160,8 @@
 /obj/item/clothing/under/solgov/utility/fleet/combat/medical
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/fleet, /obj/item/clothing/accessory/armband/medblue)
 
+/obj/item/clothing/under/solgov/utility/fleet/combat/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet)
 
 /obj/item/clothing/under/solgov/utility/marine
 	name = "marine fatigues"

--- a/maps/torch/job/outfits.dm
+++ b/maps/torch/job/outfits.dm
@@ -652,3 +652,18 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	..()
 	var/obj/item/weapon/card/id/torch/stowaway/ID = new(H.loc)
 	H.put_in_hands(ID)
+
+/decl/hierarchy/outfit/job/torch/ert
+	name = OUTFIT_JOB_NAME("ERT - Torch")
+	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat
+	head = /obj/item/clothing/head/beret/solgov/fleet
+	gloves = /obj/item/clothing/gloves/thick
+	id_type = /obj/item/weapon/card/id/centcom/ERT
+	pda_type = /obj/item/modular_computer/pda/ert
+	l_ear = /obj/item/device/radio/headset/ert
+	shoes = /obj/item/clothing/shoes/dutyboots
+
+/decl/hierarchy/outfit/job/torch/ert/leader
+	name = OUTFIT_JOB_NAME("ERT Leader - Torch")
+	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat/command
+	head = /obj/item/clothing/head/beret/solgov/fleet/command

--- a/maps/torch/torch-6.dmm
+++ b/maps/torch/torch-6.dmm
@@ -388,7 +388,6 @@
 	},
 /area/rescue_base/base)
 "abp" = (
-/obj/item/weapon/aiModule/nanotrasen,
 /obj/item/weapon/aiModule/reset,
 /obj/item/weapon/aiModule/freeformcore,
 /obj/item/weapon/aiModule/protectStation,
@@ -397,6 +396,8 @@
 /obj/item/weapon/aiModule/robocop,
 /obj/item/weapon/aiModule/safeguard,
 /obj/structure/table/rack,
+/obj/item/weapon/aiModule/solgov,
+/obj/item/weapon/aiModule/solgov_aggressive,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -950,7 +951,19 @@
 	},
 /area/rescue_base/base)
 "acw" = (
-/obj/machinery/porta_turret/crescent,
+/obj/structure/table/rack,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -1673,18 +1686,15 @@
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
 "aef" = (
-/obj/item/clothing/under/ert,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/under/rank/centcom_officer,
-/obj/item/clothing/head/beret/centcom/officer,
-/obj/item/clothing/mask/balaclava,
-/obj/item/weapon/coin/silver,
 /obj/structure/closet{
 	icon_closed = "syndicate1";
 	icon_opened = "syndicate1open";
 	icon_state = "syndicate1";
 	name = "emergency response team wardrobe"
 	},
+/obj/item/clothing/accessory/solgov/fleet_patch/fifth,
+/obj/item/clothing/head/solgov/utility/fleet,
+/obj/item/clothing/accessory/badge/solgov/tags,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2244,14 +2254,14 @@
 /obj/item/weapon/melee/baton/loaded,
 /obj/item/weapon/reagent_containers/spray/pepper,
 /obj/item/weapon/reagent_containers/spray/pepper,
-/obj/item/weapon/gun/energy/stunrevolver,
-/obj/item/weapon/gun/energy/stunrevolver,
 /obj/item/weapon/melee/telebaton,
 /obj/item/weapon/melee/telebaton,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 32
 	},
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2292,14 +2302,14 @@
 /area/rescue_base/base)
 "afD" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 32
 	},
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2307,10 +2317,10 @@
 /area/rescue_base/base)
 "afE" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/suit/armor/pcarrier/medium,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2318,8 +2328,8 @@
 /area/rescue_base/base)
 "afF" = (
 /obj/structure/table/rack,
-/obj/item/weapon/gun/energy/stunrevolver,
-/obj/item/weapon/gun/energy/stunrevolver,
+/obj/item/weapon/gun/energy/gun,
+/obj/item/weapon/gun/energy/gun,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -2591,61 +2601,6 @@
 /obj/structure/window/reinforced/holowindow,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_boxingcourt)
-"agf" = (
-/obj/machinery/vending/snack{
-	name = "Getmore Chocolate Corp";
-	prices = list()
-	},
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agg" = (
-/obj/machinery/vending/cola{
-	name = "Robust Softdrinks";
-	prices = list()
-	},
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agh" = (
-/obj/machinery/vending/cigarette{
-	prices = list()
-	},
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agi" = (
-/obj/machinery/lapvend,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agj" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
-"agk" = (
-/obj/structure/table/reinforced,
-/obj/item/device/radio/intercom/specops{
-	dir = 2;
-	pixel_y = 22
-	},
-/obj/item/weapon/storage/box/cups,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
-	},
-/area/rescue_base/base)
 "agl" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass{
@@ -3040,47 +2995,11 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
 "ahg" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahh" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/stamp/centcomm,
-/obj/item/weapon/pen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahi" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/board,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahj" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"ahk" = (
-/obj/structure/table/reinforced,
-/obj/item/modular_computer/pda/ert,
-/obj/item/modular_computer/pda/ert,
-/obj/item/modular_computer/pda/ert,
-/obj/item/modular_computer/pda/ert,
-/obj/item/modular_computer/pda/ert,
-/obj/item/modular_computer/pda/ert,
-/turf/unsimulated/floor{
-	icon_state = "vault";
+/obj/structure/bed/chair{
 	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
 	},
 /area/rescue_base/base)
 "ahl" = (
@@ -3240,13 +3159,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
-"ahG" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/fancy/cigar,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
 "ahH" = (
 /obj/structure/table/reinforced,
 /obj/item/device/megaphone,
@@ -3264,9 +3176,20 @@
 	},
 /area/rescue_base/base)
 "ahI" = (
-/obj/structure/table/reinforced,
-/obj/item/taperoll/police,
-/obj/item/taperoll/police,
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "insignias closet"
+	},
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/accessory/solgov/department/security/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/security,
+/obj/item/clothing/head/beret/solgov/fleet/security,
+/obj/item/clothing/head/beret/solgov/fleet/security,
+/obj/item/clothing/head/beret/solgov/fleet/security,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -3487,20 +3410,6 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
-	},
-/area/rescue_base/base)
-"aii" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/material/ashtray/plastic,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/rescue_base/base)
-"aij" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/box/donut,
-/turf/unsimulated/floor{
-	icon_state = "dark"
 	},
 /area/rescue_base/base)
 "aik" = (
@@ -3757,7 +3666,13 @@
 	},
 /area/rescue_base/base)
 "aiQ" = (
-/obj/machinery/computer/arcade,
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4225,7 +4140,7 @@
 /area/rescue_base/base)
 "ajR" = (
 /obj/structure/table/steel,
-/obj/item/weapon/stamp/centcomm,
+/obj/item/weapon/stamp/solgov,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4355,7 +4270,6 @@
 /obj/item/weapon/storage/box/teargas,
 /obj/item/weapon/storage/box/handcuffs,
 /obj/item/weapon/melee/baton/loaded,
-/obj/item/weapon/gun/energy/stunrevolver,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4389,8 +4303,8 @@
 /area/rescue_base/base)
 "akk" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert,
-/obj/item/clothing/head/helmet/ert,
+/obj/item/clothing/suit/armor/pcarrier/medium/command,
+/obj/item/clothing/head/helmet/solgov/command,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4460,7 +4374,7 @@
 	},
 /area/rescue_base/base)
 "akt" = (
-/obj/structure/closet/secure_closet/hos,
+/obj/structure/closet/secure_closet/cos,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -4535,17 +4449,6 @@
 /turf/unsimulated/floor{
 	name = "plating";
 	icon_state = "cult"
-	},
-/area/rescue_base/base)
-"akB" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
 	},
 /area/rescue_base/base)
 "akC" = (
@@ -4815,7 +4718,7 @@
 /obj/structure/table/woodentable{
 	dir = 5
 	},
-/obj/item/weapon/storage/fancy/cigar,
+/obj/item/clothing/head/beret/solgov/marcom,
 /turf/unsimulated/floor{
 	name = "plating";
 	icon_state = "cult"
@@ -5416,9 +5319,7 @@
 	},
 /area/rescue_base/base)
 "aml" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 9
-	},
+/turf/simulated/wall/titanium,
 /area/rescue_base/start)
 "amm" = (
 /obj/machinery/door/blast/regular{
@@ -5428,61 +5329,8 @@
 	name = "Cockpit Blast Shutters";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
-/area/rescue_base/start)
-"amn" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
-"amo" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
-"amp" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 5
-	},
-/area/rescue_base/start)
-"amq" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
 /area/rescue_base/start)
 "amr" = (
 /obj/machinery/door/blast/regular{
@@ -5492,18 +5340,7 @@
 	name = "Blast Shutters";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "ams" = (
@@ -5514,7 +5351,7 @@
 	name = "Ship External Access";
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amt" = (
 /obj/machinery/door/unpowered/simple/wood,
@@ -5608,15 +5445,15 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amE" = (
 /obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amF" = (
 /obj/machinery/computer/shuttle_control/multi/rescue,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amG" = (
 /obj/structure/table/steel_reinforced,
@@ -5626,12 +5463,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amH" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1331;
@@ -5646,18 +5480,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/red,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amJ" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1331;
@@ -5673,7 +5505,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amK" = (
 /obj/effect/overlay/palmtree_r,
@@ -5769,13 +5601,13 @@
 /area/ninja_dojo/dojo)
 "amV" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amW" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amX" = (
 /obj/structure/table/steel_reinforced,
@@ -5784,22 +5616,20 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "amY" = (
-/obj/structure/bed/chair{
+/obj/structure/handrai{
+	icon_state = "handrail";
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "amZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "ana" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/button/remote/blast_door{
 	icon_state = "doorctrl0";
 	id = "rescuedock";
@@ -5808,7 +5638,11 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/red,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anb" = (
 /obj/effect/landmark{
@@ -5901,28 +5735,29 @@
 	icon_state = "console";
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anl" = (
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anm" = (
 /obj/item/modular_computer/console/preset/engineering{
 	icon_state = "console";
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "ann" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/item/device/radio/intercom/specops{
 	dir = 8;
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/red,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "ano" = (
 /obj/structure/table/standard,
@@ -6127,19 +5962,16 @@
 	dir = 4;
 	name = "Implant Management"
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anK" = (
 /obj/item/modular_computer/console/preset/security{
 	icon_state = "console";
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "anL" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1331;
@@ -6148,21 +5980,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anM" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/meter,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anO" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1331;
@@ -6171,7 +6000,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "anP" = (
 /obj/structure/table/standard,
@@ -6282,7 +6111,7 @@
 	},
 /area/ninja_dojo/dojo)
 "aoe" = (
-/obj/effect/wingrille_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aof" = (
@@ -6291,11 +6120,11 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aog" = (
-/obj/effect/wingrille_spawn/reinforced/crescent,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aoh" = (
@@ -6306,7 +6135,7 @@
 	name = "Ship External Access";
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aoi" = (
 /turf/unsimulated/wall/fakeglass,
@@ -6434,33 +6263,18 @@
 "aov" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "rescuebridge";
 	name = "Cockpit Blast Shutters";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aow" = (
 /obj/structure/closet,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aox" = (
 /obj/structure/table/rack,
@@ -6473,7 +6287,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoy" = (
 /obj/machinery/atmospherics/pipe/tank/air{
@@ -6483,12 +6297,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -6501,33 +6315,24 @@
 	pixel_y = 25;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoB" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoC" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "rescueeva";
 	name = "Blast Shutters";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "aoD" = (
@@ -6592,71 +6397,33 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"aoL" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
 "aoM" = (
 /obj/structure/closet,
 /obj/item/weapon/storage/box/sinpockets,
 /obj/item/weapon/storage/box/sinpockets,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoN" = (
 /obj/structure/closet/bombclosetsecurity,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoO" = (
 /obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/shuttle/darkred,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoP" = (
-/turf/simulated/floor/shuttle/darkred,
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoQ" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/engineering,
-/obj/item/clothing/head/helmet/space/void/engineering,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"aoR" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescueeva";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aoT" = (
 /obj/structure/table/woodentable,
@@ -6741,25 +6508,6 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"apc" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescuebridge";
-	name = "Cockpit Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rescue_base/start)
 "apd" = (
 /obj/structure/closet,
 /obj/item/device/flashlight/flare,
@@ -6774,7 +6522,7 @@
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "ape" = (
 /obj/item/device/radio/intercom/specops{
@@ -6782,33 +6530,14 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/obj/structure/closet/l3closet,
-/turf/simulated/floor/shuttle/black,
+/obj/structure/closet/l3closet/general,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apf" = (
 /obj/structure/table/rack,
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/tank/emergency/oxygen/double,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apg" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "rescueeva";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aph" = (
 /obj/structure/bed/chair,
@@ -6886,16 +6615,12 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"apr" = (
-/obj/structure/closet,
-/turf/simulated/floor/shuttle/black,
-/area/rescue_base/start)
 "aps" = (
-/obj/structure/closet/l3closet,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apt" = (
 /obj/structure/bed/chair{
@@ -6904,16 +6629,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apu" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apv" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apw" = (
 /obj/structure/bed/chair{
@@ -6922,18 +6643,18 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apx" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apy" = (
 /obj/item/device/radio/intercom/specops{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apz" = (
 /obj/structure/table/rack,
@@ -6948,7 +6669,7 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apA" = (
 /obj/item/clothing/head/collectable/paper,
@@ -6971,30 +6692,25 @@
 	icon_state = "wood"
 	},
 /area/ninja_dojo/dojo)
-"apD" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 10
-	},
-/area/rescue_base/start)
 "apE" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crew Area";
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apF" = (
 /obj/structure/sign/poster/bay_9{
 	pixel_x = -32
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apG" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apH" = (
 /obj/machinery/vending/wallmed1{
@@ -7004,7 +6720,7 @@
 	pixel_y = 0;
 	req_access = newlist()
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apI" = (
 /obj/machinery/door/airlock/centcom{
@@ -7012,12 +6728,7 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/darkred,
-/area/rescue_base/start)
-"apJ" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 6
-	},
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apK" = (
 /obj/effect/floor_decal/carpet,
@@ -7136,13 +6847,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apY" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "apZ" = (
 /turf/unsimulated/beach/water{
@@ -7166,7 +6877,7 @@
 "aqc" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/orange,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqd" = (
 /obj/machinery/flasher{
@@ -7174,13 +6885,13 @@
 	pixel_x = 0;
 	pixel_y = 28
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqe" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqf" = (
 /obj/machinery/door/airlock/centcom{
@@ -7205,19 +6916,19 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqi" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqj" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqk" = (
 /obj/structure/table/glass,
@@ -7225,7 +6936,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aql" = (
 /obj/structure/closet/coffin,
@@ -7287,18 +6998,18 @@
 /area/ninja_dojo/dojo)
 "aqs" = (
 /obj/item/weapon/stool,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqt" = (
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqu" = (
 /obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/shuttle/darkred,
+/obj/random/solgov,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqv" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -7313,24 +7024,24 @@
 /area/rescue_base/start)
 "aqy" = (
 /obj/structure/closet/secure_closet/chemical,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqz" = (
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqC" = (
 /obj/structure/cult/pylon,
@@ -7413,7 +7124,7 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqK" = (
 /obj/machinery/light{
@@ -7423,7 +7134,7 @@
 /area/rescue_base/start)
 "aqL" = (
 /obj/structure/closet/secure_closet/medical1,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqM" = (
 /obj/structure/closet/medical_wall{
@@ -7442,25 +7153,25 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
 /obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqN" = (
 /obj/machinery/bodyscanner{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqO" = (
 /obj/machinery/body_scanconsole{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqP" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "aqQ" = (
 /obj/item/remains/human,
@@ -7492,10 +7203,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -25
 	},
-/turf/simulated/floor/shuttle/red,
-/area/rescue_base/start)
-"aqW" = (
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqX" = (
 /obj/machinery/door/airlock/centcom{
@@ -7503,37 +7211,40 @@
 	opacity = 1;
 	req_access = list(103)
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqY" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aqZ" = (
 /obj/machinery/recharge_station,
-/turf/simulated/floor/shuttle/darkred,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "ara" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/closet/crate/secure{
+	req_access = list(103)
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "arb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/defibrillator/loaded,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arc" = (
 /obj/item/device/radio/intercom/specops{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "ard" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "are" = (
 /obj/item/device/radio/intercom/specops{
@@ -7541,7 +7252,7 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arf" = (
 /mob/living/simple_animal/hostile/creature{
@@ -7617,7 +7328,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "aro" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -7641,7 +7352,7 @@
 /obj/item/weapon/reagent_containers/syringe,
 /obj/item/weapon/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arq" = (
 /obj/structure/window/reinforced{
@@ -7656,7 +7367,7 @@
 	pixel_y = -4;
 	req_access = list(108)
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arr" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -7759,17 +7470,14 @@
 	},
 /area/rescue_base/base)
 "arC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "rescuebridge";
+	name = "Blast Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
@@ -7784,7 +7492,7 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "arE" = (
 /obj/structure/shuttle/engine/heater,
@@ -7797,31 +7505,21 @@
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/sterilizine,
 /obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arG" = (
 /obj/machinery/optable,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arH" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "rescueinfirm";
 	name = "Blast Shutters";
 	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
@@ -7855,7 +7553,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "arM" = (
 /obj/structure/closet{
@@ -7863,7 +7561,7 @@
 	},
 /obj/item/clothing/shoes/orange,
 /obj/item/clothing/under/color/orange,
-/turf/simulated/floor/shuttle/red,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "arN" = (
 /obj/structure/shuttle/engine/propulsion,
@@ -7874,12 +7572,12 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/stack/medical/advanced/bruise_pack,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arP" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arQ" = (
 /obj/structure/table/glass,
@@ -7888,7 +7586,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/rescue_base/start)
 "arR" = (
 /obj/structure/flora/pottedplant/unusual,
@@ -22697,6 +22395,17 @@
 	icon_state = "desert1"
 	},
 /area/centcom/holding)
+"boI" = (
+/obj/structure/table/rack,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
+	},
+/area/rescue_base/base)
 "bpb" = (
 /obj/item/weapon/inflatable_duck,
 /turf/unsimulated/beach/sand{
@@ -23019,6 +22728,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/syndicate_station/start)
+"fuX" = (
+/obj/structure/table/reinforced,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
+"fuZ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/tableflag,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
 "fMb" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
@@ -23041,6 +22763,13 @@
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
+"hMS" = (
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
 "isk" = (
 /obj/effect/floor_decal/snow,
 /obj/structure/aliumizer,
@@ -23083,6 +22812,25 @@
 	},
 /turf/simulated/floor/airless,
 /area/syndicate_station/start)
+"jVW" = (
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "insignias closet"
+	},
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/accessory/solgov/department/medical/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/obj/item/clothing/head/beret/solgov/fleet/medical,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
 "kby" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -23108,7 +22856,7 @@
 /area/syndicate_station/start)
 "kRX" = (
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
 "kUL" = (
 /obj/machinery/porta_turret_construct,
@@ -23130,6 +22878,27 @@
 	},
 /turf/simulated/floor/airless,
 /area/syndicate_station/start)
+"lSB" = (
+/obj/structure/table/reinforced,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
+	},
+/area/rescue_base/base)
+"mgq" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rescue_base/start)
+"mEw" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/rescue_base/base)
 "mVh" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
@@ -23152,6 +22921,45 @@
 	},
 /turf/simulated/floor/shuttle/black,
 /area/syndicate_station/start)
+"owz" = (
+/obj/structure/closet{
+	icon_closed = "syndicate1";
+	icon_opened = "syndicate1open";
+	icon_state = "syndicate1";
+	name = "insignias closet"
+	},
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/obj/item/clothing/head/beret/solgov/fleet/engineering,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 1
+	},
+/area/rescue_base/base)
+"pci" = (
+/obj/structure/table/rack,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 1
+	},
+/area/rescue_base/base)
 "pMd" = (
 /obj/structure/aliumizer,
 /turf/unsimulated/floor{
@@ -23240,6 +23048,25 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/floor/shuttle/white,
 /area/syndicate_station/start)
+"uGj" = (
+/obj/structure/table/rack,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
+	},
+/area/rescue_base/base)
 "wIu" = (
 /obj/structure/aliumizer,
 /turf/simulated/floor/carpet,
@@ -24675,12 +24502,12 @@ aaL
 aaL
 aef
 aae
-agf
-aaL
-aaL
-aaL
-aaL
-aaL
+aaO
+aaO
+aaO
+aaO
+aaO
+aaO
 aiQ
 aae
 aad
@@ -24877,12 +24704,12 @@ aey
 aey
 aeg
 aae
-agg
-aaL
+aaO
+mEw
+aaO
 ahg
 ahg
-ahg
-aaL
+aaO
 aiR
 aae
 aad
@@ -25079,12 +24906,12 @@ aaL
 aaL
 aef
 aae
-agh
-aaL
-ahh
-ahG
-aii
-aaL
+aaO
+fuX
+aaO
+ahg
+ahg
+aaO
 aiS
 aae
 aad
@@ -25281,12 +25108,12 @@ aey
 aey
 aeg
 aae
-agi
-aaL
-ahi
-afh
-aij
-aaL
+aaO
+fuZ
+aaO
+ahg
+ahg
+aaO
 aiT
 aae
 aae
@@ -25483,12 +25310,12 @@ aaL
 aaL
 aef
 aae
-agj
-aaL
-ahj
-ahj
-ahj
-aaL
+aaO
+aaO
+aaO
+aaO
+aaO
+aaO
 aiU
 acy
 aaO
@@ -25685,12 +25512,12 @@ aey
 aey
 aeg
 aae
-agk
-aaL
-aaL
-aaL
-aaL
-aaL
+aaO
+aaO
+aaO
+aaO
+aaO
+aaO
 aiV
 acy
 aaO
@@ -25920,15 +25747,15 @@ alU
 alU
 alU
 aml
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
 arC
-amq
-amq
-apD
+aml
+aml
+aml
 alU
 ass
 adB
@@ -26091,9 +25918,9 @@ afh
 aae
 agl
 agE
-ahk
-ahH
 aik
+ahH
+lSB
 aaL
 aaL
 acy
@@ -26121,13 +25948,13 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqc
 aqs
 aoe
 aqV
 aqV
-amY
+mgq
 arL
 arE
 arN
@@ -26323,14 +26150,14 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqd
 anl
 aqJ
-aqW
-aqW
-aqW
-aqW
+anl
+anl
+anl
+anl
 arE
 arN
 alU
@@ -26525,11 +26352,11 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqe
 aqt
 aoe
-aqW
+anl
 arn
 arD
 arM
@@ -26698,7 +26525,7 @@ afA
 aaO
 aaO
 aaO
-afh
+aaO
 acy
 aaL
 aaL
@@ -26716,27 +26543,27 @@ adA
 alH
 alU
 aml
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
 aov
-aoL
-apc
-amq
-apD
+aov
+aov
+aml
+aml
 alU
-amp
-amq
-amq
-amq
+aml
+aml
+aml
+aml
 aqX
-amq
-amq
-amq
-amq
-apJ
+aml
+aml
+aml
+aml
+aml
 alU
 ass
 adB
@@ -26926,15 +26753,15 @@ aoe
 aow
 aoM
 apd
-apr
-amq
+aow
+aml
 alU
 alU
 alU
-amq
-aoP
-aoP
-amq
+aml
+anl
+anl
+aml
 alU
 alU
 alU
@@ -27119,7 +26946,7 @@ adB
 adB
 alH
 alU
-amn
+amm
 amE
 amW
 anl
@@ -27128,15 +26955,15 @@ aof
 anl
 anl
 anl
-anl
-amq
-amq
-amq
-amq
-amq
+hMS
+aml
+aml
+aml
+aml
+aml
 aoP
 aqY
-amq
+aml
 alU
 alU
 alU
@@ -27302,8 +27129,8 @@ aaO
 aae
 afD
 aaL
-aaL
-aaL
+uGj
+boI
 aaL
 aim
 aaL
@@ -27321,7 +27148,7 @@ adA
 adB
 alH
 alU
-amn
+amm
 amF
 kRX
 anl
@@ -27332,13 +27159,13 @@ anl
 anl
 anl
 apE
-aoP
+anl
 apX
 apI
-aoP
-aoP
+anl
+anl
 apy
-amq
+aml
 alU
 alU
 alU
@@ -27523,7 +27350,7 @@ adB
 adB
 alH
 alU
-amo
+amm
 amG
 amX
 anm
@@ -27534,13 +27361,13 @@ aoN
 ape
 aps
 aoe
-aoP
-aoP
+anl
+anl
 aoe
 aqu
 aqu
 aqZ
-amq
+aml
 alU
 alU
 alU
@@ -27718,33 +27545,33 @@ aaL
 aaL
 aaL
 aaL
-akB
+afE
 aae
 adB
 adB
 aih
 alH
 alU
-amp
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 aoP
-aoP
-amq
-amq
-amq
-amq
-amq
-amq
-apD
+hMS
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 alU
 alU
 alU
@@ -27935,12 +27762,12 @@ alU
 alU
 alU
 alU
-amq
+aml
 apt
 apF
-aoP
-aoP
-amq
+anl
+anl
+aml
 aqv
 aqK
 aqw
@@ -28101,7 +27928,7 @@ aae
 abp
 abX
 acw
-acw
+pci
 aaL
 aaO
 aae
@@ -28137,11 +27964,11 @@ alU
 alU
 alU
 alU
-amq
+aml
 apu
 apG
-aoP
-aoP
+anl
+anl
 aqf
 aqw
 aqw
@@ -28339,11 +28166,11 @@ alU
 alU
 alU
 alU
-amq
-apv
+aml
+amV
 apG
-aoP
-aoP
+anl
+anl
 aqg
 aqw
 aqw
@@ -28514,7 +28341,7 @@ aaL
 acy
 afI
 aaO
-aaO
+jVW
 aaO
 ahK
 aip
@@ -28541,12 +28368,12 @@ alU
 alU
 alU
 alU
-amq
+aml
 apw
 apH
-aoP
-aoP
-amq
+anl
+anl
+aml
 aqx
 aqx
 ara
@@ -28736,25 +28563,25 @@ adB
 alH
 alU
 aml
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 aoP
 apy
-amq
-amq
-amq
-amq
-amq
-amq
-apJ
+aml
+aml
+aml
+aml
+aml
+aml
+aml
 alU
 alU
 alU
@@ -28937,24 +28764,24 @@ adB
 adB
 alH
 alU
-amq
+aml
 amH
 amY
 amY
 anL
-amq
+aml
 aoy
 aoO
 apf
 apx
 aoe
-aoP
-aoP
+anl
+anl
 aoe
 aqy
 aqL
 arb
-amq
+aml
 alU
 alU
 alU
@@ -29146,17 +28973,17 @@ amZ
 anM
 aog
 aoz
-aoP
-aoP
-aoP
+anl
+anl
+anl
 apI
-aoP
+anl
 apY
 aqh
 aqz
 aqz
 arc
-amq
+aml
 alU
 alU
 alU
@@ -29348,17 +29175,17 @@ amZ
 anN
 aoh
 aoA
-aoP
-aoP
+anl
+anl
 apy
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
 aqM
 ard
-amq
+aml
 alU
 alU
 alU
@@ -29531,7 +29358,7 @@ aaL
 aaL
 aaL
 aae
-ajy
+owz
 ajy
 ajW
 ajW
@@ -29543,24 +29370,24 @@ ajX
 adB
 alH
 alU
-amq
+aml
 amJ
 ana
 ann
 anO
-amq
+aml
 aoB
 aoQ
 aoQ
 apz
-amq
+aml
 alU
 alU
 alU
-amq
+aml
 aqN
 aqz
-amq
+aml
 alU
 alU
 alU
@@ -29745,28 +29572,28 @@ ajX
 adB
 alH
 alU
-amp
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
+aml
 aoC
-aoR
-apg
-amq
-apJ
+aoC
+aoC
+aml
+aml
 alU
 aml
-amq
-amq
+aml
+aml
 aqO
 aqz
-amq
-amq
-amq
-amq
-apD
+aml
+aml
+aml
+aml
+aml
 alU
 ass
 adB
@@ -29959,7 +29786,7 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqi
 aqA
 aqz
@@ -30161,7 +29988,7 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqj
 aqB
 aqz
@@ -30363,7 +30190,7 @@ alU
 alU
 alU
 alU
-amq
+aml
 aqk
 aqz
 aqP
@@ -30565,16 +30392,16 @@ alU
 alU
 alU
 alU
-amp
-amq
-amq
-amq
-amq
-amq
+aml
+aml
+aml
+aml
+aml
+aml
 arH
-amq
-amq
-apJ
+aml
+aml
+aml
 alU
 ass
 adB

--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -18,17 +18,39 @@
 	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop)
 
 /datum/antagonist/ert
-	outfit_type = /decl/hierarchy/outfit/job/torch/ert
-	leader_outfit_type = /decl/hierarchy/outfit/job/torch/ert/leader
+	var/sic //Second-In-Command
+	leader_welcome_text = "As leader of the Emergency Response Team, you are part of the Sol Central Government Fleet, and are there with the intention of restoring normal operation to the vessel or the safe evacuation of crew and passengers. You should, to this effect, aid the Commanding Officer or ranking officer aboard in their endeavours to achieve this."
 
 /datum/antagonist/ert/equip(var/mob/living/carbon/human/player)
+
+	if(!..())
+		return 0
+
 	player.char_branch = mil_branches.get_branch("Fleet")
 	if(player.mind == leader)
 		player.char_rank = mil_branches.get_rank("Fleet", "Lieutenant")
+	else if(!sic)
+		sic = player.mind
+		player.char_rank = mil_branches.get_rank("Fleet", "Chief Petty Officer")
+	else if(prob(50))
+		player.char_rank = mil_branches.get_rank("Fleet", "Petty Officer Second Class")
 	else
-		switch(rand(1,2))
-			if(1)
-				player.char_rank = mil_branches.get_rank("Fleet", "Petty Officer Second Class")
-			if(2)
-				player.char_rank = mil_branches.get_rank("Fleet", "Petty Officer First Class")
-	..()
+		player.char_rank = mil_branches.get_rank("Fleet", "Petty Officer First Class")
+
+	var/decl/hierarchy/outfit/ert_outfit = outfit_by_type((player.mind == leader) ? /decl/hierarchy/outfit/job/torch/ert/leader : /decl/hierarchy/outfit/job/torch/ert)
+	ert_outfit.equip(player)
+
+	if(player.char_rank && player.char_rank.accessory)
+		for(var/accessory_path in player.char_rank.accessory)
+			var/list/accessory_data = player.char_rank.accessory[accessory_path]
+			if(islist(accessory_data))
+				var/amt = accessory_data[1]
+				var/list/accessory_args = accessory_data.Copy()
+				accessory_args[1] = src
+				for(var/i in 1 to amt)
+					player.equip_to_slot_or_del(new accessory_path(arglist(accessory_args)), slot_tie)
+			else
+				for(var/i in 1 to (isnull(accessory_data)? 1 : accessory_data))
+					player.equip_to_slot_or_del(new accessory_path(src), slot_tie)
+
+	return 1

--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -16,3 +16,19 @@
 
 /datum/antagonist/traitor
 	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop)
+
+/datum/antagonist/ert
+	outfit_type = /decl/hierarchy/outfit/job/torch/ert
+	leader_outfit_type = /decl/hierarchy/outfit/job/torch/ert/leader
+
+/datum/antagonist/ert/equip(var/mob/living/carbon/human/player)
+	player.char_branch = mil_branches.get_branch("Fleet")
+	if(player.mind == leader)
+		player.char_rank = mil_branches.get_rank("Fleet", "Lieutenant")
+	else
+		switch(rand(1,2))
+			if(1)
+				player.char_rank = mil_branches.get_rank("Fleet", "Petty Officer Second Class")
+			if(2)
+				player.char_rank = mil_branches.get_rank("Fleet", "Petty Officer First Class")
+	..()


### PR DESCRIPTION
Second try of https://github.com/Baystation12/Baystation12/pull/21921
- ERT now spawns with Fleet uniforms.
- ERT's leader is a Lieutenant (E-3).
- 2IC is a Chief Petty Officer (E-7).
- Others are E-6 and E-5, random.
- The ERT shuttle has been upgraded to match other Sol vessels. Mostly walls and windows, titanuim now.
- Stun revolvers have been replaced with energy guns.
- Everything related to Asset Protection or Nanotrasen has been removed or replaced with SCG analogue. (if I haven't forgot something)
- AP armor has been replaced with plate carriers.
- A bunch of tablets added.
- Security part of the ERT is provided with riot gear.
- ERT now uses outfit system.

:cl: Sbotkin
tweak: Emergency Response Team officially is a part of the SCG Fleet now.
/:cl: