### PR TITLE
Tweak janihud vision formula

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -6,6 +6,8 @@
 	electric = 1
 	gender = NEUTER
 
+	species_restricted = null
+
 /obj/item/clothing/glasses/proc/process_hud(var/mob/M)
 	if(hud)
 		hud.process_hud(M)

--- a/code/modules/species/species_hud.dm
+++ b/code/modules/species/species_hud.dm
@@ -75,6 +75,7 @@
 		"o_clothing" =   list("loc" = ui_shoes,     "name" = "Suit",         "slot" = slot_wear_suit, "state" = "suit",   "toggle" = 1),
 		"l_ear" =        list("loc" = ui_oclothing, "name" = "Ear",          "slot" = slot_l_ear,     "state" = "ears",   "toggle" = 1),
 		"gloves" =       list("loc" = ui_gloves,    "name" = "Gloves",       "slot" = slot_gloves,    "state" = "gloves", "toggle" = 1),
+		"eyes" =         list("loc" = ui_glasses,   "name" = "Glasses",      "slot" = slot_glasses,   "state" = "glasses","toggle" = 1),
 		"suit storage" = list("loc" = ui_sstore1,   "name" = "Suit Storage", "slot" = slot_s_store,   "state" = "suitstore"),
 		"back" =         list("loc" = ui_back,      "name" = "Back",         "slot" = slot_back,      "state" = "back"),
 		"id" =           list("loc" = ui_id,        "name" = "ID",           "slot" = slot_wear_id,   "state" = "id"),

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -122,8 +122,9 @@
 	unarmed_types = list(/datum/unarmed_attack/nabber)
 
 	equip_adjust = list(
-		slot_back_str = list(NORTH = list("x" = 0, "y" = 7), EAST = list("x" = 0, "y" = 8), SOUTH = list("x" = 0, "y" = 8), WEST = list("x" = 0, "y" = 8)),
-		slot_belt_str = list(NORTH = list("x" = 0, "y" = 0), EAST = list("x" = 8, "y" = 0), SOUTH = list("x" = 0, "y" = 0), WEST = list("x" = -8, "y" = 0)),
+		slot_back_str =    list(NORTH = list("x" = 0, "y" = 7), EAST = list("x" = 0, "y" = 8), SOUTH = list("x" = 0, "y" = 8), WEST = list("x" = 0, "y" = 8)),
+		slot_belt_str =    list(NORTH = list("x" = 0, "y" = 0), EAST = list("x" = 8, "y" = 0), SOUTH = list("x" = 0, "y" = 0), WEST = list("x" = -8, "y" = 0)),
+		slot_glasses_str = list(NORTH = list("x" = 0, "y" = 10), EAST = list("x" = 0, "y" = 11), SOUTH = list("x" = 0, "y" = 11), WEST = list("x" = 0, "y" = 11)),
 	)
 
 	descriptors = list(

--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -46,7 +46,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode, var/mob/Alt)
 
 proc/process_jani_hud(var/mob/M, var/mob/Alt)
 	var/datum/arranged_hud_process/P = arrange_hud_process(M, Alt, GLOB.jani_hud_users)
-	for (var/obj/effect/decal/cleanable/dirtyfloor in P.Mob.in_view(P.Turf))
+	for (var/obj/effect/decal/cleanable/dirtyfloor in view(P.Mob))
 		P.Client.images += dirtyfloor.hud_overlay
 
 datum/arranged_hud_process


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑 FTangSteve
tweak: janihud now bases vision off of what the mob wearing it can see instead of the tile
rscadd: nabbers can now use HUDs
/🆑

This does NOT let nabbers wear any other types of eyewear. NO WELDERS, NO SUNGLASSES, ETC.
It's JUST HUD, mostly for the janihud