### PR TITLE
Adds sound to power failure event for APCs, increases light power

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -216,6 +216,7 @@
 	if(emp_hardened)
 		return
 	failure_timer = max(failure_timer, round(duration))
+	playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
 
 /obj/machinery/power/apc/proc/make_terminal()
 	// create a terminal object at the same position as original turf loc
@@ -362,7 +363,7 @@
 		if(update_state & (UPDATE_OPENED1|UPDATE_OPENED2|UPDATE_BROKE))
 			set_light(0)
 		else if(update_state & UPDATE_BLUESCREEN)
-			set_light(0.3, 0.1, 1, 2, "0000ff")
+			set_light(0.8, 0.1, 1, 2, "#00ecff")
 		else if(!(stat & (BROKEN|MAINT)) && update_state & UPDATE_ALLGOOD)
 			var/color
 			switch(charging)
@@ -372,7 +373,7 @@
 					color = "#a8b0f8"
 				if(2)
 					color = "#82ff4c"
-			set_light(0.3, 0.1, 1, l_color = color)
+			set_light(0.8, 0.1, 1, l_color = color)
 		else
 			set_light(0)
 


### PR DESCRIPTION
This will generally make APCs more visible during power failure and also add some cool sound effect to the grid check event

🆑 CrimsonShrike
tweak: APC lights now brighter.
/🆑
