### PR TITLE
Fix sensitive data transfer between IC components

### DIFF
--- a/code/controllers/subsystems/processing/circuit.dm
+++ b/code/controllers/subsystems/processing/circuit.dm
@@ -17,7 +17,7 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 	var/cost_multiplier = SHEET_MATERIAL_AMOUNT / 10 // Each circuit cost unit is 200cm3
 
 /datum/controller/subsystem/processing/circuit/Initialize()
-	SScircuit.cipherkey = uppertext(generateRandomString(2000+rand(0,10)))
+	SScircuit.cipherkey = generateRandomString(2000+rand(0,10))
 	circuits_init()
 	. = ..()
 

--- a/code/modules/integrated_electronics/core/helpers.dm
+++ b/code/modules/integrated_electronics/core/helpers.dm
@@ -131,16 +131,14 @@
 
 	return get_pin_ref(parameters[1], parameters[2], parameters[3], components)
 
+// this is for data validation of stuff like ref encodes and more importantly ID access lists
 
+/proc/compute_signature(data)
+	return md5(SScircuit.cipherkey + data)
 
+/proc/add_data_signature(data)
+	var/signature = compute_signature(data)
+	return "[signature]:[data]"
 
-// Used to obfuscate object refs imported/exported as strings.
-// Not very secure, but if someone still finds a way to abuse refs, they deserve it.
-/proc/XorEncrypt(string, key)
-	if(!string || !key ||!istext(string)||!istext(key))
-		return
-	var/r
-	for(var/i = 1 to length(string))
-		r += ascii2text(text2ascii(string,i) ^ text2ascii(key,(i-1)%length(string)+1))
-	return r
-
+/proc/check_data_signature(signature, data)
+	return (compute_signature(data) == signature)

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -80,7 +80,7 @@
 	pull_data()
 	var/atom/A = get_pin_data(IC_INPUT, 1)
 	if(A && istype(A))
-		result = str2hex(XorEncrypt("\ref[A]", SScircuit.cipherkey))
+		result = add_data_signature("\ref[A]")
 
 	set_pin_data(IC_OUTPUT, 1, result)
 	push_data()
@@ -97,7 +97,13 @@
 
 /obj/item/integrated_circuit/converter/refdecode/do_work()
 	pull_data()
-	dec = XorEncrypt(hex2str(get_pin_data(IC_INPUT, 1), TRUE), SScircuit.cipherkey)
+	var/list/signature_and_data = splittext(get_pin_data(IC_INPUT, 1), ":")
+	var/signature = signature_and_data[1]
+	var/dec = signature_and_data[2]
+
+	if(!check_data_signature(signature, dec))
+		return FALSE
+
 	set_pin_data(IC_OUTPUT, 1, weakref(locate(dec)))
 	push_data()
 	activate_pin(2)

--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -102,11 +102,20 @@
 	var/Ps = get_pin_data(IC_INPUT, 4)
 	if(!Ps)
 		return
-	var/list/Pl = json_decode(XorEncrypt(hex2str(Ps, TRUE), SScircuit.cipherkey))
+
+	var/list/signature_and_data = splittext(Ps, ":")
+	var/signature = signature_and_data[1]
+	var/result = signature_and_data[2]
+
+	if(!check_data_signature(signature, result))
+		activate_pin(3)
+		return
+
+	var/list/Pl = json_decode(result)
 	if(Pl&&islist(Pl))
 		idc.access = Pl
 	var/turf/a_loc = get_turf(assembly)
-	var/list/P = AStar(assembly, locate(get_pin_data(IC_INPUT, 1), get_pin_data(IC_INPUT, 2), a_loc.z), /turf/proc/CardinalTurfsWithAccess, 0, 200, id=idc, exclude=get_turf(get_pin_data_as_type(IC_INPUT, 3, /atom)))
+	var/list/P = AStar(a_loc, locate(get_pin_data(IC_INPUT, 1), get_pin_data(IC_INPUT, 2), a_loc.z), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 200, id=idc, exclude=get_turf(get_pin_data_as_type(IC_INPUT, 3, /atom)))
 
 	if(!P)
 		activate_pin(3)


### PR DESCRIPTION
Also fixes advanced pathfinders. Closes #22940

This fixes anything that relied on xor ciphering for preventing users from injecting doctored data, such as ID/access circuits and reference encoders/decoders.