### PR TITLE
Yet more runtime fixes.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -238,5 +238,8 @@
 #define EMAIL_SYSADMIN  "admin@internal-services.net"
 #define EMAIL_BROADCAST "broadcast@internal-services.net"
 
+//Number of slots a modular computer has which can be tweaked via gear tweaks.
+#define TWEAKABLE_COMPUTER_PART_SLOTS 7
+
 //Lying animation
 #define ANIM_LYING_TIME 2

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -123,7 +123,7 @@
 
 #define CanPhysicallyInteractWith(user, target) CanInteractWith(user, target, GLOB.physical_state)
 
-#define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) } ; x.Cut(); x = null }
+#define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
 
 #define QDEL_NULL(x) if(x) { qdel(x) ; x = null }
 

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -43,10 +43,11 @@
 		return ..()
 
 /obj/item/inducer/proc/CannotUse(mob/user)
-	if(!get_cell())
+	var/obj/item/weapon/cell/my_cell = get_cell()
+	if(!istype(my_cell))
 		to_chat(user, "<span class='warning'>\The [src] doesn't have a power cell installed!</span>")
 		return TRUE
-	if(cell.percent() <= 0)
+	if(my_cell.percent() <= 0)
 		to_chat(user, "<span class='warning'>\The [src]'s battery is dead!</span>")
 		return TRUE
 	return FALSE
@@ -107,6 +108,10 @@
 			length += rand(40, 60)
 		while(C.charge < C.maxcharge)
 			if(MyC.charge > max(0, MyC.charge*failsafe) && do_after(user, length, target = user))
+				if(CannotUse(user))
+					return TRUE
+				if(QDELETED(C))
+					return TRUE
 				sparks.start()
 				done_any = TRUE
 				induce(C)

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -41,7 +41,7 @@
 /datum/gear_tweak/color/tweak_item(var/obj/item/I, var/metadata)
 	if(valid_colors && !(metadata in valid_colors))
 		return
-	I.color = metadata
+	I.color = sanitize_hexcolor(metadata, I.color)
 
 /*
 * Path adjustment
@@ -130,7 +130,7 @@
 			return metadata
 
 /datum/gear_tweak/contents/tweak_item(var/obj/item/I, var/list/metadata)
-	if(metadata.len != valid_contents.len)
+	if(length(metadata) != length(valid_contents))
 		return
 	for(var/i = 1 to valid_contents.len)
 		var/path
@@ -172,11 +172,13 @@
 /datum/gear_tweak/reagents/tweak_item(var/obj/item/I, var/list/metadata)
 	if(metadata == "None")
 		return
+	var/reagent
 	if(metadata == "Random")
-		. = valid_reagents[pick(valid_reagents)]
+		reagent = valid_reagents[pick(valid_reagents)]
 	else
-		. = valid_reagents[metadata]
-	I.reagents.add_reagent(., I.reagents.get_free_space())
+		reagent = valid_reagents[metadata]
+	if(reagent)
+		return I.reagents.add_reagent(reagent, I.reagents.get_free_space())
 
 /datum/gear_tweak/tablet
 	var/list/ValidProcessors = list(/obj/item/weapon/computer_hardware/processor_unit/small)
@@ -300,9 +302,13 @@
 	. += names[entry]
 
 /datum/gear_tweak/tablet/get_default()
-	return list(1, 1, 1, 1, 1, 1, 1)
+	. = list()
+	for(var/i in 1 to TWEAKABLE_COMPUTER_PART_SLOTS)
+		. += 1
 
 /datum/gear_tweak/tablet/tweak_item(var/obj/item/modular_computer/tablet/I, var/list/metadata)
+	if(length(metadata) < TWEAKABLE_COMPUTER_PART_SLOTS)
+		return
 	if(ValidProcessors[metadata[1]])
 		var/t = ValidProcessors[metadata[1]]
 		I.processor_unit = new t(I)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -167,13 +167,16 @@ var/list/gear_datums = list()
 		var/list/entry = list()
 		var/datum/gear/G = LC.gear[gear_name]
 		var/ticked = (G.display_name in pref.gear_list[pref.gear_slot])
-		entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=[html_encode(G.display_name)]'>[G.display_name]</a></td>"
+		entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=[G.display_name]'>[G.display_name]</a></td>"
 		entry += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
 		entry += "<td><font size=2>[G.get_description(get_gear_metadata(G,1))]</font>"
 		var/allowed = 1
-		if(G.allowed_branches && pref.char_branch)
+		if(length(G.allowed_branches))
 			var/datum/mil_branch/player_branch = mil_branches.get_branch(pref.char_branch)
-			if(!(player_branch.type in G.allowed_branches))
+			if(!player_branch)
+				entry += "<br><i><font color=cc5555>Needs branch selected</font></i>"
+				allowed = 0
+			else if(!(player_branch.type in G.allowed_branches))
 				entry += "<br><i><font color=cc5555>[player_branch.name]</font></i>"
 				allowed = 0
 		if(allowed && G.allowed_roles)
@@ -226,6 +229,8 @@ var/list/gear_datums = list()
 /datum/category_item/player_setup_item/loadout/OnTopic(href, href_list, user)
 	if(href_list["toggle_gear"])
 		var/datum/gear/TG = gear_datums[href_list["toggle_gear"]]
+		if(!TG)
+			return TOPIC_REFRESH
 		if(TG.display_name in pref.gear_list[pref.gear_slot])
 			pref.gear_list[pref.gear_slot] -= TG.display_name
 		else
@@ -334,10 +339,10 @@ var/list/gear_datums = list()
 /datum/gear/proc/spawn_item(var/location, var/metadata)
 	var/datum/gear_data/gd = new(path, location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
-		gt.tweak_gear_data(metadata["[gt]"], gd)
+		gt.tweak_gear_data(metadata && metadata["[gt]"], gd)
 	var/item = new gd.path(gd.location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
-		gt.tweak_item(item, metadata["[gt]"])
+		gt.tweak_item(item, metadata && metadata["[gt]"])
 	return item
 
 /datum/gear/proc/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
@@ -348,6 +353,7 @@ var/list/gear_datums = list()
 
 /datum/gear/proc/spawn_in_storage_or_drop(var/mob/living/carbon/human/H, var/metadata)
 	var/obj/item/item = spawn_item(H, metadata)
+	item.add_fingerprint(H)
 
 	var/atom/placed_in = H.equip_to_storage(item)
 	if(placed_in)
@@ -358,5 +364,3 @@ var/list/gear_datums = list()
 		to_chat(H, "<span class='notice'>Placing \the [item] in your hands!</span>")
 	else
 		to_chat(H, "<span class='danger'>Dropping \the [item] on the ground!</span>")
-		item.forceMove(get_turf(H))
-		item.add_fingerprint(H)

--- a/code/modules/mob/living/carbon/alien/diona/nymph_inventory.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_inventory.dm
@@ -50,8 +50,9 @@
 		if(food.trash) holding_item = new food.trash(src)
 		qdel(food)
 
-	holding_item.equipped(src)
-	holding_item.screen_loc = DIONA_SCREEN_LOC_HELD
+	if(!QDELETED(holding_item))
+		holding_item.equipped(src)
+		holding_item.screen_loc = DIONA_SCREEN_LOC_HELD
 
 /mob/living/carbon/alien/diona/verb/drop_item_verb()
 	set name = "Drop Held Item"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -168,7 +168,7 @@
 		if(I.obj_flags & OBJ_FLAG_CONDUCTIBLE)
 			burn_damage += I.w_class * rand(power, 3*power)
 
-	if(burn_damage)
+	if(owner && burn_damage)
 		owner.custom_pain("Something inside your [src] burns a [severity < 2 ? "bit" : "lot"]!", power * 15) //robotic organs won't feel it anyway
 		take_external_damage(0, burn_damage, 0, used_weapon = "Hot metal")
 

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -1,6 +1,4 @@
 /mob/living/carbon/human/proc/create_stack()
-	set waitfor=0
-	sleep(10)
 	internal_organs_by_name[BP_STACK] = new /obj/item/organ/internal/stack(src,1)
 	to_chat(src, "<span class='notice'>You feel a faint sense of vertigo as your neural lace boots.</span>")
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -29,11 +29,8 @@ var/list/organ_cache = list()
 	var/death_time
 
 /obj/item/organ/Destroy()
-
 	owner = null
 	dna = null
-	species = null
-
 	return ..()
 
 /obj/item/organ/proc/refresh_action_button()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -275,13 +275,13 @@ var/global/photo_count = 0
 /obj/item/weapon/photo/proc/copy(var/copy_id = 0)
 	var/obj/item/weapon/photo/p = new/obj/item/weapon/photo()
 
-	p.SetName(name)
-	p.icon = icon(icon, icon_state)
-	p.tiny = icon(tiny)
+	p.SetName(name) // Do this first, manually, to make sure listeners are alerted properly.
+	p.appearance = appearance
+
+	p.tiny = new
+	p.tiny.appearance = tiny.appearance
 	p.img = icon(img)
-	p.desc = desc
-	p.pixel_x = pixel_x
-	p.pixel_y = pixel_y
+
 	p.photo_size = photo_size
 	p.scribble = scribble
 


### PR DESCRIPTION
Fixes #22396
Fixes #21880
Fixes #19193
Fixes #22695
Fixes #22696

Fixes #23506

Fixes icon runtime with photocopiers and photos; "improper icon operation" runtimes are not reported to the issue tracker due to lack of line numbers.

Fixes #22325
Fixes #22560
Fixes #20089
Fixes #21528

Fixes #22910
Fixes #22754
Fixes #22833
Fixes #22289
Fixes #21709

Experiment regarding the following, where I prevent nulling the species on organ deletion (not necessary anyway). If they actually don't reopen, that means organ deletion isn't being handled properly.

Closes #22447
Closes #23063
Closes #23470
Closes #21372