### PR TITLE
Fix qdel() mob duplications

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -107,6 +107,7 @@
 	if(istype(cooking_obj, /obj/item/weapon/holder))
 		for(var/mob/living/M in cooking_obj.contents)
 			M.death()
+			qdel(M)
 
 	// Cook the food.
 	var/cook_path

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -361,6 +361,13 @@
 
 /obj/machinery/microwave/proc/fail()
 	var/amount = 0
+
+	// Kill + delete mobs in mob holders
+	for (var/obj/item/weapon/holder/H in contents)
+		for (var/mob/living/M in H.contents)
+			M.death()
+			qdel(M)
+
 	for (var/obj/O in contents)
 		amount++
 		if (O.reagents)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -362,7 +362,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		var/datum/reagent/R = locate(href_list["disposeP"]) in linked_lathe.reagents.reagent_list
 		if(R)
 			linked_lathe.reagents.del_reagent(R.type)
-	
+
 	else if(href_list["disposeallP"]) //Causes the protolathe to dispose of all it's reagents.
 		. = TOPIC_REFRESH
 		CHECK_LATHE
@@ -463,6 +463,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	for(var/obj/I in linked_destroy.contents)
 		for(var/mob/M in I.contents)
 			M.death()
+			qdel(M)
 		if(istype(I,/obj/item/stack/material))//Only deconsturcts one sheet at a time instead of the entire stack
 			var/obj/item/stack/material/S = I
 			if(S.get_amount() > 1)


### PR DESCRIPTION
:cl: sierrakomodo
fix: Fixes mouse/drone duplication bugs with cookers, microwaves, and destructive analyzers (#14179)
/:cl:

This is more of a patchjob instead of a proper fix of the root issue in my opinion, but @afterthought2 believes how `qdel()` is handling deletion of mob holders isn't actually a bug and should be left as is. See #23522 for specific details on the qdel() issue.