### PR TITLE
Overmap Autopilot Adjustments

### DIFF
--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -94,10 +94,10 @@
 	return round(num_burns/burns_per_grid)
 
 /obj/effect/overmap/ship/proc/decelerate()
-	if(!is_still() && can_burn())
-		if (MOVING(speed[1]))
+	if(((speed[1]) || (speed[2])) && can_burn())
+		if (speed[1])
 			adjust_speed(-SIGN(speed[1]) * min(get_burn_acceleration(),abs(speed[1])), 0)
-		if (MOVING(speed[2]))
+		if (speed[2])
 			adjust_speed(0, -SIGN(speed[2]) * min(get_burn_acceleration(),abs(speed[2])))
 		last_burn = world.time
 


### PR DESCRIPTION
DNM if #23794 is merged

Various tweaks and fixes to autopilot.

:cl: SierraKomodo
tweak: Autopilot default speed lowered from 2 (Exceeds max speed hardcap of 0.1) to 0.0025 (40 seconds ETA per tile)
fix: Autopilot no longer burns fuel needlessly bouncing above/below the speedlimit, and will now never go above the speedlimit.
tweak: Autopilot now handles changing direction/destination and diagonal movement much more efficiently fuel wise
fix: It is once again possible to decelerate to a speed of 0.
/:cl: