### PR TITLE
Gives offstation roles a few more skills to choose

### DIFF
--- a/code/modules/mob/skills/antag_skill_setter.dm
+++ b/code/modules/mob/skills/antag_skill_setter.dm
@@ -3,7 +3,7 @@
 /datum/antag_skill_setter
 	var/nm_type                        //A nano_module with custom ui, if any.
 	var/list/base_skill_list = list()  //Format: list(path = value).
-	var/default_value = SKILL_DEFAULT  //If not in base_skill_list or added in another way, skill value will be this. 
+	var/default_value = SKILL_DEFAULT  //If not in base_skill_list or added in another way, skill value will be this.
 
 /datum/antag_skill_setter/proc/initialize_skills(datum/skillset/skillset)
 	skillset.skill_list = base_skill_list.Copy()
@@ -35,6 +35,10 @@
 			var/datum/job/job = job_master.GetJob(skillset.owner.mind.assigned_role)
 			skillset.obtain_from_client(job, my_client, 1)
 	skillset.open_ui()
+
+//This will obtain skills from the job selection before giving additional buffs.
+/datum/antag_skill_setter/station/offstation
+	nm_type = /datum/nano_module/skill_ui/antag/station/offstation
 
 //Placeholder for ai; defaults to experienced in everything like usual.
 /datum/antag_skill_setter/ai

--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -185,6 +185,11 @@ Similar, but for station antags that have jobs.
 /datum/nano_module/skill_ui/antag/station
 	max_choices = list(0, 0, 3, 1, 0)
 /*
+Similar, but for off-station jobs (Bearcat, Verne, survivor etc.).
+*/
+/datum/nano_module/skill_ui/antag/station/offstation
+	max_choices = list(0, 2, 2, 1, 1)
+/*
 Admin version, with debugging options.
 */
 /datum/nano_module/skill_ui/admin

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -3,7 +3,7 @@
 	var/decl/submap_archetype/archetype
 	var/list/jobs
 	var/associated_z
-	var/datum/antag_skill_setter/skill_setter = /datum/antag_skill_setter/station
+	var/datum/antag_skill_setter/skill_setter = /datum/antag_skill_setter/station/offstation
 
 /datum/submap/New(var/existing_z)
 	SSmapping.submaps[src] = TRUE


### PR DESCRIPTION
🆑Roland410
:tweak:Off station nonantag roles (Bearcat, Verne, survivor etc.) can choose one master, one experienced, two trained and two basic skills now.
/🆑
The point of this PR is to allow off station roles to have more varied skills as they do not start with any unlike the personnel of the Torch.