### PR TITLE
Handles teleporter edge cases

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -25,12 +25,19 @@
 		hub = locate(/obj/machinery/teleport/hub, get_step(station, turn(dir, 90)))
 
 	if(istype(station))
-		station.com = hub
+		station.hub = hub
+		station.com = src
 		station.set_dir(dir)
 
 	if(istype(hub))
 		hub.com = src
 		hub.set_dir(dir)
+
+/obj/machinery/computer/teleporter/power_change()
+	. = ..()
+	if (stat & NOPOWER)
+		// Lose memory
+		locked = null
 
 /obj/machinery/computer/teleporter/examine(mob/user)
 	. = ..()
@@ -75,7 +82,7 @@
 				//
 			else
 				for(var/mob/O in hearers(src, null))
-					O.show_message("<span class='notice'>Locked In</span>", 2)
+					O.show_message("<span class='notice'>Locked in.</span>", 2)
 				src.locked = L
 				one_time_use = 1
 
@@ -152,19 +159,25 @@
 		src.id = t
 	return
 
+/obj/machinery/computer/teleporter/proc/target_lost()
+	audible_message("<span class='warning'>Connection with locked in coordinates has been lost.</span>")
+	clear_target()
+
 /obj/machinery/computer/teleporter/proc/clear_target()
 	if(src.locked)
-		GLOB.destroyed_event.unregister(locked, src, .proc/clear_target)
+		GLOB.destroyed_event.unregister(locked, src, .proc/target_lost)
 	src.locked = null
-	if(station)
+	if(station && station.engaged)
 		station.disengage()
 
 /obj/machinery/computer/teleporter/proc/set_target(var/obj/O)
 	src.locked = O
-	GLOB.destroyed_event.register(locked, src, .proc/clear_target)
+	GLOB.destroyed_event.register(locked, src, .proc/target_lost)
 
 /obj/machinery/computer/teleporter/Destroy()
 	clear_target()
+	station = null
+	hub = null
 	return ..()
 
 /proc/find_loc(obj/R as obj)
@@ -193,7 +206,6 @@
 	active_power_usage = 2000
 	var/obj/machinery/computer/teleporter/com
 
-
 /obj/machinery/teleport/hub/New()
 	..()
 	underlays.Cut()
@@ -207,115 +219,27 @@
 	return
 
 /obj/machinery/teleport/hub/proc/teleport(atom/movable/M as mob|obj)
-	if (!com)
-		return
-	if (!com.locked)
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
-		return
 	do_teleport(M, com.locked)
 	if(com.one_time_use) //Make one-time-use cards only usable one time!
 		com.one_time_use = 0
 		com.locked = null
 	return
