### PR TITLE
Makes hacking use the electrical skill.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -408,6 +408,7 @@
 #include "code\datums\wires\smes.dm"
 #include "code\datums\wires\suit_storage_unit.dm"
 #include "code\datums\wires\vending.dm"
+#include "code\datums\wires\wire_description.dm"
 #include "code\datums\wires\wires.dm"
 #include "code\game\atoms.dm"
 #include "code\game\atoms_movable.dm"

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -33,7 +33,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		return 1
 	return 0
 
-/datum/wires/airlock/GetInteractWindow()
+/datum/wires/airlock/GetInteractWindow(mob/user)
 	var/obj/machinery/door/airlock/A = holder
 	var/haspower = A.arePowerSystemsOn() //If there's no power, then no lights will be on.
 
@@ -174,3 +174,26 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = !A.lights
 			A.update_icon()
+
+/datum/wires/airlock/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(AIRLOCK_WIRE_IDSCAN)
+				. = "This wire is connected to the ID scanning panel."
+			if(AIRLOCK_WIRE_LIGHT)
+				. = "This wire powers the airlock's built-in lighting."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(AIRLOCK_WIRE_AI_CONTROL)
+				. = "This wire connects to automated control systems."
+			if(AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2, AIRLOCK_WIRE_BACKUP_POWER1, AIRLOCK_WIRE_BACKUP_POWER2, AIRLOCK_WIRE_ELECTRIFY)
+				. = "This wire seems to be carrying a heavy current."
+			if(AIRLOCK_WIRE_DOOR_BOLTS)
+				. = "This wire runs down to the very base of the airlock."
+			if(AIRLOCK_WIRE_SPEED)
+				. = "This wire appears to connect to the airlock's proximity detector modules."
+			if(AIRLOCK_WIRE_OPEN_DOOR)
+				. = "This wire connects to the door motors."
+			if(AIRLOCK_WIRE_SAFETY)
+				. = "This wire connects to a safety override."

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -9,6 +9,20 @@
 	holder_type = /obj/machinery/door/airlock
 	wire_count = 12
 	window_y = 570
+	descriptions = list(
+		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERT),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_DOOR_BOLTS, "This wire runs down to the very base of the airlock."),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "This wire connects to the door motors."),
+		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
+		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "This wire connects to a safety override."),
+		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "This wire appears to connect to the airlock's proximity detector modules."),
+		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "This wire powers the airlock's built-in lighting.", SKILL_EXPERT)
+	)
 
 var/const/AIRLOCK_WIRE_IDSCAN = 1
 var/const/AIRLOCK_WIRE_MAIN_POWER1 = 2
@@ -174,26 +188,3 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = !A.lights
 			A.update_icon()
-
-/datum/wires/airlock/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(AIRLOCK_WIRE_IDSCAN)
-				. = "This wire is connected to the ID scanning panel."
-			if(AIRLOCK_WIRE_LIGHT)
-				. = "This wire powers the airlock's built-in lighting."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(AIRLOCK_WIRE_AI_CONTROL)
-				. = "This wire connects to automated control systems."
-			if(AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2, AIRLOCK_WIRE_BACKUP_POWER1, AIRLOCK_WIRE_BACKUP_POWER2, AIRLOCK_WIRE_ELECTRIFY)
-				. = "This wire seems to be carrying a heavy current."
-			if(AIRLOCK_WIRE_DOOR_BOLTS)
-				. = "This wire runs down to the very base of the airlock."
-			if(AIRLOCK_WIRE_SPEED)
-				. = "This wire appears to connect to the airlock's proximity detector modules."
-			if(AIRLOCK_WIRE_OPEN_DOOR)
-				. = "This wire connects to the door motors."
-			if(AIRLOCK_WIRE_SAFETY)
-				. = "This wire connects to a safety override."

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -1,6 +1,13 @@
 /datum/wires/alarm
 	holder_type = /obj/machinery/alarm
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(AALARM_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERT),
+		new /datum/wire_description(AALARM_WIRE_POWER, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AALARM_WIRE_SYPHON, "This wire runs to atmospherics logic circuits of some sort."),
+		new /datum/wire_description(AALARM_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
+		new /datum/wire_description(AALARM_WIRE_AALARM, "This wire gives power to the actual alarm mechanism.")
+	)
 
 var/const/AALARM_WIRE_IDSCAN = 1
 var/const/AALARM_WIRE_POWER = 2
@@ -100,20 +107,3 @@ var/const/AALARM_WIRE_AALARM = 16
 			if (A.alarm_area.atmosalert(0, A))
 				A.post_alert(0)
 			A.update_icon()
-
-/datum/wires/alarm/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(AALARM_WIRE_IDSCAN)
-				. = "This wire is connected to the ID scanning panel."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(AALARM_WIRE_AI_CONTROL)
-				. = "This wire connects to automated control systems."
-			if(AALARM_WIRE_POWER)
-				. = "This wire seems to be carrying a heavy current."
-			if(AALARM_WIRE_SYPHON)
-				. = "This wire runs to atmospherics logic circuits of some sort."
-			if(AALARM_WIRE_AALARM)
-				. = "This wire gives power to the actual alarm mechanism."

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -15,7 +15,7 @@ var/const/AALARM_WIRE_AALARM = 16
 		return 1
 	return 0
 
