### PR TITLE
Added antag checks to shredding and leap behavior.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -130,6 +130,8 @@
 		return
 
 	T.Weaken(3)
+	if(mind && !player_is_antag(mind))
+		Weaken(3)
 
 	if(src.make_grab(src, T))
 		src.visible_message("<span class='warning'><b>\The [src]</b> seizes [T]!</span>")

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -464,9 +464,12 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	return FALSE
 
 // Called when using the shredding behavior.
-/datum/species/proc/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
+/datum/species/proc/can_shred(var/mob/living/carbon/human/H, var/ignore_intent, var/ignore_antag)
 
 	if((!ignore_intent && H.a_intent != I_HURT) || H.pulling_punches)
+		return 0
+
+	if(!ignore_antag && H.mind && !player_is_antag(H.mind))
 		return 0
 
 	for(var/datum/unarmed_attack/attack in unarmed_attacks)

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -195,9 +195,9 @@
 	return FALSE
 
 
-/datum/species/nabber/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
+/datum/species/nabber/can_shred(var/mob/living/carbon/human/H, var/ignore_intent, var/ignore_antag)
 	if(!H.handcuffed || H.buckled)
-		return ..()
+		return ..(H, ignore_intent, TRUE)
 	else
 		return 0
 


### PR DESCRIPTION
This largely just means Vox stowaways/merchants and incorrectly spawned xenophage will not have access to cuff breaking, APC shredding, and consequence-free leap.