### PR TITLE
Fixes teleporter sending people to nullspace

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -135,8 +135,7 @@
 		return
 	if(get_dist(src, usr) > 1 && !issilicon(usr))
 		return
-
-	src.locked = L[desc]
+	set_target(L[desc])
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='notice'>Locked In</span>", 2)
 	return
@@ -152,6 +151,21 @@
 	if (t)
 		src.id = t
 	return
+
+/obj/machinery/computer/teleporter/proc/clear_target()
+	if(src.locked)
+		GLOB.destroyed_event.unregister(locked, src, .proc/clear_target)
+	src.locked = null
+	if(station)
+		station.disengage()
+
+/obj/machinery/computer/teleporter/proc/set_target(var/obj/O)
+	src.locked = O
+	GLOB.destroyed_event.register(locked, src, .proc/clear_target)
+
+/obj/machinery/computer/teleporter/Destroy()
+	clear_target()
+	return ..()
 
 /proc/find_loc(obj/R as obj)
 	if (!R)	return null


### PR DESCRIPTION
:cl: Hubblenaut
bugfix: The teleporters will no longer send people to nullspace when the beacon does no longer exist.
/:cl:
Deletion of teleporter console or target beacon will now cause it to disengage.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
