### PR TITLE
Add skillcheck for slips

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -109,7 +109,11 @@
 
 		if(src.wet)
 
-			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(16/wet))) ) )
+			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(wet/10))) ) )
+				return
+
+			// skillcheck for slipping
+			if(prob(min(100, 100 - (M.skill_fail_chance(SKILL_HAULING, 100, SKILL_EXPERT)/(16/wet)))))
 				return
 
 			var/slip_dist = 1

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -113,7 +113,7 @@
 				return
 
 			// skillcheck for slipping
-			if(prob(min(100, 100 - (M.skill_fail_chance(SKILL_HAULING, 100, SKILL_EXPERT)/(16/wet)))))
+			if(!prob(min(100, M.skill_fail_chance(SKILL_HAULING, 100, SKILL_MAX+1)/(3/wet))))
 				return
 
 			var/slip_dist = 1


### PR DESCRIPTION
:cl: Atebite
tweak: Added a skillcheck for slips based on athletics
/:cl:

Also fixes the well-meant but in-hindsight-poorly-understood "slip fix" I put up earlier. Seems like it was actually right, but I missed that it was meant for *no-slip* chance when *walking*. Of course that should be higher for less wet floor. Oops.

**Below is old:**
Here's how the probability of slipping develops for wetness = 8 (after a good moppin'). Skill points are on the x-axis.
![](https://i.imgur.com/9sYWOwr.png)

And for wetness = 80 (space lube)
![](https://i.imgur.com/yofvh3f.png)