### PR TITLE
Adds brittle and crystalline status for limbs.

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -32,29 +32,29 @@
 #define  AIR_DAMAGE_MODIFIER 2.025  // More means less damage from hot air scalding lungs, less = more damage. (default 2.025)
 
 // Organ defines.
-#define ORGAN_CUT_AWAY   (1<<0)
-#define ORGAN_BLEEDING   (1<<1)
-#define ORGAN_BROKEN     (1<<2)
-#define ORGAN_DEAD       (1<<3)
-#define ORGAN_MUTATED    (1<<4)
-#define ORGAN_ARTERY_CUT (1<<6)
-#define ORGAN_TENDON_CUT (1<<7)
-#define ORGAN_DISFIGURED (1<<8)
-#define ORGAN_SABOTAGED  (1<<9)
-#define ORGAN_ASSISTED   (1<<10)
-#define ORGAN_ROBOTIC    (1<<11)
-#define ORGAN_BRITTLE    (1<<12)
-#define ORGAN_CRYSTAL    (1<<13)
+#define ORGAN_CUT_AWAY   (1<<0)  // The organ is in the process of being surgically removed.
+#define ORGAN_BLEEDING   (1<<1)  // The organ is currently bleeding.
+#define ORGAN_BROKEN     (1<<2)  // The organ is broken.
+#define ORGAN_DEAD       (1<<3)  // The organ is necrotic.
+#define ORGAN_MUTATED    (1<<4)  // The organ is unusable due to genetic damage.
+#define ORGAN_ARTERY_CUT (1<<6)  // The organ has had its artery cut.
+#define ORGAN_TENDON_CUT (1<<7)  // The organ has had its tendon cut.
+#define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised.
+#define ORGAN_SABOTAGED  (1<<9)  // The organ will explode if exposed to EMP, if prosthetic.
+#define ORGAN_ASSISTED   (1<<10) // The organ is partially prosthetic. No mechanical effect.
+#define ORGAN_ROBOTIC    (1<<11) // The organ is robotic. Changes numerous behaviors, search BP_IS_ROBOTIC for checks.
+#define ORGAN_BRITTLE    (1<<12) // The organ takes additional blunt damage. If robotic, cannot be repaired through normal means.
+#define ORGAN_CRYSTAL    (1<<13) // The organ does not suffer laser damage, but shatters on droplimb.
 
 // Organ flag defines.
-#define ORGAN_FLAG_CAN_AMPUTATE   (1<<0)
-#define ORGAN_FLAG_CAN_BREAK      (1<<1)
-#define ORGAN_FLAG_CAN_GRASP      (1<<2)
-#define ORGAN_FLAG_CAN_STAND      (1<<3)
-#define ORGAN_FLAG_HAS_TENDON     (1<<4)
-#define ORGAN_FLAG_FINGERPRINT    (1<<5)
-#define ORGAN_FLAG_GENDERED_ICON  (1<<6)
-#define ORGAN_FLAG_HEALS_OVERKILL (1<<7)
+#define ORGAN_FLAG_CAN_AMPUTATE   (1<<0) // The organ can be amputated.
+#define ORGAN_FLAG_CAN_BREAK      (1<<1) // The organ can be broken.
+#define ORGAN_FLAG_CAN_GRASP      (1<<2) // The organ contributes to grasping.
+#define ORGAN_FLAG_CAN_STAND      (1<<3) // The organ contributes to standing.
+#define ORGAN_FLAG_HAS_TENDON     (1<<4) // The organ can have its tendon cut.
+#define ORGAN_FLAG_FINGERPRINT    (1<<5) // The organ has a fingerprint.
+#define ORGAN_FLAG_GENDERED_ICON  (1<<6) // The icon state for this organ appends _m/_f.
+#define ORGAN_FLAG_HEALS_OVERKILL (1<<7) // The organ heals from overkill damage.
 
 // Droplimb types.
 #define DROPLIMB_EDGE 0

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -12,6 +12,7 @@
 #define BRUISE    "bruise"
 #define PIERCE    "pierce"
 #define LASER     "laser"
+#define SHATTER   "shatter"
 
 #define STUN      "stun"
 #define WEAKEN    "weaken"
@@ -42,6 +43,8 @@
 #define ORGAN_SABOTAGED  (1<<9)
 #define ORGAN_ASSISTED   (1<<10)
 #define ORGAN_ROBOTIC    (1<<11)
+#define ORGAN_BRITTLE    (1<<12)
+#define ORGAN_CRYSTAL    (1<<13)
 
 // Organ flag defines.
 #define ORGAN_FLAG_CAN_AMPUTATE   (1<<0)

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -220,6 +220,7 @@
 #define BP_IS_ROBOTIC(org)  (org.status & ORGAN_ROBOTIC)
 #define BP_IS_ASSISTED(org) (org.status & ORGAN_ASSISTED)
 #define BP_IS_BRITTLE(org)  (org.status & ORGAN_BRITTLE)
+#define BP_IS_CRYSTAL(org)  (org.status & ORGAN_CRYSTAL)
 
 #define SYNTH_BLOOD_COLOUR "#030303"
 #define SYNTH_FLESH_COLOUR "#575757"

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -219,6 +219,7 @@
 // Prosthetic helpers.
 #define BP_IS_ROBOTIC(org)  (org.status & ORGAN_ROBOTIC)
 #define BP_IS_ASSISTED(org) (org.status & ORGAN_ASSISTED)
+#define BP_IS_BRITTLE(org)  (org.status & ORGAN_BRITTLE)
 
 #define SYNTH_BLOOD_COLOUR "#030303"
 #define SYNTH_FLESH_COLOUR "#575757"

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -30,6 +30,11 @@
 
 		if(!S)
 			to_chat(user, "<span class='warning'>\The [M] is missing that body part.</span>")
+			return
+
+		if(BP_IS_BRITTLE(S))
+			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
+			return
 
 		if(S && BP_IS_ROBOTIC(S) && S.hatch_state == HATCH_OPENED)
 			if(!S.get_damage())

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -560,6 +560,10 @@
 		if(!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
 			return ..()
 
+		if(BP_IS_BRITTLE(S))
+			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src]  cannot repair it.</span>")
+			return 1
+
 		if(!welding)
 			to_chat(user, "<span class='warning'>You'll need to turn [src] on to patch the damage on [M]'s [S.name]!</span>")
 			return 1

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -271,6 +271,11 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	conductive = 0
 
+/material/diamond/crystal
+	name = "crystal"
+	hardness = 80
+	stack_type = null
+
 /material/gold
 	name = "gold"
 	stack_type = /obj/item/stack/material/gold

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -46,8 +46,8 @@
 	var/is_synth = isSynthetic()
 	if(!(skipjumpsuit && skipface))
 		var/species_name = "\improper "
-		if(is_synth && species.type != /datum/species/machine)
-			species_name += "Cyborg "
+		if(is_synth && species.cyborg_noun)
+			species_name += "[species.cyborg_noun] "
 		species_name += "[species.name]"
 		msg += ", <b><font color='[species.get_flesh_colour(src)]'> \a [species_name]!</font></b>"
 	var/extra_species_text = species.get_additional_examine_text(src)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -331,6 +331,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 	for(var/obj/item/organ/O in (H.organs|H.internal_organs))
 		O.owner = H
+		post_organ_rejuvenate(O)
 
 	H.sync_organ_dna()
 
@@ -696,3 +697,6 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		if(23 to 30) 	. = 0
 		if(31 to 45)	. = 4
 		else			. = 8
+
+/datum/species/proc/post_organ_rejuvenate(var/obj/item/organ/org)
+	return

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -8,6 +8,7 @@
 	var/name                                             // Species name.
 	var/name_plural                                      // Pluralized name (since "[name]s" is not always valid)
 	var/blurb = "A completely nondescript species."      // A brief lore summary for use in the chargen screen.
+	var/cyborg_noun = "Cyborg"
 
 	// Icon/appearance vars.
 	var/icobase =      'icons/mob/human_races/species/human/body.dmi'          // Normal icon set.

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -29,9 +29,10 @@
 	if(H.mind)
 		H.mind.assigned_role = "Golem"
 		H.mind.special_role = "Golem"
-	H.real_name = "adamantine golem ([rand(1, 1000)])"
+	H.real_name = "golem ([rand(1, 1000)])"
 	H.SetName(H.real_name)
-	for(var/thing in H.organs)
-		var/obj/item/organ/external/E = thing
-		E.brittle = TRUE
 	..()
+
+/datum/species/golem/post_organ_rejuvenate(var/obj/item/organ/org)
+	org.status |= ORGAN_BRITTLE
+	org.status |= ORGAN_CRYSTAL

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -31,4 +31,7 @@
 		H.mind.special_role = "Golem"
 	H.real_name = "adamantine golem ([rand(1, 1000)])"
 	H.SetName(H.real_name)
+	for(var/thing in H.organs)
+		var/obj/item/organ/external/E = thing
+		E.brittle = TRUE
 	..()

--- a/code/modules/mob/living/carbon/human/species/station/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine.dm
@@ -7,6 +7,7 @@
 	to corporate operations. IPCs (Integrated Positronic Chassis) are a loose category of self-willed robots with a humanoid form, \
 	generally self-owned after being 'born' into servitude; they are reliable and dedicated workers, albeit more than slightly \
 	inhuman in outlook and perspective."
+	cyborg_noun = null
 
 	preview_icon = 'icons/mob/human_races/species/ipc/preview.dmi'
 

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -270,7 +270,7 @@
 	var/mob/living/carbon/human/G = new(src.loc)
 	G.set_species("Golem")
 	G.key = ghost.key
-	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. Serve [user], and assist them in completing their goals at any cost.")
+	to_chat(G, "You are a golem. You move slowly, but are highly resistant to heat and cold. You are however vulnerable to blunt trauma. Serve [user], and assist them in completing their goals at any cost.")
 	qdel(src)
 
 

--- a/code/modules/mob/living/deity/phenomena/transmutation.dm
+++ b/code/modules/mob/living/deity/phenomena/transmutation.dm
@@ -21,6 +21,6 @@
 
 /datum/phenomena/rock_form/activate(var/mob/living/carbon/human/H)
 	..()
-	to_chat(H, "<span class='danger'>You feel your body harden as it rapidly is transformed into living stone!</span>")
+	to_chat(H, "<span class='danger'>You feel your body harden as it rapidly is transformed into living crystal!</span>")
 	H.set_species("Golem")
 	H.Weaken(5)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -63,7 +63,6 @@
 	var/arterial_bleed_severity = 1    // Multiplier for bleeding in a limb.
 	var/tendon_name = "tendon"         // Flavour text for Achilles tendon, etc.
 	var/cavity_name = "cavity"
-	var/brittle = FALSE // Temp, replace with bitflag when organ PR is merged.
 
 	// Surgery vars.
 	var/cavity_max_w_class = 0
@@ -143,8 +142,12 @@
 
 /obj/item/organ/external/emp_act(severity)
 
+	if(!BP_IS_ROBOTIC(src))
+		return
 
-	if(robotic <= 0)
+	if(owner && BP_IS_CRYSTAL(src)) // Crystalline robotics == piezoelectrics.
+		owner.Weaken(5 - severity)
+		owner.confused = max(owner.confused, 10 - (severity * 2))
 		return
 
 	var/burn_damage = 0
@@ -425,6 +428,9 @@ This function completely restores a damaged organ to perfect condition.
 					robotize()
 		owner.updatehealth()
 
+	if(!QDELETED(src) && species)
+		species.post_organ_rejuvenate(src)
+
 /obj/item/organ/external/remove_rejuv()
 	if(owner)
 		owner.organs -= src
@@ -441,8 +447,25 @@ This function completely restores a damaged organ to perfect condition.
 
 /obj/item/organ/external/proc/createwound(var/type = CUT, var/damage, var/surgical)
 
-	if(damage == 0)
+	// Handle some status-based damage multipliers.
+	if(type == BRUISE && BP_IS_BRITTLE(src))
+		damage = Floor(damage * 1.5)
+
+	if(BP_IS_CRYSTAL(src))
+		// this needs to cover type == BURN because lasers don't use LASER, but with the way bodytemp
+		// damage is handled currently that isn't really possible without an infinite feedback loop.
+		if(type == LASER)
+			owner.bodytemperature += ceil(damage/10)
+			owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
+			return
+		damage = Floor(damage * 0.8)
+		type = SHATTER
+
+	if(damage <= 0)
 		return
+
+	if(loc && type == SHATTER)
+		playsound(loc, 'sound/effects/hit_on_shattered_glass.ogg', 40, 1) // Crash!
 
 	//moved these before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 	//Brute damage can possibly trigger an internal wound, too.
@@ -479,12 +502,16 @@ This function completely restores a damaged organ to perfect condition.
 				var/datum/wound/W = pick(compatible_wounds)
 				W.open_wound(damage)
 				if(prob(25))
-					if(BP_IS_ROBOTIC(src))
-						owner.visible_message("<span class='danger'>The damage to [owner.name]'s [name] worsens.</span>",\
+					if(BP_IS_CRYSTAL(src))
+						owner.visible_message("<span class='danger'>The cracks in \the [owner]'s [name] spread.</span>",\
+						"<span class='danger'>The cracks in your [name] spread.</span>",\
+						"<span class='danger'>You hear the cracking of crystal.</span>")
+					else if(BP_IS_ROBOTIC(src))
+						owner.visible_message("<span class='danger'>The damage to \the [owner]'s [name] worsens.</span>",\
 						"<span class='danger'>The damage to your [name] worsens.</span>",\
 						"<span class='danger'>You hear the screech of abused metal.</span>")
 					else
-						owner.visible_message("<span class='danger'>The wound on [owner.name]'s [name] widens with a nasty ripping noise.</span>",\
+						owner.visible_message("<span class='danger'>The wound on \the [owner]'s [name] widens with a nasty ripping noise.</span>",\
 						"<span class='danger'>The wound on your [name] widens with a nasty ripping noise.</span>",\
 						"<span class='danger'>You hear a nasty ripping noise, as if flesh is being torn apart.</span>")
 				return W
@@ -701,13 +728,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 		H = owner
 
 	//update damage counts
+	var/bleeds = (!BP_IS_ROBOTIC(src) && !BP_IS_CRYSTAL(src))
 	for(var/datum/wound/W in wounds)
 		if(W.damage_type == BURN)
 			burn_dam += W.damage
 		else
 			brute_dam += W.damage
 
-		if(!BP_IS_ROBOTIC(src) && W.bleeding() && (H && H.should_have_organ(BP_HEART)))
+		if(bleeds && W.bleeding() && (H && H.should_have_organ(BP_HEART)))
 			W.bleed_timer--
 			status |= ORGAN_BLEEDING
 
@@ -760,30 +788,39 @@ Note that amputating the affected organ does in fact remove the infection from t
 			   DISMEMBERMENT
 ****************************************************/
 /obj/item/organ/external/proc/get_droplimb_messages_for(var/droptype, var/clean)
-	switch(droptype)
-		if(DROPLIMB_EDGE)
-			if(!clean)
-				var/gore_sound = "[BP_IS_ROBOTIC(src) ? "tortured metal" : "ripping tendons and flesh"]"
+
+	if(BP_IS_CRYSTAL(src))
+		playsound(src, "shatter", 70, 1)
+		return list(
+			"\The [owner]'s [src.name] shatters into a thousand pieces!",
+			"Your [src.name] shatters into a thousand pieces!",
+			"You hear the sound of something shattering!"
+		)
+	else
+		switch(droptype)
+			if(DROPLIMB_EDGE)
+				if(!clean)
+					var/gore_sound = "[BP_IS_ROBOTIC(src) ? "tortured metal" : "ripping tendons and flesh"]"
+					return list(
+						"\The [owner]'s [src.name] flies off in an arc!",
+						"Your [src.name] goes flying off!",
+						"You hear a terrible sound of [gore_sound]."
+						)
+			if(DROPLIMB_BURN)
+				var/gore = "[BP_IS_ROBOTIC(src) ? "": " of burning flesh"]"
 				return list(
-					"\The [owner]'s [src.name] flies off in an arc!",\
-					"Your [src.name] goes flying off!",\
-					"You hear a terrible sound of [gore_sound]." \
+					"\The [owner]'s [src.name] flashes away into ashes!",
+					"Your [src.name] flashes away into ashes!",
+					"You hear a crackling sound[gore]."
 					)
-		if(DROPLIMB_BURN)
-			var/gore = "[BP_IS_ROBOTIC(src) ? "": " of burning flesh"]"
-			return list(
-				"\The [owner]'s [src.name] flashes away into ashes!",\
-				"Your [src.name] flashes away into ashes!",\
-				"You hear a crackling sound[gore]." \
-				)
-		if(DROPLIMB_BLUNT)
-			var/gore = "[BP_IS_ROBOTIC(src) ? "": " in shower of gore"]"
-			var/gore_sound = "[BP_IS_ROBOTIC(src) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
-			return list(
-				"\The [owner]'s [src.name] explodes[gore]!",\
-				"Your [src.name] explodes[gore]!",\
-				"You hear the [gore_sound]." \
-				)
+			if(DROPLIMB_BLUNT)
+				var/gore = "[BP_IS_ROBOTIC(src) ? "": " in shower of gore"]"
+				var/gore_sound = "[BP_IS_ROBOTIC(src) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
+				return list(
+					"\The [owner]'s [src.name] explodes[gore]!",
+					"Your [src.name] explodes[gore]!",
+					"You hear the [gore_sound]."
+					)
 
 //Handles dismemberment
 /obj/item/organ/external/proc/droplimb(var/clean, var/disintegrate = DROPLIMB_EDGE, var/ignore_children, var/silent)
@@ -791,7 +828,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!(limb_flags & ORGAN_FLAG_CAN_AMPUTATE) || !owner)
 		return
 
-	if(disintegrate == DROPLIMB_EDGE && species.limbs_are_nonsolid)
+	if(BP_IS_CRYSTAL(src) || (disintegrate == DROPLIMB_EDGE && species.limbs_are_nonsolid))
 		disintegrate = DROPLIMB_BLUNT //splut
 
 	var/list/organ_msgs = get_droplimb_messages_for(disintegrate, clean)
@@ -823,8 +860,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 			stump.artery_name = "mangled [artery_name]"
 			stump.arterial_bleed_severity = arterial_bleed_severity
 			stump.add_pain(max_damage)
-			if(BP_IS_ROBOTIC(src))
-				stump.robotize()
 			W.parent_organ = stump
 			stump.wounds |= W
 			victim.organs |= stump
@@ -857,15 +892,18 @@ Note that amputating the affected organ does in fact remove the infection from t
 					I.loc = get_turf(src)
 			qdel(src)
 		if(DROPLIMB_BLUNT)
-			var/obj/effect/decal/cleanable/blood/gibs/gore
-			if(BP_IS_ROBOTIC(src))
+			var/obj/gore
+			if(BP_IS_CRYSTAL(src))
+				gore = new /obj/item/weapon/material/shard(get_turf(victim), "crystal")
+			else if(BP_IS_ROBOTIC(src))
 				gore = new /obj/effect/decal/cleanable/blood/gibs/robot(get_turf(victim))
 			else
 				gore = new /obj/effect/decal/cleanable/blood/gibs(get_turf(victim))
 				if(species)
-					gore.fleshcolor = use_flesh_colour
-					gore.basecolor =  use_blood_colour
-					gore.update_icon()
+					var/obj/effect/decal/cleanable/blood/gibs/G = gore
+					G.fleshcolor = use_flesh_colour
+					G.basecolor =  use_blood_colour
+					G.update_icon()
 
 			gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -146,8 +146,8 @@
 		return
 
 	if(owner && BP_IS_CRYSTAL(src)) // Crystalline robotics == piezoelectrics.
-		owner.Weaken(5 - severity)
-		owner.confused = max(owner.confused, 10 - (severity * 2))
+		owner.Weaken(4 - severity)
+		owner.confused = max(owner.confused, 6 - (severity * 2))
 		return
 
 	var/burn_damage = 0
@@ -456,7 +456,8 @@ This function completely restores a damaged organ to perfect condition.
 		// damage is handled currently that isn't really possible without an infinite feedback loop.
 		if(type == LASER)
 			owner.bodytemperature += ceil(damage/10)
-			owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
+			if(prob(25))
+				owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
 			return
 		damage = Floor(damage * 0.8)
 		type = SHATTER

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -63,6 +63,7 @@
 	var/arterial_bleed_severity = 1    // Multiplier for bleeding in a limb.
 	var/tendon_name = "tendon"         // Flavour text for Achilles tendon, etc.
 	var/cavity_name = "cavity"
+	var/brittle = FALSE // Temp, replace with bitflag when organ PR is merged.
 
 	// Surgery vars.
 	var/cavity_max_w_class = 0
@@ -141,6 +142,11 @@
 	s_base = new_dna.s_base
 
 /obj/item/organ/external/emp_act(severity)
+
+
+	if(robotic <= 0)
+		return
+
 	var/burn_damage = 0
 	switch (severity)
 		if (1)

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -15,6 +15,8 @@
 		max_damage = limb.max_damage
 		if(BP_IS_ROBOTIC(limb) && (!parent || BP_IS_ROBOTIC(parent)))
 			robotize() //if both limb and the parent are robotic, the stump is robotic too
+		if(BP_IS_CRYSTAL(limb) && (!parent || BP_IS_CRYSTAL(parent)))
+			status |= ORGAN_CRYSTAL // Likewise with crystalline limbs.
 
 /obj/item/organ/external/stump/is_stump()
 	return 1

--- a/code/modules/organs/external/wounds/wound_types.dm
+++ b/code/modules/organs/external/wounds/wound_types.dm
@@ -45,6 +45,19 @@
 					return /datum/wound/burn/large
 				if(0 to 15)
 					return /datum/wound/burn/moderate
+		if(SHATTER)
+			switch(damage)
+				if(50 to INFINITY)
+					return /datum/wound/shatter/smashed
+				if(40 to 50)
+					return /datum/wound/shatter/wide
+				if(30 to 40)
+					return /datum/wound/shatter/narrow
+				if(15 to 30)
+					return /datum/wound/shatter/cracked
+				if(0 to 15)
+					return /datum/wound/shatter/chipped
+
 	return null //no wound
 
 /** CUTS **/
@@ -260,17 +273,26 @@ datum/wound/puncture/massive
 	switch(losstype)
 		if(DROPLIMB_EDGE, DROPLIMB_BLUNT)
 			damage_type = CUT
-			max_bleeding_stage = 3 //clotted stump and above can bleed.
-			stages = list(
-				"ripped stump" = damage_amt*1.3,
-				"bloody stump" = damage_amt,
-				"clotted stump" = damage_amt*0.5,
-				"scarred stump" = 0
+			if(BP_IS_ROBOTIC(lost_limb))
+				max_bleeding_stage = -1
+				bleed_threshold = INFINITY
+				stages = list("mangled robotic socket" = 0)
+			else if(BP_IS_CRYSTAL(lost_limb))
+				max_bleeding_stage = -1
+				bleed_threshold = INFINITY
+				stages = list("shattered stump" = 0)
+			else
+				max_bleeding_stage = 3 //clotted stump and above can bleed.
+				stages = list(
+					"ripped stump" = damage_amt*1.3,
+					"bloody stump" = damage_amt,
+					"clotted stump" = damage_amt*0.5,
+					"scarred stump" = 0
 				)
 		if(DROPLIMB_BURN)
 			damage_type = BURN
 			stages = list(
-				"ripped charred stump" = damage_amt*1.3,
+				"mangled charred stump" = damage_amt*1.3,
 				"charred stump" = damage_amt,
 				"scarred stump" = damage_amt*0.5,
 				"scarred stump" = 0
@@ -280,3 +302,33 @@ datum/wound/puncture/massive
 
 /datum/wound/lost_limb/can_merge(var/datum/wound/other)
 	return 0 //cannot be merged
+
+/** CRYSTALLINE WOUNDS **/
+/datum/wound/shatter
+	bleed_threshold = INFINITY
+	damage_type = SHATTER
+	max_bleeding_stage = -1
+
+/datum/wound/shatter/bleeding()
+	return FALSE
+
+/datum/wound/shatter/can_autoheal()
+	return FALSE
+
+/datum/wound/shatter/infection_check()
+	return FALSE
+
+/datum/wound/shatter/smashed
+	stages = list("shattered hole" = 0)
+
+/datum/wound/shatter/wide
+	stages = list("gaping crack" = 0)
+
+/datum/wound/shatter/narrow
+	stages = list("wide crack" = 0)
+
+/datum/wound/shatter/cracked
+	stages = list("narrow crack" = 0)
+
+/datum/wound/shatter/chipped
+	stages = list("chip" = 0)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -320,7 +320,9 @@ var/list/organ_cache = list()
 
 /obj/item/organ/proc/get_scan_results()
 	. = list()
-	if(BP_IS_ASSISTED(src))
+	if(BP_IS_CRYSTAL(src))
+		. += "Crystalline"
+	else if(BP_IS_ASSISTED(src))
 		. += "Assisted"
 	else if(BP_IS_ROBOTIC(src))
 		. += "Mechanical"
@@ -334,6 +336,9 @@ var/list/organ_cache = list()
 			. += "Decaying"
 		else
 			. += "Necrotic"
+	if(BP_IS_BRITTLE(src))
+		. += "Brittle"
+
 	switch (germ_level)
 		if (INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + ((INFECTION_LEVEL_TWO - INFECTION_LEVEL_ONE) / 3))
 			. +=  "Mild Infection"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -527,6 +527,10 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		if(!BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
 			return ..()
 
+		if(BP_IS_BRITTLE(S))
+			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
+			return 1
+
 		var/use_amt = min(src.amount, ceil(S.burn_dam/3), 5)
 		if(can_use(use_amt))
 			if(S.robo_repair(3*use_amt, BURN, "some damaged wiring", src, user))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -528,7 +528,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 			return ..()
 
 		if(BP_IS_BRITTLE(S))
-			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
+			to_chat(user, "<span class='warning'>\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
 			return 1
 
 		var/use_amt = min(src.amount, ceil(S.burn_dam/3), 5)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -26,7 +26,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !BP_IS_ROBOTIC(affected) && affected.how_open() >= 2 && affected.stage == 0
+	return affected && !BP_IS_ROBOTIC(affected) && !BP_IS_CRYSTAL(affected) && affected.how_open() >= 2 && (BP_IS_BRITTLE(affected) || affected.stage == 0)
 
 /datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -42,7 +42,9 @@
 	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
 	user.visible_message("<span class='notice'>[user] applies some [tool.name] to [bone]</span>", \
 		"<span class='notice'>You apply some [tool.name] to [bone].</span>")
-	affected.stage = 1
+	if(affected.stage == 0)
+		affected.stage = 1
+	affected.status &= ~ORGAN_BRITTLE
 
 /datum/surgery_step/glue_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -68,7 +70,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.organ_tag != BP_HEAD && !BP_IS_ROBOTIC(affected) && affected.how_open() >= SURGERY_RETRACTED && affected.stage == 1
+	return affected && affected.organ_tag != BP_HEAD && !BP_IS_CRYSTAL(affected) && !BP_IS_ROBOTIC(affected) && affected.how_open() >= SURGERY_RETRACTED && affected.stage == 1
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -18,7 +18,7 @@
 		return 0
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !BP_IS_ROBOTIC(affected) && affected.encased && affected.how_open() >= SURGERY_RETRACTED
+	return affected && !BP_IS_ROBOTIC(affected) && !BP_IS_CRYSTAL(affected) && affected.encased && affected.how_open() >= SURGERY_RETRACTED
 
 //////////////////////////////////////////////////////////////////
 //	ribcage sawing surgery step
@@ -26,7 +26,7 @@
 /datum/surgery_step/open_encased/saw
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100,
-	/obj/item/weapon/material/knife = 50, \
+	/obj/item/weapon/material/knife = 50,
 	/obj/item/weapon/material/hatchet = 75
 	)
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -14,7 +14,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if (!affected || BP_IS_ROBOTIC(affected))
+	if (!affected || BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		return 0
 	return target_zone == BP_MOUTH
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -23,7 +23,7 @@
 		return 0
 	if (affected.is_stump())
 		return 0
-	return !BP_IS_ROBOTIC(affected)
+	return !(BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 
 //////////////////////////////////////////////////////////////////
 //	laser scalpel surgery step

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -42,7 +42,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(!affected)
 		return FALSE
-	if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		return FALSE
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I.damage > 0)
@@ -141,7 +141,7 @@
 	if(!affected)
 		return 0
 
-	if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		return 0
 
 	target.op_stage.current_organ = null
@@ -278,8 +278,12 @@
 	if(!istype(O))
 		return 0
 
+	if(!(BP_IS_CRYSTAL(affected) && BP_IS_CRYSTAL(O)))
+		to_chat(user, "<span class='warning'>You cannot install a crystalline organ into a non-crystalline bodypart.</span>")
+		return SURGERY_FAILURE
+
 	if(BP_IS_ROBOTIC(affected) && !BP_IS_ROBOTIC(O))
-		to_chat(user, "<span class='danger'>You cannot install a naked organ into a robotic body.</span>")
+		to_chat(user, "<span class='warning'>You cannot install a naked organ into a robotic body.</span>")
 		return SURGERY_FAILURE
 
 	if(!target.species)
@@ -355,7 +359,7 @@
 	target.op_stage.current_organ = null
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!affected || BP_IS_ROBOTIC(affected))
+	if(!affected || BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		// robotic attachment handled via screwdriver
 		return 0
 
@@ -435,7 +439,7 @@
 	if(!affected)
 		return 0
 
-	if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		return 0
 
 	target.op_stage.current_organ = null

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -202,7 +202,7 @@
 			var/obj/item/weapon/weldingtool/welder = tool
 			if(!welder.isOn() || !welder.remove_fuel(1,user))
 				return 0
-		return affected && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.brute_dam > 0) && target_zone != BP_MOUTH
+		return affected && !BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.brute_dam > 0) && target_zone != BP_MOUTH
 
 /datum/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -244,7 +244,7 @@
 	if(..())
 		var/obj/item/stack/cable_coil/C = tool
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		var/limb_can_operate = ((affected && affected.hatch_state == HATCH_OPENED) && ((affected.status & ORGAN_DISFIGURED) || affected.burn_dam > 0) && target_zone != BP_MOUTH)
+		var/limb_can_operate = ((affected && !BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED) && ((affected.status & ORGAN_DISFIGURED) || affected.burn_dam > 0) && target_zone != BP_MOUTH)
 		if(limb_can_operate)
 			if(istype(C))
 				if(!C.get_amount() >= 3)
@@ -301,7 +301,7 @@
 	if (!hasorgans(target))
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!affected) return
+	if(!affected || BP_IS_BRITTLE(affected)) return
 
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(BP_IS_ROBOTIC(I) && I.damage > 0)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -486,6 +486,10 @@
 		to_chat(user, "<span class='danger'>That brain is not usable.</span>")
 		return SURGERY_FAILURE
 
+	if(BP_IS_CRYSTAL(affected))
+		to_chat(user, "<span class='danger'>The crystalline interior of \the [affected] is incompatible with \the [M].</span>")
+		return SURGERY_FAILURE
+
 	if(!target.isSynthetic())
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat body.</span>")
 		return SURGERY_FAILURE

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -18,7 +18,7 @@
 		return 0
 	if (affected.status & ORGAN_CUT_AWAY)
 		return 0
-	if (!BP_IS_ROBOTIC(affected))
+	if (!BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		return 0
 	return 1
 
@@ -201,8 +201,16 @@
 		if(isWelder(tool))
 			var/obj/item/weapon/weldingtool/welder = tool
 			if(!welder.isOn() || !welder.remove_fuel(1,user))
-				return 0
-		return affected && !BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.brute_dam > 0) && target_zone != BP_MOUTH
+				return SURGERY_FAILURE
+
+		if(!affected)
+			return SURGERY_FAILURE
+
+		if(BP_IS_BRITTLE(affected))
+			to_chat(user, "<span class='warning'>\The [target]'s [affected.name] is too brittle to be repaired normally.</span>")
+			return SURGERY_FAILURE
+
+		return affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.brute_dam > 0) && target_zone != BP_MOUTH
 
 /datum/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -222,6 +230,41 @@
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>")
 	target.apply_damage(rand(5,10), BURN, affected)
+
+//////////////////////////////////////////////////////////////////
+//	robotic limb brittleness repair surgery step
+//////////////////////////////////////////////////////////////////
+/datum/surgery_step/robotics/repair_brittle
+	allowed_tools = list(/obj/item/stack/nanopaste = 100)
+	min_duration = 50
+	max_duration = 60
+
+/datum/surgery_step/robotics/repair_brittle/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
+		. += 10
+
+/datum/surgery_step/robotics/repair_brittle/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	return ..() && affected && BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED && target_zone != BP_MOUTH
+
+/datum/surgery_step/robotics/repair_brittle/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("[user] begins to repair the brittle metal inside \the [target]'s [affected.name]." , \
+	"You begin to repair the brittle metal inside \the [target]'s [affected.name].")
+	..()
+
+/datum/surgery_step/robotics/repair_brittle/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='notice'>[user] finishes repairing the brittle interior of \the [target]'s [affected.name].</span>", \
+	"<span class='notice'>You finish repairing the brittle interior of \the [target]'s [affected.name].</span>")
+	affected.status &= ~ORGAN_BRITTLE
+
+/datum/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'>[user] causes some of \the [target]'s [affected.name] to crumble!</span>",
+	"<span class='warning'>You cause some of \the [target]'s [affected.name] to crumble!</span>")
+	target.apply_damage(rand(5,10), BRUTE, affected)
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb burn damage repair surgery step
@@ -244,7 +287,12 @@
 	if(..())
 		var/obj/item/stack/cable_coil/C = tool
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		var/limb_can_operate = ((affected && !BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED) && ((affected.status & ORGAN_DISFIGURED) || affected.burn_dam > 0) && target_zone != BP_MOUTH)
+		if(!affected)
+			return SURGERY_FAILURE
+		if(BP_IS_BRITTLE(affected))
+			to_chat(user, "<span class='warning'>\The [target]'s [affected.name] is too brittle for this kind of repair.</span>")
+			return SURGERY_FAILURE
+		var/limb_can_operate = ((affected.hatch_state == HATCH_OPENED) && ((affected.status & ORGAN_DISFIGURED) || affected.burn_dam > 0) && target_zone != BP_MOUTH)
 		if(limb_can_operate)
 			if(istype(C))
 				if(!C.get_amount() >= 3)
