### PR TITLE
Gives forensics secbelt back

### DIFF
--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -136,6 +136,7 @@
 		/obj/item/device/holowarrant,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/storage/belt/holster/forensic,
+		/obj/item/weapon/storage/belt/holster/security,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)


### PR DESCRIPTION
fitting sec gear in bags isn't ideal

🆑 CrimsonShrike
tweak: Forensics locker will once again contain a security belt for those who feel the need of carrying their gear.
/🆑
