### PR TITLE
Reshuffles layout of Background tab

### DIFF
--- a/code/modules/client/preference_setup/background/03_records.dm
+++ b/code/modules/client/preference_setup/background/03_records.dm
@@ -26,13 +26,13 @@
 	if(jobban_isbanned(user, "Records"))
 		. += "<span class='danger'>You are banned from using character records.</span><br>"
 	else
-		. += "Medical Records:<br>"
-		. += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><br><br>"
-		. += "Employment Records:<br>"
-		. += "<a href='?src=\ref[src];set_general_records=1'>[TextPreview(pref.gen_record,40)]</a><br><br>"
-		. += "Security Records:<br>"
+		. += "Medical Records: "
+		. += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><br>"
+		. += "Employment Records: "
+		. += "<a href='?src=\ref[src];set_general_records=1'>[TextPreview(pref.gen_record,40)]</a><br>"
+		. += "Security Records: "
 		. += "<a href='?src=\ref[src];set_security_records=1'>[TextPreview(pref.sec_record,40)]</a><br>"
-		. += "Memory:<br>"
+		. += "Memory: "
 		. += "<a href='?src=\ref[src];set_memory=1'>[TextPreview(pref.memory,40)]</a><br>"
 	. = jointext(.,null)
 

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -13,6 +13,11 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	sort_order = 2
 	category_item_type = /datum/category_item/player_setup_item/background
 
+/datum/category_group/player_setup_category/background_preferences/content(var/mob/user)
+	. = ""
+	for(var/datum/category_item/player_setup_item/PI in items)
+		. += "[PI.content(user)]<br>"
+
 /datum/category_group/player_setup_category/occupation_preferences
 	name = "Occupation"
 	sort_order = 3

--- a/code/modules/culture_descriptor/_culture.dm
+++ b/code/modules/culture_descriptor/_culture.dm
@@ -55,12 +55,12 @@
 /decl/cultural_info/proc/get_description(var/header, var/append, var/verbose = TRUE)
 	var/list/dat = list()
 	dat += "<table padding='8px'><tr>"
-	dat += "<td width = 55%>"
+	dat += "<td width='210px'>"
 	dat += "[header ? header : "<b>[desc_type]:</b> [name]"]<br>"
 	dat += "<small>"
 	dat += "[jointext(get_text_details(), "<br>")]"
 	dat += "</small></td>"
-	dat += "<td width = 45%>"
+	dat += "<td width>"
 	if(verbose || length(get_text_body()) <= MAX_DESC_LEN)
 		dat += "[get_text_body()]"
 	else


### PR DESCRIPTION
Makes better use of horizontal space.
Records are now in ass end of the tab, but not that far.

AFTER
![](https://i.imgur.com/aN7u5yu.png)

BEFORE

![](https://i.imgur.com/uFz4vl7.png)
