### PR TITLE
Adds "All" Buttons to Antag Role Selection

### DIFF
--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -76,14 +76,14 @@
 
 /datum/category_item/player_setup_item/antagonism/candidacy/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["add_special"])
-		if(!(href_list["add_special"] in valid_special_roles()))
+		if(!(href_list["add_special"] in valid_special_roles(FALSE)))
 			return TOPIC_HANDLED
 		pref.be_special_role |= href_list["add_special"]
 		pref.never_be_special_role -= href_list["add_special"]
 		return TOPIC_REFRESH
 
 	if(href_list["del_special"])
-		if(!(href_list["del_special"] in valid_special_roles()))
+		if(!(href_list["del_special"] in valid_special_roles(FALSE)))
 			return TOPIC_HANDLED
 		pref.be_special_role -= href_list["del_special"]
 		pref.never_be_special_role -= href_list["del_special"]
@@ -119,8 +119,9 @@
 	for(var/antag_type in GLOB.all_antag_types_)
 		if(!include_bans)
 			if(jobban_isbanned(preference_mob(), antag_type))
-				if(((antag_type  == MODE_MALFUNCTION) && jobban_isbanned(preference_mob(), "AI")))
-					continue
+				continue
+			if(((antag_type  == MODE_MALFUNCTION) && jobban_isbanned(preference_mob(), "AI")))
+				continue
 		private_valid_special_roles += antag_type
 
 	var/list/ghost_traps = get_ghost_traps()

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -96,14 +96,9 @@
 
 	if(href_list["select_all"])		
 		var/selection = text2num(href_list["select_all"])
-		var/list/roles = valid_special_roles()
-		var/list/allowed_roles = list()
+		var/list/roles = valid_special_roles(FALSE)
 
-		for(var/role in roles)
-			if(!jobban_isbanned(preference_mob(), role))
-				if(!((role  == MODE_MALFUNCTION) && jobban_isbanned(preference_mob(), "AI")))
-					allowed_roles += role
-		for(var/id in allowed_roles)
+		for(var/id in roles)
 			switch(selection)
 				if(0)
 					pref.be_special_role -= id
@@ -118,10 +113,14 @@
 
 	return ..()
 
-/datum/category_item/player_setup_item/antagonism/candidacy/proc/valid_special_roles()
+/datum/category_item/player_setup_item/antagonism/candidacy/proc/valid_special_roles(var/include_bans = TRUE)
 	var/list/private_valid_special_roles = list()
 
 	for(var/antag_type in GLOB.all_antag_types_)
+		if(!include_bans)
+			if(jobban_isbanned(preference_mob(), antag_type))
+				if(((antag_type  == MODE_MALFUNCTION) && jobban_isbanned(preference_mob(), "AI")))
+					continue
 		private_valid_special_roles += antag_type
 
 	var/list/ghost_traps = get_ghost_traps()
@@ -129,7 +128,11 @@
 		var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
 		if(!ghost_trap.list_as_special_role)
 			continue
+		if(!include_bans)
+			if(banned_from_ghost_role(preference_mob(), ghost_trap))		
+				continue
 		private_valid_special_roles += ghost_trap.pref_check
+
 
 	return private_valid_special_roles
 

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -64,6 +64,7 @@
 		else
 			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
 		. += "</td></tr>"
+	. += "<tr><td>Select All: </td><td><a href='?src=\ref[src];select_all=2'>High</a> <a href='?src=\ref[src];select_all=1'>Low</a> <a href='?src=\ref[src];select_all=0'>Never</a></td></tr>"
 	. += "</table>"
 	. = jointext(.,null)
 
@@ -91,6 +92,34 @@
 	if(href_list["add_never"])
 		pref.be_special_role -= href_list["add_never"]
 		pref.never_be_special_role |= href_list["add_never"]
+		return TOPIC_REFRESH
+
+	if(href_list["select_all"])		
+		var/selection = text2num(href_list["select_all"])
+		var/list/all_antag_types = GLOB.all_antag_types_
+		var/list/antag_list = list()
+		for(var/antag_type in all_antag_types)
+			var/datum/antagonist/antag = all_antag_types[antag_type]
+			if((antag.id in valid_special_roles())&&(!jobban_isbanned(preference_mob(), antag.id)))
+				if(!(antag.id == MODE_MALFUNCTION && jobban_isbanned(preference_mob(), "AI")))
+					antag_list += antag.id
+		var/list/ghost_traps = get_ghost_traps()
+		for(var/ghost_trap_key in ghost_traps)
+			var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
+			if(ghost_trap.list_as_special_role && (!banned_from_ghost_role(preference_mob(), ghost_trap)))
+				antag_list += ghost_trap.pref_check
+
+		for(var/id in antag_list)
+			switch(selection)
+				if(0)
+					pref.be_special_role -= id
+					pref.never_be_special_role |= id					
+				if(1)
+					pref.be_special_role -= id
+					pref.never_be_special_role -= id					
+				if(2)					
+					pref.be_special_role |= id
+					pref.never_be_special_role -= id
 		return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -96,20 +96,14 @@
 
 	if(href_list["select_all"])		
 		var/selection = text2num(href_list["select_all"])
-		var/list/all_antag_types = GLOB.all_antag_types_
-		var/list/antag_list = list()
-		for(var/antag_type in all_antag_types)
-			var/datum/antagonist/antag = all_antag_types[antag_type]
-			if((antag.id in valid_special_roles())&&(!jobban_isbanned(preference_mob(), antag.id)))
-				if(!(antag.id == MODE_MALFUNCTION && jobban_isbanned(preference_mob(), "AI")))
-					antag_list += antag.id
-		var/list/ghost_traps = get_ghost_traps()
-		for(var/ghost_trap_key in ghost_traps)
-			var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
-			if(ghost_trap.list_as_special_role && (!banned_from_ghost_role(preference_mob(), ghost_trap)))
-				antag_list += ghost_trap.pref_check
+		var/list/roles = valid_special_roles()
+		var/list/allowed_roles = list()
 
-		for(var/id in antag_list)
+		for(var/role in roles)
+			if(!jobban_isbanned(preference_mob(), role))
+				if(!((role  == MODE_MALFUNCTION) && jobban_isbanned(preference_mob(), "AI")))
+					allowed_roles += role
+		for(var/id in allowed_roles)
 			switch(selection)
 				if(0)
 					pref.be_special_role -= id


### PR DESCRIPTION
:cl: Textor
rscadd: Adds buttons to allow selecting "high," "low," or "never" on all antag roles with a single click.
/:cl:

Because screenshots are nice:
![image](https://user-images.githubusercontent.com/12721324/46496954-20a9f600-c7ce-11e8-9d2b-73471206f5c2.png)
