### PR TITLE
Replace Crowbars in Medical Storage with Prybars

### DIFF
--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -1474,9 +1474,6 @@
 /area/storage/medical)
 "da" = (
 /obj/structure/table/rack,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/crowbar,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
@@ -1485,6 +1482,9 @@
 /obj/item/device/radio,
 /obj/item/weapon/storage/box/bodybags,
 /obj/structure/catwalk,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
 /turf/simulated/floor/plating,
 /area/storage/medical)
 "db" = (


### PR DESCRIPTION
🆑 nearlyNon
maptweak: Replace the crowbars in medical storage with prybars, which makes more sense and was requested in the Little Things thread.
/🆑