### PR TITLE
Fixes runtime reporting in 512.

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -2,7 +2,7 @@ GLOBAL_VAR_INIT(total_runtimes, 0)
 GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 
 #ifdef DEBUG
-/world/Error(exception/E, datum/e_src)
+/world/Error(exception/E)
 	if(!istype(E)) //Something threw an unusual exception
 		log_world("\[[time_stamp()]] Uncaught exception: [E]")
 		return ..()

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -28,7 +28,7 @@ var/list/stored_shock_by_ref = list()
 			// Apply all pixel shifts for each direction.
 			for(var/shift_facing in shifts)
 				var/list/facing_list = shifts[shift_facing]
-				var/use_dir = text2dir(shift_facing)
+				var/use_dir = text2num(shift_facing)
 				var/icon/equip = new(mob_icon, icon_state = mob_state, dir = use_dir)
 				var/icon/canvas = new(icon_template)
 				canvas.Blend(equip, ICON_OVERLAY, facing_list["x"]+1, facing_list["y"]+1)

--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -105,13 +105,13 @@
 
 /datum/species/adherent/New()
 	equip_adjust = list(
-		"[slot_l_hand_str]" = list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 0, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = 0,  "y" = 14)),
-		"[slot_r_hand_str]" = list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 0, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = 0,  "y" = 14)),
-		"[slot_back_str]" =   list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 0, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = 0,  "y" = 14)),
-		"[slot_belt_str]" =   list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 0, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = 0,  "y" = 14)),
-		"[slot_head_str]" =   list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 3, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = -3, "y" = 14)),
-		"[slot_l_ear_str]" =  list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 0, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = 0,  "y" = 14)),
-		"[slot_r_ear_str]" =  list(NORTH = list("x" = 0, "y" = 14), EAST = list("x" = 0, "y" = 14), SOUTH = list("x" = 0, "y" = 14), WEST = list("x" = 0,  "y" = 14))
+		"[slot_l_hand_str]" = list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 0, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = 0,  "y" = 14)),
+		"[slot_r_hand_str]" = list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 0, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = 0,  "y" = 14)),
+		"[slot_back_str]" =   list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 0, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = 0,  "y" = 14)),
+		"[slot_belt_str]" =   list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 0, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = 0,  "y" = 14)),
+		"[slot_head_str]" =   list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 3, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = -3, "y" = 14)),
+		"[slot_l_ear_str]" =  list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 0, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = 0,  "y" = 14)),
+		"[slot_r_ear_str]" =  list("[NORTH]" = list("x" = 0, "y" = 14), "[EAST]" = list("x" = 0, "y" = 14), "[SOUTH]" = list("x" = 0, "y" = 14), "[WEST]" = list("x" = 0,  "y" = 14))
 	)
 	..()
 

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -53,13 +53,15 @@
 		TAG_FACTION =   FACTION_TEST_SUBJECTS
 	)
 
+/datum/species/monkey/New()
 	equip_adjust = list(
-		slot_l_hand_str = list(NORTH = list("x" = 1, "y" = 3), EAST = list("x" = -3, "y" = 2), SOUTH = list("x" = -1, "y" = 3), WEST = list("x" = 3, "y" = 2)),
-		slot_r_hand_str = list(NORTH = list("x" = -1, "y" = 3), EAST = list("x" = 3, "y" = 2), SOUTH = list("x" = 1, "y" = 3), WEST = list("x" = -3, "y" = 2)),
-		slot_shoes_str = list(NORTH = list("x" = 0, "y" = 7), EAST = list("x" = -1, "y" = 7), SOUTH = list("x" = 0, "y" = 7), WEST = list("x" = 1, "y" = 7)),
-		slot_head_str = list(NORTH = list("x" = 0, "y" = 0), EAST = list("x" = -2, "y" = 0), SOUTH = list("x" = 0, "y" = 0), WEST = list("x" = 2, "y" = 0)),
-		slot_wear_mask_str = list(NORTH = list("x" = 0, "y" = 0), EAST = list("x" = -1, "y" = 0), SOUTH = list("x" = 0, "y" = 0), WEST = list("x" = 1, "y" = 0))
+		slot_l_hand_str = list("[NORTH]" = list("x" = 1, "y" = 3), "[EAST]" = list("x" = -3, "y" = 2), "[SOUTH]" = list("x" = -1, "y" = 3), "[WEST]" = list("x" = 3, "y" = 2)),
+		slot_r_hand_str = list("[NORTH]" = list("x" = -1, "y" = 3), "[EAST]" = list("x" = 3, "y" = 2), "[SOUTH]" = list("x" = 1, "y" = 3), "[WEST]" = list("x" = -3, "y" = 2)),
+		slot_shoes_str = list("[NORTH]" = list("x" = 0, "y" = 7), "[EAST]" = list("x" = -1, "y" = 7), "[SOUTH]" = list("x" = 0, "y" = 7), "[WEST]" = list("x" = 1, "y" = 7)),
+		slot_head_str = list("[NORTH]" = list("x" = 0, "y" = 0), "[EAST]" = list("x" = -2, "y" = 0), "[SOUTH]" = list("x" = 0, "y" = 0), "[WEST]" = list("x" = 2, "y" = 0)),
+		slot_wear_mask_str = list("[NORTH]" = list("x" = 0, "y" = 0), "[EAST]" = list("x" = -1, "y" = 0), "[SOUTH]" = list("x" = 0, "y" = 0), "[WEST]" = list("x" = 1, "y" = 0))
 	)
+	..()
 
 /datum/species/monkey/handle_npc(var/mob/living/carbon/human/H)
 	if(H.stat != CONSCIOUS)

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -121,12 +121,6 @@
 
 	unarmed_types = list(/datum/unarmed_attack/nabber)
 
-	equip_adjust = list(
-		slot_back_str =    list(NORTH = list("x" = 0, "y" = 7), EAST = list("x" = 0, "y" = 8), SOUTH = list("x" = 0, "y" = 8), WEST = list("x" = 0, "y" = 8)),
-		slot_belt_str =    list(NORTH = list("x" = 0, "y" = 0), EAST = list("x" = 8, "y" = 0), SOUTH = list("x" = 0, "y" = 0), WEST = list("x" = -8, "y" = 0)),
-		slot_glasses_str = list(NORTH = list("x" = 0, "y" = 10), EAST = list("x" = 0, "y" = 11), SOUTH = list("x" = 0, "y" = 11), WEST = list("x" = 0, "y" = 11)),
-	)
-
 	descriptors = list(
 		/datum/mob_descriptor/height = 3,
 		/datum/mob_descriptor/body_length = 0
@@ -157,6 +151,14 @@
 			EDUCATION_NABBER_APLUS
 		)
 	)
+
+/datum/species/nabber/New()
+	equip_adjust = list(
+		slot_back_str =    list("[NORTH]" = list("x" = 0, "y" = 7), "[EAST]" = list("x" = 0, "y" = 8), "[SOUTH]" = list("x" = 0, "y" = 8), "[WEST]" = list("x" = 0, "y" = 8)),
+		slot_belt_str =    list("[NORTH]" = list("x" = 0, "y" = 0), "[EAST]" = list("x" = 8, "y" = 0), "[SOUTH]" = list("x" = 0, "y" = 0), "[WEST]" = list("x" = -8, "y" = 0)),
+		slot_glasses_str = list("[NORTH]" = list("x" = 0, "y" = 10), "[EAST]" = list("x" = 0, "y" = 11), "[SOUTH]" = list("x" = 0, "y" = 11), "[WEST]" = list("x" = 0, "y" = 11)),
+	)
+	..()
 
 /datum/species/nabber/get_blood_name()
 	return "haemolymph"


### PR DESCRIPTION
Fixes #23412
Fixes #23413.

Now, for the latter, you may wonder, "How could this possibly fix a bug that's essentially about `world/Error()` failing to trigger? 

And I have no answer for this question, except to point out that prior to this PR species datums would be created just fine. It's left as an exercise to the reader to figure out exactly what the value of `equip_adjust` was previously.