### PR TITLE
Fixes body scanner moving mobs to nullspace

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -112,6 +112,9 @@
 	user.visible_message("<span class='notice'>\The [user] begins placing \the [target] into \the [src].</span>", "<span class='notice'>You start placing \the [target] into \the [src].</span>")
 	if(!do_after(user, 30, src))
 		return
+	if (src.occupant)
+		to_chat(usr, "<span class='warning'>The scanner is already occupied!</span>")
+		return
 	var/mob/M = target
 	M.forceMove(src)
 	src.occupant = M
@@ -367,7 +370,7 @@
 		subdat += jointext(row, null)
 	if(skill_level < SKILL_BASIC)
 		pick_n_take(subdat)
-	else 
+	else
 		if(skill_level <= SKILL_ADEPT)
 			table += shuffle(subdat)
 		else table += subdat


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes body scanner moving mobs to nullspace.
/:cl:

Fixes #22010
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
