### PR TITLE
Parrying fix & tweak

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -487,8 +487,11 @@ var/list/global/slot_flags_enumeration = list(
 //For non-projectile attacks this usually means the attack is blocked.
 //Otherwise should return 0 to indicate that the attack is not affected in any way.
 /obj/item/proc/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	if(get_parry_chance(user))
-		if(default_parry_check(user, attacker, damage_source) && prob(get_parry_chance()))
+	var/parry_chance = get_parry_chance(user)
+	if(attacker)	
+		parry_chance = max(0, parry_chance - 10 * attacker.get_skill_difference(SKILL_COMBAT, user))
+	if(parry_chance)
+		if(default_parry_check(user, attacker, damage_source) && prob(parry_chance))
 			user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 			playsound(user.loc, 'sound/weapons/punchmiss.ogg', 50, 1)
 			on_parry()
@@ -501,7 +504,8 @@ var/list/global/slot_flags_enumeration = list(
 /obj/item/proc/get_parry_chance(mob/user)
 	. = base_parry_chance
 	if(user)
-		. += 15 * (user.get_skill_value(SKILL_COMBAT) - SKILL_BASIC)
+		if(base_parry_chance || user.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+			. += 10 * (user.get_skill_value(SKILL_COMBAT) - SKILL_BASIC)
 
 /obj/item/proc/get_loc_turf()
 	var/atom/L = loc

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -12,6 +12,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 2)
 	attack_verb = list("beaten")
+	base_parry_chance = 30
 	var/stunforce = 0
 	var/agonyforce = 30
 	var/status = 0		//whether the thing is on or not


### PR DESCRIPTION
Fixes parrying chance not actually taking skill in account.
Locked parry-with-anything behind Trained skill.
Parry chance now is also affected by skill difference between you and attacker.
Gave stunbatons smol parry chance.
