### PR TITLE
Fixes lodge-related Travis failures.

### DIFF
--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -75,9 +75,6 @@
 /turf/simulated/floor/usedup
 	initial_gas = list("carbon_dioxide" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
 
-/turf/simulated/floor/wood/usedup
-	initial_gas = list("carbon_dioxide" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
-
 /turf/simulated/floor/tiled/usedup
 	initial_gas = list("carbon_dioxide" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
 

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
@@ -5,3 +5,6 @@
 	suffixes = list("lodge/lodge.dmm")
 	cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
+
+/turf/simulated/floor/wood/usedup
+	initial_gas = list("carbon_dioxide" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)


### PR DESCRIPTION
Depending on the combination of away sites and exoplanets a map decides to load, the location of this definition will cause Travis to fail. It does not seem to be used in the bearcat wreck, despite its location.