### PR TITLE
Removes glucose and radium from the chemical injector rig module, fixes names

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -123,14 +123,12 @@
 	interface_desc = "Dispenses loaded chemicals directly into the wearer's bloodstream."
 
 	charges = list(
-		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     80),
-		list("dramadol",      "tramadol",      /datum/reagent/tramadol,          80),
 		list("dexalin plus",  "dexalin plus",  /datum/reagent/dexalinp,          80),
-		list("antibiotics",   "antibiotics",   /datum/reagent/spaceacillin,      80),
-		list("antitoxins",    "antitoxins",    /datum/reagent/dylovene,          80),
-		list("glucose",       "glucose",       /datum/reagent/nutriment/glucose, 80),
+		list("dylovene",    "dylovene",    /datum/reagent/dylovene,          80),
 		list("hyronalin",     "hyronalin",     /datum/reagent/hyronalin,         80),
-		list("radium",        "radium",        /datum/reagent/radium,            80)
+		list("spaceacillin",   "spaceacillin",   /datum/reagent/spaceacillin,      80),
+		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          80),
+		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     80)
 		)
 
 	var/max_reagent_volume = 80 //Used when refilling.
@@ -140,14 +138,12 @@
 
 	//just over a syringe worth of each. Want more? Go refill. Gives the ninja another reason to have to show their face.
 	charges = list(
-		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     20),
-		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          20),
 		list("dexalin plus",  "dexalin plus",  /datum/reagent/dexalinp,          20),
-		list("antibiotics",   "antibiotics",   /datum/reagent/spaceacillin,      20),
-		list("antitoxins",    "antitoxins",    /datum/reagent/dylovene,          20),
-		list("glucose",       "glucose",       /datum/reagent/nutriment/glucose, 80),
+		list("dylovene",    "dylovene",    /datum/reagent/dylovene,          20),
 		list("hyronalin",     "hyronalin",     /datum/reagent/hyronalin,         20),
-		list("radium",        "radium",        /datum/reagent/radium,            20)
+		list("spaceacillin",   "spaceacillin",   /datum/reagent/spaceacillin,      20),
+		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          20),
+		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     20)
 		)
 
 /obj/item/rig_module/chem_dispenser/accepts_item(var/obj/item/input_item, var/mob/living/user)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -140,7 +140,9 @@
 	charges = list(
 		list("dexalin plus",  "dexalin plus",  /datum/reagent/dexalinp,          20),
 		list("dylovene",    "dylovene",    /datum/reagent/dylovene,          20),
+		list("glucose",       "glucose",       /datum/reagent/nutriment/glucose, 80),
 		list("hyronalin",     "hyronalin",     /datum/reagent/hyronalin,         20),
+		list("radium",        "radium",        /datum/reagent/radium,            20)
 		list("spaceacillin",   "spaceacillin",   /datum/reagent/spaceacillin,      20),
 		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          20),
 		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     20)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -142,7 +142,7 @@
 		list("dylovene",    "dylovene",    /datum/reagent/dylovene,          20),
 		list("glucose",       "glucose",       /datum/reagent/nutriment/glucose, 80),
 		list("hyronalin",     "hyronalin",     /datum/reagent/hyronalin,         20),
-		list("radium",        "radium",        /datum/reagent/radium,            20)
+		list("radium",        "radium",        /datum/reagent/radium,            20),
 		list("spaceacillin",   "spaceacillin",   /datum/reagent/spaceacillin,      20),
 		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          20),
 		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     20)


### PR DESCRIPTION
:cl:
tweak: The rescue hardsuit's and the ninja rig's chemical injector now list their chemicals properly.
rscdel: Removed glucose and radium from the rescue hardsuit.
/:cl:

Fixed typo ("dramadol").
Removed glucose and radium from the medical hardsuit. Glucose isn't necessary to save people, radium was just used for virology. (...)
Dylovene and spaceacillin are now called by their names.
Alphabetized them.
Changed the ninja one too as they are essentially the same.

Didn't touch the combat one.