### PR TITLE
Re-allows XOs and COs to pick departmental skills.

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -63,7 +63,19 @@
 	                    SKILL_PILOT       = SKILL_ADEPT)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
-	                    SKILL_SCIENCE     = SKILL_MAX)
+						SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_SCIENCE     = SKILL_MAX,
+	                    SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX,
+	                    SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX,
+	                    SKILL_CONSTRUCTION= SKILL_MAX,
+	                    SKILL_ELECTRICAL  = SKILL_MAX,
+	                    SKILL_ATMOS       = SKILL_MAX,
+	                    SKILL_ENGINES     = SKILL_MAX)
 	skill_points = 30
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -97,7 +109,19 @@
 	                    SKILL_PILOT       = SKILL_BASIC)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
-	                    SKILL_SCIENCE     = SKILL_MAX)
+	                    SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_DEVICES     = SKILL_MAX,
+	                    SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX,
+	                    SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX,
+	                    SKILL_FORENSICS   = SKILL_MAX,
+	                    SKILL_CONSTRUCTION= SKILL_MAX,
+	                    SKILL_ELECTRICAL  = SKILL_MAX,
+	                    SKILL_ATMOS       = SKILL_MAX,
+	                    SKILL_ENGINES     = SKILL_MAX)
 
 	skill_points = 30
 
@@ -285,7 +309,7 @@
 	                    SKILL_COMBAT      = SKILL_BASIC,
 	                    SKILL_WEAPONS     = SKILL_ADEPT,
 	                    SKILL_FORENSICS   = SKILL_BASIC)
-	
+
 	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
 	                    SKILL_WEAPONS     = SKILL_MAX,
 	                    SKILL_FORENSICS   = SKILL_MAX)


### PR DESCRIPTION
🆑 Cakey
tweak: COs and XOs can now pick skills again. 
/🆑

Both XO and CO are meant to be roles that other heads promote into, and it doesn't make sense for them to suddenly lose the ability to maintain their abilities.