### PR TITLE
May fix multiple circuit issues

### DIFF
--- a/code/controllers/subsystems/processing/circuit.dm
+++ b/code/controllers/subsystems/processing/circuit.dm
@@ -97,7 +97,7 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 // With immediate set, will generally imitate the order of the call stack if execution happened directly.
 // With immediate off, you go to the bottom of the pile.
 /datum/controller/subsystem/processing/circuit/proc/queue_component(obj/item/integrated_circuit/circuit, immediate = TRUE)
-	var/list/entry = list(circuit, args.Copy(3))
+	var/list/entry = list(circuit) + args.Copy(3)
 	if(!immediate || !position)
 		queued_components.Insert(1, list(entry))
 		if(position)


### PR DESCRIPTION
So some debugging showed that regularly, circuits would get passed empty lists as arguments instead of numerical values as expected for parameter "ord". 

Other observed issues once older designs worked is that this subsystem is introducing delays on top of circuit use delays, cooldowns and timers, which may lead to harder to predict movement and manipulation; As it stands all drones seem to move as slow as a walking human and manipulators have noticeable delay in action.

This PR attempts to fix first issue which should largely fix #23765


edit: I will admit I did not understand parts of original code, so replacements I did for debug may or may nto defeat original author's intent.