### PR TITLE
Tweak movement handling

### DIFF
--- a/code/datums/movement/_defines.dm
+++ b/code/datums/movement/_defines.dm
@@ -1,2 +1,4 @@
+// These are designed to be used within /datum/movement_handler procs
+// Do not attempt to use in /atom/movable/proc/DoMove, /atom/movable/proc/MayMove, etc.
 #define IS_SELF(w) !IS_NOT_SELF(w)
 #define IS_NOT_SELF(w) (w && w != host)

--- a/code/datums/movement/atom_movable.dm
+++ b/code/datums/movement/atom_movable.dm
@@ -9,9 +9,9 @@
 // Movement relay
 /datum/movement_handler/move_relay/DoMove(var/direction, var/mover)
 	var/atom/movable/AM = host.loc
-	if(!istype(AM) || ismob(AM)) // For now mobs have to be moved in other ways even if you are inside them
+	if(!istype(AM))
 		return
-	. = AM.DoMove(direction, mover)
+	. = AM.DoMove(direction, mover, FALSE)
 	if(!(. & MOVEMENT_HANDLED))
 		. = MOVEMENT_HANDLED
 		AM.relaymove(mover, direction)

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -1,3 +1,24 @@
+// Movement relayed to self handling
+/datum/movement_handler/mob/relayed_movement
+	var/prevent_host_move = FALSE
+	var/list/allowed_movers
+
+/datum/movement_handler/mob/relayed_movement/MayMove(var/mob/mover, var/is_external)
+	if(is_external)
+		return MOVEMENT_PROCEED
+	if(mover == mob && !(prevent_host_move && LAZYLEN(allowed_movers) && !LAZYISIN(allowed_movers, mover)))
+		return MOVEMENT_PROCEED
+	if(LAZYISIN(allowed_movers, mover))
+		return MOVEMENT_PROCEED
+
+	return MOVEMENT_STOP
+
+/datum/movement_handler/mob/relayed_movement/proc/AddAllowedMover(var/mover)
+	LAZYDISTINCTADD(allowed_movers, mover)
+
+/datum/movement_handler/mob/relayed_movement/proc/RemoveAllowedMover(var/mover)
+	LAZYREMOVE(allowed_movers, mover)
+
 // Admin object possession
 /datum/movement_handler/mob/admin_possess/DoMove(var/direction)
 	if(QDELETED(mob.control_object))
@@ -107,15 +128,15 @@
 
 /datum/movement_handler/mob/buckle_relay/MayMove(var/mover)
 	if(mob.buckled)
-		return mob.buckled.MayMove(mover) ? (MOVEMENT_PROCEED|MOVEMENT_HANDLED) : MOVEMENT_STOP
+		return mob.buckled.MayMove(mover, FALSE) ? (MOVEMENT_PROCEED|MOVEMENT_HANDLED) : MOVEMENT_STOP
 	return MOVEMENT_PROCEED
 
 // Movement delay
 /datum/movement_handler/mob/delay
 	var/next_move
 
-/datum/movement_handler/mob/delay/DoMove(var/direction, var/mover)
-	if(IS_NOT_SELF(mover))
+/datum/movement_handler/mob/delay/DoMove(var/direction, var/mover, var/is_external)
+	if(is_external)
 		return
 	next_move = world.time + max(1, mob.movement_delay())
 

--- a/code/modules/mob/living/silicon/ai/ai_movement.dm
+++ b/code/modules/mob/living/silicon/ai/ai_movement.dm
@@ -1,5 +1,6 @@
 /mob/living/silicon/ai
 	movement_handlers = list(
+		/datum/movement_handler/mob/relayed_movement,
 		/datum/movement_handler/mob/death,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -9,6 +9,7 @@
 	virtual_mob = /mob/observer/virtual/mob
 
 	movement_handlers = list(
+		/datum/movement_handler/mob/relayed_movement,
 		/datum/movement_handler/mob/death,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,


### PR DESCRIPTION
Relayed moves are now correctly set as internal.

Adds a handler for movement relayed to mobs. This replaces an istype() check.
By default a relayed move has to be one of the following:
* External
* Made by the host itself - And this has to be allowed (not technically a relay, is called due to being in the host's movement list)
* Made by a mob found in a list of allowed movers

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
