### PR TITLE
Adds Tile Items to the list of things Magnetic Grippers can pick up

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -25,7 +25,8 @@
 		/obj/item/weapon/computer_hardware,
 		/obj/item/weapon/fuel_assembly,
 		/obj/item/stack/material/deuterium,
-		/obj/item/stack/material/tritium
+		/obj/item/stack/material/tritium,
+		/obj/item/stack/tile
 		)
 
 	var/obj/item/wrapped = null // Item currently being held.


### PR DESCRIPTION
:cl: Textor
tweak: Lets engineering module and maint drones pick up floor tiles. They can now put the tiles they levered off the floor back.
/:cl: