### PR TITLE
Adds build descriptor modifiers to human subpsecies

### DIFF
--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_generic.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_generic.dm
@@ -35,7 +35,7 @@
 		"a bit smaller in build than you",
 		"smaller in build than you",
 		"much smaller in build than you",
-		"dwarfed by your height"
+		"dwarfed by your bulk"
 		)
 	comparative_value_descriptors_larger = list(
 		"slightly larger than you in build",

--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -16,6 +16,11 @@
 	brute_mod =     0.85
 	slowdown =      1
 
+	descriptors = list(
+		/datum/mob_descriptor/height,
+		/datum/mob_descriptor/build = 1
+		)
+
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_GRAV | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
 /datum/species/human/spacer
@@ -35,6 +40,10 @@
 	darksight_range = 6
 	darksight_tint = DARKTINT_MODERATE
 
+	descriptors = list(
+		/datum/mob_descriptor/height,
+		/datum/mob_descriptor/build = -1
+		)
 
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_SPCR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
@@ -109,4 +118,9 @@
 		/datum/unarmed_attack/bite/sharp
 	)
 
+	descriptors = list(
+		/datum/mob_descriptor/height,
+		/datum/mob_descriptor/build = 1
+		)
+	
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_TRITON | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR


### PR DESCRIPTION
Spacers are thinner, tritonians and gravvers are thiccer, vatties are average.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
