### PR TITLE
Fix floor slips

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -109,7 +109,7 @@
 
 		if(src.wet)
 
-			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(wet/10))) ) )
+			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(16/wet))) ) )
 				return
 
 			var/slip_dist = 1


### PR DESCRIPTION
:cl: Atebite
bugfix: Fixed less wet floors increasing slip chance. Mopped floors should now only have a 50% chance of slipping you.
/:cl:

Not sure if anyone knew this was a bug, but less wet floors would increase the slip chance. Mopping floors would give a 100% slip chance, while lubing would only give a 12.5% chance of slipping.

I also rebalanced it with mopping in mind. Slip chance for mopped floors should be 50% now. Lube and wizard spells should give 100% slip chance considering how ridiculously wet they make floors.