### PR TITLE
Datumlize move intents.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -248,6 +248,7 @@
 #include "code\datums\helper_datums\teleport.dm"
 #include "code\datums\helper_datums\topic_input.dm"
 #include "code\datums\licences\license.dm"
+#include "code\datums\move_intent\move_intent.dm"
 #include "code\datums\movement\_defines.dm"
 #include "code\datums\movement\atom_movable.dm"
 #include "code\datums\movement\mob.dm"

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -63,10 +63,6 @@
 #define I_GRAB		"grab"
 #define I_HURT		"harm"
 
-// Movement flags
-#define M_RUN  "run"
-#define M_WALK "walk"
-
 //These are used Bump() code for living mobs, in the mob_bump_flag, mob_swap_flags, and mob_push_flags vars to determine whom can bump/swap with whom.
 #define HUMAN 1
 #define MONKEY 2

--- a/code/__defines/movement.dm
+++ b/code/__defines/movement.dm
@@ -1,3 +1,6 @@
 #define HAS_TRANSFORMATION_MOVEMENT_HANDLER(X) X.HasMovementHandler(/datum/movement_handler/mob/transformation)
 #define ADD_TRANSFORMATION_MOVEMENT_HANDLER(X) X.AddMovementHandler(/datum/movement_handler/mob/transformation)
 #define DEL_TRANSFORMATION_MOVEMENT_HANDLER(X) X.RemoveMovementHandler(/datum/movement_handler/mob/transformation)
+
+#define MOVING_DELIBERATELY(X) (X.move_intent.flags & MOVE_INTENT_DELIBERATE)
+#define MOVING_QUICKLY(X) (X.move_intent.flags & MOVE_INTENT_QUICK)

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -12,7 +12,7 @@
 	using.SetName("mov_intent")
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_alien.dmi'
-	using.icon_state = (mymob.m_intent == M_RUN ? "running" : "walking")
+	using.icon_state = mymob.move_intent.hud_icon_state
 	using.screen_loc = ui_acti
 	src.adding += using
 	move_intent = using

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -67,7 +67,7 @@
 		using = new /obj/screen()
 		using.SetName("mov_intent")
 		using.icon = ui_style
-		using.icon_state = (mymob.m_intent == M_RUN ? "running" : "walking")
+		using.icon_state = mymob.move_intent.hud_icon_state
 		using.screen_loc = ui_movi
 		using.color = ui_color
 		using.alpha = ui_alpha

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -210,13 +210,9 @@
 				L.resist()
 
 		if("mov_intent")
-			switch(usr.m_intent)
-				if(M_RUN)
-					usr.m_intent = M_WALK
-					usr.hud_used.move_intent.icon_state = "walking"
-				if(M_WALK)
-					usr.m_intent = M_RUN
-					usr.hud_used.move_intent.icon_state = "running"
+			var/move_intent_type = next_in_list(usr.move_intent.type, usr.move_intents)
+			usr.move_intent = decls_repository.get_decl(move_intent_type)
+			usr.hud_used.move_intent.icon_state = usr.move_intent.hud_icon_state
 
 		if("Reset Machine")
 			usr.unset_machine()

--- a/code/controllers/subsystems/processing/airflow.dm
+++ b/code/controllers/subsystems/processing/airflow.dm
@@ -47,7 +47,7 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 			continue
 		else if (target.airflow_process_delay)
 			target.airflow_process_delay = 0
-		
+
 		target.airflow_speed = min(target.airflow_speed, 15)
 		target.airflow_speed -= vsc.airflow_speed_decay
 		if (!target.airflow_skip_speedcheck)
@@ -89,15 +89,16 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		
+
 		step_towards(target, target.airflow_dest)
-		if (ismob(target) && target:client)
-			target:setMoveCooldown(vsc.airflow_mob_slowdown)
+		if (ismob(target))
+			var/mob/M = target
+			M.SetMoveCooldown(vsc.airflow_mob_slowdown)
 
 		if (MC_TICK_CHECK)
 			return
 
-#undef CLEAR_OBJECT		
+#undef CLEAR_OBJECT
 
 /atom/movable
 	var/tmp/airflow_xo
@@ -128,9 +129,9 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 	if (airflow_falloff < 1)
 		airflow_dest = null
 		return FALSE
-	
-	airflow_speed = min(max(n * (9 / airflow_falloff), 1), 9)	
-	
+
+	airflow_speed = min(max(n * (9 / airflow_falloff), 1), 9)
+
 	airflow_od = 0
 
 	if (!density)
@@ -153,7 +154,7 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 /atom/movable/proc/RepelAirflowDest(n)
 	if (!prepare_airflow(n))
 		return
-	
+
 	airflow_xo = -(airflow_dest.x - src.x)
 	airflow_yo = -(airflow_dest.y - src.y)
 

--- a/code/datums/move_intent/move_intent.dm
+++ b/code/datums/move_intent/move_intent.dm
@@ -1,0 +1,29 @@
+// Quick and deliberate movements are not necessarily mutually exclusive
+#define MOVE_INTENT_DELIBERATE 0x0001
+#define MOVE_INTENT_EXERTIVE   0x0002
+#define MOVE_INTENT_QUICK      0x0004
+
+/decl/move_intent
+	var/name
+	var/flags = 0
+	var/move_delay = 1
+	var/hud_icon_state
+
+/decl/move_intent/walk
+	name = "Walk"
+	flags = MOVE_INTENT_DELIBERATE
+	hud_icon_state = "walking"
+
+/decl/move_intent/walk/Initialize()
+	. = ..()
+	move_delay = config.walk_speed + 7
+
+
+/decl/move_intent/run
+	name = "Run"
+	flags = MOVE_INTENT_EXERTIVE | MOVE_INTENT_QUICK
+	hud_icon_state = "running"
+
+/decl/move_intent/run/Initialize()
+	. = ..()
+	move_delay = config.run_speed + 1

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -258,13 +258,13 @@ var/list/mob/living/forced_ambiance_list = new
 	var/area/newarea = get_area(L.loc)
 	var/area/oldarea = L.lastarea
 	if(oldarea.has_gravity != newarea.has_gravity)
-		if(newarea.has_gravity == 1 && L.m_intent == M_RUN) // Being ready when you change areas allows you to avoid falling.
+		if(newarea.has_gravity == 1 && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
 			thunk(L)
 		L.update_floating()
 
 	play_ambience(L)
 	L.lastarea = newarea
-	
+
 /area/proc/play_ambience(var/mob/living/L)
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
 	if(!(L && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))	return
@@ -284,7 +284,7 @@ var/list/mob/living/forced_ambiance_list = new
 		if(L.client.ambience_playing)
 			L.client.ambience_playing = 0
 			sound_to(L, sound(null, channel = 2))
-	
+
 	if(L.lastarea != src)
 		if(LAZYLEN(forced_ambience))
 			forced_ambiance_list |= L
@@ -314,7 +314,7 @@ var/list/mob/living/forced_ambiance_list = new
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
 		if(prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_PROF)))
-			if(H.m_intent == M_RUN)
+			if(!MOVING_DELIBERATELY(H))
 				H.AdjustStunned(6)
 				H.AdjustWeakened(6)
 			else

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -115,7 +115,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if ((M.m_intent != M_WALK) && (src.anchored))
+		if (!MOVING_DELIBERATELY(M) && (src.anchored))
 			src.flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -323,7 +323,7 @@
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(M.m_intent == M_RUN)
+		if(!MOVING_DELIBERATELY(M))
 			to_chat(M, "<span class='warning'>You step on the snap pop!</span>")
 
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -95,7 +95,7 @@
 /obj/item/weapon/beartrap/Crossed(AM as mob|obj)
 	if(deployed && isliving(AM))
 		var/mob/living/L = AM
-		if(L.m_intent == M_RUN)
+		if(!MOVING_DELIBERATELY(L))
 			L.visible_message(
 				"<span class='danger'>[L] steps on \the [src].</span>",
 				"<span class='danger'>You step on \the [src]!</span>",

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -95,7 +95,7 @@
 			if(H.shoes)
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
-					S.handle_movement(src,(H.m_intent == M_RUN ? 1 : 0))
+					S.handle_movement(src, MOVING_QUICKLY(H))
 					if(S.track_blood && S.blood_DNA)
 						bloodDNA = S.blood_DNA
 						bloodcolor=S.blood_color
@@ -116,7 +116,7 @@
 
 		if(src.wet)
 
-			if(M.buckled || (M.m_intent == M_WALK && prob(min(100, 100/(wet/10))) ) )
+			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(wet/10))) ) )
 				return
 
 			var/slip_dist = 1

