### PR TITLE
fixes construction-related admin spam

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -357,8 +357,9 @@
 		difficulty += material.construction_difficulty
 
 /datum/stack_recipe/proc/display_name()
-	var/material = material_display_name(use_material)
-	return material ? "[material] [title]" : title
+	if(!use_material)
+		return title
+	return "[material_display_name(use_material)] [title]"
 
 /*
  * Recipe list datum


### PR DESCRIPTION
`get_material_by_name()` has the wonderful feature of spamming admins on failure, instead of, say, returning null and being done with it.