### PR TITLE
Implements assembly destruction

### DIFF
--- a/html/changelogs/TheWelp - circuitDamage.yml
+++ b/html/changelogs/TheWelp - circuitDamage.yml
@@ -1,0 +1,4 @@
+author: TheWelp
+delete-after: True
+changes: 
+  - rscadd: "Adds ability to destroy circuit assemblies via damage. Bigger assemblies means more health. Can be healed with wire."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
You can now destroy assemblies by bashing them or shooting them. Cheers!