### PR TITLE
Various fixes to supply hierarchy handling.

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -277,10 +277,6 @@
 			return global.can_call_ert;
 		if("captain_announcement")
 			return global.captain_announcement;
-		if("cargo_supply_pack_root")
-			return global.cargo_supply_pack_root;
-		if("cargo_supply_packs")
-			return global.cargo_supply_packs;
 		if("changelog_hash")
 			return global.changelog_hash;
 		if("channel_color_presets")
@@ -1266,10 +1262,6 @@
 			global.can_call_ert=newval;
 		if("captain_announcement")
 			global.captain_announcement=newval;
-		if("cargo_supply_pack_root")
-			global.cargo_supply_pack_root=newval;
-		if("cargo_supply_packs")
-			global.cargo_supply_packs=newval;
 		if("changelog_hash")
 			global.changelog_hash=newval;
 		if("channel_color_presets")
@@ -2116,8 +2108,6 @@
 	"cameranet",
 	"can_call_ert",
 	"captain_announcement",
-	"cargo_supply_pack_root",
-	"cargo_supply_packs",
 	"changelog_hash",
 	"channel_color_presets",
 	"channel_to_radio_key",

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -35,9 +35,11 @@ SUBSYSTEM_DEF(supply)
 	ordernum = rand(1,9000)
 
 	//Build master supply list
-	for(var/decl/hierarchy/supply_pack/sp in cargo_supply_pack_root.children)
+	var/decl/hierarchy/supply_pack/root = decls_repository.get_decl(/decl/hierarchy/supply_pack)
+	for(var/decl/hierarchy/supply_pack/sp in root.children)
 		if(sp.is_category())
-			for(var/decl/hierarchy/supply_pack/spc in sp.children)
+			for(var/decl/hierarchy/supply_pack/spc in sp.get_descendents())
+				spc.setup()
 				master_supply_list += spc
 
 	for(var/material/mat in SSmaterials.materials)

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -26,5 +26,13 @@
 /decl/hierarchy/proc/is_hidden_category()
 	return hierarchy_type == type
 
+/decl/hierarchy/proc/get_descendents()
+	if(!children)
+		return
+	. = children.Copy()
+	for(var/decl/hierarchy/child in children)
+		if(child.children)
+			. += child.get_descendents()
+
 /decl/hierarchy/dd_SortValue()
 	return name

--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -1,8 +1,6 @@
-var/decl/hierarchy/supply_pack/cargo_supply_pack_root = new()
-var/decl/hierarchy/supply_pack/cargo_supply_packs	// Non-category supply packs
-
 /decl/hierarchy/supply_pack
 	name = "Supply Packs"
+	hierarchy_type = /decl/hierarchy/supply_pack
 	var/list/contains = list()
 	var/manifest = ""
 	var/cost = null
@@ -15,14 +13,8 @@ var/decl/hierarchy/supply_pack/cargo_supply_packs	// Non-category supply packs
 	var/supply_method = /decl/supply_method
 	var/decl/security_level/security_level
 
-/decl/hierarchy/supply_pack/New()
-	..()
-	if(is_hidden_category())
-		return	// Don't init the manifest for category entries
-
-	if(!cargo_supply_packs) cargo_supply_packs = list()
-	dd_insertObjectList(cargo_supply_packs, src)	// Add all non-category supply packs to the list
-
+//Is run once on init for non-base-category supplypacks.
+/decl/hierarchy/supply_pack/proc/setup()
 	if(!num_contained)
 		for(var/entry in contains)
 			num_contained += max(1, contains[entry])

--- a/code/modules/events/shipping_error.dm
+++ b/code/modules/events/shipping_error.dm
@@ -1,6 +1,6 @@
 /datum/event/shipping_error/start()
 	var/datum/supply_order/O = new /datum/supply_order()
 	O.ordernum = SSsupply.ordernum
-	O.object = pick(cargo_supply_packs)
+	O.object = pick(SSsupply.master_supply_list)
 	O.orderedby = random_name(pick(MALE,FEMALE), species = SPECIES_HUMAN)
 	SSsupply.shoppinglist += O

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -102,7 +102,7 @@
 
 	if(href_list["order"])
 		var/decl/hierarchy/supply_pack/P = locate(href_list["order"]) in SSsupply.master_supply_list
-		if(!istype(P) || P.is_category())
+		if(!istype(P))
 			return 1
 
 		if(P.hidden && !emagged)
@@ -210,19 +210,21 @@
 /datum/nano_module/supply/proc/generate_categories()
 	category_names = list()
 	category_contents = list()
-	for(var/decl/hierarchy/supply_pack/sp in cargo_supply_pack_root.children)
-		if(sp.is_category())
-			category_names.Add(sp.name)
-			var/list/category[0]
-			for(var/decl/hierarchy/supply_pack/spc in sp.children)
-				if((spc.hidden || spc.contraband || !spc.sec_available()) && !emagged)
-					continue
-				category.Add(list(list(
-					"name" = spc.name,
-					"cost" = spc.cost,
-					"ref" = "\ref[spc]"
-				)))
-			category_contents[sp.name] = category
+	var/decl/hierarchy/supply_pack/root = decls_repository.get_decl(/decl/hierarchy/supply_pack)
+	for(var/decl/hierarchy/supply_pack/sp in root.children)
+		if(!sp.is_category())
+			continue // No children
+		category_names.Add(sp.name)
+		var/list/category[0]
+		for(var/decl/hierarchy/supply_pack/spc in sp.get_descendents())
+			if((spc.hidden || spc.contraband || !spc.sec_available()) && !emagged)
+				continue
+			category.Add(list(list(
+				"name" = spc.name,
+				"cost" = spc.cost,
+				"ref" = "\ref[spc]"
+			)))
+		category_contents[sp.name] = category
 
 /datum/nano_module/supply/proc/get_shuttle_status()
 	var/datum/shuttle/autodock/ferry/supply/shuttle = SSsupply.shuttle

--- a/code/unit_tests/cargo_tests.dm
+++ b/code/unit_tests/cargo_tests.dm
@@ -6,7 +6,7 @@
 /datum/unit_test/cargo_crates_containment_test/start_test()
 	var/bad_tests = 0
 
-	for(var/decl/hierarchy/supply_pack/supply_pack in cargo_supply_packs)
+	for(var/decl/hierarchy/supply_pack/supply_pack in SSsupply.master_supply_list)
 		if(!ispath(supply_pack.containertype, /obj/structure/closet))
 			continue
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -242,7 +242,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '4dff5da9e13dc4f8407294a300d2d81a *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< 'e7b41bf7acd9f6adf565a446dde2636f *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Fixes #22654 and other similar issues.
Fixes various other broken stuff with the supply hierarchy interaction, such as ordering category-level supply entities via the random supply event.

Notably, supply decls are now fully compatible with subtyping below the category level, although _all_ crates (`/my_category/foo` and `/my_category/foo/bar`) will be displayed in the program and be orderable.