### PR TITLE
Fixes the microphone circuit

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -887,7 +887,7 @@
 
 	push_data()
 	activate_pin(1)
-	if(translated)
+	if(translated && !(speaking.name == LANGUAGE_GALCOM))
 		activate_pin(2)
 
 /obj/item/integrated_circuit/input/sensor


### PR DESCRIPTION
>This will automatically translate most languages it hears to Galactic Common. The first activation pin is always pulsed when the circuit hears someone talk, while the second one is only triggered if it hears someone speaking a language other than Galactic Common.

:cl: Sbotkin
bugfix: The microphone circuit now translates non-GalCom languages only.
/:cl: