### PR TITLE
Changes the 'broad-shouldered' generic descriptor to 'well-built'.

### DIFF
--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_generic.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_generic.dm
@@ -28,7 +28,7 @@
 		"rail thin",
 		"thin",
 		"of average build",
-		"broad-shouldered",
+		"well-built",
 		"heavily built"
 		)
 	comparative_value_descriptors_smaller = list(


### PR DESCRIPTION
Broad-shouldered seemed like a strange term to have in what seemed like a potentially relatively uniform set of physical descriptions (rail thin - thin - normal - broad-shouldered - heavily-built)

I feel as if the broad-shouldered descriptor would be better replaced with well-built as a description for characters that are more athletic or even muscular in build but do not approach the body-building feeling that 'broad-shouldered' may convey.

:cl: Melioa
tweak: Replaces 'Broad-shouldered' setup build for 'Well-built'
/:cl: