### PR TITLE
Removes cameras from explorer helmets

### DIFF
--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -368,6 +368,3 @@
 	icon = 'maps/torch/icons/obj/solgov-head.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/solgov-head.dmi')
 	starting_accessories = null
-
-/obj/item/clothing/head/helmet/space/void/exploration
-	camera = /obj/machinery/camera/network/exploration

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -201,7 +201,6 @@
 	req_access = list(access_pathfinder)
 
 /obj/item/clothing/head/helmet/space/rig/command/exploration
-	camera = /obj/machinery/camera/network/exploration
 	icon_state = "command_exp_rig"
 /obj/item/clothing/suit/space/rig/command/exploration
 	icon_state = "command_exp_rig"


### PR DESCRIPTION
Gives way too much visibility for away missions to bridge crew.
Cameras seeing across vast distances isn't really intended, I just couldn't figure out how to restrict them to their zs when I was cutting ties between ship and away missions, do not want more things that point that disperancy out.
Also was put in as 'map tweak?' in 'fixes' PR?

Fixes #23481.
