### PR TITLE
Fixes windows not connecting under special circumstances

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -55,6 +55,12 @@
 	spawn(1) qdel(src)
 	return 1
 
+/obj/structure/proc/can_visually_connect()
+	return anchored
+
+/obj/structure/proc/can_visually_connect_to(var/obj/structure/S)
+	return istype(S, src)
+
 /obj/structure/proc/update_connections(propagate = 0)
 	var/list/dirs = list()
 	var/list/other_dirs = list()
@@ -63,8 +69,8 @@
 		return
 
 	for(var/obj/structure/S in orange(src, 1))
-		if(istype(S, src))
-			if(S.anchored)
+		if(can_visually_connect_to(S))
+			if(S.can_visually_connect())
 				if(propagate)
 					S.update_connections()
 					S.update_icon()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -384,6 +384,13 @@
 		verbs += /obj/structure/window/proc/rotate
 		verbs += /obj/structure/window/proc/revrotate
 
+// Visually connect with every type of window as long as it's full-tile.
+/obj/structure/window/can_visually_connect()
+	return ..() && is_fulltile()
+
+/obj/structure/window/can_visually_connect_to(var/obj/structure/S)
+	return istype(S, /obj/structure/window)
+
 //merges adjacent full-tile windows into one (blatant ripoff from game/smoothwall.dm)
 /obj/structure/window/update_icon()
 	//A little cludge here, since I don't know how it will work with slim windows. Most likely VERY wrong.
@@ -395,24 +402,23 @@
 		layer = SIDE_WINDOW_LAYER
 		icon_state = "[basestate]"
 		return
+
+	var/image/I
+	icon_state = ""
+	if(on_frame)
+		for(var/i = 1 to 4)
+			if(other_connections[i] != "0")
+				I = image(icon, "[basestate]_other_onframe[connections[i]]", dir = 1<<(i-1))
+			else
+				I = image(icon, "[basestate]_onframe[connections[i]]", dir = 1<<(i-1))
+			overlays += I
 	else
-		var/image/I
-		icon_state = ""
-		if(on_frame)
-			for(var/i = 1 to 4)
-				if(other_connections[i] != "0")
-					I = image(icon, "[basestate]_other_onframe[connections[i]]", dir = 1<<(i-1))
-				else
-					I = image(icon, "[basestate]_onframe[connections[i]]", dir = 1<<(i-1))
-				overlays += I
-		else
-			for(var/i = 1 to 4)
-				if(other_connections[i] != "0")
-					I = image(icon, "[basestate]_other[connections[i]]", dir = 1<<(i-1))
-				else
-					I = image(icon, "[basestate][connections[i]]", dir = 1<<(i-1))
-				overlays += I
-	return
+		for(var/i = 1 to 4)
+			if(other_connections[i] != "0")
+				I = image(icon, "[basestate]_other[connections[i]]", dir = 1<<(i-1))
+			else
+				I = image(icon, "[basestate][connections[i]]", dir = 1<<(i-1))
+			overlays += I
 
 /obj/structure/window/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > maximal_heat)


### PR DESCRIPTION
Windows that have a different type will not connect, thus any subtype of window for a different material or for a full-tile window will not connect to the other types. Fixed by introducing `can_visually_connect()` and `can_visually_connect_to(obj/structure/S)` to overwrite the connection checks when necessary.

Fixes #22145
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
