### PR TITLE
Emergency Holodeck Wiring + Piping Fix

### DIFF
--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -5140,6 +5140,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
+/obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "mr" = (
@@ -6778,6 +6779,13 @@
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	name = "Holodeck"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/holocontrol)
 "qd" = (
@@ -16289,6 +16297,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
+"MZ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/lounge)
 "Na" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38670,7 +38683,7 @@ Vy
 xk
 Ok
 Hb
-Sk
+MZ
 HA
 aI
 aa


### PR DESCRIPTION
🆑 Nearlynon
bugfix: Fixed missing pipes + wires in holodeck.
maptweak: Adds 2 paperbins to deck 3 in the mess and lounge respectively.
/🆑
I fucked up and deleted the pipes and wires to the Holodeck control room.