### PR TITLE
Minor buffs for Chemistry

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_INIT(chemical_products_list, new)
 	result = /datum/reagent/tramadol/oxycodone
 	required_reagents = list(/datum/reagent/ethanol = 1, /datum/reagent/tramadol = 1)
 	catalysts = list(/datum/reagent/toxin/phoron = 5)
-	result_amount = 1
+	result_amount = 2
 
 /datum/chemical_reaction/sterilizine
 	name = "Sterilizine"
@@ -208,7 +208,7 @@ GLOBAL_LIST_INIT(chemical_products_list, new)
 	result = /datum/reagent/peridaxon
 	required_reagents = list(/datum/reagent/bicaridine = 2, /datum/reagent/clonexadone = 2)
 	catalysts = list(/datum/reagent/toxin/phoron = 5)
-	result_amount = 2
+	result_amount = 3
 
 /datum/chemical_reaction/virus_food
 	name = "Virus Food"
@@ -307,7 +307,7 @@ GLOBAL_LIST_INIT(chemical_products_list, new)
 	name = "Ethylredoxrazine"
 	result = /datum/reagent/ethylredoxrazine
 	required_reagents = list(/datum/reagent/acetone = 1, /datum/reagent/dylovene = 1, /datum/reagent/carbon = 1)
-	result_amount = 3
+	result_amount = 4
 
 /datum/chemical_reaction/soporific
 	name = "Soporific"
@@ -447,7 +447,7 @@ GLOBAL_LIST_INIT(chemical_products_list, new)
 /datum/chemical_reaction/noexcutite
 	name = "Noexcutite"
 	result = /datum/reagent/noexcutite
-	required_reagents = list(/datum/reagent/tramadol/oxycodone = 1, /datum/reagent/dylovene = 1)
+	required_reagents = list(/datum/reagent/synaptizine = 1, /datum/reagent/dylovene = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/methyl_bromide


### PR DESCRIPTION
:cl:
tweak: Noexcutite recipe has changed. It's now made of Dylovene + Synaptizine.
tweak: The result amount of Ethylredoxrazine, Oxycodone, and Peridaxon have been increased. Please refer to the wiki.
/:cl:

- Noexcutite yields 60u instead of that awkward 54/108 we used to have.
- Ethylredoxrazine yields 60u instead of 54/108.
- Oxycodone yields 90u instead of 54/108.
- Peridaxon yields 90u (from 60u bicaridine + 60u clonexadone). It's pretty much never used other than saving necrotic organs, by having more of it we might use it more instead of 5 minutes of cryobaths (because docs can't really monitor organ statuses in the cryotubes).

If the peri buff is too much, let me now.

New quick-ingredients-guide for each, will be changed on the wiki if this PR gets accepted:

Noexcutite:
10u ammonia
10u potassium
10u silicon
10u lithium
10u sugar
10u water
(yields 60u)

Ethylredoxrazine:
5u Ammonia
5u Potassium
5u Silicon
15u Acetone
15u Carbon
(yields 60u)

Peridaxon:
2 beakers
First beaker (or 60u Bicaridine)
40u Carbon
10u Acetone
10u Sugar
Second (large) beaker
1u Phoron
30u Acetone
10u Water
30u Sodium
Minimum 8u Phoron
Pour first beaker into second
Remove Phoron
(yields 90u)

Oxycodone:
5u Acetone
5u Carbon
5u Sugar
15u Ethanol
15u Acetone
45u Ethanol
5u Phoron
(yields 90u)