### PR TITLE
Modify the changelog header & credits

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -23,11 +23,13 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>Space Station 13</b></font></div>
+			<div align='center'><font size='3'><b>Baystation 12</b></font></div>
+			<div align='center'><font size='3'><b><i>A Space Station 13 Project</i></b></font></div>
 			
 			<p><div align='center'><font size='3'><a href="http://wiki.baystation12.net/">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
             <font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/agpl.html">AGPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
-			<font size='2'><b>Visit our IRC channel:</b> #bs12 on irc.sorcery.net</font>
+			<font size='2'><b>Visit our IRC channels:</b> #bs12 and #codershuttle on irc.sorcery.net</font><br>
+			<font size='2'><b>Join our Discord server:</b> <a href='https://discord.gg/DrtRFxs'>-Click Here-</a><br></font>
 			</td>
 	</tr>
 </table>
@@ -36,14 +38,11 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-            <font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/Baystation12?tab=members'>-Click Here-</a><br></font>
+            <font size='2'><b>Developers:</b> chinsky, F-Tang Steve, mloc, PsiOmegaDelta, sabiram, Snapshot, xales, Zuhayr<br></font>
 			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Baystation12/Baystation12/graphs/contributors'>-Click Here-</a><br></font>
-			<font size='2'><b>Code:</b> Abi79, Aryn, Cael_Aislinn, Ccomp5950, Chinsky, cib, CompactNinja, DopeGhoti, Erthilo, Hawk_v3, Head, Ispil, JoeyJo0, Lexusjjss, Melonstorm, Miniature, Mloc, NerdyBoy1104, PsiOmegaDelta, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty<br></font>
-			<font size='2'><b>Sprites:</b> Apple_Master, Arcalane, Chinsky, CompactNinja, Deus Dactyl, Erthilo, Flashkirby, JoeyJo0, Miniature, Searif, Xenone, faux<br></font>
-			<font size='2'><b>Sounds:</b> Aryn<br></font>
-            <font size='2'><b>Main Testers:</b> Anyone who has submitted a bug to the issue tracker<br></font>
-			<font size='2'><b>Thanks to:</b> /tg/ station, /vg/station, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on irc.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Baystation12/Baystation12/issues?labels=Bug&state=open">Issue Tracker</a>.<br></font>
+			<p><font size='2'><b>Credits:</b> Abi79, Apple_Master, Arcalane, Aryn, Cael_Aislinn, Ccomp5950, chinsky, CompactNinja, Deus Dactyl, DopeGhoti, Erthilo, Flashkirby, Hawk_v3, Head, Ipsil, Invisty, JoeyJo0, Lexusjjss, Melonstorm, Miniature, mloc, NerdyBoy1104, PsiOmegaDelta, sabiram, Searif, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty, Xenone, cib, faux<br></p>
+			<font size='2'><b>Special thanks to:</b> The developers of /tg/ station, /vg/station, GoonStation and the original Space Station 13</font>
+			<div align='center'><font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Baystation12/Baystation12/issues?labels=Bug&state=open">Issue Tracker</a>.<br></font></div>
 		</td>
 	</tr>
 </table>
@@ -64,7 +63,8 @@
 			<h3 class="author">sabiram updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="maptweak">Added some lights to dark spots in hallways around research, chemistry and the D3 ladders, the main hallway through D2 maint from the stairs/elevator, and the medbay.</li>
-				<li class="maptweak">The greedy NT guards are now only provided with one chair for their window desk. imgadd: Changed the intercom icon to be more in line with what it used to be. Dark frame, green console.</li>
+				<li class="maptweak">The greedy NT guards are now only provided with one chair for their window desk.</li>
+				<li class="imageadd">Changed the intercom icon to be more in line with what it used to be. Dark frame, green console.</li>
 			</ul>
 
 			<h2 class="date">14 July 2018</h2>
@@ -93,7 +93,8 @@
 			<h3 class="author">Cakey updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="tweak">The Pathfinder job is now Ensign only</li>
