### PR TITLE
Fixes adminordrazine.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -111,27 +111,7 @@
 	affect_blood(M, alien, removed)
 
 /datum/reagent/adminordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.setCloneLoss(0)
-	M.setOxyLoss(0)
-	M.radiation = 0
-	M.heal_organ_damage(5,5)
-	M.adjustToxLoss(-5)
-	M.hallucination_power = 0
-	M.setBrainLoss(0)
-	M.disabilities = 0
-	M.sdisabilities = 0
-	M.eye_blurry = 0
-	M.eye_blind = 0
-	M.SetWeakened(0)
-	M.SetStunned(0)
-	M.SetParalysis(0)
-	M.silent = 0
-	M.dizziness = 0
-	M.drowsyness = 0
-	M.stuttering = 0
-	M.confused = 0
-	M.sleeping = 0
-	M.jitteriness = 0
+	M.rejuvenate()
 
 /datum/reagent/gold
 	name = "Gold"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -103,10 +103,10 @@
 	name = "Adminordrazine pill"
 	desc = "It's magic. We don't have to explain it."
 	icon_state = "pillA"
-/obj/item/weapon/reagent_containers/pill/adminordrazine/New()
-	..()
-	reagents.add_reagent(/datum/reagent/adminordrazine, 50)
 
+/obj/item/weapon/reagent_containers/pill/adminordrazine/Initialize()
+	..()
+	reagents.add_reagent(/datum/reagent/adminordrazine, 1)
 
 /obj/item/weapon/reagent_containers/pill/stox
 	name = "Soporific (15u)"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -105,7 +105,7 @@
 	icon_state = "pillA"
 
 /obj/item/weapon/reagent_containers/pill/adminordrazine/Initialize()
-	..()
+	. = ..()
 	reagents.add_reagent(/datum/reagent/adminordrazine, 1)
 
 /obj/item/weapon/reagent_containers/pill/stox


### PR DESCRIPTION
Fixes #23487 

Adminordrazine is a silly god reagent meant to completely heal whoever ingests it. So why not make it just use rejuvenate()?

- Removed adminordrazine's superfluous code and just made it call rejuvenate() on the mob.
- The default pill now contains only 1 unit of reagent.
- ~~A new variant, super_adminordrazine, acts like the original pill (has 50 units for some stupid reason).~~
- Fun bonus: it now revives dead bodies, so you can inject corpses for events or whatever.
- Also made the respective pills use Initialize() instead of New(), because I know you rat bastards will make me fix it if I touch it.