### PR TITLE
Makes construction skill relevant

### DIFF
--- a/code/modules/materials/definitions/materials_glass.dm
+++ b/code/modules/materials/definitions/materials_glass.dm
@@ -118,7 +118,7 @@
 	created_window = /obj/structure/window/reinforced
 	wire_product = null
 	rod_product = null
-	construction_difficulty = 1
+	construction_difficulty = 2
 
 /material/glass/phoron
 	name = MATERIAL_PHORON_GLASS
@@ -152,4 +152,5 @@
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	alloy_materials = list() //todo
 	rod_product = null
+	construction_difficulty = 2
 	integrity = 100

--- a/code/modules/materials/definitions/materials_metal.dm
+++ b/code/modules/materials/definitions/materials_metal.dm
@@ -31,7 +31,7 @@
 	chem_products = list(
 				/datum/reagent/gold = 20
 				)
-	construction_difficulty = 1
+	construction_difficulty = 2
 	ore_smelts_to = MATERIAL_GOLD
 	ore_result_amount = 5
 	ore_name = "native gold"
@@ -50,7 +50,7 @@
 	name = MATERIAL_BRONZE
 	lore_text = "An alloy of copper and tin."
 	icon_colour = "#edd12f"
-	construction_difficulty = 1
+	construction_difficulty = 2
 	ore_smelts_to = null
 	ore_compresses_to = null
 	sale_price = null
@@ -67,7 +67,7 @@
 		/datum/reagent/copper = 12,
 		/datum/reagent/silver = 8
 		)
-	construction_difficulty = 1
+	construction_difficulty = 2
 	ore_smelts_to = MATERIAL_COPPER
 	ore_result_amount = 5
 	ore_spread_chance = 10
@@ -89,7 +89,7 @@
 	chem_products = list(
 				/datum/reagent/silver = 20
 				)
-	construction_difficulty = 1
+	construction_difficulty = 2
 	ore_smelts_to = MATERIAL_SILVER
 	ore_result_amount = 5
 	ore_spread_chance = 10
@@ -116,6 +116,7 @@
 	alloy_product = TRUE
 	sale_price = 1
 	ore_smelts_to = MATERIAL_STEEL
+	construction_difficulty = 1
 
 /material/steel/holographic
 	name = "holo" + MATERIAL_STEEL
@@ -144,7 +145,7 @@
 	weight = 23
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	hitsound = 'sound/weapons/smash.ogg'
-	construction_difficulty = 1
+	construction_difficulty = 2
 	alloy_materials = list(MATERIAL_STEEL = 2500, MATERIAL_PLATINUM = 1250)
 	alloy_product = TRUE
 	sale_price = 2
@@ -163,7 +164,7 @@
 	door_icon_base = "metal"
 	icon_colour = "#d1e6e3"
 	icon_reinf = "reinf_metal"
-	construction_difficulty = 1
+	construction_difficulty = 3
 	alloy_materials = null
 	alloy_product = FALSE
 
@@ -180,7 +181,7 @@
 	weight = 27
 	stack_origin_tech = list(TECH_MATERIAL = 3)
 	alloy_materials = list(MATERIAL_PLASTEEL = 7500, MATERIAL_OSMIUM = 3750)
-	construction_difficulty = 2
+	construction_difficulty = 3
 	alloy_product = TRUE
 	sale_price = 3
 
@@ -192,7 +193,7 @@
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
-	construction_difficulty = 1
+	construction_difficulty = 3
 	sale_price = 3
 	ore_smelts_to = MATERIAL_OSMIUM
 
@@ -248,7 +249,7 @@
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
-	construction_difficulty = 1
+	construction_difficulty = 2
 	ore_smelts_to = MATERIAL_PLATINUM
 	ore_compresses_to = MATERIAL_OSMIUM
 	ore_result_amount = 5
@@ -267,6 +268,7 @@
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	hitsound = 'sound/weapons/smash.ogg'
+	construction_difficulty = 1
 	chem_products = list(
 				/datum/reagent/iron = 20
 				)
@@ -283,7 +285,7 @@
 	explosion_resistance = 200 // Hull plating.
 	hardness = 500
 	weight = 500
-	construction_difficulty = 1
+	construction_difficulty = 2
 	hidden_from_codex = TRUE
 
 // Likewise.
@@ -305,7 +307,7 @@
 	sheet_singular_name = "chunk"
 	sheet_plural_name = "chunks"
 	stack_type = /obj/item/stack/material/aliumium
-	construction_difficulty = 2
+	construction_difficulty = 3
 	hidden_from_codex = TRUE
 
 /material/aliumium/New()

--- a/code/modules/materials/definitions/materials_organic.dm
+++ b/code/modules/materials/definitions/materials_organic.dm
@@ -11,6 +11,7 @@
 	melting_point = T0C+371 //assuming heat resistant plastic
 	stack_origin_tech = list(TECH_MATERIAL = 3)
 	conductive = 0
+	construction_difficulty = 1
 	chem_products = list(
 				/datum/reagent/toxin/plasticide = 20
 				)
@@ -49,6 +50,7 @@
 	sheet_plural_name = "planks"
 	hitsound = 'sound/effects/woodhit.ogg'
 	conductive = 0
