### PR TITLE
Robotics surgery tweaks.

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -30,6 +30,16 @@
 	min_duration = 50
 	max_duration = 70
 
+/datum/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(!..())
+		return 0
+	if(target.isSynthetic())
+		var/obj/item/organ/external/using = tool
+		if(using.robotic < ORGAN_ROBOT)
+			to_chat(user, "<span class='danger'>You cannot attach a flesh part to a robotic body.</span>")
+			return SURGERY_FAILURE
+	return 1
+
 /datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("[user] starts attaching [E.name] to [target]'s [E.amputation_point].", \
@@ -97,6 +107,7 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/limb/mechanize
 	allowed_tools = list(/obj/item/robot_parts = 100)
+	core_skill = SKILL_DEVICES
 
 	min_duration = 80
 	max_duration = 100

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -485,7 +485,7 @@
 		to_chat(user, "<span class='danger'>That brain is not usable.</span>")
 		return SURGERY_FAILURE
 
-	if(!(affected.robotic >= ORGAN_ROBOT))
+	if(!target.isSynthetic())
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat body.</span>")
 		return SURGERY_FAILURE
 


### PR DESCRIPTION
:cl:
tweak: MMIs cannot be inserted into non-synthetic mobs.
tweak: Flesh limbs cannot be attached to synthetic mobs.
tweak: Robotic limb attachment now uses the devices skill.
/:cl:

The first is an oversight and can lead to exploits, the second is plain dumb, and the third makes it more in line with the other robotic surgery steps.