### PR TITLE
Attempted fix for wall overlays runtimes.

### DIFF
--- a/code/game/gamemodes/cult/cultify/mob.dm
+++ b/code/game/gamemodes/cult/cultify/mob.dm
@@ -10,7 +10,7 @@
 	if(icon_state != "ghost-narsie")
 		icon = 'icons/mob/mob.dmi'
 		icon_state = "ghost-narsie"
-		overlays = 0
+		overlays.Cut()
 		set_invisibility(0)
 		to_chat(src, "<span class='sinister'>Even as a non-corporal being, you can feel Nar-Sie's presence altering you. You are now visible to everyone.</span>")
 
@@ -24,7 +24,7 @@
 		var/mob/observer/ghost/G = (ghostize())
 		G.icon = 'icons/mob/mob.dmi'
 		G.icon_state = "ghost-narsie"
-		G.overlays = 0
+		G.overlays.Cut()
 		G.set_invisibility(0)
 		to_chat(G, "<span class='sinister'>You feel relieved as what's left of your soul finally escapes its prison of flesh.</span>")
 	else

--- a/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
@@ -19,7 +19,7 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/singularity/narsie/large/exit/on_update_icon()
-	overlays = 0
+	overlays.Cut()
 
 /obj/singularity/narsie/large/exit/Process()
 	for(var/mob/M in GLOB.player_list)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -147,7 +147,7 @@ update_flag
 */
 
 	if (src.destroyed)
-		src.overlays = 0
+		overlays.Cut()
 		src.icon_state = text("[]-1", src.canister_color)
 		return
 
@@ -157,7 +157,7 @@ update_flag
 	if(check_change()) //Returns 1 if no change needed to icons.
 		return
 
-	src.overlays = 0
+	overlays.Cut()
 
 	if(update_flag & 1)
 		overlays += "can-open"

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -29,7 +29,7 @@
 	src.air_contents.adjust_multi("oxygen", air_mix["oxygen"], "nitrogen", air_mix["nitrogen"])
 
 /obj/machinery/portable_atmospherics/powered/pump/on_update_icon()
-	src.overlays = 0
+	overlays.Cut()
 
 	if(on && cell && cell.charge)
 		icon_state = "psiphon:1"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -44,7 +44,7 @@
 	..(severity)
 
 /obj/machinery/portable_atmospherics/powered/scrubber/on_update_icon()
-	src.overlays = 0
+	overlays.Cut()
 
 	if(on && cell && cell.charge)
 		icon_state = "pscrubber:1"
@@ -179,7 +179,7 @@
 		to_chat(usr, "<span class='notice'>You can't directly interact with this machine. Use the scrubber control console.</span>")
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/on_update_icon()
-	src.overlays = 0
+	overlays.Cut()
 
 	if(on && !(stat & (NOPOWER|BROKEN)))
 		icon_state = "scrubber:1"

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -118,7 +118,7 @@
 		if(unlocked)
 			if(open)
 				open = 0
-				overlays = null
+				overlays.Cut()
 				to_chat(user, "You crowbar the battery panel in place.")
 			else
 				if(unlocked)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -131,7 +131,7 @@
 
 /obj/item/device/transfer_valve/on_update_icon()
 	overlays.Cut()
-	underlays = null
+	underlays.Cut()
 
 	if(!tank_one && !tank_two && !attached_device)
 		icon_state = "valve_1"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -104,7 +104,7 @@
 					src.l_set = 1
 				else if ((src.code == src.l_code) && (src.emagged == 0) && (src.l_set == 1))
 					src.locked = 0
-					src.overlays = null
+					overlays.Cut()
 					overlays += image('icons/obj/storage.dmi', icon_opened)
 					src.code = null
 				else
@@ -112,7 +112,7 @@
 			else
 				if ((href_list["type"] == "R") && (src.emagged == 0) && (!src.l_setshort))
 					src.locked = 1
-					src.overlays = null
+					overlays.Cut()
 					src.code = null
 					src.close(usr)
 				else
@@ -130,7 +130,7 @@
 		emagged = 1
 		src.overlays += image('icons/obj/storage.dmi', icon_sparking)
 		sleep(6)
-		src.overlays = null
+		overlays.Cut()
 		overlays += image('icons/obj/storage.dmi', icon_locking)
 		locked = 0
 		to_chat(user, (feedback ? feedback : "You short out the lock of \the [src]."))

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -122,7 +122,6 @@
 	stuck.forceMove(get_turf(src))
 	user.put_in_hands(stuck)
 	stuck = null
-	overlays = null
 	qdel(src)
 
 /obj/item/weapon/ducttape/afterattack(var/A, mob/user, flag, params)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -149,7 +149,7 @@
 
 
 /obj/structure/janitorialcart/on_update_icon()
-	overlays = null
+	overlays.Cut()
 	if(mybag)
 		overlays += "cart_garbage"
 	if(mymop)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -76,21 +76,17 @@
 	return
 
 /obj/structure/lattice/proc/updateOverlays()
-	//if(!(istype(src.loc, /turf/space)))
-	//	qdel(src)
-	spawn(1)
-		overlays = list()
+	overlays.Cut()
 
-		var/dir_sum = 0
+	var/dir_sum = 0
 
-		var/turf/T
-		for (var/direction in GLOB.cardinal)
-			T = get_step(src, direction)
-			if(locate(/obj/structure/lattice, T) || locate(/obj/structure/catwalk, T))
+	var/turf/T
+	for (var/direction in GLOB.cardinal)
+		T = get_step(src, direction)
+		if(locate(/obj/structure/lattice, T) || locate(/obj/structure/catwalk, T))
+			dir_sum += direction
+		else
+			if(!(istype(get_step(src, direction), /turf/space)) && !(istype(get_step(src, direction), /turf/simulated/open)))
 				dir_sum += direction
-			else
-				if(!(istype(get_step(src, direction), /turf/space)) && !(istype(get_step(src, direction), /turf/simulated/open)))
-					dir_sum += direction
 
-		icon_state = "lattice[dir_sum]"
-		return
+	icon_state = "lattice[dir_sum]"

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -16,7 +16,7 @@
 
 /obj/structure/bed/chair/wheelchair/set_dir()
 	..()
-	overlays = null
+	overlays.Cut()
 	var/image/O = image(icon = 'icons/obj/furniture.dmi', icon_state = "w_overlay", dir = src.dir)
 	O.plane = ABOVE_HUMAN_PLANE
 	O.layer = ABOVE_HUMAN_LAYER

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -72,7 +72,7 @@
 	//TODO:  Change death state to health_dead for all these icon files.  This is a stop gap.
 
 	if(healths)
-		healths.overlays = null // This is specific to humans but the relevant code is here; shouldn't mess with other mobs.
+		healths.overlays.Cut() // This is specific to humans but the relevant code is here; shouldn't mess with other mobs.
 		if("health7" in icon_states(healths.icon))
 			healths.icon_state = "health7"
 		else

--- a/code/modules/mob/living/carbon/alien/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/update_icons.dm
@@ -1,3 +1,3 @@
 /mob/living/carbon/alien/regenerate_icons()
-	overlays = list()
+	overlays.Cut()
 	update_icons()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -709,13 +709,12 @@
 			clear_fullscreen("brute")
 
 		if(healths)
+			healths.overlays.Cut()
 			if (chem_effects[CE_PAINKILLER] > 100)
-				healths.overlays.Cut()
 				healths.icon_state = "health_numb"
 			else
 				// Generate a by-limb health display.
 				healths.icon_state = "blank"
-				healths.overlays = null
 
 				var/no_damage = 1
 				var/trauma_val = 0 // Used in calculating softcrit/hardcrit indicators.

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -246,7 +246,7 @@
 			dropspot = target.loc
 
 
-		overlays = null
+		overlays.Cut()
 
 		var droppedSomething = 0
 

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -211,7 +211,7 @@
 	var/obj/item/weapon/paper/P = pages[1]
 	icon_state = P.icon_state
 	overlays = P.overlays
-	underlays = 0
+	underlays.Cut()
 	var/i = 0
 	var/photo
 	for(var/obj/O in src)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -348,12 +348,12 @@
 
 	if(!(update_state & UPDATE_ALLGOOD))
 		if(overlays.len)
-			overlays = 0
+			overlays.Cut()
 			return
 
 	if(update & 2)
 		if(overlays.len)
-			overlays.len = 0
+			overlays.Cut()
 		if(!(stat & (BROKEN|MAINT)) && update_state & UPDATE_ALLGOOD)
 			overlays += status_overlays_lock[locked+1]
 			overlays += status_overlays_charging[charging+1]

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -200,7 +200,7 @@
 	. = ..()
 
 /obj/machinery/light/on_update_icon(var/trigger = 1)
-	overlays = overlays.Cut()
+	overlays.Cut()
 	icon_state = "[base_state]_empty" //Never use the initial state. That'll just reset it to the mapping icon.
 	pixel_y = 0
 	pixel_x = 0

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -135,9 +135,9 @@
 			dissipate_delay = 10
 			dissipate_track = 0
 			dissipate_strength = 1
-			overlays = 0
+			overlays.Cut()
 			if(chained)
-				overlays = "chain_s1"
+				overlays = list("chain_s1")
 			visible_message("<span class='notice'>The singularity has shrunk to a rather pitiful size.</span>")
 		if (STAGE_TWO) //1 to 3 does not check for the turfs if you put the gens right next to a 1x1 then its going to eat them.
 			SetName("gravitational singularity")
@@ -152,9 +152,9 @@
 			dissipate_delay = 5
 			dissipate_track = 0
 			dissipate_strength = 5
-			overlays = 0
+			overlays.Cut()
 			if(chained)
-				overlays = "chain_s3"
+				overlays = list("chain_s3")
 			if(growing)
 				visible_message("<span class='notice'>The singularity noticeably grows in size.</span>")
 			else
@@ -173,9 +173,9 @@
 				dissipate_delay = 4
 				dissipate_track = 0
 				dissipate_strength = 20
-				overlays = 0
+				overlays.Cut()
 				if(chained)
-					overlays = "chain_s5"
+					overlays = list("chain_s5")
 				if(growing)
 					visible_message("<span class='notice'>The singularity expands to a reasonable size.</span>")
 				else
@@ -194,9 +194,9 @@
 				dissipate_delay = 10
 				dissipate_track = 0
 				dissipate_strength = 10
-				overlays = 0
+				overlays.Cut()
 				if(chained)
-					overlays = "chain_s7"
+					overlays = list("chain_s7")
 				if(growing)
 					visible_message("<span class='warning'>The singularity expands to a dangerous size.</span>")
 				else
@@ -212,9 +212,9 @@
 			grav_pull = 10
 			consume_range = 4
 			dissipate = 0 //It cant go smaller due to e loss.
-			overlays = 0
+			overlays.Cut()
 			if(chained)
-				overlays = "chain_s9"
+				overlays = list("chain_s9")
 			if(growing)
 				visible_message("<span class='danger'><font size='2'>The singularity has grown out of control!</font></span>")
 			else
@@ -232,7 +232,7 @@
 			dissipate = 0 //It cant go smaller due to e loss
 			event_chance = 25 //Events will fire off more often.
 			if(chained)
-				overlays = "chain_s9"
+				overlays = list("chain_s9")
 			visible_message("<span class='sinister'><font size='3'>You witness the creation of a destructive force that cannot possibly be stopped by human hands.</font></span>")
 
 	if (current_size == allowed_size)
@@ -463,7 +463,7 @@
 
 /obj/singularity/proc/on_capture()
 	chained = 1
-	overlays = 0
+	overlays.Cut()
 	move_self = 0
 	switch (current_size)
 		if(1)
@@ -479,7 +479,7 @@
 
 /obj/singularity/proc/on_release()
 	chained = 0
-	overlays = 0
+	overlays.Cut()
 	move_self = 1
 
 /obj/singularity/singularity_act(S, size)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2593,7 +2593,7 @@
 
 /obj/item/pizzabox/on_update_icon()
 
-	overlays = list()
+	overlays.Cut()
 
 	// Set appropriate description
 	if( open && pizza )

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -163,7 +163,7 @@
 			usr.visible_message("<span class='notice'>\The [usr] detaches \the [rig] from \the [src].</span>", "<span class='notice'>You detach [rig] from \the [src]</span>")
 			rig.loc = get_turf(usr)
 			rig = null
-			overlays = new/list()
+			overlays.Cut()
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -73,7 +73,7 @@
 	return
 
 /obj/structure/bigDelivery/on_update_icon()
-	overlays = new()
+	overlays.Cut()
 	if(nameset || examtext)
 		var/image/I = new/image('icons/obj/storage.dmi',"delivery_label")
 		if(icon_state == "deliverycloset")
@@ -199,7 +199,7 @@
 	return
 
 /obj/item/smallDelivery/on_update_icon()
-	overlays = new()
+	overlays.Cut()
 	if((nameset || examtext) && icon_state != "deliverycrate1")
 		var/image/I = new/image('icons/obj/storage.dmi',"delivery_label")
 		if(icon_state == "deliverycrate5")

--- a/code/modules/xenoarcheaology/tools/artifact_analyser.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_analyser.dm
@@ -76,7 +76,7 @@
 		P.info += "<br>"
 		P.info += "\icon[scanned_object] [results]"
 		P.stamped = list(/obj/item/weapon/stamp)
-		P.overlays = list("paper_stamped")
+		P.queue_icon_update()
 
 		if(scanned_object && istype(scanned_object, /obj/machinery/artifact))
 			var/obj/machinery/artifact/A = scanned_object

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -268,7 +268,7 @@
 		var/obj/item/weapon/paper/P = new(src)
 		P.SetName("[src] report #[++report_num]: [scanned_item.name]")
 		P.stamped = list(/obj/item/weapon/stamp)
-		P.overlays = list("paper_stamped")
+		P.queue_icon_update()
 
 		//work out data
 		var/data = " - Mundane object: [scanned_item.desc ? scanned_item.desc : "No information on record."]<br>"


### PR DESCRIPTION
Not getting the runtimes anymore; ran init about 20 times. I think it's worth trying at this point.

If it works, I guess the moral is to not do questionable overlays/underlays ops and instead just `Cut()` them like a normal person. These wall subtypes pick up overlays and underlays from arbitrary objs beneath them, and are (conjecturally) inheriting some bad stuff that way; perhaps nulling overlays or setting it to 0 is no longer tolerated on 512 in all cases.

Anyway, shouldn't hurt.

Closes #23702
Closes #23561
Closes #23411