### PR TITLE
Small changes for command consoles and tablets

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -71,7 +71,6 @@
 /obj/item/modular_computer/console/preset/command/install_default_programs()
 	..()
 	hard_drive.store_file(new/datum/computer_file/program/chatclient())
-	hard_drive.store_file(new/datum/computer_file/program/card_mod())
 	hard_drive.store_file(new/datum/computer_file/program/comm())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())

--- a/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
@@ -52,8 +52,6 @@
 /obj/item/modular_computer/tablet/lease/preset/command/install_default_programs()
 	..()
 	hard_drive.store_file(new/datum/computer_file/program/chatclient())
-	hard_drive.store_file(new/datum/computer_file/program/card_mod())
-	hard_drive.store_file(new/datum/computer_file/program/forceauthorization())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())
 	hard_drive.store_file(new/datum/computer_file/program/records())


### PR DESCRIPTION
Removed the ID program. Because among 12 command staff members only 2 can use it, they can download it if needed.
Removed weapon authorization program. Because it doesn't work on tablets.
:cl: Sbotkin
rscdel: Removed ID modification and weapon authorization tools from command computers.
/:cl:
