### PR TITLE
Make APLU circuits printable by default

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/mecha.dm
+++ b/code/game/objects/items/weapons/circuitboards/mecha.dm
@@ -12,7 +12,7 @@
 
 
 /obj/item/weapon/circuitboard/mecha/ripley
-	origin_tech = list(TECH_DATA = 3)
+	origin_tech = list(TECH_DATA = 1)
 
 /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 	name = T_BOARD_MECHA("Ripley peripherals control")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -2013,12 +2013,14 @@ CIRCUITS BELOW
 /datum/design/circuit/mecha/ripley_main
 	name = "APLU 'Ripley' central control"
 	id = "ripley_main"
+	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/main
 	sort_string = "NAAAA"
 
 /datum/design/circuit/mecha/ripley_peri
 	name = "APLU 'Ripley' peripherals control"
 	id = "ripley_peri"
+	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 	sort_string = "NAAAB"
 


### PR DESCRIPTION
🆑 Cakey
tweak: APLU circuits can now be printed by default.
/🆑