### PR TITLE
Fix map-template-loading admin verb

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -15,15 +15,12 @@
 	if(!T)
 		return
 
-	var/clear_contents = (alert(usr, "Do you want to delete everything in the way of the template? \
-		May take a few seconds, particularly on  larger templates!", "Clear Contents", "No", "Yes") == "Yes")
-
 	var/list/preview = list()
 	for(var/S in template.get_affected_turfs(T,centered = TRUE))
 		preview += image('icons/turf/overlays.dmi',S,"greenOverlay")
 	usr.client.images += preview
 	if(alert(usr,"Confirm location.","Template Confirm","Yes","No") == "Yes")
-		if(template.load(T, centered = TRUE, clear_contents=clear_contents))
+		if(template.load(T, centered = TRUE))
 			log_and_message_admins("has placed a map template ([template.name]).")
 		else
 			to_chat(usr, "Failed to place map")

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -120,7 +120,7 @@
 	var/list/atoms_to_initialise = list()
 
 	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, clear_contents= template_flags & TEMPLATE_FLAG_CLEAR_CONTENTS)
+		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, clear_contents=(template_flags & TEMPLATE_FLAG_CLEAR_CONTENTS))
 		if (M)
 			atoms_to_initialise += M.atoms_to_initialise
 		else


### PR DESCRIPTION
We don't have a clear_contents parameter anymore as the templates themselves now decide whether to clear what they're being spawned onto.

Fixes #22554.