### PR TITLE
Gunshot residue tweaks and forensic fixes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -332,6 +332,7 @@ its easier to just keep the beam vertical.
 	if(istype(blood_DNA, /list))
 		blood_DNA = null
 		return 1
+	gunshot_residue = null
 
 /atom/proc/get_global_map_pos()
 	if(!islist(GLOB.global_map) || isemptylist(GLOB.global_map)) return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -47,11 +47,6 @@
 			ret.overlays |= A.get_mob_overlay(user_mob, slot)
 	return ret
 
-// Aurora forensics port.
-/obj/item/clothing/clean_blood()
-	. = ..()
-	gunshot_residue = null
-
 /obj/item/clothing/proc/change_smell(smell = SMELL_DEFAULT)
 	smell_state = smell
 

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -8,13 +8,13 @@ var/const/FINGERPRINT_COMPLETE = 6
 proc/is_complete_print(var/print)
 	return stringpercent(print) <= FINGERPRINT_COMPLETE
 
+atom/var/list/fingerprintshidden
+atom/var/fingerprintslast
+
 atom/var/list/suit_fibers
-atom/var/var/list/fingerprints
-atom/var/var/list/fingerprintshidden
-atom/var/var/fingerprintslast
+atom/var/list/fingerprints
+atom/var/list/gunshot_residue
 obj/item/var/list/trace_DNA
-mob/living/carbon/human/var/gunshot_residue
-obj/item/clothing/var/gunshot_residue
 
 /atom/proc/add_hiddenprint(mob/M)
 	if(!M || !M.key)
@@ -52,6 +52,7 @@ obj/item/clothing/var/gunshot_residue
 	if(!full_print)
 		return
 
+	//Using prints from severed hand items!
 	var/obj/item/organ/external/E = M.get_active_hand()
 	if(src != E && istype(E) && E.get_fingerprint())
 		full_print = E.get_fingerprint()
@@ -119,18 +120,15 @@ obj/item/clothing/var/gunshot_residue
 		LAZYDISTINCTADD(A.suit_fibers, suit_fibers)
 	if(blood_DNA)
 		A.blood_DNA |= blood_DNA
+	if(gunshot_residue)
+		var/obj/item/clothing/C = A
+		LAZYDISTINCTADD(C.gunshot_residue, gunshot_residue)
 
 /obj/item/transfer_fingerprints_to(var/atom/A)
 	..()
 	if(istype(A,/obj/item) && trace_DNA)
 		var/obj/item/I = A
 		LAZYDISTINCTADD(I.trace_DNA, trace_DNA)
-
-/obj/item/clothing/transfer_fingerprints_to(var/atom/A)
-	..()
-	if(istype(A,/obj/item/clothing) && gunshot_residue)
-		var/obj/item/clothing/C = A
-		C.gunshot_residue = gunshot_residue
 
 atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(!istype(M))
@@ -144,7 +142,6 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		if(add_blood(M.bloody_hands_mob))
 			M.bloody_hands--
 
-	if(!suit_fibers) suit_fibers = list()
 	var/fibertext
 	var/item_multiplier = istype(src,/obj/item)?1.2:1
 	var/suit_coverage = 0
@@ -152,20 +149,20 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		var/obj/item/clothing/C = M.wear_suit
 		fibertext = C.get_fibers()
 		if(fibertext && prob(10*item_multiplier))
-			suit_fibers |= fibertext
+			LAZYDISTINCTADD(suit_fibers, fibertext)
 		suit_coverage = C.body_parts_covered
 
 	if(istype(M.w_uniform, /obj/item/clothing) && (M.w_uniform.body_parts_covered & ~suit_coverage))
 		var/obj/item/clothing/C = M.w_uniform
 		fibertext = C.get_fibers()
 		if(fibertext && prob(15*item_multiplier))
-			suit_fibers |= fibertext
+			LAZYDISTINCTADD(suit_fibers, fibertext)
 
 	if(istype(M.gloves, /obj/item/clothing) && (M.gloves.body_parts_covered & ~suit_coverage))
 		var/obj/item/clothing/C = M.gloves
 		fibertext = C.get_fibers()
 		if(fibertext && prob(20*item_multiplier))
-			suit_fibers |= fibertext
+			LAZYDISTINCTADD(suit_fibers, fibertext)
 
 /obj/item/proc/add_trace_DNA(mob/living/carbon/M)
 	if(!istype(M))
@@ -201,15 +198,14 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 
 	//Detective is on the case
 	if(get_skill_value(SKILL_FORENSICS) >= SKILL_EXPERT && get_dist(src, A) <= (get_skill_value(SKILL_FORENSICS) - SKILL_ADEPT))
-		if(A.suit_fibers && A.suit_fibers.len > 0)
+		if(LAZYLEN(A.suit_fibers))
 			to_chat(src, "<span class='notice'>You notice some fibers embedded in \the [A]</span>")
-		if(A.fingerprints && A.fingerprints.len > 0)
+		if(LAZYLEN(A.fingerprints))
 			to_chat(src, "<span class='notice'>You notice a partial print on \the [A]</span>")
-		var/obj/item/clothing/O = A
-		if(istype(O) && O.gunshot_residue)
+		if(LAZYLEN(A.gunshot_residue))
 			to_chat(src, "<span class='notice'>You notice a faint acrid smell coming from \the [A]</span>")
 		//Noticing wiped blood is a bit harder
-		if((get_skill_value(SKILL_FORENSICS) >= SKILL_PROF) && A.blood_DNA)
+		if((get_skill_value(SKILL_FORENSICS) >= SKILL_PROF) && LAZYLEN(A.blood_DNA))
 			to_chat(src, "<span class='warning'>You notice faint blood traces on \The [A]</span>")
 
 

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -60,31 +60,31 @@
 
 	var/list/evidence = list()
 	var/scaned_object = sample.name
-	if(istype(sample, /obj/item/weapon/forensics))
-		if(istype(sample, /obj/item/weapon/forensics/swab))
-			var/obj/item/weapon/forensics/swab/swab = sample
-			evidence["gsr"] = swab.gsr
-		else if(istype(sample, /obj/item/weapon/sample/fibers))
-			var/obj/item/weapon/sample/fibers/fibers = sample
-			scaned_object = fibers.object
-			evidence["fibers"] = fibers.evidence.Copy()
-		else if(istype(sample, /obj/item/weapon/sample/print))
-			var/obj/item/weapon/sample/print/card = sample
-			scaned_object = card.object ? card.object : card.name
-			evidence["prints"] = card.evidence.Copy()
+	if(istype(sample, /obj/item/weapon/forensics/swab))
+		var/obj/item/weapon/forensics/swab/swab = sample
+		evidence["gunshot_residue"] = swab.gunshot_residue_sample.Copy()
+	else if(istype(sample, /obj/item/weapon/sample/fibers))
+		var/obj/item/weapon/sample/fibers/fibers = sample
+		scaned_object = fibers.object
+		evidence["fibers"] = fibers.evidence.Copy()
+	else if(istype(sample, /obj/item/weapon/sample/print))
+		var/obj/item/weapon/sample/print/card = sample
+		scaned_object = card.object ? card.object : card.name
+		evidence["prints"] = card.evidence.Copy()
 	else
-		evidence["prints"] = sample.fingerprints.Copy()
-		evidence["fibers"] = sample.suit_fibers.Copy()
-		if(istype(sample,/obj/item/clothing))
-			var/obj/item/clothing/C = sample
-			evidence["gsr"] = C.gunshot_residue
+		if(sample.fingerprints)
+			evidence["prints"] = sample.fingerprints.Copy()
+		if(sample.suit_fibers)
+			evidence["fibers"] = sample.suit_fibers.Copy()
+		if(sample.gunshot_residue)
+			evidence["gunshot_residue"] = sample.gunshot_residue.Copy()
 
 	report.SetName("Forensic report #[++report_num]: [sample.name]")
 	report.info = "<b>Scanned item:</b><br>[scaned_object]<br><br>"
-	if("gsr" in evidence)
+	if("gunshot_residue" in evidence)
 		report.info += "<b>Gunpowder residue analysis report #[report_num]</b>: [scaned_object]<br>"
-		if(evidence["gsr"])
-			report.info += "Residue from a [evidence["gsr"]] bullet detected."
+		if(evidence["gunshot_residue"])
+			report.info += "Residue from a [evidence["gunshot_residue"]] bullet detected."
 		else
 			report.info += "No gunpowder residue found."
 	if("fibers" in evidence)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -158,7 +158,7 @@
 	return (world.time >= last_upgrade + current_grab.upgrade_cooldown)
 
 /obj/item/grab/proc/leave_forensic_traces()
-	var/obj/item/clothing/C = affecting.get_covering_equipped_item(target_zone)
+	var/obj/item/clothing/C = affecting.get_covering_equipped_item_by_zone(target_zone)
 	if(istype(C))
 		C.leave_evidence(assailant)
 		if(prob(50))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -864,7 +864,10 @@
 
 /mob/living/carbon/human/clean_blood(var/clean_feet)
 	.=..()
-	gunshot_residue = null
+	for(var/obj/item/organ/external/organ in organs)
+		if(clean_feet || (organ.organ_tag in list(BP_L_HAND,BP_R_HAND)))
+			organ.gunshot_residue = null
+	
 	if(clean_feet && !shoes)
 		feet_blood_color = null
 		feet_blood_DNA = null

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -424,4 +424,10 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(handcuffed) . += handcuffed
 		if(s_store)    . += s_store
 
+//Same as get_covering_equipped_items, but using target zone instead of bodyparts flags
+/mob/living/carbon/human/proc/get_covering_equipped_item_by_zone(var/zone)
+	var/obj/item/organ/external/O = get_organ(zone)
+	if(O)
+		return get_covering_equipped_item(O.body_part)
+
 #undef REMOVE_INTERNALS

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -94,7 +94,7 @@ var/global/list/sparring_attack_cache = list()
 			target.visible_message("<span class='danger'>[target] has been weakened!</span>")
 		target.apply_effect(3, WEAKEN, armour)
 
-	var/obj/item/clothing/C = target.get_covering_equipped_item(zone)
+	var/obj/item/clothing/C = target.get_covering_equipped_item_by_zone(zone)
 	if(istype(C) && prob(10))
 		C.leave_evidence(user)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -638,7 +638,7 @@
 		if(H.pull_damage())
 			to_chat(src, "<span class='danger'>Pulling \the [H] in their current condition would probably be a bad idea.</span>")
 
-		var/obj/item/clothing/C = H.get_covering_equipped_item(BP_CHEST)
+		var/obj/item/clothing/C = H.get_covering_equipped_item_by_zone(BP_CHEST)
 		if(istype(C))
 			C.leave_evidence(src)
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -37,18 +37,26 @@
 	update_icon()
 
 /obj/item/ammo_casing/proc/leave_residue()
-	var/mob/living/carbon/human/H
-	if(ishuman(loc))
-		H = loc //in a human, somehow
-	else if(loc && ishuman(loc.loc))
-		H = loc.loc //more likely, we're in a gun being held by a human
-
+	var/mob/living/carbon/human/H = get_holder_of_type(src, /mob/living/carbon/human)
+	var/obj/item/weapon/gun/G = get_holder_of_type(src, /obj/item/weapon/gun)
+	put_residue_on(G)
 	if(H)
-		if(H.gloves && (H.l_hand == loc || H.r_hand == loc))
-			var/obj/item/clothing/G = H.gloves
-			G.gunshot_residue = caliber
-		else
-			H.gunshot_residue = caliber
+		var/zone
+		if(H.l_hand == G)
+			zone = BP_L_HAND
+		else if(H.r_hand == G)
+			zone = BP_R_HAND
+		if(zone)
+			var/target = H.get_covering_equipped_item_by_zone(zone)
+			if(!target)
+				target = H.get_organ(zone)
+			put_residue_on(target)
+	if(prob(30))
+		put_residue_on(get_turf(src))
+
+/obj/item/ammo_casing/proc/put_residue_on(atom/A)
+	if(A)
+		LAZYDISTINCTADD(A.gunshot_residue, caliber)
 
 /obj/item/ammo_casing/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isScrewdriver(W))

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -86,6 +86,18 @@
 		chambered.expend()
 		process_chambered()
 
+/obj/item/weapon/gun/projectile/process_point_blank(obj/projectile, mob/user, atom/target)
+	..()
+	if(chambered && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/zone = BP_CHEST
+		if(user && user.zone_sel)
+			zone = user.zone_sel.selecting
+		var/obj/item/organ/external/E = H.get_organ(zone)
+		if(E)
+			chambered.put_residue_on(E)
+			H.apply_damage(3, BURN, used_weapon = "Gunpowder Burn", given_organ = E)
+
 /obj/item/weapon/gun/projectile/handle_click_empty()
 	..()
 	process_chambered()

--- a/html/changelogs/chinsky - powder.yml
+++ b/html/changelogs/chinsky - powder.yml
@@ -1,0 +1,8 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Various changes to gunshot residue (GSR) forensic thingamabob."
+  - rscadd: "Shooting someone pointblank will now leave GSR on the targeted organ, and burn them a bit. Just like in those mystery novels!"
+  - rscadd: "You now need to aim at hand to take GSR from THAT hand, not from both. You can take GSR from other bodyparts by aiming at them too."
+  - rscadd: "Gun actually gets GSR too now."
+  - rscadd: "Guns have a chance to leave GSR on the ground when fired."


### PR DESCRIPTION
Leaving GSR on organs (with a smol burn) when pointblanking
GSR is now stored on hand organ rather than on human as a whole.
Leaving GSR on actual gun
Leaving GSR on turf (30% chance)

Seemingly unrelated changes are a fix for a bug I discovered. Turns out 'get item covering this' proc didn't work as I believed, and expected bitflags. Adds one that takes target zone instead.

Fixes #23023
Fixes #23106
Fixes forensic samples being treated as general objects in microscope.
Not getting smell of blood until there's actual blood in the list.