### PR TITLE
Add icon updates changes and overlay system

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -123,7 +123,7 @@
 
 #define CanPhysicallyInteractWith(user, target) CanInteractWith(user, target, GLOB.physical_state)
 
-#define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) } ; x = null }
+#define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) } ; x.Cut(); x = null }
 
 #define QDEL_NULL(x) if(x) { qdel(x) ; x = null }
 

--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -95,7 +95,7 @@
 		ability.maptext = "[i]" // Slot number
 		i++
 
-/obj/screen/movable/ability_master/update_icon()
+/obj/screen/movable/ability_master/on_update_icon()
 	if(ability_objects.len)
 		set_invisibility(0)
 	else
@@ -188,7 +188,7 @@
 	ability_master = null
 	return ..()
 
-/obj/screen/ability/update_icon()
+/obj/screen/ability/on_update_icon()
 	overlays.Cut()
 	icon_state = "[background_base_state]_spell_base"
 
@@ -398,7 +398,7 @@
 	if(spell.silenced)
 		overlays += "silence"
 
-/obj/screen/ability/spell/update_icon(var/forced = 0)
+/obj/screen/ability/spell/on_update_icon(var/forced = 0)
 	update_charge(forced)
 	return
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -155,7 +155,7 @@
 	if(old_selecting != selecting)
 		update_icon()
 
-/obj/screen/zone_sel/update_icon()
+/obj/screen/zone_sel/on_update_icon()
 	overlays.Cut()
 	overlays += image('icons/mob/zone_sel.dmi', "[selecting]")
 
@@ -181,7 +181,7 @@
 	update_icon()
 	usr.a_intent = intent
 
-/obj/screen/intent/update_icon()
+/obj/screen/intent/on_update_icon()
 	icon_state = "intent_[intent]"
 
 /obj/screen/Click(location, control, params)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -162,7 +162,7 @@ var/const/tk_maxrange = 15
 		qdel(O)
 	return
 
-/obj/item/tk_grab/update_icon()
+/obj/item/tk_grab/on_update_icon()
 	overlays.Cut()
 	if(focus && focus.icon && focus.icon_state)
 		overlays += icon(focus.icon,focus.icon_state)

--- a/code/controllers/subsystems/open_space.dm
+++ b/code/controllers/subsystems/open_space.dm
@@ -74,7 +74,7 @@ SUBSYSTEM_DEF(open_space)
 	SSopen_space.add_turf(src)
 
 
-/obj/update_icon()
+/obj/on_update_icon()
 	. = ..()
 	if(!invisibility && isturf(loc))
 		var/turf/T = GetAbove(src)

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -107,7 +107,7 @@
 	playsound(loc, "sparks", 50, 1)
 	visible_message("<span class='warning'>\The [src] shuts down with a spark.</span>")
 
-/obj/item/device/uplink_service/update_icon()
+/obj/item/device/uplink_service/on_update_icon()
 	switch(state)
 		if(AWAITING_ACTIVATION)
 			icon_state = initial(icon_state)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -73,9 +73,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT
 	ambience = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/main.ogg','sound/music/traitor.ogg')
 
-/area/space/update_icon()
-	return
-
 area/space/atmosalert()
 	return
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -160,7 +160,7 @@
 					D.open()
 	return
 
-/area/update_icon()
+/area/on_update_icon()
 	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.
 		if(fire && !eject && !party)
 			icon_state = "blue"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -235,7 +235,7 @@ its easier to just keep the beam vertical.
 /atom/proc/examine(mob/user, var/distance = -1, var/infix = "", var/suffix = "")
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
 	var/f_name = "\a [src][infix]."
-	if(src.blood_DNA && !istype(src, /obj/effect/decal))
+	if(blood_DNA && !istype(src, /obj/effect/decal))
 		if(gender == PLURAL)
 			f_name = "some "
 		else
@@ -272,6 +272,9 @@ its easier to just keep the beam vertical.
 		icon_state = new_icon_state
 
 /atom/proc/update_icon()
+	on_update_icon(arglist(args))
+
+/atom/proc/on_update_icon()
 	return
 
 /atom/proc/ex_act()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -19,7 +19,7 @@
 	blood = nblood
 	update_icon()
 
-/obj/effect/rune/update_icon()
+/obj/effect/rune/on_update_icon()
 	overlays.Cut()
 	if(GLOB.cult.rune_strokes[type])
 		var/list/f = GLOB.cult.rune_strokes[type]

--- a/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 
-/obj/singularity/narsie/large/exit/update_icon()
+/obj/singularity/narsie/large/exit/on_update_icon()
 	overlays = 0
 
 /obj/singularity/narsie/large/exit/Process()

--- a/code/game/gamemodes/godmode/form_items/starlight_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_structures.dm
@@ -151,7 +151,7 @@
 	var/charge = 0
 	var/charging = 0 //Charging, dispersing, etc.
 
-/obj/structure/deity/radiant_statue/update_icon()
+/obj/structure/deity/radiant_statue/on_update_icon()
 	if(charging)
 		icon_state = "statue_charging"
 	else if(charge)

--- a/code/game/gamemodes/godmode/god_altar.dm
+++ b/code/game/gamemodes/godmode/god_altar.dm
@@ -91,7 +91,7 @@
 			M.adjustHalLoss(30)
 		return TOPIC_REFRESH
 
-/obj/structure/deity/altar/update_icon()
+/obj/structure/deity/altar/on_update_icon()
 	overlays.Cut()
 	if(target)
 		overlays += image('icons/effects/effects.dmi', icon_state =  "summoning")

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -73,7 +73,7 @@
 	else
 		beeping--
 
-/obj/item/weapon/pinpointer/update_icon()
+/obj/item/weapon/pinpointer/on_update_icon()
 	overlays.Cut()
 	if(!active)
 		return

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -61,7 +61,7 @@
 	if(iscarbon(occupant) && stasis > 1)
 		occupant.SetStasis(stasis)
 
-/obj/machinery/sleeper/update_icon()
+/obj/machinery/sleeper/on_update_icon()
 	icon_state = "sleeper_[occupant ? "1" : "0"]"
 
 /obj/machinery/sleeper/attack_hand(var/mob/user)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -188,7 +188,7 @@
 
 
 
-/obj/machinery/body_scanconsole/update_icon()
+/obj/machinery/body_scanconsole/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "body_scannerconsole-p"
 	else if (stat & NOPOWER)

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -19,7 +19,7 @@
 	..()
 	update_icon()
 
-/obj/machinery/ai_slipper/update_icon()
+/obj/machinery/ai_slipper/on_update_icon()
 	if (stat & NOPOWER || stat & BROKEN)
 		icon_state = "motion0"
 	else

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -304,7 +304,7 @@
 		return 1
 	return 0
 
-/obj/machinery/alarm/update_icon()
+/obj/machinery/alarm/on_update_icon()
 	if(wiresexposed)
 		icon_state = "alarmx"
 		set_light(0)
@@ -901,7 +901,7 @@ FIRE ALARM
 	. = ..()
 	update_icon()
 
-/obj/machinery/firealarm/update_icon()
+/obj/machinery/firealarm/on_update_icon()
 	overlays.Cut()
 
 	pixel_x = 0

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -23,7 +23,7 @@
 
 	var/datum/radio_frequency/radio_connection
 
-/obj/machinery/air_sensor/update_icon()
+/obj/machinery/air_sensor/on_update_icon()
 	icon_state = "gsensor[on]"
 
 /obj/machinery/air_sensor/Process()

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -135,7 +135,7 @@
 	else
 		return 0
 
-/obj/machinery/portable_atmospherics/canister/update_icon()
+/obj/machinery/portable_atmospherics/canister/on_update_icon()
 /*
 update_flag
 1 = holding

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -49,7 +49,7 @@
 /obj/machinery/portable_atmospherics/proc/MolesForPressure(var/target_pressure = start_pressure)
 	return (target_pressure * air_contents.volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
-/obj/machinery/portable_atmospherics/update_icon()
+/obj/machinery/portable_atmospherics/on_update_icon()
 	return null
 
 /obj/machinery/portable_atmospherics/proc/connect(obj/machinery/atmospherics/portables_connector/new_port)

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -28,7 +28,7 @@
 	var/list/air_mix = StandardAirMix()
 	src.air_contents.adjust_multi("oxygen", air_mix["oxygen"], "nitrogen", air_mix["nitrogen"])
 
-/obj/machinery/portable_atmospherics/powered/pump/update_icon()
+/obj/machinery/portable_atmospherics/powered/pump/on_update_icon()
 	src.overlays = 0
 
 	if(on && cell && cell.charge)

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -43,7 +43,7 @@
 
 	..(severity)
 
-/obj/machinery/portable_atmospherics/powered/scrubber/update_icon()
+/obj/machinery/portable_atmospherics/powered/scrubber/on_update_icon()
 	src.overlays = 0
 
 	if(on && cell && cell.charge)
@@ -176,7 +176,7 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/attack_hand(var/mob/user as mob)
 		to_chat(usr, "<span class='notice'>You can't directly interact with this machine. Use the scrubber control console.</span>")
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/update_icon()
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/on_update_icon()
 	src.overlays = 0
 
 	if(on && !(stat & (NOPOWER|BROKEN)))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -288,7 +288,7 @@
 	if(. == TOPIC_REFRESH)
 		interact(user)
 
-/obj/machinery/autolathe/update_icon()
+/obj/machinery/autolathe/on_update_icon()
 	icon_state = (panel_open ? "autolathe_t" : "autolathe")
 
 //Updates overall lathe storage size.

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -60,7 +60,7 @@
 /obj/machinery/biogenerator/on_reagent_change()			//When the reagents change, change the icon as well.
 	update_icon()
 
-/obj/machinery/biogenerator/update_icon()
+/obj/machinery/biogenerator/on_update_icon()
 	if(state == BG_NO_BEAKER)
 		icon_state = "biogen-empty"
 	else if(state == BG_READY || state == BG_COMPLETE)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -31,7 +31,7 @@
 		return
 	return ..()
 
-/obj/machinery/organ_printer/update_icon()
+/obj/machinery/organ_printer/on_update_icon()
 	overlays.Cut()
 	if(panel_open)
 		overlays += "bioprinter_panel_open"

--- a/code/game/machinery/bluespacerelay.dm
+++ b/code/game/machinery/bluespacerelay.dm
@@ -17,7 +17,7 @@
 	update_icon()
 
 
-/obj/machinery/bluespacerelay/update_icon()
+/obj/machinery/bluespacerelay/on_update_icon()
 	if(on)
 		icon_state = initial(icon_state)
 	else

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -50,7 +50,7 @@
 	update_icon()
 	operating = 0
 
-/obj/machinery/button/update_icon()
+/obj/machinery/button/on_update_icon()
 	if(active)
 		icon_state = "launcheract"
 	else
@@ -61,7 +61,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light0"
 
-/obj/machinery/button/switch/update_icon()
+/obj/machinery/button/switch/on_update_icon()
 	icon_state = "light[active]"
 
 //alternate button with the same functionality, except has a door control sprite instead
@@ -69,7 +69,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl0"
 
-/obj/machinery/button/alternate/update_icon()
+/obj/machinery/button/alternate/on_update_icon()
 	if(active)
 		icon_state = "doorctrl0"
 	else
@@ -95,7 +95,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light0"
 
-/obj/machinery/button/toggle/switch/update_icon()
+/obj/machinery/button/toggle/switch/on_update_icon()
 	icon_state = "light[active]"
 
 
@@ -105,7 +105,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl0"
 
-/obj/machinery/button/toggle/alternate/update_icon()
+/obj/machinery/button/toggle/alternate/on_update_icon()
 	if(active)
 		icon_state = "doorctrl0"
 	else
@@ -157,7 +157,7 @@
 				8 = shock
 				16 = door safties  */
 
-/obj/machinery/button/toggle/door/update_icon()
+/obj/machinery/button/toggle/door/on_update_icon()
 	if(active)
 		icon_state = "[initial(icon_state)]"
 	else
@@ -215,7 +215,7 @@
 	. = ..()
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
 
-/obj/machinery/button/toggle/valve/update_icon()
+/obj/machinery/button/toggle/valve/on_update_icon()
 	if(!active)
 		icon_state = "launcherbtt"
 	else

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -293,7 +293,7 @@
 	if(isXRay()) return SEE_TURFS|SEE_MOBS|SEE_OBJS
 	return 0
 
-/obj/machinery/camera/update_icon()
+/obj/machinery/camera/on_update_icon()
 	pixel_x = 0
 	pixel_y = 0
 

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -142,7 +142,7 @@
 
 	..()
 
-/obj/item/weapon/camera_assembly/update_icon()
+/obj/item/weapon/camera_assembly/on_update_icon()
 	if(anchored)
 		icon_state = "camera1"
 	else

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -11,7 +11,7 @@
 	var/obj/item/weapon/cell/charging = null
 	var/chargelevel = -1
 
-/obj/machinery/cell_charger/update_icon()
+/obj/machinery/cell_charger/on_update_icon()
 	icon_state = "ccharger[charging ? 1 : 0]"
 
 	if(charging && !(stat & (BROKEN|NOPOWER)) )

--- a/code/game/machinery/computer/RCON_Console.dm
+++ b/code/game/machinery/computer/RCON_Console.dm
@@ -37,7 +37,7 @@
 /obj/machinery/computer/rcon/ui_interact(mob/user, ui_key = "rcon", var/datum/nanoui/ui = null, var/force_open = 1)
 	rcon.ui_interact(user, ui_key, ui, force_open)
 
-/obj/machinery/computer/rcon/update_icon()
+/obj/machinery/computer/rcon/on_update_icon()
 	..()
 	if(is_operable())
 		overlays += image('icons/obj/computer.dmi', "ai-fixer-empty", overlay_layer)

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -14,7 +14,7 @@ var/global/list/minor_air_alarms = list()
 
 /obj/machinery/computer/atmos_alert/Initialize()
 	. = ..()
-	atmosphere_alarm.register_alarm(src, /obj/machinery/computer/station_alert/update_icon)
+	atmosphere_alarm.register_alarm(src, /atom/proc/update_icon)
 
 /obj/machinery/computer/atmos_alert/Destroy()
 	atmosphere_alarm.unregister_alarm(src)
@@ -44,7 +44,7 @@ var/global/list/minor_air_alarms = list()
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/atmos_alert/update_icon()
+/obj/machinery/computer/atmos_alert/on_update_icon()
 	if(!(stat & (NOPOWER|BROKEN)))
 		if(atmosphere_alarm.has_major_alarms(get_z(src)))
 			icon_screen = "alert:2"

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -64,7 +64,7 @@
 		set_broken()
 	..()
 
-/obj/machinery/computer/update_icon()
+/obj/machinery/computer/on_update_icon()
 	overlays.Cut()
 	if(stat & NOPOWER)
 		set_light(0)

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -57,7 +57,7 @@
 		else
 			to_chat(user, "<span class='notice'>A no server error appears on the screen.</span>")
 
-/obj/machinery/computer/message_monitor/update_icon()
+/obj/machinery/computer/message_monitor/on_update_icon()
 	if(emag || hacking)
 		icon_screen = hack_icon
 	else

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -20,7 +20,7 @@
 
 /obj/machinery/computer/station_alert/Initialize()
 	alarm_monitor = new monitor_type(src)
-	alarm_monitor.register_alarm(src, /obj/machinery/computer/station_alert/update_icon)
+	alarm_monitor.register_alarm(src, /atom/proc/update_icon)
 	. = ..()
 	if(monitor_type)
 		register_monitor(new monitor_type(src))
@@ -34,7 +34,7 @@
 		return
 
 	alarm_monitor = monitor
-	alarm_monitor.register_alarm(src, /obj/machinery/computer/station_alert/update_icon)
+	alarm_monitor.register_alarm(src, /atom/proc/update_icon)
 
 /obj/machinery/computer/station_alert/proc/unregister_monitor()
 	if(alarm_monitor)
@@ -55,7 +55,7 @@
 /obj/machinery/computer/station_alert/nano_container()
 	return alarm_monitor
 
-/obj/machinery/computer/station_alert/update_icon()
+/obj/machinery/computer/station_alert/on_update_icon()
 	icon_screen = initial(icon_screen)
 	if(!(stat & (BROKEN|NOPOWER)))
 		if(alarm_monitor)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -210,7 +210,7 @@
 			qdel(G)
 	return
 
-/obj/machinery/atmospherics/unary/cryo_cell/update_icon()
+/obj/machinery/atmospherics/unary/cryo_cell/on_update_icon()
 	overlays.Cut()
 	icon_state = "pod[on]"
 	var/image/I

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -55,7 +55,7 @@
 /obj/machinery/button/remote/proc/trigger()
 	return
 
-/obj/machinery/button/remote/update_icon()
+/obj/machinery/button/remote/on_update_icon()
 	if(stat & NOPOWER)
 		icon_state = "[initial(icon_state)]-p"
 	else
@@ -195,7 +195,7 @@
 
 	return
 
-/obj/machinery/button/remote/driver/update_icon()
+/obj/machinery/button/remote/driver/on_update_icon()
 	if(!active || (stat & NOPOWER))
 		icon_state = "launcherbtt"
 	else

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -581,7 +581,7 @@ About the new airlock wires panel:
 		return 0
 
 
-/obj/machinery/door/airlock/update_icon(state=0, override=0)
+/obj/machinery/door/airlock/on_update_icon(state=0, override=0)
 	if(connections in list(NORTH, SOUTH, NORTH|SOUTH))
 		if(connections in list(WEST, EAST, EAST|WEST))
 			set_dir(SOUTH)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -174,7 +174,7 @@ obj/machinery/airlock_sensor
 	var/alert = 0
 	var/previousPressure
 
-obj/machinery/airlock_sensor/update_icon()
+obj/machinery/airlock_sensor/on_update_icon()
 	if(on)
 		if(alert)
 			icon_state = "airlock_sensor_alert"
@@ -254,7 +254,7 @@ obj/machinery/access_button
 	var/on = 1
 
 
-obj/machinery/access_button/update_icon()
+obj/machinery/access_button/on_update_icon()
 	if(on)
 		icon_state = "access_button_standby"
 	else

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -66,7 +66,7 @@
 // Proc: update_icon()
 // Parameters: None
 // Description: Updates icon of this object. Uses icon state variables.
-/obj/machinery/door/blast/update_icon()
+/obj/machinery/door/blast/on_update_icon()
 	if(density)
 		icon_state = icon_state_closed
 	else

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -45,7 +45,7 @@
 			return "\The [src] is in excellent condition."
 
 
-/obj/item/weapon/airlock_brace/update_icon()
+/obj/item/weapon/airlock_brace/on_update_icon()
 	if(airlock)
 		icon_state = "brace_closed"
 	else

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -212,7 +212,7 @@
 // if NOPOWER, display blank
 // if BROKEN, display blue screen of death icon AI uses
 // if timing=true, run update display function
-/obj/machinery/door_timer/update_icon()
+/obj/machinery/door_timer/on_update_icon()
 	if(stat & (NOPOWER))
 		icon_state = "frame"
 		return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -359,7 +359,7 @@
 			take_damage(100)
 
 
-/obj/machinery/door/update_icon()
+/obj/machinery/door/on_update_icon()
 	if(connections in list(NORTH, SOUTH, NORTH|SOUTH))
 		if(connections in list(WEST, EAST, EAST|WEST))
 			set_dir(SOUTH)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -386,7 +386,7 @@
 	return
 
 
-/obj/machinery/door/firedoor/update_icon()
+/obj/machinery/door/firedoor/on_update_icon()
 	var/icon/lights_overlay
 	var/icon/panel_overlay
 	var/icon/weld_overlay

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -8,7 +8,7 @@ obj/structure/firedoor_assembly
 	density = 1
 	var/wired = 0
 
-obj/structure/firedoor_assembly/update_icon()
+obj/structure/firedoor_assembly/on_update_icon()
 	if(anchored)
 		icon_state = "door_anchored"
 	else

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -37,7 +37,7 @@
 		bound_height = width * world.icon_size
 
 
-/obj/machinery/door/airlock/multi_tile/update_icon(state=0, override=0)
+/obj/machinery/door/airlock/multi_tile/on_update_icon(state=0, override=0)
 	..()
 	if(connections in list(NORTH, SOUTH, NORTH|SOUTH))
 		if(connections in list(WEST, EAST, EAST|WEST))

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -58,7 +58,7 @@
 		//cap projectile damage so that there's still a minimum number of hits required to break the door
 		take_damage(min(damage, 100))
 
-/obj/machinery/door/unpowered/simple/update_icon()
+/obj/machinery/door/unpowered/simple/on_update_icon()
 	if(density)
 		icon_state = "[icon_base]"
 	else

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -24,7 +24,7 @@
 		src.base_state = src.icon_state
 	return
 
-/obj/machinery/door/window/update_icon()
+/obj/machinery/door/window/on_update_icon()
 	if(density)
 		icon_state = base_state
 	else

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -39,7 +39,7 @@ var/list/doppler_arrays = list()
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='game say'><span class='name'>[src]</span> states coldly, \"[message]\"</span>",2)
 
-/obj/machinery/doppler_array/update_icon()
+/obj/machinery/doppler_array/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"
 	else if( !(stat & NOPOWER) )

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -147,7 +147,7 @@
 	tag_secure = 1
 
 
-/obj/machinery/embedded_controller/radio/airlock/access_controller/update_icon()
+/obj/machinery/embedded_controller/radio/airlock/access_controller/on_update_icon()
 	if(on && program)
 		if(program.memory["processing"])
 			icon_state = "access_control_process"

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -60,7 +60,7 @@ obj/machinery/embedded_controller/radio/Destroy()
 	set_frequency(frequency)
 	. = ..()
 
-/obj/machinery/embedded_controller/radio/update_icon()
+/obj/machinery/embedded_controller/radio/on_update_icon()
 	if(!on || !program)
 		icon_state = "airlock_control_off"
 	else if(program.memory["processing"])

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -37,7 +37,7 @@
 	wifi_receiver = null
 	return ..()
 
-/obj/machinery/flasher/update_icon()
+/obj/machinery/flasher/on_update_icon()
 	if ( !(stat & (BROKEN|NOPOWER)) )
 		icon_state = "[base_state]1"
 //		src.sd_SetLuminosity(2)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -19,7 +19,7 @@
 	cell = new/obj/item/weapon/cell/crap(src)
 	..()
 
-/obj/machinery/floodlight/update_icon()
+/obj/machinery/floodlight/on_update_icon()
 	overlays.Cut()
 	icon_state = "flood[open ? "o" : ""][open && cell ? "b" : ""]0[on]"
 

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -104,7 +104,7 @@ var/list/floor_light_cache = list()
 	active_power_usage = ((light_outer_range + light_max_bright) * 20)
 	update_icon()
 
-/obj/machinery/floor_light/update_icon()
+/obj/machinery/floor_light/on_update_icon()
 	overlays.Cut()
 	if(use_power && !broken())
 		if(isnull(damaged))

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -33,7 +33,7 @@
 	update_icon()
 
 //maybe add soft lighting? Maybe, though not everything needs it
-/obj/machinery/holosign/update_icon()
+/obj/machinery/holosign/on_update_icon()
 	if (!lit || (stat & (BROKEN|NOPOWER)))
 		icon_state = "sign_off"
 	else
@@ -68,6 +68,6 @@
 
 	return
 
-/obj/machinery/button/holosign/update_icon()
+/obj/machinery/button/holosign/on_update_icon()
 	icon_state = "light[active]"
 	return

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -22,7 +22,7 @@
 	if(_wifi_id)
 		wifi_receiver = new(_wifi_id, src)
 
-/obj/machinery/igniter/update_icon()
+/obj/machinery/igniter/on_update_icon()
 	..()
 	icon_state = "igniter[on]"
 
@@ -80,7 +80,7 @@
 	wifi_receiver = null
 	return ..()
 
-/obj/machinery/sparker/update_icon()
+/obj/machinery/sparker/on_update_icon()
 	..()
 	if(disable)
 		icon_state = "migniter-d"

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -70,7 +70,7 @@ datum/track/proc/GetTrack()
 	if(stat & (NOPOWER|BROKEN) && playing)
 		StopPlaying()
 
-/obj/machinery/media/jukebox/update_icon()
+/obj/machinery/media/jukebox/on_update_icon()
 	overlays.Cut()
 	if(stat & (NOPOWER|BROKEN) || !anchored)
 		if(stat & BROKEN)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	update_icon()
 
-/obj/machinery/gibber/update_icon()
+/obj/machinery/gibber/on_update_icon()
 	overlays.Cut()
 	if (dirty)
 		src.overlays += image('icons/obj/kitchen.dmi', "grbloody")

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -351,7 +351,7 @@
 	src.updateUsrDialog()
 	src.update_icon()
 
-/obj/machinery/microwave/update_icon()
+/obj/machinery/microwave/on_update_icon()
 	if(dirty == 100)
 		src.icon_state = "mwbloody[operating]"
 	else if(broken)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -157,7 +157,7 @@
 		dry()
 		update_icon()
 
-/obj/machinery/smartfridge/drying_rack/update_icon()
+/obj/machinery/smartfridge/drying_rack/on_update_icon()
 	overlays.Cut()
 	if(inoperable())
 		icon_state = icon_off
@@ -191,7 +191,7 @@
 	if(src.shoot_inventory && prob(2))
 		src.throw_item()
 
-/obj/machinery/smartfridge/update_icon()
+/obj/machinery/smartfridge/on_update_icon()
 	if(stat & (BROKEN|NOPOWER))
 		icon_state = icon_off
 	else

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -28,7 +28,7 @@
 	connected_area.set_lightswitch(on)
 	update_icon()
 
-/obj/machinery/light_switch/update_icon()
+/obj/machinery/light_switch/on_update_icon()
 	if(!overlay)
 		overlay = image(icon, "light1-overlay")
 		overlay.plane = EFFECTS_ABOVE_LIGHTING_PLANE

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -29,7 +29,7 @@ var/global/list/navbeacons = list()
 	set_invisibility(intact ? 101 : 0)
 	update_icon()
 
-/obj/machinery/navbeacon/update_icon()
+/obj/machinery/navbeacon/on_update_icon()
 	var/state="navbeacon[open]"
 
 	if(invisibility)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -168,7 +168,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	allCasters -= src
 	..()
 
-/obj/machinery/newscaster/update_icon()
+/obj/machinery/newscaster/on_update_icon()
 	if(inoperable())
 		icon_state = "newscaster_off"
 		if(stat & BROKEN) //If the thing is smashed, add crack overlay on top of the unpowered sprite.

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -347,7 +347,7 @@ var/bomb_set
 
 	SetUniversalState(/datum/universal_state/nuclear_explosion, arguments=list(src))
 
-/obj/machinery/nuclearbomb/update_icon()
+/obj/machinery/nuclearbomb/on_update_icon()
 	if(lighthack)
 		icon_state = "idle"
 	else if(timing == -1)
@@ -539,7 +539,7 @@ var/bomb_set
 	..()
 	announced = 0
 
-/obj/machinery/nuclearbomb/station/update_icon()
+/obj/machinery/nuclearbomb/station/on_update_icon()
 	var/target_icon_state
 	if(lighthack)
 		target_icon_state = "rcircuit_off"

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -161,7 +161,7 @@
 
 var/list/turret_icons
 
-/obj/machinery/porta_turret/update_icon()
+/obj/machinery/porta_turret/on_update_icon()
 	if(!turret_icons)
 		turret_icons = list()
 		turret_icons["open"] = image(icon, "openTurretCover")

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -95,7 +95,7 @@ obj/machinery/recharger/emp_act(severity)
 			C.emp_act(severity)
 	..(severity)
 
-obj/machinery/recharger/update_icon()	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
+obj/machinery/recharger/on_update_icon()	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
 	if(charging)
 		icon_state = icon_state_charging
 	else

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -198,7 +198,7 @@
 		if(99 to 110)
 			overlays += image('icons/obj/objects.dmi', "statn_c100")
 
-/obj/machinery/recharge_station/update_icon()
+/obj/machinery/recharge_station/on_update_icon()
 	..()
 	if(stat & BROKEN)
 		icon_state = "borgcharger0"

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -53,7 +53,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	light_outer_range = 0
 	var/datum/announcement/announcement = new
 
-/obj/machinery/requests_console/update_icon()
+/obj/machinery/requests_console/on_update_icon()
 	if(stat & NOPOWER)
 		if(icon_state != "req_comp_off")
 			icon_state = "req_comp_off"

--- a/code/game/machinery/resleever.dm
+++ b/code/game/machinery/resleever.dm
@@ -264,7 +264,7 @@ obj/machinery/resleever/Process()
 		else
 	return
 
-/obj/machinery/resleever/update_icon()
+/obj/machinery/resleever/on_update_icon()
 	..()
 	icon_state = empty_state
 	if(occupant)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -113,7 +113,7 @@
 		to_chat(usr, "[src] is loaded and ready to be armed.")
 		return
 
-/obj/machinery/self_destruct/update_icon()
+/obj/machinery/self_destruct/on_update_icon()
 	if(armed)
 		icon_state = "armed"
 	else if(cylinder)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -20,7 +20,7 @@
 	cell = new/obj/item/weapon/cell/high(src)
 	update_icon()
 
-/obj/machinery/space_heater/update_icon(var/rebuild_overlay = 0)
+/obj/machinery/space_heater/on_update_icon(var/rebuild_overlay = 0)
 	if(!on)
 		icon_state = "sheater-off"
 		set_light(0)

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -77,7 +77,7 @@ var/list/ai_status_emotions = list(
 /obj/machinery/ai_status_display/Process()
 	return
 
-/obj/machinery/ai_status_display/update_icon()
+/obj/machinery/ai_status_display/on_update_icon()
 	if(stat & (NOPOWER|BROKEN))
 		overlays.Cut()
 		return

--- a/code/game/machinery/status_light.dm
+++ b/code/game/machinery/status_light.dm
@@ -15,7 +15,7 @@
 	radio_connection = register_radio(src, frequency, frequency, RADIO_ATMOSIA)
 
 
-/obj/machinery/status_light/update_icon()
+/obj/machinery/status_light/on_update_icon()
 	if(stat & (NOPOWER|BROKEN))
 		icon_state = "doortimer-b"
 		return

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -162,7 +162,7 @@
 		mask = new mask_type(src)
 	update_icon()
 
-/obj/machinery/suit_storage_unit/update_icon()
+/obj/machinery/suit_storage_unit/on_update_icon()
 	overlays.Cut()
 	if(panelopen)
 		overlays += ("panel")

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -155,7 +155,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				if(src != T)
 					links |= T
 
-/obj/machinery/telecomms/update_icon()
+/obj/machinery/telecomms/on_update_icon()
 	if(on && !overloaded_for)
 		icon_state = initial(icon_state)
 	else

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -300,7 +300,7 @@
 	if (engaged && (stat & NOPOWER))
 		disengage()
 
-/obj/machinery/teleport/station/update_icon()
+/obj/machinery/teleport/station/on_update_icon()
 	if(stat & NOPOWER)
 		icon_state = "controller-p"
 	else

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -205,7 +205,7 @@
 	if(.)
 		updateTurrets()
 
-/obj/machinery/turretid/update_icon()
+/obj/machinery/turretid/on_update_icon()
 	..()
 	if(stat & NOPOWER)
 		icon_state = "control_off"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -545,7 +545,7 @@
 /obj/machinery/vending/powered()
 	return anchored && ..()
 
-/obj/machinery/vending/update_icon()
+/obj/machinery/vending/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"
 	else if( !(stat & NOPOWER) )

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -107,7 +107,7 @@
 		usr.loc = src.loc
 
 
-/obj/machinery/washing_machine/update_icon()
+/obj/machinery/washing_machine/on_update_icon()
 	icon_state = "wm_[state][panel]"
 
 /obj/machinery/washing_machine/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -57,7 +57,7 @@
 		use_power = 1
 	update_icon()
 
-/obj/machinery/mecha_part_fabricator/update_icon()
+/obj/machinery/mecha_part_fabricator/on_update_icon()
 	overlays.Cut()
 	if(panel_open)
 		icon_state = "fab-o"

--- a/code/game/mecha/mech_sensor.dm
+++ b/code/game/mecha/mech_sensor.dm
@@ -57,7 +57,7 @@
 /obj/machinery/mech_sensor/proc/enabled()
 	return on && !(stat & NOPOWER)
 
-/obj/machinery/mech_sensor/update_icon(var/safety = 0)
+/obj/machinery/mech_sensor/on_update_icon(var/safety = 0)
 	if (enabled())
 		icon_state = "airlock_sensor_standby"
 	else

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -140,7 +140,7 @@
 	update_nearby_tiles(1)
 	..()
 
-/obj/structure/foamedmetal/update_icon()
+/obj/structure/foamedmetal/on_update_icon()
 	if(metal == 1)
 		icon_state = "metalfoam"
 	else

--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -11,7 +11,7 @@
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6")
 	basecolor = "#05ee05"
 
-/obj/effect/decal/cleanable/blood/gibs/xeno/update_icon()
+/obj/effect/decal/cleanable/blood/gibs/xeno/on_update_icon()
 	color = "#ffffff"
 
 /obj/effect/decal/cleanable/blood/gibs/xeno/up

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -62,7 +62,7 @@ var/global/list/image/splatter_cache=list()
 	if(world.time > drytime)
 		dry()
 
-/obj/effect/decal/cleanable/blood/update_icon()
+/obj/effect/decal/cleanable/blood/on_update_icon()
 	if(basecolor == "rainbow") basecolor = get_random_colour(1)
 	color = basecolor
 	if(basecolor == SYNTH_BLOOD_COLOUR)
@@ -185,7 +185,7 @@ var/global/list/image/splatter_cache=list()
 	random_icon_states = list("gib1", "gib2", "gib3", "gib5", "gib6")
 	var/fleshcolor = "#ffffff"
 
-/obj/effect/decal/cleanable/blood/gibs/update_icon()
+/obj/effect/decal/cleanable/blood/gibs/on_update_icon()
 
 	var/image/giblets = new(base_icon, "[icon_state]_flesh", dir)
 	if(!fleshcolor || fleshcolor == "rainbow")

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -6,7 +6,7 @@
 	basecolor = SYNTH_BLOOD_COLOUR
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7")
 
-/obj/effect/decal/cleanable/blood/gibs/robot/update_icon()
+/obj/effect/decal/cleanable/blood/gibs/robot/on_update_icon()
 	color = "#ffffff"
 
 /obj/effect/decal/cleanable/blood/gibs/robot/dry()	//pieces of robots do not dry up like

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -46,7 +46,7 @@
 	REMOVE_ACTIVE_FLUID(src)
 	. = ..()
 
-/obj/effect/fluid/update_icon()
+/obj/effect/fluid/on_update_icon()
 
 	overlays.Cut()
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -87,7 +87,7 @@
 	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
 		fold(usr)
 
-/obj/structure/closet/body_bag/update_icon()
+/obj/structure/closet/body_bag/on_update_icon()
 	if(opened)
 		icon_state = icon_opened
 	else

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -52,7 +52,7 @@
 		STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/obj/structure/closet/body_bag/cryobag/update_icon()
+/obj/structure/closet/body_bag/cryobag/on_update_icon()
 	..()
 	overlays.Cut()
 	var/image/I = image(icon, "indicator[opened]")

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -76,7 +76,7 @@
 		update_icon()
 	return 1
 
-/obj/item/weapon/aicard/update_icon()
+/obj/item/weapon/aicard/on_update_icon()
 	overlays.Cut()
 	if(carded_ai)
 		if (!carded_ai.control_disabled)

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -162,7 +162,7 @@
 		return FALSE
 	return TRUE
 
-/obj/item/device/boombox/update_icon()
+/obj/item/device/boombox/on_update_icon()
 	icon_state = playing ? "on" : "off"
 
 /obj/item/device/boombox/proc/stop()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	update_icon()
 
-/obj/item/device/flashlight/update_icon()
+/obj/item/device/flashlight/on_update_icon()
 	if(on)
 		icon_state = "[initial(icon_state)]-on"
 		set_light(flashlight_max_bright, flashlight_inner_range, flashlight_outer_range, 2, light_color)
@@ -164,7 +164,7 @@
 	matter = list(MATERIAL_STEEL = 200,MATERIAL_GLASS = 100)
 	flashlight_outer_range = 5
 
-/obj/item/device/flashlight/lantern/update_icon()
+/obj/item/device/flashlight/lantern/on_update_icon()
 	..()
 	if(on)
 		item_state = "lantern-on"
@@ -284,7 +284,7 @@
 		force = initial(force)
 		damtype = initial(damtype)
 
-/obj/item/device/flashlight/flare/update_icon()
+/obj/item/device/flashlight/flare/on_update_icon()
 	..()
 	if(!on && !fuel)
 		icon_state = "[initial(icon_state)]-empty"
@@ -310,7 +310,7 @@
 	fuel = rand(1600, 2000)
 	light_color = color
 
-/obj/item/device/flashlight/flare/glowstick/update_icon()
+/obj/item/device/flashlight/flare/glowstick/on_update_icon()
 	item_state = "glowstick"
 	overlays.Cut()
 	if(!fuel)
@@ -380,7 +380,7 @@
 /obj/item/device/flashlight/slime/New()
 	..()
 
-/obj/item/device/flashlight/slime/update_icon()
+/obj/item/device/flashlight/slime/on_update_icon()
 	return
 
 /obj/item/device/flashlight/slime/attack_self(mob/user)

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -39,7 +39,7 @@
 	update_icon()
 	to_chat(user, "<span class='notice'>\icon[src] You switch [scanning ? "on" : "off"] [src].</span>")
 
-/obj/item/device/geiger/update_icon()
+/obj/item/device/geiger/on_update_icon()
 	if(!scanning)
 		icon_state = "geiger_off"
 		return 1

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -72,7 +72,7 @@
 			"<span class='notice'>You show the warrant to [M].</span>")
 	M.examinate(src)
 
-/obj/item/device/holowarrant/update_icon()
+/obj/item/device/holowarrant/on_update_icon()
 	if(active)
 		icon_state = "holowarrant_filled"
 	else

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -153,7 +153,7 @@
 	if(opened)
 		to_chat(M,"<span class='notice'>Its battery compartment is open.</span>")
 
-/obj/item/inducer/update_icon()
+/obj/item/inducer/on_update_icon()
 	overlays.Cut()
 	if(opened)
 		if(!get_cell())
@@ -179,7 +179,7 @@
 		return
 	. = ..()
 
-/obj/item/inducer/borg/update_icon()
+/obj/item/inducer/borg/on_update_icon()
 	. = ..()
 	overlays += image("icons/obj/gun.dmi","safety[safety()]")
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -124,7 +124,7 @@
 	*/
 	to_chat(usr, "It has [uses] lights remaining.")
 
-/obj/item/device/lightreplacer/update_icon()
+/obj/item/device/lightreplacer/on_update_icon()
 	icon_state = "lightreplacer[emagged]"
 
 

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -61,7 +61,7 @@
 	var/list/air_mix = list("oxygen" = 1 * (target_pressure * air_contents.volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
 	air_contents.adjust_multi("oxygen", air_mix["oxygen"])
 
-/obj/item/device/oxycandle/update_icon()
+/obj/item/device/oxycandle/on_update_icon()
 	if(on == 1)
 		icon_state = "oxycandle_on"
 		item_state = icon_state

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -27,7 +27,7 @@
 		update_icon()
 		return
 
-/obj/item/device/personal_shield/update_icon()
+/obj/item/device/personal_shield/on_update_icon()
 	if(uses)
 		icon_state = "batterer"
 	else

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -413,7 +413,7 @@ proc/get_wound_severity(var/damage_ratio, var/can_heal_overkill = 0)
 /obj/item/device/mass_spectrometer/on_reagent_change()
 	update_icon()
 
-/obj/item/device/mass_spectrometer/update_icon()
+/obj/item/device/mass_spectrometer/on_update_icon()
 	icon_state = initial(icon_state)
 	if(reagents.total_volume)
 		icon_state += "_s"

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -134,7 +134,7 @@
 
 	return ..()
 
-/obj/item/device/suit_cooling_unit/update_icon()
+/obj/item/device/suit_cooling_unit/on_update_icon()
 	overlays.Cut()
 	if (cover_open)
 		if (cell)

--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -62,7 +62,7 @@
 		else
 			to_chat(user, "<span class='warning'>You're unable to insert the battery.</span>")
 
-/obj/item/device/suit_sensor_jammer/update_icon()
+/obj/item/device/suit_sensor_jammer/on_update_icon()
 	overlays.Cut()
 	if(bcell)
 		var/percent = bcell.percent()

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -24,7 +24,7 @@
 	if(on)
 		set_active(FALSE)
 
-/obj/item/device/t_scanner/update_icon()
+/obj/item/device/t_scanner/on_update_icon()
 	icon_state = "t-ray[on]"
 
 /obj/item/device/t_scanner/emp_act()

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -364,7 +364,7 @@
 		record()
 
 
-/obj/item/device/taperecorder/update_icon()
+/obj/item/device/taperecorder/on_update_icon()
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
 
 	if(!mytape)
@@ -393,7 +393,7 @@
 	var/doctored = 0
 
 
-/obj/item/device/tape/update_icon()
+/obj/item/device/tape/on_update_icon()
 	overlays.Cut()
 	if(ruined && max_capacity)
 		overlays += "ribbonoverlay"
@@ -528,7 +528,7 @@
 /obj/item/device/tape/loose/fix()
 	return
 
-/obj/item/device/tape/loose/update_icon()
+/obj/item/device/tape/loose/on_update_icon()
 	return
 
 /obj/item/device/tape/loose/get_loose_tape()

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -129,7 +129,7 @@
 		spawn(50) // To stop a signal being spammed from a proxy sensor constantly going off or whatever
 			toggle = 1
 
-/obj/item/device/transfer_valve/update_icon()
+/obj/item/device/transfer_valve/on_update_icon()
 	overlays.Cut()
 	underlays = null
 

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -77,7 +77,7 @@
 	if(!href_list["close"])
 		attack_self(usr)
 
-/obj/item/device/camera/tvcamera/update_icon()
+/obj/item/device/camera/tvcamera/on_update_icon()
 	..()
 	if(camera.status)
 		icon_state = "camcorder_on"

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -76,7 +76,7 @@
 		user.visible_message("<span class='notice'>[user] puts [S.worth] [S.worth > 1 ? "thalers" : "thaler"] into \the [src].</span>")
 		update_icon()
 
-/obj/item/glass_jar/update_icon() // Also updates name and desc
+/obj/item/glass_jar/on_update_icon() // Also updates name and desc
 	underlays.Cut()
 	overlays.Cut()
 	switch(contains)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -110,7 +110,7 @@
 	..()
 	src.update_icon()
 
-/obj/item/robot_parts/robot_suit/update_icon()
+/obj/item/robot_parts/robot_suit/on_update_icon()
 	src.overlays.Cut()
 	if(src.parts[BP_L_ARM])
 		src.overlays += "l_arm+o"

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -100,7 +100,7 @@
 		use(2)
 	return
 
-/obj/item/stack/rods/update_icon()
+/obj/item/stack/rods/on_update_icon()
 	if(amount == 1)
 		icon = 'icons/obj/weapons.dmi'
 		icon_state = "metal-rod"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -85,7 +85,7 @@
 				qdel(src)
 	return
 
-/obj/item/toy/water_balloon/update_icon()
+/obj/item/toy/water_balloon/on_update_icon()
 	if(src.reagents.total_volume >= 1)
 		icon_state = "waterballoon"
 		item_state = "balloon"
@@ -859,7 +859,7 @@
 	var/on = 0
 	var/activation_sound = 'sound/effects/flashlight.ogg'
 
-/obj/item/toy/desk/update_icon()
+/obj/item/toy/desk/on_update_icon()
 	if(on)
 		icon_state = "[initial(icon_state)]-on"
 	else

--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -13,7 +13,7 @@
 
 	..()
 
-/obj/item/weapon/flame/candle/update_icon()
+/obj/item/weapon/flame/candle/on_update_icon()
 	var/i
 	if(wax > 1500)
 		i = 1

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -46,7 +46,7 @@
 	else
 		..()
 
-/obj/item/weapon/cane/concealed/update_icon()
+/obj/item/weapon/cane/concealed/on_update_icon()
 	if(concealed_blade)
 		SetName(initial(name))
 		icon_state = initial(icon_state)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -59,7 +59,7 @@
 	.=..()
 	update_icon()
 
-/obj/item/weapon/card/data/update_icon()
+/obj/item/weapon/card/data/on_update_icon()
 	overlays.Cut()
 	var/image/detail_overlay = image('icons/obj/card.dmi', src,"[icon_state]-color")
 	detail_overlay.color = detail_color

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -157,7 +157,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(location)
 		location.hotspot_expose(700, 5)
 
-/obj/item/clothing/mask/smokable/update_icon()
+/obj/item/clothing/mask/smokable/on_update_icon()
 	if(lit && icon_on)
 		icon_state = icon_on
 		item_state = icon_on
@@ -262,13 +262,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	for(var/R in filling)
 		reagents.add_reagent(R, filling[R])
 
-/obj/item/clothing/mask/smokable/cigarette/update_icon()
+/obj/item/clothing/mask/smokable/cigarette/on_update_icon()
 	..()
 	overlays.Cut()
 	if(lit)
 		overlays += overlay_image(icon, "cigon", flags=RESET_COLOR)
 
-/obj/item/clothing/mask/smokable/cigarette/trident/update_icon()
+/obj/item/clothing/mask/smokable/cigarette/trident/on_update_icon()
 	..()
 	overlays.Cut()
 	if(lit)
@@ -1121,7 +1121,7 @@ obj/item/clothing/mask/chewable/Destroy()
 	else
 		extinguish(user)
 
-/obj/item/weapon/flame/lighter/update_icon()
+/obj/item/weapon/flame/lighter/on_update_icon()
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
 
 	if(lit)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -37,7 +37,7 @@
 /obj/item/weapon/defibrillator/loaded //starts with regular power cell for R&D to replace later in the round.
 	bcell = /obj/item/weapon/cell/apc
 
-/obj/item/weapon/defibrillator/update_icon()
+/obj/item/weapon/defibrillator/on_update_icon()
 	var/list/new_overlays = list()
 
 	if(paddles) //in case paddles got destroyed somehow.
@@ -235,7 +235,7 @@
 	update_icon()
 	..()
 
-/obj/item/weapon/shockpaddles/update_icon()
+/obj/item/weapon/shockpaddles/on_update_icon()
 	icon_state = "defibpaddles[wielded]"
 	item_state = "defibpaddles[wielded]"
 	if(cooldown)

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -128,7 +128,7 @@ obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
 				return
 			ec_cartridge.reagents.trans_to_mob(C, REM, CHEM_INGEST, 0.4) // Most of it is not inhaled... balance reasons.
 
-/obj/item/clothing/mask/smokable/ecig/update_icon()
+/obj/item/clothing/mask/smokable/ecig/on_update_icon()
 	if (active)
 		item_state = icon_on
 		icon_state = icon_on

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -42,7 +42,7 @@
 	return
 
 
-/obj/item/weapon/flamethrower/update_icon()
+/obj/item/weapon/flamethrower/on_update_icon()
 	overlays.Cut()
 	if(igniter)
 		overlays += "+igniter[status]"

--- a/code/game/objects/items/weapons/grenades/supermatter.dm
+++ b/code/game/objects/items/weapons/grenades/supermatter.dm
@@ -18,7 +18,7 @@
 	update_icon()
 	playsound(src, 'sound/weapons/wave.ogg', 100)
 
-/obj/item/weapon/grenade/supermatter/update_icon()
+/obj/item/weapon/grenade/supermatter/on_update_icon()
 	overlays.Cut()
 	if(implode_at)
 		overlays += image(icon = 'icons/obj/machines/power/fusion.dmi', icon_state = "emfield_s1")

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -26,7 +26,7 @@
 		desc = "A case for implants."
 		origin_tech.Cut()
 
-/obj/item/weapon/implantcase/update_icon()
+/obj/item/weapon/implantcase/on_update_icon()
 	if (imp)
 		icon_state = "implantcase-[imp.implant_color]"
 	else

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -15,7 +15,7 @@
 	..()
 	update_icon()
 
-/obj/item/weapon/implanter/update_icon()
+/obj/item/weapon/implanter/on_update_icon()
 	if (imp)
 		icon_state = "implanter1"
 	else

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -9,7 +9,7 @@
 	w_class = ITEM_SIZE_SMALL
 	var/obj/item/weapon/implant/imp
 
-/obj/item/weapon/implantpad/update_icon()
+/obj/item/weapon/implantpad/on_update_icon()
 	if (imp)
 		icon_state = "implantpad-1"
 	else

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -49,7 +49,7 @@
 	var/safe = 1
 	imp = /obj/item/weapon/implant/compressed
 
-/obj/item/weapon/implanter/compressed/update_icon()
+/obj/item/weapon/implanter/compressed/on_update_icon()
 	if (imp)
 		var/obj/item/weapon/implant/compressed/c = imp
 		if(!c.scanned)

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -17,7 +17,7 @@
 	else if(contents.len)
 		to_chat(user, "It has [contents.len] cig butts in it.")
 
-/obj/item/weapon/material/ashtray/update_icon()
+/obj/item/weapon/material/ashtray/on_update_icon()
 	overlays.Cut()
 	if (contents.len == max_butts)
 		overlays |= image('icons/obj/objects.dmi',"ashtray_full")

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -14,7 +14,7 @@
 	icon_state = "coin[rand(1,10)]"
 	..()
 
-/obj/item/weapon/material/coin/update_icon()
+/obj/item/weapon/material/coin/on_update_icon()
 	if(!isnull(string_colour))
 		var/image/I = image(icon = icon, icon_state = "coin_string_overlay")
 		I.appearance_flags |= RESET_COLOR

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -36,7 +36,7 @@
 	else
 		qdel(src)
 
-/obj/item/weapon/material/shard/update_icon()
+/obj/item/weapon/material/shard/on_update_icon()
 	if(material)
 		color = material.icon_colour
 		// 1-(1-x)^2, so that glass shards with 0.3 opacity end up somewhat visible at 0.51 opacity

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -57,7 +57,7 @@
 	if(wielded)
 		. += wielded_parry_bonus
 
-/obj/item/weapon/material/twohanded/update_icon()
+/obj/item/weapon/material/twohanded/on_update_icon()
 	icon_state = "[base_icon][wielded]"
 	item_state_slots[slot_l_hand_str] = icon_state
 	item_state_slots[slot_r_hand_str] = icon_state

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -38,7 +38,7 @@ var/list/tape_roll_applications = list()
 	var/tape_dir = 0
 	var/icon_base = "tape"
 
-/obj/item/tape/update_icon()
+/obj/item/tape/on_update_icon()
 	//Possible directional bitflags: 0 (AIRLOCK), 1 (NORTH), 2 (SOUTH), 4 (EAST), 8 (WEST), 3 (VERTICAL), 12 (HORIZONTAL)
 	switch (tape_dir)
 		if(0)  // AIRLOCK
@@ -123,7 +123,7 @@ var/list/tape_roll_applications = list()
 	req_one_access = list(access_medical)
 	color = COLOR_GREEN
 
-/obj/item/taperoll/update_icon()
+/obj/item/taperoll/on_update_icon()
 	overlays.Cut()
 	var/image/overlay = image(icon = src.icon)
 	overlay.appearance_flags = RESET_COLOR

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -193,7 +193,7 @@
 	add_fingerprint(user)
 	return
 
-/obj/item/weapon/shield/energy/update_icon()
+/obj/item/weapon/shield/energy/on_update_icon()
 	icon_state = "eshield[active]"
 	if(active)
 		set_light(0.4, 0.1, 1, 2, "#006aff")

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -69,7 +69,7 @@
 		return
 	..()
 
-/obj/item/weapon/soap/update_icon()
+/obj/item/weapon/soap/on_update_icon()
 	overlays.Cut()
 	if(key_data)
 		overlays += image('icons/obj/items.dmi', icon_state = "soap_key_overlay")

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -54,7 +54,7 @@
 	..()
 	update_icon()
 
-/obj/item/weapon/storage/bag/trash/update_icon()
+/obj/item/weapon/storage/bag/trash/on_update_icon()
 	switch(w_class)
 		if(2) icon_state = "[initial(icon_state)]"
 		if(3) icon_state = "[initial(icon_state)]1"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -21,7 +21,7 @@
 	use_alt_layer = !use_alt_layer
 	update_icon()
 
-/obj/item/weapon/storage/belt/update_icon()
+/obj/item/weapon/storage/belt/on_update_icon()
 	if (ismob(src.loc))
 		var/mob/M = src.loc
 		M.update_inv_belt()
@@ -83,7 +83,7 @@
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	H.examine_holster(user)
 
-/obj/item/weapon/storage/belt/holster/update_icon()
+/obj/item/weapon/storage/belt/holster/on_update_icon()
 	if (ismob(src.loc))
 		var/mob/M = src.loc
 		M.update_inv_belt()

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -22,7 +22,7 @@
 		update_icon()
 
 
-/obj/item/weapon/storage/fancy/update_icon()
+/obj/item/weapon/storage/fancy/on_update_icon()
 	if(!opened)
 		src.icon_state = initial(icon_state)
 	else
@@ -106,7 +106,7 @@
 		/obj/item/weapon/pen/crayon/purple,
 		)
 
-/obj/item/weapon/storage/fancy/crayons/update_icon()
+/obj/item/weapon/storage/fancy/crayons/on_update_icon()
 	overlays = list() //resets list
 	overlays += image('icons/obj/crayons.dmi',"crayonbox")
 	for(var/obj/item/weapon/pen/crayon/crayon in contents)
@@ -295,7 +295,7 @@
 	key_type = /obj/item/weapon/reagent_containers/glass/beaker/vial
 	startswith = list(/obj/item/weapon/reagent_containers/glass/beaker/vial = 12)
 
-/obj/item/weapon/storage/fancy/vials/update_icon()
+/obj/item/weapon/storage/fancy/vials/on_update_icon()
 	var/key_count = count_by_type(contents, key_type)
 	src.icon_state = "[initial(icon_state)][Floor(key_count/2)]"
 
@@ -318,7 +318,7 @@
 	..()
 	update_icon()
 
-/obj/item/weapon/storage/lockbox/vials/update_icon()
+/obj/item/weapon/storage/lockbox/vials/on_update_icon()
 	var/total_contents = count_by_type(contents, /obj/item/weapon/reagent_containers/glass/beaker/vial)
 	src.icon_state = "vialbox[Floor(total_contents/2)]"
 	src.overlays.Cut()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -205,7 +205,7 @@
 	. = ..()
 	update_icon()
 
-/obj/item/weapon/storage/pill_bottle/update_icon()
+/obj/item/weapon/storage/pill_bottle/on_update_icon()
 	overlays.Cut()
 	if(wrapper_color)
 		var/image/I = image(icon, "pillbottle_wrap")

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -50,7 +50,7 @@
 	linked = O
 	return
 
-/obj/item/weapon/storage/laundry_basket/update_icon()
+/obj/item/weapon/storage/laundry_basket/on_update_icon()
 	if(contents.len)
 		icon_state = "laundry-full"
 	else

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -35,7 +35,7 @@ Single Use Emergency Pouches
 		A.band_color = color
 		A.update_icon()
 
-/obj/item/weapon/storage/med_pouch/update_icon()
+/obj/item/weapon/storage/med_pouch/on_update_icon()
 	overlays.Cut()
 	if(!cross_overlay)
 		cross_overlay = image(icon, "cross")

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -38,7 +38,7 @@
 
 	startswith = list(/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 6)
 
-/obj/item/weapon/storage/box/donut/update_icon()
+/obj/item/weapon/storage/box/donut/on_update_icon()
 	overlays.Cut()
 	var/i = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/donut/D in contents)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -66,7 +66,7 @@
 			front_id = W
 			update_icon()
 
