### PR TITLE
Adds a disposals network unit test.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -500,150 +500,138 @@
 
 
 	// initialize a holder from the contents of a disposal unit
-	proc/init(var/obj/machinery/disposal/D, var/datum/gas_mixture/flush_gas)
-		gas = flush_gas// transfer gas resv. into holder object -- let's be explicit about the data this proc consumes, please.
+/obj/structure/disposalholder/proc/init(var/obj/machinery/disposal/D, var/datum/gas_mixture/flush_gas)
+	gas = flush_gas// transfer gas resv. into holder object -- let's be explicit about the data this proc consumes, please.
 
-		//Check for any living mobs trigger hasmob.
-		//hasmob effects whether the package goes to cargo or its tagged destination.
-		for(var/mob/living/M in D)
-			if(M && M.stat != 2 && !istype(M,/mob/living/silicon/robot/drone))
-				hasmob = 1
+	//Check for any living mobs trigger hasmob.
+	//hasmob effects whether the package goes to cargo or its tagged destination.
+	for(var/mob/living/M in D)
+		if(M && M.stat != 2 && !istype(M,/mob/living/silicon/robot/drone))
+			hasmob = 1
 
-		//Checks 1 contents level deep. This means that players can be sent through disposals...
-		//...but it should require a second person to open the package. (i.e. person inside a wrapped locker)
-		for(var/obj/O in D)
-			if(O.contents)
-				for(var/mob/living/M in O.contents)
-					if(M && M.stat != 2 && !istype(M,/mob/living/silicon/robot/drone))
-						hasmob = 1
+	//Checks 1 contents level deep. This means that players can be sent through disposals...
+	//...but it should require a second person to open the package. (i.e. person inside a wrapped locker)
+	for(var/obj/O in D)
+		if(O.contents)
+			for(var/mob/living/M in O.contents)
+				if(M && M.stat != 2 && !istype(M,/mob/living/silicon/robot/drone))
+					hasmob = 1
 
-		// now everything inside the disposal gets put into the holder
-		// note AM since can contain mobs or objs
-		for(var/atom/movable/AM in D)
-			AM.forceMove(src)
-			if(istype(AM, /obj/structure/bigDelivery) && !hasmob)
-				var/obj/structure/bigDelivery/T = AM
-				src.destinationTag = T.sortTag
-			if(istype(AM, /obj/item/smallDelivery) && !hasmob)
-				var/obj/item/smallDelivery/T = AM
-				src.destinationTag = T.sortTag
-			//Drones can mail themselves through maint.
-			if(istype(AM, /mob/living/silicon/robot/drone))
-				var/mob/living/silicon/robot/drone/drone = AM
-				src.destinationTag = drone.mail_destination
+	// now everything inside the disposal gets put into the holder
+	// note AM since can contain mobs or objs
+	for(var/atom/movable/AM in D)
+		AM.forceMove(src)
+		if(istype(AM, /obj/structure/bigDelivery) && !hasmob)
+			var/obj/structure/bigDelivery/T = AM
+			src.destinationTag = T.sortTag
+		if(istype(AM, /obj/item/smallDelivery) && !hasmob)
+			var/obj/item/smallDelivery/T = AM
+			src.destinationTag = T.sortTag
+		//Drones can mail themselves through maint.
+		if(istype(AM, /mob/living/silicon/robot/drone))
+			var/mob/living/silicon/robot/drone/drone = AM
+			src.destinationTag = drone.mail_destination
 
 
 	// start the movement process
 	// argument is the disposal unit the holder started in
-	proc/start(var/obj/machinery/disposal/D)
-		if(!D.trunk)
-			D.expel(src)	// no trunk connected, so expel immediately
-			return
-
-		forceMove(D.trunk)
-		active = 1
-		set_dir(DOWN)
-		spawn(1)
-			move()		// spawn off the movement process
-
+/obj/structure/disposalholder/proc/start(var/obj/machinery/disposal/D)
+	if(!D.trunk)
+		D.expel(src)	// no trunk connected, so expel immediately
 		return
