### PR TITLE
Cracks down on RC and newscaster abuse

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -161,9 +161,9 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		screen = RCS_SENTFAIL
 		var/obj/machinery/message_server/MS = get_message_server(get_z(src))
 		if(MS)
-			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority)
-			screen = RCS_SENTPASS
-			message_log += "<B>Message sent to [recipient]</B><BR>[message]"
+			if(MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority))
+				screen = RCS_SENTPASS
+				message_log += "<B>Message sent to [recipient]</B><BR>[message]"
 		else
 			audible_message(text("\icon[src] *The Requests Console beeps: 'NOTICE: No server detected!'"),,4)
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -3,20 +3,6 @@
 
 var/global/list/obj/machinery/message_server/message_servers = list()
 
-/datum/data_pda_msg
-	var/recipient = "Unspecified" //name of the person
-	var/sender = "Unspecified" //name of the sender
-	var/message = "Blank" //transferred message
-
-/datum/data_pda_msg/New(var/param_rec = "",var/param_sender = "",var/param_message = "")
-
-	if(param_rec)
-		recipient = param_rec
-	if(param_sender)
-		sender = param_sender
-	if(param_message)
-		message = param_message
-
 /datum/data_rc_msg
 	var/rec_dpt = "Unspecified" //name of the person
 	var/send_dpt = "Unspecified" //name of the sender
@@ -57,7 +43,6 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	idle_power_usage = 10
 	active_power_usage = 100
 
-	var/list/datum/data_pda_msg/pda_msgs = list()
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/active = 1
 	var/power_failure = 0 // Reboot timer after power outage
@@ -98,11 +83,16 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 		authmsg += "[id_auth]<br>"
 	if (stamp)
 		authmsg += "[stamp]<br>"
+	. = FALSE
+	var/list/good_z = GetConnectedZlevels(z)
 	for (var/obj/machinery/requests_console/Console in allConsoles)
+		if(!(Console.z in good_z))
+			continue
 		if (ckey(Console.department) == ckey(recipient))
 			if(Console.inoperable())
 				Console.message_log += "<B>Message lost due to console failure.</B><BR>Please contact [station_name()] system administrator or AI for technical assistance.<BR>"
 				continue
+			. = TRUE
 			if(Console.newmessagepriority < priority)
 				Console.newmessagepriority = priority
 				Console.icon_state = "req_comp[priority]"
@@ -115,7 +105,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 					playsound(Console.loc, 'sound/machines/twobeep.ogg', 50, 1)
 					Console.audible_message("\icon[Console]<span class='notice'>\The [Console] announces: 'Message received from [sender].'</span>", hearing_distance = 5)
 				Console.message_log += "<B>Message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></B><BR>[authmsg]"
-		Console.set_light(0.3, 0.1, 2)
+			Console.set_light(0.3, 0.1, 2)
 
 
 /obj/machinery/message_server/attack_hand(user as mob)
@@ -294,8 +284,6 @@ var/obj/machinery/blackbox_recorder/blackbox
 	var/rc_msg_amt = 0
 
 	for(var/obj/machinery/message_server/MS in SSmachines.machinery)
-		if(MS.pda_msgs.len > pda_msg_amt)
-			pda_msg_amt = MS.pda_msgs.len
 		if(MS.rc_msgs.len > rc_msg_amt)
 			rc_msg_amt = MS.rc_msgs.len
 

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -918,9 +918,6 @@
 	pixel_x = 21
 	},
 /obj/machinery/camera/network/exploration_shuttle,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
 "cq" = (
@@ -17284,9 +17281,6 @@
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/guppy_hangar/start)

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -2993,9 +2993,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "hk" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/bed/chair/shuttle/blue{
 	icon_state = "shuttle_chair_preview";
 	dir = 4


### PR DESCRIPTION
Request Consoles now only reach consoles on zlevels connected to zlevel message server is at.
Newscasters were removed from shuttles, since they would require a much deeper rehaul to respect z.