### PR TITLE
Makes secret (almost) never fail to start.

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -1,8 +1,9 @@
 //Used with the ticker to help choose the gamemode.
-#define CHOOSE_GAMEMODE_SUCCESS 1 // A gamemode was successfully chosen.
-#define CHOOSE_GAMEMODE_RETRY   2 // The gamemode could not be chosen; we will use the next most popular option voted in, or the default.
-#define CHOOSE_GAMEMODE_REVOTE  3 // The gamemode could not be chosen; we need to have a revote.
-#define CHOOSE_GAMEMODE_RESTART 4 // The gamemode could not be chosen; we will restart the server.
+#define CHOOSE_GAMEMODE_SUCCESS     1 // A gamemode was successfully chosen.
+#define CHOOSE_GAMEMODE_RETRY       2 // The gamemode could not be chosen; we will use the next most popular option voted in, or the default.
+#define CHOOSE_GAMEMODE_REVOTE      3 // The gamemode could not be chosen; we need to have a revote.
+#define CHOOSE_GAMEMODE_RESTART     4 // The gamemode could not be chosen; we will restart the server.
+#define CHOOSE_GAMEMODE_SILENT_REDO 5 // The gamemode could not be chosen; we request to have the the proc rerun on the next tick.
 
 //End game state, to manage round end.
 #define END_GAME_NOT_OVER         1

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -858,7 +858,7 @@ var/list/gamemode_cache = list()
 	for(var/game_mode in gamemode_cache)
 		var/datum/game_mode/M = gamemode_cache[game_mode]
 		if(M && !M.startRequirements() && !isnull(config.probabilities[M.config_tag]) && config.probabilities[M.config_tag] > 0)
-			runnable_modes[M] = config.probabilities[M.config_tag]
+			runnable_modes[M.config_tag] = config.probabilities[M.config_tag]
 	return runnable_modes
 
 /datum/configuration/proc/load_event(filename)


### PR DESCRIPTION
:cl:
tweak: Secret and random will (almost) never fail to start when voted in.
/:cl:

Not sure whether the community wants it to work this way or not. 

Currently it doesn't accurately check for whether there are sufficient available antags before starting (if someone is selected to be CO, but was needed as the only one who can be the ling, it fails, and similar). This will make it keep trying (other modes) if such a fail occurs. As it's almost guaranteed to start extended, this will make it nearly impossible to fail. The retrying process is silent, and the original list is displayed; players won't know that it failed.