### PR TITLE
Reconfigure permissions for tactical equipment 

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/tactical.dm
+++ b/code/modules/client/preference_setup/loadout/lists/tactical.dm
@@ -3,51 +3,6 @@
 	category = /datum/gear/tactical/
 	slot = slot_tie
 
-/datum/gear/tactical/pcarrier
-	display_name = "plate carrier selection"
-	path = /obj/item/clothing/suit/armor/pcarrier
-	cost = 1
-	slot = slot_wear_suit
-
-/datum/gear/tactical/pcarrier/New()
-	..()
-	var/armors = list()
-	armors["green plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/green
-	armors["navy blue plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/navy
-	armors["tan plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/tan
-	gear_tweaks += new/datum/gear_tweak/path(armors)
-
-/datum/gear/tactical/armor_pouches
-	display_name = "armor pouches"
-	path = /obj/item/clothing/accessory/storage/pouches
-	cost = 2
-	
-/datum/gear/tactical/armor_pouches/New()
-	..()
-	var/pouches = list()
-	pouches["black armor pouches"] = /obj/item/clothing/accessory/storage/pouches
-	pouches["blue armor pouches"] = /obj/item/clothing/accessory/storage/pouches/blue
-	pouches["navy blue armor pouches"] = /obj/item/clothing/accessory/storage/pouches/navy
-	pouches["green armor pouches"] = /obj/item/clothing/accessory/storage/pouches/green
-	pouches["tan armor pouches"] = /obj/item/clothing/accessory/storage/pouches/tan
-	gear_tweaks += new/datum/gear_tweak/path(pouches)
-
-/datum/gear/tactical/large_pouches
-	display_name = "armor large pouches"
-	path = /obj/item/clothing/accessory/storage/pouches/large
-	cost = 5
-
-/datum/gear/tactical/large_pouches/New()
-	..()
-	var/bigpouches = list()
-	bigpouches["large black armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large
-	bigpouches["large blue armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/blue
-	bigpouches["large navy blue armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/navy
-	bigpouches["large green armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/green
-	bigpouches["large tan armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/tan
-	gear_tweaks += new/datum/gear_tweak/path(bigpouches)
-
-
 /datum/gear/tactical/armor_deco
 	display_name = "armor customization"
 	path = /obj/item/clothing/accessory/armor/tag

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -1,9 +1,3 @@
-/datum/gear/tactical/ubac
-	display_name = "ubac selection"
-	path = /obj/item/clothing/accessory/ubac
-	allowed_roles = MILITARY_ROLES
-	flags = GEAR_HAS_TYPE_SELECTION
-
 /datum/gear/accessory/solawardmajor
 	display_name = "SolGov major award selection"
 	description = "A medal or ribbon awarded to SolGov personnel for significant accomplishments."
@@ -130,9 +124,6 @@
 /datum/gear/tactical/holster
 	allowed_roles = ARMED_ROLES
 
-/datum/gear/tactical/large_pouches
-	allowed_roles = ARMORED_ROLES
-
 /datum/gear/tactical/armor_deco
 	allowed_roles = ARMORED_ROLES
 
@@ -191,3 +182,77 @@
 
 /datum/gear/accessory/ftupin
 	allowed_branches = CIVILIAN_BRANCHES
+
+/*********************
+ tactical accessories
+*********************/
+/datum/gear/tactical/ubac
+	display_name = "black UBAC shirt"
+	path = /obj/item/clothing/accessory/ubac
+	allowed_roles = ARMORED_ROLES
+	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
+
+/datum/gear/tactical/ubac/blue
+	display_name = "navy blue UBAC shirt"
+	path = /obj/item/clothing/accessory/ubac/blue
+	allowed_branches = list(/datum/mil_branch/fleet)
+
+/datum/gear/tactical/ubac/misc
+	display_name = "miscellaneous UBAC shirt selection"
+	path = /obj/item/clothing/accessory/ubac
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/tactical/ubac/misc/New()
+	..()
+	var/shirts = list()
+	shirts["green UBAC shirt"] = /obj/item/clothing/accessory/ubac/green
+	shirts["tan UBAC shirt"] = /obj/item/clothing/accessory/ubac/tan
+	gear_tweaks += new/datum/gear_tweak/path(shirts)
+
+/datum/gear/tactical/armor_pouches
+	display_name = "black armor pouches"
+	path = /obj/item/clothing/accessory/storage/pouches
+	cost = 2
+	allowed_roles = ARMORED_ROLES
+	allowed_branches = UNIFORMED_BRANCHES
+
+/datum/gear/tactical/armor_pouches/navy
+	display_name = "navy armor pouches"
+	path = /obj/item/clothing/accessory/storage/pouches/navy
+	allowed_branches = list(/datum/mil_branch/fleet)
+
+/datum/gear/tactical/armor_pouches/misc
+	display_name = "miscellaneous armor pouches selection"
+	path = /obj/item/clothing/accessory/storage/pouches
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/tactical/armor_pouches/misc/New()
+	..()
+	var/pouches = list()
+	pouches["green armor pouches"] = /obj/item/clothing/accessory/storage/pouches/green
+	pouches["tan armor pouches"] = /obj/item/clothing/accessory/storage/pouches/tan
+	gear_tweaks += new/datum/gear_tweak/path(pouches)
+
+/datum/gear/tactical/large_pouches
+	display_name = "black large armor pouches"
+	path = /obj/item/clothing/accessory/storage/pouches/large
+	cost = 5
+	allowed_roles = ARMORED_ROLES
+	allowed_branches = UNIFORMED_BRANCHES
+
+/datum/gear/tactical/large_pouches/navy
+	display_name = "navy large armor pouches"
+	path = /obj/item/clothing/accessory/storage/pouches/large/navy
+	allowed_branches = list(/datum/mil_branch/fleet)
+
+/datum/gear/tactical/large_pouches/misc
+	display_name = "miscellaneous large armor pouches selection"
+	path = /obj/item/clothing/accessory/storage/pouches
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/tactical/large_pouches/misc/New()
+	..()
+	var/pouches = list()
+	pouches["green large armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/green
+	pouches["tan large armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/tan
+	gear_tweaks += new/datum/gear_tweak/path(pouches)

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -56,4 +56,26 @@
 	allowed_roles = RESTRICTED_ROLES
 
 /datum/gear/tactical/pcarrier
+	display_name = "black plate carrier"
+	path = /obj/item/clothing/suit/armor/pcarrier
+	cost = 1
+	slot = slot_wear_suit
 	allowed_roles = ARMORED_ROLES
+	allowed_branches = UNIFORMED_BRANCHES
+
+/datum/gear/tactical/pcarrier/navy
+	display_name = "navy blue plate carrier"
+	path = /obj/item/clothing/suit/armor/pcarrier/navy
+	allowed_branches = list(/datum/mil_branch/fleet)
+
+/datum/gear/tactical/pcarrier/misc
+	display_name = "miscellaneous plate carrier selection"
+	allowed_roles = ARMORED_ROLES
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/tactical/pcarrier/misc/New()
+	..()
+	var/armors = list()
+	armors["green plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/green
+	armors["tan plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/tan
+	gear_tweaks += new/datum/gear_tweak/path(armors)


### PR DESCRIPTION
:cl:
tweak: Reconfigured access requirements for tactical equipment in the loadout.
tweak: Sol personnel may no longer select green or tan plate carriers, UBACs or pouches.
tweak: Expeditionary Corps personnel additionally may no longer select navy blue equipment.
/:cl:

People are using these to have a different colour shirt, which defeats the purpose of uniforms.