### PR TITLE
Map Tweaks to Deck 3

### DIFF
--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -3834,10 +3834,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
-"iZ" = (
-/obj/structure/noticeboard,
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/galley)
 "ja" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -4333,9 +4329,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Holodeck - Center"
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
@@ -4593,19 +4586,15 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/bar)
 "kW" = (
-/obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
 	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
 /obj/machinery/light/spot,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/holocontrol)
 "kY" = (
@@ -5213,6 +5202,10 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Holodeck Control";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/holocontrol)
 "mB" = (
@@ -5527,6 +5520,10 @@
 "nl" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/holocontrol)
@@ -6417,17 +6414,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Holodeck - Control Room";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/holocontrol)
@@ -6757,9 +6745,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "pY" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6768,8 +6753,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/noticeboard,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/mess)
 "pZ" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -6790,15 +6775,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/mess)
 "qc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/civilian{
+/obj/machinery/door/airlock/multi_tile/glass/civilian{
 	name = "Holodeck"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -6848,20 +6825,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
-"qk" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "qo" = (
 /obj/machinery/firealarm{
@@ -7267,9 +7230,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
 "rr" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -7280,17 +7240,21 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rt" = (
-/obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
-	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Aft"
 	},
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/half{
+	icon_state = "bordercolorhalf";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -7304,6 +7268,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"rv" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Holodeck - Center"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/holocontrol)
 "rw" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -9686,6 +9663,16 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/lino,
 /area/crew_quarters/diplomat)
+"wB" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aft)
 "wD" = (
 /obj/machinery/door/airlock/command{
 	name = "Officer's Mess";
@@ -11744,6 +11731,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/commissary)
+"Bg" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aft)
 "Bi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -13075,6 +13072,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
+"Er" = (
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/lino,
+/area/vacant/office)
 "Es" = (
 /obj/random/closet,
 /turf/simulated/floor/plating,
@@ -18489,7 +18492,7 @@
 "Uz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
@@ -36416,7 +36419,7 @@ Qg
 fp
 RO
 Tg
-iZ
+ev
 Ug
 Vg
 Vg
@@ -42493,7 +42496,7 @@ xp
 Og
 yq
 zn
-wp
+Er
 AP
 Mr
 vh
@@ -42888,8 +42891,8 @@ my
 nt
 ol
 pk
-gE
-qk
+om
+lc
 sF
 je
 vg
@@ -43082,7 +43085,7 @@ ve
 gE
 gE
 gE
-gE
+rv
 kd
 kW
 gE
@@ -43103,7 +43106,7 @@ wp
 mB
 AS
 vh
-SW
+Ba
 CU
 Dn
 Fj
@@ -43293,7 +43296,7 @@ hA
 hA
 hA
 gE
-lJ
+Bg
 AR
 ua
 vh
@@ -43697,7 +43700,7 @@ hA
 hA
 hA
 gE
-lc
+wB
 sJ
 uc
 vl


### PR DESCRIPTION
🆑 nearlyNon
maptweak: Moves notice board between main mess hall doors, removing the window. RIP.
maptweak: Adds a holopad to the holodeck, so the AI can hang out there.
maptweak: Expands holodeck door to be two tiles wide, to prevent bottlenecking.
maptweak: Adds a newscaster to the vacant office.
/🆑
Add holopad to holodeck; increase holodeck door size; add newscaster to vacant office; move notice board in bar to a place where it can be read by people other than the chef.