### PR TITLE
Railing climb adjustments

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -485,7 +485,7 @@ its easier to just keep the beam vertical.
 	user.visible_message("<span class='warning'>\The [user] starts climbing onto \the [src]!</span>")
 	LAZYDISTINCTADD(climbers,user)
 
-	if(!do_after(user,(issmall(user) ? 30 : 50), src))
+	if(!do_after(user,(issmall(user) ? 20 : 40), src, same_direction = TRUE))
 		LAZYREMOVE(climbers,user)
 		return 0
 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -73,6 +73,15 @@
 		return !density
 	return TRUE
 
+/obj/structure/railing/Bumped(atom/A)
+	if(isliving(A))
+		var/mob/living/L = A
+		
+		if(can_climb(L))
+			do_climb(L)
+	
+	. = ..()
+	
 /obj/structure/railing/examine(mob/user)
 	. = ..()
 	if(health < maxhealth)

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -71,14 +71,14 @@
 /area/constructionsite)
 "m" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "n" = (
 /obj/machinery/atmospherics/portables_connector{
-	 icon_state = "map_connector";
+	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -86,21 +86,21 @@
 /area/constructionsite)
 "o" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "p" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "q" = (
 /obj/machinery/atmospherics/portables_connector{
-	 icon_state = "map_connector";
+	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -108,7 +108,7 @@
 /area/constructionsite)
 "r" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	 icon_state = "map_scrubber_on";
+	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -215,6 +215,11 @@
 /obj/effect/landmark/test/space_turf,
 /turf/space,
 /area/space)
+"R" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled,
+/area/constructionsite)
 
 (1,1,1) = {"
 a
@@ -1012,7 +1017,7 @@ b
 c
 w
 w
-w
+R
 c
 c
 c
@@ -1046,7 +1051,7 @@ b
 c
 b
 w
-w
+R
 c
 c
 g
@@ -1080,7 +1085,7 @@ b
 c
 w
 w
-w
+R
 c
 c
 c

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -85,7 +85,7 @@
 /area/maintenance/fsmaint2)
 "q" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -93,7 +93,7 @@
 /area/maintenance/fsmaint2)
 "r" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -101,7 +101,7 @@
 /area/maintenance/fsmaint2)
 "s" = (
 /obj/machinery/atmospherics/portables_connector{
-	 icon_state = "map_connector";
+	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -110,7 +110,7 @@
 /area/maintenance/fsmaint2)
 "t" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -118,7 +118,7 @@
 /area/maintenance/fsmaint2)
 "u" = (
 /obj/machinery/atmospherics/portables_connector{
-	 icon_state = "map_connector";
+	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -134,7 +134,7 @@
 /area/maintenance/fsmaint2)
 "w" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	 icon_state = "map_scrubber_on";
+	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -182,6 +182,10 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
+/area/maintenance/fsmaint2)
+"H" = (
+/obj/structure/railing/mapped,
+/turf/simulated/open,
 /area/maintenance/fsmaint2)
 
 (1,1,1) = {"
@@ -980,7 +984,7 @@ c
 d
 f
 g
-g
+H
 d
 d
 d
@@ -1014,7 +1018,7 @@ c
 f
 f
 g
-g
+H
 d
 d
 d


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
🆑 FTangSteve
rscadd: running into a rail now begins climbing
tweak: slightly lowers climb time
/🆑

Adjust railing climbing  …
- Reduce time to climb slightly

- Make it so changing direction stops climb

- Running into a railing causes you to start climbing it

- You can change direction to cancel