### PR TITLE
Makes autoantag not hard-kill antag adds if at antag capacity

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -62,9 +62,6 @@
 		return 0
 	if(!(id in SSticker.mode.latejoin_antag_tags))
 		return 0
-	update_current_antag_max(SSticker.mode)
-	if(get_antag_count() >= cur_max)
-		return 0
 	return 1
 
 /datum/antagonist/proc/is_latejoin_template()


### PR DESCRIPTION
This will also improve admin logging on failure. Note that antag total is checked on `attempt_auto_spawn` anyway, so this shouldn't cause overpopulation.