### PR TITLE
Fix full cable coils being dropped from certain telecomms machinery

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -89,8 +89,8 @@
 							for(var/i = 1, i <= C.req_components[I], i++)
 								var/obj/item/s = new I
 								s.dropInto(user.loc)
-								if(istype(P, /obj/item/stack/cable_coil))
-									var/obj/item/stack/cable_coil/A = P
+								if(istype(s, /obj/item/stack/cable_coil))
+									var/obj/item/stack/cable_coil/A = s
 									A.amount = 1
 
 						// Drop a circuit board too


### PR DESCRIPTION
:cl: Funce
bugfix: You can no longer get infinite amounts of cable coil from constructing and deconstructing certain telecomms equipment
/:cl:

Something I found was amiss when I was testing my last PR