### PR TITLE
Fix being able to insert any item into the uniform vendor

### DIFF
--- a/maps/torch/items/uniform_vendor.dm
+++ b/maps/torch/items/uniform_vendor.dm
@@ -64,7 +64,7 @@
 			selected_outfit.Cut()
 		else
 			var/obj/item/weapon/card/id/I = user.get_active_hand()
-			if(I && user.unEquip(I, src))
+			if(istype(I) && user.unEquip(I, src))
 				ID = I
 		. = TOPIC_REFRESH
 	if(href_list["get_all"])


### PR DESCRIPTION
I'm not sure what the intention of this check was. I assume it was so that you could insert a PDA with an ID inside, but that doesn't work. What does work is inserting any item in the game and bricking the vendor if you don't remove it before closing the window.