### PR TITLE
Makes intent-based unholstering a preference option

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -68,7 +68,8 @@
 	if(user.get_active_hand() && user.get_inactive_hand())
 		to_chat(user, "<span class='warning'>You need an empty hand to draw \the [holstered]!</span>")
 		return 1
-	if(avoid_intent || user.a_intent != I_HELP)
+	var/using_intent_preference = user.client ? user.client.get_preference_value(/datum/client_preference/holster_on_intent) == GLOB.PREF_YES : FALSE
+	if(avoid_intent || (using_intent_preference && user.a_intent != I_HELP))
 		var/sound_vol = 25
 		if(user.a_intent == I_HURT)
 			sound_vol = 50

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -194,6 +194,10 @@ var/list/_client_preferences_by_type
 	key = "HARDSUIT_ACTIVATION"
 	options = list(GLOB.PREF_MIDDLE_CLICK, GLOB.PREF_CTRL_CLICK, GLOB.PREF_ALT_CLICK, GLOB.PREF_CTRL_SHIFT_CLICK)
 
+/datum/client_preference/holster_on_intent
+	description = "Draw gun based on intent"
+	key = "HOLSTER_ON_INTENT"
+
 /datum/client_preference/show_credits
 	description = "Show End Titles"
 	key = "SHOW_CREDITS"


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Drawing guns based on intent is now a preference option.
/🆑 

Reasons being:
 - Not being on help intent does not imply that the only weapon you want to access is the gun.
 - There already is a default shortcut for holstering and players can even make their own.
 - It is not very intuitive.

**Edit:**
It's a preference now.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->