### PR TITLE
Infirmary minor mapping

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_telescreen.dm
@@ -7,8 +7,21 @@
 
 /obj/item/modular_computer/telescreen/preset/generic/install_default_programs()
 	..()
-	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
-	hard_drive.store_file(new/datum/computer_file/program/email_client())
 	set_autorun("cammon")
+
+/obj/item/modular_computer/telescreen/preset/medical/install_default_programs()
+	..()
+	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
+	hard_drive.store_file(new/datum/computer_file/program/records())
+	hard_drive.store_file(new/datum/computer_file/program/suit_sensors())
+	set_autorun("sensormonitor")
+
+/obj/item/modular_computer/telescreen/preset/engineering/install_default_programs()
+	..()
+	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
+	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
+	hard_drive.store_file(new/datum/computer_file/program/shields_monitor())
+	hard_drive.store_file(new/datum/computer_file/program/supermatter_monitor())
+	set_autorun("alarmmonitor")

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -8216,6 +8216,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/modular_computer/telescreen/preset/engineering{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/hallway)
 "qM" = (

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -17767,11 +17767,13 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/obj/structure/table/standard,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/modular_computer/laptop/preset/records,
+/obj/item/modular_computer/console/preset/medical{
+	icon_state = "console";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/autopsy)
 "ewb" = (
@@ -18093,7 +18095,6 @@
 /area/assembly/robotics_surgery)
 "eRb" = (
 /obj/structure/table/standard,
-/obj/item/device/mass_spectrometer/adv,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
@@ -18219,7 +18220,6 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
 	},
-/obj/item/modular_computer/laptop/preset/records,
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
@@ -18564,6 +18564,9 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/item/modular_computer/telescreen/preset/medical{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
 "fub" = (
@@ -19004,6 +19007,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
 	},
+/obj/item/modular_computer/telescreen/preset/medical{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
 "fVb" = (
@@ -19394,14 +19400,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "gsb" = (
-/obj/item/modular_computer/console/preset/medical,
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "gtb" = (
-/obj/structure/table/reinforced,
-/obj/item/modular_computer/laptop/preset/records,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/modular_computer/console/preset/medical{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
@@ -19579,7 +19585,6 @@
 /area/medical/equipstorage)
 "gFb" = (
 /obj/structure/table/standard,
-/obj/item/device/mass_spectrometer/adv,
 /obj/item/clothing/glasses/science,
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
@@ -19589,6 +19594,7 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
+/obj/item/device/mass_spectrometer,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "gGb" = (
@@ -24280,7 +24286,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "mnb" = (
-/obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/medical/infirmary)
 "mob" = (
@@ -25896,7 +25901,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/modular_computer/laptop/preset/records,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},


### PR DESCRIPTION
:cl: Sbotkin
maptweak: Replaces strategic reserve of laptops in the infirmary with consoles and telescreens, where needed.
/:cl:

Also adds a telescreen to the engineering.
Also changes the reception table a little bit so it would make sense for both orderlies (if that's a word) there.
Replaced advanced mass spectrometer with a basic one, go research the better one.