### PR TITLE
Fixes botanical satchel lag.

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -20,6 +20,8 @@
 	var/denied = 0
 	var/build_eff = 1
 	var/eat_eff = 1
+	var/ingredients = 0 //How many processable ingredients are stored inside.
+	var/capacity = 10   //How many ingredients can we store?
 	var/list/products = list(
 		"Food" = list(
 			/obj/item/weapon/reagent_containers/food/drinks/milk/smallcarton = 30,
@@ -85,42 +87,33 @@
 			updateUsrDialog()
 	else if(processing)
 		to_chat(user, "<span class='notice'>\The [src] is currently processing.</span>")
+	else if(ingredients >= capacity)
+		to_chat(user, "<span class='notice'>\The [src] is already full! Activate it.</span>")
 	else if(istype(O, /obj/item/weapon/storage/plants))
 		var/obj/item/weapon/storage/plants/P = O
-		var/i = 0
-		for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in contents)
-			i++
-		if(i >= 10)
-			to_chat(user, "<span class='notice'>\The [src] is already full! Activate it.</span>")
-		else
-			var/hadPlants = 0
-			for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in P.contents)
-				hadPlants = 1
-				P.remove_from_storage(G, src)
-				i++
-				if(i >= 10)
-					to_chat(user, "<span class='notice'>You fill \the [src] to its capacity.</span>")
-					break
-			if(!hadPlants)
-				to_chat(user, "<span class='notice'>\The [P] has no produce inside.</span>")
-			else if(i < 10)
-				to_chat(user, "<span class='notice'>You empty \the [P] into \the [src].</span>")
+		var/hadPlants = 0
+		for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in P.contents)
+			hadPlants = 1
+			P.remove_from_storage(G, src, 1) //No UI updates until we are all done.
+			ingredients++
+			if(ingredients >= capacity)
+				to_chat(user, "<span class='notice'>You fill \the [src] to its capacity.</span>")
+				break
+		P.finish_bulk_removal() //Now do the UI stuff once.
+		if(!hadPlants)
+			to_chat(user, "<span class='notice'>\The [P] has no produce inside.</span>")
+		else if(ingredients < capacity)
+			to_chat(user, "<span class='notice'>You empty \the [P] into \the [src].</span>")
 
 
 	else if(!istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown))
 		to_chat(user, "<span class='notice'>You cannot put this in \the [src].</span>")
 	else
-		var/i = 0
-		for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in contents)
-			i++
-		if(i >= 10)
-			to_chat(user, "<span class='notice'>\The [src] is full! Activate it.</span>")
-		else
-			user.remove_from_mob(O)
-			O.forceMove(src)
-			to_chat(user, "<span class='notice'>You put \the [O] in \the [src]</span>")
+		user.remove_from_mob(O)
+		O.forceMove(src)
+		ingredients++
+		to_chat(user, "<span class='notice'>You put \the [O] in \the [src]</span>")
 	update_icon()
