### PR TITLE
Stops detectives from leaving fibers and fingerprints when investigating an item

### DIFF
--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -161,12 +161,6 @@
 	else
 		to_chat(user, "<span class='warning'>You are unable to locate any [evidence_type]s on \the [A].</span>")
 		. = ..()
-		
-	// WHO THE FUCK THOUGHT THIS WAS A GOOD IDEA
-	// WHY WOULD I LEAVE MY OWN FINGERPRINTS WHEN TAKING FINGERPRINTS
-	// WHO DO I LEAVE MY OWN FIBERS [occasionally] WHEN TAKING FIBERS
-	// A.add_fingerprint(user)
-	
 
 /obj/item/weapon/forensics/sample_kit/MouseDrop(atom/over)
 	if(ismob(src.loc) && CanMouseDrop(over))

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -161,7 +161,12 @@
 	else
 		to_chat(user, "<span class='warning'>You are unable to locate any [evidence_type]s on \the [A].</span>")
 		. = ..()
-	A.add_fingerprint(user)
+		
+	// WHO THE FUCK THOUGHT THIS WAS A GOOD IDEA
+	// WHY WOULD I LEAVE MY OWN FINGERPRINTS WHEN TAKING FINGERPRINTS
+	// WHO DO I LEAVE MY OWN FIBERS [occasionally] WHEN TAKING FIBERS
+	// A.add_fingerprint(user)
+	
 
 /obj/item/weapon/forensics/sample_kit/MouseDrop(atom/over)
 	if(ismob(src.loc) && CanMouseDrop(over))


### PR DESCRIPTION
This is so broken it's impossible to justify.
