### PR TITLE
Attempt to fix assembly lag

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -139,7 +139,7 @@
 
 	var/total_part_size = return_total_size()
 	var/total_complexity = return_total_complexity()
-	var/HTML = ""
+	var/list/HTML = list()
 
 	HTML += "<html><head><title>[name]</title></head><body>"
 
@@ -188,7 +188,7 @@
 			HTML += "<br>"
 
 	HTML += "</body></html>"
-	show_browser(user, HTML, "window=assembly-\ref[src];size=655x350;border=1;can_resize=1;can_close=1;can_minimize=1")
+	show_browser(user, jointext(HTML, null), "window=assembly-\ref[src];size=655x350;border=1;can_resize=1;can_close=1;can_minimize=1")
 
 /obj/item/device/electronic_assembly/Topic(href, href_list)
 	if(href_list["ghostscan"])


### PR DESCRIPTION
Uses list ops instead of string. Whether this is the root of the problem, I do not know, but its worth a shot.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