-/datum/wires/alarm/GetInteractWindow()
+/datum/wires/alarm/GetInteractWindow(mob/user)
 	var/obj/machinery/alarm/A = holder
 	. += ..()
 	. += text("<br>\n[(A.locked ? "The Air Alarm is locked." : "The Air Alarm is unlocked.")]<br>\n[((A.shorted || (A.stat & (NOPOWER|BROKEN))) ? "The Air Alarm is offline." : "The Air Alarm is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
@@ -100,3 +100,20 @@ var/const/AALARM_WIRE_AALARM = 16
 			if (A.alarm_area.atmosalert(0, A))
 				A.post_alert(0)
 			A.update_icon()
+
+/datum/wires/alarm/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(AALARM_WIRE_IDSCAN)
+				. = "This wire is connected to the ID scanning panel."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(AALARM_WIRE_AI_CONTROL)
+				. = "This wire connects to automated control systems."
+			if(AALARM_WIRE_POWER)
+				. = "This wire seems to be carrying a heavy current."
+			if(AALARM_WIRE_SYPHON)
+				. = "This wire runs to atmospherics logic circuits of some sort."
+			if(AALARM_WIRE_AALARM)
+				. = "This wire gives power to the actual alarm mechanism."

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -1,11 +1,17 @@
-/datum/wires/apc
-	holder_type = /obj/machinery/power/apc
-	wire_count = 4
-
 #define APC_WIRE_IDSCAN 1
 #define APC_WIRE_MAIN_POWER1 2
 #define APC_WIRE_MAIN_POWER2 4
 #define APC_WIRE_AI_CONTROL 8
+
+/datum/wires/apc
+	holder_type = /obj/machinery/power/apc
+	wire_count = 4	
+	descriptions = list(
+		new /datum/wire_description(APC_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERT),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(APC_WIRE_AI_CONTROL, "This wire connects to automated control systems.")
+	)
 
 /datum/wires/apc/GetInteractWindow(mob/user)
 	var/obj/machinery/power/apc/A = holder
@@ -70,16 +76,3 @@
 			else
 				if (A.aidisabled == 1)
 					A.aidisabled = 0
-
-/datum/wires/apc/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(APC_WIRE_IDSCAN)
-				. = "This wire is connected to the ID scanning panel."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(APC_WIRE_AI_CONTROL)
-				. = "This wire connects to automated control systems."
-			if(APC_WIRE_MAIN_POWER1, APC_WIRE_MAIN_POWER2)
-				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -7,7 +7,7 @@
 #define APC_WIRE_MAIN_POWER2 4
 #define APC_WIRE_AI_CONTROL 8
 
-/datum/wires/apc/GetInteractWindow()
+/datum/wires/apc/GetInteractWindow(mob/user)
 	var/obj/machinery/power/apc/A = holder
 	. += ..()
 	. += text("<br>\n[(A.locked ? "The APC is locked." : "The APC is unlocked.")]<br>\n[(A.shorted ? "The APCs power has been shorted." : "The APC is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
@@ -70,3 +70,16 @@
 			else
 				if (A.aidisabled == 1)
 					A.aidisabled = 0
+
+/datum/wires/apc/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(APC_WIRE_IDSCAN)
+				. = "This wire is connected to the ID scanning panel."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(APC_WIRE_AI_CONTROL)
+				. = "This wire connects to automated control systems."
+			if(APC_WIRE_MAIN_POWER1, APC_WIRE_MAIN_POWER2)
+				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -2,6 +2,11 @@
 
 	holder_type = /obj/machinery/autolathe
 	wire_count = 6
+	descriptions = list(
+		new /datum/wire_description(AUTOLATHE_HACK_WIRE, "This wire appears to lead to an auxiliary data storage unit."),
+		new /datum/wire_description(AUTOLATHE_SHOCK_WIRE, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AUTOLATHE_DISABLE_WIRE, "This wire is connected to the power switch.", SKILL_EXPERT)
+	)
 
 var/const/AUTOLATHE_HACK_WIRE = 1
 var/const/AUTOLATHE_SHOCK_WIRE = 2
@@ -58,16 +63,3 @@ var/const/AUTOLATHE_DISABLE_WIRE = 4
 				if(A && !IsIndexCut(index))
 					A.disabled = 0
 					Interact(usr)
-
-/datum/wires/autolathe/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(AUTOLATHE_DISABLE_WIRE)
-				. = "This wire is connected to the power switch."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(AUTOLATHE_HACK_WIRE)
-				. = "This wire appears to lead to an auxiliary data storage unit."
-			if(AUTOLATHE_SHOCK_WIRE)
-				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -7,7 +7,7 @@ var/const/AUTOLATHE_HACK_WIRE = 1
 var/const/AUTOLATHE_SHOCK_WIRE = 2
 var/const/AUTOLATHE_DISABLE_WIRE = 4
 
-/datum/wires/autolathe/GetInteractWindow()
+/datum/wires/autolathe/GetInteractWindow(mob/user)
 	var/obj/machinery/autolathe/A = holder
 	. += ..()
 	. += "<BR>The red light is [A.disabled ? "off" : "on"]."
@@ -58,3 +58,16 @@ var/const/AUTOLATHE_DISABLE_WIRE = 4
 				if(A && !IsIndexCut(index))
 					A.disabled = 0
 					Interact(usr)
+
+/datum/wires/autolathe/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(AUTOLATHE_DISABLE_WIRE)
+				. = "This wire is connected to the power switch."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(AUTOLATHE_HACK_WIRE)
+				. = "This wire appears to lead to an auxiliary data storage unit."
+			if(AUTOLATHE_SHOCK_WIRE)
+				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -4,6 +4,12 @@
 	random = 1
 	holder_type = /obj/machinery/camera
 	wire_count = 6
+	descriptions = list(
+		new /datum/wire_description(CAMERA_WIRE_FOCUS, "This wire runs to the camera's lens adjustment motors."),
+		new /datum/wire_description(CAMERA_WIRE_POWER, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(CAMERA_WIRE_LIGHT, "This wire seems connected to the built-in light.", SKILL_EXPERT),
+		new /datum/wire_description(CAMERA_WIRE_ALARM, "This wire is connected to a remote signaling device of some sort.")
+	)
 
 /datum/wires/camera/GetInteractWindow(mob/user)
 
@@ -69,18 +75,3 @@ var/const/CAMERA_WIRE_NOTHING2 = 32
 		return 1
 	else
 		return 0
-
-/datum/wires/camera/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(CAMERA_WIRE_LIGHT)
-				. = "This wire seems connected to the built-in light."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(CAMERA_WIRE_POWER)
-				. = "This wire seems to be carrying a heavy current."
-			if(CAMERA_WIRE_ALARM)
-				. = "This wire is connected to a remote signaling device of some sort."
-			if(CAMERA_WIRE_FOCUS)
-				. = "This wire runs to the camera's lens adjustment motors."

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -5,7 +5,7 @@
 	holder_type = /obj/machinery/camera
 	wire_count = 6
 
-/datum/wires/camera/GetInteractWindow()
+/datum/wires/camera/GetInteractWindow(mob/user)
 
 	. = ..()
 	var/obj/machinery/camera/C = holder
@@ -69,3 +69,18 @@ var/const/CAMERA_WIRE_NOTHING2 = 32
 		return 1
 	else
 		return 0
+
+/datum/wires/camera/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(CAMERA_WIRE_LIGHT)
+				. = "This wire seems connected to the built-in light."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(CAMERA_WIRE_POWER)
+				. = "This wire seems to be carrying a heavy current."
+			if(CAMERA_WIRE_ALARM)
+				. = "This wire is connected to a remote signaling device of some sort."
+			if(CAMERA_WIRE_FOCUS)
+				. = "This wire runs to the camera's lens adjustment motors."

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -2,6 +2,11 @@
 	holder_type = /obj/machinery/nuclearbomb
 	random = 1
 	wire_count = 7
+	descriptions = list(
+		new /datum/wire_description(NUCLEARBOMB_WIRE_LIGHT, "This wire seems to connect to the small light on the device.", SKILL_EXPERT),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_TIMING, "This wire connects to the time display."),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_SAFETY, "This wire connects to a safety override.")
+	)
 
 var/const/NUCLEARBOMB_WIRE_LIGHT		= 1
 var/const/NUCLEARBOMB_WIRE_TIMING		= 2
@@ -56,16 +61,3 @@ var/const/NUCLEARBOMB_WIRE_SAFETY		= 4
 		if(NUCLEARBOMB_WIRE_LIGHT)
 			N.lighthack = !mended
 			N.update_icon()
-
-/datum/wires/nuclearbomb/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(NUCLEARBOMB_WIRE_LIGHT)
-				. = "This wire seems to connect to the small light on the device."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(NUCLEARBOMB_WIRE_TIMING)
-				. = "This wire connects to the time display."
-			if(NUCLEARBOMB_WIRE_SAFETY)
-				. = "This wire connects to a safety override."

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -11,7 +11,7 @@ var/const/NUCLEARBOMB_WIRE_SAFETY		= 4
 	var/obj/machinery/nuclearbomb/N = holder
 	return N.panel_open
 
-/datum/wires/nuclearbomb/GetInteractWindow()
+/datum/wires/nuclearbomb/GetInteractWindow(mob/user)
 	var/obj/machinery/nuclearbomb/N = holder
 	. += ..()
 	. += "<BR>The device is [N.timing ? "shaking!" : "still."]<BR>"
@@ -56,3 +56,16 @@ var/const/NUCLEARBOMB_WIRE_SAFETY		= 4
 		if(NUCLEARBOMB_WIRE_LIGHT)
 			N.lighthack = !mended
 			N.update_icon()
+
+/datum/wires/nuclearbomb/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(NUCLEARBOMB_WIRE_LIGHT)
+				. = "This wire seems to connect to the small light on the device."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(NUCLEARBOMB_WIRE_TIMING)
+				. = "This wire connects to the time display."
+			if(NUCLEARBOMB_WIRE_SAFETY)
+				. = "This wire connects to a safety override."

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -50,3 +50,18 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 			C.strength_upper_limit = (mended ? 2 : 3)
 			if(C.strength_upper_limit < C.strength)
 				C.remove_strength()
+
+/datum/wires/particle_acc/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(PARTICLE_TOGGLE_WIRE)
+				. = "This wire seems to connect to the main power toggle."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(PARTICLE_STRENGTH_WIRE)
+				. = "This wire connects to the primary magnets."
+			if(PARTICLE_INTERFACE_WIRE)
+				. = "This wire appears connected to the user panel."
+			if(PARTICLE_LIMIT_POWER_WIRE)
+				. = "This wire connects to the primary magnets."

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -1,6 +1,12 @@
 /datum/wires/particle_acc/control_box
 	wire_count = 5
 	holder_type = /obj/machinery/particle_accelerator/control_box
+	descriptions = list(
+		new /datum/wire_description(PARTICLE_TOGGLE_WIRE, "This wire seems to connect to the main power toggle.", SKILL_EXPERT),
+		new /datum/wire_description(PARTICLE_STRENGTH_WIRE, "This wire connects to the primary magnets."),
+		new /datum/wire_description(PARTICLE_INTERFACE_WIRE, "This wire appears connected to the user panel."),
+		new /datum/wire_description(PARTICLE_LIMIT_POWER_WIRE, "This wire connects to the primary magnets.")
+	)
 
 var/const/PARTICLE_TOGGLE_WIRE = 1 // Toggles whether the PA is on or not.
 var/const/PARTICLE_STRENGTH_WIRE = 2 // Determines the strength of the PA.
@@ -50,18 +56,3 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 			C.strength_upper_limit = (mended ? 2 : 3)
 			if(C.strength_upper_limit < C.strength)
 				C.remove_strength()
-
-/datum/wires/particle_acc/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(PARTICLE_TOGGLE_WIRE)
-				. = "This wire seems to connect to the main power toggle."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(PARTICLE_STRENGTH_WIRE)
-				. = "This wire connects to the primary magnets."
-			if(PARTICLE_INTERFACE_WIRE)
-				. = "This wire appears connected to the user panel."
-			if(PARTICLE_LIMIT_POWER_WIRE)
-				. = "This wire connects to the primary magnets."

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -1,6 +1,11 @@
 /datum/wires/radio
 	holder_type = /obj/item/device/radio
 	wire_count = 3
+	descriptions = list(
+		new /datum/wire_description(WIRE_SIGNAL, "This wire connects several radio components."),
+		new /datum/wire_description(WIRE_RECEIVE, "This wire runs to the radio reciever.", SKILL_EXPERT),
+		new /datum/wire_description(WIRE_TRANSMIT, "This wire runs to the radio transmitter.")
+	)
 
 var/const/WIRE_SIGNAL = 1
 var/const/WIRE_RECEIVE = 2
@@ -45,16 +50,3 @@ var/const/WIRE_TRANSMIT = 4
 		if(WIRE_TRANSMIT)
 			R.broadcasting = mended && !IsIndexCut(WIRE_SIGNAL)
 	SSnano.update_uis(holder)
-
-/datum/wires/radio/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(WIRE_RECEIVE)
-				. = "This wire runs to the radio reciever."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(WIRE_SIGNAL)
-				. = "This wire connects several radio components."
-			if(WIRE_TRANSMIT)
-				. = "This wire runs to the radio transmitter."

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -12,7 +12,7 @@ var/const/WIRE_TRANSMIT = 4
 		return 1
 	return 0
 
-/datum/wires/radio/GetInteractWindow()
+/datum/wires/radio/GetInteractWindow(mob/user)
 	var/obj/item/device/radio/R = holder
 	. += ..()
 	if(R.cell)
@@ -45,3 +45,16 @@ var/const/WIRE_TRANSMIT = 4
 		if(WIRE_TRANSMIT)
 			R.broadcasting = mended && !IsIndexCut(WIRE_SIGNAL)
 	SSnano.update_uis(holder)
+
+/datum/wires/radio/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(WIRE_RECEIVE)
+				. = "This wire runs to the radio reciever."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(WIRE_SIGNAL)
+				. = "This wire connects several radio components."
+			if(WIRE_TRANSMIT)
+				. = "This wire runs to the radio transmitter."

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -2,6 +2,13 @@
 	random = 1
 	holder_type = /mob/living/silicon/robot
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module."),
+		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERT),
+		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override."),
+		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
+		new /datum/wire_description(BORG_WIRE_CAMERA,  "This wire runs to the unit's vision modules.")
+	)
 
 var/const/BORG_WIRE_LAWCHECK = 1
 var/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy
@@ -71,20 +78,3 @@ var/const/BORG_WIRE_CAMERA = 16
 
 /datum/wires/robot/proc/LockedCut()
 	return wires_status & BORG_WIRE_LOCKED_DOWN
-
-/datum/wires/robot/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(BORG_WIRE_MAIN_POWER)
-				. = "This wire seems to be carrying a heavy current."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(BORG_WIRE_LAWCHECK)
-				. = "This wire runs to the unit's law module."
-			if(BORG_WIRE_CAMERA)
-				. = "This wire runs to the unit's vision modules."
-			if(BORG_WIRE_LOCKED_DOWN)
-				. = "This wire connects to the unit's safety override."
-			if(BORG_WIRE_AI_CONTROL)
-				. = "This wire connects to automated control systems."

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -9,7 +9,7 @@ var/const/BORG_WIRE_LOCKED_DOWN = 4
 var/const/BORG_WIRE_AI_CONTROL = 8
 var/const/BORG_WIRE_CAMERA = 16
 
-/datum/wires/robot/GetInteractWindow()
+/datum/wires/robot/GetInteractWindow(mob/user)
 
 	. = ..()
 	var/mob/living/silicon/robot/R = holder
@@ -39,10 +39,6 @@ var/const/BORG_WIRE_CAMERA = 16
 		if (BORG_WIRE_CAMERA)
 			if(!isnull(R.camera) && !R.scrambledcodes)
 				R.camera.status = mended
-
-		if(BORG_WIRE_LAWCHECK)	//Forces a law update if the borg is set to receive them. Since an update would happen when the borg checks its laws anyway, not much use, but eh
-			if (R.lawupdate)
-				R.lawsync()
 
 		if(BORG_WIRE_LOCKED_DOWN)
 			R.SetLockdown(!mended)
@@ -75,3 +71,20 @@ var/const/BORG_WIRE_CAMERA = 16
 
 /datum/wires/robot/proc/LockedCut()
 	return wires_status & BORG_WIRE_LOCKED_DOWN
+
+/datum/wires/robot/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(BORG_WIRE_MAIN_POWER)
+				. = "This wire seems to be carrying a heavy current."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(BORG_WIRE_LAWCHECK)
+				. = "This wire runs to the unit's law module."
+			if(BORG_WIRE_CAMERA)
+				. = "This wire runs to the unit's vision modules."
+			if(BORG_WIRE_LOCKED_DOWN)
+				. = "This wire connects to the unit's safety override."
+			if(BORG_WIRE_AI_CONTROL)
+				. = "This wire connects to automated control systems."

--- a/code/datums/wires/shield_generator.dm
+++ b/code/datums/wires/shield_generator.dm
@@ -37,10 +37,25 @@ var/const/SHIELDGEN_WIRE_NOTHING = 16		// A blank wire that doesn't have any spe
 		if(SHIELDGEN_WIRE_HACK)
 			S.hacked = 1
 
