### PR TITLE
Make lighting respect pixel shifted objects

### DIFF
--- a/code/_helpers/atom_movables.dm
+++ b/code/_helpers/atom_movables.dm
@@ -21,6 +21,8 @@
 
 	//Find coordinates
 	var/turf/T = get_turf(AM) //use AM's turfs, as it's coords are the same as AM's AND AM's coords are lost if it is inside another atom
+	if(!T)
+		return null
 	var/final_x = T.x + rough_x
 	var/final_y = T.y + rough_y
 

--- a/code/_helpers/atom_movables.dm
+++ b/code/_helpers/atom_movables.dm
@@ -9,11 +9,12 @@
 	var/pixel_y_offset = AM.pixel_y + M.get_y_shift()
 
 	//Irregular objects
-	if(AM.bound_height != world.icon_size || AM.bound_width != world.icon_size)
-		var/icon/AMicon = icon(AM.icon, AM.icon_state)
-		pixel_x_offset += ((AMicon.Width()/world.icon_size)-1)*(world.icon_size*0.5)
-		pixel_y_offset += ((AMicon.Height()/world.icon_size)-1)*(world.icon_size*0.5)
-		qdel(AMicon)
+	var/icon/AMicon = icon(AM.icon, AM.icon_state)
+	var/AMiconheight = AMicon.Height()
+	var/AMiconwidth = AMicon.Width()
+	if(AMiconheight != world.icon_size || AMiconwidth != world.icon_size)
+		pixel_x_offset += ((AMiconwidth/world.icon_size)-1)*(world.icon_size*0.5)
+		pixel_y_offset += ((AMiconheight/world.icon_size)-1)*(world.icon_size*0.5)
 
 	//DY and DX
 	var/rough_x = round(round(pixel_x_offset,world.icon_size)/world.icon_size)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -7,6 +7,7 @@
 	var/atom/source_atom     // The atom that we belong to.
 
 	var/turf/source_turf     // The turf under the above.
+	var/turf/pixel_turf      // The turf the top_atom appears to over.
 	var/light_max_bright = 1  // intensity of the light within the full brightness range. Value between 0 and 1
 	var/light_inner_range = 0 // range, in tiles, the light is at full brightness
 	var/light_outer_range = 0 // range, in tiles, where the light becomes darkness
@@ -48,6 +49,8 @@
 		top_atom.light_sources += src
 
 	source_turf = top_atom
+	pixel_turf = get_turf_pixel(top_atom) || source_turf
+
 	light_max_bright = source_atom.light_max_bright
 	light_inner_range = source_atom.light_inner_range
 	light_outer_range = source_atom.light_outer_range
@@ -138,10 +141,17 @@
 	if(isturf(top_atom))
 		if(source_turf != top_atom)
 			source_turf = top_atom
+			pixel_turf = source_turf
 			. = 1
 	else if(top_atom.loc != source_turf)
 		source_turf = top_atom.loc
+		pixel_turf = get_turf_pixel(top_atom)
 		. = 1
+	else
+		var/P = get_turf_pixel(top_atom)
+		if (P != pixel_turf)
+			. = 1
+			pixel_turf = get_turf_pixel(top_atom)
 
 	if(source_atom.light_max_bright != light_max_bright)
 		light_max_bright = source_atom.light_max_bright
@@ -185,7 +195,7 @@
 // The braces and semicolons are there to be able to do this on a single line.
 
 #define APPLY_CORNER(C)              \
-	. = LUM_FALLOFF(C, source_turf); \
+	. = LUM_FALLOFF(C, pixel_turf); \
 	. *= (light_max_bright ** 2);    \
 	. *= light_max_bright < 0 ? -1:1;\
 	effect_str[C] = .;               \

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -49,7 +49,7 @@
 		top_atom.light_sources += src
 
 	source_turf = top_atom
-	pixel_turf = get_turf_pixel(top_atom) || source_turf
+	pixel_turf = (top_atom.pixel_x || top_atom.pixel_y) ? get_turf_pixel(top_atom) : source_turf
 
 	light_max_bright = source_atom.light_max_bright
 	light_inner_range = source_atom.light_inner_range


### PR DESCRIPTION
Basiclly I ported some changes from tg, which make lighting respect shifted objects such like APC or other onwall things.
![image](https://user-images.githubusercontent.com/44920739/48966804-d92f3180-efe8-11e8-8050-1927899cbdee.png)
There's no very big difference for the light fixtures, because they only slightly change their pixel x/y and not originally have centered icon like APC have.

Another comparison:
<details><summary>Old</summary>

![image](https://user-images.githubusercontent.com/44920739/48966745-789ff480-efe8-11e8-854e-94911a83d480.png)
</details>
<details><summary>New</summary>

![image](https://user-images.githubusercontent.com/44920739/48966767-a9802980-efe8-11e8-8deb-648466807415.png)
</details>
