### PR TITLE
Make boomboxes play speed adjustable

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -172,3 +172,7 @@
 #define FLAGS_EQUALS(flag, flags) ((flag & (flags)) == (flags))
 
 #define JOINTEXT(X) jointext(X, null)
+
+#define SPAN_NOTICE(X) "<span class='notice'>[X]</span>"
+
+#define SPAN_WARNING(X) "<span class='warning'>[X]</span>"

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -10,26 +10,26 @@
 	var/playing = 0
 	var/track_num = 1
 	var/volume = 40
+	var/frequency = 1
 	var/datum/sound_token/sound_token
 	var/list/datum/track/tracks
 	var/sound_id
 
-/obj/item/device/boombox/attack_self(mob/user)
+/obj/item/device/boombox/attack_self(var/mob/user)
 	interact(user)
-
-/obj/item/device/boombox/New()
-	..()
-	sound_id = "[type]_[sequential_id(type)]"
 
 /obj/item/device/boombox/Initialize()
 	. = ..()
+	sound_id = "[type]_[sequential_id(type)]"
 	tracks = setup_music_tracks(tracks)
 
 /obj/item/device/boombox/Destroy()
 	stop()
 	. = ..()
 
-/obj/item/device/boombox/interact(mob/user)
+/obj/item/device/boombox/interact(var/mob/user)
+	if(!CanPhysicallyInteract(user))
+		return
 	var/dat = "<A href='?src=\ref[src];tracknum=1;'>NEXT</a>"
 	dat += "<A href='?src=\ref[src];tracknum=-1;'>PREV</a>"
 	dat += "<A href='?src=\ref[src];start=1;'>PLAY</a>"
@@ -38,13 +38,12 @@
 	popup.set_content(dat)
 	popup.open()
 
-/obj/item/device/boombox/attack_ai(mob/user)
-	return //silicons have no groove
+/obj/item/device/boombox/DefaultTopicState()
+	return GLOB.physical_state
 
 /obj/item/device/boombox/CouldUseTopic(var/mob/user)
 	..()
-	if(istype(user, /mob/living/carbon))
-		playsound(src, "switch", 40)
+	playsound(src, "switch", 40)
 
 /obj/item/device/boombox/OnTopic(var/user, var/list/href_list)
 	if(href_list["tracknum"])
@@ -64,6 +63,64 @@
 		start()
 		return TOPIC_HANDLED
 
+/obj/item/device/boombox/attackby(var/obj/item/W, var/mob/user)
+	if(isScrewdriver(W))
+		AdjustFrequency(W, user)
+		return TRUE
+	else
+		. = ..()
+
+/obj/item/device/boombox/proc/AdjustFrequency(var/obj/item/W, var/mob/user)
+	var/const/MIN_FREQUENCY = 0.5
+	var/const/MAX_FREQUENCY = 1.5
+
+	if(!MayAdjust(user))
+		return FALSE
+
+	var/list/options = list()
+	var/tighten = "Tighten (play slower)"
+	var/loosen  = "Loosen (play faster)"
+
+	if(frequency > MIN_FREQUENCY)
+		options += tighten
+	if(frequency < MAX_FREQUENCY)
+		options += loosen
+
+	var/operation = input(user, "How do you wish to adjust the player head?", "Adjust player", options[1]) as null|anything in options
+	if(!operation)
+		return FALSE
+	if(!MayAdjust(user))
+		return FALSE
+	if(W != user.get_active_hand())
+		return FALSE
+
+	if(!CanPhysicallyInteract(user))
+		return FALSE
+
+	if(operation == loosen)
+		frequency += 0.1
+	else if(operation == tighten)
+		frequency -= 0.1
+	frequency = Clamp(frequency, MIN_FREQUENCY, MAX_FREQUENCY)
+
+	user.visible_message(SPAN_NOTICE("\The [user] adjusts \the [src]'s player head."), SPAN_NOTICE("You adjust \the [src]'s player head."))
+	playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+
+	if(frequency > 1.0)
+		to_chat(user, SPAN_NOTICE("\The [src] should be playing faster than usual."))
+	else if(frequency < 1.0)
+		to_chat(user, SPAN_NOTICE("\The [src] should be playing slower than usual."))
+	else
+		to_chat(user, SPAN_NOTICE("\The [src] should be playing as fast as usual."))
+
+	return TRUE
+
+/obj/item/device/boombox/proc/MayAdjust(var/mob/user)
+	if(playing)
+		to_chat(user, "<span class='warning'>You can only adjust \the [src] when it's not playing.</span>")
+		return FALSE
+	return TRUE
+
 /obj/item/device/boombox/update_icon()
 	icon_state = playing ? "on" : "off"
 
@@ -75,7 +132,7 @@
 /obj/item/device/boombox/proc/start()
 	QDEL_NULL(sound_token)
 	var/datum/track/T = tracks[track_num]
-	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, T.GetTrack(), volume = volume, range = 7, falloff = 4, prefer_mute = TRUE)
+	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, T.GetTrack(), volume = volume, frequency = frequency, range = 7, falloff = 4, prefer_mute = TRUE)
 	playing = 1
 	update_icon()
 

--- a/code/game/objects/topic.dm
+++ b/code/game/objects/topic.dm
@@ -1,6 +1,10 @@
-/obj/Topic(var/href, var/href_list = list(), var/datum/topic_state/state = GLOB.default_state)
+/obj/proc/DefaultTopicState()
+	return GLOB.default_state
+
+/obj/Topic(var/href, var/href_list = list(), var/datum/topic_state/state)
 	if((. = ..()))
 		return
+	state = state || DefaultTopicState() || GLOB.default_state
 	if(CanUseTopic(usr, state, href_list) == STATUS_INTERACTIVE)
 		CouldUseTopic(usr)
 		return OnTopic(usr, href_list, state)

--- a/code/modules/nano/interaction/physical.dm
+++ b/code/modules/nano/interaction/physical.dm
@@ -14,5 +14,5 @@ GLOBAL_DATUM_INIT(physical_state, /datum/topic_state/physical, new)
 /mob/living/check_physical_distance(var/src_object)
 	return shared_living_nano_distance(src_object)
 
-/mob/living/silicon/check_physical_distance(var/src_object)
+/mob/living/silicon/ai/check_physical_distance(var/src_object)
 	return max(STATUS_UPDATE, shared_living_nano_distance(src_object))


### PR DESCRIPTION
:cl:
add: It is now possible to adjust the playspeed of boomboxes using a screwdriver.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
