### PR TITLE
Various CO(2) related changes

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -160,7 +160,10 @@
 	// Not enough to breathe
 	if(inhale_efficiency < 1)
 		if(prob(20) && active_breathing)
-			owner.emote("gasp")
+			if(inhale_efficiency < 0.8)
+				owner.emote("gasp")
+			else if(prob(20))
+				to_chat(owner, SPAN_WARNING("It's hard to breathe..."))
 		breath_fail_ratio = 1 - inhale_efficiency
 		failed_inhale = 1
 	else

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -153,6 +153,12 @@
 	to_chat(user, "There [sheets == 1 ? "is" : "are"] [sheets] sheet\s left in the hopper.")
 	if(IsBroken()) to_chat(user, "<span class='warning'>\The [src] seems to have broken down.</span>")
 	if(overheating) to_chat(user, "<span class='danger'>\The [src] is overheating!</span>")
+
+/obj/machinery/power/port_gen/pacman/proc/process_exhaust()
+	var/datum/gas_mixture/environment = loc.return_air()
+	if(environment)
+		environment.adjust_gas("carbon_monoxide", 0.05*power_output)
+
 /obj/machinery/power/port_gen/pacman/HasFuel()
 	var/needed_sheets = power_output / time_per_sheet
 	if(sheets >= needed_sheets - sheet_left)
@@ -215,6 +221,7 @@
 		overheat()
 	else if (overheating > 0)
 		overheating--
+	process_exhaust()
 
 /obj/machinery/power/port_gen/pacman/handleInactive()
 	var/cooling_temperature = 20
@@ -410,6 +417,10 @@
 	time_per_sheet = 576 //same power output, but a 50 sheet stack will last 2 hours at max safe power
 	board_path = /obj/item/weapon/circuitboard/pacman/super
 	var/rad_power = 2
+
+//nuclear energy is green energy!
+/obj/machinery/power/port_gen/pacman/super/process_exhaust()
+	return
 
 /obj/machinery/power/port_gen/pacman/super/UseFuel()
 	//produces a tiny amount of radiation when in use

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -438,15 +438,15 @@
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 6)
 
-/datum/reagent/carbon_dioxide
-	name = "Carbon Dioxide"
-	description = "A byproduct of human respiration."
+/datum/reagent/carbon_monoxide
+	name = "Carbon Monoxide"
+	description = "A dangerous carbon comubstion byproduct."
 	taste_description = "stale air"
 	reagent_state = LIQUID
 	color = "#cccccc"
 	metabolism = 0.05 // As with helium.
 
-/datum/reagent/carbon_dioxide/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
+/datum/reagent/carbon_monoxide/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
 	if(!istype(M) || alien == IS_DIONA)
 		return
 	var/warning_message

--- a/code/modules/xgm/gases.dm
+++ b/code/modules/xgm/gases.dm
@@ -17,7 +17,6 @@
 	name = "Carbon Dioxide"
 	specific_heat = 30	// J/(mol*K)
 	molar_mass = 0.044	// kg/mol
-	breathed_product = /datum/reagent/carbon_dioxide
 
 /decl/xgm_gas/methyl_bromide
 	id = "methyl_bromide"
@@ -176,3 +175,10 @@
 	specific_heat = 20	// J/(mol*K)
 	molar_mass = 0.017	// kg/mol
 	breathed_product = /datum/reagent/ammonia
+	
+/decl/xgm_gas/carbon_monoxide
+	id = "carbon_monoxide"
+	name = "Carbon Monoxide"
+	specific_heat = 30	// J/(mol*K)
+	molar_mass = 0.028	// kg/mol
+	breathed_product = /datum/reagent/carbon_monoxide

--- a/html/changelogs/chinsky - gasgas.yml
+++ b/html/changelogs/chinsky - gasgas.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "CO2 is no longer poisonous. Just non-breathable. Should make Bearcat a walk in the park."
+  - tweak: "Added CO, which /is/ poisonous."
+  - tweak: "PACMANs that run on plasma now produce some CO, around a mole per 40 seconds, so make sure you open the window (or turn on scrubbers) before using."


### PR DESCRIPTION
Makes CO2 not toxic.
Adds CO which does what CO2 used to do.
PACMANs now produce some CO when running, at a rate of ~1 mole per 40 seconds of running time at power setting 3. Higher settings produce more, lower less.
Only base PACMAN does it, uranium is safe.
Also now when you didn't get enough air but not THAT much was missing, instead of gasping you get a message about it (alarm in UI still pops)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
