### PR TITLE
More safety stuff

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -72,6 +72,10 @@
 		var/sound_vol = 25
 		if(user.a_intent == I_HURT)
 			sound_vol = 50
+			if(istype(holstered, /obj/item/weapon/gun))
+				var/obj/item/weapon/gun/G = holstered
+				if(user.skill_check(SKILL_WEAPONS, SKILL_EXPERT) && G.safety()) //Experienced shooter will disable safety before shooting.
+					G.safety_state = 0
 			usr.visible_message(
 				"<span class='danger'>\The [user] draws \the [holstered], ready to go!</span>",
 				"<span class='warning'>You draw \the [holstered], ready to go!</span>"
@@ -84,10 +88,9 @@
 		if(sound_out)
 			playsound(get_turf(atom_holder), sound_out, sound_vol)
 		holstered.add_fingerprint(user)
+		holstered.queue_icon_update()
 		user.put_in_hands(holstered)
-		holstered.update_icon()
 		storage.w_class = initial(storage.w_class)
-		clear_holster()
 		atom_holder.update_icon()
 		return 1
 	return 0

--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -121,6 +121,7 @@ Weapons
 	fire_delay = 5.7 //Autorevolver. Also synced with the animation
 	fire_anim = "mosley_fire"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
+	starts_loaded = 0 //Nobody keeps ballistic weapons loaded
 
 /obj/item/weapon/gun/energy/stunrevolver/secure/nanotrasen
 	name = "corporate stun revolver"


### PR DESCRIPTION
Captain's revolver comes with no ammo. Credits to 3303.
Experienced shooters will disable safety upon drawing the gun.

:cl: Sbotkin
rscadd: Experienced shooter will disable the safety if they draw a gun with harm intent.
tweak: Captain's revolver (the one in the showcase) spawns with no ammo.
bugfix: Fixed a bug with safety state not showing after unholstering.
/:cl:

Also this nerfs Captains (I've seen several) who rush and take their revolver during minor security emergencies. This gun is more of antag's target than an active toy for the Captain.

~~Also I reverted my attempt to fix the icon bug, it caused a runtime. Still have no idea how to fix it.~~
Finally fixed the icon bug, thanks to @afterthought2 
Closes https://github.com/Baystation12/Baystation12/issues/23601