### PR TITLE
Rebalances synthetic humans.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -29,12 +29,7 @@
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(organ_name)
-			if(!E || E.is_stump())
-				tally += 4
-			else if(E.splinted)
-				tally += 0.5
-			else if(E.status & ORGAN_BROKEN)
-				tally += 1.5
+			tally += E ? E.movement_delay(4) : 4
 	else
 		var/total_item_slowdown = -1
 		for(var/slot = slot_first to slot_last)
@@ -56,12 +51,7 @@
 
 		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/E = get_organ(organ_name)
-			if(!E || E.is_stump())
-				tally += 4
-			else if(E.splinted)
-				tally += 0.5
-			else if(E.status & ORGAN_BROKEN)
-				tally += 1.5
+			tally += E ? E.movement_delay(4) : 4
 
 	if(shock_stage >= 10) tally += 3
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -154,13 +154,13 @@
 	var/burn_damage = 0
 	switch (severity)
 		if (1)
-			burn_damage = 15
+			burn_damage = 30
 		if (2)
-			burn_damage = 7
+			burn_damage = 15
 		if (3)
-			burn_damage = 3
+			burn_damage = 7.5
 
-	var/mult = BP_IS_ROBOTIC(src) + BP_IS_ASSISTED(src)
+	var/mult = 1 + !!(BP_IS_ASSISTED(src)) // This macro returns (large) bitflags.
 	burn_damage *= mult/species.burn_mod //ignore burn mod for EMP damage
 
 	var/power = 4 - severity //stupid reverse severity
@@ -1493,6 +1493,17 @@ obj/item/organ/external/proc/remove_clamps()
 	W.damage += damage
 	W.time_inflicted = world.time
 
-
 /obj/item/organ/external/proc/has_genitals()
 	return !BP_IS_ROBOTIC(src) && species && species.sexybits_location == organ_tag
+
+// Added to the mob's move delay tally if this organ is being used to move with.
+obj/item/organ/external/proc/movement_delay(max_delay)
+	. = 0
+	if(is_stump())
+		. += max_delay
+	else if(splinted)
+		. += max_delay/8
+	else if(status & ORGAN_BROKEN)
+		. += max_delay * 3/8
+	else if(BP_IS_ROBOTIC(src))
+		. += max_delay * CLAMP01(damage/max_damage)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -65,7 +65,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	if(internal_organs && internal_organs.len)
 		var/damage_amt = brute
 		var/cur_damage = brute_dam
-		if(laser)
+		if(laser || BP_IS_ROBOTIC(src))
 			damage_amt += burn
 			cur_damage += burn_dam
 		var/organ_damage_threshold = 10

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -37,6 +37,10 @@
 		cell.use(amount)
 		return 1
 
+/obj/item/organ/internal/cell/proc/get_servo_cost()
+	var/damage_factor = 1 + 10 * damage/max_damage
+	return servo_cost * damage_factor
+
 /obj/item/organ/internal/cell/Process()
 	..()
 	if(!owner)
@@ -46,19 +50,13 @@
 	if(!is_usable())
 		owner.Paralyse(3)
 		return
-	var/standing = !owner.lying && !owner.buckled //on the edge
-	var/drop
-	if(!check_charge(servo_cost)) //standing is pain
-		drop = 1
-	else if(standing)
-		use(servo_cost)
-		if(world.time - owner.l_move_time < 15) //so is
-			if(!use(servo_cost))
-				drop = 1
-	if(drop)
-		if(standing)
+	var/cost = get_servo_cost()
+	if(world.time - owner.l_move_time < 15)
+		cost *= 2
+	if(!use(cost))
+		if(!owner.lying && !owner.buckled)
 			to_chat(owner, "<span class='warning'>You don't have enough energy to function!</span>")
-		owner.Weaken(2)
+		owner.Paralyse(3)
 
 /obj/item/organ/internal/cell/emp_act(severity)
 	..()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -212,6 +212,8 @@ var/list/organ_cache = list()
 			mechassist()
 		else if(status == "mechanical")
 			robotize()
+	if(species)
+		species.post_organ_rejuvenate(src, owner)
 
 //Germs
 /obj/item/organ/proc/handle_antibiotics()


### PR DESCRIPTION
:cl:
balance: EMPs now deal much less damage to synthetic humans (FBP, IPC), though the amount is still considerable.
balance: Damaged robotic legs and feet reduce movement speed.
balance: Robotic external organs will, if heavily damaged or the damage taken is large, pass burn damage to contained internal organs.
tweak: Cell organs are dramatically less power-efficient if damaged.
tweak: If a synthetic human runs out of juice, they become unconscious.
/:cl:

Also makes rejuv work properly with IPC internal organs.

The emp was previously dealing 2048 damage (you can read the diff to discover why). With this change, emping a synthetic will force them to crawl most of the time, and dramatically slow them down even if they don't crawl. Subsequent emps might destroy limbs, and after three they should be out of power and unconscious.