### PR TITLE
Nerf spellbound servant familiars

### DIFF
--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -187,13 +187,18 @@
 	feedback = "FA"
 	possible_transformations = list()
 	drop_items = 0
-	share_damage = 0
 	invocation_type = SpI_EMOTE
 	invocation = "'s body dissipates into a pale mass of light, then reshapes!"
 	range = -1
 	spell_flags = INCLUDEUSER
 	duration = 0
-	charge_max = 100
+	charge_max = 2 MINUTES
 	toggle = 1
 
 	hud_state = "wiz_carp"
+
+/spell/targeted/shapeshift/familiar/cast(var/list/targets, mob/user)
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't cast spells right now.</span>")
+		return
+	..()


### PR DESCRIPTION
:cl:
balance: Wizard familiar transform spell recharge time increased to two minutes from ten seconds.
balance: Wizard familiars can no longer transform while incapacitated.
balance: A percentage of damage taken in a familiar animal form is now mirrored to the familiar's human form.
/:cl:
Why:
![](https://i.imgur.com/13kTuDh.gif)