-	return
 
 /**
  *  Display the NanoUI window for the vending machine.
@@ -200,6 +193,7 @@
 	var/S = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/I in contents)
 		S += 5
+		ingredients--
 		if(I.reagents.get_reagent_amount(/datum/reagent/nutriment) < 0.1)
 			points += 1
 		else points += I.reagents.get_reagent_amount(/datum/reagent/nutriment) * 10 * eat_eff

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -309,7 +309,9 @@
 		var/loaded = 0
 		for(var/obj/item/seeds/G in P.contents)
 			++loaded
-			add(G)
+			P.remove_from_storage(G, src, 1)
+			add(G, 1)
+		P.finish_bulk_removal()
 		if (loaded)
 			user.visible_message("[user] puts the seeds from \the [O.name] into \the [src].", "You put the seeds from \the [O.name] into \the [src].")
 		else
@@ -320,15 +322,16 @@
 		anchored = !anchored
 		to_chat(user, "You [anchored ? "wrench" : "unwrench"] \the [src].")
 
-/obj/machinery/seed_storage/proc/add(var/obj/item/seeds/O as obj)
-	if (istype(O.loc, /mob))
-		var/mob/user = O.loc
-		user.remove_from_mob(O)
-	else if(istype(O.loc,/obj/item/weapon/storage))
-		var/obj/item/weapon/storage/S = O.loc
-		S.remove_from_storage(O, src)
+/obj/machinery/seed_storage/proc/add(var/obj/item/seeds/O, bypass_removal = 0)
+	if(!bypass_removal)
+		if (istype(O.loc, /mob))
+			var/mob/user = O.loc
+			user.remove_from_mob(O)
+		else if(istype(O.loc,/obj/item/weapon/storage))
+			var/obj/item/weapon/storage/S = O.loc
+			S.remove_from_storage(O, src)
 
-	O.loc = src
+	O.forceMove(src)
 	var/newID = 0
 
 	for (var/datum/seed_pile/N in piles)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -241,7 +241,8 @@ var/global/list/damage_icon_parts = list()
 
 	overlays_standing[DAMAGE_LAYER]	= standing_image
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 //BASE MOB SPRITE
 /mob/living/carbon/human/proc/update_body(var/update_icons=1)
@@ -361,7 +362,7 @@ var/global/list/damage_icon_parts = list()
 	update_tail_showing(0)
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 //UNDERWEAR OVERLAY
 
@@ -376,7 +377,8 @@ var/global/list/damage_icon_parts = list()
 
 		overlays_standing[UNDERWEAR_LAYER] += I
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 //HAIR OVERLAY
 /mob/living/carbon/human/proc/update_hair(var/update_icons=1)
@@ -385,21 +387,25 @@ var/global/list/damage_icon_parts = list()
 
 	var/obj/item/organ/external/head/head_organ = get_organ(BP_HEAD)
 	if(!head_organ || head_organ.is_stump() )
-		if(update_icons)   update_icons()
+		if(update_icons)
+			queue_icon_update()
 		return
 
 	//masks and helmets can obscure our hair.
 	if( (head && (head.flags_inv & BLOCKHAIR)) || (wear_mask && (wear_mask.flags_inv & BLOCKHAIR)))
-		if(update_icons)   update_icons()
+		if(update_icons)
+			queue_icon_update()
 		return
 
 	overlays_standing[HAIR_LAYER]	= head_organ.get_hair_icon()
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/update_skin(var/update_icons=1)
 	overlays_standing[SKIN_LAYER] = species.update_skin(src)
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_mutations(var/update_icons=1)
 	var/fat
@@ -428,8 +434,8 @@ var/global/list/damage_icon_parts = list()
 		overlays_standing[MUTATIONS_LAYER]	= standing
 	else
 		overlays_standing[MUTATIONS_LAYER]	= null
-	if(update_icons)   update_icons()
-
+	if(update_icons)
+		queue_icon_update()
 /* --------------------------------------- */
 //For legacy support.
 /mob/living/carbon/human/regenerate_icons()
@@ -460,7 +466,7 @@ var/global/list/damage_icon_parts = list()
 	update_fire(0)
 	update_surgery(0)
 	UpdateDamageIcon()
-	update_icons()
+	queue_icon_update()
 	//Hud Stuff
 	update_hud()
 
@@ -474,7 +480,7 @@ var/global/list/damage_icon_parts = list()
 		overlays_standing[UNIFORM_LAYER]	= null
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)
 	var/image/id_overlay
@@ -488,7 +494,8 @@ var/global/list/damage_icon_parts = list()
 	BITSET(hud_updateflag, ID_HUD)
 	BITSET(hud_updateflag, WANTED_HUD)
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_gloves(var/update_icons=1)
 	if(gloves && !(wear_suit && wear_suit.flags_inv & HIDEGLOVES))
@@ -499,8 +506,8 @@ var/global/list/damage_icon_parts = list()
 			overlays_standing[GLOVES_LAYER]	= bloodsies
 		else
 			overlays_standing[GLOVES_LAYER]	= null
-	if(update_icons)   update_icons()
-
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_glasses(var/update_icons=1)
 	if(glasses)
@@ -509,12 +516,14 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[GLASSES_LAYER]	= null
 		overlays_standing[GOGGLES_LAYER]	= null
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_ears(var/update_icons=1)
 	overlays_standing[EARS_LAYER] = null
 	if( (head && (head.flags_inv & (BLOCKHAIR | BLOCKHEADHAIR))) || (wear_mask && (wear_mask.flags_inv & (BLOCKHAIR | BLOCKHEADHAIR))))
-		if(update_icons)   update_icons()
+		if(update_icons)
+			queue_icon_update()
 		return
 
 	if(l_ear || r_ear)
@@ -528,7 +537,8 @@ var/global/list/damage_icon_parts = list()
 
 	else
 		overlays_standing[EARS_LAYER]	= null
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_shoes(var/update_icons=1)
 	if(shoes && !((wear_suit && wear_suit.flags_inv & HIDESHOES) || (w_uniform && w_uniform.flags_inv & HIDESHOES)))
@@ -539,22 +549,24 @@ var/global/list/damage_icon_parts = list()
 			overlays_standing[SHOES_LAYER] = bloodsies
 		else
 			overlays_standing[SHOES_LAYER] = null
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_s_store(var/update_icons=1)
 	if(s_store)
 		overlays_standing[SUIT_STORE_LAYER]	= s_store.get_mob_overlay(src,slot_s_store_str)
 	else
 		overlays_standing[SUIT_STORE_LAYER]	= null
-	if(update_icons)   update_icons()
-
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_head(var/update_icons=1)
 	if(head)
 		overlays_standing[HEAD_LAYER] = head.get_mob_overlay(src,slot_head_str)
 	else
 		overlays_standing[HEAD_LAYER]	= null
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_belt(var/update_icons=1)
 	if(belt)
