### PR TITLE
Removes Diona from RD & Liason

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -11,7 +11,7 @@
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
 		/datum/species/tajaran = list(HUMAN_ONLY_JOBS),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/guard, /datum/job/officer),	//Other jobs unavailable via branch restrictions,
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/guard, /datum/job/officer, /datum/job/rd, /datum/job/liaison),	//Other jobs unavailable via branch restrictions,
 	)
 #undef HUMAN_ONLY_JOBS
 


### PR DESCRIPTION
🆑 Cakey
tweak: Dionae may no longer fill in as research director among Nanotrasen staff, as the board of directors felt they weren't evil enough to push the Nanotrasen agenda.
/🆑

Personally don't believe Dionae make sense to be within a managerial position, and they aren't very good at portraying the corporate scum the RD is meant to be.