### PR TITLE
Fixes a bunch of runtime errors.

### DIFF
--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -58,3 +58,6 @@ SUBSYSTEM_DEF(chemistry)
 
 /datum/controller/subsystem/chemistry/proc/mark_for_update(var/datum/reagents/holder)
 	active_holders[holder] = TRUE
+
+/datum/controller/subsystem/chemistry/proc/unmark_for_update(var/datum/reagents/holder)
+	active_holders -= holder

--- a/code/modules/augment/passive/boost.dm
+++ b/code/modules/augment/passive/boost.dm
@@ -57,6 +57,8 @@
 
 /obj/item/organ/internal/augment/boost/Process()
 	..()
+	if(!owner)
+		return
 	if(is_broken() && !debuffing)
 		debuff()
 	else if(!is_broken() && debuffing)

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -76,6 +76,7 @@ obj/item/var/list/trace_DNA
 	return 1
 
 /atom/proc/add_partial_print(full_print, bonus)
+	LAZYINITLIST(fingerprints)
 	if(!fingerprints[full_print])
 		fingerprints[full_print] = stars(full_print, rand(0 + bonus, 20 + bonus))	//Initial touch, not leaving much evidence the first time.
 	else
@@ -119,7 +120,7 @@ obj/item/var/list/trace_DNA
 	if(suit_fibers)
 		LAZYDISTINCTADD(A.suit_fibers, suit_fibers)
 	if(blood_DNA)
-		A.blood_DNA |= blood_DNA
+		LAZYDISTINCTADD(A.blood_DNA, blood_DNA)
 	if(gunshot_residue)
 		var/obj/item/clothing/C = A
 		LAZYDISTINCTADD(C.gunshot_residue, gunshot_residue)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -15,7 +15,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 
 /datum/reagents/Destroy()
 	. = ..()
-
+	SSchemistry.unmark_for_update(src) // While marking for reactions should be avoided just before deleting if possible, the async nature means it might be impossible.
 	QDEL_NULL_LIST(reagent_list)
 	my_atom = null
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 12 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 45 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 636 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 635 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 25 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
Fixes #23350
Fixes #23000
Fixes #22775
Fixes #22374
Fixes #21588
Fixes #16766

Fixes #23330
Fixes #23048
Fixes #23030
Fixes #21941
Fixes #21589

Fixes #23380

Also should remove remaining chemistry debug messages by removing deleted reagent holders from the SS on `Destroy()`. I did some testing, and at least most of them appear to be caused by real async issues (queue, up, wait a bit, destroy, try to process).