+	construction_difficulty = 1
 	chem_products = list(
 				/datum/reagent/carbon = 10,
 				/datum/reagent/water = 5
@@ -93,6 +95,7 @@
 	conductive = 0
 	stack_type = null
 	hidden_from_codex = TRUE
+	construction_difficulty = 1
 
 //TODO PLACEHOLDERS:
 /material/leather
@@ -105,6 +108,7 @@
 	conductive = 0
 	stack_type = null
 	hidden_from_codex = TRUE
+	construction_difficulty = 1
 
 /material/carpet
 	name = MATERIAL_CARPET
@@ -118,6 +122,7 @@
 	sheet_plural_name = "tiles"
 	conductive = 0
 	stack_type = null
+	construction_difficulty = 1
 
 /material/cloth
 	name = MATERIAL_COTTON
@@ -130,6 +135,7 @@
 	conductive = 0
 	stack_type = null
 	hidden_from_codex = TRUE
+	construction_difficulty = 1
 
 /material/cloth/carpet
 	name = "carpet"

--- a/code/modules/materials/definitions/materials_stone.dm
+++ b/code/modules/materials/definitions/materials_stone.dm
@@ -13,7 +13,7 @@
 	burn_armor = 50		// Diamond walls are immune to fire, therefore it makes sense for them to be almost undamageable by burn damage type.
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	conductive = 0
-	construction_difficulty = 2
+	construction_difficulty = 3
 	ore_compresses_to = MATERIAL_DIAMOND
 	ore_result_amount = 5
 	ore_spread_chance = 10
@@ -61,4 +61,5 @@
 	brute_armor = 3
 	integrity = 201 //hack to stop kitchen benches being flippable, todo: refactor into weight system
 	stack_type = /obj/item/stack/material/marble
+	construction_difficulty = 2
 	chem_products = null

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -70,7 +70,7 @@
 	req_amount = 6
 	time = 20
 	on_floor = 1
-	difficulty = 3
+	difficulty = 1
 	send_material_data = 1
 
 /datum/stack_recipe/grip
@@ -79,7 +79,7 @@
 	req_amount = 4
 	time = 20
 	on_floor = 1
-	difficulty = 3
+	difficulty = 1
 	send_material_data = 1
 
 /datum/stack_recipe/key
@@ -145,25 +145,25 @@
 	title = "modular console frame"
 	result_type = /obj/item/modular_computer/console
 	req_amount = 20
-	difficulty = 3
+	difficulty = 2
 
 /datum/stack_recipe/computer/telescreen
 	title = "modular telescreen frame"
 	result_type = /obj/item/modular_computer/telescreen
 	req_amount = 10
-	difficulty = 3
+	difficulty = 2
 
 /datum/stack_recipe/computer/laptop
 	title = "modular laptop frame"
 	result_type = /obj/item/modular_computer/laptop
 	req_amount = 10
-	difficulty = 3
+	difficulty = 2
 
 /datum/stack_recipe/computer/tablet
 	title = "modular tablet frame"
 	result_type = /obj/item/modular_computer/tablet
 	req_amount = 5
-	difficulty = 3
+	difficulty = 2
 
 /datum/stack_recipe/hazard_cone
 	title = "hazard cone"
@@ -218,6 +218,7 @@
 	title = "stick"
 	result_type = /obj/item/weapon/material/stick
 	send_material_data = 1
+	difficulty = 0
 
 /datum/stack_recipe/crossbowframe
 	title = "crossbow frame"
@@ -239,11 +240,14 @@
 	title = "cardborg suit"
 	result_type = /obj/item/clothing/suit/cardborg
 	req_amount = 3
+	difficulty = 0
 
 /datum/stack_recipe/cardborg_helmet
 	title = "cardborg helmet"
 	result_type = /obj/item/clothing/head/cardborg
+	difficulty = 0
 
 /datum/stack_recipe/candle
 	title = "candle"
 	result_type = /obj/item/weapon/flame/candle
+	difficulty = 0

--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -2,6 +2,7 @@
 	res_amount = 4
 	max_res_amount = 20
 	time = 5
+	difficulty = 1
 
 /datum/stack_recipe/tile/metal/floor
 	title = "regular floor tile"
@@ -57,3 +58,4 @@
 	res_amount = 2
 	max_res_amount = 60
 	time = 5
+	difficulty = 1

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -131,7 +131,7 @@
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(   SKILL_COMPUTER      = SKILL_BASIC,
 	                    SKILL_EVA           = SKILL_BASIC,
-	                    SKILL_CONSTRUCTION	= SKILL_BASIC,
+	                    SKILL_CONSTRUCTION	= SKILL_ADEPT,
 	                    SKILL_ELECTRICAL    = SKILL_BASIC,
 	                    SKILL_ATMOS         = SKILL_BASIC,
 	                    SKILL_ENGINES       = SKILL_BASIC)


### PR DESCRIPTION
🆑Roland410
tweak: Construction skill is required for basically any recipes now, and material difficulty (what skill you need to be able to craft from it) has been upped for most of them.
tweak: Engineering contractors receive trained construction now to be able to handle plasteel.
/🆑
After feedback decided to just do this instead of lowering the console requirements. Steel, plastic and wood only need basic, cardboard retains the untrained, but basically everything else needs trained, and titanium, OCP, diamond and alium material needs experienced to use.