### PR TITLE
Adds oxygen regenerator boards to printer

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/oxyregenerator.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/oxyregenerator.dm
@@ -6,7 +6,7 @@
 	name = T_BOARD("oxygen regenerator")
 	build_path = /obj/machinery/atmospherics/binary/oxyregenerator
 	board_type = "machine"
-	origin_tech = list(TECH_DATA = 2)
+	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	req_components = list(
 							/obj/item/weapon/stock_parts/micro_laser = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1966,6 +1966,13 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/unary_atmos/cooler
 	sort_string = "JCAAB"
 
+/datum/design/circuit/oxyregenerator
+	name = "oxygen regenerator"
+	id = "oxyregen"
+	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/circuitboard/oxyregenerator
+	sort_string = "JCAAC"
+
 /datum/design/circuit/secure_airlock
 	name = "secure airlock electronics"
 	desc =  "Allows for the construction of a tamper-resistant airlock electronics."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑CrimsonShrike
rscadd: Oxygen regenerator board added to circuit printer.
/🆑