### PR TITLE
Splits Medical Contractor into two; gives the same access/skill/equipment as to uniformed personnel

### DIFF
--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -53,8 +53,11 @@
 /obj/item/weapon/card/id/torch/crew/medical/senior
 	job_access_type = /datum/job/senior_doctor
 
-/obj/item/weapon/card/id/torch/contractor/medical
+/obj/item/weapon/card/id/torch/contractor/doctor
 	job_access_type = /datum/job/doctor_contractor
+
+/obj/item/weapon/card/id/torch/contractor/nurse
+	job_access_type = /datum/job/nurse
 
 /obj/item/weapon/card/id/torch/contractor/chemist
 	job_access_type = /datum/job/chemist

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -2,7 +2,6 @@
 	title = "Physician"
 	department = "Medical"
 	department_flag = MED
-
 	minimal_player_age = 2
 	ideal_character_age = 45
 	total_positions = 2
@@ -45,6 +44,8 @@
 
 /datum/job/doctor
 	title = "Corpsman"
+	department = "Medical"
+	department_flag = MED
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Chief Medical Officer"
@@ -87,22 +88,51 @@
 	required_education = EDUCATION_TIER_TRADE
 
 /datum/job/doctor_contractor
-	title = "Medical Contractor"
+	title = "Contracted Doctor"
 	department = "Medical"
 	department_flag = MED
-
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the Chief Medical Officer, the Corporate Liaison and Medical Personnel"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief Medical Officer, the Workplace Liaison and Medical Personnel"
 	selection_color = "#013d3b"
 	economic_power = 3
-	ideal_character_age = 30
-	alt_titles = list(
-		"Orderly" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/orderly,
-		"Virologist" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist,
-		"Xenosurgeon" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/xenosurgeon,
-		"Paramedic" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/paramedic)
+	ideal_character_age = 45
+	minimal_player_age = 24
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_MEDICAL     = SKILL_ADEPT,
+	                    SKILL_ANATOMY     = SKILL_EXPERT,
+	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+	                    SKILL_VIROLOGY    = SKILL_BASIC)
+
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	                    SKILL_ANATOMY     = SKILL_MAX,
+	                    SKILL_CHEMISTRY   = SKILL_MAX,
+	                    SKILL_VIROLOGY    = SKILL_MAX)
+	skill_points = 32
+
+	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
+			            access_crematorium, access_chemistry, access_surgery,
+			            access_medical_equip, access_solgov_crew, access_senmed)
+
+	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/camera_monitor)
+	required_education = EDUCATION_TIER_MEDSCHOOL
+
+/datum/job/nurse
+	title = "Nurse"
+	department = "Medical"
+	department_flag = MED
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the Chief Medical Officer, the Workplace Liaison and Medical Personnel"
+	selection_color = "#013d3b"
+	economic_power = 7
+	ideal_character_age = 40
+	alt_titles = list("Paramedic")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/nurse
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
@@ -113,20 +143,20 @@
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX,
 	                    SKILL_VIROLOGY    = SKILL_MAX)
-	skill_points = 32
 
-	access = list(access_medical, access_morgue, access_crematorium, access_virology, access_surgery, access_medical_equip, access_solgov_crew,
-		            access_eva, access_maint_tunnels, access_emergency_storage, access_external_airlocks, access_hangar)
+	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+			            access_eva, access_surgery, access_medical_equip, access_solgov_crew, access_hangar)
+	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
+	skill_points = 26
 	required_education = EDUCATION_TIER_TRADE
 
 /datum/job/biomech
 	title = "Biomechanical Engineer"
 	department = "Medical"
 	department_flag = MED
-
 	minimal_player_age = 0
 	ideal_character_age = 45
 	total_positions = 1
@@ -159,7 +189,6 @@
 	title = "Corpsman Trainee"
 	department = "Medical"
 	department_flag = MED
-
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Chief Medical Officer and Medical Personnel"
@@ -203,7 +232,6 @@
 	title = "Chemist"
 	department = "Medical"
 	department_flag = MED
-
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Chief Medical Officer, the Corporate Liaison and Medical Personnel"
@@ -227,6 +255,8 @@
 
 /datum/job/psychiatrist
 	title = "Counselor"
+	department = "Medical"
+	department_flag = MED
 	total_positions = 1
 	spawn_positions = 1
 	ideal_character_age = 40

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -3,7 +3,7 @@
 		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor, /datum/job/chef, /datum/job/bartender, /datum/job/cargo_contractor,
 										/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
-									 /datum/job/roboticist, /datum/job/biomech, /datum/job/cargo_contractor, /datum/job/chef, /datum/job/engineer_contractor, /datum/job/doctor_contractor, /datum/job/bartender),
+									 /datum/job/roboticist, /datum/job/biomech, /datum/job/cargo_contractor, /datum/job/chef, /datum/job/engineer_contractor, /datum/job/nurse, /datum/job/bartender),
 		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway)
 	)
 
@@ -21,7 +21,7 @@
 						/datum/job/bridgeofficer, /datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
 						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/engineer_trainee,
 						/datum/job/officer, /datum/job/warden, /datum/job/detective,
-						/datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor,/datum/job/biomech, /datum/job/chemist, /datum/job/medical_trainee,
+						/datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/biomech, /datum/job/chemist, /datum/job/medical_trainee,
 						/datum/job/psychiatrist,
 						/datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor, /datum/job/mining,
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
@@ -70,5 +70,5 @@
 	..()
 
 /decl/cultural_info/education/nabber/a/plus/New()
-	LAZYADD(valid_jobs, /datum/job/doctor_contractor)
+	LAZYADD(valid_jobs, /datum/job/nurse)
 	..()

--- a/maps/torch/job/torch_outfits.dm
+++ b/maps/torch/job/torch_outfits.dm
@@ -328,26 +328,16 @@ decl/hierarchy/outfit/job/torch/passenger/research/cl/union
 	l_ear = /obj/item/device/radio/headset/headset_corpsman
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor
-	name = OUTFIT_JOB_NAME("Medical Contractor")
-	uniform = /obj/item/clothing/under/rank/medical
+	name = OUTFIT_JOB_NAME("Contracted Doctor")
+	uniform = /obj/item/clothing/under/sterile
 	shoes = /obj/item/clothing/shoes/white
-	id_type = /obj/item/weapon/card/id/torch/contractor/medical
+	id_type = /obj/item/weapon/card/id/torch/contractor/doctor
 
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/orderly
-	name = OUTFIT_JOB_NAME("Orderly")
-	uniform = /obj/item/clothing/under/rank/orderly
-
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/resident
-	name = OUTFIT_JOB_NAME("Medical Resident")
-	uniform = /obj/item/clothing/under/color/white
-
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/xenosurgeon
-	name = OUTFIT_JOB_NAME("Xenosurgeon")
-	uniform = /obj/item/clothing/under/rank/medical/scrubs/purple
-
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/mortus
-	name = OUTFIT_JOB_NAME("Mortician")
-	uniform = /obj/item/clothing/under/rank/medical/scrubs/black
+/decl/hierarchy/outfit/job/torch/crew/medical/contractor/nurse
+	name = OUTFIT_JOB_NAME("Nurse")
+	uniform = /obj/item/clothing/under/sterile
+	shoes = /obj/item/clothing/shoes/white
+	id_type = /obj/item/weapon/card/id/torch/contractor/nurse
 
 /decl/hierarchy/outfit/job/torch/crew/medical/biomech
 	name = OUTFIT_JOB_NAME("Biomechanical Engineer")

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -13,7 +13,7 @@
 #define MILITARY_ENLISTED_ROLES list(/datum/job/sea, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/qm, /datum/job/cargo_tech, /datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/explorer, /datum/job/officer, /datum/job/engineer_trainee, /datum/job/medical_trainee, /datum/job/xenolife_technician)
 
 //For all civilians or off-duty personnel, regardless of formality of dress or job.
-#define NON_MILITARY_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway, /datum/job/biomech)
+#define NON_MILITARY_ROLES list(/datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/representative, /datum/job/assistant, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/merchant,/datum/job/stowaway, /datum/job/biomech)
 //For jobs that allow for decorative or ceremonial clothing
 #define FORMAL_ROLES list(/datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/guard, /datum/job/detective)
 
@@ -24,7 +24,7 @@
 #define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway, /datum/job/detective)
 
 //For contractors
-#define CONTRACTOR_ROLES list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/chef, /datum/job/janitor, /datum/job/detective, /datum/job/guard, /datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/biomech)
+#define CONTRACTOR_ROLES list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/cargo_contractor, /datum/job/bartender, /datum/job/chef, /datum/job/janitor, /datum/job/detective, /datum/job/guard, /datum/job/rd, /datum/job/liaison, /datum/job/senior_scientist, /datum/job/nt_pilot, /datum/job/scientist,/datum/job/mining, /datum/job/guard, /datum/job/scientist_assistant, /datum/job/biomech)
 
 //For corporate or government representatives
 #define REPRESENTATIVE_ROLES list(/datum/job/representative, /datum/job/liaison)
@@ -36,10 +36,10 @@
 #define COMMAND_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/bridgeofficer, /datum/job/sea)
 
 //For members of the medical department
-#define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/medical_trainee, /datum/job/biomech)
+#define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/medical_trainee, /datum/job/biomech)
 
 //For members of the medical department, roboticists, and some Research
-#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/medical_trainee, /datum/job/biomech)
+#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/medical_trainee, /datum/job/biomech)
 
 //For members of the engineering department
 #define ENGINEERING_ROLES list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/engineer_trainee)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -76,7 +76,7 @@
 	allowed_roles = MEDICAL_ROLES
 
 /datum/gear/accessory/armband_emt
-	allowed_roles = list(/datum/job/doctor, /datum/job/doctor_contractor)
+	allowed_roles = list(/datum/job/doctor, /datum/job/nurse)
 
 /datum/gear/accessory/armband_corpsman
 	display_name = "medical corps armband"
@@ -112,7 +112,7 @@
 	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/guard, /datum/job/merchant)
 
 /datum/gear/storage/white_vest
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/storage/brown_drop_pouches
 	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
@@ -122,7 +122,7 @@
 	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/guard, /datum/job/merchant)
 
 /datum/gear/storage/white_drop_pouches
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/nurse, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/tactical/holster
 	allowed_roles = ARMED_ROLES

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -17,7 +17,7 @@
 	allowed_roles = list(/datum/job/guard, /datum/job/merchant)
 
 /datum/gear/suit/medical_poncho
-	allowed_roles = list(/datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/doctor_contractor, /datum/job/nurse, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/suit/engineering_poncho
 	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/merchant)

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -101,6 +101,66 @@
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
 	)
 
+/obj/structure/closet/secure_closet/medical_torchdoctor
+	name = "doctor's locker"
+	req_access = list(access_senmed)
+	icon_state = "securemed1"
+	icon_closed = "securemed"
+	icon_locked = "securemed1"
+	icon_opened = "securemedopen"
+	icon_off = "securemedoff"
+
+/obj/structure/closet/secure_closet/medical_torchdoctor/WillContain()
+	return list(
+		/obj/item/clothing/under/sterile,
+		/obj/item/clothing/suit/storage/toggle/labcoat,
+		/obj/item/clothing/suit/surgicalapron,
+		/obj/item/clothing/shoes/white,
+		/obj/item/device/radio/headset/headset_med,
+		/obj/item/device/radio/headset/headset_med/alt,
+		/obj/item/weapon/storage/belt/medical,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/device/healthanalyzer,
+		/obj/item/clothing/accessory/stethoscope,
+		/obj/item/device/flashlight/pen,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/weapon/storage/firstaid/adv,
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
+	)
+
+/obj/structure/closet/secure_closet/medical_torchnurse
+	name = "nurse's locker"
+	req_access = list(access_medical_equip)
+	icon_state = "securemed1"
+	icon_closed = "securemed"
+	icon_locked = "securemed1"
+	icon_opened = "securemedopen"
+	icon_off = "securemedoff"
+
+/obj/structure/closet/secure_closet/medical_torchnurse/WillContain()
+	return list(
+		/obj/item/clothing/under/sterile,
+		/obj/item/clothing/head/soft/mime,
+		/obj/item/clothing/head/nursehat,
+		/obj/item/clothing/accessory/storage/white_vest,
+		/obj/item/clothing/suit/storage/toggle/labcoat,
+		/obj/item/clothing/suit/storage/toggle/fr_jacket,
+		/obj/item/clothing/shoes/white,
+		/obj/item/device/radio/headset/headset_med,
+		/obj/item/device/radio/headset/headset_med/alt,
+		/obj/item/weapon/storage/belt/medical,
+		/obj/item/weapon/storage/belt/medical/emt,
+		/obj/item/clothing/mask/gas/half,
+		/obj/item/weapon/tank/emergency/oxygen/engi,
+		/obj/item/weapon/storage/box/autoinjectors,
+		/obj/item/device/healthanalyzer,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/weapon/storage/firstaid/adv,
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
+	)
+
 /obj/structure/closet/secure_closet/medical_contractor
 	name = "medical contractor's locker"
 	req_access = list(access_medical)

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -16946,11 +16946,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "dqb" = (
-/obj/structure/closet/secure_closet/medical_contractor,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/medical_torchdoctor,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "drb" = (
@@ -17171,7 +17171,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/structure/closet/secure_closet/medical_contractor,
+/obj/structure/closet/secure_closet/medical_torchnurse,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "dFb" = (


### PR DESCRIPTION
:cl:
tweak: Separated "Medical Contractor" into "Contracted Doctor" and "Nurse" (alt title: Paramedic). Doctors need MD, nurses need trade school education at minimum.
tweak: Contracted Doctors were given the same access as Physicians. Nurses/Paramedics were given the same access as Corpsmen. They also have the same amount of skill points.
maptweak: Replaced medical contractor lockers with doctor and nurse lockers.
rscdel: No more medical contractor alt titles. You can still be a virologist or a surgeon - build your character accordingly!
/:cl:

**This will conflict with #23595!**

- Doctors have to be minimum 24 years old.
- They both wear sterile, white jumpsuits. They can accessorize from their lockers/loadout.
- This expands contractors' access to chemistry, virology, and the crematorium. Paramedics(/nurses) will have access to EVA and hangar.
- GAS can be nurses/paramedics but not doctors.
- Slots are not increased. Med contractor had 2 slots, each job has 1 slot now.
- The only notable thing contracted doctors lack compared to physicians is the flash.

The idea is to make civilian doctors equal to uniformed personnel in terms of skills, access, equipment, and duties. Education conflicts (orderlies having to be MDs) are fixed this way, too. Nurses should not do EVA but ah well 26th century, if they got EVA training, I'm personally ok with it.