### PR TITLE
Crates no longer mentioned in shipment title in the cargo order interface but remains on the actual delivered crate Fix

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -3,11 +3,11 @@
 	containertype = /obj/structure/closet/crate/internals
 
 /decl/hierarchy/supply_pack/atmospherics/internals
-	name = "Gear - Internals crate"
+	name = "Gear - Internals"
 	contains = list(/obj/item/clothing/mask/gas = 3,
 					/obj/item/weapon/tank/air = 3)
 	cost = 10
-	containername = "\improper Internals crate"
+	containername = "internals crate"
 
 /decl/hierarchy/supply_pack/atmospherics/evacuation
 	name = "Emergency equipment"
@@ -21,48 +21,48 @@
 					/obj/item/device/flashlight/flare/glowstick = 5)
 	cost = 45
 
-	containername = "\improper Emergency crate"
+	containername = "emergency crate"
 
 /decl/hierarchy/supply_pack/atmospherics/inflatable
 	name = "Equipment - Inflatable barriers"
 	contains = list(/obj/item/weapon/storage/briefcase/inflatable = 3)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper Inflatable Barrier Crate"
+	containername = "inflatable barrier crate"
 
 /decl/hierarchy/supply_pack/atmospherics/canister_empty
 	name = "Equipment - Empty gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister)
 	cost = 7
-	containername = "\improper Empty gas canister crate"
+	containername = "empty gas canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_air
 	name = "Gas - Air canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/air)
 	cost = 10
-	containername = "\improper Air canister crate"
+	containername = "air canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_oxygen
 	name = "Gas - Oxygen canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 	cost = 15
-	containername = "\improper Oxygen canister crate"
+	containername = "oxygen canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_nitrogen
 	name = "Gas - Nitrogen canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
 	cost = 10
-	containername = "\improper Nitrogen canister crate"
+	containername = "nitrogen canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_phoron
 	name = "Gas - Phoron gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/phoron)
 	cost = 70
-	containername = "\improper Phoron gas canister crate"
+	containername = "phoron gas canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
 
@@ -70,12 +70,12 @@
 	name = "Gas - Hydrogen canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/hydrogen)
 	cost = 25
-	containername = "\improper Hydrogen canister crate"
+	containername = "hydrogen canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
 
 /decl/hierarchy/supply_pack/atmospherics/canister_sleeping_agent
-	name = "Gas - N2O gas canister"
+	name = "Gas - Nitrous oxide gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/sleeping_agent)
 	cost = 40
 	containername = "\improper N2O gas canister crate"
@@ -91,16 +91,16 @@
 	access = access_atmospherics
 
 /decl/hierarchy/supply_pack/atmospherics/fuel
-	name = "Liquid - Fuel tank crate"
+	name = "Liquid - Fuel tanks"
 	contains = list(/obj/item/weapon/tank/hydrogen = 4)
 	cost = 15
-	containername = "\improper Fuel tank crate"
+	containername = "fuel tank crate"
 
 /decl/hierarchy/supply_pack/atmospherics/phoron
-	name = "Gas - Phoron tank crate"
+	name = "Gas - Phoron tanks"
 	contains = list(/obj/item/weapon/tank/phoron = 3)
 	cost = 30
-	containername = "\improper Phoron tank crate"
+	containername = "phoron tank crate"
 
 /decl/hierarchy/supply_pack/atmospherics/voidsuit
 	name = "EVA - Atmospherics voidsuit"
@@ -108,14 +108,14 @@
 					/obj/item/clothing/head/helmet/space/void/atmos/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Atmospherics voidsuit crate"
+	containername = "atmospherics voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
 
 /decl/hierarchy/supply_pack/atmospherics/scanner_module
-	name = "Electronics - Atmospherics scanner module crate"
+	name = "Electronics - Atmospherics scanner modules"
 	contains = list(/obj/item/weapon/computer_hardware/scanner/atmos = 4)
 	cost = 20
-	containername = "\improper Atmospherics scanner module crate"
+	containername = "atmospherics scanner module crate"
 	containertype = /obj/structure/closet/crate/secure
 	access = access_atmospherics

--- a/code/datums/supplypacks/custodial.dm
+++ b/code/datums/supplypacks/custodial.dm
@@ -15,20 +15,20 @@
 					/obj/structure/mopbucket)
 	cost = 20
 	containertype = /obj/structure/closet/crate/large
-	containername = "\improper Janitorial supplies"
+	containername = "janitorial supplies crate"
 
 /decl/hierarchy/supply_pack/custodial/mousetrap
 	num_contained = 3
 	contains = list(/obj/item/weapon/storage/box/mousetraps)
-	name = "Misc - Pest control crate"
+	name = "Misc - Pest control"
 	cost = 10
-	containername = "\improper Pest control crate"
+	containername = "pest control crate"
 
 /decl/hierarchy/supply_pack/custodial/lightbulbs
 	name = "Spares - Replacement lights"
 	contains = list(/obj/item/weapon/storage/box/lights/mixed = 3)
 	cost = 10
-	containername = "\improper Replacement lights"
+	containername = "replacement lights crate"
 
 /decl/hierarchy/supply_pack/custodial/cleaning
 	name = "Gear - Cleaning supplies"
@@ -41,20 +41,20 @@
 					/obj/item/weapon/soap)
 	cost = 10
 	containertype = /obj/structure/closet/crate/large
-	containername = "\improper Cleaning supplies"
+	containername = "cleaning supplies crate"
 
 /decl/hierarchy/supply_pack/custodial/bodybag
-	name = "Equipment - Body bag crate"
+	name = "Equipment - Body bags"
 	contains = list(/obj/item/weapon/storage/box/bodybags = 3)
 	cost = 10
-	containername = "\improper Body bag crate"
+	containername = "body bag crate"
 
 /decl/hierarchy/supply_pack/custodial/janitorbiosuits
-	name = "Gear - Janitor biohazard gear"
+	name = "Gear - Janitor biohazard equipment"
 	contains = list(/obj/item/clothing/head/bio_hood/janitor,
 					/obj/item/clothing/suit/bio_suit/janitor,
 					/obj/item/clothing/mask/gas,
 					/obj/item/weapon/tank/oxygen)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Janitor biohazard equipment"
+	containername = "janitor biohazard equipment crate"

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -2,103 +2,103 @@
 	name = "Engineering"
 
 /decl/hierarchy/supply_pack/engineering/smes_circuit
-	name = "Electronics - Superconducting Magnetic Energy Storage Unit Circuitry"
+	name = "Electronics - Superconducting magnetic energy storage unit circuitry"
 	contains = list(/obj/item/weapon/circuitboard/smes)
 	cost = 20
-	containername = "\improper Superconducting Magnetic Energy Storage Unit Circuitry"
+	containername = "superconducting magnetic energy storage unit circuitry crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil
-	name = "Parts - Superconductive Magnetic Coil"
+	name = "Parts - Superconductive magnetic coil"
 	contains = list(/obj/item/weapon/smes_coil)
 	cost = 35
-	containername = "\improper Superconductive Magnetic Coil crate"
+	containername = "superconductive magnetic coil crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil_weak
-	name = "Parts - Basic Superconductive Magnetic Coil"
+	name = "Parts - Basic superconductive magnetic coil"
 	contains = list(/obj/item/weapon/smes_coil/weak)
 	cost = 25
-	containername = "\improper Basic Superconductive Magnetic Coil crate"
+	containername = "basic superconductive magnetic coil crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil_super_capacity
-	name = "Parts - Superconductive Capacitance Coil"
+	name = "Parts - Superconductive capacitance coil"
 	contains = list(/obj/item/weapon/smes_coil/super_capacity)
 	cost = 45
-	containername = "\improper Superconductive Capacitance Coil crate"
+	containername = "superconductive capacitance coil crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil_super_io
 	name = "Parts- Superconductive Transmission Coil"
 	contains = list(/obj/item/weapon/smes_coil/super_io)
 	cost = 45
-	containername = "\improper Superconductive Transmission Coil crate"
+	containername = "Superconductive Transmission Coil crate"
 
 /decl/hierarchy/supply_pack/engineering/electrical
-	name = "Gear - Electrical maintenance crate"
+	name = "Gear - Electrical maintenance"
 	contains = list(/obj/item/weapon/storage/toolbox/electrical = 2,
 					/obj/item/clothing/gloves/insulated = 2,
 					/obj/item/weapon/cell = 2,
 					/obj/item/weapon/cell/high = 2)
 	cost = 15
-	containername = "\improper Electrical maintenance crate"
+	containername = "electrical maintenance crate"
 
 /decl/hierarchy/supply_pack/engineering/mechanical
-	name = "Gear - Mechanical maintenance crate"
+	name = "Gear - Mechanical maintenance"
 	contains = list(/obj/item/weapon/storage/belt/utility/full = 3,
 					/obj/item/clothing/suit/storage/hazardvest = 3,
 					/obj/item/clothing/head/welding = 2,
 					/obj/item/clothing/head/hardhat)
 	cost = 10
-	containername = "\improper Mechanical maintenance crate"
+	containername = "mechanical maintenance crate"
 
 /decl/hierarchy/supply_pack/engineering/solar
-	name = "Power - Solar Pack crate"
+	name = "Power - Solar pack"
 	contains  = list(/obj/item/solar_assembly = 14,
 					/obj/item/weapon/circuitboard/solar_control,
 					/obj/item/weapon/tracker_electronics,
 					/obj/item/weapon/paper/solar
 					)
 	cost = 15
-	containername = "\improper Solar Pack crate"
+	containername = "solar pack crate"
 
 /decl/hierarchy/supply_pack/engineering/solar_assembly
-	name = "Power - Solar Assembly crate"
+	name = "Power - Solar assembly"
 	contains  = list(/obj/item/solar_assembly = 16)
 	cost = 10
-	containername = "\improper Solar Assembly crate"
+	containername = "solar assembly crate"
 
 /decl/hierarchy/supply_pack/engineering/emitter
-	name = "Equipment - Emitter crate"
+	name = "Equipment - Emitter"
 	contains = list(/obj/machinery/power/emitter = 2)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Emitter crate"
+	containername = "emitter crate"
 	access = access_engine_equip
 
 /decl/hierarchy/supply_pack/engineering/field_gen
-	name = "Equipment - Field Generator crate"
+	name = "Equipment - Field generator"
 	contains = list(/obj/machinery/field_generator = 2)
 	containertype = /obj/structure/closet/crate/large
 	cost = 10
-	containername = "\improper Field Generator crate"
+	containername = "field generator crate"
 	access = access_ce
 
 /decl/hierarchy/supply_pack/engineering/sing_gen
-	name = "Equipment - Singularity Generator crate"
+	name = "Equipment - Singularity generator"
 	contains = list(/obj/machinery/the_singularitygen)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Singularity Generator crate"
+	containername = "singularity generator crate"
 	access = access_ce
 
 /decl/hierarchy/supply_pack/engineering/collector
-	name = "Power - Collector crate"
+	name = "Power - Collector"
 	contains = list(/obj/machinery/power/rad_collector = 2)
 	cost = 6
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Collector crate"
+	containername = "collector crate"
 	access = access_engine_equip
 
 /decl/hierarchy/supply_pack/engineering/PA
-	name = "Equipment - Particle Accelerator crate"
+	name = "Equipment - Particle accelerator"
 	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
 					/obj/machinery/particle_accelerator/control_box,
 					/obj/structure/particle_accelerator/particle_emitter/center,
@@ -108,7 +108,7 @@
 					/obj/structure/particle_accelerator/end_cap)
 	cost = 40
 	containertype = /obj/structure/largecrate
-	containername = "\improper Particle Accelerator crate"
+	containername = "particle accelerator crate"
 	access = access_ce
 
 /decl/hierarchy/supply_pack/engineering/pacman_parts
@@ -146,7 +146,7 @@
 	contains = list(/obj/machinery/atmospherics/binary/circulator)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Atmospheric circulator crate"
+	containername = "atmospheric circulator crate"
 	access = access_atmospherics
 
 /decl/hierarchy/supply_pack/engineering/air_dispenser
@@ -154,27 +154,27 @@
 	contains = list(/obj/machinery/pipedispenser/orderable)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Pipe Dispenser Crate"
+	containername = "pipe dispenser crate"
 	access = access_atmospherics
 
 /decl/hierarchy/supply_pack/engineering/disposals_dispenser
-	name = "Equipment - Disposals Pipe Dispenser"
+	name = "Equipment - Disposals pipe dispenser"
 	contains = list(/obj/machinery/pipedispenser/disposal/orderable)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Disposal Dispenser Crate"
+	containername = "disposal dispenser crate"
 	access = access_atmospherics
 
 /decl/hierarchy/supply_pack/engineering/shield_generator
-	name = "Shield Generator Construction Kit"
+	name = "Equipment - Shield generator construction kit"
 	contains = list(/obj/item/weapon/circuitboard/shield_generator, /obj/item/weapon/stock_parts/capacitor, /obj/item/weapon/stock_parts/micro_laser, /obj/item/weapon/smes_coil, /obj/item/weapon/stock_parts/console_screen)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper shield generator construction kit crate"
+	containername = "shield generator construction kit crate"
 	access = access_engine
 
 /decl/hierarchy/supply_pack/engineering/smbig
-	name = "Power - Supermatter Core"
+	name = "Power - Supermatter core"
 	contains = list(/obj/machinery/power/supermatter)
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure/large/phoron
@@ -182,21 +182,21 @@
 	access = access_ce
 
 /decl/hierarchy/supply_pack/engineering/fueltank
-	name = "Liquid - Fuel tank crate"
+	name = "Liquid - Fuel tank"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper fuel tank crate"
+	containername = "fuel tank crate"
 
 /decl/hierarchy/supply_pack/engineering/robotics
-	name = "Parts - Robotics assembly crate"
+	name = "Parts - Robotics assembly"
 	contains = list(/obj/item/device/assembly/prox_sensor = 3,
 					/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/device/flash = 4,
 					/obj/item/weapon/cell/high = 2)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper Robotics assembly"
+	containername = "robotics assembly crate"
 	access = access_robotics
 
 /decl/hierarchy/supply_pack/engineering/radsuit
@@ -205,10 +205,10 @@
 			/obj/item/clothing/head/radiation = 6)
 	cost = 20
 	containertype = /obj/structure/closet/radiation
-	containername = "\improper Radiation suit locker"
+	containername = "radiation suit locker"
 
 /decl/hierarchy/supply_pack/engineering/bluespacerelay
-	name = "Parts - Emergency Bluespace Relay Assembly Kit"
+	name = "Parts - Emergency Bluespace Relay parts"
 	contains = list(/obj/item/weapon/circuitboard/bluespacerelay,
 					/obj/item/weapon/stock_parts/manipulator,
 					/obj/item/weapon/stock_parts/manipulator,
@@ -216,7 +216,7 @@
 					/obj/item/weapon/stock_parts/subspace/crystal,
 					/obj/item/weapon/storage/toolbox/electrical)
 	cost = 75
-	containername = "\improper emergency bluespace relay assembly kit"
+	containername = "emergency bluespace relay assembly kit"
 
 /decl/hierarchy/supply_pack/engineering/firefighter
 	name = "Gear - Firefighting equipment"
@@ -227,7 +227,7 @@
 			/obj/item/clothing/head/hardhat/red)
 	cost = 20
 	containertype = /obj/structure/closet/firecloset
-	containername = "\improper fire-safety closet"
+	containername = "fire-safety closet"
 
 /decl/hierarchy/supply_pack/engineering/voidsuit_engineering
 	name = "EVA - Voidsuit, Engineering"
@@ -235,6 +235,6 @@
 					/obj/item/clothing/head/helmet/space/void/engineering/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Engineering voidsuit crate"
+	containername = "engineering voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_engine

--- a/code/datums/supplypacks/flooring.dm
+++ b/code/datums/supplypacks/flooring.dm
@@ -5,64 +5,64 @@
 	name = "Brown carpet"
 	contains = list(/obj/item/stack/tile/carpet/fifty)
 	cost = 15
-	containername = "\improper Brown carpet crate"
+	containername = "brown carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/carpetblue
 	name = "Blue and gold carpet"
 	contains = list(/obj/item/stack/tile/carpetblue/fifty)
 	cost = 15
-	containername = "\improper Blue and gold carpet crate"
+	containername = "blue and gold carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/carpetblue2
 	name = "Blue and silver carpet"
 	contains = list(/obj/item/stack/tile/carpetblue2/fifty)
 	cost = 15
-	containername = "\improper Blue and silver carpet crate"
+	containername = "blue and silver carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/carpetpurple
 	name = "Purple carpet"
 	contains = list(/obj/item/stack/tile/carpetpurple/fifty)
 	cost = 15
-	containername = "\improper Purple carpet crate"
+	containername = "purple carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/carpetorange
 	name = "Orange carpet"
 	contains = list(/obj/item/stack/tile/carpetorange/fifty)
 	cost = 15
-	containername = "\improper Orange carpet crate"
+	containername = "orange carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/carpetgreen
 	name = "Green carpet"
 	contains = list(/obj/item/stack/tile/carpetgreen/fifty)
 	cost = 15
-	containername = "\improper Green carpet crate"
+	containername = "green carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/carpetred
 	name = "Red carpet"
 	contains = list(/obj/item/stack/tile/carpetred/fifty)
 	cost = 15
-	containername = "\improper Red carpet crate"
+	containername = "red carpet crate"
 
 /decl/hierarchy/supply_pack/flooring/linoleum
 	name = "Linoleum"
 	contains = list(/obj/item/stack/tile/linoleum/fifty)
 	cost = 15
-	containername = "\improper Linoleum crate"
+	containername = "linoleum crate"
 
 /decl/hierarchy/supply_pack/flooring/white_tiles
 	name = "White floor tiles"
 	contains = list(/obj/item/stack/tile/floor_white/fifty)
 	cost = 15
-	containername = "\improper White floor tile crate"
+	containername = "white floor tile crate"
 
 /decl/hierarchy/supply_pack/flooring/dark_tiles
 	name = "Dark floor tiles"
 	contains = list(/obj/item/stack/tile/floor_dark/fifty)
 	cost = 15
-	containername = "\improper Dark floor tile crate"
+	containername = "dark floor tile crate"
 
 /decl/hierarchy/supply_pack/flooring/freezer_tiles
 	name = "Freezer floor tiles"
 	contains = list(/obj/item/stack/tile/floor_freezer/fifty)
 	cost = 15
-	containername = "\improper Freezer floor tile crate"
+	containername = "freezer floor tile crate"

--- a/code/datums/supplypacks/galley.dm
+++ b/code/datums/supplypacks/galley.dm
@@ -2,7 +2,7 @@
 	name = "Galley"
 
 /decl/hierarchy/supply_pack/galley/food
-	name = "General - Kitchen supply crate"
+	name = "General - Kitchen supplies"
 	contains = list(/obj/item/weapon/reagent_containers/food/condiment/flour = 6,
 					/obj/item/weapon/reagent_containers/food/drinks/milk = 4,
 					/obj/item/weapon/reagent_containers/food/drinks/soymilk = 2,
@@ -12,52 +12,52 @@
 					)
 	cost = 10
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Food crate"
+	containername = "kitchen supplies crate"
 
 /decl/hierarchy/supply_pack/galley/beef
-	name = "Perishables - Beef crate"
+	name = "Perishables - Beef"
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/beef = 6)
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Beef crate"
+	containername = "cow meat crate"
 	cost = 20
 
 /decl/hierarchy/supply_pack/galley/goat
-	name = "Perishables - Goat meat crate"
+	name = "Perishables - Goat meat"
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/goat = 6)
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Goat meat crate"
+	containername = "goat meat crate"
 	cost = 20
 
 /decl/hierarchy/supply_pack/galley/chicken
-	name = "Perishables - Chicken meat crate"
+	name = "Perishables - Poultry"
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/chicken = 6)
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Chicken meat crate"
+	containername = "chicken meat crate"
 	cost = 20
 
 /decl/hierarchy/supply_pack/galley/seafood
-	name = "Perishables - Seafood crate"
+	name = "Perishables - Seafood"
 	contains = list(
 		/obj/item/weapon/reagent_containers/food/snacks/fish = 2,
 		/obj/item/weapon/reagent_containers/food/snacks/fish/shark = 2,
 		/obj/item/weapon/reagent_containers/food/snacks/fish/octopus = 2
 		)
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Seafood crate"
+	containername = "seafood crate"
 	cost = 20
 
 /decl/hierarchy/supply_pack/galley/eggs
-	name = "Perishables - Eggs crate"
+	name = "Perishables - Eggs"
 	contains = list(/obj/item/weapon/storage/fancy/egg_box = 2)
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Egg crate"
+	containername = "egg crate"
 	cost = 15
 
 /decl/hierarchy/supply_pack/galley/milk
-	name = "Perishables - Milk crate"
+	name = "Perishables - Milk"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/milk = 3)
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Milk crate"
+	containername = "milk crate"
 	cost = 15
 
 /decl/hierarchy/supply_pack/galley/pizza
@@ -69,7 +69,7 @@
 					/obj/item/pizzabox/vegetable)
 	cost = 15
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Pizza crate"
+	containername = "pizza crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/galley/party
@@ -90,16 +90,16 @@
 			/obj/item/weapon/clothingbag/rubbermask,
 			/obj/item/weapon/clothingbag/rubbersuit)
 	cost = 20
-	containername = "\improper Party equipment"
+	containername = "party equipment crate"
 
 // TODO; Add more premium drinks at a later date. Could be useful for diplomatic events or fancy parties.
 /decl/hierarchy/supply_pack/galley/premiumalcohol
-	name = "Bar - Premium drinks crate"
+	name = "Bar - Premium drinks"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/premiumwine = 1,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/premiumvodka = 1)
 	cost = 60
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Premium drinks"
+	containername = "premium drinks crate"
 
 /decl/hierarchy/supply_pack/galley/barsupplies
 	name = "Bar - Bar supplies"
@@ -117,7 +117,7 @@
 			/obj/item/weapon/storage/box/glass_extras/sticks
 			)
 	cost = 10
-	containername = "crate of bar supplies"
+	containername = "bar supplies crate"
 
 /decl/hierarchy/supply_pack/galley/beer_dispenser
 	name = "Equipment - Booze dispenser"
@@ -136,65 +136,3 @@
 	cost = 25
 	containertype = /obj/structure/largecrate
 	containername = "soda dispenser crate"
-
-/decl/hierarchy/supply_pack/galley/alcohol_reagents
-	name = "Refills - Bar alcoholic dispenser refill"
-	contains = list(
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/beer,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/kahlua,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/whiskey,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/wine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/vodka,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/gin,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/rum,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tequila,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/vermouth,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cognac,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mead
-		)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "alcoholic drinks crate"
-	access = list(access_bar)
-
-/decl/hierarchy/supply_pack/galley/softdrink_reagents
-	name = "Refills - soft drink dispenser refill"
-	contains = list(
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/icetea,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cola,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/smw,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dr_gibb,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/spaceup,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tonic,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sodawater,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon_lime,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon
-		)
-	cost = 50
-	containertype = /obj/structure/closet/crate
-	containername = "soft drinks crate"
-
-/decl/hierarchy/supply_pack/galley/coffee_reagents
-	name = "Refills - Coffee machine dispenser refill"
-	contains = list(
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cafe_latte,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/soy_latte,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/milk,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice
-		)
-	cost = 50
-	containertype = /obj/structure/closet/crate
-	containername = "coffee drinks crate"

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -3,7 +3,7 @@
 	containertype = /obj/structure/closet/crate/hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/hydroponics // -- Skie
-	name = "Gear - Hydroponics Supply Crate"
+	name = "Gear - Hydroponics Supplies"
 	contains = list(/obj/item/weapon/reagent_containers/spray/plantbgone = 4,
 					/obj/item/weapon/reagent_containers/glass/bottle/ammonia = 2,
 					/obj/item/weapon/material/hatchet,
@@ -15,11 +15,11 @@
 					/obj/item/weapon/storage/box/botanydisk
 					)
 	cost = 15
-	containername = "\improper Hydroponics crate"
+	containername = "hydroponics supply crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/seeds
-	name = "Samples - Seeds crate"
+	name = "Samples - Mundane Seeds"
 	contains = list(/obj/item/seeds/chiliseed,
 					/obj/item/seeds/berryseed,
 					/obj/item/seeds/cornseed,
@@ -38,21 +38,21 @@
 					/obj/item/seeds/potatoseed,
 					/obj/item/seeds/sugarcaneseed)
 	cost = 10
-	containername = "\improper Seeds crate"
+	containername = "seeds crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/weedcontrol
-	name = "Gear - Weed control crate"
+	name = "Gear - Weed control"
 	contains = list(/obj/item/weapon/material/hatchet = 2,
 					/obj/item/weapon/reagent_containers/spray/plantbgone = 4,
 					/obj/item/clothing/mask/gas = 2,
 					/obj/item/weapon/grenade/chem_grenade/antiweed = 2)
 	cost = 25
-	containername = "\improper Weed control crate"
+	containername = "weed control crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/exoticseeds
-	name = "Samples - Exotic seeds crate"
+	name = "Samples - Exotic seeds"
 	contains = list(/obj/item/seeds/replicapod = 2,
 					/obj/item/seeds/libertymycelium,
 					/obj/item/seeds/reishimycelium,
@@ -60,36 +60,36 @@
 					/obj/item/seeds/kudzuseed)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Exotic Seeds crate"
+	containername = "exotic Seeds crate"
 	access = access_xenobiology
 
 /decl/hierarchy/supply_pack/hydroponics/watertank
-	name = "Liquid - Water tank crate"
+	name = "Liquid - Water tank"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper water tank crate"
+	containername = "water tank crate"
 
 /decl/hierarchy/supply_pack/hydroponics/bee_keeper
-	name = "Equipment - Beekeeping crate"
+	name = "Equipment - Beekeeping"
 	contains = list(/obj/item/beehive_assembly,
 					/obj/item/bee_smoker,
 					/obj/item/honey_frame = 5,
 					/obj/item/bee_pack)
 	cost = 40
-	containername = "\improper Beekeeping crate"
+	containername = "beekeeping crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/hydrotray
-	name = "Equipment - Empty hydroponics tray"
+	name = "Equipment - Hydroponics tray"
 	contains = list(/obj/machinery/portable_atmospherics/hydroponics{anchored = 0})
 	cost = 30
 	containertype = /obj/structure/closet/crate/large/hydroponics
-	containername = "\improper Hydroponics tray crate"
+	containername = "hydroponics tray crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/pottedplant
-	name = "Deco - Potted plant crate"
+	name = "Deco - Potted plants"
 	num_contained = 1
 	contains = list(/obj/structure/flora/pottedplant,
 					/obj/structure/flora/pottedplant/large,
@@ -120,5 +120,5 @@
 					/obj/structure/flora/pottedplant/decorative)
 	cost = 3
 	containertype = /obj/structure/closet/crate/large/hydroponics
-	containername = "\improper Potted plant crate"
+	containername = "potted plant crate"
 	supply_method = /decl/supply_method/randomized

--- a/code/datums/supplypacks/livecargo.dm
+++ b/code/datums/supplypacks/livecargo.dm
@@ -3,60 +3,60 @@
 	containertype = /obj/structure/closet/crate/hydroponics
 
 /decl/hierarchy/supply_pack/livecargo/monkey
-	name = "Inert - Monkey crate"
+	name = "Inert - Monkey cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Monkey crate"
+	containername = "monkey crate"
 
 /decl/hierarchy/supply_pack/livecargo/farwa
-	name = "Inert - Farwa crate"
+	name = "Inert - Farwa cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/farwacubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Farwa crate"
+	containername = "farwa crate"
 
 /decl/hierarchy/supply_pack/livecargo/skrell
-	name = "Inert - Neaera crate"
+	name = "Inert - Neaera cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/neaeracubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Neaera crate"
+	containername = "neaera crate"
 
 /decl/hierarchy/supply_pack/livecargo/stok
-	name = "Inert - Stok crate"
+	name = "Inert - Stok cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/stokcubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper Stok crate"
+	containername = "stok crate"
 
 //actual live animals
 
 /decl/hierarchy/supply_pack/livecargo/corgi
-	name = "Live - Corgi crate"
+	name = "Live - Corgi"
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/animal/corgi
-	containername = "\improper Corgi crate"
+	containername = "corgi crate"
 
 //farm animals - useless and annoying, but potentially a good source of food. expensive because they're live animals and their produce is available cheaper
 /decl/hierarchy/supply_pack/livecargo/cow
-	name = "Live - Cow crate"
+	name = "Live - Cow"
 	cost = 80
 	containertype = /obj/structure/largecrate/animal/cow
-	containername = "\improper Cow crate"
+	containername = "cow crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/livecargo/goat
-	name = "Live - Goat crate"
+	name = "Live - Goat"
 	cost = 75
 	containertype = /obj/structure/largecrate/animal/goat
-	containername = "\improper Goat crate"
+	containername = "goat crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/livecargo/chicken
-	name = "Live - Chicken crate"
+	name = "Live - Chicken"
 	cost = 70
 	containertype = /obj/structure/largecrate/animal/chick
-	containername = "\improper Chicken crate"
+	containername = "chicken crate"
 	access = access_hydroponics

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -15,89 +15,89 @@
 	name = "50 steel sheets"
 	contains = list(/obj/item/stack/material/steel/fifty)
 	cost = 10
-	containername = "\improper Steel sheets crate"
+	containername = "steel sheets crate"
 
 /decl/hierarchy/supply_pack/materials/glass50
 	name = "50 glass sheets"
 	contains = list(/obj/item/stack/material/glass/fifty)
 	cost = 10
-	containername = "\improper Glass sheets crate"
+	containername = "glass sheets crate"
 
 /decl/hierarchy/supply_pack/materials/wood50
 	name = "50 wooden planks"
 	contains = list(/obj/item/stack/material/wood/fifty)
 	cost = 10
-	containername = "\improper Wooden planks crate"
+	containername = "wooden planks crate"
 
 /decl/hierarchy/supply_pack/materials/plastic50
 	name = "50 plastic sheets"
 	contains = list(/obj/item/stack/material/plastic/fifty)
 	cost = 10
-	containername = "\improper Plastic sheets crate"
+	containername = "plastic sheets crate"
 
 /decl/hierarchy/supply_pack/materials/marble50
 	name = "50 slabs of marble"
 	contains = list(/obj/item/stack/material/marble/fifty)
 	cost = 20
-	containername = "\improper Marble slabs crate"
+	containername = "marble slabs crate"
 
 /decl/hierarchy/supply_pack/materials/plasteel50
 	name = "50 plasteel sheets"
 	contains = list(/obj/item/stack/material/plasteel/fifty)
 	cost = 20
-	containername = "\improper Plasteel sheets crate"
+	containername = "plasteel sheets crate"
 
 /decl/hierarchy/supply_pack/materials/ocp50
 	name = "50 osmium carbide plasteel sheets"
 	contains = list(/obj/item/stack/material/ocp/fifty)
 	cost = 20
-	containername = "\improper Osmium carbide plasteel sheets crate"
+	containername = "osmium carbide plasteel sheets crate"
 
 // Material sheets (10 - Smaller amounts, less cost efficient)
 /decl/hierarchy/supply_pack/materials/marble10
 	name = "10 slabs of marble"
 	contains = list(/obj/item/stack/material/marble/ten)
 	cost = 20
-	containername = "\improper Marble slabs crate"
+	containername = "marble slabs crate"
 
 /decl/hierarchy/supply_pack/materials/plasteel10
 	name = "10 plasteel sheets"
 	contains = list(/obj/item/stack/material/plasteel/ten)
 	cost = 10
-	containername = "\improper Plasteel sheets crate"
+	containername = "plasteel sheets crate"
 
 /decl/hierarchy/supply_pack/materials/ocp10
 	name = "10 osmium carbide plasteel sheets"
 	contains = list(/obj/item/stack/material/ocp/ten)
 	cost = 20
-	containername = "\improper Osmium carbide plasteel sheets crate"
+	containername = "osmium carbide plasteel sheets crate"
 .
 /decl/hierarchy/supply_pack/materials/phoron10
 	name = "10 phoron sheets"
 	contains = list(/obj/item/stack/material/phoron/ten)
 	cost = 20 // When sold yields 67 points.
-	containername = "\improper Phoron sheets crate"
+	containername = "phoron sheets crate"
 
 /decl/hierarchy/supply_pack/materials/gold10
 	name = "10 gold sheets"
 	contains = list(/obj/item/stack/material/gold/ten)
 	cost = 20
-	containername = "\improper Gold sheets crate"
+	containername = "gold sheets crate"
 
 /decl/hierarchy/supply_pack/materials/silver10
 	name = "10 silver sheets"
 	contains = list(/obj/item/stack/material/silver/ten)
 	cost = 20
-	containername = "\improper Silver sheets crate"
+	containername = "silver sheets crate"
 
 /decl/hierarchy/supply_pack/materials/uranium10
 	name = "10 uranium sheets"
 	contains = list(/obj/item/stack/material/uranium/ten)
 	cost = 20
-	containername = "\improper Uranium sheets crate"
+	containername = "uranium sheets crate"
 
 /decl/hierarchy/supply_pack/materials/diamond10
 	name = "10 diamond sheets"
 	contains = list(/obj/item/stack/material/diamond/ten)
 	cost = 20
-	containername = "\improper Diamond sheets crate"
+	containername = "diamond sheets crate"

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -3,7 +3,7 @@
 	containertype = /obj/structure/closet/crate/medical
 
 /decl/hierarchy/supply_pack/medical/medical
-	name = "Refills - Medical crate"
+	name = "Refills - Medical supplies"
 	contains = list(/obj/item/weapon/storage/firstaid/regular,
 					/obj/item/weapon/storage/firstaid/trauma,
 					/obj/item/weapon/storage/firstaid/fire,
@@ -17,73 +17,73 @@
 					/obj/item/weapon/storage/box/syringes,
 					/obj/item/weapon/storage/box/autoinjectors)
 	cost = 70
-	containername = "\improper Medical crate"
+	containername = "medical crate"
 
 /decl/hierarchy/supply_pack/medical/atk
-	name = "Triage - Advanced trauma crate"
+	name = "Triage - Advanced trauma supplies"
 	contains = list(/obj/item/stack/medical/advanced/bruise_pack = 6)
 	cost = 30
-	containername = "\improper Advanced trauma crate"
+	containername = "advanced trauma crate"
 
 /decl/hierarchy/supply_pack/medical/abk
-	name = "Triage - Advanced burn crate"
+	name = "Triage - Advanced burn supplies"
 	contains = list(/obj/item/stack/medical/advanced/ointment = 6)
 	cost = 30
-	containername = "\improper Advanced burn crate"
+	containername = "advanced burn crate"
 
 /decl/hierarchy/supply_pack/medical/trauma
-	name = "EMERGENCY - Trauma pouch crate"
+	name = "EMERGENCY - Trauma pouches"
 	contains = list(/obj/item/weapon/storage/firstaid/trauma = 3)
 	cost = 10
-	containername = "\improper Trauma pouch crate"
+	containername = "trauma pouch crate"
 
 /decl/hierarchy/supply_pack/medical/burn
-	name = "EMERGENCY - Burn pouch crate"
+	name = "EMERGENCY - Burn pouches"
 	contains = list(/obj/item/weapon/storage/firstaid/fire = 3)
 	cost = 10
-	containername = "\improper Burn pouch crate"
+	containername = "burn pouch crate"
 
 /decl/hierarchy/supply_pack/medical/toxin
-	name = "EMERGENCY - Toxin pouch crate"
+	name = "EMERGENCY - Toxin pouches"
 	contains = list(/obj/item/weapon/storage/firstaid/toxin = 3)
 	cost = 10
-	containername = "\improper Toxin pouch crate"
+	containername = "toxin pouch crate"
 
 /decl/hierarchy/supply_pack/medical/oxyloss
-	name = "EMERGENCY - Low oxygen pouch crate"
+	name = "EMERGENCY - Low oxygen pouches"
 	contains = list(/obj/item/weapon/storage/firstaid/o2 = 3)
 	cost = 10
-	containername = "\improper Low oxygen pouch crate"
+	containername = "low oxygen pouch crate"
 
 /decl/hierarchy/supply_pack/medical/stab
-	name = "Triage - Stability kit crate"
+	name = "Triage - Stability kit"
 	contains = list(/obj/item/weapon/storage/firstaid/stab = 3)
 	cost = 60
-	containername = "\improper Stability kit crate"
+	containername = "stability kit crate"
 
 /decl/hierarchy/supply_pack/medical/bloodpack
-	name = "Refills - Blood pack crate"
+	name = "Refills - Blood packs"
 	contains = list(/obj/item/weapon/storage/box/bloodpacks = 3)
 	cost = 10
-	containername = "\improper Blood pack crate"
+	containername = "blood pack crate"
 
 /decl/hierarchy/supply_pack/medical/blood
-	name = "Refills - Nanoblood crate"
+	name = "Refills - Nanoblood"
 	contains = list(/obj/item/weapon/reagent_containers/ivbag/nanoblood = 4)
 	cost = 15
-	containername = "\improper Nanoblood crate"
+	containername = "nanoblood crate"
 
 /decl/hierarchy/supply_pack/medical/bodybag
-	name = "Equipment - Body bag crate"
+	name = "Equipment - Body bags"
 	contains = list(/obj/item/weapon/storage/box/bodybags = 3)
 	cost = 10
-	containername = "\improper Body bag crate"
+	containername = "body bag crate"
 
 /decl/hierarchy/supply_pack/medical/cryobag
-	name = "Equipment - Stasis bag crate"
+	name = "Equipment - Stasis bags"
 	contains = list(/obj/item/bodybag/cryobag = 3)
 	cost = 50
-	containername = "\improper Stasis bag crate"
+	containername = "stasis bag crate"
 
 /decl/hierarchy/supply_pack/medical/medicalextragear
 	name = "Gear - Medical surplus equipment"
@@ -91,7 +91,7 @@
 					/obj/item/clothing/glasses/hud/health = 3)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Medical surplus equipment"
+	containername = "medical surplus equipment crate"
 	access = access_medical
 
 /decl/hierarchy/supply_pack/medical/cmogear
@@ -112,7 +112,7 @@
 					/obj/item/weapon/reagent_containers/syringe)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Chief medical officer equipment"
+	containername = "chief medical officer equipment crate"
 	access = access_cmo
 
 /decl/hierarchy/supply_pack/medical/doctorgear
@@ -132,7 +132,7 @@
 					/obj/item/weapon/reagent_containers/syringe)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Medical Doctor equipment"
+	containername = "medical Doctor equipment crate"
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/chemistgear
@@ -152,7 +152,7 @@
 					/obj/item/weapon/reagent_containers/syringe)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Chemist equipment"
+	containername = "chemist equipment crate"
 	access = access_chemistry
 
 /decl/hierarchy/supply_pack/medical/paramedicgear
@@ -177,7 +177,7 @@
 					/obj/item/clothing/accessory/storage/white_vest)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Paramedic equipment"
+	containername = "paramedic equipment crate"
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/psychiatristgear
@@ -193,7 +193,7 @@
 					/obj/item/weapon/pen)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Psychiatrist equipment"
+	containername = "psychiatrist equipment crate"
 	access = access_psychiatrist
 
 /decl/hierarchy/supply_pack/medical/medicalscrubs
@@ -211,7 +211,7 @@
 					/obj/item/weapon/storage/box/gloves)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Medical scrubs crate"
+	containername = "medical scrubs crate"
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/autopsy
@@ -226,7 +226,7 @@
 					/obj/item/weapon/pen)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Autopsy equipment crate"
+	containername = "autopsy equipment crate"
 	access = access_morgue
 
 /decl/hierarchy/supply_pack/medical/medicaluniforms
@@ -250,7 +250,7 @@
 					/obj/item/weapon/storage/box/gloves)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Medical uniform crate"
+	containername = "medical uniform crate"
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/medicalbiosuits
@@ -265,19 +265,19 @@
 					/obj/item/weapon/storage/box/gloves)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Medical biohazard equipment"
+	containername = "medical biohazard equipment crate"
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/portablefreezers
-	name = "Equipment - Portable freezers crate"
+	name = "Equipment - Portable freezers"
 	contains = list(/obj/item/weapon/storage/box/freezer = 7)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Portable freezers"
+	containername = "portable freezers crate"
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/surgery
-	name = "Gear - Surgery crate"
+	name = "Gear - Surgery tools"
 	contains = list(/obj/item/weapon/cautery,
 					/obj/item/weapon/surgicaldrill,
 					/obj/item/clothing/mask/breath/medical,
@@ -291,11 +291,11 @@
 					/obj/item/weapon/circular_saw)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Surgery crate"
+	containername = "surgery crate"
 	access = access_medical
 
 /decl/hierarchy/supply_pack/medical/sterile
-	name = "Gear - Sterile equipment crate"
+	name = "Gear - Sterile clothes"
 	contains = list(/obj/item/clothing/under/rank/medical/scrubs/green = 2,
 					/obj/item/clothing/head/surgery/green = 2,
 					/obj/item/weapon/storage/box/masks,
@@ -303,12 +303,12 @@
 					/obj/item/weapon/storage/belt/medical = 3)
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "\improper Sterile equipment crate"
+	containername = "sterile clothes crate"
 
 /decl/hierarchy/supply_pack/medical/scanner_module
-	name = "Electronics - Medical scanner module crate"
+	name = "Electronics - Medical scanner modules"
 	contains = list(/obj/item/weapon/computer_hardware/scanner/medical = 4)
 	cost = 20
-	containername = "\improper Medical scanner module crate"
+	containername = "medical scanner module crate"
 	containertype = /obj/structure/closet/crate/secure
 	access = access_medical_equip

--- a/code/datums/supplypacks/nonessent.dm
+++ b/code/datums/supplypacks/nonessent.dm
@@ -7,7 +7,7 @@
 					/obj/item/device/floor_painter = 2,
 					/obj/item/device/cable_painter = 2)
 	cost = 10
-	containername = "\improper painting supplies crate"
+	containername = "painting supplies crate"
 	containertype = /obj/structure/closet/crate
 
 /decl/hierarchy/supply_pack/nonessent/artscrafts
@@ -27,7 +27,7 @@
 	/obj/item/weapon/contraband/poster,
 	/obj/item/weapon/wrapping_paper = 3)
 	cost = 10
-	containername = "\improper Arts and Crafts crate"
+	containername = "arts and Crafts crate"
 
 
 /decl/hierarchy/supply_pack/nonessent/card_packs
@@ -35,9 +35,9 @@
 	contains = list(/obj/item/weapon/pack/cardemon,
 					/obj/item/weapon/pack/spaceball,
 					/obj/item/weapon/deck/holder)
-	name = "\improper Rec - Trading Card Crate"
+	name = "Rec - Trading Cards"
 	cost = 20
-	containername = "\improper cards crate"
+	containername = "trading cards crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/nonessent/lasertag
@@ -48,15 +48,15 @@
 					/obj/item/clothing/suit/bluetag = 3)
 	cost = 20
 	containertype = /obj/structure/closet
-	containername = "\improper Lasertag Closet"
+	containername = "lasertag Closet"
 
 /decl/hierarchy/supply_pack/nonessent/instruments
-	name = "Rec - Instrument shipment"
+	name = "Rec - Musical Instruments"
 	contains = list(/obj/item/device/synthesized_instrument/synthesizer,
 					/obj/item/device/synthesized_instrument/guitar/multi,
 					/obj/item/device/synthesized_instrument/trumpet)
 	cost = 40
-	containername = "\improper Musical instrument crate"
+	containername = "musical instrument crate"
 
 
 /decl/hierarchy/supply_pack/nonessent/llamps
@@ -72,18 +72,18 @@
 					/obj/item/device/flashlight/lamp/lava/pink)
 	name = "Deco - Lava lamps"
 	cost = 10
-	containername = "\improper Lava lamp crate"
+	containername = "lava lamp crate"
 	supply_method = /decl/supply_method/randomized
 
 
 /decl/hierarchy/supply_pack/nonessent/wizard
-	name = "Costume - Wizard costume"
+	name = "Costume - Wizard"
 	contains = list(/obj/item/weapon/staff,
 					/obj/item/clothing/suit/wizrobe/fake,
 					/obj/item/clothing/shoes/sandal,
 					/obj/item/clothing/head/wizard/fake)
 	cost = 20
-	containername = "\improper Wizard costume crate"
+	containername = "wizard costume crate"
 
 /decl/hierarchy/supply_pack/nonessent/costume
 	num_contained = 2
@@ -117,9 +117,9 @@
 					/obj/item/clothing/under/savage_hunter,
 					/obj/item/clothing/under/savage_hunter/female,
 					/obj/item/clothing/under/wetsuit)
-	name = "Costume - Costumes crate"
+	name = "Costume - Random"
 	cost = 10
-	containername = "\improper Actor Costumes"
+	containername = "actor costumes crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/nonessent/formal_wear
@@ -137,10 +137,10 @@
 					/obj/item/clothing/shoes/black,
 					/obj/item/clothing/shoes/leather,
 					/obj/item/clothing/accessory/wcoat)
-	name = "Costume - Formalwear closet"
+	name = "Costume - Formalwear"
 	cost = 30
 	containertype = /obj/structure/closet
-	containername = "\improper Formalwear for the best occasions."
+	containername = "formalwear for the best occasions."
 
 
 /decl/hierarchy/supply_pack/nonessent/hats
@@ -165,23 +165,23 @@
 					/obj/item/clothing/head/collectable/slime,
 					/obj/item/clothing/head/collectable/xenom,
 					/obj/item/clothing/head/collectable/petehat)
-	name = "Costume - Collectable hat crate!"
+	name = "Costume - Collectible hats!"
 	cost = 200
 	containername = "\improper Collectable hats crate! Brought to you by Bass.inc!"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/nonessent/witch
-	name = "Costume - Witch costume"
+	name = "Costume - Witch"
 	contains = list(/obj/item/clothing/suit/wizrobe/marisa/fake,
 					/obj/item/clothing/shoes/sandal,
 					/obj/item/clothing/head/wizard/marisa/fake,
 					/obj/item/weapon/staff/broom)
 	cost = 20
-	containername = "\improper Witch costume"
+	containername = "witch costume crate"
 	containertype = /obj/structure/closet
 
 /decl/hierarchy/supply_pack/nonessent/costume_hats
-	name = "Costume - Costume hats"
+	name = "Costume - Regular hats"
 	contains = list(/obj/item/clothing/head/redcoat,
 					/obj/item/clothing/head/mailman,
 					/obj/item/clothing/head/plaguedoctorhat,
@@ -198,7 +198,7 @@
 					/obj/item/clothing/head/ushanka,
 					/obj/item/clothing/mask/spirit)
 	cost = 10
-	containername = "\improper Actor hats crate"
+	containername = "actor hats crate"
 	containertype = /obj/structure/closet
 	num_contained = 2
 	supply_method = /decl/supply_method/randomized
@@ -217,7 +217,7 @@
 					/obj/item/clothing/under/dress/dress_yellow,
 					/obj/item/clothing/under/dress/dress_saloon)
 	cost = 15
-	containername = "\improper Pretty dress locker"
+	containername = "pretty dress locker"
 	containertype = /obj/structure/closet
 	num_contained = 1
 	supply_method = /decl/supply_method/randomized
@@ -231,10 +231,10 @@
 					/obj/item/toy/desk/officetoy,
 					/obj/item/toy/desk/dippingbird)
 	cost = 15
-	containername = "\improper Office toys crate"
+	containername = "office toys crate"
 
 /decl/hierarchy/supply_pack/nonessent/chaplaingear
-	name = "Costume - Chaplain equipment"
+	name = "Costume - Chaplain"
 	contains = list(/obj/item/clothing/under/rank/chaplain,
 					/obj/item/clothing/shoes/black,
 					/obj/item/clothing/suit/nun,
@@ -246,7 +246,7 @@
 //					/obj/item/weapon/storage/backpack/cultpack,
 					/obj/item/weapon/storage/fancy/candle_box = 3)
 	cost = 10
-	containername = "\improper Chaplain equipment crate"
+	containername = "chaplain equipment crate"
 
 /decl/hierarchy/supply_pack/nonessent/exosuit_mod_ripl1
 	name = "Mod - Ripley APLU modkit"

--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -2,25 +2,25 @@
 	name = "Operations"
 
 /decl/hierarchy/supply_pack/operations/mule
-	name = "Equipment - MULEbot Crate"
+	name = "Equipment - MULEbot"
 	contains = list()
 	cost = 20
 	containertype = /obj/structure/largecrate/animal/mulebot
-	containername = "Mulebot Crate"
+	containername = "mulebot crate"
 
 /decl/hierarchy/supply_pack/operations/cargotrain
 	name = "Equipment - Cargo Train Tug"
 	contains = list(/obj/vehicle/train/cargo/engine)
 	cost = 45
 	containertype = /obj/structure/largecrate
-	containername = "\improper Cargo Train Tug Crate"
+	containername = "cargo train tug crate"
 
 /decl/hierarchy/supply_pack/operations/cargotrailer
 	name = "Equipment - Cargo Train Trolley"
 	contains = list(/obj/vehicle/train/cargo/trolley)
 	cost = 15
 	containertype = /obj/structure/largecrate
-	containername = "\improper Cargo Train Trolley Crate"
+	containername = "cargo train trolley crate"
 
 /decl/hierarchy/supply_pack/operations/contraband
 	num_contained = 5
@@ -31,7 +31,7 @@
 
 	name = "UNLISTED - Contraband crate"
 	cost = 30
-	containername = "\improper Unlabeled crate"
+	containername = "unlabeled crate"
 	contraband = 1
 	supply_method = /decl/supply_method/randomized
 
@@ -40,10 +40,10 @@
 	contains = list()
 	cost = 80
 	containertype = /obj/structure/largecrate/hoverpod
-	containername = "\improper Hoverpod Crate"
+	containername = "hoverpod crate"
 
 /decl/hierarchy/supply_pack/operations/webbing
-	name = "Gear - Webbing crate"
+	name = "Gear - Webbing, vests, holsters."
 	num_contained = 4
 	contains = list(/obj/item/clothing/accessory/storage/holster,
 					/obj/item/clothing/accessory/storage/black_vest,
@@ -54,7 +54,7 @@
 					/obj/item/clothing/accessory/storage/drop_pouches/white,
 					/obj/item/clothing/accessory/storage/webbing)
 	cost = 15
-	containername = "\improper Webbing crate"
+	containername = "webbing crate"
 
 /decl/hierarchy/supply_pack/operations/voidsuit_engineering
 	name = "EVA - Engineering voidsuit"
@@ -62,7 +62,7 @@
 					/obj/item/clothing/head/helmet/space/void/engineering/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Engineering voidsuit crate"
+	containername = "engineering voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_engine
 
@@ -72,7 +72,7 @@
 					/obj/item/clothing/head/helmet/space/void/medical/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Medical voidsuit crate"
+	containername = "medical voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_medical_equip
 
@@ -82,7 +82,7 @@
 					/obj/item/clothing/head/helmet/space/void/security/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Security voidsuit crate"
+	containername = "security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_brig
 
@@ -103,5 +103,5 @@
 	name = "Office supplies"
 	cost = 15
 	containertype = /obj/structure/closet/crate/large
-	containername = "\improper Office supplies crate"
+	containername = "office supplies crate"
 

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -11,56 +11,56 @@
 	containername = "reagent dispenser crate"
 
 /decl/hierarchy/supply_pack/science/virus
-	name = "Samples - Virus sample crate"
+	name = "Samples - Virus (BIOHAZARD)"
 	contains = list(/obj/item/weapon/virusdish/random = 4)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Virus sample crate"
+	containername = "virus sample crate"
 	access = access_cmo
 
 /decl/hierarchy/supply_pack/science/coolanttank
-	name = "Liquid - Coolant tank crate"
+	name = "Liquid - Coolant tank"
 	contains = list(/obj/structure/reagent_dispensers/coolanttank)
 	cost = 16
 	containertype = /obj/structure/largecrate
-	containername = "\improper coolant tank crate"
+	containername = "coolant tank crate"
 
 /decl/hierarchy/supply_pack/science/mecha_odysseus
-	name = "Electronics - Circuit Crate (\"Odysseus\")"
+	name = "Electronics - Circuit (\"Odysseus\")"
 	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer,
 					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper \"Odysseus\" Circuit Crate"
+	containername = "\improper \"Odysseus\" Circuit crate"
 	access = access_robotics
 
 /decl/hierarchy/supply_pack/science/robotics
-	name = "Parts - Robotics assembly crate"
+	name = "Parts - Robotics"
 	contains = list(/obj/item/device/assembly/prox_sensor = 3,
 					/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/device/flash = 4,
 					/obj/item/weapon/cell/high = 2)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper Robotics assembly"
+	containername = "robotics assembly crate"
 	access = access_robotics
 
 /decl/hierarchy/supply_pack/science/phoron
-	name = "Parts - Phoron assembly crate"
+	name = "Parts - Phoron device kit"
 	contains = list(/obj/item/weapon/tank/phoron = 3,
 					/obj/item/device/assembly/igniter = 3,
 					/obj/item/device/assembly/prox_sensor = 3,
 					/obj/item/device/assembly/timer = 3)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/phoron
-	containername = "\improper Phoron assembly crate"
+	containername = "phoron assembly crate"
 	access = access_tox_storage
 
 /decl/hierarchy/supply_pack/science/scanner_module
-	name = "Electronics - Reagent scanner module crate"
+	name = "Electronics - Reagent scanner modules"
 	contains = list(/obj/item/weapon/computer_hardware/scanner/reagent = 4)
 	cost = 20
-	containername = "\improper Reagent scanner module crate"
+	containername = "reagent scanner module crate"
 
 /decl/hierarchy/supply_pack/science/minergear
 	name = "Shaft miner equipment"
@@ -80,20 +80,20 @@
 					/obj/item/clothing/glasses/meson)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Shaft miner equipment"
+	containername = "shaft miner equipment crate"
 	access = access_mining
 
 /decl/hierarchy/supply_pack/science/flamps
 	num_contained = 3
 	contains = list(/obj/item/device/flashlight/lamp/floodlamp,
 					/obj/item/device/flashlight/lamp/floodlamp/green)
-	name = "Flood lamps"
+	name = "Equipment - Flood lamps"
 	cost = 20
-	containername = "\improper Flood lamp crate"
+	containername = "flood lamp crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/science/illuminate
-	name = "Illumination grenades"
+	name = "Gear - Illumination grenades"
 	contains = list(/obj/item/weapon/grenade/light = 8)
 	cost = 20
-	containername = "\improper Illumination grenade crate"
+	containername = "illumination grenade crate"

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -7,7 +7,7 @@
 					/obj/item/weapon/grenade/smokebomb = 3,
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
 	cost = 20
-	containername = "\improper Special Ops crate"
+	containername = "special ops crate"
 	hidden = 1
 
 /decl/hierarchy/supply_pack/security/lightarmor
@@ -16,7 +16,7 @@
 					/obj/item/clothing/head/helmet =4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Light armor crate"
+	containername = "light armor crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/armor
@@ -25,7 +25,7 @@
 					/obj/item/clothing/head/helmet =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Armor crate"
+	containername = "armor crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/tacticalarmor
@@ -40,7 +40,7 @@
 					/obj/item/clothing/gloves/tactical)
 	cost = 45
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Tactical armor crate"
+	containername = "tactical armor crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/blackguards
@@ -49,7 +49,7 @@
 					/obj/item/clothing/accessory/legguards = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Arm and leg guards crate"
+	containername = "arm and leg guards crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/blueguards
@@ -58,7 +58,7 @@
 					/obj/item/clothing/accessory/legguards/blue = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Arm and leg guards crate"
+	containername = "arm and leg guards crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/greenguards
@@ -67,7 +67,7 @@
 					/obj/item/clothing/accessory/legguards/green = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Arm and leg guards crate"
+	containername = "arm and leg guards crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/navyguards
@@ -76,7 +76,7 @@
 					/obj/item/clothing/accessory/legguards/navy = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Arm and leg guards crate"
+	containername = "arm and leg guards crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/tanguards
@@ -85,7 +85,7 @@
 					/obj/item/clothing/accessory/legguards/tan = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Arm and leg guards crate"
+	containername = "arm and leg guards crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/riotarmor
@@ -97,7 +97,7 @@
 					/obj/item/weapon/storage/box/teargas)
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Riot armor crate"
+	containername = "riot armor crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/ballisticarmor
@@ -106,7 +106,7 @@
 					/obj/item/clothing/suit/armor/bulletproof = 4)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Ballistic suit crate"
+	containername = "ballistic suit crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/ablativearmor
@@ -115,7 +115,7 @@
 					/obj/item/clothing/suit/armor/laserproof = 4)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Ablative suit crate"
+	containername = "ablative suit crate"
 	access = access_armory
 
 /decl/hierarchy/supply_pack/security/weapons
@@ -126,7 +126,7 @@
 					/obj/item/weapon/gun/energy/taser = 4)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Weapons crate"
+	containername = "weapons crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/egun
@@ -134,7 +134,7 @@
 	contains = list(/obj/item/weapon/gun/energy/gun/secure = 4)
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Energy sidearms crate"
+	containername = "energy sidearms crate"
 	access = access_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -151,7 +151,7 @@
 					/obj/item/weapon/storage/box/emps)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Electromagnetic weapons crate"
+	containername = "electromagnetic weapons crate"
 	access = access_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -160,7 +160,7 @@
 	contains = list(/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Shotgun crate"
+	containername = "shotgun crate"
 	access = access_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -169,7 +169,7 @@
 	contains = list(/obj/item/weapon/storage/box/flashbangs = 2)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Flashbang crate"
+	containername = "flashbang crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/teargas
@@ -177,7 +177,7 @@
 	contains = list(/obj/item/weapon/storage/box/teargas = 2)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Tear gas grenades crate"
+	containername = "tear gas grenades crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/shotgunammo
@@ -186,7 +186,7 @@
 					/obj/item/weapon/storage/box/shotgunshells = 2)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Lethal shotgun shells crate"
+	containername = "lethal shotgun shells crate"
 	access = access_security
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -195,7 +195,7 @@
 	contains = list(/obj/item/weapon/storage/box/beanbags = 3)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Beanbag shotgun shells crate"
+	containername = "beanbag shotgun shells crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/pdwammo
@@ -203,7 +203,7 @@
 	contains = list(/obj/item/ammo_magazine/mc9mmt = 4)
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm ammunition crate"
+	containername = "9mm ammunition crate"
 	access = access_security
 	security_level = SUPPLY_SECURITY_HIGH
 
@@ -212,7 +212,7 @@
 	contains = list(/obj/item/ammo_magazine/mc9mmt/rubber = 4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm rubber ammunition crate"
+	containername = "9mm rubber ammunition crate"
 	access = access_security
 
 
@@ -221,7 +221,7 @@
 	contains = list(/obj/item/ammo_magazine/mc9mmt/flash = 4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm stun ammunition crate"
+	containername = "9mm stun ammunition crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/pdwammopractice
@@ -229,7 +229,7 @@
 	contains = list(/obj/item/ammo_magazine/mc9mmt/practice = 8)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm practice ammunition crate"
+	containername = "9mm practice ammunition crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/bullpupammo
@@ -237,7 +237,7 @@
 	contains = list(/obj/item/ammo_magazine/a762 = 4)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 7.62 ammunition crate"
+	containername = "7.62 ammunition crate"
 	access = access_security
 	security_level = SUPPLY_SECURITY_HIGH
 
@@ -246,7 +246,7 @@
 	contains = list(/obj/item/ammo_magazine/a762/practice = 8)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 7.62 practice ammunition crate"
+	containername = "7.62 practice ammunition crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/forensics //Not access-restricted so PIs can use it.
@@ -256,7 +256,7 @@
 					/obj/item/weapon/storage/box/swabs = 3,
 					/obj/item/weapon/reagent_containers/spray/luminol)
 	cost = 30
-	containername = "\improper Auxiliary forensic tools crate"
+	containername = "auxiliary forensic tools crate"
 
 /decl/hierarchy/supply_pack/security/detectivegear
 	name = "Forensics - investigation equipment"
@@ -276,7 +276,7 @@
 					/obj/item/weapon/storage/briefcase/crimekit = 2)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Forensic equipment crate"
+	containername = "forensic equipment crate"
 	access = access_forensics_lockers
 
 /decl/hierarchy/supply_pack/security/securitybarriers
@@ -284,7 +284,7 @@
 	contains = list(/obj/machinery/deployable/barrier = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper Security barrier crate"
+	containername = "security barrier crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/securitybarriers
@@ -292,7 +292,7 @@
 	contains = list(/obj/machinery/shieldwallgen = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper wall shield generators crate"
+	containername = "wall shield generators crate"
 	access = access_brig
 
 /decl/hierarchy/supply_pack/security/securitybiosuit
@@ -304,7 +304,7 @@
 					/obj/item/clothing/gloves/latex)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Security biohazard gear crate"
+	containername = "security biohazard gear crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/voidsuit_security
@@ -313,6 +313,6 @@
 					/obj/item/clothing/head/helmet/space/void/security/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Security voidsuit crate"
+	containername = "security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_brig

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -6,37 +6,37 @@
 	name = "Refills - Toner cartridges"
 	contains = list(/obj/item/device/toner = 3)
 	cost = 10
-	containername = "\improper Toner cartridges"
+	containername = "toner cartridges"
 
 /decl/hierarchy/supply_pack/supply/cardboard_sheets
 	name = "Material - cardboard sheets (50)"
 	contains = list(/obj/item/stack/material/cardboard/fifty)
 	cost = 10
-	containername = "\improper Cardboard sheets crate"
+	containername = "cardboard sheets crate"
 
 /decl/hierarchy/supply_pack/supply/wpaper
 	name = "Cargo - Wrapping paper"
 	contains = list(/obj/item/stack/package_wrap/twenty_five = 3)
 	cost = 10
-	containername = "\improper Wrapping paper"
+	containername = "wrapping paper"
 
 /decl/hierarchy/supply_pack/supply/tapes
 	name = "Medium - Blank Tapes (14)"
 	contains = list (/obj/item/weapon/storage/box/tapes)
 	cost = 10
-	containername = "\improper Blank tapes crate"
+	containername = "blank tapes crate"
 
 /decl/hierarchy/supply_pack/supply/scanner_module
-	name = "Electronics - Paper scanner module crate"
+	name = "Electronics - Paper scanner modules"
 	contains = list(/obj/item/weapon/computer_hardware/scanner/paper = 4)
 	cost = 20
-	containername = "\improper Paper scanner module crate"
+	containername = "paper scanner module crate"
 
 /decl/hierarchy/supply_pack/supply/spare_pda
 	name = "Electronics - Spare PDAs"
 	contains = list(/obj/item/modular_computer/pda = 3)
 	cost = 10
-	containername = "\improper Spare PDA crate"
+	containername = "spare PDA crate"
 
 /decl/hierarchy/supply_pack/supply/eftpos
 	contains = list(/obj/item/device/eftpos)
@@ -45,10 +45,10 @@
 	containername = "\improper EFTPOS crate"
 
 /decl/hierarchy/supply_pack/supply/water
-	name = "Refills - Bottled water crate"
+	name = "Refills - Bottled water"
 	contains = list (/obj/item/weapon/storage/box/water = 2)
 	cost = 12
-	containername = "\improper Bottled water crate"
+	containername = "bottled water crate"
 
 /decl/hierarchy/supply_pack/supply/sodas
 	num_contained = 2
@@ -61,9 +61,9 @@
 					/obj/item/weapon/storage/box/cola/icedtea,
 					/obj/item/weapon/storage/box/cola/grapejuice,
 					/obj/item/weapon/storage/box/cola/sodawater)
