### PR TITLE
Runtime fixes

### DIFF
--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -18,7 +18,7 @@
 		my_mob = owner
 		update_abilities(0, owner)
 	else
-		message_admins("ERROR: ability_master's New() was not given an owner argument.  This is a bug.")
+		CRASH("ERROR: ability_master's New() was not given an owner argument.  This is a bug.")
 	..()
 
 /obj/screen/movable/ability_master/Destroy()
@@ -67,19 +67,19 @@
 
 	//Create list of X offsets
 	var/list/screen_loc_X = splittext(screen_loc_xy[1],":")
-	var/x_position = decode_screen_X(screen_loc_X[1])
+	var/x_position = decode_screen_X(screen_loc_X[1], my_mob)
 	var/x_pix = screen_loc_X[2]
 
 	//Create list of Y offsets
 	var/list/screen_loc_Y = splittext(screen_loc_xy[2],":")
-	var/y_position = decode_screen_Y(screen_loc_Y[1])
+	var/y_position = decode_screen_Y(screen_loc_Y[1], my_mob)
 	var/y_pix = screen_loc_Y[2]
 
 	for(var/i = 1; i <= ability_objects.len; i++)
 		var/obj/screen/ability/A = ability_objects[i]
 		var/xpos = x_position + (x_position < 8 ? 1 : -1)*(i%7)
 		var/ypos = y_position + (y_position < 8 ? round(i/7) : -round(i/7))
-		A.screen_loc = "[encode_screen_X(xpos)]:[x_pix],[encode_screen_Y(ypos)]:[y_pix]"
+		A.screen_loc = "[encode_screen_X(xpos, my_mob)]:[x_pix],[encode_screen_Y(ypos, my_mob)]:[y_pix]"
 		if(my_mob && my_mob.client)
 			my_mob.client.screen += A
 //			A.handle_icon_updates = 1

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -31,10 +31,10 @@
 
 	//Split X+Pixel_X up into list(X, Pixel_X)
 	var/list/screen_loc_X = splittext(screen_loc_params[1],":")
-	screen_loc_X[1] = encode_screen_X(text2num(screen_loc_X[1]))
+	screen_loc_X[1] = encode_screen_X(text2num(screen_loc_X[1]), usr)
 	//Split Y+Pixel_Y up into list(Y, Pixel_Y)
 	var/list/screen_loc_Y = splittext(screen_loc_params[2],":")
-	screen_loc_Y[1] = encode_screen_Y(text2num(screen_loc_Y[1]))
+	screen_loc_Y[1] = encode_screen_Y(text2num(screen_loc_Y[1]), usr)
 
 	if(snap2grid) //Discard Pixel Values
 		screen_loc = "[screen_loc_X[1]],[screen_loc_Y[1]]"
@@ -44,8 +44,8 @@
 		var/pix_Y = text2num(screen_loc_Y[2]) - 16
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
-/obj/screen/movable/proc/encode_screen_X(X)
-	var/view = usr.client ? usr.client.view : world.view
+/obj/screen/movable/proc/encode_screen_X(var/X, var/mob/viewer)
+	var/view = viewer.client ? viewer.client.view : world.view
 	if(X > view+1)
 		. = "EAST-[view*2 + 1-X]"
 	else if(X < view+1)
@@ -53,8 +53,8 @@
 	else
 		. = "CENTER"
 
-/obj/screen/movable/proc/decode_screen_X(X)
-	var/view = usr.client ? usr.client.view : world.view
+/obj/screen/movable/proc/decode_screen_X(var/X, var/mob/viewer)
+	var/view = viewer.client ? viewer.client.view : world.view
 	//Find EAST/WEST implementations
 	if(findtext(X,"EAST-"))
 		var/num = text2num(copytext(X,6)) //Trim EAST-
@@ -69,17 +69,17 @@
 	else if(findtext(X,"CENTER"))
 		. = view+1
 
-/obj/screen/movable/proc/encode_screen_Y(Y)
-	var/view = usr.client ? usr.client.view : world.view
+/obj/screen/movable/proc/encode_screen_Y(var/Y, var/mob/viewer)
+	var/view = viewer.client ? viewer.client.view : world.view
 	if(Y > view+1)
 		. = "NORTH-[view*2 + 1-Y]"
-	else if(Y < usr.client.view+1)
+	else if(Y < viewer.client.view+1)
 		. = "SOUTH+[Y-1]"
 	else
 		. = "CENTER"
 
-/obj/screen/movable/proc/decode_screen_Y(Y)
-	var/view = usr.client ? usr.client.view : world.view
+/obj/screen/movable/proc/decode_screen_Y(var/Y, var/mob/viewer)
+	var/view = viewer.client ? viewer.client.view : world.view
 	if(findtext(Y,"NORTH-"))
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-
 		if(!num)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1999,7 +1999,7 @@ mob/living/silicon/ai/can_centcom_reply()
 	return list("<A HREF='?[source];adminplayerobservefollow=\ref[src]'>[prefix][short_links ? "J" : "JMP"][sufix]</A>")
 
 /client/extra_admin_link(source, var/prefix, var/sufix, var/short_links)
-	return mob.extra_admin_link(source, prefix, sufix, short_links)
+	return mob ? mob.extra_admin_link(source, prefix, sufix, short_links) : list()
 
 /mob/extra_admin_link(var/source, var/prefix, var/sufix, var/short_links)
 	. = ..()
@@ -2011,8 +2011,9 @@ mob/living/silicon/ai/can_centcom_reply()
 	if(mind && (mind.current && !isghost(mind.current)))
 		. += "<A HREF='?[source];adminplayerobservefollow=\ref[mind.current]'>[prefix][short_links ? "B" : "BDY"][sufix]</A>"
 
-/proc/admin_jump_link(var/atom/target, var/source, var/delimiter = "|", var/prefix, var/sufix, var/short_links)
-	if(!target) return
+/proc/admin_jump_link(var/datum/target, var/source, var/delimiter = "|", var/prefix, var/sufix, var/short_links)
+	if(!istype(target))
+		CRASH("Invalid admin jump link target: [log_info_line(target)]")
 	// The way admin jump links handle their src is weirdly inconsistent...
 	if(istype(source, /datum/admins))
 		source = "src=\ref[source]"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -231,6 +231,12 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 		return 1
 
 	. = OnTopic(href, href_list, usr)
+
+	// The user might have joined the game or otherwise had a change of mob while tweaking their preferences.
+	pref_mob = preference_mob()
+	if(!pref_mob || !pref_mob.client)
+		return 1
+
 	if(. & TOPIC_UPDATE_PREVIEW)
 		pref_mob.client.prefs.preview_icon = null
 	if(. & TOPIC_REFRESH)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -313,5 +313,7 @@ datum/preferences
 	panel.open()
 
 /datum/preferences/proc/close_load_dialog(mob/user)
+	if(panel)
+		panel.close()
+		panel = null
 	user << browse(null, "window=saves")
-	panel.close()


### PR DESCRIPTION
Fix runtimes when giving mobs abilities with HUD buttons.
Fix preference panel runtime.
Fix preferences runtime of the user has switched mob.
Fix admin-link runtimes due to mobless clients.

This fixes noteworthy runtimes that occur before stack tracing suddenly breaks.