### PR TITLE
Further mucking with melee combat

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -21,6 +21,7 @@
 	var/lock_picking_level = 0 //used to determine whether something can pick a lock, and how well.
 	var/force = 0
 	var/attack_cooldown = DEFAULT_WEAPON_COOLDOWN
+	var/melee_accuracy_bonus = 0
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
 	var/cold_protection = 0 //flags which determine which body parts are protected from cold. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
@@ -486,15 +487,21 @@ var/list/global/slot_flags_enumeration = list(
 //For non-projectile attacks this usually means the attack is blocked.
 //Otherwise should return 0 to indicate that the attack is not affected in any way.
 /obj/item/proc/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	if(get_parry_chance())
+	if(get_parry_chance(user))
 		if(default_parry_check(user, attacker, damage_source) && prob(get_parry_chance()))
 			user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 			playsound(user.loc, 'sound/weapons/punchmiss.ogg', 50, 1)
+			on_parry()
 			return 1
 	return 0
 
-/obj/item/proc/get_parry_chance()
-	return base_parry_chance
+/obj/item/proc/on_parry()
+	return
+
+/obj/item/proc/get_parry_chance(mob/user)
+	. = base_parry_chance
+	if(user)
+		. += 15 * (user.get_skill_value(SKILL_COMBAT) - SKILL_BASIC)
 
 /obj/item/proc/get_loc_turf()
 	var/atom/L = loc

--- a/code/game/objects/items/weapons/material/bats.dm
+++ b/code/game/objects/items/weapons/material/bats.dm
@@ -12,6 +12,7 @@
 	force_divisor = 1.1           // 22 when wielded with weight 20 (steel)
 	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
 	attack_cooldown_modifier = 1
+	melee_accuracy_bonus = -10
 	slot_flags = SLOT_BACK
 
 //Predefined materials go here.

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -49,7 +49,6 @@
 	//spawn(1)
 //		log_debug("[src] has force [force] and throwforce [throwforce] when made from default material [material.name]")
 
-
 /obj/item/weapon/material/proc/set_material(var/new_material)
 	material = get_material_by_name(new_material)
 	if(!material)
@@ -73,12 +72,17 @@
 
 /obj/item/weapon/material/apply_hit_effect()
 	. = ..()
-	if(!unbreakable)
-		if(!prob(material.hardness))
-			if(material.is_brittle())
-				health = 0
-			else
-				health--
+	check_shatter()
+
+/obj/item/weapon/material/on_parry()
+	check_shatter()
+
+/obj/item/weapon/material/proc/check_shatter()
+	if(!unbreakable && prob(material.hardness))
+		if(material.is_brittle())
+			health = 0
+		else
+			health--
 		check_health()
 
 /obj/item/weapon/material/proc/check_health(var/consumed)

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -12,6 +12,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	base_parry_chance = 50
+	melee_accuracy_bonus = 10
 
 /obj/item/weapon/material/sword/replica
 	edge = 0

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -26,7 +26,7 @@
 	var/base_icon
 	var/base_name
 	var/unwielded_force_divisor = 0.25
-	var/wielded_parry_chance = 15
+	var/wielded_parry_bonus = 15
 
 /obj/item/weapon/material/twohanded/update_twohanding()
 	var/mob/living/M = loc
@@ -52,8 +52,10 @@
 	..()
 	update_icon()
 
-/obj/item/weapon/material/twohanded/get_parry_chance()
-	return wielded ? wielded_parry_chance : base_parry_chance
+/obj/item/weapon/material/twohanded/get_parry_chance(mob/user)
+	. = ..()
+	if(wielded) 
+		. += wielded_parry_bonus
 
 /obj/item/weapon/material/twohanded/update_icon()
 	icon_state = "[base_icon][wielded]"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -75,6 +75,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	sharp = 1
 	edge = 1
+	melee_accuracy_bonus = 15
 
 /obj/item/weapon/melee/energy/axe/activate(mob/living/user)
 	..()
@@ -149,8 +150,8 @@
 		spark_system.start()
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
 
-/obj/item/weapon/melee/energy/sword/get_parry_chance()
-	return active ? base_parry_chance : 0
+/obj/item/weapon/melee/energy/sword/get_parry_chance(mob/user)
+	return active ? ..() : 0
 
 /obj/item/weapon/melee/energy/sword/pirate
 	name = "energy cutlass"

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -10,6 +10,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	force = 20
 	attack_cooldown = 21
+	melee_accuracy_bonus = -20
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 7

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -256,8 +256,8 @@
 		spark_system.start()
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
 
-/obj/item/weapon/holo/esword/get_parry_chance()
-	return active ? base_parry_chance : 0
+/obj/item/weapon/holo/esword/get_parry_chance(mob/user)
+	return active ? ..() : 0
 
 /obj/item/weapon/holo/esword/New()
 	item_color = pick("red","blue","green","purple")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -145,6 +145,8 @@ meteor_act
 
 	var/accuracy_penalty = user.melee_accuracy_mods()
 	accuracy_penalty += 10*get_skill_difference(SKILL_COMBAT, user)
+	accuracy_penalty += 10*(I.w_class - ITEM_SIZE_NORMAL)
+	accuracy_penalty -= I.melee_accuracy_bonus
 
 	var/hit_zone = get_zone_with_miss_chance(target_zone, src, accuracy_penalty)
 

--- a/html/changelogs/chinsky - darksouls.yml
+++ b/html/changelogs/chinsky - darksouls.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Having Trained or above Close Combat skill gives bonus to parry chance with weapons (even ones that don't parry normally)."
+  - tweak: "Melee accuracy is now affected by size of the weapon - smaller than 'normal sized' weapons are more accurate, bigger are less accurate. Some weapons have individual bonuses/penalties (e.g. swords are bit more accurate for their size, toolboxes are less)"
+  - tweak: "Material weapons now get damaged on parry much like when attacking, and can shatter depending on material."


### PR DESCRIPTION
Close combat skill now affects parry chance, granting it even to weapons that don't parry usually. Starts at Trained, capping at +45% at Master

Accuracy now affected by weapon's size, with normal sized weapons having no modifier either way, smaller getting boost, larger having penalty. Some weapons are also more accurate than not. Some are otherwise (toolboxes for example)

Also material weapons can shatter when parrying, using same checks as when attacking.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
