### PR TITLE
Adds character setup SS to handle init order for character setup.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -190,6 +190,7 @@
 #include "code\controllers\subsystems\trade.dm"
 #include "code\controllers\subsystems\wireless.dm"
 #include "code\controllers\subsystems\xenoarch.dm"
+#include "code\controllers\subsystems\initialization\character_setup.dm"
 #include "code\controllers\subsystems\initialization\codex.dm"
 #include "code\controllers\subsystems\initialization\culture.dm"
 #include "code\controllers\subsystems\initialization\materials.dm"

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -43,12 +43,13 @@
 // Subsystems shutdown in the reverse of the order they initialize in
 // The numbers just define the ordering, they are meaningless otherwise.
 
-#define SS_INIT_GARBAGE          12
-#define SS_INIT_CHEMISTRY        11
-#define SS_INIT_MATERIALS        10
-#define SS_INIT_PLANTS           9
-#define SS_INIT_ANTAGS           8
-#define SS_INIT_CULTURE          7
+#define SS_INIT_GARBAGE          13
+#define SS_INIT_CHEMISTRY        12
+#define SS_INIT_MATERIALS        11
+#define SS_INIT_PLANTS           10
+#define SS_INIT_ANTAGS           9
+#define SS_INIT_CULTURE          8
+#define SS_INIT_CHAR_SETUP       7
 #define SS_INIT_SKYBOX           6
 #define SS_INIT_MAPPING          5
 #define SS_INIT_CIRCUIT          4

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -43,6 +43,8 @@
 			return global.SSantags;
 		if("SSatoms")
 			return global.SSatoms;
+		if("SScharacter_setup")
+			return global.SScharacter_setup;
 		if("SSchemistry")
 			return global.SSchemistry;
 		if("SScircuit")
@@ -87,6 +89,8 @@
 			return global.SSopen_space;
 		if("SSpersistence")
 			return global.SSpersistence;
+		if("SSplants")
+			return global.SSplants;
 		if("SSprocessing")
 			return global.SSprocessing;
 		if("SSradiation")
@@ -685,8 +689,6 @@
 			return global.powerinstances;
 		if("powers")
 			return global.powers;
-		if("preferences_datums")
-			return global.preferences_datums;
 		if("priority_air_alarms")
 			return global.priority_air_alarms;
 		if("priority_announcement")
@@ -1026,6 +1028,8 @@
 			global.SSantags=newval;
 		if("SSatoms")
 			global.SSatoms=newval;
+		if("SScharacter_setup")
+			global.SScharacter_setup=newval;
 		if("SSchemistry")
 			global.SSchemistry=newval;
 		if("SScircuit")
@@ -1070,6 +1074,8 @@
 			global.SSopen_space=newval;
 		if("SSpersistence")
 			global.SSpersistence=newval;
+		if("SSplants")
+			global.SSplants=newval;
 		if("SSprocessing")
 			global.SSprocessing=newval;
 		if("SSradiation")
@@ -1668,8 +1674,6 @@
 			global.powerinstances=newval;
 		if("powers")
 			global.powers=newval;
-		if("preferences_datums")
-			global.preferences_datums=newval;
 		if("priority_air_alarms")
 			global.priority_air_alarms=newval;
 		if("priority_announcement")
@@ -1987,6 +1991,7 @@
 	"SSalarm",
 	"SSantags",
 	"SSatoms",
+	"SScharacter_setup",
 	"SSchemistry",
 	"SScircuit",
 	"SScodex",
@@ -2009,6 +2014,7 @@
 	"SSobj",
 	"SSopen_space",
 	"SSpersistence",
+	"SSplants",
 	"SSprocessing",
 	"SSradiation",
 	"SSshuttle",
@@ -2308,7 +2314,6 @@
 	"power_alarm",
 	"powerinstances",
 	"powers",
-	"preferences_datums",
 	"priority_air_alarms",
 	"priority_announcement",
 	"priv_all_access",