-/datum/wires/shield_generator/GetInteractWindow()
+/datum/wires/shield_generator/GetInteractWindow(mob/user)
 	var/obj/machinery/power/shield_generator/S = holder
 	. += ..()
 	. += "<BR>A red light labeled \"Safety Override\" is [S.hacked ? "blinking" : "off"]."
 	. += "<BR>A green light labeled \"Power Connection\" is [S.input_cut ? "off" : "on"]."
 	. += "<BR>A blue light labeled \"Network Control\" is [S.ai_control_disabled ? "off" : "on"]."
 	. += "<BR>A yellow light labeled \"Interface Connection\" is [S.mode_changes_locked ? "off" : "on"].<BR>"
+
+/datum/wires/shield_generator/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(SHIELDGEN_WIRE_POWER)
+				. = "This wire seems to be carrying a heavy current."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(SHIELDGEN_WIRE_HACK)
+				. = "This wire seems designed to enable a manual override."
+			if(SHIELDGEN_WIRE_CONTROL)
+				. = "This wire connects to the main control panel."
+			if(SHIELDGEN_WIRE_AICONTROL)
+				. = "This wire connects to automated control systems."

--- a/code/datums/wires/shield_generator.dm
+++ b/code/datums/wires/shield_generator.dm
@@ -1,6 +1,12 @@
 /datum/wires/shield_generator
 	holder_type = /obj/machinery/power/shield_generator/
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERT),
+		new /datum/wire_description(SHIELDGEN_WIRE_HACK, "This wire seems designed to enable a manual override."),
+		new /datum/wire_description(SHIELDGEN_WIRE_CONTROL, "This wire connects to the main control panel."),
+		new /datum/wire_description(SHIELDGEN_WIRE_AICONTROL, "This wire connects to automated control systems.")
+	)
 
 var/const/SHIELDGEN_WIRE_POWER = 1			// Cut to disable power input into the generator. Pulse does nothing. Mend to restore.
 var/const/SHIELDGEN_WIRE_HACK = 2			// Pulse to hack the generator, enabling hacked modes. Cut to unhack. Mend does nothing.
@@ -36,26 +42,3 @@ var/const/SHIELDGEN_WIRE_NOTHING = 16		// A blank wire that doesn't have any spe
 	switch(index)
 		if(SHIELDGEN_WIRE_HACK)
 			S.hacked = 1
-
-/datum/wires/shield_generator/GetInteractWindow(mob/user)
-	var/obj/machinery/power/shield_generator/S = holder
-	. += ..()
-	. += "<BR>A red light labeled \"Safety Override\" is [S.hacked ? "blinking" : "off"]."
-	. += "<BR>A green light labeled \"Power Connection\" is [S.input_cut ? "off" : "on"]."
-	. += "<BR>A blue light labeled \"Network Control\" is [S.ai_control_disabled ? "off" : "on"]."
-	. += "<BR>A yellow light labeled \"Interface Connection\" is [S.mode_changes_locked ? "off" : "on"].<BR>"
-
-/datum/wires/shield_generator/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(SHIELDGEN_WIRE_POWER)
-				. = "This wire seems to be carrying a heavy current."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(SHIELDGEN_WIRE_HACK)
-				. = "This wire seems designed to enable a manual override."
-			if(SHIELDGEN_WIRE_CONTROL)
-				. = "This wire connects to the main control panel."
-			if(SHIELDGEN_WIRE_AICONTROL)
-				. = "This wire connects to automated control systems."

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -1,6 +1,11 @@
 /datum/wires/smartfridge
 	holder_type = /obj/machinery/smartfridge
 	wire_count = 3
+	descriptions = list(
+		new /datum/wire_description(SMARTFRIDGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_THROW, "This wire leads to the item dispensor force controls."),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERT)
+	)
 
 /datum/wires/smartfridge/secure
 	random = 1
@@ -49,16 +54,3 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 				S.seconds_electrified = -1
 		if(SMARTFRIDGE_WIRE_IDSCAN)
 			S.scan_id = 1
-
-/datum/wires/smartfridge/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(SMARTFRIDGE_WIRE_IDSCAN)
-				. = "This wire is connected to the ID scanning panel."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(SMARTFRIDGE_WIRE_THROW)
-				. = "This wire leads to the item dispensor force controls."
-			if(SMARTFRIDGE_WIRE_ELECTRIFY)
-				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -20,7 +20,7 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 		return 1
 	return 0
 
-/datum/wires/smartfridge/GetInteractWindow()
+/datum/wires/smartfridge/GetInteractWindow(mob/user)
 	var/obj/machinery/smartfridge/S = holder
 	. += ..()
 	. += "<BR>The orange light is [S.seconds_electrified ? "off" : "on"].<BR>"
@@ -49,3 +49,16 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 				S.seconds_electrified = -1
 		if(SMARTFRIDGE_WIRE_IDSCAN)
 			S.scan_id = 1
+
+/datum/wires/smartfridge/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(SMARTFRIDGE_WIRE_IDSCAN)
+				. = "This wire is connected to the ID scanning panel."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(SMARTFRIDGE_WIRE_THROW)
+				. = "This wire leads to the item dispensor force controls."
+			if(SMARTFRIDGE_WIRE_ELECTRIFY)
+				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -1,6 +1,13 @@
 /datum/wires/smes
 	holder_type = /obj/machinery/power/smes/buildable
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(SMES_WIRE_RCON, "This wire runs to a remote signaling mechanism."),
+		new /datum/wire_description(SMES_WIRE_INPUT, "This seems to be the primary input.", SKILL_EXPERT),
+		new /datum/wire_description(SMES_WIRE_OUTPUT, "This seems to be the primary output.", SKILL_EXPERT),
+		new /datum/wire_description(SMES_WIRE_GROUNDING, "This wire appeas to connect directly to the floor.", SKILL_EXPERT),
+		new /datum/wire_description(SMES_WIRE_FAILSAFES, "This wire appears to connect to a failsafe mechanism.")
+	)
 
 var/const/SMES_WIRE_RCON = 1		// Remote control (AI and consoles), cut to disable
 var/const/SMES_WIRE_INPUT = 2		// Input wire, cut to disable input, pulse to disable for 60s
@@ -58,20 +65,3 @@ var/const/SMES_WIRE_FAILSAFES = 16	// Cut to disable failsafes, mend to reenable
 				S.safeties_enabled = 0
 				spawn(10)
 					S.safeties_enabled = 1
-
-/datum/wires/smes/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(SMES_WIRE_GROUNDING)
-				. = "This wire appeas to connect directly to the floor."
-			if(SMES_WIRE_INPUT)
-				. = "This seems to be the primary input."
-			if(SMES_WIRE_OUTPUT)
-				. = "This seems to be the primary output."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(SMES_WIRE_RCON)
-				. = "This wire runs to a remote signaling mechanism."
-			if(SMES_WIRE_FAILSAFES)
-				. = "This wire appears to connect to a failsafe mechanism."

--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -16,7 +16,7 @@ var/const/SMES_WIRE_FAILSAFES = 16	// Cut to disable failsafes, mend to reenable
 	return 0
 
 
-/datum/wires/smes/GetInteractWindow()
+/datum/wires/smes/GetInteractWindow(mob/user)
 	var/obj/machinery/power/smes/buildable/S = holder
 	. += ..()
 	. += "The green light is [(S.input_cut || S.input_pulsed || S.output_cut || S.output_pulsed) ? "off" : "on"]<br>"
@@ -58,3 +58,20 @@ var/const/SMES_WIRE_FAILSAFES = 16	// Cut to disable failsafes, mend to reenable
 				S.safeties_enabled = 0
 				spawn(10)
 					S.safeties_enabled = 1
+
+/datum/wires/smes/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(SMES_WIRE_GROUNDING)
+				. = "This wire appeas to connect directly to the floor."
+			if(SMES_WIRE_INPUT)
+				. = "This seems to be the primary input."
+			if(SMES_WIRE_OUTPUT)
+				. = "This seems to be the primary output."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(SMES_WIRE_RCON)
+				. = "This wire runs to a remote signaling mechanism."
+			if(SMES_WIRE_FAILSAFES)
+				. = "This wire appears to connect to a failsafe mechanism."

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -16,7 +16,7 @@ var/const/SUIT_STORAGE_WIRE_LOCKED		= 4
 		return 1
 	return 0
 
