### PR TITLE
Don't start the round if subsystems haven't been initialised

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -69,8 +69,13 @@ var/global/datum/controller/gameticker/ticker
 							sleep(1)
 							vote.process()
 			if(pregame_timeleft <= 0 || ((initialization_stage & INITIALIZATION_NOW_AND_COMPLETE) == INITIALIZATION_NOW_AND_COMPLETE))
-				current_state = GAME_STATE_SETTING_UP
-				Master.SetRunLevel(RUNLEVEL_SETUP)
+				if (Master.current_runlevel >= RUNLEVEL_LOBBY)
+					current_state = GAME_STATE_SETTING_UP
+					Master.SetRunLevel(RUNLEVEL_SETUP)
+				else
+					var/additional_time = 20
+					to_world("<B><FONT color='blue'>Waiting an additional [additional_time] seconds for initializations to complete...</FONT></B>")
+					pregame_timeleft += additional_time // yeah, this will repeat, but it's not good to go into a round with stuff not initialized!
 
 	while (!setup())
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -75,7 +75,7 @@ var/global/datum/controller/gameticker/ticker
 				else
 					var/additional_time = 20
 					to_world("<B><FONT color='blue'>Waiting an additional [additional_time] seconds for initializations to complete...</FONT></B>")
-					log_warning("Master initializations were not complete by the time the round was due to start! Waiting an additional [additional_time] seconds...")
+					log_world("Master initializations were not complete by the time the round was due to start! Waiting an additional [additional_time] seconds...")
 					pregame_timeleft += additional_time // yeah, this will repeat, but it's not good to go into a round with stuff not initialized!
 
 	while (!setup())

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -75,6 +75,7 @@ var/global/datum/controller/gameticker/ticker
 				else
 					var/additional_time = 20
 					to_world("<B><FONT color='blue'>Waiting an additional [additional_time] seconds for initializations to complete...</FONT></B>")
+					log_warning("Master initializations were not complete by the time the round was due to start! Waiting an additional [additional_time] seconds...")
 					pregame_timeleft += additional_time // yeah, this will repeat, but it's not good to go into a round with stuff not initialized!
 
 	while (!setup())


### PR DESCRIPTION
This PR is intended to fix #22793 by preventing a round from starting at all if Master hasn't finished initialising.

There's supposed to be a warning-level log message emitted when roundstart is delayed due to initialisation, but I don't know if that shows up on Travis, so I don't know if the lack of build failures has just been a string of luck or the system working.