### PR TITLE
Hacky fix for some layering issues on 512.

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -121,6 +121,7 @@ What is the naming convention for planes or layers?
 	#define BELOW_TABLE_LAYER       0.75
 	#define TABLE_LAYER             1
 	#define BELOW_OBJ_LAYER         2
+	#define STRUCTURE_LAYER         2.5
 	// OBJ_LAYER                    3
 	#define ABOVE_OBJ_LAYER         4
 	#define CLOSED_DOOR_LAYER       5

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -143,20 +143,6 @@
 			if (prob(5))
 				qdel(src)
 
-/obj/item/verb/move_to_top()
-	set name = "Move To Top"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!istype(src.loc, /turf) || usr.stat || usr.restrained() )
-		return
-
-	var/turf/T = src.loc
-
-	src.loc = null
-
-	src.loc = T
-
 /obj/item/examine(mob/user, var/distance = -1)
 	var/size
 	switch(src.w_class)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -1,7 +1,7 @@
 /obj/structure
 	icon = 'icons/obj/structures.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
-
+	layer = STRUCTURE_LAYER
 	var/breakable
 	var/parts
 


### PR DESCRIPTION
:cl:
rscdel: The Move To Top object verb has been removed due to changes in the new BYOND version making it no longer work consistently.
/:cl:

Closes #23553

I don't know what the underlying issue actually is. If the new item layering is considered unacceptable by the community, we could consider manually setting item layers on item movement (but for that, the loc setting PR seems a prerequisite).