### PR TITLE
Disallows choosing above Trained in non-generic job-unrelated skills.

### DIFF
--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -5,14 +5,23 @@
 
 /datum/preferences/proc/get_max_skill(datum/job/job, decl/hierarchy/skill/S)
 	var/min = get_min_skill(job, S)
-	var/job_max_skill = job && job.max_skill[S.type]
-	return max(min, job_max_skill || S.default_max || SKILL_MAX)
+	if(job && job.max_skill)
+		. = job.max_skill[S.type]
+	if(!.)
+		. = S.default_max
+	if(!.)
+		. = SKILL_MAX
+	. = max(min, .)
 
 /datum/preferences/proc/get_min_skill(datum/job/job, decl/hierarchy/skill/S)
-	var/datum/mil_branch/branch = mil_branches.get_branch(char_branch)
-	var/job_min_skill = job && job.min_skill && job.min_skill[S.type]
-	var/branch_min_skill = branch && branch.min_skill && branch.min_skill[S.type]
-	return job_min_skill || branch_min_skill || SKILL_MIN
+	if(job && job.min_skill)
+		. = job.min_skill[S.type]
+	if(!.)
+		var/datum/mil_branch/branch = mil_branches.get_branch(char_branch)
+		if(branch && branch.min_skill)
+			. = branch.min_skill[S.type]
+	if(!.)
+		. = SKILL_MIN
 
 /datum/preferences/proc/get_spent_points(datum/job/job, decl/hierarchy/skill/S)
 	if(!(job in skills_allocated))

--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -5,7 +5,8 @@
 
 /datum/preferences/proc/get_max_skill(datum/job/job, decl/hierarchy/skill/S)
 	var/min = get_min_skill(job, S)
-	return max(min, job.max_skill[S.type] || SKILL_MAX)
+	var/job_max_skill = job && job.max_skill[S.type]
+	return max(min, job_max_skill || S.default_max || SKILL_MAX)
 
 /datum/preferences/proc/get_min_skill(datum/job/job, decl/hierarchy/skill/S)
 	var/datum/mil_branch/branch = mil_branches.get_branch(char_branch)

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -11,7 +11,8 @@ GLOBAL_LIST_EMPTY(skills)
 							"Trained"			= "Trained Description",
 							"Experienced"		= "Experienced Description",
 							"Master"		= "Professional Description")
-	var/difficulty = SKILL_AVERAGE
+	var/difficulty = SKILL_AVERAGE   //Used to compute how expensive the skill is
+	var/default_max = SKILL_ADEPT    //Makes the skill capped at this value in selection unless overriden at job level.
 
 /decl/hierarchy/skill/proc/get_cost(var/level)
 	switch(level)
@@ -39,16 +40,19 @@ GLOBAL_LIST_EMPTY(skills)
 	name = "Organizational"
 	ID	 = "1"
 	difficulty = SKILL_EASY
+	default_max = SKILL_MAX
 
 /decl/hierarchy/skill/general
 	name = "General"
 	ID	 = "2"
 	difficulty = SKILL_EASY
+	default_max = SKILL_MAX
 
 /decl/hierarchy/skill/service
 	name = "Service"
 	ID	 = "service"
 	difficulty = SKILL_EASY
+	default_max = SKILL_MAX
 
 /decl/hierarchy/skill/security
 	name = "Security"
@@ -123,6 +127,7 @@ GLOBAL_LIST_EMPTY(skills)
 						"Experienced"		= "You are an experienced pilot, and can safely take the helm of many types of craft. You could probably live in a spacecraft, and you're very well versed in essentially everything related to space-faring vessels. Not only can you fly a ship, but you can perform difficult maneuvers, and make most calculations related to piloting a spacecraft. You can maintain a ship. Skills of this level are typical for very experienced pilots. You have received formal piloting training.",
 						"Master"		= "Not only are you an exceptional pilot, but you have mastered peripheral functions such as stellar navigation and bluespace jump plotting. You have experience performing complex maneuvers, managing squadrons of small craft, and operating in hostile environments.")
 	difficulty = SKILL_AVERAGE
+	default_max = SKILL_ADEPT
 
 /decl/hierarchy/skill/general/hauling
 	ID = "hauling"

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -61,7 +61,10 @@
 	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_SCIENCE     = SKILL_ADEPT,
 						SKILL_PILOT       = SKILL_ADEPT)
-	skill_points = 36
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
+	skill_points = 30
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/card_mod,
@@ -92,7 +95,11 @@
 	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
 						SKILL_COMPUTER    = SKILL_BASIC,
 						SKILL_PILOT       = SKILL_BASIC)
