### PR TITLE
Fixes a few of the starlight bugs

### DIFF
--- a/code/datums/extensions/deity_be_near.dm
+++ b/code/datums/extensions/deity_be_near.dm
@@ -27,9 +27,9 @@
 		if(dist < min_dist)
 			min_dist = dist
 	if(min_dist)
-		deal_damage(I.loc, round(min_dist/max(1,threshold_base)))
+		deal_damage(I.loc, round(min(5,min_dist/max(1,threshold_base))))
 	else if(keep_away_instead)
-		deal_damage(I.loc, round(threshold_base/max(1,(min_dist*2))))
+		deal_damage(I.loc, round(min(5,threshold_base/max(1,(min_dist*2)))))
 
 
 /datum/extension/deity_be_near/proc/deal_damage(var/mob/living/victim, var/mult)

--- a/code/game/gamemodes/godmode/form_items/starlight_mobs.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_mobs.dm
@@ -1,22 +1,26 @@
 /mob/living/starlight_soul
 	name = "soul"
 	desc = "A captured soul."
+	anchored = 1
 
 /mob/living/starlight_soul/Initialize(var/maploading, var/mob/living/old_mob)
 	. = ..()
-	var/mob/observer/eye/cult/C = new(src)
-	C.suffix = "Soul"
 	if(old_mob)
 		name = old_mob.real_name
-	eyeobj = C
 
 /mob/living/starlight_soul/proc/set_deity(var/mob/living/deity/deity)
-	var/mob/observer/eye/eye = eyeobj
-	eyeobj.release(src)
+	if(eyeobj)
+		eyeobj.release(src)
+	else
+		var/mob/observer/eye/cult/eye = new(src)
+		eye.suffix = "Soul"
+		eyeobj = eye
 	eyeobj.visualnet = deity.eyeobj.visualnet
 	GLOB.godcult.add_antagonist_mind(src.mind,1,"lost soul of [deity]", "You have been captured by \the [deity]! You now can only see into your own reality through the same rips and tears it uses. Your only chance at another body will be one in your captor's image...",specific_god=deity)
-	eye.possess(src)
+	eyeobj.possess(src)
 
 /mob/living/starlight_soul/Destroy()
-	QDEL_NULL(eyeobj)
+	if(eyeobj)
+		eyeobj.release(src)
+		QDEL_NULL(eyeobj)
 	. = ..()

--- a/code/game/gamemodes/godmode/form_items/starlight_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_structures.dm
@@ -111,9 +111,9 @@
 
 /obj/structure/deity/gateway/proc/stop_looking_for(var/successful)
 	if(looking_for)
-		looking_for = null
 		if(!successful)
 			to_chat(linked_god, "<span class='warning'>\The [src] did not find any [looking_for]. You may try again if you wish.</span>")
+		looking_for = null
 
 /obj/structure/deity/gateway/OnTopic(var/mob/user, var/list/href_list)
 	if(href_list["accept"] && istype(user,/mob/living/starlight_soul))

--- a/code/modules/mob/living/deity/deity.dm
+++ b/code/modules/mob/living/deity/deity.dm
@@ -18,10 +18,10 @@
 
 /mob/living/deity/New()
 	..()
-	if(eye_type)
-		eyeobj = new eye_type(src)
-		eyeobj.possess(src)
-		eyeobj.visualnet.add_source(src)
+	var/visualnet = new /datum/visualnet/cultnet()
+	eyeobj = new /mob/observer/eye/cult(get_turf(src), visualnet)
+	eyeobj.possess(src)
+	eyeobj.visualnet.add_source(src)
 
 /mob/living/deity/death()
 	. = ..()
@@ -46,6 +46,7 @@
 	minions.Cut()
 	eyeobj.release()
 	structures.Cut()
+	QDEL_NULL(eyeobj.visualnet) //We do it here as some mobs have eyes that have access to the visualnet and we only want to destroy it when the deity is destroyed
 	QDEL_NULL(eyeobj)
 	QDEL_NULL(form)
 	return ..()

--- a/code/modules/mob/living/deity/forms/starlight.dm
+++ b/code/modules/mob/living/deity/forms/starlight.dm
@@ -17,7 +17,9 @@
 					/obj/structure/deity/pylon/starlight,
 					/obj/structure/deity/radiant_statue,
 					)
-	items = list(/datum/deity_item/boon/blazing_blade,
+	items = list(/datum/deity_item/general/potential,
+				/datum/deity_item/general/regeneration,
+				/datum/deity_item/boon/blazing_blade,
 				/datum/deity_item/boon/holy_beacon,
 				/datum/deity_item/boon/black_death,
 				/datum/deity_item/blood_crafting/firecrafting,

--- a/code/modules/mob/living/deity/items/generic.dm
+++ b/code/modules/mob/living/deity/items/generic.dm
@@ -21,9 +21,6 @@
 	. = ..()
 	if(istype(.,/spell))
 		var/spell/S = .
-		if(S.spell_flags & NEEDSCLOTHES)
-			S.spell_flags &= ~NEEDSCLOTHES
-
 		S.charge_max = 1
 		S.charge_counter = 1
 		S.charge_type = Sp_CHARGES

--- a/code/modules/mob/living/deity/items/starlight/spells.dm
+++ b/code/modules/mob/living/deity/items/starlight/spells.dm
@@ -16,7 +16,7 @@
 	name = "Radiant Aura"
 	desc = "This spell makes one of your followers immune to laser fire, for a short while at least."
 	base_cost = 70
-	boon_path = /spell/radiant_aura
+	boon_path = /spell/radiant_aura/starlight
 	category = DEITY_TREE_FIRECONJ
 
 /datum/deity_item/boon/burning_touch
@@ -51,7 +51,7 @@
 	name = "Disable Machinery"
 	desc = "Gives your follower a spell of disabling machinery, and mechanical hearts."
 	base_cost = 110
-	boon_path = /spell/aoe_turf/disable_tech
+	boon_path = /spell/aoe_turf/disable_tech/starlight
 	category = DEITY_TREE_FIRECONJ
 
 /datum/deity_item/boon/cure_light

--- a/code/modules/mob/living/deity/phenomena/starlight.dm
+++ b/code/modules/mob/living/deity/phenomena/starlight.dm
@@ -28,6 +28,9 @@
 /datum/phenomena/herald/can_activate(var/a)
 	if(!..())
 		return FALSE
+	return valid_for_herald(a)
+
+/datum/phenomena/herald/proc/valid_for_herald(var/a)
 	var/mob/living/carbon/human/H = a
 	if(!istype(H))
 		return FALSE
@@ -47,13 +50,13 @@
 /datum/phenomena/herald/Topic(var/href, var/list/href_list)
 	if(..())
 		return 1
-	if(!istype(usr, /mob/living/starlight_soul))
+	if(usr != linked)
 		return 1
 
 	if(href_list["herald"])
 		var/list/form = possible_forms[href_list["herald"]]
 		var/mob/living/L = locate(href_list["target"])
-		if(!L || !can_activate(L) || !form)
+		if(!L || !valid_for_herald(L) || !form)
 			return 1
 		var/type = form["armor"]
 		var/obj/item/I = new type

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -175,6 +175,9 @@
 
 /proc/seen_turfs_in_range(var/source, var/range)
 	var/turf/pos = get_turf(source)
-	return hear(range, pos)
+	if(pos)
+		. = hear(range, pos)
+	else
+		. = list()
 
 #undef UPDATE_BUFFER

--- a/code/modules/mob/observer/freelook/cult/mask.dm
+++ b/code/modules/mob/observer/freelook/cult/mask.dm
@@ -2,12 +2,12 @@
 	name = "Mask of God"
 	desc = "A terrible fracture of reality coinciding into a mirror to another world."
 
-/mob/observer/eye/cult/New()
+/mob/observer/eye/cult/New(var/loc, var/net)
 	..()
-	visualnet = new /datum/visualnet/cultnet()
+	visualnet = net
 
 /mob/observer/eye/cult/Destroy()
-	QDEL_NULL(visualnet)
+	visualnet = null
 	return ..()
 
 mob/observer/eye/cult/EyeMove()

--- a/code/modules/spells/aoe_turf/disable_tech.dm
+++ b/code/modules/spells/aoe_turf/disable_tech.dm
@@ -30,3 +30,7 @@
 	emp_light += 2
 
 	return "You've increased the range of [src]."
+
+/spell/aoe_turf/disable_tech/starlight
+	charge_max = 600
+	spell_flags = 0

--- a/code/modules/spells/general/radiant_aura.dm
+++ b/code/modules/spells/general/radiant_aura.dm
@@ -6,6 +6,7 @@
 	invocation_type = SpI_EMOTE
 	invocation = "conjures a sphere of fire around themselves."
 	school = "conjuration"
+	spell_flags = NEEDSCLOTHES
 	charge_max = 300
 	cooldown_min = 100
 	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 2, Sp_POWER = 0)
@@ -19,3 +20,7 @@
 /spell/radiant_aura/cast(var/list/targets, var/mob/user)
 	var/obj/aura/radiant_aura/A = new(user)
 	QDEL_IN(A,duration)
+
+/spell/radiant_aura/starlight
+	spell_flags = 0
+	charge_max = 400

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -103,7 +103,7 @@ code\game\dna\genes\goon_powers.dm
 	invocation = "Tid Caeh Yor!"
 	spell_flags = NOFACTION
 	invocation_type = SpI_SHOUT
-	charge_max = 30 SECONDS
+	charge_max = 60 SECONDS
 	spell_flags = 0
 
 	amt_dizziness = 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Fixes deity_be_near not having a ceiling and causing heralds to instantly gib if they are far enough from a structure.

Makes souls anchored. Also makes them use generic eyes.

Makes gateway failure output be a little more clear.

Removes clothing requirements from all deity spells.

Adds generic deity items to starlight.

Fixes a few checks.