### PR TITLE
Fixes wired network cards having slow connection

### DIFF
--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -72,11 +72,12 @@ var/global/ntnet_card_uid = 1
 	if(!check_functionality() || !ntnet_global || is_banned())
 		return 0
 
-	if(ethernet && !specific_action) // Computer is connected via wired connection and we're not using a specific service.
-		return 3
-
 	if(!ntnet_global.check_function(specific_action)) // NTNet is down and we are not connected via wired connection. No signal.
-		return 0
+		if(!ethernet || specific_action) // Wired connection ensures a basic connection to NTNet, however no usage of disabled network services.
+			return 0
+
+	if(ethernet) // Computer is connected via wired connection.
+		return 3
 
 	if(holder2)
 		var/turf/T = get_turf(holder2)


### PR DESCRIPTION
Must have slept when I did that last change. Wired network cards once again return 3 when they have a connection.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
