### PR TITLE
Fixes Automatic Shutoff Valve Examine Echo

### DIFF
--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -14,7 +14,7 @@
 
 /obj/machinery/atmospherics/valve/shutoff/examine(var/mob/user)
 	..()
-	to_chat(user, "The automatic shutoff circuit is [close_on_leaks ? "disabled" : "enabled"].")
+	to_chat(user, "The automatic shutoff circuit is [close_on_leaks ? "enabled" : "disabled"].")
 
 /obj/machinery/atmospherics/valve/shutoff/New()
 	open()


### PR DESCRIPTION
`Auto` Shutoff Valves would initially start off ENABLED and OPEN, however, when examining, would display that they are DISABLED and OPEN.

I've swapped ENABLED and DISABLED in the piece of code that shows the current status when you examine it to address recent confusion.

They still work just the same as they did before the tweak.

:cl: Melioa
bugfix: Fixes text displayed when examining an Automatic Shutoff Valve.
/:cl:
