### PR TITLE
Unify log directory on something less verbose

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -71,7 +71,7 @@
 
 	//logs
 	SetupLogs()
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
+	var/date_string = time2text(world.realtime, "YYYY/MM/DD")
 	href_logfile = file("data/logs/[date_string] hrefs.htm")
 	diary = file("data/logs/[date_string].log")
 	diary << "[log_end]\n[log_end]\nStarting up. (ID: [game_id]) [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]"


### PR DESCRIPTION
This brings this at least a little bit more in line with the other "newer" logging configured elsewhere. The files as they are now are annoyingly verbose and ends up causing unnecessary confusion when browsing logs.

![Logs](https://puu.sh/BUi2v/b5a00b86b1.png)