### PR TITLE
Attempt at reducing number of proxy listeners used by instruments

### DIFF
--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -115,7 +115,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	listeners = list()
 	listener_status = list()
 
-	GLOB.destroyed_event.register(source, src, /datum/sound_token/proc/Stop)
+	GLOB.destroyed_event.register(source, src, /datum/proc/qdel_self)
 
 	if(ismovable(source))
 		proxy_listener = new(source, /datum/sound_token/proc/PrivAddListener, /datum/sound_token/proc/PrivLocateListeners, range, proc_owner = src)

--- a/code/modules/synthesized_instruments/song.dm
+++ b/code/modules/synthesized_instruments/song.dm
@@ -85,7 +85,7 @@
 
 	var/current_volume = Clamp(sound_copy.volume, 0, 100)
 	sound_copy.volume = current_volume //Sanitize volume
-	var/datum/sound_token/token = new /datum/sound_token/instrument(src.player.actual_instrument, src.sound_id, sound_copy, src.player.range, FALSE, use_env)
+	var/datum/sound_token/token = new /datum/sound_token/instrument(src.player.actual_instrument, src.sound_id, sound_copy, src.player.range, FALSE, use_env, player)
 	#if DM_VERSION < 511
 	sound_copy.frequency = 1
 	#endif

--- a/code/modules/synthesized_instruments/sound_player.dm
+++ b/code/modules/synthesized_instruments/sound_player.dm
@@ -18,7 +18,7 @@
 	var/datum/musical_event_manager/event_manager = new
 
 	var/datum/proximity_trigger/square/proxy_listener
-	var/datum/sound_token/instrument/tokens = list()
+	var/list/datum/sound_token/instrument/tokens = list()
 	var/list/seen_turfs
 
 /datum/sound_player/New(datum/real_instrument/where, datum/instrument/what)
@@ -37,8 +37,7 @@
 	QDEL_NULL(event_manager)
 	QDEL_NULL(proxy_listener)
 	seen_turfs.Cut()
-	var/list/temp = tokens
-	temp.Cut()
+	tokens.Cut()
 	. = ..()
 
 /datum/sound_player/proc/subscribe(var/datum/sound_token/instrument/newtoken)

--- a/code/modules/synthesized_instruments/sound_player.dm
+++ b/code/modules/synthesized_instruments/sound_player.dm
@@ -17,13 +17,17 @@
 
 	var/datum/musical_event_manager/event_manager = new
 
+	var/datum/proximity_trigger/square/proxy_listener
+	var/datum/sound_token/instrument/tokens = list()
+	var/list/seen_turfs
 
 /datum/sound_player/New(datum/real_instrument/where, datum/instrument/what)
 	src.song = new (src, what)
 	src.actual_instrument = where
 	src.echo = GLOB.musical_config.echo_default.Copy()
 	src.env = GLOB.musical_config.env_default.Copy()
-
+	src.proxy_listener = new(src.actual_instrument, /datum/sound_player/proc/on_turf_entered_relay, /datum/sound_player/proc/on_turfs_changed_relay, range, proc_owner = src)
+	proxy_listener.register_turfs()
 
 /datum/sound_player/Destroy()
 	src.song.playing = 0
@@ -31,8 +35,34 @@
 	src.instrument = null
 	QDEL_NULL(song)
 	QDEL_NULL(event_manager)
+	QDEL_NULL(proxy_listener)
+	seen_turfs.Cut()
+	var/list/temp = tokens
+	temp.Cut()
 	. = ..()
 
+/datum/sound_player/proc/subscribe(var/datum/sound_token/instrument/newtoken)
+	if(!istype(newtoken))
+		CRASH("Non token type passed to subscribe function.")
+	tokens += newtoken
+
+	//Tell it of what we saw prior to it spawning
+	newtoken.PrivLocateListeners(list(), seen_turfs.Copy())
+
+
+/datum/sound_player/proc/unsubscribe(var/datum/sound_token/instrument/oldtoken)
+	if(!istype(oldtoken))
+		CRASH("Non token type passed to unsubscribe function.")
+	tokens -= oldtoken
+
+/datum/sound_player/proc/on_turf_entered_relay(var/atom/enteree)
+	for(var/datum/sound_token/instrument/I in tokens)
+		I.PrivAddListener(enteree)
+
+/datum/sound_player/proc/on_turfs_changed_relay(var/list/prior_turfs, var/list/current_turfs)
+	seen_turfs = current_turfs
+	for(var/datum/sound_token/instrument/I in tokens)
+		I.PrivLocateListeners(prior_turfs.Copy(), current_turfs.Copy())
 
 /datum/sound_player/proc/apply_modifications(sound/what, note_num, which_line, which_note) // You don't need to override this
 	what.volume = volume

--- a/code/modules/synthesized_instruments/sound_token.dm
+++ b/code/modules/synthesized_instruments/sound_token.dm
@@ -32,7 +32,7 @@
 	listeners = list()
 	listener_status = list()
 
-	GLOB.destroyed_event.register(source, src, /datum/sound_token/proc/Stop)
+	GLOB.destroyed_event.register(source, src, /datum/proc/qdel_self)
 
 	player.subscribe(src)
 

--- a/code/modules/synthesized_instruments/sound_token.dm
+++ b/code/modules/synthesized_instruments/sound_token.dm
@@ -65,3 +65,7 @@ datum/sound_token/instrument/PrivAddListener(var/atom/listener)
 /datum/sound_token/instrument/Stop()
 	player.unsubscribe(src)
 	. = ..()
+
+/datum/sound_token/instrument/Destroy()
+	. = ..()
+	player = null

--- a/code/modules/synthesized_instruments/sound_token.dm
+++ b/code/modules/synthesized_instruments/sound_token.dm
@@ -3,9 +3,10 @@
 
 /datum/sound_token/instrument
 	var/use_env = 0
+	var/datum/sound_player/player
 
 //Slight duplication, but there's key differences
-/datum/sound_token/instrument/New(var/atom/source, var/sound_id, var/sound/sound, var/range = 4, var/prefer_mute = FALSE, var/use_env)
+/datum/sound_token/instrument/New(var/atom/source, var/sound_id, var/sound/sound, var/range = 4, var/prefer_mute = FALSE, var/use_env, var/datum/sound_player/player)
 	if(!istype(source))
 		CRASH("Invalid sound source: [log_info_line(source)]")
 	if(!istype(sound))
@@ -21,6 +22,7 @@
 	src.sound       = sound
 	src.sound_id    = sound_id
 	src.use_env = use_env
+	src.player = player
 
 	var/channel = GLOB.sound_player.PrivGetChannel(src) //Attempt to find a channel
 	if(!isnum(channel))
@@ -32,9 +34,7 @@
 
 	GLOB.destroyed_event.register(source, src, /datum/sound_token/proc/Stop)
 
-	if(ismovable(source))
-		proxy_listener = new(source, /datum/sound_token/proc/PrivAddListener, /datum/sound_token/proc/PrivLocateListeners, range, proc_owner = src)
-		proxy_listener.register_turfs()
+	player.subscribe(src)
 
 
 /datum/sound_token/instrument/PrivGetEnvironment(var/listener)
@@ -61,3 +61,7 @@ datum/sound_token/instrument/PrivAddListener(var/atom/listener)
 			PrivRemoveListener(listener)
 			return
 	return ..()
+
+/datum/sound_token/instrument/Stop()
+	player.unsubscribe(src)
+	. = ..()

--- a/tools/midi2piano/midi2piano.py
+++ b/tools/midi2piano/midi2piano.py
@@ -9,7 +9,7 @@ import pyperclip as pclip
 
 LINE_LENGTH_LIM = 50
 LINES_LIMIT = 200
-TICK_LAG = 0.5
+TICK_LAG = 0.6
 OVERALL_IMPORT_LIM = 2*50*200
 END_OF_LINE_CHAR = """
 """ # BYOND can't parse \n and I am forced to define my own NEWLINE char


### PR DESCRIPTION
I think having a single proxy that informs tokens should at least reduce the CPU usage coming directly from the proxy functions.
