### PR TITLE
Nerfs Soap, Makes Catwalks Not Be Irritating

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -11,15 +11,18 @@
 	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")
 	var/mopping = 0
 	var/mopcount = 0
-
-GLOBAL_LIST_INIT(moppable_types, list(/obj/effect/decal/cleanable,/obj/effect/overlay,/obj/effect/rune,/obj/structure/catwalk))
+	var/list/moppable_types = list(
+		/obj/effect/decal/cleanable,
+		/obj/effect/overlay,
+		/obj/effect/rune,
+		/obj/structure/catwalk)
 
 /obj/item/weapon/mop/New()
 	create_reagents(30)
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
-	if(istype(A, /turf) || (A in GLOB.moppable_types))
+	if(istype(A, /turf) || is_type_in_list(A,moppable_types))
 		if(reagents.total_volume < 1)
 			to_chat(user, "<span class='notice'>Your mop is dry!</span>")
 			return

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -12,13 +12,14 @@
 	var/mopping = 0
 	var/mopcount = 0
 
+GLOBAL_LIST_INIT(moppable_types, list(/obj/effect/decal/cleanable,/obj/effect/overlay,/obj/effect/rune,/obj/structure/catwalk))
 
 /obj/item/weapon/mop/New()
 	create_reagents(30)
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
-	if(istype(A, /turf) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay) || istype(A, /obj/effect/rune))
+	if(istype(A, /turf) || (A in GLOB.moppable_types))
 		if(reagents.total_volume < 1)
 			to_chat(user, "<span class='notice'>Your mop is dry!</span>")
 			return

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -19,10 +19,11 @@
 /obj/item/weapon/soap/proc/wet()
 	reagents.add_reagent(/datum/reagent/space_cleaner, 15)
 
-/obj/item/weapon/soap/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living))
-		var/mob/living/M =	AM
-		M.slip("the [src.name]",3)
+/obj/item/weapon/soap/Crossed(var/mob/living/AM)
+	if (istype(AM))
+		if(AM.pulledby)
+			return
+		AM.slip("the [src.name]",3)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return
@@ -36,10 +37,12 @@
 	else if(istype(target,/obj/effect/decal/cleanable))
 		to_chat(user, "<span class='notice'>You scrub \the [target.name] out.</span>")
 		qdel(target)
-	else if(istype(target,/turf))
-		to_chat(user, "<span class='notice'>You scrub \the [target.name] clean.</span>")
-		var/turf/T = target
-		T.clean(src, user)
+	else if(istype(target,/turf) || istype(target, /obj/structure/catwalk))
+		var/turf/T = get_turf(target)
+		if(!T)
+			return
+		user.visible_message("<span class='warning'>[user] gets down on their hands and knees and starts scrubbing \the [T].</span>")
+		T.clean(src, user, 80, "<span class='notice'>You scrub \the [target.name] clean.</span>")
 	else if(istype(target,/obj/structure/hygiene/sink))
 		to_chat(user, "<span class='notice'>You wet \the [src] in the sink.</span>")
 		wet()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -41,7 +41,7 @@
 		var/turf/T = get_turf(target)
 		if(!T)
 			return
-		user.visible_message("<span class='warning'>[user] gets down on their hands and knees and starts scrubbing \the [T].</span>")
+		user.visible_message("<span class='warning'>[user] starts scrubbing \the [T].</span>")
 		T.clean(src, user, 80, "<span class='notice'>You scrub \the [target.name] clean.</span>")
 	else if(istype(target,/obj/structure/hygiene/sink))
 		to_chat(user, "<span class='notice'>You wet \the [src] in the sink.</span>")

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -237,10 +237,14 @@ var/const/enterloopsanity = 100
 	return 0
 
 //expects an atom containing the reagents used to clean the turf
-/turf/proc/clean(atom/source, mob/user = null)
+/turf/proc/clean(atom/source, mob/user = null, var/time = null, var/message = null)
 	if(source.reagents.has_reagent(/datum/reagent/water, 1) || source.reagents.has_reagent(/datum/reagent/space_cleaner, 1))
+		if(user && time && !do_after(user, time, src))
+			return
 		clean_blood()
 		remove_cleanables()
+		if(message)
+			to_chat(user, message)
 	else
 		to_chat(user, "<span class='warning'>\The [source] is too dry to wash that.</span>")
 	source.reagents.trans_to_turf(src, 1, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.


### PR DESCRIPTION
:cl:Textor
bugfix: Catwalks can now be cleaned by mops and soap by simply clicking on them. Janitors everywhere rejoice at having to do less work.
tweak: Soap now takes a longer time than a mop to scrub floors. Janitors everywhere grumble at having to take longer at doing their job.
tweak: Soap no longer can be used to knock people over by dragging them onto it. Janitors everywhere are sad they can no longer prank people as easily.
/:cl:

This is redone from #22934 due to the sink remap forcing a rebase that became the bane of my existence.