### PR TITLE
Allows cancelling of Skrell holobadge SDTF prompt

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -203,12 +203,31 @@
 		return
 	desc = "Blood type: [H.b_type]"
 	
-/obj/item/clothing/accessory/badge/tags/skrell/verb/set_sdtf(mob/user as mob)
+/obj/item/clothing/accessory/badge/tags/skrell/verb/set_sdtf()
 	set name = "Set SDTF Name"
 	set category = "Object"
-	desc = "Set your SDTF origin!"
+	set src in usr
+	
+	if(usr.incapacitated())
+		to_chat(usr, "<span class='warning'>You're unable to do that.</span>")
+		return
+	
+	var/obj/item/in_hand = usr.get_active_hand()
+	if(in_hand != src)
+		to_chat(usr, "<span class='warning'>You have to be holding [src] to modify it.</span>")
+		return
 	
 	badge_string = sanitize(input(usr, "Input your SDTF.", "SDTF Holobadge") as null|text, MAX_NAME_LEN)
-	set_name(user.real_name)
-	set_desc(user)
-	verbs -= /obj/item/clothing/accessory/badge/tags/skrell/verb/set_sdtf
+	
+	if(usr.incapacitated())	//Because things can happen while you're typing
+		to_chat(usr, "<span class='warning'>You're unable to do that.</span>")
+		return
+	in_hand = usr.get_active_hand()
+	if(in_hand != src)
+		to_chat(usr, "<span class='warning'>You have to be holding [src] to modify it.</span>")
+		return
+		
+	if(badge_string)
+		set_name(usr.real_name)
+		set_desc(usr)
+		verbs -= /obj/item/clothing/accessory/badge/tags/skrell/verb/set_sdtf


### PR DESCRIPTION
Whoops.

:cl:
fix: Cancelling SDTF naming for Skrell badges no longer blocks setting in the future.
/:cl: