### PR TITLE
Give bridge officers Charon access

### DIFF
--- a/maps/torch/job/jobs.dm
+++ b/maps/torch/job/jobs.dm
@@ -464,7 +464,7 @@
 	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
 			            access_bridge, access_janitor, access_kitchen, access_cargo, access_RC_announce, access_keycard_auth,
 			            access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
-			            access_eva, access_hangar, access_cent_creed, access_explorer)
+			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,


### PR DESCRIPTION
## Charon
As a bridge officer, I find command expecting me to have the skills and access to use the Charon as a backup pilot and even sometimes as a backup pathfinder, and even I keep wondering why I don't at least have access to the Charon when I have access to the bridge helm, Aquila, hanger, and GUP.

:cl: sierrakomodo
add: Bridge Officers now have access to the Charon's Airlock and Charon's Helm
/:cl: