### PR TITLE
Fixes snow planet ore maps

### DIFF
--- a/code/modules/overmap/exoplanets/snow.dm
+++ b/code/modules/overmap/exoplanets/snow.dm
@@ -43,7 +43,9 @@
 
 /datum/random_map/noise/ore/poor
 	deep_val = 0.8
-	rare_val = 0.9
+	rare_val = 0.7
+	min_rare_ratio = 0.02
+	min_rare_ratio = 0.01
 
 /turf/simulated/floor/exoplanet/ice
 	name = "ice"

--- a/code/modules/overmap/exoplanets/volcanic.dm
+++ b/code/modules/overmap/exoplanets/volcanic.dm
@@ -67,8 +67,8 @@
 				map[current_cell] = 1
 
 /datum/random_map/noise/ore/filthy_rich
-	deep_val = 0.9
-	rare_val = 0.7
+	deep_val = 0.6
+	rare_val = 0.4
 
 /area/exoplanet/volcanic
 	forced_ambience = list('sound/ambience/magma.ogg')

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -3,6 +3,9 @@
 	var/deep_val = 0.8              // Threshold for deep metals, set in new as percentage of cell_range.
 	var/rare_val = 0.7              // Threshold for rare metal, set in new as percentage of cell_range.
 	var/chunk_size = 4              // Size each cell represents on map
+	var/min_surface_ratio = MIN_SURFACE_COUNT_PER_CHUNK
+	var/min_rare_ratio = MIN_RARE_COUNT_PER_CHUNK
+	var/min_deep_ratio = MIN_DEEP_COUNT_PER_CHUNK
 
 /datum/random_map/noise/ore/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0)
 	rare_val = cell_range * rare_val
@@ -27,13 +30,13 @@
 	var/num_chunks = surface_count + rare_count + deep_count
 
 	// Sanity check.
-	if(surface_count < (MIN_SURFACE_COUNT_PER_CHUNK * num_chunks))
+	if(surface_count < (min_surface_ratio * num_chunks))
 		admin_notice("<span class='danger'>Insufficient surface minerals. Rerolling...</span>", R_DEBUG)
 		return 0
-	else if(rare_count < (MIN_RARE_COUNT_PER_CHUNK * num_chunks))
+	else if(rare_count < (min_rare_ratio * num_chunks))
 		admin_notice("<span class='danger'>Insufficient rare minerals. Rerolling...</span>", R_DEBUG)
 		return 0
-	else if(deep_count < (MIN_DEEP_COUNT_PER_CHUNK * num_chunks))
+	else if(deep_count < (min_deep_ratio * num_chunks))
 		admin_notice("<span class='danger'>Insufficient deep minerals. Rerolling...</span>", R_DEBUG)
 		return 0
 	else


### PR DESCRIPTION
They were so poor they didn't pass sanity. Now sanity is more tweakable.

Also fixes lava planet's ultra rich ore map actually being super poor.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
