### PR TITLE
Updates globals script to use python3

### DIFF
--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -241,7 +241,7 @@ function run_byond_tests {
         ./install-byond.sh || exit 1
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
-    run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
+    run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
     run_test "check globals unchanged" "md5sum -c - <<< '1c0968e5324f78d2eb6663a9c8400e13 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"

--- a/tools/GenerateGlobalVarAccess/gen_globals.py
+++ b/tools/GenerateGlobalVarAccess/gen_globals.py
@@ -52,7 +52,7 @@ def main():
 
 	else:
 		tree = CompileFile(namespace.projectfile)
-		with open("dump.txt", "wt") as f:
+		with open("dump.txt", "wt", encoding='latin-1') as f:
 			f.write(tree)
 
 
@@ -83,7 +83,7 @@ def GenerateMD5(fname):
 def CompileFile(filename):
 	compiler_path = FindCompiler()
 
-	return subprocess.check_output([compiler_path, "-code_tree", filename], universal_newlines=True)
+	return subprocess.check_output([compiler_path, "-code_tree", filename]).decode(encoding='latin-1')
 
 def FindCompiler():
 	compiler_path = None;


### PR DESCRIPTION
Not a python wizard, so if anyone has advice or better solutions, go for it. Bonus points if you can make it version agnostic.

This should work on python 3.6 and python 3.7 (CORRECTION: new, oldschool, version works on 3.4 and probably even earlier), but will probably not work on python 2 of any flavor.