-	skill_points = 36
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
+
+	skill_points = 30
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
 			            access_medical, access_morgue, access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -138,7 +145,11 @@
 						SKILL_ANATOMY     = SKILL_BASIC,
 						SKILL_DEVICES     = SKILL_BASIC,
 						SKILL_SCIENCE     = SKILL_ADEPT)
-	skill_points = 36
+
+	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_DEVICES     = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
+	skill_points = 30
 
 	access = list(access_tox, access_tox_storage, access_emergency_storage, access_teleporter, access_heads, access_rd,
 						access_research, access_mining, access_mining_office, access_mining_station, access_xenobiology,
@@ -176,7 +187,12 @@
 						SKILL_ANATOMY     = SKILL_EXPERT,
 						SKILL_CHEMISTRY   = SKILL_BASIC,
 						SKILL_VIROLOGY    = SKILL_BASIC)
-	skill_points = 36
+
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
+						SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX,
+						SKILL_VIROLOGY    = SKILL_MAX)
+	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_heads,
@@ -216,6 +232,11 @@
 						SKILL_ELECTRICAL   = SKILL_ADEPT,
 						SKILL_ATMOS        = SKILL_ADEPT,
 						SKILL_ENGINES      = SKILL_EXPERT)
+
+	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 30
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -264,6 +285,10 @@
 						SKILL_COMBAT      = SKILL_BASIC,
 						SKILL_WEAPONS     = SKILL_ADEPT,
 						SKILL_FORENSICS   = SKILL_BASIC)
+	
+	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
+						SKILL_WEAPONS     = SKILL_MAX,
+						SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 28
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -363,6 +388,14 @@
 	min_skill = list(	SKILL_EVA        = SKILL_BASIC,
 						SKILL_COMBAT     = SKILL_BASIC,
 						SKILL_WEAPONS    = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_COMBAT       = SKILL_MAX,
+						SKILL_WEAPONS      = SKILL_MAX,
+						SKILL_PILOT        = SKILL_MAX,
+						SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX)
 	skill_points = 24
 
 
@@ -400,6 +433,8 @@
 	)
 	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_PILOT       = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
 	skill_points = 20
 
 
@@ -442,6 +477,11 @@
 						SKILL_EVA         = SKILL_ADEPT,
 						SKILL_SCIENCE     = SKILL_ADEPT,
 						SKILL_PILOT       = SKILL_BASIC)
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_COMBAT      = SKILL_EXPERT,
+						SKILL_WEAPONS     = SKILL_EXPERT)
 	skill_points = 22
 
 	access = list(access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_cent_creed)
@@ -483,6 +523,9 @@
 	min_skill = list(	SKILL_EVA   = SKILL_BASIC,
 						SKILL_PILOT = SKILL_ADEPT)
 
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
+
 /datum/job/explorer
 	title = "Explorer"
 	department = "Exploration"
@@ -500,6 +543,11 @@
 		/datum/mil_rank/ec/e5
 	)
 	min_skill = list(	SKILL_EVA = SKILL_BASIC)
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_COMBAT      = SKILL_EXPERT,
+						SKILL_WEAPONS     = SKILL_EXPERT)
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_cent_creed)
 
@@ -539,6 +587,11 @@
 						SKILL_ELECTRICAL   = SKILL_ADEPT,
 						SKILL_ATMOS        = SKILL_BASIC,
 						SKILL_ENGINES      = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 24
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -592,6 +645,12 @@
 						SKILL_ATMOS        = SKILL_BASIC,
 						SKILL_ENGINES      = SKILL_BASIC)
 
+	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX)
+	skill_points = 20
+
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
 			            access_solgov_crew, access_hangar)
@@ -634,6 +693,11 @@
 						SKILL_ELECTRICAL    = SKILL_BASIC,
 						SKILL_ATMOS         = SKILL_BASIC,
 						SKILL_ENGINES       = SKILL_BASIC)
+
+	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -683,6 +747,11 @@
 						SKILL_ATMOS        = SKILL_ADEPT,
 						SKILL_ENGINES      = SKILL_ADEPT)
 
+	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX)
+
 	access = list(access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_eva, access_tech_storage, access_janitor, access_construction,
 			            access_solgov_crew, access_hangar)
@@ -716,8 +785,16 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(	SKILL_COMPUTER		= SKILL_ADEPT,
-						SKILL_MECH = SKILL_ADEPT,
+						SKILL_MECH          = SKILL_ADEPT,
 						SKILL_DEVICES		= SKILL_ADEPT)
+
+	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX,
+						SKILL_DEVICES      = SKILL_MAX,
+						SKILL_ANATOMY      = SKILL_MAX,
+						SKILL_MEDICAL      = SKILL_MAX)
 
 	access = list(access_robotics, access_robotics_engineering, access_tech_storage, access_morgue, access_medical, access_robotics_engineering, access_solgov_crew)
 	minimal_access = list()
@@ -751,6 +828,10 @@
 						SKILL_COMBAT      = SKILL_BASIC,
 						SKILL_WEAPONS     = SKILL_BASIC,
 						SKILL_FORENSICS   = SKILL_BASIC)
+
+	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
+						SKILL_WEAPONS     = SKILL_MAX,
+						SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -794,6 +875,10 @@
 						SKILL_COMBAT      = SKILL_BASIC,
 						SKILL_WEAPONS     = SKILL_BASIC,
 						SKILL_FORENSICS   = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
+						SKILL_WEAPONS     = SKILL_MAX,
+						SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_security, access_brig, access_forensics_lockers,
@@ -829,6 +914,10 @@
 						SKILL_COMBAT      = SKILL_BASIC,
 						SKILL_WEAPONS     = SKILL_ADEPT,
 						SKILL_FORENSICS   = SKILL_BASIC)
+
+	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
+						SKILL_WEAPONS     = SKILL_MAX,
+						SKILL_FORENSICS   = SKILL_MAX)
 
 	access = list(access_security, access_brig, access_maint_tunnels,
 						access_external_airlocks, access_emergency_storage,
@@ -868,6 +957,11 @@
 						SKILL_ANATOMY     = SKILL_EXPERT,
 						SKILL_CHEMISTRY   = SKILL_BASIC,
 						SKILL_VIROLOGY    = SKILL_BASIC)
+
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
+						SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX,
+						SKILL_VIROLOGY    = SKILL_MAX)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
@@ -904,6 +998,12 @@
 	min_skill = list(	SKILL_EVA     = SKILL_BASIC,
 						SKILL_MEDICAL = SKILL_BASIC,
 						SKILL_ANATOMY = SKILL_BASIC)
+
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
+						SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX,
+						SKILL_VIROLOGY    = SKILL_MAX)
+
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_eva, access_surgery, access_medical_equip, access_solgov_crew, access_hangar)
 	minimal_access = list()
@@ -934,6 +1034,11 @@
 	min_skill = list(	SKILL_EVA     = SKILL_BASIC,
 						SKILL_MEDICAL = SKILL_BASIC,
 						SKILL_ANATOMY = SKILL_BASIC)
+
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
+						SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX,
+						SKILL_VIROLOGY    = SKILL_MAX)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_crematorium, access_virology, access_surgery, access_medical_equip, access_solgov_crew,
@@ -971,6 +1076,11 @@
 						SKILL_MEDICAL = SKILL_EXPERT,
 						SKILL_ANATOMY = SKILL_BASIC)
 
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
+						SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX,
+						SKILL_VIROLOGY    = SKILL_MAX)
+
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_surgery, access_medical_equip, access_solgov_crew)
 
@@ -996,6 +1106,9 @@
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(	SKILL_MEDICAL   = SKILL_BASIC,
 						SKILL_CHEMISTRY = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX)
 	skill_points = 26
 
 	access = list(access_medical, access_maint_tunnels, access_emergency_storage, access_medical_equip, access_solgov_crew, access_chemistry)
@@ -1024,6 +1137,8 @@
 		/datum/mil_rank/ec/o1)
 	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
 						SKILL_MEDICAL     = SKILL_BASIC)
+
+	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX)
 
 	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_psychiatrist, access_solgov_crew)
 	minimal_access = list()
@@ -1062,6 +1177,8 @@
 						SKILL_HAULING     = SKILL_BASIC,
 						SKILL_EVA         = SKILL_BASIC,
 						SKILL_PILOT       = SKILL_BASIC)
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
 	skill_points = 18
 
 	access = list(access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
@@ -1095,6 +1212,8 @@
 						SKILL_FINANCE     = SKILL_BASIC,
 						SKILL_HAULING     = SKILL_BASIC)
 
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+
 	access = list(access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
 						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar)
 	minimal_access = list()
@@ -1121,6 +1240,8 @@
 						SKILL_FINANCE     = SKILL_BASIC,
 						SKILL_HAULING     = SKILL_BASIC)
 
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+
 	access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting, access_hangar, access_guppy, access_guppy_helm, access_solgov_crew)
 
 	software_on_spawn = list(/datum/computer_file/program/supply,
@@ -1144,6 +1265,8 @@
 	min_skill = list(	SKILL_MECH    = SKILL_BASIC,
 						SKILL_HAULING = SKILL_ADEPT,
 						SKILL_EVA     = SKILL_BASIC)
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -1285,6 +1408,10 @@
 						SKILL_ANATOMY     = SKILL_BASIC,
 						SKILL_DEVICES     = SKILL_ADEPT,
 						SKILL_SCIENCE     = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_DEVICES     = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
 	skill_points = 20
 
 /datum/job/scientist
@@ -1305,6 +1432,10 @@
 						SKILL_COMPUTER    = SKILL_BASIC,
 						SKILL_DEVICES     = SKILL_BASIC,
 						SKILL_SCIENCE     = SKILL_ADEPT)
