### PR TITLE
Gets Rid of a Ton of "in world" Checks

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_interdiction.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_interdiction.dm
@@ -83,7 +83,7 @@
 	if(!target)
 		var/list/robots = list()
 		var/list/robot_names = list()
-		for(var/mob/living/silicon/robot/R in world)
+		for(var/mob/living/silicon/robot/R in GLOB.silicon_mob_list)
 			if(istype(R, /mob/living/silicon/robot/drone))	// No drones.
 				continue
 			if(R.connected_ai != user)						// No robots linked to other AIs

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -165,7 +165,7 @@
 		var/turf/T = get_turf(src)
 		if(!T.loc) return
 		var/area/A = T.loc
-		for(var/obj/machinery/portable_atmospherics/powered/scrubber/huge/scrubber in world )
+		for(var/obj/machinery/portable_atmospherics/powered/scrubber/huge/scrubber in SSmachines.machinery )
 			var/turf/T2 = get_turf(scrubber)
 			if(T2 && T2.loc)
 				var/area/A2 = T2.loc

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -32,19 +32,19 @@
 		to_chat(viewers(null, null), "Cannot locate mass driver connector. Cancelling firing sequence!")
 		return
 
-	for(var/obj/machinery/door/blast/M in world)
+	for(var/obj/machinery/door/blast/M in SSmachines.machinery)
 		if(M.id == id)
 			M.open()
 
 	sleep(20)
 
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in SSmachines.machinery)
 		if(M.id == id)
 			M.power = connected.power
 			M.drive()
 
 	sleep(50)
-	for(var/obj/machinery/door/blast/M in world)
+	for(var/obj/machinery/door/blast/M in SSmachines.machinery)
 		if(M.id == id)
 			M.close()
 			return
@@ -181,7 +181,7 @@
 		time = min(max(round(time), 0), 120)
 		. = TOPIC_REFRESH
 	else if(href_list["door"])
-		for(var/obj/machinery/door/blast/M in world)
+		for(var/obj/machinery/door/blast/M in SSmachines.machinery)
 			if(M.id == id)
 				if(M.density)
 					M.open()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -86,7 +86,7 @@
 	*/
 
 /obj/machinery/button/remote/airlock/trigger()
-	for(var/obj/machinery/door/airlock/D in world)
+	for(var/obj/machinery/door/airlock/D in SSmachines.machinery)
 		if(D.id_tag == src.id)
 			if(specialfunctions & OPEN)
 				if (D.density)
@@ -131,7 +131,7 @@
 	icon_state = "blastctrl"
 
 /obj/machinery/button/remote/blast_door/trigger()
-	for(var/obj/machinery/door/blast/M in world)
+	for(var/obj/machinery/door/blast/M in SSmachines.machinery)
 		if(M.id == src.id)
 			if(M.density)
 				spawn(0)
@@ -150,7 +150,7 @@
 	desc = "It controls emitters, remotely."
 
 /obj/machinery/button/remote/emitter/trigger(mob/user as mob)
-	for(var/obj/machinery/power/emitter/E in world)
+	for(var/obj/machinery/power/emitter/E in SSmachines.machinery)
 		if(E.id == src.id)
 			spawn(0)
 				E.activate(user)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -225,7 +225,7 @@
 		..()
 
 		if(autolink)
-			for(var/obj/machinery/magnetic_module/M in world)
+			for(var/obj/machinery/magnetic_module/M in SSmachines.machinery)
 				if(M.freq == frequency && M.code == code)
 					magnets.Add(M)
 
@@ -241,7 +241,7 @@
 
 	Process()
 		if(magnets.len == 0 && autolink)
-			for(var/obj/machinery/magnetic_module/M in world)
+			for(var/obj/machinery/magnetic_module/M in SSmachines.machinery)
 				if(M.freq == frequency && M.code == code)
 					magnets.Add(M)
 

--- a/code/modules/atmospherics/atmos_primitives.dm
+++ b/code/modules/atmospherics/atmos_primitives.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/atmospherics/var/debug = 0
 
-/client/proc/atmos_toggle_debug(var/obj/machinery/atmospherics/M in world)
+/client/proc/atmos_toggle_debug(var/obj/machinery/atmospherics/M in SSmachines.machinery)
 	set name = "Toggle Debug Messages"
 	set category = "Debug"
 	M.debug = !M.debug

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -15,7 +15,7 @@
 
 /datum/event/spider_infestation/start()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSmachines.machinery)
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in affecting_z)
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -753,7 +753,7 @@
 		src.verbs -= /mob/living/carbon/human/proc/remotesay
 		return
 	var/list/creatures = list()
-	for(var/mob/living/carbon/h in world)
+	for(var/mob/living/carbon/h in GLOB.living_mob_list_)
 		creatures += h
 	var/mob/target = input("Who do you want to project your mind to ?") as null|anything in creatures
 	if (isnull(target))
@@ -766,7 +766,7 @@
 		target.show_message("<span class='notice'>You hear a voice that seems to echo around the room: [say]</span>")
 	usr.show_message("<span class='notice'>You project your mind into [target.real_name]: [say]</span>")
 	log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]")
-	for(var/mob/observer/ghost/G in world)
+	for(var/mob/observer/ghost/G in GLOB.ghost_mob_list)
 		G.show_message("<i>Telepathic message from <b>[src]</b> to <b>[target]</b>: [say]</i>")
 
 /mob/living/carbon/human/proc/remoteobserve()
@@ -791,7 +791,7 @@
 
 	var/list/mob/creatures = list()
 
-	for(var/mob/living/carbon/h in world)
+	for(var/mob/living/carbon/h in GLOB.living_mob_list_)
 		var/turf/temp_turf = get_turf(h)
 		if((temp_turf.z != 1 && temp_turf.z != 5) || h.stat!=CONSCIOUS) //Not on mining or the station. Or dead
 			continue
@@ -872,7 +872,7 @@
 	for(var/obj/item/organ/external/organ in organs)
 		if(clean_feet || (organ.organ_tag in list(BP_L_HAND,BP_R_HAND)))
 			organ.gunshot_residue = null
-	
+
 	if(clean_feet && !shoes)
 		feet_blood_color = null
 		feet_blood_DNA = null

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -10,7 +10,7 @@
 	stop_malf(0) // Remove AI's malfunction status, that will fix all hacked APCs, disable delta, etc.
 	remove_ai_verbs(src)
 
-	for(var/obj/machinery/ai_status_display/O in world)
+	for(var/obj/machinery/ai_status_display/O in SSmachines.machinery)
 		O.mode = 2
 
 	if (istype(loc, /obj/item/weapon/aicard))

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/ai/Logout()
 	..()
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in SSmachines.machinery) //change status
 		O.mode = 0
 	if(!isturf(loc))
 		if (client)

--- a/code/modules/mob/living/silicon/decoy/death.dm
+++ b/code/modules/mob/living/silicon/decoy/death.dm
@@ -3,6 +3,6 @@
 	icon_state = "ai-crash"
 	spawn(10)
 		explosion(loc, 3, 6, 12, 15)
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in SSmachines.machinery) //change status
 		O.mode = 2
 	return ..(gibbed, deathmessage, "You have suffered a critical system failure, and are dead.")

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -27,7 +27,7 @@
 	var/dat
 	dat += "<B>Maintenance Units</B><BR>"
 
-	for(var/mob/living/silicon/robot/drone/D in world)
+	for(var/mob/living/silicon/robot/drone/D in GLOB.silicon_mob_list)
 		if(D.z != src.z)
 			continue
 		dat += "<BR>[D.real_name] ([D.stat == 2 ? "<font color='red'>INACTIVE</FONT>" : "<font color='green'>ACTIVE</FONT>"])"
@@ -69,7 +69,7 @@
 	else if (href_list["ping"])
 
 		to_chat(usr, "<span class='notice'>You issue a maintenance request for all active drones, highlighting [drone_call_area].</span>")
-		for(var/mob/living/silicon/robot/drone/D in world)
+		for(var/mob/living/silicon/robot/drone/D in GLOB.silicon_mob_list)
 			if(D.client && D.stat == 0)
 				to_chat(D, "-- Maintenance drone presence requested in: [drone_call_area].")
 

--- a/code/modules/power/fusion/_setup.dm
+++ b/code/modules/power/fusion/_setup.dm
@@ -40,7 +40,7 @@
 		var/list/delayed_objects = list()
 
 		// SETUP PHASE
-		for(var/obj/effect/engine_setup/S in world)
+		for(var/obj/effect/engine_setup/S in landmarks_list)
 			var/result = S.activate(0)
 			switch(result)
 				if(SETUP_OK)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -173,7 +173,7 @@
 
 	spawn(5)		// allow map load
 		conveyors = list()
-		for(var/obj/machinery/conveyor/C in world)
+		for(var/obj/machinery/conveyor/C in SSmachines.machinery)
 			if(C.id == id)
 				conveyors += C
 
@@ -221,7 +221,7 @@
 	update_icon()
 
 	// find any switches with same id as this one, and set their positions to match us
-	for(var/obj/machinery/conveyor_switch/S in world)
+	for(var/obj/machinery/conveyor_switch/S in SSmachines.machinery)
 		if(S.id == src.id)
 			S.position = position
 			S.update_icon()
@@ -250,7 +250,7 @@
 	update_icon()
 
 	// find any switches with same id as this one, and set their positions to match us
-	for(var/obj/machinery/conveyor_switch/S in world)
+	for(var/obj/machinery/conveyor_switch/S in SSmachines.machinery)
 		if(S.id == src.id)
 			S.position = position
 			S.update_icon()

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -152,10 +152,10 @@
 		sleep(10)
 
 		var/spawn_marauder[] = new()
-		for(var/obj/effect/landmark/L in world)
+		for(var/obj/effect/landmark/L in landmarks_list)
 			if(L.name == "Marauder Entry")
 				spawn_marauder.Add(L)
-		for(var/obj/effect/landmark/L in world)
+		for(var/obj/effect/landmark/L in landmarks_list)
 			if(L.name == "Marauder Exit")
 				var/obj/effect/portal/P = new(L.loc)
 				P.set_invisibility(101)//So it is not seen by anyone.

--- a/code/modules/supermatter/setup_supermatter.dm
+++ b/code/modules/supermatter/setup_supermatter.dm
@@ -116,7 +116,7 @@
 	icon_state = "x3"
 
 /obj/effect/engine_setup/Initialize()
-	..()
+	.=..()
 	landmarks_list += src
 
 /obj/effect/engine_setup/Destroy()

--- a/code/modules/supermatter/setup_supermatter.dm
+++ b/code/modules/supermatter/setup_supermatter.dm
@@ -33,7 +33,7 @@
 
 	// CONFIGURATION PHASE
 	// Coolant canisters, set types according to response.
-	for(var/obj/effect/engine_setup/coolant_canister/C in world)
+	for(var/obj/effect/engine_setup/coolant_canister/C in landmarks_list)
 		switch(response)
 			if("N2")
 				C.canister_type = /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup/
@@ -48,7 +48,7 @@
 				C.canister_type = /obj/machinery/portable_atmospherics/canister/hydrogen/engine_setup/
 				continue
 
-	for(var/obj/effect/engine_setup/core/C in world)
+	for(var/obj/effect/engine_setup/core/C in landmarks_list)
 		switch(response)
 			if("N2")
 				C.energy_setting = ENERGY_NITROGEN
@@ -63,12 +63,12 @@
 				C.energy_setting = ENERGY_HYDROGEN
 				continue
 
-	for(var/obj/effect/engine_setup/filter/F in world)
+	for(var/obj/effect/engine_setup/filter/F in landmarks_list)
 		F.coolant = response
 
 	var/list/delayed_objects = list()
 	// SETUP PHASE
-	for(var/obj/effect/engine_setup/S in world)
+	for(var/obj/effect/engine_setup/S in landmarks_list)
 		var/result = S.activate(0)
 		switch(result)
 			if(SETUP_OK)
@@ -114,6 +114,14 @@
 	density = 0
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "x3"
+
+/obj/effect/engine_setup/Initialize()
+	..()
+	landmarks_list += src
+
+/obj/effect/engine_setup/Destroy()
+	landmarks_list -= src
+	return ..()
 
 /obj/effect/engine_setup/proc/activate(var/last = 0)
 	return 1


### PR DESCRIPTION
As in the title. For engine setup landmarks, I added those to the landmarks list upon initialization, because they aren't actually a child of /obj/effect/landmark, but I didn't want to make a new list just for loose landmarks like that.