### PR TITLE
Fixes Nav-related consoles not working after damage, XO windowtint button.

### DIFF
--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -19,9 +19,7 @@
 
 /obj/machinery/computer/ship/engines/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
-		var/datum/browser/popup = new (user, "Engine Control", "[src]")
-		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to ship control systems.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
-		popup.open()
+		display_reconnect_dialog(user, "ship control systems")
 		return
 
 	var/data[0]

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -5,7 +5,7 @@
 	icon_keyboard = "tech_key"
 	icon_screen = "engines"
 	circuit = /obj/item/weapon/circuitboard/engine
-	var/state = "status"
+	var/display_state = "status"
 
 /obj/machinery/computer/ship/engines/attack_hand(var/mob/user as mob)
 	if(..())
@@ -23,7 +23,7 @@
 		return
 
 	var/data[0]
-	data["state"] = state
+	data["state"] = display_state	
 	data["global_state"] = linked.engines_state
 	data["global_limit"] = round(linked.thrust_limit*100)
 	var/total_thrust = 0
@@ -50,51 +50,57 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/ship/engines/Topic(href, href_list, ui_state)
+/obj/machinery/computer/ship/engines/OnTopic(var/mob/user, var/list/href_list, state)
 	if(..())
-		return 1
+		return TOPIC_HANDLED
 
 	if(href_list["state"])
-		state = href_list["state"]
+		display_state = href_list["state"]
+		return TOPIC_REFRESH
 
 	if(href_list["global_toggle"])
 		linked.engines_state = !linked.engines_state
 		for(var/datum/ship_engine/E in linked.engines)
 			if(linked.engines_state != E.is_on())
-				E.toggle()
+				E.toggle()				
+		return TOPIC_REFRESH
 
 	if(href_list["set_global_limit"])
 		var/newlim = input("Input new thrust limit (0..100%)", "Thrust limit", linked.thrust_limit*100) as num
-		if(!CanInteract(usr,ui_state))
-			return
+		if(!CanInteract(user, state))
+			return TOPIC_NOACTION
 		linked.thrust_limit = Clamp(newlim/100, 0, 1)
 		for(var/datum/ship_engine/E in linked.engines)
 			E.set_thrust_limit(linked.thrust_limit)
+		return TOPIC_REFRESH
 
 	if(href_list["global_limit"])
 		linked.thrust_limit = Clamp(linked.thrust_limit + text2num(href_list["global_limit"]), 0, 1)
 		for(var/datum/ship_engine/E in linked.engines)
 			E.set_thrust_limit(linked.thrust_limit)
+		return TOPIC_REFRESH
 
 	if(href_list["engine"])
 		if(href_list["set_limit"])
 			var/datum/ship_engine/E = locate(href_list["engine"])
 			var/newlim = input("Input new thrust limit (0..100)", "Thrust limit", E.get_thrust_limit()) as num
-			if(!CanInteract(usr,ui_state))
+			if(!CanInteract(user, state))
 				return
 			var/limit = Clamp(newlim/100, 0, 1)
 			if(istype(E))
 				E.set_thrust_limit(limit)
-
+			return TOPIC_REFRESH			
 		if(href_list["limit"])
 			var/datum/ship_engine/E = locate(href_list["engine"])
 			var/limit = Clamp(E.get_thrust_limit() + text2num(href_list["limit"]), 0, 1)
 			if(istype(E))
 				E.set_thrust_limit(limit)
+			return TOPIC_REFRESH
 
 		if(href_list["toggle"])
 			var/datum/ship_engine/E = locate(href_list["engine"])
 			if(istype(E))
 				E.toggle()
-
-	updateUsrDialog()
+			return TOPIC_REFRESH
+		return TOPIC_REFRESH
+	return TOPIC_NOACTION

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -19,7 +19,9 @@
 
 /obj/machinery/computer/ship/engines/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
-		to_chat(user, "<span class='warning'>Unable to connect to ship control systems.</span>")
+		var/datum/browser/popup = new (user, "Engine Control", "[src]")
+		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to ship control systems.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
+		popup.open()
 		return
 
 	var/data[0]
@@ -53,6 +55,9 @@
 /obj/machinery/computer/ship/engines/Topic(href, href_list, ui_state)
 	if(..())
 		return 1
+
+	if(href_list["sync"])
+		sync_linked()
 
 	if(href_list["state"])
 		state = href_list["state"]

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -52,7 +52,7 @@
 
 /obj/machinery/computer/ship/engines/OnTopic(var/mob/user, var/list/href_list, state)
 	if(..())
-		return TOPIC_HANDLED
+		return ..()
 
 	if(href_list["state"])
 		display_state = href_list["state"]

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -54,9 +54,6 @@
 	if(..())
 		return 1
 
-	if(href_list["sync"])
-		sync_linked()
-
 	if(href_list["state"])
 		state = href_list["state"]
 

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -80,9 +80,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	if(linked)
 		ui_interact(user)
 	else
-		var/datum/browser/popup = new (user, "Helm Control", "[src]")
-		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
-		popup.open()
+		display_reconnect_dialog(user, "ship control systems")
 
 /obj/machinery/computer/ship/helm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
@@ -229,9 +227,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 /obj/machinery/computer/ship/navigation/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
-		var/datum/browser/popup = new (user, "Navigation", "[src]")
-		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to sensors.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
-		popup.open()
+		display_reconnect_dialog(user, "Navigation")
 		return
 
 	var/data[0]

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -67,77 +67,69 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 /obj/machinery/computer/ship/helm/attack_hand(var/mob/user as mob)
 	if(..())
-		user.unset_machine()
 		manual_control = 0
 		return
 
 	if(!isAI(user))
-		user.set_machine(src)
 		operator_skill = user.get_skill_value(core_skill)
 		if(linked)
 			user.reset_view(linked)
 
-	if(linked)
-		ui_interact(user)
-	else
-		display_reconnect_dialog(user, "ship control systems")
-
 /obj/machinery/computer/ship/helm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 
-	var/turf/T = get_turf(linked)
-	var/obj/effect/overmap/sector/current_sector = locate() in T
-
-	data["sector"] = current_sector ? current_sector.name : "Deep Space"
-	data["sector_info"] = current_sector ? current_sector.desc : "Not Available"
-	data["landed"] = linked.get_landed_info()
-	data["s_x"] = linked.x
-	data["s_y"] = linked.y
-	data["dest"] = dy && dx
-	data["d_x"] = dx
-	data["d_y"] = dy
-	data["speedlimit"] = speedlimit ? speedlimit : "None"
-	data["speed"] = linked.get_speed()
-	data["accel"] = linked.get_acceleration()
-	data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
-	data["autopilot"] = autopilot
-	data["manual_control"] = manual_control
-	data["canburn"] = linked.can_burn()
-
-	if(linked.get_speed())
-		data["ETAnext"] = "[round(linked.ETA()/10)] seconds"
+	if(!linked)
+		display_reconnect_dialog(user, "helm")
 	else
-		data["ETAnext"] = "N/A"
+		var/turf/T = get_turf(linked)
+		var/obj/effect/overmap/sector/current_sector = locate() in T
 
-	var/list/locations[0]
-	for (var/key in known_sectors)
-		var/datum/computer_file/data/waypoint/R = known_sectors[key]
-		var/list/rdata[0]
-		rdata["name"] = R.fields["name"]
-		rdata["x"] = R.fields["x"]
-		rdata["y"] = R.fields["y"]
-		rdata["reference"] = "\ref[R]"
-		locations.Add(list(rdata))
+		data["sector"] = current_sector ? current_sector.name : "Deep Space"
+		data["sector_info"] = current_sector ? current_sector.desc : "Not Available"
+		data["landed"] = linked.get_landed_info()
+		data["s_x"] = linked.x
+		data["s_y"] = linked.y
+		data["dest"] = dy && dx
+		data["d_x"] = dx
+		data["d_y"] = dy
+		data["speedlimit"] = speedlimit ? speedlimit : "None"
+		data["speed"] = linked.get_speed()
+		data["accel"] = linked.get_acceleration()
+		data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
+		data["autopilot"] = autopilot
+		data["manual_control"] = manual_control
+		data["canburn"] = linked.can_burn()
 