+
+	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_DEVICES     = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/scientist
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -1334,6 +1465,11 @@
 	min_skill = list(	SKILL_COMBAT  = SKILL_BASIC,
 						SKILL_WEAPONS = SKILL_BASIC)
 
+	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
+						SKILL_WEAPONS     = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_DEVICES     = SKILL_MAX)
+
 	access = list(access_tox, access_tox_storage,access_research, access_mining, access_mining_office, access_mining_station, access_xenobiology,
 						access_xenoarch, access_nanotrasen, access_sec_guard, access_hangar, access_petrov, access_expedition_shuttle, access_guppy)
 
@@ -1360,6 +1496,10 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/assist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
+
+	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_DEVICES     = SKILL_MAX,
+						SKILL_SCIENCE     = SKILL_MAX)
 
 	access = list(access_research, access_mining_office, access_nanotrasen, access_petrov, access_expedition_shuttle, access_guppy, access_hangar)
 
@@ -1419,6 +1559,8 @@
 	announced = FALSE
 	min_skill = list(	SKILL_FINANCE = SKILL_ADEPT,
 						SKILL_PILOT	  = SKILL_BASIC)
+
+	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
 	skill_points = 24
 
 /datum/job/stowaway

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -826,7 +826,7 @@
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
 	                    SKILL_EVA         = SKILL_BASIC,
 	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_ADEPT,
 	                    SKILL_FORENSICS   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,

--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -58,12 +58,12 @@
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o6
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_SCIENCE     = SKILL_ADEPT,
-						SKILL_PILOT       = SKILL_ADEPT)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_ADEPT,
+	                    SKILL_PILOT       = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 	skill_points = 30
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -92,12 +92,12 @@
 		/datum/mil_rank/fleet/o5,
 		/datum/mil_rank/fleet/o4
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
-						SKILL_COMPUTER    = SKILL_BASIC,
-						SKILL_PILOT       = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 
 	skill_points = 30
 
@@ -138,17 +138,17 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/rd
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
-						SKILL_COMPUTER    = SKILL_BASIC,
-						SKILL_FINANCE     = SKILL_ADEPT,
-						SKILL_BOTANY      = SKILL_BASIC,
-						SKILL_ANATOMY     = SKILL_BASIC,
-						SKILL_DEVICES     = SKILL_BASIC,
-						SKILL_SCIENCE     = SKILL_ADEPT)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_ADEPT,
+	                    SKILL_BOTANY      = SKILL_BASIC,
+	                    SKILL_ANATOMY     = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_DEVICES     = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 	skill_points = 30
 
 	access = list(access_tox, access_tox_storage, access_emergency_storage, access_teleporter, access_heads, access_rd,
@@ -182,16 +182,16 @@
 		/datum/mil_rank/ec/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_MEDICAL     = SKILL_ADEPT,
-						SKILL_ANATOMY     = SKILL_EXPERT,
-						SKILL_CHEMISTRY   = SKILL_BASIC,
-						SKILL_VIROLOGY    = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_ADEPT,
+	                    SKILL_ANATOMY     = SKILL_EXPERT,
+	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+	                    SKILL_VIROLOGY    = SKILL_BASIC)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
-						SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_CHEMISTRY   = SKILL_MAX,
-						SKILL_VIROLOGY    = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -225,18 +225,18 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	SKILL_BUREAUCRACY  = SKILL_BASIC,
-						SKILL_COMPUTER     = SKILL_ADEPT,
-						SKILL_EVA          = SKILL_ADEPT,
-						SKILL_CONSTRUCTION = SKILL_ADEPT,
-						SKILL_ELECTRICAL   = SKILL_ADEPT,
-						SKILL_ATMOS        = SKILL_ADEPT,
-						SKILL_ENGINES      = SKILL_EXPERT)
+	min_skill = list(   SKILL_BUREAUCRACY  = SKILL_BASIC,
+	                    SKILL_COMPUTER     = SKILL_ADEPT,
+	                    SKILL_EVA          = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
+	                    SKILL_ATMOS        = SKILL_ADEPT,
+	                    SKILL_ENGINES      = SKILL_EXPERT)
 
-	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX)
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 30
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -280,15 +280,15 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o2
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
-						SKILL_EVA         = SKILL_BASIC,
-						SKILL_COMBAT      = SKILL_BASIC,
-						SKILL_WEAPONS     = SKILL_ADEPT,
-						SKILL_FORENSICS   = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 	
-	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_FORENSICS   = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 28
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -324,8 +324,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/cl
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
-	min_skill = list(	SKILL_BUREAUCRACY	= SKILL_EXPERT,
-						SKILL_FINANCE		= SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
+	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_liaison, access_tox, access_tox_storage, access_heads, access_research,
@@ -352,8 +352,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/representative
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/civ)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_EXPERT,
-						SKILL_FINANCE     = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_EXPERT,
+	                    SKILL_FINANCE     = SKILL_BASIC)
 	skill_points = 20
 
 	access = list(access_representative, access_security, access_medical,
@@ -385,17 +385,17 @@
 		/datum/mil_rank/fleet/e9_alt1,
 		/datum/mil_rank/fleet/e8
 	)
-	min_skill = list(	SKILL_EVA        = SKILL_BASIC,
-						SKILL_COMBAT     = SKILL_BASIC,
-						SKILL_WEAPONS    = SKILL_ADEPT)
+	min_skill = list(   SKILL_EVA        = SKILL_BASIC,
+	                    SKILL_COMBAT     = SKILL_BASIC,
+	                    SKILL_WEAPONS    = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_COMBAT       = SKILL_MAX,
-						SKILL_WEAPONS      = SKILL_MAX,
-						SKILL_PILOT        = SKILL_MAX,
-						SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT       = SKILL_MAX,
+	                    SKILL_WEAPONS      = SKILL_MAX,
+	                    SKILL_PILOT        = SKILL_MAX,
+	                    SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX)
 	skill_points = 24
 
 
@@ -431,10 +431,10 @@
 		/datum/mil_rank/ec/o1,
 		/datum/mil_rank/fleet/o1
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_PILOT       = SKILL_ADEPT)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 	skill_points = 20
 
 
@@ -473,15 +473,15 @@
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o1
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_EVA         = SKILL_ADEPT,
-						SKILL_SCIENCE     = SKILL_ADEPT,
-						SKILL_PILOT       = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_ADEPT,
+	                    SKILL_SCIENCE     = SKILL_ADEPT,
+	                    SKILL_PILOT       = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX,
-						SKILL_COMBAT      = SKILL_EXPERT,
-						SKILL_WEAPONS     = SKILL_EXPERT)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX,
+	                    SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT)
 	skill_points = 22
 
 	access = list(access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_cent_creed)
@@ -520,11 +520,11 @@
 	access = list(access_mining_office,
 						access_mining_station, access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy,
 						access_hangar, access_guppy_helm, access_mining, access_pilot, access_solgov_crew)
-	min_skill = list(	SKILL_EVA   = SKILL_BASIC,
-						SKILL_PILOT = SKILL_ADEPT)
+	min_skill = list(   SKILL_EVA   = SKILL_BASIC,
+	                    SKILL_PILOT = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 
 /datum/job/explorer
 	title = "Explorer"
@@ -542,12 +542,12 @@
 		/datum/mil_rank/ec/e3,
 		/datum/mil_rank/ec/e5
 	)
-	min_skill = list(	SKILL_EVA = SKILL_BASIC)
+	min_skill = list(   SKILL_EVA = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX,
-						SKILL_COMBAT      = SKILL_EXPERT,
-						SKILL_WEAPONS     = SKILL_EXPERT)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX,
+	                    SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT)
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage, access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_cent_creed)
 
@@ -581,17 +581,17 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/ec/e5
 	)
-	min_skill = list(	SKILL_COMPUTER     = SKILL_BASIC,
-						SKILL_EVA          = SKILL_ADEPT,
-						SKILL_CONSTRUCTION = SKILL_ADEPT,
-						SKILL_ELECTRICAL   = SKILL_ADEPT,
-						SKILL_ATMOS        = SKILL_BASIC,
-						SKILL_ENGINES      = SKILL_ADEPT)
+	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
+	                    SKILL_EVA          = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
+	                    SKILL_ATMOS        = SKILL_BASIC,
+	                    SKILL_ENGINES      = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX)
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 24
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -638,17 +638,17 @@
 		/datum/mil_rank/ec/e3,
 		/datum/mil_rank/fleet/e2
 	)
-	min_skill = list(	SKILL_COMPUTER     = SKILL_BASIC,
-						SKILL_EVA          = SKILL_BASIC,
-						SKILL_CONSTRUCTION = SKILL_ADEPT,
-						SKILL_ELECTRICAL   = SKILL_BASIC,
-						SKILL_ATMOS        = SKILL_BASIC,
-						SKILL_ENGINES      = SKILL_BASIC)
+	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
+	                    SKILL_EVA          = SKILL_BASIC,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_BASIC,
+	                    SKILL_ATMOS        = SKILL_BASIC,
+	                    SKILL_ENGINES      = SKILL_BASIC)
 
