### PR TITLE
Make some spells check incapacitated; prevent holodeck items from being deconstructed

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -15,6 +15,7 @@
 	var/damtype = "brute"
 	var/armor_penetration = 0
 	var/anchor_fall = FALSE
+	var/holographic = 0 //if the obj is a holographic object spawned by the holodeck
 
 /obj/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -291,6 +291,7 @@
 	holographic_objs = A.copy_contents_to(linkedholodeck , 1)
 	for(var/obj/holo_obj in holographic_objs)
 		holo_obj.alpha *= 0.8 //give holodeck objs a slight transparency
+		holo_obj.holographic = TRUE
 
 	if(HP.ambience)
 		linkedholodeck.forced_ambience = HP.ambience

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -72,7 +72,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 			if(!O.origin_tech)
 				to_chat(user, "<span class='notice'>This doesn't seem to have a tech origin.</span>")
 				return
-			if(O.origin_tech.len == 0)
+			if(O.origin_tech.len == 0 || O.holographic)
 				to_chat(user, "<span class='notice'>You cannot deconstruct this item.</span>")
 				return
 

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -17,6 +17,8 @@
 /spell/aoe_turf/blink/cast(var/list/targets, mob/user)
 	if(!targets.len)
 		return
+	if(user.incapacitated())
+		return
 
 	var/turf/T = pick(targets)
 	var/turf/starting = get_turf(user)

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -17,7 +17,9 @@
 /spell/aoe_turf/blink/cast(var/list/targets, mob/user)
 	if(!targets.len)
 		return
-	if(user.incapacitated())
+
+	if(user.incapacitated(INCAPACITATION_STUNNED | INCAPACITATION_FORCELYING | INCAPACITATION_KNOCKOUT))
+		to_chat(user, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
 		return
 
 	var/turf/T = pick(targets)

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -38,6 +38,8 @@
 	if(!end)
 		to_chat(user, "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.")
 		return
+	if(user.incapacitated())
+		return
 	return
 
 /spell/area_teleport/after_cast()

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -38,7 +38,8 @@
 	if(!end)
 		to_chat(user, "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.")
 		return
-	if(user.incapacitated())
+	if(user.incapacitated(INCAPACITATION_STUNNED | INCAPACITATION_FORCELYING | INCAPACITATION_KNOCKOUT))
+		to_chat(user, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
 		return
 	return
 

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -20,6 +20,9 @@
 		if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(target))
 			continue
 
+		if(target.incapacitated())
+			return
+
 		if(target.buckled)
 			target.buckled.unbuckle_mob()
 		spawn(0)

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -20,7 +20,8 @@
 		if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(target))
 			continue
 
-		if(target.incapacitated())
+		if(target.incapacitated(INCAPACITATION_STUNNED | INCAPACITATION_FORCELYING | INCAPACITATION_KNOCKOUT))
+			to_chat(target, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
 			return
 
 		if(target.buckled)


### PR DESCRIPTION
:cl:
balance: Blink, teleport and ethereal jaunt can no longer be cast while incapacitated.
tweak: Holographic items created by the holodeck can no longer be deconstructed.
/:cl:

Closes #22054