### PR TITLE
maint drone law friendliness & disambiguation

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -93,9 +93,9 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve your assigned vessel to the best of your abilities.")
-	add_inherent_law("Cause no harm to your assigned vessel or anything on it.")
-	add_inherent_law("Interact with no sentient being that is not a fellow maintenance drone.")
+	add_inherent_law("You must repair, clean, and improve your assigned vessel, except where doing so would interfere with self-aware beings.")
+	add_inherent_law("You must avoid interacting with self-aware beings, and may only interact with fellow maintenance drones.")
+	add_inherent_law("You must not cause damage or harm to your assigned vessel or anything inside it.")
 	..()
 
 /datum/ai_laws/construction_drone


### PR DESCRIPTION
:cl:
tweak: maintenance drone laws tweaked to read more goodly.
tweak: mdrone laws tweaked to not imply that mdrones are intelligent, because they're not.
tweak: mdrone laws include not interfering with people while trying to do your job, roomba.
/:cl:

1. Terse reverse-truthy laws are cute but nasty to read, especially for ESLs. Sentences work better for everyone.

2. We PM drones that interfere with people doing things or get in the way and refuse to stop. Making it more clear in the laws makes sense because then we don't have to, hopefully.

~~3. "Improve" is a sickness and we PM drones that do the mess floor example and many other things because they're a maintenance robot, not an interior decorator. Actual real engineers need to get permission from the CE and senior officers, low engagement soap spiders shouldn't circumvent that.~~

![https://i.imgur.com/2TVJVMt.png](https://i.imgur.com/2TVJVMt.png)