### PR TITLE
Makes engine skill effect the SM monitor and emitters.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -59,8 +59,20 @@
 	for(var/obj/machinery/power/supermatter/S in supermatters)
 		. = max(., S.get_status())
 
+/datum/nano_module/supermatter_monitor/proc/process_data_output(skill, value)
+	switch(skill)
+		if(SKILL_NONE)
+			return (0.6 + 0.8 * rand()) * value
+		if(SKILL_BASIC)
+			return (0.8 + 0.4 * rand()) * value
+		if(SKILL_ADEPT)
+			return (0.95 + 0.1 * rand()) * value
+		else
+			return value
+
 /datum/nano_module/supermatter_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
+	var/engine_skill = user.get_skill_value(SKILL_ENGINES)
 
 	if(istype(active))
 		var/turf/T = get_turf(active)
@@ -73,11 +85,11 @@
 			return
 
 		data["active"] = 1
-		data["SM_integrity"] = active.get_integrity()
-		data["SM_power"] = active.power
-		data["SM_ambienttemp"] = air.temperature
-		data["SM_ambientpressure"] = air.return_pressure()
-		data["SM_EPR"] = active.get_epr()
+		data["SM_integrity"] = min(process_data_output(engine_skill, active.get_integrity()), 100)
+		data["SM_power"] = process_data_output(engine_skill, active.power)
+		data["SM_ambienttemp"] = process_data_output(engine_skill, air.temperature)
+		data["SM_ambientpressure"] = process_data_output(engine_skill, air.return_pressure())
+		data["SM_EPR"] = process_data_output(engine_skill, active.get_epr())
 		if(air.total_moles)
 			data["SM_gas_O2"] = round(100*air.gas["oxygen"]/air.total_moles,0.01)
 			data["SM_gas_CO2"] = round(100*air.gas["carbon_dioxide"]/air.total_moles,0.01)
@@ -101,7 +113,7 @@
 
 			SMS.Add(list(list(
 			"area_name" = A.name,
-			"integrity" = S.get_integrity(),
+			"integrity" = process_data_output(engine_skill, S.get_integrity()),
 			"uid" = S.uid
 			)))
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -30,6 +30,7 @@
 
 	var/_wifi_id
 	var/datum/wifi/receiver/button/emitter/wifi_receiver
+	core_skill = SKILL_ENGINES
 
 /obj/machinery/power/emitter/anchored
 	anchored = 1
@@ -86,6 +87,8 @@
 				investigate_log("turned <font color='red'>off</font> by [user.key]","singulo")
 			else
 				src.active = 1
+				operator_skill = user.get_skill_value(core_skill)
+				update_efficiency()
 				to_chat(user, "You turn on \the [src].")
 				src.shot_number = 0
 				src.fire_delay = get_initial_fire_delay()
@@ -98,6 +101,12 @@
 		to_chat(user, "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>")
 		return 1
 
+/obj/machinery/power/emitter/proc/update_efficiency()
+	efficiency = initial(efficiency)
+	if(!operator_skill)
+		return
+	var/skill_modifier = 0.8 * (SKILL_MAX - operator_skill)/(SKILL_MAX - SKILL_MIN) //How much randomness is added
+	efficiency *= 1 + (rand() - 1) * skill_modifier //subtract off between 0.8 and 0, depending on skill and luck.
 
 /obj/machinery/power/emitter/emp_act(var/severity)
 	return 1

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -245,6 +245,24 @@
 		explosion(TS, explosion_power/2, explosion_power, explosion_power * 2, explosion_power * 4, 1)
 		qdel(src)
 
+/obj/machinery/power/supermatter/examine(mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_ENGINES, SKILL_EXPERT))
+		var/integrity_message 
+		switch(get_integrity())
+			if(0 to 30)
+				integrity_message = "<span class='danger'>It looks highly unstable!</span>"
+			if(31 to 70)
+				integrity_message = "It appears to be losing cohesion!"
+			else
+				integrity_message = "At a glance, it seems to be in sound shape."
+		to_chat(user, integrity_message)
+		if(user.skill_check(SKILL_ENGINES, SKILL_PROF))
+			var/display_power = power
+			display_power *= (0.85 + 0.3 * rand())
+			display_power = round(display_power, 20)
+			to_chat(user, "Eyeballing it, you place the relative EER at around [display_power] MeV/cm3.")
+
 //Changes color and luminosity of the light to these values if they were not already set
 /obj/machinery/power/supermatter/proc/shift_light(var/lum, var/clr)
 	if(lum != light_outer_range || clr != light_color)


### PR DESCRIPTION
:cl:
rscadd: The SM monitor readings will fluctuate with some errors at Trained in Engines skill and below (max 40%, 20%, and 5% at Untrained, Basic, and Trained). At master they'll be like previously.
rscadd: Turning on the emitter will recompute its efficiency (i.e. power) to a lower random value, depending on skill.
rscadd: Examining the SM at Expert skill will give some information about its integrity. At Master, it will give a guesstimate for the EER.
/:cl:

The second change is designed to make the first one more significant, so that if you have low skill bypassing the SM monitor and counting your shots is not a great way to go.