### PR TITLE
SPACE PETA OPEN UP: Preventing Diona Death

### DIFF
--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -1,3 +1,7 @@
 /turf/unsimulated
 	name = "command"
 	initial_gas = list("oxygen" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
+
+// the new Diona Death Prevention Feature: gives an average amount of lumination
+/turf/unsimulated/get_lumcount(var/minlum = 0, var/maxlum = 1)
+	return 0.8

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -6,6 +6,10 @@
 /turf/simulated/floor/holofloor
 	thermal_conductivity = 0
 
+// the new Diona Death Prevention Feature: gives an average amount of lumination
+/turf/simulated/floor/holofloor/get_lumcount(var/minlum = 0, var/maxlum = 1)
+	return 0.8
+
 /turf/simulated/floor/holofloor/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	return
 	// HOLOFLOOR DOES NOT GIVE A FUCK

--- a/code/modules/hydroponics/_hydro_setup.dm
+++ b/code/modules/hydroponics/_hydro_setup.dm
@@ -63,7 +63,7 @@
 // Seed noun datums
 #define SEED_NOUN_SPORES          "spores"
 #define SEED_NOUN_PITS            "pits"
-#define SEED_NOUN_NODES           "notes"
+#define SEED_NOUN_NODES           "nodes"
 #define SEED_NOUN_CUTTINGS        "cuttings"
 #define SEED_NOUN_SEEDS           "seeds"
 


### PR DESCRIPTION
🆑 nearlyNon
bugfix: Saves diona from their impending death in holodecks & when preparing to go to the ship as off-vessel antags.
bugfix: Fixed grammar on diona nodes. "You plant the diona notes" no more.
/🆑

Makes unsimulated tiles and holodeck tiles return a light level of 0.5. Enough to keep diona alive.