### PR TITLE
Fix space tiles in crashed pod map file

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -617,10 +617,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"bs" = (
-/obj/structure/grille,
-/turf/space,
-/area/map_template/crashed_pod)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1093,9 +1089,9 @@
 
 (1,1,1) = {"
 aa
-bs
-bs
-bs
+aa
+aa
+aa
 ab
 ab
 ab


### PR DESCRIPTION
Fix made by @Aticius who can't mapmerge or create PRs.

:cl: Aticius
fix: Crashed pod should no longer have random space tiles causing constant air flow/air loss.
/:cl: