### PR TITLE
Makes CO2 poisoning slower

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -444,7 +444,7 @@
 	taste_description = "stale air"
 	reagent_state = LIQUID
 	color = "#cccccc"
-	metabolism = 0.05 // As with helium.
+	metabolism = 0.025 * REAGENT_GAS_EXCHANGE_FACTOR
 
 /datum/reagent/carbon_dioxide/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
 	if(!istype(M) || alien == IS_DIONA)
@@ -452,16 +452,16 @@
 	var/warning_message
 	var/warning_prob = 10
 	var/dosage = M.chem_doses[type]
-	if(dosage >= 3)
+	if(dosage >= 3 * REAGENT_GAS_EXCHANGE_FACTOR)
 		warning_message = pick("extremely dizzy","short of breath","faint","confused")
 		warning_prob = 15
 		M.adjustOxyLoss(10,20)
 		M.co2_alert = 1
-	else if(dosage >= 1.5)
+	else if(dosage >= 1.5 * REAGENT_GAS_EXCHANGE_FACTOR)
 		warning_message = pick("dizzy","short of breath","faint","momentarily confused")
 		M.co2_alert = 1
 		M.adjustOxyLoss(3,5)
-	else if(dosage >= 0.25)
+	else if(dosage >= 0.25 * REAGENT_GAS_EXCHANGE_FACTOR)
 		warning_message = pick("a little dizzy","short of breath")
 		warning_prob = 10
 		M.co2_alert = 0

--- a/html/changelogs/chinsky - co.yml
+++ b/html/changelogs/chinsky - co.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "CO2 poisoning now takes much longer to set in, around 10 times of breathing it compared to before.."


### PR DESCRIPTION
Makes Bearcat survivable.
What happened is you got ~2u of CO2 reagent from a breath on '20% CO2 in 101 kPa' setup.
And damage started at 1.5u, with severe damage at 3u. And with 0.05 metabolism that meant it stayed in system for a /while/.

I bumped all thresholds by 10, and metabolism by 5
Now in same atmo you get to warning stage in 1-2 breaths, to damage in 7, to severe damage in 15

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
