### PR TITLE
Fix job slots not opening on cryo

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -168,6 +168,13 @@ var/global/datum/controller/occupations/job_master
 			job.make_position_available()
 			return 1
 		return 0
+	
+	proc/ClearSlot(var/rank) // Removing one from the current filled counter
+		var/datum/job/job = GetJob(rank)
+		if (job && job.current_positions > 0)
+			job.current_positions -= 1
+			return TRUE
+		return FALSE
 
 	proc/FindOccupationCandidates(datum/job/job, level, flag)
 		Debug("Running FOC, Job: [job], Level: [level], Flag: [flag]")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -383,7 +383,7 @@
 	//Handle job slot/tater cleanup.
 	if(occupant.mind)
 		var/job = occupant.mind.assigned_role
-		job_master.FreeRole(job)
+		job_master.ClearSlot(job)
 
 		if(occupant.mind.objectives.len)
 			occupant.mind.objectives = null

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -362,7 +362,7 @@
 	//Handle job slot/tater cleanup.
 	var/job = mind.assigned_role
 
-	job_master.FreeRole(job)
+	job_master.ClearSlot(job)
 
 	if(mind.objectives.len)
 		qdel(mind.objectives)


### PR DESCRIPTION
Solves that issue of job slots not reliably opening back up whenever someone cryos from a multi-slot job role.

:cl: SierraKomodo
fix: Job slots should now open back up properly whenever someone cryos from a multi-slot job
/:cl: