### PR TITLE
Removes MREs from vending machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -743,9 +743,7 @@
 					/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/proteinshake = 8,
 					/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask = 8,
 					/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar = 8,
-					/obj/item/weapon/storage/mre/random = 8,
-					/obj/item/weapon/storage/mre/menu9 = 4,
-					/obj/item/weapon/storage/mre/menu10 = 4,
+					/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 8,
 					/obj/item/weapon/reagent_containers/pill/diet = 8,
 					/obj/item/weapon/towel/random = 8)
 
@@ -754,9 +752,7 @@
 					/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/proteinshake = 20,
 					/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask = 5,
 					/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar = 5,
-					/obj/item/weapon/storage/mre/random = 50,
-					/obj/item/weapon/storage/mre/menu9 = 50,
-					/obj/item/weapon/storage/mre/menu10 = 50,
+					/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 5,
 					/obj/item/weapon/reagent_containers/pill/diet = 25,
 					/obj/item/weapon/towel/random = 40)
 

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -225,26 +225,6 @@ MRE Stuff
 	/obj/item/weapon/reagent_containers/food/condiment/small/packet/mayo
 	)
 
-/obj/item/weapon/storage/mre/random
-	desc = "A vacuum-sealed bag containing a day's worth of nutrients for an adult in strenuous situations. There is no visible expiration date on the package. This one has a random menu."
-	startswith = list(
-	/obj/random/mremain,
-	/obj/item/weapon/storage/mrebag/side = 2,
-	/obj/item/weapon/storage/mrebag/dessert,
-	/obj/item/weapon/storage/fancy/crackers = 2,
-	/obj/item/weapon/material/kitchen/utensil/spoon/plastic,
-	/obj/random/mrejuice = 2,
-	/obj/random/mrehotdrinks,
-	/obj/item/weapon/reagent_containers/food/condiment/small/packet/salt,
-	/obj/item/weapon/reagent_containers/food/condiment/small/packet/pepper,
-	/obj/item/weapon/reagent_containers/food/condiment/small/packet/sugar,
-	/obj/item/weapon/reagent_containers/food/condiment/small/packet/capsaicin,
-	/obj/item/weapon/reagent_containers/food/condiment/small/packet/ketchup,
-	/obj/item/weapon/reagent_containers/food/condiment/small/packet/mayo,
-	/obj/random/mrespread,
-	/obj/item/clothing/mask/chewable/candy/gum = 2
-	)
-
 /obj/item/weapon/storage/mrebag
 	name = "main course"
 	desc = "A vacuum-sealed bag containing the MRE's main course. Self-heats when opened."


### PR DESCRIPTION
Because it apparently makes cooks redundant or something. Reverts to how the machine was before, and now MREs can only be found inside emergency rations crates.