### PR TITLE
Fixes shuttle gravity; makes Initialize pass arguments on mapload.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -20,15 +20,17 @@
 		GLOB._preloader.load(src)
 
 	var/do_initialize = SSatoms.initialized
+	var/list/created = SSatoms.created_atoms
 	if(do_initialize != INITIALIZATION_INSSATOMS)
 		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD
 		if(SSatoms.InitAtom(src, args))
 			//we were deleted
 			return
-
-	var/list/created = SSatoms.created_atoms
-	if(created)
-		created += src
+	else if(created)
+		var/list/argument_list
+		if(length(args) > 1)
+			argument_list = args.Copy(2)
+			created[src] = argument_list
 
 	if(atom_flags & ATOM_FLAG_CLIMBABLE)
 		verbs += /atom/proc/climb_on
@@ -40,7 +42,7 @@
 //Called from base of New if the map is not being loaded. mapload = FALSE
 //This base must be called or derivatives must set initialized to TRUE
 //must not sleep
-//Other parameters are passed from New (excluding loc), this does not happen if mapload is TRUE
+//Other parameters are passed from New (excluding loc)
 //Must return an Initialize hint. Defined in __DEFINES/subsystems.dm
 
 /atom/proc/Initialize(mapload, ...)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -159,11 +159,14 @@
 //	log_debug("move_shuttle() called for [shuttle_tag] leaving [origin] en route to [destination].")
 //	log_degug("area_coming_from: [origin]")
 //	log_debug("destination: [destination]")
-	if((flags & SHUTTLE_FLAGS_ZERO_G) && (destination.flags & SLANDMARK_FLAG_ZERO_G))
-		var/area/new_area = get_area(destination)
+	if((flags & SHUTTLE_FLAGS_ZERO_G))
+		var/new_grav = 1
+		if(destination.flags & SLANDMARK_FLAG_ZERO_G)
+			var/area/new_area = get_area(destination)
+			new_grav = new_area.has_gravity
 		for(var/area/our_area in shuttle_area)
-			if(our_area.has_gravity != new_area.has_gravity)
-				our_area.gravitychange(new_area.has_gravity)
+			if(our_area.has_gravity != new_grav)
+				our_area.gravitychange(new_grav)
 
 	for(var/turf/src_turf in turf_translation)
 		var/turf/dst_turf = turf_translation[src_turf]


### PR DESCRIPTION
Fixes #23598
Fixes #23597

Note that there are apparently 30,000 or so atoms that try passing arguments to Initialize on mapload but can't, so this may fix/cause all kinds of other stuff. But it seems like a more consistent way for things to work.

Maybe to avoid confusion on review: neither the argument nor the return value to `InitializeAtoms` is used further.