### PR TITLE
5.56 and 7.62 ammo rebalance

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -241,9 +241,9 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "a762"
-	matter = list(MATERIAL_STEEL = 1800)
+	matter = list(MATERIAL_STEEL = 2400)
 	ammo_type = /obj/item/ammo_casing/a762
-	max_ammo = 15 //if we lived in a world where normal mags had 30 rounds, this would be a 20 round mag
+	max_ammo = 20
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/a762/empty
@@ -298,9 +298,9 @@
 	icon_state = "c762"
 	mag_type = MAGAZINE
 	caliber = "a556"
-	matter = list(MATERIAL_STEEL = 1800)
+	matter = list(MATERIAL_STEEL = 2700)
 	ammo_type = /obj/item/ammo_casing/a556
-	max_ammo = 20
+	max_ammo = 30
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/caps

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -189,7 +189,7 @@
 
 /obj/item/projectile/bullet/rifle/a556
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
-	damage = 30
+	damage = 20
 
 /obj/item/projectile/bullet/rifle/a762
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'


### PR DESCRIPTION
5.56:
- Damage lowered to 20.
- STS-35 magazine capacity raised from 20 to 30 rounds (maintaining the potential damage on 600).
- LMG potential damage lowered from 1500 to 1000 (maintains its 50 round box).

7.62:
- Z8 magazine capacity raised from 15 to 20 rounds (potential damage up to 700 from 525).

Reasoning:
- 7.62x51 mm is considerably more powerful in real life than 5.56x45 mm.
- The Z8, although now able to potentially do more damage, fires twice as slow as the STS.
- Most modern assault rifles today have 30 round magazines at the minimum, with battle rifles having an average of 20. I don't see why that'd be lowered in the future.
- Although this is a minor buff to the STS, as it now can fire more bullets before reloading, it still maintains the same level of lethality. The Z8 is buffed comparatively more, but this merely brings the two weapons closer together balance wise. Consider the fact that the STS is exceedingly easy to acquire, while the Z8 is exceedingly difficult to.