### PR TITLE
Makes guns use Initialize.

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -288,15 +288,13 @@
 	var/obj/item/projectile/copy_projectile
 	var/global/list/gun_choices
 
-/obj/item/weapon/gun/energy/chameleon/New()
-	..()
-
+/obj/item/weapon/gun/energy/chameleon/Initialize()
+	. = ..()
 	if(!gun_choices)
 		gun_choices = list()
 		for(var/gun_type in typesof(/obj/item/weapon/gun/) - src.type)
 			var/obj/item/weapon/gun/G = gun_type
 			src.gun_choices[initial(G.name)] = gun_type
-	return
 
 /obj/item/weapon/gun/energy/chameleon/consume_next_projectile()
 	var/obj/item/projectile/P = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -86,8 +86,8 @@
 	var/safety_state = 1
 	var/has_safety = TRUE
 
-/obj/item/weapon/gun/New()
-	..()
+/obj/item/weapon/gun/Initialize()
+	. = ..()
 	for(var/i in 1 to firemodes.len)
 		firemodes[i] = new /datum/firemode(src, firemodes[i])
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -31,8 +31,8 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 	..()
 	update_icon()
 
-/obj/item/weapon/gun/energy/New()
-	..()
+/obj/item/weapon/gun/energy/Initialize()
+	. = ..()
 	if(cell_type)
 		power_supply = new cell_type(src)
 	else

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -65,13 +65,13 @@
 	one_hand_penalty = 0
 	has_safety = FALSE
 
-/obj/item/weapon/gun/energy/gun/secure/mounted/New()
+/obj/item/weapon/gun/energy/gun/secure/mounted/Initialize()
 	var/mob/borg = get_holder_of_type(src, /mob/living/silicon/robot)
 	if(!borg)
 		CRASH("Invalid spawn location.")
 	registered_owner = borg.name
 	GLOB.registered_cyborg_weapons += src
-	..()
+	. = ..()
 
 /obj/item/weapon/gun/energy/laser/secure
 	name = "laser carbine"

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -106,8 +106,8 @@
 	return TRUE
 
 // For uplink purchase, comes loaded with a random assortment of grenades
-/obj/item/weapon/gun/launcher/grenade/loaded/New()
-	..()
+/obj/item/weapon/gun/launcher/grenade/loaded/Initialize()
+	. = ..()
 
 	var/list/grenade_types = list(
 		/obj/item/weapon/grenade/anti_photon = 2,

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -22,8 +22,8 @@
 	var/force_divisor = 400                             // Force equates to speed. Speed/5 equates to a damage multiplier for whoever you hit.
 	                                                    // For reference, a fully pressurized oxy tank at 50% gas release firing a health
 	                                                    // analyzer with a force_divisor of 10 hit with a damage multiplier of 3000+.
-/obj/item/weapon/gun/launcher/pneumatic/New()
-	..()
+/obj/item/weapon/gun/launcher/pneumatic/Initialize()
+	. = ..()
 	item_storage = new(src)
 	item_storage.SetName("hopper")
 	item_storage.max_w_class = max_w_class

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -42,8 +42,8 @@
 	//var/list/icon_keys = list()		//keys
 	//var/list/ammo_states = list()	//values
 
-/obj/item/weapon/gun/projectile/New()
-	..()
+/obj/item/weapon/gun/projectile/Initialize()
+	. = ..()
 	if (starts_loaded)
 		if(ispath(ammo_type) && (load_method & (SINGLE_CASING|SPEEDLOADER)))
 			for(var/i in 1 to max_shells)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -170,8 +170,8 @@
 	var/use_launcher = 0
 	var/obj/item/weapon/gun/launcher/grenade/underslung/launcher
 
-/obj/item/weapon/gun/projectile/automatic/z8/New()
-	..()
+/obj/item/weapon/gun/projectile/automatic/z8/Initialize()
+	. = ..()
 	launcher = new(src)
 
 /obj/item/weapon/gun/projectile/automatic/z8/attackby(obj/item/I, mob/user)

--- a/code/modules/projectiles/guns/projectile/detective.dm
+++ b/code/modules/projectiles/guns/projectile/detective.dm
@@ -4,8 +4,8 @@
 	var/static/list/gun_options
 	magazine_type = /obj/item/ammo_magazine/c45m/flash
 
-/obj/item/weapon/gun/projectile/colt/detective/New()
-	..()
+/obj/item/weapon/gun/projectile/colt/detective/Initialize()
+	. = ..()
 	if(!gun_options)
 		gun_options = init_subtypes(/datum/detective_gun_skin)
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -230,13 +230,13 @@
 /obj/item/weapon/gun/projectile/pirate/toggle_safety(var/mob/user)
 	to_chat(user, "<span class='warning'>There's no safety on \the [src]!</span>")
 
-/obj/item/weapon/gun/projectile/pirate/New()
+/obj/item/weapon/gun/projectile/pirate/Initialize()
 	ammo_type = pick(ammo_types)
 	desc += " Uses [ammo_types[ammo_type]] rounds."
 
 	var/obj/item/ammo_casing/ammo = ammo_type
 	caliber = initial(ammo.caliber)
-	..()
+	. = ..()
 
 // Zip gun construction.
 /obj/item/weapon/zipgunframe


### PR DESCRIPTION
This complements #23605 and is an alternative to #23603. Any of the three would fix the issue.

Maybe to clarify the overarching issue: if something is created prior to SSatoms init with optional arguments (beyond loc) passed to new, those arguments will be passed to New() but not to Initialize(). In particular, this will effect any atoms that are spawned in atom/New() of another atom which is mapped in.