### PR TITLE
Prevented dead nymphs from entering or remaining in a gestalt.

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_nymph.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/alien/diona/proc/gestalt_with(var/mob/living/carbon/alien/diona/chirp)
-	if(!istype(chirp) || chirp == src || istype(chirp.loc, /obj/structure/diona_gestalt) || istype(loc, /obj/structure/diona_gestalt))
+	if(!istype(chirp) || chirp == src || chirp.incapacitated() || incapacitated())
+		return FALSE
+	if(istype(chirp.loc, /obj/structure/diona_gestalt) || istype(loc, /obj/structure/diona_gestalt))
 		return FALSE
 	visible_message("<span class='notice'>\The [chirp] and \the [src] twine together in gestalt!</span>")
 	var/obj/structure/diona_gestalt/blob = new(get_turf(src))

--- a/code/modules/mob/living/carbon/alien/diona/nymph_death.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_death.dm
@@ -39,6 +39,10 @@
 
 /mob/living/carbon/alien/diona/death(gibbed)
 
+	var/obj/structure/diona_gestalt/gestalt = loc
+	if(istype(gestalt))
+		gestalt.shed_nymph(src, TRUE, FALSE)
+
 	if(holding_item)
 		unEquip(holding_item)
 	if(hat)

--- a/code/modules/mob/living/carbon/alien/diona/nymph_gestalting.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_gestalting.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/alien/diona/proc/do_merge(var/mob/living/carbon/human/H)
-	if(!istype(H) || !src || !(src.Adjacent(H)))
+	if(!istype(H) || !src || !(src.Adjacent(H)) || src.incapacitated() || H.incapacitated())
 		return 0
 	to_chat(H, "You feel your being twine with that of \the [src] as it merges with your biomass.")
 	H.status_flags |= PASSEMOTES


### PR DESCRIPTION
This closes an exploit in which clientless hydroponics nymphs could be grabbed shortly before dying to bypass the requirements for achieving humanoid form.