### PR TITLE
Drastically increases tcomm relay power usage

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -368,7 +368,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	if(z in GLOB.using_map.station_levels)
 		idle_power_usage = 2.5 KILOWATTS
 	else
-		idle_power_usage = 30 KILOWATTS
+		idle_power_usage = 100 KILOWATTS
 
 /obj/machinery/telecomms/relay/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 

--- a/html/changelogs/chinsky - fuckcomms.yml
+++ b/html/changelogs/chinsky - fuckcomms.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Telecomms relays power usage is upper /considerably/ when used off-ship. Expect to drain Charon in 10 minutes when you switch it on."


### PR DESCRIPTION
30-45 minutes is hardly 'short transmissions' when our missions last sometimes less.
I'm of half mind to just remove offsite capability, but I am content with it being /actually/ costly, instead of no-effort thing it is.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
