### PR TITLE
Redesigns the crashed pod into a crashed survival pod

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2891,6 +2891,7 @@
 #include "maps\random_ruins\exoplanet_ruins\marooned\marooned.dm"
 #include "maps\random_ruins\exoplanet_ruins\monoliths\monoliths.dm"
 #include "maps\random_ruins\exoplanet_ruins\oasis\oasis.dm"
+#include "maps\random_ruins\exoplanet_ruins\oldpod\oldpod.dm"
 #include "maps\random_ruins\space_ruins\space_ruins.dm"
 #include "maps\torch\torch.dm"
 #include "maps\torch\torch_define.dm"

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -1,19 +1,19 @@
 GLOBAL_LIST_INIT(crashed_pod_areas, new)
 
 /datum/map_template/ruin/exoplanet/crashed_pod
-	name = "crashed escape pod"
+	name = "crashed survival pod"
 	id = "crashed_pod"
-	description = "A crashed escape pod from a destroyed ship."
+	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
 	cost = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 
 /area/map_template/crashed_pod
-	name = "\improper Crashed Escape Pod"
+	name = "\improper Crashed Survival Pod"
 	icon_state = "blue"
 
 /decl/submap_archetype/crashed_pod
-	descriptor = "crashed escape pod"
+	descriptor = "crashed survival pod"
 	crew_jobs = list(/datum/job/submap/pod)
 
 /datum/submap/crashed_pod/sync_cell(var/obj/effect/overmap/cell)
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	..()
 	if(_owner) // Might be called from admin tools, etc
 		info = "Your ship, the [_owner.name], has been destroyed by a terrible disaster, \
-		leaving you stranded in your escape pod on a hostile exoplanet. Your pod's distress \
+		leaving you stranded in your survival pod on a hostile exoplanet. Your pod's distress \
 		signal might draw help, but even if you should be so lucky, you must survive long \
 		enough for it to arrive."
 
@@ -41,7 +41,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	name = "Stranded Survivor"
 
 /obj/effect/submap_landmark/joinable_submap/crashed_pod
-	name = "Crashed Escape Pod"
+	name = "Crashed Survival Pod"
 	archetype = /decl/submap_archetype/crashed_pod
 	submap_datum_type = /datum/submap/crashed_pod
 

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -1,526 +1,1309 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 9
-	},
-/area/map_template/crashed_pod)
-"b" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
+"aa" = (
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
-"c" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
+"ab" = (
+/turf/simulated/wall/r_wall,
 /area/map_template/crashed_pod)
-"d" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
+"ac" = (
+/obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
-"e" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"f" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 5
-	},
-/area/map_template/crashed_pod)
-"g" = (
+"ad" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
 	dir = 1
 	},
-/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/wall_frame,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
 /obj/effect/submap_landmark/joinable_submap/crashed_pod,
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
-"h" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"i" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"j" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"k" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"l" = (
+"ae" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
 	dir = 1
 	},
-/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/wall_frame,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
-"m" = (
+"af" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/wall/r_wall,
+/area/map_template/crashed_pod)
+"ag" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/structure/wall_frame,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/map_template/crashed_pod)
+"ah" = (
 /obj/machinery/alarm{
 	dir = 4;
+	locked = 0;
 	pixel_x = -25;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"n" = (
-/obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
-	icon_state = "shuttle_chair_preview";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
-/turf/simulated/floor/tiled/monotile,
+"ai" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/raisins,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"o" = (
-/obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
-	icon_state = "shuttle_chair_preview";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
-/turf/simulated/floor/tiled/monotile,
+"aj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"p" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"q" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"r" = (
-/obj/structure/closet/hydrant{
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"s" = (
+"ak" = (
+/obj/machinery/power/terminal,
 /obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"t" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"u" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+"al" = (
+/obj/structure/sign/kiddieplaque{
+	desc = "A plaque with information regarding this particular lifepod. It reads: 'Armalev Industries Skyfin-E, Exoplanetary Suvival Pod' there's a registry number, and an assigned mothership, but they've both been scratched to illegiblity.";
+	name = "\improper Lifepod Plaque";
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"v" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"w" = (
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"x" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/steel/fifty,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"y" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/weapon/storage/belt/utility/full,
-/obj/item/weapon/storage/belt/utility/full,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"z" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/item/weapon/pickaxe,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"A" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"B" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/crashed_pod)
-"C" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"D" = (
+"am" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"an" = (
+/obj/machinery/atmospherics/omni/filter,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"ao" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/tastybread,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"ap" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/curtain/open/shower/engineering,
+/obj/structure/hygiene/toilet{
+	dir = 8
+	},
+/obj/item/weapon/storage/mirror{
+	pixel_x = 27
+	},
+/obj/item/weapon/circuitboard/solar_control,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/hydrant{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"ar" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"as" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/power/apc{
+	dir = 2;
+	locked = 0;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"at" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes/buildable{
+	charge = 50000;
+	inputting = 1;
+	outputting = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"au" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	icon_state = "map";
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"av" = (
+/obj/machinery/atmospherics/omni/filter,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aw" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"ax" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/map_template/crashed_pod)
+"ay" = (
+/turf/simulated/wall,
+/area/map_template/crashed_pod)
+"az" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/wall,
+/area/map_template/crashed_pod)
+"aA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aB" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/wall,
+/area/map_template/crashed_pod)
+"aE" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aG" = (
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/item/device/analyzer,
+/obj/item/weapon/circuitboard/unary_atmos/cooler,
+/obj/item/weapon/circuitboard/unary_atmos/heater,
+/obj/item/weapon/circuitboard/oxyregenerator,
+/obj/item/weapon/tank/oxygen/red,
+/obj/structure/cable,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/stack/material/uranium/ten,
+/obj/item/clothing/under/savage_hunter,
+/obj/item/clothing/under/savage_hunter/female,
+/obj/item/clothing/under/wetsuit,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/liquidfood,
+/obj/item/weapon/stock_parts/matter_bin/super,
+/obj/item/weapon/circuitboard/biogenerator,
+/obj/item/weapon/bedsheet/orange,
+/obj/item/weapon/bedsheet/orange,
+/obj/item/weapon/stock_parts/matter_bin/adv,
+/obj/item/weapon/stock_parts/micro_laser/ultra,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/stack/material/sandstone{
+	amount = 50
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aI" = (
+/obj/machinery/atmospherics/pipe/tank/air,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/curtain/open/shower/engineering,
+/obj/structure/hygiene/shower{
+	dir = 8;
+	icon_state = "shower";
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/weapon/mop,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/liquidfood,
+/obj/item/weapon/storage/box/detergent,
+/obj/item/clothing/mask/plunger,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aM" = (
+/obj/machinery/pipedispenser,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	icon_state = "map_universal";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aR" = (
+/obj/machinery/autolathe,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"aS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/civilian,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/tastybread,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aV" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aW" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/civilian,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"aZ" = (
+/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/structure/bed/chair/shuttle/black,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
+"ba" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bb" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/map_template/crashed_pod)
+"bc" = (
+/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
+"bd" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/random/plushie,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
+"be" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/bed/chair,
+/obj/structure/closet/hydrant{
+	pixel_x = -27
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bf" = (
+/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/structure/bed/chair/shuttle/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
+"bg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bh" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bi" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bj" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/metal,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
+"bk" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bm" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bq" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/weapon/crowbar,
+/obj/item/weapon/crowbar,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"br" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bs" = (
+/obj/structure/grille,
+/turf/space,
+/area/map_template/crashed_pod)
+"bt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bu" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill,
+/obj/effect/decal/cleanable/flour,
+/obj/item/trash/candy/proteinbar,
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/food/condiment/small/sugar,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bx" = (
+/obj/machinery/alarm{
+	dir = 4;
+	locked = 0;
+	pixel_x = -25;
+	pixel_y = 0
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"by" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bD" = (
+/obj/effect/floor_decal/industrial/hatch/orange,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bH" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"bI" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bJ" = (
 /obj/machinery/door/airlock/external{
 	name = "escape pod airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
-"E" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/cyan,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
-	},
-/obj/machinery/power/smes/buildable/power_shuttle,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"F" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"G" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"H" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/closet/crate/freezer/rations,
-/obj/random/handgun,
-/obj/random/handgun,
-/obj/random/handgun,
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"I" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/item/weapon/tank/oxygen,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/weapon/tank/oxygen,
-/obj/structure/table/rack,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"J" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"K" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/obj/item/stack/material/phoron/fifty,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"L" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"M" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"N" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"O" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"P" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"Q" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/cyan,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"R" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/firstaid,
-/obj/random/firstaid,
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/crashed_pod)
-"S" = (
+"bK" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/ash,
+/obj/item/trash/cigbutt/cigarbutt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"T" = (
-/obj/machinery/sleeper{
+"bL" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"bM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/gloves,
+/obj/random/gloves,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/item/clothing/under/color/orange,
+/obj/item/clothing/under/color/orange,
+/obj/item/clothing/under/color/blackjumpshorts,
+/obj/item/clothing/under/color/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bN" = (
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"bO" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel_reinforced,
+/obj/item/device/binoculars,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy/proteinbar,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bP" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"bQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/gloves,
+/obj/random/gloves,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/item/clothing/under/color/orange,
+/obj/item/clothing/under/color/orange,
+/obj/item/clothing/under/color/blackjumpshorts,
+/obj/item/clothing/under/color/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bR" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/tastybread,
+/obj/item/device/geiger,
+/obj/item/device/geiger,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bS" = (
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"bT" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/crowbar,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/gloves,
+/obj/random/hat,
+/obj/random/hat,
+/obj/random/hat,
+/obj/item/clothing/under/color/orange,
+/obj/item/clothing/under/color/orange,
+/obj/item/clothing/under/color/blackjumpshorts,
+/obj/item/clothing/under/color/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"bV" = (
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"U" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 10
-	},
+"bW" = (
+/obj/structure/closet/crate/medical,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/weapon/storage/firstaid/stab,
+/obj/item/weapon/storage/pill_bottle/antidexafen,
+/obj/item/weapon/storage/pill_bottle/antidexafen,
+/obj/item/weapon/storage/med_pouch/radiation,
+/obj/item/weapon/storage/med_pouch/radiation,
+/obj/item/weapon/storage/med_pouch/radiation,
+/obj/item/weapon/storage/med_pouch/radiation,
+/obj/item/weapon/storage/pill_bottle/assorted,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"V" = (
-/turf/simulated/shuttle/wall/corner/dark{
-	dir = 6
+"bX" = (
+/obj/structure/closet/crate,
+/obj/random/handgun,
+/obj/random/handgun,
+/obj/random/handgun,
+/obj/item/weapon/pickaxe,
+/obj/item/weapon/pickaxe,
+/obj/item/weapon/pickaxe,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plasteel/fifty,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/weapon/storage/box/glowsticks,
+/obj/item/weapon/storage/box/glowsticks,
+/obj/item/weapon/storage/box/glowsticks,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"bY" = (
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/item/weapon/storage/fancy/egg_box,
+/obj/item/weapon/storage/fancy/egg_box,
+/obj/item/weapon/storage/fancy/egg_box,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/drinks/milk,
+/obj/item/weapon/reagent_containers/food/drinks/milk,
+/obj/item/trash/liquidfood,
+/obj/item/trash/liquidfood,
+/obj/item/trash/liquidfood,
+/obj/item/trash/liquidfood,
+/obj/item/weapon/beartrap,
+/obj/item/weapon/material/knife/butch,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"bZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
+/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"ca" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/backpack/dufflebag/eng,
+/obj/item/weapon/material/ashtray/bronze,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"cb" = (
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"cc" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/multitool,
+/obj/item/weapon/screwdriver,
+/obj/item/weapon/cell/device/high,
+/obj/item/weapon/cell/device/high,
+/obj/item/weapon/cell/crap,
+/obj/item/weapon/storage/box/lights,
+/obj/item/device/analyzer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/specialwhiskey,
+/obj/item/weapon/tracker_electronics,
+/obj/item/weapon/pen/blue,
+/obj/item/weapon/pen/green,
+/obj/item/weapon/pen/red,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"cd" = (
+/obj/structure/closet/crate/large/hydroponics,
+/obj/item/seeds/potatoseed,
+/obj/item/seeds/potatoseed,
+/obj/item/seeds/wheatseed,
+/obj/item/seeds/wheatseed,
+/obj/item/seeds/orangeseed,
+/obj/item/seeds/orangeseed,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/cornseed,
+/obj/item/weapon/material/hatchet,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/plantspray/pests,
+/obj/item/weapon/plantspray/pests,
+/obj/item/weapon/plantspray/weeds,
+/obj/item/seeds/poppyseed,
+/obj/item/seeds/towermycelium,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/whitebeetseed,
+/obj/item/weapon/storage/plants,
+/obj/item/seeds/bananaseed,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 
 (1,1,1) = {"
-a
-c
-c
-c
-e
-e
-c
-c
-c
-U
+aa
+bs
+bs
+bs
+ab
+ab
+ab
+ab
+ab
+bb
+ab
+ab
+ab
+ab
+ab
+ab
 "}
 (2,1,1) = {"
-b
-g
-m
-s
-w
-w
-d
-I
-O
-c
+ab
+ab
+ab
+ab
+ab
+aE
+aB
+ay
+be
+ca
+bx
+bK
+ax
+bV
+bS
+ab
 "}
 (3,1,1) = {"
-c
-c
-n
-n
-x
-w
-D
-J
-P
-D
+ac
+ad
+ah
+aq
+aA
+aF
+aN
+aS
+bg
+bg
+bC
+bL
+bJ
+bD
+bD
+bJ
 "}
 (4,1,1) = {"
-c
-h
-o
-o
-y
-B
-c
-c
-c
-c
+ab
+ab
+ai
+as
+ay
+aK
+aO
+ay
+aZ
+bh
+bE
+bO
+ab
+ab
+ab
+ab
 "}
 (5,1,1) = {"
-d
-i
-p
-t
-w
-C
-E
-K
-Q
-d
+ac
+ae
+aj
+ar
+ay
+aH
+aV
+ay
+bc
+bi
+bt
+bR
+ay
+bY
+bX
+ab
 "}
 (6,1,1) = {"
-e
-j
-q
-u
-w
-w
-w
-w
-w
-e
+ab
+ab
+ak
+at
+ax
+aI
+ba
+ax
+bd
+bk
+bG
+bv
+bB
+bF
+bZ
+ax
 "}
 (7,1,1) = {"
-c
-k
-n
-n
-z
-w
-F
-L
-R
-c
+ab
+ab
+al
+aG
+ax
+aI
+aQ
+ax
+bj
+bl
+bw
+bM
+ay
+bW
+cc
+ab
 "}
 (8,1,1) = {"
-c
-c
-o
-o
-A
-w
-G
-M
-S
-c
+ac
+ae
+am
+au
+az
+aP
+aT
+ay
+bc
+bm
+by
+bQ
+ay
+ay
+ay
+ab
 "}
 (9,1,1) = {"
-b
-l
-r
-v
-w
-w
-H
-N
-T
-c
+ab
+af
+an
+av
+aD
+aU
+aW
+ay
+bf
+bn
+by
+bU
+ay
+bH
+bN
+ab
 "}
 (10,1,1) = {"
-f
-c
-c
-c
-e
-e
-c
-c
-c
-V
+ac
+ag
+ao
+aw
+aC
+aL
+aX
+aY
+bp
+bo
+bA
+bz
+bB
+bI
+cb
+ax
+"}
+(11,1,1) = {"
+ab
+ab
+ap
+aJ
+ay
+aM
+aR
+ay
+bq
+bu
+br
+bT
+ay
+bP
+cd
+ab
+"}
+(12,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ax
+ab
+ab
+ab
+ab
+ab
+ab
 "}

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
@@ -1,0 +1,11 @@
+/datum/map_template/ruin/exoplanet/oldpod
+	name = "old pod"
+	id = "oldpod"
+	description = "A now unused, crashed escape pod."
+	suffixes = list("oldpod/oldpod.dmm")
+	cost = 0.5
+	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
+
+/area/map_template/oldpod
+	name = "\improper Abandoned Escape Pod"
+	icon_state = "blue"

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -1,0 +1,642 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/simulated/shuttle/wall/corner/dark{
+	dir = 9
+	},
+/area/map_template/oldpod)
+"ab" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"ac" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/map_template/oldpod)
+"ad" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"ae" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"af" = (
+/turf/simulated/shuttle/wall/corner/dark{
+	dir = 5
+	},
+/area/map_template/oldpod)
+"ag" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"ah" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"ai" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aj" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"ak" = (
+/obj/structure/bed,
+/obj/effect/landmark/corpse/doctor,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"al" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"am" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"an" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"ao" = (
+/obj/structure/bed/chair/shuttle{
+	tag = "icon-shuttle_chair_preview (WEST)";
+	icon_state = "shuttle_chair_preview";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"ap" = (
+/obj/structure/bed/chair/shuttle{
+	tag = "icon-shuttle_chair_preview (NORTH)";
+	icon_state = "shuttle_chair_preview";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aq" = (
+/obj/structure/closet/hydrant{
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"ar" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"as" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"at" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"au" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"av" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aw" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"ax" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"ay" = (
+/obj/item/frame/air_alarm,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/airalarm_electronics,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"az" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aA" = (
+/obj/random/firstaid,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aC" = (
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aD" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/item/weapon/pickaxe,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aG" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aH" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/item/frame/apc,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/cell/crap/empty,
+/obj/item/weapon/module/power_control,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aI" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aJ" = (
+/obj/effect/landmark/corpse/pirate,
+/obj/item/weapon/gun/energy/retro,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aK" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aL" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aM" = (
+/obj/effect/landmark/corpse/scientist,
+/obj/item/weapon/material/wirerod,
+/obj/item/weapon/material/shard,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/wall_frame/hull,
+/obj/structure/grille,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/weapon/material/shard,
+/obj/item/weapon/material/shard,
+/obj/item/weapon/material/shard,
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"aO" = (
+/obj/machinery/door/airlock/external{
+	name = "escape pod airlock"
+	},
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"aP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/cyan,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 5
+	},
+/obj/machinery/power/smes/buildable/power_shuttle,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"aQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"aR" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"aS" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"aT" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/crate/freezer/rations,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/gun/projectile/pirate,
+/obj/item/weapon/gun/projectile/pirate,
+/obj/item/weapon/gun/projectile/pirate,
+/obj/item/weapon/gun/projectile/pirate,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"aU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"aV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"aW" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/item/weapon/tank/oxygen,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"aX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"aY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"aZ" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"ba" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/item/clothing/suit/space/emergency,
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"bb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"bc" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/cyan,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/map_template/oldpod)
+"bd" = (
+/obj/effect/landmark/corpse/bridgeofficer,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
+"be" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"bf" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"bg" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/oldpod)
+"bh" = (
+/turf/simulated/shuttle/wall/corner/dark{
+	dir = 10
+	},
+/area/map_template/oldpod)
+"bi" = (
+/turf/simulated/shuttle/wall/corner/dark{
+	dir = 6
+	},
+/area/map_template/oldpod)
+
+(1,1,1) = {"
+aa
+ac
+ac
+ac
+ax
+ae
+ac
+ac
+ac
+bh
+"}
+(2,1,1) = {"
+ab
+ag
+ak
+ar
+ay
+aG
+ad
+aU
+ba
+ac
+"}
+(3,1,1) = {"
+ac
+ac
+al
+as
+az
+am
+aO
+aV
+bb
+aO
+"}
+(4,1,1) = {"
+ac
+ah
+al
+at
+aA
+aH
+ac
+ac
+ac
+ac
+"}
+(5,1,1) = {"
+ad
+ai
+am
+au
+aB
+aI
+aP
+aW
+bc
+ad
+"}
+(6,1,1) = {"
+ae
+ai
+an
+av
+aC
+aJ
+aQ
+aK
+bd
+ae
+"}
+(7,1,1) = {"
+ac
+aj
+ao
+ao
+aD
+aK
+aR
+aX
+be
+ac
+"}
+(8,1,1) = {"
+ac
+ac
+ap
+ap
+aE
+aL
+aS
+aY
+bf
+ac
+"}
+(9,1,1) = {"
+ab
+ag
+aq
+aw
+aF
+aM
+aT
+aZ
+bg
+ac
+"}
+(10,1,1) = {"
+af
+ac
+ac
+ac
+ae
+aN
+ac
+ac
+ac
+bi
+"}


### PR DESCRIPTION
🆑Aticius
rscadd: Added a playable crashed survival pod.
maptweak: Converted the old crashed pod into a random ruin.
/🆑
This is basically @Aticius work(TM), just needed me to PR this. The crashed pod has been totally remade into a crashed survival pod, which now contains a multitude of supplies (but not enough for it to be effortless) that should make playing it actually possible AND fun.
![image](https://user-images.githubusercontent.com/6581435/47736135-47910600-dc6e-11e8-9cb8-993a0426cc0f.png)
The old pod got a few changes after discussions:
![image](https://user-images.githubusercontent.com/6581435/48175720-79a90480-e30d-11e8-87fd-fd31fe778fac.png)
