### PR TITLE
Spells can no longer be cast by incapacited individuals.

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -69,6 +69,7 @@
 //End split flags
 #define CONSTRUCT_CHECK	0x100	//used by construct spells - checks for nullrods
 #define NO_BUTTON		0x200	//spell won't show up in the HUD with this
+#define NO_SOMATIC		0x400	//spell will go off if the person is incapacitated (kind of like STATALLOWED but w/ handcuffs n junk)
 
 //invocation
 #define SpI_SHOUT	"shout"

--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -55,7 +55,7 @@
 #define NEEDSCLOTHES	0x2		//does it need the wizard garb to cast? Nonwizard spells should not have this
 #define NEEDSHUMAN		0x4		//does it require the caster to be human?
 #define Z2NOCAST		0x8		//if this is added, the spell can't be cast at centcomm
-#define STATALLOWED		0x10	//if set, the user doesn't have to be conscious to cast. Required for ghost spells
+#define NO_SOMATIC		0x10	//spell will go off if the person is incapacitated or stunned
 #define IGNOREPREV		0x20	//if set, each new target does not overlap with the previous one
 //The following flags only affect different types of spell, and therefore overlap
 //Targeted spells
@@ -69,7 +69,6 @@
 //End split flags
 #define CONSTRUCT_CHECK	0x100	//used by construct spells - checks for nullrods
 #define NO_BUTTON		0x200	//spell won't show up in the HUD with this
-#define NO_SOMATIC		0x400	//spell will go off if the person is incapacitated (kind of like STATALLOWED but w/ handcuffs n junk)
 
 //invocation
 #define SpI_SHOUT	"shout"

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -18,10 +18,6 @@
 	if(!targets.len)
 		return
 
-	if(user.incapacitated(INCAPACITATION_STUNNED | INCAPACITATION_FORCELYING | INCAPACITATION_KNOCKOUT))
-		to_chat(user, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
-		return
-
 	var/turf/T = pick(targets)
 	var/turf/starting = get_turf(user)
 	if(T)

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -38,9 +38,6 @@
 	if(!end)
 		to_chat(user, "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.")
 		return
-	if(user.incapacitated(INCAPACITATION_STUNNED | INCAPACITATION_FORCELYING | INCAPACITATION_KNOCKOUT))
-		to_chat(user, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
-		return
 	return
 
 /spell/area_teleport/after_cast()

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -43,9 +43,9 @@
 	if(!..())
 		return 0
 
-	spell_flags = STATALLOWED
+	spell_flags = STATALLOWED|NO_SOMATIC
 
-	return "You no longer have to be conscious to activate this spell."
+	return "You will always be able to cast this spell, even unconscious or handcuffed."
 
 /obj/effect/cleanable/wizard_mark
 	name = "\improper Mark of the Wizard"

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -45,7 +45,7 @@
 
 	spell_flags = NO_SOMATIC
 
-	return "You will always be able to cast this spell, even unconscious or handcuffed."
+	return "You will always be able to cast this spell, even while unconscious or handcuffed."
 
 /obj/effect/cleanable/wizard_mark
 	name = "\improper Mark of the Wizard"

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -43,7 +43,7 @@
 	if(!..())
 		return 0
 
-	spell_flags = STATALLOWED|NO_SOMATIC
+	spell_flags = NO_SOMATIC
 
 	return "You will always be able to cast this spell, even unconscious or handcuffed."
 

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -238,7 +238,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(istype(user, /mob/living/simple_animal))
 			var/mob/living/simple_animal/SA = user
 			if(SA.purge)
-				to_chat(SA, "<span class='warning'>The nullrod's power interferes with your own!</span>")
+				to_chat(SA, "<span class='warning'>The null sceptre's power interferes with your own!</span>")
 				return 0
 
 		if(!(spell_flags & GHOSTCAST))

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -231,35 +231,32 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			if(findNullRod(T))
 				return 0
 
-	if(istype(user, /mob/living/simple_animal) && holder == user)
-		var/mob/living/simple_animal/SA = user
-		if(SA.purge)
-			to_chat(SA, "<span class='warning'>The nullrod's power interferes with your own!</span>")
-			return 0
-
 	if(!src.check_charge(skipcharge, user)) //sees if we can cast based on charges alone
 		return 0
 
-	if(!(spell_flags & GHOSTCAST) && holder == user)
-		if(user.stat && !(spell_flags & STATALLOWED))
-			to_chat(usr, "Not when you're incapacitated.")
-			return 0
-
-		if(ishuman(user) && !(invocation_type in list(SpI_EMOTE, SpI_NONE)))
-			if(istype(user.wear_mask, /obj/item/clothing/mask/muzzle))
-				to_chat(user, "Mmmf mrrfff!")
+	if(holder == user)
+		if(istype(user, /mob/living/simple_animal))
+			var/mob/living/simple_animal/SA = user
+			if(SA.purge)
+				to_chat(SA, "<span class='warning'>The nullrod's power interferes with your own!</span>")
 				return 0
 
-	if(!(spell_flags & NO_SOMATIC) && holder == user)
-		var/mob/living/L = user
-		if(L.incapacitated())
-			to_chat(user, "<span class='warning'>You can't cast spells while incapacitated!</span>")
-			return 0
+		if(!(spell_flags & GHOSTCAST))
+			if(!(spell_flags & NO_SOMATIC))
+				var/mob/living/L = user
+				if(L.incapacitated(INCAPACITATION_STUNNED|INCAPACITATION_RESTRAINED|INCAPACITATION_BUCKLED_FULLY|INCAPACITATION_FORCELYING|INCAPACITATION_KNOCKOUT))
+					to_chat(user, "<span class='warning'>You can't cast spells while incapacitated!</span>")
+					return 0
 
-	var/spell/noclothes/spell = locate() in user.mind.learned_spells
-	if((spell_flags & NEEDSCLOTHES) && !(spell && istype(spell)) && holder == user)//clothes check
-		if(!user.wearing_wiz_garb())
-			return 0
+			if(ishuman(user) && !(invocation_type in list(SpI_EMOTE, SpI_NONE)))
+				if(istype(user.wear_mask, /obj/item/clothing/mask/muzzle))
+					to_chat(user, "Mmmf mrrfff!")
+					return 0
+
+		var/spell/noclothes/spell = locate() in user.mind.learned_spells
+		if((spell_flags & NEEDSCLOTHES) && !(spell && istype(spell)))//clothes check
+			if(!user.wearing_wiz_garb())
+				return 0
 
 	return 1
 
@@ -385,8 +382,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	if(!user || isnull(user))
 		return 0
 
-	var/incap_flags = INCAPACITATION_STUNNED
-	if(!(spell_flags & (STATALLOWED|GHOSTCAST)))
+	var/incap_flags = INCAPACITATION_STUNNED|INCAPACITATION_RESTRAINED|INCAPACITATION_BUCKLED_FULLY|INCAPACITATION_FORCELYING
+	if(!(spell_flags & (GHOSTCAST)))
 		incap_flags |= INCAPACITATION_KNOCKOUT
 
 	return do_after(user,delay, incapacitation_flags = incap_flags)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -250,6 +250,12 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 				to_chat(user, "Mmmf mrrfff!")
 				return 0
 
+	if(!(spell_flags & NO_SOMATIC) && holder == user)
+		var/mob/living/L = user
+		if(L.incapacitated())
+			to_chat(user, "<span class='warning'>You can't cast spells while incapacitated!</span>")
+			return 0
+
 	var/spell/noclothes/spell = locate() in user.mind.learned_spells
 	if((spell_flags & NEEDSCLOTHES) && !(spell && istype(spell)) && holder == user)//clothes check
 		if(!user.wearing_wiz_garb())

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -20,10 +20,6 @@
 		if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(target))
 			continue
 
-		if(target.incapacitated(INCAPACITATION_STUNNED | INCAPACITATION_FORCELYING | INCAPACITATION_KNOCKOUT))
-			to_chat(target, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
-			return
-
 		if(target.buckled)
 			target.buckled.unbuckle_mob()
 		spawn(0)

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -196,9 +196,3 @@
 	toggle = 1
 
 	hud_state = "wiz_carp"
-
-/spell/targeted/shapeshift/familiar/cast(var/list/targets, mob/user)
-	if(user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't cast spells right now.</span>")
-		return
-	..()

--- a/html/changelogs/TheWelp - ultimateWizardNerf.yml
+++ b/html/changelogs/TheWelp - ultimateWizardNerf.yml
@@ -1,0 +1,4 @@
+author: TheWelp
+delete-after: True
+changes: 
+  - rscadd: "Spells without the NO_SOMATIC flag now require you to not be incapacitated (handcuffed, stunned, etc). This currently means all spells."

--- a/html/changelogs/TheWelp - ultimateWizardNerf.yml
+++ b/html/changelogs/TheWelp - ultimateWizardNerf.yml
@@ -1,4 +1,4 @@
 author: TheWelp
 delete-after: True
 changes: 
-  - rscadd: "Spells without the NO_SOMATIC flag now require you to not be incapacitated (handcuffed, stunned, etc). This currently means all spells."
+  - rscadd: "Spells now require you to not be incapacitated (handcuffed, stunned, etc)."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Title. This check can be switched off with the NO_SOMATIC flag, which only one spell gets as of right now (upgraded mark and recall)