-/datum/wires/suit_storage_unit/GetInteractWindow()
+/datum/wires/suit_storage_unit/GetInteractWindow(mob/user)
 	var/obj/machinery/suit_cycler/S = holder
 	. += ..()
 	. += "<BR>The orange light is [S.electrified ? "off" : "on"].<BR>"
@@ -45,3 +45,16 @@ var/const/SUIT_STORAGE_WIRE_LOCKED		= 4
 				S.electrified = 0
 			else
 				S.electrified = -1
+
+/datum/wires/suit_storage_unit/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(SUIT_STORAGE_WIRE_SAFETY)
+				. = "This wire seems connected to a safety override"
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(SUIT_STORAGE_WIRE_ELECTRIFY)
+				. = "This wire seems to be carrying a heavy current."
+			if(SUIT_STORAGE_WIRE_LOCKED)
+				. = "This wire is connected to the ID scanning panel."

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -1,6 +1,11 @@
 /datum/wires/suit_storage_unit
 	holder_type = /obj/machinery/suit_cycler
 	wire_count = 3
+	descriptions = list(
+		new /datum/wire_description(SUIT_STORAGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_SAFETY, "This wire seems connected to a safety override", SKILL_EXPERT),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_LOCKED, "This wire is connected to the ID scanning panel.")
+	)
 
 var/const/SUIT_STORAGE_WIRE_ELECTRIFY	= 1
 var/const/SUIT_STORAGE_WIRE_SAFETY		= 2
@@ -45,16 +50,3 @@ var/const/SUIT_STORAGE_WIRE_LOCKED		= 4
 				S.electrified = 0
 			else
 				S.electrified = -1
-
-/datum/wires/suit_storage_unit/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(SUIT_STORAGE_WIRE_SAFETY)
-				. = "This wire seems connected to a safety override"
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(SUIT_STORAGE_WIRE_ELECTRIFY)
-				. = "This wire seems to be carrying a heavy current."
-			if(SUIT_STORAGE_WIRE_LOCKED)
-				. = "This wire is connected to the ID scanning panel."

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -3,6 +3,12 @@
 /datum/wires/vending
 	holder_type = /obj/machinery/vending
 	wire_count = 4
+	descriptions = list(
+		new /datum/wire_description(VENDING_WIRE_THROW, "This wire leads to the item dispensor force controls."),
+		new /datum/wire_description(VENDING_WIRE_CONTRABAND, "This wire appears connected to a reserve inventory compartment."),
+		new /datum/wire_description(VENDING_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(VENDING_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERT)
+	)
 
 var/const/VENDING_WIRE_THROW = 1
 var/const/VENDING_WIRE_CONTRABAND = 2
@@ -53,18 +59,3 @@ var/const/VENDING_WIRE_IDSCAN = 8
 				V.seconds_electrified = -1
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = 1
-
-/datum/wires/vending/examine(index, mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
-		switch(index)
-			if(VENDING_WIRE_IDSCAN)
-				. = "This wire is connected to the ID scanning panel."
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
-		switch(index)
-			if(VENDING_WIRE_THROW)
-				. = "This wire leads to the item dispensor force controls."
-			if(VENDING_WIRE_CONTRABAND)
-				. = "This wire appears connected to a reserve inventory compartment."
-			if(VENDING_WIRE_ELECTRIFY)
-				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -19,7 +19,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		return 1
 	return 0
 
-/datum/wires/vending/GetInteractWindow()
+/datum/wires/vending/GetInteractWindow(mob/user)
 	var/obj/machinery/vending/V = holder
 	. += ..()
 	. += "<BR>The orange light is [V.seconds_electrified ? "off" : "on"].<BR>"
@@ -53,3 +53,18 @@ var/const/VENDING_WIRE_IDSCAN = 8
 				V.seconds_electrified = -1
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = 1
+
+/datum/wires/vending/examine(index, mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_EXPERT))
+		switch(index)
+			if(VENDING_WIRE_IDSCAN)
+				. = "This wire is connected to the ID scanning panel."
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_PROF))
+		switch(index)
+			if(VENDING_WIRE_THROW)
+				. = "This wire leads to the item dispensor force controls."
+			if(VENDING_WIRE_CONTRABAND)
+				. = "This wire appears connected to a reserve inventory compartment."
+			if(VENDING_WIRE_ELECTRIFY)
+				. = "This wire seems to be carrying a heavy current."

--- a/code/datums/wires/wire_description.dm
+++ b/code/datums/wires/wire_description.dm
@@ -1,0 +1,12 @@
+/datum/wire_description
+	var/index
+	var/description
+	var/skill_level = SKILL_PROF
+
+/datum/wire_description/New(index, description, skill_level)
+	src.index = index
+	if(description)
+		src.description = description
+	if(skill_level)
+		src.skill_level = skill_level
+	..()

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -26,6 +26,8 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	var/window_x = 450
 	var/window_y = 470
 
+	var/list/descriptions // Descriptions of wires (datum/wire_description) for use with examining.
+
 /datum/wires/New(var/atom/holder)
 	..()
 	src.holder = holder
@@ -36,6 +38,9 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	// Generate new wires
 	if(random)
 		GenerateWires()
+		for(var/datum/wire_description/desc in descriptions)
+			if(prob(50))
+				desc.skill_level++
 	// Get the same wires
 	else
 		// We don't have any wires to copy yet, generate some and then copy it.
@@ -67,7 +72,6 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 		src.wires[colour] = index
 		//wires = shuffle(wires)
-
 
 /datum/wires/proc/Interact(var/mob/living/user)
 
@@ -192,7 +196,14 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	return
 
 /datum/wires/proc/examine(index, mob/user)
-	return "You aren't sure what this wire does."
+	. = "You aren't sure what this wire does."
+
+	var/datum/wire_description/wd = get_description(index)
+	if(!wd)
+		return 
+	if(wd.skill_level && !user.skill_check(SKILL_ELECTRICAL, wd.skill_level))
+		return
+	return wd.description
 
 /datum/wires/proc/CanUse(var/mob/living/L)
 	return 1
@@ -222,6 +233,11 @@ var/const/POWER = 8
 //
 // Helper Procs
 //
+
+/datum/wires/proc/get_description(index)
+	for(var/datum/wire_description/desc in descriptions)
+		if(desc.index == index)
+			return desc
 
 /datum/wires/proc/PulseColour(var/colour)
 	PulseIndex(GetIndex(colour))

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -99,7 +99,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 	var/list/wires_used = list()
 	for(var/colour in wires)
-		wires_used += prob(user.skill_fail_chance(SKILL_ELECTRICAL, 20, SKILL_EXPERT)) ? pick(wires) : colour
+		wires_used += prob(user.skill_fail_chance(SKILL_ELECTRICAL, 20, SKILL_ADEPT)) ? pick(wires) : colour
 	if(!user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
 		wires_used = shuffle(wires_used)
 
@@ -156,7 +156,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 					to_chat(L, "<span class='error'>You need a multitool!</span>")
 			else if(href_list["attach"])
 				var/colour = href_list["attach"]
-				if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 80, SKILL_PROF)))
+				if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 80, SKILL_EXPERT)))
 					colour = pick(wires)
 					to_chat(L, "<span class='danger'>Are you sure you got the right wire?</span>")
 				// Detach

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -117,7 +117,7 @@
 	//Hacking.
 	if(panel_open)
 		dat += "<h2>Maintenance Panel</h2>"
-		dat += wires.GetInteractWindow()
+		dat += wires.GetInteractWindow(user)
 
 		dat += "<hr>"
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -141,11 +141,6 @@
 /mob/observer/ghost/has_internal_radio_channel_access(var/list/req_one_accesses)
 	return can_admin_interact()
 
-/obj/item/device/radio/proc/text_wires()
-	if (b_stat)
-		return wires.GetInteractWindow()
-	return
-
 /obj/item/device/radio/get_cell()
 	return cell
 

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -1,13 +1,21 @@
-/datum/wires/rig
-	random = 1
-	holder_type = /obj/item/weapon/rig
-	wire_count = 5
-
 #define RIG_SECURITY 1
 #define RIG_AI_OVERRIDE 2
 #define RIG_SYSTEM_CONTROL 4
 #define RIG_INTERFACE_LOCK 8
 #define RIG_INTERFACE_SHOCK 16
+
+/datum/wires/rig
+	random = 1
+	holder_type = /obj/item/weapon/rig
+	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(RIG_SECURITY, "This wire is connected to the ID scanning panel."),
+		new /datum/wire_description(RIG_AI_OVERRIDE, "This wire connects to automated control systems."),
+		new /datum/wire_description(RIG_SYSTEM_CONTROL, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(RIG_INTERFACE_LOCK, "This wire connects to the interface panel.", SKILL_EXPERT),
+		new /datum/wire_description(RIG_INTERFACE_SHOCK, "This wire seems to be carrying a heavy current.")
+	)
+
 /*
  * Rig security can be snipped to disable ID access checks on rig.
  * Rig AI override can be pulsed to toggle whether or not the AI can take control of the suit.


### PR DESCRIPTION
:cl:
rscadd: Hacking without the electrical skill is harder now.
rscadd: If you are unskilled in electrical, hacking will randomize the wire positions (not meanings) each time you open the screen. If you are basic, you'll get some possible duplicate colors/omitted colors, with smaller probabilities.
rscadd: If you pulse a wire below trained skill, you have (progressively smaller) chances of pulsing the wrong wire. If you are untrained, you may randomize wire positions for everyone else trying to hack the thing.
rscadd: If you cut/mend wires below trained skill, you may cut/mend some extra wires by accident.
rscadd: If you try to place a remote signaler with low skill (trained or lower), you might place it on the wrong wire, and then have a hard time removing it.
rscadd: A new "Examine" option has been added to the hacking menu. Below experienced it doesn't do much. On experienced one or two wires will be identifiable on examine, while at master most will be. Less effective for "secure" objects with randomized wiring.
/:cl: