### PR TITLE
Add Cosmetics Vending Machine to Holodeck

### DIFF
--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -4594,7 +4594,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light/spot,
-/obj/structure/table/standard,
+/obj/machinery/vending/fashionvend,
 /turf/simulated/floor/tiled/dark,
 /area/holocontrol)
 "kY" = (


### PR DESCRIPTION
🆑nearlyNon
maptweak: Adds the Cosmetics Vending Machine to Holodeck. Because the holodeck has a theatre setting.
/🆑
If anyone can think of a better place to put it, tell me.