### PR TITLE
Safety and holsters

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -85,6 +85,7 @@
 			playsound(get_turf(atom_holder), sound_out, sound_vol)
 		holstered.add_fingerprint(user)
 		user.put_in_hands(holstered)
+		holstered.update_icon()
 		storage.w_class = initial(storage.w_class)
 		clear_holster()
 		atom_holder.update_icon()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -83,7 +83,7 @@
 	var/tmp/told_cant_shoot = 0 //So that it doesn't spam them with the fact they cannot hit them.
 	var/tmp/lock_time = -100
 	var/tmp/last_safety_check = -INFINITY
-	var/safety_state = 0
+	var/safety_state = 1
 	var/has_safety = TRUE
 
 /obj/item/weapon/gun/New()


### PR DESCRIPTION
Made all of the guns start with safety on. Safety first & all.

:cl: Sbotkin
tweak: All guns now spawn with safety on.
/:cl:

Also there is a bug: you wouldn't see the safety state of the gun you unholstered through the holstering verb. I couldn't test it locally because I encounter weird unrelated icon updating bugs. So, here is a try to fix it, should work. Probably.