-/obj/item/weapon/storage/wallet/update_icon()
+/obj/item/weapon/storage/wallet/on_update_icon()
 	overlays.Cut()
 	if(front_id)
 		var/tiny_state = "id-generic"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -47,7 +47,7 @@
 			return 0
 	return null
 
-/obj/item/weapon/melee/baton/update_icon()
+/obj/item/weapon/melee/baton/on_update_icon()
 	if(status)
 		icon_state = "[initial(name)]_active"
 	else if(!bcell)
@@ -230,7 +230,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "electrified_arm"
 
-/obj/item/weapon/melee/baton/robot/electrified_arm/update_icon()
+/obj/item/weapon/melee/baton/robot/electrified_arm/on_update_icon()
 	if(status)
 		icon_state = "electrified_arm_active"
 		set_light(0.4, 0.1, 1, 2, "#006aff")

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -63,7 +63,7 @@
 	update_icon()
 	update_held_icon()
 
-/obj/item/weapon/melee/telebaton/update_icon()
+/obj/item/weapon/melee/telebaton/on_update_icon()
 	if(on)
 		icon_state = "telebaton_1"
 		item_state = "telebaton_1"

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -49,7 +49,7 @@ var/list/global/tank_gauge_cache = list()
 	air_contents.update_values()
 
 	START_PROCESSING(SSobj, src)
-	update_icon(override = TRUE)
+	update_icon(TRUE)
 
 /obj/item/weapon/tank/Destroy()
 	QDEL_NULL(air_contents)
@@ -113,7 +113,7 @@ var/list/global/tank_gauge_cache = list()
 		if(C.use(1))
 			wired = 1
 			to_chat(user, "<span class='notice'>You attach the wires to the tank.</span>")
-			update_icon(override = TRUE)
+			update_icon(TRUE)
 
 	if(isWirecutter(W))
 		if(wired && proxyassembly.assembly)
@@ -135,7 +135,7 @@ var/list/global/tank_gauge_cache = list()
 						assy.a_right = null
 						proxyassembly.assembly = null
 						qdel(assy)
-				update_icon(override = TRUE)
+				update_icon(TRUE)
 
 			else
 				to_chat(user, "<span class='danger'>You slip and bump the igniter!</span>")
@@ -146,7 +146,7 @@ var/list/global/tank_gauge_cache = list()
 			if(do_after(user, 10, src))
 				to_chat(user, "<span class='notice'>You quickly clip the wire from the tank.</span>")
 				wired = 0
-				update_icon(override = TRUE)
+				update_icon(TRUE)
 
 		else
 			to_chat(user, "<span class='notice'>There are no wires to cut!</span>")
@@ -328,7 +328,7 @@ var/list/global/tank_gauge_cache = list()
 	air_contents.react() //cooking up air tanks - add phoron and oxygen, then heat above PHORON_MINIMUM_BURN_TEMPERATURE
 	check_status()
 
-/obj/item/weapon/tank/update_icon(var/override)
+/obj/item/weapon/tank/on_update_icon(var/override)
 
 	var/list/overlays_to_add
 	if(override && (proxyassembly.assembly || wired))
@@ -495,7 +495,7 @@ var/list/global/tank_gauge_cache = list()
 	H.master = proxyassembly
 
 	H.update_icon()
-	update_icon(override = TRUE)
+	update_icon(TRUE)
 
 /obj/item/weapon/tank/phoron/onetankbomb/Initialize()
 	. = ..()
@@ -557,7 +557,7 @@ var/list/global/tank_gauge_cache = list()
 
 	air_contents.add_thermal_energy(15000)
 
-/obj/item/device/tankassemblyproxy/update_icon()
+/obj/item/device/tankassemblyproxy/on_update_icon()
 	tank.update_icon()
 
 /obj/item/device/tankassemblyproxy/HasProximity(atom/movable/AM as mob|obj)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -363,7 +363,7 @@
 		return ITEM_SIZE_NO_CONTAINER
 	return ..()
 
-/obj/item/weapon/weldingtool/update_icon()
+/obj/item/weapon/weldingtool/on_update_icon()
 	..()
 
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)

--- a/code/game/objects/items/weapons/tools_crystal.dm
+++ b/code/game/objects/items/weapons/tools_crystal.dm
@@ -22,7 +22,7 @@
 		return
 	. = ..()
 
-/obj/item/weapon/weldingtool/crystal/update_icon()
+/obj/item/weapon/weldingtool/crystal/on_update_icon()
 	icon_state = welding ? "crystal_welder_on" : "crystal_welder"
 	item_state = welding ? "crystal_tool_lit"  : "crystal_tool"
 	var/mob/M = loc

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -108,7 +108,7 @@
 			update_icon()
 	..()
 
-/obj/item/weapon/beartrap/update_icon()
+/obj/item/weapon/beartrap/on_update_icon()
 	..()
 
 	if(!deployed)

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -70,7 +70,7 @@
 	else
 		..()
 
-/obj/item/weapon/weldpack/update_icon()
+/obj/item/weapon/weldpack/on_update_icon()
 	..()
 
 	overlays.Cut()

--- a/code/game/objects/structures/alien/egg.dm
+++ b/code/game/objects/structures/alien/egg.dm
@@ -35,7 +35,7 @@
 		STOP_PROCESSING(SSobj, src)
 		update_icon()
 
-/obj/structure/alien/egg/update_icon()
+/obj/structure/alien/egg/on_update_icon()
 	if(progress == -1)
 		icon_state = "egg_hatched"
 	else if(progress < MAX_PROGRESS)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -118,7 +118,7 @@ LINEN BINS
 	to_chat(user, "There are [amount] bed sheets in the bin.")
 
 
-/obj/structure/bedsheetbin/update_icon()
+/obj/structure/bedsheetbin/on_update_icon()
 	switch(amount)
 		if(0)				icon_state = "linenbin-empty"
 		if(1 to amount / 2)	icon_state = "linenbin-half"

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -37,7 +37,7 @@
 			L.update_icon() //so siding get updated properly
 
 
-/obj/structure/catwalk/update_icon()
+/obj/structure/catwalk/on_update_icon()
 	update_connections()
 	overlays.Cut()
 	icon_state = ""

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -41,7 +41,7 @@
 	else
 		return 1
 
-/obj/structure/coatrack/update_icon()
+/obj/structure/coatrack/on_update_icon()
 	overlays.Cut()
 	if (istype(coat, /obj/item/clothing/suit/storage/toggle/labcoat))
 		overlays += image(icon, icon_state = "coat_lab")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -386,7 +386,7 @@
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
-/obj/structure/closet/update_icon()//Putting the welded stuff in update_icon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
+/obj/structure/closet/on_update_icon()//Putting the welded stuff in update_icon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.Cut()
 
 	if(!opened)

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -6,7 +6,7 @@
 	icon_opened = "coffin_open"
 	setup = 0
 
-/obj/structure/closet/coffin/update_icon()
+/obj/structure/closet/coffin/on_update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -5,7 +5,7 @@
 	icon_closed = "cabinet_closed"
 	icon_opened = "cabinet_open"
 
-/obj/structure/closet/cabinet/update_icon()
+/obj/structure/closet/cabinet/on_update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -21,7 +21,7 @@
 	..()
 	update_icon()
 
-/obj/structure/closet/secure_closet/guncabinet/update_icon()
+/obj/structure/closet/secure_closet/guncabinet/on_update_icon()
 	overlays.Cut()
 	if(opened)
 		overlays += icon(icon,"door_open")

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -121,7 +121,7 @@
 /obj/structure/closet/statue/verb_toggleopen()
 	return
 
-/obj/structure/closet/statue/update_icon()
+/obj/structure/closet/statue/on_update_icon()
 	return
 
 /obj/structure/closet/statue/proc/shatter(mob/user as mob)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -89,7 +89,7 @@
 		/obj/item/weapon/extinguisher,
 		/obj/item/clothing/head/hardhat/red)
 
-/obj/structure/closet/firecloset/update_icon()
+/obj/structure/closet/firecloset/on_update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else
@@ -231,7 +231,7 @@
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
 
-/obj/structure/closet/medical_wall/update_icon()
+/obj/structure/closet/medical_wall/on_update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else
@@ -254,7 +254,7 @@
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
 
-/obj/structure/closet/shipping_wall/update_icon()
+/obj/structure/closet/shipping_wall/on_update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -82,7 +82,7 @@ obj/structure/closet/crate
 	. = ..()
 	update_icon()
 
-/obj/structure/closet/crate/secure/update_icon()
+/obj/structure/closet/crate/secure/on_update_icon()
 	..()
 	if(broken)
 		overlays += emag

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -55,7 +55,7 @@
 	else
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 
-/obj/structure/displaycase/update_icon()
+/obj/structure/displaycase/on_update_icon()
 	if(destroyed)
 		icon_state = "glassboxb"
 	else

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -32,7 +32,7 @@
 		return
 	return ..()
 
-/obj/structure/drain/update_icon()
+/obj/structure/drain/on_update_icon()
 	icon_state = "[initial(icon_state)][welded ? "-welded" : ""]"
 
 /obj/structure/drain/Process()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -58,7 +58,7 @@
 		opened = !opened
 	update_icon()
 
-/obj/structure/extinguisher_cabinet/update_icon()
+/obj/structure/extinguisher_cabinet/on_update_icon()
 	if(!opened)
 		icon_state = "extinguisher_closed"
 		return

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -26,7 +26,7 @@
 	playsound(user, 'sound/effects/Glassbr3.ogg', 100, 1)
 	update_icon()
 
-/obj/structure/fireaxecabinet/update_icon()
+/obj/structure/fireaxecabinet/on_update_icon()
 	overlays.Cut()
 	if(fireaxe)
 		overlays += image(icon, "fireaxe_item")

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -23,7 +23,7 @@
 /obj/structure/grille/ex_act(severity)
 	qdel(src)
 
-/obj/structure/grille/update_icon()
+/obj/structure/grille/on_update_icon()
 	update_onframe()
 
 	overlays.Cut()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -214,7 +214,7 @@
 	update_icon()
 	isSwitchingStates = 0
 
-/obj/structure/inflatable/door/update_icon()
+/obj/structure/inflatable/door/on_update_icon()
 	if(state)
 		icon_state = "door_open"
 	else

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -46,7 +46,7 @@
 	if(cloth)
 		to_chat(user, "<span class='notice'>\The \icon[cloth] [cloth] lies on it.</span>")
 
-/obj/structure/bed/roller/ironingboard/update_icon()
+/obj/structure/bed/roller/ironingboard/on_update_icon()
 	if(density)
 		icon_state = "up"
 	else

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -148,7 +148,7 @@
 	updateUsrDialog()
 
 
-/obj/structure/janitorialcart/update_icon()
+/obj/structure/janitorialcart/on_update_icon()
 	overlays = null
 	if(mybag)
 		overlays += "cart_garbage"

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -441,7 +441,7 @@
 	req_access = list(access_crematorium)
 	id = 1
 
-/obj/machinery/button/crematorium/update_icon()
+/obj/machinery/button/crematorium/on_update_icon()
 	return
 
 /obj/machinery/button/crematorium/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -35,7 +35,7 @@
 		return
 	..()
 
-/obj/structure/pit/update_icon()
+/obj/structure/pit/on_update_icon()
 	icon_state = "pit[open]"
 	if(istype(loc,/turf/simulated/floor/exoplanet))
 		var/turf/simulated/floor/exoplanet/E = loc

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -128,7 +128,7 @@
 			if (UpdateNeighbors)
 				R.update_icon(0)
 
-/obj/structure/railing/update_icon(var/update_neighbors = TRUE)
+/obj/structure/railing/on_update_icon(var/update_neighbors = TRUE)
 	NeighborsCheck(update_neighbors)
 	overlays.Cut()
 	if (!neighbor_status || !anchored)

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -23,7 +23,7 @@
 	. = ..()
 	update_icon()
 
-/obj/structure/rubble/update_icon()
+/obj/structure/rubble/on_update_icon()
 	overlays.Cut()
 	var/list/parts = list()
 	for(var/i = 1 to 7)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -65,7 +65,7 @@ FLOOR SAFES
 	return num
 
 
-/obj/structure/safe/update_icon()
+/obj/structure/safe/on_update_icon()
 	if(open)
 		icon_state = "[initial(icon_state)]-open"
 	else

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -78,7 +78,7 @@
 		I.forceMove(loc)
 	. = ..()
 
-/obj/structure/skele_stand/update_icon()
+/obj/structure/skele_stand/on_update_icon()
 	overlays.Cut()
 	for(var/slot in swag)
 		var/obj/item/I = swag[slot]

--- a/code/game/objects/structures/stasis_cage.dm
+++ b/code/game/objects/structures/stasis_cage.dm
@@ -21,7 +21,7 @@
 	if(Adjacent(user))
 		release()
 
-/obj/structure/stasis_cage/update_icon()
+/obj/structure/stasis_cage/on_update_icon()
 	if(contained)
 		icon_state = "[initial(icon_state)]_on"
 	else

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -9,7 +9,7 @@
 	buckle_pixel_shift = "x=0;y=6"
 	var/health = 100
 
-/obj/structure/bed/nest/update_icon()
+/obj/structure/bed/nest/on_update_icon()
 	return
 
 /obj/structure/bed/nest/user_unbuckle_mob(mob/user as mob)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -38,7 +38,7 @@
 	return material
 
 // Reuse the cache/code from stools, todo maybe unify.
-/obj/structure/bed/update_icon()
+/obj/structure/bed/on_update_icon()
 	// Prep icon.
 	icon_state = ""
 	overlays.Cut()
@@ -194,7 +194,7 @@
 	buckle_pixel_shift = "x=0;y=6"
 	var/item_form_type = /obj/item/roller	//The folded-up object path.
 
-/obj/structure/bed/roller/update_icon()
+/obj/structure/bed/roller/on_update_icon()
 	if(density)
 		icon_state = "up"
 	else

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -36,7 +36,7 @@
 	update_icon()
 	return ..()
 
-/obj/structure/bed/chair/update_icon()
+/obj/structure/bed/chair/on_update_icon()
 	..()
 
 	var/cache_key = "[base_icon]-[material.name]-over"
@@ -182,7 +182,7 @@
 	base_icon = "capchair"
 	buckle_movable = 1
 
-/obj/structure/bed/chair/comfy/captain/update_icon()
+/obj/structure/bed/chair/comfy/captain/on_update_icon()
 	..()
 	var/image/I = image(icon, "[base_icon]_special")
 	I.plane = ABOVE_HUMAN_PLANE
@@ -347,7 +347,7 @@
 		base_icon = "shuttle_chair"
 	..()
 
-/obj/structure/bed/chair/shuttle/update_icon()
+/obj/structure/bed/chair/shuttle/on_update_icon()
 	..()
 	if(!buckled_mob)
 		var/image/I = image(icon, "[base_icon]_special")

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -46,7 +46,7 @@ var/global/list/stool_cache = list() //haha stool
 /obj/item/weapon/stool/bar/padded/New(var/newloc, var/new_material)
 	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
 
-/obj/item/weapon/stool/update_icon()
+/obj/item/weapon/stool/on_update_icon()
 	// Prep icon.
 	icon_state = ""
 	// Base icon.

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -11,7 +11,7 @@
 
 	movement_handlers = list(/datum/movement_handler/delay = list(2), /datum/movement_handler/move_relay_self)
 
-/obj/structure/bed/chair/wheelchair/update_icon()
+/obj/structure/bed/chair/wheelchair/on_update_icon()
 	return
 
 /obj/structure/bed/chair/wheelchair/set_dir()

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -23,7 +23,7 @@
 	update_icon()
 
 
-/obj/structure/dispenser/update_icon()
+/obj/structure/dispenser/on_update_icon()
 	overlays.Cut()
 	switch(oxygentanks)
 		if(1 to 3)	overlays += "oxygen-[oxygentanks]"

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -111,7 +111,7 @@
 
 // icon related
 
-/obj/structure/wall_frame/update_icon()
+/obj/structure/wall_frame/on_update_icon()
 	overlays.Cut()
 	var/image/I
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -111,7 +111,7 @@
 	open = !open
 	update_icon()
 
-/obj/structure/hygiene/toilet/update_icon()
+/obj/structure/hygiene/toilet/on_update_icon()
 	icon_state = "toilet[open][cistern]"
 
 /obj/structure/hygiene/toilet/attackby(obj/item/I as obj, var/mob/living/user)
@@ -235,7 +235,7 @@
 			return
 	. = ..()
 
-/obj/structure/hygiene/shower/update_icon()	//this is terribly unreadable, but basically it makes the shower mist up
+/obj/structure/hygiene/shower/on_update_icon()	//this is terribly unreadable, but basically it makes the shower mist up
 	overlays.Cut()					//once it's been on for a while, in addition to handling the water overlay.
 	if(mymist)
 		qdel(mymist)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -43,7 +43,7 @@ obj/structure/windoor_assembly/Destroy()
 	update_nearby_tiles()
 	..()
 
-/obj/structure/windoor_assembly/update_icon()
+/obj/structure/windoor_assembly/on_update_icon()
 	icon_state = "[facing]_[secure]windoor_assembly[state]"
 
 /obj/structure/windoor_assembly/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -398,7 +398,7 @@
 	return istype(S, /obj/structure/window)
 
 //merges adjacent full-tile windows into one (blatant ripoff from game/smoothwall.dm)
-/obj/structure/window/update_icon()
+/obj/structure/window/on_update_icon()
 	//A little cludge here, since I don't know how it will work with slim windows. Most likely VERY wrong.
 	//this way it will only update full-tile ones
 	overlays.Cut()
@@ -650,5 +650,5 @@
 	if(active && !powered(power_channel))
 		toggle_tint()
 
-/obj/machinery/button/windowtint/update_icon()
+/obj/machinery/button/windowtint/on_update_icon()
 	icon_state = "light[active]"

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -91,7 +91,7 @@
 					S.handle_movement(src, MOVING_QUICKLY(H))
 					if(S.track_blood && S.blood_DNA)
 						bloodDNA = S.blood_DNA
-						bloodcolor=S.blood_color
+						bloodcolor = S.blood_color
 						S.track_blood--
 			else
 				if(H.track_blood && H.feet_blood_DNA)

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -1,6 +1,6 @@
 var/list/flooring_cache = list()
 
-/turf/simulated/floor/update_icon(var/update_neighbors)
+/turf/simulated/floor/on_update_icon(var/update_neighbors)
 
 	..()
 