-	data["locations"] = locations
+		if(linked.get_speed())
+			data["ETAnext"] = "[round(linked.ETA()/10)] seconds"
+		else
+			data["ETAnext"] = "N/A"
 
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
-	if (!ui)
-		ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 400, 630)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
+		var/list/locations[0]
+		for (var/key in known_sectors)
+			var/datum/computer_file/data/waypoint/R = known_sectors[key]
+			var/list/rdata[0]
+			rdata["name"] = R.fields["name"]
+			rdata["x"] = R.fields["x"]
+			rdata["y"] = R.fields["y"]
+			rdata["reference"] = "\ref[R]"
+			locations.Add(list(rdata))
+
+		data["locations"] = locations
+
+		ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+		if (!ui)
+			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 400, 630)
+			ui.set_initial_data(data)
+			ui.open()
+			ui.set_auto_update(1)
 
 /obj/machinery/computer/ship/helm/Topic(href, href_list, state)
 	if(..())
 		return 1
 
-	if (!linked)
-		if(href_list["sync"])
-			sync_linked()
-			return 1
-		else
-			return 1
+	if(!linked)
+		return 1
 
 	if (href_list["add"])
 		var/datum/computer_file/data/waypoint/R = new()
@@ -267,23 +259,17 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 /obj/machinery/computer/ship/navigation/attack_hand(var/mob/user as mob)
 	if(..())
-		user.unset_machine()
 		viewing = 0
 		return
 
 	if(viewing && linked &&!isAI(user))
-		user.set_machine(src)
 		user.reset_view(linked)
-
-	ui_interact(user)
 
 /obj/machinery/computer/ship/navigation/Topic(href, href_list)
 	if(..())
 		return 1
 
 	if (!linked)
-		if(href_list["sync"])
-			sync_linked()
 		return
 
 	if (href_list["viewing"])

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -77,12 +77,14 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		if(linked)
 			user.reset_view(linked)
 
-	ui_interact(user)
+	if(linked)
+		ui_interact(user)
+	else
+		var/datum/browser/popup = new (user, "Helm Control", "[src]")
+		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
+		popup.open()
 
 /obj/machinery/computer/ship/helm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	if(!linked)
-		return
-
 	var/data[0]
 
 	var/turf/T = get_turf(linked)
@@ -133,7 +135,11 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		return 1
 
 	if (!linked)
-		return
+		if(href_list["sync"])
+			sync_linked()
+			return 1
+		else
+			return 1
 
 	if (href_list["add"])
 		var/datum/computer_file/data/waypoint/R = new()
@@ -223,6 +229,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 /obj/machinery/computer/ship/navigation/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
+		var/datum/browser/popup = new (user, "Navigation", "[src]")
+		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to sensors.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
+		popup.open()
 		return
 
 	var/data[0]
@@ -277,6 +286,8 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		return 1
 
 	if (!linked)
+		if(href_list["sync"])
+			sync_linked()
 		return
 
 	if (href_list["viewing"])

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -124,35 +124,35 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 			ui.open()
 			ui.set_auto_update(1)
 
-/obj/machinery/computer/ship/helm/Topic(href, href_list, state)
+/obj/machinery/computer/ship/helm/OnTopic(var/mob/user, var/list/href_list, state)
 	if(..())
-		return 1
+		return TOPIC_HANDLED
 
 	if(!linked)
-		return 1
+		return TOPIC_HANDLED
 
 	if (href_list["add"])
 		var/datum/computer_file/data/waypoint/R = new()
 		var/sec_name = input("Input naviation entry name", "New navigation entry", "Sector #[known_sectors.len]") as text
-		if(!CanInteract(usr,state))
-			return
+		if(!CanInteract(user,state))
+			return TOPIC_NOACTION
 		if(!sec_name)
 			sec_name = "Sector #[known_sectors.len]"
 		R.fields["name"] = sec_name
 		if(sec_name in known_sectors)
-			to_chat(usr, "<span class='warning'>Sector with that name already exists, please input a different name.</span>")
-			return
+			to_chat(user, "<span class='warning'>Sector with that name already exists, please input a different name.</span>")
+			return TOPIC_REFRESH
 		switch(href_list["add"])
 			if("current")
 				R.fields["x"] = linked.x
 				R.fields["y"] = linked.y
 			if("new")
 				var/newx = input("Input new entry x coordinate", "Coordinate input", linked.x) as num
-				if(!CanInteract(usr,state))
-					return
+				if(!CanInteract(user,state))
+					return TOPIC_REFRESH
 				var/newy = input("Input new entry y coordinate", "Coordinate input", linked.y) as num
-				if(!CanInteract(usr,state))
-					return
+				if(!CanInteract(user,state))
+					return TOPIC_NOACTION
 				R.fields["x"] = Clamp(newx, 1, world.maxx)
 				R.fields["y"] = Clamp(newy, 1, world.maxy)
 		known_sectors[sec_name] = R
@@ -165,14 +165,14 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 	if (href_list["setx"])
 		var/newx = input("Input new destiniation x coordinate", "Coordinate input", dx) as num|null
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return
 		if (newx)
 			dx = Clamp(newx, 1, world.maxx)
 
 	if (href_list["sety"])
 		var/newy = input("Input new destiniation y coordinate", "Coordinate input", dy) as num|null
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return
 		if (newy)
 			dy = Clamp(newy, 1, world.maxy)
@@ -192,10 +192,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 	if (href_list["move"])
 		var/ndir = text2num(href_list["move"])
-		var/mob/M = usr
-		if(istype(M) && prob(M.skill_fail_chance(SKILL_PILOT, 50, SKILL_ADEPT, factor = 1)))
+		if(prob(user.skill_fail_chance(SKILL_PILOT, 50, SKILL_ADEPT, factor = 1)))
 			ndir = turn(ndir,pick(90,-90))
-		linked.relaymove(usr, ndir)
+		linked.relaymove(user, ndir)
 
 	if (href_list["brake"])
 		linked.decelerate()
@@ -206,7 +205,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	if (href_list["manual"])
 		manual_control = !manual_control
 
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	updateUsrDialog()
 
 
@@ -265,16 +264,15 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	if(viewing && linked &&!isAI(user))
 		user.reset_view(linked)
 
-/obj/machinery/computer/ship/navigation/Topic(href, href_list)
+/obj/machinery/computer/ship/navigation/OnTopic(var/mob/user, var/list/href_list)
 	if(..())
-		return 1
+		return TOPIC_HANDLED
 
 	if (!linked)
-		return
+		return TOPIC_NOACTION
 
 	if (href_list["viewing"])
 		viewing = !viewing
-		if(viewing && !isAI(usr))
-			var/mob/user = usr
+		if(viewing && !isAI(user))
 			user.reset_view(linked)
-		return 1
+		return TOPIC_REFRESH

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -103,39 +103,39 @@
 	GLOB.stat_set_event.unregister(user, src, /obj/machinery/computer/ship/sensors/proc/unlook)
 	LAZYREMOVE(viewers, weakref(user))
 
-/obj/machinery/computer/ship/sensors/Topic(href, href_list, state)
+/obj/machinery/computer/ship/sensors/OnTopic(var/mob/user, var/list/href_list, state)
 	if(..())
-		return 1
+		return TOPIC_HANDLED
 
 	if(href_list["close"])
-		unlook(usr)
-		usr.unset_machine()
-		return 1
+		unlook(user)
+		user.unset_machine()
+		return TOPIC_HANDLED
 
 	if (!linked)
-		return
+		return TOPIC_NOACTION
 
 	if (href_list["viewing"])
 		viewing = !viewing
-		if(usr && !isAI(usr))
-			viewing ? look(usr) : unlook(usr)
-		return 1
+		if(user && !isAI(user))
+			viewing ? look(user) : unlook(user)
+		return TOPIC_REFRESH
 
 	if (href_list["link"])
 		find_sensors()
-		return 1
+		return TOPIC_REFRESH
 
 	if(sensors)
 		if (href_list["range"])
 			var/nrange = input("Set new sensors range", "Sensor range", sensors.range) as num|null
-			if(!CanInteract(usr,state))
-				return
+			if(!CanInteract(user,state))
+				return TOPIC_NOACTION
 			if (nrange)
 				sensors.set_range(Clamp(nrange, 1, world.view))
-			return 1
+			return TOPIC_REFRESH
 		if (href_list["toggle"])
 			sensors.toggle()
-			return 1
+			return TOPIC_REFRESH
 
 /obj/machinery/computer/ship/sensors/CouldNotUseTopic(mob/user)
 	unlook(user)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -35,9 +35,7 @@
 
 /obj/machinery/computer/ship/sensors/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
-		var/datum/browser/popup = new (user, "Navigation", "[src]")
-		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to sensors.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
-		popup.open()
+		display_reconnect_dialog(user, "sensors")
 		return
 
 	var/data[0]

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -78,16 +78,13 @@
 
 /obj/machinery/computer/ship/sensors/attack_hand(var/mob/user as mob)
 	if(..())
-		user.unset_machine()
 		viewing = 0
 		unlook(user)
 		return
 
 	if(!isAI(user))
-		user.set_machine(src)
 		if(viewing)
 			look(user)
-	ui_interact(user)
 
 /obj/machinery/computer/ship/sensors/proc/look(var/mob/user)
 	if(linked)
@@ -114,9 +111,8 @@
 		unlook(usr)
 		usr.unset_machine()
 		return 1
+
 	if (!linked)
-		if(href_list["sync"])
-			sync_linked()
 		return
 
 	if (href_list["viewing"])

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -35,6 +35,9 @@
 
 /obj/machinery/computer/ship/sensors/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(!linked)
+		var/datum/browser/popup = new (user, "Navigation", "[src]")
+		popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to sensors.<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
+		popup.open()
 		return
 
 	var/data[0]
@@ -114,6 +117,8 @@
 		usr.unset_machine()
 		return 1
 	if (!linked)
+		if(href_list["sync"])
+			sync_linked()
 		return
 
 	if (href_list["viewing"])

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -35,14 +35,17 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 /obj/machinery/computer/ship/attack_hand(var/mob/user as mob)
 	if(..())
 		user.unset_machine()
+		return ..()
 
 	if(!isAI(user))
 		user.set_machine(src)
 
 	ui_interact(user)
 
-/obj/machinery/computer/ship/Topic(href, href_list)
+/obj/machinery/computer/ship/OnTopic(var/mob/user, var/list/href_list)
 	if(..())
-		return 1
+		return TOPIC_HANDLED
 	if(href_list["sync"])
 		sync_linked()
+		return TOPIC_REFRESH
+	return TOPIC_NOACTION

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -13,3 +13,16 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	if(sector.check_ownership(src))
 		linked = sector
 		return 1
+
+/obj/machinery/computer/ship/proc/sync_linked()
+	var/obj/effect/overmap/ship/sector = map_sectors["[z]"]
+	if(!sector)
+		return
+	return attempt_hook_up_recursive(sector)
+
+/obj/machinery/computer/ship/proc/attempt_hook_up_recursive(obj/effect/overmap/ship/sector)
+	if(attempt_hook_up(sector))
+		return sector
+	for(var/obj/effect/overmap/ship/candidate in sector)
+		if((. = .(candidate)))
+			return

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -26,3 +26,8 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	for(var/obj/effect/overmap/ship/candidate in sector)
 		if((. = .(candidate)))
 			return
+
+/obj/machinery/computer/ship/proc/display_reconnect_dialog(var/mob/user, var/flavor)
+	var/datum/browser/popup = new (user, "[src]", "[src]")
+	popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to [flavor].<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
+	popup.open()

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -31,3 +31,18 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	var/datum/browser/popup = new (user, "[src]", "[src]")
 	popup.set_content("<center><strong><font color = 'red'>Error</strong></font><br>Unable to connect to [flavor].<br><a href='?src=\ref[src];sync=1'>Reconnect</a></center>")
 	popup.open()
+
+/obj/machinery/computer/ship/attack_hand(var/mob/user as mob)
+	if(..())
+		user.unset_machine()
+
+	if(!isAI(user))
+		user.set_machine(src)
+
+	ui_interact(user)
+
+/obj/machinery/computer/ship/Topic(href, href_list)
+	if(..())
+		return 1
+	if(href_list["sync"])
+		sync_linked()

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -781,7 +781,7 @@
 	req_access = list(20)
 	},
 /obj/machinery/button/windowtint{
-	id = "co_windows";
+	id = "xo_windows";
 	pixel_x = 0;
 	pixel_y = 32
 	},


### PR DESCRIPTION
:cl: Textor
bugfix: Helm control, engine control, sensor, and navigation consoles no longer stop functioning after repair or construction. Just hit "reconnect."
bugfix: The windowtint button on the back wall of the XO's office actually works now.
/:cl:

closes #23145 
closes #23142 