### PR TITLE
Ensures Galcom is the default language for new humans.

### DIFF
--- a/code/modules/culture_descriptor/culture/_culture.dm
+++ b/code/modules/culture_descriptor/culture/_culture.dm
@@ -2,3 +2,4 @@
 	desc_type = "Culture"
 	category = TAG_CULTURE
 	language = LANGUAGE_GALCOM
+	default_language = LANGUAGE_GALCOM

--- a/code/modules/culture_descriptor/culture/cultures_hidden.dm
+++ b/code/modules/culture_descriptor/culture/cultures_hidden.dm
@@ -10,7 +10,7 @@
 /decl/cultural_info/culture/hidden/shadow
 	name =             CULTURE_STARLIGHT
 	language =         LANGUAGE_GALCOM
-	additional_langs = list(LANGUAGE_CULT,LANGUAGE_OCCULT)
+	additional_langs = list(LANGUAGE_CULT, LANGUAGE_OCCULT)
 
 /decl/cultural_info/culture/hidden/cultist
 	name =   CULTURE_CULTIST


### PR DESCRIPTION
Fresh humans were spawning without galcom at all, which is nice but should be choosable and also discussed before being made a feature.