+
+	forceMove(D.trunk)
+	active = 1
+	set_dir(DOWN)
+	START_PROCESSING(SSfastprocess, src)
 
 	// movement process, persists while holder is moving through pipes
-	proc/move()
-		var/obj/structure/disposalpipe/last
-		while(active)
-			sleep(1)		// was 1
-			if(!loc) return // check if we got GC'd
+/obj/structure/disposalholder/Process()
+	if(!(count--))
+		active = 0
+	if(!active)
+		return PROCESS_KILL
+	
+	var/obj/structure/disposalpipe/last
 
-			if(hasmob && prob(3))
-				for(var/mob/living/H in src)
-					if(!istype(H,/mob/living/silicon/robot/drone)) //Drones use the mailing code to move through the disposal system,
-						H.take_overall_damage(20, 0, "Blunt Trauma")//horribly maim any living creature jumping down disposals.  c'est la vie
+	if(hasmob && prob(3))
+		for(var/mob/living/H in src)
+			if(!istype(H,/mob/living/silicon/robot/drone)) //Drones use the mailing code to move through the disposal system,
+				H.take_overall_damage(20, 0, "Blunt Trauma")//horribly maim any living creature jumping down disposals.  c'est la vie
 
-			var/obj/structure/disposalpipe/curr = loc
-			last = curr
-			curr = curr.transfer(src)
+	var/obj/structure/disposalpipe/curr = loc
+	last = curr
+	curr = curr.transfer(src)
 
-			if(!loc) return //side effects
+	if(QDELETED(src))
+		return PROCESS_KILL
 
-			if(!curr)
-				last.expel(src, loc, dir)
-
-			//
-			if(!(count--))
-				active = 0
-		return
-
-
+	if(!curr)
+		last.expel(src, loc, dir)
 
 	// find the turf which should contain the next pipe
-	proc/nextloc()
-		return get_step(loc,dir)
+/obj/structure/disposalholder/proc/nextloc()
+	return get_step(loc,dir)
 
-	// find a matching pipe on a turf
-	proc/findpipe(var/turf/T)
-
-		if(!T)
-			return null
-
-		var/fdir = turn(dir, 180)	// flip the movement direction
-		for(var/obj/structure/disposalpipe/P in T)
-			if(fdir & P.dpdir)		// find pipe direction mask that matches flipped dir
-				return P
-		// if no matching pipe, return null
+// find a matching pipe on a turf
+/obj/structure/disposalholder/proc/findpipe(var/turf/T)
+	if(!T)
 		return null
 
-	// merge two holder objects
-	// used when a a holder meets a stuck holder
-	proc/merge(var/obj/structure/disposalholder/other)
-		for(var/atom/movable/AM in other)
-			AM.forceMove(src)		// move everything in other holder to this one
-			if(ismob(AM))
-				var/mob/M = AM
-				if(M.client)	// if a client mob, update eye to follow this holder
-					M.client.eye = src
+	var/fdir = turn(dir, 180)	// flip the movement direction
+	for(var/obj/structure/disposalpipe/P in T)
+		if(fdir & P.dpdir)		// find pipe direction mask that matches flipped dir
+			return P
+	// if no matching pipe, return null
+	return null
 
-		qdel(other)
+// merge two holder objects
+// used when a a holder meets a stuck holder
+/obj/structure/disposalholder/proc/merge(var/obj/structure/disposalholder/other)
+	for(var/atom/movable/AM in other)
+		AM.forceMove(src)		// move everything in other holder to this one
+		if(ismob(AM))
+			var/mob/M = AM
+			if(M.client)	// if a client mob, update eye to follow this holder
+				M.client.eye = src
+	qdel(other)
 
+/obj/structure/disposalholder/proc/settag(var/new_tag)
+	destinationTag = new_tag
 
-	proc/settag(var/new_tag)
+/obj/structure/disposalholder/proc/setpartialtag(var/new_tag)
+	if(partialTag == new_tag)
 		destinationTag = new_tag
+		partialTag = ""
+	else
+		partialTag = new_tag
 