-	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX)
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -687,17 +687,17 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	SKILL_COMPUTER      = SKILL_BASIC,
-						SKILL_EVA           = SKILL_BASIC,
-						SKILL_CONSTRUCTION	= SKILL_BASIC,
-						SKILL_ELECTRICAL    = SKILL_BASIC,
-						SKILL_ATMOS         = SKILL_BASIC,
-						SKILL_ENGINES       = SKILL_BASIC)
+	min_skill = list(   SKILL_COMPUTER      = SKILL_BASIC,
+	                    SKILL_EVA           = SKILL_BASIC,
+	                    SKILL_CONSTRUCTION	= SKILL_BASIC,
+	                    SKILL_ELECTRICAL    = SKILL_BASIC,
+	                    SKILL_ATMOS         = SKILL_BASIC,
+	                    SKILL_ENGINES       = SKILL_BASIC)
 
-	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX)
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
@@ -739,18 +739,18 @@
 	skill_points = 4
 	no_skill_buffs = TRUE
 
-	min_skill = list(	SKILL_COMPUTER     = SKILL_BASIC,
-						SKILL_HAULING      = SKILL_ADEPT,
-						SKILL_EVA          = SKILL_ADEPT,
-						SKILL_CONSTRUCTION = SKILL_ADEPT,
-						SKILL_ELECTRICAL   = SKILL_ADEPT,
-						SKILL_ATMOS        = SKILL_ADEPT,
-						SKILL_ENGINES      = SKILL_ADEPT)
+	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
+	                    SKILL_HAULING      = SKILL_ADEPT,
+	                    SKILL_EVA          = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
+	                    SKILL_ATMOS        = SKILL_ADEPT,
+	                    SKILL_ENGINES      = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX)
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX)
 
 	access = list(access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_eva, access_tech_storage, access_janitor, access_construction,
@@ -784,17 +784,17 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	SKILL_COMPUTER		= SKILL_ADEPT,
-						SKILL_MECH          = SKILL_ADEPT,
-						SKILL_DEVICES		= SKILL_ADEPT)
+	min_skill = list(   SKILL_COMPUTER		= SKILL_ADEPT,
+	                    SKILL_MECH          = SKILL_ADEPT,
+	                    SKILL_DEVICES		= SKILL_ADEPT)
 
-	max_skill = list(	SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX,
-						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX,
-						SKILL_DEVICES      = SKILL_MAX,
-						SKILL_ANATOMY      = SKILL_MAX,
-						SKILL_MEDICAL      = SKILL_MAX)
+	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
+	                    SKILL_ELECTRICAL   = SKILL_MAX,
+	                    SKILL_ATMOS        = SKILL_MAX,
+	                    SKILL_ENGINES      = SKILL_MAX,
+	                    SKILL_DEVICES      = SKILL_MAX,
+	                    SKILL_ANATOMY      = SKILL_MAX,
+	                    SKILL_MEDICAL      = SKILL_MAX)
 
 	access = list(access_robotics, access_robotics_engineering, access_tech_storage, access_morgue, access_medical, access_robotics_engineering, access_solgov_crew)
 	minimal_access = list()
@@ -823,15 +823,15 @@
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e5
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
-						SKILL_EVA         = SKILL_BASIC,
-						SKILL_COMBAT      = SKILL_BASIC,
-						SKILL_WEAPONS     = SKILL_BASIC,
-						SKILL_FORENSICS   = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
-	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_FORENSICS   = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
@@ -869,16 +869,16 @@
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor,
 		/datum/mil_rank/civ/agent = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/agent
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_COMPUTER    = SKILL_BASIC,
-						SKILL_EVA         = SKILL_BASIC,
-						SKILL_COMBAT      = SKILL_BASIC,
-						SKILL_WEAPONS     = SKILL_BASIC,
-						SKILL_FORENSICS   = SKILL_ADEPT)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_FORENSICS   = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 20
 
 	access = list(access_security, access_brig, access_forensics_lockers,
@@ -909,15 +909,15 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_EVA         = SKILL_BASIC,
-						SKILL_COMBAT      = SKILL_BASIC,
-						SKILL_WEAPONS     = SKILL_ADEPT,
-						SKILL_FORENSICS   = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
-	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_FORENSICS   = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX)
 
 	access = list(access_security, access_brig, access_maint_tunnels,
 						access_external_airlocks, access_emergency_storage,
@@ -952,16 +952,16 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o1
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_MEDICAL     = SKILL_ADEPT,
-						SKILL_ANATOMY     = SKILL_EXPERT,
-						SKILL_CHEMISTRY   = SKILL_BASIC,
-						SKILL_VIROLOGY    = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_ADEPT,
+	                    SKILL_ANATOMY     = SKILL_EXPERT,
+	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+	                    SKILL_VIROLOGY    = SKILL_BASIC)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
-						SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_CHEMISTRY   = SKILL_MAX,
-						SKILL_VIROLOGY    = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
@@ -995,14 +995,14 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6
 	)
-	min_skill = list(	SKILL_EVA     = SKILL_BASIC,
-						SKILL_MEDICAL = SKILL_BASIC,
-						SKILL_ANATOMY = SKILL_BASIC)
+	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
+	                    SKILL_MEDICAL = SKILL_BASIC,
+	                    SKILL_ANATOMY = SKILL_BASIC)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
-						SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_CHEMISTRY   = SKILL_MAX,
-						SKILL_VIROLOGY    = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX)
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_eva, access_surgery, access_medical_equip, access_solgov_crew, access_hangar)
@@ -1031,14 +1031,14 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	SKILL_EVA     = SKILL_BASIC,
-						SKILL_MEDICAL = SKILL_BASIC,
-						SKILL_ANATOMY = SKILL_BASIC)
+	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
+	                    SKILL_MEDICAL = SKILL_BASIC,
+	                    SKILL_ANATOMY = SKILL_BASIC)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
-						SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_CHEMISTRY   = SKILL_MAX,
-						SKILL_VIROLOGY    = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX)
 	skill_points = 32
 
 	access = list(access_medical, access_morgue, access_crematorium, access_virology, access_surgery, access_medical_equip, access_solgov_crew,
@@ -1071,15 +1071,15 @@
 	skill_points = 4
 	no_skill_buffs = TRUE
 
-	min_skill = list(	SKILL_EVA     = SKILL_ADEPT,
-						SKILL_HAULING = SKILL_ADEPT,
-						SKILL_MEDICAL = SKILL_EXPERT,
-						SKILL_ANATOMY = SKILL_BASIC)
+	min_skill = list(   SKILL_EVA     = SKILL_ADEPT,
+	                    SKILL_HAULING = SKILL_ADEPT,
+	                    SKILL_MEDICAL = SKILL_EXPERT,
+	                    SKILL_ANATOMY = SKILL_BASIC)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
-						SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_CHEMISTRY   = SKILL_MAX,
-						SKILL_VIROLOGY    = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX)
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_surgery, access_medical_equip, access_solgov_crew)
@@ -1104,11 +1104,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	SKILL_MEDICAL   = SKILL_BASIC,
-						SKILL_CHEMISTRY = SKILL_ADEPT)
+	min_skill = list(   SKILL_MEDICAL   = SKILL_BASIC,
+	                    SKILL_CHEMISTRY = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX,
-						SKILL_CHEMISTRY   = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX)
 	skill_points = 26
 
 	access = list(access_medical, access_maint_tunnels, access_emergency_storage, access_medical_equip, access_solgov_crew, access_chemistry)
@@ -1135,10 +1135,10 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/ec/o1)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_MEDICAL     = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_BASIC)
 
-	max_skill = list(	SKILL_MEDICAL     = SKILL_MAX)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX)
 
 	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_psychiatrist, access_solgov_crew)
 	minimal_access = list()
@@ -1172,13 +1172,13 @@
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_ADEPT,
-						SKILL_FINANCE     = SKILL_BASIC,
-						SKILL_HAULING     = SKILL_BASIC,
-						SKILL_EVA         = SKILL_BASIC,
-						SKILL_PILOT       = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_BASIC,
+	                    SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 	skill_points = 18
 
 	access = list(access_maint_tunnels, access_heads, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
@@ -1208,11 +1208,11 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_FINANCE     = SKILL_BASIC,
-						SKILL_HAULING     = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
 						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar)
@@ -1236,11 +1236,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_FINANCE     = SKILL_BASIC,
-						SKILL_HAULING     = SKILL_BASIC)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 
 	access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting, access_hangar, access_guppy, access_guppy_helm, access_solgov_crew)
 
@@ -1262,11 +1262,11 @@
 		"Drill Technician",
 		"Shaft Miner",
 		"Salvage Technician")
-	min_skill = list(	SKILL_MECH    = SKILL_BASIC,
-						SKILL_HAULING = SKILL_ADEPT,
-						SKILL_EVA     = SKILL_BASIC)
+	min_skill = list(   SKILL_MECH    = SKILL_BASIC,
+	                    SKILL_HAULING = SKILL_ADEPT,
+	                    SKILL_EVA     = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -1303,7 +1303,7 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	SKILL_HAULING = SKILL_BASIC)
+	min_skill = list(   SKILL_HAULING = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew)
 	minimal_access = list()
@@ -1332,9 +1332,9 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
-	min_skill = list(	SKILL_COOKING   = SKILL_ADEPT,
-						SKILL_BOTANY    = SKILL_BASIC,
-						SKILL_CHEMISTRY = SKILL_BASIC)
+	min_skill = list(   SKILL_COOKING   = SKILL_ADEPT,
+	                    SKILL_BOTANY    = SKILL_BASIC,
+	                    SKILL_CHEMISTRY = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_hydroponics, access_kitchen, access_solgov_crew, access_bar)
 	minimal_access = list()
@@ -1351,9 +1351,9 @@
 
 	access = list(access_hydroponics, access_bar, access_solgov_crew, access_kitchen)
 	minimal_access = list()
-	min_skill = list(	SKILL_COOKING   = SKILL_BASIC,
-						SKILL_BOTANY    = SKILL_BASIC,
-						SKILL_CHEMISTRY = SKILL_BASIC)
+	min_skill = list(   SKILL_COOKING   = SKILL_BASIC,
+	                    SKILL_BOTANY    = SKILL_BASIC,
+	                    SKILL_CHEMISTRY = SKILL_BASIC)
 
 /datum/job/crew
 	title = "Crewman"
@@ -1401,17 +1401,17 @@
 	access = list(access_tox, access_tox_storage, access_research, access_mining, access_mining_office,
 						access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen,
 						access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_COMPUTER    = SKILL_BASIC,
-						SKILL_FINANCE     = SKILL_BASIC,
-						SKILL_BOTANY      = SKILL_BASIC,
-						SKILL_ANATOMY     = SKILL_BASIC,
-						SKILL_DEVICES     = SKILL_ADEPT,
-						SKILL_SCIENCE     = SKILL_ADEPT)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_FINANCE     = SKILL_BASIC,
+	                    SKILL_BOTANY      = SKILL_BASIC,
+	                    SKILL_ANATOMY     = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_ADEPT,
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_DEVICES     = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 	skill_points = 20
 
 /datum/job/scientist
@@ -1428,14 +1428,14 @@
 		"Xenobiologist",
 		"Xenobotanist",
 		"Psychologist" = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/psych)
-	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
-						SKILL_COMPUTER    = SKILL_BASIC,
-						SKILL_DEVICES     = SKILL_BASIC,
-						SKILL_SCIENCE     = SKILL_ADEPT)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_DEVICES     = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/scientist
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -1462,13 +1462,13 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/guard
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt, /datum/mil_rank/civ/contractor)
-	min_skill = list(	SKILL_COMBAT  = SKILL_BASIC,
-						SKILL_WEAPONS = SKILL_BASIC)
+	min_skill = list(   SKILL_COMBAT  = SKILL_BASIC,
+	                    SKILL_WEAPONS = SKILL_BASIC)
 
-	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX,
-						SKILL_DEVICES     = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX)
 
 	access = list(access_tox, access_tox_storage,access_research, access_mining, access_mining_office, access_mining_station, access_xenobiology,
 						access_xenoarch, access_nanotrasen, access_sec_guard, access_hangar, access_petrov, access_expedition_shuttle, access_guppy)
@@ -1497,9 +1497,9 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/nt)
 
-	max_skill = list(	SKILL_ANATOMY     = SKILL_MAX,
-						SKILL_DEVICES     = SKILL_MAX,
-						SKILL_SCIENCE     = SKILL_MAX)
+	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX)
 
 	access = list(access_research, access_mining_office, access_nanotrasen, access_petrov, access_expedition_shuttle, access_guppy, access_hangar)
 
@@ -1557,10 +1557,10 @@
 	latejoin_at_spawnpoints = 1
 	access = list(access_merchant)
 	announced = FALSE
-	min_skill = list(	SKILL_FINANCE = SKILL_ADEPT,
-						SKILL_PILOT	  = SKILL_BASIC)
+	min_skill = list(   SKILL_FINANCE = SKILL_ADEPT,
+	                    SKILL_PILOT	  = SKILL_BASIC)
 
-	max_skill = list(	SKILL_PILOT       = SKILL_MAX)
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 	skill_points = 24
 
 /datum/job/stowaway


### PR DESCRIPTION
:cl:
tweak: Check your skill loadout; it may have been reset!
tweak: Skills outside your job and not in the general, organizational, or service categories (minus pilot) are no longer selectable above "Trained" level.
tweak: Some head roles had skill point allocations reduced. Engineers' skill points have been brought in line with contractors (increased). Brig Officers' starting skills brought in line with MaA.
/:cl:

Part of this is at admin request. May need further tweaking.