### PR TITLE
Lets Bridge Officers access their lockers

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -357,7 +357,7 @@
 	skill_points = 20
 
 	access = list(access_representative, access_security, access_medical,
-			            access_heads, access_cargo, access_solgov_crew, access_hangar)
+			            access_bridge, access_cargo, access_solgov_crew, access_hangar)
 
 	software_on_spawn = list(/datum/computer_file/program/reports)
 

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -95,7 +95,7 @@
 
 /obj/structure/closet/secure_closet/bridgeofficer
 	name = "bridge officer's locker"
-	req_access = list(access_heads)
+	req_access = list(access_bridge)
 	icon_state = "sol1"
 	icon_closed = "sol"
 	icon_locked = "sol1"


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Bridge Officers can once again access their lockers.
bugfix: SCGR can once again access the bridge.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
