### PR TITLE
Cleans up health analyzer code. Adds allowed items to medical belt

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -63,14 +63,6 @@
 		src.overlays.Cut()
 		to_chat(user, "You cut the tag off \the [src].")
 		return
-	else if(istype(W, /obj/item/device/healthanalyzer/) && !opened)
-		if(contains_body)
-			var/obj/item/device/healthanalyzer/HA = W
-			for(var/mob/living/L in contents)
-				HA.scan_mob(L, user)
-		else
-			to_chat(user, "\The [W] reports that \the [src] is empty.")
-		return
 
 /obj/structure/closet/body_bag/store_mobs(var/stored_units)
 	contains_body = ..()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -14,6 +14,7 @@ REAGENT SCANNER
 	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
 	icon_state = "health"
 	item_state = "analyzer"
+	item_flags = ITEM_FLAG_NO_BLUDGEON
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
 	throwforce = 3
@@ -27,35 +28,58 @@ REAGENT SCANNER
 /obj/item/device/healthanalyzer/do_surgery(mob/living/M, mob/living/user)
 	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
 		return ..()
-	scan_mob(M, user) //default surgery behaviour is just to scan as usual
+	medical_scan_action(M, user, src, mode) //default surgery behaviour is just to scan as usual
 	return 1
 
-/obj/item/device/healthanalyzer/attack(mob/living/M, mob/living/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	scan_mob(M, user)
+/obj/item/device/healthanalyzer/afterattack(atom/target, mob/user, proximity)
+	if(!proximity)
+		return
 
-/obj/item/device/healthanalyzer/proc/scan_mob(var/mob/living/carbon/human/H, var/mob/living/user)
+	medical_scan_action(target, user, src, mode)
 
+/proc/medical_scan_action(atom/target, mob/living/user, obj/scanner, var/verbose)
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You are not nimble enough to use this device.</span>")
 		return
 
 	if ((CLUMSY in user.mutations) && prob(50))
-		user.visible_message("<span class='notice'>\The [user] runs \the [src] over the floor.")
+		user.visible_message("<span class='notice'>\The [user] runs \the [scanner] over the floor.")
 		to_chat(user, "<span class='notice'><b>Scan results for the floor:</b></span>")
 		to_chat(user, "Overall Status: Healthy</span>")
 		return
 
-	if (!istype(H) || H.isSynthetic())
-		to_chat(user, "<span class='warning'>\The [src] is designed for organic humanoid patients only.</span>")
+	var/mob/living/carbon/human/scan_subject = null
+	if (istype(target, /mob/living/carbon/human))
+		user.visible_message("<span class='notice'>\The [user] runs \the [scanner] over \the [target].</span>")
+		scan_subject = target
+	else if (istype(target, /obj/structure/closet/body_bag))
+		user.visible_message("<span class='notice'>\The [user] runs \the [scanner] over \the [target].</span>")
+		var/obj/structure/closet/body_bag/B = target
+		if(!B.opened)
+			var/list/scan_content = list()
+			for(var/mob/living/L in B.contents)
+				scan_content.Add(L)
+
+			if (scan_content.len == 1)
+				for(var/mob/living/carbon/human/L in scan_content)
+					scan_subject = L
+			else if (scan_content.len > 1)
+				to_chat(user, "<span class='warning'>\The [scanner] picks up multiple readings inside \the [target], too close together to scan properly.</span>")
+				return
+			else
+				to_chat(user, "\The [scanner] does not detect anyone inside \the [target].")
+				return
+	else
 		return
 
-	user.visible_message("<span class='notice'>\The [user] runs \the [src] over \the [H].</span>")
-	to_chat(user, "<hr>")
-	to_chat(user, medical_scan_results(H, mode, user.get_skill_value(SKILL_MEDICAL)))
-	to_chat(user, "<hr>")
+	if (scan_subject.isSynthetic())
+		to_chat(user, "<span class='warning'>\The [scanner] is designed for organic humanoid patients only.</span>")
+		return
 
-proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose, var/skill_level = SKILL_DEFAULT)
+	. = medical_scan_results(scan_subject, verbose, user.get_skill_value(SKILL_MEDICAL))
+	to_chat(user, "<hr>[.]<hr>")
+
+/proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose, var/skill_level = SKILL_DEFAULT)
 	. = list()
 	var/header = list()
 	var/b
@@ -113,6 +137,7 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose, var/skill_
 
 	// Pulse rate.
 	var/pulse_result = "normal"
+	var/pulse_suffix = "bpm"
 	if(H.should_have_organ(BP_HEART))
 		if(H.status_flags & FAKEDEATH)
 			pulse_result = 0
@@ -120,13 +145,16 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose, var/skill_
 			pulse_result = H.get_pulse(1)
 	else
 		pulse_result = "<span class='scan_danger'>ERROR - Nonstandard biology</span>"
-
-	dat += "<span class='scan_notice'>Pulse rate: [pulse_result]bpm.</span>"
+		pulse_suffix = ""
+	dat += "<span class='scan_notice'>Pulse rate: [pulse_result][pulse_suffix].</span>"
 
 	// Blood pressure. Based on the idea of a normal blood pressure being 120 over 80.
-	if(H.get_blood_volume() <= 70)
-		dat += "<span class='scan_danger'>Severe blood loss detected.</span>"
-	dat += "[b]Blood pressure:[endb] [H.get_blood_pressure()] ([H.get_blood_oxygenation()]% blood oxygenation)"
+	if(H.should_have_organ(BP_HEART))
+		if(H.get_blood_volume() <= 70)
+			dat += "<span class='scan_danger'>Severe blood loss detected.</span>"
+		dat += "[b]Blood pressure:[endb] [H.get_blood_pressure()] ([H.get_blood_oxygenation()]% blood oxygenation)"
+	else
+		dat += "[b]Blood pressure:[endb] N/A"
 
 	// Body temperature.
 	dat += "<span class='scan_notice'>Body temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span>"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -172,7 +172,9 @@
 		/obj/item/weapon/crowbar,
 		/obj/item/device/flashlight,
 		/obj/item/taperoll,
-		/obj/item/weapon/extinguisher/mini
+		/obj/item/weapon/extinguisher/mini,
+		/obj/item/weapon/storage/med_pouch,
+		/obj/item/bodybag
 		)
 
 /obj/item/weapon/storage/belt/medical/emt

--- a/code/modules/modular_computers/hardware/scanners/scanner_medical.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_medical.dm
@@ -2,24 +2,12 @@
 	name = "medical scanner module"
 	desc = "A medical scanner module. It can be used to scan patients and display medical information."
 
-/obj/item/weapon/computer_hardware/scanner/medical/can_use_scanner(mob/user, mob/living/carbon/human/target, proximity = TRUE)
-	if(!..())
-		return 0
-	if(CLUMSY in user.mutations)
-		return 0
-	if(!istype(target))
-		return 0
-	if(target.isSynthetic())
-		to_chat(user, "<span class='warning'>\The [src] on \the [holder2] is designed for organic humanoid patients only.</span>")
-		return 0
-	return 1
-
-/obj/item/weapon/computer_hardware/scanner/medical/do_on_afterattack(mob/user, mob/living/carbon/human/target, proximity)
+/obj/item/weapon/computer_hardware/scanner/medical/do_on_afterattack(mob/user, atom/target, proximity)
 	if(!can_use_scanner(user, target, proximity))
 		return
-	var/dat = medical_scan_results(target, 1)
-	if(driver && driver.using_scanner)
+
+	var/dat = medical_scan_action(target, user, holder2, 1)
+
+	if(dat && driver && driver.using_scanner)
 		driver.data_buffer = html2pencode(dat)
 		SSnano.update_uis(driver.NM)
-	user.visible_message("<span class='notice'>\The [user] runs \the [src] on \the [holder2] over \the [target].</span>")
-	to_chat(user, "<hr>[dat]<hr>")

--- a/html/changelogs/Ithalan-Healthscanfix.yml
+++ b/html/changelogs/Ithalan-Healthscanfix.yml
@@ -1,0 +1,7 @@
+author: Ithalan
+
+delete-after: True
+
+changes: 
+  - bugfix: "PDA medical scanner now works on body bags and stasis bags like the regular health analyzer, and uses user medicine skill level"
+  - rscadd: "Medical belts can now also hold body bags, stasis bag and emergency medical pouches"


### PR DESCRIPTION
Ports some of the code from my previous PR, but leaves out the abstract scan extension

Health analyzer and the PDA medical scanner module now share all the code for their common behavior, and the handling of body/stasis bags have been moved into the scan action itself so that the PDA medical scanner can also use it. PDA medical scanner now also uses user medicine skill.

Body/Stasis bags and emergency medical pouches can now also be stored in medical belts. Seemed like an oversight more than anything that they couldn't before.

Edit: Noticed that health analyzers had a misleading blood pressure reading for species without a heart, like Diona. Such species now just show N/A for blood pressure. (Brings the health analyzer in line with how the crew monitor treats such cases)