### PR TITLE
Fixes vagrants not properly incapacitating targets

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -100,6 +100,7 @@
 		var/mob/living/carbon/human/H = .
 		if(gripping == H)
 			H.Weaken(3)
+			H.Stun(3)
 			return
 		//This line ensures there's always a reasonable chance of grabbing, while still
 		//Factoring in health
@@ -108,6 +109,7 @@
 			cloaked = 0
 			update_icon()
 			H.Weaken(3)
+			H.Stun(3)
 			H.visible_message("<span class='danger'>\the [src] latches onto \the [H], pulsating!</span>")
 			if(carried && length(gripping.virus2) == 0)
 				infect_virus2(gripping, carried, 1)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
This was broken when we decided to let things crawl and act while downed. This fixes it.
The weaken is there to add residual effects.