### PR TITLE
Enable supplying additional arguments to predicates

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -23,7 +23,7 @@
 /proc/get_subarea_turfs(var/area/A, var/list/predicates)
 	. = new/list()
 	A = istype(A) ? A.type : A
-	if(!A)
+	if(!ispath(A))
 		return
 	for(var/sub_area_type in typesof(A))
 		var/area/sub_area = locate(sub_area_type)
@@ -46,7 +46,7 @@
 */
 /proc/pick_subarea_turf(var/areatype, var/list/predicates)
 	var/list/turfs = get_subarea_turfs(areatype, predicates)
-	if(turfs && turfs.len)
+	if(LAZYLEN(turfs))
 		return pick(turfs)
 
 /proc/pick_area_turf(var/areatype, var/list/predicates)
@@ -56,18 +56,29 @@
 
 /proc/pick_area(var/list/predicates)
 	var/list/areas = get_filtered_areas(predicates)
-	if(areas && areas.len)
+	if(LAZYLEN(areas))
 		. = pick(areas)
 
 /proc/pick_area_and_turf(var/list/area_predicates, var/list/turf_predicates)
-	var/area/A = pick_area(area_predicates)
-	if(!A)
-		return
-	return pick_area_turf(A, turf_predicates)
+	var/list/areas = get_filtered_areas(area_predicates)
+	// We loop over all area candidates, until we finally get a valid turf or run out of areas
+	while(!. && length(areas))
+		var/area/A = pick_n_take(areas)
+		. = pick_area_turf(A, turf_predicates)
+
+/proc/pick_area_turf_in_connected_z_levels(var/list/area_predicates, var/list/turf_predicates, var/z_level)
+	area_predicates = area_predicates.Copy()
+
+	var/z_levels = GetConnectedZlevels(z_level)
+	area_predicates[/proc/area_belongs_to_zlevels] = z_levels
+	return pick_area_and_turf(area_predicates, turf_predicates)
 
 /*
 	Predicate Helpers
 */
+/proc/area_belongs_to_zlevels(var/area/A, var/list/z_levels)
+	. = (A.z in z_levels)
+
 /proc/is_station_area(var/area/A)
 	. = isStationLevel(A.z)
 

--- a/code/_helpers/functional.dm
+++ b/code/_helpers/functional.dm
@@ -1,28 +1,36 @@
-/proc/all_predicates_true(var/list/input, var/list/predicates)
-	predicates = istype(predicates) ? predicates : list(predicates)
+#define PREPARE_INPUT \
+predicates = istype(predicates) ? predicates : list(predicates);\
+input = istype(input) ? input : list(input);
 
-	for(var/i = 1 to predicates.len)
-		if(istype(input))
-			if(!call(predicates[i])(arglist(input)))
-				return FALSE
-		else
-			if(!call(predicates[i])(input))
-				return FALSE
+#define PREPARE_ARGUMENTS \
+var/extra_arguments = predicates[predicate];\
+var/list/predicate_input = input;\
+if(LAZYLEN(extra_arguments)) {\
+	predicate_input = predicate_input.Copy();\
+	predicate_input += list(extra_arguments);\
+}
+
+/proc/all_predicates_true(var/list/input, var/list/predicates)
+	PREPARE_INPUT
+	for(var/predicate in predicates)
+		PREPARE_ARGUMENTS
+		if(!call(predicate)(arglist(predicate_input)))
+			return FALSE
 	return TRUE
 
 /proc/any_predicate_true(var/list/input, var/list/predicates)
-	predicates = istype(predicates) ? predicates : list(predicates)
+	PREPARE_INPUT
 	if(!predicates.len)
 		return TRUE
 
-	for(var/i = 1 to predicates.len)
-		if(istype(input))
-			if(call(predicates[i])(arglist(input)))
-				return TRUE
-		else
-			if(call(predicates[i])(input))
-				return TRUE
+	for(var/predicate in predicates)
+		PREPARE_ARGUMENTS
+		if(call(predicate)(arglist(predicate_input)))
+			return TRUE
 	return FALSE
+
+#undef PREPARE_ARGUMENTS
+#undef PREPARE_INPUT
 
 /proc/is_atom_predicate(var/value, var/feedback_receiver)
 	. = isatom(value)

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -221,7 +221,9 @@
 	if(islist(d))
 		var/list/L = list()
 		for(var/e in d)
-			L += log_info_line(e)
+			// Indexing on numbers just gives us the same number again in the best case and causes an index out of bounds runtime in the worst
+			var/v = isnum(e) ? null : d[e]
+			L += "[log_info_line(e)][v ? " - [log_info_line(v)]" : ""]"
 		return "\[[jointext(L, ", ")]\]" // We format the string ourselves, rather than use json_encode(), because it becomes difficult to read recursively escaped "
 	if(!istype(d))
 		return json_encode(d)


### PR DESCRIPTION
Includes a helper to get a random turf within a desired set of
 connected Z-levels.

Also makes it so that pick_area_and_turf() will be able to return a
 valid turf is such exists, even if areas without valid turfs are
 picked first.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
