### PR TITLE
Fix fire alarm, add KoG pixel offsets

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -35,6 +35,7 @@
 	maxHealth = 750
 	melee_damage_lower = 40
 	melee_damage_upper = 60
+	default_pixel_y = 5
 	var/spellscast = 0
 	var/phase3 = FALSE
 	var/datum/sound_token/boss_theme
@@ -134,6 +135,7 @@
 		var/matrix/M = new
 		M.Scale(1.5)
 		transform = M
+		default_pixel_y = 10
 
 /mob/living/simple_animal/hostile/retaliate/goat/king/proc/OnDeath()
 	if(prob(85))

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -10367,7 +10367,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Auxiliary Cryogenic Storage Maintenance"
+	name = "Auxiliary Cryogenic Storage Maintenance";
 	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/white,
@@ -16850,7 +16850,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 1;
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white,


### PR DESCRIPTION
Fixes unreported issue with fire alarm hanging off the wall in research

Adds pixel offsets to the Scale'd goats so they're centre in the tile still