### PR TITLE
Fixes improper capitalization from audible (!) emotes.

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -108,12 +108,12 @@
 		if(start_char != "," && start_char != "'")
 			subtext = " " + subtext
 
-	pretext = html_encode(pretext)
+	pretext = capitalize(html_encode(pretext))
 	nametext = html_encode(nametext)
 	subtext = html_encode(subtext)
 	// Store the player's name in a nice bold, naturalement
 	nametext = "<B>[emoter]</B>"
-	return capitalize(pretext + nametext + subtext)
+	return pretext + nametext + subtext
 
 /mob/proc/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message = null)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -150,7 +150,7 @@ proc/get_radio_key_from_channel(var/channel)
 	if(!(end_char in list(".", "?", "!", "-", "~")))
 		message += "."
 
-	return html_encode(capitalize(message))
+	return html_encode(message)
 
 /mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", whispering)
 	if(client)


### PR DESCRIPTION
oops! turns out the order of functions is important! I also removed capitalization from says entirely, since it occurred to me that they've always been automatically capitalized.

![image](https://user-images.githubusercontent.com/8765210/48178496-7f87f100-e2df-11e8-8970-e3df9bc5efc3.png)
