### PR TITLE
Add ability to grant access to arrest warrants

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -266,3 +266,9 @@ proc/age2agedescription(age)
 				selected = M
 				break
 	return selected
+
+// Find a human mob with a certain (real) name
+/proc/find_human_by_name(var/name)
+	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
+		if(H.real_name == name)
+			return H

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -266,9 +266,3 @@ proc/age2agedescription(age)
 				selected = M
 				break
 	return selected
-
-// Find a human mob with a certain (real) name
-/proc/find_human_by_name(var/name)
-	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
-		if(H.real_name == name)
-			return H

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -22,6 +22,18 @@
 	else
 		to_chat(user, "<span class='notice'>You have to be closer if you want to read it.</span>")
 
+// an active warrant with access authorized grants access
+/obj/item/device/holowarrant/GetAccess()
+	. = list()
+
+	if(!active)
+		return
+
+	if(active.archived)
+		return
+
+	. |= active.fields["access"]
+
 //hit yourself with it
 /obj/item/device/holowarrant/attack_self(mob/living/user as mob)
 	active = null

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -129,43 +129,43 @@ KEY.set_access(ACCESS, ACCESS_EDIT || ACCESS || access_bridge)}
 // Fear not the preprocessor, for it is a friend. To add a field, use one of these, depending on value type and if you need special access to see it.
 // It will also create getter/setter procs for record datum, named like /get_[key here]() /set_[key_here](value) e.g. get_name() set_name(value)
 // Use getter setters to avoid errors caused by typoing the string key.
-#define FIELD_SHORT(NAME, KEY, ACCESS) SETUP_FIELD(NAME, KEY, simple_text/crew_record, ACCESS, null)
-#define FIELD_LONG(NAME, KEY, ACCESS) SETUP_FIELD(NAME, KEY, pencode_text/crew_record, ACCESS, null)
-#define FIELD_NUM(NAME, KEY, ACCESS) SETUP_FIELD(NAME, KEY, number/crew_record, ACCESS, null)
-#define FIELD_LIST(NAME, KEY, OPTIONS, ACCESS) FIELD_LIST_EDIT(NAME, KEY, OPTIONS, ACCESS, null)
+#define FIELD_SHORT(NAME, KEY, ACCESS, ACCESS_EDIT) SETUP_FIELD(NAME, KEY, simple_text/crew_record, ACCESS, ACCESS_EDIT)
+#define FIELD_LONG(NAME, KEY, ACCESS, ACCESS_EDIT) SETUP_FIELD(NAME, KEY, pencode_text/crew_record, ACCESS, ACCESS_EDIT)
+#define FIELD_NUM(NAME, KEY, ACCESS, ACCESS_EDIT) SETUP_FIELD(NAME, KEY, number/crew_record, ACCESS, ACCESS_EDIT)
+#define FIELD_LIST(NAME, KEY, OPTIONS, ACCESS, ACCESS_EDIT) FIELD_LIST_EDIT(NAME, KEY, OPTIONS, ACCESS, ACCESS_EDIT)
 #define FIELD_LIST_EDIT(NAME, KEY, OPTIONS, ACCESS, ACCESS_EDIT) SETUP_FIELD(NAME, KEY, options/crew_record, ACCESS, ACCESS_EDIT);\
 /datum/report_field/options/crew_record/##KEY/get_options(){return OPTIONS}
 
 // GENERIC RECORDS
-FIELD_SHORT("Name", name, null)
-FIELD_SHORT("Job",job, null)
-FIELD_LIST("Sex", sex, record_genders(), null)
-FIELD_NUM("Age", age, null)
+FIELD_SHORT("Name", name, null, access_change_ids)
+FIELD_SHORT("Job", job, null, access_change_ids)
+FIELD_LIST("Sex", sex, record_genders(), null, access_change_ids)
+FIELD_NUM("Age", age, null, access_change_ids)
 FIELD_LIST_EDIT("Status", status, GLOB.physical_statuses, null, access_medical)
 
-FIELD_SHORT("Species",species, null)
-FIELD_LIST("Branch", branch, record_branches(), null)
-FIELD_LIST("Rank", rank, record_ranks(), null)
+FIELD_SHORT("Species",species, null, access_change_ids)
+FIELD_LIST("Branch", branch, record_branches(), null, access_change_ids)
+FIELD_LIST("Rank", rank, record_ranks(), null, access_change_ids)
 
 // MEDICAL RECORDS
-FIELD_LIST("Blood Type", bloodtype, GLOB.blood_types, null)
-FIELD_LONG("Medical Record", medRecord, access_medical)
-FIELD_SHORT("Religion", religion, access_medical)
+FIELD_LIST("Blood Type", bloodtype, GLOB.blood_types, access_medical, access_medical)
+FIELD_LONG("Medical Record", medRecord, access_medical, access_medical)
+FIELD_SHORT("Religion", religion, access_medical, access_medical)
 
 // SECURITY RECORDS
-FIELD_LIST("Criminal Status", criminalStatus, GLOB.security_statuses, access_security)
-FIELD_LONG("Security Record", secRecord, access_security)
-FIELD_SHORT("DNA", dna, access_security)
-FIELD_SHORT("Fingerprint", fingerprint, access_security)
+FIELD_LIST("Criminal Status", criminalStatus, GLOB.security_statuses, access_security, access_security)
+FIELD_LONG("Security Record", secRecord, access_security, access_security)
+FIELD_SHORT("DNA", dna, access_security, access_security)
+FIELD_SHORT("Fingerprint", fingerprint, access_security, access_security)
 
 // EMPLOYMENT RECORDS
-FIELD_LONG("Employment Record", emplRecord, access_bridge)
-FIELD_SHORT("Home System", homeSystem, access_bridge)
-FIELD_SHORT("Faction", faction, access_bridge)
-FIELD_LONG("Qualifications", skillset, access_bridge)
+FIELD_LONG("Employment Record", emplRecord, access_bridge, access_bridge)
+FIELD_SHORT("Home System", homeSystem, access_bridge, access_change_ids)
+FIELD_SHORT("Faction", faction, access_bridge, access_bridge)
+FIELD_LONG("Qualifications", skillset, access_bridge, access_bridge)
 
 // ANTAG RECORDS
-FIELD_LONG("Exploitable Information", antagRecord, access_syndicate)
+FIELD_LONG("Exploitable Information", antagRecord, access_syndicate, access_syndicate)
 
 //Options builderes
 /datum/report_field/options/crew_record/rank/proc/record_ranks()

--- a/nano/templates/digitalwarrant.tmpl
+++ b/nano/templates/digitalwarrant.tmpl
@@ -14,6 +14,14 @@
 		<div class='itemContent'>
 			{{:data.warrantname}}
 		</div>
+		{{if data.type == "arrest"}}
+			<div class='itemLabel'>
+				Job:
+			</div>
+			<div class='itemContent'>
+				{{:data.warrantjob}}
+			</div>
+		{{/if}}
 	</div>
 	<div class='item'>
 		{{if data.type == "arrest"}}
@@ -55,7 +63,7 @@
 		<div class='itemContent'>
 			<table>
 				{{if data.type == "arrest"}}
-					<tr><td>{{:helper.link('Edit Name', null, {'editwarrantname' : 1})}}{{:helper.link('Custom Name', null, {'editwarrantnamecustom' : 1})}}
+					<tr><td>{{:helper.link('Edit Name/Job', null, {'editwarrantname' : 1})}}{{:helper.link('Custom Name/Job', null, {'editwarrantnamecustom' : 1})}}
 					<tr><td>{{:helper.link('Edit Charges', null, {'editwarrantcharges' : 1})}}
 				{{/if}}
 				{{if data.type == "search"}}

--- a/nano/templates/digitalwarrant.tmpl
+++ b/nano/templates/digitalwarrant.tmpl
@@ -38,6 +38,16 @@
 			{{:data.warrantauth}}
 		</div>
 	</div>
+	{{if data.type == "arrest"}}
+		<div class='item'>
+			<div class='itemLabel'>
+				Access authorized by:
+			</div>
+			<div class='itemContent'>
+				{{:data.warrantidauth}}
+			</div>
+		</div>
+	{{/if}}
 	<div class='item'>
 		<div class='itemLabel'>
 			Actions:
@@ -53,6 +63,9 @@
 					<tr><td>{{:helper.link('Edit Reason', null, {'editwarrantcharges' : 1})}}	
 				{{/if}}
 				<tr><td>{{:helper.link('Authorize', null, {'editwarrantauth' : 1})}}
+				{{if data.type == "arrest"}}
+					<tr><td>{{:helper.link('Authorize access', null, {'editwarrantidauth' : 1})}}
+				{{/if}}
 				<tr><td>{{:helper.link('Save', null, {'savewarrant' : 1})}}
 				<td>{{:helper.link('Delete', 'trash', {'deletewarrant' : 1})}}
 				<tr><td>{{:helper.link('Back to Menu', null, {'back' : 1})}}


### PR DESCRIPTION
:cl:Atebite
rscadd: Anyone with access to change IDs can now authorize access on arrest warrants. Holoprojectors can then be used as ID cards as long as the selected warrant is active. Warrants copy all the job access of the job listed in the person's crew records, except for command access
tweak: Changing most information in crew records now requires ID changing accesss
/:cl:

CL and title should be pretty descriptive.