### PR TITLE
Fixes punctuation and spacing issues with emotes; auto-formats spoken text.

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -60,36 +60,35 @@
 		if (I.implanted)
 			I.trigger(act, src)
 
-/mob/proc/format_emote(var/source = null, var/message = null)
+/mob/proc/format_emote(var/emoter = null, var/message = null)
 	var/pretext
 	var/subtext
 	var/nametext
 	var/end_char
 	var/start_char
 	var/name_anchor
+	var/anchor_char = get_prefix_key(/decl/prefix/visible_emote)
 
-	if(!message || !source)
+	if(!message || !emoter)
 		return
 
-	// Store the player's name in a nice bold, naturalement
-	nametext = "<B>[source]</B>"
+	message = html_decode(message)
 
-	name_anchor = findtext(message, "^")
-	if(name_anchor > 0) // User supplied emote with a carat
+	name_anchor = findtext(message, anchor_char)
+	if(name_anchor > 0) // User supplied emote with visible_emote token (default ^)
 		pretext = copytext(message, 1, name_anchor)
 		subtext = copytext(message, name_anchor + 1, lentext(message) + 1)
 	else
-		// No carat. Just the emote as usual.
+		// No token. Just the emote as usual.
 		subtext = message
 
-	// Oh shit, we got this far! Let's see... did the user attempt to use more than one carat?
-	if(findtext(subtext, "^"))
+	// Oh shit, we got this far! Let's see... did the user attempt to use more than one token?
+	if(findtext(subtext, anchor_char))
 		// abort abort!
-		return 0
+		to_chat(emoter, "<span class='warning'>You may use only one \"[anchor_char]\" symbol in your emote.</span>")
+		return
 
-	// Auto-capitalize our pretext if there is any.
 	if(pretext)
-		pretext = capitalize(pretext)
 		// Add a space at the end if we didn't already supply one.
 		end_char = copytext(pretext, lentext(pretext), lentext(pretext) + 1)
 		if(end_char != " ")
@@ -97,17 +96,24 @@
 
 	// Grab the last character of the emote message.
 	end_char = copytext(subtext, lentext(subtext), lentext(subtext) + 1)
-	if(end_char != "." && end_char != "?" && end_char != "!" && end_char != "\"")
+	if(!(end_char in list(".", "?", "!", "\"", "-", "~"))) // gotta include ~ for all you fucking weebs
 		// No punctuation supplied. Tack a period on the end.
 		subtext += "."
 
-	// Add a space to the subtext, unless it begins with an apostrophe or comma... or a space.
+	// Add a space to the subtext, unless it begins with an apostrophe or comma.
 	if(subtext != ".")
+		// First, let's get rid of any existing space, to account for sloppy emoters ("X, ^ , Y")
+		subtext = trim_left(subtext)
 		start_char = copytext(subtext, 1, 2)
-		if(start_char != "," && start_char != " " && start_char != "&") // Apostrophes are parsed as "&#039;", so uhh, yeah.
+		if(start_char != "," && start_char != "'")
 			subtext = " " + subtext
 
-	return pretext + nametext + subtext
+	pretext = html_encode(pretext)
+	nametext = html_encode(nametext)
+	subtext = html_encode(subtext)
+	// Store the player's name in a nice bold, naturalement
+	nametext = "<B>[emoter]</B>"
+	return capitalize(pretext + nametext + subtext)
 
 /mob/proc/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message = null)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -140,6 +140,18 @@ proc/get_radio_key_from_channel(var/channel)
 		return "asks"
 	return verb
 
+/mob/living/proc/format_say_message(var/message = null)
+	if(!message)
+		return
+
+	message = html_decode(message)
+
+	var/end_char = copytext(message, lentext(message), lentext(message) + 1)
+	if(!(end_char in list(".", "?", "!", "-", "~")))
+		message += "."
+
+	return html_encode(capitalize(message))
+
 /mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", whispering)
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
@@ -192,8 +204,8 @@ proc/get_radio_key_from_channel(var/channel)
 			verb = say_quote(message, speaking)
 
 	message = trim_left(message)
-
 	message = handle_autohiss(message, speaking)
+	message = format_say_message(message)
 
 	if(!(speaking && (speaking.flags & NO_STUTTER)))
 		var/list/message_data = list(message, verb, 0)


### PR DESCRIPTION
🆑 Earthcrusher
fix: Emotes ending in quotation marks will no longer add a superfluous period on the end.
fix: Lazy typists rejoice! When speaking, the game will automatically capitalize and add punctuation where needed. Well at least on the end of the sentence.
tweak: Emotes now use the visible emote character set in your Character Setup, which defaults to "^".
/ 🆑 

Fixed a small issue with my formatted emote code, where if you ended an emote with a quote (`me angrily snarls, "Get outta here!"`), it would add a period on the end. (Bob angrily snarls, "Get outta here!".)

Also tweaked a bit of saycode (holy shit saycode is gross) so that people look less like dumbasses if they type lazily. `say blah blah` will produce "Blah blah."