### PR TITLE
Nerfs Malfunctioning drone on away sites

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -7,7 +7,7 @@
 	icon_living = "drone"
 	icon_dead = "drone_dead"
 	ranged = 1
-	rapid = 1
+	rapid = 0
 	speak_chance = 5
 	turns_per_move = 3
 	response_help = "pokes"
@@ -20,6 +20,7 @@
 	health = 300
 	maxHealth = 300
 	speed = 8
+	move_to_delay = 6
 	projectiletype = /obj/item/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
 	destroy_surroundings = 0

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -94,7 +94,6 @@
 	icon_living = "farmbot"
 	icon_dead = "farmbot_dead"
 	faction = "farmbots"
-	rapid = 0
 	health = 225
 	maxHealth = 225
 	malfunctioning = 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 
tweak: the malfunctioning drone on away sites has had its damage adjusted
/🆑 

The drone is the only ranged retaliate mob, it seems really strong right now as a result. This should bring it more in-line with other away site ranged mobs (which are still very powerful). 