### PR TITLE
Stops the supermatter monitor from reporting on off-site crystals

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -248,7 +248,7 @@
 /obj/machinery/power/supermatter/examine(mob/user)
 	. = ..()
 	if(user.skill_check(SKILL_ENGINES, SKILL_EXPERT))
-		var/integrity_message 
+		var/integrity_message
 		switch(get_integrity())
 			if(0 to 30)
 				integrity_message = "<span class='danger'>It looks highly unstable!</span>"
@@ -320,14 +320,14 @@
 
 	if(damage > explosion_point)
 		if(!exploded)
-			if(!istype(L, /turf/space))
+			if(!istype(L, /turf/space) && L.z in GLOB.using_map.station_levels)
 				announce_warning()
 			explode()
 	else if(damage > warning_point) // while the core is still damaged and it's still worth noting its status
 		shift_light(5, warning_color)
 		if(damage > emergency_point)
 			shift_light(7, emergency_color)
-		if(!istype(L, /turf/space) && (world.timeofday - lastwarning) >= WARNING_DELAY * 10)
+		if(!istype(L, /turf/space) && ((world.timeofday - lastwarning) >= WARNING_DELAY * 10) && L.z in GLOB.using_map.station_levels)
 			announce_warning()
 	else
 		shift_light(4,initial(light_color))

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -320,14 +320,14 @@
 
 	if(damage > explosion_point)
 		if(!exploded)
-			if(!istype(L, /turf/space) && L.z in GLOB.using_map.station_levels)
+			if(!istype(L, /turf/space) && (L.z in GLOB.using_map.station_levels))
 				announce_warning()
 			explode()
 	else if(damage > warning_point) // while the core is still damaged and it's still worth noting its status
 		shift_light(5, warning_color)
 		if(damage > emergency_point)
 			shift_light(7, emergency_color)
-		if(!istype(L, /turf/space) && ((world.timeofday - lastwarning) >= WARNING_DELAY * 10) && L.z in GLOB.using_map.station_levels)
+		if(!istype(L, /turf/space) && ((world.timeofday - lastwarning) >= WARNING_DELAY * 10) && (L.z in GLOB.using_map.station_levels))
 			announce_warning()
 	else
 		shift_light(4,initial(light_color))


### PR DESCRIPTION
:cl: Textor
bugfix: The supermatter monitor no longer cares about delaminating supermatter crystals not on board the Torch. Those other crystals must suffer silently, now.
/:cl: