### PR TITLE
Adds shuttle shuttles

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -146,6 +146,10 @@
 	for(var/obj/O in source)
 		if(O.simulated)
 			O.forceMove(new_turf)
+		else if(istype(O,/obj/effect/shuttle_landmark))
+			var/obj/effect/shuttle_landmark/L = O
+			if(L.mobile)
+				L.forceMove(new_turf)
 
 	for(var/mob/M in source)
 		if(isEye(M)) continue // If we need to check for more mobs, I'll add a variable

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -92,6 +92,14 @@ SUBSYSTEM_DEF(shuttle)
 		if((shuttle in shuttles_to_initialize) || !initial(shuttle.defer_initialisation))
 			initialise_shuttle(shuttle_type, TRUE)
 	shuttles_to_initialize = null
+	for(var/datum/shuttle/S in shuttles)
+		if(S.mothershuttle)
+			var/datum/shuttle/mothership = shuttles[S.mothershuttle]
+			if(mothership)
+				S.motherdock = S.current_location.landmark_tag
+				mothership.shuttle_area |= S.shuttle_area
+			else
+				error("Shuttle [S] was unable to find mothership [mothership]!")
 
 /datum/controller/subsystem/shuttle/proc/initialise_shuttle(var/shuttle_type, during_init = FALSE)
 	if(!initialized && !during_init)

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -92,8 +92,11 @@ SUBSYSTEM_DEF(shuttle)
 		if((shuttle in shuttles_to_initialize) || !initial(shuttle.defer_initialisation))
 			initialise_shuttle(shuttle_type, TRUE)
 	shuttles_to_initialize = null
+	hook_up_motherships()
+
+/datum/controller/subsystem/shuttle/proc/hook_up_motherships()
 	for(var/datum/shuttle/S in shuttles)
-		if(S.mothershuttle)
+		if(S.mothershuttle && !S.motherdock)
 			var/datum/shuttle/mothership = shuttles[S.mothershuttle]
 			if(mothership)
 				S.motherdock = S.current_location.landmark_tag

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -69,6 +69,7 @@
 /datum/map_template/proc/init_shuttles()
 	for (var/shuttle_type in shuttles_to_initialise)
 		SSshuttle.initialise_shuttle(shuttle_type)
+	SSshuttle.hook_up_motherships()
 
 /datum/map_template/proc/load_new_z()
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -57,12 +57,19 @@
 			S.linked = src
 
 //If shuttle_name is false, will add to generic waypoints; otherwise will add to restricted. Does not do checks.
-obj/effect/overmap/proc/add_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
+/obj/effect/overmap/proc/add_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
 	landmark.sector_set(src)
 	if(shuttle_name)
 		LAZYADD(restricted_waypoints[shuttle_name], landmark)
 	else
 		generic_waypoints += landmark
+
+/obj/effect/overmap/proc/remove_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
+	if(shuttle_name)
+		var/list/shuttles = restricted_waypoints[shuttle_name]
+		LAZYREMOVE(shuttles, landmark)
+	else
+		generic_waypoints -= landmark
 
 /obj/effect/overmap/proc/get_waypoints(var/shuttle_name)
 	. = generic_waypoints.Copy()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -21,6 +21,10 @@
 	var/turf/base_turf
 	//If set, will set base area and turf type to same as where it was spawned at
 	var/autoset
+	//Will be moved by the shuttle when it moves
+	var/mobile
+	//Name of the shuttle, null for generic waypoint
+	var/shuttle_restricted 
 
 /obj/effect/shuttle_landmark/Initialize()
 	. = ..()
@@ -45,6 +49,16 @@
 				docking_controller.docking_codes = location.docking_codes
 
 	SSshuttle.register_landmark(landmark_tag, src)
+
+/obj/effect/shuttle_landmark/forceMove()
+	var/obj/effect/overmap/map_origin = map_sectors["[z]"]
+	. = ..()
+	var/obj/effect/overmap/map_destination = map_sectors["[z]"]
+	if(map_origin != map_destination)
+		if(map_origin)
+			map_origin.remove_landmark(src, shuttle_restricted)
+		if(map_destination)
+			map_destination.add_landmark(src, shuttle_restricted)
 
 //Called when the landmark is added to an overmap sector.
 /obj/effect/shuttle_landmark/proc/sector_set(var/obj/effect/overmap/O)
@@ -74,15 +88,14 @@
 	name = "Navpoint"
 	landmark_tag = "navpoint"
 	autoset = 1
-	var/shuttle_restricted //name of the shuttle, null for generic waypoint
 
 /obj/effect/shuttle_landmark/automatic/Initialize()
-	landmark_tag += "-[x]-[y]-[z]"
+	landmark_tag += "-[x]-[y]-[z]-[random_id("landmarks",1,9999)]"
 	return ..()
 
 /obj/effect/shuttle_landmark/automatic/sector_set(var/obj/effect/overmap/O)
 	..()
-	SetName("[O.name] - [name]")
+	SetName("[O.name] - [initial(name)] ([x],[y])")
 
 //Subtype that calls explosion on init to clear space for shuttles
 /obj/effect/shuttle_landmark/automatic/clearing

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -25,6 +25,9 @@
 	var/logging_home_tag   //Whether in-game logs will be generated whenever the shuttle leaves/returns to the landmark with this landmark_tag.
 	var/logging_access     //Controls who has write access to log-related stuff; should correlate with pilot access.
 
+	var/mothershuttle //tag of mothershuttle
+	var/motherdock    //tag of mothershuttle landmark, defaults to starting location
+
 /datum/shuttle/New(_name, var/obj/effect/shuttle_landmark/initial_location)
 	..()
 	if(_name)
@@ -207,6 +210,14 @@
 			var/datum/powernet/NewPN = new()
 			NewPN.add_cable(C)
 			propagate_network(C,C.powernet)
+	
+	if(mothershuttle)
+		var/datum/shuttle/mothership = SSshuttle.shuttles[mothershuttle]
+		if(mothership)
+			if(current_location.landmark_tag == motherdock)
+				mothership.shuttle_area |= shuttle_area
+			else
+				mothership.shuttle_area -= shuttle_area
 
 //returns 1 if the shuttle has a valid arrive time
 /datum/shuttle/proc/has_arrive_time()


### PR DESCRIPTION
Shuttle shuttles are shuttles that inside other shuttles. Or outside. They travel together, unless they fly somewhere from their starting point.
Mothershuttle carries their point around, so they can always rejoin if it's reachable.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
