### PR TITLE
Allow Deck Officers to have high school education

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -1216,7 +1216,7 @@
 	software_on_spawn = list(/datum/computer_file/program/supply,
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
-	required_education = EDUCATION_TIER_BACHELOR
+	required_education = EDUCATION_TIER_BASIC
 
 /datum/job/cargo_tech
 	title = "Deck Technician"


### PR DESCRIPTION
For those senior enlisted deck officers that enlisted instead of getting a college degree.

The current degree-only restriction looks like an oversight, since a degree means you're an officer, but Deck Officers can also be senior enlisted. 'High School' restriction was based on the restriction used for other senior enlisted roles (Shuttle Pilot) that don't have specific requirements like senior engineer would.

:cl: SierraKomodo
tweak: Deck Officers can have high school education - Senior enlisted are no longer barred from the role.
/:cl: