### PR TITLE
Makes O2 Tank Removable From Worn Hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -117,7 +117,7 @@
 			if(!to_remove)
 				return
 
-			if(istype(src.loc,/mob/living/carbon/human) && to_remove != "cell")
+			if(istype(src.loc,/mob/living/carbon/human) && to_remove != "cell" && to_remove != "tank")
 				var/mob/living/carbon/human/H = src.loc
 				if(H.back == src)
 					to_chat(user, "You can't remove an installed device while the hardsuit is being worn.")


### PR DESCRIPTION
:cl: Textor
tweak: O2 Tanks are once again removable without having to take your entire hardsuit off. Hardsuit users will no longer risk suffocating in a vacuum because they ran low on air.
/:cl: