### PR TITLE
Forensics additions

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -583,6 +583,7 @@ var/list/global/slot_flags_enumeration = list(
 	if(istype(src, /obj/item/clothing/gloves))
 		var/obj/item/clothing/gloves/G = src
 		G.transfer_blood = 0
+	trace_DNA = null
 
 /obj/item/reveal_blood()
 	if(was_bloodied && !fluorescent)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -232,8 +232,6 @@
 		S.add(transfer)
 		if (prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(S)
-			if(blood_DNA)
-				S.blood_DNA |= blood_DNA
 		return transfer
 	return 0
 
@@ -252,8 +250,6 @@
 		newstack.color = color
 		if (prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(newstack)
-			if(blood_DNA)
-				newstack.blood_DNA |= blood_DNA
 		return newstack
 	return null
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -127,6 +127,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/mob/living/carbon/human/C = loc
 			if (src == C.wear_mask && C.check_has_mouth()) // if it's in the human/monkey mouth, transfer reagents to the mob
 				reagents.trans_to_mob(C, REM, CHEM_INGEST, 0.2) // Most of it is not inhaled... balance reasons.
+				add_trace_DNA(C)
 		else // else just remove some of the reagents
 			reagents.remove_any(REM)
 
@@ -376,6 +377,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			return 1
 		to_chat(H, "<span class='notice'>You take a drag on your [name].</span>")
 		smoke(5)
+		add_trace_DNA(H)
 		return 1
 	return ..()
 
@@ -853,6 +855,7 @@ obj/item/clothing/mask/chewable/Destroy()
 			var/mob/living/carbon/human/C = loc
 			if (src == C.wear_mask && C.check_has_mouth()) // if it's in the human/monkey mouth, transfer reagents to the mob
 				reagents.trans_to_mob(C, REM, CHEM_INGEST, 0.2) // I am keeping this one because gum is not a replacement for real food. Fuck off Wonka.
+			add_trace_DNA(C)
 		else // else just remove some of the reagents
 			reagents.remove_any(REM)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -4,7 +4,6 @@
 	var/flash_protection = FLASH_PROTECTION_NONE	// Sets the item's level of flash protection.
 	var/tint = TINT_NONE							// Sets the item's level of visual impairment tint.
 	var/list/species_restricted = list("exclude", SPECIES_NABBER) //Only these species can wear this kit.
-	var/gunshot_residue //Used by forensics.
 
 	var/list/accessories = list()
 	var/list/valid_accessory_slots
@@ -60,6 +59,11 @@
 			acc += A.get_fibers()
 	if(acc.len)
 		. += " with traces of [english_list(acc)]"
+
+/obj/item/clothing/proc/leave_evidence(mob/source)
+	add_fingerprint(source)
+	if(prob(10))
+		ironed_state = WRINKLES_WRINKLY
 
 /obj/item/clothing/New()
 	..()

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -11,7 +11,10 @@ proc/is_complete_print(var/print)
 atom/var/list/suit_fibers
 atom/var/var/list/fingerprints
 atom/var/var/list/fingerprintshidden
-atom/var/var/fingerprintslast = null
+atom/var/var/fingerprintslast
+obj/item/var/list/trace_DNA
+mob/living/carbon/human/var/gunshot_residue
+obj/item/clothing/var/gunshot_residue
 
 /atom/proc/add_hiddenprint(mob/M)
 	if(!M || !M.key)
@@ -108,14 +111,26 @@ atom/var/var/fingerprintslast = null
 
 /atom/proc/transfer_fingerprints_to(var/atom/A)
 	if(fingerprints)
-		if(!A.fingerprints)
-			A.fingerprints = list()
-		A.fingerprints |= fingerprints.Copy()            //detective
+		LAZYDISTINCTADD(A.fingerprints, fingerprints)
 	if(fingerprintshidden)
-		if(!A.fingerprintshidden)
-			A.fingerprintshidden = list()
-		A.fingerprintshidden |= fingerprintshidden.Copy()    //admin
+		LAZYDISTINCTADD(A.fingerprintshidden, fingerprintshidden)
 		A.fingerprintslast = fingerprintslast
+	if(suit_fibers)
+		LAZYDISTINCTADD(A.suit_fibers, suit_fibers)
+	if(blood_DNA)
+		A.blood_DNA |= blood_DNA
+
+/obj/item/transfer_fingerprints_to(var/atom/A)
+	..()
+	if(istype(A,/obj/item) && trace_DNA)
+		var/obj/item/I = A
+		LAZYDISTINCTADD(I.trace_DNA, trace_DNA)
+
+/obj/item/clothing/transfer_fingerprints_to(var/atom/A)
+	..()
+	if(istype(A,/obj/item/clothing) && gunshot_residue)
+		var/obj/item/clothing/C = A
+		C.gunshot_residue = gunshot_residue
 
 atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(!istype(M))
@@ -151,6 +166,14 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		fibertext = C.get_fibers()
 		if(fibertext && prob(20*item_multiplier))
 			suit_fibers |= fibertext
+
+/obj/item/proc/add_trace_DNA(mob/living/carbon/M)
+	if(!istype(M))
+		return
+	if(M.isSynthetic())
+		return
+	if(istype(M.dna))
+		LAZYDISTINCTADD(trace_DNA, M.dna.unique_enzymes)
 
 /mob/proc/get_full_print()
 	return FALSE

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -108,10 +108,12 @@
 		P.overlays = list("paper_stamped")
 		//dna data itself
 		var/data = "No scan information available."
-		if(bloodsamp.dna != null)
-			data = "Spectometric analysis on provided sample has determined the presence of [bloodsamp.dna.len] strings of DNA.<br><br>"
+		if(bloodsamp.dna != null || bloodsamp.trace_dna != null)
+			data = "Spectometric analysis on provided sample has determined the presence of DNA.<br><br>"
 			for(var/blood in bloodsamp.dna)
-				data += "<span class='notice'>Blood type: [bloodsamp.dna[blood]]<br>\nDNA: [blood]</span><br><br>"
+				data += "<span class='notice'>Blood type: [bloodsamp.dna[blood]]<br>DNA: [blood]</span><br><br>"
+			for(var/trace in bloodsamp.trace_dna)
+				data += "<span class='notice'>Trace DNA: [trace]</span><br><br>"
 		else
 			data += "No DNA found.<br>"
 		P.info = "<b>[src] analysis report #[report_num]</b><br>"

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -4,6 +4,7 @@
 	icon_state = "swab"
 	var/gsr = 0
 	var/list/dna
+	var/list/trace_dna
 	var/used
 
 /obj/item/weapon/forensics/swab/proc/is_used()
@@ -83,6 +84,8 @@
 	var/list/choices = list()
 	if(A.blood_DNA)
 		choices |= "Blood"
+	if(istype(A, /obj/item/))
+		choices |= "DNA traces"
 	if(istype(A, /obj/item/clothing))
 		choices |= "Gunshot Residue"
 
@@ -100,7 +103,9 @@
 
 	var/sample_type
 	if(choice == "Blood")
-		if(!A.blood_DNA || !A.blood_DNA.len) return
+		if(!A.blood_DNA || !A.blood_DNA.len)
+			to_chat(user, "<span class='warning'>There is no blood on \the [A].</span>")
+			return
 		dna = A.blood_DNA.Copy()
 		sample_type = "blood"
 
@@ -111,6 +116,14 @@
 			return
 		gsr = B.gunshot_residue
 		sample_type = "residue"
+
+	else if(choice == "DNA traces")
+		var/obj/item/I = A
+		if(!istype(I) || !I.trace_DNA)
+			to_chat(user, "<span class='warning'>There is no non-blood DNA on \the [A].</span>")
+			return
+		trace_dna = I.trace_DNA.Copy()
+		sample_type = "trace DNA"
 
 	if(sample_type)
 		user.visible_message("\The [user] swabs \the [A] for a sample.", "You swab \the [A] for a sample.")

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -149,6 +149,7 @@
 /obj/item/grab/proc/action_used()
 	assailant.remove_cloaking_source(assailant.species)
 	last_action = world.time
+	leave_forensic_traces()
 
 /obj/item/grab/proc/check_action_cooldown()
 	return (world.time >= last_action + current_grab.action_cooldown)
@@ -156,6 +157,13 @@
 /obj/item/grab/proc/check_upgrade_cooldown()
 	return (world.time >= last_upgrade + current_grab.upgrade_cooldown)
 
+/obj/item/grab/proc/leave_forensic_traces()
+	var/obj/item/clothing/C = affecting.get_covering_equipped_item(target_zone)
+	if(istype(C))
+		C.leave_evidence(assailant)
+		if(prob(50))
+			C.ironed_state = WRINKLES_WRINKLY
+	
 /obj/item/grab/proc/upgrade(var/bypass_cooldown = FALSE)
 	if(!check_upgrade_cooldown() && !bypass_cooldown)
 		to_chat(assailant, "<span class='danger'>It's too soon to upgrade.</span>")
@@ -167,6 +175,7 @@
 		last_upgrade = world.time
 		adjust_position()
 		update_icons()
+		leave_forensic_traces()
 		current_grab.enter_as_up(src)
 
 /obj/item/grab/proc/downgrade()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -70,7 +70,6 @@
 	var/hand_blood_color
 
 	var/list/flavor_texts = list()
-	var/gunshot_residue
 	var/pulling_punches    // Are you trying not to hurt your opponent?
 	var/full_prosthetic    // We are a robutt.
 	var/robolimb_count = 0 // Number of robot limbs.

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -94,6 +94,10 @@ var/global/list/sparring_attack_cache = list()
 			target.visible_message("<span class='danger'>[target] has been weakened!</span>")
 		target.apply_effect(3, WEAKEN, armour)
 
+	var/obj/item/clothing/C = target.get_covering_equipped_item(zone)
+	if(istype(C) && prob(10))
+		C.leave_evidence(user)
+
 /datum/unarmed_attack/proc/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/obj/item/organ/external/affecting = target.get_organ(zone)
 	user.visible_message("<span class='warning'>[user] [pick(attack_verb)] [target] in the [affecting.name]!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -637,6 +637,11 @@
 		var/mob/living/carbon/human/H = AM
 		if(H.pull_damage())
 			to_chat(src, "<span class='danger'>Pulling \the [H] in their current condition would probably be a bad idea.</span>")
+			
+		var/obj/item/clothing/C = H.get_covering_equipped_item(BP_CHEST)
+		if(istype(C))
+			C.leave_evidence(src)
+
 	//Attempted fix for people flying away through space when cuffed and dragged.
 	if(ismob(AM))
 		var/mob/pulled = AM

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -128,6 +128,7 @@
 			self_feed_message(user)
 			reagents.trans_to_mob(user, issmall(user) ? ceil(amount_per_transfer_from_this/2) : amount_per_transfer_from_this, CHEM_INGEST)
 			feed_sound(user)
+			add_trace_DNA(user)
 			return 1
 
 
@@ -154,6 +155,7 @@
 
 			reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INGEST)
 			feed_sound(user)
+			add_trace_DNA(target)
 			return 1
 
 	return 0

--- a/html/changelogs/chinsky - trace.yml
+++ b/html/changelogs/chinsky - trace.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "New forensic evidence type - trace DNA. Left on unfinished food, glasses people drank from, cig butts and gum wads. Collected with swab kits, investigated in DNA scanner."
+  - rscadd: "Grabbing, pulling, and hitting people unarmed now will wrinkle their uniform/suit and leave fingerprints. Usual protections against prints apply there."


### PR DESCRIPTION
Added trace DNA evidence, currently left on cigs/chewables and glasses people drink from / food they nibble on.

Grabbing people / pulling / punching will now have a chance to leave fingerprints on their clothing.

Made forensic evidence transfer procs more robust, they failed to move newer stuff.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
