### PR TITLE
Add General Notes (Public) field to Crew Records

### DIFF
--- a/code/modules/client/preference_setup/background/03_records.dm
+++ b/code/modules/client/preference_setup/background/03_records.dm
@@ -1,4 +1,5 @@
 /datum/preferences
+	var/public_record = ""
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""
@@ -9,12 +10,14 @@
 	sort_order = 3
 
 /datum/category_item/player_setup_item/background/records/load_character(var/savefile/S)
+	from_file(S["public_record"],pref.public_record)
 	from_file(S["med_record"],pref.med_record)
 	from_file(S["sec_record"],pref.sec_record)
 	from_file(S["gen_record"],pref.gen_record)
 	from_file(S["memory"],pref.memory)
 
 /datum/category_item/player_setup_item/background/records/save_character(var/savefile/S)
+	to_file(S["public_record"],pref.public_record)
 	to_file(S["med_record"],pref.med_record)
 	to_file(S["sec_record"],pref.sec_record)
 	to_file(S["gen_record"],pref.gen_record)
@@ -26,6 +29,8 @@
 	if(jobban_isbanned(user, "Records"))
 		. += "<span class='danger'>You are banned from using character records.</span><br>"
 	else
+		. += "General Notes (Public): "
+		. += "<a href='?src=\ref[src];set_public_record=1'>[TextPreview(pref.public_record,40)]</a><br>"
 		. += "Medical Records: "
 		. += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><br>"
 		. += "Employment Records: "
@@ -37,7 +42,13 @@
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/background/records/OnTopic(var/href,var/list/href_list, var/mob/user)
-	if(href_list["set_medical_records"])
+	if (href_list["set_public_record"])
+		var/new_public = sanitize(input(user,"Enter general public record information here.",CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.public_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
+		if (!isnull(new_public) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
+			pref.public_record = new_public
+		return TOPIC_REFRESH
+
+	else if(href_list["set_medical_records"])
 		var/new_medical = sanitize(input(user,"Enter medical information here.",CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.med_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 		if(!isnull(new_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.med_record = new_medical

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -293,6 +293,7 @@ datum/preferences
 	character.flavor_texts["legs"] = flavor_texts["legs"]
 	character.flavor_texts["feet"] = flavor_texts["feet"]
 
+	character.public_record = public_record
 	character.med_record = med_record
 	character.sec_record = sec_record
 	character.gen_record = gen_record

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -88,6 +88,7 @@
 	var/equipment_light_protection
 	var/list/equipment_overlays = list()	// Extra overlays from equipped items
 
+	var/public_record = ""
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -54,6 +54,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	set_species(H ? H.get_species() : SPECIES_HUMAN)
 	set_branch(H ? (H.char_branch && H.char_branch.name) : "None")
 	set_rank(H ? (H.char_rank && H.char_rank.name) : "None")
+	set_public_record(H && H.public_record && !jobban_isbanned(H, "Records") ? html_decode(H.public_record) : "No record supplied")
 
 	// Medical record
 	set_bloodtype(H ? H.b_type : "Unset")
@@ -175,6 +176,8 @@ FIELD_LIST_EDIT("Status", status, GLOB.physical_statuses, null, access_medical)
 FIELD_SHORT("Species",species, null, access_change_ids)
 FIELD_LIST("Branch", branch, record_branches(), null, access_change_ids)
 FIELD_LIST("Rank", rank, record_ranks(), null, access_change_ids)
+
+FIELD_LONG("General Notes (Public)", public_record, null, access_bridge)
 
 // MEDICAL RECORDS
 FIELD_LIST("Blood Type", bloodtype, GLOB.blood_types, access_medical, access_medical)


### PR DESCRIPTION
Adds a 'General Record' field to crew records. This serves as a field that anyone with crew records access can see, for people (Like me) that want to add 'common' information between medical, employment, and security records.

General records can be edited in game by anyone with access to the bridge (bridge officers and any head of staff)

![2018-11-26_14-33-54](https://user-images.githubusercontent.com/11140088/49046338-a459e080-f188-11e8-9397-830d36fb1201.png)

:cl: SierraKomodo
add: General Notes (Public) field has been added to crew records. These are records visible to anyone who can open crew records, and are intended for 'common' information between security, medical, /and/ employment records.
/:cl: