### PR TITLE
Opens up Research to SCG Scientists.

### DIFF
--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -182,7 +182,7 @@
 
 /obj/item/clothing/head/beret/solgov/research
 	name = "government research beret"
-	desc = "A green beret denoting service in the Bureau of Research. For explorers that are more inclined towards style than safety."
+	desc = "A green beret denoting service in the Bureau of Research. For scientists that are more inclined towards style than safety."
 	icon_state = "beret_green"
 
 /obj/item/clothing/head/beret/solgov/health

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -1,6 +1,6 @@
 /obj/item/device/radio/headset/torchnanotrasen
-	name = "corporate headset"
-	desc = "A headset for corporate drones."
+	name = "research headset"
+	desc = "A headset for researchers."
 	icon_state = "nt_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/headset_torchnt

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -5,7 +5,7 @@
 
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Research Director and the Corporate Liaison"
+	supervisors = "the Research Director and the Workplace Liaison"
 	selection_color = "#633d63"
 	economic_power = 12
 	minimal_player_age = 3
@@ -38,7 +38,7 @@
 	title = "Scientist"
 	total_positions = 6
 	spawn_positions = 6
-	supervisors = "the Research Director and the Corporate Liaison"
+	supervisors = "the Research Director and the Workplace Liaison"
 	economic_power = 10
 	ideal_character_age = 45
 	minimal_player_age = 0
@@ -59,8 +59,10 @@
 	                    SKILL_SCIENCE     = SKILL_MAX)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/scientist
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	allowed_branches = list(/datum/mil_branch/civilian,
+							/datum/mil_branch/solgov)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor,
+						 /datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/solgov)
 
 	access = list(access_tox, access_tox_storage, access_research, access_petrov, access_petrov_helm,
 						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
@@ -76,7 +78,7 @@
 	department_flag = SCI
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "the Research Director, the Corporate Liaison and science personnel"
+	supervisors = "the Research Director, the Workplace Liaison and science personnel"
 	selection_color = "#633d63"
 	economic_power = 6
 	minimal_player_age = 0
@@ -104,7 +106,7 @@
 	department_flag = SCI
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = "the Research Director, the Corporate Liaison and science personnel"
+	supervisors = "the Research Director, the Workplace Liaison and science personnel"
 	selection_color = "#633d63"
 	economic_power = 3
 	ideal_character_age = 30
@@ -117,8 +119,10 @@
 		"Field Assistant")
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/assist
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	allowed_branches = list(/datum/mil_branch/civilian,
+							/datum/mil_branch/solgov)
+	allowed_ranks = list(/datum/mil_rank/civ/contractor,
+						 /datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov)
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,

--- a/maps/torch/job/torch_outfits.dm
+++ b/maps/torch/job/torch_outfits.dm
@@ -613,6 +613,10 @@ decl/hierarchy/outfit/job/torch/passenger/research/cl/union
 	..()
 	BACKPACK_OVERRIDE_RESEARCH
 
+/decl/hierarchy/outfit/job/torch/passenger/research/scientist/solgov
+	name = OUTFIT_JOB_NAME("Scientist - SCG")
+	head = /obj/item/clothing/head/beret/solgov/research
+
 /decl/hierarchy/outfit/job/torch/passenger/research/scientist/psych
 	name = OUTFIT_JOB_NAME("Psychologist - Torch")
 	uniform = /obj/item/clothing/under/rank/psych
@@ -647,6 +651,10 @@ decl/hierarchy/outfit/job/torch/passenger/research/cl/union
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/modular_computer/pda/science
 	id_type = /obj/item/weapon/card/id/torch/passenger/research
+
+/decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov
+	name = OUTFIT_JOB_NAME("Research Assistant - SCG")
+	head = /obj/item/clothing/head/beret/solgov/research
 
 
 /decl/hierarchy/outfit/job/torch/passenger/research/assist/janitor

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -218,12 +218,14 @@
 
 	rank_types = list(
 		/datum/mil_rank/sol/gov,
-		/datum/mil_rank/sol/agent
+		/datum/mil_rank/sol/agent,
+		/datum/mil_rank/sol/scientist
 	)
 
 	spawn_rank_types = list(
 		/datum/mil_rank/sol/gov,
-		/datum/mil_rank/sol/agent
+		/datum/mil_rank/sol/agent,
+		/datum/mil_rank/sol/scientist
 	)
 
 /datum/mil_rank/grade()
@@ -636,3 +638,6 @@
 	name = "OCIE Agent"
 	name_short = "AGT"
 	accessory = list(/obj/item/clothing/accessory/badge/ocieagent)
+
+/datum/mil_rank/sol/scientist
+	name = "Scientist"


### PR DESCRIPTION
:cl: Broseph Stylin
rscadd: A new Scientist rank is now available for the SolGov Employee branch.
tweak: The Scientist and Research Assistant jobs are now open for the SolGov Employee rank of Scientist.
/:cl:

This creates the new "rank" of Scientist within the SolGov Employee branch.

The only two jobs available for them are Research Assistant and Scientist. They are still barred from Senior Researcher and Research Director. They are functionally the same as a corporate scientist, with the exception that they do not work for any corporation, but rather for the Sol Central Government itself. Think of NASA or CERN scientists for a real world parallel.

Their uniform is largely the same as a corporate scientist, aside form them spawning with a government research beret by default. They can also pick some SCG-specific stuff from the loadout, and are barred from some corporate-specific stuff, such as awards.

Also rewords some references to "Corporate Liaison" into "Workplace Liaison", as well as the basic research headset from being explicitly corporate, to now being more general researcher, in order to comply with both SCG scientists and the already present EC Xenolife Technicians.

PLEASE NOTE THAT THESE GUYS ARE FULLY CIVILIAN AND NOT AT ALL INVOLVED WITH EITHER THE EC, FLEET, OR ANY OTHER SUCH UNIFORMED SERVICE.