### PR TITLE
Small robot QoL changes

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -65,6 +65,10 @@
 		do_pull_click(user, src)
 	return 1
 
+/turf/attack_robot(var/mob/user)
+	if(Adjacent(user))
+		attack_hand(user)
+
 turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -615,7 +615,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/transfer_to(obj/item/stack/cable_coil/S)
 	if(!istype(S))
 		return
-	if(!can_merge(S))
+	if(!(can_merge(S) || S.can_merge(src)))
 		return
 
 	..()


### PR DESCRIPTION
🆑
tweak: Engineering robots can now collect cables regardless of the currently selected color of their synthesizer
tweak: Robots can now pull-drag (by clicking on an adjacent turf while pulling something)
/🆑

I was made aware that the latter feature had possibly caused issues at some point (apparently making it possible to permanently stun someone by dragging them around continuously), but I ran some test and couldn't reproduce it myself.