### PR TITLE
Reduce lag when interacting with ICs

### DIFF
--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -38,19 +38,6 @@ a creative player the means to solve many problems.  Circuits are held inside an
 
 // This should be used when someone is examining while the case is opened.
 /obj/item/integrated_circuit/proc/internal_examine(mob/user)
-	to_chat(user, "\The [src] has [LAZYLEN(inputs)] input pin\s, [LAZYLEN(outputs)] output pin\s and [LAZYLEN(activators)] activation pin\s.")
-	for(var/k in 1 to LAZYLEN(inputs))
-		var/datum/integrated_io/I = inputs[k]
-		if(I.linked.len)
-			to_chat(user, "The '[I]' is connected to [I.get_linked_to_desc()].")
-	for(var/k in 1 to LAZYLEN(outputs))
-		var/datum/integrated_io/O = outputs[k]
-		if(O.linked.len)
-			to_chat(user, "The '[O]' is connected to [O.get_linked_to_desc()].")
-	for(var/k in 1 to LAZYLEN(activators))
-		var/datum/integrated_io/activate/A = activators[k]
-		if(A.linked.len)
-			to_chat(user, "The '[A]' is connected to [A.get_linked_to_desc()].")
 	any_examine(user)
 	interact(user)
 


### PR DESCRIPTION
Reworks open_interact() for integrated circuits to cap the amount of HTML that's generated for each proc call. I changed the UI to use pages, with 5 components per page. Up/down buttons have been replaced with slot selection. This also removes the annoying truckload of "X is connected to Y and has value Z yadda yadda" messages whenever you examine the assembly, and fixes ghosts being able to interact with circuits.

![](https://i.imgur.com/HCKLdeO.png)

The circuit pictured above would previously cause 396 lines of HTML to be made (for the components only) each proc call. It now makes 50.