--- a/code/controllers/subsystems/initialization/character_setup.dm
+++ b/code/controllers/subsystems/initialization/character_setup.dm
@@ -1,0 +1,14 @@
+SUBSYSTEM_DEF(character_setup)
+	name = "Character Setup"
+	init_order = SS_INIT_CHAR_SETUP
+	flags = SS_NO_FIRE
+
+	var/list/prefs_awaiting_setup = list()
+	var/list/preferences_datums = list()
+
+/datum/controller/subsystem/character_setup/Initialize()
+	while(prefs_awaiting_setup.len)
+		var/datum/preferences/prefs = prefs_awaiting_setup[prefs_awaiting_setup.len]
+		prefs_awaiting_setup.len--
+		prefs.setup()
+	. = ..()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -544,7 +544,7 @@ var/list/admin_verbs_mentor = list(
 	var/datum/preferences/D
 	var/client/C = GLOB.ckey_directory[warned_ckey]
 	if(C)	D = C.prefs
-	else	D = preferences_datums[warned_ckey]
+	else	D = SScharacter_setup.preferences_datums[warned_ckey]
 
 	if(!D)
 		to_chat(src, "<font color='red'>Error: warn(): No such ckey found.</font>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -441,7 +441,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	else
 		new_character.gender = pick(MALE,FEMALE)
 		var/datum/preferences/A = new()
-		A.sanitize_preferences()
+		A.setup()
 		A.randomize_appearance_and_body_for(new_character)
 		new_character.real_name = G_found.real_name
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -149,16 +149,14 @@
 		holder.owner = src
 
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)
-	prefs = preferences_datums[ckey]
+	prefs = SScharacter_setup.preferences_datums[ckey]
 	if(!prefs)
 		prefs = new /datum/preferences(src)
-		preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
 	apply_fps(prefs.clientfps)
 
 	. = ..()	//calls mob.Login()
-	prefs.sanitize_preferences()
 
 	GLOB.using_map.map_info(src)
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1,7 +1,5 @@
 #define SAVE_RESET -1
 
-var/list/preferences_datums = list()
-
 datum/preferences
 	//doohickeys for savefiles
 	var/path
@@ -29,6 +27,17 @@ datum/preferences
 	var/datum/browser/panel
 
 /datum/preferences/New(client/C)
+	if(istype(C))
+		client = C
+		client_ckey = C.ckey
+		SScharacter_setup.preferences_datums += src
+		if(SScharacter_setup.initialized)
+			setup()
+		else
+			SScharacter_setup.prefs_awaiting_setup += src
+	..()
+
+/datum/preferences/proc/setup()
 	if(!length(GLOB.skills))
 		decls_repository.get_decl(/decl/hierarchy/skill)
 	player_setup = new(src)
@@ -36,13 +45,11 @@ datum/preferences
 	real_name = random_name(gender,species)
 	b_type = RANDOM_BLOOD_TYPE
 
-	if(istype(C))
-		client = C
-		client_ckey = C.ckey
-		if(!IsGuestKey(C.key))
-			load_path(C.ckey)
-			load_preferences()
-			load_and_update_character()
+	if(client && !IsGuestKey(client.key))
+		load_path(client.ckey)
+		load_preferences()
+		load_and_update_character()
+	sanitize_preferences()
 
 /datum/preferences/proc/load_and_update_character(var/slot)
 	load_character(slot)
@@ -51,7 +58,10 @@ datum/preferences
 		save_character()
 
 /datum/preferences/proc/ShowChoices(mob/user)
-	if(!user || !user.client)	return
+	if(!SScharacter_setup.initialized)
+		return
+	if(!user || !user.client)
+		return
 
 	if(!get_mob_by_key(client_ckey))
 		to_chat(user, "<span class='danger'>No mob exists for the given client!</span>")

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -242,7 +242,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '9e9d4150b1f942b17b9139bbd476c73f *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '1c0968e5324f78d2eb6663a9c8400e13 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Fixes #23213
Fixes #23146

There are several issues (will see if I can find other runtimes) caused by unpredictable init order involving preferences. This blocks the character setup window from opening until sufficient init has occured.

Note that this inits quite early, so user impact will be minimal.