### PR TITLE
Suit sensors start on vital settings by default

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -720,6 +720,8 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/New()
 	..()
+	if(has_sensor == SUIT_HAS_SENSORS)
+		sensor_mode = SUIT_SENSOR_VITAL
 	update_rolldown_status()
 	update_rollsleeves_status()
 	if(rolled_down == -1)


### PR DESCRIPTION
🆑Roland410
tweak: All eligible jumpsuits (non-locked and sensor equipped) start with their sensors on vitals. You can still disable or lower them if you wish.
/🆑
Not much else to say, this is mainly a medical QoL, everything functions as before, disabling, etc.