### PR TITLE
Restores laptops to medical.

### DIFF
--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -18228,6 +18228,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
+/obj/item/modular_computer/laptop/preset/records,
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
 "eYb" = (
@@ -19018,9 +19019,6 @@
 "fUb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
-	},
-/obj/item/modular_computer/telescreen/preset/medical{
-	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
@@ -26222,6 +26220,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/item/modular_computer/laptop/preset/records,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "okp" = (


### PR DESCRIPTION
:cl:
maptweak: The telescreen by the copier in medical has been removed; some laptops have been restored.
/:cl:

The telescreens are poorly positioned. The laptops are specifically placed in locations where they would be used for various RP purposes (patient exam, entertainment while in subacute, writing reports).