### PR TITLE
Removed peacekeeper armband from loadout

### DIFF
--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -66,11 +66,6 @@
 	path = /obj/item/clothing/accessory/armband/solgov/ma
 	allowed_roles = SECURITY_ROLES
 
-/datum/gear/accessory/armband_solgov
-	display_name = "peacekeeper armband"
-	path = /obj/item/clothing/accessory/armband/bluegold
-	allowed_roles = SOLGOV_ROLES
-
 /datum/gear/accessory/armband_security
 	allowed_roles = SECURITY_ROLES
 


### PR DESCRIPTION
:cl: Sbotkin
rscdel: Removed peacekeeper armband from loadout.
/:cl:

This is why: the purpose of armbands is to show your **current** assignment. Torch doesn't have billeted peacekeepers onboard, which only makes people who wears this violating uniform regulations. If you want to show your peacekeeping backstory, grab the ribbon.