### PR TITLE
Move Charon/Guppy airlock controllers inside the shuttless

### DIFF
--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -520,14 +520,14 @@
 	command = "cycle_exterior";
 	frequency = 1431;
 	id_tag = "guppy_shuttle_sensor_external";
-	pixel_x = 25;
-	pixel_y = 25
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1431;
 	master_tag = "guppy_shuttle";
-	pixel_x = 36;
-	pixel_y = 25
+	pixel_x = 24;
+	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -568,6 +568,12 @@
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
 	dir = 1
+	},
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1431;
+	master_tag = "guppy_shuttle";
+	pixel_x = -24;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -849,14 +855,14 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
+/obj/machinery/access_button{
+	command = "cycle_interior";
 	frequency = 1431;
-	id_tag = "guppy_shuttle";
-	pixel_x = -32;
+	master_tag = "guppy_shuttle";
+	name = "interior access button";
+	pixel_x = -24;
 	pixel_y = -24;
-	req_access = list(89);
-	tag_exterior_sensor = "guppy_shuttle_sensor_external"
+	req_access = list(89)
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -939,7 +945,7 @@
 	dir = 10
 	},
 /obj/machinery/computer/cryopod{
-	pixel_y = -32
+	pixel_y = -24
 	},
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -1038,6 +1044,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1431;
+	id_tag = "guppy_shuttle";
+	pixel_x = -36;
+	pixel_y = 0;
+	req_access = list(89);
+	tag_exterior_sensor = "guppy_shuttle_sensor_external"
+	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "cB" = (
@@ -1070,15 +1085,6 @@
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/crew)
 "cF" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1431;
-	master_tag = "guppy_shuttle";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access = list(89)
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -1105,6 +1111,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1431;
+	master_tag = "guppy_shuttle";
+	name = "interior access button";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access = list(89)
 	},
 /turf/simulated/floor/tiled,
 /area/guppy_hangar/start)
@@ -1176,18 +1191,15 @@
 	icon_state = "techfloor_edges";
 	dir = 1
 	},
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1331;
+	master_tag = "calypso_shuttle";
+	pixel_x = -20;
+	pixel_y = 20
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
 "cL" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
-	frequency = 1331;
-	id_tag = "calypso_shuttle";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(88);
-	tag_exterior_sensor = "calypso_shuttle_sensor_external"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -1220,6 +1232,12 @@
 	icon_state = "techfloor_edges";
 	dir = 1
 	},
+/obj/machinery/access_button/airlock_interior{
+	frequency = 1331;
+	master_tag = "calypso_shuttle";
+	pixel_x = 20;
+	pixel_y = 20
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
 "cN" = (
@@ -1242,6 +1260,15 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1331;
+	id_tag = "calypso_shuttle";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(88);
+	tag_exterior_sensor = "calypso_shuttle_sensor_external"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
@@ -1276,6 +1303,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
 "cS" = (
+/turf/simulated/floor/tiled/dark,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
@@ -1293,7 +1321,6 @@
 /obj/item/device/spaceflare,
 /obj/item/device/spaceflare,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/airlock)
 "cT" = (
@@ -13118,15 +13145,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"IT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/guppy_hangar/start)
 "IY" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/newscaster{


### PR DESCRIPTION
QOL update that places the airlock controllers for the GUP and Charon inside the shuttles, with cycle in/cycle out buttons added inside the airlocks themselves. This allows someone that is currently inside the shuttle proper (I.e., designated pilot) to set the cycle mode, or force the airlock, when airlocks start getting weird with breaking/not cycling/somehow (We all know why this happens) losing all its air.

![dreamseeker_2018-10-10_15-58-42](https://user-images.githubusercontent.com/11140088/46770802-bb5e7500-cca5-11e8-86d9-26d87681347c.png)

![dreamseeker_2018-10-15_21-17-35](https://user-images.githubusercontent.com/11140088/46992640-ee4aa380-d0bf-11e8-8a2a-6580b63e4de9.png)

![dreamseeker_2018-10-15_21-17-44](https://user-images.githubusercontent.com/11140088/46992645-f1de2a80-d0bf-11e8-8518-670600bdb90f.png)

The current layout has the GUP's controller accessible from both inside the airlocki and inside the GUP itself, by magic of placing it on the door tile. The Charon's controller is only accessible from inside, as the Charon should have a pilot inside it anyway.

~~Map hasn't been run through the mapmerge thing yet because I cannot for the life of me figure out how to get it to work. If anyone can give me a hand with that, please do.~~

:cl: SierraKomodo
tweak: Charon airlock controller has been moved to the interior of the shuttle, to allow full airlock access to the pilot or anyone else inside.
tweak: GUP airlock controller has been positioned to be accessible from both the airlock and the interior of the GUP itself, to allow full airlock access to people inside the pod.
tweak: Airlock access buttons have been added inside the Charon and GUP airlocks as alternatives to using the airlock controller to cycle in/out.
wip: The above changes will be applied to all other shuttles depending on how well this fixes issues with people getting stuck with infinite cycle airlocks.
/:cl:
