### PR TITLE
Fixes yet more runtimes. Makes click catcher screen objs shared.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -339,6 +339,8 @@
 	if(direction != dir)
 		facedir(direction)
 
+GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
+
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "click_catcher"

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -253,11 +253,7 @@
 	update_action_buttons()
 
 /mob/proc/add_click_catcher()
-	if(!client.void)
-		client.void = create_click_catcher()
-	if(!client.screen)
-		client.screen = list()
-	client.screen |= client.void
+	client.screen |= GLOB.click_catchers
 
 /mob/new_player/add_click_catcher()
 	return

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -67,7 +67,7 @@
 		isbroken = 0
 		set_density(1)
 		icon_state = "pylon"
-		set_light(5)
+		set_light(0.5)
 
 /obj/structure/cult/tome
 	name = "Desk"

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -395,7 +395,7 @@ var/global/datum/controller/occupations/job_master
 		for(var/mob/new_player/player in unassigned)
 			if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
 				player.ready = 0
-				player.new_player_panel_proc()
+				player.new_player_panel()
 				unassigned -= player
 		return 1
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -263,9 +263,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		hologram.SetName("[A.name] (Hologram)") //If someone decides to right click.
 		A.holo = src
 		masters[A] = hologram
-	hologram.set_light(2)	//hologram lighting
+	hologram.set_light(1, 0.1, 2)	//hologram lighting
 	hologram.color = color //painted holopad gives coloured holograms
-	set_light(2)			//pad lighting
+	set_light(1, 0.1, 2)			//pad lighting
 	icon_state = "[base_icon]1"
 	return 1
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -44,4 +44,3 @@
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
 	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
-	var/static/obj/screen/click_catcher/void

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -253,15 +253,18 @@
 	else if(href_list["show_branches"])
 		var/rank = href_list["show_branches"]
 		var/datum/job/job = job_master.GetJob(rank)
-		to_chat(user, "<span clas='notice'>Valid branches for [rank]: [job.get_branches()]</span>")
+		if(job)
+			to_chat(user, "<span clas='notice'>Valid branches for [rank]: [job.get_branches()]</span>")
 	else if(href_list["show_ranks"])
 		var/rank = href_list["show_ranks"]
 		var/datum/job/job = job_master.GetJob(rank)
-		to_chat(user, "<span clas='notice'>Valid ranks for [rank] ([pref.char_branch]): [job.get_ranks(pref.char_branch)]</span>")
+		if(job)
+			to_chat(user, "<span clas='notice'>Valid ranks for [rank] ([pref.char_branch]): [job.get_ranks(pref.char_branch)]</span>")
 	else if(href_list["set_skills"])
 		var/rank = href_list["set_skills"]
 		var/datum/job/job = job_master.GetJob(rank)
-		open_skill_setup(user, job)
+		if(job)
+			open_skill_setup(user, job)
 
 	//From the skills popup
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -50,6 +50,9 @@ datum/preferences
 		load_preferences()
 		load_and_update_character()
 	sanitize_preferences()
+	if(client && istype(client.mob, /mob/new_player))
+		var/mob/new_player/np = client.mob
+		np.new_player_panel(TRUE)
 
 /datum/preferences/proc/load_and_update_character(var/slot)
 	load_character(slot)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -23,12 +23,11 @@
 	..()
 	verbs += /mob/proc/toggle_antag_pool
 
-/mob/new_player/verb/new_player_panel()
-	set src = usr
-	new_player_panel_proc()
-
-/mob/new_player/proc/new_player_panel_proc()
-	var/output = "<div align='center'>"
+/mob/new_player/proc/new_player_panel(force = FALSE)
+	if(!SScharacter_setup.initialized && !force)
+		return // Not ready yet.
+	var/output = list()
+	output += "<div align='center'>"
 	output +="<hr>"
 	output += "<p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A></p>"
 
@@ -66,9 +65,8 @@
 
 	panel = new(src, "Welcome","Welcome", 210, 280, src)
 	panel.set_window_options("can_close=0")
-	panel.set_content(output)
+	panel.set_content(JOINTEXT(output))
 	panel.open()
-	return
 
 /mob/new_player/Stat()
 	. = ..()
@@ -109,7 +107,7 @@
 
 	if(href_list["refresh"])
 		panel.close()
-		new_player_panel_proc()
+		new_player_panel()
 
 	if(href_list["observe"])
 		if(!(initialization_stage&INITIALIZATION_COMPLETE))


### PR DESCRIPTION
Fixes #23102.
Fixes #21311 (the muzzle there is obsolete, currently occurs on live in holograms. will likely be reopned with other culprits).
Closes #20414 (not clear if this will fix it).
Fixes #23423.

Note that currently, click catchers are added to the client inconsistently due to above runtime.

This will make the new player panel (with buttons like Ready, Character Setup, etc.) not come up until the character setup SS inits (it's currently not interactive until approximately then anyway).