### PR TITLE
Cig tweaks

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -109,6 +109,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/weldermes = "USER lights NAME with FLAME"
 	var/ignitermes = "USER lights NAME with FLAME"
 	var/brand
+	var/gas_consumption = 0.04
 
 /obj/item/clothing/mask/smokable/New()
 	..()
@@ -120,6 +121,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit)
 		STOP_PROCESSING(SSobj, src)
 
+/obj/item/clothing/mask/smokable/fire_act()
+	light(0)
+
 /obj/item/clothing/mask/smokable/proc/smoke(amount)
 	smoketime -= amount
 	if(reagents && reagents.total_volume) // check if it has any reagents at all
@@ -130,13 +134,26 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				add_trace_DNA(C)
 		else // else just remove some of the reagents
 			reagents.remove_any(REM)
+	var/turf/T = get_turf(src)
+	if(T)
+		var/datum/gas_mixture/environment = T.return_air()
+		if(ishuman(loc))
+			var/mob/living/carbon/human/C = loc
+			if (src == C.wear_mask && C.internal)
+				environment = C.internal.return_air()
+		if(environment.get_by_flag(XGM_GAS_OXIDIZER) < gas_consumption)
+			extinguish()
+		else
+			environment.remove_by_flag(XGM_GAS_OXIDIZER, gas_consumption)
+			environment.adjust_gas("carbon_dioxide", 0.5*gas_consumption,0)
+			environment.adjust_gas("carbon_monoxide", 0.5*gas_consumption)
 
 /obj/item/clothing/mask/smokable/Process()
 	var/turf/location = get_turf(src)
-	smoke(1)
 	if(submerged() || smoketime < 1)
 		extinguish()
 		return
+	smoke(1)
 	if(location)
 		location.hotspot_expose(700, 5)
 
@@ -181,9 +198,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		atom_flags &= ~ATOM_FLAG_NO_REACT // allowing reagents to react after being lit
 		reagents.process_reactions()
 		update_icon()
-		var/turf/T = get_turf(src)
-		T.visible_message(flavor_text)
-		set_light(0.6, 0.5, 2, 2, "#e38f46")
+		if(flavor_text)
+			var/turf/T = get_turf(src)
+			T.visible_message(flavor_text)
 		START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/mask/smokable/proc/extinguish(var/mob/user, var/no_message)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -178,7 +178,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 			if(I.flags_inv & (BLOCKHAIR|BLOCKHEADHAIR))
 				update_hair(0)	//rebuild hair
 				update_inv_ears(0)
-		REMOVE_INTERNALS
+		var/obj/item/clothing/mask/head = src.get_equipped_item(slot_head)
+		if(!(head && (head.item_flags & ITEM_FLAG_AIRTIGHT)))
+			REMOVE_INTERNALS
 		update_inv_wear_mask()
 	else if (W == wear_id)
 		wear_id = null


### PR DESCRIPTION
Smokables now require proper gas to burn, any oxydizer will do.
They also consume it and produce trace amounts of CO2 and CO. Not really enough to be an issue in bigger rooms or with working scrubbers, but if you're being really stupid with limited space and air, it'll do something.
Fixes #10371. Similar check existed in helmet off code, but not for masks.
Removes light setting for cigs. It was just too huge, and our mangled light system doesn't allow subtle lights anymore. Ember is layered over darkness anyway.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
