### PR TITLE
Adds basic lost souls for starlight deity

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -503,6 +503,7 @@
 #include "code\game\gamemodes\godmode\form_items\narsie_items.dm"
 #include "code\game\gamemodes\godmode\form_items\narsie_structures.dm"
 #include "code\game\gamemodes\godmode\form_items\starlight_items.dm"
+#include "code\game\gamemodes\godmode\form_items\starlight_mobs.dm"
 #include "code\game\gamemodes\godmode\form_items\starlight_structures.dm"
 #include "code\game\gamemodes\godmode\form_items\wizard_structures.dm"
 #include "code\game\gamemodes\heist\heist.dm"

--- a/code/game/gamemodes/godmode/form_items/starlight_mobs.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_mobs.dm
@@ -2,14 +2,20 @@
 	name = "soul"
 	desc = "A captured soul."
 
-/mob/living/starlight_soul/New(var/loc, var/mob/living/old_mob)
-	..(loc)
+/mob/living/starlight_soul/Initialize(var/maploading, var/mob/living/old_mob)
+	. = ..()
 	var/mob/observer/eye/cult/C = new(src)
 	C.suffix = "Soul"
 	name = old_mob.real_name
 	eyeobj = C
 
 /mob/living/starlight_soul/proc/set_deity(var/mob/living/deity/deity)
+	var/mob/observer/eye/eye = eyeobj
+	eyeobj.release(src)
 	eyeobj.visualnet = deity.eyeobj.visualnet
 	GLOB.godcult.add_antagonist_mind(src.mind,1,"lost soul of [deity]", "You have been captured by \the [deity]! You now can only see into your own reality through the same rips and tears it uses. Your only chance at another body will be one in your captor's image...",specific_god=deity)
-	eyeobj.possess(src)
+	eye.possess(src)
+
+/mob/living/starlight_soul/Destroy()
+	QDEL_NULL(eyeobj)
+	. = ..()

--- a/code/game/gamemodes/godmode/form_items/starlight_mobs.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_mobs.dm
@@ -1,0 +1,15 @@
+/mob/living/starlight_soul
+	name = "soul"
+	desc = "A captured soul."
+
+/mob/living/starlight_soul/New(var/loc, var/mob/living/old_mob)
+	..(loc)
+	var/mob/observer/eye/cult/C = new(src)
+	C.suffix = "Soul"
+	name = old_mob.real_name
+	eyeobj = C
+
+/mob/living/starlight_soul/proc/set_deity(var/mob/living/deity/deity)
+	eyeobj.visualnet = deity.eyeobj.visualnet
+	GLOB.godcult.add_antagonist_mind(src.mind,1,"lost soul of [deity]", "You have been captured by \the [deity]! You now can only see into your own reality through the same rips and tears it uses. Your only chance at another body will be one in your captor's image...",specific_god=deity)
+	eyeobj.possess(src)

--- a/code/game/gamemodes/godmode/form_items/starlight_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_structures.dm
@@ -4,7 +4,6 @@
 	power_adjustment = 0
 	var/weakref/target_ref
 	var/start_time = 0
-	var/active_souls = 0
 	var/power_drain = 15
 
 /obj/structure/deity/gateway/New()
@@ -14,21 +13,36 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/deity/gateway/Process()
-	var/mob/living/carbon/human/target = target_ref.resolve()
+	if(!linked_god)
+		return
+	if(linked_god.power <= 0)
+		to_chat(linked_god,"<span class='warning'>\The [src] disappears from your lack of power!</span>")
+		qdel(src)
+		return
+	var/mob/living/carbon/human/target
+	if(target_ref)
+		target = target_ref.resolve()
 	if(target)
 		if(get_turf(target) != get_turf(src))
 			target = null
+			target_ref = null
 			start_time = 0
+			return
 		else if(prob(5))
 			to_chat(target,"<span class='danger'>\The [src] sucks at your lifeforce!</span>")
-	if(start_time && world.time > start_time + 3000)
-		start_time = 0
-		to_chat(target,"<span class='danger'>You have been sucked into \the [src], your soul used to fuel \the [linked_god]'s minions.</span>")
-		target.dust()
-		active_souls++
-		if(linked_god && power_drain < 5)
-			linked_god.power_per_regen += 3
-			power_drain += 3
+		if(start_time && world.time > start_time + 300)
+			start_time = 0
+			to_chat(target,"<span class='danger'>You have been sucked into \the [src], your soul used to fuel \the [linked_god]'s minions.</span>")
+			var/mob/living/starlight_soul/ss = new(get_turf(linked_god),target)
+			if(target.mind)
+				target.mind.transfer_to(ss)
+			else
+				ss.ckey = target.ckey
+			ss.set_deity(linked_god)
+			target.dust()
+			if(power_drain > 5)
+				linked_god.power_per_regen += 3
+				power_drain -= 3
 	else
 		//Get new target
 		var/mob/living/carbon/human/T = locate() in get_turf(src)

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -39,6 +39,20 @@
 	intuned -= L
 	GLOB.destroyed_event.unregister(L, src)
 
+/obj/structure/deity/pylon/OnTopic(var/user, var/href_list)
+	if(href_list["vision_jump"])
+		if(istype(user, /mob/living/carbon/human))
+			to_chat(user,"<span class='warning'>You feel your body lurch uncomfortably as your consciousness jumps to \the [src]</span>")
+			if(prob(5))
+				var/mob/living/carbon/human/H = user
+				H.vomit()
+		else
+			to_chat(user, "<span class='notice'>You jump to \the [src]</span>")
+		var/mob/M = user
+		if(M.eyeobj)
+			M.eyeobj.setLoc(locate(href_list["vision_jump"]))
+		else
+			CRASH("[user] does not have an eyeobj")
 
 /obj/structure/deity/pylon/hear_talk(mob/M as mob, text, verb, datum/language/speaking)
 	if(!linked_god)
@@ -51,3 +65,8 @@
 				continue
 			P.audible_message("<b>\The [P]</b> resonates, \"[text]\"")
 	to_chat(linked_god, "\icon[src] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[linked_god];jump=\ref[src];'>P</A>) [verb], [linked_god.pylon == src ? "<b>" : ""]<span class='message'><span class='body'>\"[text]\"</span></span>[linked_god.pylon == src ? "</b>" : ""]</span>")
+	if(linked_god.minions.len)
+		for(var/minion in linked_god.minions)
+			var/datum/mind/mind = minion
+			if(mind.current && mind.current.eyeobj) //If it is currently having a vision of some sort
+				to_chat(mind.current,"\icon[src] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span></span>")

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -69,4 +69,4 @@
 		for(var/minion in linked_god.minions)
 			var/datum/mind/mind = minion
 			if(mind.current && mind.current.eyeobj) //If it is currently having a vision of some sort
-				to_chat(mind.current,"\icon[src] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span></span>")
+				to_chat(mind.current,"\icon[src] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span>")

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -39,20 +39,20 @@
 	intuned -= L
 	GLOB.destroyed_event.unregister(L, src)
 
-/obj/structure/deity/pylon/OnTopic(var/user, var/href_list)
+/obj/structure/deity/pylon/OnTopic(var/mob/living/carbon/human/user, var/href_list)
 	if(href_list["vision_jump"])
-		if(istype(user, /mob/living/carbon/human))
+		if(istype(user))
 			to_chat(user,"<span class='warning'>You feel your body lurch uncomfortably as your consciousness jumps to \the [src]</span>")
 			if(prob(5))
-				var/mob/living/carbon/human/H = user
-				H.vomit()
+				user.vomit()
 		else
 			to_chat(user, "<span class='notice'>You jump to \the [src]</span>")
-		var/mob/M = user
-		if(M.eyeobj)
-			M.eyeobj.setLoc(locate(href_list["vision_jump"]))
+		if(user.eyeobj)
+			user.eyeobj.setLoc(locate(href_list["vision_jump"]))
 		else
 			CRASH("[user] does not have an eyeobj")
+		. = TOPIC_REFRESH
+	. = ..()
 
 /obj/structure/deity/pylon/hear_talk(mob/M as mob, text, verb, datum/language/speaking)
 	if(!linked_god)

--- a/html/changelogs/TheWelp - lostSouls.yml
+++ b/html/changelogs/TheWelp - lostSouls.yml
@@ -1,0 +1,6 @@
+author: zaredman
+delete-after: True
+
+changes: 
+  - rscadd: "Adds the Lost Souls, the remnants of souls sucked into the Starlight Gateway (for future deity mode)."
+  - rscadd: "Added the ability for god cultists (and lost souls) to be able to hear through the pylons like the deity can."

--- a/html/changelogs/TheWelp - lostSouls.yml
+++ b/html/changelogs/TheWelp - lostSouls.yml
@@ -1,4 +1,4 @@
-author: zaredman
+author: TheWelp
 delete-after: True
 
 changes: 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Lost Souls are the starlight deity's fuel for the three starlight races. They use a phenomena on a gateway, and if there are any souls, a soldier pops out!

Now in this PR I have not implemented that part, I think I'll save that for the phenomena PR, but instead I have made the actual lost souls themselves.

They cannot move, but they can see whatever the deity sees. They cannot interact with the crew, BUT they can interact with the deity itself, by talking to it. They can listen in on the pylons, same as the deity, and they can even jump to them like the deity does.