### PR TITLE
Adds access_solgov_crew and access_eva to Prospector

### DIFF
--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -124,7 +124,7 @@
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 
 	access = list(access_mining, access_mining_office, access_mining_station,
-						access_expedition_shuttle, access_guppy, access_hangar, access_guppy_helm)
+						access_expedition_shuttle, access_guppy, access_hangar, access_guppy_helm, access_solgov_crew, access_eva)
 	minimal_access = list()
 	required_education = EDUCATION_TIER_DROPOUT
 	maximum_education = EDUCATION_TIER_TRADE


### PR DESCRIPTION
:cl:
rscadd: Prospectors were given EVA and SolGov crew access.
/:cl:

SolGov access: They lack SolGov access, something that all contractors have.
EVA access: They lack access to suit coolers (FBP, IPC), shortwave radios, and it has a mining suit cycler by default.