### PR TITLE
Changes how pointblanking multiplies damage

### DIFF
--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -11,7 +11,7 @@
 	reverse_facing = 0
 	can_absorb = 0
 	shield_assailant = 0
-	point_blank_mult = 1
+	point_blank_mult = 1.5
 	same_tile = 0
 	can_throw = 1
 	force_danger = 1

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -9,7 +9,7 @@
 	reverse_facing = 1
 	can_absorb = 1
 	shield_assailant = 0
-	point_blank_mult = 1
+	point_blank_mult = 2
 	same_tile = 1
 	force_danger = 1
 	restrains = 1

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -13,7 +13,7 @@
 	reverse_facing = 1
 	can_absorb = 1
 	shield_assailant = 1
-	point_blank_mult = 1
+	point_blank_mult = 2
 	same_tile = 1
 	can_throw = 1
 	force_danger = 1

--- a/code/modules/mob/grab/normal/norm_passive.dm
+++ b/code/modules/mob/grab/normal/norm_passive.dm
@@ -10,7 +10,7 @@
 	reverse_facing = 0
 	can_absorb = 0
 	shield_assailant = 0
-	point_blank_mult = 1
+	point_blank_mult = 1.1
 	same_tile = 0
 
 	icon_state = "reinforce"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -315,14 +315,15 @@
 		return //default behaviour only applies to true projectiles
 
 	//default point blank multiplier
-	var/max_mult = 1.3
+	var/max_mult = 1
 
 	//determine multiplier due to the target being grabbed
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		for(var/obj/item/grab/G in H.grabbed_by)
-			if(G.point_blank_mult() > max_mult)
-				max_mult = G.point_blank_mult()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.incapacitated())
+			max_mult = 1.2
+		for(var/obj/item/grab/G in L.grabbed_by)
+			max_mult = max(max_mult, G.point_blank_mult())
 	P.damage *= max_mult
 
 /obj/item/weapon/gun/proc/process_accuracy(obj/projectile, mob/living/user, atom/target, var/burst, var/held_twohanded)


### PR DESCRIPTION
Now it doesn't really give you more bang unless you're grabbing the victim, or they're incapacitated. It's still an almost guaranteed hit accuracy wise, just without the extra bang unless you're putting more effort into it.

So with this, if you just run up to the guy and unload, you'll hit him, but you won't get that sweet damage boost. Otherwise, it goes like this (only highest boost used, not cumulative)
If he's knocked out/down/bucklecuffed or otherwise incapacitated, that's +20%
Grabbing him passively nets you 10% boost.
Aggressive grab for whooping 50% more bang.
Neck grab? Double damage!
Don't ask me how it works, I don't make the rules.

Overall I mostly made it to make run-up-gib-head thing less viable, since grabs give victim some time to react usually.