### PR TITLE
All maintenance airlocks now require maint access.

### DIFF
--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -470,6 +470,7 @@
 "bk" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hangar Maintenance";
+	req_access = list(12)
 	req_one_access = list(73)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -2345,7 +2346,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(93)
+	req_access = list(12,93)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/fourthdeck/aft)
@@ -2617,6 +2618,7 @@
 "fC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Expedition EVA Maintenance";
+	req_access = list(12);
 	req_one_access = list(48,65)
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -3665,7 +3667,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(93)
+	req_access = list(12,93)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8250,7 +8252,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(12,73)
+	req_access = list(12,73)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -11427,7 +11429,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(12,73)
+	req_access = list(12,73)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/fourthdeck/aft)
@@ -16713,7 +16715,7 @@
 "Gp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Maintenance";
-	req_access = list(31)
+	req_access = list(12,31)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17713,7 +17715,7 @@
 "Iv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Maintenance";
-	req_access = list(31)
+	req_access = list(12,31)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/techfloor/corner{
@@ -17781,7 +17783,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Hangar Maintenance";
-	req_one_access = list(73)
+	req_access = list(12,73)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17974,7 +17976,7 @@
 "IX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hangar Maintenance";
-	req_one_access = list(73)
+	req_access = list(12,73)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -19612,7 +19614,7 @@
 "WI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Laundry Maintenance";
-	req_access = list(14)
+	req_access = list(12,14)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/laundry)

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -1050,7 +1050,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Storage Maintenance"
+	name = "Hydroponics Storage Maintenance";
+	req_access = list(12)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1272,6 +1273,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance"
+	req_access = list(12)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2422,6 +2424,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Expedition Storage Maintenance";
+	req_access = list(12)
 	req_one_access = list(48,65)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -2604,7 +2607,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Wing Maintenance";
-	req_access = list(1);
+	req_access = list(1,12);
 	secured_wires = 1
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -2892,7 +2895,8 @@
 "gA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Mess Hall Maintenance"
+	name = "Mess Hall Maintenance";
+	req_access = list(12)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6880,7 +6884,7 @@
 "nW" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(14)
+	req_access = list(12,14)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9777,7 +9781,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Equipment Maintenance";
-	req_access = list(1)
+	req_access = list(1,12)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11818,7 +11822,7 @@
 "xf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firing Range Maintenance";
-	req_access = list(80)
+	req_access = list(12,80)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -13912,7 +13916,7 @@
 "BN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Forensics Maintenance";
-	req_access = list(4)
+	req_access = list(4,12)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13984,7 +13988,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Evidence Storage Maintenance";
-	req_access = list(1)
+	req_access = list(1,12)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14119,7 +14123,8 @@
 "Cm" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Bunk Room Maintenance"
+	name = "Bunk Room Maintenance";
+	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/sleep/bunk)
@@ -14871,7 +14876,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Cryogenic Storage Maintenance"
+	name = "Cryogenic Storage Maintenance";
+	req_access = list(12)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15413,7 +15419,7 @@
 "Ff" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Storage Maintenance";
-	req_access = list(31)
+	req_access = list(12,31)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -15942,7 +15948,7 @@
 "GE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Galley Maintenance";
-	req_access = list(28)
+	req_access = list(12,28)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20530,7 +20536,8 @@
 /area/crew_quarters/gym)
 "Wf" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Gym Maintenance"
+	name = "Gym Maintenance";
+	req_access = list(12)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -1202,7 +1202,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Storage Maintenance";
-	req_access = list(5)
+	req_access = list(5,12)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/medical)
@@ -1454,6 +1454,7 @@
 "cY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Expedition Storage Maintenance";
+	req_access = list(12);
 	req_one_access = list(48,65)
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -2809,6 +2810,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Expedition Storage Maintenance";
+	req_access = list(12);
 	req_one_access = list(48,65)
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -3015,7 +3017,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Docking Port";
-	req_access = list(13)
+	req_access = list(12,13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -5160,6 +5162,7 @@
 "kg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Expedition Storage Maintenance";
+	req_access = list(12);
 	req_one_access = list(48,65)
 	},
 /obj/structure/cable{
@@ -5190,7 +5193,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Teleporter";
-	req_access = list(17)
+	req_access = list(12,17)
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/seconddeck)
@@ -5380,7 +5383,7 @@
 "kC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Teleporter";
-	req_access = list(17)
+	req_access = list(12,17)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/corner_techfloor_grid{
@@ -7174,6 +7177,7 @@
 "pc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
+	req_access = list(12);
 	req_one_access = list(14,23)
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -7246,9 +7250,7 @@
 "pl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = newlist()
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/seconddeck/foreport)
 "pm" = (
@@ -7258,9 +7260,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = newlist()
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/seconddeck/forestarboard)
@@ -8551,7 +8551,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(14)
+	req_access = list(12,14)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/seconddeck/foreport)
@@ -11639,8 +11639,7 @@
 "zJ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Incinerator";
-	req_access = list(12);
-	req_one_access = newlist()
+	req_access = list(12)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -12153,7 +12152,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Storage Maintenance";
-	req_access = list(31)
+	req_access = list(12,31)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/cargo)
@@ -12729,7 +12728,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Storage Maintenance";
-	req_access = list(47)
+	req_access = list(12,47)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/research)
@@ -14683,9 +14682,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/catwalk,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = newlist()
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/seconddeck/foreport)
 "Hn" = (

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -1678,7 +1678,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(12,5,39)
+	req_access = list(12)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4112,7 +4112,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
-	req_access = list(27)
+	req_access = list(12,27)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4608,7 +4608,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Synthetic Storage";
-	req_one_access = list(16)
+	req_access = list(12,16)
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -10062,7 +10062,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "First Deck Teleporter Access";
-	req_access = list(17)
+	req_access = list(12,17)
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
@@ -10364,6 +10364,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Cryogenic Storage Maintenance"
+	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo/aux)
@@ -17123,7 +17124,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(12,5,39)
+	req_access = list(12)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17193,7 +17194,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
-	req_access = list(6)
+	req_access = list(6,12)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17389,7 +17390,7 @@
 "cGb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Infirmary Maintenance Access";
-	req_one_access = list(66)
+	req_access = list(12,66)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white/monotile,
@@ -17660,7 +17661,7 @@
 "ddb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Infirmary Maintenance Access";
-	req_one_access = list(66)
+	req_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
@@ -22188,7 +22189,7 @@
 "jtb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance Access";
-	req_one_access = list(47)
+	req_access = list(12,47)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -23001,8 +23002,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Robotics Maintenance";
-	req_access = list(82);
-	req_one_access = newlist()
+	req_access = list(12,82)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/robotics)
@@ -27738,7 +27738,7 @@
 "seb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenoflora Lab Maintenance";
-	req_access = list(55)
+	req_access = list(12,55)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -12192,7 +12192,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Disciplinary Board Room Maintenance Access";
-	req_access = list(19)
+	req_access = list(12,19)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/disciplinary_board_room)


### PR DESCRIPTION
:cl:
tweak: Almost all maint airlocks now require maint access.
/:cl:

Closes #21494
Almost all maintenance airlocks now require maint access (12). The only exceptions are the ones required to get from the stairs to the elevator to the ladders on deck 2.