### PR TITLE
Dynamically setup list of cable colors

### DIFF
--- a/code/_global_vars/lists/flavor.dm
+++ b/code/_global_vars/lists/flavor.dm
@@ -111,3 +111,26 @@ GLOBAL_LIST_INIT(music_tracks, list(
 	for(var/track_name in track_list)
 		var/track_path = track_list[track_name]
 		. += new/datum/track(track_name, track_path)
+
+GLOBAL_LIST_INIT(possible_cable_colours, SetupCableColors())
+
+/proc/SetupCableColors()
+	. = list()
+
+	var/invalid_cable_coils = list(
+		/obj/item/stack/cable_coil/single,
+		/obj/item/stack/cable_coil/cut,
+		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/stack/cable_coil/random
+	)
+
+	var/special_name_mappings = list(/obj/item/stack/cable_coil = "Red")
+
+	for(var/coil_type in (typesof(/obj/item/stack/cable_coil) - invalid_cable_coils))
+		var/name = special_name_mappings[coil_type] || capitalize(copytext_after_last("[coil_type]", "/"))
+
+		var/obj/item/stack/cable_coil/C = coil_type
+		var/color = initial(C.color)
+
+		.[name] = color
+	. = sortAssoc(.)

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -669,8 +669,6 @@
 			return global.playable_species;
 		if("point_source_descriptions")
 			return global.point_source_descriptions;
-		if("possible_cable_coil_colours")
-			return global.possible_cable_coil_colours;
 		if("possible_changeling_IDs")
 			return global.possible_changeling_IDs;
 		if("power_alarm")
@@ -1654,8 +1652,6 @@
 			global.playable_species=newval;
 		if("point_source_descriptions")
 			global.point_source_descriptions=newval;
-		if("possible_cable_coil_colours")
-			global.possible_cable_coil_colours=newval;
 		if("possible_changeling_IDs")
 			global.possible_changeling_IDs=newval;
 		if("power_alarm")
@@ -2304,7 +2300,6 @@
 	"plant_seed_sprites",
 	"playable_species",
 	"point_source_descriptions",
-	"possible_cable_coil_colours",
 	"possible_changeling_IDs",
 	"power_alarm",
 	"powerinstances",

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -85,19 +85,6 @@ var/global/list/string_slot_flags = list(
 /////Initial Building/////
 //////////////////////////
 
-/hook/global_init/proc/populateGlobalLists()
-	possible_cable_coil_colours = sortAssoc(list(
-		"Yellow" = COLOR_AMBER,
-		"Green" = COLOR_GREEN,
-		"Pink" = COLOR_PURPLE,
-		"Blue" = COLOR_CYAN_BLUE,
-		"Orange" = COLOR_ORANGE,
-		"Cyan" = COLOR_SKY_BLUE,
-		"Red" = COLOR_MAROON,
-		"White" = COLOR_SILVER
-	))
-	return 1
-
 /proc/get_mannequin(var/ckey)
 	if(!mannequins_)
 		mannequins_ = new()

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -523,3 +523,9 @@ proc/TextPreview(var/string,var/len=40)
 		if (text2ascii(A, i) != text2ascii(B, i))
 			return FALSE
 	return TRUE
+
+// If char isn't part of the text the entire text is returned
+/proc/copytext_after_last(var/text, var/char)
+	var/regex/R = regex("(\[^[char]\]*)$")
+	R.Find(text)
+	return R.group[1]

--- a/code/datums/extensions/multitool/items/cable.dm
+++ b/code/datums/extensions/multitool/items/cable.dm
@@ -6,10 +6,10 @@
 	var/obj/item/stack/cable_coil/cable_coil = holder
 	. += "<b>Available Colors</b><br>"
 	. += "<table>"
-	for(var/cable_color in possible_cable_coil_colours)
+	for(var/cable_color in GLOB.possible_cable_colours)
 		. += "<tr>"
 		. += "<td>[cable_color]</td>"
-		if(cable_coil.color == possible_cable_coil_colours[cable_color])
+		if(cable_coil.color == GLOB.possible_cable_colours[cable_color])
 			. += "<td>Selected</td>"
 		else
 			. += "<td><a href='?src=\ref[src];select_color=[cable_color]'>Select</a></td>"
@@ -18,7 +18,7 @@
 
 /datum/extension/interactive/multitool/items/cable/on_topic(href, href_list, user)
 	var/obj/item/stack/cable_coil/cable_coil = holder
-	if(href_list["select_color"] && href_list["select_color"] in possible_cable_coil_colours)
+	if(href_list["select_color"] && href_list["select_color"] in GLOB.possible_cable_colours)
 		cable_coil.set_cable_color(href_list["select_color"], user)
 		return MT_REFRESH
 

--- a/code/game/objects/items/devices/cable_painter.dm
+++ b/code/game/objects/items/devices/cable_painter.dm
@@ -12,7 +12,7 @@ obj/item/device/cable_painter
 
 obj/item/device/cable_painter/New()
 	..()
-	color_selection = pick(possible_cable_coil_colours)
+	color_selection = pick(GLOB.possible_cable_colours)
 
 obj/item/device/cable_painter/examine(var/user)
 	. = ..(user, 1)
@@ -20,7 +20,7 @@ obj/item/device/cable_painter/examine(var/user)
 		to_chat(user, "The color is currently set to [lowertext(color_selection)].")
 
 obj/item/device/cable_painter/attack_self(mob/user)
-	var/new_color_selection = input("What color would you like to use?", "Choose a Color", color_selection) as null|anything in possible_cable_coil_colours
+	var/new_color_selection = input("What color would you like to use?", "Choose a Color", color_selection) as null|anything in GLOB.possible_cable_colours
 	if(new_color_selection && !user.incapacitated() && (src in user))
 		color_selection = new_color_selection
 		to_chat(user, "<span class='notice'>You change the paint mode to [lowertext(color_selection)].</span>")
@@ -29,7 +29,7 @@ obj/item/device/cable_painter/attack_self(mob/user)
 	if(!proximity)
 		return ..()
 	if(istype(A, /obj/structure/cable))
-		var/picked_color = possible_cable_coil_colours[color_selection]
+		var/picked_color = GLOB.possible_cable_colours[color_selection]
 		if(!picked_color || A.color == picked_color)
 			return
 		A.color = picked_color

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -22,8 +22,6 @@ If d1 = dir1 and d2 = dir2, it's a full X-X cable, getting from dir1 to dir2
 By design, d1 is the smallest direction and d2 is the highest
 */
 
-var/list/possible_cable_coil_colours
-
 /obj/structure/cable
 	level = 1
 	anchored =1
@@ -529,7 +527,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 /obj/item/stack/cable_coil/update_icon()
 	if (!color)
-		color = possible_cable_coil_colours[pick(possible_cable_coil_colours)]
+		color = GLOB.possible_cable_colours[pick(GLOB.possible_cable_colours)]
 	if(amount == 1)
 		icon_state = "coil1"
 		SetName("cable piece")
@@ -544,10 +542,10 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	if(!selected_color)
 		return
 
-	var/final_color = possible_cable_coil_colours[selected_color]
+	var/final_color = GLOB.possible_cable_colours[selected_color]
 	if(!final_color)
 		selected_color = "Red"
-		final_color = possible_cable_coil_colours[selected_color]
+		final_color = GLOB.possible_cable_colours[selected_color]
 	color = final_color
 	to_chat(user, "<span class='notice'>You change \the [src]'s color to [lowertext(selected_color)].</span>")
 
@@ -592,7 +590,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	set name = "Change Colour"
 	set category = "Object"
 
-	var/selected_type = input("Pick new colour.", "Cable Colour", null, null) as null|anything in possible_cable_coil_colours
+	var/selected_type = input("Pick new colour.", "Cable Colour", null, null) as null|anything in GLOB.possible_cable_colours
 	set_cable_color(selected_type, usr)
 
 // Items usable on a cable coil :
@@ -821,5 +819,5 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	color = COLOR_SILVER
 
 /obj/item/stack/cable_coil/random/New()
-	color = possible_cable_coil_colours[pick(possible_cable_coil_colours)]
+	color = GLOB.possible_cable_colours[pick(GLOB.possible_cable_colours)]
 	..()

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -1,3 +1,26 @@
+/datum/unit_test/cable_colors_shall_be_unique
+	name = "UNIQUENESS: Cable Colors Shall Be Unique"
+
+/datum/unit_test/cable_colors_shall_be_unique/start_test()
+	var/list/names = list()
+	var/list/colors = list()
+
+	var/index = 0
+	for(var/color_name in GLOB.possible_cable_colours)
+		group_by(names, color_name, index)
+		group_by(colors, GLOB.possible_cable_colours[color_name], index)
+		index++
+
+	var/number_of_issues = number_of_issues(names, "Names")
+	number_of_issues += number_of_issues(colors, "Colors")
+
+	if(number_of_issues)
+		fail("[number_of_issues] issues with cable colors found.")
+	else
+		pass("All cable colors are unique.")
+
+	return 1
+
 /datum/unit_test/research_designs_shall_be_unique
 	name = "UNIQUENESS: Research Designs Shall Be Unique"
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -242,7 +242,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '4420e6cd1414072a0c12f411578801f8 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '7aacd66adf63cf2fa643481cb641b83c *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
The list of cable colors is now setup based on available cable coils.
Includes the ability to except specified subtypes.
Includes a unit test to prevent intentional or accidental addition of duplicate colors.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
