### PR TITLE
Add spy versus spy mode, traitors and renegades

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -527,6 +527,7 @@
 #include "code\game\gamemodes\mixed\lizard.dm"
 #include "code\game\gamemodes\mixed\paranoia.dm"
 #include "code\game\gamemodes\mixed\siege.dm"
+#include "code\game\gamemodes\mixed\spyvspy.dm"
 #include "code\game\gamemodes\mixed\traitorling.dm"
 #include "code\game\gamemodes\mixed\unity.dm"
 #include "code\game\gamemodes\mixed\uprising.dm"

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -3,11 +3,12 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 /datum/antagonist/renegade
 	role_text = "Renegade"
 	role_text_plural = "Renegades"
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/hos, /datum/job/captain)
 	welcome_text = "Something's going to go wrong today, you can just feel it. You're paranoid, you've got a gun, and you're going to survive."
 	antag_text = "You are a <b>minor</b> antagonist! Within the rules, \
-		try to protect yourself and what's important to you. You aren't here to cause trouble, \
-		you're just more willing (and equipped) to go to extremes to stop it than others are. \
-		Your job is to somewhat oppose the other antagonists, should they threaten you, in ways that aren't quite legal themselves. \
+		try to protect yourself and what's important to you. You aren't here to <i>cause</i> trouble, \
+		you're just willing (and equipped) to go to extremes to <b>stop</b> it. \
+		Your job is to oppose the other antagonists, should they threaten you, in ways that aren't quite legal. \
 		Try to make sure other players have <i>fun</i>! If you are confused or at a loss, always adminhelp, \
 		and before taking extreme actions, please try to also contact the administration! \
 		Think through your actions and make the roleplay immersive! <b>Please remember all \
@@ -33,12 +34,13 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 		/obj/item/weapon/gun/projectile/automatic/mini_uzi,
 		/obj/item/weapon/gun/projectile/automatic/c20r,
 		/obj/item/weapon/gun/projectile/automatic/wt550,
-		/obj/item/weapon/gun/projectile/colt/detective,
-		/obj/item/weapon/gun/projectile/sec/wood,
+		/obj/item/weapon/gun/projectile/colt,
+		/obj/item/weapon/gun/projectile/sec/wood/lethal,
 		/obj/item/weapon/gun/projectile/silenced,
 		/obj/item/weapon/gun/projectile/beretta,
 		/obj/item/weapon/gun/projectile/pistol,
 		/obj/item/weapon/gun/projectile/revolver,
+		/obj/item/weapon/gun/projectile/revolver/webley,
 		/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn,
 		/obj/item/weapon/gun/projectile/magnum_pistol,
 		list(/obj/item/weapon/gun/projectile/revolver/detective, /obj/item/weapon/gun/projectile/revolver/deckard)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -275,7 +275,8 @@ var/global/list/additional_antag_types = list()
 		"an emissary for the gestalt requesting a security detail",
 		"a Tajaran slave rebellion",
 		"radical Skrellian transevolutionaries",
-		"classified security operations"
+		"classified security operations",
+		"a gargantuan glowing goat"
 		)
 	command_announcement.Announce("The presence of [pick(reasons)] in the region is tying up all available local emergency resources; emergency response teams cannot be called at this time, and post-evacuation recovery efforts will be substantially delayed.","Emergency Transmission")
 

--- a/code/game/gamemodes/mixed/spyvspy.dm
+++ b/code/game/gamemodes/mixed/spyvspy.dm
@@ -1,0 +1,12 @@
+/datum/game_mode/spyvspy
+	name = "Spy v. Spy"
+	round_description = "There are traitorous forces at play, but some crew have resolved to stop them by any means necessary!"
+	extended_round_description = "Traitors and renegades both spawn during this mode."
+	config_tag = "spyvspy"
+	required_players = 10
+	required_enemies = 4
+	end_on_antag_death = 0
+	antag_tags = list(MODE_TRAITOR, MODE_RENEGADE)
+	require_all_templates = 1
+	antag_scaling_coeff = 5
+	latejoin_antag_tags = list(MODE_TRAITOR)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -62,6 +62,9 @@
 	else
 		icon_state = "secgundark-e"
 
+/obj/item/weapon/gun/projectile/sec/wood/lethal
+	magazine_type = /obj/item/ammo_magazine/c45m
+
 /obj/item/weapon/gun/projectile/silenced
 	name = "silenced pistol"
 	desc = "A handgun with an integral silencer. Uses .45 rounds."
@@ -76,10 +79,10 @@
 
 /obj/item/weapon/gun/projectile/magnum_pistol
 	name = ".50 magnum pistol"
-	desc = "The HelTek Magnus, a robust terran handgun that uses .50 AE ammo."
+	desc = "The HelTek Magnus, a robust Terran handgun that uses .50 AE ammo."
 	icon_state = "magnum"
 	item_state = "revolver"
-	force = 14.0
+	force = 9
 	caliber = ".50"
 	fire_delay = 12
 	screen_shake = 2


### PR DESCRIPTION
:cl:
rscadd: Added spy v. spy (autotraitors and renegades) to game mode selection and secret.
tweak: Law enforcement (security officer, warden, HoS) and the Captain may no longer be renegades at round start.
tweak: Reduced the force of the magnum pistol's melee attack from 14 to 9.
/:cl: