### PR TITLE
Adds fatigues for fleet shuttle pilot, fixes define

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -158,12 +158,12 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
-/decl/hierarchy/mil_uniform/fleet/srv
+/decl/hierarchy/mil_uniform/fleet/exp
 	name = "Fleet exploration"
 	departments = EXP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/exploration
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/exploration, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/exploration, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet, /obj/item/clothing/under/solgov/utility/fleet/combat/exploration)
 
 /decl/hierarchy/mil_uniform/fleet/exp/noncom
 	name = "Fleet exploration SNCO"
@@ -212,4 +212,3 @@
 	dress_over = /obj/item/clothing/suit/storage/toggle/dress/fleet/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
-

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -172,6 +172,9 @@
 /obj/item/clothing/under/solgov/utility/fleet/combat/command
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet)
 
+/obj/item/clothing/under/solgov/utility/fleet/combat/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/fleet)
+
 /obj/item/clothing/under/solgov/utility/army
 	name = "army fatigues"
 	desc = "The utility uniform of the SCG Army, made from durable material."


### PR DESCRIPTION
🆑 
tweak: Shuttle pilot can now pick fatigues if desired
/🆑 

Also fixes a bad define but that shouldn't be user-facing.

I strongly believe that everyone who regularly leaves the Torch should have the option of fatigues. IRL your boat teams aren't driving around wearing overalls, and it's my opinion that the shuttle pilot is comparable in this regard. 