### PR TITLE
Virology-related tweak + bugfix

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -315,3 +315,11 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spra
 	blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
 	blood_volume = blood_volume * blood_volume_mod
 	return min(blood_volume, 100)
+
+/mob/living/carbon/human/proc/cure_virus(var/virus_uuid)
+	if(vessel && virus_uuid)
+		for(var/datum/reagent/blood/B in vessel.reagent_list)
+			var/list/viruses = list()
+			viruses = B.data["virus2"]
+			viruses.Remove(virus_uuid)
+			B.data["virus2"] = viruses

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -118,7 +118,14 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 /datum/disease2/disease/proc/cure(var/mob/living/carbon/mob, antigen)
 	for(var/datum/disease2/effect/e in effects)
 		e.deactivate(mob)
+
 	mob.virus2.Remove("[uniqueID]")
+
+	//Tries to remove the virus also from the bloodstream (only for human-like lifeforms).
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		H.cure_virus(uniqueID)
+
 	if(antigen)
 		mob.antibodies |= antigen
 
@@ -143,9 +150,8 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 
 	effects += get_random_virus2_effect(effect_stage, badness, exclude)
 
-	if (prob(5))
-		antigen = list(pick(ALL_ANTIGENS))
-		antigen |= pick(ALL_ANTIGENS)
+	antigen = list(pick(ALL_ANTIGENS))
+	antigen |= pick(ALL_ANTIGENS)
 
 	if (prob(5) && all_species.len)
 		affected_species = get_infectable_species()


### PR DESCRIPTION
:cl: Ne_Propheta
tweak: a mutated virus (not limited to dishes only) will always have a new set of Antigens when possible.
bugfix: any trace of a virus that was annihilated by antibodies is removed from human-like mobs' bloodstream.
/:cl: