### PR TITLE
Replaces unary vent in Xenoflora with a gas injector.

### DIFF
--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -26586,9 +26586,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "qab" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	injecting = 1;
+	use_power = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)


### PR DESCRIPTION
Fixes this boi right here:
![image](https://user-images.githubusercontent.com/8765210/43370123-0b3e9582-933f-11e8-8652-21edd7f6eb38.png)

Previously, Xenoflora couldn't experiment with gas without unlocking the air alarm somehow. This should fix that!

As an aside, I tried to fix up the Petrov the same way but it's honestly a fucking mess. I'll let someone braver tackle that