### PR TITLE
Water tanks can be wrenched to spread water.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -79,6 +79,7 @@
 	icon_state = "watertank"
 	amount_per_transfer_from_this = 10
 	var/modded = 0
+	var/fill_level = FLUID_SHALLOW // Can be adminbussed for silly room-filling tanks.
 	possible_transfer_amounts = "10;25;50;100"
 	initial_capacity = 50000
 	initial_reagent_types = list(/datum/reagent/water = 1)
@@ -88,8 +89,13 @@
 	if(reagents.total_volume <= 0)
 		return
 
-	// For now, this cheats and only checks/leaks water, pending additions to the fluid system.
+	// Check for depth first, and pass if the water's too high. A four foot high water tank
+	// cannot jettison water above the level of a grown adult's head!
 	var/turf/T = get_turf(src)
+	if(T.get_fluid_depth() > fill_level)
+		return
+
+	// For now, this cheats and only checks/leaks water, pending additions to the fluid system.
 	var/W = reagents.remove_reagent(/datum/reagent/water, amount_per_transfer_from_this * 5)
 	if(W > 0)
 		// Artificially increased flow - a 1:1 rate doesn't result in very much water at all

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -89,21 +89,25 @@
 	if(reagents.total_volume <= 0)
 		return
 
+	// To prevent it from draining while in a container.
+	if(!isturf(src.loc))
+		return
+
 	// Check for depth first, and pass if the water's too high. A four foot high water tank
 	// cannot jettison water above the level of a grown adult's head!
 	var/turf/T = get_turf(src)
-	if(T.get_fluid_depth() > fill_level)
+
+	if(!T || T.get_fluid_depth() > fill_level)
 		return
 
 	// For now, this cheats and only checks/leaks water, pending additions to the fluid system.
 	var/W = reagents.remove_reagent(/datum/reagent/water, amount_per_transfer_from_this * 5)
 	if(W > 0)
-		// Artificially increased flow - a 1:1 rate doesn't result in very much water at all
+		// Artificially increased flow - a 1:1 rate doesn't result in very much water at all.
 		T.add_fluid(W * 100, /datum/reagent/water)
 
 /obj/structure/reagent_dispensers/watertank/examine(mob/user)
-	if(!..(user, 2))
-		return
+	. = ..()
 
 	if(modded)
 		to_chat(user, "<span class='warning'>Someone has wrenched open its tap - it's spilling everywhere!</span>")
@@ -116,27 +120,20 @@
 			"<span class='notice'>You wrench [src]'s drain [modded ? "open" : "shut"].</span>")
 
 		if (modded)
-			log_and_message_admins("opened a water tank at [loc.loc.name], leaking water.")
+			log_and_message_admins("opened a water tank at [get_area(loc)], leaking water.")
 			// Allows the water tank to continuously expel water, differing it from the fuel tank.
 			START_PROCESSING(SSprocessing, src)
-			drain_water()
 		else
 			STOP_PROCESSING(SSprocessing, src)
 
 	return ..()
 
 /obj/structure/reagent_dispensers/watertank/Process()
-	if (..() && modded)
-		drain_water()
-
-/obj/structure/reagent_dispensers/watertank/Move()
-	. = ..()
-
-	if (. && modded)
+	if(modded)
 		drain_water()
 
 /obj/structure/reagent_dispensers/watertank/Destroy()
-	. = .. ()
+	. = ..()
 
 	STOP_PROCESSING(SSprocessing, src)
 
@@ -152,8 +149,8 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 
 /obj/structure/reagent_dispensers/fueltank/examine(mob/user)
-	if(!..(user, 2))
-		return
+	. = ..()
+
 	if (modded)
 		to_chat(user, "<span class='warning'>The faucet is wrenched open, leaking fuel!</span>")
 	if(rig)


### PR DESCRIPTION
🆑 Earthcrusher
tweak: Water tanks can be wrenched just like fuel tanks, and will spill water. Slip your enemies!
/🆑 

Wrench the tank and watch the flood!

Flooding amount is determined by how much you set the tank to dispense. I added a multiplier to the add_fluid proc for cosmetic reasons - makes it look more convincingly like a proper flood.