### PR TITLE
Fix various crew manifest issues

### DIFF
--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -38,7 +38,7 @@
 	"}
 	// sort mobs
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
-		var/name = CR.get_name()
+		var/name = CR.get_formal_name()
 		var/rank = CR.get_job()
 		mil_ranks[name] = ""
 
@@ -52,7 +52,8 @@
 		if(OOC)
 			var/active = 0
 			for(var/mob/M in GLOB.player_list)
-				if(M.real_name == name && M.client && M.client.inactivity <= 10 * 60 * 10)
+				var/mob_real_name = M.real_name
+				if(sanitize(mob_real_name) == CR.get_name() && M.client && M.client.inactivity <= 10 MINUTES)
 					active = 1
 					break
 			isactive[name] = active ? "Active" : "Inactive"

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -45,7 +45,8 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 					formal_name = "[culture.get_formal_name_prefix()][formal_name][culture.get_formal_name_suffix()]"
 
 	// Generic record
-	set_name(formal_name)
+	set_name(H ? H.real_name : "Unset")
+	set_formal_name(formal_name)
 	set_job(H ? GetAssignment(H) : "Unset")
 	set_sex(H ? gender2text(H.get_sex()) : "Unset")
 	set_age(H ? H.age : 30)
@@ -165,6 +166,7 @@ KEY.set_access(ACCESS, ACCESS_EDIT || ACCESS || access_bridge)}
 
 // GENERIC RECORDS
 FIELD_SHORT("Name", name, null, access_change_ids)
+FIELD_SHORT("Formal Name", formal_name, null, access_change_ids)
 FIELD_SHORT("Job", job, null, access_change_ids)
 FIELD_LIST("Sex", sex, record_genders(), null, access_change_ids)
 FIELD_NUM("Age", age, null, access_change_ids)


### PR DESCRIPTION
Currently should fix part of #23614 

TODO (things left to fix):
 - [X] Crew members with apostrophes in their names are always marked 'INACTIVE' in the OOC lobby manifest
 - [x] Crew members with doctorates are always marked 'INACTIVE' in the OOC lobby manifest


:cl: SierraKomodo
fix: OOC lobby manifest entries should now show proper Active/Inactive status
add: Crew records now have a separate 'Formal Name' field that contains the MD/PhD/etc suffix. This will be the name displayed on manifests.
/:cl: