### PR TITLE
fixes paper bundles

### DIFF
--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/paper/carbon
-	name = "paper"
+	name = "sheet of paper"
 	icon_state = "paper_stack"
 	item_state = "paper"
 	var/copied = 0

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -55,14 +55,15 @@
 	return
 
 /obj/item/weapon/paper_bundle/proc/insert_sheet_at(mob/user, var/index, obj/item/weapon/sheet)
-	if(istype(sheet, /obj/item/weapon/paper))
-		to_chat(user, "<span class='notice'>You add [(sheet.name == "paper") ? "the paper" : sheet.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>")
-	else if(istype(sheet, /obj/item/weapon/photo))
-		to_chat(user, "<span class='notice'>You add [(sheet.name == "photo") ? "the photo" : sheet.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>")
-	else if(!user.unEquip(sheet, src))
+	if (!user.unEquip(sheet, src))
 		return
+	var/bundle_name = "paper bundle"
+	var/sheet_name = istype(sheet, /obj/item/weapon/photo) ? "photo" : "sheet of paper"
+	bundle_name = (bundle_name == name) ? "the [bundle_name]" : name
+	sheet_name = (sheet_name == sheet.name) ? "the [sheet_name]" : sheet.name
+	
+	to_chat(user, "<span class='notice'>You add [sheet_name] to [bundle_name].</span>")
 	pages.Insert(index, sheet)
-
 	if(index <= page)
 		page++
 


### PR DESCRIPTION
:cl:
bugfix: Paper bundles bundle correctly.
tweak: Carbon copy paper is now default named "sheet of paper" instead of "paper", the same as regular paper.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
