### PR TITLE
Restricts cyborgs by regional accesses

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -273,7 +273,7 @@ var/const/NO_EMAG_ACT = -50
 	assignment = "Synthetic"
 
 /obj/item/weapon/card/id/synthetic/New()
-	access = get_all_station_access() + access_synth
+	access = get_region_accesses(ACCESS_REGION_GENERAL) + get_region_accesses(ACCESS_REGION_COMMAND) + access_synth + access_robotics + access_maint_tunnels
 	..()
 
 /obj/item/weapon/card/id/centcom

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -272,8 +272,12 @@ var/const/NO_EMAG_ACT = -50
 	item_state = "tdgreen"
 	assignment = "Synthetic"
 
-/obj/item/weapon/card/id/synthetic/New()
+/obj/item/weapon/card/id/synthetic/robot/New()
 	access = get_region_accesses(ACCESS_REGION_GENERAL) + get_region_accesses(ACCESS_REGION_COMMAND) + access_synth + access_robotics + access_maint_tunnels
+	..()
+
+/obj/item/weapon/card/id/synthetic/ai/New()
+	access = get_all_station_access() + access_synth
 	..()
 
 /obj/item/weapon/card/id/centcom

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -50,6 +50,7 @@ var/list/ai_verbs_default = list(
 	status_flags = CANSTUN|CANPARALYSE|CANPUSH
 	shouldnt_see = list(/obj/effect/rune)
 	maxHealth = 200
+	idcard = /obj/item/weapon/card/id/synthetic/ai
 	var/list/network = list("Exodus")
 	var/obj/machinery/camera/camera = null
 	var/list/connected_robots = list()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -12,6 +12,8 @@
 	mob_swap_flags = ROBOT|MONKEY|SLIME|SIMPLE_ANIMAL
 	mob_push_flags = ~HEAVY //trundle trundle
 
+	idcard = /obj/item/weapon/card/id/synthetic/robot
+
 	var/lights_on = 0 // Is our integrated light on?
 	var/used_power_this_tick = 0
 	var/sight_mode = 0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -46,6 +46,7 @@ var/global/list/robot_modules = list(
 	// Bookkeeping
 	var/list/original_languages = list()
 	var/list/added_networks = list()
+	var/list/access_departments
 
 /obj/item/weapon/robot_module/New(var/mob/living/silicon/robot/R)
 	..()
@@ -58,6 +59,7 @@ var/global/list/robot_modules = list(
 	add_languages(R)
 	add_subsystems(R)
 	apply_status_flags(R)
+	add_regional_access(R)
 
 	if(R.silicon_radio)
 		R.silicon_radio.recalculateChannels()
@@ -73,6 +75,7 @@ var/global/list/robot_modules = list(
 	remove_languages(R)
 	remove_subsystems(R)
 	remove_status_flags(R)
+	remove_regional_access(R)
 
 	if(R.silicon_radio)
 		R.silicon_radio.recalculateChannels()
@@ -172,6 +175,16 @@ var/global/list/robot_modules = list(
 	if(!can_be_pushed)
 		R.status_flags |= CANPUSH
 
+/obj/item/weapon/robot_module/proc/add_regional_access(var/mob/living/silicon/robot/R)
+	for(var/region in access_departments)
+		R.idcard.access += get_region_accesses(region)
+
+/obj/item/weapon/robot_module/proc/remove_regional_access(var/mob/living/silicon/robot/R)
+	for(var/region in access_departments)
+		for(var/access in get_region_accesses(region))
+			R.idcard.access += access
+
+
 /obj/item/weapon/robot_module/standard
 	name = "standard robot module"
 	sprites = list(	"Basic" = "robot_old",
@@ -197,6 +210,7 @@ var/global/list/robot_modules = list(
 	networks = list(NETWORK_MEDICAL)
 	subsystems = list(/datum/nano_module/crew_monitor)
 	can_be_pushed = 0
+	access_departments = list(ACCESS_REGION_MEDBAY)
 
 /obj/item/weapon/robot_module/medical/surgeon
 	name = "surgeon robot module"
@@ -262,6 +276,7 @@ var/global/list/robot_modules = list(
 					"Drone - Chemistry" = "drone-chemistry",
 					"Doot" = "eyebot-medical"
 					)
+	access_departments = list(ACCESS_REGION_SECURITY, ACCESS_REGION_MEDBAY, ACCESS_REGION_ENGINEERING, ACCESS_REGION_SUPPLY)
 
 /obj/item/weapon/robot_module/medical/crisis/New()
 	src.modules += new /obj/item/weapon/crowbar(src)
@@ -334,6 +349,7 @@ var/global/list/robot_modules = list(
 					"Doot" = "eyebot-engineering"
 					)
 	no_slip = 1
+	access_departments = list(ACCESS_REGION_ENGINEERING)
 
 /obj/item/weapon/robot_module/engineering/general/New()
 	src.modules += new /obj/item/device/flash(src)
@@ -414,6 +430,7 @@ var/global/list/robot_modules = list(
 	subsystems = list(/datum/nano_module/crew_monitor, /datum/nano_module/digitalwarrant)
 	can_be_pushed = 0
 	supported_upgrades = list(/obj/item/borg/upgrade/weaponcooler)
+	access_departments = list(ACCESS_REGION_SECURITY)
 
 /obj/item/weapon/robot_module/security/general
 	sprites = list(
@@ -463,6 +480,7 @@ var/global/list/robot_modules = list(
 					"Drone" = "drone-janitor",
 					"Doot" = "eyebot-janitor"
 					)
+	access_departments = list(ACCESS_REGION_SUPPLY)
 
 /obj/item/weapon/robot_module/janitor/New()
 	src.modules += new /obj/item/device/flash(src)
@@ -495,6 +513,7 @@ var/global/list/robot_modules = list(
 					LANGUAGE_INDEPENDENT= 1,
 					LANGUAGE_SPACER = 1
 					)
+	access_departments = list(ACCESS_REGION_SUPPLY)
 
 /obj/item/weapon/robot_module/clerical/butler
 	sprites = list(	"Waitress" = "Service",
@@ -592,6 +611,7 @@ var/global/list/robot_modules = list(
 					"Doot" = "eyebot-miner"
 				)
 	supported_upgrades = list(/obj/item/borg/upgrade/jetpack)
+	access_departments = list(ACCESS_REGION_SUPPLY)
 
 /obj/item/weapon/robot_module/miner/New()
 	src.modules += new /obj/item/device/flash(src)
@@ -616,6 +636,7 @@ var/global/list/robot_modules = list(
 					"Drone" = "drone-science",
 					"Doot" = "eyebot-science"
 					)
+	access_departments = list(ACCESS_REGION_RESEARCH)
 
 /obj/item/weapon/robot_module/research/New()
 	src.modules += new /obj/item/device/flash(src)
@@ -694,6 +715,7 @@ var/global/list/robot_modules = list(
 	hide_on_manifest = 1
 	no_slip = 1
 	networks = list(NETWORK_ENGINEERING)
+	access_departments = list(ACCESS_REGION_SECURITY, ACCESS_REGION_MEDBAY, ACCESS_REGION_RESEARCH, ACCESS_REGION_ENGINEERING, ACCESS_REGION_SUPPLY)
 
 /obj/item/weapon/robot_module/drone/New(var/mob/living/silicon/robot/robot)
 	src.modules += new /obj/item/weapon/weldingtool(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -177,12 +177,12 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/proc/add_regional_access(var/mob/living/silicon/robot/R)
 	for(var/region in access_departments)
-		R.idcard.access += get_region_accesses(region)
+		R.idcard.access |= get_region_accesses(region)
 
 /obj/item/weapon/robot_module/proc/remove_regional_access(var/mob/living/silicon/robot/R)
 	for(var/region in access_departments)
 		for(var/access in get_region_accesses(region))
-			R.idcard.access += access
+			R.idcard.access -= access
 
 
 /obj/item/weapon/robot_module/standard

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -181,8 +181,7 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/proc/remove_regional_access(var/mob/living/silicon/robot/R)
 	for(var/region in access_departments)
-		for(var/access in get_region_accesses(region))
-			R.idcard.access -= access
+		R.idcard.access -= get_region_accesses(region)
 
 
 /obj/item/weapon/robot_module/standard


### PR DESCRIPTION
🆑 Cakey
tweak: Cyborgs are now restricted to regional accesses based on their selected modules, with all cyborgs being given access to general and command regional accesses by default. Additional accesses includ maintenance tunnels and robotics.
/🆑

Unsurprisingly, Cyborgs currently let people into places they shouldn't be let into even though they aren't meant to, because hey, why not, right?

Not sure if command access should be all-module, open to feedback.

[Thread](https://forums.baystation12.net/threads/regional-synthetic-access.6945/)