### PR TITLE
Fixes runtime 22873

### DIFF
--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -20,14 +20,13 @@
 	. = ..()
 
 /obj/item/device/camera/tvcamera/Initialize()
-	. = ..()
 	camera = new(src)
 	camera.c_tag = channel
 	camera.status = FALSE
 	radio = new(src)
 	radio.listening = FALSE
 	radio.set_frequency(ENT_FREQ)
-	update_icon()
+	. = ..()
 
 /obj/item/device/camera/tvcamera/examine()
 	. = ..()


### PR DESCRIPTION
Fixes how update_icon was called before camera was created. Should have no other effects.