-				<li class="rscadd">Belts have been overhauled to have holster slots on certain belts. These holsters function the exact same way as uniform holsters do. imgadd: Certain belts now show what their contents are on their icons.</li>
+				<li class="rscadd">Belts have been overhauled to have holster slots on certain belts. These holsters function the exact same way as uniform holsters do.</li>
+				<li class="imageadd">Certain belts now show what their contents are on their icons.</li>
 				<li class="rscadd">Added general and general holster belts, used by command, bridge officers, and supply. Holds general office supplies, tablets, and stamps as well as other various supply equipment.</li>
 				<li class="maptweak">Uniform holsters have been removed in favor of belt holsters, however they can still be found within the loadout menu.</li>
 				<li class="tweak">Uniform holsters have been modified to use the same slot as webbings to counter being able to carry two holstered weapons.</li>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -23,11 +23,13 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>Space Station 13</b></font></div>
+			<div align='center'><font size='3'><b>Baystation 12</b></font></div>
+			<div align='center'><font size='3'><b><i>A Space Station 13 Project</i></b></font></div>
 			
 			<p><div align='center'><font size='3'><a href="http://wiki.baystation12.net/">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
             <font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/agpl.html">AGPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
-			<font size='2'><b>Visit our IRC channel:</b> #bs12 on irc.sorcery.net</font>
+			<font size='2'><b>Visit our IRC channels:</b> #bs12 and #codershuttle on irc.sorcery.net</font><br>
+			<font size='2'><b>Join our Discord server:</b> <a href='https://discord.gg/DrtRFxs'>-Click Here-</a><br></font>
 			</td>
 	</tr>
 </table>
@@ -36,14 +38,11 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-            <font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/Baystation12?tab=members'>-Click Here-</a><br></font>
+            <font size='2'><b>Developers:</b> chinsky, F-Tang Steve, mloc, PsiOmegaDelta, sabiram, Snapshot, xales, Zuhayr<br></font>
 			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Baystation12/Baystation12/graphs/contributors'>-Click Here-</a><br></font>
-			<font size='2'><b>Code:</b> Abi79, Aryn, Cael_Aislinn, Ccomp5950, Chinsky, cib, CompactNinja, DopeGhoti, Erthilo, Hawk_v3, Head, Ispil, JoeyJo0, Lexusjjss, Melonstorm, Miniature, Mloc, NerdyBoy1104, PsiOmegaDelta, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty<br></font>
-			<font size='2'><b>Sprites:</b> Apple_Master, Arcalane, Chinsky, CompactNinja, Deus Dactyl, Erthilo, Flashkirby, JoeyJo0, Miniature, Searif, Xenone, faux<br></font>
-			<font size='2'><b>Sounds:</b> Aryn<br></font>
-            <font size='2'><b>Main Testers:</b> Anyone who has submitted a bug to the issue tracker<br></font>
-			<font size='2'><b>Thanks to:</b> /tg/ station, /vg/station, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on irc.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Baystation12/Baystation12/issues?labels=Bug&state=open">Issue Tracker</a>.<br></font>
+			<p><font size='2'><b>Credits:</b> Abi79, Apple_Master, Arcalane, Aryn, Cael_Aislinn, Ccomp5950, chinsky, CompactNinja, Deus Dactyl, DopeGhoti, Erthilo, Flashkirby, Hawk_v3, Head, Ipsil, Invisty, JoeyJo0, Lexusjjss, Melonstorm, Miniature, mloc, NerdyBoy1104, PsiOmegaDelta, sabiram, Searif, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty, Xenone, cib, faux<br></p>
+			<font size='2'><b>Special thanks to:</b> The developers of /tg/ station, /vg/station, GoonStation and the original Space Station 13</font>
+			<div align='center'><font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Baystation12/Baystation12/issues?labels=Bug&state=open">Issue Tracker</a>.<br></font></div>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
:cl:
tweak: Changed the changelog header and credits.
/:cl:
You can open these files in your browser to see what they look like.


- This credit list is rather out of date. Consolidated the different categories into one legacy 'credits' section.
- Anyone with more than 50 merged commits and in good standing _(same as contributor role on discord)_ can add themselves to this list **IN ALPHABETICAL ORDER** at their own leisure.
- Plaintext developer list. Many devs aren't listed on repo members list, and many non-devs aren't.
- Various other tweaks and changes.
- Fixes two 'imgadd' tagged entires