### PR TITLE
Disables wired network cards from using disabled features

### DIFF
--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -72,7 +72,7 @@ var/global/ntnet_card_uid = 1
 	if(!check_functionality() || !ntnet_global || is_banned())
 		return 0
 
-	if(ethernet) // Computer is connected via wired connection.
+	if(ethernet && !specific_action) // Computer is connected via wired connection and we're not using a specific service.
 		return 3
 
 	if(!ntnet_global.check_function(specific_action)) // NTNet is down and we are not connected via wired connection. No signal.


### PR DESCRIPTION
If NTNet services like downloading or remote controls are disabled in the firewall, wired network cards will no longer be able to bypass that fact.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
