### PR TITLE
Atmospheric pump efficiency rebalance

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -73,13 +73,13 @@ var/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,"Secret
  *	Atmospherics Machinery.
 */
 #define MAX_SIPHON_FLOWRATE   2500 // L/s. This can be used to balance how fast a room is siphoned. Anything higher than CELL_VOLUME has no effect.
-#define MAX_SCRUBBER_FLOWRATE 200  // L/s. Max flow rate when scrubbing from a turf.
+#define MAX_SCRUBBER_FLOWRATE 750  // L/s. Max flow rate when scrubbing from a turf.
 
 // These balance how easy or hard it is to create huge pressure gradients with pumps and filters.
 // Lower values means it takes longer to create large pressures differences.
 // Has no effect on pumping gasses from high pressure to low, only from low to high.
-#define ATMOS_PUMP_EFFICIENCY   2.5
-#define ATMOS_FILTER_EFFICIENCY 2.5
+#define ATMOS_PUMP_EFFICIENCY   3.5
+#define ATMOS_FILTER_EFFICIENCY 4.5
 
 // Will not bother pumping or filtering if the gas source as fewer than this amount of moles, to help with performance.
 #define MINIMUM_MOLES_TO_PUMP   0.01

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -11,7 +11,7 @@
 
 	use_power = 0
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 15000	//15000 W ~ 20 HP
+	power_rating = 30000	//30000 W ~ 40 HP -- yeah that's a lot of power
 
 	var/injecting = 0
 
@@ -25,7 +25,7 @@
 
 /obj/machinery/atmospherics/unary/outlet_injector/New()
 	..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
+	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 1000	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
 
 /obj/machinery/atmospherics/unary/outlet_injector/update_icon()
 	if(!powered())


### PR DESCRIPTION
🆑
balance: Increased atmospheric pump efficiency, and atmospheric filter efficiencies. Pipe wizards rejoice!
balance: Increased air injector internal tank size as well as power cap. this increases its flow rate due to how atmospheric devices perform their math. Pipe wizards rejoice!
/🆑

**Due to the deep and lasting mechanical changes that these changes can have, I would recommend test merge rounds to see to exactly what extent things are affected. I've done some testing here and there, tweaking as I could, but there will be cases that I wasn't counting on.** 

The torch is a big map. A really big map. Atmospherics is honestly too weak to properly handle the ship with any semblance of efficiency without doing quite a few atmospheric optimizations, and even then, it's only "eh".

I've dug into the atmospheric system and tried, to the best of my ability, to understand what is going on. As it turns out, the reason for the unrobustness is as follows.

The way that the atmospheric system works, is through the use of a pump_gas proc, which doesn't only move gas, but calculates the **power** required to move them. Power is calculated from a few factors, but for this post, we'll focus on the big one: pressure difference, or ΔP (delta P).

Devices have two factors as well that we need to keep in mind.

- The first is a hard flow rate limit. No matter what you do, the devices cannot pump faster than this.
- The second is a power limit. All atmos devices not only consume power, but they also have an upper power LIMIT. When this power limit is hit, pump volume is reduced.

Now, to bring it all together:

When pumping from a high pressure, to a low pressure, we can think of the ΔP being negative for the purposes of this post. Negative ΔP costs NO power when pumping gas (passive operation). This results in devices slamming against hard limits as long as the ΔP remains negative.

When pumping from a low pressure to a high pressure, we can think of this being a positive ΔP. This consumes power, and there are TWO factors limiting how quickly this occurs, as illustrated above. The hard limit, and the **power limit**.

**It is this power limit that was causing problems.** pump_gas very quickly ramps up the power utilization with even moderate pressure differences of a few hundred kPa. This quickly lowered the throughput of pumps, and the ones that particularly suffered were the air injectors inside the atmospheric tanks.

What I have done is changed three things:

Increased hard limit on scrubber mode by ~3x. It was 1/10th the power of siphon mode. That's really bad... Now it's high enough to be reasonable. I wanted to push it higher, but there's such deep running implications to this, that I felt it would be better to give things a test, and tweak more later.

Increased internal tanks on air injectors, as well as doubled their maximum power draw. The internal tank change was needed because it also increases the amount it can inject per tick, as it only draws from said internal tank... not the pipenet it's attached to.

The BIG change: there are two defines.
ATMOS_PUMP_EFFICIENCY
ATMOS_FILTER_EFFICIENCY

pump_gas uses these as a modifier to determine power use. Higher means less power use. Filter Efficiency has been almost doubled (it might still be too low IMO, but again... can tweak more later, I want to see how things work for now and work from there). Pump efficiency increased by almost 50%.

Now, as a result, pumps can pump substantially higher pressures before hitting those power limits. I was aiming for more than enough to handle the torch defaults plus a little more. A few atmospheric optimizations made by competent engineers will make atmospherics quite respectable now, too. 

Note that fires and such are still quite powerful. It just shouldn't take 2+ hours to clean up anymore (though, if people learn to use fire extinguishers more to cool air, that will help). The main reason why fires are *still* powerful, is because they will back up atmos quite fast. Remember that ΔP from earlier? Scrubbers are subject to it too. If atmos backs up, the waste line backs up, and scrubbers become ineffective.

I intend to, in a future PR, map in an atmospheric "waste" tank that the thrusters in engineering will use (the black pipes). Any types of unique gasses, like water vapor, that doesn't have an atmos tank specifically for storing them will go into this waste tank. This tank will feature an emergency dump control that basically opens a blast door to space, allowing very fast purging of the atmos piping with the flip of a few buttons. This makes it very capable as another means of venting the ship in the hands of a very experienced atmos tech (scrubbers > waste > atmosperhics > pumping to black piping > waste tank > space). Until this waste tank change is made and tested, I don't want to do any more tweaks to atmos, as it might become too powerful.

EDIT: 

I forgot to mention. One major change this brings is the way the SM engine works. This is an expected, but still an unintended consequence. It's cooling much more efficiently. It does not mean that the EER to running temperature has changed (meaning, it doesn't lower the temperature for a given EER, all other factors the same and given enough time to equalize), but it does take **much longer** for temps to cap out.

This is both a blessing and a curse: experienced engine techs could ramp up the engine EER to an obscene value during startup for that initial power burst and get things charged, before having to let it de-energize before it overheats. At the same time, an unfortunate event, such as a power grid failure, can result in severe engine damage **very** quickly if the engine room looses power at high EER.

Note: this *might* have increased power generation output, though. I am not 100% sure. This is probably the single item from this PR that needs to be examined in fine detail; we can always change the SM heat output and lower teg efficiency to compensate if needed.