### PR TITLE
Added ANFO and recepies

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -120,6 +120,9 @@
 	holder = null
 	. = ..()
 
+/datum/reagent/proc/ex_act(obj/item/weapon/reagent_containers/holder, severity)
+	return
+
 /* DEPRECATED - TODO: REMOVE EVERYWHERE */
 
 /datum/reagent/proc/reaction_turf(var/turf/target)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -222,3 +222,15 @@
 	if(istype(L))
 		L.adjust_fire_stacks(amount / 10) // Splashing people with welding fuel to make them easy to ignite!
 
+/datum/reagent/fuel/ex_act(obj/item/weapon/reagent_containers/holder, severity)
+	if(volume <= 50)
+		return
+	var/turf/T = get_turf(holder)
+	if(volume > 500)
+		explosion(T,1,2,4)
+	else if(volume > 100)
+		explosion(T,0,1,3)
+	else if(volume > 50)
+		explosion(T,-1,1,2)
+	remove_self(volume)
+

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -489,3 +489,34 @@
 		M.co2_alert = 0
 	if(warning_message && prob(warning_prob))
 		to_chat(M, "<span class='warning'>You feel [warning_message].</span>")
+
+/datum/reagent/anfo
+	name = "ANFO"
+	description = "Ammonia Nitrate Fuel Oil mix, an explosive compound known for centuries. Safe to handle, can be set off with a small explosion."
+	taste_description = "fertilizer and fuel"
+	reagent_state = SOLID
+	color = "#dbc3c3"
+	var/boompower = 1
+
+/datum/reagent/anfo/ex_act(obj/item/weapon/reagent_containers/holder, severity)
+	var/activated_volume = volume
+	switch(severity)
+		if(2)
+			if(prob(max(0, 2*(volume - 120))))
+				activated_volume = rand(volume/4, volume)
+		if(3)
+			if(prob(max(0, 2*(volume - 60))))
+				activated_volume = rand(0, max(volume, 120))
+	if(activated_volume < 30) //whiff
+		return
+	var/turf/T = get_turf(holder)
+	if(T)
+		var/adj_power = round(boompower * activated_volume/60)
+		explosion(T, adj_power, adj_power + 1, adj_power*2 + 2)
+		remove_self(activated_volume)
+
+/datum/reagent/anfo/plus
+	name = "ANFO+"
+	description = "Ammonia Nitrate Fuel Oil, with aluminium powder, an explosive compound known for centuries. Safe to handle, can be set off with a small explosion."
+	color = "#ffe8e8"
+	boompower = 2

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -193,7 +193,7 @@
 	. = ..()
 
 /datum/reagent/toxin/fertilizer //Reagents used for plant fertilizers.
-	name = /datum/reagent/toxin/fertilizer
+	name = "Fertilizer"
 	description = "A chemical mix good for growing plants with."
 	taste_description = "plant food"
 	taste_mult = 0.5

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2039,3 +2039,33 @@
 	result = /datum/reagent/nutriment/mayo
 	required_reagents = list(/datum/reagent/drink/juice/lemon = 5, /datum/reagent/nutriment/protein/egg = 5)
 	result_amount = 10
+
+/datum/chemical_reaction/anfo
+	name = "EZ-ANFO"
+	result = /datum/reagent/anfo
+	required_reagents = list(/datum/reagent/toxin/fertilizer/eznutrient=20, /datum/reagent/fuel=10)
+	result_amount = 15
+
+/datum/chemical_reaction/anfo2
+	name = "Left 4 ANFO"
+	result = /datum/reagent/anfo
+	required_reagents = list(/datum/reagent/toxin/fertilizer/left4zed=10, /datum/reagent/fuel=5)
+	result_amount = 10
+
+/datum/chemical_reaction/anfo3
+	name = "Robust ANFO"
+	result = /datum/reagent/anfo
+	required_reagents = list(/datum/reagent/toxin/fertilizer/robustharvest=15, /datum/reagent/fuel=5)
+	result_amount = 10
+
+/datum/chemical_reaction/anfo4
+	name = "Chemlab ANFO"
+	result = /datum/reagent/anfo
+	required_reagents = list(/datum/reagent/ammonia=10, /datum/reagent/fuel=5)
+	result_amount = 15
+
+/datum/chemical_reaction/anfo_plus
+	name = "ANFO+"
+	result = /datum/reagent/anfo/plus
+	required_reagents = list(/datum/reagent/anfo=15, /datum/reagent/aluminum=5)
+	result_amount = 20

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -205,3 +205,9 @@
 		to_chat(user, "<span class='notice'>The [src] contains: [reagents.get_reagents(precision = prec)].</span>")
 	else if((loc == user) && user.skill_check(SKILL_CHEMISTRY, SKILL_EXPERT))
 		to_chat(user, "<span class='notice'>Using your chemistry knowledge, you indentify the following reagents in \the [src]: [reagents.get_reagents(!user.skill_check(SKILL_CHEMISTRY, SKILL_PROF), 5)].</span>")
+
+/obj/item/weapon/reagent_containers/ex_act(severity)
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			R.ex_act(src, severity)
+	..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -168,18 +168,10 @@
 		if(!istype(Proj ,/obj/item/projectile/beam/lastertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			explode()
 
-/obj/structure/reagent_dispensers/fueltank/ex_act()
-	explode()
-
 /obj/structure/reagent_dispensers/fueltank/proc/explode()
-	if (reagents.total_volume > 500)
-		explosion(src.loc,1,2,4)
-	else if (reagents.total_volume > 100)
-		explosion(src.loc,0,1,3)
-	else if (reagents.total_volume > 50)
-		explosion(src.loc,-1,1,2)
-	if(src)
-		qdel(src)
+	for(var/datum/reagent/R in reagents.reagent_list)
+		R.ex_act(src, 1)
+	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/fire_act(datum/gas_mixture/air, temperature, volume)
 	if (modded)

--- a/html/changelogs/chinsky - anfo.yml
+++ b/html/changelogs/chinsky - anfo.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Added ANFO, a fertilizer+fuel explosive. Mix any of fertilizers (EZ-nutriment, Left 4 Zed or Robust Harvest) with welder fuel to make it. Add aluminium for more oomph if you can get it."
+  - rscadd: "To actually make it boom, you need ANOTHER explosion first. A weak explosion will pretty reliably activate <60u, strong <120u, devastating for more. If it wasn't strong enough, it can still trigger part of reagent."
+  - rscadd: "Due to related changes, any container holding welder fuel can now explode if caught in an explosion, though don't expect much oomph."


### PR DESCRIPTION
Putting BS12 on every watchlist, one PR at a time.

ANFO is an explosive compound made with bascially fertilizer and diesel fuel. So in game that's any fertilizers (EZ,L4Z,Robust) and welder fuel. Different fertilizers give bit more or less output, generally less than components combined.

ANFO is pretty lazy, so to explode it you need /another/ explosion. Explosion power needed depends on how much of ANFO you want to activate.
For volumes under 60u, severity 3 boom will do, 2 for 120u, 1 for more. If you're lucky, a weaker boom can activate part of solution anyway.

Codeside, reagents can now have special interactions when theyir container is being exploded. Moved weldertank's explosion to welderfuel's interaction instead, so I guess technically adding second way to make bombs there.
