### PR TITLE
Jacks up guaranteed gib threshold

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -58,7 +58,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			var/total_damage = brute_dam + burn_dam + brute + burn + spillover
 			var/threshold = max_damage * config.organ_health_multiplier
 			if(total_damage > threshold)
-				if(attempt_dismemberment(pure_brute, burn, edge, used_weapon, spillover, total_damage > threshold*3))
+				if(attempt_dismemberment(pure_brute, burn, edge, used_weapon, spillover, total_damage > threshold*6))
 					return
 
 	// High brute damage or sharp objects may damage internal organs


### PR DESCRIPTION
It seems that 'just hit head with baton until it splodes' is a thing now, unintended side-effect of fixing guaranteed gibs. Putting threshold for it into ridiculous damage values, where it belongs, use normal dismemberment chances before that.
