### PR TITLE
Keycard Authentication Device Tweaks

### DIFF
--- a/code/controllers/evacuation/evacuation_option.dm
+++ b/code/controllers/evacuation/evacuation_option.dm
@@ -4,6 +4,7 @@
 	var/option_target = "generic"
 	var/needs_syscontrol = FALSE
 	var/silicon_allowed = TRUE
+	var/abandon_ship = FALSE
 
 /datum/evacuation_option/proc/execute(var/mob/user)
 	return

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -70,6 +70,7 @@
 	option_target = EVAC_OPT_ABANDON_SHIP
 	needs_syscontrol = TRUE
 	silicon_allowed = TRUE
+	abandon_ship = TRUE
 
 /datum/evacuation_option/abandon_ship/execute(mob/user)
 	if (!ticker || !evacuation_controller)

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -89,6 +89,8 @@
 	var/list/processed_evac_options = list()
 	if(!isnull(evacuation_controller))
 		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
+			if(EO.type == /datum/evacuation_option/abandon_ship)
+				break
 			var/list/option = list()
 			option["option_text"] = EO.option_text
 			option["option_target"] = EO.option_target
@@ -250,6 +252,12 @@
 						to_chat(usr, "<span class='notice'>Hardware Error: Printer was unable to print the selected file.</span>")
 					else
 						program.computer.visible_message("<span class='notice'>\The [program.computer] prints out a paper.</span>")
+		if("unbolt_doors")
+			GLOB.using_map.unbolt_saferooms()
+			to_chat(usr, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms unbolted.</span>")
+		if("bolt_doors")
+			GLOB.using_map.bolt_saferooms()
+			to_chat(usr, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms bolted.</span>")
 
 #undef STATE_DEFAULT
 #undef STATE_MESSAGELIST

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -90,7 +90,7 @@
 	if(!isnull(evacuation_controller))
 		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
 			if(EO.abandon_ship)
-				break
+				continue
 			var/list/option = list()
 			option["option_text"] = EO.option_text
 			option["option_target"] = EO.option_target

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -89,7 +89,7 @@
 	var/list/processed_evac_options = list()
 	if(!isnull(evacuation_controller))
 		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
-			if(EO.type == /datum/evacuation_option/abandon_ship)
+			if(EO.abandon_ship)
 				break
 			var/list/option = list()
 			option["option_text"] = EO.option_text

--- a/maps/torch/machinery/keycard authentication.dm
+++ b/maps/torch/machinery/keycard authentication.dm
@@ -12,7 +12,9 @@
 
 	user.set_machine(src)
 
-	var/dat = "<h1>Keycard Authentication Device</h1>"
+	var/list/dat = list()
+	
+	dat += "<h1>Keycard Authentication Device</h1>"
 
 	dat += "This device is used to trigger some high security events. It requires the simultaneous swipe of two high-level ID cards."
 	dat += "<br><hr><br>"
@@ -87,6 +89,6 @@
 				to_chat(usr, "<span class='danger'>Unable to initiate evacuation!</span>")
 				return
 			for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
-				if(EO.type == /datum/evacuation_option/abandon_ship)
+				if(EO.abandon_ship)
 					evacuation_controller.handle_evac_option(EO.option_target, usr)
 					return

--- a/maps/torch/machinery/keycard authentication.dm
+++ b/maps/torch/machinery/keycard authentication.dm
@@ -18,34 +18,34 @@
 	dat += "<br><hr><br>"
 
 	if(screen == 1)
-		dat += "Select an event to trigger:<ul>"
+		dat += "Select an event to trigger:<br>"
 
 		var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 		if(security_state.current_security_level == security_state.severe_security_level)
-			dat += "<li>Cannot modify the alert level at this time: [security_state.severe_security_level.name] engaged.</li>"
+			dat += "Cannot modify the alert level at this time: [security_state.severe_security_level.name] engaged.<br>"
 		else
 			if(security_state.current_security_level == security_state.high_security_level)
-				dat += "<li><A href='?src=\ref[src];triggerevent=Revert alert'>Disengage [security_state.high_security_level.name]</A></li>"
+				dat += "<A href='?src=\ref[src];triggerevent=Revert alert'>Disengage [security_state.high_security_level.name]</A><br>"
 			else
-				dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Engage [security_state.high_security_level.name]</A></li>"
+				dat += "<A href='?src=\ref[src];triggerevent=Red alert'>Engage [security_state.high_security_level.name]</A><br>"
 
 		if(!config.ert_admin_call_only)
-			dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>"
+			dat += "<A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A><br>"
 
-		dat += "<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Grant Nuclear Authorization Code'>Grant Nuclear Authorization Code</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Bolt All Saferooms'>Bolt All Saferooms</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Unbolt All Saferooms'>Unbolt All Saferooms</A></li>"
-		dat += "</ul>"
-		user << browse(dat, "window=keycard_auth;size=500x250")
+		dat += "<A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A><br>"
+		dat += "<A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A><br>"
+		dat += "<A href='?src=\ref[src];triggerevent=Grant Nuclear Authorization Code'>Grant Nuclear Authorization Code</A><br>"
+		dat += "<a href='?src=\ref[src];triggerevent=Evacuate'>Initiate Evacuation Procedures</a><br>"
 	if(screen == 2)
 		dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
 		dat += "<p><A href='?src=\ref[src];reset=1'>Back</A>"
-		user << browse(dat, "window=keycard_auth;size=500x250")
+	
+	var/datum/browser/popup = new(user, "kad_window", "Keycard Authentication Device", 500, 250)
+	popup.set_content(JOINTEXT(dat))
+	popup.open()
 	return
 
-/obj/machinery/keycard_auth/torch/trigger_event()
+/obj/machinery/keycard_auth/torch/trigger_event()	
 	switch(event)
 		if("Red alert")
 			var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
@@ -82,3 +82,11 @@
 		if("Unbolt All Saferooms")
 			GLOB.using_map.unbolt_saferooms()
 			feedback_inc("unbolted_saferoom",1)
+		if("Evacuate")
+			if(!evacuation_controller)
+				to_chat(usr, "<span class='danger'>Unable to initiate evacuation!</span>")
+				return
+			for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
+				if(EO.type == /datum/evacuation_option/abandon_ship)
+					evacuation_controller.handle_evac_option(EO.option_target, usr)
+					return

--- a/nano/templates/communication.tmpl
+++ b/nano/templates/communication.tmpl
@@ -20,6 +20,8 @@
 
 		<h4>Additional</h4>
 		<div class=itemGroup>
+			<div class="item">{{:helper.link('Unbolt saferoom doors', null, {'action' : 'unbolt_doors'})}}</div>
+			<div class="item">{{:helper.link('Bolt saferoom doors', null, {'action' : 'bolt_doors'})}}</div>		
 			{{for data.evac_options}}
 				<div class="item">
 					{{:helper.link(value.option_text, null, {'action' : 'evac', 'target' : value.option_target}, ((value.needs_syscontrol && !data.net_syscont) || (!value.silicon_allowed && data.isAI)) ? 'disabled' : null, 'redButton')}}

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 12 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 45 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 632 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 630 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 25 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
:cl: Textor
tweak: Due to the extremely likely outcome of death for the crew upon ejection of the escape pods, command has moved abandon ship from Command and Communciations to Keycard Authentication Devices and renamed it to "Initiate Evacuation Procedures." Abort still occurs at C&C consoles, as does bluespace jump initiation.
tweak: Moves bolt/unbolt saferooms from Keycard Authentication Devices to C&C
tweak: Changes Keycard Authentication Device interface to NanoUI
/:cl: