### PR TITLE
Renames Uplink Kits After Spawning

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -17,6 +17,7 @@
 
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"
+	desc = "Comes with all you need to fake paperwork. Assumes you have passed basic writing lessons."
 	item_cost = 16
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/clerical
 

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -21,6 +21,7 @@
 
 /datum/uplink_item/item/visible_weapons/g9mm
 	name = "Silenced Holdout Pistol"
+	desc = "9mm with silencer kit and ammunition."
 	item_cost = 32
 	path = /obj/item/weapon/storage/box/syndie_kit/g9mm
 
@@ -42,12 +43,14 @@
 
 /datum/uplink_item/item/visible_weapons/revolver
 	name = "Revolver, .357"
+	desc = ".357 revolver, with ammunition."
 	item_cost = 56
 	antag_costs = list(MODE_MERCENARY = 14)
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
 
 /datum/uplink_item/item/visible_weapons/revolver2
 	name = "Revolver, .44"
+	desc = ".44 magnum revolver, with ammunition."
 	item_cost = 48
 	antag_costs = list(MODE_MERCENARY = 5)
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver2

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -11,6 +11,7 @@
 
 /datum/uplink_item/item/stealth_items/spy
 	name = "Bug Kit"
+	desc = "For when you want to conduct voyeurism from afar."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/spy
 
@@ -21,6 +22,7 @@
 
 /datum/uplink_item/item/stealth_items/chameleon_kit
 	name = "Chameleon Kit"
+	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 	item_cost = 20
 	path = /obj/item/weapon/storage/backpack/chameleon/sydie_kit
 

--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -11,6 +11,7 @@
 
 /datum/uplink_item/item/stealthy_weapons/cigarette_kit
 	name = "Cigarette Kit"
+	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xMindBreaker, 1xTricordrazine. Avoid mixing them up."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/cigarette
 
@@ -21,6 +22,7 @@
 
 /datum/uplink_item/item/stealthy_weapons/random_toxin
 	name = "Random Toxin - Beaker"
+	desc = "An apple will not be enough to keep the doctor away after this."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/toxin
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -14,28 +14,22 @@
 	desc = "A sleek, sturdy dufflebag."
 	icon_state = "duffle_syndie"
 
-
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom
-	name = "box (F)"
 	startswith = list(/obj/item/weapon/implanter/freedom)
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink
-	name = "box (U)"
 	startswith = list(/obj/item/weapon/implanter/uplink)
 
 /obj/item/weapon/storage/box/syndie_kit/imp_compress
-	name = "box (C)"
 	startswith = list(/obj/item/weapon/implanter/compressed)
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	name = "box (E)"
 	startswith = list(
 		/obj/item/weapon/implanter/explosive,
 		/obj/item/weapon/implantpad
 		)
 
 /obj/item/weapon/storage/box/syndie_kit/imp_imprinting
-	name = "box (I)"
 	startswith = list(
 		/obj/item/weapon/implanter/imprinting,
 		/obj/item/weapon/implantpad,
@@ -65,8 +59,6 @@
 		)
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
-	name = "chameleon kit"
-	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 	startswith = list(
 		/obj/item/clothing/gloves/chameleon,
 		/obj/item/clothing/glasses/chameleon,
@@ -75,8 +67,6 @@
 
 // Clerical uplink kit
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/clerical
-	name = "clerical kit"
-	desc = "Comes with all you need to fake paperwork. Assumes you have passed basic writing lessons."
 	startswith = list(
 		/obj/item/stack/package_wrap/twenty_five,
 		/obj/item/weapon/hand_labeler,
@@ -86,16 +76,12 @@
 		)
 
 /obj/item/weapon/storage/box/syndie_kit/spy
-	name = "spy kit"
-	desc = "For when you want to conduct voyeurism from afar."
 	startswith = list(
 		/obj/item/device/spy_bug = 6,
 		/obj/item/device/spy_monitor
 	)
 
 /obj/item/weapon/storage/box/syndie_kit/g9mm
-	name = "\improper Smooth operator"
-	desc = "9mm with silencer kit and ammunition."
 	startswith = list(
 		/obj/item/weapon/gun/projectile/pistol,
 		/obj/item/weapon/silencer,
@@ -103,24 +89,18 @@
 	)
 
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
-	name = "\improper Tough operator"
-	desc = ".357 revolver, with ammunition."
 	startswith = list(
 		/obj/item/weapon/gun/projectile/revolver,
 		/obj/item/ammo_magazine/a357
 	)
 
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver2
-	name = "\improper Dandy tough operator"
-	desc = ".44 magnum revolver, with ammunition."
 	startswith = list(
 		/obj/item/weapon/gun/projectile/revolver/webley,
 		/obj/item/ammo_magazine/c44
 	)
 
 /obj/item/weapon/storage/box/syndie_kit/toxin
-	name = "toxin kit"
-	desc = "An apple will not be enough to keep the doctor away after this."
 	startswith = list(
 		/obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin,
 		/obj/item/weapon/reagent_containers/syringe
@@ -135,7 +115,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/cigarette
 	name = "\improper Tricky smokes"
-	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xMindBreaker, 1xTricordrazine. Avoid mixing them up."
+	desc = "Smokes so good, you'd think it was a trick!"
 
 /obj/item/weapon/storage/box/syndie_kit/cigarette/New()
 	..()
@@ -172,8 +152,6 @@
 
 //Rig Electrowarfare and Voice Synthesiser kit
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/ewar_voice
-	//name = "\improper Electrowarfare and Voice Synthesiser pack"
-	//desc = "Kit for confounding organic and synthetic entities alike."
 	startswith = list(
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/voice,
@@ -194,8 +172,6 @@
 	startswith = list(/obj/item/weapon/spacecash/bundle/c1000 = 10)
 
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
-	name = "armor satchel"
-	desc = "A satchel for when you don't want to try a diplomatic approach."
 	startswith = list(
 		/obj/item/clothing/suit/armor/pcarrier/merc,
 		/obj/item/clothing/head/helmet/merc


### PR DESCRIPTION
🆑
tweak: Uplink kits come in generic containers now.
/🆑

Came up in a round recently, figured this was a good way to start a conversation if it's supposed to be obvious or not.