### PR TITLE
Increases lobby vote start time, and time before retrying should non-secret mode fail

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -58,7 +58,7 @@ SUBSYSTEM_DEF(ticker)
 		if(CHOOSE_GAMEMODE_SILENT_REDO)
 			return
 		if(CHOOSE_GAMEMODE_RETRY)
-			pregame_timeleft = 15 SECONDS
+			pregame_timeleft = 60 SECONDS
 			Master.SetRunLevel(RUNLEVEL_LOBBY)
 			to_world("<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby to try again.")
 			return
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(ticker)
 					to_world("<span class='notice'><b>Restarting in [restart_timeout/10] seconds</b></span>")
 
 			if(blackbox)
-				blackbox.save_all_data_to_sql()	
+				blackbox.save_all_data_to_sql()
 			handle_tickets()
 		if(END_GAME_ENDING)
 			restart_timeout -= (world.time - last_fire)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -148,8 +148,8 @@ VOTE_AUTOTRANSFER_INITIAL 108000
 ##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
 VOTE_AUTOTRANSFER_INTERVAL 18000
 
-## Time left (seconds) before round start when automatic gamemote vote is called (default 100).
-VOTE_AUTOGAMEMODE_TIMELEFT 100
+## Time left (seconds) before round start when automatic gamemote vote is called (default 160).
+VOTE_AUTOGAMEMODE_TIMELEFT 160
 
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE


### PR DESCRIPTION
🆑Roland410
tweak: Gamemode vote starts at 160 seconds, giving players 100 seconds to change their character/preferences according to the voted gamemode.
tweak: Should a non-secret mode fail to start, you will have one minute to adjust your preferences or unready before roundstart.
/🆑
Pretty much what I wrote for changelog. WARNING requires a config change or it will be pointless. The example config has been committed on purpose, and that will have to be changed server side as well.
Closes #23660 