--- a/code/game/turfs/simulated/floor_static.dm
+++ b/code/game/turfs/simulated/floor_static.dm
@@ -12,7 +12,7 @@
 		return
 	return ..()
 
-/turf/simulated/floor/fixed/update_icon()
+/turf/simulated/floor/fixed/on_update_icon()
 	update_flood_overlay()
 
 /turf/simulated/floor/fixed/is_plating()

--- a/code/game/turfs/simulated/turf_ocean.dm
+++ b/code/game/turfs/simulated/turf_ocean.dm
@@ -32,7 +32,7 @@
 		detail_decal = "asteroid[rand(0,9)]"
 		update_icon()
 
-/turf/simulated/ocean/update_icon(update_neighbors)
+/turf/simulated/ocean/on_update_icon(update_neighbors)
 	..(update_neighbors)
 	if(detail_decal)
 		overlays += image(icon = 'icons/turf/mining_decals.dmi', icon_state = detail_decal)

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -33,7 +33,7 @@
 	reinf_material = newrmaterial
 	update_material()
 
-/turf/simulated/wall/update_icon()
+/turf/simulated/wall/on_update_icon()
 
 	..()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -46,7 +46,7 @@
 	else
 		luminosity = 1
 
-/turf/update_icon()
+/turf/on_update_icon()
 	update_flood_overlay()
 
 /turf/proc/update_flood_overlay()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -51,7 +51,7 @@
 	set_active(secured ? FALSE : on)
 	return secured
 
-/obj/item/device/assembly/infra/update_icon()
+/obj/item/device/assembly/infra/on_update_icon()
 	overlays.Cut()
 	if(on)
 		overlays += "infrared_on"

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -91,7 +91,7 @@
 	return
 
 
-/obj/item/device/assembly/prox_sensor/update_icon()
+/obj/item/device/assembly/prox_sensor/on_update_icon()
 	overlays.Cut()
 	attached_overlays = list()
 	if(timing)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -33,7 +33,7 @@
 	signal()
 	return 1
 
-/obj/item/device/assembly/signaler/update_icon()
+/obj/item/device/assembly/signaler/on_update_icon()
 	if(holder)
 		holder.update_icon()
 	return

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -57,7 +57,7 @@
 	return
 
 
-/obj/item/device/assembly/timer/update_icon()
+/obj/item/device/assembly/timer/on_update_icon()
 	overlays.Cut()
 	attached_overlays = list()
 	if(timing)

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -136,5 +136,5 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 
 /obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
 
-/obj/machinery/atmospherics/update_icon()
+/obj/machinery/atmospherics/on_update_icon()
 	return null

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -74,7 +74,7 @@
 		recent_moles_transferred = 0
 		update_icon()
 
-/obj/machinery/atmospherics/binary/circulator/update_icon()
+/obj/machinery/atmospherics/binary/circulator/on_update_icon()
 	if(stat & (BROKEN|NOPOWER) || !anchored)
 		icon_state = "circ-p"
 	else if(last_pressure_delta > 0 && recent_moles_transferred > 0)

--- a/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
@@ -55,7 +55,7 @@
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/binary/dp_vent_pump/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
 

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -157,7 +157,7 @@
 		if (inner_tank.return_pressure() <= 0.1)
 			phase = "filling"
 
-/obj/machinery/atmospherics/binary/oxyregenerator/update_icon()
+/obj/machinery/atmospherics/binary/oxyregenerator/on_update_icon()
 	if(!powered())
 		icon_state = "off"
 	else

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -33,7 +33,7 @@
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 
-/obj/machinery/atmospherics/binary/passive_gate/update_icon()
+/obj/machinery/atmospherics/binary/passive_gate/on_update_icon()
 	icon_state = (unlocked && flowing)? "on" : "off"
 
 /obj/machinery/atmospherics/binary/passive_gate/update_underlays()

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -47,7 +47,7 @@ Thus, the two variables affect pump operation are set in New():
 	use_power = 1
 
 
-/obj/machinery/atmospherics/binary/pump/update_icon()
+/obj/machinery/atmospherics/binary/pump/on_update_icon()
 	if(!powered())
 		icon_state = "off"
 	else

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -12,7 +12,7 @@
 	use_power = 1
 	icon_state = "map_on"
 
-/obj/machinery/atmospherics/binary/pump/high_power/update_icon()
+/obj/machinery/atmospherics/binary/pump/high_power/on_update_icon()
 	if(!powered())
 		icon_state = "off"
 	else

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -46,7 +46,7 @@
 
 	build_icons()
 
-/obj/machinery/atmospherics/omni/update_icon()
+/obj/machinery/atmospherics/omni/on_update_icon()
 	if(stat & NOPOWER)
 		overlays = overlays_off
 	else if(error_check())

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -23,7 +23,7 @@
 	initialize_directions = dir
 	. = ..()
 
-/obj/machinery/atmospherics/portables_connector/update_icon()
+/obj/machinery/atmospherics/portables_connector/on_update_icon()
 	icon_state = "connector"
 
 /obj/machinery/atmospherics/portables_connector/update_underlays()

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -9,7 +9,7 @@
 	connect_types = CONNECT_TYPE_SCRUBBER | CONNECT_TYPE_SUPPLY | CONNECT_TYPE_REGULAR
 
 
-/obj/machinery/atmospherics/valve/shutoff/update_icon()
+/obj/machinery/atmospherics/valve/shutoff/on_update_icon()
 	icon_state = "vclamp[open]"
 
 /obj/machinery/atmospherics/valve/shutoff/examine(var/mob/user)

--- a/code/modules/atmospherics/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/components/trinary_devices/filter.dm
@@ -57,7 +57,7 @@
 	air2.volume = ATMOS_DEFAULT_VOLUME_FILTER
 	air3.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
-/obj/machinery/atmospherics/trinary/filter/update_icon()
+/obj/machinery/atmospherics/trinary/filter/on_update_icon()
 	if(istype(src, /obj/machinery/atmospherics/trinary/filter/m_filter))
 		icon_state = "m"
 	else

--- a/code/modules/atmospherics/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/components/trinary_devices/mixer.dm
@@ -19,7 +19,7 @@
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
-/obj/machinery/atmospherics/trinary/mixer/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/trinary/mixer/on_update_icon(var/safety = 0)
 	if(istype(src, /obj/machinery/atmospherics/trinary/mixer/m_mixer))
 		icon_state = "m"
 	else if(istype(src, /obj/machinery/atmospherics/trinary/mixer/t_mixer))

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -22,7 +22,7 @@
 	icon_state = "map_tvalve1"
 	state = 1
 
-/obj/machinery/atmospherics/tvalve/update_icon(animation)
+/obj/machinery/atmospherics/tvalve/on_update_icon(animation)
 	if(animation)
 		flick("tvalve[src.state][!src.state]",src)
 	else
@@ -289,7 +289,7 @@
 	icon_state = "map_tvalve1"
 	state = 1
 
-/obj/machinery/atmospherics/tvalve/digital/update_icon()
+/obj/machinery/atmospherics/tvalve/digital/on_update_icon()
 	..()
 	if(!powered())
 		icon_state = "tvalvenopower"
@@ -405,7 +405,7 @@
 	update_icon()
 	update_underlays()
 
-/obj/machinery/atmospherics/tvalve/mirrored/update_icon(animation)
+/obj/machinery/atmospherics/tvalve/mirrored/on_update_icon(animation)
 	if(animation)
 		flick("tvalvem[src.state][!src.state]",src)
 	else
@@ -424,7 +424,7 @@
 	icon_state = "map_tvalvem1"
 	state = 1
 
-/obj/machinery/atmospherics/tvalve/mirrored/digital/update_icon()
+/obj/machinery/atmospherics/tvalve/mirrored/digital/on_update_icon()
 	..()
 	if(!powered())
 		icon_state = "tvalvemnopower"

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -53,7 +53,7 @@
 
 	update_icon()
 
-/obj/machinery/atmospherics/unary/freezer/update_icon()
+/obj/machinery/atmospherics/unary/freezer/on_update_icon()
 	if(node)
 		if(use_power && cooling)
 			icon_state = "freezer_1"

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -56,7 +56,7 @@
 	update_icon()
 
 
-/obj/machinery/atmospherics/unary/heater/update_icon()
+/obj/machinery/atmospherics/unary/heater/on_update_icon()
 	if(node)
 		if(use_power && heating)
 			icon_state = "heater_1"

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -27,7 +27,7 @@
 	..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
 
-/obj/machinery/atmospherics/unary/outlet_injector/update_icon()
+/obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()
 	if(!powered())
 		icon_state = "off"
 	else

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -99,7 +99,7 @@
 	..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500 //meant to match air injector
 
-/obj/machinery/atmospherics/unary/vent_pump/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/unary/vent_pump/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
 	if (!node)

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -42,7 +42,7 @@
 	unregister_radio(src, frequency)
 	..()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/unary/vent_scrubber/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
 

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -20,7 +20,7 @@
 	open = 1
 	icon_state = "map_valve1"
 
-/obj/machinery/atmospherics/valve/update_icon(animation)
+/obj/machinery/atmospherics/valve/on_update_icon(animation)
 	if(animation)
 		flick("valve[src.open][!src.open]",src)
 	else
@@ -244,7 +244,7 @@
 	open = 1
 	icon_state = "map_valve1"
 
-/obj/machinery/atmospherics/valve/digital/update_icon()
+/obj/machinery/atmospherics/valve/digital/on_update_icon()
 	..()
 	if(!powered())
 		icon_state = "valve[open]nopower"

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -283,7 +283,7 @@
 	if(node2)
 		node2.update_underlays()
 
-/obj/machinery/atmospherics/pipe/simple/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/simple/on_update_icon(var/safety = 0)
 	if(!atmos_initalized)
 		return
 	if(!check_icon_cache())
@@ -536,7 +536,7 @@
 	if(node3)
 		node3.update_underlays()
 
-/obj/machinery/atmospherics/pipe/manifold/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/manifold/on_update_icon(var/safety = 0)
 	if(!atmos_initalized)
 		return
 	if(!check_icon_cache())
@@ -795,7 +795,7 @@
 	if(node4)
 		node4.update_underlays()
 
-/obj/machinery/atmospherics/pipe/manifold4w/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/manifold4w/on_update_icon(var/safety = 0)
 	if(!atmos_initalized)
 		return
 	if(!check_icon_cache())
@@ -1031,7 +1031,7 @@
 	if(node)
 		node.update_underlays()
 
-/obj/machinery/atmospherics/pipe/cap/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/cap/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
 
@@ -1324,7 +1324,7 @@
 /obj/machinery/atmospherics/pipe/vent/pipeline_expansion()
 	return list(node1)
 
-/obj/machinery/atmospherics/pipe/vent/update_icon()
+/obj/machinery/atmospherics/pipe/vent/on_update_icon()
 	if(node1)
 		icon_state = "intact"
 
@@ -1369,7 +1369,7 @@
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	icon_state = "map_universal"
 
-/obj/machinery/atmospherics/pipe/simple/visible/universal/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/simple/visible/universal/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
 
@@ -1404,7 +1404,7 @@
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	icon_state = "map_universal"
 
-/obj/machinery/atmospherics/pipe/simple/hidden/universal/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/simple/hidden/universal/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
 

--- a/code/modules/augment/active/tool/engineering.dm
+++ b/code/modules/augment/active/tool/engineering.dm
@@ -19,7 +19,7 @@
 	icon = 'icons/obj/augment_tools.dmi'
 
 
-/obj/item/weapon/weldingtool/finger/update_icon()
+/obj/item/weapon/weldingtool/finger/on_update_icon()
 	icon_state = welding ? "welder_finger_on" : "welder_finger"
 
 /obj/item/weapon/wirecutters/finger

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -14,7 +14,7 @@
 		set_density(0)
 	. = ..()
 
-/obj/machinery/gateway/update_icon()
+/obj/machinery/gateway/on_update_icon()
 	if(active)
 		icon_state = "on"
 		return
@@ -40,7 +40,7 @@
 	awaygate = locate(/obj/machinery/gateway/centeraway)
 	. = ..()
 
-/obj/machinery/gateway/centerstation/update_icon()
+/obj/machinery/gateway/centerstation/on_update_icon()
 	if(active)
 		icon_state = "oncenter"
 		return
@@ -154,7 +154,7 @@ obj/machinery/gateway/centerstation/Process()
 	stationgate = locate(/obj/machinery/gateway/centerstation)
 	. = ..()
 
-/obj/machinery/gateway/centeraway/update_icon()
+/obj/machinery/gateway/centeraway/on_update_icon()
 	if(active)
 		icon_state = "oncenter"
 		return

--- a/code/modules/awaymissions/pamphlet.dm
+++ b/code/modules/awaymissions/pamphlet.dm
@@ -34,5 +34,5 @@
 			environs."
 
 //we don't want the silly text overlay!
-/obj/item/weapon/paper/pamphlet/update_icon()
+/obj/item/weapon/paper/pamphlet/on_update_icon()
 	return

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -42,7 +42,7 @@
 		if(3)
 			take_damage(rand(20, 60) / brute_resist)
 
-/obj/effect/blob/update_icon()
+/obj/effect/blob/on_update_icon()
 	if(health > maxHealth / 2)
 		icon_state = "blob"
 	else
@@ -177,7 +177,7 @@
 	var/growth_range = 10 // Maximal distance for new blob pieces from this core.
 
 // Rough icon state changes that reflect the core's health
-/obj/effect/blob/core/update_icon()
+/obj/effect/blob/core/on_update_icon()
 	var/health_percent = (health / maxHealth) * 100
 	switch(health_percent)
 		if(66 to INFINITY)
@@ -221,7 +221,7 @@
 
 	layer = BLOB_NODE_LAYER
 
-/obj/effect/blob/core/secondary/update_icon()
+/obj/effect/blob/core/secondary/on_update_icon()
 	icon_state = (health / maxHealth >= 0.5) ? "blob_node" : "blob_factory"
 
 /obj/effect/blob/shield
@@ -242,7 +242,7 @@
 	update_nearby_tiles()
 	..()
 
-/obj/effect/blob/shield/update_icon()
+/obj/effect/blob/shield/on_update_icon()
 	if(health > maxHealth * 2 / 3)
 		icon_state = "blob_idle"
 	else if(health > maxHealth / 3)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -466,7 +466,7 @@ BLIND     // can't see anything
 		to_chat(user, "<span class='notice'>You crawl under \the [src].</span>")
 	return 1
 
-/obj/item/clothing/head/update_icon(var/mob/user)
+/obj/item/clothing/head/on_update_icon(var/mob/user)
 
 	overlays.Cut()
 	if(on)
@@ -628,7 +628,7 @@ BLIND     // can't see anything
 	else
 		return ..()
 
-/obj/item/clothing/shoes/update_icon()
+/obj/item/clothing/shoes/on_update_icon()
 	overlays.Cut()
 	if(holding)
 		overlays += image(icon, "[icon_state]_knife")

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -384,7 +384,7 @@
 		user.update_inv_glasses()
 		user.update_action_buttons()
 
-/obj/item/clothing/glasses/sunglasses/sechud/toggle/update_icon()
+/obj/item/clothing/glasses/sunglasses/sechud/toggle/on_update_icon()
 	if(on)
 		icon_state = initial(icon_state)
 	else
@@ -458,7 +458,7 @@
 	..()
 	update_icon()
 
-/obj/item/clothing/glasses/eyepatch/hud/update_icon()
+/obj/item/clothing/glasses/eyepatch/hud/on_update_icon()
 	overlays.Cut()
 	if(active)
 		var/image/eye = overlay_image(icon, "[icon_state]_eye", flags=RESET_COLOR)

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -15,7 +15,7 @@
 	set_extension(src, /datum/extension/base_icon_state, /datum/extension/base_icon_state, icon_state)
 	update_icon()
 
-/obj/item/clothing/head/soft/update_icon()
+/obj/item/clothing/head/soft/on_update_icon()
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
 	if(flipped)
 		icon_state = "[bis.base_icon_state]_flipped"

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -86,7 +86,7 @@
 		monitor_state_index = choice
 		update_icon()
 
-/obj/item/clothing/mask/monitor/update_icon()
+/obj/item/clothing/mask/monitor/on_update_icon()
 	if(!(monitor_state_index in monitor_states))
 		monitor_state_index = initial(monitor_state_index)
 	icon_state = monitor_states[monitor_state_index]

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -508,7 +508,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/item/weapon/rig/update_icon(var/update_mob_icon)
+/obj/item/weapon/rig/on_update_icon(var/update_mob_icon)
 
 	//TODO: Maybe consider a cache for this (use mob_icon as blank canvas, use suit icon overlay).
 	overlays.Cut()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -57,7 +57,7 @@
 	else
 		RemoveHood()
 
-/obj/item/clothing/suit/storage/hooded/update_icon()
+/obj/item/clothing/suit/storage/hooded/on_update_icon()
 	if(suittoggled)
 		icon_state = "[initial(icon_state)]_t"
 	else

--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -268,7 +268,7 @@
 	H.update_icon()
 	update_clothing_icon()
 
-/obj/item/clothing/accessory/toggleable/flannel/update_icon()
+/obj/item/clothing/accessory/toggleable/flannel/on_update_icon()
 	icon_state = initial(icon_state)
 	if(rolled)
 		icon_state += "r"

--- a/code/modules/clothing/under/accessories/ties.dm
+++ b/code/modules/clothing/under/accessories/ties.dm
@@ -92,7 +92,7 @@
 
 	update_icon()
 
-/obj/item/clothing/accessory/bowtie/update_icon()
+/obj/item/clothing/accessory/bowtie/on_update_icon()
 	if(icon_state == icon_tied)
 		icon_state = "[icon_tied]_untied"
 	else

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -145,7 +145,7 @@
 	closed = !closed
 	src.update_icon()
 
-/obj/machinery/dnaforensics/update_icon()
+/obj/machinery/dnaforensics/on_update_icon()
 	..()
 	if(!(stat & NOPOWER) && scanning)
 		icon_state = "dnaworking"

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -135,7 +135,7 @@
 	else
 		return ..()
 
-/obj/machinery/microscope/update_icon()
+/obj/machinery/microscope/on_update_icon()
 	icon_state = "microscope"
 	if(sample)
 		icon_state += "slide"

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -62,7 +62,7 @@
 	w_class = I.w_class
 	update_icon()
 
-/obj/item/weapon/evidencebag/update_icon()
+/obj/item/weapon/evidencebag/on_update_icon()
 	overlays.Cut()
 	if(stored_item)
 		icon_state = "evidence"

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -66,7 +66,7 @@
 	else
 		SetName("dry [initial(name)]")
 
-/obj/item/weapon/reagent_containers/glass/rag/update_icon()
+/obj/item/weapon/reagent_containers/glass/rag/on_update_icon()
 	if(on_fire)
 		icon_state = "raglit"
 	else

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -66,7 +66,7 @@
 	if(num == 0) // Less than one thaler, let's just make it look like 1 for ease
 		. += "spacecash1"
 
-/obj/item/weapon/spacecash/bundle/update_icon()
+/obj/item/weapon/spacecash/bundle/on_update_icon()
 	overlays.Cut()
 	var/list/images = src.getMoneyImages()
 

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -59,7 +59,7 @@
 		..()
 	return
 
-/obj/machinery/food_replicator/update_icon()
+/obj/machinery/food_replicator/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"
 	else if( !(stat & NOPOWER) )

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -233,7 +233,7 @@
 		for(var/datum/playingcard/P in cards)
 			to_chat(user, "The [P.name].")
 
-/obj/item/weapon/hand/update_icon(var/direction = 0)
+/obj/item/weapon/hand/on_update_icon(var/direction = 0)
 
 	if(!cards.len)
 		qdel(src)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -414,7 +414,7 @@
 	if(numbuttons == numready)
 		begin_event()
 
-/obj/machinery/readybutton/update_icon()
+/obj/machinery/readybutton/on_update_icon()
 	if(ready)
 		icon_state = "auth_on"
 	else

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	update_icon()
 
-/obj/machinery/beehive/update_icon()
+/obj/machinery/beehive/on_update_icon()
 	overlays.Cut()
 	icon_state = "beehive-[closed]"
 	if(closed)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -129,7 +129,7 @@
 		SSplants.product_descs["[seed.uid]"] = desc
 	desc += ". Delicious! Probably."
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/update_icon()
+/obj/item/weapon/reagent_containers/food/snacks/grown/on_update_icon()
 	if(!seed)
 		return
 	overlays.Cut()

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -129,7 +129,7 @@
 		var/turf/T = get_turf(src)
 		T.ex_act(prob(80) ? 3 : 2)
 
-/obj/effect/vine/update_icon()
+/obj/effect/vine/on_update_icon()
 	overlays.Cut()
 	var/growth = growth_threshold ? min(max_growth, round(health/growth_threshold)) : 1
 	var/at_fringe = get_dist(src,parent)

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -1,5 +1,5 @@
 //Refreshes the icon and sets the luminosity
-/obj/machinery/portable_atmospherics/hydroponics/update_icon()
+/obj/machinery/portable_atmospherics/hydroponics/on_update_icon()
 	// Update name.
 	if(seed)
 		if(mechanical)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -265,7 +265,7 @@
 /obj/item/device/electronic_assembly/proc/can_move()
 	return FALSE
 
-/obj/item/device/electronic_assembly/update_icon()
+/obj/item/device/electronic_assembly/on_update_icon()
 	if(opened)
 		icon_state = initial(icon_state) + "-open"
 	else

--- a/code/modules/integrated_electronics/core/detailer.dm
+++ b/code/modules/integrated_electronics/core/detailer.dm
@@ -32,7 +32,7 @@
 	.=..()
 	update_icon()
 
-/obj/item/device/integrated_electronics/detailer/update_icon()
+/obj/item/device/integrated_electronics/detailer/on_update_icon()
 	overlays.Cut()
 	var/image/detail_overlay = image('icons/obj/assemblies/electronic_tools.dmi',src, "detailer-color")
 	detail_overlay.color = detail_color

--- a/code/modules/integrated_electronics/core/wirer.dm
+++ b/code/modules/integrated_electronics/core/wirer.dm
@@ -15,7 +15,7 @@
 	var/datum/integrated_io/selected_io = null
 	var/mode = WIRE
 
-/obj/item/device/integrated_electronics/wirer/update_icon()
+/obj/item/device/integrated_electronics/wirer/on_update_icon()
 	icon_state = "wirer-[mode]"
 
 /obj/item/device/integrated_electronics/wirer/proc/wire(var/datum/integrated_io/io, mob/user)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -86,7 +86,7 @@
 		else
 	return
 
-/obj/structure/bookcase/update_icon()
+/obj/structure/bookcase/on_update_icon()
 	if(contents.len < 5)
 		icon_state = "book-[contents.len]"
 	else

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -201,7 +201,7 @@
 
 	update_icon()
 
-/obj/machinery/mining/drill/update_icon()
+/obj/machinery/mining/drill/on_update_icon()
 	if(need_player_check)
 		icon_state = "mining_drill_error"
 	else if(active)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -57,7 +57,7 @@ var/list/mining_floors = list()
 /turf/simulated/mineral/is_plating()
 	return 1
 
-/turf/simulated/mineral/update_icon(var/update_neighbors)
+/turf/simulated/mineral/on_update_icon(var/update_neighbors)
 	if(!istype(mineral))
 		SetName(initial(name))
 		icon_state = "rock"

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -133,7 +133,7 @@
 	last_target = assailant.zone_sel.selecting
 	affecting.UpdateLyingBuckledAndVerbStatus()
 	adjust_position()
-	update_icons()
+	update_icon()
 	action_used()
 
 // Returns the organ of the grabbed person that the grabber is targeting
@@ -174,7 +174,7 @@
 		current_grab = upgrab
 		last_upgrade = world.time
 		adjust_position()
-		update_icons()
+		update_icon()
 		leave_forensic_traces()
 		current_grab.enter_as_up(src)
 
@@ -182,9 +182,9 @@
 	var/datum/grab/downgrab = current_grab.downgrade(src)
 	if(downgrab)
 		current_grab = downgrab
-		update_icons()
+		update_icon()
 
-/obj/item/grab/proc/update_icons()
+/obj/item/grab/on_update_icon()
 	if(current_grab.icon)
 		icon = current_grab.icon
 	if(current_grab.icon_state)

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/_gestalt.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/_gestalt.dm
@@ -22,7 +22,7 @@
 	update_icon()
 	. = ..(mapload)
 
-/obj/structure/diona_gestalt/update_icon()
+/obj/structure/diona_gestalt/on_update_icon()
 	overlays = list(eyes_overlay)
 	if(nymphs && nymphs.len)
 		var/matrix/M = matrix()

--- a/code/modules/mob/living/carbon/alien/diona/nymph_ui.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_ui.dm
@@ -3,7 +3,7 @@
 	icon_state = "intent_devour"
 	screen_loc = DIONA_SCREEN_LOC_INTENT
 
-/obj/screen/intent/diona_nymph/update_icon()
+/obj/screen/intent/diona_nymph/on_update_icon()
 	if(intent == I_HURT || intent == I_GRAB)
 		icon_state = "intent_expel"
 	else

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -689,7 +689,7 @@ var/list/ai_verbs_default = list(
 	multitool_mode = !multitool_mode
 	to_chat(src, "<span class='notice'>Multitool mode: [multitool_mode ? "E" : "Dise"]ngaged</span>")
 
-/mob/living/silicon/ai/update_icon()
+/mob/living/silicon/ai/on_update_icon()
 	if(!selected_sprite || !(selected_sprite in available_icons()))
 		selected_sprite = decls_repository.get_decl(default_ai_icon)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -163,7 +163,7 @@ var/list/mob_hat_cache = list()
 		real_name = "[initial(name)] ([random_id(type,100,999)])"
 	SetName(real_name)
 
-/mob/living/silicon/robot/drone/update_icon()
+/mob/living/silicon/robot/drone/on_update_icon()
 
 	overlays.Cut()
 	if(stat == 0)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -165,7 +165,7 @@
 	to_chat(src.loc, "<span class='warning'>You drop \the [wrapped].</span>")
 	wrapped.loc = get_turf(src)
 	wrapped = null
-	//update_icon()
+	//on_update_icon()
 
 /obj/item/weapon/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	// Don't fall through and smack people with gripper, instead just no-op

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -757,7 +757,7 @@
 			return 1
 	return 0
 
-/mob/living/silicon/robot/update_icon()
+/mob/living/silicon/robot/on_update_icon()
 	overlays.Cut()
 	if(stat == CONSCIOUS)
 		var/eye_icon_state = "eyes-[module_sprites[icontype]]"

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -112,7 +112,7 @@
 	else
 		activate_strobe()
 
-/obj/item/weapon/party_light/update_icon()
+/obj/item/weapon/party_light/on_update_icon()
 	if (activated)
 		icon_state = "partylight-on"
 		set_light(1, 1, 7)

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -52,7 +52,7 @@
 	ghostize()
 	qdel(src)
 
-/mob/living/simple_animal/construct/update_icon()
+/mob/living/simple_animal/construct/on_update_icon()
 	overlays.Cut()
 	..()
 	add_glow()

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -39,7 +39,7 @@
 	if(full == SOULSTONE_CRACKED)
 		to_chat(user, "This one is cracked and useless.")
 
-/obj/item/device/soulstone/update_icon()
+/obj/item/device/soulstone/on_update_icon()
 	if(full == SOULSTONE_EMPTY)
 		icon_state = "soulstone"
 	if(full == SOULSTONE_ESSENCE)

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -125,7 +125,7 @@
 		if(access_card)
 			to_chat(user, "It has an access cuff with \the [access_card] inserted.")
 
-/mob/living/simple_animal/crow/update_icon()
+/mob/living/simple_animal/crow/on_update_icon()
 	..()
 	overlays -= "bag"
 	overlays -= "bag_dead"
@@ -140,7 +140,7 @@
 	desc = "A large cybercrow. k4w k4w."
 	speak_emote = list("beeps")
 
-/mob/living/simple_animal/crow/cyber/update_icon()
+/mob/living/simple_animal/crow/cyber/on_update_icon()
 	..()
 	overlays -= "cyber"
 	overlays -= "cyber_dead"

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -154,7 +154,7 @@
 	eject_brain()
 	death()
 
-/mob/living/simple_animal/spiderbot/update_icon()
+/mob/living/simple_animal/spiderbot/on_update_icon()
 	if(mmi)
 		if(positronic)
 			icon_state = "spiderbot-chassis-posi"

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -84,7 +84,7 @@
 		gib() //Leave no identifiable evidence.
 		return
 
-/mob/living/simple_animal/hostile/vagrant/update_icon()
+/mob/living/simple_animal/hostile/vagrant/on_update_icon()
 	if(cloaked) //It's fun time
 		alpha = 45
 		set_light(0)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1010,7 +1010,7 @@
 
 // A mob should either use update_icon(), overriding this definition, or use update_icons(), not touching update_icon().
 // It should not use both.
-/mob/update_icon()
+/mob/on_update_icon()
 	return update_icons()
 
 /mob/verb/face_direction()

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -37,7 +37,7 @@ var/list/all_virtual_listeners = list()
 	host = null
 	return ..()
 
-/mob/observer/virtual/update_icon()
+/mob/observer/virtual/on_update_icon()
 	if(!overlay_icons)
 		overlay_icons = list()
 		for(var/i_state in icon_states(icon))

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -29,7 +29,7 @@
 		return 0
 	return 1
 
-/obj/machinery/ntnet_relay/update_icon()
+/obj/machinery/ntnet_relay/on_update_icon()
 	if(operable())
 		icon_state = "bus"
 	else

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -91,7 +91,7 @@
 		to_chat(user, "You emag \the [src]. It's screen briefly shows a \"OVERRIDE ACCEPTED: New software downloads available.\" message.")
 		return 1
 
-/obj/item/modular_computer/update_icon()
+/obj/item/modular_computer/on_update_icon()
 	icon_state = icon_state_unpowered
 
 	overlays.Cut()

--- a/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
@@ -28,7 +28,7 @@
 	screen_on = anchored
 	update_icon()
 
-/obj/item/modular_computer/laptop/update_icon()
+/obj/item/modular_computer/laptop/on_update_icon()
 	if(anchored)
 		..()
 	else

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -93,7 +93,7 @@ obj/machinery/atmospherics/pipe/zpipe/Destroy()
 obj/machinery/atmospherics/pipe/zpipe/pipeline_expansion()
 	return list(node1, node2)
 
-obj/machinery/atmospherics/pipe/zpipe/update_icon()
+obj/machinery/atmospherics/pipe/zpipe/on_update_icon()
 	return
 
 obj/machinery/atmospherics/pipe/zpipe/disconnect(obj/machinery/atmospherics/reference)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -151,7 +151,7 @@
 /obj/structure/ladder/CanPass(obj/mover, turf/source, height, airflow)
 	return airflow || !density
 
-/obj/structure/ladder/update_icon()
+/obj/structure/ladder/on_update_icon()
 	icon_state = "ladder[!!(allowed_directions & UP)][!!(allowed_directions & DOWN)]"
 
 /obj/structure/ladder/up

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -89,7 +89,7 @@
 /**
 * Update icon and overlays of open space to be that of the turf below, plus any visible objects on that turf.
 */
-/turf/simulated/open/update_icon()
+/turf/simulated/open/on_update_icon()
 	overlays.Cut()
 	underlays.Cut()
 	var/turf/below = GetBelow(src)

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -65,7 +65,7 @@ var/list/limb_icon_cache = list()
 		icon_cache_key += "[M][markings[M]["color"]]"
 
 /obj/item/organ/external/var/icon_cache_key
-/obj/item/organ/external/update_icon(var/regenerate = 0)
+/obj/item/organ/external/on_update_icon(var/regenerate = 0)
 	var/gender = "_m"
 	if(!(limb_flags & ORGAN_FLAG_GENDERED_ICON))
 		gender = null

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -115,7 +115,7 @@
 		if (burn_dam > 40)
 			disfigure("burn")
 
-/obj/item/organ/external/head/update_icon()
+/obj/item/organ/external/head/on_update_icon()
 
 	..()
 

--- a/code/modules/organs/internal/appendix.dm
+++ b/code/modules/organs/internal/appendix.dm
@@ -5,7 +5,7 @@
 	organ_tag = BP_APPENDIX
 	var/inflamed = 0
 
-/obj/item/organ/internal/appendix/update_icon()
+/obj/item/organ/internal/appendix/on_update_icon()
 	..()
 	if(inflamed)
 		icon_state = "appendixinflamed"

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -134,7 +134,7 @@
 	verbs -= shackled_verbs
 	update_icon()
 
-/obj/item/organ/internal/posibrain/update_icon()
+/obj/item/organ/internal/posibrain/on_update_icon()
 	if(src.brainmob && src.brainmob.key)
 		icon_state = "posibrain-occupied"
 	else

--- a/code/modules/overmap/exoplanets/desert.dm
+++ b/code/modules/overmap/exoplanets/desert.dm
@@ -135,7 +135,7 @@
 	..()
 	update_icon()
 
-/obj/structure/quicksand/update_icon()
+/obj/structure/quicksand/on_update_icon()
 	if(!exposed)
 		return
 	icon_state = "open"

--- a/code/modules/overmap/exoplanets/volcanic.dm
+++ b/code/modules/overmap/exoplanets/volcanic.dm
@@ -83,7 +83,7 @@
 	. = ..()
 	update_icon(1)
 
-/turf/simulated/floor/exoplanet/volcanic/update_icon(var/update_neighbors)
+/turf/simulated/floor/exoplanet/volcanic/on_update_icon(var/update_neighbors)
 	overlays.Cut()
 	for(var/direction in GLOB.cardinal)
 		var/turf/turf_to_check = get_step(src,direction)

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -132,7 +132,7 @@
 		user.put_in_hands(contents[1])
 	update_icon()
 
-/obj/structure/fuel_port/update_icon()
+/obj/structure/fuel_port/on_update_icon()
 	if(opened)
 		if(contents.len > 0)
 			icon_state = icon_full

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -193,7 +193,7 @@
 			return 0
 	return 1
 
-/obj/machinery/shipsensors/update_icon()
+/obj/machinery/shipsensors/on_update_icon()
 	if(use_power)
 		icon_state = "sensors"
 	else

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -107,7 +107,7 @@
 			handle_wraparound()
 		update_icon()
 
-/obj/effect/overmap/ship/update_icon()
+/obj/effect/overmap/ship/on_update_icon()
 	if(!is_still())
 		icon_state = moving_state
 		dir = get_heading()

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -6,7 +6,7 @@
 	var/iscopy = 0
 
 
-/obj/item/weapon/paper/carbon/update_icon()
+/obj/item/weapon/paper/carbon/on_update_icon()
 	if(iscopy)
 		if(info)
 			icon_state = "cpaper_words"

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -33,7 +33,7 @@
 			add_fingerprint(usr)
 			return
 
-/obj/item/weapon/clipboard/update_icon()
+/obj/item/weapon/clipboard/on_update_icon()
 	overlays.Cut()
 	if(toppaper)
 		overlays += toppaper.icon_state

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -25,7 +25,7 @@
 	desc = "A corporate folder."
 	icon_state = "folder_nt"
 
-/obj/item/weapon/folder/update_icon()
+/obj/item/weapon/folder/on_update_icon()
 	overlays.Cut()
 	if(contents.len)
 		overlays += "folder_paper"
@@ -115,7 +115,7 @@
 	icon_state = "envelope_sealed"
 	var/sealed = 1
 
-/obj/item/weapon/folder/envelope/update_icon()
+/obj/item/weapon/folder/envelope/on_update_icon()
 	if(sealed)
 		icon_state = "envelope_sealed"
 	else

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -51,7 +51,7 @@
 	update_space(info)
 	updateinfolinks()
 
-/obj/item/weapon/paper/update_icon()
+/obj/item/weapon/paper/on_update_icon()
 	if(icon_state == "paper_talisman")
 		return
 	else if(info)
@@ -437,7 +437,7 @@
 	name = "paper scrap"
 	icon_state = "scrap"
 
-/obj/item/weapon/paper/crumpled/update_icon()
+/obj/item/weapon/paper/crumpled/on_update_icon()
 	return
 
 /obj/item/weapon/paper/crumpled/bloody

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -208,7 +208,7 @@
 	qdel(src)
 
 
-/obj/item/weapon/paper_bundle/update_icon()
+/obj/item/weapon/paper_bundle/on_update_icon()
 	var/obj/item/weapon/paper/P = pages[1]
 	icon_state = P.icon_state
 	overlays = P.overlays

--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -12,7 +12,7 @@
 	var/written_by
 	var/paper_type = /obj/item/weapon/paper/sticky
 
-/obj/item/sticky_pad/update_icon()
+/obj/item/sticky_pad/on_update_icon()
 	if(papers <= 15)
 		icon_state = "pad_empty"
 	else if(papers <= 50)
@@ -94,7 +94,7 @@
 	GLOB.moved_event.unregister(src, src)
 	. = ..()
 
-/obj/item/weapon/paper/sticky/update_icon()
+/obj/item/weapon/paper/sticky/on_update_icon()
 	if(icon_state != "scrap")
 		icon_state = info ? "paper_words" : "paper"
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -111,7 +111,7 @@
 	return
 
 
-/obj/item/weapon/paper_bin/update_icon()
+/obj/item/weapon/paper_bin/on_update_icon()
 	if(amount < 1)
 		icon_state = "paper_bin0"
 	else

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -95,7 +95,7 @@
 	paperamount--
 	return new /obj/item/weapon/shreddedp(get_turf(src))
 
-/obj/machinery/papershredder/update_icon()
+/obj/machinery/papershredder/on_update_icon()
 	icon_state = "papershredder[max(0,min(5,Floor(paperamount/2)))]"
 
 /obj/item/weapon/shreddedp/attackby(var/obj/item/W as obj, var/mob/user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -42,7 +42,7 @@ var/global/photo_count = 0
 /obj/item/weapon/photo/attack_self(mob/user as mob)
 	user.examinate(src)
 
-/obj/item/weapon/photo/update_icon()
+/obj/item/weapon/photo/on_update_icon()
 	overlays.Cut()
 	var/scale = 8/(photo_size*32)
 	var/image/small_img = image(img.icon)
@@ -151,7 +151,7 @@ var/global/photo_count = 0
 	var/icon_on = "camera"
 	var/icon_off = "camera_off"
 	var/size = 3
-/obj/item/device/camera/update_icon()
+/obj/item/device/camera/on_update_icon()
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
 	if(on)
 		icon_state = "[bis.base_icon_state]"

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -82,7 +82,7 @@
 /obj/structure/noticeboard/ex_act(var/severity)
 	dismantle()
 
-/obj/structure/noticeboard/update_icon()
+/obj/structure/noticeboard/on_update_icon()
 	icon_state = "[base_icon_state][LAZYLEN(notices)]"
 
 /obj/structure/noticeboard/attackby(var/obj/item/weapon/thing, var/mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -274,7 +274,7 @@
 
 // update the APC icon to show the three base states
 // also add overlays for indicator lights
-/obj/machinery/power/apc/update_icon()
+/obj/machinery/power/apc/on_update_icon()
 	if (!status_overlays)
 		status_overlays = 1
 		status_overlays_lock = new

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -60,7 +60,7 @@
 	internal_cells = null
 	return ..()
 
-/obj/machinery/power/smes/batteryrack/update_icon()
+/obj/machinery/power/smes/batteryrack/on_update_icon()
 	overlays.Cut()
 	icon_update = 0
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -125,7 +125,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/hides_under_flooring()
 	return 1
 
-/obj/structure/cable/update_icon()
+/obj/structure/cable/on_update_icon()
 	icon_state = "[d1]-[d2]"
 	alpha = invisibility ? 127 : 255
 
@@ -539,7 +539,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	return ..()
 
 
-/obj/item/stack/cable_coil/update_icon()
+/obj/item/stack/cable_coil/on_update_icon()
 	if (!color)
 		color = GLOB.possible_cable_colours[pick(GLOB.possible_cable_colours)]
 	if(amount == 1)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -40,7 +40,7 @@
 
 	return use(cell_amt) / CELLRATE
 
-/obj/item/weapon/cell/update_icon()
+/obj/item/weapon/cell/on_update_icon()
 
 	var/new_overlay_state = null
 	if(percent() >= 95)

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -44,7 +44,7 @@ var/list/gyrotrons = list()
 	E.damage = mega_energy * 50
 	return E
 
-/obj/machinery/power/emitter/gyrotron/update_icon()
+/obj/machinery/power/emitter/gyrotron/on_update_icon()
 	if (active && powernet && avail(active_power_usage))
 		icon_state = "emitter-on"
 	else

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -55,7 +55,7 @@
 				circ1 = null
 				circ2 = null
 
-/obj/machinery/power/generator/update_icon()
+/obj/machinery/power/generator/on_update_icon()
 	if(stat & (NOPOWER|BROKEN))
 		overlays.Cut()
 	else

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -42,7 +42,7 @@
 
 	update_icon()
 
-/obj/machinery/light_construct/update_icon()
+/obj/machinery/light_construct/on_update_icon()
 	switch(stage)
 		if(1) icon_state = "tube-construct-stage1"
 		if(2) icon_state = "tube-construct-stage2"
@@ -125,7 +125,7 @@
 	fixture_type = /obj/machinery/light/small
 	sheets_refunded = 1
 
-/obj/machinery/light_construct/small/update_icon()
+/obj/machinery/light_construct/small/on_update_icon()
 	switch(stage)
 		if(1) icon_state = "bulb-construct-stage1"
 		if(2) icon_state = "bulb-construct-stage2"
@@ -199,7 +199,7 @@
 	QDEL_NULL(s)
 	. = ..()
 
-/obj/machinery/light/update_icon(var/trigger = 1)
+/obj/machinery/light/on_update_icon(var/trigger = 1)
 	overlays = overlays.Cut()
 	icon_state = "[base_state]_empty" //Never use the initial state. That'll just reset it to the mapping icon.
 	pixel_y = 0
@@ -621,7 +621,7 @@
 	matter = list(MATERIAL_GLASS = 100)
 
 // update the icon state and description of the light
-/obj/item/weapon/light/update_icon()
+/obj/item/weapon/light/on_update_icon()
 	color = b_colour
 	var/broken
 	switch(status)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -40,7 +40,7 @@
 		handleInactive()
 	update_icon()
 
-/obj/machinery/power/port_gen/update_icon()
+/obj/machinery/power/port_gen/on_update_icon()
 	if(!active)
 		icon_state = initial(icon_state)
 		return 1
@@ -428,7 +428,7 @@
 		SSradiation.radiate(src, 2*rad_power)
 	..()
 
-/obj/machinery/power/port_gen/pacman/super/update_icon()
+/obj/machinery/power/port_gen/pacman/super/on_update_icon()
 	if(..())
 		set_light(0)
 		return 1
@@ -486,7 +486,7 @@
 		temperature_gain = initial(temperature_gain)
 	..()
 
-/obj/machinery/power/port_gen/pacman/super/potato/update_icon()
+/obj/machinery/power/port_gen/pacman/super/potato/on_update_icon()
 	if(..())
 		return 1
 	if(power_output > max_safe_output)

--- a/code/modules/power/sensors/sensor_monitoring.dm
+++ b/code/modules/power/sensors/sensor_monitoring.dm
@@ -29,7 +29,7 @@
 		update_icon()
 
 // Updates icon of this computer according to current status.
-/obj/machinery/computer/power_monitor/update_icon()
+/obj/machinery/computer/power_monitor/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "powerb"
 		return

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -68,7 +68,7 @@ var/global/list/rad_collectors = list()
 		if(!user.unEquip(W, src))
 			return
 		src.P = W
-		update_icons()
+		update_icon()
 		return 1
 	else if(isCrowbar(W))
 		if(P && !src.locked)
@@ -131,7 +131,7 @@ var/global/list/rad_collectors = list()
 	if(active)
 		toggle_power()
 	else
-		update_icons()
+		update_icon()
 
 /obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(P && active)
@@ -143,7 +143,12 @@ var/global/list/rad_collectors = list()
 	return
 
 
-/obj/machinery/power/rad_collector/proc/update_icons()
+/obj/machinery/power/rad_collector/on_update_icon()
+	if(active)
+		icon_state = "ca_on"
+	else
+		icon_state = "ca"
+
 	overlays.Cut()
 	if(P)
 		overlays += image('icons/obj/singularity.dmi', "ptank")
@@ -156,10 +161,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/toggle_power()
 	active = !active
 	if(active)
-		icon_state = "ca_on"
 		flick("ca_active", src)
 	else
-		icon_state = "ca"
 		flick("ca_deactive", src)
-	update_icons()
-	return
+	update_icon()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -61,7 +61,7 @@
 	wifi_receiver = null
 	return ..()
 
-/obj/machinery/power/emitter/update_icon()
+/obj/machinery/power/emitter/on_update_icon()
 	if (active && powernet && avail(active_power_usage))
 		icon_state = "emitter_+a"
 	else

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -37,7 +37,7 @@ field_generator power level display
 	var/field_power_draw = 2000	//power needed per field object
 
 
-/obj/machinery/field_generator/update_icon()
+/obj/machinery/field_generator/on_update_icon()
 	overlays.Cut()
 	if(!active)
 		if(warming_up)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -84,7 +84,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	icon_state = "end_cap"
 	reference = "end_cap"
 
-/obj/structure/particle_accelerator/update_icon()
+/obj/structure/particle_accelerator/on_update_icon()
 	..()
 	return
 
@@ -157,7 +157,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		else
 	return
 
-/obj/structure/particle_accelerator/update_icon()
+/obj/structure/particle_accelerator/on_update_icon()
 	switch(construction_state)
 		if(0,1)
 			icon_state="[reference]"
@@ -290,7 +290,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	src.set_dir(turn(src.dir, 90))
 	return 1
 
-/obj/machinery/particle_accelerator/update_icon()
+/obj/machinery/particle_accelerator/on_update_icon()
 	return
 
 /obj/machinery/particle_accelerator/examine(mob/user)

--- a/code/modules/power/singularity/particle_accelerator/particle_chamber.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_chamber.dm
@@ -5,6 +5,6 @@
 	icon_state = "fuel_chamber"
 	reference = "fuel_chamber"
 
-/obj/structure/particle_accelerator/fuel_chamber/update_icon()
+/obj/structure/particle_accelerator/fuel_chamber/on_update_icon()
 	..()
 	return

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -58,7 +58,7 @@
 
 	return
 
-/obj/machinery/particle_accelerator/control_box/update_icon()
+/obj/machinery/particle_accelerator/control_box/on_update_icon()
 	if(active)
 		icon_state = "[reference]p1"
 	else

--- a/code/modules/power/singularity/particle_accelerator/particle_power.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_power.dm
@@ -5,6 +5,6 @@
 	icon_state = "power_box"
 	reference = "power_box"
 
-/obj/structure/particle_accelerator/power_box/update_icon()
+/obj/structure/particle_accelerator/power_box/on_update_icon()
 	..()
 	return

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -92,7 +92,7 @@
 	terminals -= term
 	term.master = null
 
-/obj/machinery/power/smes/update_icon()
+/obj/machinery/power/smes/on_update_icon()
 	overlays.Cut()
 	if(stat & BROKEN)	return
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -316,7 +316,7 @@
 // Proc: update_icon()
 // Parameters: None
 // Description: Allows us to use special icon overlay for critical SMESs
-/obj/machinery/power/smes/buildable/update_icon()
+/obj/machinery/power/smes/buildable/on_update_icon()
 	if (failing)
 		overlays.Cut()
 		overlays += image('icons/obj/power.dmi', "smes-crit")

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -87,7 +87,7 @@ var/list/solars_list = list()
 
 
 
-/obj/machinery/power/solar/update_icon()
+/obj/machinery/power/solar/on_update_icon()
 	..()
 	overlays.Cut()
 	if(stat & BROKEN)
@@ -352,7 +352,7 @@ var/list/solars_list = list()
 	if(!connect_to_network()) return
 	set_panels(cdir)
 
-/obj/machinery/power/solar_control/update_icon()
+/obj/machinery/power/solar_control/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "broken"
 		overlays.Cut()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -76,7 +76,7 @@
 			BB.SetName("[initial(BB.name)] (\"[label_text]\")")
 	else ..()
 
-/obj/item/ammo_casing/update_icon()
+/obj/item/ammo_casing/on_update_icon()
 	if(spent_icon && !BB)
 		icon_state = spent_icon
 
@@ -175,7 +175,7 @@
 		..()
 		return
 
-/obj/item/ammo_magazine/update_icon()
+/obj/item/ammo_magazine/on_update_icon()
 	if(multiple_sprites)
 		//find the lowest key greater than or equal to stored_ammo.len
 		var/new_state = null

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -99,7 +99,7 @@
 		update_icon() // In case item_state is set somewhere else.
 	..()
 
-/obj/item/weapon/gun/update_icon()
+/obj/item/weapon/gun/on_update_icon()
 	var/mob/living/M = loc
 	overlays.Cut()
 	if(istype(M))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 	to_chat(user, "Has [shots_remaining] shot\s remaining.")
 	return
 
-/obj/item/weapon/gun/energy/update_icon()
+/obj/item/weapon/gun/energy/on_update_icon()
 	..()
 	if(charge_meter && power_supply)
 		var/ratio = power_supply.percent()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -141,7 +141,7 @@ obj/item/weapon/gun/energy/retro
 	scoped_accuracy = 0
 	wielded_item_state = "gun_wielded"
 
-/obj/item/weapon/gun/energy/sniperrifle/update_icon()
+/obj/item/weapon/gun/energy/sniperrifle/on_update_icon()
 	..()
 	item_state_slots[slot_back_str] = icon_state //so that the on-back overlay uses the different charged states
 

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -93,7 +93,7 @@
 		if("stun") return "nucgun-stun"
 		if("kill") return "nucgun-kill"
 
-/obj/item/weapon/gun/energy/gun/nuclear/update_icon()
+/obj/item/weapon/gun/energy/gun/nuclear/on_update_icon()
 	var/list/new_overlays = list()
 
 	new_overlays += get_charge_overlay()

--- a/code/modules/projectiles/guns/launcher/alien.dm
+++ b/code/modules/projectiles/guns/launcher/alien.dm
@@ -55,5 +55,5 @@
 	fire_sound_text = "a strange noise"
 	fire_sound = 'sound/weapons/bladeslice.ogg'
 
-/obj/item/weapon/gun/launcher/alien/spikethrower/update_icon()
+/obj/item/weapon/gun/launcher/alien/spikethrower/on_update_icon()
 	icon_state = "spikethrower[ammo]"

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -189,7 +189,7 @@
 	bolt.icon_state = "metal-rod-superheated"
 	cell.use(500)
 
-/obj/item/weapon/gun/launcher/crossbow/update_icon()
+/obj/item/weapon/gun/launcher/crossbow/on_update_icon()
 	if(tension > 1)
 		icon_state = "crossbow-drawn"
 	else if(bolt)
@@ -207,7 +207,7 @@
 
 	var/buildstate = 0
 
-/obj/item/weapon/crossbowframe/update_icon()
+/obj/item/weapon/crossbowframe/on_update_icon()
 	icon_state = "crossbowframe[buildstate]"
 
 /obj/item/weapon/crossbowframe/examine(mob/user)

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -123,7 +123,7 @@
 		if(T) T.assume_air(removed)
 	..()
 
-/obj/item/weapon/gun/launcher/pneumatic/update_icon()
+/obj/item/weapon/gun/launcher/pneumatic/on_update_icon()
 	if(tank)
 		icon_state = "pneumatic-tank"
 		item_state = "pneumatic-tank"
@@ -143,7 +143,7 @@
 
 	var/buildstate = 0
 
-/obj/item/weapon/cannonframe/update_icon()
+/obj/item/weapon/cannonframe/on_update_icon()
 	icon_state = "pneumatic[buildstate]"
 
 /obj/item/weapon/cannonframe/examine(mob/user)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -12,7 +12,7 @@
 	w_class = ITEM_SIZE_TINY
 	var/obj/item/weapon/reagent_containers/syringe/syringe
 
-/obj/item/weapon/syringe_cartridge/update_icon()
+/obj/item/weapon/syringe_cartridge/on_update_icon()
 	underlays.Cut()
 	if(syringe)
 		underlays += image(syringe.icon, src, syringe.icon_state)

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -49,7 +49,7 @@
 			capacitor.use(capacitor.charge * 0.05)
 	update_icon()
 
-/obj/item/weapon/gun/magnetic/update_icon()
+/obj/item/weapon/gun/magnetic/on_update_icon()
 	var/list/overlays_to_add = list()
 	if(removable_components)
 		if(cell)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -41,7 +41,7 @@
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    one_hand_penalty=2, burst_accuracy=list(0,-1,-1,-1,-2), dispersion=list(0.6, 0.6, 1.0, 1.0, 1.2)),
 		)
 
-/obj/item/weapon/gun/projectile/automatic/mini_uzi/update_icon()
+/obj/item/weapon/gun/projectile/automatic/mini_uzi/on_update_icon()
 	..()
 	if(ammo_magazine)
 		icon_state = "mpistolen"
@@ -72,7 +72,7 @@
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    one_hand_penalty=4, burst_accuracy=list(0,-1,-1,-1,-2), dispersion=list(0.6, 0.6, 1.0, 1.0, 1.2)),
 		)
 
-/obj/item/weapon/gun/projectile/automatic/c20r/update_icon()
+/obj/item/weapon/gun/projectile/automatic/c20r/on_update_icon()
 	..()
 	if(ammo_magazine)
 		icon_state = "c20r-[round(ammo_magazine.stored_ammo.len,4)]"
@@ -105,7 +105,7 @@
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=6,    one_hand_penalty=6, burst_accuracy=list(0,-1,-2,-3,-3), dispersion=list(0.6, 1.0, 1.2, 1.2, 1.5)),
 		)
 
-/obj/item/weapon/gun/projectile/automatic/sts35/update_icon()
+/obj/item/weapon/gun/projectile/automatic/sts35/on_update_icon()
 	icon_state = (ammo_magazine)? "arifle" : "arifle-empty"
 	wielded_item_state = (ammo_magazine)? "arifle-wielded" : "arifle-wielded-empty"
 	..()
@@ -131,7 +131,7 @@
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    one_hand_penalty=2, burst_accuracy=list(0,-1,-1,-1,-2), dispersion=list(0.6, 0.6, 1.0, 1.0, 1.2)),
 		)
 
-/obj/item/weapon/gun/projectile/automatic/wt550/update_icon()
+/obj/item/weapon/gun/projectile/automatic/wt550/on_update_icon()
 	..()
 	if(ammo_magazine)
 		icon_state = "wt550-[round(ammo_magazine.stored_ammo.len,4)]"
@@ -194,7 +194,7 @@
 	else
 		..()
 
-/obj/item/weapon/gun/projectile/automatic/z8/update_icon()
+/obj/item/weapon/gun/projectile/automatic/z8/on_update_icon()
 	..()
 	if(ammo_magazine)
 		if(ammo_magazine.stored_ammo.len)
@@ -268,7 +268,7 @@
 	else
 		return ..() //once open, behave like normal
 
-/obj/item/weapon/gun/projectile/automatic/l6_saw/update_icon()
+/obj/item/weapon/gun/projectile/automatic/l6_saw/on_update_icon()
 	if(istype(ammo_magazine, /obj/item/ammo_magazine/box))
 		icon_state = "l6[cover_open ? "open" : "closed"][round(ammo_magazine.stored_ammo.len, 25)]"
 		item_state = "l6[cover_open ? "open" : "closed"]"

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -76,7 +76,7 @@
 	. = ..()
 	update_icon()
 
-/obj/item/weapon/gun/projectile/dartgun/update_icon()
+/obj/item/weapon/gun/projectile/dartgun/on_update_icon()
 	if(!ammo_magazine)
 		icon_state = "dartgun-empty"
 		return 1

--- a/code/modules/projectiles/guns/projectile/detective.dm
+++ b/code/modules/projectiles/guns/projectile/detective.dm
@@ -9,7 +9,7 @@
 	if(!gun_options)
 		gun_options = init_subtypes(/datum/detective_gun_skin)
 
-/obj/item/weapon/gun/projectile/colt/detective/update_icon()
+/obj/item/weapon/gun/projectile/colt/detective/on_update_icon()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
 		if(unique_reskin)
 			icon_state = unique_reskin.icon_state

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -20,7 +20,7 @@
 	accuracy = 0.35
 	fire_delay = 6.5
 
-/obj/item/weapon/gun/projectile/military/update_icon()
+/obj/item/weapon/gun/projectile/military/on_update_icon()
 	..()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
 		icon_state = "usp"
@@ -39,7 +39,7 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	load_method = MAGAZINE
 
-/obj/item/weapon/gun/projectile/sec/update_icon()
+/obj/item/weapon/gun/projectile/sec/on_update_icon()
 	..()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
 		icon_state = "secguncomp"
@@ -55,7 +55,7 @@
 	icon_state = "secgundark"
 	accuracy = 0
 
-/obj/item/weapon/gun/projectile/sec/wood/update_icon()
+/obj/item/weapon/gun/projectile/sec/wood/on_update_icon()
 	..()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
 		icon_state = "secgundark"
@@ -92,7 +92,7 @@
 	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/hpistol_magout.ogg'
 
-/obj/item/weapon/gun/projectile/magnum_pistol/update_icon()
+/obj/item/weapon/gun/projectile/magnum_pistol/on_update_icon()
 	..()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
 		icon_state = "magnum"
@@ -115,7 +115,7 @@
 	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/hpistol_magout.ogg'
 
-/obj/item/weapon/gun/projectile/gyropistol/update_icon()
+/obj/item/weapon/gun/projectile/gyropistol/on_update_icon()
 	..()
 	if(ammo_magazine)
 		icon_state = "gyropistolloaded"
@@ -133,7 +133,7 @@
 	load_method = MAGAZINE
 	accuracy = 0.35
 
-/obj/item/weapon/gun/projectile/beretta/update_icon()
+/obj/item/weapon/gun/projectile/beretta/on_update_icon()
 	..()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
 		icon_state = "92fs"
@@ -186,7 +186,7 @@
 		return
 	..()
 
-/obj/item/weapon/gun/projectile/pistol/update_icon()
+/obj/item/weapon/gun/projectile/pistol/on_update_icon()
 	..()
 	if(silenced)
 		icon_state = "pistol-silencer"
@@ -246,7 +246,7 @@
 	item_state = "zipgun-solid"
 	var/buildstate = 0
 
-/obj/item/weapon/zipgunframe/update_icon()
+/obj/item/weapon/zipgunframe/on_update_icon()
 	icon_state = "zipgun[buildstate]"
 
 /obj/item/weapon/zipgunframe/examine(mob/user)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -84,7 +84,7 @@
 /obj/item/weapon/gun/projectile/revolver/deckard/emp
 	ammo_type = /obj/item/ammo_casing/c38/emp
 
-/obj/item/weapon/gun/projectile/revolver/deckard/update_icon()
+/obj/item/weapon/gun/projectile/revolver/deckard/on_update_icon()
 	..()
 	if(loaded.len)
 		icon_state = "deckard-loaded"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -20,7 +20,7 @@
 	wielded_item_state = "heavysniper-wielded" //sort of placeholder
 	load_sound = 'sound/weapons/guns/interaction/rifle_load.ogg'
 
-/obj/item/weapon/gun/projectile/heavysniper/update_icon()
+/obj/item/weapon/gun/projectile/heavysniper/on_update_icon()
 	..()
 	if(bolt_open)
 		icon_state = "heavysniper-open"

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -178,7 +178,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 	GLOB.moved_event.register(aiming_at, src, /obj/aiming_overlay/proc/target_moved)
 	GLOB.destroyed_event.register(aiming_at, src, /obj/aiming_overlay/proc/cancel_aiming)
 
-/obj/aiming_overlay/update_icon()
+/obj/aiming_overlay/on_update_icon()
 	if(locked)
 		icon_state = "locked"
 	else

--- a/code/modules/random_map/automata/diona.dm
+++ b/code/modules/random_map/automata/diona.dm
@@ -44,7 +44,7 @@
 			existing.growth = new_growth
 			existing.update_icon()
 
-/obj/structure/diona/vines/update_icon()
+/obj/structure/diona/vines/on_update_icon()
 	icon_state = "vines[growth]"
 
 /obj/structure/diona/bulb

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -345,7 +345,7 @@
 	..()
 	beaker = new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
 
-/obj/machinery/reagentgrinder/update_icon()
+/obj/machinery/reagentgrinder/on_update_icon()
 	icon_state = "juicer"+num2text(!isnull(beaker))
 
 /obj/machinery/reagentgrinder/attackby(var/obj/item/O as obj, var/mob/user as mob)

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -148,7 +148,7 @@
 			use_power = 1
 			update_icon()
 
-/obj/machinery/portable_atmospherics/reagent_sublimator/update_icon()
+/obj/machinery/portable_atmospherics/reagent_sublimator/on_update_icon()
 	icon_state = "sublimator-[use_power == 2 ? "on" : "off"]-[container ? "loaded" : "unloaded"]-[holding ? "tank" : "notank"]"
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/examine(var/mob/user)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -181,7 +181,7 @@
 /obj/machinery/chemical_dispenser/attack_hand(mob/user as mob)
 	ui_interact(user)
 
-/obj/machinery/chemical_dispenser/update_icon()
+/obj/machinery/chemical_dispenser/on_update_icon()
 	overlays.Cut()
 	if(container)
 		var/mutable_appearance/beaker_overlay

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -31,7 +31,7 @@
 
 /obj/item/weapon/reagent_containers/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
-/obj/item/weapon/reagent_containers/ivbag/update_icon()
+/obj/item/weapon/reagent_containers/ivbag/on_update_icon()
 	overlays.Cut()
 	var/percent = round(reagents.total_volume / volume * 100)
 	if(reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -91,7 +91,7 @@
 
 	return 1
 
-/obj/item/weapon/reagent_containers/food/drinks/glass2/update_icon()
+/obj/item/weapon/reagent_containers/food/drinks/glass2/on_update_icon()
 	underlays.Cut()
 
 	if (reagents.reagent_list.len > 0)

--- a/code/modules/reagents/reagent_containers/drinkingglass/shaker.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/shaker.dm
@@ -17,7 +17,7 @@
 	lid_color = pick("black", "red", "blue")
 	update_icon()
 
-/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/update_icon()
+/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/on_update_icon()
 	..()
 	icon_state = "[base_icon]_[lid_color]"
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -88,7 +88,7 @@
 		if(percent <= k)
 			return k
 
-/obj/item/weapon/reagent_containers/food/drinks/update_icon()
+/obj/item/weapon/reagent_containers/food/drinks/on_update_icon()
 	overlays.Cut()
 	if(reagents.reagent_list.len > 0)
 		if(base_name)

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -104,7 +104,7 @@
 	if(rag) return
 	..()
 
-/obj/item/weapon/reagent_containers/food/drinks/bottle/update_icon()
+/obj/item/weapon/reagent_containers/food/drinks/bottle/on_update_icon()
 	underlays.Cut()
 	if(rag)
 		var/underlay_image = image(icon='icons/obj/drinks.dmi', icon_state=rag.on_fire? "[rag_underlay]_lit" : rag_underlay)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2590,7 +2590,7 @@
 	var/list/boxes = list()// If the boxes are stacked, they come here
 	var/boxtag = ""
 
-/obj/item/pizzabox/update_icon()
+/obj/item/pizzabox/on_update_icon()
 
 	overlays = list()
 

--- a/code/modules/reagents/reagent_containers/food/sushi.dm
+++ b/code/modules/reagents/reagent_containers/food/sushi.dm
@@ -42,7 +42,7 @@
 			qdel(rice)
 	update_icon()
 
-/obj/item/weapon/reagent_containers/food/snacks/sushi/update_icon()
+/obj/item/weapon/reagent_containers/food/snacks/sushi/on_update_icon()
 	name = "[fish_type] sushi"
 	overlays = list("[fish_type]", "nori")
 
@@ -65,7 +65,7 @@
 	name = "[fish_type] sashimi"
 	update_icon()
 
-/obj/item/weapon/reagent_containers/food/snacks/sashimi/update_icon()
+/obj/item/weapon/reagent_containers/food/snacks/sashimi/on_update_icon()
 	icon_state = "sashimi_base"
 	var/list/adding = list()
 	var/slice_offset = (slices-1)*2

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -257,7 +257,7 @@
 	else
 		return ..()
 
-/obj/item/weapon/reagent_containers/glass/bucket/update_icon()
+/obj/item/weapon/reagent_containers/glass/bucket/on_update_icon()
 	overlays.Cut()
 	if (!is_open_container())
 		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -136,7 +136,7 @@
 	update_icon()
 	return
 
-/obj/item/weapon/reagent_containers/hypospray/autoinjector/update_icon()
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/on_update_icon()
 	overlays.Cut()
 	if(reagents.total_volume > 0)
 		icon_state = "[initial(icon_state)]1"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -85,7 +85,7 @@
 
 	handleTarget(target, user)
 
-/obj/item/weapon/reagent_containers/syringe/update_icon()
+/obj/item/weapon/reagent_containers/syringe/on_update_icon()
 	overlays.Cut()
 
 	if(mode == SYRINGE_BROKEN)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -48,7 +48,7 @@
 	else operating = 0
 	update_icon()
 
-/obj/machinery/conveyor/update_icon()
+/obj/machinery/conveyor/on_update_icon()
 	if(stat & BROKEN)
 		icon_state = "conveyor-broken"
 		operating = 0
@@ -179,7 +179,7 @@
 
 // update the icon depending on the position
 
-/obj/machinery/conveyor_switch/update_icon()
+/obj/machinery/conveyor_switch/on_update_icon()
 	if(position<0)
 		icon_state = "switch-rev"
 	else if(position>0)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -326,7 +326,7 @@
 	update_icon()
 
 // update the icon & overlays to reflect mode & status
-/obj/machinery/disposal/update_icon()
+/obj/machinery/disposal/on_update_icon()
 	overlays.Cut()
 	if(stat & BROKEN)
 		mode = 0

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -72,7 +72,7 @@
 				"You hear someone scribbling a note.")
 	return
 
-/obj/structure/bigDelivery/update_icon()
+/obj/structure/bigDelivery/on_update_icon()
 	overlays = new()
 	if(nameset || examtext)
 		var/image/I = new/image('icons/obj/storage.dmi',"delivery_label")
@@ -198,7 +198,7 @@
 				"You hear someone scribbling a note.")
 	return
 
-/obj/item/smallDelivery/update_icon()
+/obj/item/smallDelivery/on_update_icon()
 	overlays = new()
 	if((nameset || examtext) && icon_state != "deliverycrate1")
 		var/image/I = new/image('icons/obj/storage.dmi',"delivery_label")
@@ -404,7 +404,7 @@
 /obj/machinery/disposal/deliveryChute/interact()
 	return
 
-/obj/machinery/disposal/deliveryChute/update_icon()
+/obj/machinery/disposal/deliveryChute/on_update_icon()
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(var/atom/movable/AM) //Go straight into the chute

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -71,7 +71,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	mat_efficiency = 1 - (T - 1) / 4
 	speed = T
 
-/obj/machinery/r_n_d/circuit_imprinter/update_icon()
+/obj/machinery/r_n_d/circuit_imprinter/on_update_icon()
 	if(panel_open)
 		icon_state = "circuit_imprinter_t"
 	else if(busy)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -31,7 +31,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		T += S.rating
 	decon_mod = T * 0.1
 
-/obj/machinery/r_n_d/destructive_analyzer/update_icon()
+/obj/machinery/r_n_d/destructive_analyzer/on_update_icon()
 	if(panel_open)
 		icon_state = "d_analyzer_t"
 	else if(loaded_item)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -125,7 +125,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	else
 		..(O, user)
 
-/obj/machinery/message_server/update_icon()
+/obj/machinery/message_server/on_update_icon()
 	if((stat & (BROKEN|NOPOWER)))
 		icon_state = "server-nopower"
 	else if (!active)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -69,7 +69,7 @@
 	speed = T / 2
 
 
-/obj/machinery/r_n_d/protolathe/update_icon()
+/obj/machinery/r_n_d/protolathe/on_update_icon()
 	if(panel_open)
 		icon_state = "protolathe_t"
 	else if(busy)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -43,7 +43,7 @@
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
 
 //icon_state gets set everwhere besides here, that needs to be fixed sometime
-/obj/machinery/keycard_auth/update_icon()
+/obj/machinery/keycard_auth/on_update_icon()
 	if(stat &NOPOWER)
 		icon_state = "auth_off"
 

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -34,7 +34,7 @@
 	if(default_part_replacement(user, O))
 		return
 
-/obj/machinery/shield_diffuser/update_icon()
+/obj/machinery/shield_diffuser/on_update_icon()
 	if(alarm)
 		icon_state = "fdiffuser_emergency"
 		return

--- a/code/modules/shield_generators/handheld_diffuser.dm
+++ b/code/modules/shield_generators/handheld_diffuser.dm
@@ -7,7 +7,7 @@
 	var/obj/item/weapon/cell/device/cell
 	var/enabled = 0
 
-/obj/item/weapon/shield_diffuser/update_icon()
+/obj/item/weapon/shield_diffuser/on_update_icon()
 	if(enabled)
 		icon_state = "hdiffuser_on"
 	else

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -14,7 +14,7 @@
 	atmos_canpass = CANPASS_PROC
 
 
-/obj/effect/shield/update_icon()
+/obj/effect/shield/on_update_icon()
 	if(gen && gen.check_flag(MODEFLAG_PHOTONIC) && !disabled_for && !diffused_for)
 		set_opacity(1)
 	else

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -28,7 +28,7 @@
 	var/ai_control_disabled = 0			// Whether the AI control is disabled.
 	var/list/mode_list = null			// A list of shield_mode datums.
 
-/obj/machinery/power/shield_generator/update_icon()
+/obj/machinery/power/shield_generator/on_update_icon()
 	if(running)
 		icon_state = "generator1"
 	else

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -325,7 +325,7 @@
 		..()
 
 
-/obj/machinery/shieldgen/update_icon()
+/obj/machinery/shieldgen/on_update_icon()
 	if(active && !(stat & NOPOWER))
 		src.icon_state = malfunction ? "shieldonbr":"shieldon"
 	else

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -34,7 +34,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/shieldwallgen/update_icon()
+/obj/machinery/shieldwallgen/on_update_icon()
 //	if(stat & BROKEN) -TODO: Broken icon
 	if(!active)
 		icon_state = "Shield_Gen"

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -138,7 +138,7 @@
 	T.hotspot_expose(1500, 5)
 	update_icon()
 
-/obj/item/device/spaceflare/update_icon()
+/obj/item/device/spaceflare/on_update_icon()
 	if(active)
 		icon_state = "bluflare_on"
 		set_light(0.3, 0.1, 6, 2, "85d1ff")

--- a/code/modules/tables/rack.dm
+++ b/code/modules/tables/rack.dm
@@ -24,7 +24,7 @@
 /obj/structure/table/rack/update_desc()
 	return
 
-/obj/structure/table/rack/update_icon()
+/obj/structure/table/rack/on_update_icon()
 	return
 
 /obj/structure/table/rack/can_connect()

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -295,7 +295,7 @@
 	qdel(src)
 	return shards
 
-/obj/structure/table/update_icon()
+/obj/structure/table/on_update_icon()
 	if(flipped != 1)
 		icon_state = "blank"
 		overlays.Cut()

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -83,7 +83,7 @@
 	light_up = TRUE
 	update_icon()
 
-/obj/structure/lift/button/update_icon()
+/obj/structure/lift/button/on_update_icon()
 	if(light_up)
 		icon_state = "button_lit"
 	else

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -194,7 +194,7 @@
 		return
 	..()
 
-/obj/vehicle/bike/update_icon()
+/obj/vehicle/bike/on_update_icon()
 	overlays.Cut()
 
 	if(on)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -89,7 +89,7 @@
 		return
 	..()
 
-/obj/vehicle/train/cargo/update_icon()
+/obj/vehicle/train/cargo/on_update_icon()
 	if(open)
 		icon_state = initial(icon_state) + "_open"
 	else

--- a/code/modules/virus2/antibodyanalyser.dm
+++ b/code/modules/virus2/antibodyanalyser.dm
@@ -12,7 +12,7 @@
 
 	var/obj/item/weapon/reagent_containers/container = null
 
-/obj/machinery/disease2/antibodyanalyser/update_icon()
+/obj/machinery/disease2/antibodyanalyser/on_update_icon()
 	if(scanning)
 		icon_state = "analyser_processing"
 	else

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -27,7 +27,7 @@
 
 	src.attack_hand(user)
 
-/obj/machinery/computer/centrifuge/update_icon()
+/obj/machinery/computer/centrifuge/on_update_icon()
 	..()
 	if(! (stat & (BROKEN|NOPOWER)))
 		icon_state = (isolating || curing) ? "centrifuge_moving" : "centrifuge"

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -15,7 +15,7 @@
 	var/datum/computer_file/data/virus_record/entry = null
 	var/obj/item/weapon/reagent_containers/syringe/sample = null
 
-/obj/machinery/disease2/isolator/update_icon()
+/obj/machinery/disease2/isolator/on_update_icon()
 	if (stat & (BROKEN|NOPOWER))
 		icon_state = "isolator"
 		return

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -188,7 +188,7 @@ obj/structure/net/Initialize(var/mapload)
 /obj/item/stack/net/thirty
 	amount = 30
 
-/obj/item/stack/net/update_icon()
+/obj/item/stack/net/on_update_icon()
 	if(amount == 1)
 		icon_state = "net"
 	else

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -28,7 +28,7 @@
 		if(istype(E))
 			desc += "\nThere are images on it: [E.get_engravings()]"
 
-/obj/structure/monolith/update_icon()
+/obj/structure/monolith/on_update_icon()
 	overlays.Cut()
 	if(active)
 		var/image/I = image(icon,"[icon_state]decor")

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,6 +34,7 @@ exactly 45 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 632 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 25 "text2path uses" 'text2path'
+exactly 1 "update_icon() override" '/update_icon\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
`update_icon()` now calls `on_update_icon()` and should typically never be overriden.
Instead atoms should override `on_update_icon()`.

Also adds the overlay subsystem, which is used to add or remove overlays efficiently.