### PR TITLE
Enslaves circuits to the SS

### DIFF
--- a/code/controllers/subsystems/processing/circuit.dm
+++ b/code/controllers/subsystems/processing/circuit.dm
@@ -8,13 +8,16 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 
 	var/cipherkey
 
-	var/list/all_components = list()								// Associative list of [component_name]:[component_path] pairs
-	var/list/cached_components = list()								// Associative list of [component_path]:[component] pairs
-	var/list/all_assemblies = list()								// Associative list of [assembly_name]:[assembly_path] pairs
-	var/list/cached_assemblies = list()								// Associative list of [assembly_path]:[assembly] pairs
-	var/list/all_circuits = list()									// Associative list of [circuit_name]:[circuit_path] pairs
-	var/list/circuit_fabricator_recipe_list = list()				// Associative list of [category_name]:[list_of_circuit_paths] pairs
+	var/list/all_components = list()                 // Associative list of [component_name]:[component_path] pairs
+	var/list/cached_components = list()              // Associative list of [component_path]:[component] pairs
+	var/list/all_assemblies = list()                 // Associative list of [assembly_name]:[assembly_path] pairs
+	var/list/cached_assemblies = list()              // Associative list of [assembly_path]:[assembly] pairs
+	var/list/all_circuits = list()                   // Associative list of [circuit_name]:[circuit_path] pairs
+	var/list/circuit_fabricator_recipe_list = list() // Associative list of [category_name]:[list_of_circuit_paths] pairs
 	var/cost_multiplier = SHEET_MATERIAL_AMOUNT / 10 // Each circuit cost unit is 200cm3
+
+	var/list/queued_components = list()              // Queue of components for activation
+	var/position = 1                                 // Helper index to order newly activated components properly
 
 /datum/controller/subsystem/processing/circuit/Initialize()
 	SScircuit.cipherkey = generateRandomString(2000+rand(0,10))
@@ -59,3 +62,53 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 		/obj/item/weapon/card/data/full_color,
 		/obj/item/weapon/card/data/disk
 		)
+
+/datum/controller/subsystem/processing/circuit/fire(resumed = FALSE)
+	if(!resumed || current_run.len)
+		if((. = ..()))
+			return
+
+	var/list/queued_components = src.queued_components
+	while(length(queued_components))
+		var/list/entry = queued_components[queued_components.len]
+		position = queued_components.len
+		queued_components.len--
+		if(!length(entry))
+			if(MC_TICK_CHECK)
+				break
+			continue
+
+		var/obj/item/integrated_circuit/circuit = entry[1]
+		entry.Cut(1,2)
+		if(QDELETED(circuit))
+			if(MC_TICK_CHECK)
+				break
+			continue
+
+		circuit.check_then_do_work(arglist(entry))
+		if(MC_TICK_CHECK)
+			break
+	position = null
+
+/datum/controller/subsystem/processing/circuit/stat_entry()
+	..(" C:[queued_components.len]")
+
+// Store the entries like this so that components can be queued multiple times at once.
+// With immediate set, will generally imitate the order of the call stack if execution happened directly.
+// With immediate off, you go to the bottom of the pile.
+/datum/controller/subsystem/processing/circuit/proc/queue_component(obj/item/integrated_circuit/circuit, immediate = TRUE)
+	var/list/entry = list(circuit, args.Copy(3))
+	if(!immediate || !position)
+		queued_components.Insert(1, list(entry))
+		if(position)
+			position++
+	else
+		queued_components.Insert(position, list(entry))
+
+/datum/controller/subsystem/processing/circuit/proc/dequeue_component(obj/item/integrated_circuit/circuit)
+	for(var/i = 1, i <= length(queued_components), i++)
+		var/list/entry = queued_components[i]
+		if(length(entry) && entry[1] == circuit)
+			queued_components.Cut(i, i+1)
+			if(position > i)
+				position--

--- a/code/controllers/subsystems/processing/processing.dm
+++ b/code/controllers/subsystems/processing/processing.dm
@@ -13,8 +13,8 @@ SUBSYSTEM_DEF(processing)
 	var/debug_last_thing
 	var/debug_original_process_proc // initial() does not work with procs
 
-/datum/controller/subsystem/processing/stat_entry()
-	..("P:[processing.len]")
+/datum/controller/subsystem/processing/stat_entry(msg)
+	..("P:[processing.len][msg]")
 
 /datum/controller/subsystem/processing/fire(resumed = 0)
 	if (!resumed)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -83,6 +83,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	QDEL_NULL_LIST(inputs)
 	QDEL_NULL_LIST(outputs)
 	QDEL_NULL_LIST(activators)
+	SScircuit.dequeue_component(src)
 	. = ..()
 
 /obj/item/integrated_circuit/emp_act(severity)

--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -137,7 +137,7 @@ D [1]/  ||
 /datum/integrated_io/activate/push_data()
 	for(var/k in 1 to linked.len)
 		var/datum/integrated_io/io = linked[k]
-		io.holder.check_then_do_work(io.ord)
+		SScircuit.queue_component(io.holder, TRUE, io.ord)
 
 /datum/integrated_io/proc/pull_data()
 	for(var/k in 1 to linked.len)


### PR DESCRIPTION
An experiment to assess the performance of circuits. This makes their expensive proc called only from the SS, except possibly if activated by an external event (and even then, the components which would normally be triggered won't be triggered until the next SS tick). It (hopefully) preserves the order of things in situations where that's expected or matters.

The upside is (a) it now checks tick and (b) we'll have concrete numbers about lag. There have been reports that these are laggy, but it's nearly impossible to assess currently. The downside is that they are less responsive now.