### PR TITLE
BUFF WATER

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -165,7 +165,7 @@
 
 	else if(volume >= 10)
 		var/turf/simulated/S = T
-		S.wet_floor(1, TRUE)
+		S.wet_floor(8, TRUE)
 
 
 /datum/reagent/water/touch_obj(var/obj/O)


### PR DESCRIPTION
🆑nearlyNon
tweak: Water now lasts a minute on the ground, to make it more useful to have wet floor signs. For reference, space lube is 10 minutes, and the cult spell is 6 minutes.
/🆑