### PR TITLE
Removes the autopilot function completely

### DIFF
--- a/code/modules/overmap/README.dm
+++ b/code/modules/overmap/README.dm
@@ -49,7 +49,6 @@ restricted_waypoints is list of 'shuttle name = list(landmark_tags)' pairs for w
 /obj/machinery/computer/ship/helm
 ### WHAT IT DOES
 Lets you steer ship around on overmap.
-Lets you use autopilot.
 ### HOW TO USE
 Just place it anywhere on the ship.
 

--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -81,36 +81,6 @@
 	</div>
 </div>
 
-<div class='item'>
-	<div class="itemLabel">
-		<h3>Autopilot</h3>
-	</div>
-	<div class="itemContent" style="padding-top: 10px;">
-		{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
-	</div>
-</div> 
-<div class='block'>
-	<div class='item'>
-		<div style="float:left;width:45%">
-			<span class='white'>Target coordinates:</span>
-		</div>
-		<div style="float:left;width:20%">
-			{{if data.dest}}
-				{{:helper.link(data.d_x, null, { 'setx' : 1 }, null, null)}} {{:helper.link(data.d_y, null, { 'sety' : 1 }, null, null)}}
-			{{else}}
-				{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
-			{{/if}}
-		</div>
-	</div> 
-	<div class='item'>
-		<div style="float:left;width:45%">
-			<span class='white'>Maximum speed:</span>
-		</div>
-		<div style="float:left;width:20%">
-			{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}}
-		</div>
-	</div> 
-</div>
 
 <h3>Navigation data</h3>
 <div class='item'>
@@ -126,7 +96,6 @@
 				<span class='white'>{{:value.x}} : {{:value.y}}</span>
 		  </div>
 		  <div class='item'>
-			{{:helper.link('Plot course', 'arrowreturnthick-1-e', { 'x' : value.x, 'y' : value.y }, null, null)}}
 			{{:helper.link('Remove entry', 'close', { 'remove' : value.reference }, null, null)}}
 		  </div>
 		{{/for}}


### PR DESCRIPTION
🆑Roland410:
:rscdel:Removes the autopilot function completely.
/🆑
This function while good in theory, has been implemented in a way that only allows the ship to go straight to the set coordinates not paying any attention to obstacles in the way.
It often was a tool for griefing or bad antag gimmicks, but also resulted in a lot of new players thinking it was good then causing a lot of damage with it.