### PR TITLE
Rebalances blob resistance values

### DIFF
--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -19,7 +19,7 @@
 	var/regen_rate = 5
 	var/brute_resist = 4
 	var/fire_resist = 1
-	var/laser_resist = 4	// Special resist for laser based weapons - Emitters or handheld energy weaponry. Damage is divided by this and THEN by fire_resist.
+	var/laser_resist = 2	// Special resist for laser based weapons - Emitters or handheld energy weaponry. Damage is divided by this and THEN by fire_resist.
 	var/expandType = /obj/effect/blob
 	var/secondary_core_growth_chance = 5 //% chance to grow a secondary blob core instead of whatever was suposed to grown. Secondary cores are considerably weaker, but still nasty.
 
@@ -165,9 +165,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_core"
 	maxHealth = 200
-	brute_resist = 2
-	fire_resist = 2
-	laser_resist = 8
+	brute_resist = 1
+	fire_resist = 4
 	regen_rate = 2
 
 	layer = BLOB_CORE_LAYER
@@ -213,9 +212,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_node"
 	maxHealth = 100
-	brute_resist = 1
-	fire_resist = 1
-	laser_resist = 5
 	regen_rate = 1
 	growth_range = 3
 
@@ -230,9 +226,7 @@
 	icon_state = "blob_idle"
 	desc = "Some blob creature thingy."
 	maxHealth = 60
-	brute_resist = 1
-	fire_resist = 2
-	laser_resist = 6
+
 /obj/effect/blob/shield/New()
 	..()
 	update_nearby_tiles()


### PR DESCRIPTION
Summary:
 - Blob and strong blob is strong against brute, weak
 against fire
 - Blob cores are strong against fire, weak against brute
 - Laser weapons deal half base damage on top of the above resistances, while being more useful than they currently are against blobs.

The intent of this is to re-balance blob resistance values to make various weapons more feasible, and to make laser weapons (This includes emitters) actually decently effective against them again.

The fireaxe still holds its place as the best all-round weapon against blobs.

Fighting the standard blob and strong blob will be more effective with lasers and welders, while cores are best taken down with brute weapons. This _looked_ like it was the original intent with current values, but they were skewed in such that you had weird side effects, such as a strong blob feeling weaker than regular blobs, or a main blob core being very difficult to kill without a fireaxe.

Blob health was untouched, and is now used to determine the overall 'strength' of the blob, with resistance values used solely to determine what weapons are stronger against the types of blobs.

I'm open to suggestions for any further balance tweaks to blobs

## Theoretical resist values, computed damage, and hits-to-kill before these changes:
![blobbalance_before](https://user-images.githubusercontent.com/11140088/48373092-9a5abc80-e675-11e8-99c4-708a6f81a5ce.png)

## After these changes:
![blobbalance_after](https://user-images.githubusercontent.com/11140088/48373096-9dee4380-e675-11e8-9d3d-52bfdb32da68.png)

:cl: SierraKomodo
tweak: Blob resistance has been rebalanced. Brute-based weapons (Crowbars, fireaxes) are more effective against cores, while fire-based weapons (Welders, lasers*) are more effective against blob and strong blob. *Laser rifles take a 1/2 damage penalty against all blob targets. See https://github.com/Baystation12/Baystation12/pull/23774 for specific numbers.
/:cl:
