### PR TITLE
Changes robotics maintenance airlock access

### DIFF
--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -23009,7 +23009,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
 	name = "Robotics Maintenance";
-	req_access = list(12,82)
+	req_access = list(82)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/robotics)


### PR DESCRIPTION
Roboticist storage is in there.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑 CrimsonShrike
tweak: Roboticist now has access to their own maintenance airlock again.
/🆑