### PR TITLE
Buffs pathfinder

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -439,6 +439,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/pathfinder
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
 	allowed_ranks = list(
+		/datum/mil_rank/ec/e7,
 		/datum/mil_rank/ec/o1
 	)
 	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,


### PR DESCRIPTION
🆑 Cakey
tweak: Chief explorers can now qualify for pathfinder.
/🆑

Brings pathfinder in line with deck officer as they're the same position within their respective departments.