### PR TITLE
Adds Spacer to certain background factions, locations, and a religion

### DIFF
--- a/code/modules/culture_descriptor/faction/factions.dm
+++ b/code/modules/culture_descriptor/faction/factions.dm
@@ -12,6 +12,7 @@
 	its massive bureaucracy and the distance between worlds. Through its member states, the SCG governs as one of the \
 	most advanced and powerful civilisations in the known galaxy."
 	language = LANGUAGE_SOL_COMMON
+	secondary_langs = list(LANGUAGE_SPACER)
 
 /decl/cultural_info/faction/scg/fleet
 	name = FACTION_FLEET
@@ -39,6 +40,7 @@
 	economic_power = 0.9
 	subversive_potential = 50
 	language = LANGUAGE_INDEPENDENT
+	secondary_langs = list(LANGUAGE_SPACER)
 
 /decl/cultural_info/faction/remote
 	name = FACTION_EXPEDITIONARY
@@ -102,3 +104,4 @@
 	description = "You belong to one of the many other factions that operate in the galaxy. Numerous, too numerous to list, these factions represent a variety of interests, purposes, intents and goals."
 	subversive_potential = 25
 	language = LANGUAGE_GALCOM
+	secondary_langs = list(LANGUAGE_SPACER)

--- a/code/modules/culture_descriptor/location/locations.dm
+++ b/code/modules/culture_descriptor/location/locations.dm
@@ -13,6 +13,7 @@
 	capital = "Various"
 	economic_power = 1
 	ruling_body = "Various"
+	secondary_langs = list(LANGUAGE_SPACER)
 
 /decl/cultural_info/location/deep_space
 	name = HOME_SYSTEM_DEEP_SPACE


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Adds `Spacer` to the SCG, TCC, and Other factions and the Other location.
/:cl:

![discord_2018-08-26_20-58-06](https://user-images.githubusercontent.com/11140088/44640262-902df980-a975-11e8-83f7-45cb1200efb0.png)

NOTE: Due to what appears to be a (lack of) config issue on my test environment, I can't actually ensure these changes work correctly because my server's granting me every language even on an unchanged dev branch. It compiles, though, so that's good.

ALSO: https://forums.baystation12.net/threads/backgrounds-provide-more-options-for-spacer-and-sign-language.6892

Relevant forum thread.