### PR TITLE
Integrated Boombox for Emagged Service Borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -533,6 +533,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/tray/robotray(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/service(src)
 	src.emag = new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer(src)
+	src.emag  += new /obj/item/device/boombox(src)
 
 	var/datum/reagents/R = src.emag.create_reagents(50)
 	R.add_reagent(/datum/reagent/chloralhydrate/beer2, 50)


### PR DESCRIPTION
🆑nearlyNon
tweak: Emagged service borgs get a boombox now. Why? Because if you're gonna waste an emag on a service borg it might as well be hilarious.
/🆑