### PR TITLE
Bar area remap and associated changes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2326,6 +2326,7 @@
 #include "code\modules\reagents\reagent_containers\food\fish.dm"
 #include "code\modules\reagents\reagent_containers\food\lunch.dm"
 #include "code\modules\reagents\reagent_containers\food\sandwich.dm"
+#include "code\modules\reagents\reagent_containers\food\shaker.dm"
 #include "code\modules\reagents\reagent_containers\food\snacks.dm"
 #include "code\modules\reagents\reagent_containers\food\sushi.dm"
 #include "code\modules\reagents\reagent_containers\food\drinks\bottle.dm"

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -17,8 +17,7 @@
 	density = 1
 	anchored = 0
 	use_power = 0
-	atom_flags = ATOM_FLAG_NO_REACT
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
 
 	var/list/product_types = list()
 	var/dispense_flavour = ICECREAM_VANILLA

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -9,8 +9,7 @@
 	use_power = 1
 	idle_power_usage = 5
 	active_power_usage = 100
-	atom_flags = ATOM_FLAG_NO_REACT
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
 	var/operating = 0 // Is it on?
 	var/dirty = 0 // = {0..100} Does it need cleaning?
 	var/broken = 0 // ={0,1,2} How broken is it???

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -61,7 +61,8 @@
 		overlays |= stool_cache[padding_cache_key]
 
 	if(buckled_mob)
-		cache_key = "[base_icon]-armrest-[padding_material.name]"
+		if(padding_material)
+			cache_key = "[base_icon]-armrest-[padding_material.name]"
 		if(isnull(stool_cache[cache_key]))
 			var/image/I = image(icon, "[base_icon]_armrest")
 			I.plane = ABOVE_HUMAN_PLANE

--- a/code/modules/integrated_electronics/manipulation.dm
+++ b/code/modules/integrated_electronics/manipulation.dm
@@ -133,8 +133,7 @@
 	desc = "Stores liquid inside, and away from electrical components.  Can store up to 60u.  This will also suppress reactions."
 	icon_state = "reagent_storage_cryo"
 	extended_desc = "This is effectively an internal cryo beaker."
-	atom_flags = ATOM_FLAG_NO_REACT
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
 	complexity = 8
 	inputs = list()
 	outputs = list("volume used")

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -723,14 +723,21 @@
 
 /datum/reagent/drink/tea/icetea
 	name = "Iced Tea"
-	description = "No relation to a certain rap artist/ actor."
-	taste_description = "sweet tea"
-	color = "#104038" // rgb: 16, 64, 56
+	description = "It's the tea you know and love, but now it's cold."
+	taste_description = "cold black tea"
 	adj_temp = -5
 
 	glass_name = "iced tea"
-	glass_desc = "No relation to a certain rap artist/ actor."
+	glass_desc = "It's the tea you know and love, but now it's cold."
 	glass_special = list(DRINK_ICE)
+
+/datum/reagent/drink/tea/icetea/sweet
+	name = "Sweet Tea"
+	description = "It's the tea you know and love, but now it's cold. And sweet."
+	taste_description = "sweet tea"
+
+	glass_name = "sweet tea"
+	glass_desc = "It's the tea you know and love, but now it's cold. And sweet."
 
 /datum/reagent/drink/coffee
 	name = "Coffee"
@@ -1666,7 +1673,7 @@
 /datum/reagent/ethanol/gintonic
 	name = "Gin and Tonic"
 	description = "An all time classic, mild cocktail."
-	taste_description = "mild and tart"
+	taste_description = "mild tartness" //???
 	color = "#0064c8"
 	strength = 50
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1427,8 +1427,14 @@
 /datum/chemical_reaction/icetea
 	name = "Iced Tea"
 	result = /datum/reagent/drink/tea/icetea
-	required_reagents = list(/datum/reagent/drink/ice = 1, /datum/reagent/drink/tea = 2)
+	required_reagents = list(/datum/reagent/drink/ice = 1, /datum/reagent/drink/tea = 2, /datum/reagent/sugar = 1)
 	result_amount = 3
+
+/datum/chemical_reaction/sweettea
+	name = "Sweet Tea"
+	result = /datum/reagent/drink/tea/icetea
+	required_reagents = list(/datum/chemical_reaction/icetea = 3, /datum/reagent/sugar = 1)
+	result_amount = 4
 
 /datum/chemical_reaction/icecoffee
 	name = "Iced Coffee"

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -70,6 +70,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/icetea,

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
@@ -10,6 +10,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/rocks
 	name = "rocks glass"
+	desc = "A robust tumbler with a thick, weighted bottom."
 	base_name = "glass"
 	base_icon = "rocks"
 	filling_states = "25;50;75;100"
@@ -18,7 +19,8 @@
 	rim_pos = "y=21;x_left=10;x_right=23"
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/shake
-	name = "tall cocktail glass"
+	name = "sherry glass"
+	desc = "Stemware with an untapered conical bowl."
 	base_name = "glass"
 	base_icon = "shake"
 	filling_states = "25;50;75;100"
@@ -28,6 +30,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/cocktail
 	name = "cocktail glass"
+	desc = "Fragile stemware with a stout conical bowl. Don't spill."
 	base_name = "glass"
 	base_icon = "cocktail"
 	filling_states = "33;66;100"
@@ -37,6 +40,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/shot
 	name = "shot glass"
+	desc = "A small glass, designed so that its contents can be consumed in one gulp."
 	base_name = "shot"
 	base_icon = "shot"
 	filling_states = "33;66;100"
@@ -56,6 +60,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/mug
 	name = "glass mug"
+	desc = "A heavy mug with thick walls."
 	base_name = "mug"
 	base_icon = "mug"
 	filling_states = "25;50;75;100"
@@ -65,6 +70,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/wine
 	name = "wine glass"
+	desc = "A piece of elegant stemware."
 	base_name = "glass"
 	base_icon = "wine"
 	filling_states = "20;40;60;80;100"
@@ -73,8 +79,9 @@
 	rim_pos = "y=25;x_left=12;x_right=21"
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/carafe
-	name = "carafe"
-	base_name = "carafe"
+	name = "pitcher"
+	desc = "A handled glass pitcher."
+	base_name = "pitcher"
 	base_icon = "carafe"
 	filling_states = "10;20;30;40;50;60;70;80;90;100"
 	volume = 120

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -256,8 +256,8 @@
 	center_of_mass = "x=17;y=7"
 
 /obj/item/weapon/reagent_containers/food/drinks/pitcher
-	name = "pitcher"
-	desc = "Everyone's best friend in the morning."
+	name = "insulated pitcher"
+	desc = "A stainless steel insulated pitcher. Everyone's best friend in the morning."
 	icon_state = "pitcher"
 	volume = 120
 	amount_per_transfer_from_this = 10

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -232,19 +232,10 @@
 			icon_state = "water_cup_e"
 
 
-//////////////////////////drinkingglass and shaker//
+//////////////////////////pitchers, pots, flasks and cups //
 //Note by Darem: This code handles the mixing of drinks. New drinks go in three places: In Chemistry-Reagents.dm (for the drink
 //	itself), in Chemistry-Recipes.dm (for the reaction that changes the components into the drink), and here (for the drinking glass
 //	icon states.
-
-/obj/item/weapon/reagent_containers/food/drinks/shaker
-	name = "shaker"
-	desc = "A metal shaker to mix drinks in."
-	icon_state = "shaker"
-	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = "5;10;15;25;30;60" //Professional bartender should be able to transfer as much as needed
-	volume = 120
-	center_of_mass = "x=17;y=10"
 
 /obj/item/weapon/reagent_containers/food/drinks/teapot
 	name = "teapot"

--- a/code/modules/reagents/reagent_containers/food/shaker.dm
+++ b/code/modules/reagents/reagent_containers/food/shaker.dm
@@ -1,0 +1,35 @@
+/obj/item/weapon/reagent_containers/food/drinks/shaker
+	name = "shaker"
+	desc = "A three piece Cobbler-style shaker. Used to mix, cool, and strain drinks."
+	icon_state = "shaker"
+	amount_per_transfer_from_this = 10
+	possible_transfer_amounts = "5;10;15;25;30;60" //Professional bartender should be able to transfer as much as needed
+	volume = 120
+	center_of_mass = "x=17;y=10"
+	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_REACT
+
+/obj/item/weapon/reagent_containers/food/drinks/shaker/attack_self(mob/user as mob)
+	if(user.skill_check(SKILL_COOKING, SKILL_PROF))
+		user.visible_message("<span class='rose'>\The [user] shakes \the [src] briskly in one hand, with supreme confidence and competence.</span>", "<span class='rose'>You shake \the [src] briskly with one hand.</span>")
+		mix()
+		return
+	if(user.skill_check(SKILL_COOKING, SKILL_ADEPT))
+		user.visible_message(SPAN_NOTICE("\The [user] shakes \the [src] briskly, with some skill."), SPAN_NOTICE("You shake \the [src] briskly, with some skill."))
+		mix()
+		return
+	else
+		user.visible_message(SPAN_NOTICE("\The [user] shakes \the [src] gingerly."), SPAN_NOTICE("You shake \the [src] gingerly."))
+		if(prob(15) && (reagents && reagents.total_volume))
+			user.visible_message(SPAN_WARNING("\The [user] spills the contents of \the [src] over themselves!"), SPAN_WARNING("You spill the contents of \the [src] over yourself!"))
+			reagents.splash(user, reagents.total_volume)
+		else
+			mix()
+
+/obj/item/weapon/reagent_containers/food/drinks/shaker/proc/mix()
+	if(reagents && reagents.total_volume)
+		atom_flags &= ~ATOM_FLAG_NO_REACT
+		reagents.process_reactions()
+		addtimer(CALLBACK(src, .proc/stop_react), 0)
+
+/obj/item/weapon/reagent_containers/food/drinks/shaker/proc/stop_react()
+	atom_flags |= ATOM_FLAG_NO_REACT

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -114,7 +114,7 @@
 
 	New()
 		..()
-		desc += " Can hold up to [volume] units."
+		desc += " It can hold up to [volume] units."
 
 	on_reagent_change()
 		update_icon()

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -470,10 +470,10 @@
 /turf/simulated/wall/prepainted,
 /area/hydroponics)
 "bB" = (
-/obj/machinery/light{
+/obj/item/weapon/stool/padded,
+/obj/machinery/light/spot{
 	dir = 1
 	},
-/obj/item/weapon/stool/padded,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bC" = (
@@ -771,6 +771,8 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/corner/green/mono,
+/obj/structure/closet/crate/hydroponics/beekeeping,
+/obj/item/weapon/screwdriver,
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics)
 "cf" = (
@@ -896,10 +898,6 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/thirddeck/aftstarboard)
-"cw" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/bar)
 "cx" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1193,7 +1191,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/item/weapon/reagent_containers/glass/rag,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "cV" = (
@@ -1369,7 +1366,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/thirddeck/aftstarboard)
 "dk" = (
-/obj/machinery/gibber,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "dl" = (
@@ -1497,14 +1496,13 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/structure/bed/chair/padded{
-	icon_state = "chair_preview";
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/bed/chair{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
@@ -1740,11 +1738,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
 /obj/machinery/power/smes/buildable/preset/torch/substation{
 	RCon_tag = "Substation - Third Deck"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/thirddeck)
@@ -1865,6 +1863,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/weapon/reagent_containers/food/condiment/barbecue,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "eu" = (
@@ -1890,6 +1891,11 @@
 "ey" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen";
+	name = "Kitchen Shutters"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/galley)
 "eA" = (
@@ -1905,8 +1911,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/green/mono,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Hydroponics Bay"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
 /area/hydroponics)
 "eE" = (
 /obj/structure/closet/secure_closet/crew/research,
@@ -1932,6 +1940,11 @@
 /obj/machinery/vending/snix,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/thirddeck/aftstarboard)
+"eH" = (
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/drinks/teapot,
+/turf/simulated/floor/tiled/dark,
+/area/command/captainmess)
 "eI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/substation/thirddeck)
@@ -2039,6 +2052,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/item/weapon/reagent_containers/glass/rag,
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "eR" = (
@@ -2273,9 +2292,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/bar_torch,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
@@ -2315,7 +2331,6 @@
 "fy" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
-/obj/item/stack/package_wrap/twenty_five,
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
@@ -2357,6 +2372,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -2762,17 +2780,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
 "gs" = (
-/obj/structure/kitchenspike,
-/obj/machinery/alarm/cold{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
 /turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/galleybackroom)
-"gt" = (
-/obj/structure/sink/kitchen,
-/turf/simulated/wall/prepainted,
 /area/crew_quarters/galleybackroom)
 "gu" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -2817,11 +2825,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/green{
-	dir = 9
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "gz" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -2847,7 +2855,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hydroponics)
+/area/crew_quarters/mess)
 "gC" = (
 /obj/structure/disposalpipe/up{
 	dir = 1
@@ -3098,8 +3106,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "ho" = (
@@ -3183,11 +3192,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/green{
-	dir = 10
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "hx" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled,
@@ -3208,7 +3217,7 @@
 	icon_state = "warning";
 	dir = 1
 	},
-/obj/structure/catwalk,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "hz" = (
@@ -3228,7 +3237,7 @@
 	icon_state = "warningcorner";
 	dir = 1
 	},
-/obj/structure/catwalk,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "hA" = (
@@ -3636,15 +3645,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hydroponics)
+/area/crew_quarters/mess)
 "iv" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass/civilian{
-	name = "Hydroponics Bay"
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "iG" = (
 /obj/structure/cable{
 	d1 = 32;
@@ -3798,16 +3806,17 @@
 /turf/simulated/open,
 /area/maintenance/thirddeck/forestarboard)
 "iU" = (
-/obj/structure/kitchenspike,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "iW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo";
+	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
@@ -3820,6 +3829,9 @@
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
+	},
+/obj/structure/sink/kitchen{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
@@ -3878,9 +3890,6 @@
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Mess Hall - Center"
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -3891,23 +3900,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/mess)
-"jg" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/item/device/radio/intercom{
+/obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 21
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = 24
-	},
-/obj/structure/bed/chair/padded{
-	icon_state = "chair_preview";
-	dir = 8
-	},
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "jh" = (
@@ -3929,6 +3931,13 @@
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
+"jj" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/machinery/vending/games,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "jn" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -3937,6 +3946,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair{
+	icon_state = "chair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -4319,11 +4329,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/green/three_quarters{
-	dir = 8
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "kd" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4518,13 +4528,13 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/bar)
 "kM" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = newlist()
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
 	},
-/obj/machinery/light{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "kN" = (
 /obj/machinery/requests_console{
@@ -4561,14 +4571,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/mess)
-"kR" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/book/manual/sol_sop,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "kT" = (
@@ -4616,6 +4618,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"ld" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/command/captainmess)
 "lj" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Emergency Storage";
@@ -4757,7 +4767,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/structure/bed/chair/padded,
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "lC" = (
@@ -5088,7 +5098,6 @@
 	c_tag = "Mess Hall - Bar";
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "mm" = (
@@ -5140,7 +5149,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "mr" = (
@@ -5150,15 +5158,6 @@
 /turf/simulated/floor/plating,
 /area/command/captainmess)
 "ms" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "offmess_windows";
-	pixel_x = 6;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -5515,8 +5514,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/structure/bed/chair/padded{
-	icon_state = "chair_preview";
+/obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -5859,6 +5857,27 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
+"nZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "oa" = (
 /obj/structure/stairs/west,
 /obj/structure/railing/mapped,
@@ -6214,16 +6233,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "oZ" = (
@@ -6368,34 +6384,28 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual/sol_sop,
-/obj/item/weapon/book/manual/solgov_law,
-/obj/item/weapon/book/manual/military_law,
-/obj/item/weapon/book/manual/nt_regs,
-/obj/item/weapon/book/manual/chef_recipes,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "pg" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/item/modular_computer/console/preset/civilian{
-	icon_state = "console";
-	dir = 1
-	},
 /obj/machinery/light/spot,
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "pi" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/vending/games,
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Mess Hall - Port";
 	dir = 1
 	},
+/obj/machinery/computer/arcade,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "pj" = (
@@ -6840,6 +6850,13 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
+"qn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/gibber,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/galleybackroom)
 "qo" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -7238,6 +7255,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
+"rm" = (
+/obj/structure/table/marble,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/book/manual/chef_recipes,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/galley)
 "rp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -7356,11 +7381,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/green{
-	dir = 10
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "rN" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -8510,7 +8535,7 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/plating,
-/area/vacant/mess)
+/area/maintenance/thirddeck/starboard)
 "tv" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -8763,24 +8788,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
-"uh" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/machinery/light/spot{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/bed/chair/padded{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/mess)
 "uj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9163,6 +9170,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
+"vm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/lino,
+/area/command/captainmess)
 "vn" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/diplomat)
@@ -9688,6 +9706,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"wC" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/galleybackroom)
 "wD" = (
 /obj/machinery/door/airlock/command{
 	name = "Officer's Mess";
@@ -10786,16 +10808,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
-"yK" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/structure/bed/chair/padded{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/mess)
 "yL" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -11439,12 +11451,14 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/machinery/vending/fitness,
-/obj/effect/floor_decal/corner/green{
-	dir = 6
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "Ar" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11463,6 +11477,19 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/vacant/office)
+"As" = (
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen";
+	name = "Kitchen Shutters"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/material/bell,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/galley)
 "At" = (
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
@@ -11504,7 +11531,11 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "Az" = (
 /obj/machinery/light,
@@ -11538,6 +11569,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
+"AC" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "AD" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/cryopod{
@@ -11726,6 +11769,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"AX" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = newlist()
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/galleybackroom)
 "AY" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/lino,
@@ -12400,6 +12453,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
+"CH" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/captainmess)
 "CI" = (
 /obj/effect/floor_decal/corner/green/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12561,15 +12624,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
-"Dj" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = newlist()
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/galleybackroom)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12654,10 +12708,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Dz" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "DA" = (
 /obj/machinery/biogenerator,
@@ -13677,13 +13729,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
-"Gg" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/galleybackroom)
 "Gh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/camera/network/command{
@@ -14998,6 +15043,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
+"JA" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/lino,
+/area/command/captainmess)
 "JB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15376,8 +15429,19 @@
 /obj/structure/sink/kitchen{
 	pixel_y = -32
 	},
+/obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"Ko" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "Kp" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -15924,10 +15988,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
-"LI" = (
-/obj/effect/floor_decal/corner/green/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/hydroponics)
 "LM" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -15971,11 +16031,10 @@
 /turf/simulated/floor/lino,
 /area/vacant/office)
 "LR" = (
-/obj/machinery/vending/boozeomat,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "LV" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -16147,6 +16206,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "Mo" = (
@@ -16275,7 +16338,15 @@
 /area/storage/tools)
 "MO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "MQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16427,16 +16498,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/habcheck)
-"Nu" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/condiment/enzyme,
-/obj/item/weapon/reagent_containers/food/condiment/barbecue,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/galleybackroom)
 "Nv" = (
 /obj/machinery/cooker/oven,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -16519,12 +16580,7 @@
 /area/maintenance/thirddeck/aftstarboard)
 "NQ" = (
 /obj/structure/table/marble,
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/weapon/material/kitchen/rollingpin,
-/obj/item/weapon/reagent_containers/food/condiment/enzyme,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "NV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16743,7 +16799,11 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/vending/coffee,
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/military_law,
+/obj/item/weapon/book/manual/nt_regs,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "OC" = (
@@ -16806,8 +16866,12 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/diplomat)
 "ON" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "OP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16822,13 +16886,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"OQ" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/mess)
 "OS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
@@ -17019,12 +17076,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
-"Pv" = (
-/obj/structure/table/standard,
-/obj/item/weapon/screwdriver,
-/obj/effect/floor_decal/corner/green/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/hydroponics)
 "Pw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17053,8 +17104,8 @@
 /area/maintenance/thirddeck/foreport)
 "Py" = (
 /obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc/full,
-/obj/structure/disposalpipe/segment,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/carafe,
+/obj/item/weapon/reagent_containers/food/drinks/pitcher,
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "Pz" = (
@@ -17178,14 +17229,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "PS" = (
-/obj/structure/table/woodentable,
 /obj/structure/disposalpipe/segment,
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
+/obj/structure/bed/chair/wood/wings{
+	icon_state = "wooden_chair_wings_preview";
+	dir = 1
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
@@ -17451,17 +17498,24 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "QR" = (
-/obj/structure/bed/chair/wood/wings{
-	icon_state = "wooden_chair_wings_preview";
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/blue2,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "QS" = (
-/obj/structure/table/marble,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "QT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17470,6 +17524,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/bed/chair/wood/wings,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "QV" = (
@@ -17631,6 +17686,20 @@
 /obj/machinery/meter,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
+"Ry" = (
+/obj/machinery/alarm/cold{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/galleybackroom)
+"RD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/captainmess)
 "RE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -17638,16 +17707,16 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "RF" = (
-/obj/structure/bed/chair/wood/wings{
-	icon_state = "wooden_chair_wings_preview";
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/turf/simulated/floor/carpet/blue2,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue,
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "RH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -17696,14 +17765,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
-"RO" = (
-/obj/structure/table/marble,
-/obj/item/weapon/reagent_containers/food/snacks/mint,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/galley)
 "RQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17733,10 +17794,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
-"RT" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/command/captainmess)
 "RU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17903,10 +17960,17 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "Su" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/aft)
 "Sv" = (
@@ -17932,11 +17996,12 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/plating,
-/area/vacant/mess)
+/area/maintenance/thirddeck/starboard)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/bed/chair/wood/wings,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "SA" = (
@@ -17999,18 +18064,25 @@
 /turf/simulated/floor/lino,
 /area/vacant/office)
 "SM" = (
-/obj/structure/table/marble,
-/obj/item/weapon/material/bell,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "SN" = (
-/obj/structure/bed/chair/wood/wings,
 /obj/structure/disposalpipe/segment,
+/obj/structure/table/woodentable,
+/obj/item/weapon/tableflag,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "SO" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "SP" = (
 /obj/structure/table/standard,
@@ -18039,9 +18111,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/corner/green/three_quarters,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "ST" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -18083,7 +18157,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/obj/machinery/light_switch{
+	pixel_x = 4;
+	pixel_y = -24
+	},
+/obj/machinery/button/windowtint{
+	id = "offmess_windows";
+	pixel_x = -4;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "Ta" = (
 /obj/structure/window/reinforced/tinted/frosted{
@@ -18099,11 +18182,14 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/green{
-	dir = 5
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "Tc" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -18250,16 +18336,20 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "Tz" = (
-/obj/structure/bed/chair/wood/wings,
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "TC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"TE" = (
-/turf/simulated/wall/prepainted,
-/area/vacant/mess)
 "TH" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -18297,21 +18387,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
-"TT" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/command/captainmess)
 "TU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "TW" = (
 /obj/structure/table/marble,
@@ -18322,6 +18407,7 @@
 	c_tag = "Mess Hall - Galley";
 	dir = 4
 	},
+/obj/item/weapon/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "TX" = (
@@ -18525,9 +18611,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/vacant/office)
-"Ux" = (
-/turf/simulated/floor/plating,
-/area/vacant/mess)
 "Uz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green{
@@ -18555,23 +18638,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/habcheck)
-"UB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/green/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "UC" = (
 /obj/effect/floor_decal/spline/plain/red,
 /obj/structure/window/reinforced,
@@ -18685,7 +18751,9 @@
 /area/thruster/d3starboard)
 "UV" = (
 /obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/structure/flora/pottedplant/deskferntrim{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "UX" = (
@@ -18714,6 +18782,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/bed/chair/wood/wings,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "Vb" = (
@@ -18818,6 +18887,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair/wood/wings,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "Vq" = (
@@ -18826,10 +18896,16 @@
 /area/engineering/hardstorage/lower)
 "Vu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "Vv" = (
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "Vx" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -18873,8 +18949,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/center)
 "VD" = (
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled/dark,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "VF" = (
 /turf/simulated/floor/tiled,
@@ -18953,8 +19038,11 @@
 	name = "Hydroponics";
 	sortType = "Hydroponics"
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "VU" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled,
@@ -19064,7 +19152,6 @@
 	dir = 4
 	},
 /obj/machinery/smartfridge/foods,
-/obj/item/weapon/material/bell,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "Wu" = (
@@ -19118,12 +19205,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "WF" = (
-/obj/structure/table/marble,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 10
+	},
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "WH" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -19148,6 +19240,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
+"WN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Service Entrance";
+	req_access = list(12);
+	req_one_access = list(19,28,91)
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/command/captainmess)
 "WO" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
@@ -19156,6 +19256,10 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
+"WS" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/lino,
+/area/command/captainmess)
 "WV" = (
 /obj/machinery/papershredder,
 /obj/machinery/light,
@@ -19334,7 +19438,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/machinery/recharger,
+/obj/item/weapon/board,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "Xt" = (
@@ -19370,10 +19474,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "XH" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
@@ -19412,6 +19513,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair{
+	icon_state = "chair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -19587,6 +19689,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
+"Yl" = (
+/obj/structure/table/standard,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
 "Ym" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder,
@@ -19615,10 +19722,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "Yp" = (
-/obj/structure/table/marble,
-/obj/item/weapon/soap,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "Ys" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19661,14 +19773,18 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/weapon/board,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
@@ -19691,10 +19807,10 @@
 "YH" = (
 /obj/machinery/door/airlock/command{
 	name = "Officer's Mess";
-	req_one_access = list(19,28,91)
+	req_one_access = list(19,91)
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/command/captainmess)
 "YJ" = (
 /obj/structure/cable/green{
@@ -19721,8 +19837,16 @@
 /area/maintenance/thirddeck/forestarboard)
 "YO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "YP" = (
 /obj/machinery/door/blast/shutters{
@@ -19891,10 +20015,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
-"Zt" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/hydroponics)
 "Zx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19972,12 +20092,21 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/bunk)
 "ZK" = (
-/obj/structure/closet/crate/hydroponics/beekeeping,
-/obj/effect/floor_decal/corner/green/three_quarters{
-	dir = 1
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/random/single{
+	icon = 'icons/obj/drinks.dmi';
+	icon_state = "cola";
+	name = "randomly spawned cola";
+	spawn_nothing_percentage = 50;
+	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "ZN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/tcommsat/chamber)
@@ -19988,7 +20117,10 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/structure/bed/chair/padded,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "ZX" = (
@@ -34231,10 +34363,10 @@ aO
 aO
 aO
 cK
-bs
-bs
-bs
-bp
+cG
+dy
+dy
+dy
 dy
 dy
 GE
@@ -34435,12 +34567,12 @@ aO
 cK
 cG
 dy
-dy
-dy
-dy
-ih
+AX
+Ry
+qn
+wC
 Uq
-Dj
+PI
 kK
 lu
 lu
@@ -34639,10 +34771,10 @@ WQ
 dy
 iU
 gs
-Gg
-eu
+gs
+gs
 Uq
-PI
+ih
 kK
 lu
 lu
@@ -34844,7 +34976,7 @@ SA
 hm
 Zx
 ST
-ih
+eu
 kK
 lu
 lu
@@ -35042,7 +35174,7 @@ cK
 dz
 dy
 dk
-Nu
+gs
 hn
 ij
 iW
@@ -35247,7 +35379,7 @@ dy
 dy
 dy
 IR
-gt
+dy
 dy
 kK
 kK
@@ -35452,7 +35584,7 @@ ik
 iX
 kL
 OX
-cw
+SP
 ml
 cU
 eQ
@@ -36059,9 +36191,9 @@ ev
 kL
 kN
 mn
-ne
 oi
-SP
+ne
+Yl
 pa
 pV
 qQ
@@ -36457,7 +36589,7 @@ bA
 Rq
 Qg
 fp
-RO
+gx
 Tg
 ev
 Ug
@@ -36863,7 +36995,7 @@ fv
 gw
 hs
 ir
-TH
+As
 jV
 kQ
 PO
@@ -37062,7 +37194,7 @@ wn
 xn
 ey
 fw
-gx
+rm
 ht
 is
 TH
@@ -37270,8 +37402,8 @@ ev
 ev
 jX
 lz
-lz
 mp
+lz
 ka
 RN
 pf
@@ -37471,10 +37603,10 @@ SS
 iu
 hu
 UK
-kR
 lz
 lz
-ka
+lz
+Ko
 RN
 pg
 qa
@@ -37665,12 +37797,12 @@ bC
 Oy
 in
 wn
-On
-LI
+nZ
+Sw
 Tb
 VT
 rM
-Zt
+qb
 ly
 Tx
 XO
@@ -37678,7 +37810,7 @@ XO
 XO
 jn
 RN
-fu
+jj
 qb
 qQ
 sk
@@ -37868,8 +38000,8 @@ Oy
 in
 wn
 On
-LI
-Oy
+bA
+AC
 Sr
 hw
 iv
@@ -37880,7 +38012,7 @@ jd
 jd
 nj
 Lx
-OQ
+fu
 qb
 Xn
 sj
@@ -38070,12 +38202,12 @@ Oy
 in
 wn
 Pn
-Pv
+bA
 ZK
 Aq
-UB
-Sw
-yK
+rM
+jc
+AA
 dF
 jc
 lB
@@ -38273,13 +38405,13 @@ kn
 wn
 Qn
 bA
-bA
-bA
+fB
+fB
 gA
-bA
+fB
 jf
 YD
-jc
+Ci
 ZQ
 Xs
 nk
@@ -38478,10 +38610,10 @@ bA
 fD
 gC
 hy
-fB
-jg
-uh
-Ci
+Ot
+Ot
+Ot
+Ot
 Ot
 mr
 mr
@@ -38680,11 +38812,11 @@ bA
 fE
 gD
 hz
-Ot
-Ot
-Ot
-Ot
-Ot
+WN
+WS
+eH
+ld
+RD
 ms
 nm
 nm
@@ -38880,7 +39012,7 @@ cY
 dN
 bA
 fF
-Ux
+aY
 Ot
 Ot
 VD
@@ -38889,7 +39021,7 @@ WF
 QS
 QT
 Tz
-TT
+ps
 RF
 Ot
 MS
@@ -39082,7 +39214,7 @@ cZ
 bA
 bA
 fG
-TE
+cl
 Ot
 SO
 Vv
@@ -39090,9 +39222,9 @@ Vu
 MO
 Yp
 Va
-Tz
-VV
+yQ
 ps
+CH
 mr
 ra
 RQ
@@ -39289,12 +39421,12 @@ Ot
 ON
 Vv
 NQ
-Vv
+vm
 SM
 Sy
-Tz
-yQ
+VV
 ps
+CH
 mr
 tA
 st
@@ -39489,7 +39621,7 @@ fH
 tu
 Ot
 Dz
-RT
+Vv
 Py
 YO
 TU
@@ -39688,12 +39820,12 @@ da
 cl
 cl
 cl
-TE
+cl
 Ot
 Ot
 Ay
 UV
-Vv
+JA
 LR
 XN
 XN

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -1914,6 +1914,7 @@
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Hydroponics Bay"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hydroponics)
 "eE" = (
@@ -3908,7 +3909,6 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/item/weapon/book/manual/sol_sop,
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
@@ -6309,11 +6309,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Bar";
-	req_access = list(25)
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -6327,6 +6322,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Bar";
+	req_access = list(25)
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -12509,6 +12508,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
+"CV" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/command/captainmess)
 "CX" = (
 /obj/structure/curtain/open/bed,
 /obj/effect/floor_decal/techfloor{
@@ -17707,15 +17714,19 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "RF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue,
+/obj/machinery/button/windowtint{
+	id = "offmess_windows";
+	pixel_x = -4;
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 4;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "RH" = (
@@ -18157,13 +18168,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 4;
-	pixel_y = -24
-	},
-/obj/machinery/button/windowtint{
-	id = "offmess_windows";
-	pixel_x = -4;
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19246,6 +19253,7 @@
 	req_access = list(12);
 	req_one_access = list(19,28,91)
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/command/captainmess)
 "WO" = (
@@ -39828,7 +39836,7 @@ UV
 JA
 LR
 XN
-XN
+CV
 TX
 SZ
 Ot

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -686,14 +686,9 @@
 	name = "\improper Prototype Fusion Reactor Chamber"
 	icon_state = "firingrange"
 
-
 /area/vacant/cargo
 	name = "\improper Requisitions Office"
 	icon_state = "quart"
-
-/area/vacant/mess
-	name = "\improper Officer's Mess"
-	icon_state = "bar"
 
 /area/vacant/missile
 	name = "\improper Third Deck Port Missile Pod"


### PR DESCRIPTION
:cl:
rscadd: The shaker now really acts like a shaker, and must be interacted with to mix its contents (click it in hand).
maptweak: The bar, mess hall, captain's mess, and cold storage rooms have been redesigned.
tweak: Iced tea is no longer sweet.
tweak: Added sweet tea. 3 measures of iced tea + 1 measure of sugar.
/:cl:

Fixes a runtime when buckling to wood chairs (Fixes #22243)
Fixes #22603
Add descriptions to drinking glasses
Add hot cocoa to soft drinks machine

Video walk-through to supplement the diff bot
https://streamable.com/avila

Map design goals:
- The mess should be an eating area, not a cooking area - especially for people who aren't the chef/bartender.
    - Added a 2nd meat locker in the pantry to make up for lost supplies.
- Get the chairs away from the window. Easier to move around and looks nicer (imo)
- Do something useful with the weird hydroponics foyer thing.
    - With the captain's mess redesign, some seating was removed. Replaced it here. There are more seats now than before.
- Add a 'service entrance' to the captain's mess.
    - An entrance for the chef to move relatively unimpeded into and out of the captain's mess, with straight lanes to the kitchen, to more easily serve.
- Remove superfluous clutter in the bar and kitchen areas to allow players to put more of their own stuff on the tables without having to stow half the room in a locker
    - Removed the hot drinks machine from the bar and added hot cocoa to the soft drinks machine. Hot cocoa was the only reason you'd need the hot drinks machine.