### PR TITLE
Add helm access flags to overmap shuttle APCs

### DIFF
--- a/maps/torch/machinery/apc_shuttle.dm
+++ b/maps/torch/machinery/apc_shuttle.dm
@@ -1,0 +1,25 @@
+/obj/machinery/power/apc/shuttle
+	req_access = list()
+	req_one_access = list(access_engine_equip)
+
+/obj/machinery/power/apc/high/shuttle
+	req_access = list()
+	req_one_access = list(access_engine_equip)
+
+/obj/machinery/power/apc/hyper/shuttle
+	req_access = list()
+	req_one_access = list(access_engine_equip)
+
+
+/obj/machinery/power/apc/shuttle/charon
+	req_one_access = list(access_engine_equip, access_expedition_shuttle_helm)
+
+/obj/machinery/power/apc/high/shuttle/charon
+	req_one_access = list(access_engine_equip, access_expedition_shuttle_helm)
+
+
+/obj/machinery/power/apc/shuttle/aquila
+	req_one_access = list(access_engine_equip, access_aquila_helm)
+
+/obj/machinery/power/apc/hyper/shuttle/aquila
+	req_one_access = list(access_engine_equip, access_aquila_helm)

--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -453,12 +453,10 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/charon{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(11)
+	pixel_y = 24
 	},
 /obj/structure/bed/chair/shuttle/blue,
 /turf/simulated/floor/tiled,
@@ -902,10 +900,8 @@
 /obj/machinery/light,
 /obj/structure/cable/cyan,
 /obj/machinery/hologram/holopad/longrange,
-/obj/machinery/power/apc{
-	dir = 2;
+/obj/machinery/power/apc/shuttle/charon{
 	name = "south bump";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1707,7 +1703,7 @@
 /obj/item/weapon/material/hatchet,
 /obj/item/weapon/storage/box/glowsticks,
 /obj/item/weapon/material/hatchet,
-/obj/machinery/power/apc/high{
+/obj/machinery/power/apc/high/shuttle/charon{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
@@ -2228,10 +2224,8 @@
 	icon_state = "handrail";
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 2;
+/obj/machinery/power/apc/shuttle/charon{
 	name = "south bump";
-	operating = 1;
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -2342,10 +2336,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/handrai,
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/charon{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/catwalk,
@@ -2814,10 +2807,8 @@
 "fP" = (
 /obj/machinery/floodlight,
 /obj/structure/cable/cyan,
-/obj/machinery/power/apc{
-	dir = 2;
+/obj/machinery/power/apc/shuttle/charon{
 	name = "south bump";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/catwalk,

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -2681,7 +2681,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/random/toolbox,
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/aquila{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
@@ -3310,10 +3310,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
 "hO" = (
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/aquila{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/cyan{
@@ -4015,7 +4014,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
 "jl" = (
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/aquila{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
@@ -4351,10 +4350,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/power/apc{
-	dir = 2;
+/obj/machinery/power/apc/shuttle/aquila{
 	name = "south bump";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
@@ -7956,7 +7953,7 @@
 	c_tag = "Aquila - Storage";
 	dir = 1
 	},
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/aquila{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
@@ -8557,7 +8554,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/aquila{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
@@ -8865,10 +8862,9 @@
 	pixel_x = 21
 	},
 /obj/structure/handrai,
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/shuttle/aquila{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/cyan{
@@ -12620,10 +12616,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 2;
+/obj/machinery/power/apc/shuttle/aquila{
 	name = "south bump";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
@@ -15842,7 +15836,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/power/apc/hyper{
+/obj/machinery/power/apc/hyper/shuttle/aquila{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -54,6 +54,7 @@
 	#include "job/service_jobs.dm"
 	#include "job/supply_jobs.dm"
 
+	#include "machinery/apc_shuttle.dm"
 	#include "machinery/keycard authentication.dm"
 	#include "machinery/suit_storage.dm"
 


### PR DESCRIPTION
As requested on the forums: https://forums.baystation12.net/threads/allow-the-shuttle-pilot-to-access-the-charons-guppys-apcs.7207

Aquila and Charon APCs are now unlockable by anyone with helm access to the respective shuttles, alongside the usual engineering access flags. This translates to the following getting APC access added:

Charon APC Access:
 - Bridge Officer
 - Shuttle Pilot
 - Pathfinder

Aquila APC Access:
 - Bridge Officer

:cl: SierraKomodo
tweak: Charon and Aquila APCs now include helm access flags, meaning anyone who can access the shuttle's helm can also unlock the shuttle's APCs. Engineers still have APC access as well.
/:cl: