### PR TITLE
I give up on clonex fixes.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -181,7 +181,7 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	heating_products = list(/datum/reagent/cryoxadone, /datum/reagent/sodium)
-	heating_point = 10 CELCIUS
+	heating_point = 50 CELCIUS
 	heating_message = "turns back to sludge."
 
 /datum/reagent/clonexadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
:cl:
tweak: Clonex now won't denature below 50 C (i.e. unless you heat it).
/:cl:

Was kind of a cool idea, but buggy and needs more work before being ready for prime time. Players have suffered enough.

If someone plans on undoing this, you need to fix at least the following two things:

- Reagents being heated by mob ambient temperature before being absorbed. (You need a non-hacky fix for this, which will likely require integrating mobs with the temperature system fully).
- Synthmeat being impossible to make.