### PR TITLE
Moves nabber nabbing into nabber species nab proc. Nab.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1723,6 +1723,7 @@
 #include "code\modules\mob\living\carbon\human\species\species.dm"
 #include "code\modules\mob\living\carbon\human\species\species_attack.dm"
 #include "code\modules\mob\living\carbon\human\species\species_getters.dm"
+#include "code\modules\mob\living\carbon\human\species\species_grab.dm"
 #include "code\modules\mob\living\carbon\human\species\species_helpers.dm"
 #include "code\modules\mob\living\carbon\human\species\species_hud.dm"
 #include "code\modules\mob\living\carbon\human\species\species_random.dm"

--- a/code/__defines/species.dm
+++ b/code/__defines/species.dm
@@ -6,10 +6,9 @@
 #define SPECIES_FLAG_NO_SLIP             0x0010  // Cannot fall over.
 #define SPECIES_FLAG_NO_POISON           0x0020  // Cannot not suffer toxloss.
 #define SPECIES_FLAG_NO_EMBED            0x0040  // Can step on broken glass with no ill-effects and cannot have shrapnel embedded in it.
-#define SPECIES_FLAG_CAN_NAB             0x0080  // Uses the special set of grab rules.
+#define SPECIES_FLAG_NO_TANGLE           0x0080  // This species wont get tangled up in weeds
 #define SPECIES_FLAG_NO_BLOCK            0x0100  // Unable to block or defend itself from attackers.
 #define SPECIES_FLAG_NEED_DIRECT_ABSORB  0x0200  // This species can only have their DNA taken by direct absorption.
-#define SPECIES_FLAG_NO_TANGLE           0x0400  // This species wont get tangled up in weeds
 
 // unused: 0x8000 - higher than this will overflow
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -564,7 +564,7 @@
 	return 1
 
 /mob/living/carbon/human/IsAdvancedToolUser(var/silent)
-	if(species.has_fine_manipulation && !nabbing)
+	if(species.has_fine_manipulation(src))
 		return 1
 	if(!silent)
 		to_chat(src, "<span class='warning'>You don't have the dexterity to use that!</span>")
@@ -1303,14 +1303,10 @@
 	return 0
 
 /mob/living/carbon/human/verb/pull_punches()
-	set name = "Pull Punches"
+	set name = "Switch Stance"
 	set desc = "Try not to hurt them."
 	set category = "IC"
-
-	if(incapacitated() || species.species_flags & SPECIES_FLAG_CAN_NAB) return
-	pulling_punches = !pulling_punches
-	to_chat(src, "<span class='notice'>You are now [pulling_punches ? "pulling your punches" : "not pulling your punches"].</span>")
-	return
+	species.toggle_stance(src)
 
 //generates realistic-ish pulse output based on preset levels
 /mob/living/carbon/human/proc/get_pulse(var/method)	//method 0 is for hands, 1 is for machines, more accurate

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -15,7 +15,7 @@
 		var/obj/item/organ/external/temp = H.organs_by_name[BP_R_HAND]
 		if(H.hand)
 			temp = H.organs_by_name[BP_L_HAND]
-		if(!temp || (!temp.is_usable() && !M.nabbing))
+		if(!temp || !temp.is_usable())
 			to_chat(H, "<span class='warning'>You can't use your hand.</span>")
 			return
 
@@ -114,8 +114,7 @@
 			return 1
 
 		if(I_GRAB)
-			visible_message("<span class='danger'>[M] attempted to grab \the [src]!</span>")
-			return H.make_grab(H, src)
+			return H.species.attempt_grab(H, src)
 
 		if(I_HURT)
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -258,74 +258,6 @@
 	visible_message("<span class='warning'>\The [src] quivers slightly, then splits apart with a wet slithering noise.</span>")
 	qdel(src)
 
-
-/************
- nabber verbs
-************/
-/mob/living/carbon/human/proc/can_nab(var/mob/living/target)
-	if(QDELETED(src))
-		return FALSE
-
-	if(last_special > world.time)
-		to_chat(src, "<span class='warning'>It is too soon to make another nab attempt.</span>")
-		return FALSE
-
-	if(incapacitated())
-		to_chat(src, "<span class='warning'>You cannot nab in your current state.</span>")
-		return FALSE
-
-	if(!is_cloaked() || pulling_punches)
-		to_chat(src, "<span class='warning'>You can only nab people when you are well hidden and ready to hunt.</span>")
-		return FALSE
-
-	if(target)
-		if(!istype(target) || issilicon(target))
-			return FALSE
-		if(!Adjacent(target))
-			to_chat(src, "<span class='warning'>\The [target] has to be adjacent to you.</span>")
-			return FALSE
-
-	return TRUE
-
-/mob/living/carbon/human/proc/nab()
-	set category = "Abilities"
-	set name = "Nab"
-	set desc = "Nab someone."
-
-	if(!can_nab())
-		return
-
-	var/list/choices = list()
-	for(var/mob/living/M in view(1,src))
-		if(!istype(M,/mob/living/silicon) && Adjacent(M))
-			choices += M
-	choices -= src
-
-	var/mob/living/T = input(src, "Who do you wish to nab?") as null|anything in choices
-	if(!T || !can_nab(T))
-		return
-
-	last_special = world.time + 50
-
-	if(l_hand) unEquip(l_hand)
-	if(r_hand) unEquip(r_hand)
-	to_chat(src, "<span class='warning'>You drop everything as you spring out to nab someone!.</span>")
-
-	playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-	remove_cloaking_source(species)
-
-	if(prob(90) && src.make_grab(src, T, GRAB_NAB_SPECIAL))
-		T.Weaken(rand(1,3))
-		visible_message("<span class='danger'>\The [src] suddenly lunges out and grabs \the [T]!</span>")
-		LAssailant = src
-
-		src.do_attack_animation(T)
-		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-		return 1
-
-	else
-		visible_message("<span class='danger'>\The [src] suddenly lunges out, almost grabbing \the [T]!</span>")
-
 /mob/living/carbon/human/proc/active_camo()
 	set category = "Abilities"
 	set name = "Active Camo"
@@ -336,53 +268,6 @@
 	else
 		add_cloaking_source(species)
 		apply_effect(2, STUN, 0)
-
-/mob/living/carbon/human/proc/switch_stance()
-	set category = "Abilities"
-	set name = "Switch Stance"
-	set desc = "Toggle between your hunting and manipulation stance"
-
-	if(stat) return
-
-	to_chat(src, "<span class='notice'>You begin to adjust the fluids in your arms, dropping everything and getting ready to swap which set you're using.</span>")
-	var/hidden = is_cloaked()
-	if(!hidden)
-		visible_message("[src] shifts \his arms.")
-
-	if(l_hand) unEquip(l_hand)
-	if(r_hand) unEquip(r_hand)
-
-	if(do_after(src, 30))
-		arm_swap()
-	else
-		to_chat(src, "<span class='notice'>You stop adjusting your arms and don't switch between them.</span>")
-
-/mob/living/carbon/human/proc/arm_swap(var/forced = FALSE)
-	if(l_hand) unEquip(l_hand)
-	if(r_hand) unEquip(r_hand)
-	var/hidden = is_cloaked()
-	pulling_punches = !pulling_punches
-	nabbing = !pulling_punches
-
-	if(pulling_punches)
-		current_grab_type = all_grabobjects[GRAB_NORMAL]
-		if(forced)
-			to_chat(src, "<span class='notice'>You can't keep your hunting arms prepared and they drop, forcing you to use your manipulation arms.</span>")
-			if(!hidden)
-				visible_message("<span class='notice'>[src] falters, hunting arms failing.</span>")
-		else
-			to_chat(src, "<span class='notice'>You relax your hunting arms, lowering the pressure and folding them tight to your thorax.\
-			You reach out with your manipulation arms, ready to use complex items.</span>")
-			if(!hidden)
-				visible_message("<span class='notice'>[src] seems to relax as \he folds \his massive curved arms to \his thorax and reaches out \
-				with \his small handlike limbs.</span>")
-	else
-		current_grab_type = all_grabobjects[GRAB_NAB]
-		to_chat(src, "<span class='notice'>You pull in your manipulation arms, dropping any items and unfolding your massive hunting arms in preparation of grabbing prey.</span>")
-		if(!hidden)
-			visible_message("<span class='warning'>[src] tenses as \he brings \his smaller arms in close to \his body. \His two massive spiked arms reach \
-			out. \He looks ready to attack.</span>")
-
 
 /mob/living/carbon/human/proc/change_colour()
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/species/species_grab.dm
+++ b/code/modules/mob/living/carbon/human/species/species_grab.dm
@@ -1,0 +1,3 @@
+/datum/species/proc/attempt_grab(var/mob/living/carbon/human/grabber, var/atom/movable/target, var/grab_type)
+	grabber.visible_message("<span class='danger'>[grabber] attempted to grab \the [target]!</span>")
+	return grabber.make_grab(grabber, target, grab_type)

--- a/code/modules/mob/living/carbon/human/species/species_helpers.dm
+++ b/code/modules/mob/living/carbon/human/species/species_helpers.dm
@@ -4,3 +4,11 @@ var/list/stored_shock_by_ref = list()
 	if(stored_shock_by_ref["\ref[src]"])
 		target.electrocute_act(stored_shock_by_ref["\ref[src]"]*0.9, src)
 		stored_shock_by_ref["\ref[src]"] = 0
+
+/datum/species/proc/has_fine_manipulation(var/mob/living/carbon/human/H)
+	return has_fine_manipulation
+
+/datum/species/proc/toggle_stance(var/mob/living/carbon/human/H)
+	if(!H.incapacitated())
+		H.pulling_punches = !H.pulling_punches
+		to_chat(H, "<span class='notice'>You are now [H.pulling_punches ? "pulling your punches" : "not pulling your punches"].</span>")

--- a/code/modules/mob/living/carbon/human/species/station/nabber.dm
+++ b/code/modules/mob/living/carbon/human/species/station/nabber.dm
@@ -67,7 +67,7 @@
 	heat_level_2 = 440 //Default 400
 	heat_level_3 = 800 //Default 1000
 
-	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_CAN_NAB | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NEED_DIRECT_ABSORB
+	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NEED_DIRECT_ABSORB
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_SKIN_TONE_NORMAL | HAS_BASE_SKIN_COLOURS
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN | SPECIES_NO_LACE
 
@@ -132,9 +132,7 @@
 	unarmed_types = list(/datum/unarmed_attack/nabber)
 
 	inherent_verbs = list(
-		/mob/living/carbon/human/proc/nab,
 		/mob/living/carbon/human/proc/active_camo,
-		/mob/living/carbon/human/proc/switch_stance,
 		/mob/living/carbon/human/proc/threat_display
 		)
 
@@ -201,9 +199,9 @@
 		var/pressure = mixture.return_pressure()
 		if(pressure > 50)
 			if(istype(landing, /turf/simulated/open))
-				H.visible_message("\The [src] descends from the deck above through \the [landing]!", "Your wings slow your descent.")
+				H.visible_message("\The [H] descends from the deck above through \the [landing]!", "Your wings slow your descent.")
 			else
-				H.visible_message("\The [src] buzzes down from \the [landing], wings slowing their descent!", "You land on \the [landing], folding your wings.")
+				H.visible_message("\The [H] buzzes down from \the [landing], wings slowing their descent!", "You land on \the [landing], folding your wings.")
 
 			return TRUE
 
@@ -306,5 +304,73 @@
 /datum/species/nabber/handle_post_spawn(var/mob/living/carbon/human/H)
 	..()
 	H.pulling_punches = TRUE
-	H.nabbing = FALSE
 
+/datum/species/nabber/has_fine_manipulation(var/mob/living/carbon/human/H)
+	return (..() && (H && H.pulling_punches))
+
+/datum/species/nabber/attempt_grab(var/mob/living/carbon/human/grabber, var/mob/living/target)
+
+	if(grabber.pulling_punches)
+		return ..()
+	grabber.unEquip(grabber.l_hand)
+	grabber.unEquip(grabber.r_hand)
+	to_chat(grabber, "<span class='warning'>You drop everything as you spring out to nab \the [target]!.</span>")
+	playsound(grabber.loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
+
+	if(!grabber.is_cloaked())
+		return ..(grabber, target, GRAB_NAB)
+
+	if(grabber.last_special > world.time)
+		to_chat(grabber, "<span class='warning'>It is too soon to make another nab attempt.</span>")
+		return
+
+	grabber.last_special = world.time + 50
+
+	grabber.remove_cloaking_source(src)
+	if(prob(90) && grabber.make_grab(grabber, target, GRAB_NAB_SPECIAL))
+		target.Weaken(rand(1,3))
+		target.LAssailant = grabber
+		grabber.visible_message("<span class='danger'>\The [grabber] suddenly lunges out and grabs \the [target]!</span>")
+		grabber.do_attack_animation(target)
+		playsound(grabber.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		return 1
+	else
+		grabber.visible_message("<span class='danger'>\The [grabber] suddenly lunges out, almost grabbing \the [target]!</span>")
+
+/datum/species/nabber/toggle_stance(var/mob/living/carbon/human/H)
+	if(H.incapacitated())
+		return FALSE
+	to_chat(H, "<span class='notice'>You begin to adjust the fluids in your arms, dropping everything and getting ready to swap which set you're using.</span>")
+	var/hidden = H.is_cloaked()
+	if(!hidden) H.visible_message("<span class='warning'>\The [H] shifts \his arms.</span>")
+	H.unEquip(H.l_hand)
+	H.unEquip(H.r_hand)
+	if(do_after(H, 30))
+		arm_swap(H)
+	else
+		to_chat(H, "<span class='notice'>You stop adjusting your arms and don't switch between them.</span>")
+	return TRUE
+
+/datum/species/nabber/proc/arm_swap(var/mob/living/carbon/human/H, var/forced)
+	H.unEquip(H.l_hand)
+	H.unEquip(H.r_hand)
+	var/hidden = H.is_cloaked()
+	H.pulling_punches = !H.pulling_punches
+	if(H.pulling_punches)
+		H.current_grab_type = all_grabobjects[GRAB_NORMAL]
+		if(forced)
+			to_chat(H, "<span class='notice'>You can't keep your hunting arms prepared and they drop, forcing you to use your manipulation arms.</span>")
+			if(!hidden)
+				H.visible_message("<span class='notice'>[H] falters, hunting arms failing.</span>")
+		else
+			to_chat(H, "<span class='notice'>You relax your hunting arms, lowering the pressure and folding them tight to your thorax.\
+			You reach out with your manipulation arms, ready to use complex items.</span>")
+			if(!hidden)
+				H.visible_message("<span class='notice'>[H] seems to relax as \he folds \his massive curved arms to \his thorax and reaches out \
+				with \his small handlike limbs.</span>")
+	else
+		H.current_grab_type = all_grabobjects[GRAB_NAB]
+		to_chat(H, "<span class='notice'>You pull in your manipulation arms, dropping any items and unfolding your massive hunting arms in preparation of grabbing prey.</span>")
+		if(!hidden)
+			H.visible_message("<span class='warning'>[H] tenses as \he brings \his smaller arms in close to \his body. \His two massive spiked arms reach \
+			out. \He looks ready to attack.</span>")

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -174,8 +174,6 @@
 	var/memory = ""
 	var/flavor_text = ""
 
-	var/nabbing = 0  // Whether a creature with a CAN_NAB tag is grabbing normally or in nab mode.
-
 	var/datum/skillset/skillset = /datum/skillset
 
 	var/last_radio_sound = -INFINITY

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -1,4 +1,3 @@
-
 /obj/item/organ/external/head
 	organ_tag = BP_HEAD
 	icon_name = "head"

--- a/code/modules/organs/subtypes/nabber_organ.dm
+++ b/code/modules/organs/subtypes/nabber_organ.dm
@@ -181,12 +181,14 @@
 			lowblood_tally = 6
 			if(prob(15))
 				to_chat(owner, "<span class='warning'>You're almost unable to move!</span>")
-				if(owner.nabbing)
-					owner.arm_swap(TRUE)
+				if(!owner.pulling_punches)
+					var/datum/species/nabber/nab = species
+					nab.arm_swap(owner, TRUE)
 		if(-(INFINITY) to BLOOD_VOLUME_SURVIVE)
 			lowblood_tally = 10
-			if(prob(30) && owner.nabbing)
-				owner.arm_swap(TRUE)
+			if(prob(30) && !owner.pulling_punches)
+				var/datum/species/nabber/nab = species
+				nab.arm_swap(owner, TRUE)
 			if(prob(10))
 				to_chat(owner, "<span class='warning'>Your body is barely functioning and is starting to shut down.</span>")
 				owner.Paralyse(1)

--- a/html/changelogs/zuhayr-nab.yml
+++ b/html/changelogs/zuhayr-nab.yml
@@ -1,0 +1,6 @@
+author: Zuhayr
+delete-after: True
+changes: 
+  - tweak: "The Pull Punches verb has been renamed to Switch Stance."
+  - tweak: "Nabber stance switching behavior now replaces pulling punches for them."
+  - tweak: "Nabber nabbing is now achieved by trying to grab someone rather than a verb."


### PR DESCRIPTION
- Renames Pull Punches to Switch Stance. It is essentially the same idea, and allows for making stance behavior species-level.
- Nabbers now use `pulling_punches` var instead of special `nabbing` var.
- Nabber nabbing is now a function of using a grab while correctly situated/prepared, rather than a verb.
- Initial grabbing behavior is now per-species and associated human-level nabber procs have been tidied away.
- ~~Not completely sure about this last note, but I think this will fix nabbers being able to use complex devices while using their beefy murder arms.~~