### PR TITLE
Adds a ping button to the file menu.

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -821,6 +821,11 @@ menu "menu"
 		category = "&File"
 		saved-params = "is-checked"
 	elem 
+		name = "&Check ping"
+		command = ".ping"
+		category = "&File"
+		saved-params = "is-checked"
+	elem 
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"


### PR DESCRIPTION
🆑 
rscadd: A ping button for checking your ping has been added to the "file" tab.
/ 🆑 
[why]: L3 outages across the US, so I figured no harm would be done in making this easy for players. Furthermore, It's an easy change to do while my ears heal.