-/*
-/proc/do_teleport(atom/movable/M as mob|obj, atom/destination, precision)
-	if(istype(M, /obj/effect))
-		qdel(M)
-		return
-	if (istype(M, /obj/item/weapon/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
-		for(var/mob/O in viewers(M, null))
-			O.show_message(text("<span class='danger'>The [] bounces off of the portal!</span>", M.name), 1)
-		return
-	if (istype(M, /mob/living))
-		var/mob/living/MM = M
-		if(MM.check_contents_for(/obj/item/weapon/disk/nuclear))
-			to_chat(MM, "<span class='warning'>Something you are carrying seems to be unable to pass through the portal. Better drop it if you want to go through.</span>")
-			return
-	var/disky = 0
-	for (var/atom/O in M.contents) //I'm pretty sure this accounts for the maximum amount of container in container stacking. --NeoFite
-		if (istype(O, /obj/item/weapon/storage) || istype(O, /obj/item/weapon/gift))
-			for (var/obj/OO in O.contents)
-				if (istype(OO, /obj/item/weapon/storage) || istype(OO, /obj/item/weapon/gift))
-					for (var/obj/OOO in OO.contents)
-						if (istype(OOO, /obj/item/weapon/disk/nuclear))
-							disky = 1
-				if (istype(OO, /obj/item/weapon/disk/nuclear))
-					disky = 1
-		if (istype(O, /obj/item/weapon/disk/nuclear))
-			disky = 1
-		if (istype(O, /mob/living))
-			var/mob/living/MM = O
-			if(MM.check_contents_for(/obj/item/weapon/disk/nuclear))
-				disky = 1
-	if (disky)
-		for(var/mob/P in viewers(M, null))
-			P.show_message(text("<span class='danger'>The [] bounces off of the portal!</span>", M.name), 1)
-		return
 
-//Bags of Holding cause bluespace teleportation to go funky. --NeoFite
-	if (istype(M, /mob/living))
-		var/mob/living/MM = M
-		if(MM.check_contents_for(/obj/item/weapon/storage/backpack/holding))
-			to_chat(MM, "<span class='warning'>The Bluespace interface on your Bag of Holding interferes with the teleport!</span>")
-			precision = rand(1,100)
-	if (istype(M, /obj/item/weapon/storage/backpack/holding))
-		precision = rand(1,100)
-	for (var/atom/O in M.contents) //I'm pretty sure this accounts for the maximum amount of container in container stacking. --NeoFite
-		if (istype(O, /obj/item/weapon/storage) || istype(O, /obj/item/weapon/gift))
-			for (var/obj/OO in O.contents)
-				if (istype(OO, /obj/item/weapon/storage) || istype(OO, /obj/item/weapon/gift))
-					for (var/obj/OOO in OO.contents)
-						if (istype(OOO, /obj/item/weapon/storage/backpack/holding))
-							precision = rand(1,100)
-				if (istype(OO, /obj/item/weapon/storage/backpack/holding))
-					precision = rand(1,100)
-		if (istype(O, /obj/item/weapon/storage/backpack/holding))
-			precision = rand(1,100)
-		if (istype(O, /mob/living))
-			var/mob/living/MM = O
-			if(MM.check_contents_for(/obj/item/weapon/storage/backpack/holding))
-				precision = rand(1,100)
-
-
-	var/turf/destturf = get_turf(destination)
-
-	var/tx = destturf.x + rand(precision * -1, precision)
-	var/ty = destturf.y + rand(precision * -1, precision)
-
-	var/tmploc
-
-	if (ismob(destination.loc)) //If this is an implant.
-		tmploc = locate(tx, ty, destturf.z)
-	else
-		tmploc = locate(tx, ty, destination.z)
-
-	if(tx == destturf.x && ty == destturf.y && (istype(destination.loc, /obj/structure/closet) || istype(destination.loc, /obj/structure/closet/secure_closet)))
-		tmploc = destination.loc
-
-	if(tmploc==null)
-		return
-
-	M.forceMove(tmploc)
-	sleep(2)
-
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, M)
-	s.start()
-	return
-*/
+/obj/machinery/teleport/hub/Destroy()
+	com = null
+	return ..()
 
 /obj/machinery/teleport/station
 	name = "station"
 	desc = "It's the station thingy of a teleport thingy." //seriously, wtf.
 	icon_state = "controller"
 	dir = 4
-	var/active = 0
 	var/engaged = 0
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
-	var/obj/machinery/teleport/hub/com
+	var/obj/machinery/computer/teleporter/com
+	var/obj/machinery/teleport/hub/hub
 
 /obj/machinery/teleport/station/New()
 	..()
@@ -329,6 +253,7 @@
 	src.attack_hand()
 
 /obj/machinery/teleport/station/attack_hand()
+	. = ..()
 	if(engaged)
 		src.disengage()
 	else
@@ -338,36 +263,44 @@
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	if (com)
-		com.icon_state = "tele1"
+	if (!(com && com.locked))
+		audible_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
+		return
+
+	if (hub)
+		hub.icon_state = "tele1"
 		use_power(5000)
 		update_use_power(2)
-		com.update_use_power(2)
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='notice'>Teleporter engaged!</span>", 2)
-	src.add_fingerprint(usr)
+		hub.update_use_power(2)
+		audible_message("<span class='notice'>Teleporter engaged!</span>")
 	src.engaged = 1
 	return
 
 /obj/machinery/teleport/station/proc/disengage()
-	if(stat & (BROKEN|NOPOWER))
+	if(stat & BROKEN)
 		return
 
-	if (com)
-		com.icon_state = "tele0"
-		com.update_use_power(1)
+	if (hub)
+		hub.icon_state = "tele0"
+		hub.update_use_power(1)
 		update_use_power(1)
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='notice'>Teleporter disengaged!</span>", 2)
-	src.add_fingerprint(usr)
+		audible_message("<span class='notice'>Teleporter disengaged!</span>")
 	src.engaged = 0
 	return
+
+/obj/machinery/teleport/station/Destroy()
+	disengage()
+	com = null
+	hub = null
+	return ..()
+
+/obj/machinery/teleport/station/power_change()
+	. = ..()
+	if (engaged && (stat & NOPOWER))
+		disengage()
 
 /obj/machinery/teleport/station/update_icon()
 	if(stat & NOPOWER)
 		icon_state = "controller-p"
-
-		if(com)
-			com.icon_state = "tele0"
 	else
 		icon_state = "controller"


### PR DESCRIPTION
Handles a few edge cases that involved the teleporter still working when other equipment has been destroyed or similar.
 - An active teleporter hub with a missing station, computer or target is now no longer a valid state.
 - Teleporter now cleanly disengages on power loss instead of merely changing icon state.
 - Displays an error message now when target gets destroyed.
 - Cleaned up a bit of touched code, removed dead code.

As it stands, the entire file could use a complete rewrite, but that'd be too much work right now.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