-	name = "Refills - Soda can crate"
+	name = "Refills - Soda cans"
 	cost = 10
-	containername = "\improper Soda can crate"
+	containername = "soda can crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/supply/snacks
@@ -75,28 +75,28 @@
 					/obj/item/weapon/storage/box/snack/tastybread,
 					/obj/item/weapon/storage/box/snack/candy,
 					/obj/item/weapon/storage/box/snack/chips)
-	name = "Refills - Snack foods crate"
+	name = "Refills - Snack foods"
 	cost = 10
-	containername = "\improper Snack foods crate"
+	containername = "snack foods crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/supply/coolanttank
-	name = "Liquid - Coolant tank crate"
+	name = "Liquid - Coolant tank"
 	contains = list(/obj/structure/reagent_dispensers/coolanttank)
 	cost = 16
 	containertype = /obj/structure/largecrate
-	containername = "\improper coolant tank crate"
+	containername = "coolant tank crate"
 
 /decl/hierarchy/supply_pack/supply/fueltank
-	name = "Liquid - Fuel tank crate"
+	name = "Liquid - Fuel tank"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper fuel tank crate"
+	containername = "fuel tank crate"
 
 /decl/hierarchy/supply_pack/supply/watertank
-	name = "Liquid - Water tank crate"
+	name = "Liquid - Water tank"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper water tank crate"
+	containername = "water tank crate"

--- a/maps/torch/datums/supplypacks/science.dm
+++ b/maps/torch/datums/supplypacks/science.dm
@@ -4,7 +4,7 @@
 					/obj/item/clothing/head/helmet/space/void/excavation,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Excavation voidsuit crate"
+	containername = "excavation voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_nanotrasen
 
@@ -14,7 +14,7 @@
 					/obj/item/clothing/head/helmet/space/void/mining/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Mining voidsuit crate"
+	containername = "mining voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_nanotrasen
 
@@ -24,7 +24,7 @@
 					/obj/item/clothing/head/helmet/space/void/pilot,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Pilot voidsuit crate"
+	containername = "pilot voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_nanotrasen
 
@@ -34,7 +34,7 @@
 					/obj/item/clothing/head/helmet/space/void/exploration,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Exploration voidsuit crate"
+	containername = "exploration voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_explorer
 
@@ -44,7 +44,7 @@
 					/obj/item/clothing/head/helmet/space/void/excavation,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Excavation voidsuit crate"
+	containername = "excavation voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_nanotrasen
 
@@ -54,7 +54,7 @@
 					/obj/item/clothing/head/helmet/space/void/mining/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Mining voidsuit crate"
+	containername = "mining voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_nanotrasen
 
@@ -64,7 +64,7 @@
 					/obj/item/clothing/head/helmet/space/void/pilot,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Pilot voidsuit crate"
+	containername = "pilot voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_nanotrasen
 
@@ -74,6 +74,6 @@
 					/obj/item/clothing/head/helmet/space/void/exploration,
 					/obj/item/clothing/shoes/magboots)
 	cost = 120
-	containername = "\improper Exploration voidsuit crate"
+	containername = "exploration voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_explorer

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -16,7 +16,7 @@
 					/obj/item/clothing/head/helmet/solgov/security =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Security armor crate"
+	containername = "security armor crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/solarmor
@@ -25,7 +25,7 @@
 					/obj/item/clothing/head/helmet/solgov =2)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Peacekeeper armor crate"
+	containername = "peacekeeper armor crate"
 	access = access_emergency_armory
 
 /decl/hierarchy/supply_pack/security/comarmor
@@ -34,7 +34,7 @@
 					/obj/item/clothing/head/helmet/solgov/command =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Command armor crate"
+	containername = "command armor crate"
 	access = access_heads
 
 /decl/hierarchy/supply_pack/security/nanoarmor
@@ -43,7 +43,7 @@
 					/obj/item/clothing/head/helmet/nt/guard =2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Corporate armor crate"
+	containername = "corporate armor crate"
 	access = access_nanotrasen
 
 /decl/hierarchy/supply_pack/security/lightnanoarmor
@@ -52,7 +52,7 @@
 					/obj/item/clothing/head/helmet/nt/guard =2)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Corporate light armor crate"
+	containername = "corporate light armor crate"
 	access = access_nanotrasen
 
 /decl/hierarchy/supply_pack/security/pistol
@@ -60,7 +60,7 @@
 	contains = list(/obj/item/weapon/gun/projectile/military = 4)
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Ballistic sidearms crate"
+	containername = "ballistic sidearms crate"
 	access = access_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -69,7 +69,7 @@
 	contains = list(/obj/item/weapon/gun/energy/laser/secure = 4)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Laser carbines crate"
+	containername = "laser carbines crate"
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -87,7 +87,7 @@
 					/obj/item/weapon/shield/energy = 2)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Advanced Laser Weapons crate"
+	containername = "advanced Laser Weapons crate"
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_HIGH
 
@@ -96,7 +96,7 @@
 	contains = list(/obj/item/weapon/gun/energy/sniperrifle = 2)
 	cost = 70
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Energy marksman crate"
+	containername = "energy marksman crate"
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_HIGH
 
@@ -114,7 +114,7 @@
 	contains = list(/obj/item/weapon/gun/projectile/automatic/z8 = 2)
 	cost = 80 //Because 5.56 is OP as fuck right now.
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Bullpup automatic rifle crate"
+	containername = "bullpup automatic rifle crate"
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_HIGH
 
@@ -123,7 +123,7 @@
 	contains = list(/obj/item/ammo_magazine/c45mds = 4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper .45 ammunition crate"
+	containername = ".45 ammunition crate"
 	access = access_security
 	security_level = SUPPLY_SECURITY_ELEVATED
 
@@ -132,7 +132,7 @@
 	contains = list(/obj/item/ammo_magazine/c45mds/rubber = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper .45 rubber ammunition crate"
+	containername = ".45 rubber ammunition crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/pistolammopractice
@@ -140,7 +140,7 @@
 	contains = list(/obj/item/ammo_magazine/c45mds/practice = 8)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper .45 practice ammunition crate"
+	containername = ".45 practice ammunition crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/holster
@@ -148,7 +148,7 @@
 	contains = list(/obj/item/clothing/accessory/storage/holster/hip = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Holster crate"
+	containername = "holster crate"
 	access = access_solgov_crew
 
 /decl/hierarchy/supply_pack/security/securityextragear
@@ -163,7 +163,7 @@
 					/obj/item/device/flashlight/maglight = 2)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Security equipment crate"
+	containername = "security equipment crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/cosextragear
@@ -186,7 +186,7 @@
 	contains = list(/obj/item/weapon/gun/energy/laser/practice = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper Practice laser carbine crate"
+	containername = "practice laser carbine crate"
 	access = access_solgov_crew
 
 /decl/hierarchy/supply_pack/security/magnum_ammo
@@ -194,6 +194,6 @@
 	contains = list(/obj/item/ammo_magazine/c44 = 4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper .44 magnum ammunition crate"
+	containername = ".44 magnum ammunition crate"
 	access = access_heads
 	security_level = SUPPLY_SECURITY_ELEVATED


### PR DESCRIPTION
:cl: Cajoes
rscdel: Removed the mention of crate in the cargo interface order form. Since it is implied the shipment will be in a crate.. or locker.. or otherwise sealed in some material.
rscdel: Removed \improper tags from labels that didn't require them. You will neither notice nor care.
rscdel: Removed dispenser cartridge packs from Galley-Cargo due to redundancy. Refer to Dispenser Refills-Cargo.
/:cl:
