### PR TITLE
Buildable Light Switches and Window Tint Switches

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -784,6 +784,7 @@
 #include "code\game\objects\items\apc_frame.dm"
 #include "code\game\objects\items\blueprints.dm"
 #include "code\game\objects\items\bodybag.dm"
+#include "code\game\objects\items\buttons.dm"
 #include "code\game\objects\items\contraband.dm"
 #include "code\game\objects\items\crayons.dm"
 #include "code\game\objects\items\cryobag.dm"

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -64,6 +64,12 @@
 	playsound(src, "switch", 30)
 	set_state(!on)
 
+/obj/machinery/light_switch/attackby(obj/item/tool as obj, mob/user as mob)
+	if(istype(tool, /obj/item/weapon/screwdriver))
+		new /obj/item/frame/light_switch(user.loc, 1)
+		qdel(src)
+
+
 /obj/machinery/light_switch/powered()
 	. = ..(power_channel, connected_area) //tie our powered status to the connected area
 

--- a/code/game/objects/items/buttons.dm
+++ b/code/game/objects/items/buttons.dm
@@ -1,0 +1,85 @@
+// Lightswitch Hull
+
+/obj/item/frame/light_switch
+	name = "light switch frame"
+	desc = "Used for building a light switch."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "light-p"
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
+
+/obj/item/frame/light_switch/windowtint
+	name = "window tint switch frame"
+	desc = "Used for building a window tint switch."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "light-p"
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
+
+GLOBAL_LIST_INIT(possible_switch_offsets, list(
+		"North" = list(
+			"Middle Lower" = list(0,25),
+			"Offset Lower" = list(7,25),
+			"Middle Upper" = list(0,32),
+			"Offset Upper" = list(7,32)),
+		"East" = list(
+			"Middle Lower" = list(25,0),
+			"Offset Lower" = list(25,7),
+			"Middle Upper" = list(32,0),
+			"Offset Upper" = list(32,7)),
+		"South" = list(
+			"Middle Lower" = list(0,-25),
+			"Offset Lower" = list(7,-25),
+			"Middle Upper" = list(0,-32),
+			"Offset Upper" = list(7,-32)),
+		"West" = list(
+			"Middle Lower" = list(-25,0),
+			"Offset Lower" = list(-25,7),
+			"Middle Upper" = list(-32,0),
+			"Offset Upper" = list(-32,7))))
+
+
+/obj/item/frame/light_switch/proc/position_with_direction(obj/item/frame/light_switch/S as obj, mob/user as mob)
+	for(var/i = 5; i >= 0; i -= 1)
+		var/direction_choice = input(user, "In which direction?", "Select direction.") as null|anything in GLOB.possible_switch_offsets
+		if(!direction_choice || user.incapacitated() || !user.Adjacent(src))
+			return 0
+
+		var/list/position_options = GLOB.possible_switch_offsets[direction_choice]
+
+		var/position_choice = input(user, "Which position?", "Select Position") as null|anything in position_options
+		if(!position_choice || user.incapacitated() || !user.Adjacent(src))
+			return 0
+
+		var/list/position_data = position_options[position_choice]
+		S.pixel_x = position_data[1]
+		S.pixel_y = position_data[2]
+
+		var/confirm = alert(user, "Is this what you want? Chances Remaining: [i]", "Confirmation", "Yes", "No")
+		if(confirm == "Yes")
+			break
+	return 1
+
+/obj/item/frame/light_switch/attackby(obj/item/tool as obj, mob/user as mob)	//construction
+	if(isWrench(tool))
+		new /obj/item/stack/material/steel( get_turf(src.loc), 1 )
+		qdel(src)
+	else if(istype(tool, /obj/item/weapon/screwdriver) && isturf(user.loc))
+		var/obj/machinery/light_switch/S = new (user.loc)
+		if(position_with_direction(S, user))
+			to_chat(user, "You fasten \the [S] with your [tool].")
+			qdel(src)
+		else
+			qdel(S)
+	else ..()
+
+/obj/item/frame/light_switch/windowtint/attackby(obj/item/tool as obj, mob/user as mob)
+	if(isWrench(tool))
+		new /obj/item/stack/material/steel( get_turf(src.loc), 1 )
+		qdel(src)
+	else if(istype(tool, /obj/item/weapon/screwdriver) && isturf(user.loc))
+		var/obj/machinery/button/windowtint/S = new(user.loc)
+		if(position_with_direction(S, user))
+			to_chat(user, "You fasten \the [S] with your [tool].")
+			qdel(src)
+		else
+			qdel(S)
+	else ..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -256,6 +256,9 @@
 			P.set_dir(dir)
 			P.health = health
 			P.state = state
+			P.icon_state = icon_state
+			P.basestate = basestate
+			P.update_icon()
 			qdel(src)
 	else
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -543,6 +546,8 @@
 /obj/structure/window/reinforced/polarized/attackby(obj/item/W as obj, mob/user as mob)
 	if(isMultitool(W))
 		var/t = sanitizeSafe(input(user, "Enter the ID for the window.", src.name, null), MAX_NAME_LEN)
+		if(user.incapacitated() && !user.Adjacent(src))
+			return
 		if (user.get_active_hand() != W)
 			return
 		if (!in_range(src, user) && src.loc != user)
@@ -609,8 +614,21 @@
 
 /obj/machinery/button/windowtint/attackby(obj/item/device/W as obj, mob/user as mob)
 	if(isMultitool(W))
-		to_chat(user, "<span class='notice'>The ID of the button: [id]</span>")
+		var/t = sanitizeSafe(input(user, "Enter the ID for the button.", src.name, id), MAX_NAME_LEN)
+		if(user.incapacitated() && !user.Adjacent(src))
+			return
+		if (user.get_active_hand() != W)
+			return
+		if (!in_range(src, user) && src.loc != user)
+			return
+		t = sanitizeSafe(t, MAX_NAME_LEN)
+		if (t)
+			src.id = t
+			to_chat(user, "<span class='notice'>The new ID of the button is [id]</span>")
 		return
+	if(istype(W, /obj/item/weapon/screwdriver))
+		new /obj/item/frame/light_switch/windowtint(user.loc, 1)
+		qdel(src)
 
 /obj/machinery/button/windowtint/proc/toggle_tint()
 	use_power(5)

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -62,6 +62,8 @@
 	recipes += new/datum/stack_recipe/grenade(src)
 	recipes += new/datum/stack_recipe/light(src)
 	recipes += new/datum/stack_recipe/light_small(src)
+	recipes += new/datum/stack_recipe/light_switch(src)
+	recipes += new/datum/stack_recipe/light_switch/windowtint(src)
 	recipes += new/datum/stack_recipe/apc(src)
 	recipes += new/datum/stack_recipe/air_alarm(src)
 	recipes += new/datum/stack_recipe/fire_alarm(src)

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -111,6 +111,18 @@
 	result_type = /obj/item/frame/light/small
 	difficulty = 2
 
+/datum/stack_recipe/light_switch
+	title = "light switch"
+	result_type = /obj/item/frame/light_switch
+	req_amount = 1
+	difficulty = 2
+
+/datum/stack_recipe/light_switch/windowtint
+	title = "window tint switch"
+	result_type = /obj/item/frame/light_switch/windowtint
+	req_amount = 1
+	difficulty = 2
+
 /datum/stack_recipe/apc
 	title = "APC frame"
 	result_type = /obj/item/frame/apc

--- a/html/changelogs/Textor - Buildable Lighswitches.yml
+++ b/html/changelogs/Textor - Buildable Lighswitches.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Textor
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "You can now build light switches and window tint switches with a steel sheet."
+  - rscadd: "To build: use a screwdriver on the frame. You can also use a screwdriver to disassemble them."
+  - bugfix: "Fixed issue with converting new-style reinforced windows to electrochromatic windows. You can use a cable coil on them to convert them properly now."
+  - tweak: "Modified how window tint switches interact with multitools. You can now set the window ID with the multitool. You can also set the window ID by using a multitool on the electrochromatic window."


### PR DESCRIPTION
-Fixes electrochromaic window construction to work with new window frame system.
-Adds the ability to construct buttons for both electrochromatic windows and lights.
-Changes multitool function for windowtint switch from displaying associated ID to changing associated ID.