### PR TITLE
Flash rounds buff.

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -225,6 +225,15 @@
 	containername = "\improper 9mm rubber ammunition crate"
 	access = access_security
 
+
+/decl/hierarchy/supply_pack/security/pdwammoflash
+	name = "Ammunition - 9mm top mounted flash"
+	contains = list(/obj/item/ammo_magazine/mc9mmt/flash = 4)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper 9mm stun ammunition crate"
+	access = access_security
+
 /decl/hierarchy/supply_pack/security/pdwammopractice
 	name = "Ammunition - 9mm top mounted practice"
 	contains = list(/obj/item/ammo_magazine/mc9mmt/practice = 8)

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -349,8 +349,14 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	category = "Arms and Ammunition"
 
 /datum/autolathe/recipe/magazine_smg_rubber
-	name = "ammunition (9mm rubber top mounted)"
+	name = "ammunition (9mm rubber) top mounted"
 	path = /obj/item/ammo_magazine/mc9mmt/rubber
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_smg_flash
+	name = "ammunition (9mm, flash) top mounted"
+	path = /obj/item/ammo_magazine/mc9mmt/flash
 	hidden = 1
 	category = "Arms and Ammunition"
 
@@ -515,7 +521,7 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	hidden = 1
 	category = "Arms and Ammunition"
 
-/datum/autolathe/recipe/magazine_stetchkin_flash
+/datum/autolathe/recipe/magazine_9mmds_flash
 	name = "ammunition (9mm, flash) double-stack"
 	path = /obj/item/ammo_magazine/mc9mmds/flash
 	hidden = 1
@@ -534,7 +540,7 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	category = "Arms and Ammunition"
 
 /datum/autolathe/recipe/magazine_smg
-	name = "ammunition (9mm top mounted)"
+	name = "ammunition (9mm) top mounted"
 	path = /obj/item/ammo_magazine/mc9mmt
 	hidden = 1
 	category = "Arms and Ammunition"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -1,7 +1,4 @@
 /obj/item/ammo_magazine/a357
-	//name = "ammo box (.357)"
-	//desc = "A box of .357 ammo"
-	//icon_state = "357"
 	name = "speed loader (.357)"
 	desc = "A speed loader for revolvers."
 	icon_state = "38"
@@ -207,6 +204,10 @@
 /obj/item/ammo_magazine/mc9mmt/practice
 	name = "top mounted magazine (9mm, practice)"
 	ammo_type = /obj/item/ammo_casing/c9mm/practice
+
+/obj/item/ammo_magazine/mc9mmt/flash
+	name = "top mounted magazine (9mm, flash)"
+	ammo_type = /obj/item/ammo_casing/c9mm/flash
 
 /obj/item/ammo_magazine/box/c45
 	name = "ammunition box (.45)"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -25,7 +25,7 @@
 
 	//blind and confuse adjacent people
 	for (var/mob/living/carbon/M in viewers(T, flash_range))
-		if(M.eyecheck() < FLASH_PROTECTION_MODERATE)
+		if(M.eyecheck() < FLASH_PROTECTION_MAJOR)
 			M.flash_eyes()
 			M.eye_blurry += (brightness / 2)
 			M.confused += (brightness / 2)

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -189,17 +189,6 @@
 	containername = "\improper Practice laser carbine crate"
 	access = access_solgov_crew
 
-/decl/hierarchy/supply_pack/security/pistolammorubber //overriding standard pack
-	name = "Ammo - Assorted Non-Lethal, Pistol"
-	contains = list(/obj/item/ammo_magazine/c45m/rubber = 2, /obj/item/ammo_magazine/c45m/flash = 2, /obj/item/ammo_magazine/c44/rubber = 2)
-	cost = 25
-	containername = "\improper Non-lethal ammunition crate"
-	access = access_heads //only heads get these
-
-/decl/hierarchy/supply_pack/security/pistolammo //overriding standard pack
-	cost = 30
-	access = access_heads
-
 /decl/hierarchy/supply_pack/security/magnum_ammo
 	name = "Ammo - .44 Magnum"
 	contains = list(/obj/item/ammo_magazine/c44 = 4)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
This does a few things:
- Buffs flash rounds a bit. They can now affect people wearing sunglasses-level eye protection.
- Creates a new magazine type for 9mm SMGs that uses flash rounds. Obtainable via unlocked autolathe or Supply crate.
- Removes some ancient commented-out code.
- Removes some extraneous ammunition crates, not sure what their purpose was, but I don't see why anybody with bridge access should be able to get magazines for guns they don't even have.