### PR TITLE
Shutdown and update

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1589,6 +1589,7 @@
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\communications_blackout.dm"
 #include "code\modules\events\computer_damage.dm"
+#include "code\modules\events\computer_update.dm"
 #include "code\modules\events\dust.dm"
 #include "code\modules\events\electrical_storm.dm"
 #include "code\modules\events\event.dm"

--- a/code/modules/events/computer_damage.dm
+++ b/code/modules/events/computer_damage.dm
@@ -21,7 +21,7 @@
 			victim.bsod = 1
 			victim.update_icon()
 		else
-			victim.visible_message("<span class='warning'>[victim] emits some omnious clicks.</span>")
+			victim.visible_message("<span class='warning'>[victim] emits some ominous clicks.</span>")
 			if(prob(60))
 				victim.hard_drive.take_damage(victim.hard_drive.damage_failure)
 			else

--- a/code/modules/events/computer_update.dm
+++ b/code/modules/events/computer_update.dm
@@ -1,0 +1,16 @@
+/datum/event/computer_update/start()
+	commence_updates(severity)
+
+/proc/commence_updates(severity)
+	var/updates_to_install = 0
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
+			updates_to_install = rand(10000, 100000)
+		if(EVENT_LEVEL_MODERATE)
+			updates_to_install = rand(100000, 500000)
+		if(EVENT_LEVEL_MAJOR)
+			updates_to_install = rand(500000, 1000000)
+
+	for(var/obj/item/modular_computer/C in SSobj.processing)
+		if((C.z in GLOB.using_map.station_levels) && C.get_ntnet_status() && C.receives_updates)
+			C.updates = updates_to_install

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -129,6 +129,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",			/datum/event/nothing,			100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "APC Damage",		/datum/event/apc_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Computer Damage",		/datum/event/computer_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Computer Update",		/datum/event/computer_update,		40),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",/datum/event/brand_intelligence,10, 	list(ASSIGNMENT_JANITOR = 10),	1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",		/datum/event/camera_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -28,8 +28,18 @@
 	if(enabled)
 		bsod = 1
 		update_icon()
-		shutdown_computer()
 		to_chat(usr, "You press a hard-reset button on \the [src]. It displays a brief debug screen before shutting down.")
+		if(updating)
+			updating = FALSE
+			updates = 0
+			update_progress = 0
+			if(prob(10))
+				visible_message("<span class='warning'>[src] emits some ominous clicks.</span>")
+				hard_drive.take_damage(hard_drive.damage_malfunction)
+			else if(prob(5))
+				visible_message("<span class='warning'>[src] emits some ominous clicks.</span>")
+				hard_drive.take_damage(hard_drive.damage_failure)
+		shutdown_computer(FALSE)
 		spawn(2 SECONDS)
 			bsod = 0
 			update_icon()
@@ -285,7 +295,7 @@
 
 	if(enabled && .)
 		to_chat(user, "The time [stationtime2text()] is displayed in the corner of the screen.")
-		
+
 	if(card_slot && card_slot.stored_card)
 		to_chat(user, "The [card_slot.stored_card] is inserted into it.")
 

--- a/code/modules/modular_computers/computers/modular_computer/ui.dm
+++ b/code/modules/modular_computers/computers/modular_computer/ui.dm
@@ -38,6 +38,11 @@
 		programs.Add(list(program))
 
 	data["programs"] = programs
+
+	data["updating"] = updating
+	data["update_progress"] = update_progress
+	data["updates"] = updates
+
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "laptop_mainscreen.tmpl", "NTOS Main Menu", 400, 500)
@@ -45,6 +50,12 @@
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
+
+/obj/item/modular_computer/CanUseTopic()
+	//There is no bypassing the update, mwhahaha
+	if(updating)
+		return min(STATUS_UPDATE, ..())
+	return ..()
 
 // Handles user's GUI input
 /obj/item/modular_computer/Topic(href, href_list)
@@ -62,6 +73,12 @@
 		var/obj/item/weapon/computer_hardware/H = find_hardware_by_name(href_list["PC_disable_component"])
 		if(H && istype(H) && H.enabled)
 			H.enabled = 0
+		. = 1
+	if( href_list["PC_enable_update"] )
+		receives_updates = TRUE
+		. = 1
+	if( href_list["PC_disable_update"] )
+		receives_updates = FALSE
 		. = 1
 	if( href_list["PC_shutdown"] )
 		shutdown_computer()
@@ -153,6 +170,6 @@
 	data["PC_programheaders"] = program_headers
 
 	data["PC_stationtime"] = stationtime2text()
-	data["PC_hasheader"] = 1
+	data["PC_hasheader"] = !updating
 	data["PC_showexitprogram"] = active_program ? 1 : 0 // Hides "Exit Program" button on mainscreen
 	return data

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -59,3 +59,10 @@
 
 	var/stores_pen = FALSE
 	var/obj/item/weapon/pen/stored_pen
+
+	//Pain and suffering
+	var/receives_updates = TRUE
+	var/updating = FALSE
+	var/updates = 0
+	var/update_progress = 0
+	var/update_postshutdown

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -11,6 +11,7 @@
 	slot_flags = SLOT_ID | SLOT_BELT
 	stores_pen = TRUE
 	stored_pen = /obj/item/weapon/pen
+	receives_updates = FALSE
 
 /obj/item/modular_computer/pda/Initialize()
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -57,6 +57,9 @@
 		)))
 
 	data["hardware"] = all_entries
+
+	data["receives_updates"] = movable.receives_updates
+
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "laptop_configuration.tmpl", "NTOS Configuration Utility", 575, 700, state = state)

--- a/nano/templates/laptop_configuration.tmpl
+++ b/nano/templates/laptop_configuration.tmpl
@@ -66,5 +66,21 @@
 	{{/if}}
 	<br><br>
 {{/for}}
+	<h3>Auto-Updater</h3>
+	<i>Automatically downloads and installs critical OS upgrades if NTNet is reachable. Disabling voids warranty.</i><br>
+	<div class="itemLabel">
+		State: 
+	</div>
+	<div class="itemContent">
+		{{:data.receives_updates ? "Enabled" : "Disabled"}}
+	</div>	
+	<div class="itemLabel">
+		Toggle Updates: 
+	</div>
+	<div class="itemContent">
+		{{:helper.link("ON", null, {'PC_enable_update' : 1}, data.receives_updates ? 'disabled' : null)}}
+		{{:helper.link("OFF", null, {'PC_disable_update' : 1}, data.receives_updates ? null : 'disabled')}}
+	</div>
+	<br><br>
 <hr><hr>
 <i>NTOS v2.0.4b Copyright NanoTrasen 2557 - 2559</i>

--- a/nano/templates/laptop_mainscreen.tmpl
+++ b/nano/templates/laptop_mainscreen.tmpl
@@ -1,3 +1,10 @@
+{{if data.updating}}
+<div class='block' style="background-color: #001d4c; color: #FFFFFF; text-align: center; padding: 50px 0;">
+	Please do not power off or unplug your machine.
+	<br>
+	Installing update {{:data.update_progress}}/{{:data.updates}}
+</div>
+{{else}}
 <i>No program loaded. Please select program from list below.</i>
 <table>
 {{for data.programs}}
@@ -6,3 +13,4 @@
 	<td>{{:helper.link('AR', null, {'PC_setautorun' : value.name}, null, (value.autorun ? 'yellowButton' : null))}} 
 {{/for}}
 </table>
+{{/if}}


### PR DESCRIPTION
In the mind of every spaceman eventually a question comes up: "How much do I hate the other players?" My answer is this PR. It comes from the very bottom of my heart. I made this piece of art to bring the most true suffering that man has even known into the game. The pain in HRP was never so realistic before. 

Introducing a brand new random event:
![update](https://user-images.githubusercontent.com/20233732/47459757-4169d800-d7dd-11e8-8f41-51e8d0be95a5.png)
![billgates](https://user-images.githubusercontent.com/20233732/47459758-4169d800-d7dd-11e8-96cc-907337308f99.png)

Khm. In a more serious tone, this random event makes every computer on the main station/ship connected to NTNet to update when turned on or off next time. Updates can be cancelled by emergency shutdown, but this has a chance of damaging the hardware. An update takes a few seconds at best and about a maximum of five minutes at worst. Of course at average you will have to wait about two minutes.
Unlike in Windows 10, in NTOS this "feature" can be disabled from modular configuration. Starts disabled for PDAs.

🆑Bxill Gates
rscadd: NTOS now requires MANDATORY updates every once in a while.
/🆑