### PR TITLE
Fixes divide by 0 error with chemistry; makes dispensor UI update.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -279,7 +279,7 @@ its easier to just keep the beam vertical.
 /atom/proc/emag_act(var/remaining_charges, var/mob/user, var/emag_source)
 	return NO_EMAG_ACT
 
-/atom/proc/fire_act()
+/atom/proc/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 
 /atom/proc/melt()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -948,9 +948,9 @@ FIRE ALARM
 			set_light(sl.light_max_bright, sl.light_inner_range, sl.light_outer_range, 2, sl.light_color_alarm)
 			src.overlays += image(sl.icon, sl.overlay_alarm)
 
-/obj/machinery/firealarm/fire_act(datum/gas_mixture/air, temperature, volume)
+/obj/machinery/firealarm/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(src.detecting)
-		if(temperature > T0C+200)
+		if(exposed_temperature > T0C+200)
 			src.alarm()			// added check of detector status here
 	return
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -61,7 +61,7 @@
 	..()
 
 
-/obj/item/device/taperecorder/fire_act()
+/obj/item/device/taperecorder/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(mytape)
 		mytape.ruin() //Fires destroy the tape
 	return ..()
@@ -399,7 +399,7 @@
 		overlays += "ribbonoverlay"
 
 
-/obj/item/device/tape/fire_act()
+/obj/item/device/tape/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	ruin()
 
 /obj/item/device/tape/attack_self(mob/user)

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -38,8 +38,8 @@
 /obj/item/latexballon/bullet_act()
 	burst()
 
-/obj/item/latexballon/fire_act(datum/gas_mixture/air, temperature, volume)
-	if(temperature > T0C+100)
+/obj/item/latexballon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature > T0C+100)
 		burst()
 	return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -168,7 +168,7 @@ var/const/enterloopsanity = 100
 						thing.HasProximity(A, 1)
 	return
 
-/turf/proc/adjacent_fire_act(turf/simulated/floor/source, temperature, volume)
+/turf/proc/adjacent_fire_act(turf/simulated/floor/source, exposed_temperature, exposed_volume)
 	return
 
 /turf/proc/is_plating()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -307,10 +307,10 @@
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
 
-/mob/living/fire_act(datum/gas_mixture/air, temperature, volume)
+/mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	//once our fire_burn_temperature has reached the temperature of the fire that's giving fire_stacks, stop adding them.
 	//allow fire_stacks to go up to 4 for fires cooler than 700 K, since are being immersed in flame after all.
-	if(fire_stacks <= 4 || fire_burn_temperature() < temperature)
+	if(fire_stacks <= 4 || fire_burn_temperature() < exposed_temperature)
 		adjust_fire_stacks(2)
 	IgniteMob()
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -323,6 +323,6 @@
 	if(on_fire)
 		overlays += image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing")
 
-/mob/living/silicon/robot/fire_act()
+/mob/living/silicon/robot/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them
 		IgniteMob()

--- a/code/modules/overmap/exoplanets/desert.dm
+++ b/code/modules/overmap/exoplanets/desert.dm
@@ -71,7 +71,7 @@
 	icon_state = "desert[rand(0,5)]"
 	..()
 
-/turf/simulated/floor/exoplanet/desert/fire_act(datum/gas_mixture/air, temperature, volume)
+/turf/simulated/floor/exoplanet/desert/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if((temperature > T0C + 1700 && prob(5)) || temperature > T0C + 3000)
 		SetName("molten silica")
 		icon_state = "sandglass"

--- a/code/modules/overmap/exoplanets/grass.dm
+++ b/code/modules/overmap/exoplanets/grass.dm
@@ -105,7 +105,7 @@
 	if(prob(2))
 		resources[MATERIAL_DIAMOND] = 1
 
-/turf/simulated/floor/exoplanet/grass/fire_act(datum/gas_mixture/air, temperature, volume)
+/turf/simulated/floor/exoplanet/grass/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if((temperature > T0C + 200 && prob(5)) || temperature > T0C + 1000)
 		SetName("scorched ground")
 		icon_state = "scorched"

--- a/code/modules/overmap/exoplanets/snow.dm
+++ b/code/modules/overmap/exoplanets/snow.dm
@@ -62,6 +62,6 @@
 	icon_state = pick("snow[rand(1,12)]","snow0")
 	..()
 
-/turf/simulated/floor/exoplanet/snow/fire_act(datum/gas_mixture/air, temperature, volume)
+/turf/simulated/floor/exoplanet/snow/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	name = "permafrost"
 	icon_state = "permafrost"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -86,23 +86,29 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 
 	for(var/datum/chemical_reaction/C in eligible_reactions)
 		if(C.can_happen(src))
-			active_reactions |= C
+			active_reactions[C] = 1 // The number is going to be 1/(fraction of remaining reagents we are allowed to use), computed below
 			reaction_occured = 1
 
-	var/list/used_reagents = list()
+	var/list/used_reagents = list()       // this is a helper
+	// if two reactions share a reagent, each is allocated half of it, so we compute this here
 	for(var/datum/chemical_reaction/C in active_reactions)
 		var/list/adding = C.get_used_reagents()
 		for(var/R in adding)
-			used_reagents[R] += 1
+			LAZYADD(used_reagents[R], C)
 
-	var/max_split = 1
 	for(var/R in used_reagents)
-		if(used_reagents[R] > max_split)
-			max_split = used_reagents[R]
+		var/counter = length(used_reagents[R])
+		if(counter <= 1)
+			continue // Only used by one reaction, so nothing we need to do.
+		for(var/datum/chemical_reaction/C in used_reagents[R])
+			active_reactions[C] = max(counter, active_reactions[C])
+			counter-- //so the next reaction we execute uses more of the remaining reagents
+			// Note: this is not guaranteed to maximize the size of the reactions we do (if one reaction is limited by reagent A, we may be over-allocating reagent B to it)
+			// However, we are guaranteed to fully use up the most profligate reagent if possible.
+			// Further reactions may occur on the next tick, when this runs again.
 
 	for(var/datum/chemical_reaction/C in active_reactions)
-		C.process(src, max_split, total_volume)
-		--max_split
+		C.process(src, active_reactions[C])
 
 	for(var/datum/chemical_reaction/C in active_reactions)
 		C.post_reaction(src)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -140,6 +140,7 @@
 		ui = new(user, src, ui_key, "chem_disp.tmpl", ui_title, 390, 680)
 		ui.set_initial_data(data)
 		ui.open()
+		ui.set_auto_update(1)
 
 /obj/machinery/chemical_dispenser/OnTopic(mob/user, href_list)
 	if(href_list["amount"])

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -227,10 +227,10 @@
 		R.ex_act(src, 1)
 	qdel(src)
 
-/obj/structure/reagent_dispensers/fueltank/fire_act(datum/gas_mixture/air, temperature, volume)
+/obj/structure/reagent_dispensers/fueltank/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if (modded)
 		explode()
-	else if (temperature > T0C+500)
+	else if (exposed_temperature > T0C+500)
 		explode()
 	return ..()
 

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -186,7 +186,7 @@
 
 
 // Fire
-/obj/effect/shield/fire_act()
+/obj/effect/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!disabled_for)
 		take_damage(rand(5,10), SHIELD_DAMTYPE_HEAT)
 

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -52,7 +52,7 @@
 	..()
 	var/turf/simulated/T = get_turf(src)
 	if(istype(T))
-		T.fire_act(temperature = T0C + 3000)
+		T.fire_act(exposed_temperature = T0C + 3000)
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/weapon/paper/marooned/


### PR DESCRIPTION
Fixes #23214
Closes #23184
Closes #19724
This is not related to Zuh's PR, but rather is some legacy bug involving bad logic. Sort of interesting, though, and maybe someone wants to take a crack at a better solution.

Also makes the reagent dispenser auto-refresh, as with the SS changes it doesn't properly update now.