### PR TITLE
Adds random chemicals

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2469,6 +2469,8 @@
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Medicine.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Other.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Toxins.dm"
+#include "code\modules\reagents\Chemistry-Reagents\Random\Chemistry-Reagents-Random.dm"
+#include "code\modules\reagents\Chemistry-Reagents\Random\random_effects.dm"
 #include "code\modules\reagents\dispenser\_defines.dm"
 #include "code\modules\reagents\dispenser\cartridge.dm"
 #include "code\modules\reagents\dispenser\cartridge_presets.dm"

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(chemistry)
 	var/list/chemical_reactions_by_result = list()
 	var/list/processing_holders =           list()
 
+	var/list/random_chem_prototypes =       list()
+
 /datum/controller/subsystem/chemistry/stat_entry()
 	..("AH:[active_holders.len]")
 
@@ -55,3 +57,20 @@ SUBSYSTEM_DEF(chemistry)
 
 		if (MC_TICK_CHECK)
 			return
+
+/datum/controller/subsystem/chemistry/proc/get_prototype(var/datum/reagent/random/reagent)
+	if(!istype(reagent))
+		return
+	. = random_chem_prototypes[reagent.type]
+	if(!.)
+		var/datum/reagent/random/new_prototype = new reagent.type(null, TRUE)
+		new_prototype.randomize_data()
+		. = new_prototype
+		random_chem_prototypes[reagent.type] = .
+
+/datum/controller/subsystem/chemistry/proc/get_random_chem(var/only_if_unique = FALSE)
+	for(var/type in typesof(/datum/reagent/random))
+		if(only_if_unique && random_chem_prototypes[type])
+			continue
+		get_prototype(type) // we don't need it, but fill the cache to know it's been assigned
+		return type

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -26,6 +26,11 @@
 	for(var/decl_type in decl_types)
 		.[decl_type] =  get_decl(decl_type)
 
+/repository/decls/proc/get_decls_unassociated(var/list/decl_types)
+	. = list()
+	for(var/decl_type in decl_types)
+		. += get_decl(decl_type)
+
 /repository/decls/proc/get_decls_of_type(var/decl_prototype)
 	. = fetched_decl_types[decl_prototype]
 	if(!.)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -389,7 +389,7 @@ proc/get_wound_severity(var/damage_ratio, var/can_heal_overkill = 0)
 
 /obj/item/device/mass_spectrometer
 	name = "mass spectrometer"
-	desc = "A hand-held mass spectrometer which identifies trace chemicals in a blood sample."
+	desc = "A hand-held mass spectrometer which identifies trace chemicals in a blood sample or analyzes unusual chemicals."
 	icon_state = "spectrometer"
 	item_state = "analyzer"
 	w_class = ITEM_SIZE_SMALL
@@ -427,6 +427,11 @@ proc/get_wound_severity(var/damage_ratio, var/can_heal_overkill = 0)
 		var/list/blood_traces = list()
 		var/list/blood_doses = list()
 		for(var/datum/reagent/R in reagents.reagent_list)
+			if(length(reagents.reagent_list) == 1)
+				var/datum/reagent/random/random = R
+				if(istype(random))
+					random.on_chemicals_analyze(user)
+					return
 			if(R.type != /datum/reagent/blood)
 				reagents.clear_reagents()
 				to_chat(user, "<span class='warning'>The sample was contaminated! Please insert another sample</span>")

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -429,6 +429,11 @@
 		chems[/datum/reagent/nutriment] = list(rand(1,10),rand(10,20))
 
 	var/additional_chems = rand(0,5)
+	if(prob(50))
+		var/chem_type = SSchemistry.get_random_chem(TRUE)
+		if(chem_type)
+			additional_chems = 0
+			chems[chem_type] = list(rand(1,10),rand(10,20))
 
 	if(additional_chems)
 		var/list/banned_chems = list(

--- a/code/modules/item_worth/Value_procs/obj/items.dm
+++ b/code/modules/item_worth/Value_procs/obj/items.dm
@@ -11,8 +11,11 @@
 	if(reagents)
 		for(var/a in reagents.reagent_list)
 			var/datum/reagent/reg = a
-			. += reg.value * reg.volume
+			. += reg.Value() * reg.volume
 	. = round(.)
+
+/datum/reagent/proc/Value()
+	return value
 
 /obj/item/stack/Value(var/base)
 	return base * amount

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -80,6 +80,9 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 	var/temperature = my_atom ? my_atom.temperature : T20C
 	for(var/thing in reagent_list)
 		var/datum/reagent/R = thing
+		if(R.custom_temperature_effects(temperature, src))
+			reaction_occured = TRUE
+			continue
 
 		// Check if the reagent is decaying or not.
 		var/list/replace_self_with

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -150,3 +150,5 @@
 
 /datum/reagent/proc/reaction_mob(var/mob/target)
 	touch_mob(target)
+
+/datum/reagent/proc/custom_temperature_effects(var/temperature)

--- a/code/modules/reagents/Chemistry-Reagents/Random/Chemistry-Reagents-Random.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Random/Chemistry-Reagents-Random.dm
@@ -1,0 +1,150 @@
+
+
+// subtypes of stuff in here will be avoided when randomizing interactions.
+GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
+	/datum/reagent/adminordrazine,
+	/datum/reagent/nanites,
+	/datum/reagent/water/holywater,
+	/datum/reagent/chloralhydrate/beer2,
+	/datum/reagent/tobacco,
+	/datum/reagent/drink,
+	/datum/reagent/crayon_dust,
+	/datum/reagent/random,
+	/datum/reagent/toxin/phoron
+))
+
+#define FOR_ALL_EFFECTS \
+	var/list/all_effects = decls_repository.get_decls_unassociated(data);\
+	for(var/decl/random_chem_effect/effect in all_effects)
+
+/datum/reagent/random
+	name = "exotic chemical"
+	description = "A strange and exotic chemical substance."
+	taste_mult = 0 // Random taste not yet implemented
+	hidden_from_codex = TRUE
+	reagent_state = LIQUID
+	var/max_effect_number = 8
+
+/datum/reagent/random/New(var/datum/reagents/holder, var/override = FALSE)
+	if(override)
+		return // This is used for random prototypes, so we bypass further init
+	return ..(holder)
+
+/datum/reagent/random/initialize_data(var/list/newdata)
+	var/datum/reagent/random/other = SSchemistry.get_prototype(src)
+	if(istype(newdata))
+		data = newdata.Copy()
+	else
+		data = other.data.Copy()
+	chilling_products = other.chilling_products
+	heating_products = other.heating_products
+	recompute_properties()
+
+/datum/reagent/random/proc/randomize_data()
+	data = list()
+	var/list/effects_to_get = subtypesof(/decl/random_chem_effect/random_properties)
+	if(length(effects_to_get) > max_effect_number)
+		shuffle(effects_to_get)
+		effects_to_get.Cut(max_effect_number + 1)
+	effects_to_get += subtypesof(/decl/random_chem_effect/general_properties)
+	
+	var/list/decls = decls_repository.get_decls_unassociated(effects_to_get)
+	for(var/item in decls)
+		var/decl/random_chem_effect/effect = item
+		effect.prototype_process(src)
+	
+	var/whitelist = subtypesof(/datum/reagent)
+	for(var/bad_type in GLOB.random_chem_interaction_blacklist)
+		whitelist -= typesof(bad_type)
+
+	chilling_products = list()
+	for(var/i in 1 to rand(1,3))
+		chilling_products += pick_n_take(whitelist) // it's possible that these form a valid reaction, but we're OK with that.
+	heating_products = list()
+	for(var/i in 1 to rand(1,3))
+		heating_products += pick_n_take(whitelist)
+	
+	for(var/decl/random_chem_effect/random_properties/effect in decls)
+		effect.set_caches(src, whitelist)
+
+/datum/reagent/random/mix_data(var/list/other_data, var/amount)
+	if(volume <= 0)
+		return // ?? but we're about to divide by 0 if this happens, so let's avoid.
+	var/old_amount = max(volume - amount, 0) // how much we had prior to the addition
+	var/ratio = old_amount/volume
+	FOR_ALL_EFFECTS
+		data[effect.type] = effect.mix_data(data[effect.type], ratio, other_data[effect.type])
+
+/datum/reagent/random/proc/recompute_properties()
+	FOR_ALL_EFFECTS
+		effect.on_property_recompute(src, data[effect.type])
+
+/datum/reagent/random/custom_temperature_effects(var/temperature, var/datum/reagents/reagents)
+	if(temperature in (heating_point - 20) to heating_point)
+		FOR_ALL_EFFECTS
+			var/result = effect.distillation_act(src, reagents, data[effect.type])
+			if(!isnull(result))
+				data[effect.type] = result
+				. = TRUE
+	else if(temperature in chilling_point to (chilling_point + 20))
+		FOR_ALL_EFFECTS
+			var/result = effect.cooling_act(src, reagents, data[effect.type])
+			if(!isnull(result))
+				data[effect.type] = result
+				. = TRUE
+	if(.)
+		reagents.my_atom.visible_message("The chemicals in \the [reagents.my_atom] bubble slightly!")
+
+/datum/reagent/random/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	FOR_ALL_EFFECTS
+		effect.affect_blood(M, alien, removed, data[effect.type])
+
+/datum/reagent/random/proc/on_chemicals_analyze(mob/user)
+	var/list/dat = list()
+	var/chem_skill = user.get_skill_value(SKILL_CHEMISTRY)
+	if(chem_skill < SKILL_BASIC)
+		dat += "You analyze the strange liquid. The readings are confusing; could it maybe be juice?"
+	else if(chem_skill < SKILL_ADEPT)
+		dat += "You analyze the strange liquid. Based on the readings, you are skeptical that this is safe to drink."
+	else
+		dat += "The readings are very unsual and intriguing. You suspect it may be of alien origin."
+		var/sci_skill = user.get_skill_value(SKILL_SCIENCE)
+		var/beneficial
+		var/harmful
+		var/list/effect_descs = list()
+		var/list/interactions = list()
+		FOR_ALL_EFFECTS
+			if(effect.beneficial > 0)
+				beneficial = 1
+			if(effect.beneficial < 0)
+				harmful = 1
+			if(effect.desc)
+				effect_descs += effect.desc
+			var/interaction = effect.get_interactions(src, sci_skill, chem_skill)
+			if(interaction)
+				interactions += interaction
+		if(sci_skill <= SKILL_ADEPT)
+			if(beneficial)
+				dat += "The scan suggests that the chemical has some potentially beneficial effects!"
+			if(harmful)
+				dat += "The readings confirm that the chemical is not safe for human use."
+		else
+			dat += "A close analysis of the scan suggests that the chemical has some of the following effects: [english_list(effect_descs)]."
+		if(chem_skill == SKILL_ADEPT)
+			dat += "You aren't sure how this chemical will react with other reagents, but it does seem to be sensitive to changes in temperature."
+		else
+			dat += "Here are the chemicals you suspect this one will interact with, probably when heated or cooled:"
+			dat += JOINTEXT(interactions)
+	to_chat(user, jointext(dat, "<br>"))
+
+/datum/reagent/random/Value()
+	. = 0
+	FOR_ALL_EFFECTS
+		. += effect.get_value(data[effect.type])
+	. = max(., 0)
+
+// Extra unique types for exoplanet spawns, etc.
+/datum/reagent/random/one
+/datum/reagent/random/two
+
+#undef FOR_ALL_EFFECTS

--- a/code/modules/reagents/Chemistry-Reagents/Random/random_effects.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Random/random_effects.dm
@@ -53,6 +53,14 @@
 
 // All general properties will be chosen.
 
+/decl/random_chem_effect/general_properties/name
+	maximum = 999
+	minimum = 100
+	mode = RANDOM_CHEM_EFFECT_INT
+
+/decl/random_chem_effect/general_properties/name/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+	reagent.name = "[initial(reagent.name)]-[value]"
+
 /decl/random_chem_effect/general_properties/color_r
 	maximum = 255
 	mode = RANDOM_CHEM_EFFECT_INT

--- a/code/modules/reagents/Chemistry-Reagents/Random/random_effects.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Random/random_effects.dm
@@ -1,0 +1,347 @@
+#define RANDOM_CHEM_EFFECT_TRUE  1 //Boolean, starts true
+#define RANDOM_CHEM_EFFECT_INT   2
+#define RANDOM_CHEM_EFFECT_FLOAT 3
+
+/decl/random_chem_effect
+	var/minimum = 0
+	var/maximum = 1
+	var/mode = RANDOM_CHEM_EFFECT_TRUE
+	var/beneficial = 0 // Neutral; 1 for beneficial, -1 for harmful
+	var/desc
+	var/cost = 500 // Modify if an effect should be valued more.
+
+/decl/random_chem_effect/proc/get_random_value()
+	switch(mode)
+		if(RANDOM_CHEM_EFFECT_TRUE)
+			return 1
+		if(RANDOM_CHEM_EFFECT_INT)
+			return rand(minimum, maximum)
+		if(RANDOM_CHEM_EFFECT_FLOAT)
+			return rand() * (maximum - minimum) + minimum
+
+/decl/random_chem_effect/proc/mix_data(first_value, first_ratio, second_value)
+	switch(mode)
+		if(RANDOM_CHEM_EFFECT_TRUE)
+			return !!(first_value * first_ratio + second_value * (1 - first_ratio)) // Basically |, unless ratio is 0 or 1
+		if(RANDOM_CHEM_EFFECT_INT)
+			return round(first_value * first_ratio + second_value * (1 - first_ratio))
+		if(RANDOM_CHEM_EFFECT_FLOAT)
+			return first_value * first_ratio + second_value * (1 - first_ratio)
+
+/decl/random_chem_effect/proc/prototype_process(var/datum/reagent/random/prototype)
+	prototype.data[type] = get_random_value()
+
+/decl/random_chem_effect/proc/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+
+/decl/random_chem_effect/proc/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/value)
+
+/decl/random_chem_effect/proc/distillation_act(var/datum/reagent/random/reagent, var/datum/reagents/reagents)
+
+/decl/random_chem_effect/proc/cooling_act(var/datum/reagent/random/reagent, var/datum/reagents/reagents)
+
+/decl/random_chem_effect/proc/get_interactions()
+
+// This is referring to monetary value.
+/decl/random_chem_effect/proc/get_value(var/value)
+	switch(beneficial)
+		if(1)
+			return cost * (value - minimum)/(maximum - minimum)
+		if(0)
+			return 0
+		if(-1)
+			return -3 * cost * (value - minimum)/(maximum - minimum)
+
+// All general properties will be chosen.
+
+/decl/random_chem_effect/general_properties/color_r
+	maximum = 255
+	mode = RANDOM_CHEM_EFFECT_INT
+
+/decl/random_chem_effect/general_properties/color_g
+	maximum = 255
+	mode = RANDOM_CHEM_EFFECT_INT
+
+/decl/random_chem_effect/general_properties/color_b
+	maximum = 255
+	mode = RANDOM_CHEM_EFFECT_INT
+
+/decl/random_chem_effect/general_properties/color_r/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+	reagent.color = rgb(\
+		reagent.data[/decl/random_chem_effect/general_properties/color_r],\
+		reagent.data[/decl/random_chem_effect/general_properties/color_r],\
+		reagent.data[/decl/random_chem_effect/general_properties/color_b]
+	)
+
+/decl/random_chem_effect/general_properties/overdose
+	minimum = REAGENTS_OVERDOSE * 0.2
+	maximum = REAGENTS_OVERDOSE * 2
+	mode = RANDOM_CHEM_EFFECT_FLOAT
+
+/decl/random_chem_effect/general_properties/overdose/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+	reagent.overdose = value
+
+/decl/random_chem_effect/general_properties/metabolism
+	minimum = REM * 0.5
+	maximum = REM * 3
+	mode = RANDOM_CHEM_EFFECT_FLOAT
+
+/decl/random_chem_effect/general_properties/metabolism/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+	reagent.metabolism = value
+
+/decl/random_chem_effect/general_properties/chilling_point
+	minimum = T0C - 80
+	maximum = T0C - 10
+	mode = RANDOM_CHEM_EFFECT_FLOAT
+
+/decl/random_chem_effect/general_properties/chilling_point/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+	reagent.chilling_point = value
+
+/decl/random_chem_effect/general_properties/heating_point
+	minimum = T0C + 60
+	maximum = T0C + 180
+	mode = RANDOM_CHEM_EFFECT_FLOAT
+
+/decl/random_chem_effect/general_properties/heating_point/on_property_recompute(var/datum/reagent/random/reagent, var/value)
+	reagent.heating_point = value
+
+// Only some random properties are picked.
+
+/decl/random_chem_effect/random_properties
+	var/chem_effect_define                //If it corresponds to a CE_WHATEVER define, place here and it will do generic affect blood based on it
+	var/list/distillation_inhibitor_cache // Format: list(type = list(reagent types))
+	var/list/cooling_enhancer_cache
+	var/list/reaction_rate_cache
+	var/number_of_reaction_modifiers = 3
+
+/decl/random_chem_effect/random_properties/proc/set_caches(var/datum/reagent/random/prototype, var/list/whitelist)
+	LAZYSET(reaction_rate_cache, prototype.type, 1.5 * rand() + 0.5)
+	for(var/i = 1, i <= number_of_reaction_modifiers, i++)
+		if(length(whitelist))
+			LAZYINITLIST(distillation_inhibitor_cache)
+			LAZYADD(distillation_inhibitor_cache[prototype.type], pick_n_take(whitelist))
+		if(length(whitelist))
+			LAZYINITLIST(cooling_enhancer_cache)
+			LAZYADD(cooling_enhancer_cache[prototype.type], pick_n_take(whitelist))
+
+/decl/random_chem_effect/random_properties/distillation_act(var/datum/reagent/random/reagent, var/datum/reagents/reagents, var/value)
+	var/list/inhibitors = distillation_inhibitor_cache[reagent.type]
+	if(reagents.has_any_reagent(inhibitors))
+		return
+	return purify(reagent, reagents, value)
+
+/decl/random_chem_effect/random_properties/cooling_act(var/datum/reagent/random/reagent, var/datum/reagents/reagents, var/value)
+	var/list/enhancers = cooling_enhancer_cache[reagent.type]
+	if(!reagents.has_any_reagent(enhancers))
+		return
+	return purify(reagent, reagents, value)
+
+/decl/random_chem_effect/random_properties/proc/purify(var/datum/reagent/random/reagent, var/datum/reagents/reagents, var/value)
+	var/target = reagents.has_reagent(/datum/reagent/toxin/phoron) ? minimum : maximum
+	if(target == value)
+		return
+	var/rate = reaction_rate_cache[reagent.type]
+	switch(mode)
+		if(RANDOM_CHEM_EFFECT_TRUE)
+			if(prob(10 * rate))
+				return target
+			return value // this will keep us reacting
+		if(RANDOM_CHEM_EFFECT_INT)
+			var/amount = (target - value) * rate * 0.1
+			if(abs(amount) >= 1)
+				return round(amount + value)
+			else if(prob(100 * abs(amount)))
+				return value + sign(amount)
+			return value
+		if(RANDOM_CHEM_EFFECT_FLOAT)
+			var/resolution = (maximum - minimum)/100
+			var/new_val = value + (target - value) * rate * 0.1
+			var/round_dir = new_val > value ? -1 : 1                                   // Rounds up if going up, to nearest percent of max - min
+			new_val = round(round_dir * new_val / resolution) * round_dir * resolution // makes this finish in finite time to save processing power.
+			return new_val
+
+/decl/random_chem_effect/random_properties/cooling_act(var/datum/reagent/random/reagent, var/datum/reagents/reagents)
+
+/decl/random_chem_effect/random_properties/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/value)
+	if(chem_effect_define && alien != IS_DIONA) // screw diona
+		M.add_chemical_effect(chem_effect_define, value)
+
+/decl/random_chem_effect/random_properties/get_interactions(var/datum/reagent/random/reagent, var/sci_skill, var/chem_skill)
+	if(chem_skill < SKILL_EXPERT)
+		return
+	. = list("<br>")
+	if(sci_skill > SKILL_ADEPT)
+		. += "For [desc]:<br>"
+	var/list/interactions = list()
+	if(chem_skill == SKILL_PROF)
+		. += "Heating: "
+	for(var/interaction in distillation_inhibitor_cache[reagent.type])
+		var/datum/reagent/R = interaction
+		interactions += initial(R.name)
+	if(chem_skill == SKILL_PROF)
+		. += english_list(interactions)
+		interactions.Cut()
+		. += ". Cooling: "
+	for(var/interaction in cooling_enhancer_cache[reagent.type])
+		var/datum/reagent/R = interaction
+		interactions += initial(R.name)
+	if(chem_skill <= SKILL_PROF)
+		shuffle(interactions)
+	. += english_list(interactions)
+	. += "."
+
+/decl/random_chem_effect/random_properties/ce_stable
+	chem_effect_define = CE_STABLE
+	beneficial = 1
+	desc = "stabilization"
+
+/decl/random_chem_effect/random_properties/ce_antibiotic
+	chem_effect_define = CE_ANTIBIOTIC
+	beneficial = 1
+	desc = "antibiotic power"
+
+/decl/random_chem_effect/random_properties/ce_bloodrestore
+	chem_effect_define = CE_BLOODRESTORE
+	beneficial = 1
+	minimum = 1
+	maximum = 12
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "blood restoration"
+
+/decl/random_chem_effect/random_properties/ce_painkiller
+	chem_effect_define = CE_PAINKILLER
+	beneficial = 1
+	maximum = 100
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "pain suppression"
+
+/decl/random_chem_effect/random_properties/ce_alcohol
+	chem_effect_define = CE_ALCOHOL
+	beneficial = -1
+	desc = "intoxication"
+
+/decl/random_chem_effect/random_properties/ce_alcotoxic
+	chem_effect_define = CE_ALCOHOL_TOXIC
+	beneficial = -1
+	maximum = 8
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "liver damage"
+
+/decl/random_chem_effect/random_properties/ce_gofast
+	chem_effect_define = CE_SPEEDBOOST
+	beneficial = 1
+	maximum = 2
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "faster movement"
+
+/decl/random_chem_effect/random_properties/ce_goslow
+	chem_effect_define = CE_SLOWDOWN
+	beneficial = -1
+	maximum = 20
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "slower movement"
+
+/decl/random_chem_effect/random_properties/ce_xcardic
+	chem_effect_define = CE_PULSE
+	beneficial = -1
+	minimum = -2
+	maximum = 4
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "pulse destabilization"
+
+/decl/random_chem_effect/random_properties/ce_heartstop
+	chem_effect_define = CE_NOPULSE
+	beneficial = -1
+	desc = "cardiac arrest"
+
+/decl/random_chem_effect/random_properties/ce_antitox
+	chem_effect_define = CE_ANTITOX
+	beneficial = 1
+	desc = "poison removal"
+
+/decl/random_chem_effect/random_properties/ce_oxygen
+	chem_effect_define = CE_OXYGENATED
+	beneficial = 1
+	maximum = 2
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "blood oxygenation"
+
+/decl/random_chem_effect/random_properties/ce_brainfix
+	chem_effect_define = CE_BRAIN_REGEN
+	beneficial = 1
+	desc = "neurological repair"
+
+/decl/random_chem_effect/random_properties/ce_antiviral
+	chem_effect_define = CE_ANTIVIRAL
+	beneficial = 1
+	maximum = VIRUS_EXOTIC
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "antiviral action"
+
+/decl/random_chem_effect/random_properties/ce_toxins
+	chem_effect_define = CE_TOXIN
+	beneficial = -1
+	desc = "general toxicity"
+
+/decl/random_chem_effect/random_properties/ce_breathloss
+	chem_effect_define = CE_BREATHLOSS
+	beneficial = -1
+	maximum = 0.6
+	mode = RANDOM_CHEM_EFFECT_FLOAT
+	desc = "respiratory depression"
+
+/decl/random_chem_effect/random_properties/ce_mindbending
+	chem_effect_define = CE_MIND
+	beneficial = -1
+	minimum = -2
+	maximum = 2
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "phychiatric effects"
+
+/decl/random_chem_effect/random_properties/ce_cryogenic
+	chem_effect_define = CE_CRYO
+	beneficial = 1
+	desc = "hypothermia protection"
+
+/decl/random_chem_effect/random_properties/ce_blockage
+	chem_effect_define = CE_BLOCKAGE
+	beneficial = -1
+	maximum = 0.5
+	mode = RANDOM_CHEM_EFFECT_FLOAT
+	desc = "blood flow obstruction"
+
+/decl/random_chem_effect/random_properties/ce_squeaky
+	chem_effect_define = CE_SQUEAKY
+	beneficial = -1
+	desc = "abnormal speech patterns"
+
+/decl/random_chem_effect/random_properties/tox_damage
+	beneficial = -1
+	maximum = 100
+	mode = RANDOM_CHEM_EFFECT_INT
+	desc = "acute toxicity"
+
+/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/value)
+	if(alien != IS_DIONA)
+		M.adjustToxLoss(value * removed)
+
+/decl/random_chem_effect/random_properties/heal_brute
+	beneficial = 1
+	maximum = 10
+	desc = "tissue repair"
+
+/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/value)
+	if(alien != IS_DIONA)
+		M.heal_organ_damage(removed * value, 0)
+
+/decl/random_chem_effect/random_properties/heal_burns
+	beneficial = 1
+	maximum = 10
+	desc = "burn repair"
+
+/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/value)
+	if(alien != IS_DIONA)
+		M.heal_organ_damage(0, removed * value)
+
+#undef RANDOM_CHEM_EFFECT_TRUE
+#undef RANDOM_CHEM_EFFECT_INT
+#undef RANDOM_CHEM_EFFECT_FLOAT


### PR DESCRIPTION
:cl:
rscadd: Some exoplanet plants now produce exotic chemicals, with effects that are randomly generated each round.
rscadd: Inspecting these chemicals in the mass spec with high chemistry and/or science skill will reveal additional information about them.
rscadd: By heating them to almost, but not quite, their boiling points, the effects of these chemicals strengthen (if with phoron catalysis, then weaken). By also adding certain additional ingredients (depending on the effect), the effect will instead be left unchanged.
rscadd: Cooling works similarly, but now the default behavior is that the effect is left unchanged: you need to add certain additional ingredients to make the effect strengthen (or weaken, with phoron).
rscadd: These chemicals may have powerful combinations of medical (or poisonous) effects that can be used, or (if purified sufficiently) can be sold for large profits.
/:cl: