### PR TITLE
Some atmospheric pipe pressure fixes, minor refactors

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -75,10 +75,10 @@
 #define XGM_GAS_CONTAMINANT 4
 #define XGM_GAS_FUSION_FUEL 8
 
-#define TANK_LEAK_PRESSURE     (30.*ONE_ATMOSPHERE) // Tank starts leaking.
-#define TANK_RUPTURE_PRESSURE  (40.*ONE_ATMOSPHERE) // Tank spills all contents into atmosphere.
-#define TANK_FRAGMENT_PRESSURE (50.*ONE_ATMOSPHERE) // Boom 3x3 base explosion.
-#define TANK_FRAGMENT_SCALE    (10.*ONE_ATMOSPHERE) // +1 for each SCALE kPa above threshold. Was 2 atm.
+#define TANK_LEAK_PRESSURE     (30 * ONE_ATMOSPHERE) // Tank starts leaking.
+#define TANK_RUPTURE_PRESSURE  (40 * ONE_ATMOSPHERE) // Tank spills all contents into atmosphere.
+#define TANK_FRAGMENT_PRESSURE (50 * ONE_ATMOSPHERE) // Boom 3x3 base explosion.
+#define TANK_FRAGMENT_SCALE    (10 * ONE_ATMOSPHERE) // +1 for each SCALE kPa above threshold. Was 2 atm.
 
 #define NORMPIPERATE             30   // Pipe-insulation rate divisor.
 #define HEATPIPERATE             8    // Heat-exchange pipe insulation.

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -8,7 +8,7 @@
 	// Leaking nodes
 	var/list/leaks = list()
 
-	var/alert_pressure = 0
+	var/maximum_pressure = 0
 
 /datum/pipeline/New()
 	START_PROCESSING(SSprocessing, src)
@@ -30,7 +30,7 @@
 /datum/pipeline/Process()//This use to be called called from the pipe networks
 	//Check to see if pressure is within acceptable limits
 	var/pressure = air.return_pressure()
-	if(pressure > alert_pressure)
+	if(pressure > maximum_pressure)
 		for(var/obj/machinery/atmospherics/pipe/member in members)
 			if(!member.check_pressure(pressure))
 				members.Remove(member)
@@ -54,7 +54,7 @@
 
 	var/volume = base.volume
 	base.parent = src
-	alert_pressure = base.alert_pressure
+	maximum_pressure = base.maximum_pressure
 
 	if(base.air_temporary)
 		air = base.air_temporary
@@ -82,7 +82,7 @@
 						volume += item.volume
 						item.parent = src
 
-						alert_pressure = min(alert_pressure, item.alert_pressure)
+						maximum_pressure = min(maximum_pressure, item.maximum_pressure)
 
 						if(item.air_temporary)
 							air.merge(item.air_temporary)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -8,7 +8,9 @@
 	var/leaking = 0		// Do not set directly, use set_leaking(TRUE/FALSE)
 	use_power = 0
 
-	var/alert_pressure = 170*ONE_ATMOSPHERE
+	var/maximum_pressure = 210 * ONE_ATMOSPHERE
+	var/fatigue_pressure = 170 * ONE_ATMOSPHERE
+	var/alert_pressure = 170 * ONE_ATMOSPHERE
 	var/in_stasis = 0
 		//minimum pressure before check_pressure(...) should be called
 
@@ -182,10 +184,6 @@
 
 	var/minimum_temperature_difference = 300
 	var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
-
-	var/maximum_pressure = 210*ONE_ATMOSPHERE
-	var/fatigue_pressure = 170*ONE_ATMOSPHERE
-	alert_pressure = 170*ONE_ATMOSPHERE
 
 	level = 1
 

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -16,11 +16,6 @@ obj/machinery/atmospherics/pipe/zpipe
 	var/minimum_temperature_difference = 300
 	var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
 
-	var/maximum_pressure = 70*ONE_ATMOSPHERE
-	var/fatigue_pressure = 55*ONE_ATMOSPHERE
-	alert_pressure = 55*ONE_ATMOSPHERE
-
-
 	level = 1
 
 obj/machinery/atmospherics/pipe/zpipe/New()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

🆑 
tweak: All pipes, except fuel pipes, now have the same pressure damage threshold. Previously, cross-z pipes were significantly weaker. Fuel pipes' extremely high threshold remain unchanged.
tweak: All pipes have a slightly higher burst pressure threshold.
/:cl:

Moved pipe burst pressure vars to the base type. Previously, these vars were only attached to some pipes subtypes themselves.

Made a change in datum_pipeline.dm so they use max pressure, not alert pressure, for deciding when to blow up a pipe. There's logic in the pipe objects themselves for having a **chance** to burst at alert_pressure (actually, fatigue_pressure, but they were set the same anyways), which I'm not 100% sure it's even working, but regardless, datum_pipeline now uses max pressure. Would appreciate some proofreading here.

There's a slight cleanup in atmospherics.dm. Originally, I was making a define here, when afterthought pointed out it would be better to just move burst pressures to the base type, instead of creating defines for the multiple areas that had vars.

Might fix https://github.com/Baystation12/Baystation12/issues/23572

EDIT: Tested, fatigue pressures are not working, at least in the brief time that I checked. Someone more experienced than I would have to look into it. Burst pressures are 100% functional.