### PR TITLE
add metrics for SSgarbage

### DIFF
--- a/code/modules/prometheus_metrics/metrics/ss13.dm
+++ b/code/modules/prometheus_metrics/metrics/ss13.dm
@@ -23,3 +23,49 @@
 	if(Master)
 		return list(list(null, Master.current_runlevel))
 	return list()
+
+
+/datum/metric_family/ss13_garbage_queue_length
+	name = "ss13_garbage_queue_length"
+	metric_type = PROMETHEUS_METRIC_GAUGE
+	help = "Length of SSgarbage queues"
+
+/datum/metric_family/ss13_garbage_queue_length/collect()
+	var/list/out = list()
+
+	if(SSgarbage)
+		for(var/i = 1 to GC_QUEUE_COUNT)
+			out[++out.len] = list(list("queue" = "[i]"), length(SSgarbage.queues[i]))
+
+	return out
+
+
+/datum/metric_family/ss13_garbage_queue_results
+	name = "ss13_garbage_queue_results"
+	metric_type = PROMETHEUS_METRIC_COUNTER
+	help = "Counter of pass/fail results for SSgarbage queues"
+
+/datum/metric_family/ss13_garbage_queue_results/collect()
+	var/list/out = list()
+
+	if(SSgarbage)
+		for(var/i = 1 to GC_QUEUE_COUNT)
+			out[++out.len] = list(list("queue" = "[i]", "result" = "pass"), SSgarbage.pass_counts[i])
+			out[++out.len] = list(list("queue" = "[i]", "result" = "fail"), SSgarbage.fail_counts[i])
+
+	return out
+
+
+/datum/metric_family/ss13_garbage_total_cleaned
+	name = "ss13_garbage_total_cleaned"
+	metric_type = PROMETHEUS_METRIC_COUNTER
+	help = "Counter for number of objects deleted/GCed by SSgarbage"
+
+/datum/metric_family/ss13_garbage_total_cleaned/collect()
+	var/list/out = list()
+
+	if(SSgarbage)
+		out[++out.len] = list(list("type" = "gc"), SSgarbage.totalgcs)
+		out[++out.len] = list(list("type" = "del"), SSgarbage.totaldels)
+
+	return out


### PR DESCRIPTION
tracks queue length/activity and total gc/dels
possibly a bit messy and invasive, but subsystems don't have a good way to expose this info

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->