### PR TITLE
Makes broken BYOND builds kick and staffwarn, not ban.

### DIFF
--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -1,6 +1,11 @@
 datum/admins/proc/DB_staffwarn_record(var/ckey, var/reason)
 	if(!check_rights((R_ADMIN|R_MOD), 0)) return
 	if(!istext(reason)) return
+	_DB_staffwarn_record(ckey, reason)
+
+/proc/_DB_staffwarn_record(var/ckey, var/reason)
+	if(usr && !check_rights((R_ADMIN|R_MOD), 0))
+		return
 	var/dbreason = sql_sanitize_text(reason)
 	var/dbckey = sql_sanitize_text(ckey)
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -118,7 +118,8 @@
 	if(byond_version < MIN_CLIENT_VERSION)		//Out of date client.
 		return null
 	if("[byond_version].[byond_build]" in config.forbidden_versions)
-		_DB_ban_record(bantype = BANTYPE_PERMA, reason = "You have attempted connecting to the server with a BYOND client with known abuse potential.", banckey = ckey)
+		_DB_staffwarn_record(ckey, "Tried to connect with broken and possibly exploitable BYOND build.")
+		to_chat(src, "You are attempting to connect with a broken and possibly exploitable BYOND build. Please update to the latest version before trying again.")
 		qdel(src)
 		return
 


### PR DESCRIPTION
People claim to use these in good faith. While that seems hard to credit, this should remove admin overhead in dealing with the issue.