@@ -563,8 +575,8 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[BELT_LAYER] = null
 		overlays_standing[BELT_LAYER_ALT] = null
-	if(update_icons)   update_icons()
-
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_wear_suit(var/update_icons=1)
 
@@ -580,18 +592,20 @@ var/global/list/damage_icon_parts = list()
 
 	update_collar(0)
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_pockets(var/update_icons=1)
-	if(update_icons)	update_icons()
-
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_wear_mask(var/update_icons=1)
 	if( wear_mask && ( istype(wear_mask, /obj/item/clothing/mask) || istype(wear_mask, /obj/item/clothing/accessory) ) && !(head && head.flags_inv & HIDEMASK))
 		overlays_standing[FACEMASK_LAYER]	= wear_mask.get_mob_overlay(src,slot_wear_mask_str)
 	else
 		overlays_standing[FACEMASK_LAYER]	= null
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_back(var/update_icons=1)
 	if(back)
@@ -600,7 +614,7 @@ var/global/list/damage_icon_parts = list()
 		overlays_standing[BACK_LAYER] = null
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 
 /mob/living/carbon/human/update_hud()	//TODO: do away with this if possible
@@ -609,13 +623,13 @@ var/global/list/damage_icon_parts = list()
 		if(hud_used)
 			hud_used.hidden_inventory_update() 	//Updates the screenloc of the items on the 'other' inventory bar
 
-
 /mob/living/carbon/human/update_inv_handcuffed(var/update_icons=1)
 	if(handcuffed)
 		overlays_standing[HANDCUFF_LAYER] = handcuffed.get_mob_overlay(src,slot_handcuffed_str)
 	else
 		overlays_standing[HANDCUFF_LAYER]	= null
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_r_hand(var/update_icons=1)
 	if(r_hand)
@@ -628,8 +642,8 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[R_HAND_LAYER] = null
 
-	if(update_icons) update_icons()
-
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/update_inv_l_hand(var/update_icons=1)
 	if(l_hand)
@@ -642,7 +656,8 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[L_HAND_LAYER] = null
 
-	if(update_icons) update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
 	overlays_standing[TAIL_LAYER] = null
@@ -655,7 +670,7 @@ var/global/list/damage_icon_parts = list()
 		animate_tail_reset(0)
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/get_tail_icon()
 	var/icon_key = "[species.get_race_key(src)][r_skin][g_skin][b_skin][r_hair][g_hair][b_hair]"
@@ -702,19 +717,19 @@ var/global/list/damage_icon_parts = list()
 				animate_tail_stop()
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/animate_tail_start(var/update_icons=1)
 	set_tail_state("[species.get_tail(src)]_slow[rand(0,9)]")
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/animate_tail_fast(var/update_icons=1)
 	set_tail_state("[species.get_tail(src)]_loop[rand(0,9)]")
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/animate_tail_reset(var/update_icons=1)
 	if(stat != DEAD)
@@ -723,13 +738,13 @@ var/global/list/damage_icon_parts = list()
 		set_tail_state("[species.get_tail(src)]_static")
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/animate_tail_stop(var/update_icons=1)
 	set_tail_state("[species.get_tail(src)]_static")
 
 	if(update_icons)
-		update_icons()
+		queue_icon_update()
 
 
 //Adds a collar overlay above the helmet layer if the suit has one
@@ -741,7 +756,8 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[COLLAR_LAYER]	= null
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 
 /mob/living/carbon/human/update_fire(var/update_icons=1)
@@ -749,7 +765,8 @@ var/global/list/damage_icon_parts = list()
 	if(on_fire)
 		var/image/standing = overlay_image('icons/mob/OnFire.dmi', "Standing", RESET_COLOR)
 		overlays_standing[FIRE_LAYER] = standing
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 /mob/living/carbon/human/proc/update_surgery(var/update_icons=1)
 	overlays_standing[SURGERY_LEVEL] = null
@@ -760,7 +777,8 @@ var/global/list/damage_icon_parts = list()
 			total.overlays += I
 	total.appearance_flags = RESET_COLOR
 	overlays_standing[SURGERY_LEVEL] = total
-	if(update_icons)   update_icons()
+	if(update_icons)
+		queue_icon_update()
 
 //Human Overlays Indexes/////////
 #undef MUTATIONS_LAYER

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -963,8 +963,10 @@
 
 	return 0
 
+// A mob should either use update_icon(), overriding this definition, or use update_icons(), not touching update_icon().
+// It should not use both.
 /mob/update_icon()
-	return
+	return update_icons()
 
 /mob/verb/face_direction()
 


### PR DESCRIPTION
Fixes lag caused by the botanical satchel.
Fixes #22079.

Also makes some human ui calls use the icon update SS, to avoid duplicate icon updates in the same tick. This required having `mob/update_icon()` call `mob/update_icons()`; as far as I could tell, all mobs do adhere to the rule outlined in the comment there of only using one or the other.