### PR TITLE
Adds skill perks/subskills; mecha operation is now a perk.

### DIFF
--- a/code/__defines/skills.dm
+++ b/code/__defines/skills.dm
@@ -3,6 +3,7 @@
 #define SKILL_ADEPT    3
 #define SKILL_EXPERT   4
 #define SKILL_PROF     5
+#define HAS_PERK       SKILL_NONE + 1
 
 #define SKILL_MIN      1 // Min skill value selectable
 #define SKILL_MAX      5 // Max skill value selectable
@@ -15,7 +16,7 @@
 #define SKILL_BUREAUCRACY   /decl/hierarchy/skill/organizational/bureaucracy
 #define SKILL_FINANCE       /decl/hierarchy/skill/organizational/finance
 #define SKILL_EVA           /decl/hierarchy/skill/general/EVA
-#define SKILL_MECH          /decl/hierarchy/skill/general/mech
+#define SKILL_MECH          /decl/hierarchy/skill/general/EVA/mech
 #define SKILL_PILOT         /decl/hierarchy/skill/general/pilot
 #define SKILL_HAULING       /decl/hierarchy/skill/general/hauling
 #define SKILL_COMPUTER      /decl/hierarchy/skill/general/computer

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -4,7 +4,7 @@
 	var/decl/hierarchy/parent
 	var/list/decl/hierarchy/children
 
-/decl/hierarchy/New(var/full_init = TRUE)
+/decl/hierarchy/Initialize(var/full_init = TRUE)
 	children = list()
 	if(!full_init)
 		return
@@ -12,7 +12,7 @@
 	var/list/all_subtypes = list()
 	all_subtypes[type] = src
 	for(var/subtype in subtypesof(type))
-		all_subtypes[subtype] = new subtype(FALSE)
+		all_subtypes[subtype] = decls_repository.get_decl(subtype, FALSE)
 
 	for(var/subtype in (all_subtypes - type))
 		var/decl/hierarchy/subtype_instance = all_subtypes[subtype]

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -17,7 +17,7 @@ var/list/outfits_decls_by_type_
 		return
 	outfits_decls_ = list()
 	outfits_decls_by_type_ = list()
-	outfits_decls_root_ = new/decl/hierarchy/outfit()
+	outfits_decls_root_ = decls_repository.get_decl(/decl/hierarchy/outfit)
 
 /decl/hierarchy/outfit
 	name = "Naked"

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -19,7 +19,8 @@
 
 		var/decl/decl = .
 		if(istype(decl))
-			decl.Initialize()
+			var/list/arguments = length(args) > 1 ? args.Copy(2) : list()
+			decl.Initialize(arglist(arguments))
 
 /repository/decls/proc/get_decls(var/list/decl_types)
 	. = list()

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -288,7 +288,7 @@
 		HTML += "<h2>[S.name]</h2>"
 		HTML += "[S.desc]<br>"
 		var/i
-		for(i=SKILL_MIN, i <= SKILL_MAX, i++)
+		for(i=1, i <= length(S.levels), i++)
 			var/level_name = S.levels[i]
 			HTML +=	"<br><b>[level_name]</b>: [S.levels[level_name]]<br>"
 		show_browser(user, jointext(HTML, null), "window=\ref[user]skillinfo")

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(skills)
 							"Master"		= "Professional Description")
 	var/difficulty = SKILL_AVERAGE   //Used to compute how expensive the skill is
 	var/default_max = SKILL_ADEPT    //Makes the skill capped at this value in selection unless overriden at job level.
+	var/prerequisites // A list of skill prerequisites, if needed.
 
 /decl/hierarchy/skill/proc/get_cost(var/level)
 	switch(level)
@@ -24,12 +25,12 @@ GLOBAL_LIST_EMPTY(skills)
 			return 0
 
 //Do not attempt to get_decl any of these except /decl/hierarchy/skill from decls_repository. Use the children variable or GLOB.skills instead.
-/decl/hierarchy/skill/New(var/full_init = TRUE)
+/decl/hierarchy/skill/Initialize(var/full_init = TRUE)
 	..(full_init)
 	if(full_init)
 		if(!GLOB.skills.len)
 			for(var/decl/hierarchy/skill/C in children)
-				GLOB.skills += C.children
+				GLOB.skills += C.get_descendents()
 		else
 			log_error("<span class='warning'>Warning: multiple instances of /decl/hierarchy/skill have been created!</span>")
 
@@ -106,15 +107,14 @@ GLOBAL_LIST_EMPTY(skills)
 						"Experienced"		= "You can use all kinds of space suits, including specialized versions. Your years of experience in EVA keep you from being disoriented in space, and you have experience using a jetpack to move around. <br>- You cannot slip anymore.",
 						"Master"		= "You are just as much at home in a vacuum as in atmosphere. You probably do your job almost entirely EVA.<br>- You cannot get floored anymore.<br>- You get bonus speed for jetpacks.")
 
-/decl/hierarchy/skill/general/mech
+/decl/hierarchy/skill/general/EVA/mech
 	ID = "mech"
 	name = "Exosuit Operation"
-	desc = "Describes your experience and understanding of operating heavy machinery, which includes mechs and other large exosuits. Used in piloting mechs."
-	levels = list( "Unskilled"			= "You know what a mech is, and if you see one you can recognize which type it is. If your department uses exosuits, you know roughly what their capabilities are. If you were to get into one, you'd have about fifty-fifty odds of getting it moving in the direction you wanted it to go.",
-						"Basic"				= "You can drive an exosuit safely, but you specialize in only one type of mech that your department regularly uses. You're not an expert and you fumble the controls sometimes, but you're going where you want to go and you're pretty sure you know what those buttons do.",
-						"Trained"			= "You are quite comfortable using the type of exosuit you're most familiar with. You may spend entire shifts piloting one, and you're familiar with its functions. You can do basic maintenance. You can use most types of exosuits, unless they're very exotic or specialized.",
-						"Experienced"		= "You can use any type of mech comfortably and automatically. To you, a mech is more like a second skin than a vehicle. You can maintain, repair, and probably build exosuits.",
-						"Master"		= "You are a professional exosuit technician, and are well-versed in construction and maintenance procedures. You can design and construct exosuits suitable for any needs.")
+	desc = "Allows you to operate exosuits well."
+	levels = list("Untrained" = "You are unfamiliar with exosuit controls, and if you attempt to use them you are liable to make mistakes.",
+		"Trained" = "You are proficient in exosuit operation and safety, and can use them without penalties.")
+	prerequisites = list(SKILL_EVA = SKILL_ADEPT)
+	default_max = SKILL_BASIC
 	difficulty = SKILL_AVERAGE
 
 /decl/hierarchy/skill/general/pilot

--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -46,23 +46,45 @@
 		skill_cat["name"] = V.name
 		var/list/skills_in_cat = list()
 		for(var/decl/hierarchy/skill/S in V.children)
-			var/list/skill_item = list()
-			skill_item["name"] = S.name
-			var/value = get_value(S.type)
-			skill_item["val"] = value
-			skill_item["ref"] = "\ref[S.type]"
-			var/list/levels = list()
-			for(var/i in 1 to length(S.levels))
-				var/list/level = list()
-				level["val"] = i
-				level["name"] = S.levels[i]
-				level["selected"] = (i <= value)
-				levels += list(level)
-			skill_item["levels"] = levels
-			skills_in_cat += list(skill_item)
+			skills_in_cat += list(get_nano_row(S))
+			for(var/decl/hierarchy/skill/perk in S.children)
+				skills_in_cat += list(get_nano_row(perk))
 		skill_cat["skills"] = skills_in_cat
 		skill_data += list(skill_cat)
 	.["skills_by_cat"] = skill_data
+
+/datum/skillset/proc/get_nano_row(var/decl/hierarchy/skill/S)
+	var/list/skill_item = list()
+	skill_item["name"] = S.name
+	var/value = get_value(S.type)
+	skill_item["val"] = value
+	skill_item["ref"] = "\ref[S.type]"
+	skill_item["available"] = check_prerequisites(S.type)
+	var/offset = S.prerequisites ? S.prerequisites[S.parent.type] - 1 : 0
+	var/list/levels = list()
+	for(var/i in 1 to offset)
+		levels += list(list("blank" = 1))
+	for(var/i in 1 to length(S.levels))
+		var/list/level = list()
+		level["blank"] = 0
+		level["val"] = i
+		level["name"] = S.levels[i]
+		level["selected"] = (i <= value)
+		levels += list(level)
+	for(var/i in (length(levels) + 1) to SKILL_MAX)
+		levels += list(list("blank" = 1))
+	skill_item["levels"] = levels
+	return skill_item
+
+/datum/skillset/proc/check_prerequisites(skill_type)
+	var/decl/hierarchy/skill/S = decls_repository.get_decl(skill_type)
+	if(!S.prerequisites)
+		return TRUE
+	for(var/prereq_type in S.prerequisites)
+		if(!(get_value(prereq_type) >= S.prerequisites[prereq_type]))
+			return FALSE
+	return TRUE
+
 /*
 The generic antag version.
 */
@@ -147,6 +169,11 @@ The generic antag version.
 		return
 	if(skillset.get_value(skill_type) >= level)
 		return
+	var/decl/hierarchy/skill/S = decls_repository.get_decl(skill_type)
+	if(length(S.levels) < level)
+		return
+	if(S.prerequisites)
+		return // Can't select perks from here.
 	return 1
 
 /datum/nano_module/skill_ui/antag/proc/select(skill_type, level)

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -62,7 +62,7 @@
 /decl/hierarchy/outfit/corpse
 	name = "Corpse Clothing"
 
-/decl/hierarchy/outfit/corpse/New()
+/decl/hierarchy/outfit/corpse/Initialize()
 	..()
 	hierarchy_type = type
 

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -229,7 +229,6 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(   SKILL_COMPUTER		= SKILL_ADEPT,
-	                    SKILL_MECH          = SKILL_ADEPT,
 	                    SKILL_DEVICES		= SKILL_ADEPT)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -113,8 +113,7 @@
 		"Drill Technician",
 		"Shaft Miner",
 		"Salvage Technician")
-	min_skill = list(   SKILL_MECH    = SKILL_BASIC,
-	                    SKILL_HAULING = SKILL_ADEPT,
+	min_skill = list(   SKILL_HAULING = SKILL_ADEPT,
 	                    SKILL_EVA     = SKILL_BASIC)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)

--- a/nano/templates/skill_ui.tmpl
+++ b/nano/templates/skill_ui.tmpl
@@ -16,9 +16,11 @@
 		</td>
 		{{for skill_value.levels :level_value:level_key}}
 			<td>
+			{{if !level_value.blank}}
 			<div class={{if level_value.selected}}'selected'{{else}}'null'{{/if}}>
 				{{:level_value.name}}
 			</div>
+			{{/if}}
 			</td>
 		{{/for}}
 		</tr>

--- a/nano/templates/skill_ui_admin.tmpl
+++ b/nano/templates/skill_ui_admin.tmpl
@@ -25,9 +25,11 @@
 		</div>
 		</td>
 		{{for skill_value.levels :level_value:level_key}}
+			{{if !level_value.blank}}
 			<td>
 				{{:helper.link(level_value.name, null, {'value_hit' : level_value.val, 'skill' : skill_value.ref}, null, level_value.selected ? 'selected' : null)}}
 			</td>
+			{{/if}}
 		{{/for}}
 		</tr>
 	{{/for}}

--- a/nano/templates/skill_ui_antag.tmpl
+++ b/nano/templates/skill_ui_antag.tmpl
@@ -41,9 +41,11 @@
 		</td>
 		{{for skill_value.levels :level_value:level_key}}
 			<td>
+			{{if !level_value.blank}}
 			<div class={{if level_value.selected}}'selected'{{else}}'null'{{/if}}>
 				{{:level_value.name}}
 			</div>
+			{{/if}}
 			</td>
 		{{/for}}
 		</tr>


### PR DESCRIPTION
:cl:
rscadd: The mecha skill (Exosuit Operation) is now a subskill of EVA. You need to have at least Trained in EVA to select it, and then choose it from skill selection.
rscadd: Driving mecha without the mecha skill may result in unpredictable movement.
rscadd: Exiting a mecha without proper skill may occasionally force-eject you.
tweak: The mecha skill no longer has anything to do with mecha fabrication in the description.
/:cl:

Also a backend change to make `/decl/hierarchy` fully compatible with the `decls_repository`.
Antags cannot select perks as of this time. May be added later.