### PR TITLE
Implements bullet_hit

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -293,6 +293,7 @@
 #include "code\datums\music_tracks\treacherous_voyage.dm"
 #include "code\datums\music_tracks\wake.dm"
 #include "code\datums\observation\_defines.dm"
+#include "code\datums\observation\bullet_hit.dm"
 #include "code\datums\observation\death.dm"
 #include "code\datums\observation\density_set.dm"
 #include "code\datums\observation\destroyed.dm"

--- a/code/datums/observation/bullet_hit.dm
+++ b/code/datums/observation/bullet_hit.dm
@@ -1,0 +1,23 @@
+//	Observer Pattern Implementation: Bullet Hit
+//		Registration type: /atom
+//
+//		Raised when: Bullet_act is procced
+//
+//		Arguments that the called proc should expect:
+//			/atom/hittee - The atom being hit
+//			/obj/item/projectile - the projectile
+//			/def_zone - the defense zone.
+
+GLOBAL_DATUM_INIT(bullet_hit_event, /decl/observ/death, new)
+
+/decl/observ/bullet_hit
+	name = "Bullet Hit"
+	expected_type = /atom
+
+/*****************
+* Bullet Hit Handling *
+*****************/
+
+/atom/bullet_act(obj/item/projectile/P, def_zone)
+	GLOB.bullet_hit_event.raise_event(src, P, def_zone)
+	. = ..()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -126,6 +126,9 @@
 		density = !!new_density
 
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
+	. = do_bullet_act(P, def_zone)
+
+/atom/proc/do_bullet_act(var/obj/item/projectile/P, def_zone)
 	P.on_hit(src, 0, def_zone)
 	. = 0
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -308,7 +308,7 @@
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 
-/obj/effect/cultwall/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/cultwall/do_bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		return
 	take_damage(Proj.damage)
@@ -376,10 +376,10 @@
 		user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
 	O = user.get_equipped_item(slot_wear_suit)
 	if(O && !istype(O, /obj/item/clothing/suit/cultrobes) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)	
+		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
 	O = user.get_equipped_item(slot_shoes)
 	if(O && !istype(O, /obj/item/clothing/shoes/cult) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)	
+		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 
 	O = user.get_equipped_item(slot_back)
 	if(istype(O, /obj/item/weapon/storage) && !istype(O, /obj/item/weapon/storage/backpack/cultpack) && user.unEquip(O)) // We don't want to make the vox drop their nitrogen tank, though

--- a/code/game/gamemodes/godmode/god_structures.dm
+++ b/code/game/gamemodes/godmode/god_structures.dm
@@ -56,7 +56,7 @@
 		src.visible_message("\The [src] crumbles!")
 		qdel(src)
 
-/obj/structure/deity/bullet_act(var/obj/item/projectile/P)
+/obj/structure/deity/do_bullet_act(var/obj/item/projectile/P)
 	take_damage(P.damage)
 
 /obj/structure/deity/proc/attack_deity(var/mob/living/deity/deity)

--- a/code/game/gamemodes/godmode/god_trap.dm
+++ b/code/game/gamemodes/godmode/god_trap.dm
@@ -20,7 +20,7 @@
 	trigger(user)
 	return ..()
 
-/obj/structure/deity/trap/bullet_act()
+/obj/structure/deity/trap/do_bullet_act()
 	return
 
 /obj/structure/deity/trap/proc/trigger(var/atom/entered, var/atom/movable/enterer)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -957,7 +957,7 @@ FIRE ALARM
 /obj/machinery/firealarm/attack_ai(mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/machinery/firealarm/bullet_act()
+/obj/machinery/firealarm/do_bullet_act()
 	return src.alarm()
 
 /obj/machinery/firealarm/emp_act(severity)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -242,7 +242,7 @@ update_flag
 		return GM.return_pressure()
 	return 0
 
-/obj/machinery/portable_atmospherics/canister/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/portable_atmospherics/canister/do_bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		return
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -138,7 +138,7 @@
 			update_coverage()
 			START_PROCESSING(SSmachines, src)
 
-/obj/machinery/camera/bullet_act(var/obj/item/projectile/P)
+/obj/machinery/camera/do_bullet_act(var/obj/item/projectile/P)
 	take_damage(P.get_structure_damage())
 
 /obj/machinery/camera/ex_act(severity)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -59,7 +59,7 @@
 		else
 	return
 
-/obj/machinery/computer/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/computer/do_bullet_act(var/obj/item/projectile/Proj)
 	if(prob(Proj.get_structure_damage()))
 		set_broken()
 	..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -158,7 +158,7 @@
 			do_animate("deny")
 	return
 
-/obj/machinery/door/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/door/do_bullet_act(var/obj/item/projectile/Proj)
 	..()
 
 	var/damage = Proj.get_structure_damage()

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -52,7 +52,7 @@
 /obj/machinery/door/unpowered/simple/get_material_name()
 	return material.name
 
-/obj/machinery/door/unpowered/simple/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/door/unpowered/simple/do_bullet_act(var/obj/item/projectile/Proj)
 	var/damage = Proj.get_structure_damage()
 	if(damage)
 		//cap projectile damage so that there's still a minimum number of hits required to break the door

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -385,7 +385,7 @@ var/list/turret_icons
 	if(health <= 0)
 		die()	//the death process :(
 
-/obj/machinery/porta_turret/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/porta_turret/do_bullet_act(obj/item/projectile/Proj)
 	var/damage = Proj.get_structure_damage()
 
 	if(!damage)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -608,7 +608,7 @@
 			src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 	return
 
-/obj/mecha/bullet_act(var/obj/item/projectile/Proj)
+/obj/mecha/do_bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.damage_type == PAIN && !(src.r_deflect_coeff > 1))
 		use_power(Proj.agony * 5)
 

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -25,7 +25,7 @@
 			qdel(src)
 	return
 
-/obj/effect/decal/mecha_wreckage/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/decal/mecha_wreckage/do_bullet_act(var/obj/item/projectile/Proj)
 	return
 
 

--- a/code/game/objects/auras/aura.dm
+++ b/code/game/objects/auras/aura.dm
@@ -29,7 +29,7 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 /obj/aura/attackby(var/obj/item/I, var/mob/user)
 	return 0
 
-/obj/aura/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/obj/aura/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 	return 0
 
 /obj/aura/hitby(var/atom/movable/M, var/speed)
@@ -42,7 +42,7 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 	log_debug("Attackby for \ref[src]: [I], [user]")
 	return returning
 
-/obj/aura/debug/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/obj/aura/debug/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 	log_debug("Bullet Act for \ref[src]: [P], [def_zone]")
 	return returning
 

--- a/code/game/objects/auras/blueforge_aura.dm
+++ b/code/game/objects/auras/blueforge_aura.dm
@@ -9,7 +9,7 @@
 	user.adjustToxLoss(-10)
 	return 0
 
-/obj/aura/blueforge_aura/bullet_act(var/obj/item/projectile/P)
+/obj/aura/blueforge_aura/do_bullet_act(var/obj/item/projectile/P)
 	if(P.damtype == BURN)
 		P.damage *=2
 	else if(P.agony || P.stun)

--- a/code/game/objects/auras/personal_shields/personal_shield.dm
+++ b/code/game/objects/auras/personal_shields/personal_shield.dm
@@ -6,7 +6,7 @@
 	playsound(user,'sound/weapons/flash.ogg',35,1)
 	to_chat(user,"<span class='notice'>You feel your body prickle as \the [src] comes online.</span>")
 
-/obj/aura/personal_shield/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/obj/aura/personal_shield/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 	user.visible_message("<span class='warning'>\The [user]'s [src.name] flashes before \the [P] can hit them!</span>")
 	new /obj/effect/temporary(get_turf(src), 2 SECONDS,'icons/obj/machines/shielding.dmi',"shield_impact")
 	playsound(user,'sound/effects/basscannon.ogg',35,1)
@@ -20,7 +20,7 @@
 /obj/aura/personal_shield/device
 	var/obj/item/device/personal_shield/shield
 
-/obj/aura/personal_shield/device/bullet_act()
+/obj/aura/personal_shield/device/do_bullet_act()
 	. = ..()
 	if(shield)
 		shield.take_charge()

--- a/code/game/objects/auras/radiant_aura.dm
+++ b/code/game/objects/auras/radiant_aura.dm
@@ -14,7 +14,7 @@
 	to_chat(user, "<span class='warning'>Your protective aura dissipates, leaving you feeling cold and unsafe.</span>")
 	..()
 
-/obj/aura/radiant_aura/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/obj/aura/radiant_aura/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 	if(P.check_armour == "laser")
 		user.visible_message("<span class='warning'>\The [P] refracts, bending into \the [user]'s aura.</span>")
 		return AURA_FALSE

--- a/code/game/objects/auras/shadowling_aura.dm
+++ b/code/game/objects/auras/shadowling_aura.dm
@@ -14,7 +14,7 @@
 		user.mutations -= SPACERES
 	..()
 
-/obj/aura/shadowling_aura/bullet_act(var/obj/item/projectile/P)
+/obj/aura/shadowling_aura/do_bullet_act(var/obj/item/projectile/P)
 	if(P.check_armour == "laser")
 		P.damage *= 2
 	if(P.agony)

--- a/code/game/objects/auras/starlight.dm
+++ b/code/game/objects/auras/starlight.dm
@@ -6,7 +6,7 @@
 	plane = ABOVE_HUMAN_PLANE
 	layer = MOB_LAYER
 
-/obj/aura/starborn/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/obj/aura/starborn/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 	if(P.damage_type == BURN)
 		user.visible_message("<span class='warning'>\The [P] seems to only make \the [user] stronger.</span>")
 		user.adjustBruteLoss(-P.damage)

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -149,7 +149,7 @@
 /obj/structure/foamedmetal/ex_act(severity)
 	qdel(src)
 
-/obj/structure/foamedmetal/bullet_act()
+/obj/structure/foamedmetal/do_bullet_act()
 	if(metal == 1 || prob(50))
 		qdel(src)
 

--- a/code/game/objects/effects/force_portal.dm
+++ b/code/game/objects/effects/force_portal.dm
@@ -54,7 +54,7 @@
 /obj/effect/force_portal/Bumped(var/atom/movable/AM)
 	AM.dropInto(src)
 
-/obj/effect/force_portal/bullet_act(var/obj/item/projectile/P)
+/obj/effect/force_portal/do_bullet_act(var/obj/item/projectile/P)
 	var/atom/movable/AM = new P.type()
 	if(istype(P, /obj/item/projectile/bullet/pellet))
 		var/obj/item/projectile/bullet/pellet/old_pellet = P

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -40,7 +40,7 @@
 	health -= damage
 	healthcheck()
 
-/obj/effect/spider/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/spider/do_bullet_act(var/obj/item/projectile/Proj)
 	..()
 	health -= Proj.get_structure_damage()
 	healthcheck()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -117,7 +117,7 @@
 		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
 	master.disrupt()
 
-/obj/effect/dummy/chameleon/bullet_act()
+/obj/effect/dummy/chameleon/do_bullet_act()
 	for(var/mob/M in src)
 		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
 	..()

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -35,7 +35,7 @@
 			if (prob(50))
 				qdel(src)
 
-/obj/item/latexballon/bullet_act()
+/obj/item/latexballon/do_bullet_act()
 	burst()
 
 /obj/item/latexballon/fire_act(datum/gas_mixture/air, temperature, volume)

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -41,7 +41,7 @@
 	desc = "A shooting target with a threatening silhouette."
 	hp = 2350 // alium onest too kinda
 
-/obj/item/target/bullet_act(var/obj/item/projectile/Proj)
+/obj/item/target/do_bullet_act(var/obj/item/projectile/Proj)
 	var/p_x = Proj.p_x + pick(0,0,0,0,0,-1,1) // really ugly way of coding "sometimes offset Proj.p_x!"
 	var/p_y = Proj.p_y + pick(0,0,0,0,0,-1,1)
 	var/decaltype = 1 // 1 - scorch, 2 - bullet

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -49,7 +49,7 @@
 	playsound(src, "shatter", 70, 1)
 	desc = "Oh no, seven years of bad luck!"
 
-/obj/item/weapon/storage/mirror/bullet_act(var/obj/item/projectile/Proj)
+/obj/item/weapon/storage/mirror/do_bullet_act(var/obj/item/projectile/Proj)
 
 	if(prob(Proj.get_structure_damage() * 2))
 		if(!shattered)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -193,7 +193,7 @@
 			visible_message("<span class='danger'>\The [src] is torn apart!</span>")
 		qdel(src)
 
-/obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/energy_net/do_bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()
 	healthcheck()
 	return 0

--- a/code/game/objects/structures/alien/alien.dm
+++ b/code/game/objects/structures/alien/alien.dm
@@ -11,7 +11,7 @@
 		qdel(src)
 	return
 
-/obj/structure/alien/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/alien/do_bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
 	..()
 	healthcheck()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -242,7 +242,7 @@
 			A.forceMove(src.loc)
 		qdel(src)
 
-/obj/structure/closet/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/closet/do_bullet_act(var/obj/item/projectile/Proj)
 	var/proj_damage = Proj.get_structure_damage()
 	if(proj_damage)
 		..()

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -86,7 +86,7 @@
 		for(var/mob/M in src)
 			shatter(M)
 
-/obj/structure/closet/statue/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/closet/statue/do_bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()
 	check_health()
 

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -13,7 +13,7 @@
 	layer = ABOVE_HUMAN_LAYER
 	opacity = 0
 
-/obj/structure/curtain/bullet_act(obj/item/projectile/P, def_zone)
+/obj/structure/curtain/do_bullet_act(obj/item/projectile/P, def_zone)
 	if(!P.nodamage)
 		visible_message("<span class='warning'>[P] tears [src] down!</span>")
 		qdel(src)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -37,7 +37,7 @@
 			if (prob(50))
 				take_damage(5)
 
-/obj/structure/displaycase/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/displaycase/do_bullet_act(var/obj/item/projectile/Proj)
 	..()
 	take_damage(Proj.get_structure_damage())
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -29,7 +29,7 @@
 	spawn(1) dismantle()
 	return 1
 
-/obj/structure/girder/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/girder/do_bullet_act(var/obj/item/projectile/Proj)
 	//Girders only provide partial cover. There's a chance that the projectiles will just pass through. (unless you are trying to shoot the girder)
 	if(Proj.original != src && !prob(cover))
 		return PROJECTILE_CONTINUE //pass through

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -87,7 +87,7 @@
 		else
 			return !density
 
-/obj/structure/grille/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/grille/do_bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)	return
 
 	//Flimsy grilles aren't so great at stopping projectiles. However they can absorb some of the impact

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -56,7 +56,7 @@
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 0
 
-/obj/structure/inflatable/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/inflatable/do_bullet_act(var/obj/item/projectile/Proj)
 	var/proj_damage = Proj.get_structure_damage()
 	if(!proj_damage) return
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -273,7 +273,7 @@
 				buckled_mob.pixel_y = 7
 
 
-/obj/structure/bed/chair/janicart/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/bed/chair/janicart/do_bullet_act(var/obj/item/projectile/Proj)
 	if(buckled_mob)
 		if(prob(85))
 			return buckled_mob.bullet_act(Proj)

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -153,7 +153,7 @@
 			color = adjust_brightness(color, bleach_factor)
 	update_icon()
 
-/obj/structure/wall_frame/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/wall_frame/do_bullet_act(var/obj/item/projectile/Proj)
 	var/proj_damage = Proj.get_structure_damage()
 	var/damage = min(proj_damage, 100)
 	take_damage(damage)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -104,7 +104,7 @@
 	return
 
 
-/obj/structure/window/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/window/do_bullet_act(var/obj/item/projectile/Proj)
 
 	var/proj_damage = Proj.get_structure_damage()
 	if(!proj_damage) return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -69,7 +69,7 @@
 /turf/simulated/wall/proc/get_material()
 	return material
 
-/turf/simulated/wall/bullet_act(var/obj/item/projectile/Proj)
+/turf/simulated/wall/do_bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj,/obj/item/projectile/beam))
 		burn(2500)
 	else if(istype(Proj,/obj/item/projectile/ion))

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -133,7 +133,7 @@
 	if(forceLeft)
 		B.pulse(forceLeft - 1, dirs)
 
-/obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/blob/do_bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
 		return
 

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -157,7 +157,7 @@
 	if(locate(/obj/item/seeds) in get_turf(src))
 		plant()
 
-/obj/machinery/portable_atmospherics/hydroponics/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/portable_atmospherics/hydroponics/do_bullet_act(var/obj/item/projectile/Proj)
 
 	//Don't act on seeds like dionaea that shouldn't change.
 	if(seed && seed.get_trait(TRAIT_IMMUTABLE) > 0)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -104,7 +104,7 @@ var/list/mining_floors = list()
 			mined_ore = 2 //some of the stuff gets blown up
 			GetDrilled()
 
-/turf/simulated/mineral/bullet_act(var/obj/item/projectile/Proj)
+/turf/simulated/mineral/do_bullet_act(var/obj/item/projectile/Proj)
 
 	// Emitter blasts
 	if(istype(Proj, /obj/item/projectile/beam/emitter))

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -123,7 +123,7 @@
 		emagged = 2
 		return 1
 
-/mob/living/bot/secbot/bullet_act(var/obj/item/projectile/P)
+/mob/living/bot/secbot/do_bullet_act(var/obj/item/projectile/P)
 	var/curhealth = health
 	var/mob/shooter = P.firer
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_attacks.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	shed_nymph(forcefully = TRUE)
 
-/obj/structure/diona_gestalt/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/obj/structure/diona_gestalt/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 	. = ..()
 	if(P && (P.damage_type == BRUTE || P.damage_type == BURN))
 		shed_nymph(forcefully = TRUE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -7,7 +7,7 @@ meteor_act
 
 */
 
-/mob/living/carbon/human/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/mob/living/carbon/human/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 
 	def_zone = check_zone(def_zone)
 	if(!has_organ(def_zone))

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -159,7 +159,7 @@
 	..(-abs(amount)) // Heals them
 	return
 
-/mob/living/carbon/slime/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/carbon/slime/do_bullet_act(var/obj/item/projectile/Proj)
 	attacked += 10
 	..(Proj)
 	return 0

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -60,7 +60,7 @@
 	return 0
 
 
-/mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/mob/living/do_bullet_act(var/obj/item/projectile/P, var/def_zone)
 
 	//Being hit while using a deadman switch
 	var/obj/item/device/assembly/signaler/signaler = get_active_hand()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -476,7 +476,7 @@
 /mob/living/silicon/robot/restrained()
 	return 0
 
-/mob/living/silicon/robot/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/silicon/robot/do_bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)
 	if(prob(75) && Proj.damage > 0) spark_system.start()
 	return 2

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -108,7 +108,7 @@
 /mob/living/silicon/IsAdvancedToolUser()
 	return 1
 
-/mob/living/silicon/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/silicon/do_bullet_act(var/obj/item/projectile/Proj)
 
 	if(!Proj.nodamage)
 		switch(Proj.damage_type)

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -120,7 +120,7 @@
 	weakened = 0
 	..()
 
-/mob/living/simple_animal/construct/armoured/bullet_act(var/obj/item/projectile/P)
+/mob/living/simple_animal/construct/armoured/do_bullet_act(var/obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
 		var/reflectchance = 80 - round(P.damage/3)
 		if(prob(reflectchance))

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -120,7 +120,7 @@
 	. = ..()
 	set_flee_target(src.loc)
 
-/mob/living/simple_animal/cat/bullet_act(var/obj/item/projectile/proj)
+/mob/living/simple_animal/cat/do_bullet_act(var/obj/item/projectile/proj)
 	. = ..()
 	set_flee_target(proj.firer? proj.firer : src.loc)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -54,7 +54,7 @@
 		var/obj/mecha/M = A
 		if(!M.occupant)
 			return FALSE
-	
+
 	return TRUE
 
 /mob/living/simple_animal/hostile/proc/Found(var/atom/A)
@@ -174,7 +174,7 @@
 		target_mob = M
 		MoveToTarget()
 
-/mob/living/simple_animal/hostile/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/do_bullet_act(var/obj/item/projectile/Proj)
 	var/oldhealth = health
 	. = ..()
 	if(!target_mob && health < oldhealth && !incapacitated(INCAPACITATION_KNOCKOUT))

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -67,7 +67,7 @@
 		visible_message("<span class='warning'>\The [user] gently taps \the [src] with \the [O].</span>")
 
 
-/mob/living/simple_animal/hostile/syndicate/melee/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/syndicate/melee/do_bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)	return
 	if(prob(65))
 		src.health -= Proj.damage

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -45,7 +45,7 @@
 /mob/living/simple_animal/hostile/vagrant/Allow_Spacemove(var/check_drift = 0)
 	return 1
 
-/mob/living/simple_animal/hostile/vagrant/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/vagrant/do_bullet_act(var/obj/item/projectile/Proj)
 	var/oldhealth = health
 	. = ..()
 	if((target_mob != Proj.firer) && health < oldhealth && !incapacitated(INCAPACITATION_KNOCKOUT)) //Respond to being shot at

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -243,7 +243,7 @@
 	return
 
 //Bullets
-/mob/living/simple_animal/parrot/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/parrot/do_bullet_act(var/obj/item/projectile/Proj)
 	..()
 	if(!stat && !client)
 		if(parrot_state == PARROT_PERCH)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -63,7 +63,7 @@
 	//Null rod stuff
 	var/supernatural = 0
 	var/purge = 0
-	
+
 	var/bleed_ticks = 0
 	var/bleed_colour = COLOR_BLOOD_HUMAN
 	var/can_bleed = TRUE
@@ -98,7 +98,7 @@
 	handle_confused()
 	handle_supernatural()
 	handle_impaired_vision()
-	
+
 	if(can_bleed && bleed_ticks > 0)
 		handle_bleeding()
 
@@ -193,7 +193,7 @@
 /mob/living/simple_animal/proc/audible_emote(var/act_desc)
 	custom_emote(2, act_desc)
 
-/mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/do_bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj || Proj.nodamage)
 		return
 
@@ -407,13 +407,13 @@
 		bleed_ticks = max(bleed_ticks, amount)
 	else
 		bleed_ticks = max(bleed_ticks + amount, 0)
-		
+
 	bleed_ticks = round(bleed_ticks)
-	
+
 /mob/living/simple_animal/proc/handle_bleeding()
 	bleed_ticks--
 	adjustBruteLoss(1)
-	
+
 	var/obj/effect/decal/cleanable/blood/drip/drip = new(get_turf(src))
 	drip.basecolor = bleed_colour
 	drip.update_icon()

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -48,7 +48,7 @@
 // "Stun" weapons can cause minor damage to components (short-circuits?)
 // "Burn" damage is equally strong against internal components and exterior casing
 // "Brute" damage mostly damages the casing.
-/obj/item/modular_computer/bullet_act(var/obj/item/projectile/Proj)
+/obj/item/modular_computer/do_bullet_act(var/obj/item/projectile/Proj)
 	switch(Proj.damage_type)
 		if(BRUTE)
 			take_damage(Proj.damage, Proj.damage / 2)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -199,7 +199,7 @@
 	else if(health < max_health * 0.75)
 		to_chat(user, "\The [src] shows signs of damage!")
 
-/obj/machinery/shipsensors/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/shipsensors/do_bullet_act(var/obj/item/projectile/Proj)
 	take_damage(Proj.get_structure_damage())
 	..()
 

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -79,7 +79,7 @@ var/list/fusion_cores = list()
 		owned_field.AddParticles(name, quantity)
 		. = 1
 
-/obj/machinery/power/fusion_core/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/power/fusion_core/do_bullet_act(var/obj/item/projectile/Proj)
 	if(owned_field)
 		. = owned_field.bullet_act(Proj)
 

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -308,11 +308,11 @@
 /obj/effect/fusion_em_field/proc/change_size(var/newsize = 1)
 	var/changed = 0
 	var/static/list/size_to_icon = list(
-			"3" = 'icons/effects/96x96.dmi', 
-			"5" = 'icons/effects/160x160.dmi', 
-			"7" = 'icons/effects/224x224.dmi', 
-			"9" = 'icons/effects/288x288.dmi', 
-			"11" = 'icons/effects/352x352.dmi', 
+			"3" = 'icons/effects/96x96.dmi',
+			"5" = 'icons/effects/160x160.dmi',
+			"7" = 'icons/effects/224x224.dmi',
+			"9" = 'icons/effects/288x288.dmi',
+			"11" = 'icons/effects/352x352.dmi',
 			"13" = 'icons/effects/416x416.dmi'
 			)
 
@@ -453,7 +453,7 @@
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/obj/effect/fusion_em_field/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/fusion_em_field/do_bullet_act(var/obj/item/projectile/Proj)
 	AddEnergy(Proj.damage)
 	update_icon()
 	return 0

--- a/code/modules/power/fusion/fusion_particle_catcher.dm
+++ b/code/modules/power/fusion/fusion_particle_catcher.dm
@@ -32,7 +32,7 @@
 		set_density(0)
 		SetName("collector [mysize] OFF")
 
-/obj/effect/fusion_particle_catcher/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/fusion_particle_catcher/do_bullet_act(var/obj/item/projectile/Proj)
 	parent.AddEnergy(Proj.damage)
 	update_icon()
 	return 0

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -157,7 +157,7 @@ field_generator power level display
 /obj/machinery/field_generator/emp_act()
 	return 0
 
-/obj/machinery/field_generator/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/field_generator/do_bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj, /obj/item/projectile/beam))
 		power += Proj.damage * EMITTER_DAMAGE_POWER_TRANSFER
 		update_icon()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -69,7 +69,7 @@
 			energy += round((rand(20,60)/2),1)
 			return
 
-/obj/singularity/bullet_act(obj/item/projectile/P)
+/obj/singularity/do_bullet_act(obj/item/projectile/P)
 	return 0 //Will there be an impact? Who knows. Will we see it? No.
 
 /obj/singularity/Bump(atom/A)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -471,7 +471,7 @@
 	update_icon()
 	..()
 
-/obj/machinery/power/smes/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/power/smes/do_bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.damage_type == BRUTE || Proj.damage_type == BURN)
 		take_damage(Proj.damage)
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -155,7 +155,7 @@
 	return ..()
 
 
-/obj/structure/reagent_dispensers/fueltank/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/reagent_dispensers/fueltank/do_bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())
 		if(istype(Proj.firer))
 			var/turf/turf = get_turf(src)

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -192,7 +192,7 @@
 
 
 // Projectiles
-/obj/effect/shield/bullet_act(var/obj/item/projectile/proj)
+/obj/effect/shield/do_bullet_act(var/obj/item/projectile/proj)
 	if(proj.damage_type == BURN)
 		take_damage(proj.get_structure_damage(), SHIELD_DAMTYPE_HEAT)
 	else if (proj.damage_type == BRUTE)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -60,7 +60,7 @@
 
 	..()
 
-/obj/machinery/shield/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/shield/do_bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()
 	..()
 	check_failure()

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -26,7 +26,7 @@
 /obj/effect/energy_field/ex_act(var/severity)
 	Stress(0.5 + severity)
 
-/obj/effect/energy_field/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/energy_field/do_bullet_act(var/obj/item/projectile/Proj)
 	Stress(Proj.get_structure_damage() / 10)
 
 /obj/effect/energy_field/proc/Stress(var/severity)

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -315,7 +315,7 @@
 		G.storedpower -= power_usage
 
 
-/obj/machinery/shieldwall/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/shieldwall/do_bullet_act(var/obj/item/projectile/Proj)
 	if(needs_power)
 		var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
 		G.storedpower -= 400 * Proj.get_structure_damage()

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -105,7 +105,7 @@
 		to_chat(user, "You short out the console's ID checking system. It's now available to everyone!")
 		return 1
 
-/obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/computer/shuttle_control/do_bullet_act(var/obj/item/projectile/Proj)
 	visible_message("\The [Proj] ricochets off \the [src]!")
 
 /obj/machinery/computer/shuttle_control/ex_act()

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -36,7 +36,7 @@
 	density = 1
 	unacidable = 1
 
-/obj/effect/forcefield/bullet_act(var/obj/item/projectile/Proj, var/def_zone)
+/obj/effect/forcefield/do_bullet_act(var/obj/item/projectile/Proj, var/def_zone)
 	var/turf/T = get_turf(src.loc)
 	if(T)
 		for(var/mob/M in T)

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -113,5 +113,5 @@
 
 /obj/effect/dummy/spell_jaunt/ex_act(blah)
 	return
-/obj/effect/dummy/spell_jaunt/bullet_act(blah)
+/obj/effect/dummy/spell_jaunt/do_bullet_act(blah)
 	return

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -406,7 +406,7 @@
 	return 1
 
 
-/obj/machinery/power/supermatter/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/power/supermatter/do_bullet_act(var/obj/item/projectile/Proj)
 	var/turf/L = loc
 	if(!istype(L))		// We don't run process() when we are in space
 		return 0	// This stops people from being able to really power up the supermatter

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -42,7 +42,7 @@
 		return 0 //blocked
 	return 1
 
-/obj/structure/table/bullet_act(obj/item/projectile/P)
+/obj/structure/table/do_bullet_act(obj/item/projectile/P)
 	if(!(P.damage_type == BRUTE || P.damage_type == BURN))
 		return 0
 

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -188,7 +188,7 @@
 
 	..()
 
-/obj/vehicle/bike/bullet_act(var/obj/item/projectile/Proj)
+/obj/vehicle/bike/do_bullet_act(var/obj/item/projectile/Proj)
 	if(buckled_mob && prob((100-protection_percent)))
 		buckled_mob.bullet_act(Proj)
 		return

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -83,7 +83,7 @@
 	..()
 
 //cargo trains are open topped, so there is a chance the projectile will hit the mob ridding the train instead
-/obj/vehicle/train/cargo/bullet_act(var/obj/item/projectile/Proj)
+/obj/vehicle/train/cargo/do_bullet_act(var/obj/item/projectile/Proj)
 	if(buckled_mob && prob(70))
 		buckled_mob.bullet_act(Proj)
 		return

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -113,7 +113,7 @@
 	else
 		..()
 
-/obj/vehicle/bullet_act(var/obj/item/projectile/Proj)
+/obj/vehicle/do_bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()
 	..()
 	healthcheck()

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -266,7 +266,7 @@
 				to_chat(M, "<b>You accidentally touch [src].</b>")
 	..()
 
-/obj/machinery/artifact/bullet_act(var/obj/item/projectile/P)
+/obj/machinery/artifact/do_bullet_act(var/obj/item/projectile/P)
 	if(istype(P,/obj/item/projectile/bullet) ||\
 		istype(P,/obj/item/projectile/hivebotbullet))
 		if(my_effect.trigger == TRIGGER_FORCE)

--- a/code/modules/xenoarcheaology/tools/coolant_tank.dm
+++ b/code/modules/xenoarcheaology/tools/coolant_tank.dm
@@ -9,7 +9,7 @@
 	..()
 	reagents.add_reagent(/datum/reagent/coolant, 1000)
 
-/obj/structure/reagent_dispensers/coolanttank/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/reagent_dispensers/coolanttank/do_bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())
 		explode()
 

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -122,7 +122,7 @@ obj/structure/net/Initialize(var/mapload)
 		new /obj/item/stack/net(src.loc)
 		qdel(src)
 
-/obj/structure/net/bullet_act(obj/item/projectile/P)
+/obj/structure/net/do_bullet_act(obj/item/projectile/P)
 	. = PROJECTILE_CONTINUE //few cloth ribbons won't stop bullet or energy ray
 	if(P.damage_type != BURN)//beams, lasers, fire. Bullets won't make a lot of damage to the few hanging belts.
 		return


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Implements bullet_hit as how afterthought suggested:
Basically replace all occurances of bullet_act with do_bullet_act, then have regular bullet hit call do_bullet_act after calling the bullet hit event.

Still touches a lot of files, but is guaranteed to interact with all occurrences of bullet_act without messing with any actual bullet_act code.