### PR TITLE
Makes piping and cabling trip you in maintenance

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 
 #define OBJ_FLAG_ANCHORABLE              0x0001 // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE             0x0002 // Conducts electricity. (metal etc.)
+#define OBJ_FLAG_TRIPPABLE               0x0003 // Objects like piping on the ground that can cause a trip
 
 #define MOB_FLAG_HOLY_BAD                0x001  // If this mob is allergic to holiness
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -161,3 +161,22 @@
 
 /obj/is_fluid_pushable(var/amt)
 	return ..() && w_class <= round(amt/20)
+
+/obj/proc/trip_check(mob/user as mob)
+	for(var/obj/structure/catwalk/C in get_turf(src))
+		return FALSE
+	if(!ishuman(user) || !has_gravity(src) || user.resting || user.can_overcome_gravity() || user.move_intent.flags & MOVE_INTENT_DELIBERATE)
+		return FALSE
+	if(user.get_skill_value(SKILL_HAULING) >= SKILL_ADEPT)
+		return FALSE
+	return TRUE
+
+/obj/Crossed(mob/living/carbon/M as mob)
+	..()
+	if(obj_flags & OBJ_FLAG_TRIPPABLE)
+		if(prob(40) && trip_check(M))
+			M.apply_damage(5,BRUTE)
+			M.slip(src, 6)
+			M.visible_message(\
+				"<span class='warning'>[M] trips over \the [src]!</span>",\
+				"<span class='notice'>You trip over \the [src]!</span>")

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -17,6 +17,8 @@
 	buckle_lying = -1
 	var/datum/sound_token/sound_token
 
+	obj_flags = OBJ_FLAG_TRIPPABLE
+
 /obj/machinery/atmospherics/pipe/drain_power()
 	return -1
 
@@ -1432,6 +1434,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/update_underlays()
 	..()
 	update_icon()
+
+/obj/machinery/atmospherics/pipe/trip_check(mob/user as mob)
+	var/turf/T = src.loc
+	if(!T.is_plating())
+		return FALSE
+	if(initialize_directions & user.dir)
+		return FALSE
+	. = ..()
 
 /obj/machinery/atmospherics/proc/universal_underlays(var/obj/machinery/atmospherics/node, var/direction)
 	var/turf/T = loc

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -39,6 +39,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	color = COLOR_MAROON
 	var/obj/machinery/power/breakerbox/breaker_box
 
+	obj_flags = OBJ_FLAG_TRIPPABLE
+
 
 /obj/structure/cable/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -460,6 +462,14 @@ obj/structure/cable/proc/cableColor(var/colorC)
 				P.disconnect_from_network() //remove from current network
 
 	powernet = null // And finally null the powernet var.
+
+/obj/structure/cable/trip_check(mob/user as mob)
+	var/turf/T = src.loc
+	if(!T.is_plating())
+		return FALSE
+	if((user.dir == d1 || user.dir == d2))
+		return FALSE
+	. = ..()
 
 ///////////////////////////////////////////////
 // The cable coil object, used for laying cable

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -663,6 +663,8 @@
 	var/base_icon_state	// initial icon state on map
 	var/sortType = ""
 	var/subtype = 0
+
+	obj_flags = OBJ_FLAG_TRIPPABLE
 	// new pipe, set the icon_state as on map
 	New()
 		..()
@@ -958,6 +960,14 @@
 
 /obj/structure/disposalpipe/hides_under_flooring()
 	return 1
+
+/obj/structure/disposalpipe/trip_check(mob/user as mob)
+	var/turf/T = src.loc
+	if(!T.is_plating())
+		return FALSE
+	if(dpdir & user.dir)
+		return FALSE
+	. = ..()
 
 // *** TEST verb
 //client/verb/dispstop()


### PR DESCRIPTION
🆑 Cakey
tweak: Running over piping and cabling over plating can now trip you if your athletics skill is below trained.
/🆑

An attempt to hopefully bring more of an incentive to install overplating/stick to catwalks within maintenance V2.
Only affects you if the piping/wiring is over plating, so shouldn't affect engineering rooms.