--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -108,7 +108,7 @@
 	if(buckled || lying || throwing)
 		return //people flying, lying down or sitting do not step
 
-	if(m_intent == M_RUN)
+	if(MOVING_QUICKLY(src))
 		if(step_count % 2) //every other turf makes a sound
 			return
 
@@ -134,7 +134,7 @@
 	if(footsound)
 		var/range = -(world.view - 2)
 		var/volume = 70
-		if(m_intent == M_WALK)
+		if(MOVING_DELIBERATELY(src))
 			volume -= 45
 			range -= 0.333
 		if(!shoes)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -84,7 +84,7 @@
 		if(armed)
 			if(ishuman(AM))
 				var/mob/living/carbon/H = AM
-				if(H.m_intent == M_RUN)
+				if(!MOVING_DELIBERATELY(H))
 					triggered(H)
 					H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 									  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -27,17 +27,19 @@
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
-	if(.)
-		if(src.nutrition && src.stat != 2)
-			src.nutrition -= DEFAULT_HUNGER_FACTOR/10
-			if(src.m_intent == M_RUN)
-				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
-		if((FAT in src.mutations) && src.m_intent == M_RUN && src.bodytemperature <= 360)
-			src.bodytemperature += 2
+	if(!.)
+		return
 
-		// Moving around increases germ_level faster
-		if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
-			germ_level++
+	if (src.nutrition && src.stat != 2)
+		src.nutrition -= DEFAULT_HUNGER_FACTOR/10
+		if (move_intent.flags & MOVE_INTENT_EXERTIVE)
+			src.nutrition -= DEFAULT_HUNGER_FACTOR/10
+	if((FAT in src.mutations) && (move_intent.flags & MOVE_INTENT_EXERTIVE) && src.bodytemperature <= 360)
+		src.bodytemperature += 2
+
+	// Moving around increases germ_level faster
+	if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
+		germ_level++
 
 /mob/living/carbon/relaymove(var/mob/living/user, direction)
 	if((user in src.stomach_contents) && istype(user))
@@ -300,10 +302,10 @@
 		itemsize = I.w_class
 
 	if(!unEquip(item))
-		return	
+		return
 	if(!item || !isturf(item.loc))
 		return
-	
+
 	var/message = "\The [src] has thrown \the [item]."
 	var/skill_mod = 0.2
 	if(!skill_check(SKILL_HAULING, min(round(itemsize - ITEM_SIZE_HUGE) + 2, SKILL_MAX)))
@@ -312,7 +314,7 @@
 			message = "\The [src] barely manages to throw \the [item], and is knocked off-balance!"
 	else
 		skill_mod += 0.2
-	
+
 	skill_mod += 0.8 * (get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)
 	throw_range *= skill_mod
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -59,7 +59,7 @@
 	. = ..()
 	if(statpanel("Status"))
 		stat("Intent:", "[a_intent]")
-		stat("Move Mode:", "[m_intent]")
+		stat("Move Mode:", "[move_intent.name]")
 
 		if(evacuation_controller)
 			var/eta_status = evacuation_controller.get_status_panel_eta()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -129,7 +129,7 @@ default behaviour is:
 		spawn(0)
 			..()
 			if (!istype(AM, /atom/movable) || AM.anchored)
-				if(confused && prob(50) && m_intent==M_RUN)
+				if(confused && prob(50) && !MOVING_DELIBERATELY(src))
 					Weaken(2)
 					playsound(loc, "punch", 25, 1, -1)
 					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -47,6 +47,7 @@
 /mob/Initialize()
 	. = ..()
 	skillset = new skillset(src)
+	move_intent = decls_repository.get_decl(move_intent)
 	START_PROCESSING(SSmobs, src)
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
@@ -147,6 +148,12 @@
 	if(istype(loc, /turf))
 		var/turf/T = loc
 		. += T.movement_delay
+
+	if ((drowsyness > 0) && !MOVING_DELIBERATELY(src))
+		. += 6
+	if(lying) //Crawling, it's slower
+		. += 8 + (weakened * 2)
+	. += move_intent.move_delay
 	. += encumbrance() * (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN)) //Varies between 0.5 and 2, depending on skill
 
 //How much the stuff the mob is pulling contributes to its movement delay.
@@ -740,7 +747,7 @@
 	set_dir(ndir)
 	if(buckled && buckled.buckle_movable)
 		buckled.set_dir(ndir)
-	setMoveCooldown(movement_delay())
+	SetMoveCooldown(movement_delay())
 	return 1
 
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -105,7 +105,10 @@
 
 	var/shakecamera = 0
 	var/a_intent = I_HELP//Living
-	var/m_intent = M_RUN//Living
+
+	var/decl/move_intent/move_intent = /decl/move_intent/run
+	var/move_intents = list(/decl/move_intent/run, /decl/move_intent/walk)
+
 	var/obj/buckled = null//Living
 	var/obj/item/l_hand = null//Living
 	var/obj/item/r_hand = null//Living

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -1,6 +1,5 @@
 /mob
-	var/move_delay		= 1
-	var/moving			= FALSE
+	var/moving           = FALSE
 
 /mob/proc/SelfMove(var/direction)
 	if(DoMove(direction, src) & MOVEMENT_HANDLED)
@@ -18,7 +17,12 @@
 		return (!mover.density || !density || lying)
 	return
 
-/mob/proc/setMoveCooldown(var/timeout)
+/mob/proc/SetMoveCooldown(var/timeout)
+	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
+	if(delay)
+		delay.SetDelay(timeout)
+
+/mob/proc/ExtraMoveCooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
 	if(delay)
 		delay.AddDelay(timeout)
@@ -223,7 +227,7 @@
 		return 0
 	if(Check_Shoegrip())
 		return 0
-	if(m_intent == M_WALK)
+	if(MOVING_DELIBERATELY(src))
 		prob_slip *= 0.5
 	return prob_slip
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -200,7 +200,7 @@
 	last_safety_check = world.time
 	var/shoot_time = (burst - 1)* burst_delay
 	user.setClickCooldown(shoot_time) //no clicking on things while shooting
-	user.setMoveCooldown(shoot_time) //no moving while shooting either
+	user.SetMoveCooldown(shoot_time) //no moving while shooting either
 	next_fire_time = world.time + shoot_time
 
 	var/held_twohanded = (user.can_wield_item(src) && src.is_held_twohanded(user))
@@ -231,7 +231,7 @@
 
 	//update timing
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user.setMoveCooldown(move_delay)
+	user.SetMoveCooldown(move_delay)
 	next_fire_time = world.time + fire_delay
 
 //obtains the next projectile to fire
@@ -345,7 +345,7 @@
 			disp_mod += one_hand_penalty*0.5 //dispersion per point of two-handedness
 
 	if(burst > 1 && !user.skill_check(SKILL_WEAPONS, SKILL_ADEPT))
-		acc_mod -= 1 
+		acc_mod -= 1
 		disp_mod += 0.5
 
 	//Accuracy modifiers
@@ -478,7 +478,7 @@
 	var/next_mode = get_next_firemode()
 	if(!next_mode || next_mode == sel_mode)
 		return null
-	
+
 	sel_mode = next_mode
 	var/datum/firemode/new_mode = firemodes[sel_mode]
 	new_mode.apply_to(src)

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -45,7 +45,7 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	if(hand_spell.cast_hand(A,user))
 		next_spell_time = world.time + hand_spell.spell_delay
 		if(hand_spell.move_delay)
-			user.setMoveCooldown(hand_spell.move_delay)
+			user.ExtraMoveCooldown(hand_spell.move_delay)
 		if(hand_spell.click_delay)
 			user.setClickCooldown(hand_spell.move_delay)
 

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -42,7 +42,7 @@
 			user.remove_ventcrawl()
 			user.forceMove(src.loc)
 			user.visible_message("You hear something squeezing through the pipes.", "You climb out the ventilation system.")
-	user.setMoveCooldown(user.movement_delay())
+	user.SetMoveCooldown(user.movement_delay())
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return 1


### PR DESCRIPTION
Creates a basic foundation for having different movement intents in the future.
Is currently only move and run but could in the future include intents such as proper crawling.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