-	proc/setpartialtag(var/new_tag)
-		if(partialTag == new_tag)
-			destinationTag = new_tag
-			partialTag = ""
-		else
-			partialTag = new_tag
-
-
-	// called when player tries to move while in a pipe
-	relaymove(mob/user as mob)
-
-		if(!istype(user,/mob/living))
-			return
-
-		var/mob/living/U = user
-
-		if (U.stat || U.last_special <= world.time)
-			return
-
-		U.last_special = world.time+100
-
-		if (src.loc)
-			for (var/mob/M in hearers(src.loc.loc))
-				to_chat(M, "<FONT size=[max(0, 5 - get_dist(src, M))]>CLONG, clong!</FONT>")
-
-		playsound(src.loc, 'sound/effects/clang.ogg', 50, 0, 0)
-
-	// called to vent all gas in holder to a location
-	proc/vent_gas(var/atom/location)
-		location.assume_air(gas)  // vent all gas to turf
+// called when player tries to move while in a pipe
+/obj/structure/disposalholder/relaymove(mob/user as mob)
+	if(!istype(user,/mob/living))
 		return
+
+	var/mob/living/U = user
+
+	if (U.stat || U.last_special <= world.time)
+		return
+
+	U.last_special = world.time+100
+
+	if (src.loc)
+		for (var/mob/M in hearers(src.loc.loc))
+			to_chat(M, "<FONT size=[max(0, 5 - get_dist(src, M))]>CLONG, clong!</FONT>")
+
+	playsound(src.loc, 'sound/effects/clang.ogg', 50, 0, 0)
+
+// called to vent all gas in holder to a location
+/obj/structure/disposalholder/proc/vent_gas(var/atom/location)
+	location.assume_air(gas)  // vent all gas to turf
 
 /obj/structure/disposalholder/Destroy()
 	qdel(gas)
 	active = 0
+	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 
 // Disposal pipes
@@ -1407,7 +1395,7 @@
 	// if coming in from sortdir, go to posdir
 
 	nextdir(var/fromdir, var/sortTag)
-		if(fromdir != sortdir)	// probably came from the negdir
+		if(fromdir != turn(sortdir, 180))	// probably came from the negdir
 			if(divert_check(sortTag))
 				return sortdir
 			else

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -243,13 +243,13 @@ SUBSYSTEM_DEF(unit_tests)
 
 	var/list/async = current_async
 	while (async.len)
-		var/datum/unit_test/test = current_async[current_async.len]
-		current_async.len--
+		var/datum/unit_test/test = current_async[async.len]
+		async.len--
 		if(check_unit_test(test, end_unit_tests))
 			async_tests -= test
 		if (MC_TICK_CHECK)
 			return
-	if (!async.len)
+	if (!async_tests.len)
 		stage++
 
 /datum/controller/subsystem/unit_tests/fire(resumed = 0)

--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -9353,7 +9353,7 @@
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Mining";
-	sortType = "Bridge"
+	sortType = "Mining"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -10589,17 +10589,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Petrov";
-	sortType = "Petrov"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "yA" = (

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -3159,8 +3159,8 @@
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
-	name = "Pathfinder's Office";
-	sortType = "Pathfinder's Office"
+	name = "Commissary";
+	sortType = "Commissary"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5358,9 +5358,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
 "sC" = (
@@ -5373,9 +5370,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -5395,16 +5389,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8;
-	name = "Security Checkpoint - Deck 4";
-	sortType = "Security Checkpoint - Deck 4"
-	},
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -1277,8 +1277,8 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Pilot's Lounge";
-	sortType = "Pilot's Lounge"
+	name = "XO's Office";
+	sortType = "XO's Office"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,


### PR DESCRIPTION
Fixes myriad disposal system bugs. Adds unit test so that I never have to do this again.

This is a brute force check of all disposal routing, and quite expensive. However, the cost is all on the SS and so may still be OK. If Travis can't complete under the allotted time, I'll make it choose random starting locations instead to decrease cost, but I can complete it on my computer locally.

Also moves disposal movement processing to the SS and fixes a bug with self-mailing packages to a disposal.

EDIT: also fixes async unit tests not working correctly.
EDIT: now spawns fewer objects.