### PR TITLE
Adds sticky note pads to map, noticeboards to offices, fixed piping a…

### DIFF
--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -4237,6 +4237,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
 "jM" = (
@@ -6628,6 +6633,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -11548,6 +11558,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
+"CN" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "CS" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -12407,12 +12430,6 @@
 /area/shuttle/petrov/eva)
 "GG" = (
 /obj/machinery/artifact_scanpad,
-/obj/machinery/alarm{
-	alarm_id = "petrov1";
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
 "GI" = (
@@ -13871,6 +13888,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	icon_state = "map_scrubber_off";
 	dir = 1
+	},
+/obj/machinery/alarm{
+	alarm_id = "petrov1";
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
@@ -32716,7 +32739,7 @@ aX
 aX
 aX
 oM
-kU
+CN
 aX
 aX
 aX

--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -4577,7 +4577,7 @@
 	name = "Hangar Exit Door Control";
 	pixel_x = -24;
 	pixel_y = 0;
-	req_access = list(207)
+	req_access = newlist()
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -6747,7 +6747,7 @@
 	name = "Hangar Exit Door Control";
 	pixel_x = 24;
 	pixel_y = 0;
-	req_access = list(207)
+	req_access = newlist()
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -10691,6 +10691,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
+"zf" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "zi" = (
 /obj/structure/bed,
 /obj/structure/cable/cyan{
@@ -11558,19 +11571,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
-"CN" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/light/spot{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "CS" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -32739,7 +32739,7 @@ aX
 aX
 aX
 oM
-CN
+zf
 aX
 aX
 aX

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -4789,6 +4789,7 @@
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/lino,
 /area/tcommsat/computer)
 "kD" = (
@@ -7660,6 +7661,7 @@
 	dir = 4
 	},
 /obj/item/weapon/book/manual/chef_recipes,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "rp" = (
@@ -18011,6 +18013,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/lino,
 /area/vacant/office)
 "RT" = (
@@ -18325,6 +18328,7 @@
 /area/maintenance/thirddeck/starboard)
 "SP" = (
 /obj/structure/table/standard,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "SS" = (

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -4241,8 +4241,10 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "iP" = (
@@ -9409,6 +9411,8 @@
 	icon_state = "0-2"
 	},
 /obj/item/weapon/tape_roll,
+/obj/item/weapon/paper/sticky,
+/obj/item/weapon/paper/sticky,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_monitoring)
 "vc" = (
@@ -15816,11 +15820,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	layer = 2.4;
-	level = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5;

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -6091,6 +6091,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "asy" = (
@@ -8164,11 +8165,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "azN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -9854,6 +9861,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "aFT" = (
@@ -15393,6 +15401,24 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"bEQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "bFb" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
@@ -15859,6 +15885,9 @@
 "cgu" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -18971,6 +19000,7 @@
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	pixel_x = -5
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "fRb" = (
@@ -20157,15 +20187,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "hhB" = (
@@ -20385,7 +20415,6 @@
 "hub" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20393,6 +20422,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/entry)
 "huf" = (
@@ -20406,6 +20438,10 @@
 "hvb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/entry)
 "hwb" = (
@@ -21696,8 +21732,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/valve/shutoff,
-/obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "iVM" = (
@@ -21995,6 +22029,7 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
+/obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "jpt" = (
@@ -26544,6 +26579,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/carpet/green,
 /area/rnd/breakroom)
 "oFb" = (
@@ -26558,6 +26594,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/carpet/green,
 /area/rnd/breakroom)
 "oGG" = (
@@ -28448,6 +28485,11 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rcx" = (
+/obj/machinery/atmospherics/valve/shutoff,
+/obj/effect/floor_decal/industrial/shutoff,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "rdb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -30834,6 +30876,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/monotile,
 /area/security/processing)
 "uRO" = (
@@ -30913,6 +30956,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
+"uZi" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "uZO" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -53440,8 +53489,8 @@ gBb
 mzb
 gWb
 ivT
-hnN
-aGx
+bEQ
+rcx
 hvb
 hGb
 nKb
@@ -57279,7 +57328,7 @@ avw
 awB
 fhx
 hnN
-aGx
+uZi
 sOg
 aCo
 moh

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -3495,6 +3495,10 @@
 /area/crew_quarters/heads/office/ce)
 "ij" = (
 /obj/machinery/papershredder,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "ik" = (
@@ -3795,12 +3799,8 @@
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
+/obj/structure/noticeboard{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
@@ -4185,6 +4185,9 @@
 /obj/structure/closet/secure_closet/engineering_chief_torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "jN" = (
@@ -5583,9 +5586,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = 24
+/obj/structure/noticeboard{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
@@ -5620,6 +5622,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 38;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mK" = (
@@ -6835,6 +6841,7 @@
 /obj/item/weapon/hand_labeler,
 /obj/item/device/destTagger,
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "pu" = (
@@ -10056,6 +10063,7 @@
 	},
 /obj/item/weapon/stamp/nt,
 /obj/effect/floor_decal/corner/b_green/diagonal,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cl)
 "vv" = (
@@ -10086,6 +10094,7 @@
 	},
 /obj/item/weapon/stamp/solgov,
 /obj/item/documents/scgr,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sgr)
 "vy" = (
@@ -12344,6 +12353,7 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/stamp/ce,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "Dg" = (
@@ -12491,6 +12501,7 @@
 	pixel_x = 24;
 	pixel_y = 16
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "Ei" = (
@@ -12580,6 +12591,9 @@
 /obj/machinery/keycard_auth/torch{
 	pixel_x = 0;
 	pixel_y = -24
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -13345,6 +13359,7 @@
 	icon_state = "4-8"
 	},
 /obj/random_multi/single_item/boombox,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "Ih" = (
@@ -14016,6 +14031,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "KR" = (
@@ -14173,6 +14189,7 @@
 	},
 /obj/item/weapon/stamp/rd,
 /obj/item/weapon/pen,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/rd)
 "Li" = (
@@ -14960,6 +14977,7 @@
 	},
 /obj/item/weapon/pen,
 /obj/item/weapon/stamp/sea,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "Qg" = (
@@ -15588,6 +15606,7 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "Uf" = (
@@ -16253,6 +16272,9 @@
 	},
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
 "Yd" = (
@@ -16274,7 +16296,6 @@
 	pixel_x = 0;
 	pixel_y = -3
 	},
-/obj/random/documents,
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "Yf" = (
@@ -16373,12 +16394,12 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Zc" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
 "Zd" = (


### PR DESCRIPTION
🆑 Cakey
maptweak: Fixes Petrov isolation cell alarm placement.
maptweak: Added sticky notes to offices around the ship.
maptweak: Added noticeboard to head of staff offices where missing.
maptweak: Added missing air alarms to hangar, hangar storage.
maptweak: Fixes hangar exit button access.
/🆑

Fixes #23475 
Fixes #23462 
Fixes #23488 
Fixes #23465 