### PR TITLE
Removes hardcoded zlists from torch define

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -4,9 +4,6 @@
 	path = "torch"
 	flags = MAP_HAS_BRANCH | MAP_HAS_RANK
 
-	station_levels = list(0,1,2,3,4,5)
-	contact_levels = list(0,1,2,3,4,5)
-	player_levels = list(0,1,2,3,4,5,8)
 	admin_levels = list(6,7)
 	empty_levels = list(8)
 	accessible_z_levels = list("0"=1,"1"=1,"2"=1,"3"=1,"4"=1,"5"=1,"8"=30)


### PR DESCRIPTION
They're populated by overmap object
Prevents some weirdness, like NTnet not hooking up.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
