### PR TITLE
Implement RGB for IPC, FBP, Adherent, and Synthetic Eyes

### DIFF
--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -26,10 +26,30 @@
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "camera"
 	dead_icon = "camera_broken"
+	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 	update_colour()
 
 /obj/item/organ/internal/eyes/robot
 	name = "optical sensor"
+
+/obj/item/organ/internal/eyes/proc/change_eye_color()
+	set name = "Change Eye Color"
+	set desc = "Changes your robotic eye color."
+	set category = "IC"
+	set src in usr
+	if (owner.incapacitated())
+		return
+	var/new_eyes = input("Please select eye color.", "Eye Color", rgb(owner.r_eyes, owner.g_eyes, owner.b_eyes)) as color|null
+	if(new_eyes)
+		var/r_eyes = hex2num(copytext(new_eyes, 2, 4))
+		var/g_eyes = hex2num(copytext(new_eyes, 4, 6))
+		var/b_eyes = hex2num(copytext(new_eyes, 6, 8))
+		if(do_after(owner, 10) && owner.change_eye_color(r_eyes, g_eyes, b_eyes))
+			update_colour()
+			// Finally, update the eye icon on the mob.
+			owner.regenerate_icons()
+			owner.visible_message(SPAN_NOTICE("\The [owner] changes their eye color."),SPAN_NOTICE("You change your eye color."),)
+
 
 /obj/item/organ/internal/eyes/robot/New()
 	..()

--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -110,6 +110,10 @@
 	status = ORGAN_ROBOTIC
 	phoron_guard = TRUE
 
+/obj/item/organ/internal/eyes/adherent/Initialize()
+	. = ..()
+	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
+
 /obj/item/organ/internal/cell/adherent
 	name = "piezoelectric core"
 	icon = 'icons/mob/human_races/species/adherent/organs.dmi'

--- a/code/modules/species/station/machine.dm
+++ b/code/modules/species/station/machine.dm
@@ -37,7 +37,7 @@
 
 	species_flags = SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_POISON
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_LACE
-	appearance_flags = HAS_UNDERWEAR //IPCs can wear undies too :(
+	appearance_flags = HAS_UNDERWEAR | HAS_EYE_COLOR //IPCs can wear undies too :(
 
 	blood_color = "#1f181f"
 	flesh_color = "#575757"
@@ -49,8 +49,6 @@
 		)
 
 	vision_organ = BP_OPTICS
-
-	override_limb_types = list(BP_HEAD = /obj/item/organ/external/head/no_eyes)
 
 	heat_discomfort_level = 373.15
 	heat_discomfort_strings = list(


### PR DESCRIPTION
🆑nearlyNon
rscadd: Ports Polaris's synthetic eye color changing. IPC, synthetic human, and Adherent eyes are now RGB. Properly covered by display monitors too.
/🆑

https://gfycat.com/CarefulLividAnkole

You can't see it in this video (because it only records the main BYOND window, but it opens up the regular color picker.