### PR TITLE
Make simple mobs take different amounts of damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,4 +1,7 @@
-/mob/living/carbon/human/proc/get_unarmed_attack(var/mob/living/carbon/human/target, var/hit_zone)
+/mob/living/carbon/human/proc/get_unarmed_attack(var/mob/target, var/hit_zone = null)
+	if(!hit_zone)
+		hit_zone = zone_sel.selecting
+
 	for(var/datum/unarmed_attack/u_attack in species.unarmed_attacks)
 		if(u_attack.is_usable(src, target, hit_zone))
 			if(pulling_punches)

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -23,12 +23,6 @@ var/global/list/sparring_attack_cache = list()
 		return PAIN
 	return BRUTE
 
-/datum/unarmed_attack/proc/get_simple_damage()
-	var/simple_damage = damage
-	simple_damage += damage * edge
-	simple_damage += damage * sharp
-	return simple_damage
-	
 /datum/unarmed_attack/proc/get_sparring_variant()
 	if(sparring_variant_type)
 		if(!sparring_attack_cache[sparring_variant_type])

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -23,13 +23,19 @@ var/global/list/sparring_attack_cache = list()
 		return PAIN
 	return BRUTE
 
+/datum/unarmed_attack/proc/get_simple_damage()
+	var/simple_damage = damage
+	simple_damage += damage * edge
+	simple_damage += damage * sharp
+	return simple_damage
+	
 /datum/unarmed_attack/proc/get_sparring_variant()
 	if(sparring_variant_type)
 		if(!sparring_attack_cache[sparring_variant_type])
 			sparring_attack_cache[sparring_variant_type] = new sparring_variant_type()
 		return sparring_attack_cache[sparring_variant_type]
 
-/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
+/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/target, var/zone)
 	if(user.restrained())
 		return 0
 

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -24,6 +24,8 @@
 	mob_size = MOB_SMALL
 	can_escape = 1
 
+	bleed_colour = "#816e12"
+
 	var/generation = 1
 	var/static/list/borer_names = list(
 		"Primary", "Secondary", "Tertiary", "Quaternary", "Quinary", "Senary",

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -29,6 +29,8 @@
 	mob_swap_flags = HUMAN|SIMPLE_ANIMAL|SLIME|MONKEY
 	mob_push_flags = ALLMOBS
 
+	bleed_colour = "#331111"
+
 	var/list/construct_spells = list()
 
 /mob/living/simple_animal/construct/cultify()

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -32,6 +32,8 @@
 
 	faction = "carp"
 
+	bleed_colour = "#5d0d71"
+
 	pass_flags = PASS_FLAG_TABLE
 
 /mob/living/simple_animal/hostile/carp/Allow_Spacemove(var/check_drift = 0)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -38,6 +38,8 @@
 	mob_size = MOB_LARGE
 	pass_flags = PASS_FLAG_TABLE
 
+	bleed_colour = "#0d5a71"
+
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/giant_spider/nurse
 	desc = "Furry and beige, it makes you shudder to look at it. This one has brilliant green eyes."

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -22,6 +22,8 @@
 	minbodytemp = 0
 	speed = 4
 
+	bleed_colour = SYNTH_BLOOD_COLOUR
+
 /mob/living/simple_animal/hostile/hivebot/range
 	name = "Hivebot"
 	desc = "A smallish robot, this one is armed!"

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -34,6 +34,8 @@
 	var/health_per_tick = 0.8
 	pass_flags = PASS_FLAG_TABLE
 
+	bleed_colour = "#aad9de"
+
 /mob/living/simple_animal/hostile/vagrant/Initialize()
 	. = ..()
 	if(prob(40))

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -28,6 +28,8 @@
 	supernatural = 1
 	status_flags = CANPUSH
 
+	bleed_colour = "#181933"
+
 /mob/living/simple_animal/shade/cultify()
 	return
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -209,8 +209,14 @@
 			//TODO: Push the mob away or something
 
 		if(I_HURT)
-			adjustBruteLoss(harm_intent_damage)
-			M.visible_message("<span class='warning'>[M] [response_harm] \the [src]!</span>")
+			var/dealt_damge = harm_intent_damage
+			var/harm_verb = response_harm
+			if(ishuman(M) && M.species)
+				dealt_damge += M.species.get_simple_attack_damage(M, src)
+				harm_verb = M.species.get_simple_attack_verb(M, src, response_harm)
+
+			adjustBruteLoss(dealt_damge)
+			M.visible_message("<span class='warning'>[M] [harm_verb] \the [src]!</span>")
 			M.do_attack_animation(src)
 
 	return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -62,6 +62,10 @@
 	//Null rod stuff
 	var/supernatural = 0
 	var/purge = 0
+	
+	var/bleed_ticks = 0
+	var/bleed_colour = COLOR_BLOOD_HUMAN
+	var/can_bleed = TRUE
 
 	// contained in a cage
 	var/in_stasis = 0
@@ -92,6 +96,9 @@
 	handle_confused()
 	handle_supernatural()
 	handle_impaired_vision()
+	
+	if(can_bleed && bleed_ticks > 0)
+		handle_bleeding()
 
 	if(buckled && can_escape)
 		if(istype(buckled, /obj/effect/energy_net))
@@ -209,13 +216,16 @@
 			//TODO: Push the mob away or something
 
 		if(I_HURT)
-			var/dealt_damge = harm_intent_damage
+			var/dealt_damage = harm_intent_damage
 			var/harm_verb = response_harm
 			if(ishuman(M) && M.species)
-				dealt_damge += M.species.get_simple_attack_damage(M, src)
-				harm_verb = M.species.get_simple_attack_verb(M, src, response_harm)
+				var/datum/unarmed_attack/attack = M.get_unarmed_attack(src)
+				dealt_damage = attack.damage <= dealt_damage ? dealt_damage : attack.damage
+				harm_verb = pick(attack.attack_verb)
+				if(attack.sharp || attack.edge)
+					adjustBleedTicks(dealt_damage)
 
-			adjustBruteLoss(dealt_damge)
+			adjustBruteLoss(dealt_damage)
 			M.visible_message("<span class='warning'>[M] [harm_verb] \the [src]!</span>")
 			M.do_attack_animation(src)
 
@@ -262,6 +272,8 @@
 		damage *= 2
 		purge = 3
 	adjustBruteLoss(damage)
+	if(O.edge || O.sharp)
+		adjustBleedTicks(damage)
 
 	return 0
 
@@ -361,7 +373,10 @@
 			meat.SetName("[src.name] [meat.name]")
 		if(issmall(src))
 			user.visible_message("<span class='danger'>[user] chops up \the [src]!</span>")
-			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
+			if(can_bleed)
+				var/obj/effect/decal/cleanable/blood/splatter/splat = new(get_turf(src))
+				splat.basecolor = bleed_colour
+				splat.update_icon()
 			qdel(src)
 		else
 			user.visible_message("<span class='danger'>[user] butchers \the [src] messily!</span>")
@@ -379,3 +394,22 @@
 
 /mob/living/simple_animal/is_burnable()
 	return heat_damage_per_tick
+
+/mob/living/simple_animal/proc/adjustBleedTicks(var/amount)
+	if(!can_bleed)
+		return
+
+	if(amount > 0)
+		bleed_ticks = max(bleed_ticks, amount)
+	else
+		bleed_ticks = max(bleed_ticks + amount, 0)
+		
+	bleed_ticks = round(bleed_ticks)
+	
+/mob/living/simple_animal/proc/handle_bleeding()
+	bleed_ticks--
+	adjustBruteLoss(1)
+	
+	var/obj/effect/decal/cleanable/blood/drip/drip = new(get_turf(src))
+	drip.basecolor = bleed_colour
+	drip.update_icon()

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -767,19 +767,3 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				if(player_count >= max_players)
 					return FALSE
 	return TRUE
-
-/datum/species/proc/get_simple_attack_damage(var/mob/living/carbon/human/H, var/mob/living/simple_animal/target)
-	var/simple_damage = 0
-	if(!H.pulling_punches)
-		var/datum/unarmed_attack/attack = H.get_unarmed_attack(target)
-		if(attack)
-			simple_damage = attack.get_simple_damage()
-	return simple_damage
-
-/datum/species/proc/get_simple_attack_verb(var/mob/living/carbon/human/H, var/mob/living/simple_animal/target, var/default_attack_verb)
-	var/simple_attack_verb = default_attack_verb
-	var/datum/unarmed_attack/attack = H.get_unarmed_attack(target)
-	if(attack)
-		simple_attack_verb = pick(attack.attack_verb)
-	return simple_attack_verb
-

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -767,3 +767,19 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				if(player_count >= max_players)
 					return FALSE
 	return TRUE
+
+/datum/species/proc/get_simple_attack_damage(var/mob/living/carbon/human/H, var/mob/living/simple_animal/target)
+	var/simple_damage = 0
+	if(!H.pulling_punches)
+		var/datum/unarmed_attack/attack = H.get_unarmed_attack(target)
+		if(attack)
+			simple_damage = attack.get_simple_damage()
+	return simple_damage
+
+/datum/species/proc/get_simple_attack_verb(var/mob/living/carbon/human/H, var/mob/living/simple_animal/target, var/default_attack_verb)
+	var/simple_attack_verb = default_attack_verb
+	var/datum/unarmed_attack/attack = H.get_unarmed_attack(target)
+	if(attack)
+		simple_attack_verb = pick(attack.attack_verb)
+	return simple_attack_verb
+


### PR DESCRIPTION
- Depends on unarmed attack used
- Uses the unarmed attack's verb
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑 FTangSteve
rscadd: simple mobs now take different damage from different unarmed attacks
/🆑