@@ -301,10 +349,10 @@
 	if (!hasorgans(target))
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!affected || BP_IS_BRITTLE(affected)) return
+	if(!affected) return
 
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(BP_IS_ROBOTIC(I) && I.damage > 0)
+		if(BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
 			if(I.surface_accessible)
 				return TRUE
 			if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED) || affected.hatch_state == HATCH_OPENED)
@@ -377,7 +425,7 @@
 	var/list/attached_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && !(I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
+		if(I && !(I.status & ORGAN_CUT_AWAY) && !BP_IS_CRYSTAL(I) && I.parent_organ == target_zone)
 			attached_organs |= organ
 
 	var/organ_to_remove = input(user, "Which organ do you want to prepare for removal?") as null|anything in attached_organs
@@ -418,7 +466,7 @@
 
 /datum/surgery_step/robotics/attach_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!(affected && (BP_IS_ROBOTIC(affected))))
+	if(!affected || !BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))
 		return 0
 	if(affected.hatch_state != HATCH_OPENED)
 		return 0
@@ -427,7 +475,7 @@
 
 	var/list/removable_organs = list()
 	for(var/obj/item/organ/I in affected.implants)
-		if ((I.status & ORGAN_CUT_AWAY) && (BP_IS_ROBOTIC(I)) && (I.parent_organ == target_zone))
+		if ((I.status & ORGAN_CUT_AWAY) && BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && (I.parent_organ == target_zone))
 			removable_organs |= I.organ_tag
 
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 12 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 46 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 649 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 651 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
Snipping some stuff out of the Vigil PR for ease of review.

- Brittle limbs take 50% additional brute damage and, if robotic, cannot be repaired through surgery or tools.
- Crystalline limbs are immune to laser fire and have specific wound types/sound effects/messages for damage and breaking.
- Golems now use both brittle and crystalline flags. They're the only thing that uses the mechanic currently.